### PR TITLE
fix(eslint): stop registering rails-file-structure-method-order without a manifest

### DIFF
--- a/docs/infrastructure/rails-file-structure-mirror-plan.md
+++ b/docs/infrastructure/rails-file-structure-mirror-plan.md
@@ -581,6 +581,13 @@ as a passing one. Previously the rule was registered against an empty
 manifest and passed every file, so a violation was invisible to the job
 named "Lint" — the condition this decision records.
 
+Because that leaves exactly one enforcing job, that job must not be able to
+degrade quietly. Omitting `--allow-missing` covers a missing
+`rails-api.json`; the builder additionally fails when a real extract yields a
+manifest with zero entries, which would leave the rule unregistered and the
+step green. Restricting enforcement to one job is only safe while that job
+cannot silently stop enforcing.
+
 ## 6. Wave-based rollout
 
 Each PR sized to ≤500 LOC per [CLAUDE.md](../../CLAUDE.md). Estimates are

--- a/docs/infrastructure/rails-file-structure-mirror-plan.md
+++ b/docs/infrastructure/rails-file-structure-mirror-plan.md
@@ -561,6 +561,26 @@ need to swap, the fix is one range covering both.
 - Tests in `eslint/rails-file-structure.test.mjs` follow the
   `RuleTester` pattern used by sibling rules.
 
+#### Which CI job enforces method order (decided)
+
+Enforcement is **deliberately restricted to the Rails API/Test Comparison
+job**, which runs `pnpm api:compare` and therefore has a real
+`scripts/api-compare/output/rails-api.json` to build the manifest from. The
+Lint job has no Ruby toolchain and no `rails-api.json`, so its manifest is
+the builder's empty fallback — reproducing one there would mean running the
+whole extractor in a second job for no additional coverage.
+
+What changed is that the fallback no longer masquerades as enforcement.
+`scripts/api-compare/require-rails-api.ts` already makes a missing
+`rails-api.json` a hard error unless the caller opts in with
+`--allow-missing` (the `prelint` chain, hence the Lint job). On top of that,
+`eslint.config.mjs` (via `isManifestAvailable()`) leaves the rule
+**unregistered** whenever the manifest has no entries, and prints a notice
+naming the job that does enforce it — so an inert run cannot present itself
+as a passing one. Previously the rule was registered against an empty
+manifest and passed every file, so a violation was invisible to the job
+named "Lint" — the condition this decision records.
+
 ## 6. Wave-based rollout
 
 Each PR sized to ≤500 LOC per [CLAUDE.md](../../CLAUDE.md). Estimates are

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,9 @@ import noNativeDate from "./eslint/no-native-date.mjs";
 import noGetterCalledAsMethod from "./eslint/no-getter-called-as-method.mjs";
 import sqliteDriverAwait from "./eslint/sqlite-driver-await.mjs";
 import preferAwaitRelation from "./eslint/prefer-await-relation.mjs";
-import railsFileStructureMethodOrder from "./eslint/rails-file-structure-method-order.mjs";
+import railsFileStructureMethodOrder, {
+  isManifestAvailable as railsFileStructureManifestAvailable,
+} from "./eslint/rails-file-structure-method-order.mjs";
 import expectedFixtures from "./eslint/expected-fixtures.mjs";
 import manifestComplete from "./eslint/manifest-complete.mjs";
 import testFixtureParity from "./eslint/test-fixture-parity.mjs";
@@ -29,6 +31,19 @@ import noStandaloneAssociations from "./eslint/no-standalone-associations.mjs";
 import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.mjs";
 import noExplicitAnyDisable from "./eslint/no-explicit-any-disable.mjs";
 import { readFileSync } from "node:fs";
+
+// See the rails-file-structure-method-order block below: without real order
+// data the rule passes every file, so we register it only when the manifest
+// has data, and announce the skip instead of pretending to enforce.
+const railsFileStructureManifestReady = railsFileStructureManifestAvailable();
+if (!railsFileStructureManifestReady) {
+  console.warn(
+    "[eslint.config] rails-file-structure-method-order NOT registered: " +
+      "eslint/rails-file-structure-method-order.json has no order data " +
+      "(run `pnpm api:compare` to build it). Method order is enforced by the " +
+      "Rails API/Test Comparison CI job, not this run.",
+  );
+}
 
 /** @type {string[]} */
 const noExplicitAnySrcExclude = JSON.parse(
@@ -387,13 +402,23 @@ export default defineConfig(
   // documented in `eslint/rails-file-structure-method-order.json` (built
   // by `pnpm tsx scripts/build-rails-file-structure-manifest.ts`,
   // invoked by `pnpm api:compare`). Autofixable.
-  {
-    files: ["packages/arel/src/**/*.ts", "packages/activemodel/src/**/*.ts"],
-    ignores: ["**/*.test.ts"],
-    rules: {
-      "blazetrails/rails-file-structure-method-order": "error",
-    },
-  },
+  //
+  // Enforcement lives in the Rails API/Test Comparison job, the only job that
+  // builds rails-api.json. Everywhere else (the Lint job, a local `pnpm lint`
+  // without a compare run) the manifest is the builder's empty fallback, under
+  // which the rule passes every file. Registering it there would advertise
+  // enforcement that cannot happen, so we skip the block and say so out loud.
+  ...(railsFileStructureManifestReady
+    ? [
+        {
+          files: ["packages/arel/src/**/*.ts", "packages/activemodel/src/**/*.ts"],
+          ignores: ["**/*.test.ts"],
+          rules: {
+            "blazetrails/rails-file-structure-method-order": "error",
+          },
+        },
+      ]
+    : []),
 
   // ── nie-requires-annotation: every `throw new NotImplementedError` must
   // carry a `// @nie disposition=…` comment. Tracks the elimination

--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -47,14 +47,32 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MANIFEST_PATH = path.resolve(__dirname, "rails-file-structure-method-order.json");
 
+/**
+ * True when the manifest on disk carries real order data.
+ *
+ * The manifest is generated from `scripts/api-compare/output/rails-api.json`,
+ * which only exists after `pnpm api:compare` (Ruby + vendored Rails). Runs
+ * without it pass `--allow-missing` to the builder (see
+ * scripts/api-compare/require-rails-api.ts) and get an empty manifest, under
+ * which this rule would pass every file. `eslint.config.mjs` uses this to
+ * leave the rule unregistered for those runs rather than registering it
+ * inert — see docs/infrastructure/rails-file-structure-mirror-plan.md.
+ */
+export function isManifestAvailable(manifestPath = MANIFEST_PATH) {
+  // The real manifest is megabytes; go through the cache for the default path
+  // so config-time gating and rule-time lookups parse it once.
+  const manifest = manifestPath === MANIFEST_PATH ? loadManifest() : readManifest(manifestPath);
+  return Object.keys(manifest.files ?? {}).length > 0;
+}
+
+function readManifest(manifestPath) {
+  if (!fs.existsSync(manifestPath)) return { files: {} };
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
 let manifestCache = null;
 function loadManifest() {
-  if (manifestCache) return manifestCache;
-  if (!fs.existsSync(MANIFEST_PATH)) {
-    manifestCache = { files: {} };
-    return manifestCache;
-  }
-  manifestCache = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
+  if (!manifestCache) manifestCache = readManifest(MANIFEST_PATH);
   return manifestCache;
 }
 

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -2,7 +2,7 @@ import { RuleTester } from "eslint";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import rule from "./rails-file-structure-method-order.mjs";
+import rule, { isManifestAvailable } from "./rails-file-structure-method-order.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -532,3 +532,28 @@ try {
   // restore is scheduled even if registration above throws.
   afterAll(restoreManifest);
 }
+
+// isManifestAvailable() — what eslint.config.mjs gates registration on. A
+// manifest with no order data must read as unavailable however it got that
+// way (absent file, or the `--allow-missing` builder's empty `files` map), so
+// the rule is never registered against data that would pass every file. Each case
+// passes an explicit path, so none of this touches the shared manifest the
+// RuleTester cases above depend on.
+describe("isManifestAvailable", () => {
+  const tmp = path.join(__dirname, ".tmp-availability.json");
+  afterAll(() => fs.rmSync(tmp, { force: true }));
+
+  it("is false when the manifest file is absent", () => {
+    expect(isManifestAvailable(path.join(__dirname, ".tmp-absent.json"))).toBe(false);
+  });
+
+  it("is false for the --allow-missing builder's empty manifest", () => {
+    fs.writeFileSync(tmp, JSON.stringify({ files: {} }));
+    expect(isManifestAvailable(tmp)).toBe(false);
+  });
+
+  it("is true for a manifest carrying order data", () => {
+    fs.writeFileSync(tmp, JSON.stringify(fixture));
+    expect(isManifestAvailable(tmp)).toBe(true);
+  });
+});

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -3,6 +3,9 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import rule, { isManifestAvailable } from "./rails-file-structure-method-order.mjs";
+// describe/it/afterAll come from the vitest globals the RuleTester cases rely
+// on; `expect` is not in that global set here, so import it.
+import { expect } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..");

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -340,6 +340,18 @@ const nameCount = Object.values(final.files).reduce(
 );
 console.log(`Wrote ${OUT} — ${fileCount} files (${nameCount} ordered names)`);
 
+// A manifest with no entries reads as unavailable to eslint.config.mjs, which
+// then leaves the rule unregistered — silently, and green. Reaching here means
+// rails-api.json WAS present, so an empty result is a broken extract, not the
+// documented `--allow-missing` path.
+if (fileCount === 0) {
+  throw new Error(
+    `[build-rails-file-structure-manifest] built manifest has no entries, so ` +
+      `blazetrails/rails-file-structure-method-order would not be registered. ` +
+      `Check that ${RAILS_API_PATH} holds a real extract.`,
+  );
+}
+
 // Every package has been visited, so an operator entry that never resolved names a
 // class/operator the Ruby extract does not have. Unlike a last-segment collision
 // (which follows from Rails' own structure and only warns), a dead entry is always


### PR DESCRIPTION
## Problem

`blazetrails/rails-file-structure-method-order` reads a generated manifest built
from `scripts/api-compare/output/rails-api.json`. The **Lint** job runs the
builder with no `rails-api.json` present, so the builder logged
`rails-api.json missing; wrote empty manifest` and the rule — still registered —
passed every file. A method-order violation was invisible to the job named
"Lint" and enforced only by the **Rails API/Test Comparison** job, which runs
`pnpm api:compare` first.

## Decision

Enforcement stays **deliberately restricted to the compare job** — the only job
with a Ruby toolchain and a real `rails-api.json`. Reproducing that in Lint
would mean running the whole extractor twice for no additional coverage.

What changes is that an inert run can no longer present itself as a passing one:

- the rule exports `isManifestAvailable()` (false for an absent manifest or one
  with no entries), reading through the existing manifest cache so the
  megabyte-scale manifest is parsed once per process;
- `eslint.config.mjs` **does not register the rule** when there is no order
  data, and prints a notice naming the job that does enforce it;
- the builder fails when a real `rails-api.json` yields a zero-entry manifest —
  which would leave the rule unregistered and the compare step green.

**Rebased onto #5423's `require-rails-api.ts`**, which landed the complementary
half while this PR was open: a missing `rails-api.json` is now a hard error
unless the caller passes `--allow-missing` (`prelint`, hence the Lint job). My
earlier `--require-data` flag did the same job with inverted polarity, so it is
gone — one mechanism, and the safer default (fail) is now the default. The
`unavailable: true` manifest marker went with it: an empty `files` map already
says the same thing.

Recorded in `docs/infrastructure/rails-file-structure-mirror-plan.md` §5.4.

## The 4 pre-existing `packages/arel` violations

Already resolved on `main`. Verified by generating a real `rails-api.json`
(`ruby scripts/api-compare/extract-ruby-api.rb`), building the manifest, and
running `pnpm exec eslint packages/arel/src packages/activemodel/src` → exit 0,
no diagnostics. No reorder was needed, so nothing is waived.

## Verification

All four paths exercised locally with a real extract:

| state | result |
| --- | --- |
| manifest has data | rule registered; arel + activemodel clean (exit 0) |
| builder, data present | exit 0 |
| builder, no `rails-api.json`, no flag | exit 1 (`require-rails-api.ts`) |
| builder `--allow-missing` | exit 0, empty manifest |
| empty manifest | notice printed, rule absent, lint exits 0 |

`pnpm vitest run eslint/rails-file-structure-method-order.test.mjs` passes (37
tests; 46 with `require-rails-api` + `ci-suite-coverage`), including new coverage of all four `isManifestAvailable()` branches.
This file is vitest-only since #5424 made it a real suite (`afterAll`, RuleTester
registering through vitest globals) — `node <file>` fails on `origin/main` too,
so the new cases use `describe`/`it`/`expect` rather than reintroducing a
standalone-script idiom the file no longer supports.

api:compare / test:compare unaffected — no `packages/` source changes.

Rebased onto green `main`; the `scripts/ci-suite-coverage.test.ts` failure noted
earlier was the pre-existing main breakage and now passes (4/4).

Note (out of this story's scope): `build-rails-privates-manifest.ts` has the
same silent empty-manifest fallback for `rails-private-jsdoc`.

Closes-story: rails-file-structure-lint-rule-no-ops-in-lint-job


