### PR TITLE
feat(tasks-cli): add RFC-level ready-queue priority

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -97,6 +97,9 @@ import {
   formatStaleClaims,
   DEFAULT_STALE_HOURS,
   RfcEntry,
+  comparePriority,
+  priorityContext,
+  remainingStoryCounts,
   applyRfcPriorities,
   effectivePriority,
   parseRfcPriority,
@@ -3702,7 +3705,113 @@ describe("RFC-level priority", () => {
     });
   });
 
+  describe("equal-priority RFC tie-break (fewer stories remaining wins)", () => {
+    it("counts only stories that are neither done nor closed as remaining", () => {
+      const idx = idxWith([
+        story({ id: "a", rfc: "0001-r", status: "ready" }),
+        story({ id: "b", rfc: "0001-r", status: "in-progress" }),
+        story({ id: "c", rfc: "0001-r", status: "done" }),
+        story({ id: "d", rfc: "0001-r", status: "closed" }),
+        story({ id: "e", rfc: "0003-r", status: "blocked" }),
+      ]);
+      expect([...remainingStoryCounts(idx)]).toEqual([
+        ["0001-r", 2],
+        ["0003-r", 1],
+      ]);
+    });
+
+    it("orders the RFC with fewer stories left first when priorities are equal", () => {
+      const idx = idxWith(
+        [
+          story({ id: "big1", rfc: "0001-r" }),
+          story({ id: "big2", rfc: "0001-r" }),
+          story({ id: "big3", rfc: "0001-r" }),
+          story({ id: "small1", rfc: "0003-r" }),
+        ],
+        { "0001-r": 2, "0003-r": 2 },
+      );
+      expect(ready(idx)[0].id).toBe("small1");
+    });
+
+    it("ignores shipped work: an RFC with many done stories still counts as near-empty", () => {
+      const idx = idxWith(
+        [
+          story({ id: "lean1", rfc: "0001-r", status: "done" }),
+          story({ id: "lean2", rfc: "0001-r", status: "done" }),
+          story({ id: "lean3", rfc: "0001-r", status: "ready" }),
+          story({ id: "fat1", rfc: "0003-r" }),
+          story({ id: "fat2", rfc: "0003-r" }),
+        ],
+        { "0001-r": 1, "0003-r": 1 },
+      );
+      expect(ready(idx)[0].id).toBe("lean3");
+    });
+
+    it("breaks a tie between two stories that set the same priority themselves", () => {
+      const idx = idxWith(
+        [
+          story({ id: "fromBig", rfc: "0001-r", priority: 4 }),
+          story({ id: "fromBigB", rfc: "0001-r" }),
+          story({ id: "fromSmall", rfc: "0003-r", priority: 4 }),
+        ],
+        { "0001-r": 7, "0003-r": 7 },
+      );
+      expect(ready(idx)[0].id).toBe("fromSmall");
+    });
+
+    it("does not apply when the two RFC priorities differ", () => {
+      const idx = idxWith(
+        [
+          story({ id: "bigRfcFirst", rfc: "0001-r", priority: 4 }),
+          story({ id: "bigRfcSecond", rfc: "0001-r", priority: 4 }),
+          story({ id: "smallRfc", rfc: "0003-r", priority: 4 }),
+        ],
+        { "0001-r": 1, "0003-r": 2 },
+      );
+      expect(ready(idx).map((s) => s.id)).toEqual(["bigRfcFirst", "bigRfcSecond", "smallRfc"]);
+    });
+
+    it("does not reshuffle unprioritized RFCs by size", () => {
+      const idx = idxWith([
+        story({ id: "big1", rfc: "0001-r" }),
+        story({ id: "big2", rfc: "0001-r" }),
+        story({ id: "small1", rfc: "0003-r" }),
+      ]);
+      expect(ready(idx).map((s) => s.id)).toEqual(["big1", "big2", "small1"]);
+    });
+
+    it("leaves stories of one RFC in index order", () => {
+      const idx = idxWith(
+        [
+          story({ id: "s1", rfc: "0001-r" }),
+          story({ id: "s2", rfc: "0001-r" }),
+          story({ id: "s3", rfc: "0001-r" }),
+        ],
+        { "0001-r": 1 },
+      );
+      expect(ready(idx).map((s) => s.id)).toEqual(["s1", "s2", "s3"]);
+    });
+
+    it("returns 0 for two unprioritized stories rather than NaN", () => {
+      const idx = idxWith([story({ id: "a" }), story({ id: "b", rfc: "0003-r" })]);
+      const ctx = priorityContext(idx);
+      expect(comparePriority(idx.stories[0], idx.stories[1], ctx)).toBe(0);
+    });
+  });
+
   describe("nextBundle", () => {
+    it("leads the bundle with the nearer-to-done of two equal-priority RFCs", () => {
+      const idx = idxWith(
+        [
+          story({ id: "big1", rfc: "0001-r", cluster: "c1", est_loc: 100 }),
+          story({ id: "big2", rfc: "0001-r", cluster: "c1", est_loc: 100 }),
+          story({ id: "small1", rfc: "0003-r", cluster: "c2", est_loc: 100 }),
+        ],
+        { "0001-r": 3, "0003-r": 3 },
+      );
+      expect(nextBundle(idx, { maxLoc: 250 })[0].id).toBe("small1");
+    });
+
     it("leads with a story that inherits its RFC's priority, overriding LOC packing", () => {
       const idx = idxWith(
         [

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3464,10 +3464,6 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
   });
 
   it("ignores a pre-v2 entry for the same sha (it carries no RFC priorities)", () => {
-    // The cache is keyed by tree sha alone, so an entry an older CLI wrote
-    // would otherwise be served forever — missing rfcs[].priority and silently
-    // reverting the scheduler to story-only ordering. The version suffix is
-    // what forces the rebuild.
     const { gitDir, seen } = setup();
     const cacheDir = join(gitDir, "trails-tasks-read-index");
     mkdirSync(cacheDir, { recursive: true });
@@ -3623,8 +3619,6 @@ describe("syncWorktreeToOrigin (pre-read sync)", () => {
 });
 
 describe("RFC-level priority", () => {
-  // `index()` ships 0001-r (active) and 0002-r (closed); add an active third so
-  // cross-RFC ordering can be exercised.
   function idxWith(stories: StoryEntry[], priorities: Record<string, number> = {}): Index {
     const idx = index(stories);
     idx.rfcs.push({
@@ -3656,7 +3650,6 @@ describe("RFC-level priority", () => {
     });
 
     it("takes a story priority of 0 literally rather than inheriting", () => {
-      // `0 ?? x` is 0 — the guard against a truthiness-based fallback.
       const m = new Map([["0001-r", 5]]);
       expect(effectivePriority(story({ priority: 0 }), m)).toBe(0);
     });
@@ -3679,9 +3672,6 @@ describe("RFC-level priority", () => {
     });
 
     it("treats a story-set priority as absolute, never clamped to its RFC's band", () => {
-      // `low` sets priority 2 under an RFC prioritized 9; `high` merely inherits
-      // 3 from a better-prioritized RFC. Story priority is global, so 2 < 3 wins
-      // even though its RFC sorts after the other one.
       const idx = idxWith(
         [
           story({ id: "high", rfc: "0001-r", priority: null }),
@@ -3714,8 +3704,6 @@ describe("RFC-level priority", () => {
 
   describe("nextBundle", () => {
     it("leads with a story that inherits its RFC's priority, overriding LOC packing", () => {
-      // c2 packs more LOC (240 > 200), but a1's RFC is prioritized and a1 sets
-      // no priority of its own — it must still lead.
       const idx = idxWith(
         [
           story({ id: "a1", rfc: "0001-r", cluster: "c1", est_loc: 100 }),
@@ -3771,7 +3759,6 @@ describe("RFC-level priority", () => {
       expect(readRfcPriority(rfcDir(), "0005-gaps")).toBeNull();
     });
 
-    // Minimal RFC index rows for the applyRfcPriorities cases below.
     function idxOf(...rfcs: Partial<RfcEntry>[]): Index {
       return {
         generated_at: "now",
@@ -3798,20 +3785,44 @@ describe("RFC-level priority", () => {
 
     it("does not re-read an RFC whose priority is already populated", () => {
       const idx = idxOf({ id: "0005-gaps", priority: 2 });
-      // Points at a dir with no READMEs at all: an unconditional read would
-      // clobber the 2 with null.
       applyRfcPriorities(idx, mkdtempSync(join(tmpdir(), "tasks-test-")));
       expect(idx.rfcs[0].priority).toBe(2);
     });
 
-    it("round-trips a set then a clear through the frontmatter helpers", () => {
-      const dir = rfcDir(`---\nstatus: active\n---\nbody\n`);
+    const REAL_README = [
+      "---",
+      'rfc: "0005-gaps"',
+      'title: "Gaps"',
+      "status: active",
+      "created: 2026-07-04",
+      "updated: 2026-07-25",
+      'owner: "@your-handle"',
+      "packages: []",
+      "clusters: []",
+      "---",
+      "",
+      "# RFC 0005 — Gaps",
+      "",
+    ].join("\n");
+
+    it("round-trips a set then a clear on a real-shaped RFC README", () => {
+      const dir = rfcDir(REAL_README);
       const readme = join(dir, "rfcs", "0005-gaps", "README.md");
       editFrontmatter(readme, { priority: "4" });
       expect(readRfcPriority(dir, "0005-gaps")).toBe(4);
       removeFrontmatterKey(readme, "priority");
       expect(readRfcPriority(dir, "0005-gaps")).toBeNull();
-      expect(readFileSync(readme, "utf8")).toContain("status: active");
+      expect(readFileSync(readme, "utf8")).toBe(REAL_README);
+    });
+
+    it("leaves the RFC\'s other frontmatter keys untouched by a priority set", () => {
+      const dir = rfcDir(REAL_README);
+      const readme = join(dir, "rfcs", "0005-gaps", "README.md");
+      editFrontmatter(readme, { priority: "0" });
+      const out = readFileSync(readme, "utf8");
+      for (const line of REAL_README.split("\n")) expect(out).toContain(line);
+      expect(out).toContain("priority: 0");
+      expect(out).toContain("# RFC 0005 — Gaps");
     });
   });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -96,6 +96,13 @@ import {
   staleClaims,
   formatStaleClaims,
   DEFAULT_STALE_HOURS,
+  RfcEntry,
+  applyRfcPriorities,
+  effectivePriority,
+  parseRfcPriority,
+  readRfcPriority,
+  rfcPriorityFlag,
+  rfcPriorityMap,
 } from "./cli.ts";
 
 function story(over: Partial<StoryEntry>): StoryEntry {
@@ -3449,11 +3456,28 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     const cacheDir = join(gitDir, "trails-tasks-read-index");
     mkdirSync(cacheDir, { recursive: true });
     const cached = { ...emptyIndex, generated_at: "cached" };
-    writeFileSync(join(cacheDir, `${SHA}.json`), JSON.stringify(cached));
+    writeFileSync(join(cacheDir, `${SHA}.v2.json`), JSON.stringify(cached));
     const got = buildIndexFromOriginMain();
     expect(got?.sha).toBe(SHA);
     expect(got?.index.generated_at).toBe("cached");
     expect(seen).toEqual(["fetch", "rev-parse"]);
+  });
+
+  it("ignores a pre-v2 entry for the same sha (it carries no RFC priorities)", () => {
+    // The cache is keyed by tree sha alone, so an entry an older CLI wrote
+    // would otherwise be served forever — missing rfcs[].priority and silently
+    // reverting the scheduler to story-only ordering. The version suffix is
+    // what forces the rebuild.
+    const { gitDir, seen } = setup();
+    const cacheDir = join(gitDir, "trails-tasks-read-index");
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      join(cacheDir, `${SHA}.json`),
+      JSON.stringify({ ...emptyIndex, generated_at: "v1-cached" }),
+    );
+    const got = buildIndexFromOriginMain();
+    expect(got?.index.generated_at).toBe("2026-01-01");
+    expect(seen).toContain("build-index");
   });
 
   it("exports the tree, builds the index there, and caches it by sha", () => {
@@ -3468,7 +3492,7 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     expect(got?.index.generated_at).toBe("2026-01-01");
     expect(seen).toEqual(["fetch", "rev-parse", "archive", "tar", "build-index"]);
     // Cached for the next reader, and the superseded sha is pruned.
-    expect(existsSync(join(gitDir, "trails-tasks-read-index", `${SHA}.json`))).toBe(true);
+    expect(existsSync(join(gitDir, "trails-tasks-read-index", `${SHA}.v2.json`))).toBe(true);
     expect(existsSync(stale)).toBe(false);
     // Another agent's half-written entry is not a superseded index — pruning it
     // would break its rename.
@@ -3595,5 +3619,255 @@ describe("syncWorktreeToOrigin (pre-read sync)", () => {
     const lock = acquireTasksLock(undefined, { waitMs: 300, onTimeout: "give-up" });
     expect(lock).not.toBeNull();
     releaseTasksLock(lock);
+  });
+});
+
+describe("RFC-level priority", () => {
+  // `index()` ships 0001-r (active) and 0002-r (closed); add an active third so
+  // cross-RFC ordering can be exercised.
+  function idxWith(stories: StoryEntry[], priorities: Record<string, number> = {}): Index {
+    const idx = index(stories);
+    idx.rfcs.push({
+      id: "0003-r",
+      title: "R3",
+      status: "active",
+      owner: "@x",
+      packages: [],
+      clusters: ["c1", "c2"],
+      file_path: "0003-r/README.md",
+    });
+    for (const r of idx.rfcs) r.priority = priorities[r.id] ?? null;
+    return idx;
+  }
+
+  describe("effectivePriority", () => {
+    it("uses the story's own priority when it sets one", () => {
+      const m = new Map([["0001-r", 5]]);
+      expect(effectivePriority(story({ priority: 2 }), m)).toBe(2);
+    });
+
+    it("falls back to the story's RFC priority when the story sets none", () => {
+      const m = new Map([["0001-r", 5]]);
+      expect(effectivePriority(story({ priority: null }), m)).toBe(5);
+    });
+
+    it("is Infinity when neither the story nor its RFC sets a priority", () => {
+      expect(effectivePriority(story({ priority: null }), new Map())).toBe(Infinity);
+    });
+
+    it("takes a story priority of 0 literally rather than inheriting", () => {
+      // `0 ?? x` is 0 — the guard against a truthiness-based fallback.
+      const m = new Map([["0001-r", 5]]);
+      expect(effectivePriority(story({ priority: 0 }), m)).toBe(0);
+    });
+  });
+
+  describe("rfcPriorityMap", () => {
+    it("maps only the RFCs that declare a priority", () => {
+      const idx = idxWith([], { "0001-r": 4 });
+      expect([...rfcPriorityMap(idx)]).toEqual([["0001-r", 4]]);
+    });
+  });
+
+  describe("ready ordering", () => {
+    it("orders a story with no priority of its own by its RFC's priority", () => {
+      const idx = idxWith(
+        [story({ id: "plain", rfc: "0003-r" }), story({ id: "inherits", rfc: "0001-r" })],
+        { "0001-r": 5 },
+      );
+      expect(ready(idx).map((s) => s.id)).toEqual(["inherits", "plain"]);
+    });
+
+    it("treats a story-set priority as absolute, never clamped to its RFC's band", () => {
+      // `low` sets priority 2 under an RFC prioritized 9; `high` merely inherits
+      // 3 from a better-prioritized RFC. Story priority is global, so 2 < 3 wins
+      // even though its RFC sorts after the other one.
+      const idx = idxWith(
+        [
+          story({ id: "high", rfc: "0001-r", priority: null }),
+          story({ id: "low", rfc: "0003-r", priority: 2 }),
+        ],
+        { "0001-r": 3, "0003-r": 9 },
+      );
+      expect(ready(idx).map((s) => s.id)).toEqual(["low", "high"]);
+    });
+
+    it("lets a story's own priority sort it BELOW its RFC's inherited default", () => {
+      const idx = idxWith(
+        [story({ id: "own", rfc: "0001-r", priority: 8 }), story({ id: "inh", rfc: "0001-r" })],
+        { "0001-r": 1 },
+      );
+      expect(ready(idx).map((s) => s.id)).toEqual(["inh", "own"]);
+    });
+
+    it("leaves ordering byte-identical to index order when no RFC sets a priority", () => {
+      const ids = ["z", "m", "a", "q"];
+      const idx = idxWith(ids.map((id) => story({ id })));
+      expect(ready(idx).map((s) => s.id)).toEqual(ids);
+    });
+
+    it("still honors story priority alone when no RFC sets a priority", () => {
+      const idx = idxWith([story({ id: "b", priority: 9 }), story({ id: "a", priority: 1 })]);
+      expect(ready(idx).map((s) => s.id)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("nextBundle", () => {
+    it("leads with a story that inherits its RFC's priority, overriding LOC packing", () => {
+      // c2 packs more LOC (240 > 200), but a1's RFC is prioritized and a1 sets
+      // no priority of its own — it must still lead.
+      const idx = idxWith(
+        [
+          story({ id: "a1", rfc: "0001-r", cluster: "c1", est_loc: 100 }),
+          story({ id: "a2", rfc: "0001-r", cluster: "c1", est_loc: 100 }),
+          story({ id: "b1", rfc: "0003-r", cluster: "c2", est_loc: 240 }),
+        ],
+        { "0001-r": 2 },
+      );
+      const bundle = nextBundle(idx, { maxLoc: 250 });
+      expect(bundle[0].id).toBe("a1");
+      expect(bundle.map((s) => s.id).sort()).toEqual(["a1", "a2"]);
+    });
+
+    it("packs by cluster LOC exactly as before when no RFC sets a priority", () => {
+      const idx = idxWith([
+        story({ id: "a1", cluster: "c1", est_loc: 100 }),
+        story({ id: "a2", cluster: "c1", est_loc: 100 }),
+        story({ id: "b1", cluster: "c2", est_loc: 240 }),
+      ]);
+      expect(nextBundle(idx, { maxLoc: 250 }).map((s) => s.id)).toEqual(["b1"]);
+    });
+  });
+
+  describe("parseRfcPriority / readRfcPriority / applyRfcPriorities", () => {
+    function rfcDir(readme?: string): string {
+      const dir = mkdtempSync(join(tmpdir(), "tasks-test-"));
+      mkdirSync(join(dir, "rfcs", "0005-gaps"), { recursive: true });
+      if (readme !== undefined) {
+        writeFileSync(join(dir, "rfcs", "0005-gaps", "README.md"), readme);
+      }
+      return dir;
+    }
+
+    it("reads the priority scalar from an RFC README", () => {
+      expect(
+        readRfcPriority(rfcDir(`---\nstatus: active\npriority: 3\n---\nbody\n`), "0005-gaps"),
+      ).toBe(3);
+    });
+
+    it("reads 0 as a real priority, not as absent", () => {
+      expect(parseRfcPriority(`---\npriority: 0\n---\nbody\n`)).toBe(0);
+    });
+
+    it("returns null for an absent, malformed, negative, or non-integer priority", () => {
+      expect(parseRfcPriority(`---\nstatus: active\n---\nbody\n`)).toBeNull();
+      expect(parseRfcPriority(`---\npriority: high\n---\n`)).toBeNull();
+      expect(parseRfcPriority(`---\npriority: -1\n---\n`)).toBeNull();
+      expect(parseRfcPriority(`---\npriority: 1.5\n---\n`)).toBeNull();
+      expect(parseRfcPriority(`no frontmatter here\n`)).toBeNull();
+    });
+
+    it("returns null when the README is missing", () => {
+      expect(readRfcPriority(rfcDir(), "0005-gaps")).toBeNull();
+    });
+
+    // Minimal RFC index rows for the applyRfcPriorities cases below.
+    function idxOf(...rfcs: Partial<RfcEntry>[]): Index {
+      return {
+        generated_at: "now",
+        rfcs: rfcs.map((r) => ({
+          id: "0005-gaps",
+          title: "G",
+          status: "active",
+          owner: "@x",
+          packages: [],
+          clusters: [],
+          file_path: `rfcs/${r.id ?? "0005-gaps"}/README.md`,
+          ...r,
+        })),
+        stories: [],
+      };
+    }
+
+    it("fills rfcs[].priority from each README, leaving unreadable ones null", () => {
+      const dir = rfcDir(`---\nstatus: active\npriority: 7\n---\nbody\n`);
+      const idx = idxOf({ id: "0005-gaps" }, { id: "0006-missing" });
+      applyRfcPriorities(idx, dir);
+      expect(idx.rfcs.map((r) => r.priority)).toEqual([7, null]);
+    });
+
+    it("does not re-read an RFC whose priority is already populated", () => {
+      const idx = idxOf({ id: "0005-gaps", priority: 2 });
+      // Points at a dir with no READMEs at all: an unconditional read would
+      // clobber the 2 with null.
+      applyRfcPriorities(idx, mkdtempSync(join(tmpdir(), "tasks-test-")));
+      expect(idx.rfcs[0].priority).toBe(2);
+    });
+
+    it("round-trips a set then a clear through the frontmatter helpers", () => {
+      const dir = rfcDir(`---\nstatus: active\n---\nbody\n`);
+      const readme = join(dir, "rfcs", "0005-gaps", "README.md");
+      editFrontmatter(readme, { priority: "4" });
+      expect(readRfcPriority(dir, "0005-gaps")).toBe(4);
+      removeFrontmatterKey(readme, "priority");
+      expect(readRfcPriority(dir, "0005-gaps")).toBeNull();
+      expect(readFileSync(readme, "utf8")).toContain("status: active");
+    });
+  });
+
+  describe("rfcPriorityFlag (rfc --priority argument)", () => {
+    const parse = (args: string[]) => rfcPriorityFlag(parseFlags(args).flags);
+
+    it("returns undefined when --priority is absent (the RFC is left untouched)", () => {
+      expect(parse(["0001-r", "--status", "active"])).toBeUndefined();
+    });
+
+    it("parses --priority <N>", () => {
+      expect(parse(["0001-r", "--priority", "3"])).toBe(3);
+      expect(parse(["0001-r", "--priority", "0"])).toBe(0);
+    });
+
+    it("returns null for --priority --clear", () => {
+      expect(parse(["0001-r", "--priority", "--clear"])).toBeNull();
+    });
+
+    it("rejects a non-integer or negative N, a valueless --priority, and <N> --clear", () => {
+      expect(parse(["0001-r", "--priority", "high"])).toBe("invalid");
+      expect(parse(["0001-r", "--priority", "1.5"])).toBe("invalid");
+      expect(parse(["0001-r", "--priority", "-2"])).toBe("invalid");
+      expect(parse(["0001-r", "--priority"])).toBe("invalid");
+      expect(parse(["0001-r", "--priority", "3", "--clear"])).toBe("invalid");
+    });
+  });
+
+  describe("formatRows surface", () => {
+    it("marks an inherited priority with a trailing *", () => {
+      const out = formatRows(
+        [story({ id: "a", priority: null })],
+        new Set(),
+        new Map([["0001-r", 6]]),
+      );
+      expect(out.split("\n").find((l) => l.startsWith("a"))!).toContain("6*");
+    });
+
+    it("shows a story's own priority unmarked, even under a prioritized RFC", () => {
+      const out = formatRows(
+        [story({ id: "a", priority: 2 })],
+        new Set(),
+        new Map([["0001-r", 6]]),
+      );
+      const dataLine = out.split("\n").find((l) => l.startsWith("a"))!;
+      expect(dataLine).toContain("2");
+      expect(dataLine).not.toContain("*");
+    });
+
+    it("renders an em dash when neither the story nor its RFC is prioritized", () => {
+      const out = formatRows([story({ id: "a", priority: null })]);
+      expect(out.split("\n").find((l) => l.startsWith("a"))!).toContain("—");
+    });
+
+    it("documents the inherited marker in the legend", () => {
+      expect(PRIORITY_LEGEND).toContain("N* = inherited");
+    });
   });
 });

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -103,10 +103,6 @@ export interface RfcEntry {
   owner: string | null;
   packages: string[];
   clusters: string[];
-  // RFC-level ready-queue priority: the default for this RFC's stories that
-  // set no `priority` of their own (see effectivePriority). Optional because
-  // build-index.mjs doesn't emit it — applyRfcPriorities fills it in from the
-  // README on load, so `undefined` is "not read yet", `null` is "none set".
   priority?: number | null;
   file_path: string;
 }
@@ -162,9 +158,6 @@ export function loadIndex(): Index {
 
 const READ_INDEX_CACHE_DIRNAME = "trails-tasks-read-index";
 
-// Bumped whenever the cached shape gains a field the CLI derives itself: the
-// cache is keyed by tree sha alone, so an entry written by an older CLI would
-// otherwise be served forever. `v2` adds rfcs[].priority.
 const READ_INDEX_CACHE_VERSION = "v2";
 
 export interface ReadIndex {
@@ -244,9 +237,6 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
     execFileSync("tar", ["-xf", tarPath, "-C", treeDir], { stdio: "ignore" });
     linkNodeModules(treeDir, cwd ?? TASKS_DIR);
     execFileSync(process.execPath, ["scripts/build-index.mjs"], { cwd: treeDir, stdio: "ignore" });
-    // build-index.mjs doesn't carry RFC priority into index.json, so read it
-    // from the exported tree's READMEs while they're still on disk — the cached
-    // entry then serves priorities on every later hit for this sha.
     const index = applyRfcPriorities(
       JSON.parse(readFileSync(join(treeDir, "index.json"), "utf8")) as Index,
       treeDir,
@@ -343,21 +333,12 @@ export function isDepResolved(status: string | null | undefined): boolean {
   return status === "done" || status === "closed";
 }
 
-// RFC slug → RFC-level priority, for the RFCs that declare one. Built once per
-// query and threaded into effectivePriority so the scheduler never re-reads
-// files per story.
 export function rfcPriorityMap(index: Index): Map<string, number> {
   const m = new Map<string, number>();
   for (const r of index.rfcs) if (typeof r.priority === "number") m.set(r.id, r.priority);
   return m;
 }
 
-// The ready-queue sort key: a story's own `priority` if it sets one, else its
-// RFC's, else unprioritized (Infinity, sorts last). A story-set priority is
-// ABSOLUTE and global — never clamped into its RFC's band, so an explicit
-// `priority: 1` in an unprioritized RFC still leads every story that merely
-// inherits `priority: 5` from a prioritized one. RFC priority is a default for
-// that RFC's un-prioritized stories, nothing more.
 export function effectivePriority(s: StoryEntry, rfcPriority: ReadonlyMap<string, number>): number {
   return s.priority ?? rfcPriority.get(s.rfc) ?? Infinity;
 }
@@ -387,12 +368,11 @@ export function ready(index: Index, opts: { rfc?: string } = {}): StoryEntry[] {
         if (s.deps_rfc.some((d) => rfcStatus.get(d) !== "closed")) return false;
         return true;
       })
-      // Order the ready queue by EFFECTIVE priority (lower N first): the
-      // story's own `priority` frontmatter, falling back to its RFC's. Both
-      // honor the documented "ready-queue priority" contract. Unprioritized
-      // stories sort last. Array.sort is stable, so ties — including the
-      // all-unprioritized common case — keep index order, leaving callers whose
-      // stories and RFCs set no priority (and their tests) unaffected.
+      // Order the ready queue by effective priority (lower N first), honoring
+      // the `priority` frontmatter's documented contract ("ready-queue
+      // priority"). Unprioritized stories sort last. Array.sort is stable, so
+      // ties — including the all-unprioritized common case — keep index order,
+      // leaving callers that don't set priority (and their tests) unaffected.
       // `next-bundle` re-derives its own ordering on top of this; the gain here
       // is that the `ready` command's output reflects priority too.
       .sort((a, b) => effectivePriority(a, rfcPriority) - effectivePriority(b, rfcPriority))
@@ -435,8 +415,6 @@ export function nextBundle(
   // Priority overrides cluster-LOC packing. The legend says "lower N = higher
   // priority"; honor it literally — any prioritized story outranks every
   // unprioritized one, regardless of cluster or how well it fills the budget.
-  // "Prioritized" here means EFFECTIVE priority, so a story inheriting its
-  // RFC's priority leads the same way an explicitly prioritized one does.
   // The loop takes stories[0], so the head must be the globally-highest
   // priority candidate; we then fill the rest of the budget from that story's
   // cluster (so a prioritized cluster still bundles together). A prioritized
@@ -1750,7 +1728,6 @@ function rfc(
     relate?: string;
     clusters?: string;
     packages?: string;
-    // undefined = untouched, null = clear, number = set.
     priority?: number | null;
   },
 ): void {
@@ -1788,10 +1765,6 @@ function rfc(
     usage();
   }
 
-  // Same no-op guard as setPriority: re-setting the value already in the
-  // frontmatter would leave nothing to commit and make `git commit` error.
-  // loadIndex() populates rfcs[].priority from the README, so the indexed value
-  // is authoritative here.
   let priority = opts.priority;
   if (priority !== undefined) {
     const current = index.rfcs.find((r) => r.id === slug)?.priority ?? null;
@@ -1803,8 +1776,6 @@ function rfc(
       );
       priority = undefined;
       if (!otherEdits) {
-        // Nothing left to write; loadIndex() may have dirtied the generated
-        // index files, so restore them before this early return.
         restoreGeneratedFiles(TASKS_DIR);
         return;
       }
@@ -2210,10 +2181,6 @@ export function readRfcStatus(tasksDir: string, rfcSlug: string): RfcStatus | nu
   }
 }
 
-// Reads the `priority:` scalar out of a README's raw text, with the same
-// yaml.load semantics as readRfcStatus. Returns null when there is no
-// frontmatter, it doesn't parse, or the value isn't a non-negative integer —
-// the shape validate.mjs already enforces for story priority.
 export function parseRfcPriority(text: string): number | null {
   const fmMatch = text.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return null;
@@ -2226,8 +2193,6 @@ export function parseRfcPriority(text: string): number | null {
   }
 }
 
-// The RFC-level counterpart to readRfcStatus: the RFC's default ready-queue
-// priority, or null when the README is missing or sets none.
 export function readRfcPriority(tasksDir: string, rfcSlug: string): number | null {
   try {
     return parseRfcPriority(readFileSync(join(tasksDir, "rfcs", rfcSlug, "README.md"), "utf8"));
@@ -2236,12 +2201,6 @@ export function readRfcPriority(tasksDir: string, rfcSlug: string): number | nul
   }
 }
 
-// Fills in rfcs[].priority for every RFC that hasn't got one yet, reading each
-// README under `rootDir`. The tasks repo's build-index.mjs knows nothing about
-// RFC priority, so this is where the scheduler's RFC model acquires it. Mutates
-// and returns `index`, so callers get a fully-populated index from
-// loadIndex/buildIndexFromOriginMain and never touch the filesystem again. An
-// unreadable README leaves the RFC unprioritized ("absent = unprioritized").
 export function applyRfcPriorities(index: Index, rootDir: string): Index {
   for (const r of index.rfcs) {
     if (r.priority !== undefined) continue;
@@ -2985,9 +2944,6 @@ export function formatRows(
   if (!rows.length) return "(none)";
   const cols = ["id", "rfc", "status", "priority", "est_loc", "cluster"] as const;
   const cell = (r: StoryEntry, c: (typeof cols)[number]) => {
-    // The priority column shows the EFFECTIVE priority the scheduler sorts by,
-    // marking an inherited one with `*` so it stays distinguishable from a
-    // priority the story sets itself. Column set is unchanged.
     if (c === "priority" && r.priority === null) {
       const inherited = rfcPriority.get(r.rfc);
       return inherited === undefined ? "—" : `${inherited}*`;
@@ -3069,10 +3025,6 @@ export function numberFlag(flags: Record<string, string | boolean>, name: string
   return Number(v);
 }
 
-// Resolves the `rfc <slug> --priority` argument: `--priority <N>` sets N,
-// `--priority --clear` clears, absence leaves the RFC untouched. Returns
-// "invalid" (a usage error for the caller) for a non-integer, a negative, or
-// the ambiguous `--priority <N> --clear`. Pure, so it's unit-testable.
 export function rfcPriorityFlag(
   flags: Record<string, string | boolean>,
 ): number | null | undefined | "invalid" {
@@ -3151,11 +3103,9 @@ function main(): void {
     "packages",
     "stale-hours",
   ];
-  // `--priority --clear` is the documented clear form (`rfc <slug> --priority
-  // --clear`), so a valueless `--priority` is legal exactly when `--clear`
-  // accompanies it; every other bare value-flag is still a usage error.
+  const rfcPriorityClear = cmd === "rfc" && flags.priority === true && flags.clear === true;
   for (const k of valueFlags) {
-    if (flags[k] === true && !(k === "priority" && flags.clear === true)) usage();
+    if (flags[k] === true && !(k === "priority" && rfcPriorityClear)) usage();
   }
 
   switch (cmd) {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -103,6 +103,11 @@ export interface RfcEntry {
   owner: string | null;
   packages: string[];
   clusters: string[];
+  // RFC-level ready-queue priority: the default for this RFC's stories that
+  // set no `priority` of their own (see effectivePriority). Optional because
+  // build-index.mjs doesn't emit it — applyRfcPriorities fills it in from the
+  // README on load, so `undefined` is "not read yet", `null` is "none set".
+  priority?: number | null;
   file_path: string;
 }
 export interface StoryEntry {
@@ -150,12 +155,17 @@ export function loadIndex(): Index {
       stdio: "inherit",
     });
   }
-  return JSON.parse(readFileSync(indexPath, "utf8")) as Index;
+  return applyRfcPriorities(JSON.parse(readFileSync(indexPath, "utf8")) as Index, TASKS_DIR);
 }
 
 // ──────────────────── read path (origin/main tree) ────────────────────
 
 const READ_INDEX_CACHE_DIRNAME = "trails-tasks-read-index";
+
+// Bumped whenever the cached shape gains a field the CLI derives itself: the
+// cache is keyed by tree sha alone, so an entry written by an older CLI would
+// otherwise be served forever. `v2` adds rfcs[].priority.
+const READ_INDEX_CACHE_VERSION = "v2";
 
 export interface ReadIndex {
   index: Index;
@@ -216,7 +226,7 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
   }
   if (!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/.test(sha) || !gitDir) return null;
   const cacheDir = join(gitDir, READ_INDEX_CACHE_DIRNAME);
-  const entryName = `${sha}.json`;
+  const entryName = `${sha}.${READ_INDEX_CACHE_VERSION}.json`;
   const cached = join(cacheDir, entryName);
   if (existsSync(cached)) {
     try {
@@ -234,9 +244,14 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
     execFileSync("tar", ["-xf", tarPath, "-C", treeDir], { stdio: "ignore" });
     linkNodeModules(treeDir, cwd ?? TASKS_DIR);
     execFileSync(process.execPath, ["scripts/build-index.mjs"], { cwd: treeDir, stdio: "ignore" });
-    const built = readFileSync(join(treeDir, "index.json"), "utf8");
-    const index = JSON.parse(built) as Index;
-    writeCacheEntryAtomically(cacheDir, entryName, built);
+    // build-index.mjs doesn't carry RFC priority into index.json, so read it
+    // from the exported tree's READMEs while they're still on disk — the cached
+    // entry then serves priorities on every later hit for this sha.
+    const index = applyRfcPriorities(
+      JSON.parse(readFileSync(join(treeDir, "index.json"), "utf8")) as Index,
+      treeDir,
+    );
+    writeCacheEntryAtomically(cacheDir, entryName, JSON.stringify(index));
     return { index, sha };
   } catch {
     return null;
@@ -328,7 +343,27 @@ export function isDepResolved(status: string | null | undefined): boolean {
   return status === "done" || status === "closed";
 }
 
+// RFC slug → RFC-level priority, for the RFCs that declare one. Built once per
+// query and threaded into effectivePriority so the scheduler never re-reads
+// files per story.
+export function rfcPriorityMap(index: Index): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const r of index.rfcs) if (typeof r.priority === "number") m.set(r.id, r.priority);
+  return m;
+}
+
+// The ready-queue sort key: a story's own `priority` if it sets one, else its
+// RFC's, else unprioritized (Infinity, sorts last). A story-set priority is
+// ABSOLUTE and global — never clamped into its RFC's band, so an explicit
+// `priority: 1` in an unprioritized RFC still leads every story that merely
+// inherits `priority: 5` from a prioritized one. RFC priority is a default for
+// that RFC's un-prioritized stories, nothing more.
+export function effectivePriority(s: StoryEntry, rfcPriority: ReadonlyMap<string, number>): number {
+  return s.priority ?? rfcPriority.get(s.rfc) ?? Infinity;
+}
+
 export function ready(index: Index, opts: { rfc?: string } = {}): StoryEntry[] {
+  const rfcPriority = rfcPriorityMap(index);
   const rfcStatus = new Map(index.rfcs.map((r) => [r.id, r.status]));
   const storyStatus = new Map(index.stories.map((s) => [s.id, s.status]));
   return (
@@ -352,14 +387,15 @@ export function ready(index: Index, opts: { rfc?: string } = {}): StoryEntry[] {
         if (s.deps_rfc.some((d) => rfcStatus.get(d) !== "closed")) return false;
         return true;
       })
-      // Order the ready queue by priority (lower N first), honoring the
-      // `priority` frontmatter's documented contract ("ready-queue priority").
-      // Unprioritized stories (null) sort last. Array.sort is stable, so ties —
-      // including the all-null common case — keep index order, leaving callers
-      // that don't set priority (and their tests) unaffected. `next-bundle`
-      // re-derives its own ordering on top of this; the gain here is that the
-      // `ready` command's output reflects priority too.
-      .sort((a, b) => (a.priority ?? Infinity) - (b.priority ?? Infinity))
+      // Order the ready queue by EFFECTIVE priority (lower N first): the
+      // story's own `priority` frontmatter, falling back to its RFC's. Both
+      // honor the documented "ready-queue priority" contract. Unprioritized
+      // stories sort last. Array.sort is stable, so ties — including the
+      // all-unprioritized common case — keep index order, leaving callers whose
+      // stories and RFCs set no priority (and their tests) unaffected.
+      // `next-bundle` re-derives its own ordering on top of this; the gain here
+      // is that the `ready` command's output reflects priority too.
+      .sort((a, b) => effectivePriority(a, rfcPriority) - effectivePriority(b, rfcPriority))
   );
 }
 
@@ -399,6 +435,8 @@ export function nextBundle(
   // Priority overrides cluster-LOC packing. The legend says "lower N = higher
   // priority"; honor it literally — any prioritized story outranks every
   // unprioritized one, regardless of cluster or how well it fills the budget.
+  // "Prioritized" here means EFFECTIVE priority, so a story inheriting its
+  // RFC's priority leads the same way an explicitly prioritized one does.
   // The loop takes stories[0], so the head must be the globally-highest
   // priority candidate; we then fill the rest of the budget from that story's
   // cluster (so a prioritized cluster still bundles together). A prioritized
@@ -411,7 +449,8 @@ export function nextBundle(
   // `.filter()` preserves order, so `prioritized[0]` is the highest-priority
   // candidate without re-sorting here — the ordering source of truth stays in
   // `ready()`.
-  const prioritized = inScope.filter((s) => s.priority !== null);
+  const rfcPriority = rfcPriorityMap(index);
+  const prioritized = inScope.filter((s) => effectivePriority(s, rfcPriority) !== Infinity);
   if (prioritized.length > 0) {
     const lead = prioritized[0];
     const leadLoc = lead.est_loc ?? 0;
@@ -419,7 +458,7 @@ export function nextBundle(
       (s) => s.id !== lead.id && s.cluster === lead.cluster && s.est_loc !== null,
     );
     const fill = bestBundle(rest, opts.maxLoc - leadLoc).sort(
-      (a, b) => (a.priority ?? Infinity) - (b.priority ?? Infinity),
+      (a, b) => effectivePriority(a, rfcPriority) - effectivePriority(b, rfcPriority),
     );
     return [lead, ...fill];
   }
@@ -1711,6 +1750,8 @@ function rfc(
     relate?: string;
     clusters?: string;
     packages?: string;
+    // undefined = untouched, null = clear, number = set.
+    priority?: number | null;
   },
 ): void {
   inGitTasks();
@@ -1737,14 +1778,37 @@ function rfc(
   const clusters = opts.clusters !== undefined ? parseCsv(opts.clusters) : undefined;
   const packages = opts.packages !== undefined ? parseCsv(opts.packages) : undefined;
 
-  if (
-    status === undefined &&
-    relate === undefined &&
-    clusters === undefined &&
-    packages === undefined
-  ) {
+  const otherEdits =
+    status !== undefined ||
+    relate !== undefined ||
+    clusters !== undefined ||
+    packages !== undefined;
+  if (!otherEdits && opts.priority === undefined) {
     restoreGeneratedFiles(TASKS_DIR);
     usage();
+  }
+
+  // Same no-op guard as setPriority: re-setting the value already in the
+  // frontmatter would leave nothing to commit and make `git commit` error.
+  // loadIndex() populates rfcs[].priority from the README, so the indexed value
+  // is authoritative here.
+  let priority = opts.priority;
+  if (priority !== undefined) {
+    const current = index.rfcs.find((r) => r.id === slug)?.priority ?? null;
+    if (current === priority) {
+      console.log(
+        priority === null
+          ? `priority already clear on rfc ${slug}`
+          : `rfc ${slug} already priority ${priority}`,
+      );
+      priority = undefined;
+      if (!otherEdits) {
+        // Nothing left to write; loadIndex() may have dirtied the generated
+        // index files, so restore them before this early return.
+        restoreGeneratedFiles(TASKS_DIR);
+        return;
+      }
+    }
   }
 
   // Warn (don't block) on a clusters change that drops a cluster still referenced
@@ -1771,6 +1835,9 @@ function rfc(
   if (relate !== undefined) changes.push(`relate [${relate.join(", ")}]`);
   if (clusters !== undefined) changes.push(`clusters [${clusters.join(", ")}]`);
   if (packages !== undefined) changes.push(`packages [${packages.join(", ")}]`);
+  if (priority !== undefined) {
+    changes.push(priority === null ? "priority clear" : `priority ${priority}`);
+  }
 
   commitAndPush({
     message: `rfc ${slug}: ${changes.join(", ")}`,
@@ -1787,6 +1854,8 @@ function rfc(
       if (relate !== undefined) setFrontmatterList(file, "related-rfcs", relate);
       if (clusters !== undefined) setFrontmatterList(file, "clusters", clusters);
       if (packages !== undefined) setFrontmatterList(file, "packages", packages);
+      if (priority === null) removeFrontmatterKey(file, "priority");
+      else if (priority !== undefined) editFrontmatter(file, { priority: String(priority) });
       editFrontmatter(file, { updated: today() });
     },
   });
@@ -2139,6 +2208,50 @@ export function readRfcStatus(tasksDir: string, rfcSlug: string): RfcStatus | nu
   } catch {
     return null;
   }
+}
+
+// Reads the `priority:` scalar out of a README's raw text, with the same
+// yaml.load semantics as readRfcStatus. Returns null when there is no
+// frontmatter, it doesn't parse, or the value isn't a non-negative integer —
+// the shape validate.mjs already enforces for story priority.
+export function parseRfcPriority(text: string): number | null {
+  const fmMatch = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+  try {
+    const fm = parseYaml(fmMatch[1]) as { priority?: unknown } | null;
+    const p = fm?.priority;
+    return Number.isInteger(p) && (p as number) >= 0 ? (p as number) : null;
+  } catch {
+    return null;
+  }
+}
+
+// The RFC-level counterpart to readRfcStatus: the RFC's default ready-queue
+// priority, or null when the README is missing or sets none.
+export function readRfcPriority(tasksDir: string, rfcSlug: string): number | null {
+  try {
+    return parseRfcPriority(readFileSync(join(tasksDir, "rfcs", rfcSlug, "README.md"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// Fills in rfcs[].priority for every RFC that hasn't got one yet, reading each
+// README under `rootDir`. The tasks repo's build-index.mjs knows nothing about
+// RFC priority, so this is where the scheduler's RFC model acquires it. Mutates
+// and returns `index`, so callers get a fully-populated index from
+// loadIndex/buildIndexFromOriginMain and never touch the filesystem again. An
+// unreadable README leaves the RFC unprioritized ("absent = unprioritized").
+export function applyRfcPriorities(index: Index, rootDir: string): Index {
+  for (const r of index.rfcs) {
+    if (r.priority !== undefined) continue;
+    try {
+      r.priority = parseRfcPriority(readFileSync(join(rootDir, r.file_path), "utf8"));
+    } catch {
+      r.priority = null;
+    }
+  }
+  return index;
 }
 
 // Pure content generator — exported so tests can verify the exact file format
@@ -2809,7 +2922,8 @@ export function prLocDelta(pr: number, estLoc: number | null): string | null {
 // direction is documented wherever the ordering is shown (`ready`, `list`,
 // `next-bundle`). Ties at the same priority have no defined order.
 export const PRIORITY_LEGEND =
-  "priority: lower N = higher priority; absent = unprioritized; ties have undefined order";
+  "priority: lower N = higher priority; absent = unprioritized; ties have undefined order; " +
+  "N* = inherited from the story's RFC";
 
 // Default age (hours) past which a `claimed` story with no PR is flagged stale.
 // Overridable via `--stale-hours N`. Read once per command so `status` and
@@ -2863,10 +2977,21 @@ export function formatStaleClaims(rows: StoryEntry[], nowMs: number): string {
 // content (e.g. est_loc rendered from a numeric value, priority shown) without
 // capturing stdout. `null` cells render as an em dash. Ids in `staleIds` get a
 // `!` suffix in the status column, computed by the caller via staleClaims().
-export function formatRows(rows: StoryEntry[], staleIds: ReadonlySet<string> = new Set()): string {
+export function formatRows(
+  rows: StoryEntry[],
+  staleIds: ReadonlySet<string> = new Set(),
+  rfcPriority: ReadonlyMap<string, number> = new Map(),
+): string {
   if (!rows.length) return "(none)";
   const cols = ["id", "rfc", "status", "priority", "est_loc", "cluster"] as const;
   const cell = (r: StoryEntry, c: (typeof cols)[number]) => {
+    // The priority column shows the EFFECTIVE priority the scheduler sorts by,
+    // marking an inherited one with `*` so it stays distinguishable from a
+    // priority the story sets itself. Column set is unchanged.
+    if (c === "priority" && r.priority === null) {
+      const inherited = rfcPriority.get(r.rfc);
+      return inherited === undefined ? "—" : `${inherited}*`;
+    }
     const v = String(r[c] ?? "—");
     return c === "status" && staleIds.has(r.id) ? `${v}!` : v;
   };
@@ -2879,8 +3004,12 @@ export function formatRows(rows: StoryEntry[], staleIds: ReadonlySet<string> = n
   ].join("\n");
 }
 
-function fmt(rows: StoryEntry[], staleIds?: ReadonlySet<string>): void {
-  console.log(formatRows(rows, staleIds));
+function fmt(
+  rows: StoryEntry[],
+  staleIds?: ReadonlySet<string>,
+  rfcPriority?: ReadonlyMap<string, number>,
+): void {
+  console.log(formatRows(rows, staleIds, rfcPriority));
 }
 
 // Pure renderer for `show <id>`: the resolved file path followed by the story's
@@ -2938,6 +3067,19 @@ export function numberFlag(flags: Record<string, string | boolean>, name: string
   const v = flags[name];
   if (typeof v !== "string" || !/^\d+$/.test(v)) return null;
   return Number(v);
+}
+
+// Resolves the `rfc <slug> --priority` argument: `--priority <N>` sets N,
+// `--priority --clear` clears, absence leaves the RFC untouched. Returns
+// "invalid" (a usage error for the caller) for a non-integer, a negative, or
+// the ambiguous `--priority <N> --clear`. Pure, so it's unit-testable.
+export function rfcPriorityFlag(
+  flags: Record<string, string | boolean>,
+): number | null | undefined | "invalid" {
+  if (flags.priority === undefined) return undefined;
+  const raw = stringFlag(flags, "priority");
+  if (flags.clear === true) return raw === undefined ? null : "invalid";
+  return raw !== undefined && /^\d+$/.test(raw) ? Number(raw) : "invalid";
 }
 
 export function stringFlag(
@@ -3009,19 +3151,28 @@ function main(): void {
     "packages",
     "stale-hours",
   ];
-  for (const k of valueFlags) if (flags[k] === true) usage();
+  // `--priority --clear` is the documented clear form (`rfc <slug> --priority
+  // --clear`), so a valueless `--priority` is legal exactly when `--clear`
+  // accompanies it; every other bare value-flag is still a usage error.
+  for (const k of valueFlags) {
+    if (flags[k] === true && !(k === "priority" && flags.clear === true)) usage();
+  }
 
   switch (cmd) {
     case "ready": {
-      const rows = ready(readIndexSource().index, { rfc: stringFlag(flags, "rfc") });
-      flags.json ? console.log(JSON.stringify(rows, null, 2)) : fmt(rows);
+      const idx = readIndexSource().index;
+      const rows = ready(idx, { rfc: stringFlag(flags, "rfc") });
+      flags.json
+        ? console.log(JSON.stringify(rows, null, 2))
+        : fmt(rows, undefined, rfcPriorityMap(idx));
       break;
     }
     case "next-bundle": {
       const maxLocRaw = stringFlag(flags, "max-loc") ?? "250";
       if (!/^\d+$/.test(maxLocRaw) || Number(maxLocRaw) <= 0) usage();
       const maxLoc = Number(maxLocRaw);
-      const rows = nextBundle(readIndexSource().index, {
+      const idx = readIndexSource().index;
+      const rows = nextBundle(idx, {
         maxLoc,
         cluster: stringFlag(flags, "cluster"),
         rfc: stringFlag(flags, "rfc"),
@@ -3035,7 +3186,7 @@ function main(): void {
         console.log(`no ready stories within ${maxLoc} LOC`);
       } else {
         console.log(`bundle (sum ${total} / max ${maxLoc}):`);
-        fmt(rows);
+        fmt(rows, undefined, rfcPriorityMap(idx));
       }
       break;
     }
@@ -3051,7 +3202,9 @@ function main(): void {
           (s) => s.id,
         ),
       );
-      flags.json ? console.log(JSON.stringify(rows, null, 2)) : fmt(rows, staleIds);
+      flags.json
+        ? console.log(JSON.stringify(rows, null, 2))
+        : fmt(rows, staleIds, rfcPriorityMap(idx));
       break;
     }
     case "show": {
@@ -3216,7 +3369,10 @@ function main(): void {
     case "rfc": {
       const slug = pos[0];
       if (!slug) usage();
+      const priority = rfcPriorityFlag(flags);
+      if (priority === "invalid") usage();
       rfc(slug, {
+        priority,
         status: stringFlag(flags, "status"),
         supersede: stringFlag(flags, "supersede"),
         relate: stringFlag(flags, "relate"),
@@ -3259,6 +3415,7 @@ function usage(): never {
   priority <id> <N> | priority <id> --clear    (lower N = higher priority)
   status-set <id> <status>                     (draft ↔ ready, blocked → ready, closed → ready; validates the transition)
   rfc <slug> [--status <s>] [--supersede <other-slug>] [--relate <csv>] [--clusters <csv>] [--packages <csv>]
+             [--priority <N> | --priority --clear]   (RFC-level default priority for its un-prioritized stories)
   set-deps <id> <csv>                          (replace deps; checks references + cycles; empty csv clears)
   set-deps-rfc <id> <csv>                      (replace deps-rfc; checks references; empty csv clears)
   new <rfc-slug> <story-slug> [--title "text"] [--status <v>] [--cluster <name>] [--est-loc <N>] [--deps <csv>] [--priority <N>] [--body-file <path>] [--allow-empty]

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -343,8 +343,38 @@ export function effectivePriority(s: StoryEntry, rfcPriority: ReadonlyMap<string
   return s.priority ?? rfcPriority.get(s.rfc) ?? Infinity;
 }
 
+export interface PriorityContext {
+  rfcPriority: ReadonlyMap<string, number>;
+  remaining: ReadonlyMap<string, number>;
+}
+
+export function remainingStoryCounts(index: Index): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const s of index.stories) {
+    if (isDepResolved(s.status)) continue;
+    m.set(s.rfc, (m.get(s.rfc) ?? 0) + 1);
+  }
+  return m;
+}
+
+export function priorityContext(index: Index): PriorityContext {
+  return { rfcPriority: rfcPriorityMap(index), remaining: remainingStoryCounts(index) };
+}
+
+export function comparePriority(a: StoryEntry, b: StoryEntry, ctx: PriorityContext): number {
+  const ea = effectivePriority(a, ctx.rfcPriority);
+  const eb = effectivePriority(b, ctx.rfcPriority);
+  if (ea !== eb) return ea < eb ? -1 : 1;
+  const pa = ctx.rfcPriority.get(a.rfc);
+  const pb = ctx.rfcPriority.get(b.rfc);
+  if (pa === undefined || pa !== pb) return 0;
+  const ra = ctx.remaining.get(a.rfc) ?? 0;
+  const rb = ctx.remaining.get(b.rfc) ?? 0;
+  return ra === rb ? 0 : ra - rb;
+}
+
 export function ready(index: Index, opts: { rfc?: string } = {}): StoryEntry[] {
-  const rfcPriority = rfcPriorityMap(index);
+  const ctx = priorityContext(index);
   const rfcStatus = new Map(index.rfcs.map((r) => [r.id, r.status]));
   const storyStatus = new Map(index.stories.map((s) => [s.id, s.status]));
   return (
@@ -375,7 +405,7 @@ export function ready(index: Index, opts: { rfc?: string } = {}): StoryEntry[] {
       // leaving callers that don't set priority (and their tests) unaffected.
       // `next-bundle` re-derives its own ordering on top of this; the gain here
       // is that the `ready` command's output reflects priority too.
-      .sort((a, b) => effectivePriority(a, rfcPriority) - effectivePriority(b, rfcPriority))
+      .sort((a, b) => comparePriority(a, b, ctx))
   );
 }
 
@@ -427,17 +457,15 @@ export function nextBundle(
   // `.filter()` preserves order, so `prioritized[0]` is the highest-priority
   // candidate without re-sorting here — the ordering source of truth stays in
   // `ready()`.
-  const rfcPriority = rfcPriorityMap(index);
-  const prioritized = inScope.filter((s) => effectivePriority(s, rfcPriority) !== Infinity);
+  const ctx = priorityContext(index);
+  const prioritized = inScope.filter((s) => effectivePriority(s, ctx.rfcPriority) !== Infinity);
   if (prioritized.length > 0) {
     const lead = prioritized[0];
     const leadLoc = lead.est_loc ?? 0;
     const rest = inScope.filter(
       (s) => s.id !== lead.id && s.cluster === lead.cluster && s.est_loc !== null,
     );
-    const fill = bestBundle(rest, opts.maxLoc - leadLoc).sort(
-      (a, b) => effectivePriority(a, rfcPriority) - effectivePriority(b, rfcPriority),
-    );
+    const fill = bestBundle(rest, opts.maxLoc - leadLoc).sort((a, b) => comparePriority(a, b, ctx));
     return [lead, ...fill];
   }
   // Unprioritized path: knapsack same-cluster stories by est_loc, so stories
@@ -2879,10 +2907,11 @@ export function prLocDelta(pr: number, estLoc: number | null): string | null {
 
 // One-line legend printed above every story table so the priority column's
 // direction is documented wherever the ordering is shown (`ready`, `list`,
-// `next-bundle`). Ties at the same priority have no defined order.
+// `next-bundle`). Ties break toward the equal-priority RFC with fewer stories
+// left; anything still tied after that has no defined order.
 export const PRIORITY_LEGEND =
-  "priority: lower N = higher priority; absent = unprioritized; ties have undefined order; " +
-  "N* = inherited from the story's RFC";
+  "priority: lower N = higher priority; absent = unprioritized; N* = inherited from the " +
+  "story's RFC; equal-priority RFCs: fewer stories remaining first";
 
 // Default age (hours) past which a `claimed` story with no PR is flagged stale.
 // Overridable via `--stale-hours N`. Read once per command so `status` and


### PR DESCRIPTION
Adds **RFC-level priority** to the tasks CLI so the ready-queue scheduler can order work by RFC, while an individual story can still override its RFC.

## Effective-priority model

`effective = story.priority ?? rfc.priority ?? Infinity`, sorted ascending (lower N first).

- A story that sets `priority` is taken **literally and globally**, exactly as today — never clamped into its RFC's band. An explicit `priority: 2` under an RFC prioritized 9 still outranks a story inheriting `priority: 3` from a better-prioritized RFC.
- A story that sets none inherits its RFC's priority: RFC priority is a *default* for that RFC's un-prioritized stories, nothing more.
- Neither set → unprioritized, sorts last. `??` (not `||`) so `priority: 0` is a real priority.
- **Ties break toward the RFC with fewer stories remaining** (see below).
- **Backward compatible:** an RFC with no `priority` produces byte-identical ordering to before — covered by an explicit regression test.

## Equal-priority tie-break

Two RFCs at the same priority are not equally close to done, so when the effective priorities tie **and both stories' RFCs declare the same priority**, the RFC with fewer stories left to ship goes first — finishing the nearer one frees a whole RFC sooner. "Remaining" is every story that is neither `done` nor `closed` (reusing `isDepResolved`), so an RFC with a long shipped history still counts as near-empty.

The tie-break is deliberately confined to *equal-priority* RFCs. Widening it to unprioritized ones would reshuffle the entire default queue by RFC size, which nothing asked for; a test pins that unprioritized RFCs are not reordered, and stories within one RFC keep index order.

While rewriting the comparator: the old `(a.priority ?? Infinity) - (b.priority ?? Infinity)` returns `Infinity - Infinity` = **NaN** for two unprioritized stories — not a valid comparator result. It happened to behave because V8 treats NaN as "equal", but it is now an explicit comparison, with a test.

## Commands

```
pnpm tasks rfc <slug> --priority <N>        # set
pnpm tasks rfc <slug> --priority --clear    # clear
```

Extends the existing `rfc` subcommand (no new top-level verb), storing `priority:` in the RFC README frontmatter through the same `editFrontmatter` / `removeFrontmatterKey` helpers story priority uses. Same no-op guard as `setPriority` — re-setting the current value would leave nothing to commit and make `git commit` error, so it prints `rfc <slug> already priority N` and returns (restoring the generated index files, since that early return skips `commitAndPush`'s restore). Same integer validation. Usage banner updated.

`--priority --clear` is the only valueless value-flag the parser accepts, and only for `rfc` — `tasks new … --priority --clear` remains a usage error.

## Scheduler + surface

- `ready()` and `next-bundle` sort by effective priority. `next-bundle`'s "priority overrides cluster-LOC packing" contract is preserved, with "prioritized" now meaning *effective*: a story inheriting its RFC's priority leads exactly the way an explicitly prioritized one does.
- Listing tables keep their exact column set; the `priority` column renders the effective value and marks an inherited one `N*`. `PRIORITY_LEGEND` is reused (not duplicated) and documents the marker.
- `--json` still emits raw index rows; the ordering is the contract there and it reflects effective priority.

## Plumbing note

The tasks repo's `build-index.mjs` doesn't emit RFC priority into `index.json`, and it's a different repo — so the CLI derives it. `applyRfcPriorities()` reads each RFC README once per index load (in `loadIndex`, and in the origin/main tree export where the READMEs are already on disk), so no later caller touches the filesystem per story.

The origin/main read cache is keyed by tree sha alone, so an entry written by an older CLI would be served forever — missing `rfcs[].priority` and silently reverting the scheduler to story-only ordering. Cache entries are therefore version-suffixed (`<sha>.v2.json`); a test pins that a pre-v2 entry for the same sha forces a rebuild.

## Tests

`scripts/tasks/cli.test.ts`, **299 passing**:

- `effectivePriority` — story-overrides-RFC-globally, unset-inherits-RFC, and `priority: 0` taken literally rather than falling back.
- `ready` ordering — inheritance, absolute story priority across RFCs, a story priority sorting *below* its RFC's default, and the no-RFC-priority regression guard (order identical to index order).
- `nextBundle` — an inherited priority leads over better LOC packing; cluster packing unchanged when no RFC is prioritized.
- `parseRfcPriority` / `readRfcPriority` / `applyRfcPriorities` — absent, malformed, negative and non-integer values → null; missing README; already-populated entries not re-read.
- Persistence — set then clear over a **real-shaped** RFC README (quoted scalars, trailing inline flow lists, so `priority:` appends after a list-valued key) returns the file byte-for-byte.
- Tie-break — fewer-remaining RFC first at equal priority; `done`/`closed` excluded from the count; not applied when the RFC priorities differ; unprioritized RFCs not reshuffled; same-RFC stories stay in index order; `comparePriority` returns 0 (not NaN) for two unprioritized stories; and `next-bundle` leads with the nearer-to-done RFC.
- `rfcPriorityFlag` validation, and the `formatRows` inherited-`N*` marker + legend.

Also verified end-to-end against the real tasks repo read-only: with a priority injected in memory for `0061-ci-failures`, the real ready queue reorders and renders `1*`; and with `0061` (6 stories left) and `0025-fidelity-verification-tooling` (56 left) both at priority 1, the queue leads with `0061`. No real RFC data was mutated.

**Size:** 602 LOC, over the 500 ceiling. The tie-break was requested as part of this feature and shares its comparator, tests and legend, so splitting it would mean re-reviewing the same diff twice. Happy to move it to a follow-up story if you'd rather keep the ceiling hard.
