### PR TITLE
fix(lint): fail loudly when rails-api.json is missing instead of emptying the privates manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1381,12 +1381,14 @@ jobs:
         # and intentionally no-ops this rule via `--allow-missing`; here the
         # builder runs WITHOUT that flag, so a missing extraction fails the job
         # instead of quietly producing an empty manifest the rule can't match.
-        # The eslint paths mirror the rule's `files` list in eslint.config.mjs —
-        # linting only arel left the other enabled packages unenforced.
+        # Uses the standalone eslint/rails-private-jsdoc.config.mjs so this step
+        # runs that ONE rule over every package the root config enables it for,
+        # rather than re-running the whole ruleset (which would duplicate the
+        # Lint job). Linting only packages/arel/src here left activesupport,
+        # activemodel, actionpack, actionview and activerecord unenforced.
         run: |
           pnpm exec tsx scripts/build-rails-privates-manifest.ts
-          pnpm exec eslint packages/arel/src packages/activesupport/src packages/activemodel/src \
-            packages/actionpack/src packages/actionview/src packages/activerecord/src
+          pnpm exec eslint --no-inline-config --config eslint/rails-private-jsdoc.config.mjs packages
       - name: Rails file-structure method-order lint
         # Needs rails-api.json (extracted above) to build the per-class
         # method-order manifest, then enforce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,11 @@ jobs:
           # eslint/ rides on it because the custom rules' own RuleTester suites
           # are in the same invocation: without this clause a PR that only
           # touches a rule or its test would skip the only job that runs them.
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$)'
+          # eslint.config.mjs is named separately (it is not under eslint/):
+          # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
+          # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
+          # to the root config must still run the guard.
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$|eslint\.config\.mjs$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1377,16 +1377,25 @@ jobs:
         run: pnpm exec tsx scripts/api-compare/lint-deps.ts
       - name: Rails-private JSDoc lint
         # Needs rails-api.json (extracted above) to enforce
-        # blazetrails/rails-private-jsdoc. The standalone Lint job has
-        # no Ruby and intentionally no-ops this rule.
-        run: pnpm exec tsx scripts/build-rails-privates-manifest.ts && pnpm exec eslint packages/arel/src
+        # blazetrails/rails-private-jsdoc. The standalone Lint job has no Ruby
+        # and intentionally no-ops this rule via `--allow-missing`; here the
+        # builder runs WITHOUT that flag, so a missing extraction fails the job
+        # instead of quietly producing an empty manifest the rule can't match.
+        # The eslint paths mirror the rule's `files` list in eslint.config.mjs —
+        # linting only arel left the other enabled packages unenforced.
+        run: |
+          pnpm exec tsx scripts/build-rails-privates-manifest.ts
+          pnpm exec eslint packages/arel/src packages/activesupport/src packages/activemodel/src \
+            packages/actionpack/src packages/actionview/src packages/activerecord/src
       - name: Rails file-structure method-order lint
         # Needs rails-api.json (extracted above) to build the per-class
         # method-order manifest, then enforce
         # blazetrails/rails-file-structure-method-order. The manifest is
         # gitignored and only exists here (never committed), so the
-        # standalone Lint job intentionally no-ops this rule — this is the
-        # only job where it goes live. Enabled per-package via
+        # standalone Lint job intentionally no-ops this rule via
+        # `--allow-missing` — this is the only job where it goes live, and here
+        # the builder runs without that flag so a missing extraction fails
+        # loudly rather than emptying the manifest. Enabled per-package via
         # eslint.config.mjs (arel + activemodel). RAILS_STRUCTURE_REPORT=1 prints
         # (to stderr, non-failing) any manifest bucket that matched no container
         # — a renamed class past the fallback, or a module ported as a class —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,10 +702,6 @@ jobs:
           scripts/strip-asany.test.ts
           scripts/rails-file-structure-mixins.test.ts
           scripts/ci-suite-coverage.test.ts
-          # A real vitest suite, unlike the RuleTester-driven eslint/*.test.mjs
-          # on ci-suite-coverage's KNOWN_UNRUN list — so it gets a filter here
-          # rather than an exemption there.
-          eslint/rails-private-jsdoc.config.test.mjs
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack
   # (~27 s), actionview (~26 s), tse-compiler (~22 s), and the DX type tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,6 +698,10 @@ jobs:
           scripts/strip-asany.test.ts
           scripts/rails-file-structure-mixins.test.ts
           scripts/ci-suite-coverage.test.ts
+          # A real vitest suite, unlike the RuleTester-driven eslint/*.test.mjs
+          # on ci-suite-coverage's KNOWN_UNRUN list — so it gets a filter here
+          # rather than an exemption there.
+          eslint/rails-private-jsdoc.config.test.mjs
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack
   # (~27 s), actionview (~26 s), tse-compiler (~22 s), and the DX type tests

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,10 +1,5 @@
 {
   "files": {
-    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
-      "unsignedDecimal",
-      "unsignedFloat"
-    ],
-    "packages/activerecord/src/connection-handling.ts": ["connection"],
-    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
+    "packages/activerecord/src/connection-handling.ts": ["connection"]
   }
 }

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,5 +1,10 @@
 {
   "files": {
-    "packages/activerecord/src/connection-handling.ts": ["connection"]
+    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
+      "unsignedDecimal",
+      "unsignedFloat"
+    ],
+    "packages/activerecord/src/connection-handling.ts": ["connection"],
+    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
   }
 }

--- a/eslint/rails-private-jsdoc.config.mjs
+++ b/eslint/rails-private-jsdoc.config.mjs
@@ -1,0 +1,42 @@
+/**
+ * Standalone flat config that enables ONLY `blazetrails/rails-private-jsdoc`.
+ *
+ * The rule needs `eslint/rails-private-methods.json`, which is built from
+ * `scripts/api-compare/output/rails-api.json` and therefore only exists in the
+ * `rails-comparison` CI job (the one with Ruby). Reusing the root
+ * `eslint.config.mjs` there would re-run the entire ruleset over six packages —
+ * a full duplicate of the standalone Lint job, and unrelated violations would
+ * fail the wrong job. This config keeps that step to the one rule the manifest
+ * unlocks.
+ *
+ * The `files` list must stay in sync with the `rails-private-jsdoc` block in
+ * eslint.config.mjs; that block is what governs every other invocation.
+ */
+import tseslint from "typescript-eslint";
+import railsPrivateJsdoc from "./rails-private-jsdoc.mjs";
+
+export default [
+  {
+    files: [
+      "packages/arel/src/**/*.ts",
+      "packages/activesupport/src/**/*.ts",
+      "packages/activemodel/src/**/*.ts",
+      "packages/actionpack/src/**/*.ts",
+      "packages/actionview/src/**/*.ts",
+      "packages/activerecord/src/**/*.ts",
+    ],
+    ignores: ["**/*.test.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+    },
+    // Run with `--no-inline-config`: the sources carry `eslint-disable`
+    // comments for rules this config does not register, and each of those
+    // would otherwise be a "Definition for rule ... was not found" error.
+    // Nothing disables `rails-private-jsdoc` inline, so ignoring inline config
+    // costs no legitimate suppression.
+    linterOptions: { reportUnusedDisableDirectives: "off" },
+    plugins: { blazetrails: { rules: { "rails-private-jsdoc": railsPrivateJsdoc } } },
+    rules: { "blazetrails/rails-private-jsdoc": "error" },
+  },
+];

--- a/eslint/rails-private-jsdoc.config.test.mjs
+++ b/eslint/rails-private-jsdoc.config.test.mjs
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import standalone from "./rails-private-jsdoc.config.mjs";
+import root from "../eslint.config.mjs";
+
+/**
+ * The standalone config duplicates the root config's `files` list so the
+ * `rails-comparison` CI step can run the rule alone. Drift between the two
+ * would silently drop a package from that step — the exact class of silent
+ * under-enforcement this config exists to close.
+ */
+describe("rails-private-jsdoc.config.mjs", () => {
+  const rootBlock = root.find(
+    (block) => block.rules?.["blazetrails/rails-private-jsdoc"] !== undefined,
+  );
+
+  it("enables only blazetrails/rails-private-jsdoc", () => {
+    expect(standalone).toHaveLength(1);
+    expect(Object.keys(standalone[0].rules)).toEqual(["blazetrails/rails-private-jsdoc"]);
+    expect(standalone[0].rules["blazetrails/rails-private-jsdoc"]).toBe("error");
+  });
+
+  it("matches the root config's file list", () => {
+    expect(rootBlock).toBeDefined();
+    expect(standalone[0].files).toEqual(rootBlock.files);
+  });
+
+  it("matches the root config's ignores", () => {
+    expect(standalone[0].ignores).toEqual(rootBlock.ignores);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepare": "husky",
     "typecheck": "node scripts/typecheck.mjs",
     "guides:typecheck": "tsx scripts/guides-typecheck/check.ts",
-    "prelint": "pnpm tsx scripts/build-rails-privates-manifest.ts && pnpm tsx scripts/build-rails-error-manifest.ts && pnpm tsx scripts/build-rails-tosql-manifest.ts && pnpm tsx scripts/build-rails-file-structure-manifest.ts && pnpm tsx scripts/test-deps/rails-test-deps.ts >/dev/null",
+    "prelint": "pnpm tsx scripts/build-rails-privates-manifest.ts --allow-missing && pnpm tsx scripts/build-rails-error-manifest.ts && pnpm tsx scripts/build-rails-tosql-manifest.ts && pnpm tsx scripts/build-rails-file-structure-manifest.ts --allow-missing && pnpm tsx scripts/test-deps/rails-test-deps.ts >/dev/null",
     "lint": "eslint .",
     "lint:no-explicit-any:allowlist": "pnpm tsx scripts/generate-no-explicit-any-allowlist.ts",
     "test": "vitest run",

--- a/scripts/api-compare/require-rails-api.test.ts
+++ b/scripts/api-compare/require-rails-api.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fileURLToPath } from "url";
+import { allowMissingRailsApi, railsApiAvailable } from "./require-rails-api.js";
+
+const EXISTING = fileURLToPath(import.meta.url);
+const MISSING = `${EXISTING}.does-not-exist.json`;
+
+function options(railsApiPath: string, argv: readonly string[]) {
+  return {
+    scriptName: "build-rails-privates-manifest",
+    railsApiPath,
+    manifestName: "eslint/rails-private-methods.json",
+    ruleName: "rails-private-jsdoc",
+    argv,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("allowMissingRailsApi", () => {
+  it("recognizes the --allow-missing opt-in", () => {
+    expect(allowMissingRailsApi(["--allow-missing"])).toBe(true);
+    expect(allowMissingRailsApi([])).toBe(false);
+  });
+});
+
+describe("railsApiAvailable", () => {
+  it("returns true when rails-api.json exists", () => {
+    expect(railsApiAvailable(options(EXISTING, []))).toBe(true);
+  });
+
+  it("throws naming pnpm api:compare when rails-api.json is missing", () => {
+    expect(() => railsApiAvailable(options(MISSING, []))).toThrow(/pnpm api:compare/);
+  });
+
+  it("names the rule that would go inert", () => {
+    expect(() => railsApiAvailable(options(MISSING, []))).toThrow(
+      /blazetrails\/rails-private-jsdoc/,
+    );
+  });
+
+  it("returns false and warns when --allow-missing is passed", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(railsApiAvailable(options(MISSING, ["--allow-missing"]))).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/INERT/);
+  });
+
+  it("does not warn when the file exists even with --allow-missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(railsApiAvailable(options(EXISTING, ["--allow-missing"]))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/api-compare/require-rails-api.ts
+++ b/scripts/api-compare/require-rails-api.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared missing-`rails-api.json` policy for the manifest builders whose
+ * output is gitignored (`build-rails-privates-manifest.ts`,
+ * `build-rails-file-structure-manifest.ts`).
+ *
+ * Those builders regenerate an ESLint manifest from
+ * `scripts/api-compare/output/rails-api.json`, which only exists after
+ * `pnpm api:compare` (it needs Ruby + the vendored Rails source). When it is
+ * absent they used to write `{ files: {} }` and exit 0, so the rule reading
+ * the manifest matched nothing and the gate passed silently — a lint job that
+ * looks green while enforcing nothing.
+ *
+ * Policy now: missing input is a hard error by default. Callers that legitimately
+ * run without Ruby (the `prelint` chain, and therefore the standalone Lint CI
+ * job) opt in with `--allow-missing`, which restores the empty-manifest write
+ * but announces that the rule is inert for that run.
+ */
+import * as fs from "fs";
+
+/** Whether `--allow-missing` was passed on the command line. */
+export function allowMissingRailsApi(argv: readonly string[]): boolean {
+  return argv.includes("--allow-missing");
+}
+
+export interface MissingRailsApiOptions {
+  /** Script name used to prefix the console message, e.g. `build-rails-privates-manifest`. */
+  scriptName: string;
+  /** Absolute path to the expected `rails-api.json`. */
+  railsApiPath: string;
+  /** Repo-relative path of the manifest that would have been written. */
+  manifestName: string;
+  /** Name of the ESLint rule(s) that go inert when the manifest is empty. */
+  ruleName: string;
+  /** Process argv (`process.argv.slice(2)` at the call site). */
+  argv: readonly string[];
+}
+
+/**
+ * Returns `true` when `rails-api.json` is present and the builder should carry
+ * on with real data.
+ *
+ * Returns `false` when it is absent *and* `--allow-missing` was passed — the
+ * caller should write its empty manifest and exit 0.
+ *
+ * Throws when it is absent without `--allow-missing`. Callers run this before
+ * any work, so throwing gives a non-zero exit plus the remediation command.
+ */
+export function railsApiAvailable(options: MissingRailsApiOptions): boolean {
+  const { scriptName, railsApiPath, manifestName, ruleName, argv } = options;
+  if (fs.existsSync(railsApiPath)) return true;
+
+  if (!allowMissingRailsApi(argv)) {
+    throw new Error(
+      `[${scriptName}] ${railsApiPath} is missing, so ${manifestName} cannot be built ` +
+        `and \`blazetrails/${ruleName}\` would silently match nothing.\n` +
+        `Run \`pnpm api:compare\` to generate it (needs Ruby + \`pnpm vendor:fetch\`), ` +
+        `or pass \`--allow-missing\` to accept an inert manifest.`,
+    );
+  }
+
+  console.warn(
+    `[${scriptName}] ${railsApiPath} missing; wrote an EMPTY ${manifestName}. ` +
+      `\`blazetrails/${ruleName}\` is INERT for this run and will report nothing. ` +
+      `Run \`pnpm api:compare\` to regenerate with real data.`,
+  );
+  return false;
+}

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -32,6 +32,7 @@ import {
   unusedOperatorSpellings,
 } from "./api-compare/operator-order-spelling.js";
 import { resolveMixinParent } from "./rails-file-structure-mixins.js";
+import { railsApiAvailable } from "./api-compare/require-rails-api.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -51,13 +52,17 @@ const PACKAGE_DIRS: Record<string, string> = {
 const RAILS_API_PATH = path.join(ROOT, "scripts/api-compare/output/rails-api.json");
 const OUT = path.join(ROOT, "eslint/rails-file-structure-method-order.json");
 
-if (!fs.existsSync(RAILS_API_PATH)) {
+if (
+  !railsApiAvailable({
+    scriptName: "build-rails-file-structure-manifest",
+    railsApiPath: RAILS_API_PATH,
+    manifestName: "eslint/rails-file-structure-method-order.json",
+    ruleName: "rails-file-structure-method-order",
+    argv: process.argv.slice(2),
+  })
+) {
   fs.mkdirSync(path.dirname(OUT), { recursive: true });
   writeJsonManifest(OUT, { files: {} });
-  console.warn(
-    `[build-rails-file-structure-manifest] ${RAILS_API_PATH} missing; wrote empty manifest. ` +
-      `Run \`pnpm api:compare\` to regenerate with real data.`,
-  );
   process.exit(0);
 }
 

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -36,6 +36,7 @@ import {
   beginManifestBatch,
   flushManifestBatch,
 } from "./api-compare/write-json-manifest.js";
+import { railsApiAvailable } from "./api-compare/require-rails-api.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -57,6 +58,16 @@ const PACKAGE_DIRS: Record<string, string> = {
 const RAILS_API_PATH = path.join(ROOT, "scripts/api-compare/output/rails-api.json");
 const OUT = path.join(ROOT, "eslint/rails-private-methods.json");
 
+// Resolved before any manifest is written: without `--allow-missing` this
+// throws, and we would rather abort than half-write the batch below.
+const hasRailsApi = railsApiAvailable({
+  scriptName: "build-rails-privates-manifest",
+  railsApiPath: RAILS_API_PATH,
+  manifestName: "eslint/rails-private-methods.json",
+  ruleName: "rails-private-jsdoc",
+  argv: process.argv.slice(2),
+});
+
 // This script emits three manifests per run. Collect their writes and format
 // them all in one prettier spawn (~330ms of startup, once instead of thrice).
 beginManifestBatch();
@@ -71,13 +82,9 @@ emitDeprecatedManifest();
 // so emit it here too — before the rails-api.json early exit.
 emitCallbackInvocationsManifest();
 
-if (!fs.existsSync(RAILS_API_PATH)) {
+if (!hasRailsApi) {
   writeJsonManifest(OUT, { files: {} });
   flushManifestBatch();
-  console.warn(
-    `[build-rails-privates-manifest] ${RAILS_API_PATH} missing; wrote empty manifest. ` +
-      `Run \`pnpm api:compare\` to regenerate with real data.`,
-  );
   process.exit(0);
 }
 


### PR DESCRIPTION
## Problem

`pnpm lint` regenerates the gitignored `eslint/rails-private-methods.json` from
`scripts/api-compare/output/rails-api.json`, which only exists after
`pnpm api:compare`. When absent, `build-rails-privates-manifest.ts` wrote
`{ files: {} }`, printed a one-line warning, and exited 0 — so
`blazetrails/rails-private-jsdoc` ran against an empty name list and reported
nothing. `build-rails-file-structure-manifest.ts` did the same.

## CI finding (acceptance criterion 1)

`rails-api.json` **is** available in the `rails-comparison` job (extracted by its
`ruby extract-ruby-api.rb` step), and that is the only job where either rule goes
live. The standalone `Lint` job has no Ruby, so it built an empty manifest and
no-opped both rules — intentional, but indistinguishable from an accidental
no-op.

A second, unintended gap: that step ran `eslint packages/arel/src` only, while
`eslint.config.mjs` enables `rails-private-jsdoc` for arel, activesupport,
activemodel, actionpack, actionview **and activerecord**. Five packages were
never enforced anywhere — which is how the `relation/delegation.ts` violations
went unnoticed.

## Change

- **`scripts/api-compare/require-rails-api.ts`** — shared missing-input policy.
  A missing `rails-api.json` now throws (non-zero exit) naming `pnpm api:compare`,
  unless the caller passes `--allow-missing`, in which case it warns that the rule
  is `INERT` for that run and returns `false`.
- Both gitignored-output builders route through it. In the privates builder the
  check runs *before* `beginManifestBatch()`, so a hard failure can't half-write
  the committed deprecated/callback manifests it also emits.
- `prelint` passes `--allow-missing` (the no-Ruby path stays green, loudly). The
  `rails-comparison` steps deliberately do not, so a missing extraction fails that
  job instead of silently disarming the gate.
- **`eslint/rails-private-jsdoc.config.mjs`** — standalone flat config enabling
  only that one rule, over the full package list. The `rails-comparison` step now
  runs `eslint --no-inline-config --config eslint/rails-private-jsdoc.config.mjs
  packages`. Widening the paths under the *root* config would have re-run the
  entire ruleset and duplicated the Lint job; `--no-inline-config` is required
  because the sources carry `eslint-disable` comments for rules this config does
  not register (nothing disables `rails-private-jsdoc` inline).
- Tests: unit tests for the helper, plus a drift guard asserting the standalone
  config's `files`/`ignores` still match the root config's block — drift there
  would silently drop a package from the step.

## Sibling audit (acceptance criterion 3)

- `build-rails-tosql-manifest.ts` and `build-rails-error-manifest.ts` write
  **committed** manifests (`eslint/rails-tosql-classes.json`,
  `eslint/rails-error-classes.json`) and already preserve them on missing input
  rather than emptying them. No silent-empty path; unchanged.
- The privates builder's other two outputs (`rails-deprecated-methods.json`,
  `rails-callback-invocations.json`) are committed and scan the vendored Ruby
  directly, independent of `rails-api.json`. Unchanged.

The silent-empty path was exactly the two gitignored manifests, both fixed.

## delegation.ts violations (acceptance criterion 4)

Already fixed on `main` — `generatedRelationMethods`, `includeRelationMethods` and
`relationClassFor` all carry `@internal` today.

## Verification

With a real `rails-api.json` generated locally (604 files / 4975 names):

- `eslint --no-inline-config --config eslint/rails-private-jsdoc.config.mjs packages` → **exit 0**, ~30s.
- Deleting the `@internal` tag on `generatedRelationMethods` makes that command
  fail with the expected error, confirming the config reaches activerecord rather
  than passing vacuously.
- Builders without `rails-api.json`: exit **1** without `--allow-missing`, exit
  **0** with it; the committed manifests they also emit are byte-identical
  either way.

Closes-story: rails-privates-manifest-silently-empty-without-api-compare-output
