### PR TITLE
test(ar-suite): run with partial_inserts=true (Rails helper.rb ambient)

### DIFF
--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -28,11 +28,6 @@ import {
   TEST_KEY_DERIVATION_SALT,
 } from "../encryption/test-keys.js";
 
-// Rails' AR test suite never calls `config.load_defaults` — it runs on the gem
-// framework defaults, so `partial_inserts` stays `true` (dirty.rb:50). Keep the
-// same ambient here rather than modelling a 7.0 app; the versioned-defaults
-// mechanism itself is covered by trailtie.test.ts.
-
 // Mirror Rails activerecord/test/cases/helper.rb:46 — register the fake adapter
 // for the whole suite, before any model calls establish_connection(adapter:
 // "fake") at load time (test/models/contact.rb:6).

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -13,7 +13,6 @@ import "../sqlite/better-sqlite3.js";
 import { beforeEach } from "vitest";
 import { Base } from "../base.js";
 import { DelegateCache } from "../relation/delegation.js";
-import { loadDefaults } from "../trailtie.js";
 import {
   setBelongsToRequiredValidatesForeignKey,
   setRaiseOnAssignToAttrReadonly,
@@ -29,11 +28,10 @@ import {
   TEST_KEY_DERIVATION_SALT,
 } from "../encryption/test-keys.js";
 
-// The test app runs with the Rails 7.0+ defaults (`config.load_defaults 7.0`),
-// which sets `config.active_record.partial_inserts = false` (partial_updates
-// stays true). Use the versioned-defaults mechanism rather than poking Base
-// directly; this exercises the real code path that a consuming app would use.
-loadDefaults("7.0");
+// Rails' AR test suite never calls `config.load_defaults` — it runs on the gem
+// framework defaults, so `partial_inserts` stays `true` (dirty.rb:50). Keep the
+// same ambient here rather than modelling a 7.0 app; the versioned-defaults
+// mechanism itself is covered by trailtie.test.ts.
 
 // Mirror Rails activerecord/test/cases/helper.rb:46 — register the fake adapter
 // for the whole suite, before any model calls establish_connection(adapter:

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -484,13 +484,6 @@ describeIfMysql("DefaultsTestWithoutTransactionalFixtures", () => {
       });
       class TestMysqlNotNullDefault extends Base {
         static override tableName = "test_mysql_not_null_defaults";
-        // Rails' AR test suite runs with the framework default
-        // `partial_inserts = true` (dirty.rb:50), which the trails harness flips
-        // to false via `load_defaults 7.0` (cases/helper.ts). Restore the Rails
-        // test-env value here so `new` (no attrs) omits the NOT NULL columns from
-        // the INSERT — letting the DB apply implicit 0/"" defaults in non-strict
-        // mode — exactly as Rails exercises this test.
-        static override partialInserts = true;
       }
       TestMysqlNotNullDefault.adapter = adapter;
       await TestMysqlNotNullDefault.loadSchema();

--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -66,13 +66,6 @@ describe("HotCompatibilityTest", () => {
     class HotCompatibility extends Base {}
     HotCompatibility.tableName = "hot_compatibilities";
     (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
-    // Rails' AR test suite runs with the gem default `partial_inserts = true`
-    // (dirty.rb:50); only attributes assigned away from their default are
-    // written, so the dropped `bar` is simply omitted from the INSERT. The
-    // trails test harness flips this to false via `load_defaults("7.0")`
-    // (cases/helper.ts), so restore the Rails-ambient default for this model.
-    HotCompatibility.partialInserts = true;
-
     return { klass: HotCompatibility, adapter };
   }
 

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1198,9 +1198,9 @@ describe("PersistenceTest", () => {
     await expect(Topic.destroy([99999])).rejects.toThrow();
   });
 
-  // Guard for partial_inserts=true (Rails' test ambient; harness currently runs
-  // false via load_defaults 7.0). Pins the callbacks.ts null-only PK skip-set;
-  // flip-the-ambient or a refactor that drops it regresses this without a guard.
+  // Guard for partial_inserts=true (Rails' test ambient, which the harness now
+  // runs). Pins the callbacks.ts null-only PK skip-set; a refactor that drops
+  // it regresses this without a guard.
   // Mirrors Rails _create_record writing a returning column back only when
   // _read_attribute(column) is nil.
   it("create prefetched pk", async () => {

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -225,19 +225,6 @@ describe("UpdateableViewTest", () => {
   class PrintedBook extends Base {
     static override _tableName = "printed_books";
     static override _primaryKey = "id";
-    // Rails' AR test suite runs with the class default `partial_inserts = true`
-    // (helper.rb never flips it — only a `config.load_defaults 7.0+` app does),
-    // while our cases/helper.ts deliberately runs loadDefaults("7.0"), i.e.
-    // partialInserts=false. That difference is fatal here on MySQL only: the
-    // updatable view reports its NOT-NULL `id` with a fabricated default "0"
-    // (SHOW FULL FIELDS strips `auto_increment` from Extra, so the column is
-    // not auto-populated and survives the full-insert column set), and with
-    // NO_AUTO_VALUE_ON_ZERO in sql_mode the INSERT stores literal 0 instead of
-    // letting the underlying `books` table auto-assign. Rails under
-    // partial_inserts=false fails identically — there is no adapter gap — so
-    // restore Rails' own test-suite setting for this model: the unchanged `id`
-    // then stays out of the INSERT column list and MySQL auto-assigns.
-    static override partialInserts = true;
   }
 
   beforeAll(rebuildBooksTables);


### PR DESCRIPTION
Rails' AR test suite (`activerecord/test/cases/helper.rb`) never calls
`config.load_defaults` — it runs on the gem framework defaults, so
`partial_inserts` stays `true` (dirty.rb:50). Our harness modelled a 7.0 app via
`loadDefaults("7.0")` in `cases/helper.ts`, flipping it to `false`.

The three systemic gaps that blocked this flip (composite-PK key retention
#3783, optimistic-locking initial value #3788, test-schema DB-default fidelity
#3789) are all merged, so this drops the `loadDefaults("7.0")` call and the
now-redundant per-model `partialInserts = true` opt-ins in `view.test.ts`,
`hot-compatibility.test.ts`, and `defaults.test.ts`.

`loadDefaults` itself is unchanged and still covered by `trailtie.test.ts`.
`has_and_belongs_to_many_while_partial_inserts_false` keeps its explicit local
flip — that is Rails' own test.

Locally green: persistence, timestamp, dirty, locking(+trails), sql-default,
defaults, view, hot-compatibility, trailtie, habtm.

Closes-story: partial-inserts-flip-ar-test-suite-ambient
