### PR TITLE
feat(tooling): lint files auto-merged by a rebase or merge

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,2 @@
+git rev-parse --verify ORIG_HEAD >/dev/null 2>&1 || exit 0
+printf "%s %s\n" "$(git rev-parse ORIG_HEAD)" "$(git rev-parse HEAD)" | bash scripts/lint-rewritten-files.sh merge

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,0 +1,1 @@
+bash scripts/lint-rewritten-files.sh "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,46 @@ TypeDoc build runs with `excludeInternal: true`, and the
 Active across all Rails-mirroring packages (`arel`, `activesupport`,
 `activemodel`, `activerecord`, `actionpack`, `actionview`).
 
+## After a rebase: lint the auto-merged files
+
+The pre-commit hook runs `lint-staged`, which lints only what is staged for
+that commit. A `git rebase` replays commits **without** running pre-commit, so
+files git auto-merged never get linted locally — and a defect can exist in the
+merged result while existing in neither parent branch. Two sibling PRs each
+deleting a different caller of the same import orphans that import; the first
+signal is the `Lint` CI job (this bit #5356).
+
+The `post-rewrite` and `post-merge` husky hooks now lint the files each
+**replayed commit** touches (`scripts/lint-rewritten-files.sh` — for each
+`<old> <new>` pair git reports, it lints `git diff <new>^!`). That is
+deliberately narrower than `<old>..<new>`, which is a tree diff across the base
+move and would also name every file the new upstream changed and your commit
+never did. They **report and never block** — a rebase is not a commit you can
+amend in flight — so read the output: a failure prints a red banner. A plain
+`git commit --amend` is skipped, since pre-commit already linted its staged
+files.
+
+Manual fallback, for when the hook did not run (a rebase driven by a tool that
+skips hooks, `--no-verify`, a hooks-less clone) — this one lints the whole
+`ORIG_HEAD..HEAD` span, upstream-only files included, so it is noisier than the
+hook:
+
+```bash
+# 1. lint what the rebase moved
+# The empty check is load-bearing: a bare `eslint` with no paths lints the whole
+# repo (the >2min run this replaces). Don't reach for `xargs -r` — that flag is
+# GNU-only and BSD/macOS xargs rejects it.
+moved=$(git diff --name-only ORIG_HEAD..HEAD -- '*.ts' '*.tsx' '*.jsx' '*.js' '*.mjs' '*.cjs')
+if [ -n "$moved" ]; then echo "$moved" | xargs pnpm exec eslint; fi
+
+# 2. re-read each file you believe you changed, against the new base
+git diff origin/main -- <file>
+```
+
+Step 2 matters as much as step 1: lint catches orphaned imports, but a
+duplicated guard — the same fix landed twice at slightly different offsets and
+merged cleanly, the second copy unreachable — needs a human reading the diff.
+
 ## Measuring progress
 
 Primary signals: `pnpm run api:compare` (use `--package <name>` for one

--- a/scripts/lint-rewritten-files.sh
+++ b/scripts/lint-rewritten-files.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Lint files whose working-tree content was produced by a rebase/merge auto-merge.
+#
+# Those files never pass through `lint-staged`: a rebase replays commits without
+# running the pre-commit hook, so a defect that exists in neither parent branch
+# (e.g. an import orphaned by two sibling deletions) first surfaces in CI.
+#
+# Reads "<old-sha> <new-sha>" commit pairs on stdin (the post-rewrite format) and
+# lints the files each *replayed* commit touches. Reports only — never blocks,
+# since a rebase is not a commit the user can amend in flight.
+#
+# Scope is `<new>^..<new>`, NOT `<old>..<new>`: the latter is a tree diff across
+# the base move, so it also names every file the new upstream changed and the
+# rewritten commit never touched (main edits `upstream.ts`, the feature edits
+# only `feature.ts`, and `upstream.ts` shows up anyway). Those files are
+# byte-identical to upstream, which CI already linted. A defect that exists in
+# neither parent needs both sides to have touched the file, so it always appears
+# in the replayed commit's own diff.
+#
+# Usage: lint-rewritten-files.sh [kind]   # kind: rebase | amend | merge
+set -uo pipefail
+
+# `git commit --amend` also fires post-rewrite, but its files were staged and so
+# were already linted by pre-commit; re-linting them buys nothing.
+[ "${1:-}" = "amend" ] && exit 0
+
+ranges=$(cat)
+[ -n "$ranges" ] || exit 0
+
+# Read loop rather than `mapfile`: stock macOS ships Bash 3.2, which has no
+# `mapfile`, and husky runs hooks on the contributor's own bash.
+# Paths a later commit in the rewrite deleted, or renamed away, are not lintable.
+existing=()
+while IFS= read -r f; do
+  [ -n "$f" ] && [ -f "$f" ] && existing+=("$f")
+done < <(
+  while read -r _old new _rest; do
+    [ -n "${new:-}" ] || continue
+    # `<sha>^!` is "this commit against its parent(s)" — empty for a root commit.
+    git diff --name-only --diff-filter=ACMR "$new^!" 2>/dev/null
+  done <<<"$ranges" |
+    grep -E '\.(js|jsx|mjs|cjs|ts|tsx)$' |
+    grep -v '__fixtures__' |
+    sort -u
+)
+[ "${#existing[@]}" -gt 0 ] || exit 0
+
+# A clone without `pnpm install` has no eslint; stay silent rather than cry wolf.
+# Probe the installed binary directly instead of `pnpm exec eslint --version`:
+# that would hand control to pnpm's dependency-status path, which can install
+# into an uninstalled clone as a side effect of a hook that promised only to
+# report. Invoking the binary also skips a pnpm spawn on every rewrite.
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+eslint="$root/node_modules/.bin/eslint"
+[ -x "$eslint" ] || exit 0
+
+printf '\n\033[1mlinting %s file(s) rewritten by this %s...\033[0m\n' \
+  "${#existing[@]}" "${1:-rewrite}"
+
+if "$eslint" "${existing[@]}"; then
+  printf '\033[32m✔ rewritten files lint clean\033[0m\n\n'
+  exit 0
+fi
+
+printf '\n\033[41;97m ✖ LINT ERRORS IN FILES AUTO-MERGED BY THIS REBASE/MERGE \033[0m\n'
+printf '\033[1;31mThese files were never seen by the pre-commit hook.\033[0m\n'
+printf '\033[1;31mFix them and commit before pushing — CI will fail otherwise.\033[0m\n\n'
+exit 0


### PR DESCRIPTION
A `git rebase` replays commits without running the pre-commit hook, and
auto-merged files never enter a staged-for-commit state — so `lint-staged`
never sees them. A defect can therefore exist in the merged result while
existing in neither parent branch, with CI as the first signal (this bit #5356:
two sibling PRs each deleted a different caller of the same `inheritance.js`
imports, orphaning three of them).

Adds `post-rewrite` and `post-merge` husky hooks that lint the files the
rewrite touched, via `scripts/lint-rewritten-files.sh`:

- reads `<old> <new>` commit pairs on stdin (post-rewrite format) and diffs each
  *replayed* commit (`git diff <new>^!`), then filters to lintable extensions minus `__fixtures__`, and runs `eslint` on the
  union — scoped to changed files so it stays fast; the full-repo run stays CI's job.
- deliberately does NOT use `git diff <old> <new>`: that is a tree diff across the
  base move, so it also names files only the new upstream touched (verified: with
  main changing `upstream.ts` and the feature changing only `feature.ts`,
  `<old>..<new>` prints `upstream.ts` while `<new>^!` prints `feature.ts`). Those
  files are byte-identical to upstream, which CI already linted; a defect present
  in neither parent requires both sides to have touched the file, so it always
  shows up in the replayed commit's own diff.
- reports, never blocks (a rebase is not a commit you can amend in flight), but
  a failure prints a red-background banner and the errors.
- skips a plain `git commit --amend` (its files were staged, so pre-commit
  already linted them) and stays silent in a clone without `pnpm install` — it probes
  `node_modules/.bin/eslint` directly rather than `pnpm exec`, so a hook that
  promised only to report cannot trigger pnpm's install path as a side effect.
- `post-merge` feeds it `ORIG_HEAD HEAD`.

Verified against the #5356 reproduction: branched at `c3b8008b6~1`, restored
the pre-rebase import block, and rebased onto `7bf0abdf2` (#5357, which deleted
`buildThroughAssociation`/`createThroughAssociation`). Both parents lint clean;
the rebased result trips the hook with exactly the three historical errors:

```
   98:3  error  'getInheritanceColumn' is defined but never used  unused-imports/no-unused-imports
   99:3  error  'findStiClass' is defined but never used          unused-imports/no-unused-imports
  100:3  error  'stiEnabled' is defined but never used            unused-imports/no-unused-imports
```

CONTRIBUTING.md documents the failure mode and the manual fallback for when the
hook does not run, including re-reading `git diff origin/main -- <file>` for
each file you believe you changed — the duplicated-guard case (#5355/#5356)
needs semantic analysis, not lint, and is out of scope here.

Closes-story: lint-rebase-automerged-files
