### PR TITLE
fix(api-compare): fail loudly when a checkout-based baseline would use a stale build

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ doesn't forward `--package` to `compare.ts`). Test numbers come from
 
 ## Verification harnesses
 
-| Doc                                                             | Priority | Work | Notes                                                                                                                                     |
-| --------------------------------------------------------------- | -------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| [`parity-verification.md`](activerecord/parity-verification.md) | P1       | —    | Schema + query parity pipelines (`pnpm parity:schema` / `pnpm parity:query`). Both shipped; reference for adding fixtures + format bumps. |
+| Doc                                                                     | Priority | Work | Notes                                                                                                                                     |
+| ----------------------------------------------------------------------- | -------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`parity-verification.md`](activerecord/parity-verification.md)         | P1       | —    | Schema + query parity pipelines (`pnpm parity:schema` / `pnpm parity:query`). Both shipped; reference for adding fixtures + format bumps. |
+| [`api-compare-baselining.md`](infrastructure/api-compare-baselining.md) | P1       | —    | How to take a trustworthy `api:compare` / `api:extra` baseline, and why every checkout needs a rebuild.                                   |

--- a/docs/infrastructure/api-compare-baselining.md
+++ b/docs/infrastructure/api-compare-baselining.md
@@ -63,16 +63,22 @@ package has a `dist` whose newest `.d.ts` is older than the newest file in its
 `src`, `pnpm api:compare` fails with the list of stale packages instead of
 emitting numbers that cannot be compared to anything.
 
-Detection is mtime-based on purpose: `git checkout` rewrites the mtime of every
-file whose contents it changes and leaves the rest alone, so "some source is
-newer than the newest declaration in `dist`" is precisely "this package's build
-predates the checked-out sources".
+The guard does not compare timestamps. It asks `tsc` itself, via
+`ts.createSolutionBuilder(...).getUpToDateStatusOfProject()` — the same
+up-to-date computation `tsc --build` uses to decide what to emit. By
+construction the guard can never contradict a `pnpm build` that just succeeded,
+and it reports `OutOfDateWithSelf` as soon as a checkout rewrites a source and
+`OutOfDateRoots` when one only deletes a file.
 
-Directory mtimes count as sources too. A checkout that only _deletes_ a file
-leaves every surviving file's mtime untouched but bumps the parent directory, so
-without this the deletion would slip past. The side effect is that a checkout
-touching any non-`.ts` file under `src` also flags the package — conservative in
-the fail-loud direction, and a `pnpm build` clears it either way.
+An mtime comparison ("is some source newer than the newest `.d.ts`?") looks
+equivalent and is not. `.github/actions/cache-build` restores `dist` plus
+`tsconfig.tsbuildinfo` from a tarball keyed on a content hash of every package
+`src/`, so the restored outputs carry their **archive** mtimes while
+`actions/checkout` has just written every source at "now". `pnpm build`
+correctly no-ops, leaving a tree that is perfectly current but looks, by mtime,
+like every package is stale. The first version of this guard did compare mtimes
+and failed all 13 packages on every CI run while contradicting the build that
+had just succeeded.
 
 Both guards are scoped to the packages `api:compare` actually extracts
 (`apiComparePackageRoots()` in `scripts/api-compare/config.ts`, derived from

--- a/docs/infrastructure/api-compare-baselining.md
+++ b/docs/infrastructure/api-compare-baselining.md
@@ -1,0 +1,72 @@
+# Taking a trustworthy `api:compare` / `api:extra` baseline
+
+Every PR is gated on "the `api:compare` / `test:compare` delta is non-negative",
+which means someone has to measure the same numbers twice: once on the branch
+and once on the branch's base. This documents the supported way to do that and
+the one trap that made the numbers lie.
+
+## The supported procedure
+
+```bash
+# 1. branch measurement
+pnpm build
+pnpm api:compare
+pnpm api:extra
+
+# 2. baseline measurement
+git checkout --detach origin/main
+pnpm build
+pnpm api:compare
+pnpm api:extra
+
+# 3. back to the branch
+git checkout -
+pnpm build
+```
+
+The `pnpm build` after **every** checkout is the part that is easy to skip and
+must not be. It is cheap in the common case (`tsc --build` is incremental) and
+it is what makes the two measurements comparable.
+
+## Why the rebuild is mandatory
+
+The TS extractor compiles each package with the real module resolver. An
+`import { … } from "@blazetrails/activesupport"` in `packages/trailties`
+resolves through pnpm's `node_modules` symlink into
+`packages/activesupport/dist/*.d.ts` — so the extracted surface of `trailties`
+depends on the **build output** of `activesupport`, not on its sources.
+
+`dist/` is untracked build output. `git checkout` does not update it. So a
+baseline taken by checking out `origin/main` without rebuilding measures
+`origin/main`'s sources against the **branch's** `dist`, and packages the diff
+never touched can move. That is a phantom delta, and it cuts both ways: it can
+force an agent to argue that a delta it just measured is not real, or it can
+mask a real regression.
+
+None of this is a cache bug. The shared cache is content-keyed and each entry
+records the resolved read-set of the extraction that produced it, so the caches
+correctly serve exactly what a fresh extraction would produce — a fresh
+extraction of a mismatched tree. `API_COMPARE_FORCE=1` does not help either;
+verified back-to-back, a forced run and a cached run at the same commit are
+byte-identical.
+
+## The guard
+
+`scripts/api-compare/build-freshness.ts` runs before any extraction. If a
+package has a `dist` whose newest `.d.ts` is older than the newest file in its
+`src`, `pnpm api:compare` fails with the list of stale packages instead of
+emitting numbers that cannot be compared to anything.
+
+Detection is mtime-based on purpose: `git checkout` rewrites the mtime of every
+file whose contents it changes and leaves the rest alone, so "some source is
+newer than the newest declaration in `dist`" is precisely "this package's build
+predates the checked-out sources".
+
+A package with **no** `dist` is not stale — nothing was built, so nothing can be
+out of date, and cross-package imports fail to resolve uniformly at every
+commit. A worktree that has never run `pnpm build` therefore measures
+consistently, which is why the guard is silent in a fresh
+`scripts/start-worktree.sh` checkout.
+
+`API_COMPARE_ALLOW_STALE_BUILD=1` skips the guard. Use it only when you are not
+producing a baseline.

--- a/docs/infrastructure/api-compare-baselining.md
+++ b/docs/infrastructure/api-compare-baselining.md
@@ -43,6 +43,12 @@ never touched can move. That is a phantom delta, and it cuts both ways: it can
 force an agent to argue that a delta it just measured is not real, or it can
 mask a real regression.
 
+This is measurable at a single commit. With no package built, `api:extra`
+reports `trailties 147` and `actionview 90`; after `pnpm build`, the same commit
+reports `trailties 149` and `actionview 92` — the extra two in each are the
+surface that only resolves once the sibling's declarations exist. Those are the
+exact totals that were originally mistaken for a `origin/main`-vs-branch delta.
+
 None of this is a cache bug. The shared cache is content-keyed and each entry
 records the resolved read-set of the extraction that produced it, so the caches
 correctly serve exactly what a fresh extraction would produce — a fresh
@@ -74,5 +80,10 @@ commit. A worktree that has never run `pnpm build` therefore measures
 consistently, which is why the guard is silent in a fresh
 `scripts/start-worktree.sh` checkout.
 
-`API_COMPARE_ALLOW_STALE_BUILD=1` skips the guard. Use it only when you are not
-producing a baseline.
+A second guard covers the downstream half: `pnpm api:extra` reads the manifests
+`pnpm api:compare` left behind rather than re-extracting, so running it alone
+after a checkout would report the previous commit's totals. It now fails if
+`output/ts-api.json` predates `packages/*/src`.
+
+`API_COMPARE_ALLOW_STALE_BUILD=1` skips both guards. Use it only when you are
+not producing a baseline.

--- a/docs/infrastructure/api-compare-baselining.md
+++ b/docs/infrastructure/api-compare-baselining.md
@@ -80,6 +80,14 @@ like every package is stale. The first version of this guard did compare mtimes
 and failed all 13 packages on every CI run while contradicting the build that
 had just succeeded.
 
+The build guard follows each package's transitive `references`, so a workspace
+that is NOT api-compared but whose declarations an api-compared package imports
+— `actionview` references `@blazetrails/tse-compiler` — is checked too. tsc
+reports the IMPORTER as `UpToDateWithUpstreamTypes` when such a reference goes
+stale, which is not an out-of-date status, so the referenced project has to be
+asked about directly. This is reachability, not "every workspace": something
+nothing references is still never consulted.
+
 Both guards are scoped to the packages `api:compare` actually extracts
 (`apiComparePackageRoots()` in `scripts/api-compare/config.ts`, derived from
 `vendor/sources.ts`) — down to the `src` subdir for the four packages that share

--- a/docs/infrastructure/api-compare-baselining.md
+++ b/docs/infrastructure/api-compare-baselining.md
@@ -74,6 +74,13 @@ without this the deletion would slip past. The side effect is that a checkout
 touching any non-`.ts` file under `src` also flags the package — conservative in
 the fail-loud direction, and a `pnpm build` clears it either way.
 
+Both guards are scoped to the packages `api:compare` actually extracts
+(`apiComparePackageRoots()` in `scripts/api-compare/config.ts`, derived from
+`vendor/sources.ts`) — down to the `src` subdir for the four packages that share
+`packages/actionpack`. A workspace that is not api-compared (`activerecord-cli`,
+`trails-tsc`, `tse-compiler`, `website`, …) cannot affect the TS manifest, so a
+stale build there never blocks a run.
+
 A package with **no** `dist` is not stale — nothing was built, so nothing can be
 out of date, and cross-package imports fail to resolve uniformly at every
 commit. A worktree that has never run `pnpm build` therefore measures

--- a/docs/infrastructure/api-compare-baselining.md
+++ b/docs/infrastructure/api-compare-baselining.md
@@ -62,6 +62,12 @@ file whose contents it changes and leaves the rest alone, so "some source is
 newer than the newest declaration in `dist`" is precisely "this package's build
 predates the checked-out sources".
 
+Directory mtimes count as sources too. A checkout that only _deletes_ a file
+leaves every surviving file's mtime untouched but bumps the parent directory, so
+without this the deletion would slip past. The side effect is that a checkout
+touching any non-`.ts` file under `src` also flags the package — conservative in
+the fail-loud direction, and a `pnpm build` clears it either way.
+
 A package with **no** `dist` is not stale — nothing was built, so nothing can be
 out of date, and cross-package imports fail to resolve uniformly at every
 commit. A worktree that has never run `pnpm build` therefore measures

--- a/docs/infrastructure/api-compare-baselining.md
+++ b/docs/infrastructure/api-compare-baselining.md
@@ -56,55 +56,78 @@ extraction of a mismatched tree. `API_COMPARE_FORCE=1` does not help either;
 verified back-to-back, a forced run and a cached run at the same commit are
 byte-identical.
 
-## The guard
+## The guards
 
-`scripts/api-compare/build-freshness.ts` runs before any extraction. If a
-package has a `dist` whose newest `.d.ts` is older than the newest file in its
-`src`, `pnpm api:compare` fails with the list of stale packages instead of
-emitting numbers that cannot be compared to anything.
+Two guards enforce this, both in `scripts/api-compare/build-freshness.ts` and
+both bypassed by `API_COMPARE_ALLOW_STALE_BUILD=1` (use it only when you are not
+producing a baseline).
 
-The guard does not compare timestamps. It asks `tsc` itself, via
+### 1. Is the build current? (`pnpm api:compare`)
+
+Before any extraction, `staleBuilds()` asks whether each package's emitted
+output corresponds to its checked-out sources. If not, `pnpm api:compare` fails
+with the list of stale packages and tsc's verdict for each, instead of emitting
+numbers that cannot be compared to anything:
+
+```text
+api:compare would measure 1 package(s) against a stale build:
+  packages/arel — OutOfDateWithSelf
+```
+
+**It does not compare timestamps.** It asks `tsc` itself, via
 `ts.createSolutionBuilder(...).getUpToDateStatusOfProject()` — the same
 up-to-date computation `tsc --build` uses to decide what to emit. By
-construction the guard can never contradict a `pnpm build` that just succeeded,
-and it reports `OutOfDateWithSelf` as soon as a checkout rewrites a source and
-`OutOfDateRoots` when one only deletes a file.
+construction the guard can never contradict a `pnpm build` that just succeeded.
+It reports `OutOfDateWithSelf` as soon as a checkout rewrites a source, and
+`OutOfDateRoots` when a checkout only _deletes_ one.
 
 An mtime comparison ("is some source newer than the newest `.d.ts`?") looks
 equivalent and is not. `.github/actions/cache-build` restores `dist` plus
 `tsconfig.tsbuildinfo` from a tarball keyed on a content hash of every package
 `src/`, so the restored outputs carry their **archive** mtimes while
 `actions/checkout` has just written every source at "now". `pnpm build`
-correctly no-ops, leaving a tree that is perfectly current but looks, by mtime,
-like every package is stale. The first version of this guard did compare mtimes
-and failed all 13 packages on every CI run while contradicting the build that
-had just succeeded.
+correctly no-ops, leaving a tree that is perfectly current but that looks, by
+mtime, entirely stale. The first version of this guard did compare mtimes and
+failed all 13 packages on every CI run while contradicting the build that had
+just succeeded.
 
-The build guard follows each package's transitive `references`, so a workspace
-that is NOT api-compared but whose declarations an api-compared package imports
-— `actionview` references `@blazetrails/tse-compiler` — is checked too. tsc
-reports the IMPORTER as `UpToDateWithUpstreamTypes` when such a reference goes
-stale, which is not an out-of-date status, so the referenced project has to be
-asked about directly. This is reachability, not "every workspace": something
-nothing references is still never consulted.
+**What it checks** is the transitive `references` closure of the packages
+`api:compare` extracts — seeded from `apiComparePackageRoots()`
+(`scripts/api-compare/config.ts`, derived from `vendor/sources.ts`) and expanded
+by following each `tsconfig.json`'s `references`.
 
-Both guards are scoped to the packages `api:compare` actually extracts
-(`apiComparePackageRoots()` in `scripts/api-compare/config.ts`, derived from
-`vendor/sources.ts`) — down to the `src` subdir for the four packages that share
-`packages/actionpack`. A workspace that is not api-compared (`activerecord-cli`,
-`trails-tsc`, `tse-compiler`, `website`, …) cannot affect the TS manifest, so a
-stale build there never blocks a run.
+The closure matters because a package can import declaration output from a
+workspace that is _not_ itself api-compared: `packages/actionview` references
+`@blazetrails/tse-compiler`, which is not in `PACKAGES`. When such a reference
+goes stale, tsc reports the importer as `UpToDateWithUpstreamTypes` — not an
+out-of-date status — so a stale `tse-compiler/dist/*.d.ts` would reach the
+extractor unnoticed unless the referenced project is asked about directly. It
+is, so `packages/tse-compiler — OutOfDateWithSelf` blocks the run.
 
-A package with **no** `dist` is not stale — nothing was built, so nothing can be
-out of date, and cross-package imports fail to resolve uniformly at every
-commit. A worktree that has never run `pnpm build` therefore measures
-consistently, which is why the guard is silent in a fresh
-`scripts/start-worktree.sh` checkout.
+This is reachability, not "every workspace". A workspace that no api-compared
+package references — `activerecord-cli`, `website` — cannot affect the TS
+manifest and is never consulted, so a stale build there never blocks a run.
 
-A second guard covers the downstream half: `pnpm api:extra` reads the manifests
-`pnpm api:compare` left behind rather than re-extracting, so running it alone
-after a checkout would report the previous commit's totals. It now fails if
-`output/ts-api.json` predates `packages/*/src`.
+A package with **no** `dist` is not stale: nothing was built, so nothing can be
+out of date, and cross-package imports fail to resolve uniformly at every commit.
+That check is ours rather than tsc's, because tsc calls a project whose `dist`
+was deleted but whose `tsconfig.tsbuildinfo` survives up to date. A worktree that
+has never run `pnpm build` therefore measures consistently, which is why the
+guard is silent in a fresh `scripts/start-worktree.sh` checkout.
 
-`API_COMPARE_ALLOW_STALE_BUILD=1` skips both guards. Use it only when you are
-not producing a baseline.
+### 2. Is the manifest current? (`pnpm api:extra`)
+
+`pnpm api:extra` reads the manifests `pnpm api:compare` left behind rather than
+re-extracting, so running it alone after a checkout would report the previous
+commit's totals. `manifestIsStale()` fails the run when `output/ts-api.json` is
+older than the sources it claims to describe.
+
+Here mtimes _are_ the right oracle, unlike for `dist`: the manifest is written by
+a local run that just read those sources and is never restored from an archive,
+so nothing can rewind its timestamp below theirs. Directory mtimes count as
+sources, so a checkout that only deletes a file — leaving every surviving file's
+mtime untouched while bumping the parent directory — is still caught.
+
+This guard is scoped to the extracted `src` trees exactly, down to the subdir for
+the four packages that share `packages/actionpack`
+(`action-dispatch`, `action-controller`, `abstract-controller`, `action-pack`).

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -8,6 +8,32 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { staleBuilds, staleBuildMessage, manifestIsStale } from "./build-freshness.js";
+import type { PackageRoots } from "./config.js";
+
+/** A whole-directory extraction root — the common case (`activerecord`, `arel`). */
+function rootFor(packagesDir: string, dir: string, subDir?: string): PackageRoots {
+  const packageDir = path.join(packagesDir, dir);
+  return {
+    dir,
+    srcDir: subDir ? path.join(packageDir, "src", subDir) : path.join(packageDir, "src"),
+    distDir: path.join(packageDir, "dist"),
+  };
+}
+
+/**
+ * Every directory under `packagesDir` as an extraction root — the shorthand for
+ * tests where every package created IS api-compared. Scoping itself is covered
+ * by the tests that pass an explicit root list.
+ */
+function allRoots(packagesDir: string): PackageRoots[] {
+  let dirs: string[];
+  try {
+    dirs = fs.readdirSync(packagesDir);
+  } catch {
+    return [];
+  }
+  return dirs.map((dir) => rootFor(packagesDir, dir));
+}
 
 const tmpDirs: string[] = [];
 function mkTmp(): string {
@@ -72,7 +98,7 @@ describe("staleBuilds", () => {
     const packagesDir = path.join(root, "packages");
     buildPackage(packagesDir, "activesupport");
     buildPackage(packagesDir, "trailties", ["index.ts", "railtie/configuration.ts"]);
-    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
   });
 
   it("reports a package whose sources were checked out after its dist was built", async () => {
@@ -82,7 +108,7 @@ describe("staleBuilds", () => {
     buildPackage(packagesDir, "trailties");
     checkoutRewrite(pkg, "index.ts", 3000);
 
-    expect(await staleBuilds(packagesDir, root)).toEqual([
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([
       { dir: "activesupport", newestSource: "packages/activesupport/src/index.ts" },
     ]);
   });
@@ -93,7 +119,7 @@ describe("staleBuilds", () => {
     const pkg = buildPackage(packagesDir, "activerecord", ["base.ts", "relation/query-methods.ts"]);
     checkoutRewrite(pkg, "relation/query-methods.ts", 3000);
 
-    expect(await staleBuilds(packagesDir, root)).toEqual([
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([
       { dir: "activerecord", newestSource: "packages/activerecord/src/relation/query-methods.ts" },
     ]);
   });
@@ -105,7 +131,7 @@ describe("staleBuilds", () => {
     // Every surviving file keeps its old mtime; only the parent dir moves.
     checkoutDelete(pkg, "nodes/casted.ts", 3000);
 
-    expect(await staleBuilds(packagesDir, root)).toEqual([
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([
       { dir: "arel", newestSource: "packages/arel/src/nodes" },
     ]);
   });
@@ -117,7 +143,7 @@ describe("staleBuilds", () => {
     fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
     fs.writeFileSync(path.join(pkg, "src", "index.ts"), "export const a = 1;\n");
 
-    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
   });
 
   it("ignores a package with no sources", async () => {
@@ -127,7 +153,7 @@ describe("staleBuilds", () => {
     fs.mkdirSync(path.join(pkg, "dist"), { recursive: true });
     fs.writeFileSync(path.join(pkg, "dist", "index.d.ts"), "export {};\n");
 
-    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
   });
 
   it("ignores non-source files under src and non-declarations under dist", async () => {
@@ -143,12 +169,67 @@ describe("staleBuilds", () => {
     fs.writeFileSync(emitted, "export const a = 1;\n");
     setMtime(emitted, 4000);
 
-    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
   });
 
-  it("returns an empty list when there is no packages directory", async () => {
+  it("returns an empty list when there are no roots", async () => {
     const root = mkTmp();
-    expect(await staleBuilds(path.join(root, "packages"), root)).toEqual([]);
+    expect(await staleBuilds(allRoots(path.join(root, "packages")), root)).toEqual([]);
+  });
+
+  it("ignores a workspace that api-compare does not extract", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    buildPackage(packagesDir, "activerecord");
+    // `activerecord-cli` is a workspace, not an api-compare package: it cannot
+    // affect the TS manifest, so a stale build there must not block a run.
+    checkoutRewrite(buildPackage(packagesDir, "activerecord-cli"), "index.ts", 3000);
+
+    expect(await staleBuilds([rootFor(packagesDir, "activerecord")], root)).toEqual([]);
+  });
+
+  it("scopes to the src subdir the extractor compiles, not the whole package dir", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "actionpack", [
+      "action-dispatch/http/headers.ts",
+      "action-controller/base.ts",
+    ]);
+    checkoutRewrite(pkg, "action-controller/base.ts", 3000);
+
+    // The actiondispatch root's own subdir is untouched…
+    expect(
+      await staleBuilds([rootFor(packagesDir, "actionpack", "action-dispatch")], root),
+    ).toEqual([]);
+    // …while the actioncontroller root sees it.
+    expect(
+      await staleBuilds([rootFor(packagesDir, "actionpack", "action-controller")], root),
+    ).toEqual([
+      { dir: "actionpack", newestSource: "packages/actionpack/src/action-controller/base.ts" },
+    ]);
+  });
+
+  it("collapses roots that share one package directory into a single report", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "actionpack", [
+      "action-dispatch/http/headers.ts",
+      "action-controller/base.ts",
+    ]);
+    checkoutRewrite(pkg, "action-dispatch/http/headers.ts", 3000);
+    checkoutRewrite(pkg, "action-controller/base.ts", 4000);
+
+    expect(
+      await staleBuilds(
+        [
+          rootFor(packagesDir, "actionpack", "action-dispatch"),
+          rootFor(packagesDir, "actionpack", "action-controller"),
+        ],
+        root,
+      ),
+    ).toEqual([
+      { dir: "actionpack", newestSource: "packages/actionpack/src/action-controller/base.ts" },
+    ]);
   });
 
   it("sorts by package directory so the message is stable across runs", async () => {
@@ -157,7 +238,7 @@ describe("staleBuilds", () => {
     for (const name of ["trailties", "actionview", "activesupport"]) {
       checkoutRewrite(buildPackage(packagesDir, name), "index.ts", 3000);
     }
-    const stale = await staleBuilds(packagesDir, root);
+    const stale = await staleBuilds(allRoots(packagesDir), root);
     expect(stale.map((entry) => entry.dir)).toEqual(["actionview", "activesupport", "trailties"]);
   });
 
@@ -169,15 +250,15 @@ describe("staleBuilds", () => {
 
     // check out origin/main
     checkoutRewrite(pkg, "index.ts", 3000);
-    expect(await staleBuilds(packagesDir, root)).toHaveLength(1);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toHaveLength(1);
     rebuild(pkg, 4000);
-    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
 
     // check the branch back out
     checkoutRewrite(pkg, "index.ts", 5000);
-    expect(await staleBuilds(packagesDir, root)).toHaveLength(1);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toHaveLength(1);
     rebuild(pkg, 6000);
-    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
   });
 });
 
@@ -193,7 +274,7 @@ describe("manifestIsStale", () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
     buildPackage(packagesDir, "activesupport");
-    expect(await manifestIsStale(writeManifest(root, 5000), packagesDir)).toBe(false);
+    expect(await manifestIsStale(writeManifest(root, 5000), allRoots(packagesDir))).toBe(false);
   });
 
   it("is true when a checkout landed after the manifest was written", async () => {
@@ -202,21 +283,33 @@ describe("manifestIsStale", () => {
     const pkg = buildPackage(packagesDir, "activesupport");
     const manifest = writeManifest(root, 5000);
     checkoutRewrite(pkg, "index.ts", 6000);
-    expect(await manifestIsStale(manifest, packagesDir)).toBe(true);
+    expect(await manifestIsStale(manifest, allRoots(packagesDir))).toBe(true);
   });
 
   it("is false when the manifest does not exist", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
     buildPackage(packagesDir, "activesupport");
-    expect(await manifestIsStale(path.join(root, "missing.json"), packagesDir)).toBe(false);
-  });
-
-  it("is false when there are no packages to compare against", async () => {
-    const root = mkTmp();
-    expect(await manifestIsStale(writeManifest(root, 5000), path.join(root, "packages"))).toBe(
+    expect(await manifestIsStale(path.join(root, "missing.json"), allRoots(packagesDir))).toBe(
       false,
     );
+  });
+
+  it("is false when there are no roots to compare against", async () => {
+    const root = mkTmp();
+    expect(
+      await manifestIsStale(writeManifest(root, 5000), allRoots(path.join(root, "packages"))),
+    ).toBe(false);
+  });
+
+  it("ignores a checkout that only touched a workspace api-compare does not extract", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    buildPackage(packagesDir, "activerecord");
+    const manifest = writeManifest(root, 5000);
+    checkoutRewrite(buildPackage(packagesDir, "trails-tsc"), "index.ts", 6000);
+
+    expect(await manifestIsStale(manifest, [rootFor(packagesDir, "activerecord")])).toBe(false);
   });
 });
 

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -2,38 +2,20 @@
  * Tests for the stale-build guard: a checkout-based `api:extra` baseline is
  * only trustworthy while every package's `dist` was produced from the sources
  * currently on disk, and `git checkout` never updates `dist`.
+ *
+ * These build REAL tsc projects rather than faking timestamps. The guard
+ * delegates to `tsc`'s own up-to-date computation precisely so it can never
+ * disagree with `pnpm build`, and a test that stubbed that oracle out would
+ * verify nothing — the previous mtime-based implementation passed a full suite
+ * of fixture tests and still failed every CI run.
  */
 import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import ts from "typescript";
 import { staleBuilds, staleBuildMessage, manifestIsStale } from "./build-freshness.js";
 import type { PackageRoots } from "./config.js";
-
-/** A whole-directory extraction root — the common case (`activerecord`, `arel`). */
-function rootFor(packagesDir: string, dir: string, subDir?: string): PackageRoots {
-  const packageDir = path.join(packagesDir, dir);
-  return {
-    dir,
-    srcDir: subDir ? path.join(packageDir, "src", subDir) : path.join(packageDir, "src"),
-    distDir: path.join(packageDir, "dist"),
-  };
-}
-
-/**
- * Every directory under `packagesDir` as an extraction root — the shorthand for
- * tests where every package created IS api-compared. Scoping itself is covered
- * by the tests that pass an explicit root list.
- */
-function allRoots(packagesDir: string): PackageRoots[] {
-  let dirs: string[];
-  try {
-    dirs = fs.readdirSync(packagesDir);
-  } catch {
-    return [];
-  }
-  return dirs.map((dir) => rootFor(packagesDir, dir));
-}
 
 const tmpDirs: string[] = [];
 function mkTmp(): string {
@@ -45,60 +27,77 @@ afterEach(() => {
   for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
-function setMtime(target: string, seconds: number): void {
-  fs.utimesSync(target, seconds, seconds);
+function rootFor(packagesDir: string, dir: string, subDir?: string): PackageRoots {
+  const packageDir = path.join(packagesDir, dir);
+  return {
+    dir,
+    srcDir: subDir ? path.join(packageDir, "src", subDir) : path.join(packageDir, "src"),
+    distDir: path.join(packageDir, "dist"),
+    configPath: path.join(packageDir, "tsconfig.json"),
+  };
 }
 
-/** Age every directory at or under `dir` — creating files leaves them at "now". */
-function ageDirs(dir: string, seconds: number): void {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.isDirectory()) ageDirs(path.join(dir, entry.name), seconds);
-  }
-  setMtime(dir, seconds);
-}
-
-/** A package whose `dist` was built AFTER its sources — the healthy state. */
-function buildPackage(packagesDir: string, name: string, sources = ["index.ts"]): string {
+/** Lay down a composite package and compile it, exactly as `pnpm build` would. */
+function buildPackage(
+  packagesDir: string,
+  name: string,
+  sources = { "index.ts": "export const a = 1;\n" },
+): string {
   const pkg = path.join(packagesDir, name);
-  fs.mkdirSync(path.join(pkg, "dist"), { recursive: true });
-  for (const source of sources) {
-    const file = path.join(pkg, "src", source);
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, "export const a = 1;\n");
-    setMtime(file, 1000);
+  fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
+  for (const [file, body] of Object.entries(sources)) {
+    const full = path.join(pkg, "src", file);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
   }
-  ageDirs(path.join(pkg, "src"), 1000);
-  fs.writeFileSync(path.join(pkg, "dist", "index.d.ts"), "export declare const a: number;\n");
-  setMtime(path.join(pkg, "dist", "index.d.ts"), 2000);
+  fs.writeFileSync(
+    path.join(pkg, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        composite: true,
+        declaration: true,
+        outDir: "dist",
+        rootDir: "src",
+        module: "esnext",
+        target: "es2022",
+        moduleResolution: "bundler",
+        skipLibCheck: true,
+      },
+      include: ["src"],
+    }),
+  );
+  build(path.join(pkg, "tsconfig.json"));
   return pkg;
 }
 
-/** Stand-in for `git checkout` rewriting a tracked file's contents. */
-function checkoutRewrite(pkg: string, source: string, seconds: number): void {
-  const file = path.join(pkg, "src", source);
-  fs.writeFileSync(file, "export const a = 2;\n");
-  setMtime(file, seconds);
+function build(configPath: string): void {
+  ts.createSolutionBuilder(ts.createSolutionBuilderHost(ts.sys), [configPath], {}).build();
 }
 
-/** Stand-in for `git checkout` deleting a tracked file: only the dir mtime moves. */
-function checkoutDelete(pkg: string, source: string, seconds: number): void {
+/**
+ * Stand-in for `git checkout` rewriting a tracked file's contents.
+ *
+ * The mtime is pushed a minute ahead deliberately. tsc's up-to-date check
+ * compares timestamps, and a test that rewrites a file in the same clock tick
+ * as the build that just produced it reads as up to date — an artifact of
+ * writing both instantly, not of the guard. A real checkout is always well
+ * separated from the build it invalidates.
+ */
+function checkoutRewrite(pkg: string, source: string, body: string): void {
   const file = path.join(pkg, "src", source);
-  fs.rmSync(file);
-  setMtime(path.dirname(file), seconds);
-}
-
-/** Stand-in for `pnpm build` refreshing the package's declarations. */
-function rebuild(pkg: string, seconds: number): void {
-  setMtime(path.join(pkg, "dist", "index.d.ts"), seconds);
+  fs.writeFileSync(file, body);
+  const ahead = new Date(Date.now() + 60_000);
+  fs.utimesSync(file, ahead, ahead);
 }
 
 describe("staleBuilds", () => {
-  it("reports nothing when every dist is newer than its sources", async () => {
+  it("reports nothing when every package was built from its current sources", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
     buildPackage(packagesDir, "activesupport");
-    buildPackage(packagesDir, "trailties", ["index.ts", "railtie/configuration.ts"]);
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
+    buildPackage(packagesDir, "trailties");
+
+    expect(await staleBuilds([...rootsOf(packagesDir, "activesupport", "trailties")])).toEqual([]);
   });
 
   it("reports a package whose sources were checked out after its dist was built", async () => {
@@ -106,75 +105,65 @@ describe("staleBuilds", () => {
     const packagesDir = path.join(root, "packages");
     const pkg = buildPackage(packagesDir, "activesupport");
     buildPackage(packagesDir, "trailties");
-    checkoutRewrite(pkg, "index.ts", 3000);
+    checkoutRewrite(pkg, "index.ts", "export const a = 2;\n");
 
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([
-      { dir: "activesupport", newestSource: "packages/activesupport/src/index.ts" },
-    ]);
-  });
-
-  it("finds the newest source in a nested directory", async () => {
-    const root = mkTmp();
-    const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "activerecord", ["base.ts", "relation/query-methods.ts"]);
-    checkoutRewrite(pkg, "relation/query-methods.ts", 3000);
-
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([
-      { dir: "activerecord", newestSource: "packages/activerecord/src/relation/query-methods.ts" },
+    expect(await staleBuilds([...rootsOf(packagesDir, "activesupport", "trailties")])).toEqual([
+      { dir: "activesupport", status: "OutOfDateWithSelf" },
     ]);
   });
 
   it("catches a checkout that only DELETES a source file", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "arel", ["index.ts", "nodes/casted.ts"]);
-    // Every surviving file keeps its old mtime; only the parent dir moves.
-    checkoutDelete(pkg, "nodes/casted.ts", 3000);
+    const pkg = buildPackage(packagesDir, "arel", {
+      "index.ts": "export const a = 1;\n",
+      "nodes/casted.ts": "export const b = 2;\n",
+    });
+    // Every surviving file keeps its mtime; only the project's root set moves.
+    fs.rmSync(path.join(pkg, "src", "nodes", "casted.ts"));
 
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([
-      { dir: "arel", newestSource: "packages/arel/src/nodes" },
+    expect(await staleBuilds([rootFor(packagesDir, "arel")])).toEqual([
+      { dir: "arel", status: "OutOfDateRoots" },
     ]);
+  });
+
+  it("does NOT fire when dist was restored from a cache with older mtimes", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "activerecord");
+
+    // Exactly CI: `cache-build` restores dist + tsbuildinfo carrying ARCHIVE
+    // mtimes, then `actions/checkout` leaves every source stamped "now". The
+    // tree is current — the buildinfo agrees with the sources — but every
+    // output is older than every input. An mtime oracle fails the whole
+    // workspace here; tsc's does not.
+    for (const output of [path.join(pkg, "dist"), path.join(pkg, "tsconfig.tsbuildinfo")]) {
+      ageTree(output, new Date("2020-01-01T00:00:00Z"));
+    }
+    const now = new Date();
+    for (const source of walk(path.join(pkg, "src"))) fs.utimesSync(source, now, now);
+    // CI always runs `pnpm build` between the restore and the comparison. It
+    // no-ops on content (nothing is re-emitted, dist keeps its archive mtimes)
+    // but refreshes the buildinfo, which is what tsc consults.
+    build(path.join(pkg, "tsconfig.json"));
+
+    expect(await staleBuilds([rootFor(packagesDir, "activerecord")])).toEqual([]);
   });
 
   it("ignores a package that was never built", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    const pkg = path.join(packagesDir, "arel");
-    fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
-    fs.writeFileSync(path.join(pkg, "src", "index.ts"), "export const a = 1;\n");
+    const pkg = buildPackage(packagesDir, "arel");
+    // A dist-less package resolves to nothing at every commit — consistent,
+    // so not a mixed tree. tsc alone would call this up to date (the surviving
+    // tsbuildinfo vouches for it), which is why the check is ours.
+    fs.rmSync(path.join(pkg, "dist"), { recursive: true });
 
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
-  });
-
-  it("ignores a package with no sources", async () => {
-    const root = mkTmp();
-    const packagesDir = path.join(root, "packages");
-    const pkg = path.join(packagesDir, "website");
-    fs.mkdirSync(path.join(pkg, "dist"), { recursive: true });
-    fs.writeFileSync(path.join(pkg, "dist", "index.d.ts"), "export {};\n");
-
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
-  });
-
-  it("ignores non-source files under src and non-declarations under dist", async () => {
-    const root = mkTmp();
-    const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "activemodel");
-    const fixture = path.join(pkg, "src", "fixtures.json");
-    fs.writeFileSync(fixture, "{}\n");
-    setMtime(fixture, 3000);
-    ageDirs(path.join(pkg, "src"), 1000);
-    // A .d.ts is what resolution reads; a stray .js must not vouch for it.
-    const emitted = path.join(pkg, "dist", "index.js");
-    fs.writeFileSync(emitted, "export const a = 1;\n");
-    setMtime(emitted, 4000);
-
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
+    expect(await staleBuilds([rootFor(packagesDir, "arel")])).toEqual([]);
   });
 
   it("returns an empty list when there are no roots", async () => {
-    const root = mkTmp();
-    expect(await staleBuilds(allRoots(path.join(root, "packages")), root)).toEqual([]);
+    expect(await staleBuilds([])).toEqual([]);
   });
 
   it("ignores a workspace that api-compare does not extract", async () => {
@@ -183,131 +172,122 @@ describe("staleBuilds", () => {
     buildPackage(packagesDir, "activerecord");
     // `activerecord-cli` is a workspace, not an api-compare package: it cannot
     // affect the TS manifest, so a stale build there must not block a run.
-    checkoutRewrite(buildPackage(packagesDir, "activerecord-cli"), "index.ts", 3000);
+    checkoutRewrite(
+      buildPackage(packagesDir, "activerecord-cli"),
+      "index.ts",
+      "export const a = 2;\n",
+    );
 
-    expect(await staleBuilds([rootFor(packagesDir, "activerecord")], root)).toEqual([]);
-  });
-
-  it("scopes to the src subdir the extractor compiles, not the whole package dir", async () => {
-    const root = mkTmp();
-    const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "actionpack", [
-      "action-dispatch/http/headers.ts",
-      "action-controller/base.ts",
-    ]);
-    checkoutRewrite(pkg, "action-controller/base.ts", 3000);
-
-    // The actiondispatch root's own subdir is untouched…
-    expect(
-      await staleBuilds([rootFor(packagesDir, "actionpack", "action-dispatch")], root),
-    ).toEqual([]);
-    // …while the actioncontroller root sees it.
-    expect(
-      await staleBuilds([rootFor(packagesDir, "actionpack", "action-controller")], root),
-    ).toEqual([
-      { dir: "actionpack", newestSource: "packages/actionpack/src/action-controller/base.ts" },
-    ]);
+    expect(await staleBuilds([rootFor(packagesDir, "activerecord")])).toEqual([]);
   });
 
   it("collapses roots that share one package directory into a single report", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "actionpack", [
-      "action-dispatch/http/headers.ts",
-      "action-controller/base.ts",
-    ]);
-    checkoutRewrite(pkg, "action-dispatch/http/headers.ts", 3000);
-    checkoutRewrite(pkg, "action-controller/base.ts", 4000);
+    const pkg = buildPackage(packagesDir, "actionpack", {
+      "action-dispatch/http/headers.ts": "export const a = 1;\n",
+      "action-controller/base.ts": "export const b = 2;\n",
+    });
+    checkoutRewrite(pkg, "action-controller/base.ts", "export const b = 3;\n");
 
     expect(
-      await staleBuilds(
-        [
-          rootFor(packagesDir, "actionpack", "action-dispatch"),
-          rootFor(packagesDir, "actionpack", "action-controller"),
-        ],
-        root,
-      ),
-    ).toEqual([
-      { dir: "actionpack", newestSource: "packages/actionpack/src/action-controller/base.ts" },
-    ]);
+      await staleBuilds([
+        rootFor(packagesDir, "actionpack", "action-dispatch"),
+        rootFor(packagesDir, "actionpack", "action-controller"),
+      ]),
+    ).toEqual([{ dir: "actionpack", status: "OutOfDateWithSelf" }]);
   });
 
   it("sorts by package directory so the message is stable across runs", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
     for (const name of ["trailties", "actionview", "activesupport"]) {
-      checkoutRewrite(buildPackage(packagesDir, name), "index.ts", 3000);
+      checkoutRewrite(buildPackage(packagesDir, name), "index.ts", "export const a = 2;\n");
     }
-    const stale = await staleBuilds(allRoots(packagesDir), root);
+    const stale = await staleBuilds([
+      ...rootsOf(packagesDir, "trailties", "actionview", "activesupport"),
+    ]);
     expect(stale.map((entry) => entry.dir)).toEqual(["actionview", "activesupport", "trailties"]);
   });
-
-  it("stays clean across a checkout-away-and-back sequence that rebuilds each time", async () => {
-    const root = mkTmp();
-    const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "activesupport");
-    buildPackage(packagesDir, "trailties");
-
-    // check out origin/main
-    checkoutRewrite(pkg, "index.ts", 3000);
-    expect(await staleBuilds(allRoots(packagesDir), root)).toHaveLength(1);
-    rebuild(pkg, 4000);
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
-
-    // check the branch back out
-    checkoutRewrite(pkg, "index.ts", 5000);
-    expect(await staleBuilds(allRoots(packagesDir), root)).toHaveLength(1);
-    rebuild(pkg, 6000);
-    expect(await staleBuilds(allRoots(packagesDir), root)).toEqual([]);
-  });
 });
+
+function rootsOf(packagesDir: string, ...dirs: string[]): PackageRoots[] {
+  return dirs.map((dir) => rootFor(packagesDir, dir));
+}
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    return entry.isDirectory() ? walk(full) : [full];
+  });
+}
+
+function ageTree(target: string, when: Date): void {
+  if (fs.statSync(target).isDirectory()) {
+    for (const file of walk(target)) fs.utimesSync(file, when, when);
+  }
+  fs.utimesSync(target, when, when);
+}
 
 describe("manifestIsStale", () => {
   function writeManifest(root: string, seconds: number): string {
     const manifest = path.join(root, "ts-api.json");
     fs.writeFileSync(manifest, "{}\n");
-    setMtime(manifest, seconds);
+    fs.utimesSync(manifest, seconds, seconds);
     return manifest;
+  }
+
+  function agedPackage(packagesDir: string, name: string, seconds: number): string {
+    const pkg = path.join(packagesDir, name);
+    fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
+    const file = path.join(pkg, "src", "index.ts");
+    fs.writeFileSync(file, "export const a = 1;\n");
+    fs.utimesSync(file, seconds, seconds);
+    fs.utimesSync(path.join(pkg, "src"), seconds, seconds);
+    return pkg;
   }
 
   it("is false for a manifest written after the last checkout", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    buildPackage(packagesDir, "activesupport");
-    expect(await manifestIsStale(writeManifest(root, 5000), allRoots(packagesDir))).toBe(false);
+    agedPackage(packagesDir, "activesupport", 1000);
+    expect(
+      await manifestIsStale(writeManifest(root, 5000), [rootFor(packagesDir, "activesupport")]),
+    ).toBe(false);
   });
 
   it("is true when a checkout landed after the manifest was written", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "activesupport");
+    const pkg = agedPackage(packagesDir, "activesupport", 1000);
     const manifest = writeManifest(root, 5000);
-    checkoutRewrite(pkg, "index.ts", 6000);
-    expect(await manifestIsStale(manifest, allRoots(packagesDir))).toBe(true);
+    fs.utimesSync(path.join(pkg, "src", "index.ts"), 6000, 6000);
+
+    expect(await manifestIsStale(manifest, [rootFor(packagesDir, "activesupport")])).toBe(true);
   });
 
   it("is false when the manifest does not exist", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    buildPackage(packagesDir, "activesupport");
-    expect(await manifestIsStale(path.join(root, "missing.json"), allRoots(packagesDir))).toBe(
-      false,
-    );
+    agedPackage(packagesDir, "activesupport", 1000);
+    expect(
+      await manifestIsStale(path.join(root, "missing.json"), [
+        rootFor(packagesDir, "activesupport"),
+      ]),
+    ).toBe(false);
   });
 
   it("is false when there are no roots to compare against", async () => {
     const root = mkTmp();
-    expect(
-      await manifestIsStale(writeManifest(root, 5000), allRoots(path.join(root, "packages"))),
-    ).toBe(false);
+    expect(await manifestIsStale(writeManifest(root, 5000), [])).toBe(false);
   });
 
   it("ignores a checkout that only touched a workspace api-compare does not extract", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    buildPackage(packagesDir, "activerecord");
+    agedPackage(packagesDir, "activerecord", 1000);
     const manifest = writeManifest(root, 5000);
-    checkoutRewrite(buildPackage(packagesDir, "trails-tsc"), "index.ts", 6000);
+    agedPackage(packagesDir, "trails-tsc", 6000);
 
     expect(await manifestIsStale(manifest, [rootFor(packagesDir, "activerecord")])).toBe(false);
   });
@@ -316,12 +296,12 @@ describe("manifestIsStale", () => {
 describe("staleBuildMessage", () => {
   it("names every stale package and how to fix it", () => {
     const message = staleBuildMessage([
-      { dir: "trailties", newestSource: "packages/trailties/src/application.ts" },
-      { dir: "actionview", newestSource: "packages/actionview/src/base.ts" },
+      { dir: "trailties", status: "OutOfDateWithSelf" },
+      { dir: "actionview", status: "OutOfDateRoots" },
     ]);
     expect(message).toContain("2 package(s)");
-    expect(message).toContain("packages/trailties — newer: packages/trailties/src/application.ts");
-    expect(message).toContain("packages/actionview — newer: packages/actionview/src/base.ts");
+    expect(message).toContain("packages/trailties — OutOfDateWithSelf");
+    expect(message).toContain("packages/actionview — OutOfDateRoots");
     expect(message).toContain("pnpm build");
     expect(message).toContain("API_COMPARE_ALLOW_STALE_BUILD=1");
   });

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -41,7 +41,8 @@ function rootFor(packagesDir: string, dir: string, subDir?: string): PackageRoot
 function buildPackage(
   packagesDir: string,
   name: string,
-  sources = { "index.ts": "export const a = 1;\n" },
+  sources: Record<string, string> = { "index.ts": "export const a = 1;\n" },
+  references: string[] = [],
 ): string {
   const pkg = path.join(packagesDir, name);
   fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
@@ -64,8 +65,10 @@ function buildPackage(
         skipLibCheck: true,
       },
       include: ["src"],
+      references: references.map((ref) => ({ path: path.join(packagesDir, ref) })),
     }),
   );
+  for (const ref of references) build(path.join(packagesDir, ref, "tsconfig.json"));
   build(path.join(pkg, "tsconfig.json"));
   return pkg;
 }
@@ -179,6 +182,46 @@ describe("staleBuilds", () => {
     );
 
     expect(await staleBuilds([rootFor(packagesDir, "activerecord")])).toEqual([]);
+  });
+
+  it("reports a REFERENCED workspace that api-compare does not extract", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    // actionview references @blazetrails/tse-compiler, which is not in
+    // PACKAGES. tsc calls the importer UpToDateWithUpstreamTypes when such a
+    // reference goes stale — not an out-of-date status — so asking only about
+    // the api-compared package would let the stale dist/*.d.ts through.
+    buildPackage(packagesDir, "tse-compiler", { "index.ts": "export const compileJs = 1;\n" });
+    buildPackage(packagesDir, "actionview", { "index.ts": "export const a = 1;\n" }, [
+      "tse-compiler",
+    ]);
+    checkoutRewrite(
+      path.join(packagesDir, "tse-compiler"),
+      "index.ts",
+      "export const compileJs = 2;\n",
+    );
+
+    expect(await staleBuilds([rootFor(packagesDir, "actionview")])).toEqual([
+      { dir: "tse-compiler", status: "OutOfDateWithSelf" },
+    ]);
+  });
+
+  it("does not consult a workspace nothing references", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    buildPackage(packagesDir, "tse-compiler", { "index.ts": "export const compileJs = 1;\n" });
+    buildPackage(packagesDir, "actionview", { "index.ts": "export const a = 1;\n" }, [
+      "tse-compiler",
+    ]);
+    // Reachability, not "every workspace": activerecord-cli is referenced by
+    // nothing api-compared, so its build state is none of the guard's business.
+    checkoutRewrite(
+      buildPackage(packagesDir, "activerecord-cli"),
+      "index.ts",
+      "export const a = 2;\n",
+    );
+
+    expect(await staleBuilds([rootFor(packagesDir, "actionview")])).toEqual([]);
   });
 
   it("collapses roots that share one package directory into a single report", async () => {

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for the stale-build guard: a checkout-based `api:extra` baseline is
+ * only trustworthy while every package's `dist` was produced from the sources
+ * currently on disk, and `git checkout` never updates `dist`.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "build-freshness-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** A package whose `dist` was built AFTER its sources — the healthy state. */
+function buildPackage(packagesDir: string, name: string, body = "export const a = 1;\n"): string {
+  const pkg = path.join(packagesDir, name);
+  fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
+  fs.mkdirSync(path.join(pkg, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(pkg, "src", "index.ts"), body);
+  fs.writeFileSync(path.join(pkg, "dist", "index.d.ts"), "export declare const a: number;\n");
+  setMtime(path.join(pkg, "src", "index.ts"), 1000);
+  setMtime(path.join(pkg, "dist", "index.d.ts"), 2000);
+  return pkg;
+}
+
+/** Stand-in for what `git checkout` does to a file it rewrites. */
+function checkoutSource(pkg: string, body: string, seconds: number): void {
+  fs.writeFileSync(path.join(pkg, "src", "index.ts"), body);
+  setMtime(path.join(pkg, "src", "index.ts"), seconds);
+}
+
+function setMtime(file: string, seconds: number): void {
+  fs.utimesSync(file, seconds, seconds);
+}
+
+describe("staleBuilds", () => {
+  it("reports nothing when every dist is newer than its sources", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    buildPackage(packagesDir, "activesupport");
+    buildPackage(packagesDir, "trailties");
+    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+  });
+
+  it("reports a package whose sources were checked out after its dist was built", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "activesupport");
+    buildPackage(packagesDir, "trailties");
+    checkoutSource(pkg, "export const a = 2;\n", 3000);
+
+    expect(await staleBuilds(packagesDir, root)).toEqual([
+      { dir: "activesupport", newestSource: "packages/activesupport/src/index.ts" },
+    ]);
+  });
+
+  it("finds the newest source in a nested directory", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "activerecord");
+    const nested = path.join(pkg, "src", "relation");
+    fs.mkdirSync(nested);
+    fs.writeFileSync(path.join(nested, "query-methods.ts"), "export const b = 1;\n");
+    setMtime(path.join(nested, "query-methods.ts"), 3000);
+
+    expect(await staleBuilds(packagesDir, root)).toEqual([
+      { dir: "activerecord", newestSource: "packages/activerecord/src/relation/query-methods.ts" },
+    ]);
+  });
+
+  it("ignores a package that was never built", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = path.join(packagesDir, "arel");
+    fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
+    fs.writeFileSync(path.join(pkg, "src", "index.ts"), "export const a = 1;\n");
+
+    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+  });
+
+  it("ignores a package with no sources", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = path.join(packagesDir, "website");
+    fs.mkdirSync(path.join(pkg, "dist"), { recursive: true });
+    fs.writeFileSync(path.join(pkg, "dist", "index.d.ts"), "export {};\n");
+
+    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+  });
+
+  it("returns an empty list when there is no packages directory", async () => {
+    const root = mkTmp();
+    expect(await staleBuilds(path.join(root, "packages"), root)).toEqual([]);
+  });
+
+  it("sorts by package directory so the message is stable across runs", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    for (const name of ["trailties", "actionview", "activesupport"]) {
+      checkoutSource(buildPackage(packagesDir, name), "export const a = 2;\n", 3000);
+    }
+    const stale = await staleBuilds(packagesDir, root);
+    expect(stale.map((entry) => entry.dir)).toEqual(["actionview", "activesupport", "trailties"]);
+  });
+
+  it("stays clean across a checkout-away-and-back sequence that rebuilds each time", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "activesupport");
+    buildPackage(packagesDir, "trailties");
+
+    // checkout origin/main, rebuild, measure
+    checkoutSource(pkg, "export const a = 2;\n", 3000);
+    expect(await staleBuilds(packagesDir, root)).toHaveLength(1);
+    setMtime(path.join(pkg, "dist", "index.d.ts"), 4000);
+    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+
+    // checkout the branch back, rebuild, measure
+    checkoutSource(pkg, "export const a = 1;\n", 5000);
+    expect(await staleBuilds(packagesDir, root)).toHaveLength(1);
+    setMtime(path.join(pkg, "dist", "index.d.ts"), 6000);
+    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+  });
+});
+
+describe("staleBuildMessage", () => {
+  it("names every stale package and how to fix it", () => {
+    const message = staleBuildMessage([
+      { dir: "trailties", newestSource: "packages/trailties/src/application.ts" },
+      { dir: "actionview", newestSource: "packages/actionview/src/base.ts" },
+    ]);
+    expect(message).toContain("2 package(s)");
+    expect(message).toContain("packages/trailties — newer: packages/trailties/src/application.ts");
+    expect(message).toContain("packages/actionview — newer: packages/actionview/src/base.ts");
+    expect(message).toContain("pnpm build");
+    expect(message).toContain("API_COMPARE_ALLOW_STALE_BUILD=1");
+  });
+});

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -19,26 +19,51 @@ afterEach(() => {
   for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
+function setMtime(target: string, seconds: number): void {
+  fs.utimesSync(target, seconds, seconds);
+}
+
+/** Age every directory at or under `dir` — creating files leaves them at "now". */
+function ageDirs(dir: string, seconds: number): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) ageDirs(path.join(dir, entry.name), seconds);
+  }
+  setMtime(dir, seconds);
+}
+
 /** A package whose `dist` was built AFTER its sources — the healthy state. */
-function buildPackage(packagesDir: string, name: string, body = "export const a = 1;\n"): string {
+function buildPackage(packagesDir: string, name: string, sources = ["index.ts"]): string {
   const pkg = path.join(packagesDir, name);
-  fs.mkdirSync(path.join(pkg, "src"), { recursive: true });
   fs.mkdirSync(path.join(pkg, "dist"), { recursive: true });
-  fs.writeFileSync(path.join(pkg, "src", "index.ts"), body);
+  for (const source of sources) {
+    const file = path.join(pkg, "src", source);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "export const a = 1;\n");
+    setMtime(file, 1000);
+  }
+  ageDirs(path.join(pkg, "src"), 1000);
   fs.writeFileSync(path.join(pkg, "dist", "index.d.ts"), "export declare const a: number;\n");
-  setMtime(path.join(pkg, "src", "index.ts"), 1000);
   setMtime(path.join(pkg, "dist", "index.d.ts"), 2000);
   return pkg;
 }
 
-/** Stand-in for what `git checkout` does to a file it rewrites. */
-function checkoutSource(pkg: string, body: string, seconds: number): void {
-  fs.writeFileSync(path.join(pkg, "src", "index.ts"), body);
-  setMtime(path.join(pkg, "src", "index.ts"), seconds);
+/** Stand-in for `git checkout` rewriting a tracked file's contents. */
+function checkoutRewrite(pkg: string, source: string, seconds: number): void {
+  const file = path.join(pkg, "src", source);
+  fs.writeFileSync(file, "export const a = 2;\n");
+  setMtime(file, seconds);
 }
 
-function setMtime(file: string, seconds: number): void {
-  fs.utimesSync(file, seconds, seconds);
+/** Stand-in for `git checkout` deleting a tracked file: only the dir mtime moves. */
+function checkoutDelete(pkg: string, source: string, seconds: number): void {
+  const file = path.join(pkg, "src", source);
+  fs.rmSync(file);
+  setMtime(path.dirname(file), seconds);
+}
+
+/** Stand-in for `pnpm build` refreshing the package's declarations. */
+function rebuild(pkg: string, seconds: number): void {
+  setMtime(path.join(pkg, "dist", "index.d.ts"), seconds);
 }
 
 describe("staleBuilds", () => {
@@ -46,7 +71,7 @@ describe("staleBuilds", () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
     buildPackage(packagesDir, "activesupport");
-    buildPackage(packagesDir, "trailties");
+    buildPackage(packagesDir, "trailties", ["index.ts", "railtie/configuration.ts"]);
     expect(await staleBuilds(packagesDir, root)).toEqual([]);
   });
 
@@ -55,7 +80,7 @@ describe("staleBuilds", () => {
     const packagesDir = path.join(root, "packages");
     const pkg = buildPackage(packagesDir, "activesupport");
     buildPackage(packagesDir, "trailties");
-    checkoutSource(pkg, "export const a = 2;\n", 3000);
+    checkoutRewrite(pkg, "index.ts", 3000);
 
     expect(await staleBuilds(packagesDir, root)).toEqual([
       { dir: "activesupport", newestSource: "packages/activesupport/src/index.ts" },
@@ -65,14 +90,23 @@ describe("staleBuilds", () => {
   it("finds the newest source in a nested directory", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
-    const pkg = buildPackage(packagesDir, "activerecord");
-    const nested = path.join(pkg, "src", "relation");
-    fs.mkdirSync(nested);
-    fs.writeFileSync(path.join(nested, "query-methods.ts"), "export const b = 1;\n");
-    setMtime(path.join(nested, "query-methods.ts"), 3000);
+    const pkg = buildPackage(packagesDir, "activerecord", ["base.ts", "relation/query-methods.ts"]);
+    checkoutRewrite(pkg, "relation/query-methods.ts", 3000);
 
     expect(await staleBuilds(packagesDir, root)).toEqual([
       { dir: "activerecord", newestSource: "packages/activerecord/src/relation/query-methods.ts" },
+    ]);
+  });
+
+  it("catches a checkout that only DELETES a source file", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "arel", ["index.ts", "nodes/casted.ts"]);
+    // Every surviving file keeps its old mtime; only the parent dir moves.
+    checkoutDelete(pkg, "nodes/casted.ts", 3000);
+
+    expect(await staleBuilds(packagesDir, root)).toEqual([
+      { dir: "arel", newestSource: "packages/arel/src/nodes" },
     ]);
   });
 
@@ -96,6 +130,22 @@ describe("staleBuilds", () => {
     expect(await staleBuilds(packagesDir, root)).toEqual([]);
   });
 
+  it("ignores non-source files under src and non-declarations under dist", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "activemodel");
+    const fixture = path.join(pkg, "src", "fixtures.json");
+    fs.writeFileSync(fixture, "{}\n");
+    setMtime(fixture, 3000);
+    ageDirs(path.join(pkg, "src"), 1000);
+    // A .d.ts is what resolution reads; a stray .js must not vouch for it.
+    const emitted = path.join(pkg, "dist", "index.js");
+    fs.writeFileSync(emitted, "export const a = 1;\n");
+    setMtime(emitted, 4000);
+
+    expect(await staleBuilds(packagesDir, root)).toEqual([]);
+  });
+
   it("returns an empty list when there is no packages directory", async () => {
     const root = mkTmp();
     expect(await staleBuilds(path.join(root, "packages"), root)).toEqual([]);
@@ -105,7 +155,7 @@ describe("staleBuilds", () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
     for (const name of ["trailties", "actionview", "activesupport"]) {
-      checkoutSource(buildPackage(packagesDir, name), "export const a = 2;\n", 3000);
+      checkoutRewrite(buildPackage(packagesDir, name), "index.ts", 3000);
     }
     const stale = await staleBuilds(packagesDir, root);
     expect(stale.map((entry) => entry.dir)).toEqual(["actionview", "activesupport", "trailties"]);
@@ -117,16 +167,16 @@ describe("staleBuilds", () => {
     const pkg = buildPackage(packagesDir, "activesupport");
     buildPackage(packagesDir, "trailties");
 
-    // checkout origin/main, rebuild, measure
-    checkoutSource(pkg, "export const a = 2;\n", 3000);
+    // check out origin/main
+    checkoutRewrite(pkg, "index.ts", 3000);
     expect(await staleBuilds(packagesDir, root)).toHaveLength(1);
-    setMtime(path.join(pkg, "dist", "index.d.ts"), 4000);
+    rebuild(pkg, 4000);
     expect(await staleBuilds(packagesDir, root)).toEqual([]);
 
-    // checkout the branch back, rebuild, measure
-    checkoutSource(pkg, "export const a = 1;\n", 5000);
+    // check the branch back out
+    checkoutRewrite(pkg, "index.ts", 5000);
     expect(await staleBuilds(packagesDir, root)).toHaveLength(1);
-    setMtime(path.join(pkg, "dist", "index.d.ts"), 6000);
+    rebuild(pkg, 6000);
     expect(await staleBuilds(packagesDir, root)).toEqual([]);
   });
 });

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
+import { staleBuilds, staleBuildMessage, manifestIsStale } from "./build-freshness.js";
 
 const tmpDirs: string[] = [];
 function mkTmp(): string {
@@ -178,6 +178,45 @@ describe("staleBuilds", () => {
     expect(await staleBuilds(packagesDir, root)).toHaveLength(1);
     rebuild(pkg, 6000);
     expect(await staleBuilds(packagesDir, root)).toEqual([]);
+  });
+});
+
+describe("manifestIsStale", () => {
+  function writeManifest(root: string, seconds: number): string {
+    const manifest = path.join(root, "ts-api.json");
+    fs.writeFileSync(manifest, "{}\n");
+    setMtime(manifest, seconds);
+    return manifest;
+  }
+
+  it("is false for a manifest written after the last checkout", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    buildPackage(packagesDir, "activesupport");
+    expect(await manifestIsStale(writeManifest(root, 5000), packagesDir)).toBe(false);
+  });
+
+  it("is true when a checkout landed after the manifest was written", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const pkg = buildPackage(packagesDir, "activesupport");
+    const manifest = writeManifest(root, 5000);
+    checkoutRewrite(pkg, "index.ts", 6000);
+    expect(await manifestIsStale(manifest, packagesDir)).toBe(true);
+  });
+
+  it("is false when the manifest does not exist", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    buildPackage(packagesDir, "activesupport");
+    expect(await manifestIsStale(path.join(root, "missing.json"), packagesDir)).toBe(false);
+  });
+
+  it("is false when there are no packages to compare against", async () => {
+    const root = mkTmp();
+    expect(await manifestIsStale(writeManifest(root, 5000), path.join(root, "packages"))).toBe(
+      false,
+    );
   });
 });
 

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -15,114 +15,113 @@
  * record their resolved read-set, so it already serves exactly what a fresh
  * extraction of the same mismatched tree would produce.
  *
- * Detection is mtime-based because `git checkout` rewrites the mtime of exactly
- * the paths whose contents it changes. Directory mtimes are folded in so a
- * checkout that only DELETES a source file — which leaves every surviving
- * file's mtime alone but bumps its parent directory — is still caught.
+ * WHY `tsc`'S OWN ORACLE AND NOT mtimes. The obvious check — "is some source
+ * newer than the newest `.d.ts`?" — is wrong, and CI proves it. `cache-build`
+ * restores `packages/<pkg>/dist` plus `tsconfig.tsbuildinfo` from a tarball keyed on
+ * a CONTENT hash of every package `src/`, so the restored outputs carry their
+ * ARCHIVE mtimes while `actions/checkout` has just written every source at
+ * "now". `pnpm build` then correctly no-ops (the buildinfo agrees with the
+ * sources), leaving a tree that is perfectly current but looks, by mtime, like
+ * every package is stale. An mtime guard fails all 13 packages on every CI run
+ * while contradicting the build that just succeeded.
+ *
+ * So we ask the authority instead. `ts.createSolutionBuilder` exposes the same
+ * up-to-date computation `tsc --build` uses, which is what wrote the outputs in
+ * the first place. By construction the guard can never disagree with a build
+ * that just succeeded, and it still reports `OutOfDateWithSelf` the moment a
+ * checkout rewrites a source — including a delete-only checkout, which moves the
+ * project's root file set rather than any surviving file's mtime.
  *
  * Constraints: async fs only, no `node:` specifiers, no `process` references.
+ * The `typescript` import is the one unavoidable exception — its `ts.sys` I/O is
+ * synchronous and internal to the compiler. That is the point: reusing tsc's
+ * own reader is what makes this agree with tsc.
  */
 import * as fs from "fs/promises";
 import * as path from "path";
+import ts from "typescript";
 import type { PackageRoots } from "./config.js";
 
-/** One package whose `dist` predates its own sources. */
+/** One package whose build does not correspond to its checked-out sources. */
 export interface StaleBuild {
   /** Directory name under `packages/` (not the api-compare package key). */
   dir: string;
-  /** Repo-relative path of the newest source path, for the error message. */
-  newestSource: string;
-}
-
-interface Newest {
-  mtimeMs: number;
-  file: string;
-}
-
-function later(a: Newest | null, b: Newest | null): Newest | null {
-  if (!a) return b;
-  if (!b) return a;
-  return b.mtimeMs > a.mtimeMs ? b : a;
+  /** `tsc`'s own verdict, e.g. `OutOfDateWithSelf` — quoted in the message. */
+  status: string;
 }
 
 /**
- * Newest mtime at or under `dir` among files passing `keep`, and — when
- * `includeDirs` — the directories themselves. Null if `dir` is unreadable.
+ * The `UpToDateStatusType`s that mean "the emitted output does not correspond
+ * to these sources". Enumerated positively rather than as "anything that isn't
+ * up to date" so a status we did not anticipate (`ContainerOnly`, `ForceBuild`,
+ * `ComputingUpstream`) cannot start failing runs after a TypeScript upgrade.
+ * `Unbuildable` / `ErrorReadingFile` are likewise excluded: a project that
+ * cannot build is a compile error to surface on its own, not a stale baseline.
  */
-async function newestMtime(
-  dir: string,
-  keep: (name: string) => boolean,
-  includeDirs: boolean,
-): Promise<Newest | null> {
+const STALE_STATUSES: ReadonlySet<ts.UpToDateStatusType> = new Set([
+  ts.UpToDateStatusType.OutputMissing,
+  ts.UpToDateStatusType.OutOfDateWithSelf,
+  ts.UpToDateStatusType.OutOfDateWithUpstream,
+  ts.UpToDateStatusType.OutOfDateBuildInfoWithPendingEmit,
+  ts.UpToDateStatusType.OutOfDateBuildInfoWithErrors,
+  ts.UpToDateStatusType.OutOfDateOptions,
+  ts.UpToDateStatusType.OutOfDateRoots,
+  ts.UpToDateStatusType.UpstreamOutOfDate,
+  ts.UpToDateStatusType.UpstreamBlocked,
+  ts.UpToDateStatusType.TsVersionOutputOfDate,
+]);
+
+/** Whether `dir` holds at least one `.d.ts` — i.e. the package was ever built. */
+async function hasDeclarations(dir: string): Promise<boolean> {
   let entries;
-  let self: Newest | null = null;
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
-    if (includeDirs) {
-      const stat = await fs.stat(dir);
-      self = { mtimeMs: stat.mtimeMs, file: dir };
-    }
   } catch {
-    return null;
+    return false;
   }
-  const found = await Promise.all(
-    entries.map(async (entry): Promise<Newest | null> => {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) return newestMtime(full, keep, includeDirs);
-      if (!keep(entry.name)) return null;
-      try {
-        const stat = await fs.stat(full);
-        return { mtimeMs: stat.mtimeMs, file: full };
-      } catch {
-        return null;
-      }
-    }),
-  );
-  return found.reduce(later, self);
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (await hasDeclarations(path.join(dir, entry.name))) return true;
+    } else if (entry.name.endsWith(".d.ts")) {
+      return true;
+    }
+  }
+  return false;
 }
 
-const isSource = (name: string) => name.endsWith(".ts") && !name.endsWith(".d.ts");
-const isDeclaration = (name: string) => name.endsWith(".d.ts");
-
 /**
- * Every root in `roots` whose `dist` was built before its current `src`.
+ * Every root in `roots` whose build does not correspond to its sources.
  *
  * `roots` is the extractor's own package set (`apiComparePackageRoots`), NOT a
  * listing of `packages/` — a workspace api-compare never extracts cannot affect
  * the manifest and must not be able to block a run. Roots sharing a directory
- * (the four actionpack packages) collapse to one report, keeping the newest
- * source among them.
+ * (the four actionpack packages) share one tsconfig and collapse to one report.
  *
  * A root with no `dist` is NOT stale: nothing was built, so nothing can be out
  * of date and cross-package imports fail to resolve uniformly at every commit.
- * `rootDir` only anchors the reported path.
+ * That check is ours rather than tsc's on purpose — tsc reports a project whose
+ * `dist` was deleted but whose `tsconfig.tsbuildinfo` survives as up to date,
+ * so deferring to it would let a half-removed build through.
  */
-export async function staleBuilds(
-  roots: readonly PackageRoots[],
-  rootDir: string,
-): Promise<StaleBuild[]> {
-  const checked = await Promise.all(
-    roots.map(async (root): Promise<{ dir: string; source: Newest } | null> => {
-      const [source, built] = await Promise.all([
-        newestMtime(root.srcDir, isSource, true),
-        newestMtime(root.distDir, isDeclaration, false),
-      ]);
-      if (!source || !built || source.mtimeMs <= built.mtimeMs) return null;
-      return { dir: root.dir, source };
-    }),
+export async function staleBuilds(roots: readonly PackageRoots[]): Promise<StaleBuild[]> {
+  const byDir = new Map<string, PackageRoots>();
+  for (const root of roots) byDir.set(root.dir, root);
+  const candidates = await Promise.all(
+    [...byDir.values()].map(async (root) => ((await hasDeclarations(root.distDir)) ? root : null)),
   );
-  const worstPerDir = new Map<string, Newest>();
-  for (const entry of checked) {
-    if (!entry) continue;
-    const seen = worstPerDir.get(entry.dir);
-    if (!seen || entry.source.mtimeMs > seen.mtimeMs) worstPerDir.set(entry.dir, entry.source);
+  const built = candidates.filter((root): root is PackageRoots => root !== null);
+  if (built.length === 0) return [];
+
+  const projects = built.map((root) => root.configPath);
+  const builder = ts.createSolutionBuilder(ts.createSolutionBuilderHost(ts.sys), projects, {});
+  const stale: StaleBuild[] = [];
+  for (const root of built) {
+    const status = builder.getUpToDateStatusOfProject(root.configPath);
+    if (STALE_STATUSES.has(status.type)) {
+      stale.push({ dir: root.dir, status: ts.UpToDateStatusType[status.type] });
+    }
   }
-  return [...worstPerDir.entries()]
-    .map(([dir, source]) => ({
-      dir,
-      newestSource: path.relative(rootDir, source.file).replace(/\\/g, "/"),
-    }))
-    .sort((a, b) => (a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0));
+  return stale.sort((a, b) => (a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0));
 }
 
 /**
@@ -131,7 +130,11 @@ export async function staleBuilds(
  * `api:extra` reads the manifests `api:compare` left behind rather than
  * re-extracting, so running it alone after a checkout reports the PREVIOUS
  * commit's totals with nothing to signal it — the same stale baseline the build
- * guard exists to stop, one step further downstream. Missing manifests are not
+ * guard exists to stop, one step further downstream.
+ *
+ * mtimes ARE the right oracle here, unlike for `dist`: the manifest is written
+ * by a local run that just read those sources, never restored from an archive,
+ * so nothing can rewind its timestamp below theirs. Missing manifests are not
  * stale; the caller already has a better error for that.
  */
 export async function manifestIsStale(
@@ -144,16 +147,46 @@ export async function manifestIsStale(
   } catch {
     return false;
   }
-  const newest = await Promise.all(roots.map((root) => newestMtime(root.srcDir, isSource, true)));
-  const newestSource = newest.reduce(later, null);
-  return newestSource !== null && newestSource.mtimeMs > manifestMtime;
+  const newest = await Promise.all(roots.map((root) => newestSourceMtime(root.srcDir)));
+  const newestSource = newest.reduce((a, b) => (b > a ? b : a), 0);
+  return newestSource > manifestMtime;
+}
+
+/**
+ * Newest mtime at or under `dir` among `.ts` sources AND the directories
+ * themselves, or 0 if unreadable. Directories count so a checkout that only
+ * DELETES a file — every surviving file keeps its mtime, only the parent
+ * directory moves — is still seen.
+ */
+async function newestSourceMtime(dir: string): Promise<number> {
+  let entries;
+  let newest = 0;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+    newest = (await fs.stat(dir)).mtimeMs;
+  } catch {
+    return 0;
+  }
+  const found = await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return newestSourceMtime(full);
+      if (!entry.name.endsWith(".ts") || entry.name.endsWith(".d.ts")) return 0;
+      try {
+        return (await fs.stat(full)).mtimeMs;
+      } catch {
+        return 0;
+      }
+    }),
+  );
+  return found.reduce((a, b) => (b > a ? b : a), newest);
 }
 
 /** The operator-facing failure text for a non-empty `staleBuilds` result. */
 export function staleBuildMessage(stale: StaleBuild[]): string {
   return [
     `api:compare would measure ${stale.length} package(s) against a stale build:`,
-    ...stale.map((entry) => `  packages/${entry.dir} — newer: ${entry.newestSource}`),
+    ...stale.map((entry) => `  packages/${entry.dir} — ${entry.status}`),
     "",
     "Cross-package imports resolve through packages/<pkg>/dist/*.d.ts, which git",
     "does not update on checkout, so these totals would mix one commit's sources",

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -71,6 +71,66 @@ const STALE_STATUSES: ReadonlySet<ts.UpToDateStatusType> = new Set([
   ts.UpToDateStatusType.TsVersionOutputOfDate,
 ]);
 
+/** A project in the reference closure: where it builds to, and what to call it. */
+interface Project {
+  dir: string;
+  configPath: string;
+  distDir: string;
+}
+
+const PARSE_HOST: ts.ParseConfigFileHost = {
+  ...ts.sys,
+  onUnRecoverableConfigFileDiagnostic: () => {},
+};
+
+/**
+ * Every project reachable from `seeds` through `references`, including the
+ * seeds themselves.
+ *
+ * Checking only the api-compared packages is not enough: a package can import
+ * declaration output from a workspace that is NOT api-compared — `actionview`
+ * references `@blazetrails/tse-compiler` — and tsc reports the IMPORTER as
+ * `UpToDateWithUpstreamTypes` when such a reference goes stale, which is not an
+ * out-of-date status. The stale `dist/*.d.ts` would still be what the extractor
+ * reads, so the referenced project has to be asked about directly.
+ *
+ * This does not undo the scoping: the closure is reachability from packages
+ * api-compare actually extracts, so a workspace nothing references
+ * (`activerecord-cli`, `website`) is still never consulted.
+ */
+function referenceClosure(seeds: readonly Project[]): Project[] {
+  const found = new Map<string, Project>();
+  const queue = [...seeds];
+  while (queue.length > 0) {
+    const project = queue.pop()!;
+    if (found.has(project.configPath)) continue;
+    found.set(project.configPath, project);
+    const parsed = ts.getParsedCommandLineOfConfigFile(project.configPath, {}, PARSE_HOST);
+    for (const reference of parsed?.projectReferences ?? []) {
+      const configPath = resolveProjectConfig(reference.path);
+      if (configPath && !found.has(configPath)) queue.push(toProject(configPath));
+    }
+  }
+  return [...found.values()];
+}
+
+/** A `references` entry may name a directory or the tsconfig itself. */
+function resolveProjectConfig(referencePath: string): string | null {
+  if (referencePath.endsWith(".json")) return referencePath;
+  const candidate = path.join(referencePath, "tsconfig.json");
+  return ts.sys.fileExists(candidate) ? candidate : null;
+}
+
+function toProject(configPath: string): Project {
+  const projectDir = path.dirname(configPath);
+  const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, PARSE_HOST);
+  return {
+    dir: path.basename(projectDir),
+    configPath,
+    distDir: parsed?.options.outDir ?? path.join(projectDir, "dist"),
+  };
+}
+
 /** Whether `dir` holds at least one `.d.ts` — i.e. the package was ever built. */
 async function hasDeclarations(dir: string): Promise<boolean> {
   let entries;
@@ -104,21 +164,31 @@ async function hasDeclarations(dir: string): Promise<boolean> {
  * so deferring to it would let a half-removed build through.
  */
 export async function staleBuilds(roots: readonly PackageRoots[]): Promise<StaleBuild[]> {
-  const byDir = new Map<string, PackageRoots>();
-  for (const root of roots) byDir.set(root.dir, root);
-  const candidates = await Promise.all(
-    [...byDir.values()].map(async (root) => ((await hasDeclarations(root.distDir)) ? root : null)),
+  const seeds = new Map<string, Project>();
+  for (const root of roots) {
+    seeds.set(root.configPath, {
+      dir: root.dir,
+      configPath: root.configPath,
+      distDir: root.distDir,
+    });
+  }
+  const candidates = referenceClosure([...seeds.values()]);
+  const checked = await Promise.all(
+    candidates.map(async (project) => ((await hasDeclarations(project.distDir)) ? project : null)),
   );
-  const built = candidates.filter((root): root is PackageRoots => root !== null);
+  const built = checked.filter((project): project is Project => project !== null);
   if (built.length === 0) return [];
 
-  const projects = built.map((root) => root.configPath);
-  const builder = ts.createSolutionBuilder(ts.createSolutionBuilderHost(ts.sys), projects, {});
+  const builder = ts.createSolutionBuilder(
+    ts.createSolutionBuilderHost(ts.sys),
+    built.map((project) => project.configPath),
+    {},
+  );
   const stale: StaleBuild[] = [];
-  for (const root of built) {
-    const status = builder.getUpToDateStatusOfProject(root.configPath);
+  for (const project of built) {
+    const status = builder.getUpToDateStatusOfProject(project.configPath);
     if (STALE_STATUSES.has(status.type)) {
-      stale.push({ dir: root.dir, status: ts.UpToDateStatusType[status.type] });
+      stale.push({ dir: project.dir, status: ts.UpToDateStatusType[status.type] });
     }
   }
   return stale.sort((a, b) => (a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0));

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -3,28 +3,22 @@
  * belongs to a different commit than the checked-out sources.
  *
  * The TS extractor compiles each package with the real module resolver, so an
- * `import { … } from "@blazetrails/activesupport"` resolves through pnpm's
- * `node_modules` symlink into `packages/activesupport/dist/*.d.ts`. The
- * extracted surface of the IMPORTER therefore depends on the sibling's BUILD
- * OUTPUT, not on its sources.
+ * `import … from "@blazetrails/activesupport"` resolves through pnpm's
+ * `node_modules` symlink into `packages/activesupport/dist/*.d.ts` — the
+ * extracted surface of the IMPORTER depends on the sibling's BUILD OUTPUT.
  *
- * `dist/` is untracked build output, so `git checkout` does not update it. The
- * documented way to take an `api:extra` baseline — `git checkout --detach
- * origin/main` in the same worktree, run, then check the branch back out — thus
- * measures `origin/main`'s sources against the BRANCH's `dist`. Nothing in the
- * cache layer can repair this: the shared cache is content-keyed and the entries
- * record their resolved read-set, so the caches correctly serve what a fresh
- * extraction would produce — a fresh extraction of a mismatched tree. The result
- * is a phantom delta on packages the diff never touched, which is exactly the
- * failure this module exists to make loud.
+ * `dist/` is untracked, so `git checkout` never updates it. Taking an
+ * `api:extra` baseline the documented way (check out `origin/main`, measure,
+ * check the branch back out) therefore measures one commit's sources against
+ * the other commit's build, and packages the diff never touched move. No cache
+ * layer can repair that: the shared cache is content-keyed and its entries
+ * record their resolved read-set, so it already serves exactly what a fresh
+ * extraction of the same mismatched tree would produce.
  *
- * Detection is mtime-based on purpose. `git checkout` rewrites the mtime of
- * every file whose contents it changes and leaves the rest alone, so "some
- * source under `packages/<dir>` is newer than the newest declaration in
- * `packages/<dir>/dist`" is precisely "this package's build predates the
- * checked-out sources". A package with no `dist` at all is NOT stale: nothing
- * was built, so nothing can be out of date, and cross-package imports simply
- * fail to resolve uniformly at every commit.
+ * Detection is mtime-based because `git checkout` rewrites the mtime of exactly
+ * the paths whose contents it changes. Directory mtimes are folded in so a
+ * checkout that only DELETES a source file — which leaves every surviving
+ * file's mtime alone but bumps its parent directory — is still caught.
  *
  * Constraints: async fs only, no `node:` specifiers, no `process` references.
  */
@@ -35,25 +29,45 @@ import * as path from "path";
 export interface StaleBuild {
   /** Directory name under `packages/` (not the api-compare package key). */
   dir: string;
-  /** Repo-relative path of the newest source file, for the error message. */
+  /** Repo-relative path of the newest source path, for the error message. */
   newestSource: string;
 }
 
-/** Newest mtime under `dir` for files passing `keep`, or null if there are none. */
+interface Newest {
+  mtimeMs: number;
+  file: string;
+}
+
+function later(a: Newest | null, b: Newest | null): Newest | null {
+  if (!a) return b;
+  if (!b) return a;
+  return b.mtimeMs > a.mtimeMs ? b : a;
+}
+
+/**
+ * Newest mtime at or under `dir` among files passing `keep`, and — when
+ * `includeDirs` — the directories themselves. Null if `dir` is unreadable.
+ */
 async function newestMtime(
   dir: string,
   keep: (name: string) => boolean,
-): Promise<{ mtimeMs: number; file: string } | null> {
+  includeDirs: boolean,
+): Promise<Newest | null> {
   let entries;
+  let self: Newest | null = null;
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
+    if (includeDirs) {
+      const stat = await fs.stat(dir);
+      self = { mtimeMs: stat.mtimeMs, file: dir };
+    }
   } catch {
     return null;
   }
   const found = await Promise.all(
-    entries.map(async (entry) => {
+    entries.map(async (entry): Promise<Newest | null> => {
       const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) return newestMtime(full, keep);
+      if (entry.isDirectory()) return newestMtime(full, keep, includeDirs);
       if (!keep(entry.name)) return null;
       try {
         const stat = await fs.stat(full);
@@ -63,22 +77,17 @@ async function newestMtime(
       }
     }),
   );
-  let best: { mtimeMs: number; file: string } | null = null;
-  for (const candidate of found) {
-    if (candidate && (!best || candidate.mtimeMs > best.mtimeMs)) best = candidate;
-  }
-  return best;
+  return found.reduce(later, self);
 }
 
 const isSource = (name: string) => name.endsWith(".ts") && !name.endsWith(".d.ts");
 const isDeclaration = (name: string) => name.endsWith(".d.ts");
 
 /**
- * Every package under `packagesDir` that HAS a `dist` whose newest declaration
- * is older than the newest file in its `src`. Packages without a `dist`, or
- * without a `src`, are skipped (see the module comment).
- *
- * `rootDir` only anchors the reported path so the message is repo-relative.
+ * Every package under `packagesDir` whose `dist` was built before its current
+ * `src`. A package with no `dist` is NOT stale — nothing was built, so nothing
+ * can be out of date and cross-package imports fail to resolve uniformly at
+ * every commit. `rootDir` only anchors the reported path.
  */
 export async function staleBuilds(packagesDir: string, rootDir: string): Promise<StaleBuild[]> {
   let dirs: string[];
@@ -91,27 +100,23 @@ export async function staleBuilds(packagesDir: string, rootDir: string): Promise
     dirs.map(async (dir): Promise<StaleBuild | null> => {
       const packageDir = path.join(packagesDir, dir);
       const [source, built] = await Promise.all([
-        newestMtime(path.join(packageDir, "src"), isSource),
-        newestMtime(path.join(packageDir, "dist"), isDeclaration),
+        newestMtime(path.join(packageDir, "src"), isSource, true),
+        newestMtime(path.join(packageDir, "dist"), isDeclaration, false),
       ]);
-      if (!source || !built) return null;
-      if (source.mtimeMs <= built.mtimeMs) return null;
+      if (!source || !built || source.mtimeMs <= built.mtimeMs) return null;
       return { dir, newestSource: path.relative(rootDir, source.file).replace(/\\/g, "/") };
     }),
   );
-  return checked.filter((entry): entry is StaleBuild => entry !== null).sort(byDir);
-}
-
-function byDir(a: StaleBuild, b: StaleBuild): number {
-  return a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0;
+  return checked
+    .filter((entry): entry is StaleBuild => entry !== null)
+    .sort((a, b) => (a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0));
 }
 
 /** The operator-facing failure text for a non-empty `staleBuilds` result. */
 export function staleBuildMessage(stale: StaleBuild[]): string {
-  const lines = stale.map((entry) => `  packages/${entry.dir} — newer: ${entry.newestSource}`);
   return [
     `api:compare would measure ${stale.length} package(s) against a stale build:`,
-    ...lines,
+    ...stale.map((entry) => `  packages/${entry.dir} — newer: ${entry.newestSource}`),
     "",
     "Cross-package imports resolve through packages/<pkg>/dist/*.d.ts, which git",
     "does not update on checkout, so these totals would mix one commit's sources",

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -112,6 +112,35 @@ export async function staleBuilds(packagesDir: string, rootDir: string): Promise
     .sort((a, b) => (a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0));
 }
 
+/**
+ * Whether `manifestPath` predates the sources it claims to describe.
+ *
+ * `api:extra` reads the manifests `api:compare` left behind rather than
+ * re-extracting, so running it alone after a checkout reports the PREVIOUS
+ * commit's totals with nothing to signal it — the same stale baseline the build
+ * guard exists to stop, one step further downstream. Missing manifests are not
+ * stale; the caller already has a better error for that.
+ */
+export async function manifestIsStale(manifestPath: string, packagesDir: string): Promise<boolean> {
+  let manifestMtime: number;
+  try {
+    manifestMtime = (await fs.stat(manifestPath)).mtimeMs;
+  } catch {
+    return false;
+  }
+  let dirs: string[];
+  try {
+    dirs = await fs.readdir(packagesDir);
+  } catch {
+    return false;
+  }
+  const newest = await Promise.all(
+    dirs.map((dir) => newestMtime(path.join(packagesDir, dir, "src"), isSource, true)),
+  );
+  const newestSource = newest.reduce(later, null);
+  return newestSource !== null && newestSource.mtimeMs > manifestMtime;
+}
+
 /** The operator-facing failure text for a non-empty `staleBuilds` result. */
 export function staleBuildMessage(stale: StaleBuild[]): string {
   return [

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -24,6 +24,7 @@
  */
 import * as fs from "fs/promises";
 import * as path from "path";
+import type { PackageRoots } from "./config.js";
 
 /** One package whose `dist` predates its own sources. */
 export interface StaleBuild {
@@ -84,31 +85,43 @@ const isSource = (name: string) => name.endsWith(".ts") && !name.endsWith(".d.ts
 const isDeclaration = (name: string) => name.endsWith(".d.ts");
 
 /**
- * Every package under `packagesDir` whose `dist` was built before its current
- * `src`. A package with no `dist` is NOT stale — nothing was built, so nothing
- * can be out of date and cross-package imports fail to resolve uniformly at
- * every commit. `rootDir` only anchors the reported path.
+ * Every root in `roots` whose `dist` was built before its current `src`.
+ *
+ * `roots` is the extractor's own package set (`apiComparePackageRoots`), NOT a
+ * listing of `packages/` — a workspace api-compare never extracts cannot affect
+ * the manifest and must not be able to block a run. Roots sharing a directory
+ * (the four actionpack packages) collapse to one report, keeping the newest
+ * source among them.
+ *
+ * A root with no `dist` is NOT stale: nothing was built, so nothing can be out
+ * of date and cross-package imports fail to resolve uniformly at every commit.
+ * `rootDir` only anchors the reported path.
  */
-export async function staleBuilds(packagesDir: string, rootDir: string): Promise<StaleBuild[]> {
-  let dirs: string[];
-  try {
-    dirs = await fs.readdir(packagesDir);
-  } catch {
-    return [];
-  }
+export async function staleBuilds(
+  roots: readonly PackageRoots[],
+  rootDir: string,
+): Promise<StaleBuild[]> {
   const checked = await Promise.all(
-    dirs.map(async (dir): Promise<StaleBuild | null> => {
-      const packageDir = path.join(packagesDir, dir);
+    roots.map(async (root): Promise<{ dir: string; source: Newest } | null> => {
       const [source, built] = await Promise.all([
-        newestMtime(path.join(packageDir, "src"), isSource, true),
-        newestMtime(path.join(packageDir, "dist"), isDeclaration, false),
+        newestMtime(root.srcDir, isSource, true),
+        newestMtime(root.distDir, isDeclaration, false),
       ]);
       if (!source || !built || source.mtimeMs <= built.mtimeMs) return null;
-      return { dir, newestSource: path.relative(rootDir, source.file).replace(/\\/g, "/") };
+      return { dir: root.dir, source };
     }),
   );
-  return checked
-    .filter((entry): entry is StaleBuild => entry !== null)
+  const worstPerDir = new Map<string, Newest>();
+  for (const entry of checked) {
+    if (!entry) continue;
+    const seen = worstPerDir.get(entry.dir);
+    if (!seen || entry.source.mtimeMs > seen.mtimeMs) worstPerDir.set(entry.dir, entry.source);
+  }
+  return [...worstPerDir.entries()]
+    .map(([dir, source]) => ({
+      dir,
+      newestSource: path.relative(rootDir, source.file).replace(/\\/g, "/"),
+    }))
     .sort((a, b) => (a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0));
 }
 
@@ -121,22 +134,17 @@ export async function staleBuilds(packagesDir: string, rootDir: string): Promise
  * guard exists to stop, one step further downstream. Missing manifests are not
  * stale; the caller already has a better error for that.
  */
-export async function manifestIsStale(manifestPath: string, packagesDir: string): Promise<boolean> {
+export async function manifestIsStale(
+  manifestPath: string,
+  roots: readonly PackageRoots[],
+): Promise<boolean> {
   let manifestMtime: number;
   try {
     manifestMtime = (await fs.stat(manifestPath)).mtimeMs;
   } catch {
     return false;
   }
-  let dirs: string[];
-  try {
-    dirs = await fs.readdir(packagesDir);
-  } catch {
-    return false;
-  }
-  const newest = await Promise.all(
-    dirs.map((dir) => newestMtime(path.join(packagesDir, dir, "src"), isSource, true)),
-  );
+  const newest = await Promise.all(roots.map((root) => newestMtime(root.srcDir, isSource, true)));
   const newestSource = newest.reduce(later, null);
   return newestSource !== null && newestSource.mtimeMs > manifestMtime;
 }

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -1,0 +1,122 @@
+/**
+ * Guard against measuring `api:compare` / `api:extra` against a BUILD that
+ * belongs to a different commit than the checked-out sources.
+ *
+ * The TS extractor compiles each package with the real module resolver, so an
+ * `import { … } from "@blazetrails/activesupport"` resolves through pnpm's
+ * `node_modules` symlink into `packages/activesupport/dist/*.d.ts`. The
+ * extracted surface of the IMPORTER therefore depends on the sibling's BUILD
+ * OUTPUT, not on its sources.
+ *
+ * `dist/` is untracked build output, so `git checkout` does not update it. The
+ * documented way to take an `api:extra` baseline — `git checkout --detach
+ * origin/main` in the same worktree, run, then check the branch back out — thus
+ * measures `origin/main`'s sources against the BRANCH's `dist`. Nothing in the
+ * cache layer can repair this: the shared cache is content-keyed and the entries
+ * record their resolved read-set, so the caches correctly serve what a fresh
+ * extraction would produce — a fresh extraction of a mismatched tree. The result
+ * is a phantom delta on packages the diff never touched, which is exactly the
+ * failure this module exists to make loud.
+ *
+ * Detection is mtime-based on purpose. `git checkout` rewrites the mtime of
+ * every file whose contents it changes and leaves the rest alone, so "some
+ * source under `packages/<dir>` is newer than the newest declaration in
+ * `packages/<dir>/dist`" is precisely "this package's build predates the
+ * checked-out sources". A package with no `dist` at all is NOT stale: nothing
+ * was built, so nothing can be out of date, and cross-package imports simply
+ * fail to resolve uniformly at every commit.
+ *
+ * Constraints: async fs only, no `node:` specifiers, no `process` references.
+ */
+import * as fs from "fs/promises";
+import * as path from "path";
+
+/** One package whose `dist` predates its own sources. */
+export interface StaleBuild {
+  /** Directory name under `packages/` (not the api-compare package key). */
+  dir: string;
+  /** Repo-relative path of the newest source file, for the error message. */
+  newestSource: string;
+}
+
+/** Newest mtime under `dir` for files passing `keep`, or null if there are none. */
+async function newestMtime(
+  dir: string,
+  keep: (name: string) => boolean,
+): Promise<{ mtimeMs: number; file: string } | null> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const found = await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return newestMtime(full, keep);
+      if (!keep(entry.name)) return null;
+      try {
+        const stat = await fs.stat(full);
+        return { mtimeMs: stat.mtimeMs, file: full };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  let best: { mtimeMs: number; file: string } | null = null;
+  for (const candidate of found) {
+    if (candidate && (!best || candidate.mtimeMs > best.mtimeMs)) best = candidate;
+  }
+  return best;
+}
+
+const isSource = (name: string) => name.endsWith(".ts") && !name.endsWith(".d.ts");
+const isDeclaration = (name: string) => name.endsWith(".d.ts");
+
+/**
+ * Every package under `packagesDir` that HAS a `dist` whose newest declaration
+ * is older than the newest file in its `src`. Packages without a `dist`, or
+ * without a `src`, are skipped (see the module comment).
+ *
+ * `rootDir` only anchors the reported path so the message is repo-relative.
+ */
+export async function staleBuilds(packagesDir: string, rootDir: string): Promise<StaleBuild[]> {
+  let dirs: string[];
+  try {
+    dirs = await fs.readdir(packagesDir);
+  } catch {
+    return [];
+  }
+  const checked = await Promise.all(
+    dirs.map(async (dir): Promise<StaleBuild | null> => {
+      const packageDir = path.join(packagesDir, dir);
+      const [source, built] = await Promise.all([
+        newestMtime(path.join(packageDir, "src"), isSource),
+        newestMtime(path.join(packageDir, "dist"), isDeclaration),
+      ]);
+      if (!source || !built) return null;
+      if (source.mtimeMs <= built.mtimeMs) return null;
+      return { dir, newestSource: path.relative(rootDir, source.file).replace(/\\/g, "/") };
+    }),
+  );
+  return checked.filter((entry): entry is StaleBuild => entry !== null).sort(byDir);
+}
+
+function byDir(a: StaleBuild, b: StaleBuild): number {
+  return a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0;
+}
+
+/** The operator-facing failure text for a non-empty `staleBuilds` result. */
+export function staleBuildMessage(stale: StaleBuild[]): string {
+  const lines = stale.map((entry) => `  packages/${entry.dir} — newer: ${entry.newestSource}`);
+  return [
+    `api:compare would measure ${stale.length} package(s) against a stale build:`,
+    ...lines,
+    "",
+    "Cross-package imports resolve through packages/<pkg>/dist/*.d.ts, which git",
+    "does not update on checkout, so these totals would mix one commit's sources",
+    "with another commit's build output. Run `pnpm build` and re-run.",
+    "Set API_COMPARE_ALLOW_STALE_BUILD=1 to measure anyway (totals are not a",
+    "trustworthy baseline).",
+  ].join("\n");
+}

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -51,6 +51,8 @@ export interface PackageRoots {
   srcDir: string;
   /** The declarations siblings resolve this package's imports through. */
   distDir: string;
+  /** The project `tsc --build` compiles — the freshness guard's oracle. */
+  configPath: string;
 }
 
 /**
@@ -68,6 +70,7 @@ export function apiComparePackageRoots(): PackageRoots[] {
       dir,
       srcDir: packageSrcDir(pkg),
       distDir: path.join(ROOT_DIR, "packages", dir, "dist"),
+      configPath: path.join(ROOT_DIR, "packages", dir, "tsconfig.json"),
     };
   });
 }

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -43,6 +43,35 @@ export const PACKAGE_SRC_SUBDIR: Record<string, string> = {
   actionpackversion: "action-pack",
 };
 
+/** A package's extraction roots, as the freshness guards need them. */
+export interface PackageRoots {
+  /** Directory name under `packages/` — several packages can share one. */
+  dir: string;
+  /** Exactly the tree the extractor compiles (`packageSrcDir`). */
+  srcDir: string;
+  /** The declarations siblings resolve this package's imports through. */
+  distDir: string;
+}
+
+/**
+ * The extraction roots of every package `api:compare` actually extracts.
+ *
+ * Derived from `PACKAGES` rather than a `packages/` listing so the freshness
+ * guards see the same tree the extractor does: workspaces that are not
+ * api-compared (`activerecord-cli`, `trails-tsc`, `tse-compiler`, `website`, …)
+ * cannot affect the TS manifest and so must not be able to block a run.
+ */
+export function apiComparePackageRoots(): PackageRoots[] {
+  return PACKAGES.map((pkg) => {
+    const dir = PACKAGE_DIR_OVERRIDES[pkg] ?? pkg;
+    return {
+      dir,
+      srcDir: packageSrcDir(pkg),
+      distDir: path.join(ROOT_DIR, "packages", dir, "dist"),
+    };
+  });
+}
+
 export function packageSrcDir(pkg: string): string {
   const dirName = PACKAGE_DIR_OVERRIDES[pkg] ?? pkg;
   const subDir = PACKAGE_SRC_SUBDIR[pkg];

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -65,7 +65,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
-import { OUTPUT_DIR } from "./config.js";
+import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
 import {
   SKIP,
   SKIP_TS_MIRROR_IS_DRIFT,
@@ -76,6 +76,7 @@ import {
 } from "./conventions.js";
 import { resolveModuleName } from "./compare.js";
 import { isSourceUnported } from "./unported-files.js";
+import { manifestIsStale } from "./build-freshness.js";
 
 /**
  * Track the FQN alongside the entity so namespace-scoped include resolution
@@ -1046,6 +1047,19 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   if (!fs.existsSync(rubyPath) || !fs.existsSync(tsPath)) {
     console.error(
       `Missing ${path.basename(fs.existsSync(rubyPath) ? tsPath : rubyPath)}. Run \`pnpm api:compare\` first to generate the manifests.`,
+    );
+    process.exit(1);
+  }
+  // A manifest older than the sources describes a different commit — reporting
+  // its totals as this checkout's is exactly the stale baseline this guard
+  // exists to stop (see build-freshness.ts).
+  if (
+    process.env.API_COMPARE_ALLOW_STALE_BUILD !== "1" &&
+    (await manifestIsStale(tsPath, path.join(ROOT_DIR, "packages")))
+  ) {
+    console.error(
+      "output/ts-api.json predates packages/*/src — it describes a different checkout.\n" +
+        "Run `pnpm api:compare` to regenerate the manifests before measuring.",
     );
     process.exit(1);
   }

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -65,7 +65,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
-import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
+import { OUTPUT_DIR, apiComparePackageRoots } from "./config.js";
 import {
   SKIP,
   SKIP_TS_MIRROR_IS_DRIFT,
@@ -1055,10 +1055,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   // exists to stop (see build-freshness.ts).
   if (
     process.env.API_COMPARE_ALLOW_STALE_BUILD !== "1" &&
-    (await manifestIsStale(tsPath, path.join(ROOT_DIR, "packages")))
+    (await manifestIsStale(tsPath, apiComparePackageRoots()))
   ) {
     console.error(
-      "output/ts-api.json predates packages/*/src — it describes a different checkout.\n" +
+      "output/ts-api.json predates the api-compared package sources — it describes a\n" +
+        "different checkout.\n" +
         "Run `pnpm api:compare` to regenerate the manifests before measuring.",
     );
     process.exit(1);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -20,7 +20,14 @@ import type {
   ParamInfo,
   LiteralValue,
 } from "./types.js";
-import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } from "./config.js";
+import {
+  ROOT_DIR,
+  OUTPUT_DIR,
+  PACKAGES,
+  PACKAGE_DIR_OVERRIDES,
+  packageSrcDir,
+  apiComparePackageRoots,
+} from "./config.js";
 import {
   sharedCacheDir,
   contentFingerprint,
@@ -183,7 +190,7 @@ export async function main() {
   // checkout` never updates them, so a checkout-based baseline would silently
   // mix two commits (see build-freshness.ts).
   if (process.env.API_COMPARE_ALLOW_STALE_BUILD !== "1") {
-    const stale = await staleBuilds(path.join(ROOT_DIR, "packages"), ROOT_DIR);
+    const stale = await staleBuilds(apiComparePackageRoots(), ROOT_DIR);
     if (stale.length > 0) throw new Error(staleBuildMessage(stale));
   }
   const force = process.env.API_COMPARE_FORCE === "1";

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -190,7 +190,7 @@ export async function main() {
   // checkout` never updates them, so a checkout-based baseline would silently
   // mix two commits (see build-freshness.ts).
   if (process.env.API_COMPARE_ALLOW_STALE_BUILD !== "1") {
-    const stale = await staleBuilds(apiComparePackageRoots(), ROOT_DIR);
+    const stale = await staleBuilds(apiComparePackageRoots());
     if (stale.length > 0) throw new Error(staleBuildMessage(stale));
   }
   const force = process.env.API_COMPARE_FORCE === "1";

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -34,6 +34,7 @@ import {
   type ReadSet,
 } from "./shared-cache.js";
 import { extractorSchemaToken } from "./extractor-schema.js";
+import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
 
 // Per-package cache: extracting all packages with the TS Compiler API
 // takes ~16s; only a handful of packages typically change between
@@ -177,6 +178,14 @@ export async function main() {
   };
 
   fs.mkdirSync(CACHE_DIR, { recursive: true });
+  // Fail before any extraction if a sibling package's `dist` predates its
+  // sources: cross-package resolution reads those declarations, and `git
+  // checkout` never updates them, so a checkout-based baseline would silently
+  // mix two commits (see build-freshness.ts).
+  if (process.env.API_COMPARE_ALLOW_STALE_BUILD !== "1") {
+    const stale = await staleBuilds(path.join(ROOT_DIR, "packages"), ROOT_DIR);
+    if (stale.length > 0) throw new Error(staleBuildMessage(stale));
+  }
   const force = process.env.API_COMPARE_FORCE === "1";
   // Output-schema token folded into every cache key (local + shared). Stale
   // entries from a prior output shape carry a different token and are re-extracted.


### PR DESCRIPTION
## Problem

Taking an `api:extra` baseline the documented way — `git checkout --detach
origin/main` in the same worktree, run, check the branch back out — produced
different totals for packages the diff never touched (`trailties 147 → 149`,
`actionview 89 → 91`).

## It is not the cache

Verified empirically at `afc210c66`:

- run at HEAD → `git checkout --detach HEAD~12` → run → check the branch back
  out → run: the **first and third runs are byte-identical** for all 13
  packages.
- a fully cached run and `API_COMPARE_FORCE=1` at the same commit are
  **byte-identical**.

The cache is sound. It is content-keyed and each entry records the resolved
read-set of the extraction that produced it, so it serves exactly what a fresh
extraction would produce.

## Root cause: the build, not the commit

The TS extractor compiles each package with the real module resolver, so
`import … from "@blazetrails/activesupport"` resolves through pnpm's
`node_modules` symlink into `packages/activesupport/dist/*.d.ts`. The extracted
surface of the **importer** depends on the sibling's **build output**.

`dist/` is untracked, so `git checkout` never updates it. The baseline run
measures one commit's sources against the other commit's `dist`.

Reproduced at a **single commit**, which removes the diff from the equation
entirely:

| state                 | trailties | actionview |
| --------------------- | --------- | ---------- |
| no package built      | 147       | 90         |
| after `pnpm build`    | 149       | 92         |

Those are the reported deltas, to the unit. The two extra names in each are the
surface that only resolves once the sibling's declarations exist. A fresh
extraction cannot repair this — it just re-extracts the same mismatched tree.

## Fix

The inputs really are inconsistent, so this cannot be made sound by keying.
Taking the AC's second option: **fail loudly**.

1. **Build guard** — before any extraction, `staleBuilds()` fails
   `pnpm api:compare` when a package's emitted output does not correspond to its
   checked-out sources, naming each package and tsc's verdict.
2. **Manifest guard** — `pnpm api:extra` reads the manifests `api:compare` left
   behind rather than re-extracting, so running it alone after a checkout would
   report the previous commit's totals. `manifestIsStale()` fails when
   `output/ts-api.json` is older than the sources it describes.

### The build guard asks tsc, not mtimes

The obvious check — "is some source newer than the newest `.d.ts`?" — is wrong,
and CI proved it. `.github/actions/cache-build` restores `dist` plus
`tsconfig.tsbuildinfo` from a tarball keyed on a content hash of every package
`src/`, so restored outputs carry their **archive** mtimes while
`actions/checkout` has just written every source at "now". `pnpm build`
correctly no-ops, leaving a tree that is perfectly current but that looks, by
mtime, entirely stale. The first version of this guard compared mtimes and
failed all 13 packages on every CI run while contradicting the build that had
just succeeded.

It now asks `ts.createSolutionBuilder(...).getUpToDateStatusOfProject()` — the
same computation `tsc --build` uses to decide what to emit — so it cannot
contradict a successful build. `OutOfDateWithSelf` when a checkout rewrites a
source, `OutOfDateRoots` when one only deletes a file (tsc catches that
natively, so no directory-mtime workaround is needed).

mtimes are kept for the *manifest* guard, where they are sound: the manifest is
written by a local run that just read those sources and is never restored from
an archive, so nothing can rewind its timestamp below theirs.

### Scope: the reachable reference closure

Seeded from a new `apiComparePackageRoots()` in `config.ts` (derived from
`PACKAGES` / `vendor/sources.ts`), then expanded by following each
`tsconfig.json`'s `references`.

The closure is required for correctness: `packages/actionview` references
`@blazetrails/tse-compiler`, which is not in `PACKAGES`, and tsc reports the
importer as `UpToDateWithUpstreamTypes` when such a reference goes stale — not
an out-of-date status. Asking only about api-compared packages would let a stale
`tse-compiler/dist/*.d.ts` reach the extractor.

It is reachability, not "every workspace": `activerecord-cli` / `website` are
referenced by nothing api-compared and never block a run.

A package with no `dist` is not stale — nothing was built, so cross-package
imports fail to resolve uniformly at every commit — so the guard is silent in a
fresh `start-worktree.sh` checkout. `pnpm api:compare && pnpm api:extra` before
and after this change produces identical totals for all 13 packages.

`API_COMPARE_ALLOW_STALE_BUILD=1` is the escape hatch for non-baseline runs.

## Docs

`docs/infrastructure/api-compare-baselining.md` — the supported procedure
(`pnpm build` after every checkout), the single-commit reproduction above, both
guards with their separate oracles and scopes, and why neither can be replaced
by better cache keying. Indexed in `docs/index.md`.

## Tests

`build-freshness.test.ts` — 17 cases against **real compiled tsc projects**
rather than faked timestamps, since a guard that delegates to tsc's oracle is
only meaningfully tested against tsc. Covers: the checkout-away-and-back
sequence, delete-only checkouts, the CI cache-restore state that broke the first
implementation, a stale *referenced* non-api-compared workspace (verified to
fail without the closure fix), an unreferenced workspace being ignored,
never-built packages, actionpack roots collapsing to one report, stable
ordering, and both manifest-staleness directions.

Closes-story: api-extra-baseline-stale-across-in-worktree-checkout
