### PR TITLE
refactor(activerecord): converge PrimaryKey id writer onto an accessor

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -685,7 +685,7 @@ describe("CollectionProxy#delete / #destroy through has_many :through — nil on
 });
 
 // RFC 0006 S1 — targetsByPrimaryKey() across non-default primary keys. The
-// token routes through `record.id` → `_getId` → `_readAttribute(primaryKey)`,
+// token routes through `record.id` → `PrimaryKey#id` → `_readAttribute(primaryKey)`,
 // so a custom single-column PK and a composite PK must key correctly, and a
 // composite new record (an `id` array with null parts) must be skipped.
 // Canonical models: `CpkAuthor has_many :books` (CpkBook PK `[author_id, id]`)

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -106,11 +106,7 @@ interface PrimaryKeyInstance {
   writeAttribute(name: string, value: unknown): void;
 }
 
-/**
- * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id
- * @internal
- */
-export function getId(this: PrimaryKeyInstance): unknown {
+function readId(this: PrimaryKeyInstance): unknown {
   const ctor = this.constructor as any;
   const pk = ctor.primaryKey as string | string[] | null;
   if (Array.isArray(pk)) return pk.map((col) => this._readAttribute(col));
@@ -119,11 +115,7 @@ export function getId(this: PrimaryKeyInstance): unknown {
   return this._readAttribute(pk as string);
 }
 
-/**
- * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id=
- * @internal
- */
-export function setId(this: PrimaryKeyInstance, value: unknown): void {
+function writeId(this: PrimaryKeyInstance, value: unknown): void {
   const ctor = this.constructor as any;
   const pk = ctor.primaryKey as string | string[] | null;
   if (Array.isArray(pk)) {
@@ -153,6 +145,32 @@ export function setId(this: PrimaryKeyInstance, value: unknown): void {
     this.writeAttribute("id", value);
   } else {
     this._writeAttribute(pk, value);
+  }
+}
+
+/**
+ * Home for the module's `id` accessor pair. Ruby names a writer after its
+ * reader (`id` / `id=`); TypeScript can only spell that pair as a `get`/`set`
+ * on a prototype, and two exported functions in one module can't share a name —
+ * so a `setId`-style export would be surface Rails does not have. Hosts pick
+ * the pair up with `include()` from `@blazetrails/activesupport`, which copies
+ * accessor descriptors intact.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey
+ */
+export class PrimaryKey {
+  // The host surface is asserted at the call, not declared as class fields:
+  // a `declare writeAttribute` here would register as TS surface this Rails
+  // module does not have (api:extra flags it as moved from write.rb).
+
+  /** Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id */
+  get id(): unknown {
+    return readId.call(this as unknown as PrimaryKeyInstance);
+  }
+
+  /** Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id= */
+  set id(value: unknown) {
+    writeId.call(this as unknown as PrimaryKeyInstance, value);
   }
 }
 
@@ -269,10 +287,10 @@ export function primaryKey(this: PrimaryKeyHost, value?: string | string[]): str
  */
 export function id(this: PrimaryKeyInstance, value?: unknown): unknown {
   if (value !== undefined) {
-    setId.call(this, value);
+    writeId.call(this, value);
     return value;
   }
-  return getId.call(this);
+  return readId.call(this);
 }
 
 export function isInstanceMethodAlreadyImplemented(

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -149,26 +149,13 @@ function writeId(this: PrimaryKeyInstance, value: unknown): void {
 }
 
 /**
- * Home for the module's `id` accessor pair. Ruby names a writer after its
- * reader (`id` / `id=`); TypeScript can only spell that pair as a `get`/`set`
- * on a prototype, and two exported functions in one module can't share a name —
- * so a `setId`-style export would be surface Rails does not have. Hosts pick
- * the pair up with `include()` from `@blazetrails/activesupport`, which copies
- * accessor descriptors intact.
- *
  * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey
  */
 export class PrimaryKey {
-  // The host surface is asserted at the call, not declared as class fields:
-  // a `declare writeAttribute` here would register as TS surface this Rails
-  // module does not have (api:extra flags it as moved from write.rb).
-
-  /** Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id */
   get id(): unknown {
     return readId.call(this as unknown as PrimaryKeyInstance);
   }
 
-  /** Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id= */
   set id(value: unknown) {
     writeId.call(this as unknown as PrimaryKeyInstance, value);
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3416,8 +3416,6 @@ export class Base extends Model {
 
   declare writeAttribute: typeof ReadonlyAttributes.writeAttribute;
 
-  // `id` / `id=` are the PrimaryKey module's accessor pair; wired onto the
-  // prototype via include() below so they keep their Rails name.
   declare id: PrimaryKeyValue;
 
   // increment/decrement/toggle + bang variants wired via include() below;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -194,8 +194,7 @@ import {
 import { normalizedAttributes as _normalizedAttributes } from "./normalization.js";
 import {
   toKey as _toKey,
-  getId as _getId,
-  setId as _setId,
+  PrimaryKey as _PrimaryKey,
   getPrimaryKeyAttr as _getPrimaryKeyAttr,
   setPrimaryKeyAttr as _setPrimaryKeyAttr,
   isCompositePrimaryKey as _isCompositePrimaryKey,
@@ -796,7 +795,7 @@ function _collectNestedAttributeSetterKeys(ctor: typeof Base | undefined): Set<s
  * handling: trails holds the `id` key out of super()'s attribute loop and
  * re-dispatches it here, once `initInternals` has run.
  *
- * `id: [a, b]` goes through the `id=` setter (`setId`, mirroring
+ * `id: [a, b]` goes through the `id=` setter (`PrimaryKey#id=`, mirroring
  * `CompositePrimaryKey#id=`), which zips the Enumerable (array/set) across the
  * key columns. A scalar `id` on a model-level composite PK raises `TypeError`
  * there, matching Rails (which wants `id: [author_id, id]`, not a bare scalar).
@@ -809,7 +808,7 @@ function _applyCompositePrimaryKey(
 ): void {
   const pk = (ctor as { primaryKey?: unknown }).primaryKey;
   if (!Array.isArray(pk) || !Object.prototype.hasOwnProperty.call(attrs, "id")) return;
-  // Dispatch through the `id=` setter (`setId`): an array spreads across the key
+  // Dispatch through the `id=` setter (`PrimaryKey#id=`): an array spreads across the key
   // columns; a scalar raises TypeError, matching `CompositePrimaryKey#id=`.
   (record as unknown as { id: unknown }).id = (attrs as { id: unknown }).id;
 }
@@ -3417,13 +3416,9 @@ export class Base extends Model {
 
   declare writeAttribute: typeof ReadonlyAttributes.writeAttribute;
 
-  get id(): PrimaryKeyValue {
-    return _getId.call(this) as PrimaryKeyValue;
-  }
-
-  set id(value: PrimaryKeyValue) {
-    _setId.call(this, value);
-  }
+  // `id` / `id=` are the PrimaryKey module's accessor pair; wired onto the
+  // prototype via include() below so they keep their Rails name.
+  declare id: PrimaryKeyValue;
 
   // increment/decrement/toggle + bang variants wired via include() below;
   // signatures live on the merged `interface Base` at the bottom of this file.
@@ -4962,6 +4957,7 @@ include(Base, {
   writeStoreAttribute: _writeStoreAttributeMethod,
   storeAccessorFor: _storeAccessorForMethod,
 });
+include(Base, _PrimaryKey);
 include(Base, LockingPessimistic.InstanceMethods);
 include(Base, LockingOptimistic.InstanceMethods);
 include(Base, Timestamp.InstanceMethods);

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -184,7 +184,7 @@ export function _writeAttribute(this: Base, name: string, value: unknown): void 
   // Mirrors Rails `_write_attribute`: skip alias resolution, unlike the public
   // `write_attribute` path above. Rails (write.rb:42) reaches `write_from_user`
   // and raises `MissingAttributeError` for an unknown name — including
-  // `id = …` on a key-less table (`setId` →
+  // `id = …` on a key-less table (`PrimaryKey#id=` →
   // `_writeAttribute(@primary_key=null, value)`).
   Model.prototype._writeAttribute.call(this, name, value);
 }


### PR DESCRIPTION
`packages/activerecord/src/attribute-methods/primary-key.ts` exported `setId`,
the writer half of `ActiveRecord::AttributeMethods::PrimaryKey#id=`.
`scripts/api-compare/conventions.ts` maps a Ruby writer `foo=` onto the *same*
camelCase name as its reader, so a `set`-prefixed sibling export is TS surface
Rails does not have.

Converged onto the accessor shape used by
`actionpack/src/action-dispatch/http/mime-negotiation.ts`: an exported
`PrimaryKey` class module carrying `get id()` / `set id()` under the Rails name,
mixed into `Base.prototype` via `include()` from `@blazetrails/activesupport`
(which copies accessor descriptors intact). `Base`'s class-body `get id` /
`set id` are replaced by a `declare id: PrimaryKeyValue` type-only field so the
mixin actually installs — `include()` never overwrites a class-body member.

The bodies moved verbatim into module-private `readId` / `writeId` helpers, so
the composite-primary-key zip/`TypeError` behaviour and the key-less-model
`writeAttribute("id", …)` path are unchanged. The combined
`id(value?)` export (Rails' `#id, id=`) now calls those helpers directly.

The class deliberately declares no host fields: a `declare writeAttribute` on it
registers as extra TS surface (api:extra flagged it as moved from `write.rb`),
so the host shape is asserted at the call site instead.

- `api:compare` activerecord unchanged at 6079/6142 (99%); `api:extra` reports
  zero entries for `attribute-methods/primary-key.ts` (before and after).
- No new allowlist entries, no `@noRailsEquivalent` tags.
- `pnpm typecheck` clean; `primary-keys`, `primary-keys.trails`,
  `attribute-methods*`, `base`, `collection-proxy` suites green.

Closes-story: converge-primary-key-id-writer-onto-accessor
