### PR TITLE
feat(api-compare): score TS files with no Rails counterpart in extra-surface

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1607,3 +1607,101 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(report.packages[0].extraFiles).toEqual([]);
   });
 });
+
+describe("buildReport — TS files with no Rails counterpart", () => {
+  function makeManifests(tsFile: string): { ruby: ApiManifest; ts: ApiManifest } {
+    // Rails: active_record.rb declares the umbrella writer `foo=`; it maps
+    // onto base.ts, so nothing in the file map points at `tsFile`.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            "ActiveRecord::Base": rubyClass({
+              name: "Base",
+              file: "base.rb",
+              instance: [method("foo=")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts_: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            Base: {
+              name: "Base",
+              file: "base.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("foo")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+          fileFunctions: { [tsFile]: [method("setFoo"), method("foo")] },
+        },
+      },
+    };
+    return { ruby, ts: ts_ };
+  }
+
+  it("scores a file no Ruby file maps onto instead of skipping it", () => {
+    const { ruby, ts: ts_ } = makeManifests("ar-config.ts");
+    const report = buildReport(ruby, ts_, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const files = report.packages[0].extraFiles;
+    expect(files.map((f) => f.tsFile)).toEqual(["ar-config.ts"]);
+    // `foo=` maps to `foo`, so the `setX` re-spelling is novel and the reader
+    // is moved (base.ts owns it) — the whole file is measured, not skipped.
+    expect(files[0].rubyFile).toBeNull();
+    expect(files[0].extras.map((e) => [e.name, e.kind])).toEqual([
+      ["setFoo", "novel"],
+      ["foo", "moved"],
+    ]);
+  });
+
+  it("holds out trees that mirror Rails test code rather than lib", () => {
+    const { ruby, ts: ts_ } = makeManifests("test-helpers/models/post.ts");
+    const report = buildReport(ruby, ts_, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.packages[0].extraFiles).toEqual([]);
+  });
+
+  it("still scores test-fixtures/, the split of lib's test_fixtures.rb", () => {
+    const { ruby, ts: ts_ } = makeManifests("test-fixtures/fixture-connection.ts");
+    const report = buildReport(ruby, ts_, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.packages[0].extraFiles.map((f) => f.tsFile)).toEqual([
+      "test-fixtures/fixture-connection.ts",
+    ]);
+  });
+
+  it("honours --exclude-glob for a file with no counterpart", () => {
+    const { ruby, ts: ts_ } = makeManifests("ar-config.ts");
+    const report = buildReport(ruby, ts_, {
+      filterPkg: null,
+      excludeGlobs: ["ar-config"],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.packages[0].extraFiles).toEqual([]);
+  });
+});

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1685,6 +1685,31 @@ describe("buildReport — TS files with no Rails counterpart", () => {
     expect(pkg.noCounterpartNovel).toBe(1);
   });
 
+  it("treats a Ruby file known only by its file-level constants as a counterpart", () => {
+    const { ruby, ts: ts_ } = makeManifests("cipher.ts");
+    // cipher.rb declares a constant and no class the extractor picked up; the
+    // literal pass still maps it through rubyFileToTs (compare.ts:1838-1841).
+    ruby.packages["activerecord"].fileConstants = {
+      "cipher.rb": { DEFAULT_ENCODING: { kind: "expr" } },
+    };
+    ts_.packages["activerecord"].fileFunctions = {
+      "cipher.ts": [method("DEFAULT_ENCODING"), method("setFoo")],
+    };
+    const report = buildReport(ruby, ts_, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const f = report.packages[0].extraFiles[0];
+    expect(f.tsFile).toBe("cipher.ts");
+    expect(f.rubyFile).toBe("cipher.rb");
+    // The constant is allowed by its own Rails file, so only `setFoo` flags —
+    // and the file is NOT counted against the no-counterpart population.
+    expect(f.extras.map((e) => e.name)).toEqual(["setFoo"]);
+    expect(report.packages[0].noCounterpartFiles).toBe(0);
+  });
+
   it("holds out trees that mirror Rails test code rather than lib", () => {
     const { ruby, ts: ts_ } = makeManifests("test-helpers/models/post.ts");
     const report = buildReport(ruby, ts_, {

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1670,6 +1670,21 @@ describe("buildReport — TS files with no Rails counterpart", () => {
     ]);
   });
 
+  it("breaks the no-counterpart slice out of the package totals", () => {
+    const { ruby, ts: ts_ } = makeManifests("ar-config.ts");
+    const report = buildReport(ruby, ts_, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const pkg = report.packages[0];
+    expect(pkg.totalExtras).toBe(2);
+    expect(pkg.noCounterpartFiles).toBe(1);
+    expect(pkg.noCounterpartExtras).toBe(2);
+    expect(pkg.noCounterpartNovel).toBe(1);
+  });
+
   it("holds out trees that mirror Rails test code rather than lib", () => {
     const { ruby, ts: ts_ } = makeManifests("test-helpers/models/post.ts");
     const report = buildReport(ruby, ts_, {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -9,7 +9,8 @@
  * can prune toward Rails-faithful shape; it never modifies source.
  *
  * Algorithm, per Rails-mirroring package:
- *   1. For each Ruby file, resolve its expected TS file via `rubyFileToTs`.
+ *   1. For each Ruby file, resolve its expected TS file via `rubyFileToTs`;
+ *      TS files nothing resolves to are scored separately (step 4b).
  *   2. Collect Ruby methods declared in (or `include`d into) the entities in
  *      that Ruby file — any visibility, since a TS method mirroring a
  *      Rails-private method exists in Rails (a visibility divergence, not
@@ -29,6 +30,11 @@
  *      should not count toward extra surface.
  *   4. Extra = TS names \ allowed names. Emit per-file, per-package, and
  *      top-N reports.
+ *   4b. TS files that NO Ruby file maps onto are scored too, with an empty
+ *      allowed set — see `uncoveredTsFiles`. Rails-test-mirroring trees
+ *      (`test-helpers/`, `support/`, `cases/`, fixture corpora) are held out
+ *      because the Ruby extractor reads `lib/` only, so they could never have
+ *      a counterpart.
  *   5. Subtract the reasoned exceptions: a declaration carrying a
  *      `@noRailsEquivalent <reason>` JSDoc tag counts as `Allowed` rather
  *      than extra. Since RFC 0080 the tag is the ONLY such source — the
@@ -317,7 +323,11 @@ export interface ExtraName {
 interface ExtraFile {
   package: string;
   tsFile: string;
-  rubyFile: string;
+  /**
+   * `null` for a TS file no Rails file maps onto — every public name in it is
+   * extra by construction (see `uncoveredTsFiles`).
+   */
+  rubyFile: string | null;
   extraCount: number;
   novelCount: number;
   movedCount: number;
@@ -700,6 +710,76 @@ export function buildCrossPackageModules(ruby: ApiManifest): {
   return { modules, pkgByFqn };
 }
 
+/**
+ * Path segments marking a TS tree that mirrors Rails' `test/` (or a codegen
+ * fixture corpus) rather than its `lib/`. The Ruby extractor only reads `lib/`,
+ * so nothing under these can ever have a counterpart in the file map — scoring
+ * them as uncovered would flag every faithfully ported test model
+ * (`test-helpers/models/post.ts` alone mirrors 168 members of
+ * `activerecord/test/models/post.rb`) as drift. `support/` and `cases/` mirror
+ * `activerecord/test/support` and `test/cases`; `fixtures/` covers both the
+ * ported Rails fixture data and `type-virtualization/fixtures` codegen
+ * input/expected pairs.
+ *
+ * Matching is per path SEGMENT, not substring: `test-fixtures/` is the split of
+ * `lib/active_record/test_fixtures.rb` and stays scored.
+ *
+ * This is the same lib-only boundary the Ruby side already draws, not an
+ * allowance for unconverged surface — a `lib/`-mirroring file with no
+ * counterpart IS scored.
+ */
+const TEST_SUPPORT_SEGMENTS = new Set([
+  "test-helpers",
+  "dx-tests",
+  "support",
+  "cases",
+  "fixtures",
+  "__fixtures__",
+]);
+
+/** Basenames of per-adapter test helper modules that sit outside those trees. */
+const TEST_SUPPORT_BASENAMES = new Set(["test-helper.ts", "test-helpers.ts"]);
+
+export function isTestSupportFile(tsFile: string): boolean {
+  const segments = tsFile.split("/");
+  const base = segments.pop() ?? "";
+  return segments.some((s) => TEST_SUPPORT_SEGMENTS.has(s)) || TEST_SUPPORT_BASENAMES.has(base);
+}
+
+/**
+ * TS files in the package that no Ruby file maps onto via `rubyFileToTs`.
+ *
+ * Before this, such a file was invisible: the report iterates Ruby files, so a
+ * TS file nothing points at was never visited and its whole public surface went
+ * unmeasured — neither novel nor moved nor allowed. That is exactly backwards,
+ * since a file Rails has no counterpart for is where extra surface is MOST
+ * likely (`ar-config.ts`'s 20+ `setX` re-spellings of Ruby `foo=` writers
+ * reported zero extras because `active_record.rb` redirects onto `base.ts`).
+ *
+ * These files are scored with an EMPTY allowed set — there is no Rails file to
+ * take allowed names from — so every public name lands as an extra, classed
+ * novel vs moved against the package-wide Rails candidates like any other. In
+ * particular the umbrella-config attribution `compare.ts` applies (crediting
+ * `setProtocolAdapters` to `ActiveRecord.protocol_adapters=` as a *move*) is
+ * deliberately NOT mirrored here: `rubyMethodToTs` maps `foo=` to `foo`, so the
+ * `setX` spelling is novel surface, which is the finding, not noise to absorb.
+ */
+export function uncoveredTsFiles(
+  coveredTsFiles: Set<string>,
+  tsClassesByFile: Map<string, ClassInfo[]>,
+  tsModulesByFile: Map<string, ClassInfo[]>,
+  tsFileFunctions: Record<string, MethodInfo[]>,
+): string[] {
+  const files = new Set<string>([
+    ...tsClassesByFile.keys(),
+    ...tsModulesByFile.keys(),
+    ...Object.keys(tsFileFunctions),
+  ]);
+  return [...files]
+    .filter((f) => !coveredTsFiles.has(f) && !isTestSupportFile(f))
+    .sort((a, b) => a.localeCompare(b));
+}
+
 function buildPackageReport(
   pkg: string,
   ruby: ApiManifest,
@@ -778,8 +858,20 @@ function buildPackageReport(
   }
   const tsFileFunctions = tsPkg.fileFunctions ?? {};
 
-  for (const [rubyFile, entities] of rubyFiles) {
-    const expectedTs = rubyFileToTs(rubyFile, pkg);
+  const coveredTsFiles = new Set<string>();
+  for (const rubyFile of rubyFiles.keys()) coveredTsFiles.add(rubyFileToTs(rubyFile, pkg));
+
+  const scoreTargets: { tsFile: string; rubyFile: string | null }[] = [
+    ...[...rubyFiles.keys()].map((rubyFile) => ({
+      tsFile: rubyFileToTs(rubyFile, pkg),
+      rubyFile,
+    })),
+    ...uncoveredTsFiles(coveredTsFiles, tsClassesByFile, tsModulesByFile, tsFileFunctions).map(
+      (tsFile) => ({ tsFile, rubyFile: null }),
+    ),
+  ];
+
+  for (const { tsFile: expectedTs, rubyFile } of scoreTargets) {
     if (excludeGlobs.some((g) => expectedTs.includes(g))) continue;
 
     const classes = tsClassesByFile.get(expectedTs) ?? [];
@@ -790,15 +882,18 @@ function buildPackageReport(
     const tsNames = collectTsFileNames(expectedTs, classes, modules, fileFns);
     if (tsNames.size === 0) continue;
 
-    const allowed = collectAllowedNames(
-      entities,
-      pkg,
-      rubyPkg.modules as Record<string, ClassInfo>,
-      moduleFqnByShort,
-      crossPackageModules,
-      crossPackagePkgByFqn,
-      Object.keys(rubyPkg.fileConstants?.[rubyFile] ?? {}),
-    );
+    const allowed =
+      rubyFile === null
+        ? new Set<string>()
+        : collectAllowedNames(
+            rubyFiles.get(rubyFile) ?? [],
+            pkg,
+            rubyPkg.modules as Record<string, ClassInfo>,
+            moduleFqnByShort,
+            crossPackageModules,
+            crossPackagePkgByFqn,
+            Object.keys(rubyPkg.fileConstants?.[rubyFile] ?? {}),
+          );
 
     const extras: ExtraName[] = [];
     let novelCount = 0;
@@ -955,7 +1050,10 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
     if (pkg.extraFiles.length === 0) continue;
     console.log(`${p.bold}${pkg.package}${p.reset}`);
     for (const f of pkg.extraFiles) {
-      console.log(`  ${f.tsFile} — ${colorCount(f.novelCount, p)} novel, ${f.movedCount} moved`);
+      const noCounterpart = f.rubyFile === null ? ` ${p.dim}[no Rails counterpart]${p.reset}` : "";
+      console.log(
+        `  ${f.tsFile} — ${colorCount(f.novelCount, p)} novel, ${f.movedCount} moved${noCounterpart}`,
+      );
       const shown = maxDetail > 0 ? f.extras.slice(0, maxDetail) : f.extras;
       const cols = 4;
       for (let i = 0; i < shown.length; i += cols) {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -762,6 +762,9 @@ export function isTestSupportFile(tsFile: string): boolean {
 
 /**
  * TS files in the package that no Ruby file maps onto via `rubyFileToTs`.
+ * "Ruby file" includes a file the extractor knows only through its file-level
+ * constants — `coveredTsFiles` unions those in, so a constant-only Rails file
+ * is a counterpart here exactly as it is in the literal pass.
  *
  * Before this, such a file was invisible: the report iterates Ruby files, so a
  * TS file nothing points at was never visited and its whole public surface went
@@ -875,11 +878,21 @@ function buildPackageReport(
   }
   const tsFileFunctions = tsPkg.fileFunctions ?? {};
 
+  // A Ruby file can declare file-level constants and no class/module at all
+  // (rails/engine/commands.rb:3-9 is `Rails::Command::…` constants only), so it
+  // never lands in `rubyFiles` — but it IS a Rails counterpart, and the literal
+  // pass already treats it as one by mapping every `fileConstants` key through
+  // `rubyFileToTs` (compare.ts:1838-1841). Score it here the same way: with an
+  // empty entity list, so `collectAllowedNames` allows exactly its constants.
+  const rubyFileNames = new Set<string>([
+    ...rubyFiles.keys(),
+    ...Object.keys(rubyPkg.fileConstants ?? {}),
+  ]);
   const coveredTsFiles = new Set<string>();
-  for (const rubyFile of rubyFiles.keys()) coveredTsFiles.add(rubyFileToTs(rubyFile, pkg));
+  for (const rubyFile of rubyFileNames) coveredTsFiles.add(rubyFileToTs(rubyFile, pkg));
 
   const scoreTargets: { tsFile: string; rubyFile: string | null }[] = [
-    ...[...rubyFiles.keys()].map((rubyFile) => ({
+    ...[...rubyFileNames].map((rubyFile) => ({
       tsFile: rubyFileToTs(rubyFile, pkg),
       rubyFile,
     })),

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -342,6 +342,15 @@ interface PackageTotals {
   totalNovel: number;
   totalMoved: number;
   totalAllowlisted: number;
+  /**
+   * The `rubyFile === null` slice of the totals above — files no Rails file
+   * maps onto. Broken out so a consumer can tell how much of a package's
+   * extra surface comes from that population (it was unmeasured before this
+   * existed, so folding it in silently would read as a regression).
+   */
+  noCounterpartFiles: number;
+  noCounterpartExtras: number;
+  noCounterpartNovel: number;
   extraFiles: ExtraFile[];
 }
 
@@ -381,6 +390,11 @@ Options:
   --max-detail <N>     Per-file detail listing cap (default 40 names;
                        0 = unlimited)
   --help               This message
+
+TS files that no Rails file maps onto are scored too, with an empty allowed
+set — every public name in them is extra. Trees mirroring Rails' test/ code
+(test-helpers/, support/, cases/, fixture corpora) are held out, since the Ruby
+extractor reads lib/ only. The NoCntrp column reports that slice separately.
 
 Reasoned exceptions: an extra is allowed by tagging its TS declaration
 \`@noRailsEquivalent <reason>\` in JSDoc. Allowed extras are subtracted from the
@@ -801,6 +815,9 @@ function buildPackageReport(
     totalNovel: 0,
     totalMoved: 0,
     totalAllowlisted: 0,
+    noCounterpartFiles: 0,
+    noCounterpartExtras: 0,
+    noCounterpartNovel: 0,
     extraFiles: [],
   };
   if (!rubyPkg || !tsPkg) return result;
@@ -935,6 +952,11 @@ function buildPackageReport(
     result.totalExtras += extras.length;
     result.totalNovel += novelCount;
     result.totalMoved += movedCount;
+    if (rubyFile === null) {
+      result.noCounterpartFiles++;
+      result.noCounterpartExtras += extras.length;
+      result.noCounterpartNovel += novelCount;
+    }
   }
 
   // Rank order: novel-first when --novel-only is on (only novel exists),
@@ -1010,17 +1032,20 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
 
   console.log(`${p.bold}Per-package totals${p.reset}`);
   console.log(
-    `  ${"Package".padEnd(20)} ${"Files".padStart(7)} ${"Novel".padStart(7)} ${"Moved".padStart(7)} ${"Total".padStart(7)} ${"Allowed".padStart(7)}`,
+    `  ${"Package".padEnd(20)} ${"Files".padStart(7)} ${"Novel".padStart(7)} ${"Moved".padStart(7)} ${"Total".padStart(7)} ${"Allowed".padStart(7)} ${"NoCntrp".padStart(7)}`,
   );
   console.log(
-    `  ${"-".repeat(20)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)}`,
+    `  ${"-".repeat(20)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)} ${"-".repeat(7)}`,
   );
   for (const pkg of report.packages) {
     const novel = padNumCell(pkg.totalNovel, colorCount(pkg.totalNovel, p), 7);
     console.log(
-      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(7)} ${novel} ${String(pkg.totalMoved).padStart(7)} ${String(pkg.totalExtras).padStart(7)} ${String(pkg.totalAllowlisted).padStart(7)}`,
+      `  ${pkg.package.padEnd(20)} ${String(pkg.filesWithDrift).padStart(7)} ${novel} ${String(pkg.totalMoved).padStart(7)} ${String(pkg.totalExtras).padStart(7)} ${String(pkg.totalAllowlisted).padStart(7)} ${String(pkg.noCounterpartExtras).padStart(7)}`,
     );
   }
+  console.log(
+    `${p.dim}  NoCntrp = the slice of Total from TS files no Rails file maps onto (scored with an empty allowed set).${p.reset}`,
+  );
   console.log(
     `\n${p.dim}@noRailsEquivalent tags: ${report.tagged.total} tag(s), ` +
       `${report.tagged.matched} matched — allowed extras are subtracted from the counts above.${p.reset}`,


### PR DESCRIPTION
## Problem

`extra-surface` iterates **Ruby** files and resolves each to its expected TS
file via `rubyFileToTs`. A TS file that nothing maps onto was therefore never
visited, and its entire public surface went unmeasured — neither novel nor
moved nor allowlisted, just invisible. That is exactly backwards: a file Rails
has no counterpart for is where extra surface is MOST likely.

The worked example: `packages/activerecord/src/ar-config.ts` reported **zero**
extras despite 20+ exported `setX` re-spellings of a Ruby `foo=` writer (the
RFC 0081 population), because `active_record.rb` redirects onto `base.ts`.

## Quantifying the hole (acceptance criterion 1)

Across every compared package, **186 TS files** with public surface had no
Rails counterpart, carrying **1119 unmeasured names (464 novel)**. Top files:

| novel/total | package | file |
| --- | --- | --- |
| 37/46 | activesupport | `fs-adapter.ts` |
| 18/21 | activerecord | `ar-config.ts` |
| 16/20 | activesupport | `crypto-adapter.ts` |
| 13/13 | activemodel | `index.ts` |
| 12/17 | activesupport | `process-adapter.ts` |
| 11/11 | activerecord | `connection-adapters/abstract/sql-datetime.ts` |

## How they score (acceptance criterion 2)

With an **empty allowed set** — there is no Rails file to draw allowed names
from — so every public name lands as an extra, classed novel vs moved against
the package-wide Rails candidates like any other extra.

The umbrella-config attribution `compare.ts:1772-1790` applies (crediting
`setProtocolAdapters` to `ActiveRecord.protocol_adapters=` as a *move*) is
deliberately **not** mirrored here: `rubyMethodToTs` maps `foo=` to `foo`, so
the `setX` spelling is novel surface. That is the finding, not noise to absorb.

## Not mass-flagging ported code (acceptance criterion 3)

A Rails file the extractor knows only through its file-level constants (no
class body — `rails/engine/commands.rb`) still counts as a counterpart: its
`fileConstants` key is mapped through `rubyFileToTs` and scored with an empty
entity list, matching what the literal pass already does at
`compare.ts:1838-1841`.

Trees mirroring Rails' `test/` are held out **per path segment**:
`test-helpers/`, `dx-tests/`, `support/` (= `activerecord/test/support`),
`cases/` (= `test/cases`), `fixtures/` / `__fixtures__/`, plus `test-helper.ts`
basenames. The Ruby extractor reads `lib/` only, so nothing under these can
ever have a counterpart — `test-helpers/models/post.ts` alone mirrors 168
members of `activerecord/test/models/post.rb`. Segment matching (not
substring) keeps `test-fixtures/`, the split of `lib/active_record/test_fixtures.rb`,
scored. Nothing is allowlisted and no `@noRailsEquivalent` tag was added.

## Delta on every package (before → after)

Verified by running the report from `origin/main` and from this branch against
the same manifests: **no already-reported file's counts changed** (0 changed,
0 dropped, 187 added; one of them, `encryption/cipher.ts`, is attributed to `encryption/cipher.rb` rather than counted as no-counterpart); tags stayed 80 total / 80 matched / 0 stale.

| package | novel | total | files |
| --- | --- | --- | --- |
| activerecord | 423 → 580 | 1340 → 1690 | 197 → 261 |
| activesupport | 122 → 280 | 277 → 684 | 51 → 90 |
| actiondispatch | 149 → 188 | 316 → 419 | 53 → 66 |
| trailties | 61 → 123 | 147 → 246 | 53 → 91 |
| activemodel | 83 → 104 | 253 → 285 | 48 → 56 |
| arel | 64 → 75 | 168 → 233 | 55 → 65 |
| actioncontroller | 57 → 61 | 137 → 142 | 35 → 37 |
| rack | 43 → 45 | 116 → 122 | 17 → 19 |
| actionview | 34 → 41 | 90 → 128 | 21 → 29 |
| globalid | 0 → 3 | 0 → 17 | 0 → 2 |

Per-file detail marks these `[no Rails counterpart]`, and the per-package table
gains a `NoCntrp` column (JSON: `noCounterpartFiles` / `noCounterpartExtras` /
`noCounterpartNovel`) reporting that slice separately — this population was
unmeasured before, so folding it silently into the totals would read as a
regression to anyone tracking the number:

```text
  Package                Files   Novel   Moved   Total Allowed NoCntrp
  -------------------- ------- ------- ------- ------- ------- -------
  activerecord             261     580    1110    1690      58     346
  activesupport             90     280     404     684       4     407
  actiondispatch            66     188     231     419       3     103
```

`@noRailsEquivalent` tags: 80 total, 80 matched, 0 stale — unchanged.

## Tests

Six new cases in `extra-surface.test.ts`: the no-counterpart file is scored
(and `setFoo` is novel while the reader is moved), test-mirroring trees are
held out, `test-fixtures/` is still scored, a constant-only Rails file counts as
a counterpart, the no-counterpart totals slice is broken out, and
`--exclude-glob` still applies.
All fail on baseline for the first case (the file was skipped entirely).

Closes-story: extra-surface-skips-files-without-rails-counterpart


