### PR TITLE
fix(api-compare): make baseline JSON writers byte-idempotent

### DIFF
--- a/scripts/api-compare/baseline-json.test.ts
+++ b/scripts/api-compare/baseline-json.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import {
+  findNonCanonicalBaselines,
+  reportNonCanonicalBaselines,
+  serializeBaseline,
+} from "./baseline-json.js";
+
+describe("serializeBaseline", () => {
+  const entry = { reason: "Converged (RFC 0032) \u2014 no include? call exists to match." };
+
+  it("writes non-ASCII literally rather than as \\uXXXX escapes", () => {
+    const out = serializeBaseline([entry]);
+    expect(out).toContain("\u2014");
+    expect(out).not.toContain("\\u2014");
+  });
+
+  it("round-trips its own output byte-for-byte", () => {
+    const once = serializeBaseline([entry]);
+    expect(serializeBaseline(JSON.parse(once))).toBe(once);
+  });
+
+  it("indents with two spaces and ends in a newline", () => {
+    expect(serializeBaseline([entry])).toMatch(/^\[\n {2}\{\n {4}"reason"/);
+    expect(serializeBaseline([entry]).endsWith("\n")).toBe(true);
+  });
+});
+
+describe("findNonCanonicalBaselines", () => {
+  const entry = { reason: "an em-dash \u2014 in prose" };
+
+  async function withFiles<T>(
+    files: Record<string, string>,
+    fn: (dir: string, paths: string[]) => Promise<T>,
+  ): Promise<T> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canon-baseline-"));
+    const paths: string[] = [];
+    for (const [name, text] of Object.entries(files)) {
+      const p = path.join(dir, name);
+      await fs.writeFile(p, text);
+      paths.push(p);
+    }
+    try {
+      return await fn(dir, paths);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("passes a file already written in canonical form", async () => {
+    await withFiles({ "a.json": serializeBaseline([entry]) }, async (_dir, paths) => {
+      expect(await findNonCanonicalBaselines(paths)).toEqual([]);
+    });
+  });
+
+  it("flags a file whose non-ASCII is escaped (the churn trap)", async () => {
+    // Semantically identical to the canonical form — only the bytes differ, so
+    // every `--write` would silently rewrite it.
+    const escaped = JSON.stringify([entry], null, 2).replace("\u2014", "\\u2014") + "\n";
+    await withFiles({ "a.json": escaped }, async (_dir, paths) => {
+      expect(JSON.parse(escaped)).toEqual([entry]);
+      expect(await findNonCanonicalBaselines(paths)).toEqual(paths);
+    });
+  });
+
+  it("flags a file missing its trailing newline", async () => {
+    const raw = JSON.stringify([entry], null, 2);
+    await withFiles({ "a.json": raw }, async (_dir, paths) => {
+      expect(await findNonCanonicalBaselines(paths)).toEqual(paths);
+    });
+  });
+});
+
+describe("reportNonCanonicalBaselines", () => {
+  it("reports nothing for canonical files", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canon-report-"));
+    const file = path.join(dir, "a.json");
+    await fs.writeFile(file, serializeBaseline([{ reason: "plain" }]));
+    try {
+      expect(await reportNonCanonicalBaselines([file], "gate")).toBe(false);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// The gate arm above only runs where a compare artifact exists; this keeps the
+// committed baselines honest in any plain `vitest` run.
+describe("committed api-compare baselines", () => {
+  const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+  async function jsonFilesUnder(dir: string): Promise<string[]> {
+    const out: string[] = [];
+    for (const d of await fs.readdir(dir, { withFileTypes: true })) {
+      const full = path.join(dir, d.name);
+      if (d.isDirectory()) out.push(...(await jsonFilesUnder(full)));
+      else if (d.name.endsWith(".json")) out.push(full);
+    }
+    return out;
+  }
+
+  it("are all written in canonical form", async () => {
+    const files = [
+      ...(await jsonFilesUnder(path.join(HERE, "call-mismatches-wide-exclude"))),
+      path.join(HERE, "call-mismatches-exclude.json"),
+      path.join(HERE, "body-pins.json"),
+      path.join(HERE, "arity-exclude.json"),
+    ];
+    expect(await findNonCanonicalBaselines(files)).toEqual([]);
+  });
+});

--- a/scripts/api-compare/baseline-json.ts
+++ b/scripts/api-compare/baseline-json.ts
@@ -1,0 +1,58 @@
+/**
+ * The one canonical on-disk form for the hand-editable JSON baselines the
+ * api-compare gates own (call-mismatches-exclude.json, the split
+ * call-mismatches-wide-exclude/ tree, body-pins.json): 2-space
+ * `JSON.stringify` plus a trailing newline, with non-ASCII written LITERALLY
+ * as UTF-8 — never as `\uXXXX` escapes.
+ *
+ * `JSON.stringify` already emits non-ASCII literally, so this is what the
+ * writers have always produced; the rule is written down (and enforced by
+ * reportNonCanonicalBaselines) because the two encodings round-trip to the
+ * same DATA but not the same BYTES. Three files had landed with escaped
+ * em-dashes in their `reason` prose, so every `--write` reseed silently
+ * re-encoded them: the reseeding agent's diff touched unrelated packages'
+ * baselines and buried the real signal (the removed entries) in line noise.
+ *
+ * Baselines written through `writeJsonManifest` (schema-compare) are excluded:
+ * prettier owns their formatting, and prettier likewise leaves non-ASCII
+ * literal.
+ *
+ * Hard rules: no node:* imports, no process.*, async fs.
+ */
+import * as fs from "fs/promises";
+import * as path from "path";
+import { ROOT_DIR } from "./config.js";
+
+export function serializeBaseline(value: unknown): string {
+  return JSON.stringify(value, null, 2) + "\n";
+}
+
+// Baseline files whose bytes are not the canonical serialization of their own
+// contents — i.e. exactly the files a no-op `--write` would rewrite.
+export async function findNonCanonicalBaselines(files: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const f of files) {
+    const text = await fs.readFile(f, "utf-8");
+    if (serializeBaseline(JSON.parse(text)) !== text) out.push(f);
+  }
+  return out;
+}
+
+// Shared gate arm: fails when any baseline file is non-canonical, so escaped
+// non-ASCII (or stray indentation) cannot re-enter and re-arm the churn trap.
+// Returns whether the caller should fail.
+export async function reportNonCanonicalBaselines(
+  files: string[],
+  label: string,
+): Promise<boolean> {
+  const bad = await findNonCanonicalBaselines(files);
+  if (bad.length === 0) return false;
+  console.error(
+    `\n${label}: ${bad.length} baseline file(s) not in canonical JSON form ` +
+      "(2-space indent, trailing newline, non-ASCII written literally rather " +
+      "than as \\uXXXX escapes). Left as-is, every reseed would rewrite them " +
+      "and bury the real diff in unrelated churn. Run `--write` to normalize:\n",
+  );
+  for (const f of [...bad].sort()) console.error(`  ! ${path.relative(ROOT_DIR, f)}`);
+  return true;
+}

--- a/scripts/api-compare/body-pins.ts
+++ b/scripts/api-compare/body-pins.ts
@@ -57,7 +57,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, PACKAGES, ROOT_DIR, SCRIPT_DIR } from "./config.js";
-import { serializeBaseline } from "./lint-call-mismatches.js";
+import { serializeBaseline } from "./baseline-json.js";
 
 export const ARTIFACT_PATH = path.join(OUTPUT_DIR, "body-hashes.json");
 export const MANIFEST_PATH = path.join(SCRIPT_DIR, "body-pins.json");

--- a/scripts/api-compare/body-pins.ts
+++ b/scripts/api-compare/body-pins.ts
@@ -57,6 +57,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, PACKAGES, ROOT_DIR, SCRIPT_DIR } from "./config.js";
+import { serializeBaseline } from "./lint-call-mismatches.js";
 
 export const ARTIFACT_PATH = path.join(OUTPUT_DIR, "body-hashes.json");
 export const MANIFEST_PATH = path.join(SCRIPT_DIR, "body-pins.json");
@@ -242,7 +243,7 @@ export async function loadArtifact(): Promise<Artifact> {
 }
 
 export async function saveManifest(pins: BodyPin[]): Promise<void> {
-  await fs.writeFile(MANIFEST_PATH, JSON.stringify(sortPins(pins), null, 2) + "\n");
+  await fs.writeFile(MANIFEST_PATH, serializeBaseline(sortPins(pins)));
 }
 
 async function main(args: string[]): Promise<number> {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
@@ -11,7 +11,7 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "callback",
     "call": "call",
-    "reason": "Syntax-only: Ruby needs `proc.call(...)` to invoke a Proc (collection_association.rb:494); JS invokes bare. The substantive part of that line \u2014 threading `method` so the object-callback arm can dispatch it \u2014 IS implemented (see callbacks.trails.test.ts)."
+    "reason": "Syntax-only: Ruby needs `proc.call(...)` to invoke a Proc (collection_association.rb:494); JS invokes bare. The substantive part of that line — threading `method` so the object-callback arm can dispatch it — IS implemented (see callbacks.trails.test.ts)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/singular-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/singular-association.json
@@ -4,7 +4,7 @@
     "tsFile": "associations/singular-association.ts",
     "rubyName": "find_target",
     "call": "first",
-    "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; the take() (unordered LIMIT 1) in the _findHasOneTarget / _findBelongsToTarget arms is the SQL-level equivalent \u2014 Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
+    "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; the take() (unordered LIMIT 1) in the _findHasOneTarget / _findBelongsToTarget arms is the SQL-level equivalent — Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
@@ -39,7 +39,7 @@
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "include?",
-    "reason": "Converged (RFC 0032): Rails iterates parts and asks `VARIABLE_PARTS.include?(part)`; trails inverts the loop (`VARIABLE_PARTS.some(...)` over the fixed parts record), so membership is the iteration itself \u2014 no include? call exists to match."
+    "reason": "Converged (RFC 0032): Rails iterates parts and asks `VARIABLE_PARTS.include?(part)`; trails inverts the loop (`VARIABLE_PARTS.some(...)` over the fixed parts record), so membership is the iteration itself — no include? call exists to match."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -62,10 +62,9 @@ import {
   findDuplicateKeys,
   flattenArtifact,
   missingScope,
-  reportNonCanonicalBaselines,
   reseed,
-  serializeBaseline,
 } from "./lint-call-mismatches.js";
+import { reportNonCanonicalBaselines, serializeBaseline } from "./baseline-json.js";
 
 // The baseline is a directory of per-source-file JSON arrays (see header),
 // not a single file. Each entry lives at <BASELINE_DIR>/<package>/<tsFile

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -62,7 +62,9 @@ import {
   findDuplicateKeys,
   flattenArtifact,
   missingScope,
+  reportNonCanonicalBaselines,
   reseed,
+  serializeBaseline,
 } from "./lint-call-mismatches.js";
 
 // The baseline is a directory of per-source-file JSON arrays (see header),
@@ -151,7 +153,7 @@ export async function writeSplitBaseline(entries: ExcludeEntry[], dir: string): 
   for (const [rel, arr] of byFile) {
     const dest = path.join(dir, rel);
     await fs.mkdir(path.dirname(dest), { recursive: true });
-    await fs.writeFile(dest, JSON.stringify(sortKeys(arr), null, 2) + "\n");
+    await fs.writeFile(dest, serializeBaseline(sortKeys(arr)));
     existing.delete(rel);
   }
 
@@ -240,6 +242,9 @@ async function main(write: boolean): Promise<number> {
     );
     return 0;
   }
+
+  const files = await listJsonFiles(BASELINE_DIR);
+  if (await reportNonCanonicalBaselines(files, "wide call-mismatches ratchet")) return 1;
 
   const { added, stale } = diffAgainstBaseline(current, baseline);
 

--- a/scripts/api-compare/lint-call-mismatches.test.ts
+++ b/scripts/api-compare/lint-call-mismatches.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
 import {
   callOf,
   compareKeys,
@@ -9,6 +12,8 @@ import {
   loadBaseline,
   missingScope,
   reseed,
+  findNonCanonicalBaselines,
+  serializeBaseline,
   type ExcludeEntry,
 } from "./lint-call-mismatches.js";
 
@@ -213,5 +218,70 @@ describe("compareKeys", () => {
     expect(compareKeys(k("permit!"), k("permit!"))).toBe(0);
     expect(compareKeys(k("permit!"), k("permit?"))).not.toBe(0);
     expect(compareKeys(k("permit!", "a"), k("permit!", "b"))).not.toBe(0);
+  });
+});
+
+describe("serializeBaseline", () => {
+  const entry = { reason: "Converged (RFC 0032) \u2014 no include? call exists to match." };
+
+  it("writes non-ASCII literally rather than as \\uXXXX escapes", () => {
+    const out = serializeBaseline([entry]);
+    expect(out).toContain("\u2014");
+    expect(out).not.toContain("\\u2014");
+  });
+
+  it("round-trips its own output byte-for-byte", () => {
+    const once = serializeBaseline([entry]);
+    expect(serializeBaseline(JSON.parse(once))).toBe(once);
+  });
+
+  it("indents with two spaces and ends in a newline", () => {
+    expect(serializeBaseline([entry])).toMatch(/^\[\n {2}\{\n {4}"reason"/);
+    expect(serializeBaseline([entry]).endsWith("\n")).toBe(true);
+  });
+});
+
+describe("findNonCanonicalBaselines", () => {
+  const entry = { reason: "an em-dash \u2014 in prose" };
+
+  async function withFiles<T>(
+    files: Record<string, string>,
+    fn: (dir: string, paths: string[]) => Promise<T>,
+  ): Promise<T> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canon-baseline-"));
+    const paths: string[] = [];
+    for (const [name, text] of Object.entries(files)) {
+      const p = path.join(dir, name);
+      await fs.writeFile(p, text);
+      paths.push(p);
+    }
+    try {
+      return await fn(dir, paths);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("passes a file already written in canonical form", async () => {
+    await withFiles({ "a.json": serializeBaseline([entry]) }, async (_dir, paths) => {
+      expect(await findNonCanonicalBaselines(paths)).toEqual([]);
+    });
+  });
+
+  it("flags a file whose non-ASCII is escaped (the churn trap)", async () => {
+    // Semantically identical to the canonical form — only the bytes differ, so
+    // every `--write` would silently rewrite it.
+    const escaped = JSON.stringify([entry], null, 2).replace("\u2014", "\\u2014") + "\n";
+    await withFiles({ "a.json": escaped }, async (_dir, paths) => {
+      expect(JSON.parse(escaped)).toEqual([entry]);
+      expect(await findNonCanonicalBaselines(paths)).toEqual(paths);
+    });
+  });
+
+  it("flags a file missing its trailing newline", async () => {
+    const raw = JSON.stringify([entry], null, 2);
+    await withFiles({ "a.json": raw }, async (_dir, paths) => {
+      expect(await findNonCanonicalBaselines(paths)).toEqual(paths);
+    });
   });
 });

--- a/scripts/api-compare/lint-call-mismatches.test.ts
+++ b/scripts/api-compare/lint-call-mismatches.test.ts
@@ -1,7 +1,4 @@
 import { describe, it, expect } from "vitest";
-import * as fs from "fs/promises";
-import * as os from "os";
-import * as path from "path";
 import {
   callOf,
   compareKeys,
@@ -12,8 +9,6 @@ import {
   loadBaseline,
   missingScope,
   reseed,
-  findNonCanonicalBaselines,
-  serializeBaseline,
   type ExcludeEntry,
 } from "./lint-call-mismatches.js";
 
@@ -218,70 +213,5 @@ describe("compareKeys", () => {
     expect(compareKeys(k("permit!"), k("permit!"))).toBe(0);
     expect(compareKeys(k("permit!"), k("permit?"))).not.toBe(0);
     expect(compareKeys(k("permit!", "a"), k("permit!", "b"))).not.toBe(0);
-  });
-});
-
-describe("serializeBaseline", () => {
-  const entry = { reason: "Converged (RFC 0032) \u2014 no include? call exists to match." };
-
-  it("writes non-ASCII literally rather than as \\uXXXX escapes", () => {
-    const out = serializeBaseline([entry]);
-    expect(out).toContain("\u2014");
-    expect(out).not.toContain("\\u2014");
-  });
-
-  it("round-trips its own output byte-for-byte", () => {
-    const once = serializeBaseline([entry]);
-    expect(serializeBaseline(JSON.parse(once))).toBe(once);
-  });
-
-  it("indents with two spaces and ends in a newline", () => {
-    expect(serializeBaseline([entry])).toMatch(/^\[\n {2}\{\n {4}"reason"/);
-    expect(serializeBaseline([entry]).endsWith("\n")).toBe(true);
-  });
-});
-
-describe("findNonCanonicalBaselines", () => {
-  const entry = { reason: "an em-dash \u2014 in prose" };
-
-  async function withFiles<T>(
-    files: Record<string, string>,
-    fn: (dir: string, paths: string[]) => Promise<T>,
-  ): Promise<T> {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canon-baseline-"));
-    const paths: string[] = [];
-    for (const [name, text] of Object.entries(files)) {
-      const p = path.join(dir, name);
-      await fs.writeFile(p, text);
-      paths.push(p);
-    }
-    try {
-      return await fn(dir, paths);
-    } finally {
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-  }
-
-  it("passes a file already written in canonical form", async () => {
-    await withFiles({ "a.json": serializeBaseline([entry]) }, async (_dir, paths) => {
-      expect(await findNonCanonicalBaselines(paths)).toEqual([]);
-    });
-  });
-
-  it("flags a file whose non-ASCII is escaped (the churn trap)", async () => {
-    // Semantically identical to the canonical form — only the bytes differ, so
-    // every `--write` would silently rewrite it.
-    const escaped = JSON.stringify([entry], null, 2).replace("\u2014", "\\u2014") + "\n";
-    await withFiles({ "a.json": escaped }, async (_dir, paths) => {
-      expect(JSON.parse(escaped)).toEqual([entry]);
-      expect(await findNonCanonicalBaselines(paths)).toEqual(paths);
-    });
-  });
-
-  it("flags a file missing its trailing newline", async () => {
-    const raw = JSON.stringify([entry], null, 2);
-    await withFiles({ "a.json": raw }, async (_dir, paths) => {
-      expect(await findNonCanonicalBaselines(paths)).toEqual(paths);
-    });
   });
 });

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -97,6 +97,52 @@ export interface ExcludeEntry extends CallMismatchKey {
   reason: string;
 }
 
+/**
+ * The one canonical on-disk form for the JSON baselines these gates own:
+ * 2-space `JSON.stringify` plus a trailing newline, with non-ASCII written
+ * LITERALLY as UTF-8 — never as `\uXXXX` escapes.
+ *
+ * `JSON.stringify` already emits non-ASCII literally, so this is what the
+ * writers have always produced; the rule is written down (and enforced by
+ * assertCanonicalBaselines below) because the two encodings round-trip to the
+ * same data but not the same bytes. Three files had landed with escaped
+ * em-dashes in their `reason` prose, so EVERY `--write` reseed re-encoded them
+ * — a reseeding agent's diff touched unrelated packages' baselines and buried
+ * the real signal (the removed entries) in line noise.
+ */
+export function serializeBaseline(value: unknown): string {
+  return JSON.stringify(value, null, 2) + "\n";
+}
+
+// Baseline files whose bytes are not the canonical serialization of their own
+// contents — i.e. files a no-op `--write` would silently rewrite.
+export async function findNonCanonicalBaselines(files: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const f of files) {
+    const text = await fs.readFile(f, "utf-8");
+    if (serializeBaseline(JSON.parse(text)) !== text) out.push(f);
+  }
+  return out;
+}
+
+// Shared gate arm: fails when any baseline file is non-canonical, so escaped
+// non-ASCII (or stray indentation) cannot re-enter and re-arm the churn trap.
+export async function reportNonCanonicalBaselines(
+  files: string[],
+  label: string,
+): Promise<boolean> {
+  const bad = await findNonCanonicalBaselines(files);
+  if (bad.length === 0) return false;
+  console.error(
+    `\n${label}: ${bad.length} baseline file(s) not in canonical JSON form ` +
+      "(2-space indent, trailing newline, non-ASCII written literally rather " +
+      "than as \\uXXXX escapes). Left as-is, every reseed would rewrite them " +
+      "and bury the real diff. Run `--write` to normalize:\n",
+  );
+  for (const f of bad.sort()) console.error(`  ! ${path.relative(ROOT_DIR, f)}`);
+  return true;
+}
+
 interface ArtifactMismatch {
   package: string;
   tsFile: string;
@@ -286,10 +332,12 @@ async function main(write: boolean): Promise<number> {
 
   if (write) {
     const next = reseed(current, baseline);
-    await fs.writeFile(BASELINE_PATH, JSON.stringify(next, null, 2) + "\n");
+    await fs.writeFile(BASELINE_PATH, serializeBaseline(next));
     console.log(`Wrote ${BASELINE_PATH}: ${next.length} baselined call mismatches`);
     return 0;
   }
+
+  if (await reportNonCanonicalBaselines([BASELINE_PATH], "call-mismatches ratchet")) return 1;
 
   const { added, stale } = diffAgainstBaseline(current, baseline);
 

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -64,6 +64,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, PACKAGES, ROOT_DIR } from "./config.js";
+import { reportNonCanonicalBaselines, serializeBaseline } from "./baseline-json.js";
 
 const BASELINE_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -95,52 +96,6 @@ export interface CallMismatchKey {
 
 export interface ExcludeEntry extends CallMismatchKey {
   reason: string;
-}
-
-/**
- * The one canonical on-disk form for the JSON baselines these gates own:
- * 2-space `JSON.stringify` plus a trailing newline, with non-ASCII written
- * LITERALLY as UTF-8 — never as `\uXXXX` escapes.
- *
- * `JSON.stringify` already emits non-ASCII literally, so this is what the
- * writers have always produced; the rule is written down (and enforced by
- * assertCanonicalBaselines below) because the two encodings round-trip to the
- * same data but not the same bytes. Three files had landed with escaped
- * em-dashes in their `reason` prose, so EVERY `--write` reseed re-encoded them
- * — a reseeding agent's diff touched unrelated packages' baselines and buried
- * the real signal (the removed entries) in line noise.
- */
-export function serializeBaseline(value: unknown): string {
-  return JSON.stringify(value, null, 2) + "\n";
-}
-
-// Baseline files whose bytes are not the canonical serialization of their own
-// contents — i.e. files a no-op `--write` would silently rewrite.
-export async function findNonCanonicalBaselines(files: string[]): Promise<string[]> {
-  const out: string[] = [];
-  for (const f of files) {
-    const text = await fs.readFile(f, "utf-8");
-    if (serializeBaseline(JSON.parse(text)) !== text) out.push(f);
-  }
-  return out;
-}
-
-// Shared gate arm: fails when any baseline file is non-canonical, so escaped
-// non-ASCII (or stray indentation) cannot re-enter and re-arm the churn trap.
-export async function reportNonCanonicalBaselines(
-  files: string[],
-  label: string,
-): Promise<boolean> {
-  const bad = await findNonCanonicalBaselines(files);
-  if (bad.length === 0) return false;
-  console.error(
-    `\n${label}: ${bad.length} baseline file(s) not in canonical JSON form ` +
-      "(2-space indent, trailing newline, non-ASCII written literally rather " +
-      "than as \\uXXXX escapes). Left as-is, every reseed would rewrite them " +
-      "and bury the real diff. Run `--write` to normalize:\n",
-  );
-  for (const f of bad.sort()) console.error(`  ! ${path.relative(ROOT_DIR, f)}`);
-  return true;
 }
 
 interface ArtifactMismatch {


### PR DESCRIPTION
A no-op `--write` reseed of the wide call-mismatch baseline rewrote three
files it had no reason to touch (`collection-association.json`,
`singular-association.json`, `activesupport/duration.json`). Their `reason`
prose stored em-dashes as `\uXXXX` escapes while the writer emits non-ASCII
literally: same data, different bytes, so every reseed re-encoded them and
each reseeding agent had to hand-revert other people's baselines — or ship a
diff where the real signal (the removed entries) was buried in line noise.

## What changed

- New `scripts/api-compare/baseline-json.ts` pins the one canonical on-disk
  form — 2-space indent, trailing newline, non-ASCII written literally — and
  documents why. Literal is the encoding 41 of the 44 checked-in baseline
  files already used; only these three deviated.
- The wide, narrow and `body-pins` writers all route through
  `serializeBaseline`, so they cannot drift apart again.
- The three offending files are re-encoded. Encoding-only: zero entries
  added, removed or changed.
- Both ratchet gates grow a `reportNonCanonicalBaselines` arm: a baseline
  file whose bytes are not the canonical serialization of its own contents
  fails loudly with a "run `--write`" pointer, so a hand-edit cannot re-arm
  the trap.

## Sibling-writer audit

| writer | verdict |
| --- | --- |
| `lint-call-mismatches-wide.ts --write` | had the bug (3 files) — fixed |
| `lint-call-mismatches.ts --write` | baseline already canonical; routed through the shared serializer + gated |
| `body-pins.ts --pin-all` | manifest already canonical; routed through the shared serializer |
| `schema-compare/compare.ts --write` | unaffected — writes via `writeJsonManifest` (prettier owns the bytes), and `invented-baseline.json` has no escaped non-ASCII |

`arity-exclude.json` was checked too and is canonical.

## Verification

- Reseeding the whole wide baseline (4851 entries, ~50 files) on a clean
  tree leaves `git status` empty, twice in a row.
- `baseline-json.test.ts` covers the escaped-non-ASCII case, the
  missing-trailing-newline case, and round-trip stability, plus a repo-level
  test asserting every committed api-compare baseline is canonical — that
  test fails on the pre-fix bytes (verified by re-escaping `duration.json`),
  and it runs under plain `vitest`, so it guards the files even where no
  compare artifact exists for the gate to run.

Closes-story: wide-ratchet-reseed-rewrites-unrelated-files
