### PR TITLE
feat(api-compare): require the negation for negating enumerable aliases

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -16,6 +16,8 @@ import {
   significantMissingCalls,
   jsEnumerableAliases,
   JS_ENUMERABLE_ALIASES,
+  NEGATED_ALIASES,
+  partitionNegatedCalls,
   WIDE_SIGNIFICANT_CALLS,
   WIDE_NO_JS_CALL_FORM,
   isDelegatingWrapper,
@@ -357,6 +359,52 @@ describe("significantMissingCalls", () => {
         wide,
       );
       expect(missing).toEqual(["any? → isAny|any"]);
+    });
+
+    it("does not flag exclude?/none? when the TS body negates the analogue", () => {
+      // ActiveSupport's `exclude?` is `!include?` and `none?` is `!any?`, so
+      // the faithful port is the NEGATED call — the form the extractor records
+      // with the `!` marker.
+      const missing = significantMissingCalls(
+        "check",
+        ["exclude?", "none?"],
+        new Set(["includes", "some"]),
+        () => true,
+        rubyMethodToTs,
+        wide,
+        jsEnumerableAliases,
+        new Set(["includes", "some"]),
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it("flags exclude?/none? when the TS body makes the analogue UNnegated", () => {
+      // The inverted condition: `xs.includes(y)` where Rails wrote `exclude?`.
+      const missing = significantMissingCalls(
+        "check",
+        ["exclude?", "none?"],
+        new Set(["includes", "some"]),
+        () => true,
+        rubyMethodToTs,
+        wide,
+      );
+      expect(missing).toEqual(["exclude? → isExclude|exclude|excludes", "none? → isNone|none"]);
+    });
+
+    it("marks only aliases the alias table itself lists", () => {
+      for (const [rubyCall, negated] of NEGATED_ALIASES) {
+        const aliases = JS_ENUMERABLE_ALIASES.get(rubyCall) ?? [];
+        expect({ rubyCall, unknown: [...negated].filter((a) => !aliases.includes(a)) }).toEqual({
+          rubyCall,
+          unknown: [],
+        });
+      }
+    });
+
+    it("partitions the extractor's negation markers out of the plain call-set", () => {
+      const { calls, negated } = partitionNegatedCalls(["includes", "!includes", "map"]);
+      expect([...calls].sort()).toEqual(["includes", "map"]);
+      expect([...negated]).toEqual(["includes"]);
     });
 
     it("aliases never widen which calls are considered ported", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -105,7 +105,13 @@ import {
   displayLiteral,
 } from "./literals.js";
 import { isSourceUnported } from "./unported-files.js";
-import { JS_ENUMERABLE_ALIASES, jsEnumerableAliases } from "./enumerable-idioms.js";
+import {
+  JS_ENUMERABLE_ALIASES,
+  jsEnumerableAliases,
+  NEGATED_ALIASES,
+  NEGATED_CALL_PREFIX,
+  requiresNegatedAlias,
+} from "./enumerable-idioms.js";
 
 // Fidelity-critical Ruby calls for the advisory calls-parity check. Omitting
 // one of these from a ported body is almost always a real bug (callback /
@@ -215,7 +221,27 @@ export const WIDE_SIGNIFICANT_CALLS: { has(value: string): boolean } = {
 
 // Re-exported from the shared idiom table so existing importers (compare.test.ts,
 // the redundancy guard) keep resolving these names from compare.ts.
-export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases };
+export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES };
+
+/**
+ * Split a raw TS call-set into the plain call names and the names the extractor
+ * saw in a NEGATED position (`!includes` → `includes`). The marked entries are
+ * kept OUT of the plain set: they are a second record of a call already in it,
+ * so leaving them in would double-count against DELEGATION_MAX_CALLS in
+ * {@link isDelegatingWrapper} and make wrapper detection body-shape dependent.
+ */
+export function partitionNegatedCalls(raw: Iterable<string>): {
+  calls: Set<string>;
+  negated: Set<string>;
+} {
+  const calls = new Set<string>();
+  const negated = new Set<string>();
+  for (const c of raw) {
+    if (c.startsWith(NEGATED_CALL_PREFIX)) negated.add(c.slice(NEGATED_CALL_PREFIX.length));
+    else calls.add(c);
+  }
+  return { calls, negated };
+}
 
 /**
  * Core of the advisory calls-parity check (pure, exported for tests). For a
@@ -241,6 +267,7 @@ export function significantMissingCalls(
   mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,
   significant: { has(value: string): boolean } = SIGNIFICANT_CALLS,
   aliasCall: (rubyCall: string) => string[] = jsEnumerableAliases,
+  negatedTsCalls: Set<string> = new Set(),
 ): string[] {
   const missing: string[] = [];
   for (const rc of rubyCalls) {
@@ -264,7 +291,15 @@ export function significantMissingCalls(
     if (!mapped || mapped.length === 0) continue;
     if (!mapped.some(isPortedWithArgs)) continue;
     if (mapped.some((c) => tsCalls.has(c))) continue;
-    if (aliasCall(rc).some((c) => tsCalls.has(c))) continue;
+    // A NEGATED alias (`exclude? → includes`) is matched against the negated
+    // call-set: a bare `xs.includes(y)` where Rails wrote `exclude?` is the
+    // inverted condition, and must not silence the ratchet. Direct aliases —
+    // including `none? → every`, whose de-Morgan port negates inside the
+    // callback — keep matching the plain call-set (see NEGATED_ALIASES).
+    const aliasMatched = aliasCall(rc).some((c) =>
+      requiresNegatedAlias(rc, c) ? negatedTsCalls.has(c) : tsCalls.has(c),
+    );
+    if (aliasMatched) continue;
     missing.push(`${rc} → ${mapped.join("|")}`);
   }
   return missing;
@@ -1165,6 +1200,9 @@ export function main() {
     // per-file scoping above is what keeps same-named methods on unrelated
     // classes from cross-satisfying.
     const tsCallsByName = new Map<string, Set<string>>();
+    // Same population as tsCallsByName, but the calls the extractor saw NEGATED
+    // (`!xs.includes(y)`), with the marker prefix stripped.
+    const tsNegatedCallsByName = new Map<string, Set<string>>();
     const recordTsParams = (m: MethodInfo, file = m.file ?? "") => {
       const sigs = tsParamsByName.get(m.name) ?? [];
       sigs.push(m.params);
@@ -1181,9 +1219,13 @@ export function main() {
         const byName = tsCallsByFileName.get(file) ?? new Map<string, string[][]>();
         byName.set(m.name, [...(byName.get(m.name) ?? []), m.calls]);
         tsCallsByFileName.set(file, byName);
+        const { calls, negated } = partitionNegatedCalls(m.calls);
         const union = tsCallsByName.get(m.name) ?? new Set<string>();
-        for (const c of m.calls) union.add(c);
+        for (const c of calls) union.add(c);
         tsCallsByName.set(m.name, union);
+        const negatedUnion = tsNegatedCallsByName.get(m.name) ?? new Set<string>();
+        for (const c of negated) negatedUnion.add(c);
+        tsNegatedCallsByName.set(m.name, negatedUnion);
       }
     };
 
@@ -1608,9 +1650,14 @@ export function main() {
         if (!tsCandidateSets || tsCandidateSets.length === 0) return;
         // Delegation transparency: a one-line forwarder is compared against the
         // call-set of the method it forwards to (see effectiveTsCalls).
-        const tsCalls = effectiveTsCalls(tsName, new Set(tsCandidateSets.flat()), (n) =>
-          tsCallsByName.get(n),
-        );
+        const own = partitionNegatedCalls(tsCandidateSets.flat());
+        const tsCalls = effectiveTsCalls(tsName, own.calls, (n) => tsCallsByName.get(n));
+        // A delegating wrapper is held to its delegate's call-set, so the
+        // delegate's NEGATED calls come along too (unioned the same way).
+        const negatedTsCalls = new Set(own.negated);
+        if (tsCalls !== own.calls) {
+          for (const c of tsNegatedCallsByName.get(tsName) ?? []) negatedTsCalls.add(c);
+        }
         callsCompared++;
         const missing = significantMissingCalls(
           rubyName,
@@ -1622,6 +1669,8 @@ export function main() {
           (c) => (tsParamsByName.get(c) ?? []).some((sig) => stripThis(sig).length > 0),
           rubyMethodToTs,
           callsSignificant,
+          jsEnumerableAliases,
+          negatedTsCalls,
         );
         if (missing.length === 0) return;
         callMismatches.push({ rubyFile, tsFile, rubyName, tsName, missing });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -109,7 +109,7 @@ import {
   JS_ENUMERABLE_ALIASES,
   jsEnumerableAliases,
   NEGATED_ALIASES,
-  NEGATED_CALL_PREFIX,
+  partitionNegatedCalls,
   requiresNegatedAlias,
 } from "./enumerable-idioms.js";
 
@@ -221,27 +221,7 @@ export const WIDE_SIGNIFICANT_CALLS: { has(value: string): boolean } = {
 
 // Re-exported from the shared idiom table so existing importers (compare.test.ts,
 // the redundancy guard) keep resolving these names from compare.ts.
-export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES };
-
-/**
- * Split a raw TS call-set into the plain call names and the names the extractor
- * saw in a NEGATED position (`!includes` → `includes`). The marked entries are
- * kept OUT of the plain set: they are a second record of a call already in it,
- * so leaving them in would double-count against DELEGATION_MAX_CALLS in
- * {@link isDelegatingWrapper} and make wrapper detection body-shape dependent.
- */
-export function partitionNegatedCalls(raw: Iterable<string>): {
-  calls: Set<string>;
-  negated: Set<string>;
-} {
-  const calls = new Set<string>();
-  const negated = new Set<string>();
-  for (const c of raw) {
-    if (c.startsWith(NEGATED_CALL_PREFIX)) negated.add(c.slice(NEGATED_CALL_PREFIX.length));
-    else calls.add(c);
-  }
-  return { calls, negated };
-}
+export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES, partitionNegatedCalls };
 
 /**
  * Core of the advisory calls-parity check (pure, exported for tests). For a
@@ -1652,10 +1632,10 @@ export function main() {
         // call-set of the method it forwards to (see effectiveTsCalls).
         const own = partitionNegatedCalls(tsCandidateSets.flat());
         const tsCalls = effectiveTsCalls(tsName, own.calls, (n) => tsCallsByName.get(n));
-        // A delegating wrapper is held to its delegate's call-set, so the
-        // delegate's NEGATED calls come along too (unioned the same way).
+        // A wrapper compared against its delegate's calls inherits its negated
+        // ones too, or the delegate's `!xs.includes(y)` would not count.
         const negatedTsCalls = new Set(own.negated);
-        if (tsCalls !== own.calls) {
+        if (isDelegatingWrapper(tsName, own.calls)) {
           for (const c of tsNegatedCallsByName.get(tsName) ?? []) negatedTsCalls.add(c);
         }
         callsCompared++;

--- a/scripts/api-compare/enumerable-idioms.ts
+++ b/scripts/api-compare/enumerable-idioms.ts
@@ -18,6 +18,9 @@
 export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
   ["any?", ["some"]],
   ["all?", ["every"]],
+  // `none?` is `!any?`: the `some` analogue must be NEGATED (see
+  // NEGATED_ALIASES), while `every` is the de-Morgan form `!xs.every(...)` OR
+  // `xs.every((x) => !p(x))`, so it counts either way.
   ["none?", ["some", "every"]],
   ["one?", ["filter"]],
   // `includes` is omitted here on purpose: it is now a naming-convention
@@ -26,9 +29,8 @@ export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
   ["include?", ["has"]],
   ["member?", ["has"]],
   // ActiveSupport's `exclude?` is `!include?`, so the containment call is the
-  // whole call — ports spell it `!xs.includes(y)` / `!set.has(y)`. As with
-  // `none? → some/every` above, the ratchet only checks that the file makes a
-  // call by that NAME; the leading `!` is not verified. (The convention
+  // whole call — ports spell it `!xs.includes(y)` / `!set.has(y)`, and the
+  // leading `!` IS required (see NEGATED_ALIASES). (The convention
   // candidate for a method NAMED `exclude?` is `excludes`, so no overlap.)
   ["exclude?", ["includes", "has"]],
   ["key?", ["has"]],
@@ -51,4 +53,38 @@ export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
 /** JS-native call names that count as making Ruby call `rubyCall`. */
 export function jsEnumerableAliases(rubyCall: string): string[] {
   return JS_ENUMERABLE_ALIASES.get(rubyCall) ?? [];
+}
+
+/**
+ * Aliases whose faithful port carries a leading `!` — the Ruby call is the
+ * NEGATION of that JS analogue, so only a NEGATED TS call counts:
+ * `none?` → `!xs.some(p)`, `exclude?` → `!xs.includes(y)` / `!set.has(y)`.
+ * Without this, a port that INVERTED the condition (a bare `xs.includes(y)`
+ * where Rails wrote `exclude?`) silenced the wide ratchet just as well as the
+ * faithful one.
+ *
+ * Keyed per-ALIAS, not per Ruby call, because a negating Ruby call can also
+ * have a de-Morgan analogue that is faithful UNnegated: `xs.none?(&:dirty?)`
+ * ports to `xs.every((t) => !t.isDirty())` (transaction.ts `isRestorable`),
+ * where the `!` sits inside the callback, not on the call. So `none? → every`
+ * stays a direct alias while `none? → some` requires the marker.
+ */
+export const NEGATED_ALIASES = new Map<string, Set<string>>([
+  ["none?", new Set(["some"])],
+  ["exclude?", new Set(["includes", "has"])],
+]);
+
+/**
+ * Prefix the TS extractor uses to mark a call it saw in a NEGATED position
+ * (`!xs.includes(y)` → `!includes`). Marked names are recorded IN ADDITION to
+ * the plain name, so every consumer that tests membership by plain name is
+ * unaffected; only the {@link NEGATED_ALIASES} check reads the marked form.
+ * Lives here, not in extract-ts-api.ts, so compare.ts can read it without
+ * importing the extractor (and its TypeScript-compiler dependency).
+ */
+export const NEGATED_CALL_PREFIX = "!";
+
+/** Whether alias `tsCall` counts for `rubyCall` only when the TS call is negated. */
+export function requiresNegatedAlias(rubyCall: string, tsCall: string): boolean {
+  return NEGATED_ALIASES.get(rubyCall)?.has(tsCall) ?? false;
 }

--- a/scripts/api-compare/enumerable-idioms.ts
+++ b/scripts/api-compare/enumerable-idioms.ts
@@ -88,3 +88,23 @@ export const NEGATED_CALL_PREFIX = "!";
 export function requiresNegatedAlias(rubyCall: string, tsCall: string): boolean {
   return NEGATED_ALIASES.get(rubyCall)?.has(tsCall) ?? false;
 }
+
+/**
+ * Split a raw TS call-set into the plain call names and the names the extractor
+ * saw in a NEGATED position (`!includes` → `includes`). The marked entries are
+ * kept OUT of the plain set: they are a second record of a call already in it,
+ * so leaving them in would double-count against DELEGATION_MAX_CALLS in
+ * `isDelegatingWrapper` (compare.ts) and make wrapper detection body-shape dependent.
+ */
+export function partitionNegatedCalls(raw: Iterable<string>): {
+  calls: Set<string>;
+  negated: Set<string>;
+} {
+  const calls = new Set<string>();
+  const negated = new Set<string>();
+  for (const c of raw) {
+    if (c.startsWith(NEGATED_CALL_PREFIX)) negated.add(c.slice(NEGATED_CALL_PREFIX.length));
+    else calls.add(c);
+  }
+  return { calls, negated };
+}

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -207,11 +207,14 @@ describe("body call capture", () => {
     expect(check.calls).toEqual(["!has", "!includes", "!loaded", "has", "includes", "loaded"]);
   });
 
-  it("does not mark a call whose negation applies to a surrounding expression", () => {
-    // `!a && xs.includes(y)` negates `a`, not the containment call.
+  it("does not mark a call the ! does not actually negate", () => {
+    // `!a &&` binds the negation to `a`; `!!` is a truthiness cast, not a
+    // negation — crediting either would be the same false positive the marker
+    // exists to prevent.
     const cls = extractFromSource(
       `class Foo {
         check(a: boolean, xs: string[]) {
+          if (!!xs.includes("a")) return true;
           return !a && xs.includes("b");
         }
       }`,

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -191,6 +191,35 @@ describe("body call capture", () => {
     expect(save.calls).toEqual(["helper", "nested", "runCallbacks", "touch"]);
   });
 
+  it("marks a call made in a negated position with the ! prefix", () => {
+    // The faithful port of ActiveSupport's `exclude?` (`!include?`); the wide
+    // call ratchet requires the marker before crediting a negating alias.
+    const cls = extractFromSource(
+      `class Foo {
+        check(xs: string[], set: Set<string>) {
+          if (!xs.includes("a")) return true;
+          if (!(set.has("b"))) return true;
+          return set.has("c") || !this.loaded;
+        }
+      }`,
+    );
+    const check = cls.instanceMethods.find((m) => m.name === "check")!;
+    expect(check.calls).toEqual(["!has", "!includes", "!loaded", "has", "includes", "loaded"]);
+  });
+
+  it("does not mark a call whose negation applies to a surrounding expression", () => {
+    // `!a && xs.includes(y)` negates `a`, not the containment call.
+    const cls = extractFromSource(
+      `class Foo {
+        check(a: boolean, xs: string[]) {
+          return !a && xs.includes("b");
+        }
+      }`,
+    );
+    const check = cls.instanceMethods.find((m) => m.name === "check")!;
+    expect(check.calls).toEqual(["includes"]);
+  });
+
   it("omits calls entirely for a body that invokes nothing", () => {
     // No calls and no property reads — a pure arithmetic return.
     const cls = extractFromSource(`class Foo { id() { return 1 + 2; } }`);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2051,6 +2051,12 @@ function collectImportAliases(sourceFile: ts.SourceFile): Map<string, string> {
  * resolved to the dispatched/original name (see the visit body) so indirect
  * invocations of a ported method still count toward its call set.
  *
+ * A call made under a `!` is recorded TWICE — plainly and with the
+ * NEGATED_CALL_PREFIX marker (`includes` + `!includes`) — so a consumer that
+ * cares about the negation can see it while every consumer that tests
+ * membership by plain name is unaffected. `partitionNegatedCalls` (compare.ts)
+ * splits the two populations back apart.
+ *
  * Wired into method/function bodies (class methods, exported + export-list
  * functions, object-literal mixin methods). Get/set accessor bodies are not
  * captured: the calls-parity check only acts on SIGNIFICANT_CALLS, none of
@@ -2094,11 +2100,10 @@ function isAssignmentWriteTarget(access: ts.PropertyAccessExpression): boolean {
 }
 
 // Whether an expression is the operand of a logical negation — `!xs.includes(y)`,
-// `!(set.has(k))`. Ruby's NEGATING Enumerable idioms (`none?`, `exclude?`) port
-// to a negated JS containment/predicate call, and the wide call ratchet needs to
-// tell `!xs.includes(y)` from a bare `xs.includes(y)` (the inverted condition) —
-// see NEGATED_CALL_PREFIX. Only the immediate parent (through parentheses) counts:
-// `!a && b.has(x)` does not negate the `has`.
+// `!(set.has(k))`. Ruby's negating Enumerable idioms (`none?`, `exclude?`) port to
+// a negated JS call, and the wide call ratchet must tell that from the inverted
+// condition (see NEGATED_CALL_PREFIX). Two shapes are deliberately NOT negations:
+// `!a && b.has(x)` (the `!` binds to `a`), and `!!x`, which is a truthiness cast.
 function isNegatedOperand(expr: ts.Node): boolean {
   let node: ts.Node = expr;
   let parent = node.parent as ts.Node | undefined;
@@ -2106,12 +2111,15 @@ function isNegatedOperand(expr: ts.Node): boolean {
     node = parent;
     parent = node.parent;
   }
-  return (
-    parent !== undefined &&
-    ts.isPrefixUnaryExpression(parent) &&
-    parent.operator === ts.SyntaxKind.ExclamationToken &&
-    parent.operand === node
-  );
+  if (
+    parent === undefined ||
+    !ts.isPrefixUnaryExpression(parent) ||
+    parent.operator !== ts.SyntaxKind.ExclamationToken ||
+    parent.operand !== node
+  ) {
+    return false;
+  }
+  return !isNegatedOperand(parent);
 }
 
 function extractCalls(node: ts.Node | undefined): string[] | undefined {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -44,6 +44,7 @@ import {
 } from "./shared-cache.js";
 import { extractorSchemaToken } from "./extractor-schema.js";
 import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
+import { NEGATED_CALL_PREFIX } from "./enumerable-idioms.js";
 
 // Per-package cache: extracting all packages with the TS Compiler API
 // takes ~16s; only a handful of packages typically change between
@@ -2092,11 +2093,36 @@ function isAssignmentWriteTarget(access: ts.PropertyAccessExpression): boolean {
   return false;
 }
 
+// Whether an expression is the operand of a logical negation — `!xs.includes(y)`,
+// `!(set.has(k))`. Ruby's NEGATING Enumerable idioms (`none?`, `exclude?`) port
+// to a negated JS containment/predicate call, and the wide call ratchet needs to
+// tell `!xs.includes(y)` from a bare `xs.includes(y)` (the inverted condition) —
+// see NEGATED_CALL_PREFIX. Only the immediate parent (through parentheses) counts:
+// `!a && b.has(x)` does not negate the `has`.
+function isNegatedOperand(expr: ts.Node): boolean {
+  let node: ts.Node = expr;
+  let parent = node.parent as ts.Node | undefined;
+  while (parent !== undefined && ts.isParenthesizedExpression(parent)) {
+    node = parent;
+    parent = node.parent;
+  }
+  return (
+    parent !== undefined &&
+    ts.isPrefixUnaryExpression(parent) &&
+    parent.operator === ts.SyntaxKind.ExclamationToken &&
+    parent.operand === node
+  );
+}
+
 function extractCalls(node: ts.Node | undefined): string[] | undefined {
   if (!node) return undefined;
   const aliases = currentImportAliases;
   const resolve = (name: string): string => aliases?.get(name) ?? name;
   const names = new Set<string>();
+  const addNegated = (expr: ts.Node, ...called: string[]): void => {
+    if (!isNegatedOperand(expr)) return;
+    for (const c of called) names.add(`${NEGATED_CALL_PREFIX}${c}`);
+  };
   const visit = (n: ts.Node): void => {
     if (ts.isNewExpression(n)) {
       // `new Foo(...)` is Ruby's `Foo.new(...)`. The Ruby extractor records the
@@ -2112,9 +2138,11 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
         // Renamed-import call (`import { a as b }; b()`): also credit the
         // original imported name so it matches the ported call set.
         names.add(resolve(callee.text));
+        addNegated(n, callee.text, resolve(callee.text));
       } else if (ts.isPropertyAccessExpression(callee)) {
         const prop = callee.name.text;
         names.add(prop);
+        addNegated(n, prop);
         // `X.call(...)` / `X.apply(...)` also dispatch the function bound to
         // `X` (the project's `this`-typed mixin convention, plus Ruby's
         // `meth.call`/`send` indirection). Additionally credit the dispatched
@@ -2149,6 +2177,7 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
         parent !== undefined && ts.isCallExpression(parent) && parent.expression === n;
       if (!isCallCallee && !isAssignmentWriteTarget(n)) {
         names.add(n.name.text);
+        addNegated(n, n.name.text);
       }
     }
     ts.forEachChild(n, visit);

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -41,7 +41,7 @@ import { hashParts } from "./shared-cache.js";
  * ADDITIONS bump the token on their own (via {@link EXTRACTOR_OUTPUT_FIELDS} and
  * the source-hash inputs), so you rarely need to touch this by hand.
  */
-export const SCHEMA_VERSION_BASE = 8;
+export const SCHEMA_VERSION_BASE = 9;
 
 /**
  * Every per-method field the extractor can emit (mirrors `MethodInfo` in


### PR DESCRIPTION
## What

The wide call ratchet credited a negating enumerable alias from the call NAME
alone: `aliasCall(rc).some((c) => tsCalls.has(c))` never looked for a leading
`!`. So `exclude? → ["includes", "has"]` was satisfied by a bare
`xs.includes(y)` exactly as well as the faithful `!xs.includes(y)` — an
INVERTED port silenced the gate. Same for `none? → ["some", "every"]`.
(Surfaced in review of #5242; no live defect — both current `exclude?`
convergences are genuinely negated.)

## How

- `extract-ts-api.ts`: a call/property read whose immediate parent (through
  parentheses) is a `!` is additionally recorded with a marker (`!includes`).
  Additive — the plain name is still recorded, so every existing consumer that
  tests membership by name is unaffected. `!a && xs.includes(y)` (the `!` binds
  to `a`) and `!!x` (a truthiness cast) are not treated as negations.
- `enumerable-idioms.ts` — the shared idiom table, and now the home of the whole
  marker convention: `NEGATED_ALIASES` (which alias of which Ruby call needs the
  negation), `NEGATED_CALL_PREFIX`, and `partitionNegatedCalls`, which splits the
  marked entries back out of a raw call-set (leaving them in would double-count
  against `DELEGATION_MAX_CALLS`).
- `compare.ts`: `significantMissingCalls` matches a negated alias against the
  negated set instead of the plain one. Delegating wrappers inherit the
  delegate's negated calls the same way they inherit its calls.
- `extractor-schema.ts`: `SCHEMA_VERSION_BASE` 8 → 9 — the `calls` field's
  value encoding changed, so stale cache entries must be evicted.

Marking is per-ALIAS, not per Ruby call: `none? → every` stays direct because
the faithful de-Morgan port negates inside the callback
(`stack.every((t) => !t.isDirty())` for `@stack.none?(&:dirty?)`,
transaction.rb:573). Requiring the marker for `every` produced 4 false
positives on exactly that shape.

`pnpm api:calls:wide` green, baseline unchanged (4851 baselined, 0 new).

Closes-story: wide-call-alias-negation-not-verified
