### PR TITLE
perf(api-compare): key the resolution shape per package dependency closure

### DIFF
--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -36,7 +36,7 @@ import {
   normalizeReadSet,
   hashReadSet,
   readSetMatches,
-  resolutionShapeKey,
+  resolutionShape,
   dependencyKey,
   hashParts,
   type ReadSet,
@@ -211,8 +211,10 @@ export async function main() {
   // package's read-set must not read the same file 13 times.
   const inputHashes = new Map<string, Promise<string | null>>();
   // Read-sets record what WAS resolvable; this covers what BECOMES resolvable
-  // (an unbuilt dependency gaining a `dist`) — see resolutionShapeKey.
-  const shapeKey = await resolutionShapeKey(path.join(ROOT_DIR, "packages"));
+  // (an unbuilt dependency gaining a `dist`) — see resolutionShape. Keyed per
+  // package over its own dependency closure, so adding a file to a package
+  // this one cannot resolve leaves its entry valid.
+  const shape = await resolutionShape(path.join(ROOT_DIR, "packages"));
   // Neither of those can see `node_modules`, which is most of what the compiler
   // reads; the lockfile stands in for all of it — coarse (any bump invalidates
   // every package) but ~2 ms a run against ~23 ms for the precise alternative,
@@ -240,6 +242,7 @@ export async function main() {
     const tsConfigPath = path.join(pkgRoot, "tsconfig.json");
     const fingerprintInputs = [...files];
     if (fs.existsSync(tsConfigPath)) fingerprintInputs.push(tsConfigPath);
+    const shapeKey = shape.keyFor(dirName);
     // Anchor relative paths at the package root so tsconfig.json
     // doesn't show up as `../tsconfig.json` (which it would if we
     // anchored at the src dir).

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -210,10 +210,6 @@ export async function main() {
   // packages resolve many of the same declarations, and validating every
   // package's read-set must not read the same file 13 times.
   const inputHashes = new Map<string, Promise<string | null>>();
-  // Read-sets record what WAS resolvable; this covers what BECOMES resolvable
-  // (an unbuilt dependency gaining a `dist`) — see resolutionShape. Keyed per
-  // package over its own dependency closure, so adding a file to a package
-  // this one cannot resolve leaves its entry valid.
   const shape = await resolutionShape(path.join(ROOT_DIR, "packages"));
   // Neither of those can see `node_modules`, which is most of what the compiler
   // reads; the lockfile stands in for all of it — coarse (any bump invalidates

--- a/scripts/api-compare/shared-cache.test.ts
+++ b/scripts/api-compare/shared-cache.test.ts
@@ -307,14 +307,9 @@ describe("resolutionShape", () => {
     writeDist(packagesDir, "activesupport", { "index.d.ts": "export declare const a: number;" });
     const built = await keyOf(packagesDir, "activesupport");
 
-    // A rebuild that only changes contents leaves the shape alone — those
-    // changes are the read-set's job, and re-keying on them would invalidate
-    // every package again.
     writeDist(packagesDir, "activesupport", { "index.d.ts": "export declare const a: string;" });
     expect(await keyOf(packagesDir, "activesupport")).toBe(built);
 
-    // A dependency that was unbuilt at extraction time resolves to nothing, so
-    // no read-set can see it become resolvable — the shape must.
     const unbuilt = mkTmp();
     fs.mkdirSync(path.join(unbuilt, "activesupport"), { recursive: true });
     expect(await keyOf(unbuilt, "activesupport")).not.toBe(built);
@@ -348,8 +343,6 @@ describe("resolutionShape", () => {
       before.keyFor(dir),
     );
 
-    // Adding a file to a package nobody in this closure depends on must leave
-    // that closure's key alone — this is the whole point of the graph walk.
     writeDist(packagesDir, "actionview", { "extra.d.ts": "" });
     const after = await resolutionShape(packagesDir);
     expect(["activesupport", "arel", "activerecord"].map((dir) => after.keyFor(dir))).toEqual(
@@ -357,7 +350,6 @@ describe("resolutionShape", () => {
     );
     expect(after.keyFor("actionview")).not.toBe(keys[3]);
 
-    // A transitive dependency two hops down still invalidates the dependent.
     writeDist(packagesDir, "activesupport", { "extra.d.ts": "" });
     const later = await resolutionShape(packagesDir);
     expect(later.keyFor("activerecord")).not.toBe(keys[2]);
@@ -371,13 +363,32 @@ describe("resolutionShape", () => {
     writeDist(packagesDir, "arel", { "index.d.ts": "" });
     writeDist(packagesDir, "actionview", { "index.d.ts": "" });
 
-    // `actionview` has no manifest, so nothing bounds what it resolves: its key
-    // must move when ANY package's shape does.
     const before = await resolutionShape(packagesDir);
     writeDist(packagesDir, "arel", { "extra.d.ts": "" });
     expect((await resolutionShape(packagesDir)).keyFor("actionview")).not.toBe(
       before.keyFor("actionview"),
     );
+  });
+
+  it("follows a workspace link that the manifest does not declare", async () => {
+    const packagesDir = mkTmp();
+    writeManifest(packagesDir, "arel", []);
+    writeManifest(packagesDir, "activesupport", []);
+    writeDist(packagesDir, "arel", { "index.d.ts": "" });
+    writeDist(packagesDir, "activesupport", { "index.d.ts": "" });
+    fs.mkdirSync(path.join(packagesDir, "arel", "node_modules", "@blazetrails"), {
+      recursive: true,
+    });
+    fs.symlinkSync(
+      path.join(packagesDir, "activesupport"),
+      path.join(packagesDir, "arel", "node_modules", "@blazetrails", "activesupport"),
+    );
+
+    const before = await resolutionShape(packagesDir);
+    writeDist(packagesDir, "activesupport", { "extra.d.ts": "" });
+    const after = await resolutionShape(packagesDir);
+    expect(after.keyFor("arel")).not.toBe(before.keyFor("arel"));
+    expect(after.keyFor("activesupport")).not.toBe(before.keyFor("activesupport"));
   });
 
   it("terminates on a dependency cycle", async () => {

--- a/scripts/api-compare/shared-cache.test.ts
+++ b/scripts/api-compare/shared-cache.test.ts
@@ -20,7 +20,7 @@ import {
   normalizeReadSet,
   hashReadSet,
   readSetMatches,
-  resolutionShapeKey,
+  resolutionShape,
   dependencyKey,
   CACHE_VERSION,
 } from "./shared-cache.js";
@@ -278,7 +278,7 @@ describe("resolved read-set", () => {
   });
 });
 
-describe("resolutionShapeKey", () => {
+describe("resolutionShape", () => {
   function writeDist(packagesDir: string, dir: string, files: Record<string, string>): void {
     for (const [name, body] of Object.entries(files)) {
       const file = path.join(packagesDir, dir, "dist", name);
@@ -287,61 +287,106 @@ describe("resolutionShapeKey", () => {
     }
   }
 
+  function writeManifest(packagesDir: string, dir: string, deps: string[]): void {
+    fs.mkdirSync(path.join(packagesDir, dir), { recursive: true });
+    fs.writeFileSync(
+      path.join(packagesDir, dir, "package.json"),
+      JSON.stringify({
+        name: `@blazetrails/${dir}`,
+        dependencies: Object.fromEntries(deps.map((dep) => [`@blazetrails/${dep}`, "workspace:*"])),
+      }),
+    );
+  }
+
+  async function keyOf(packagesDir: string, dir: string): Promise<string> {
+    return (await resolutionShape(packagesDir)).keyFor(dir);
+  }
+
   it("tracks which declarations exist, not what they say", async () => {
     const packagesDir = mkTmp();
     writeDist(packagesDir, "activesupport", { "index.d.ts": "export declare const a: number;" });
-    const built = await resolutionShapeKey(packagesDir);
+    const built = await keyOf(packagesDir, "activesupport");
 
     // A rebuild that only changes contents leaves the shape alone — those
     // changes are the read-set's job, and re-keying on them would invalidate
     // every package again.
     writeDist(packagesDir, "activesupport", { "index.d.ts": "export declare const a: string;" });
-    expect(await resolutionShapeKey(packagesDir)).toBe(built);
+    expect(await keyOf(packagesDir, "activesupport")).toBe(built);
 
     // A dependency that was unbuilt at extraction time resolves to nothing, so
     // no read-set can see it become resolvable — the shape must.
     const unbuilt = mkTmp();
     fs.mkdirSync(path.join(unbuilt, "activesupport"), { recursive: true });
-    expect(await resolutionShapeKey(unbuilt)).not.toBe(built);
+    expect(await keyOf(unbuilt, "activesupport")).not.toBe(built);
 
     writeDist(packagesDir, "activesupport", { "extra.d.ts": "export declare const b: number;" });
-    expect(await resolutionShapeKey(packagesDir)).not.toBe(built);
+    expect(await keyOf(packagesDir, "activesupport")).not.toBe(built);
   });
 
   it("ignores non-declaration output and a missing packages dir", async () => {
     const packagesDir = mkTmp();
     writeDist(packagesDir, "arel", { "index.d.ts": "" });
-    const before = await resolutionShapeKey(packagesDir);
+    const before = await keyOf(packagesDir, "arel");
     writeDist(packagesDir, "arel", { "index.js": "", "nested/index.js.map": "" });
-    expect(await resolutionShapeKey(packagesDir)).toBe(before);
-    expect(await resolutionShapeKey(path.join(packagesDir, "nope"))).toMatch(/^[0-9a-f]{40}$/);
-  });
-});
-
-describe("dependencyKey", () => {
-  it("changes when a dependency bump rewrites the lockfile", async () => {
-    const root = mkTmp();
-    const lock = path.join(root, "pnpm-lock.yaml");
-    fs.writeFileSync(lock, "'@types/node': 22.0.0\n");
-    const before = await dependencyKey(root);
-    expect(before).toMatch(/^[0-9a-f]{40}$/);
-
-    // Third-party declarations live under node_modules, which the read-set
-    // drops and the shape key never walks — without this key an install that
-    // changes what `@types/node` declares would serve every stale entry.
-    fs.writeFileSync(lock, "'@types/node': 24.0.0\n");
-    expect(await dependencyKey(root)).not.toBe(before);
-
-    fs.writeFileSync(lock, "'@types/node': 22.0.0\n");
-    expect(await dependencyKey(root)).toBe(before);
+    expect(await keyOf(packagesDir, "arel")).toBe(before);
+    expect(await keyOf(path.join(packagesDir, "nope"), "arel")).toMatch(/^[0-9a-f]{40}$/);
   });
 
-  it("keys a lockfile-less tree stably and distinctly", async () => {
-    const root = mkTmp();
-    const missing = await dependencyKey(root);
-    expect(missing).toBe(await dependencyKey(mkTmp()));
+  it("keys each package over its own transitive dependencies only", async () => {
+    const packagesDir = mkTmp();
+    for (const [dir, deps] of [
+      ["activesupport", []],
+      ["arel", ["activesupport"]],
+      ["activerecord", ["arel"]],
+      ["actionview", []],
+    ] as [string, string[]][]) {
+      writeManifest(packagesDir, dir, deps);
+      writeDist(packagesDir, dir, { "index.d.ts": "" });
+    }
+    const before = await resolutionShape(packagesDir);
+    const keys = ["activesupport", "arel", "activerecord", "actionview"].map((dir) =>
+      before.keyFor(dir),
+    );
 
-    fs.writeFileSync(path.join(root, "pnpm-lock.yaml"), "");
-    expect(await dependencyKey(root)).not.toBe(missing);
+    // Adding a file to a package nobody in this closure depends on must leave
+    // that closure's key alone — this is the whole point of the graph walk.
+    writeDist(packagesDir, "actionview", { "extra.d.ts": "" });
+    const after = await resolutionShape(packagesDir);
+    expect(["activesupport", "arel", "activerecord"].map((dir) => after.keyFor(dir))).toEqual(
+      keys.slice(0, 3),
+    );
+    expect(after.keyFor("actionview")).not.toBe(keys[3]);
+
+    // A transitive dependency two hops down still invalidates the dependent.
+    writeDist(packagesDir, "activesupport", { "extra.d.ts": "" });
+    const later = await resolutionShape(packagesDir);
+    expect(later.keyFor("activerecord")).not.toBe(keys[2]);
+    expect(later.keyFor("arel")).not.toBe(keys[1]);
+    expect(later.keyFor("actionview")).toBe(after.keyFor("actionview"));
+  });
+
+  it("falls back to the workspace-global key for an unknown package dir", async () => {
+    const packagesDir = mkTmp();
+    writeManifest(packagesDir, "arel", []);
+    writeDist(packagesDir, "arel", { "index.d.ts": "" });
+    writeDist(packagesDir, "actionview", { "index.d.ts": "" });
+
+    // `actionview` has no manifest, so nothing bounds what it resolves: its key
+    // must move when ANY package's shape does.
+    const before = await resolutionShape(packagesDir);
+    writeDist(packagesDir, "arel", { "extra.d.ts": "" });
+    expect((await resolutionShape(packagesDir)).keyFor("actionview")).not.toBe(
+      before.keyFor("actionview"),
+    );
+  });
+
+  it("terminates on a dependency cycle", async () => {
+    const packagesDir = mkTmp();
+    writeManifest(packagesDir, "arel", ["activesupport"]);
+    writeManifest(packagesDir, "activesupport", ["arel"]);
+    writeDist(packagesDir, "arel", { "index.d.ts": "" });
+    writeDist(packagesDir, "activesupport", { "index.d.ts": "" });
+    const shape = await resolutionShape(packagesDir);
+    expect(shape.keyFor("arel")).toBe(shape.keyFor("activesupport"));
   });
 });

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -117,8 +117,9 @@ export async function fileHash(file: string): Promise<string | null> {
 export type ReadSet = Record<string, string>;
 
 /**
- * Hash of the SHAPE of what the workspace can resolve: the sorted names (not
- * contents) of every built `packages/<dir>/dist/**\/*.d.ts`.
+ * Per-package hash of the SHAPE of what that package can resolve: the sorted
+ * names (not contents) of every built `dist/**\/*.d.ts` under the package's own
+ * directory and its TRANSITIVE workspace dependencies.
  *
  * A read-set records what the compiler DID read, so it cannot notice a file
  * that was not resolvable at extraction time and is now. An unbuilt dependency
@@ -128,22 +129,109 @@ export type ReadSet = Record<string, string>;
  * cache keys closes that hole without giving up the read-set's precision —
  * building or rebuilding does not change the file NAMES, so the common case
  * (contents changed) still invalidates only the packages that read them.
+ *
+ * Scoping it to the dependency closure is what keeps the remaining case —
+ * adding, deleting or renaming a source file, ~20% of commits touching
+ * `packages/` — from invalidating all 13 packages including the ones that
+ * cannot resolve the changed package at all. `keyFor` is sync so a caller can
+ * key every package off one walk of the workspace.
  */
-export async function resolutionShapeKey(packagesDir: string): Promise<string> {
+export interface ResolutionShape {
+  /**
+   * Shape key for the package directory `dirName`. A directory the workspace
+   * graph doesn't know falls back to the workspace-global key: we can't bound
+   * what it resolves, so nothing may be assumed invariant.
+   */
+  keyFor(dirName: string): string;
+}
+
+export async function resolutionShape(packagesDir: string): Promise<ResolutionShape> {
   let dirs: string[];
   try {
     dirs = await fs.readdir(packagesDir);
   } catch {
-    return hashParts([]);
+    dirs = [];
   }
-  const perPackage = await Promise.all(
+  const names = new Map<string, string[]>();
+  await Promise.all(
     dirs.map(async (dir) => {
       const dist = path.join(packagesDir, dir, "dist");
       const files = await declarationsUnder(dist);
-      return files.map((file) => `${dir}/${path.relative(dist, file).replace(/\\/g, "/")}`);
+      names.set(
+        dir,
+        files.map((file) => `${dir}/${path.relative(dist, file).replace(/\\/g, "/")}`),
+      );
     }),
   );
-  return hashParts(perPackage.flat().sort());
+  const graph = await readWorkspaceGraph(packagesDir, dirs);
+  const globalKey = hashParts([...names.values()].flat().sort());
+  const keys = new Map<string, string>();
+  for (const dir of graph.keys()) {
+    const closure = transitiveDeps(graph, dir);
+    keys.set(dir, hashParts(closure.flatMap((dep) => names.get(dep) ?? []).sort()));
+  }
+  return { keyFor: (dirName) => keys.get(dirName) ?? globalKey };
+}
+
+/**
+ * Workspace dependency graph as package DIRECTORY → directories of its direct
+ * `@blazetrails/*` dependencies. Directories, not npm names, because that is
+ * what indexes `dist` — and several api-compare packages (actiondispatch,
+ * actioncontroller, …) share one directory. Unparseable or nameless
+ * `package.json`s are skipped; they simply don't appear in the graph and their
+ * callers fall back to the global key.
+ */
+async function readWorkspaceGraph(
+  packagesDir: string,
+  dirs: string[],
+): Promise<Map<string, string[]>> {
+  const manifests = await Promise.all(
+    dirs.map(async (dir) => {
+      try {
+        const body = await fs.readFile(path.join(packagesDir, dir, "package.json"), "utf-8");
+        const json = JSON.parse(body) as {
+          name?: string;
+          dependencies?: Record<string, string>;
+          peerDependencies?: Record<string, string>;
+        };
+        if (!json.name) return null;
+        return {
+          dir,
+          name: json.name,
+          deps: Object.keys({ ...json.dependencies, ...json.peerDependencies }),
+        };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  const dirOfName = new Map<string, string>();
+  for (const manifest of manifests) {
+    if (manifest) dirOfName.set(manifest.name, manifest.dir);
+  }
+  const graph = new Map<string, string[]>();
+  for (const manifest of manifests) {
+    if (!manifest) continue;
+    const deps = manifest.deps
+      .map((dep) => dirOfName.get(dep))
+      .filter((dir): dir is string => dir !== undefined && dir !== manifest.dir);
+    graph.set(manifest.dir, [...new Set(deps)]);
+  }
+  return graph;
+}
+
+/** `dir` plus every directory reachable from it, cycle-safe (the graph may have any). */
+function transitiveDeps(graph: Map<string, string[]>, dir: string): string[] {
+  const seen = new Set<string>([dir]);
+  const queue = [dir];
+  while (queue.length > 0) {
+    for (const dep of graph.get(queue.pop() as string) ?? []) {
+      if (seen.has(dep)) continue;
+      seen.add(dep);
+      queue.push(dep);
+    }
+  }
+  return [...seen];
 }
 
 /**
@@ -151,7 +239,7 @@ export async function resolutionShapeKey(packagesDir: string): Promise<string> {
  * `pnpm-lock.yaml`.
  *
  * Neither of the other two keys can see `node_modules`: `normalizeReadSet`
- * drops every path under it and `resolutionShapeKey` only walks
+ * drops every path under it and `resolutionShape` only walks
  * `packages/*\/dist`. Yet most of what the compiler reads is third-party — on
  * actionview, 197 of 241 resolved files (`@types/node`, `typescript`'s
  * `lib.*.d.ts`, `undici-types`, `@types/pg`) — so a dependency bump changes the

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -116,32 +116,7 @@ export async function fileHash(file: string): Promise<string | null> {
  */
 export type ReadSet = Record<string, string>;
 
-/**
- * Per-package hash of the SHAPE of what that package can resolve: the sorted
- * names (not contents) of every built `dist/**\/*.d.ts` under the package's own
- * directory and its TRANSITIVE workspace dependencies.
- *
- * A read-set records what the compiler DID read, so it cannot notice a file
- * that was not resolvable at extraction time and is now. An unbuilt dependency
- * is exactly that case: with no `dist`, the import resolves to nothing and the
- * entry records nothing for it; a later `tsc --build` would silently change the
- * extraction while every recorded hash still matched. Folding this key into the
- * cache keys closes that hole without giving up the read-set's precision —
- * building or rebuilding does not change the file NAMES, so the common case
- * (contents changed) still invalidates only the packages that read them.
- *
- * Scoping it to the dependency closure is what keeps the remaining case —
- * adding, deleting or renaming a source file, ~20% of commits touching
- * `packages/` — from invalidating all 13 packages including the ones that
- * cannot resolve the changed package at all. `keyFor` is sync so a caller can
- * key every package off one walk of the workspace.
- */
 export interface ResolutionShape {
-  /**
-   * Shape key for the package directory `dirName`. A directory the workspace
-   * graph doesn't know falls back to the workspace-global key: we can't bound
-   * what it resolves, so nothing may be assumed invariant.
-   */
   keyFor(dirName: string): string;
 }
 
@@ -173,38 +148,11 @@ export async function resolutionShape(packagesDir: string): Promise<ResolutionSh
   return { keyFor: (dirName) => keys.get(dirName) ?? globalKey };
 }
 
-/**
- * Workspace dependency graph as package DIRECTORY → directories of its direct
- * `@blazetrails/*` dependencies. Directories, not npm names, because that is
- * what indexes `dist` — and several api-compare packages (actiondispatch,
- * actioncontroller, …) share one directory. Unparseable or nameless
- * `package.json`s are skipped; they simply don't appear in the graph and their
- * callers fall back to the global key.
- */
 async function readWorkspaceGraph(
   packagesDir: string,
   dirs: string[],
 ): Promise<Map<string, string[]>> {
-  const manifests = await Promise.all(
-    dirs.map(async (dir) => {
-      try {
-        const body = await fs.readFile(path.join(packagesDir, dir, "package.json"), "utf-8");
-        const json = JSON.parse(body) as {
-          name?: string;
-          dependencies?: Record<string, string>;
-          peerDependencies?: Record<string, string>;
-        };
-        if (!json.name) return null;
-        return {
-          dir,
-          name: json.name,
-          deps: Object.keys({ ...json.dependencies, ...json.peerDependencies }),
-        };
-      } catch {
-        return null;
-      }
-    }),
-  );
+  const manifests = await Promise.all(dirs.map(async (dir) => readManifest(packagesDir, dir)));
   const dirOfName = new Map<string, string>();
   for (const manifest of manifests) {
     if (manifest) dirOfName.set(manifest.name, manifest.dir);
@@ -220,12 +168,65 @@ async function readWorkspaceGraph(
   return graph;
 }
 
-/** `dir` plus every directory reachable from it, cycle-safe (the graph may have any). */
+interface PackageManifest {
+  dir: string;
+  name: string;
+  deps: string[];
+}
+
+async function readManifest(packagesDir: string, dir: string): Promise<PackageManifest | null> {
+  let json: {
+    name?: string;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  try {
+    json = JSON.parse(await fs.readFile(path.join(packagesDir, dir, "package.json"), "utf-8"));
+  } catch {
+    return null;
+  }
+  if (typeof json.name !== "string" || json.name.length === 0) return null;
+  const declared = Object.keys({
+    ...json.dependencies,
+    ...json.devDependencies,
+    ...json.peerDependencies,
+    ...json.optionalDependencies,
+  });
+  return { dir, name: json.name, deps: [...declared, ...(await linkedPackages(packagesDir, dir))] };
+}
+
+async function linkedPackages(packagesDir: string, dir: string): Promise<string[]> {
+  const scopesDir = path.join(packagesDir, dir, "node_modules");
+  let scopes: string[];
+  try {
+    scopes = (await fs.readdir(scopesDir, { withFileTypes: true }))
+      .filter((entry) => entry.name.startsWith("@"))
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+  const nested = await Promise.all(
+    scopes.map(async (scope) => {
+      try {
+        const members = await fs.readdir(path.join(scopesDir, scope));
+        return members.map((member) => `${scope}/${member}`);
+      } catch {
+        return [];
+      }
+    }),
+  );
+  return nested.flat();
+}
+
 function transitiveDeps(graph: Map<string, string[]>, dir: string): string[] {
   const seen = new Set<string>([dir]);
   const queue = [dir];
   while (queue.length > 0) {
-    for (const dep of graph.get(queue.pop() as string) ?? []) {
+    const next = queue.pop();
+    if (next === undefined) break;
+    for (const dep of graph.get(next) ?? []) {
       if (seen.has(dep)) continue;
       seen.add(dep);
       queue.push(dep);


### PR DESCRIPTION
## What

`resolutionShapeKey` hashed the sorted names of every
`packages/*/dist/**/*.d.ts` in the workspace and folded that single key into
both TS extraction cache keys. It was the one coarse edge left in an otherwise
per-file cache: adding, deleting or renaming ANY source file in ANY package
changes a `dist` file name and so invalidated all 13 packages, even the ones
that can never resolve the changed package.

## Measurement first

Per the story's first acceptance criterion: of the last 300 commits on `main`
touching `packages/`, **61 (20%) add, delete or rename a file** there — roughly
every fifth merge forcing a full 13-package re-extraction. Worth the graph.

## What changed

`resolutionShapeKey(packagesDir)` → `resolutionShape(packagesDir)`, returning
`{ keyFor(dirName) }`:

- One walk of `packages/*/dist` collects declaration NAMES per directory
  (unchanged: a contents-only rebuild still does not move any key).
- A workspace graph is built per DIRECTORY — several api-compare packages
  (actiondispatch, actioncontroller, …) share one directory, and the directory
  is what indexes `dist`. Edges are the union of the manifest's
  `dependencies` / `devDependencies` / `peerDependencies` /
  `optionalDependencies` and the package's actual
  `node_modules/@blazetrails/*` links, so an import the compiler can resolve
  cannot fall outside the closure even if the manifest omits it.
- Each package's key hashes only its own directory plus its transitive closure;
  the walk is cycle-safe.
- A directory with no parseable manifest falls back to the workspace-global
  key — nothing bounds what it resolves, so nothing may be assumed invariant.
  (All 13 api-compare packages map to a real directory with a manifest, so none
  silently takes this path.)

`extract-ts-api.ts` calls `shape.keyFor(dirName)` per package; the key is
otherwise folded into the local and shared cache keys exactly as before.

## Effect

Closure sizes in this workspace, of 16 package directories: activesupport 2,
activemodel 3, globalid 3, rack 3, arel 4, actionview 5, activerecord 7,
actionpack 8, trailties 12 — **average 4.3**. A file added or deleted in a
package is now expected to invalidate roughly a quarter of the workspace
instead of all of it.

## Verification

- `scripts/api-compare/shared-cache.test.ts` (6 shape tests): contents-vs-shape
  invariance; unbuilt-dependency detection; a file added to a package outside
  the closure leaving the dependent keys byte-identical while a two-hop
  transitive dependency still invalidates them; the undeclared-but-linked
  dependency; the unknown-directory global fallback; cycle termination.
- Cached vs `API_COMPARE_FORCE=1` parity: both runs produce an identical
  `ts-api.json` (modulo `generatedAt`), with the second reporting 13/13 served
  from cache.
- Full `scripts/api-compare` suite (604 tests) and `node scripts/typecheck.mjs`
  green.

Closes-story: api-compare-resolution-shape-key-is-workspace-global
