### PR TITLE
feat(api-compare): wire Rails test/support helpers into api:compare

### DIFF
--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord-test-support/load-schema-helper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord-test-support/load-schema-helper.json
@@ -1,0 +1,23 @@
+[
+  {
+    "package": "activerecord-test-support",
+    "tsFile": "load-schema-helper.ts",
+    "rubyName": "load_schema",
+    "call": "load",
+    "reason": "Ruby's Kernel#load evaluates schema.rb as source. trails' mirror of schema.rb is the canonical registry, so loading it means laying that registry onto the adapter — `loadCanonicalSchema(adapter)`. No JS analogue of `load` exists."
+  },
+  {
+    "package": "activerecord-test-support",
+    "tsFile": "load-schema-helper.ts",
+    "rubyName": "load_schema",
+    "call": "exist?",
+    "reason": "`File.exist?(adapter_specific_schema_file)` asks whether a Ruby schema file is on disk. trails resolves adapter-specific schemas through the ADAPTER_SPECIFIC_SCHEMAS lookup instead of the filesystem, so the presence check is a key lookup, not a stat."
+  },
+  {
+    "package": "activerecord-test-support",
+    "tsFile": "load-schema-helper.ts",
+    "rubyName": "load_schema",
+    "call": "new",
+    "reason": "`StringIO.new` backs the `$stdout` silencing around Ruby's `load`, which prints a migration line per statement. Laying the schema through the adapter prints nothing, so there is no output to silence."
+  }
+]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord-test-support/schema-dumping-helper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord-test-support/schema-dumping-helper.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord-test-support",
+    "tsFile": "schema-dumping-helper.ts",
+    "rubyName": "dump_table_schema",
+    "call": "with_connection",
+    "reason": "Rails checks a connection out of the pool solely to read `connection.data_sources`. The trails helper takes the `SchemaSource` itself — the object that both enumerates data sources and is dumped — so there is no pool to check out of; the enumeration happens directly on `source`."
+  }
+]

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -11,6 +11,7 @@ import {
   dedupeRubyMethodInto,
   selectMisplacedFile,
   MISPLACED_MIN_HITS,
+  blazetrailsDepKeys,
   buildEntitiesByName,
   significantMissingCalls,
   jsEnumerableAliases,
@@ -1232,5 +1233,26 @@ describe("buildEntitiesByName", () => {
     const candidates = map.get("Model") ?? [];
     // Local should be first (added first due to current-package priority)
     expect(candidates[0]).toBe(localModel);
+  });
+});
+
+describe("blazetrailsDepKeys", () => {
+  it("keeps a package that shares its dir with a test-support package", () => {
+    // `@blazetrails/activerecord` maps to both `activerecord` and
+    // `activerecord-test-support`; the lib package must survive the split.
+    expect(blazetrailsDepKeys("trailties")).toContain("activerecord");
+  });
+
+  it("never exposes a test-support package to its siblings", () => {
+    for (const pkg of ["trailties", "activerecord", "actioncontroller"]) {
+      expect(blazetrailsDepKeys(pkg)).not.toContain("activerecord-test-support");
+    }
+  });
+
+  it("gives a test-support package its container as a dep", () => {
+    // The helpers live in the container's npm package, so it is never listed
+    // in package.json — without this, FakeAdapter's superclass resolves to
+    // nothing.
+    expect(blazetrailsDepKeys("activerecord-test-support")).toContain("activerecord");
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -73,6 +73,7 @@ import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo, ParamInfo } from "./types.js";
 import {
   DIR_TO_PACKAGES,
+  TEST_SUPPORT_PACKAGES,
   OUTPUT_DIR,
   PACKAGE_DIR_OVERRIDES,
   PACKAGES,
@@ -1005,9 +1006,14 @@ export function blazetrailsDepKeys(pkg: string): string[] {
       // A single npm package may map to multiple api-compare keys
       // (e.g. actionpack → actiondispatch + actioncontroller).
       for (const depKey of DIR_TO_PACKAGES[depDir] ?? [depDir]) {
-        if (depKey !== pkg) keys.push(depKey);
+        if (depKey !== pkg && !TEST_SUPPORT_PACKAGES.has(depKey)) keys.push(depKey);
       }
     }
+    // A test-support package shares its container's npm package, so the
+    // container never shows up as a dependency — add it explicitly, or helpers
+    // that extend a Rails class (FakeAdapter → AbstractAdapter) resolve
+    // against nothing.
+    if (TEST_SUPPORT_PACKAGES.has(pkg) && dirName !== pkg) keys.push(dirName);
     return keys;
   } catch {
     return []; // Non-fatal: fall back to same-package only.

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -44,6 +44,15 @@ export const DIR_TO_PACKAGES: Record<string, string[]> = Object.entries(
   ),
 );
 
+/**
+ * Packages that pair against a framework's *test* helpers rather than its lib.
+ * They live inside another package's src dir and are not part of anyone's
+ * dependency surface, so `blazetrailsDepKeys` filters them out of sibling
+ * packages' entity index — a Rails lib method must never satisfy its
+ * inheritance/arity lookup against a test helper.
+ */
+export const TEST_SUPPORT_PACKAGES = new Set(["activerecord-test-support"]);
+
 /** Override package → src subdirectory when package shares a dir */
 export const PACKAGE_SRC_SUBDIR: Record<string, string> = {
   actiondispatch: "action-dispatch",
@@ -54,10 +63,10 @@ export const PACKAGE_SRC_SUBDIR: Record<string, string> = {
 };
 
 /**
- * Src dirs of packages that live *inside* another package's src dir, keyed by
- * the containing package. The container's extraction walk skips them so each
- * file lands in exactly one package manifest (`activerecord` must not also
- * extract `src/support/`, which belongs to `activerecord-test-support`).
+ * Src dirs of the packages nested inside `pkg`'s own src dir. The container's
+ * extraction walk skips them so each file lands in exactly one package manifest
+ * (`activerecord` must not also extract `src/support/`, which belongs to
+ * `activerecord-test-support`).
  *
  * Actionpack's four packages are siblings under `src/`, with no package rooted
  * at `src/` itself, so nothing is excluded there.

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -20,6 +20,7 @@ export const PACKAGE_DIR_OVERRIDES: Record<string, string> = {
   actioncontroller: "actionpack",
   abstractcontroller: "actionpack",
   actionpackversion: "actionpack",
+  "activerecord-test-support": "activerecord",
 };
 
 /**
@@ -30,10 +31,18 @@ export const PACKAGE_DIR_OVERRIDES: Record<string, string> = {
  */
 export const DIR_TO_PACKAGES: Record<string, string[]> = Object.entries(
   PACKAGE_DIR_OVERRIDES,
-).reduce<Record<string, string[]>>((acc, [pkg, dir]) => {
-  (acc[dir] ??= []).push(pkg);
-  return acc;
-}, {});
+).reduce<Record<string, string[]>>(
+  (acc, [pkg, dir]) => {
+    (acc[dir] ??= []).push(pkg);
+    return acc;
+  },
+  // A dir can host both a package of its own name and overriding pseudo-packages
+  // (`activerecord` + `activerecord-test-support`); seed the self-mapping so
+  // resolving the npm dep `@blazetrails/activerecord` doesn't lose `activerecord`.
+  Object.fromEntries(
+    PACKAGES.filter((pkg) => !PACKAGE_DIR_OVERRIDES[pkg]).map((pkg) => [pkg, [pkg]]),
+  ),
+);
 
 /** Override package → src subdirectory when package shares a dir */
 export const PACKAGE_SRC_SUBDIR: Record<string, string> = {
@@ -41,7 +50,24 @@ export const PACKAGE_SRC_SUBDIR: Record<string, string> = {
   actioncontroller: "action-controller",
   abstractcontroller: "abstract-controller",
   actionpackversion: "action-pack",
+  "activerecord-test-support": "support",
 };
+
+/**
+ * Src dirs of packages that live *inside* another package's src dir, keyed by
+ * the containing package. The container's extraction walk skips them so each
+ * file lands in exactly one package manifest (`activerecord` must not also
+ * extract `src/support/`, which belongs to `activerecord-test-support`).
+ *
+ * Actionpack's four packages are siblings under `src/`, with no package rooted
+ * at `src/` itself, so nothing is excluded there.
+ */
+export function overlappingSubDirs(pkg: string): string[] {
+  const own = packageSrcDir(pkg);
+  return PACKAGES.filter((other) => other !== pkg)
+    .map(packageSrcDir)
+    .filter((dir) => dir.startsWith(own + path.sep));
+}
 
 /** A package's extraction roots, as the freshness guards need them. */
 export interface PackageRoots {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -17,10 +17,12 @@ import {
   extractFileConstants,
   extractFileLocalHelpers,
   extractFromProgram,
+  getAllTsFiles,
   harvestObjectLiteralMethods,
   packageFingerprint,
   tsLiteralValue,
 } from "./extract-ts-api.js";
+import { overlappingSubDirs, packageSrcDir } from "./config.js";
 import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
 const VIRTUAL = "virtual.ts";
@@ -1594,5 +1596,71 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(foo.instanceMethods.find((m) => m.name === "registerModel")!.noRailsEquivalent).toBe(
       "wiring seam with no Rails counterpart",
     );
+  });
+});
+
+describe("sub-package de-overlap", () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    while (tmpDirs.length > 0) {
+      fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  /** src/{parent.ts, support/{helper.ts}} — `support` is the sub-package root. */
+  function fixture(): { srcDir: string; subDir: string } {
+    const srcDir = fs.mkdtempSync(path.join(os.tmpdir(), "deoverlap-"));
+    tmpDirs.push(srcDir);
+    const subDir = path.join(srcDir, "support");
+    fs.mkdirSync(subDir);
+    fs.writeFileSync(
+      path.join(srcDir, "parent.ts"),
+      'import { Helper } from "./support/helper.js";\nexport class Parent {\n  use(): typeof Helper {\n    return Helper;\n  }\n}\n',
+    );
+    fs.writeFileSync(
+      path.join(subDir, "helper.ts"),
+      "export class Helper {\n  ddl(): void {}\n}\n",
+    );
+    return { srcDir, subDir };
+  }
+
+  it("maps activerecord's src/support to the activerecord-test-support package", () => {
+    expect(overlappingSubDirs("activerecord")).toEqual([
+      packageSrcDir("activerecord-test-support"),
+    ]);
+    expect(packageSrcDir("activerecord-test-support")).toBe(
+      path.join(packageSrcDir("activerecord"), "support"),
+    );
+  });
+
+  it("leaves sibling sub-packages (actionpack) with nothing to exclude", () => {
+    expect(overlappingSubDirs("actiondispatch")).toEqual([]);
+    expect(overlappingSubDirs("actioncontroller")).toEqual([]);
+  });
+
+  it("omits an excluded subdir from the walked file list", () => {
+    const { srcDir, subDir } = fixture();
+    expect(getAllTsFiles(srcDir)).toContain(path.join(subDir, "helper.ts"));
+    expect(getAllTsFiles(srcDir, [subDir])).toEqual([path.join(srcDir, "parent.ts")]);
+  });
+
+  it("omits an excluded subdir's classes even when the parent imports them", () => {
+    const { srcDir, subDir } = fixture();
+    const options: ts.CompilerOptions = {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      skipLibCheck: true,
+    };
+    const entry = [path.join(srcDir, "parent.ts")];
+
+    const withOverlap = extractFromProgram(ts.createProgram(entry, options), srcDir);
+    expect(Object.keys(withOverlap.classes).sort()).toEqual([
+      "parent.ts:Parent",
+      "support/helper.ts:Helper",
+    ]);
+
+    const deOverlapped = extractFromProgram(ts.createProgram(entry, options), srcDir, [subDir]);
+    expect(Object.keys(deOverlapped.classes)).toEqual(["parent.ts:Parent"]);
   });
 });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -26,6 +26,7 @@ import {
   PACKAGES,
   PACKAGE_DIR_OVERRIDES,
   packageSrcDir,
+  overlappingSubDirs,
   apiComparePackageRoots,
 } from "./config.js";
 import {
@@ -234,7 +235,7 @@ export async function main() {
 
   for (const pkg of PACKAGES) {
     const pkgDir = packageSrcDir(pkg);
-    const files = getAllTsFiles(pkgDir);
+    const files = getAllTsFiles(pkgDir, overlappingSubDirs(pkg));
     const dirName = PACKAGE_DIR_OVERRIDES[pkg] ?? pkg;
     const pkgRoot = path.join(ROOT_DIR, "packages", dirName);
     const tsConfigPath = path.join(pkgRoot, "tsconfig.json");
@@ -383,7 +384,8 @@ interface PendingReExport {
 }
 
 function extractPackage(pkgName: string, srcDir: string): WorkerOutput {
-  const files = getAllTsFiles(srcDir);
+  const subPackageDirs = overlappingSubDirs(pkgName);
+  const files = getAllTsFiles(srcDir, subPackageDirs);
 
   // Create a TypeScript program
   const dirName = PACKAGE_DIR_OVERRIDES[pkgName] ?? pkgName;
@@ -412,7 +414,7 @@ function extractPackage(pkgName: string, srcDir: string): WorkerOutput {
 
   const program = ts.createProgram(files, compilerOptions);
   return {
-    package: extractFromProgram(program, srcDir),
+    package: extractFromProgram(program, srcDir, subPackageDirs),
     inputs: program.getSourceFiles().map((sourceFile) => sourceFile.fileName),
   };
 }
@@ -422,7 +424,15 @@ function extractPackage(pkgName: string, srcDir: string): WorkerOutput {
  * from `extractPackage` so tests can drive it with synthetic in-memory
  * programs without needing a real package directory + tsconfig.
  */
-export function extractFromProgram(program: ts.Program, srcDir: string): PackageInfo {
+export function extractFromProgram(
+  program: ts.Program,
+  srcDir: string,
+  excludeDirs: readonly string[] = [],
+): PackageInfo {
+  // The program pulls in every file its entry points import, so a sub-package's
+  // files reach it through the container's own imports even though the entry
+  // list already skipped them — filter here too or the de-overlap is a no-op.
+  const excludePrefixes = excludeDirs.map((dir) => dir.replace(/\\/g, "/") + "/");
   const info: PackageInfo = { classes: {}, modules: {}, fileFunctions: {}, fileConstants: {} };
   const pendingReExports: PendingReExport[] = [];
   const checker = program.getTypeChecker();
@@ -431,6 +441,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
     const filePath = sourceFile.fileName;
     // Only process our source files (not node_modules or test files)
     if (!filePath.startsWith(srcDir)) continue;
+    if (excludePrefixes.some((prefix) => filePath.startsWith(prefix))) continue;
     if (filePath.endsWith(".test.ts")) continue;
     if (filePath.endsWith(".d.ts")) continue;
 
@@ -2348,14 +2359,15 @@ function isExported(node: ts.Node): boolean {
   return hasModifier(node, ts.SyntaxKind.ExportKeyword);
 }
 
-function getAllTsFiles(dir: string): string[] {
+export function getAllTsFiles(dir: string, excludeDirs: readonly string[] = []): string[] {
   const results: string[] = [];
   if (!fs.existsSync(dir)) return results;
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      results.push(...getAllTsFiles(fullPath));
+      if (excludeDirs.includes(fullPath)) continue;
+      results.push(...getAllTsFiles(fullPath, excludeDirs));
     } else if (
       entry.name.endsWith(".ts") &&
       !entry.name.endsWith(".test.ts") &&

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1129,6 +1129,14 @@ export const UNPORTED_FILES: UnportedFile[] = [
       'in Rails), so `"foo"` is a missing-env lookup, not a malformed URL. ' +
       "See packages/activerecord/src/database-configurations/resolver.test.ts.",
   },
+  {
+    pattern: "tools.rb",
+    package: "activerecord-test-support",
+    reason:
+      "Rails' rake/minitest test-runner plumbing: prepends adapter globbing onto " +
+      "Rails::TestUnit::Runner and invokes it with ARGV. vitest fills that role in " +
+      "trails — no port intended.",
+  },
 ];
 
 export function isSourceUnported(file: string, pkg?: string): boolean {

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -16,7 +16,7 @@ describe("vendor/sources.ts", () => {
     expect(SOURCES.length).toBeGreaterThan(0);
   });
 
-  it("declares the rails source with all 10 packages (9 wave-1 + actionpackversion)", () => {
+  it("declares the rails source with all 11 packages (9 wave-1 + actionpackversion + test-support)", () => {
     const rails = SOURCES.find((s) => s.name === "rails");
     expect(rails).toBeDefined();
     expect(rails!.origin).toEqual({
@@ -33,6 +33,7 @@ describe("vendor/sources.ts", () => {
         "actionview",
         "activemodel",
         "activerecord",
+        "activerecord-test-support",
         "activesupport",
         "arel",
         "trailties",
@@ -190,6 +191,7 @@ describe("vendor/sources.ts", () => {
         "actionview",
         "activemodel",
         "activerecord",
+        "activerecord-test-support",
         "activesupport",
         "arel",
         "did-you-mean",

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -76,6 +76,15 @@ export const SOURCES: readonly UpstreamSource[] = [
         testPath: "activerecord/test/cases",
       },
       {
+        // Rails' test-support helpers (`test/support/*.rb`) — DDL/schema-dump/
+        // connection helpers our suite ports into
+        // `packages/activerecord/src/support/`. A pseudo-package rather than a
+        // second root on `activerecord` because api-compare keys one lib dir
+        // per package. No `testPath`: these are helpers, not test cases.
+        name: "activerecord-test-support",
+        libPath: "activerecord/test/support",
+      },
+      {
         name: "activemodel",
         libPath: "activemodel/lib/active_model",
         testPath: "activemodel/test/cases",


### PR DESCRIPTION
Wires Rails' `activerecord/test/support/*.rb` helpers into `api:compare` as a
new `activerecord-test-support` pseudo-package, so the trails ports in
`packages/activerecord/src/support/` are measured instead of tracked only by
prose `Mirrors:` comments.

## What changed

- `vendor/sources.ts`: new rails package `activerecord-test-support`
  (`libPath: activerecord/test/support`, no `testPath` — helpers, not cases).
- `scripts/api-compare/config.ts`: `PACKAGE_DIR_OVERRIDES` → `activerecord`,
  `PACKAGE_SRC_SUBDIR` → `support` (same pattern as actiondispatch onto
  actionpack), plus `overlappingSubDirs()` and `TEST_SUPPORT_PACKAGES`.
- `scripts/api-compare/extract-ts-api.ts`: sub-package de-overlap. The walked
  entry list skips a nested package's dir **and** `extractFromProgram` filters
  it — the program pulls in whatever the container imports, so the entry-list
  skip alone is a no-op.
- `scripts/api-compare/compare.ts`: `DIR_TO_PACKAGES` now maps
  `@blazetrails/activerecord` to two keys, so `blazetrailsDepKeys` gains two
  rules — a test-support package is never exposed to its siblings (a Rails lib
  method must not satisfy its inheritance/arity lookup against a test helper),
  and a test-support package gets its container as a dep (the helpers ship
  inside the container's npm package, so it never appears in package.json, and
  `FakeAdapter`'s superclass had nothing to resolve against).
- `scripts/api-compare/unported-files.ts`: excludes `support/tools.rb` (Rails'
  rake/minitest runner plumbing; vitest fills that role).
- `call-mismatches-wide-exclude/activerecord-test-support/`: the four wide-call
  mismatches the new package surfaces, each with a reason — Ruby `load`,
  `File.exist?` and `StringIO.new` in `load_schema` (trails lays the canonical
  registry through the adapter, so there is no file to load, stat, or silence),
  and `pool.with_connection` in `dump_table_schema` (the trails helper takes the
  `SchemaSource` itself, so there is no checkout).

## Results

```
activerecord-test-support — 23/43 methods (53.5%) | files: 9/9 | arity: 16/16
```

All ten paired files resolve (`ddl_helper.rb` → `ddl-helper.ts`, …);
`connection.rb` pairs but contributes no methods. The fixture data dirs
(`marshal_compatibility_fixtures`, `yaml_compatibility_fixtures`) contain no
Ruby and contribute nothing.

`activerecord` is unchanged — 6079/6142 methods, files 277/277, inheritance
209/210 — except that arity comparisons drop from 3898 to 3893: five Rails
methods were matching arity against `src/support/` TS entities that are now out
of that package's manifest. `pnpm api:extra --package activerecord` allowlist
totals are unchanged (80 total / 58 matched, no stale entries); the trails-only
`src/support/` files it scores are re-attributed to the new package rather than
newly reported.

No new CI gate — outputs feed the existing reports/stats DB only. The four
existing ratchets (`lint-call-mismatches`, `-wide`, `lint-arity-excludes`,
`lint-body-pins`) and `conventions-doc --check` all pass on a full local run.

## Follow-up

The 20 missing methods and the one inheritance mismatch surfaced by the first
run are filed as `0064/converge-test-support-api-compare-gaps` (largest
clusters: `config.rb` 0/7 and `stubs/strong_parameters.rb` 2/9;
`FakeActiveRecordAdapter` extends `FakeAdapterBase` where Rails extends
`AbstractAdapter`), not fixed here.

Closes-story: wire-test-support-into-api-compare
