### PR TITLE
fix(activerecord): converge actionSql referential action set and message

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -618,9 +618,6 @@ export class SchemaCreation {
       case "restrict":
         return `ON ${action} RESTRICT`;
       default:
-        // Rails raises ArgumentError here (schema_creation.rb:181), which
-        // foreign_key_test.rb:302 asserts on. The message reproduces the
-        // heredoc verbatim, trailing newline included.
         throw new ArgumentError(
           `'${String(dependency)}' is not supported for :on_update or :on_delete.\n` +
             `Supported values are: :nullify, :cascade, :restrict\n`,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -611,22 +611,19 @@ export class SchemaCreation {
   /** @internal */
   actionSql(action: string, dependency: ReferentialAction): string {
     switch (dependency) {
-      case "cascade":
-        return `ON ${action} CASCADE`;
       case "nullify":
         return `ON ${action} SET NULL`;
+      case "cascade":
+        return `ON ${action} CASCADE`;
       case "restrict":
         return `ON ${action} RESTRICT`;
-      case "no_action":
-        return `ON ${action} NO ACTION`;
-      case "set_default":
-        return `ON ${action} SET DEFAULT`;
       default:
         // Rails raises ArgumentError here (schema_creation.rb:181), which
-        // foreign_key_test.rb:302 asserts on.
+        // foreign_key_test.rb:302 asserts on. The message reproduces the
+        // heredoc verbatim, trailing newline included.
         throw new ArgumentError(
-          `'${String(dependency)}' is not supported for on_update or on_delete. ` +
-            `Supported values are: cascade, nullify, restrict, no_action, set_default`,
+          `'${String(dependency)}' is not supported for :on_update or :on_delete.\n` +
+            `Supported values are: :nullify, :cascade, :restrict\n`,
         );
     }
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -61,11 +61,6 @@ export type ColumnType =
 
 export type PrimaryKeyType = "uuid";
 
-/**
- * The dependency values `action_sql` (schema_creation.rb:175) accepts:
- * exactly `:nullify`, `:cascade`, `:restrict`. Anything else raises
- * ArgumentError.
- */
 export type ReferentialAction = "cascade" | "nullify" | "restrict";
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -61,7 +61,12 @@ export type ColumnType =
 
 export type PrimaryKeyType = "uuid";
 
-export type ReferentialAction = "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
+/**
+ * The dependency values `action_sql` (schema_creation.rb:175) accepts:
+ * exactly `:nullify`, `:cascade`, `:restrict`. Anything else raises
+ * ArgumentError.
+ */
+export type ReferentialAction = "cascade" | "nullify" | "restrict";
 
 /**
  * The adapter surface {@link TableDefinition.newForeignKeyDefinition} reads

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3204,8 +3204,6 @@ export class SQLite3Integer {
   }
 }
 
-// Mirrors the `case dependency` arms of action_sql (schema_creation.rb:175);
-// Rails supports exactly these three, matched exactly (no case folding).
 const REFERENTIAL_ACTION_MAP: Record<string, string> = {
   nullify: "SET NULL",
   cascade: "CASCADE",
@@ -3214,9 +3212,6 @@ const REFERENTIAL_ACTION_MAP: Record<string, string> = {
 
 function normalizeReferentialAction(action: string): string {
   const sql = REFERENTIAL_ACTION_MAP[action];
-  // Rails reaches action_sql (schema_creation.rb:175) even on SQLite's
-  // table-rebuild path, so an unsupported :on_delete/:on_update raises
-  // ArgumentError rather than emitting invalid SQL (foreign_key_test.rb:302).
   if (sql === undefined) {
     throw new ArgumentError(
       `'${action}' is not supported for :on_update or :on_delete.\n` +

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3204,23 +3204,23 @@ export class SQLite3Integer {
   }
 }
 
+// Mirrors the `case dependency` arms of action_sql (schema_creation.rb:175);
+// Rails supports exactly these three, matched exactly (no case folding).
 const REFERENTIAL_ACTION_MAP: Record<string, string> = {
   nullify: "SET NULL",
   cascade: "CASCADE",
   restrict: "RESTRICT",
-  set_default: "SET DEFAULT",
-  no_action: "NO ACTION",
 };
 
 function normalizeReferentialAction(action: string): string {
-  const sql = REFERENTIAL_ACTION_MAP[action.toLowerCase()];
+  const sql = REFERENTIAL_ACTION_MAP[action];
   // Rails reaches action_sql (schema_creation.rb:175) even on SQLite's
   // table-rebuild path, so an unsupported :on_delete/:on_update raises
   // ArgumentError rather than emitting invalid SQL (foreign_key_test.rb:302).
   if (sql === undefined) {
     throw new ArgumentError(
-      `'${action}' is not supported for on_update or on_delete. ` +
-        `Supported values are: cascade, nullify, restrict, no_action, set_default`,
+      `'${action}' is not supported for :on_update or :on_delete.\n` +
+        `Supported values are: :nullify, :cascade, :restrict\n`,
     );
   }
   return sql;


### PR DESCRIPTION
Converges `SchemaCreation#actionSql` with Rails' `action_sql`
(`schema_creation.rb:175-186`).

- **Referential action set**: Rails supports exactly `:nullify`, `:cascade`,
  `:restrict`. `no_action` and `set_default` were trails inventions with no
  Rails counterpart and no callers — dropped from `ReferentialAction`,
  `actionSql`, and SQLite's `REFERENTIAL_ACTION_MAP`.
- **Message text**: the `ArgumentError` now reproduces Rails' heredoc verbatim,
  symbol styling and trailing newline included.
- SQLite's map also case-folded the incoming action (`action.toLowerCase()`);
  Rails matches symbols exactly, so that leniency is gone too.

`foreign-key.test.ts`'s `on update and on delete raises with invalid values`
still passes (SQLite locally; PG/MySQL in CI).

Closes-story: action-sql-referential-action-set-and-message-parity
