### PR TITLE
fix(activerecord): route check-constraint construction through its ported privates

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -241,6 +241,50 @@ describe("TableDefinition#new_foreign_key_definition", () => {
   });
 });
 
+describe("TableDefinition#new_check_constraint_definition", () => {
+  it("defaults the name to chk_rails_<hex> (bare-adapter fallback)", () => {
+    const chk = new TableDefinition("products").newCheckConstraintDefinition("price > 0");
+    expect(chk.name).toMatch(/^chk_rails_[0-9a-f]{10}$/);
+    expect(chk.validate).toBe(true);
+  });
+
+  it("routes the options hash through the adapter's checkConstraintOptions", () => {
+    const calls: unknown[][] = [];
+    const adapter = {
+      checkConstraintOptions(
+        tableName: string,
+        expression: string,
+        options: Record<string, unknown>,
+      ) {
+        calls.push([tableName, expression, options]);
+        return { ...options, name: `chk_${tableName}` };
+      },
+    } as any;
+    const td = new TableDefinition("products", { adapter });
+    const chk = td.newCheckConstraintDefinition("price > 0", { validate: false });
+    // The carried expression and options must reach the adapter, not be
+    // recomputed locally — that bypass is what let the name derivation drift.
+    expect(calls).toEqual([["products", "price > 0", { validate: false }]]);
+    expect(chk.name).toBe("chk_products");
+    expect(chk.validate).toBe(false);
+  });
+
+  it("check_constraint routes through new_check_constraint_definition", () => {
+    const adapter = {
+      checkConstraintOptions(
+        tableName: string,
+        _expression: string,
+        options: Record<string, unknown>,
+      ) {
+        return { ...options, name: `chk_${tableName}` };
+      },
+    } as any;
+    const td = new TableDefinition("products", { adapter });
+    td.checkConstraint("price > 0");
+    expect(td.checkConstraints.map((c) => c.name)).toEqual(["chk_products"]);
+  });
+});
+
 describe("ReferenceDefinition helpers", () => {
   it("addTo adds id column by default", () => {
     const ref = new ReferenceDefinition("user", { index: false });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -262,8 +262,6 @@ describe("TableDefinition#new_check_constraint_definition", () => {
     } as any;
     const td = new TableDefinition("products", { adapter });
     const chk = td.newCheckConstraintDefinition("price > 0", { validate: false });
-    // The carried expression and options must reach the adapter, not be
-    // recomputed locally — that bypass is what let the name derivation drift.
     expect(calls).toEqual([["products", "price > 0", { validate: false }]]);
     expect(chk.name).toBe("chk_products");
     expect(chk.validate).toBe(false);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -97,11 +97,8 @@ export interface CheckConstraintOptionsAdapter {
 }
 
 /**
- * Mirrors Rails' check_constraint_name default: sha256 of
- * `<table>_<expression>_chk`, first 10 hex, prefixed `chk_rails_`. The schema
- * dumper's chkIgnorePattern (`^chk_rails_[0-9a-f]{10}$`) omits names matching
- * this default, matching Rails. Used only as the fallback for a bare quoter
- * that carries no `checkConstraintOptions`.
+ * Mirrors Rails' check_constraint_name default. Used only as the fallback for a
+ * bare quoter that carries no `checkConstraintOptions`.
  *
  * @internal
  */
@@ -845,8 +842,16 @@ export class AlterTable {
     this.foreignKeyDrops.push(name);
   }
 
-  addCheckConstraint(constraint: CheckConstraintDefinition): void {
-    this.checkConstraintAdds.push(constraint);
+  addCheckConstraint(
+    expression: string,
+    options: { name?: string; validate?: boolean } = {},
+  ): void {
+    if (!this._td) {
+      throw new Error(
+        "AlterTable#addCheckConstraint requires a backing TableDefinition (construct via createAlterTable)",
+      );
+    }
+    this.checkConstraintAdds.push(this._td.newCheckConstraintDefinition(expression, options));
   }
 
   dropCheckConstraint(name: string): void {
@@ -1201,9 +1206,6 @@ export class TableDefinition {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): CheckConstraintDefinition {
-    // Mirrors Rails: `options = @conn.check_constraint_options(name, expression,
-    // options)` — the adapter owns the `chk_rails_<sha>` derivation, so an
-    // adapter that overrides it is honoured here instead of being bypassed.
     const conn = this._adapter as Partial<CheckConstraintOptionsAdapter>;
     const resolved = (conn.checkConstraintOptions?.(this.tableName, expression, options) ??
       options) as { name?: string; validate?: boolean };

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -83,6 +83,35 @@ export interface ForeignKeyOptionsAdapter {
 }
 
 /**
+ * The `@conn` surface `new_check_constraint_definition` reaches for.
+ *
+ * @internal
+ */
+export interface CheckConstraintOptionsAdapter {
+  /** @internal */
+  checkConstraintOptions(
+    tableName: string,
+    expression: string,
+    options: Record<string, unknown>,
+  ): Record<string, unknown>;
+}
+
+/**
+ * Mirrors Rails' check_constraint_name default: sha256 of
+ * `<table>_<expression>_chk`, first 10 hex, prefixed `chk_rails_`. The schema
+ * dumper's chkIgnorePattern (`^chk_rails_[0-9a-f]{10}$`) omits names matching
+ * this default, matching Rails. Used only as the fallback for a bare quoter
+ * that carries no `checkConstraintOptions`.
+ *
+ * @internal
+ */
+function defaultCheckConstraintName(tableName: string, expression: string): string {
+  const identifier = `${tableName}_${expression}_chk`;
+  const hex = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
+  return `chk_rails_${hex}`;
+}
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters::ColumnDefinition
  */
 export class ColumnDefinition {
@@ -1082,24 +1111,8 @@ export class TableDefinition {
   }
 
   checkConstraint(expression: string, options: { name?: string; validate?: boolean } = {}): this {
-    this.checkConstraints.push(
-      new CheckConstraintDefinition(
-        this.tableName,
-        expression,
-        options.name ?? this._checkConstraintName(expression),
-        options.validate ?? true,
-      ),
-    );
+    this.checkConstraints.push(this.newCheckConstraintDefinition(expression, options));
     return this;
-  }
-
-  // Mirrors Rails' check_constraint_name: sha256 of `<table>_<expression>_chk`,
-  // first 10 hex, prefixed `chk_rails_`. The schema dumper's chkIgnorePattern
-  // (`^chk_rails_[0-9a-f]{10}$`) omits names matching this default, matching Rails.
-  private _checkConstraintName(expression: string): string {
-    const identifier = `${this.tableName}_${expression}_chk`;
-    const hex = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
-    return `chk_rails_${hex}`;
   }
 
   foreignKey(toTable: string, options: Partial<AddForeignKeyOptions> = {}): this {
@@ -1188,11 +1201,17 @@ export class TableDefinition {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): CheckConstraintDefinition {
+    // Mirrors Rails: `options = @conn.check_constraint_options(name, expression,
+    // options)` — the adapter owns the `chk_rails_<sha>` derivation, so an
+    // adapter that overrides it is honoured here instead of being bypassed.
+    const conn = this._adapter as Partial<CheckConstraintOptionsAdapter>;
+    const resolved = (conn.checkConstraintOptions?.(this.tableName, expression, options) ??
+      options) as { name?: string; validate?: boolean };
     return new CheckConstraintDefinition(
       this.tableName,
       expression,
-      options.name ?? this._checkConstraintName(expression),
-      options.validate ?? true,
+      resolved.name ?? defaultCheckConstraintName(this.tableName, expression),
+      resolved.validate ?? true,
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -168,15 +168,12 @@ describe("SchemaStatements privates (PR 8)", () => {
 
   it("checkConstraintOptions", () => {
     const ss = makeStatements();
-    // Rails: `options[:name] ||= check_constraint_name(table_name, expression:, **options)`
     expect(ss.checkConstraintOptions("users", "age > 0", {})).toEqual({
       name: ss.checkConstraintName("users", { expression: "age > 0" }),
     });
-    // An explicit :name wins, and unrelated keys survive the dup.
     expect(
       ss.checkConstraintOptions("users", "age > 0", { name: "my_chk", validate: false }),
     ).toEqual({ name: "my_chk", validate: false });
-    // The caller's hash is duplicated, not mutated.
     const options = {};
     ss.checkConstraintOptions("users", "age > 0", options);
     expect(options).toEqual({});
@@ -198,7 +195,6 @@ describe("SchemaStatements privates (PR 8)", () => {
     await ss.addCheckConstraint("users", "age > 0", { ifNotExists: true });
     expect((ss as any).adapter.execute).not.toHaveBeenCalled();
 
-    // Without the flag the DDL is still emitted.
     await ss.addCheckConstraint("users", "age > 0", {});
     expect((ss as any).adapter.execute).toHaveBeenCalled();
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -166,6 +166,43 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(() => ss.checkConstraintName("users", {})).toThrow(/expression/);
   });
 
+  it("checkConstraintOptions", () => {
+    const ss = makeStatements();
+    // Rails: `options[:name] ||= check_constraint_name(table_name, expression:, **options)`
+    expect(ss.checkConstraintOptions("users", "age > 0", {})).toEqual({
+      name: ss.checkConstraintName("users", { expression: "age > 0" }),
+    });
+    // An explicit :name wins, and unrelated keys survive the dup.
+    expect(
+      ss.checkConstraintOptions("users", "age > 0", { name: "my_chk", validate: false }),
+    ).toEqual({ name: "my_chk", validate: false });
+    // The caller's hash is duplicated, not mutated.
+    const options = {};
+    ss.checkConstraintOptions("users", "age > 0", options);
+    expect(options).toEqual({});
+  });
+
+  it("addCheckConstraint routes its options through checkConstraintOptions", async () => {
+    const ss = makeStatements();
+    const spy = vi.spyOn(ss, "checkConstraintOptions");
+    await ss.addCheckConstraint("users", "age > 0", { name: "my_chk" });
+    expect(spy).toHaveBeenCalledWith("users", "age > 0", { name: "my_chk" });
+  });
+
+  it("addCheckConstraint skips the DDL when ifNotExists and the constraint exists", async () => {
+    const ss = makeStatements();
+    const name = ss.checkConstraintName("users", { expression: "age > 0" });
+    vi.spyOn(ss, "checkConstraints").mockResolvedValue([
+      { tableName: "users", expression: "age > 0", name, validate: true } as any,
+    ]);
+    await ss.addCheckConstraint("users", "age > 0", { ifNotExists: true });
+    expect((ss as any).adapter.execute).not.toHaveBeenCalled();
+
+    // Without the flag the DDL is still emitted.
+    await ss.addCheckConstraint("users", "age > 0", {});
+    expect((ss as any).adapter.execute).toHaveBeenCalled();
+  });
+
   // PR 8b helpers
   it("validateIndexLengthBang throws when name too long", () => {
     const ss = makeStatements();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -897,8 +897,6 @@ export class SchemaStatements {
   async addCheckConstraint(
     tableName: string,
     expression: string,
-    // Rails forwards unrecognized options (`**options`) rather than rejecting
-    // them; only :name / :validate are consumed here.
     options: {
       name?: string;
       validate?: boolean;
@@ -913,25 +911,21 @@ export class SchemaStatements {
     ) {
       return adapter.addCheckConstraint(tableName, expression, options);
     }
-    // Mirrors Rails add_check_constraint: route the options hash through
-    // check_constraint_options (which derives :name) and let :if_not_exists
-    // short-circuit against the live constraint before emitting any DDL.
+    if (
+      typeof adapter.supportsCheckConstraints === "function" &&
+      !adapter.supportsCheckConstraints()
+    )
+      return;
+
     const resolved = this.checkConstraintOptions(tableName, expression, options) as {
       name?: string;
       validate?: boolean;
-      ifNotExists?: boolean;
     };
-    if (
-      options.ifNotExists &&
-      (await this.isCheckConstraintExists(tableName, { name: resolved.name! }))
-    ) {
-      return;
-    }
-    const validate = resolved.validate !== false;
-    const chkDef = new CheckConstraintDefinition(tableName, expression, resolved.name!, validate);
-    await this.adapter.execute(
-      `ALTER TABLE ${this._qi(tableName)} ADD ${await this.schemaCreation.accept(chkDef)}`,
-    );
+    if (options.ifNotExists && (await this.isCheckConstraintExists(tableName, resolved))) return;
+
+    const at = this.createAlterTable(tableName);
+    at.addCheckConstraint(expression, resolved);
+    await this.adapter.execute(await this.schemaCreation.accept(at));
   }
 
   async removeCheckConstraint(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -913,9 +913,22 @@ export class SchemaStatements {
     ) {
       return adapter.addCheckConstraint(tableName, expression, options);
     }
-    const name = this.checkConstraintName(tableName, { name: options.name, expression });
-    const validate = options.validate !== false;
-    const chkDef = new CheckConstraintDefinition(tableName, expression, name, validate);
+    // Mirrors Rails add_check_constraint: route the options hash through
+    // check_constraint_options (which derives :name) and let :if_not_exists
+    // short-circuit against the live constraint before emitting any DDL.
+    const resolved = this.checkConstraintOptions(tableName, expression, options) as {
+      name?: string;
+      validate?: boolean;
+      ifNotExists?: boolean;
+    };
+    if (
+      options.ifNotExists &&
+      (await this.isCheckConstraintExists(tableName, { name: resolved.name! }))
+    ) {
+      return;
+    }
+    const validate = resolved.validate !== false;
+    const chkDef = new CheckConstraintDefinition(tableName, expression, resolved.name!, validate);
     await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} ADD ${await this.schemaCreation.accept(chkDef)}`,
     );
@@ -1765,11 +1778,16 @@ export class SchemaStatements {
   }
 
   checkConstraintOptions(
-    _tableName: string,
-    _expression: string,
+    tableName: string,
+    expression: string,
     options: Record<string, unknown> = {},
   ): Record<string, unknown> {
-    return { ...options };
+    const dup = { ...options };
+    dup.name ??= this.checkConstraintName(tableName, { ...dup, expression } as {
+      name?: string;
+      expression?: string;
+    });
+    return dup;
   }
 
   async isCheckConstraintExists(

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -51,13 +51,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add_check_constraint",
-    "call": "new_check_constraint_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "add_to",
     "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -86,13 +86,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "check_constraint",
-    "call": "new_check_constraint_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "column_names",
     "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -152,13 +145,6 @@
     "rubyName": "integer_like_primary_key?",
     "call": "include?",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `!options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`. The presence check is preserved under the nil↔null mapping: an explicit `default: null` is !== undefined, so it disables the rewrite exactly as Rails' key?-present nil does; the only unmatched shape is an explicit `default: undefined`, which has no Ruby analogue and conventionally means absent in JS."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "new_check_constraint_definition",
-    "call": "check_constraint_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_check_constraint",
-    "call": "create_alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_foreign_key",
     "call": "slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -3,20 +3,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_check_constraint",
-    "call": "check_constraint_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_check_constraint",
-    "call": "check_constraint_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_check_constraint",
     "call": "create_alter_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Sweeps `packages/activerecord/` for ported Rails privates that no internal
caller routes through — the pattern PR #5025 swept out of `packages/arel/`.
An unrouted private's *parameters* are never exercised, so they silently rot.

## Inventory

Method: cross `scripts/api-compare/call-mismatches-wide-exclude/activerecord/`
(its `<method> -> <private>` entries are exactly the "declared but not routed"
edges) against `scripts/api-compare/output/ts-api.json` (every ported TS method
plus its call-set), keep only privates that carry parameters and appear in
nobody's call-set, then confirm with a real grep for call sites.

**95 candidates, 77 with no non-declaration call site at all.** The full table
is recorded on the follow-up story
`activerecord-unrouted-privates-remaining-inventory` (RFC 0072), along with the
entries already confirmed non-actionable so the next sweep doesn't re-derive
them — notably `migration/join-table.ts#joinTableName` (a *documented*
deliberate deviation, guarded by `adapter-graph-import-tdz.test.ts`) and
`postgresql/quoting.ts#checkIntInRange` (an alias, so actually routed).

## What this PR fixes

The check-constraint cluster. Rails' chain is:

```ruby
def add_check_constraint(table_name, expression, if_not_exists: false, **options)
  return unless supports_check_constraints?
  options = check_constraint_options(table_name, expression, options)
  return if if_not_exists && check_constraint_exists?(table_name, **options)
  at = create_alter_table(table_name)
  at.add_check_constraint(expression, options)
  execute schema_creation.accept(at)
end

def check_constraint_options(table_name, expression, options)
  options = options.dup
  options[:name] ||= check_constraint_name(table_name, expression: expression, **options)
  options
end

# AlterTable
def add_check_constraint(expression, options)
  @check_constraint_adds << @td.new_check_constraint_definition(expression, options)
end

# TableDefinition
def new_check_constraint_definition(expression, options)
  options = @conn.check_constraint_options(name, expression, options)
  CheckConstraintDefinition.new(name, expression, options)
end
```

Every link in it was broken:

- **`SchemaStatements#checkConstraintOptions` was a hollow `{...options}`.** It
  dropped its own Rails body (`options[:name] ||= check_constraint_name(...)`),
  so the method existed but did nothing.
- **`SchemaStatements#addCheckConstraint` never routed through it**, accepted
  `ifNotExists` while silently ignoring it (no `check_constraint_exists?`
  short-circuit, so the DDL was re-issued and raised on an existing
  constraint), skipped the `supports_check_constraints?` guard, and hand-rolled
  the `ALTER TABLE ... ADD` string instead of going through `create_alter_table`.
- **`AlterTable#addCheckConstraint` took a pre-built `CheckConstraintDefinition`**
  rather than `(expression, options)` — a signature divergence that also made
  it the only `add_*` on `AlterTable` not routed through its backing
  `TableDefinition`, unlike `addForeignKey` right above it.
- **`TableDefinition#newCheckConstraintDefinition` never routed through the
  adapter's `checkConstraintOptions`**, reimplementing the `chk_rails_<sha>`
  derivation in a private `_checkConstraintName` duplicate — so an adapter
  override was bypassed. The duplicate is deleted; the bare-quoter path keeps a
  module-level fallback.
- **`TableDefinition#checkConstraint` bypassed `newCheckConstraintDefinition`**
  entirely, constructing the definition inline.

## Tests

Five new tests, each asserting the carried expression/options actually **reach
the built definition** — not merely that the right class comes back. That weak
assertion is exactly what let the arel cases sit undetected. All five verified
to FAIL on the pre-fix tree (src reverted to `origin/main`, tests kept) and
pass with the fix.

## Gate deltas (vs `origin/main`)

| gate | main | this PR |
| --- | --- | --- |
| api:compare data layer | 7718/7813 | 7718/7813 |
| api:compare overall | 11725/17544 | 11725/17544 |
| wide matched pairs | 6117 | **6118** |
| wide call mismatches | 2476 | **2472** |
| test:compare | 14620/21663 | 14620/21663 |

Rebased onto `8526456f9`; both sides re-measured with a matching `pnpm build`.

Six wide-baseline entries converged; the baseline only shrinks.
`api:calls`, `api:calls:wide`, `api:arity`, `api:pins`, `api:extra` all OK.

Closes-story: activerecord-unrouted-privates-drop-carried-arguments

