### PR TITLE
fix(eslint): gate rails-deprecated-methods.json against partial regeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
           # explicitly: all are carved out of the infra sweep
           # (INFRA_CARVEOUT_RE), so this clause is the only thing that still
           # runs rails-comparison on a change confined to them.
-          COMPARISON_RE='^(packages/|scripts/((api|test|fixtures|schema)-compare/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins)\.ts$)|vendor/|docs/ruby-ts-conventions\.md$)'
+          COMPARISON_RE='^(packages/|scripts/((api|test|fixtures|schema)-compare/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|deprecated-manifest-diff)\.ts$)|vendor/|docs/ruby-ts-conventions\.md$)'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true"   >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
           # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
           # to the root config must still run the guard.
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage)(\.test)?\.ts$|eslint\.config\.mjs$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -701,6 +701,7 @@ jobs:
           eslint/
           scripts/strip-asany.test.ts
           scripts/rails-file-structure-mixins.test.ts
+          scripts/deprecated-manifest-diff.test.ts
           scripts/ci-suite-coverage.test.ts
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1363,6 +1363,12 @@ jobs:
         # in conventions.ts; fail if it drifts so the agent-facing doc can't
         # go stale. Regenerate with `pnpm api:conventions`.
         run: pnpm exec tsx scripts/api-compare/conventions-doc.ts --check
+      - name: Deprecation manifest up to date
+        # eslint/rails-deprecated-methods.json is generated from the vendored
+        # Ruby; fail if it drifts — a partial regeneration silently DROPS
+        # entries and with them the rails-deprecated-jsdoc coverage for those
+        # methods. Regenerate with `pnpm rails-privates:manifest`.
+        run: pnpm exec tsx scripts/build-rails-privates-manifest.ts --check-deprecated
       - name: Schema comparison
         # Structural parity of TEST_SCHEMA against the vendored
         # test/schema/schema.rb it mirrors (RFC 0025). Fails on a table or

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           # Deliberately NOT carved (genuinely cross-cutting): typecheck.mjs
           # (root `pnpm typecheck`), start-worktree.sh, and the remaining
           # top-level scripts/*.ts one-offs.
-          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage)(\.test)?\.ts$)'
+          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$)'
           # AR workspace deps: arel/activemodel/activesupport/globalid/
           # did-you-mean (per packages/activerecord/package.json). Also
           # consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
@@ -243,13 +243,20 @@ jobs:
           # PR that edits ONLY that file matches neither INFRA_RE nor the
           # package/vendor clauses, so without this it would skip the very
           # check the docs_only exception was built to preserve.
+          # eslint/rails-deprecated-methods.json is matched directly for the
+          # same reason as ruby-ts-conventions.md: it is the generated artifact
+          # the `--check-deprecated` step guards, and `eslint/` appears in
+          # neither INFRA_RE nor the package/vendor clauses. Without this, the
+          # one change shape the guard exists to catch — a commit that ONLY
+          # drops manifest entries — would skip rails-comparison entirely and
+          # never run the recompute.
           # schema-compare/ (the Schema comparison step, ci.yml:1272) and the
           # two Rails manifest builders + their shared mixin resolver (the
           # privates/file-structure steps, ci.yml:1279/1293) are named
           # explicitly: all are carved out of the infra sweep
           # (INFRA_CARVEOUT_RE), so this clause is the only thing that still
           # runs rails-comparison on a change confined to them.
-          COMPARISON_RE='^(packages/|scripts/((api|test|fixtures|schema)-compare/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|deprecated-manifest-diff)\.ts$)|vendor/|docs/ruby-ts-conventions\.md$)'
+          COMPARISON_RE='^(packages/|scripts/((api|test|fixtures|schema)-compare/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|deprecated-manifest-diff)\.ts$)|vendor/|docs/ruby-ts-conventions\.md$|eslint/rails-deprecated-methods\.json$)'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true"   >> "$GITHUB_OUTPUT"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "schema:compare": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/schema-compare/compare.ts",
     "schema:compare:reseed": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/schema-compare/compare.ts --write",
     "rails-privates:manifest": "pnpm tsx scripts/build-rails-privates-manifest.ts",
+    "rails-deprecated:check": "pnpm tsx scripts/build-rails-privates-manifest.ts --check-deprecated",
     "rails-errors:manifest": "pnpm tsx scripts/build-rails-error-manifest.ts",
     "rails-tosql:manifest": "pnpm tsx scripts/build-rails-tosql-manifest.ts",
     "api:moves": "pnpm tsx scripts/api-compare/moves.ts",

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -37,6 +37,7 @@ import {
   flushManifestBatch,
 } from "./api-compare/write-json-manifest.js";
 import { railsApiAvailable } from "./api-compare/require-rails-api.js";
+import { diffDeprecatedManifest } from "./deprecated-manifest-diff.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -402,32 +403,26 @@ function emitDeprecatedManifest(): void {
   console.log(`Wrote ${DEPRECATED_OUT} — ${fc} files (${nc} names)`);
 }
 
-// Compares the committed manifest against a full recompute. Byte comparison is
-// deliberately avoided (prettier formatting is gated separately by
-// `prettier --check .`); this compares the data, and reports lost entries
-// explicitly since that is the failure mode a partial regeneration produces.
+// Compares the committed manifest against a full recompute (see
+// scripts/deprecated-manifest-diff.ts for the comparison itself).
 function checkDeprecatedManifest(): void {
+  const rel = path.relative(ROOT, DEPRECATED_OUT);
   const expected = buildDeprecatedManifest();
   if (!expected) {
-    console.error(
-      `Cannot verify ${DEPRECATED_OUT}: vendored Ruby is incomplete. Run \`pnpm vendor:fetch\`.`,
-    );
+    console.error(`Cannot verify ${rel}: vendored Ruby is incomplete. Run \`pnpm vendor:fetch\`.`);
     process.exit(1);
   }
   const actual = fs.existsSync(DEPRECATED_OUT)
     ? JSON.parse(fs.readFileSync(DEPRECATED_OUT, "utf8"))
     : { files: {} };
-  const lost: string[] = [];
-  for (const [file, names] of Object.entries(expected.files)) {
-    const have = new Set<string>(actual.files?.[file] ?? []);
-    for (const n of names) if (!have.has(n)) lost.push(`${file}: ${n}`);
-  }
-  if (JSON.stringify(actual) === JSON.stringify(expected)) {
-    console.log(`${path.relative(ROOT, DEPRECATED_OUT)} is up to date.`);
+  const { lost, extra, drifted } = diffDeprecatedManifest(expected, actual);
+  if (!drifted) {
+    console.log(`${rel} is up to date.`);
     return;
   }
-  console.error(`${path.relative(ROOT, DEPRECATED_OUT)} is out of date.`);
+  console.error(`${rel} is out of date.`);
   if (lost.length > 0) console.error(`Missing entries:\n  ${lost.join("\n  ")}`);
+  if (extra.length > 0) console.error(`Stale entries:\n  ${extra.join("\n  ")}`);
   console.error("Regenerate with `pnpm rails-privates:manifest` and commit the result.");
   process.exit(1);
 }

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -58,6 +58,17 @@ const PACKAGE_DIRS: Record<string, string> = {
 const RAILS_API_PATH = path.join(ROOT, "scripts/api-compare/output/rails-api.json");
 const OUT = path.join(ROOT, "eslint/rails-private-methods.json");
 
+const DEPRECATED_OUT = path.join(ROOT, "eslint/rails-deprecated-methods.json");
+
+// `--check-deprecated` (CI): recompute the deprecation-parity manifest from the
+// vendored Ruby and fail if the committed file has drifted — in particular if
+// it has LOST entries. Runs before anything else because it must not depend on
+// rails-api.json, and it never writes.
+if (process.argv.slice(2).includes("--check-deprecated")) {
+  checkDeprecatedManifest();
+  process.exit(0);
+}
+
 // Resolved before any manifest is written: without `--allow-missing` this
 // throws, and we would rather abort than half-write the batch below.
 const hasRailsApi = railsApiAvailable({
@@ -349,13 +360,18 @@ function walkRubyFiles(dir: string, out: string[]): void {
   }
 }
 
-function emitDeprecatedManifest(): void {
-  const DEPRECATED_OUT = path.join(ROOT, "eslint/rails-deprecated-methods.json");
+// Returns null when the vendored Ruby is incomplete: every package this
+// manifest covers must be scannable, because a missing lib dir silently drops
+// EVERY entry sourced from it. A truncated manifest is indistinguishable from
+// "Rails deprecates nothing here" and would quietly retire the
+// `rails-deprecated-jsdoc` coverage for those methods, so callers write
+// nothing rather than replace the committed file with a partial one.
+function buildDeprecatedManifest(): { files: Record<string, string[]> } | null {
   const libPaths = libPathsManifest();
   const files: Record<string, string[]> = {};
   for (const [pkg, pkgDir] of Object.entries(PACKAGE_DIRS)) {
     const libDir = libPaths[pkg];
-    if (!libDir || !fs.existsSync(libDir)) continue;
+    if (!libDir || !fs.existsSync(libDir)) return null;
     const rubyFiles: string[] = [];
     walkRubyFiles(libDir, rubyFiles);
     for (const rubyAbs of rubyFiles) {
@@ -371,10 +387,49 @@ function emitDeprecatedManifest(): void {
 
   const sorted: Record<string, string[]> = {};
   for (const k of Object.keys(files).sort()) sorted[k] = files[k];
-  writeJsonManifest(DEPRECATED_OUT, { files: sorted });
-  const fc = Object.keys(sorted).length;
-  const nc = Object.values(sorted).reduce((n, a) => n + a.length, 0);
+  return { files: sorted };
+}
+
+function emitDeprecatedManifest(): void {
+  const manifest = buildDeprecatedManifest();
+  if (!manifest) {
+    console.log(`Skipped ${DEPRECATED_OUT} — vendored Ruby incomplete (\`pnpm vendor:fetch\`)`);
+    return;
+  }
+  writeJsonManifest(DEPRECATED_OUT, manifest);
+  const fc = Object.keys(manifest.files).length;
+  const nc = Object.values(manifest.files).reduce((n, a) => n + a.length, 0);
   console.log(`Wrote ${DEPRECATED_OUT} — ${fc} files (${nc} names)`);
+}
+
+// Compares the committed manifest against a full recompute. Byte comparison is
+// deliberately avoided (prettier formatting is gated separately by
+// `prettier --check .`); this compares the data, and reports lost entries
+// explicitly since that is the failure mode a partial regeneration produces.
+function checkDeprecatedManifest(): void {
+  const expected = buildDeprecatedManifest();
+  if (!expected) {
+    console.error(
+      `Cannot verify ${DEPRECATED_OUT}: vendored Ruby is incomplete. Run \`pnpm vendor:fetch\`.`,
+    );
+    process.exit(1);
+  }
+  const actual = fs.existsSync(DEPRECATED_OUT)
+    ? JSON.parse(fs.readFileSync(DEPRECATED_OUT, "utf8"))
+    : { files: {} };
+  const lost: string[] = [];
+  for (const [file, names] of Object.entries(expected.files)) {
+    const have = new Set<string>(actual.files?.[file] ?? []);
+    for (const n of names) if (!have.has(n)) lost.push(`${file}: ${n}`);
+  }
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    console.log(`${path.relative(ROOT, DEPRECATED_OUT)} is up to date.`);
+    return;
+  }
+  console.error(`${path.relative(ROOT, DEPRECATED_OUT)} is out of date.`);
+  if (lost.length > 0) console.error(`Missing entries:\n  ${lost.join("\n  ")}`);
+  console.error("Regenerate with `pnpm rails-privates:manifest` and commit the result.");
+  process.exit(1);
 }
 
 // --- Callback-invocation parity pass ---

--- a/scripts/deprecated-manifest-diff.test.ts
+++ b/scripts/deprecated-manifest-diff.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { diffDeprecatedManifest } from "./deprecated-manifest-diff.js";
+
+const expected = {
+  files: {
+    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
+      "unsignedDecimal",
+      "unsignedFloat",
+    ],
+    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"],
+  },
+};
+
+describe("diffDeprecatedManifest", () => {
+  it("reports no drift for an identical manifest", () => {
+    expect(diffDeprecatedManifest(expected, structuredClone(expected))).toEqual({
+      lost: [],
+      extra: [],
+      drifted: false,
+    });
+  });
+
+  it("reports a file dropped by a partial regeneration as lost", () => {
+    const actual = structuredClone(expected);
+    delete actual.files["packages/activesupport/src/core-ext/benchmark.ts"];
+    expect(diffDeprecatedManifest(expected, actual)).toEqual({
+      lost: ["packages/activesupport/src/core-ext/benchmark.ts: ms"],
+      extra: [],
+      drifted: true,
+    });
+  });
+
+  it("reports a single dropped name as lost", () => {
+    const actual = structuredClone(expected);
+    const file = "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts";
+    actual.files[file] = ["unsignedDecimal"];
+    expect(diffDeprecatedManifest(expected, actual).lost).toEqual([`${file}: unsignedFloat`]);
+  });
+
+  it("reports an entry the recompute no longer produces as stale", () => {
+    const actual = structuredClone(expected);
+    actual.files["packages/activesupport/src/core-ext/benchmark.ts"] = ["ms", "realtime"];
+    expect(diffDeprecatedManifest(expected, actual)).toEqual({
+      lost: [],
+      extra: ["packages/activesupport/src/core-ext/benchmark.ts: realtime"],
+      drifted: true,
+    });
+  });
+
+  it("treats an empty manifest as having lost every entry", () => {
+    expect(diffDeprecatedManifest(expected, { files: {} }).lost).toHaveLength(3);
+  });
+});

--- a/scripts/deprecated-manifest-diff.ts
+++ b/scripts/deprecated-manifest-diff.ts
@@ -1,0 +1,46 @@
+/**
+ * Compares a committed deprecation-parity manifest against a fresh recompute.
+ *
+ * Split out from the emitter so the comparison is unit-testable without
+ * scanning the vendored Ruby tree or touching the tracked manifest.
+ *
+ * `lost` is called out separately from plain drift because it is the specific
+ * failure mode a partial regeneration produces: the manifest is written as a
+ * whole-file replace, so an entry that was not re-derived simply disappears,
+ * and with it the `rails-deprecated-jsdoc` coverage for that method.
+ */
+export interface DeprecatedManifest {
+  files: Record<string, string[]>;
+}
+
+export interface ManifestDiff {
+  /** Entries the recompute produced that the committed manifest lacks. */
+  lost: string[];
+  /** Entries the committed manifest carries that the recompute did not produce. */
+  extra: string[];
+  /** True when the committed manifest is not identical to the recompute. */
+  drifted: boolean;
+}
+
+function entries(manifest: DeprecatedManifest): Set<string> {
+  const out = new Set<string>();
+  for (const [file, names] of Object.entries(manifest.files ?? {})) {
+    for (const name of names) out.add(`${file}: ${name}`);
+  }
+  return out;
+}
+
+export function diffDeprecatedManifest(
+  expected: DeprecatedManifest,
+  actual: DeprecatedManifest,
+): ManifestDiff {
+  const want = entries(expected);
+  const have = entries(actual);
+  const lost = [...want].filter((e) => !have.has(e)).sort();
+  const extra = [...have].filter((e) => !want.has(e)).sort();
+  // Byte-level formatting is gated separately by `prettier --check .`, so
+  // compare the serialized data — both sides are emitted with sorted keys, and
+  // a hand-reordered file is drift from the generator either way.
+  const drifted = JSON.stringify(actual) !== JSON.stringify(expected);
+  return { lost, extra, drifted };
+}


### PR DESCRIPTION
## What

`eslint/rails-deprecated-methods.json` maps TS files → methods Rails
deprecates; `blazetrails/rails-deprecated-jsdoc` consumes it to require
`@deprecated` JSDoc. It is written as a whole-file replace, so **any**
regeneration that scans less than the full vendored Ruby tree silently drops
entries — and a lost entry is indistinguishable from "Rails deprecates nothing
here", so the rule just stops covering those methods. Surfaced on #5262, where
the `mysql/schema-definitions.ts` (`unsignedFloat`, `unsignedDecimal`) and
`core-ext/benchmark.ts` (`ms`) entries vanished; Rails still deprecates both
(`activerecord/.../mysql/schema_definitions.rb:50`,
`activesupport/.../core_ext/benchmark.rb:6-10`). Nothing in CI gated it, so a
truncation could merge unnoticed.

**On the reported trigger:** I could not reproduce a rewrite from lint-staged
itself — on current `main`, `eslint --fix <one file>` does not touch the
manifest (nothing in the flat config or any rule writes it; only
`build-rails-privates-manifest.ts` does, via the `prelint` hook on a full
`pnpm lint`). So rather than chase one entry point, this closes the failure
*class*: the manifest can no longer be replaced by a partial computation, and
CI fails if the committed file has drifted regardless of what wrote it.

## Changes

- `buildDeprecatedManifest()` returns `null` when any covered package's
  vendored Ruby lib dir is missing — the truncation path, since a missing lib
  dir silently drops every entry sourced from it. Callers then write
  **nothing**, leaving the committed bytes intact, instead of replacing the
  manifest with a partial one.
- `--check-deprecated`: recomputes from the vendored Ruby and exits 1 on drift,
  naming the lost entries (and stale ones). Runs before the `rails-api.json`
  gate — this manifest does not depend on it — and never writes.
- Wired as `Deprecation manifest up to date` in the `rails-comparison` job,
  mirroring how the conventions-doc drift check is wired (`COMPARISON_RE`
  updated so a change confined to the new module still runs the job). Also
  exposed as `pnpm rails-deprecated:check`.
- The committed-vs-recomputed comparison lives in
  `scripts/deprecated-manifest-diff.ts` so it is unit-testable without scanning
  the vendored Ruby or mutating the tracked manifest.

## Evidence

- `scripts/deprecated-manifest-diff.test.ts` — 5 tests, green: dropped file,
  dropped single name, stale extra entry, empty manifest, and the no-drift case.
- Drift detected end-to-end: removing the `benchmark.ts` entry →
  `out of date` / `Missing entries: packages/activesupport/src/core-ext/benchmark.ts: ms`,
  exit 1. Restored → `is up to date`, exit 0.
- Full regen is a no-op on a clean tree (md5 unchanged).
- **Regression evidence**: both commits on this branch went through lint-staged
  staging `.ts`/`.yml`/`.json` files, and `eslint/rails-deprecated-methods.json`
  stayed byte-identical throughout — md5 `536c4170…` before and after, clean
  working tree.

Closes-story: lint-staged-rewrites-deprecated-methods-manifest
