### PR TITLE
fix(api-compare): key the TS extraction cache on the lockfile

### DIFF
--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -30,6 +30,7 @@ import {
   hashReadSet,
   readSetMatches,
   resolutionShapeKey,
+  dependencyKey,
   hashParts,
   type ReadSet,
 } from "./shared-cache.js";
@@ -196,6 +197,12 @@ export async function main() {
   // Read-sets record what WAS resolvable; this covers what BECOMES resolvable
   // (an unbuilt dependency gaining a `dist`) — see resolutionShapeKey.
   const shapeKey = await resolutionShapeKey(path.join(ROOT_DIR, "packages"));
+  // Most of what the compiler reads is third-party, and neither the read-set
+  // nor the shape key can see `node_modules`. The lockfile stands in for all of
+  // it: coarse (any bump invalidates every package) but ~2 ms per run against
+  // ~23 ms for keeping the ~200 third-party paths per package in the read-set,
+  // and third-party declarations only move on an install anyway.
+  const depKey = await dependencyKey(ROOT_DIR);
 
   // Pass 1: serve every cache hit and record the metadata needed to extract the
   // misses below. `ownRel` is the package's own fingerprint inputs (already
@@ -221,7 +228,11 @@ export async function main() {
     // Anchor relative paths at the package root so tsconfig.json
     // doesn't show up as `../tsconfig.json` (which it would if we
     // anchored at the src dir).
-    const fingerprint = hashParts([packageFingerprint(fingerprintInputs, pkgRoot), shapeKey]);
+    const fingerprint = hashParts([
+      packageFingerprint(fingerprintInputs, pkgRoot),
+      shapeKey,
+      depKey,
+    ]);
     const ownRel = new Set(
       fingerprintInputs.map((file) => path.relative(ROOT_DIR, file).replace(/\\/g, "/")),
     );
@@ -252,7 +263,7 @@ export async function main() {
     let sharedKey: string | null = null;
     if (sharedDir) {
       const ownContent = await contentFingerprint(fingerprintInputs, pkgRoot);
-      const contentKey = `${SCHEMA_VERSION}-${hashParts([ownContent, shapeKey])}`;
+      const contentKey = `${SCHEMA_VERSION}-${hashParts([ownContent, shapeKey, depKey])}`;
       const body = await readShared(sharedDir, `ts-${pkg}`, contentKey);
       if (body) {
         try {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -197,11 +197,10 @@ export async function main() {
   // Read-sets record what WAS resolvable; this covers what BECOMES resolvable
   // (an unbuilt dependency gaining a `dist`) — see resolutionShapeKey.
   const shapeKey = await resolutionShapeKey(path.join(ROOT_DIR, "packages"));
-  // Most of what the compiler reads is third-party, and neither the read-set
-  // nor the shape key can see `node_modules`. The lockfile stands in for all of
-  // it: coarse (any bump invalidates every package) but ~2 ms per run against
-  // ~23 ms for keeping the ~200 third-party paths per package in the read-set,
-  // and third-party declarations only move on an install anyway.
+  // Neither of those can see `node_modules`, which is most of what the compiler
+  // reads; the lockfile stands in for all of it — coarse (any bump invalidates
+  // every package) but ~2 ms a run against ~23 ms for the precise alternative,
+  // and third-party declarations only move on an install. See dependencyKey.
   const depKey = await dependencyKey(ROOT_DIR);
 
   // Pass 1: serve every cache hit and record the metadata needed to extract the

--- a/scripts/api-compare/shared-cache.test.ts
+++ b/scripts/api-compare/shared-cache.test.ts
@@ -21,6 +21,7 @@ import {
   hashReadSet,
   readSetMatches,
   resolutionShapeKey,
+  dependencyKey,
   CACHE_VERSION,
 } from "./shared-cache.js";
 
@@ -314,5 +315,33 @@ describe("resolutionShapeKey", () => {
     writeDist(packagesDir, "arel", { "index.js": "", "nested/index.js.map": "" });
     expect(await resolutionShapeKey(packagesDir)).toBe(before);
     expect(await resolutionShapeKey(path.join(packagesDir, "nope"))).toMatch(/^[0-9a-f]{40}$/);
+  });
+});
+
+describe("dependencyKey", () => {
+  it("changes when a dependency bump rewrites the lockfile", async () => {
+    const root = mkTmp();
+    const lock = path.join(root, "pnpm-lock.yaml");
+    fs.writeFileSync(lock, "'@types/node': 22.0.0\n");
+    const before = await dependencyKey(root);
+    expect(before).toMatch(/^[0-9a-f]{40}$/);
+
+    // Third-party declarations live under node_modules, which the read-set
+    // drops and the shape key never walks — without this key an install that
+    // changes what `@types/node` declares would serve every stale entry.
+    fs.writeFileSync(lock, "'@types/node': 24.0.0\n");
+    expect(await dependencyKey(root)).not.toBe(before);
+
+    fs.writeFileSync(lock, "'@types/node': 22.0.0\n");
+    expect(await dependencyKey(root)).toBe(before);
+  });
+
+  it("keys a lockfile-less tree stably and distinctly", async () => {
+    const root = mkTmp();
+    const missing = await dependencyKey(root);
+    expect(missing).toBe(await dependencyKey(mkTmp()));
+
+    fs.writeFileSync(path.join(root, "pnpm-lock.yaml"), "");
+    expect(await dependencyKey(root)).not.toBe(missing);
   });
 });

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -146,6 +146,30 @@ export async function resolutionShapeKey(packagesDir: string): Promise<string> {
   return hashParts(perPackage.flat().sort());
 }
 
+/**
+ * Hash of the workspace's THIRD-PARTY declaration state: the content of
+ * `pnpm-lock.yaml`.
+ *
+ * Neither of the other two keys can see `node_modules`: `normalizeReadSet`
+ * drops every path under it and `resolutionShapeKey` only walks
+ * `packages/*\/dist`. Yet most of what the compiler reads is third-party — on
+ * actionview, 197 of 241 resolved files (`@types/node`, `typescript`'s
+ * `lib.*.d.ts`, `undici-types`, `@types/pg`) — so a dependency bump changes the
+ * extracted surface with every cache entry still valid.
+ *
+ * Keeping those paths in the read-set would be precise but costs ~23 ms per
+ * warm run (228 unique third-party files hashed, memoised across the 13
+ * packages) plus a `realpath` and a cache-entry line for each of ~200 paths per
+ * package; the lockfile is one 400 KB read, ~2 ms per run, once. Third-party
+ * declarations only move on an install, and an install rewrites the lockfile,
+ * so the coarse key catches every real case at a tenth of the cost. Returns a
+ * sentinel when there is no lockfile so a lockfile-less tree still keys stably.
+ */
+export async function dependencyKey(rootDir: string): Promise<string> {
+  const hash = await fileHash(path.join(rootDir, "pnpm-lock.yaml"));
+  return hashParts([hash ?? "no-lockfile"]);
+}
+
 async function declarationsUnder(dir: string): Promise<string[]> {
   let entries;
   try {
@@ -168,8 +192,7 @@ async function declarationsUnder(dir: string): Promise<string[]> {
  * worth validating: real paths (pnpm resolves `@blazetrails/<dep>` through a
  * `node_modules` symlink into `packages/<dep>/dist`, and the symlinked spelling
  * would be an unstable key), inside `rootDir`, and outside `node_modules` —
- * third-party declarations only move on an install, which rewrites the lockfile
- * and the packages themselves. `exclude` drops paths already covered by the
+ * third-party declarations are covered instead by `dependencyKey`. `exclude` drops paths already covered by the
  * caller's own fingerprint, so the recorded set is the CROSS-package remainder.
  */
 export async function normalizeReadSet(

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -192,8 +192,9 @@ async function declarationsUnder(dir: string): Promise<string[]> {
  * worth validating: real paths (pnpm resolves `@blazetrails/<dep>` through a
  * `node_modules` symlink into `packages/<dep>/dist`, and the symlinked spelling
  * would be an unstable key), inside `rootDir`, and outside `node_modules` —
- * third-party declarations are covered instead by `dependencyKey`. `exclude` drops paths already covered by the
- * caller's own fingerprint, so the recorded set is the CROSS-package remainder.
+ * third-party declarations are covered instead by `dependencyKey`. `exclude`
+ * drops paths already covered by the caller's own fingerprint, so the recorded
+ * set is the CROSS-package remainder.
  */
 export async function normalizeReadSet(
   fileNames: string[],


### PR DESCRIPTION
## Problem

`api:compare`'s TS extraction cache is keyed on each package's own fingerprint,
the resolved read-set, and `resolutionShapeKey`. None of them can see
THIRD-PARTY declarations: `normalizeReadSet` drops every `node_modules` path
and `resolutionShapeKey` only walks `packages/*/dist`. On actionview, 197 of
241 resolved source files are third-party (`@types/node`, `typescript`'s
`lib.*.d.ts`, `undici-types`, `@types/pg`), so a dependency bump changes the
extracted surface while every cache entry stays valid.

## Change

`dependencyKey(rootDir)` hashes `pnpm-lock.yaml` (sentinel when absent) and is
folded into both cache keys in `extract-ts-api.ts` — the local fingerprint and
the shared content key — so a bump invalidates everything and a cached run and
an `API_COMPARE_FORCE=1` run agree again.

## Measurement (lockfile vs. precise read-set)

Measured on this checkout before choosing:

- Lockfile hash: **~2 ms per run**, once (one 400 KB read).
- Keeping the `node_modules` portion of the read-set: **~23 ms per warm run**
  for 228 unique third-party files hashed with the existing memo across the 13
  packages (~300 ms unmemoised), plus a `realpath` and a cache-entry line for
  each of ~200 paths per package, i.e. much larger entries.

Neither exceeds the extraction it saves, but the coarse key catches every real
case — third-party declarations only move on an install, which rewrites the
lockfile — at a tenth of the cost and none of the entry bloat. Taken, and
justified at the call site.

Fully-warm `pnpm api:compare` after the change: 6.7 s, all 13 packages cached.

## Verification

- Simulated a bump (one line appended to `pnpm-lock.yaml`): 0 of 13 packages
  served from cache, i.e. every entry invalidated. Restoring the lockfile
  returns to 13 of 13 cached.
- The cached manifest and an `API_COMPARE_FORCE=1` manifest are byte-identical
  modulo `generatedAt`.

## Coverage

Two regression tests in `scripts/api-compare/shared-cache.test.ts`: the key
moves when a bump rewrites the lockfile (and returns on revert), and a
lockfile-less tree keys stably but distinctly from an empty lockfile.

Closes-story: api-compare-cache-blind-to-third-party-declarations
