### PR TITLE
feat(test-compare): fail loudly on an unregistered gate wrapper

### DIFF
--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -7,7 +7,14 @@ import * as path from "path";
 import * as ts from "typescript";
 import { normalizeTrailsKind } from "./assertion-kinds.js";
 import { VALUE_BEARING_KINDS } from "./assertion-values.js";
-import { finalizeGate, gateFromGuardExpr, gateFromWrapper, mergeGate } from "./gates.js";
+import {
+  ADAPTER_GATE_WRAPPERS,
+  assertRegisteredGateWrapper,
+  finalizeGate,
+  gateFromGuardExpr,
+  gateFromWrapper,
+  mergeGate,
+} from "./gates.js";
 import type { TestFileInfo, TestGate } from "./types.js";
 
 const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
@@ -284,13 +291,7 @@ function collectAssertionKinds(
 // Adapter wrappers that take the title as their FIRST argument. The feature
 // wrappers (`describeIfSupports`/`itIfSupports`) instead take the feature key
 // as arg 0 and the title as arg 1, matching the support/supports.ts API.
-const ADAPTER_SUITE_WRAPPERS = new Set([
-  "describe",
-  "describeIfPg",
-  "describeIfMysql",
-  "describeIfMysqlAdapter",
-  "describeIfSqlite",
-]);
+const ADAPTER_SUITE_WRAPPERS = new Set<string>(["describe", ...ADAPTER_GATE_WRAPPERS]);
 
 /**
  * Parse a single test file's source into a {@link TestFileInfo}, including each
@@ -359,6 +360,7 @@ export function extractTestsFromSource(content: string, relativePath: string): T
       const expression = node.expression;
       if (ts.isIdentifier(expression)) {
         const funcName = expression.text;
+        assertRegisteredGateWrapper(funcName, relativePath);
 
         if (ADAPTER_SUITE_WRAPPERS.has(funcName)) {
           const title = getArgString(node, 0);
@@ -399,6 +401,7 @@ export function extractTestsFromSource(content: string, relativePath: string): T
         const base = inner.expression;
         const modifier = inner.name.text;
         if (ts.isIdentifier(base) && GATING_MODIFIERS.has(modifier)) {
+          assertRegisteredGateWrapper(base.text, relativePath);
           const guardExpr = expression.arguments[0]?.getText(sourceFile) ?? "";
           const inlineGate = gateFromGuardExpr(guardExpr, modifier === "runIf");
           if (ADAPTER_SUITE_WRAPPERS.has(base.text)) {
@@ -449,6 +452,7 @@ export function extractTestsFromSource(content: string, relativePath: string): T
       } else if (ts.isPropertyAccessExpression(expression)) {
         // Handle describe.skip, it.skip, it.todo, it.only, etc.
         const base = expression.expression;
+        if (ts.isIdentifier(base)) assertRegisteredGateWrapper(base.text, relativePath);
         if (ts.isIdentifier(base) && base.text === "describe") {
           const title = getArgString(node, 0);
           if (title) {

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -293,6 +293,17 @@ function collectAssertionKinds(
 // as arg 0 and the title as arg 1, matching the support/supports.ts API.
 const ADAPTER_SUITE_WRAPPERS = new Set<string>(["describe", ...ADAPTER_GATE_WRAPPERS]);
 
+// The identifier at the head of a call's callee, across the three shapes the
+// suite uses: `describeIfPg(…)`, `describeIfPg.skipIf(…)(…)`, `it.skip(…)`.
+function calleeRootName(expression: ts.Expression): string | null {
+  if (ts.isIdentifier(expression)) return expression.text;
+  const inner = ts.isCallExpression(expression) ? expression.expression : expression;
+  if (ts.isPropertyAccessExpression(inner) && ts.isIdentifier(inner.expression)) {
+    return inner.expression.text;
+  }
+  return null;
+}
+
 /**
  * Parse a single test file's source into a {@link TestFileInfo}, including each
  * test's adapter/feature {@link TestGate}. Conditional `describe` wrappers
@@ -358,9 +369,10 @@ export function extractTestsFromSource(content: string, relativePath: string): T
   function visit(node: ts.Node) {
     if (ts.isCallExpression(node)) {
       const expression = node.expression;
+      const root = calleeRootName(expression);
+      if (root) assertRegisteredGateWrapper(root, relativePath);
       if (ts.isIdentifier(expression)) {
         const funcName = expression.text;
-        assertRegisteredGateWrapper(funcName, relativePath);
 
         if (ADAPTER_SUITE_WRAPPERS.has(funcName)) {
           const title = getArgString(node, 0);
@@ -401,7 +413,6 @@ export function extractTestsFromSource(content: string, relativePath: string): T
         const base = inner.expression;
         const modifier = inner.name.text;
         if (ts.isIdentifier(base) && GATING_MODIFIERS.has(modifier)) {
-          assertRegisteredGateWrapper(base.text, relativePath);
           const guardExpr = expression.arguments[0]?.getText(sourceFile) ?? "";
           const inlineGate = gateFromGuardExpr(guardExpr, modifier === "runIf");
           if (ADAPTER_SUITE_WRAPPERS.has(base.text)) {
@@ -452,7 +463,6 @@ export function extractTestsFromSource(content: string, relativePath: string): T
       } else if (ts.isPropertyAccessExpression(expression)) {
         // Handle describe.skip, it.skip, it.todo, it.only, etc.
         const base = expression.expression;
-        if (ts.isIdentifier(base)) assertRegisteredGateWrapper(base.text, relativePath);
         if (ts.isIdentifier(base) && base.text === "describe") {
           const title = getArgString(node, 0);
           if (title) {

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -37,7 +37,6 @@ describe("gates.ts pure helpers", () => {
       /unregistered gate wrapper `describeIfOracle`/,
     );
     expect(() => gateFromWrapper("itIfOracle")).toThrow(/gateFromWrapper/);
-    // Plain wrappers and unrelated helpers are untouched.
     expect(gateFromWrapper("it")).toBeNull();
     expect(gateFromWrapper("itemHelper")).toBeNull();
     expect(gateFromWrapper("describeIfying")).toBeNull();
@@ -61,6 +60,34 @@ describe("gates.ts pure helpers", () => {
       });
     `;
     expect(() => tsGates(source)).toThrow(/unregistered gate wrapper `describeIfOracle`/);
+  });
+
+  it("throws for an unregistered wrapper used in its .skip form", () => {
+    const source = `
+      describeIfOracle.skip("suite", () => {
+        it("runs", () => {});
+      });
+    `;
+    expect(() => tsGates(source)).toThrow(/unregistered gate wrapper `describeIfOracle`/);
+  });
+
+  it("leaves registered wrappers and their modifier forms extracting normally", () => {
+    const source = `
+      describeIfPg("suite", () => {
+        it("runs on pg", () => {});
+      });
+      describeIfSupports.skipIf(adapterType === "mysql")("json", "supported", () => {
+        it("runs where json works", () => {});
+      });
+    `;
+    expect(tsGates(source)).toEqual({
+      "runs on pg": { adapters: ["postgresql"], source: ["wrapper"] },
+      "runs where json works": {
+        adapters: ["postgresql", "sqlite"],
+        features: ["json"],
+        source: ["test", "wrapper"],
+      },
+    });
   });
 
   it("maps support wrappers to a feature key", () => {

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -32,6 +32,37 @@ describe("gates.ts pure helpers", () => {
     expect(gateFromWrapper("describe")).toBeNull();
   });
 
+  it("throws on an unregistered describeIf*/itIf* wrapper instead of silently ungating", () => {
+    expect(() => gateFromWrapper("describeIfOracle")).toThrow(
+      /unregistered gate wrapper `describeIfOracle`/,
+    );
+    expect(() => gateFromWrapper("itIfOracle")).toThrow(/gateFromWrapper/);
+    // Plain wrappers and unrelated helpers are untouched.
+    expect(gateFromWrapper("it")).toBeNull();
+    expect(gateFromWrapper("itemHelper")).toBeNull();
+    expect(gateFromWrapper("describeIfying")).toBeNull();
+  });
+
+  it("names the offending file when an unregistered wrapper appears in a test file", () => {
+    const source = `
+      describeIfOracle("suite", () => {
+        it("runs", () => {});
+      });
+    `;
+    expect(() => tsGates(source, "packages/activerecord/src/oracle.test.ts")).toThrow(
+      /`describeIfOracle` \(used in packages\/activerecord\/src\/oracle\.test\.ts\)/,
+    );
+  });
+
+  it("throws for an unregistered wrapper used in its .skipIf form", () => {
+    const source = `
+      describeIfOracle.skipIf(adapterType === "mysql")("suite", () => {
+        it("runs", () => {});
+      });
+    `;
+    expect(() => tsGates(source)).toThrow(/unregistered gate wrapper `describeIfOracle`/);
+  });
+
   it("maps support wrappers to a feature key", () => {
     expect(gateFromWrapper("describeIfSupports", "json")).toEqual({
       features: ["json"],

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -66,11 +66,6 @@ export function finalizeGate(gate: TestGate): TestGate {
   return out;
 }
 
-/**
- * Adapter gate wrappers — the ones taking the suite title as their FIRST
- * argument. The extractor derives its own wrapper set from this so a new
- * wrapper only has to be registered here and in {@link gateFromWrapper}.
- */
 export const ADAPTER_GATE_WRAPPERS = [
   "describeIfPg",
   "describeIfMysql",
@@ -78,25 +73,19 @@ export const ADAPTER_GATE_WRAPPERS = [
   "describeIfSqlite",
 ] as const;
 
-/** Every wrapper identifier {@link gateFromWrapper} knows how to gate. */
-export const REGISTERED_GATE_WRAPPERS: ReadonlySet<string> = new Set<string>([
+const REGISTERED_GATE_WRAPPERS: ReadonlySet<string> = new Set<string>([
   ...ADAPTER_GATE_WRAPPERS,
   "describeIfSupports",
   "itIfSupports",
 ]);
 
-/** An identifier shaped like a conditional wrapper (`describeIfX` / `itIfX`). */
-export function isGateWrapperName(name: string): boolean {
+function isGateWrapperName(name: string): boolean {
   return /^(?:describe|it)If[A-Z]/.test(name);
 }
 
-/**
- * Fail loudly when a test file calls a `describeIf*` / `itIf*` wrapper the gate
- * registry doesn't know. Without this the unknown identifier falls through
- * {@link gateFromWrapper}'s `default` arm to `null` — "no gate" — and every test
- * inside it silently reads as ungated, surfacing later as an unexplained
- * gate-mismatch count with no pointer to the real cause.
- */
+// An unregistered wrapper would otherwise fall through gateFromWrapper's
+// `default` arm to `null` — "no gate" — so every test inside it reads as
+// ungated and surfaces only as an unexplained gate-mismatch count.
 export function assertRegisteredGateWrapper(name: string, file?: string): void {
   if (!isGateWrapperName(name) || REGISTERED_GATE_WRAPPERS.has(name)) return;
   const where = file ? ` (used in ${file})` : "";

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -67,8 +67,51 @@ export function finalizeGate(gate: TestGate): TestGate {
 }
 
 /**
+ * Adapter gate wrappers — the ones taking the suite title as their FIRST
+ * argument. The extractor derives its own wrapper set from this so a new
+ * wrapper only has to be registered here and in {@link gateFromWrapper}.
+ */
+export const ADAPTER_GATE_WRAPPERS = [
+  "describeIfPg",
+  "describeIfMysql",
+  "describeIfMysqlAdapter",
+  "describeIfSqlite",
+] as const;
+
+/** Every wrapper identifier {@link gateFromWrapper} knows how to gate. */
+export const REGISTERED_GATE_WRAPPERS: ReadonlySet<string> = new Set<string>([
+  ...ADAPTER_GATE_WRAPPERS,
+  "describeIfSupports",
+  "itIfSupports",
+]);
+
+/** An identifier shaped like a conditional wrapper (`describeIfX` / `itIfX`). */
+export function isGateWrapperName(name: string): boolean {
+  return /^(?:describe|it)If[A-Z]/.test(name);
+}
+
+/**
+ * Fail loudly when a test file calls a `describeIf*` / `itIf*` wrapper the gate
+ * registry doesn't know. Without this the unknown identifier falls through
+ * {@link gateFromWrapper}'s `default` arm to `null` — "no gate" — and every test
+ * inside it silently reads as ungated, surfacing later as an unexplained
+ * gate-mismatch count with no pointer to the real cause.
+ */
+export function assertRegisteredGateWrapper(name: string, file?: string): void {
+  if (!isGateWrapperName(name) || REGISTERED_GATE_WRAPPERS.has(name)) return;
+  const where = file ? ` (used in ${file})` : "";
+  throw new Error(
+    `test-compare: unregistered gate wrapper \`${name}\`${where}. ` +
+      "Tests inside it would silently read as ungated. Register it in " +
+      "`gateFromWrapper` (scripts/test-compare/gates.ts) and, if it takes the " +
+      "title as its first argument, in `ADAPTER_GATE_WRAPPERS` there too.",
+  );
+}
+
+/**
  * Gate implied by a conditional `describe`/`it` wrapper identifier. Returns
- * `null` for plain `describe`/`it`/`test` (no gate). `featureArg` carries the
+ * `null` for plain `describe`/`it`/`test` (no gate) and throws for an
+ * unregistered `describeIf*`/`itIf*` identifier. `featureArg` carries the
  * first string argument for `describeIfSupports("json", …)` /
  * `itIfSupports("json", …)`.
  */
@@ -90,6 +133,7 @@ export function gateFromWrapper(name: string, featureArg?: string | null): TestG
         ? { features: [featureArg], source: ["wrapper"] }
         : { guards: ["unknown"], source: ["wrapper"] };
     default:
+      assertRegisteredGateWrapper(name);
       return null;
   }
 }


### PR DESCRIPTION
## Problem

Adding a new conditional-`describe` wrapper made every test inside it read as
**ungated** to `scripts/test-compare`: the extractor recognises gate wrappers by
a hard-coded identifier list, and `gateFromWrapper`'s `default` arm returns
`null` (= "no gate") for anything unknown. The failure surfaced only as
`activerecord: 52 gate-mismatch (must be 0)` with no hint that the cause was an
unregistered wrapper name rather than 52 genuinely mis-gated tests.

## Change

- `gates.ts` gains `assertRegisteredGateWrapper`: an identifier shaped like
  `describeIf*`/`itIf*` that is not in the registry now throws, naming the
  identifier, the file it appears in, and both registration sites.
  `gateFromWrapper`'s `default` arm runs the same check before returning `null`,
  so plain `describe`/`it`/`test` keep their "no gate" answer.
- The registry is now one list: the extractor derives `ADAPTER_SUITE_WRAPPERS`
  from the exported `ADAPTER_GATE_WRAPPERS`, instead of a second hard-coded set
  that could drift out of sync with the `switch`.
- The extractor checks once per call node, via `calleeRootName`, which resolves
  the head identifier across all three call shapes in the suite —
  `describeIfPg(…)`, `describeIfPg.skipIf(…)(…)`, and `describeIfPg.skip(…)`.

## Verification

- `pnpm vitest run scripts/test-compare/` — 146 passed (20 in
  `extract-ts-gates.test.ts`), covering all three call shapes, the file-naming
  in the message, near-miss identifiers that must NOT throw (`itemHelper`,
  `describeIfying`), and registered wrappers still extracting their gates.
- `pnpm test:compare` on a clean tree: no gate-mismatch line (0) and overall
  totals byte-identical to `main` (14620/21663, 754/1023 files, 196 misplaced).

Closes-story: test-compare-unregistered-gate-wrapper-fails-loudly
