### PR TITLE
ci: run the no-raw-sql-scope suite in unit-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,6 @@ jobs:
           #                     - guards this file's own wiring; its only
           #                       consumer is unit-tests, which names it in
           #                       UNIT_TESTS_PKGS_RE.
-          #   eslint/no-raw-sql-scope.mjs
-          #                     - the shared scope-out glob list; a plain vitest
-          #                       suite (not a RuleTester one), so unlike the
-          #                       rest of eslint/ it runs in unit-tests.
           # IMPORTANT: carving a subtree out of the infra sweep does NOT mean
           # its own tests can go unnamed. unit-tests runs the compare/parity
           # tooling's vitest suites — api-compare, test-compare,
@@ -198,6 +194,10 @@ jobs:
           # confined to one of them would run none of its own tests.
           # schema-compare/ is deliberately absent — its suite parses the real
           # vendored schema.rb, so it runs in rails-comparison (COMPARISON_RE).
+          # eslint/no-raw-sql-scope is the one eslint/ entry here: it is a plain
+          # vitest suite rather than a RuleTester one, so unit-tests runs it (the
+          # RuleTester suites are on ci-suite-coverage's KNOWN_UNRUN instead).
+          # eslint/ is outside INFRA_RE's sweep, so this gate is its only trigger.
           UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$|eslint/no-raw-sql-scope(\.test)?\.mjs$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
           #                     - guards this file's own wiring; its only
           #                       consumer is unit-tests, which names it in
           #                       UNIT_TESTS_PKGS_RE.
+          #   eslint/no-raw-sql-scope.mjs
+          #                     - the shared scope-out glob list; a plain vitest
+          #                       suite (not a RuleTester one), so unlike the
+          #                       rest of eslint/ it runs in unit-tests.
           # IMPORTANT: carving a subtree out of the infra sweep does NOT mean
           # its own tests can go unnamed. unit-tests runs the compare/parity
           # tooling's vitest suites — api-compare, test-compare,
@@ -194,7 +198,7 @@ jobs:
           # confined to one of them would run none of its own tests.
           # schema-compare/ is deliberately absent — its suite parses the real
           # vendored schema.rb, so it runs in rails-comparison (COMPARISON_RE).
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$|eslint/no-raw-sql-scope(\.test)?\.mjs$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -694,6 +698,7 @@ jobs:
           scripts/strip-asany.test.ts
           scripts/rails-file-structure-mixins.test.ts
           scripts/ci-suite-coverage.test.ts
+          eslint/no-raw-sql-scope.test.mjs
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack
   # (~27 s), actionview (~26 s), tse-compiler (~22 s), and the DX type tests


### PR DESCRIPTION
Fixes the `Unit Tests` failure on `main` @afc210c6.

`eslint/no-raw-sql-scope.test.mjs` (added by #5408) is a plain vitest suite, not a RuleTester one, so it is correctly absent from `ci-suite-coverage`s `KNOWN_UNRUN` list — but no `ci.yml` vitest invocation named it either, so the coverage guard has failed on every push to main since.

- name it in the `unit-tests` vitest filter list
- name it in `UNIT_TESTS_PKGS_RE` so edits to the shared scope-out glob list actually trigger the job

Verified locally: `pnpm vitest run eslint/no-raw-sql-scope.test.mjs scripts/ci-suite-coverage.test.ts` → 8 passed (was 1 failed on main).

Closes-story: red-afc210c6
