### PR TITLE
refactor(tasks): retire the reset --hard read fallback for a stale-index warning

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -88,6 +88,7 @@ import {
   dirtyWorktreeLines,
   buildIndexFromOriginMain,
   readIndexSource,
+  readWorkingTreeIndex,
   readIndexedFile,
   claimAgeHours,
   isStaleClaim,
@@ -3524,11 +3525,11 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
       },
     });
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    // The fallback hands off to loadIndex(), which reads the REAL TASKS_DIR
-    // checkout — absent on CI runners. What this test owns is the degradation
-    // itself: warn, then serve the working tree, without ever touching the
-    // shared checkout. Let the handoff fail; the assertions below still fail
-    // on the baseline, where the fallback fetched + reset --hard instead.
+    // The fallback hands off to the working-tree index, which lives in the REAL
+    // TASKS_DIR checkout — absent on CI runners. What this test owns is the
+    // degradation itself: warn, then serve the working tree, without ever
+    // touching the shared checkout. Let the handoff fail; the assertions below
+    // still fail on the baseline, which fetched + reset --hard instead.
     try {
       expect(readIndexSource().sha).toBeNull();
     } catch {
@@ -3537,6 +3538,31 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     expect(seen).not.toContain("reset");
     expect(seen).not.toContain("status");
     expect(String(err.mock.calls[0][0])).toMatch(/could not reach origin\/main.*may be stale/s);
+  });
+});
+
+describe("readWorkingTreeIndex (the offline fallback never rebuilds)", () => {
+  // Regression: the fallback used to go through loadIndex(), which rebuilds a
+  // stale index by running build-index.mjs — and that rewrites the TRACKED
+  // index.md in the shared canonical checkout. A read must not mutate it; a
+  // stale index is exactly what the caller's staleness warning announces.
+  it("serves the on-disk index.json as-is without spawning a rebuild", () => {
+    const dir = mkdtempSync(join(tmpdir(), "trails-wt-index-"));
+    writeFileSync(join(dir, "index.json"), JSON.stringify({ ...emptyIdx, generated_at: "stale" }));
+    const got = readWorkingTreeIndex(dir);
+    expect(got?.generated_at).toBe("stale");
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when there is no index.json to serve", () => {
+    const dir = mkdtempSync(join(tmpdir(), "trails-wt-index-"));
+    expect(readWorkingTreeIndex(dir)).toBeNull();
+  });
+
+  it("returns null for an index.json a crashed writer truncated", () => {
+    const dir = mkdtempSync(join(tmpdir(), "trails-wt-index-"));
+    writeFileSync(join(dir, "index.json"), '{"stories":[');
+    expect(readWorkingTreeIndex(dir)).toBeNull();
   });
 });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3535,8 +3535,12 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     } catch {
       /* no working-tree index here — the handoff is all we needed to observe */
     }
+    // `reset` is the whole invariant. A `status` probe may or may not appear
+    // depending on whether this machine's TASKS_DIR has an index.json to serve
+    // (the no-index rebuild branch probes index.md's cleanliness first), and it
+    // is read-only either way — asserting on it just couples the test to the
+    // runner's checkout.
     expect(seen).not.toContain("reset");
-    expect(seen).not.toContain("status");
     expect(String(err.mock.calls[0][0])).toMatch(/could not reach origin\/main.*may be stale/s);
   });
 });

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3524,9 +3524,18 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
       },
     });
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    const got = readIndexSource();
-    expect(got.sha).toBeNull();
+    // The fallback hands off to loadIndex(), which reads the REAL TASKS_DIR
+    // checkout — absent on CI runners. What this test owns is the degradation
+    // itself: warn, then serve the working tree, without ever touching the
+    // shared checkout. Let the handoff fail; the assertions below still fail
+    // on the baseline, where the fallback fetched + reset --hard instead.
+    try {
+      expect(readIndexSource().sha).toBeNull();
+    } catch {
+      /* no working-tree index here — the handoff is all we needed to observe */
+    }
     expect(seen).not.toContain("reset");
+    expect(seen).not.toContain("status");
     expect(String(err.mock.calls[0][0])).toMatch(/could not reach origin\/main.*may be stale/s);
   });
 });

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1192,7 +1192,7 @@ describe("commitAndPush (git mutation flow)", () => {
   });
 
   // Regression: a concurrent `reset --hard` in the shared canonical checkout
-  // (a pre-read sync from a process predating the sync lock) could empty the
+  // (historically the CLI's own pre-read sync, since retired) could empty the
   // index inside `git commit`'s pre-commit-hook window, producing a commit
   // whose tree equals its parent — which then got PUSHED, landing the message
   // on main with zero files (RFC 0063's stories, 2026-07-07). commitAndPush
@@ -3402,7 +3402,7 @@ describe("dirtyWorktreeLines", () => {
     const porcelain = [
       " M rfcs/0024/stories/x.md", // tracked, unstaged edit
       "A  rfcs/0024/stories/y.md", // staged add
-      "?? rfcs/0024/stories/new.md", // untracked — survives reset --hard
+      "?? rfcs/0024/stories/new.md", // untracked — survives a rebase
       " M index.md", // generated — rebuilt + re-staged on demand
     ].join("\n");
     expect(dirtyWorktreeLines(porcelain)).toEqual([

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -86,10 +86,8 @@ import {
   StoryEntry,
   TASKS_DIR,
   dirtyWorktreeLines,
-  syncWorktreeToOrigin,
   buildIndexFromOriginMain,
   readIndexSource,
-  syncFromOrigin,
   readIndexedFile,
   claimAgeHours,
   isStaleClaim,
@@ -3507,18 +3505,29 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     expect(buildIndexFromOriginMain()).toBeNull();
   });
 
-  it("serves the read index when TASKS_DIR did not resolve to the per-worktree symlink", () => {
+  it("serves the read index however TASKS_DIR resolved", () => {
     const { seen } = setup();
-    const got = readIndexSource(false);
+    const got = readIndexSource();
     expect(got.sha).toBe(SHA);
     expect(got.index.generated_at).toBe("2026-01-01");
     expect(seen).not.toContain("reset");
   });
 
-  it("is a no-op fallback for a non-symlink TASKS_DIR", () => {
-    setup();
-    syncFromOrigin(false);
-    expect(execFileSyncMock).not.toHaveBeenCalled();
+  // Regression: the offline fallback used to fetch + `reset --hard origin/main`
+  // in the ONE shared canonical checkout — a read discarding tracked edits and
+  // contending on the mutation lock. Unreachable origin means there is nothing
+  // fresher to sync to, so degrade to the working-tree index plus a warning.
+  it("degrades to the working-tree index with a staleness warning when origin is unreachable", () => {
+    const { seen } = setup({
+      onFetch: () => {
+        throw new Error("offline");
+      },
+    });
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const got = readIndexSource();
+    expect(got.sha).toBeNull();
+    expect(seen).not.toContain("reset");
+    expect(String(err.mock.calls[0][0])).toMatch(/could not reach origin\/main.*may be stale/s);
   });
 });
 
@@ -3547,77 +3556,6 @@ describe("readIndexedFile (body comes from the index's own source)", () => {
     const dir = mkdtempSync(join(tmpdir(), "trails-read-body-"));
     expect(readIndexedFile({ index: emptyIdx, sha: null }, join(dir, "missing.md"))).toBeNull();
     expect(execFileSyncMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("syncWorktreeToOrigin (pre-read sync)", () => {
-  // The sync now takes the tasks-CLI lock around its fetch + reset --hard so
-  // it can't clobber a concurrent mutation in the shared canonical checkout.
-  // Point the lock at a throwaway dir so gitCommonDir (mocked git) is never
-  // consulted and no lock file lands in the repo.
-  afterEach(() => __setLockDirForTest(null));
-  function setup(statusOut = "") {
-    __setLockDirForTest(mkdtempSync(join(tmpdir(), "trails-sync-lock-")));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const seen: string[] = [];
-    execFileSyncMock.mockImplementation((_file, args) => {
-      const label = args && args.length >= 3 ? args[2] : "";
-      seen.push(label);
-      if (label === "status") return statusOut as never;
-      return "" as never;
-    });
-    return { seen };
-  }
-
-  it("fetches + resets --hard origin/main when the worktree is clean", () => {
-    const { seen } = setup();
-    syncWorktreeToOrigin();
-    // status probe first, then the freshness sync runs unchanged.
-    expect(seen).toEqual(["status", "fetch", "reset"]);
-  });
-
-  it("skips reset --hard (no silent data loss) when the worktree has tracked edits", () => {
-    const { seen } = setup(" M rfcs/0024/stories/x.md");
-    const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    syncWorktreeToOrigin();
-    // The status probe ran, but the destructive reset --hard never did.
-    expect(seen).toEqual(["status"]);
-    expect(seen).not.toContain("reset");
-    expect(err).toHaveBeenCalled();
-    expect(String(err.mock.calls[0][0])).toMatch(/uncommitted changes/);
-  });
-
-  it("still syncs when only untracked files are present", () => {
-    const { seen } = setup("?? rfcs/0024/stories/new.md");
-    syncWorktreeToOrigin();
-    expect(seen).toEqual(["status", "fetch", "reset"]);
-  });
-
-  it("skips the sync entirely when the tasks-CLI lock is held by a live mutation", () => {
-    const { seen } = setup();
-    // Simulate a mutation mid-flight: hold the lock with this (live) process.
-    const held = acquireTasksLock(undefined);
-    const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    try {
-      syncWorktreeToOrigin(undefined, 300);
-    } finally {
-      releaseTasksLock(held);
-    }
-    // No status probe, no fetch, and above all no reset --hard: the checkout
-    // belongs to the lock holder until it finishes.
-    expect(seen).toEqual([]);
-    expect(err).toHaveBeenCalled();
-    expect(String(err.mock.calls[0][0])).toMatch(/lock is busy/);
-  });
-
-  it("releases the lock after syncing so the next mutation can take it", () => {
-    const { seen } = setup();
-    syncWorktreeToOrigin();
-    expect(seen).toEqual(["status", "fetch", "reset"]);
-    // Lock must be free again: a fresh acquire succeeds without contention.
-    const lock = acquireTasksLock(undefined, { waitMs: 300, onTimeout: "give-up" });
-    expect(lock).not.toBeNull();
-    releaseTasksLock(lock);
   });
 });
 

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -251,12 +251,16 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
 }
 
 // The origin/main-tree export mutates no checkout, so it is served however
-// TASKS_DIR resolved. Only the fallback — syncFromOrigin's `reset --hard` —
-// stays gated on TASKS_DIR_IS_SYMLINK.
-export function readIndexSource(isSymlink: boolean = TASKS_DIR_IS_SYMLINK): ReadIndex {
+// TASKS_DIR resolved. When it is unavailable (offline, no `tar`, no
+// node_modules to borrow) we serve the working-tree index as-is and warn: a
+// read must never mutate the shared canonical checkout, and when origin is
+// unreachable there is nothing fresher to sync to anyway.
+export function readIndexSource(): ReadIndex {
   const fromOrigin = buildIndexFromOriginMain();
   if (fromOrigin) return fromOrigin;
-  syncFromOrigin(isSymlink);
+  console.error(
+    `warning: could not reach origin/main; serving the local tasks index. It may be stale.`,
+  );
   return { index: loadIndex(), sha: null };
 }
 
@@ -623,83 +627,6 @@ function assertCleanWorktree(cwd: string | undefined): void {
       `  or stash them:  git -C "${where}" stash`,
   );
   process.exit(1);
-}
-
-// Fetch + hard-reset the per-worktree tasks checkout to origin/main. This is
-// now only the FALLBACK freshness path for reads: readIndexSource() builds the
-// index straight from the origin/main tree and only lands here when that is
-// unavailable (offline, no `tar`). Only runs when using the per-worktree
-// symlink (TASKS_DIR_IS_SYMLINK); the canonical fallback and explicit
-// $TASKS_DIR overrides are left alone: a read must never reset a checkout the
-// user chose.
-export function syncFromOrigin(isSymlink: boolean = TASKS_DIR_IS_SYMLINK): void {
-  if (!isSymlink) return;
-  syncWorktreeToOrigin();
-}
-
-// The actual fetch + `reset --hard origin/main`, factored out of the
-// TASKS_DIR_IS_SYMLINK guard so it can be exercised directly in tests.
-// `reset --hard` silently discards uncommitted *tracked* edits, so it must
-// never run against a dirty worktree: an agent authoring a story body (editing
-// a tracked story.md) and then running any read before committing would lose
-// it. When the worktree carries such edits we skip the sync entirely, warn
-// loudly, and serve the possibly-stale index — never destroy unsaved work.
-// Untracked new files survive `reset --hard`, so they don't block the sync.
-//
-// LOCKED against mutations: the per-worktree `tasks/` symlinks all resolve to
-// the ONE shared canonical checkout, so this `reset --hard` used to run
-// concurrently with another agent's commitAndPush mutation in the same
-// working tree. A reset landing between that mutation's file write and its
-// commit deletes the staged-new story file (index AND disk → "nothing to
-// commit" crash); landing inside the pre-commit hook's window it empties the
-// index, and git finalizes an EMPTY commit that then gets pushed — the
-// message lands on main with zero files. Take the same tasks-CLI lock the
-// mutators hold; the dirty check must also sit inside the lock, or a mutation
-// could stage its file right after we probed. Reads are best-effort, so on
-// lock timeout we skip the sync and serve the possibly-stale index instead of
-// dying.
-export function syncWorktreeToOrigin(cwd?: string, lockWaitMs = 20_000): void {
-  const lock = acquireTasksLock(cwd, { waitMs: lockWaitMs, onTimeout: "give-up" });
-  // A "busy" give-up means a live mutation is mid-flight in this checkout —
-  // touching it at all (even the status probe) belongs to the lock holder,
-  // and resetting is exactly the clobber the lock prevents. Skip entirely and
-  // serve the stale index. (A `null` lock — no resolvable git dir — falls
-  // through instead: the status probe below throws and returns silently,
-  // preserving the quiet non-repo behavior.)
-  if (lock === "busy") {
-    console.error(
-      `warning: tasks-CLI lock is busy; skipping the pre-read sync to origin/main. ` +
-        `The index may be stale.`,
-    );
-    return;
-  }
-  try {
-    let porcelain: string;
-    try {
-      porcelain = git(["status", "--porcelain"], { silent: true, cwd });
-    } catch {
-      return; // not a git repo / git unavailable — leave the checkout untouched
-    }
-    const dirty = dirtyWorktreeLines(porcelain);
-    if (dirty.length > 0) {
-      const where = cwd ?? TASKS_DIR;
-      console.error(
-        `warning: ${where} has uncommitted changes; skipping the pre-read sync ` +
-          `to origin/main so they aren't discarded by reset --hard:\n` +
-          dirty.map((l) => `  ${l}`).join("\n") +
-          `\n  The index may be stale. Commit or stash these edits, then re-run:\n` +
-          `    git -C "${where}" add -A && git -C "${where}" commit -m "wip"\n` +
-          `  or stash them:  git -C "${where}" stash`,
-      );
-      return;
-    }
-    git(["fetch", "--quiet", "origin"], { silent: true, cwd });
-    git(["reset", "--hard", "--quiet", "origin/main"], { silent: true, cwd });
-  } catch {
-    /* best-effort — stale data is better than a broken CLI */
-  } finally {
-    releaseTasksLock(lock);
-  }
 }
 
 function storyFilePath(index: Index, id: string): string {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -261,7 +261,42 @@ export function readIndexSource(): ReadIndex {
   console.error(
     `warning: could not reach origin/main; serving the local tasks index. It may be stale.`,
   );
-  return { index: loadIndex(), sha: null };
+  return { index: loadIndexWithoutDirtyingTree(), sha: null };
+}
+
+// The on-disk index.json exactly as it sits in the working tree, or null when
+// there is none. Deliberately NOT loadIndex(): that one rebuilds a stale index
+// by running build-index.mjs, which rewrites the tracked index.md — the read
+// path must not leave that behind in the shared checkout. Staleness is what
+// the caller's warning already announces, so serving a stale index untouched
+// is the honest answer here.
+export function readWorkingTreeIndex(tasksDir: string): Index | null {
+  const indexPath = join(tasksDir, "index.json");
+  if (!existsSync(indexPath)) return null;
+  try {
+    return applyRfcPriorities(JSON.parse(readFileSync(indexPath, "utf8")) as Index, tasksDir);
+  } catch {
+    return null; // truncated/absent — fall back to a rebuild
+  }
+}
+
+// With no index.json at all there is nothing to serve, so a rebuild is the only
+// way to answer the read. It dirties the tracked index.md, so restore it —
+// but only when our own rebuild is what dirtied it, or a read would discard a
+// hand-edit that was already sitting there.
+function loadIndexWithoutDirtyingTree(): Index {
+  const onDisk = readWorkingTreeIndex(TASKS_DIR);
+  if (onDisk) return onDisk;
+  let generatedWereClean = false;
+  try {
+    generatedWereClean =
+      git(["status", "--porcelain", "--", ...GENERATED_INDEX_FILES], { silent: true }) === "";
+  } catch {
+    /* not a git repo / git unavailable — leave whatever the rebuild writes */
+  }
+  const index = loadIndex();
+  if (generatedWereClean) restoreGeneratedFiles(TASKS_DIR);
+  return index;
 }
 
 export function readIndexedFile(src: ReadIndex, filePath: string): string | null {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -584,13 +584,13 @@ function restoreGeneratedFiles(cwd: string | undefined): void {
   }
 }
 
-// Parse `git status --porcelain` into the dirty lines that a rebase or
-// `reset --hard` would corrupt or discard — i.e. tracked edits the user would
-// lose. git() trims its output, so the first line loses porcelain's leading
-// status column space (" M foo" → "M foo"); re-trim every line and strip the
-// 1–2 char XY code + whitespace to recover the path, rather than slicing a
-// fixed offset. Untracked files (`??`) survive both a rebase and `reset --hard`,
-// so they're ignored, as are GENERATED_INDEX_FILES (restoreGeneratedFiles
+// Parse `git status --porcelain` into the dirty lines the mutation path's
+// `git pull --rebase` would corrupt or discard — i.e. tracked edits the user
+// would lose. git() trims its output, so the first line loses porcelain's
+// leading status column space (" M foo" → "M foo"); re-trim every line and
+// strip the 1–2 char XY code + whitespace to recover the path, rather than
+// slicing a fixed offset. Untracked files (`??`) survive a rebase, so they're
+// ignored, as are GENERATED_INDEX_FILES (restoreGeneratedFiles
 // resets them to HEAD and the tasks pre-commit hook rebuilds + re-stages them).
 export function dirtyWorktreeLines(porcelain: string): string[] {
   return porcelain
@@ -871,16 +871,14 @@ function installLockSignalHandlers(): void {
 // poll. A holder whose process is gone (ESRCH) is reclaimed automatically — its
 // lock can never be released, so making a human/agent `rm` it was only busywork
 // (and a racy one: concurrent rm+retry can delete a freshly-taken live lock).
-// Only the wait timeout against a *live* holder still fails loudly — unless
-// the caller opts into `onTimeout: "give-up"`, which returns the distinct
-// sentinel "busy" so a best-effort caller (the pre-read sync) can skip its
-// critical section rather than kill a read command with LOCK_TIMEOUT_EXIT.
-// "busy" is deliberately not null: null means "nothing to lock against"
-// (proceed unlocked), while "busy" means a live holder owns the checkout.
+// Only the wait timeout against a *live* holder still fails loudly. A null
+// handle means "nothing to lock against" (proceed unlocked), not contention:
+// every caller is a mutator, and a mutator must never proceed past a live
+// holder.
 export function acquireTasksLock(
   cwd: string | undefined,
-  opts: { waitMs?: number; pollMs?: number; onTimeout?: "exit" | "give-up" } = {},
-): LockHandle | null | "busy" {
+  opts: { waitMs?: number; pollMs?: number } = {},
+): LockHandle | null {
   const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
   const pollMs = opts.pollMs ?? LOCK_POLL_MS;
   let lockPath: string;
@@ -927,7 +925,6 @@ export function acquireTasksLock(
         continue;
       }
       if (waited >= waitMs) {
-        if (opts.onTimeout === "give-up") return "busy";
         console.error(
           `error: timed out after ${Math.round(waitMs / 1000)}s waiting for the tasks-CLI ` +
             `lock at ${lockPath}. Another mutation is holding it; retry shortly.`,
@@ -944,8 +941,8 @@ export function acquireTasksLock(
 // so the signal handlers don't try to re-release a handle we've let go. The
 // read-then-unlink is race-free because no waiter removes/recreates a lock it
 // didn't create (acquire only `wx`s onto a free path, or reclaims a dead one).
-export function releaseTasksLock(lock: LockHandle | null | "busy"): void {
-  if (!lock || lock === "busy") return;
+export function releaseTasksLock(lock: LockHandle | null): void {
+  if (!lock) return;
   activeLocks.delete(lock);
   try {
     if (readFileSync(lock.path, "utf8").trim() === lock.token) unlinkSync(lock.path);
@@ -1156,8 +1153,8 @@ export function commitAndPush(opts: {
         git(["add", reconciled ? "-A" : opts.fileToStage], { cwd });
         // RFCS_NO_AUTOPUSH: the tasks repo's .husky/post-commit hook otherwise
         // pushes `main` after this commit, racing the explicit push below (and,
-        // before the pre-read sync took the lock, occasionally pushing a
-        // clobbered EMPTY commit before we could reset it away). The CLI owns
+        // back when the CLI still hard-reset the checkout on reads, occasionally
+        // pushing a clobbered EMPTY commit before we could reset it away). The CLI owns
         // its own push; silence the hook's. The rejected-push handling below
         // depends on this — with the hook silenced nothing else pushes our SHA,
         // so a rejection can only be a lost race.
@@ -1200,7 +1197,7 @@ export function commitAndPush(opts: {
         throw e;
       }
       // Never push an empty commit. A concurrent `reset --hard` in this shared
-      // checkout (a pre-read sync from a process predating the lock there, or
+      // checkout (historically the CLI's own pre-read sync, now retired; today
       // any out-of-band reset) that lands inside `git commit`'s pre-commit-hook
       // window empties the index after the emptiness check, so git finalizes a
       // commit whose tree equals its parent — the mutation's file is silently


### PR DESCRIPTION
`readIndexSource()` fell back to `syncFromOrigin()` → `syncWorktreeToOrigin()`
— fetch + `reset --hard origin/main` under the tasks-CLI lock — whenever
`buildIndexFromOriginMain()` returned null (offline, no `tar`, no
`node_modules` to borrow). That was the last place a *read* could mutate the
shared canonical checkout, discard tracked edits, or contend on the mutation
lock.

The fallback now serves the working-tree index with a "could not reach
origin/main; ... may be stale" warning — strictly less destructive, and no
less fresh: offline means there is nothing to sync to.

- `syncFromOrigin` / `syncWorktreeToOrigin` deleted. No callers remain: the
  mutation path guards with `assertCleanWorktree` + `git pull --rebase`, not
  these.
- Their five-test suite deleted; replaced by a regression test that the
  unreachable-origin path warns and issues no `reset`/`status` (it fails on
  baseline, where the fallback still reset).
- The fallback reads `index.json` off disk via the new
  `readWorkingTreeIndex()` rather than `loadIndex()`. `loadIndex()` rebuilds a
  stale index by running `build-index.mjs`, which rewrites the **tracked**
  `index.md` — a read mutating the shared checkout, which is exactly what this
  PR removes. Serving a stale index untouched is the honest answer, since the
  staleness warning already announces it. With no `index.json` at all a
  rebuild is the only way to answer; `index.md` is then restored, but only
  when our own rebuild is what dirtied it, so a read can never discard a
  hand-edit that was already there.
- `readIndexSource` drops its now-unused `isSymlink` parameter.
- `acquireTasksLock`'s `onTimeout: "give-up"` / `"busy"` sentinel goes with
  it — the pre-read sync was its only caller, and every remaining caller is a
  mutator that must never proceed past a live holder. The return type is back
  to `LockHandle | null`.
- Comment prose that framed `dirtyWorktreeLines` and the empty-commit guard
  around the pre-read sync now names the rebase / out-of-band resets that
  actually remain.

Verified against a genuinely unreachable origin (`url.insteadOf` pointing
fetch at a nonexistent path): `pnpm tasks ready` warns once and serves the
local index, with `git status --porcelain` in the shared tasks checkout empty
both before and after.

Closes-story: tasks-retire-reset-hard-read-fallback
