### PR TITLE
refactor(activemodel): inline is_utc? branch, drop configuredTimezone export

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -112,7 +112,6 @@ export { TimeType } from "./type/time.js";
 export {
   isUtc as isUtcTimezone,
   defaultTimezone as getDefaultTimezone,
-  configuredTimezone,
 } from "./type/helpers/timezone.js";
 
 import { StringType } from "./type/string.js";

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -7,7 +7,7 @@ import {
 } from "./internal/sentinels.js";
 import { ArgumentError } from "../attribute-assignment.js";
 import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
-import { configuredTimezone, isUtc } from "./helpers/timezone.js";
+import { isUtc } from "./helpers/timezone.js";
 import { ValueType } from "./value.js";
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
@@ -166,9 +166,13 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
       }
     }
     try {
-      return Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
-        .toZonedDateTime(configuredTimezone(this.isUtc))
-        .toInstant();
+      return (
+        Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
+          // Rails branches on `is_utc?` between `::Time.utc` and `::Time.local`;
+          // Temporal has no `Time.local`, so the local arm names the host zone.
+          .toZonedDateTime(this.isUtc ? "UTC" : Temporal.Now.timeZoneId())
+          .toInstant()
+      );
     } catch {
       return null;
     }

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
  */
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { configuredTimezone } from "./timezone.js";
+import { isUtc } from "./timezone.js";
 
 export interface TimezoneAware {
   readonly isUtc: boolean;
@@ -175,9 +175,13 @@ export function newTime(
         .toInstant();
       return offset === 0 ? instant : instant.subtract({ seconds: offset });
     }
-    return Temporal.PlainDateTime.from(components, { overflow: "reject" })
-      .toZonedDateTime(configuredTimezone(this?.isUtc))
-      .toInstant();
+    return (
+      Temporal.PlainDateTime.from(components, { overflow: "reject" })
+        // Rails branches on `is_utc?` between `::Time.utc` and `::Time.local`;
+        // Temporal has no `Time.local`, so the local arm names the host zone.
+        .toZonedDateTime((this?.isUtc ?? isUtc()) ? "UTC" : Temporal.Now.timeZoneId())
+        .toInstant()
+    );
   } catch {
     return null;
   }
@@ -217,9 +221,13 @@ export function fastStringToTime(this: TimezoneAware | void, s: string): Tempora
   const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(datetimeString);
   try {
     if (hasOffset) return Temporal.Instant.from(datetimeString);
-    return Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
-      .toZonedDateTime(configuredTimezone(this?.isUtc))
-      .toInstant();
+    return (
+      Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
+        // Rails branches on `is_utc?` between `::Time.utc` and `::Time.local`;
+        // Temporal has no `Time.local`, so the local arm names the host zone.
+        .toZonedDateTime((this?.isUtc ?? isUtc()) ? "UTC" : Temporal.Now.timeZoneId())
+        .toInstant()
+    );
   } catch {
     return null;
   }

--- a/packages/activemodel/src/type/helpers/timezone.ts
+++ b/packages/activemodel/src/type/helpers/timezone.ts
@@ -1,5 +1,4 @@
 import { getZoneDefault } from "@blazetrails/activesupport";
-import { Temporal } from "@blazetrails/activesupport/temporal";
 
 export function isUtc(): boolean {
   const zoneDefault = getZoneDefault();
@@ -9,8 +8,4 @@ export function isUtc(): boolean {
 
 export function defaultTimezone(): "utc" | "local" {
   return isUtc() ? "utc" : "local";
-}
-
-export function configuredTimezone(utc: boolean = isUtc()): string {
-  return utc ? "UTC" : Temporal.Now.timeZoneId();
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -206,13 +206,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 }
 
-/**
- * Rails' time types branch on `is_utc?` between `::Time.utc` and `::Time.local`
- * (time_value.rb:51-60). Temporal has no `Time.local`, so the local arm has to
- * name the host zone explicitly.
- *
- * @internal
- */
+/** @internal */
 function zoneForIsUtc(subtypeIsUtc?: boolean): string {
   return (subtypeIsUtc ?? isUtcTimezone()) ? "UTC" : Temporal.Now.timeZoneId();
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -2,7 +2,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion
  */
 import type { Type } from "@blazetrails/activemodel";
-import { ValueType, configuredTimezone } from "@blazetrails/activemodel";
+import { ValueType, isUtcTimezone } from "@blazetrails/activemodel";
 import { TimeWithZone, TimeZone, getZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 type ValueTypeInstance = InstanceType<typeof ValueType>;
@@ -63,7 +63,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
     // PlainDateTime: wall-clock components from multiparameter assembly (no timezone).
     // Mirrors Rails' Hash branch: set_time_zone_without_conversion(super).
     if (value instanceof Temporal.PlainDateTime) {
-      const instant = value.toZonedDateTime(configuredTimezone(this._subtypeIsUtc)).toInstant();
+      const instant = value.toZonedDateTime(zoneForIsUtc(this._subtypeIsUtc)).toInstant();
       return setTimeZoneWithoutConversion(instant, this._subtypeIsUtc);
     }
     // Strings: Rails gives String an in_time_zone method via CoreExt, so strings
@@ -207,6 +207,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
 }
 
 /**
+ * Rails' time types branch on `is_utc?` between `::Time.utc` and `::Time.local`
+ * (time_value.rb:51-60). Temporal has no `Time.local`, so the local arm has to
+ * name the host zone explicitly.
+ *
+ * @internal
+ */
+function zoneForIsUtc(subtypeIsUtc?: boolean): string {
+  return (subtypeIsUtc ?? isUtcTimezone()) ? "UTC" : Temporal.Now.timeZoneId();
+}
+
+/**
  * Walks the `subtype` chain the way Rails' OID::Range / OID::Array delegate to
  * their subtype (range.rb:8-10, array.rb:12-13), so a wrapped
  * ActiveRecord::Type::DateTime still supplies the `is_utc?` that
@@ -249,11 +260,11 @@ function setTimeZoneWithoutConversion(value: unknown, subtypeIsUtc?: boolean): u
   if (!zone) return value;
   if (value instanceof Temporal.Instant) {
     // AcceptsMultiparameterTime builds the instant by interpreting components
-    // in configuredTimezone() (UTC when default_timezone is :utc, host-local
+    // in the is_utc? zone (UTC when default_timezone is :utc, host-local
     // when :local). Extract wall-clock components using the SAME timezone so
     // we get the original component values, then re-interpret them as local
     // time in the current zone (mirrors Time.zone.local_to_utc(t).in_time_zone).
-    const zoned = value.toZonedDateTimeISO(configuredTimezone(subtypeIsUtc));
+    const zoned = value.toZonedDateTimeISO(zoneForIsUtc(subtypeIsUtc));
     const pdt = zoned.toPlainDateTime();
     // zone.local() takes milliseconds; get the ms-level result with correct DST
     // disambiguation, then add back sub-millisecond precision from the original.
@@ -350,7 +361,7 @@ function castBoundInZone(value: unknown, subtypeIsUtc?: boolean): unknown {
   if (value instanceof Temporal.Instant) return convertTimeToTimeZone(value);
   if (value instanceof Temporal.ZonedDateTime) return convertTimeToTimeZone(value.toInstant());
   if (value instanceof Temporal.PlainDateTime) {
-    const instant = value.toZonedDateTime(configuredTimezone(subtypeIsUtc)).toInstant();
+    const instant = value.toZonedDateTime(zoneForIsUtc(subtypeIsUtc)).toInstant();
     return setTimeZoneWithoutConversion(instant, subtypeIsUtc);
   }
   if (typeof value === "string") {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/date-time.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/date-time.json
@@ -46,7 +46,7 @@
     "tsFile": "type/date-time.ts",
     "rubyName": "serialize_cast_value",
     "call": "getlocal",
-    "reason": "Not applicable: Rails' `serialize_cast_value` calls `getutc`/`getlocal` to re-attach a zone to a Ruby Time. The cast value here is a zoneless Temporal.PlainTime / absolute Temporal.Instant, so both branches are identity; trails resolves `default_timezone` at parse time (`configuredTimezone`) and again at quote time in the adapter's `quotedDate`."
+    "reason": "Not applicable: Rails' `serialize_cast_value` calls `getutc`/`getlocal` to re-attach a zone to a Ruby Time. The cast value here is a zoneless Temporal.PlainTime / absolute Temporal.Instant, so both branches are identity; trails resolves `default_timezone` at parse time (the `is_utc?` branch) and again at quote time in the adapter's `quotedDate`."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/time.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/time.json
@@ -32,7 +32,7 @@
     "tsFile": "type/time.ts",
     "rubyName": "serialize_cast_value",
     "call": "getlocal",
-    "reason": "Not applicable: Rails' `serialize_cast_value` calls `getutc`/`getlocal` to re-attach a zone to a Ruby Time. The cast value here is a zoneless Temporal.PlainTime / absolute Temporal.Instant, so both branches are identity; trails resolves `default_timezone` at parse time (`configuredTimezone`) and again at quote time in the adapter's `quotedDate`."
+    "reason": "Not applicable: Rails' `serialize_cast_value` calls `getutc`/`getlocal` to re-attach a zone to a Ruby Time. The cast value here is a zoneless Temporal.PlainTime / absolute Temporal.Instant, so both branches are identity; trails resolves `default_timezone` at parse time (the `is_utc?` branch) and again at quote time in the adapter's `quotedDate`."
   },
   {
     "package": "activemodel",


### PR DESCRIPTION
Rails has no zone-name resolver. `TimeValue#new_time` and `#fast_string_to_time`
(`activemodel/lib/active_model/type/helpers/time_value.rb:51-60`, `:91-94`)
branch directly on `is_utc?` between `::Time.utc` and `::Time.local`. Trails
had a novel `configuredTimezone(utc = isUtc())` export standing in for that.

- `configuredTimezone` is deleted; the `is_utc?` branch is inlined at each
  Rails call site (`new_time`, `fast_string_to_time`, `DateTimeType#parseString`),
  with a call-site comment noting the only Temporal-shaped part: there is no
  `Time.local`, so the local arm names the host zone.
- `activerecord/src/attribute-methods/time-zone-conversion.ts` no longer imports
  it across the package boundary; it keeps a module-private `zoneForIsUtc()`
  for its three call sites.
- Two `call-mismatches-wide-exclude` reasons updated to stop naming the
  removed helper.

`pnpm api:extra` shows one fewer activemodel novel export.

Closes-story: converge-configured-timezone-helper-onto-is-utc
