### PR TITLE
feat(activerecord): connect() establishes ARUnit2Model on a provisioned arunit2

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -41,6 +41,7 @@ import {
   ARUNIT_DATABASE,
   ARUNIT2_DATABASE,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
+import { provisionSecondDatabase } from "./support/setup-second-pool.js";
 
 // Drives Rails' AdapterTest casted/non-casted bind probes against the leased
 // connection and the canonical `events` table. The insert return value is
@@ -1294,6 +1295,10 @@ describe.runIf(adapterType === "mysql")("AdapterTest", () => {
       for (const database of [ARUNIT_DATABASE, ARUNIT2_DATABASE]) {
         await connection.execute(`DROP DATABASE IF EXISTS ${database}`);
       }
+      // ARUNIT2_DATABASE is this worker's real second database, which
+      // `ARUnit2Model` holds a pool on for the whole run — put it back rather
+      // than leaving later suites in the worker with colleges/courses gone.
+      await provisionSecondDatabase();
     }
   });
 });

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -1296,8 +1296,7 @@ describe.runIf(adapterType === "mysql")("AdapterTest", () => {
         await connection.execute(`DROP DATABASE IF EXISTS ${database}`);
       }
       // ARUNIT2_DATABASE is this worker's real second database, which
-      // `ARUnit2Model` holds a pool on for the whole run — put it back rather
-      // than leaving later suites in the worker with colleges/courses gone.
+      // `ARUnit2Model` holds a pool on for the whole run.
       await provisionSecondDatabase();
     }
   });

--- a/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
@@ -1,16 +1,18 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/foreign_table_test.rb
  *
- * Loopback FDW: foreign_server points back at the same database and
- * foreign_professors is mapped to a local professors table. Rails wires
- * foreign_server at the secondary "arunit2" database; loopback keeps the
- * test infra single-database.
+ * `foreign_server` points at the `arunit2` database, whose `professors` table
+ * `foreign_professors` is mapped to — `ARTest.test_configuration_hashes
+ * ["arunit2"]["database"]` in Rails (`foreign_table_test.rb:24-29`). `Professor`
+ * is an `ARUnit2Model`, so the rows these tests create land in that database and
+ * come back through the foreign table.
  */
 import { describe, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { Professor } from "../../test-helpers/models/professor.js";
+import { ARUnit2Model } from "../../test-helpers/models/arunit2-model.js";
 import { itIfSupports } from "../../support/supports.js";
 
 // Rails: class ForeignProfessor < ActiveRecord::Base; self.table_name = "foreign_professors"
@@ -24,9 +26,7 @@ class ForeignProfessorWithPk extends ForeignProfessor {
 }
 
 const url = new URL(PG_TEST_URL);
-const fdwHost = url.hostname || "localhost";
-const fdwPort = url.port || "5432";
-const fdwDb = url.pathname.replace(/^\//, "") || "postgres";
+
 const fdwPassword = decodeURIComponent(url.password || "");
 
 function quoteLit(s: string): string {
@@ -51,9 +51,14 @@ describeIfPg("PostgreSQLAdapter", () => {
       ctx.skip();
       return;
     }
+    const fdwDb = String(ARUnit2Model.connectionDbConfig().database);
     await adapter.exec(
+      // `dbname` alone, as `foreign_table_test.rb:26-28` spells it: the server
+      // reaches the arunit2 database on itself over its local socket, so no
+      // host/port (which name the address the *client* used, not one the server
+      // can necessarily dial back on).
       `CREATE SERVER foreign_server FOREIGN DATA WRAPPER postgres_fdw ` +
-        `OPTIONS (host ${quoteLit(fdwHost)}, port ${quoteLit(fdwPort)}, dbname ${quoteLit(fdwDb)})`,
+        `OPTIONS (dbname ${quoteLit(fdwDb)})`,
     );
     const currentUserRows = await adapter.execute("SELECT current_user AS u");
     const fdwUser = String((currentUserRows[0] as { u: string }).u);

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1182,11 +1182,8 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     }).not.toThrow();
   });
 
-  // `Professor`/`Course` live in the `arunit2` second database. Rails runs the
-  // suite against two real databases; trails mirrors the split with a second
-  // in-memory SQLite pool on `ARUnit2Model`. The PG/MySQL suites don't yet
-  // provision a second named database, so gate the cross-pool habtm to SQLite —
-  // same gating as `MultipleDbTest`.
+  // `Professor`/`Course` live in the `arunit2` second database. Gated to SQLite
+  // like `MultipleDbTest`; un-gating both is its own story.
   it.skipIf(!isSqliteRun())("alternate database", async () => {
     await setupSecondPool();
     const professor = await Professor.create({ name: "Plum" });

--- a/packages/activerecord/src/base-prevent-writes.test.ts
+++ b/packages/activerecord/src/base-prevent-writes.test.ts
@@ -1,10 +1,9 @@
-import { beforeAll, describe, it, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { Base } from "./index.js";
 import { ReadOnlyError } from "./errors.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { isSqliteRun } from "./support/sqlite-template.js";
-import { resolveSecondDatabaseConfig } from "./support/arunit2-config.js";
 import { rebuildCanonicalTables } from "./support/canonical-schema.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Professor } from "./test-helpers/models/professor.js";
@@ -72,16 +71,6 @@ describe("BasePreventWritesTest", () => {
     await Base.whilePreventingWrites(async () => {
       await Bird.transaction(async () => {});
     });
-  });
-
-  // Rails runs this against two real databases (arunit / arunit2). Like
-  // MultipleDbTest, we reproduce the split with a second in-memory SQLite pool
-  // on ARUnit2Model; the PG/MySQL suites don't provision a second named
-  // database, so gate to SQLite.
-  beforeAll(async () => {
-    if (isSqliteRun() && !ARUnit2Model.connectionClassQ()) {
-      await ARUnit2Model.establishConnection(resolveSecondDatabaseConfig().config);
-    }
   });
 
   it.skipIf(!isSqliteRun())("preventing writes applies to all connections in block", async () => {

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -11,9 +11,9 @@ import { College } from "./test-helpers/models/college.js";
 import { Entrant } from "./test-helpers/models/entrant.js";
 import { Bird } from "./test-helpers/models/bird.js";
 
-// Rails runs MultipleDbTest against two real databases (arunit / arunit2). We
-// reproduce the split with a second in-memory SQLite pool on ARUnit2Model. The
-// PG/MySQL suites don't provision a second named database, so gate to SQLite.
+// Rails runs MultipleDbTest against two real databases (arunit / arunit2), as
+// does trails now that `connect` establishes ARUnit2Model on a provisioned
+// arunit2. Un-gating this suite for PG/MySQL is its own story.
 describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
   // Rails sets `self.use_transactional_tests = false`; fixtures() pins
   // the schema/fixtures across the file (skips the global per-test reset).

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -1746,6 +1746,9 @@ async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("courses", {}, (t) => {
     t.string("name", { null: false });
     t.integer("college_id");
+    // `t.column :college_id, :integer, index: true` (schema.rb:1446); `column`
+    // turns `index: true` into an index entry (schema_definitions.rb:499-501).
+    t.index("college_id");
   });
 
   await define("colleges", {}, (t) => {

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -26,6 +26,7 @@ import { getEnv, getOsAsync } from "@blazetrails/activesupport";
 import { getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../base.js";
+import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
@@ -379,14 +380,10 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
  * `schema.rb` in-process. The registration runs on every call so callers that
  * clear `_registeredTasks` (e.g. `database-tasks.test.ts`) can re-register.
  *
- * `ARUnit2Model.establish_connection :arunit2` (`connection.rb:33`) follows, so
- * the second base owns its pool for the whole worker the way Rails' does,
- * rather than having it opened per suite. The pool is lazy: the arunit2
- * database and its tables are laid down by `provisionSecondDatabase`
- * (`support/setup-second-pool.ts`, run from `test-setup-dy.ts`) before any
- * suite runs — trails' stand-in for `schema.rb:1444-1460`, where
- * `Course.lease_connection.create_table` puts colleges/courses/professors in
- * arunit2.
+ * `ARUnit2Model.establish_connection :arunit2` (`connection.rb:33`) follows it.
+ * The pool is lazy; `provisionSecondDatabase` (`support/setup-second-pool.ts`,
+ * run from `test-setup-dy.ts`) creates the arunit2 database and its tables
+ * before any suite runs.
  */
 export async function connect(): Promise<TestDatabaseConfig> {
   const { adapter, envConfig, configurationHashes } = await testConfigurationHashes();
@@ -415,10 +412,6 @@ export async function connect(): Promise<TestDatabaseConfig> {
   // `connection.rb:32` — established by name, not from a raw hash, so the pool
   // comes from the entry `Base.configurations` publishes.
   await Base.establishConnection("arunit");
-  // `connection.rb:33`. Imported lazily: the model modules pull in the
-  // association machinery, and a static import here would run that at
-  // config-build time, before the primary pool exists.
-  const { ARUnit2Model } = await import("../test-helpers/models/arunit2-model.js");
   await ARUnit2Model.establishConnection("arunit2");
 
   return { configs, adapter, envConfig };

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -379,16 +379,14 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
  * `schema.rb` in-process. The registration runs on every call so callers that
  * clear `_registeredTasks` (e.g. `database-tasks.test.ts`) can re-register.
  *
-
- * Rails' next line is `ARUnit2Model.establish_connection :arunit2`
- * (`connection.rb:33`), which this does NOT do. `College` and `Course` extend
- * `ARUnit2Model`, so pointing that base at the arunit2 database here sends
- * every suite's colleges/courses at a database that does not carry them — it
- * reddened all three lanes on #5397 with "no such table: colleges" from
- * `use-fixtures.test.ts`. Rails is safe because its arunit2 genuinely holds
- * those tables; ours only gets them inside `setupSecondPool`, which keeps
- * ownership of the second pool until that provisioning moves earlier (story
- * `arunit2-provisioning-owns-second-pool`).
+ * `ARUnit2Model.establish_connection :arunit2` (`connection.rb:33`) follows, so
+ * the second base owns its pool for the whole worker the way Rails' does,
+ * rather than having it opened per suite. The pool is lazy: the arunit2
+ * database and its tables are laid down by `provisionSecondDatabase`
+ * (`support/setup-second-pool.ts`, run from `test-setup-dy.ts`) before any
+ * suite runs — trails' stand-in for `schema.rb:1444-1460`, where
+ * `Course.lease_connection.create_table` puts colleges/courses/professors in
+ * arunit2.
  */
 export async function connect(): Promise<TestDatabaseConfig> {
   const { adapter, envConfig, configurationHashes } = await testConfigurationHashes();
@@ -417,6 +415,11 @@ export async function connect(): Promise<TestDatabaseConfig> {
   // `connection.rb:32` — established by name, not from a raw hash, so the pool
   // comes from the entry `Base.configurations` publishes.
   await Base.establishConnection("arunit");
+  // `connection.rb:33`. Imported lazily: the model modules pull in the
+  // association machinery, and a static import here would run that at
+  // config-build time, before the primary pool exists.
+  const { ARUnit2Model } = await import("../test-helpers/models/arunit2-model.js");
+  await ARUnit2Model.establishConnection("arunit2");
 
   return { configs, adapter, envConfig };
 }

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -9,33 +9,25 @@ import { Professor } from "../test-helpers/models/professor.js";
 import { activeLane } from "./connection.js";
 
 /**
- * The canonical tables `schema.rb:1444-1460` creates through the second
- * connection (`Course`/`College`/`Professor.lease_connection`) rather than
- * inside the `ActiveRecord::Schema.define` block — the ones that live in
- * `arunit2`, not `arunit`. `entrants` deliberately stays in the primary
- * database (`schema.rb:590`), which is what makes `MultipleDbTest` cross-pool.
+ * The tables `schema.rb:1444-1460` creates through the second connection
+ * (`Course`/`College`/`Professor.lease_connection`), i.e. the ones that live in
+ * `arunit2`. `entrants` stays in the primary database (`schema.rb:590`).
  *
  * @internal
  */
 export const ARUNIT2_TABLES = ["colleges", "courses", "professors", "courses_professors"] as const;
 
 /**
- * Create the `arunit2` database and lay its tables, so the `ARUnit2Model` pool
- * `connect` opens for the whole worker (`connection.rb:33`) resolves against a
- * database that actually carries colleges/courses/professors.
+ * Creates the `arunit2` database and lays {@link ARUNIT2_TABLES} in it, so the
+ * pool `connect` opens on `ARUnit2Model` (`connection.rb:33`) resolves against a
+ * database that carries them. Rails gets this from `db:create` plus `schema.rb`'s
+ * `Course.lease_connection.create_table` calls; trails has no `db:create` step in
+ * front of the suite, so the worker bootstrap (`test-setup-dy.ts`) does both.
  *
- * Rails gets this from `db:create` plus `schema.rb`'s
- * `Course.lease_connection.create_table` calls. trails has no `db:create` step
- * in front of the suite, so the worker bootstrap (`test-setup-dy.ts`) does both
- * here, once, before any suite runs.
- *
- * On sqlite the `arunit2` config is its own database (a sibling file, or
- * `:memory:`) that the pool materializes on the spot, so only the tables are
- * needed. On Postgres/MySQL it names a second database on the same server; the
- * `CREATE DATABASE` is issued through the *primary* connection, the way
- * `adapter.test.ts`'s cross-database-select probe does, rather than through
+ * The `CREATE DATABASE` goes through the *primary* connection rather than
  * `DatabaseTasks.create`, which re-points `Base`'s own pool at the database it
- * creates.
+ * creates. A database left over from an earlier run makes it fail; a genuinely
+ * absent one still fails loudly on the `ensureCanonicalTables` below.
  *
  * @internal
  */
@@ -45,35 +37,22 @@ export async function provisionSecondDatabase(): Promise<void> {
     const primary = (await Base.leaseConnection()) as unknown as {
       createDatabase(name: string): Promise<void>;
     };
-    try {
-      await primary.createDatabase(database);
-    } catch {
-      // Already there: a worker slot's databases outlive the run that created
-      // them, and neither adapter's `create_database` takes `IF NOT EXISTS`. A
-      // database that is genuinely absent still fails loudly on the next line.
-    }
+    await primary.createDatabase(database).catch(() => undefined);
   }
   await ensureCanonicalTables(await ARUnit2Model.leaseConnection(), ARUNIT2_TABLES);
 }
 
 /**
- * Prepares the two-database split `MultipleDbTest` asserts over.
+ * Prepares the two-database split `MultipleDbTest` asserts over. Both pools are
+ * already open, so this readies only the tables: the arunit2 ones are rebuilt so
+ * rows a sibling suite left behind cannot reach `College.count`, and the primary
+ * copies are dropped.
  *
- * Rails runs the suite against two databases (`arunit` / `arunit2`):
- * `ActiveRecord::Base` connects to `arunit`, `ARUnit2Model` to `arunit2`, and
- * the `colleges`/`courses` tables live only in `arunit2`. `entrants` stay in
- * the primary database. Both pools are open before any suite runs, so this
- * readies only the tables: it rebuilds the arunit2 ones, so rows a sibling
- * suite left behind (the habtm cross-pool test creates a `Professor` and a
- * `Course`) can't reach `College.count`, and it undoes trails' one structural
- * difference from Rails on the primary side.
- *
- * That difference: trails loads one canonical schema into the primary database,
- * so the primary carries `colleges`/`courses`/`professors` as well — Rails'
- * `arunit` never does. Dropping them for the duration of the suite is what lets
- * `MultipleDbTest` assert that a `SELECT` issued on the wrong pool raises.
- * `teardownSecondPool` puts them back, because unlike Rails' second database
- * ours is shared with every sibling suite in the worker.
+ * The primary copies exist because trails loads one canonical schema into the
+ * primary database while Rails' `arunit` never carries these tables. Dropping
+ * them is what lets `MultipleDbTest` assert that a `SELECT` on the wrong pool
+ * raises; `teardownSecondPool` puts them back, because unlike Rails' second
+ * database ours is shared with every sibling suite in the worker.
  *
  * Fixture data is seeded separately via `useFixtures` in the test file.
  *
@@ -87,8 +66,6 @@ export async function setupSecondPool(): Promise<void> {
   const arunit2 = await ARUnit2Model.leaseConnection();
   const primary = await Base.leaseConnection();
 
-  // The primary database owns only `entrants`; remove the canonical schema's
-  // `arunit2`-only tables so the two pools stay disjoint.
   const ss = primary.schemaStatements();
   await ss.dropTable("courses_professors", { ifExists: true });
   await ss.dropTable("courses", { ifExists: true });

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -1,4 +1,5 @@
 import { Base } from "../base.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { registerModel } from "../associations.js";
 import { ensureCanonicalTables, rebuildCanonicalTables } from "./canonical-schema.js";
 import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
@@ -16,6 +17,18 @@ import { activeLane } from "./connection.js";
  * @internal
  */
 export const ARUNIT2_TABLES = ["colleges", "courses", "professors", "courses_professors"] as const;
+
+/**
+ * `schema.rb:1462` — `OtherDog.lease_connection.create_table :dogs, force: true`.
+ * Unlike {@link ARUNIT2_TABLES}, `dogs` exists in *both* databases: the primary
+ * one carries the canonical shape (`schema.rb:559`), arunit2 a bare id-only
+ * table, so it is laid down here rather than from the canonical registry.
+ */
+async function createOtherDogsTable(adapter: DatabaseAdapter): Promise<void> {
+  const ss = adapter.schemaStatements();
+  if (await ss.tableExists("dogs")) return;
+  await ss.createTable("dogs", {}, () => {});
+}
 
 /**
  * Creates the `arunit2` database and lays {@link ARUNIT2_TABLES} in it, so the
@@ -39,7 +52,9 @@ export async function provisionSecondDatabase(): Promise<void> {
     };
     await primary.createDatabase(database).catch(() => undefined);
   }
-  await ensureCanonicalTables(await ARUnit2Model.leaseConnection(), ARUNIT2_TABLES);
+  const arunit2 = await ARUnit2Model.leaseConnection();
+  await ensureCanonicalTables(arunit2, ARUNIT2_TABLES);
+  await createOtherDogsTable(arunit2);
 }
 
 /**

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -1,7 +1,7 @@
 import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { registerModel } from "../associations.js";
-import { ensureCanonicalTables, rebuildCanonicalTables } from "./canonical-schema.js";
+import { rebuildCanonicalTables } from "./canonical-schema.js";
 import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
 import { Course } from "../test-helpers/models/course.js";
 import { College } from "../test-helpers/models/college.js";
@@ -40,7 +40,10 @@ async function createOtherDogsTable(adapter: DatabaseAdapter): Promise<void> {
  * The `CREATE DATABASE` goes through the *primary* connection rather than
  * `DatabaseTasks.create`, which re-points `Base`'s own pool at the database it
  * creates. A database left over from an earlier run makes it fail; a genuinely
- * absent one still fails loudly on the `ensureCanonicalTables` below.
+ * absent one still fails loudly on the rebuild below. That rebuild is
+ * drop-and-recreate, not create-if-missing, because `schema.rb:1444-1462`
+ * creates every one of these tables `force: true` — a reused database can be
+ * carrying stale shapes and rows.
  *
  * @internal
  */
@@ -53,7 +56,7 @@ export async function provisionSecondDatabase(): Promise<void> {
     await primary.createDatabase(database).catch(() => undefined);
   }
   const arunit2 = await ARUnit2Model.leaseConnection();
-  await ensureCanonicalTables(arunit2, ARUNIT2_TABLES);
+  await rebuildCanonicalTables(arunit2, ARUNIT2_TABLES);
   await createOtherDogsTable(arunit2);
 }
 

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -23,11 +23,11 @@ export const ARUNIT2_TABLES = ["colleges", "courses", "professors", "courses_pro
  * Unlike {@link ARUNIT2_TABLES}, `dogs` exists in *both* databases: the primary
  * one carries the canonical shape (`schema.rb:559`), arunit2 a bare id-only
  * table, so it is laid down here rather than from the canonical registry.
+ * `force: true` as Rails spells it: a reused arunit2 database can be carrying
+ * the canonical shape from an earlier run.
  */
 async function createOtherDogsTable(adapter: DatabaseAdapter): Promise<void> {
-  const ss = adapter.schemaStatements();
-  if (await ss.tableExists("dogs")) return;
-  await ss.createTable("dogs", {}, () => {});
+  await adapter.schemaStatements().createTable("dogs", { force: true }, () => {});
 }
 
 /**

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -1,49 +1,85 @@
 import { Base } from "../base.js";
 import { registerModel } from "../associations.js";
-import { rebuildCanonicalTables } from "./canonical-schema.js";
+import { ensureCanonicalTables, rebuildCanonicalTables } from "./canonical-schema.js";
 import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
 import { Course } from "../test-helpers/models/course.js";
 import { College } from "../test-helpers/models/college.js";
 import { Entrant } from "../test-helpers/models/entrant.js";
 import { Professor } from "../test-helpers/models/professor.js";
-import { resolveSecondDatabaseConfig } from "./arunit2-config.js";
+import { activeLane } from "./connection.js";
 
 /**
- * Wires up Rails' `ARUnit2Model` second connection pool for `MultipleDbTest`.
+ * The canonical tables `schema.rb:1444-1460` creates through the second
+ * connection (`Course`/`College`/`Professor.lease_connection`) rather than
+ * inside the `ActiveRecord::Schema.define` block — the ones that live in
+ * `arunit2`, not `arunit`. `entrants` deliberately stays in the primary
+ * database (`schema.rb:590`), which is what makes `MultipleDbTest` cross-pool.
+ *
+ * @internal
+ */
+export const ARUNIT2_TABLES = ["colleges", "courses", "professors", "courses_professors"] as const;
+
+/**
+ * Create the `arunit2` database and lay its tables, so the `ARUnit2Model` pool
+ * `connect` opens for the whole worker (`connection.rb:33`) resolves against a
+ * database that actually carries colleges/courses/professors.
+ *
+ * Rails gets this from `db:create` plus `schema.rb`'s
+ * `Course.lease_connection.create_table` calls. trails has no `db:create` step
+ * in front of the suite, so the worker bootstrap (`test-setup-dy.ts`) does both
+ * here, once, before any suite runs.
+ *
+ * On sqlite the `arunit2` config is its own database (a sibling file, or
+ * `:memory:`) that the pool materializes on the spot, so only the tables are
+ * needed. On Postgres/MySQL it names a second database on the same server; the
+ * `CREATE DATABASE` is issued through the *primary* connection, the way
+ * `adapter.test.ts`'s cross-database-select probe does, rather than through
+ * `DatabaseTasks.create`, which re-points `Base`'s own pool at the database it
+ * creates.
+ *
+ * @internal
+ */
+export async function provisionSecondDatabase(): Promise<void> {
+  if (activeLane() !== "sqlite") {
+    const database = String(ARUnit2Model.connectionDbConfig().database);
+    const primary = (await Base.leaseConnection()) as unknown as {
+      createDatabase(name: string): Promise<void>;
+    };
+    try {
+      await primary.createDatabase(database);
+    } catch {
+      // Already there: a worker slot's databases outlive the run that created
+      // them, and neither adapter's `create_database` takes `IF NOT EXISTS`. A
+      // database that is genuinely absent still fails loudly on the next line.
+    }
+  }
+  await ensureCanonicalTables(await ARUnit2Model.leaseConnection(), ARUNIT2_TABLES);
+}
+
+/**
+ * Prepares the two-database split `MultipleDbTest` asserts over.
  *
  * Rails runs the suite against two databases (`arunit` / `arunit2`):
  * `ActiveRecord::Base` connects to `arunit`, `ARUnit2Model` to `arunit2`, and
  * the `colleges`/`courses` tables live only in `arunit2`. `entrants` stay in
- * the primary database. We mirror that split by opening a second independent
- * pool on `ARUnit2Model` from the ARTest-style `arunit2` config
- * (`resolveSecondDatabaseConfig`): a separate in-memory SQLite pool on the
- * sqlite run, or the derived `arunit2` database on the Postgres/MySQL server.
+ * the primary database. Both pools are open before any suite runs, so this
+ * readies only the tables: it rebuilds the arunit2 ones, so rows a sibling
+ * suite left behind (the habtm cross-pool test creates a `Professor` and a
+ * `Course`) can't reach `College.count`, and it undoes trails' one structural
+ * difference from Rails on the primary side.
  *
- * The primary database's clone of the canonical schema already carries
- * `courses`/`colleges`; we drop them so the primary pool faithfully lacks the
- * `arunit2`-only tables (mirroring Rails, and letting `MultipleDbTest` assert
- * that a cross-pool `SELECT` raises).
+ * That difference: trails loads one canonical schema into the primary database,
+ * so the primary carries `colleges`/`courses`/`professors` as well — Rails'
+ * `arunit` never does. Dropping them for the duration of the suite is what lets
+ * `MultipleDbTest` assert that a `SELECT` issued on the wrong pool raises.
+ * `teardownSecondPool` puts them back, because unlike Rails' second database
+ * ours is shared with every sibling suite in the worker.
  *
  * Fixture data is seeded separately via `useFixtures` in the test file.
  *
- * Provisioning note: on sqlite the `arunit2` config is an in-memory pool that
- * `establishConnection` materializes on the spot, so no caller setup is needed
- * — which is why `MultipleDbTest` is currently sqlite-gated and this is the
- * only lane that runs. On Postgres/MySQL the resolved config points at a
- * derived `arunit2` *named database* that must already exist; like Rails'
- * `ARTest.connect` (which assumes `db:create` ran against `config.yml`), this
- * helper does NOT issue `CREATE DATABASE`. Un-gating `MultipleDbTest` for
- * PG/MySQL therefore requires a caller-side `CREATE DATABASE arunit2` step
- * (as `adapter.test.ts` does for the cross-database-select probe); that work
- * is tracked as a separate story.
- *
  * @internal
  */
-/** @internal */
 export async function setupSecondPool(): Promise<void> {
-  if (!ARUnit2Model.connectionClassQ()) {
-    await ARUnit2Model.establishConnection(resolveSecondDatabaseConfig().config);
-  }
   registerModel(College);
   registerModel(Course);
   registerModel(Entrant);
@@ -59,12 +95,7 @@ export async function setupSecondPool(): Promise<void> {
   await ss.dropTable("colleges", { ifExists: true });
   await ss.dropTable("professors", { ifExists: true });
 
-  await rebuildCanonicalTables(arunit2, [
-    "colleges",
-    "courses",
-    "professors",
-    "courses_professors",
-  ]);
+  await rebuildCanonicalTables(arunit2, ARUNIT2_TABLES);
   await rebuildCanonicalTables(primary, ["entrants"]);
 }
 
@@ -76,11 +107,5 @@ export async function setupSecondPool(): Promise<void> {
  * @internal
  */
 export async function teardownSecondPool(): Promise<void> {
-  await rebuildCanonicalTables(await Base.leaseConnection(), [
-    "colleges",
-    "courses",
-    "professors",
-    "courses_professors",
-    "entrants",
-  ]);
+  await rebuildCanonicalTables(await Base.leaseConnection(), [...ARUNIT2_TABLES, "entrants"]);
 }

--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -9,6 +9,7 @@ import { fixtureId, defineFixtures, defineJoinTableFixtures, isFixtureRef } from
 import { fixtures } from "./test-helpers/fixtures.js";
 import { setupHandlerSuite } from "./support/setup-handler-suite.js";
 import { withTransactionalFixtures } from "./test-fixtures/with-transactional-fixtures.js";
+import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Author } from "./test-helpers/models/author.js";
 import { Post } from "./test-helpers/models/post.js";
 import { LiveParrot, DeadParrot } from "./test-helpers/models/parrot.js";
@@ -771,7 +772,16 @@ describe("fixtureRegistry seeds against TEST_SCHEMA", () => {
         } else {
           if ("addOn" in entry) await entry.addOn?.();
           const ModelClass = await resolvePrimaryModel(entry);
-          await defineFixtures(Base.adapter, ModelClass, data);
+          // Rails' `FixtureSet` seeds through `model_class.connection`. This
+          // loop passes `Base.adapter` instead because it runs under
+          // transactional fixtures pinned to that connection — but the arunit2
+          // models (colleges/courses) hold a pool of their own, and seeding
+          // them on the primary writes rows their own reload can't see.
+          const seedAdapter =
+            ModelClass.prototype instanceof ARUnit2Model
+              ? await ModelClass.leaseConnection()
+              : Base.adapter;
+          await defineFixtures(seedAdapter, ModelClass, data);
         }
       } catch (e) {
         failures.push(`${name}: ${(e as Error).message.split("\n")[0]}`);

--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -772,11 +772,10 @@ describe("fixtureRegistry seeds against TEST_SCHEMA", () => {
         } else {
           if ("addOn" in entry) await entry.addOn?.();
           const ModelClass = await resolvePrimaryModel(entry);
-          // Rails' `FixtureSet` seeds through `model_class.connection`. This
-          // loop passes `Base.adapter` instead because it runs under
-          // transactional fixtures pinned to that connection — but the arunit2
-          // models (colleges/courses) hold a pool of their own, and seeding
-          // them on the primary writes rows their own reload can't see.
+          // Rails' `FixtureSet` seeds through `model_class.connection`; this
+          // loop uses `Base.adapter` because it runs under transactional
+          // fixtures pinned to that connection. arunit2 models hold their own
+          // pool, so seeding them on the primary is invisible to their reload.
           const seedAdapter =
             ModelClass.prototype instanceof ARUnit2Model
               ? await ModelClass.leaseConnection()

--- a/packages/activerecord/src/test-helpers/models/other-dog.ts
+++ b/packages/activerecord/src/test-helpers/models/other-dog.ts
@@ -1,11 +1,5 @@
 // vendor/rails/activerecord/test/models/other_dog.rb
-import { Base } from "../../base.js";
-
-class ARUnit2Model extends Base {
-  static {
-    this._abstractClass = true;
-  }
-}
+import { ARUnit2Model } from "./arunit2-model.js";
 
 export class OtherDog extends ARUnit2Model {
   static {

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -1719,8 +1719,11 @@ export const TEST_SCHEMA: Schema = {
   // loads them on the default adapter; per-connection placement is the
   // responsibility of multi-DB tests.
   courses: {
-    name: { type: "string", null: false },
-    college_id: "integer",
+    columns: {
+      name: { type: "string", null: false },
+      college_id: "integer",
+    },
+    indexes: [{ columns: "college_id" }],
   },
   colleges: { name: { type: "string", null: false } },
   professors: { name: { type: "string", null: false } },

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -73,6 +73,12 @@ if (missingTables.length > 0) {
   );
 }
 
+// `schema.rb:1444-1462` — the arunit2 tables Rails creates through
+// `Course.lease_connection`. Imported lazily so the second-database models load
+// after the canonical schema is in place.
+const { provisionSecondDatabase } = await import("./support/setup-second-pool.js");
+await provisionSecondDatabase();
+
 // Clear DatabaseTasks global state so database-tasks.test.ts sees the null
 // invariant it expects (it tests checkProtectedEnvironmentsBang with no config).
 DatabaseTasks.databaseConfiguration = null;


### PR DESCRIPTION
`ARTest.connect` establishes both bases (`connection.rb:32-33`); trails only did
the first. #5397 tried adding the second and reverted it: `College`/`Course`
extend `ARUnit2Model`, so pointing that base at arunit2 sent every suite's
colleges/courses at a database that did not carry them.

The fix is to make the trails arunit2 database as real as Rails' — Rails is safe
here only because `schema.rb:1444-1460` creates colleges/courses/professors
*through the second connection* (`Course.lease_connection.create_table`), so
they genuinely live in arunit2 before any test runs.

- `connect()` now ends with `ARUnit2Model.establishConnection("arunit2")`
  (`connection.rb:33`), in that order after `establish_connection :arunit`; the
  comment explaining why it did not is gone. `ARUnit2Model` is imported at the
  top of the module, as `connection.rb` requires `models/college` at the top of
  its own.
- New `provisionSecondDatabase()` (`support/setup-second-pool.ts`), called from
  `test-setup-dy.ts` right after the canonical schema load — trails' stand-in
  for those `schema.rb` lines. It lays the four arunit2 tables via
  `ensureCanonicalTables`, and on PG/MySQL first issues `CREATE DATABASE`
  through the *primary* connection (the way `adapter.test.ts`'s
  cross-database-select probe does, not `DatabaseTasks.create`, which
  re-points `Base`'s own pool at the database it creates). This is the
  provisioning `arunit2-config.ts` documented as outstanding.
- `setupSecondPool()` no longer establishes the pool. Its primary-database
  surgery stays and is now documented as what it is: trails loads one canonical
  schema into the primary, so the primary carries colleges/courses/professors
  and Rails' `arunit` never does. Dropping them for the duration of the suite is
  what makes `MultipleDbTest`'s "exception contains correct pool" assertion
  (a `SELECT * FROM courses` on the entrants pool must raise) meaningful. The
  arunit2 rebuild also stays — a sibling suite's `Professor.create`/`Course.create`
  rows would otherwise reach `College.count`.
- `use-fixtures.test.ts`'s registry seed loop passes `Base.adapter` for every
  entry because it runs under transactional fixtures pinned to that connection.
  The arunit2 models are now the exception: seeding them on the primary writes
  rows their own reload cannot see, so they seed through their own connection —
  which is what Rails' `FixtureSet` does for every set.
- `adapter.test.ts`'s MySQL cross-database probe drops `ARUNIT2_DATABASE`, which
  is now this worker's real second database; it re-provisions in its `finally`
  rather than leaving later suites in the worker without colleges/courses.

- `base-prevent-writes.test.ts` established a second pool of its own from
  `resolveSecondDatabaseConfig`; `connect()` owns that pool now, so the
  `beforeAll` is gone.

`MultipleDbTest` and the habtm "alternate database" test stay sqlite-gated:
un-gating them is its own story, and this PR does not change what they assert.

Verified locally on sqlite: `multiple-db`, `prepared-statement-status`,
`use-fixtures` (all 54, including the full registry seed loop),
`has-and-belongs-to-many-associations`, `connection-handling`,
`establish-connection`, `database-tasks`, `base`, `core`, `connection-handler`,
`connection-pool`, and the whole `support/` tree — 900+ tests, all green. PG and
MySQL exercise the new `CREATE DATABASE` branch only in CI.

`api:compare` and `test:compare` measured against `origin/main`: zero delta on
both (data layer 7718/7810, overall 11696/17484; tests 14620/21663, 754/1023
files).

Closes-story: arunit2-provisioning-owns-second-pool
