### PR TITLE
refactor(activerecord): route PG session/transaction statements through the ported exec primitives

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -281,7 +281,7 @@ describe("PostgreSQLAdapter#sqlKey", () => {
   it("setSchemaSearchPath re-scopes the key so no stale statement is reused", async () => {
     // Drive the real setSchemaSearchPath path (which issues SET search_path and
     // updates the memo) and confirm sqlKey tracks the active path end-to-end.
-    vi.spyOn(adapter, "execute").mockResolvedValue(undefined as never);
+    vi.spyOn(adapter, "internalExecute").mockResolvedValue(undefined as never);
 
     await adapter.setSchemaSearchPath("schema_a, public");
     const keyA = sqlKey("SELECT * FROM widgets");

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2161,7 +2161,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     this._cancelAnyRunningQuery();
     if (!this._client) throw new Error("No active transaction");
     try {
-      await this._client.query("ROLLBACK");
+      await this.internalExecute("ROLLBACK", "TRANSACTION");
     } catch (e) {
       // ROLLBACK on a poisoned socket (e.g. 08P01 after the cancel
       // race) — tear down and reconnect; closing the socket implicitly
@@ -2230,7 +2230,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)
   async execRestartDbTransaction(): Promise<void> {
     this._cancelAnyRunningQuery();
-    await this.execute("ROLLBACK AND CHAIN");
+    await this.internalExecute("ROLLBACK AND CHAIN", "TRANSACTION");
   }
 
   // Mirrors: PostgreSQL::DatabaseStatements#cancel_any_running_query (database_statements.rb private)
@@ -3724,19 +3724,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async extensionEnabled(name: string): Promise<boolean> {
-    const rows = await this.schemaQuery(
-      `SELECT COUNT(*) AS count FROM pg_extension WHERE extname = $1`,
-      [name],
+    return (
+      (await this.queryValue(
+        `SELECT installed_version IS NOT NULL FROM pg_available_extensions WHERE name = ${this.quote(name)}`,
+        "SCHEMA",
+      )) === true
     );
-    return Number(rows[0].count) > 0;
   }
 
   async extensionAvailable(name: string): Promise<boolean> {
-    const rows = await this.schemaQuery(
-      `SELECT COUNT(*) AS count FROM pg_available_extensions WHERE name = $1`,
-      [name],
+    return (
+      (await this.queryValue(
+        `SELECT true FROM pg_available_extensions WHERE name = ${this.quote(name)}`,
+        "SCHEMA",
+      )) === true
     );
-    return Number(rows[0].count) > 0;
   }
 
   async enableExtension(name: string, _options?: Record<string, unknown>): Promise<void> {
@@ -4079,7 +4081,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const [, unqualifiedNew] = this.extractSchemaQualifiedName(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, oldName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, newName);
-    await this.exec(
+    await this.execute(
       `ALTER TABLE ${this.quoteTableName(oldName)} RENAME TO ${this.quoteIdentifier(unqualifiedNew)}`,
     );
     // Rails reads max_identifier_length here, which lazily runs the SHOW query

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -79,7 +79,10 @@ function makeSchemaAdapter() {
     execute: vi.fn(async (sql: string) => {
       execed.push(sql);
     }),
-    schemaQuery: vi.fn(async () => [{ search_path: '"$user", public' }]),
+    internalExecute: vi.fn(async (sql: string) => {
+      execed.push(sql);
+    }),
+    queryValue: vi.fn(async () => '"$user", public'),
   } as unknown as DatabaseAdapter;
   return { adapter, execed };
 }
@@ -107,7 +110,7 @@ describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
     expect(await ss.schemaSearchPath()).toBe('"$user", public');
     expect(await ss.schemaSearchPath()).toBe('"$user", public');
     expect(
-      (adapter as unknown as { schemaQuery: ReturnType<typeof vi.fn> }).schemaQuery,
+      (adapter as unknown as { queryValue: ReturnType<typeof vi.fn> }).queryValue,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -118,7 +121,7 @@ describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
     expect(execed).toEqual([`SET search_path TO my_schema, public`]);
     expect(await ss.schemaSearchPath()).toBe("my_schema, public");
     expect(
-      (adapter as unknown as { schemaQuery: ReturnType<typeof vi.fn> }).schemaQuery,
+      (adapter as unknown as { queryValue: ReturnType<typeof vi.fn> }).queryValue,
     ).not.toHaveBeenCalled();
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -46,6 +46,7 @@ interface PgSchemaAdapter {
   queryValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
   exec(sql: string): Promise<void>;
   execute(sql: string): Promise<unknown>;
+  internalExecute(sql: string, name?: string): Promise<unknown>;
   clearCacheBang(): void;
   quote(value: unknown): string;
   quoteIdentifier(name: string): string;
@@ -529,30 +530,27 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       );
     }
     if (options.force) {
-      await this.pg.exec(`DROP SCHEMA IF EXISTS ${this.quoteSchemaName(name)} CASCADE`);
+      await this.dropSchema(name, { ifExists: true });
     }
     const ifNotExists = options.ifNotExists ? " IF NOT EXISTS" : "";
-    await this.pg.exec(`CREATE SCHEMA${ifNotExists} ${this.quoteSchemaName(name)}`);
+    await this.adapter.execute(`CREATE SCHEMA${ifNotExists} ${this.quoteSchemaName(name)}`);
   }
 
   async dropSchema(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    // Rails' drop_schema unconditionally appends CASCADE — it is not gated on
-    // an option (PostgreSQL::SchemaStatements#drop_schema).
     const ifExists = options.ifExists ? " IF EXISTS" : "";
-    await this.pg.exec(`DROP SCHEMA${ifExists} ${this.quoteSchemaName(name)} CASCADE`);
+    await this.adapter.execute(`DROP SCHEMA${ifExists} ${this.quoteSchemaName(name)} CASCADE`);
   }
 
   async schemaExists(name: string): Promise<boolean> {
-    const rows = await this.pg.schemaQuery(
-      `SELECT COUNT(*) AS count FROM pg_namespace WHERE nspname = $1`,
-      [name],
+    const count = await this.pg.queryValue(
+      `SELECT COUNT(*) FROM pg_namespace WHERE nspname = ${this.pg.quote(name)}`,
+      "SCHEMA",
     );
-    return Number(rows[0].count) > 0;
+    return Number(count) > 0;
   }
 
   async currentSchema(): Promise<string> {
-    const rows = await this.pg.schemaQuery("SELECT current_schema() AS schema");
-    return rows[0].schema as string;
+    return (await this.pg.queryValue("SELECT current_schema", "SCHEMA")) as string;
   }
 
   // ---------------------------------------------------------------------------
@@ -587,11 +585,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       }
       optionString += ` CONNECTION LIMIT = ${limit}`;
     }
-    await this.pg.exec(`CREATE DATABASE ${this.pg.quoteIdentifier(name)}${optionString}`);
+    await this.adapter.execute(`CREATE DATABASE ${this.pg.quoteIdentifier(name)}${optionString}`);
   }
 
   async dropDatabase(name: string): Promise<void> {
-    await this.pg.exec(`DROP DATABASE IF EXISTS ${this.pg.quoteIdentifier(name)}`);
+    await this.adapter.execute(`DROP DATABASE IF EXISTS ${this.pg.quoteIdentifier(name)}`);
   }
 
   async recreateDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
@@ -600,29 +598,28 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async currentDatabase(): Promise<string> {
-    const rows = await this.pg.schemaQuery("SELECT current_database() AS name");
-    return rows[0].name as string;
+    return (await this.pg.queryValue("SELECT current_database()", "SCHEMA")) as string;
   }
 
   async encoding(): Promise<string> {
-    const rows = await this.pg.schemaQuery(
-      "SELECT pg_encoding_to_char(encoding) AS enc FROM pg_database WHERE datname = current_database()",
-    );
-    return rows[0].enc as string;
+    return (await this.pg.queryValue(
+      "SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = current_database()",
+      "SCHEMA",
+    )) as string;
   }
 
   async collation(): Promise<string> {
-    const rows = await this.pg.schemaQuery(
-      "SELECT datcollate AS col FROM pg_database WHERE datname = current_database()",
-    );
-    return rows[0].col as string;
+    return (await this.pg.queryValue(
+      "SELECT datcollate FROM pg_database WHERE datname = current_database()",
+      "SCHEMA",
+    )) as string;
   }
 
   async ctype(): Promise<string> {
-    const rows = await this.pg.schemaQuery(
-      "SELECT datctype AS ct FROM pg_database WHERE datname = current_database()",
-    );
-    return rows[0].ct as string;
+    return (await this.pg.queryValue(
+      "SELECT datctype FROM pg_database WHERE datname = current_database()",
+      "SCHEMA",
+    )) as string;
   }
 
   // ---------------------------------------------------------------------------
@@ -630,34 +627,27 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // ---------------------------------------------------------------------------
 
   async schemaSearchPath(): Promise<string> {
-    // Rails memoizes: @schema_search_path ||= query_value("SHOW search_path").
-    // The memo lives on the adapter (connection-scoped), since this statements
-    // object is reconstructed per call.
     if (this.pg._schemaSearchPathMemo == null) {
-      const rows = await this.pg.schemaQuery("SHOW search_path");
-      this.pg._schemaSearchPathMemo = rows[0].search_path as string;
+      this.pg._schemaSearchPathMemo = (await this.pg.queryValue(
+        "SHOW search_path",
+        "SCHEMA",
+      )) as string;
     }
     return this.pg._schemaSearchPathMemo;
   }
 
   async setSchemaSearchPath(searchPath: string | null): Promise<void> {
-    // Rails guards with `if schema_csv` (truthy), so "" is also a no-op.
     if (!searchPath) return;
-    // Mirrors Rails' schema_search_path= which uses direct interpolation:
-    //   internal_execute("SET search_path TO #{schema_csv}"); @schema_search_path = schema_csv
-    // This means unquoted $user causes a PG parse error (dollar-quoted string),
-    // matching Rails' behavior. Use '$user' (with single quotes) for the special token.
-    await this.pg.execute(`SET search_path TO ${searchPath}`);
+    await this.pg.internalExecute(`SET search_path TO ${searchPath}`);
     this.pg._schemaSearchPathMemo = searchPath;
   }
 
   async clientMinMessages(): Promise<string> {
-    const rows = await this.pg.schemaQuery("SHOW client_min_messages");
-    return rows[0].client_min_messages as string;
+    return (await this.pg.queryValue("SHOW client_min_messages", "SCHEMA")) as string;
   }
 
   async setClientMinMessages(level: string): Promise<void> {
-    await this.pg.exec(`SET client_min_messages TO ${this.pg.quoteLiteral(level)}`);
+    await this.pg.internalExecute(`SET client_min_messages TO '${level}'`, "SCHEMA");
   }
 
   private quoteSchemaName(name: string): string {
@@ -1897,11 +1887,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async serialSequence(tableName: string, column: string): Promise<string | null> {
-    const rows = await this.pg.schemaQuery(`SELECT pg_get_serial_sequence($1, $2) AS seq`, [
-      tableName,
-      column,
-    ]);
-    return (rows[0]?.seq as string | null) ?? null;
+    return ((await this.pg.queryValue(
+      `SELECT pg_get_serial_sequence(${this.pg.quote(tableName)}, ${this.pg.quote(column)})`,
+      "SCHEMA",
+    )) ?? null) as string | null;
   }
 
   async defaultSequenceName(

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -114,23 +114,9 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "client_min_messages",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "client_min_messages=",
     "call": "internal_execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "collation",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): setClientMinMessages does call the ported internal_execute primitive — `this.pg.internalExecute(\"SET client_min_messages TO '<level>'\", \"SCHEMA\")` in postgresql/schema-statements-class.ts. The call goes unmatched because this entry is anchored to postgresql-adapter.ts, whose setClientMinMessages is a one-line delegation into that statements class."
   },
   {
     "package": "activerecord",
@@ -227,13 +213,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "create_database",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "create_database",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -275,43 +254,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "create_schema",
-    "call": "drop_schema",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "create_schema",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "create_schema_dumper",
     "call": "create",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "ctype",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "current_database",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "current_schema",
-    "call": "query_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -352,13 +296,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "drop_database",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "drop_enum",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -373,13 +310,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "drop_schema",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "enable_extension",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -389,13 +319,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "enable_extension",
     "call": "values_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "encoding",
-    "call": "query_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -499,20 +422,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exec_restart_db_transaction",
-    "call": "internal_execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exec_rollback_db_transaction",
-    "call": "internal_execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "explain",
     "call": "build_explain_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -529,34 +438,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "explain",
     "call": "to_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "extension_available?",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "extension_available?",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "extension_enabled?",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "extension_enabled?",
-    "call": "quote",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -599,7 +480,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "get_advisory_lock",
     "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deliberate deviation (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): PG advisory locks are session-scoped, so the lock must be taken on the pinned raw client and serialized against in-flight maintenance queries (_acquireFreshClient + _serializePinnedQuery). Routing through query_value would run it on whatever connection selectAll materializes and could hand the lock to a connection the caller does not hold. trails also accepts string lock ids (hashtext) that Rails rejects outright."
   },
   {
     "package": "activerecord",
@@ -830,7 +711,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "release_advisory_lock",
     "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deliberate deviation (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): mirror of get_advisory_lock — the unlock must target the same pinned session that took the lock, so it runs on the pinned raw client rather than through query_value."
   },
   {
     "package": "activerecord",
@@ -920,13 +801,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "rename_table",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_table",
     "call": "rename_table_indexes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -961,30 +835,9 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "schema_exists?",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "schema_exists?",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "schema_search_path",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "schema_search_path=",
     "call": "internal_execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): setSchemaSearchPath does call the ported internal_execute primitive — `this.pg.internalExecute(`SET search_path TO ${searchPath}`)` in postgresql/schema-statements-class.ts. Unmatched for the same reason as client_min_messages=: the entry is anchored to postgresql-adapter.ts, which only delegates."
   },
   {
     "package": "activerecord",
@@ -992,20 +845,6 @@
     "rubyName": "sequence_name_from_parts",
     "call": "sum",
     "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Array#sum(&:length)`; JS has no Array#sum, so the three lengths are added directly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "serial_sequence",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "serial_sequence",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Follow-up half of `converge-pg-ddl-exec-primitive-and-quoting-routing` (RFC 0072), which shipped the alter-table / quoting half and stopped at the 500-LOC ceiling. This finishes the session / transaction / read-side entries.

Rebased onto `main` after #5384 (`route schema introspection through ported exec primitives`) landed. That sibling PR independently converged `table_comment`, `schema_names`, `primary_keys` and `foreign_tables`, so those are no longer part of this diff — I took `main`'s versions wholesale (its `table_comment` is the better port: it threads `quoted_scope(table_name, type: "BASE TABLE")` and interpolates `${scope.type}`, matching `schema_statements.rb:176-184` exactly). My separate `quote(quote_table_name(...))` fix for `primary_keys` turned out to be identical to what #5384 shipped, so that commit dropped out of the rebase entirely.

## What changed

**DDL writes** — `create_schema`, `drop_schema`, `create_database`, `drop_database`, `rename_table` now call the public `execute` primitive instead of the trails-private `this.pg.exec`. `create_schema`'s `force:` arm delegates to `dropSchema(name, { ifExists: true })`, matching `schema_statements.rb:261-263`.

**Session writers** — `client_min_messages=`, `schema_search_path=`, `exec_rollback_db_transaction` and `exec_restart_db_transaction` route through `internalExecute`. `execRollbackDbTransaction` previously bypassed the primitive entirely with a bare `this._client.query("ROLLBACK")`; it now matches `rollback()`, which already used `internalExecute("ROLLBACK", "TRANSACTION")` with the same connection-error teardown. Rails' `allow_retry: false, materialize_transactions: true` are trails' defaults on that call.

**Read-side accessors** — `encoding`, `collation`, `ctype`, `current_database`, `current_schema`, `schema_search_path`, `client_min_messages`, `serial_sequence`, `schema_exists?` now go through `queryValue` carrying Rails' own SQL text and the `"SCHEMA"` log name, instead of issuing `this.pg.schemaQuery(...)` and indexing the row map by an invented `AS` alias. `extension_enabled?` / `extension_available?` adopt Rails' `pg_available_extensions` predicates in place of the trails `COUNT(*)` variants, and `schema_exists?` / `serial_sequence` switch from binds to Rails' inline `quote(...)` interpolation.

## Baseline

`scripts/api-compare/call-mismatches-wide-exclude/.../postgresql-adapter.json` loses 23 entries (down from 27 pre-rebase — #5384 claimed four of them). Four listed in the story stay, with specific reasons:

- `client_min_messages= internal_execute` and `schema_search_path= internal_execute` — both *do* call the ported primitive now, but the baseline entry is anchored to `postgresql-adapter.ts`, whose setters are one-line delegations into the statements class where the call actually lives.
- `get_advisory_lock` / `release_advisory_lock` `query_value` — deliberate deviation. PG advisory locks are session-scoped, so they must run on the pinned raw client (`_acquireFreshClient` + `_serializePinnedQuery`); `query_value` would run them on whatever connection `selectAll` materializes.

`pnpm api:calls:wide` passes with a strictly smaller baseline (4834).

## Tests

No new test names were needed — the Rails-verbatim tests covering these paths already exist and now exercise the converged routing: `test_encoding` / `test_collation` / `test_ctype` / `test_default_client_min_messages` / `test_current_database_logs_name` / `test_encoding_logs_name` / `test_schema_names_logs_name` (`connection.test.ts`), `test_current_schema` / `test_schema_exists?` / `test_create_schema` / `test_drop_schema` / `test_force_create_schema` / `test_reset_pk_sequence` (`schema.test.ts`). The `"logs name"` tests in particular assert the `"SCHEMA"` instrumentation label that the `queryValue` routing now supplies.

The fake-adapter unit tests in `schema-statements-class.test.ts` were updated to stub `queryValue` / `internalExecute` in place of `schemaQuery`.

Verified locally against postgres:17 on the rebased tree: `adapters/postgresql/` + `connection-adapters/postgresql/` — 1317 passed, 3 skipped. The 4 `foreign-table.test.ts` record-CRUD failures are environmental (the `postgres_fdw` foreign server cannot dial back into the host from inside the container) and are unrelated to this diff.

Closes-story: converge-pg-session-and-transaction-exec-primitive-routing
