### PR TITLE
test(eslint): collect the rule tests under vitest and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,10 @@ jobs:
           # confined to one of them would run none of its own tests.
           # schema-compare/ is deliberately absent — its suite parses the real
           # vendored schema.rb, so it runs in rails-comparison (COMPARISON_RE).
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$)'
+          # eslint/ rides on it because the custom rules' own RuleTester suites
+          # are in the same invocation: without this clause a PR that only
+          # touches a rule or its test would skip the only job that runs them.
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,7 @@ jobs:
           scripts/test-deps
           scripts/rails-find
           scripts/parity
-          eslint
+          eslint/
           scripts/strip-asany.test.ts
           scripts/rails-file-structure-mixins.test.ts
           scripts/ci-suite-coverage.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,6 +691,7 @@ jobs:
           scripts/test-deps
           scripts/rails-find
           scripts/parity
+          eslint
           scripts/strip-asany.test.ts
           scripts/rails-file-structure-mixins.test.ts
           scripts/ci-suite-coverage.test.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,6 +107,21 @@ export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   {
+    // The rule tests run under vitest, where RuleTester picks up the injected
+    // describe/it globals; the hooks around them are equally global.
+    files: ["eslint/*.test.mjs"],
+    languageOptions: {
+      globals: {
+        describe: "readonly",
+        it: "readonly",
+        beforeEach: "readonly",
+        afterEach: "readonly",
+        beforeAll: "readonly",
+        afterAll: "readonly",
+      },
+    },
+  },
+  {
     plugins: {
       "unused-imports": unusedImports,
     },

--- a/eslint/no-native-date.test.mjs
+++ b/eslint/no-native-date.test.mjs
@@ -95,5 +95,3 @@ function f(x: unknown) {
     },
   ],
 });
-
-console.log("no-native-date: all tests passed");

--- a/eslint/no-node-builtins.test.mjs
+++ b/eslint/no-node-builtins.test.mjs
@@ -104,5 +104,3 @@ tester.run("no-node-builtins", rule, {
     },
   ],
 });
-
-console.log("All tests passed.");

--- a/eslint/no-standalone-associations.test.mjs
+++ b/eslint/no-standalone-associations.test.mjs
@@ -2,8 +2,11 @@ import { RuleTester } from "eslint";
 import rule from "./no-standalone-associations.mjs";
 
 // Point the rule at a non-existent exclude baseline so the committed list
-// never grandfathers these synthetic fixtures.
-process.env.NO_STANDALONE_ASSOCIATIONS_EXCLUDE_PATH = "/nonexistent-exclude.json";
+// never grandfathers these synthetic fixtures. The baseline suite at the
+// bottom of this file overrides it in a nested hook.
+beforeEach(() => {
+  process.env.NO_STANDALONE_ASSOCIATIONS_EXCLUDE_PATH = "/nonexistent-exclude.json";
+});
 
 const FILENAME = "packages/activerecord/src/associations.test.ts";
 
@@ -202,22 +205,33 @@ const baselineTester = new RuleTester({
   },
 });
 
-baselineTester.run("no-standalone-associations (baseline)", rule, {
-  valid: [
-    // Grandfathered site (key present in the baseline) → suppressed.
-    { filename: FILENAME, code: "Associations.hasMany.call(P, 'cs', {});" },
-  ],
-  invalid: [
-    // A different site in the same file (key NOT in the baseline) still fires —
-    // proves suppression is site-granular, not file-wide.
-    {
-      filename: FILENAME,
-      code: "Associations.hasMany.call(P, 'other', {});",
-      errors: [{ messageId: "standaloneNoFix" }],
-    },
-  ],
+// RuleTester registers its cases through describe/it, whose bodies run only
+// after this module has finished evaluating — so the env var cannot be aimed
+// at a baseline at module scope: whichever value it lands on would apply to
+// every case in the file. Each suite points it where it needs through hooks
+// instead, and the tmp file is removed once the cases have actually run.
+describe("with a baseline exclude file", () => {
+  beforeEach(() => {
+    process.env.NO_STANDALONE_ASSOCIATIONS_EXCLUDE_PATH = tmpBaseline;
+  });
+
+  baselineTester.run("no-standalone-associations (baseline)", rule, {
+    valid: [
+      // Grandfathered site (key present in the baseline) → suppressed.
+      { filename: FILENAME, code: "Associations.hasMany.call(P, 'cs', {});" },
+    ],
+    invalid: [
+      // A different site in the same file (key NOT in the baseline) still fires
+      // — proves suppression is site-granular, not file-wide.
+      {
+        filename: FILENAME,
+        code: "Associations.hasMany.call(P, 'other', {});",
+        errors: [{ messageId: "standaloneNoFix" }],
+      },
+    ],
+  });
 });
 
-// Restore the non-existent path so any later import sees a clean slate.
-process.env.NO_STANDALONE_ASSOCIATIONS_EXCLUDE_PATH = "/nonexistent-exclude.json";
-fs.rmSync(tmpBaseline, { force: true });
+afterAll(() => {
+  fs.rmSync(tmpBaseline, { force: true });
+});

--- a/eslint/prefer-await-relation.test.mjs
+++ b/eslint/prefer-await-relation.test.mjs
@@ -125,5 +125,3 @@ tester.run("prefer-await-relation", rule, {
     },
   ],
 });
-
-console.log("prefer-await-relation: all tests passed");

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,10 +1,5 @@
 {
   "files": {
-    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
-      "unsignedDecimal",
-      "unsignedFloat"
-    ],
-    "packages/activerecord/src/connection-handling.ts": ["connection"],
-    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
+    "packages/activerecord/src/connection-handling.ts": ["connection"]
   }
 }

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,5 +1,10 @@
 {
   "files": {
-    "packages/activerecord/src/connection-handling.ts": ["connection"]
+    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
+      "unsignedDecimal",
+      "unsignedFloat"
+    ],
+    "packages/activerecord/src/connection-handling.ts": ["connection"],
+    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
   }
 }

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -525,11 +525,10 @@ try {
     ],
   });
 } finally {
-  // RuleTester registers its cases through describe/it, whose bodies run only
-  // AFTER this module has finished evaluating. Restoring the manifest here
-  // would pull the fixture out from under every case before the first one
-  // runs, and the rule would then read the real manifest and report nothing.
+  // Restoring here would pull the fixture manifest out from under every case:
+  // RuleTester only REGISTERS its cases through describe/it, whose bodies run
+  // after this module finishes evaluating, so the rule would read the real
+  // manifest and report nothing. The finally still matters — it guarantees the
+  // restore is scheduled even if registration above throws.
   afterAll(restoreManifest);
 }
-
-console.log("rails-file-structure-method-order tests passed");

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -91,9 +91,9 @@ function restoreManifest() {
 }
 fs.writeFileSync(MANIFEST_PATH, JSON.stringify(fixture, null, 2));
 // Fallback restore — covers process crash mid-test. The primary
-// restoration lives in the try/finally around `tester.run(...)` below
-// so we don't leak the fixture manifest into sibling test files when
-// Vitest reuses a worker process across files.
+// restoration lives in the afterAll below so we don't leak the fixture
+// manifest into sibling test files when Vitest reuses a worker process
+// across files.
 process.on("exit", restoreManifest);
 
 const classFile = path.join(REPO_ROOT, "packages/arel/src/fixture-class.ts");
@@ -525,7 +525,11 @@ try {
     ],
   });
 } finally {
-  restoreManifest();
+  // RuleTester registers its cases through describe/it, whose bodies run only
+  // AFTER this module has finished evaluating. Restoring the manifest here
+  // would pull the fixture out from under every case before the first one
+  // runs, and the rule would then read the real manifest and report nothing.
+  afterAll(restoreManifest);
 }
 
 console.log("rails-file-structure-method-order tests passed");

--- a/eslint/sqlite-driver-await.test.mjs
+++ b/eslint/sqlite-driver-await.test.mjs
@@ -83,5 +83,3 @@ tester.run("sqlite-driver-await", rule, {
     },
   ],
 });
-
-console.log("sqlite-driver-await: all tests passed");

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -25,36 +25,6 @@ const TOOLING_ROOTS = ["scripts", "eslint", "vendor"];
 // Suites that deliberately do not run in CI yet. Every entry needs a reason
 // and the story that removes it — this list must shrink, never grow.
 const KNOWN_UNRUN: Record<string, string> = {
-  // ESLint RuleTester drives itself through global describe/it that vitest
-  // does not supply, so every one of these collects as "No test suite found".
-  // Story: run-eslint-rule-tests-in-ci.
-  ...Object.fromEntries(
-    [
-      "expected-fixtures",
-      "manifest-complete",
-      "nie-requires-annotation",
-      "no-explicit-any-disable",
-      "no-getter-called-as-method",
-      "no-internal-canonical-loaders",
-      "no-native-date",
-      "no-node-builtins",
-      "no-process-bypass",
-      "no-raw-sql",
-      "no-standalone-associations",
-      "prefer-await-relation",
-      "rails-arel-tosql",
-      "rails-callback-invocations",
-      "rails-deprecated-jsdoc",
-      "rails-error-parity",
-      "rails-error-parity-unported",
-      "rails-file-structure-method-order",
-      "rails-private-jsdoc",
-      "require-canonical-rebuild",
-      "require-table-teardown",
-      "sqlite-driver-await",
-      "test-fixture-parity",
-    ].map((n) => [`eslint/${n}.test.mjs`, "run-eslint-rule-tests-in-ci"]),
-  ),
   // vendor/fetch.test.ts fails outside a freshly fetched vendor/ tree.
   // Story: run-vendor-fetch-tests-in-ci.
   "vendor/fetch.test.ts": "run-vendor-fetch-tests-in-ci",

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -91,6 +91,15 @@ function ciVitestFilters(yml: string): string[] {
   return filters;
 }
 
+/** The `unit-tests:` job block, sliced out at the next job at the same indent. */
+function unitTestsJob(yml: string): string {
+  const lines = yml.split("\n");
+  const start = lines.findIndex((l) => l === "  unit-tests:");
+  if (start === -1) throw new Error("no unit-tests job in ci.yml");
+  const end = lines.findIndex((l, i) => i > start && /^ {2}[\w-]+:/.test(l));
+  return lines.slice(start, end === -1 ? undefined : end).join("\n");
+}
+
 describe("CI runs every tooling test suite", () => {
   it("covers each scripts/eslint/vendor test file with a ci.yml vitest filter", async () => {
     const yml = await readFile(CI_YML, "utf8");
@@ -109,6 +118,27 @@ describe("CI runs every tooling test suite", () => {
       .filter((f) => !(f in KNOWN_UNRUN))
       .filter((f) => !filters.some((filter) => f.startsWith(filter)));
     expect(uncovered).toEqual([]);
+  });
+
+  // A path filter in a gated job only runs when the gate fires. unit-tests is
+  // gated on `unit_tests_affected`, which the changes job computes from
+  // UNIT_TESTS_PKGS_RE — so a filter naming a tree the regex does not match is
+  // dead for any PR confined to that tree: the suite it points at is skipped
+  // exactly when it is the thing that changed.
+  it("matches every unit-tests filter against the gate that runs the job", async () => {
+    const yml = await readFile(CI_YML, "utf8");
+    const gateSource = yml.match(/UNIT_TESTS_PKGS_RE='([^']+)'/)?.[1];
+    expect(gateSource).toBeDefined();
+    const gate = new RegExp(gateSource as string);
+
+    const filters = ciVitestFilters(unitTestsJob(yml));
+    expect(filters.length).toBeGreaterThan(5);
+
+    // A filter is a path prefix, so probe it with a file that lives under it.
+    const ungated = filters.filter(
+      (f) => !gate.test(f.endsWith(".ts") ? f : `${f.replace(/\/?$/, "/")}probe.test.ts`),
+    );
+    expect(ungated).toEqual([]);
   });
 
   it("keeps KNOWN_UNRUN free of entries CI already runs", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -400,6 +400,12 @@ export default defineConfig({
         resolve: { alias },
         test: {
           name: "other",
+          // Projects do NOT inherit the root `test.globals`, and ESLint's
+          // RuleTester registers its cases through whatever describe/it it
+          // finds on globalThis at import time. Without this, every
+          // eslint/*.test.mjs that drives RuleTester alone registers zero
+          // cases and collects as "No test suite found in file".
+          globals: true,
           include: [
             "packages/*/src/**/*.test.ts",
             "scripts/guides-typecheck/*.test.ts",


### PR DESCRIPTION
## What

`eslint/*.test.mjs` is in the `other` vitest project's `include`, but the
project does not enable `globals` — and vitest projects do **not** inherit the
root `test.globals`. ESLint's `RuleTester` registers its cases through whatever
`describe`/`it` it finds on `globalThis` at import time, so every rule test that
drives `RuleTester` alone registered zero cases and collected as
`Error: No test suite found in file …` / `Tests no tests`.

**Do they run in CI today? No.** Every `pnpm vitest run` in `ci.yml` passes
explicit path filters and none of them named `eslint/`, so the failing
collection never reached a job. That is also why
`scripts/ci-suite-coverage.test.ts` was already red on `main`:
`eslint/no-raw-sql-scope.test.mjs` (added by #5408) was neither in `KNOWN_UNRUN`
nor covered by a filter.

## Changes

- `vitest.config.ts`: `globals: true` on the `other` project. All 24 rule test
  files now collect — **421 tests**, up from 0 in 19 of them.
- `ci.yml`: add `eslint/` to the tooling job's vitest filter list.
- `scripts/ci-suite-coverage.test.ts`: drop the 23-entry `eslint/*` block from
  `KNOWN_UNRUN` (the story it pointed at is this one). This also un-reds the
  `no-raw-sql-scope` failure.
- `eslint.config.mjs`: declare the vitest hook globals for `eslint/*.test.mjs`
  so the new `beforeEach`/`afterAll` aren't `no-undef`.
- Two files set fixture state at module scope and tore it down at module scope
  too — which under lazy collection happens *before* any registered case runs,
  so the rule read the real manifest/baseline and reported nothing:
  - `rails-file-structure-method-order.test.mjs`: restore the fixture manifest
    in `afterAll` instead of directly in the `finally` (the `finally` still
    schedules it, so a throw during registration can't leak the fixture; the
    `process.on("exit")` net stays).
  - `no-standalone-associations.test.mjs`: point
    `NO_STANDALONE_ASSOCIATIONS_EXCLUDE_PATH` per suite via `beforeEach` (the
    rule's exclude cache is path-keyed, so switching paths re-reads), and
    remove the tmp baseline in `afterAll`.
- Drop the five module-scope `console.log("… tests passed")` lines left over
  from the `node --test` era. Under lazy collection they printed before a
  single case had run, so they claimed a pass that had not happened yet.

## Proof the wiring bites

Mutating `messageId` in `eslint/require-canonical-rebuild.mjs` to a bogus id:

```
 Test Files  1 failed (1)
      Tests  6 failed | 11 passed (17)
```

Reverted. Green afterwards:

- `npx vitest run eslint/ scripts/ci-suite-coverage.test.ts` → 25 files, 424 tests
- `npx vitest run packages/arel packages/activemodel` → 151 files, 3445 tests
  (sanity check that `globals: true` doesn't disturb the rest of the `other`
  project)
- `npx eslint eslint/` → clean

From here on, a rule test that stops collecting fails the job instead of
disappearing.

Closes-story: eslint-rule-tests-do-not-collect-under-vitest
