### PR TITLE
feat(api-compare): record define_method / alias_method surface in the Ruby extractor

### DIFF
--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1054,21 +1054,6 @@ class ApiExtractor
     maybe_update_module_file(fqn, target)
   end
 
-  # Aliases are recorded with empty params (the `alias`/`alias_method` form
-  # names no parameters), but at runtime an alias shares its target method's
-  # arity. A faithful TS port spells the delegator with the real parameters, so
-  # the advisory arity check would false-flag the alias as a mismatch
-  # (ruby min:0,max:0 vs ts min:N,max:N). Resolve each alias to its target's
-  # param list — searching the same class/module bucket — so the comparison
-  # sees the true arity. Runs after all package files are processed (targets may
-  # be in a different file of a reopened class) and iterates to follow alias
-  # chains (`alias a b; alias b c`). Cross-class/inherited targets that aren't in
-  # the package stay empty (best-effort — the static walker can't see another
-  # gem's source) and are left WITHOUT the `aliasResolved` flag, which is what
-  # distinguishes them from an alias whose target legitimately takes zero
-  # arguments. Drops the transient `alias_target` key afterward so it never
-  # reaches the manifest.
-  # Public: invoked by `run` per package and by the extractor unit test.
   # Drop a `define_method` entry when a literal `def` of the same name already
   # occupies the same bucket. Ruby source can define a method both ways in
   # mutually exclusive branches the extractor walks unconditionally — rack's
@@ -1088,6 +1073,21 @@ class ApiExtractor
     end
   end
 
+  # Aliases are recorded with empty params (the `alias`/`alias_method` form
+  # names no parameters), but at runtime an alias shares its target method's
+  # arity. A faithful TS port spells the delegator with the real parameters, so
+  # the advisory arity check would false-flag the alias as a mismatch
+  # (ruby min:0,max:0 vs ts min:N,max:N). Resolve each alias to its target's
+  # param list — searching the same class/module bucket — so the comparison
+  # sees the true arity. Runs after all package files are processed (targets may
+  # be in a different file of a reopened class) and iterates to follow alias
+  # chains (`alias a b; alias b c`). Cross-class/inherited targets that aren't in
+  # the package stay empty (best-effort — the static walker can't see another
+  # gem's source) and are left WITHOUT the `aliasResolved` flag, which is what
+  # distinguishes them from an alias whose target legitimately takes zero
+  # arguments. Drops the transient `alias_target` key afterward so it never
+  # reaches the manifest.
+  # Public: invoked by `run` per package and by the extractor unit test.
   public def resolve_aliases!
     all = @classes.merge(@modules)
     # Candidate table per (fqn, bucket): the bucket's own methods first, then —
@@ -2405,9 +2405,11 @@ def run
     umbrella_file = "#{pkg_dir.sub(%r{/\z}, '')}.rb"
     extractor.scan_umbrella_file(umbrella_file, pkg_dir) if File.file?(umbrella_file)
 
+    # Drop define_method entries a literal `def` in the same bucket supersedes.
+    extractor.dedupe_define_methods!
+
     # Fill alias param lists from their targets now that every file in the
     # package has been seen (a reopened class may define the target elsewhere).
-    extractor.dedupe_define_methods!
     extractor.resolve_aliases!
 
     # Normalize into the JSON shape. Non-public methods are kept (tagged

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -468,9 +468,12 @@ class ApiExtractor
       # the literal-name form here, and the loop-unrolled interpolated form via
       # process_each_metaprogramming. Both leave the generic descent intact.
       process_each_metaprogramming(node)
-      process_define_method_block(node)
+      # When the call part is a recorded `define_method`, descend into the block
+      # only: re-walking the call would reach process_method_add_arg's
+      # define_method arm and record the same method a second time.
+      consumed_call = process_define_method_block(node)
       unless process_each_codegen(node)
-        node.each { |child| walk(child) if child.is_a?(Array) }
+        (consumed_call ? [node[2]] : node).each { |child| walk(child) if child.is_a?(Array) }
       end
     when :sclass
       process_sclass(node)
@@ -1066,6 +1069,25 @@ class ApiExtractor
   # arguments. Drops the transient `alias_target` key afterward so it never
   # reaches the manifest.
   # Public: invoked by `run` per package and by the extractor unit test.
+  # Drop a `define_method` entry when a literal `def` of the same name already
+  # occupies the same bucket. Ruby source can define a method both ways in
+  # mutually exclusive branches the extractor walks unconditionally — rack's
+  # `utils.rb:183` picks `define_method(:escape_html, ERB…)` or `def
+  # escape_html` off an `if defined?(ERB::Escape)` — and only one of the two is
+  # ever live. The literal `def` wins: it carries the deps, calls and body
+  # digest a metaprogrammed entry has no way to supply.
+  public def dedupe_define_methods!
+    (@classes.to_a + @modules.to_a).each do |_fqn, info|
+      [:instanceMethods, :classMethods].each do |bucket|
+        next unless info[bucket].any? { |m| m[:notes] == "define_method" }
+        literal = info[bucket].each_with_object(Set.new) do |m, acc|
+          acc << m[:name] unless m[:notes]
+        end
+        info[bucket].reject! { |m| m[:notes] == "define_method" && literal.include?(m[:name]) }
+      end
+    end
+  end
+
   public def resolve_aliases!
     all = @classes.merge(@modules)
     # Candidate table per (fqn, bucket): the bucket's own methods first, then —
@@ -1436,6 +1458,10 @@ class ApiExtractor
   end
 
   def process_define_method(args, params_node)
+    # Umbrella scans harvest only module-level singleton config (see
+    # process_def); anything else recorded there surfaces as false-missing.
+    return false if @scanning_umbrella
+
     list = positional_arg_list(args)
     return false unless list.is_a?(Array)
     name = literal_method_name(list[0])
@@ -1445,7 +1471,7 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return false unless target
 
-    record_metaprogrammed_method(target, name, extract_params(params_node), "define_method")
+    record_metaprogrammed_method(fqn, target, name, extract_params(params_node), "define_method")
     maybe_update_module_file(fqn, target)
     true
   end
@@ -1464,6 +1490,8 @@ class ApiExtractor
   # picked up by the plain define_method/alias_method recorders during the
   # generic descent. Returns true when it emitted anything.
   def process_each_metaprogramming(node)
+    return false if @scanning_umbrella
+
     call = node[1]
     return false unless call.is_a?(Array) && call[0] == :call
     return false unless ident_name(call[3]) == "each"
@@ -1488,10 +1516,10 @@ class ApiExtractor
         name = unrolled_name(list[0], loop_var, member)
         next unless name
         if kind == "define_method"
-          record_metaprogrammed_method(target, name, extract_params(params_node), "define_method")
+          record_metaprogrammed_method(fqn, target, name, extract_params(params_node), "define_method")
         else
           old = list[1] && unrolled_name(list[1], loop_var, member)
-          record_metaprogrammed_method(target, name, [], "alias", alias_target: old)
+          record_metaprogrammed_method(fqn, target, name, [], "alias", alias_target: old)
         end
         emitted = true
       end
@@ -1500,7 +1528,7 @@ class ApiExtractor
     emitted
   end
 
-  def record_metaprogrammed_method(target, name, params, notes, alias_target: nil)
+  def record_metaprogrammed_method(fqn, target, name, params, notes, alias_target: nil)
     entry = {
       name: name,
       visibility: current_visibility.to_s,
@@ -1512,7 +1540,10 @@ class ApiExtractor
     # Same as process_alias_method: the alias inherits the target's arity, so
     # record the target for resolve_aliases! to copy params from.
     entry[:alias_target] = alias_target if alias_target
-    target[@in_sclass ? :classMethods : :instanceMethods] << entry
+    # Same bucketing rule as process_def: `class << self` and `module_function`
+    # both make the generated method a class method.
+    on_class = @in_sclass || (@module_function_stack.last && @modules[fqn])
+    target[on_class ? :classMethods : :instanceMethods] << entry
   end
 
   # Members of a literal `[:a, :b]` / `%w[a b]` receiver, as strings. Any
@@ -2376,6 +2407,7 @@ def run
 
     # Fill alias param lists from their targets now that every file in the
     # package has been seen (a reopened class may define the target elsewhere).
+    extractor.dedupe_define_methods!
     extractor.resolve_aliases!
 
     # Normalize into the JSON shape. Non-public methods are kept (tagged

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -724,6 +724,14 @@ class ApiExtractor
       process_attr(args, :accessor, force_class: on_singleton)
     when "alias_method"
       process_alias_method(args)
+    when "define_method"
+      # Block-less bare-command form, `define_method :foo, &blk`. The block
+      # forms (`define_method :foo do … end`, `define_method(:foo) { … }`) do
+      # NOT arrive here: they are method_add_block nodes consumed by
+      # process_define_method_block, which needs the block to read the params
+      # off. This arm and the method_add_arg one below it exist so the two
+      # block-less shapes are handled as symmetrically as alias_method's.
+      process_define_method(args, nil)
     when "class_attribute"
       process_mattr(args, reader: true, writer: true, predicate: true, class_attr: true)
     when "cattr_accessor", "mattr_accessor"
@@ -803,8 +811,10 @@ class ApiExtractor
       when "module_function"
         process_module_function(node[2])
       when "define_method"
-        # Block-less `define_method(:foo, some_proc)`; the far commoner
-        # `define_method(:foo) { … }` arrives as a method_add_block instead.
+        # Block-less parenthesized form, `define_method(:foo, some_proc)` —
+        # the counterpart of process_command's bare-command arm. The far
+        # commoner `define_method(:foo) { … }` is a method_add_block instead,
+        # and the descent guard in walk keeps it from reaching here twice.
         process_define_method(node[2], nil)
       end
     else

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -463,6 +463,12 @@ class ApiExtractor
       # (e.g. relation/query_methods.rb's VALUE_METHODS loop). Falls through to
       # the generic child-walk when it isn't a recognized codegen loop so normal
       # blocks (`included do … end`, `scope :x do … end`) keep working.
+      #
+      # `define_method`/`alias_method` metaprogramming is recorded alongside:
+      # the literal-name form here, and the loop-unrolled interpolated form via
+      # process_each_metaprogramming. Both leave the generic descent intact.
+      process_each_metaprogramming(node)
+      process_define_method_block(node)
       unless process_each_codegen(node)
         node.each { |child| walk(child) if child.is_a?(Array) }
       end
@@ -793,6 +799,10 @@ class ApiExtractor
         process_delegate(node[2])
       when "module_function"
         process_module_function(node[2])
+      when "define_method"
+        # Block-less `define_method(:foo, some_proc)`; the far commoner
+        # `define_method(:foo) { … }` arrives as a method_add_block instead.
+        process_define_method(node[2], nil)
       end
     else
       walk(node[1]) if node[1].is_a?(Array)
@@ -1411,6 +1421,210 @@ class ApiExtractor
       }
     end
     maybe_update_module_file(fqn, target)
+  end
+
+  # `define_method "<name>" do … end` / `define_method(:name) { … }` with a name
+  # that is a plain literal. The block's parameters become the method's params,
+  # so a metaprogrammed method carries the same arity information a literal
+  # `def` would. A name that isn't a bare literal (an interpolation, a local
+  # variable, a constant) is skipped, never guessed — the loop-unrolled
+  # interpolation case is handled by process_each_metaprogramming instead.
+  def process_define_method_block(node)
+    name, args = meta_call_parts(node[1])
+    return false unless name == "define_method"
+    process_define_method(args, block_params_node(node[2]))
+  end
+
+  def process_define_method(args, params_node)
+    list = positional_arg_list(args)
+    return false unless list.is_a?(Array)
+    name = literal_method_name(list[0])
+    return false unless name
+
+    fqn = current_fqn
+    target = @classes[fqn] || @modules[fqn]
+    return false unless target
+
+    record_metaprogrammed_method(target, name, extract_params(params_node), "define_method")
+    maybe_update_module_file(fqn, target)
+    true
+  end
+
+  # Unrolls a literal-array `.each` loop that metaprograms methods whose names
+  # interpolate the loop variable (abstract_controller/callbacks.rb:230):
+  #
+  #   [:before, :after, :around].each do |callback|
+  #     define_method "#{callback}_action" do |*names, &blk| … end
+  #     alias_method :"append_#{callback}_action", :"#{callback}_action"
+  #   end
+  #
+  # Emits one entry per generated name (twelve, above). Only names that
+  # actually interpolate the loop variable are unrolled: a loop-invariant
+  # literal name would otherwise be recorded once per member, and it is already
+  # picked up by the plain define_method/alias_method recorders during the
+  # generic descent. Returns true when it emitted anything.
+  def process_each_metaprogramming(node)
+    call = node[1]
+    return false unless call.is_a?(Array) && call[0] == :call
+    return false unless ident_name(call[3]) == "each"
+    members = literal_array_members(call[1])
+    return false unless members && !members.empty?
+
+    block = node[2]
+    return false unless block.is_a?(Array) &&
+                        [:do_block, :brace_block].include?(block[0])
+    loop_var = block_param_name(block)
+    return false unless loop_var
+
+    fqn = current_fqn
+    target = @classes[fqn] || @modules[fqn]
+    return false unless target
+
+    emitted = false
+    each_metaprogramming_call(block[2]) do |kind, args, params_node|
+      list = positional_arg_list(args)
+      next unless list.is_a?(Array)
+      members.each do |member|
+        name = unrolled_name(list[0], loop_var, member)
+        next unless name
+        if kind == "define_method"
+          record_metaprogrammed_method(target, name, extract_params(params_node), "define_method")
+        else
+          old = list[1] && unrolled_name(list[1], loop_var, member)
+          record_metaprogrammed_method(target, name, [], "alias", alias_target: old)
+        end
+        emitted = true
+      end
+    end
+    maybe_update_module_file(fqn, target) if emitted
+    emitted
+  end
+
+  def record_metaprogrammed_method(target, name, params, notes, alias_target: nil)
+    entry = {
+      name: name,
+      visibility: current_visibility.to_s,
+      params: params,
+      file: @current_file,
+      line: @current_line,
+      notes: notes,
+    }
+    # Same as process_alias_method: the alias inherits the target's arity, so
+    # record the target for resolve_aliases! to copy params from.
+    entry[:alias_target] = alias_target if alias_target
+    target[@in_sclass ? :classMethods : :instanceMethods] << entry
+  end
+
+  # Members of a literal `[:a, :b]` / `%w[a b]` receiver, as strings. Any
+  # non-literal element (a constant, a splat, an interpolation) disqualifies the
+  # whole array — an unrollable loop must be fully known.
+  def literal_array_members(node)
+    return nil unless node.is_a?(Array) && node[0] == :array
+    elems = node[1]
+    return nil unless elems.is_a?(Array)
+    members = []
+    elems.each do |el|
+      name = literal_method_name(el)
+      return nil unless name
+      members << name
+    end
+    members
+  end
+
+  # A bare literal name: `:foo`, `"foo"`, or a `%w[]`/`%i[]` element. Returns
+  # nil for anything interpolated or computed.
+  def literal_method_name(node)
+    return nil unless node.is_a?(Array)
+    case node[0]
+    when :symbol_literal
+      symbol_name(node)
+    when :@tstring_content
+      node[1]
+    when :string_literal, :dyna_symbol
+      content = node[1]
+      return nil unless content.is_a?(Array) && content[0] == :string_content
+      parts = content[1..]
+      return nil unless parts.length == 1
+      part = parts[0]
+      part.is_a?(Array) && part[0] == :@tstring_content ? part[1] : nil
+    end
+  end
+
+  # Resolve a name node for one unrolled loop member. Every part must be either
+  # literal text or an interpolation of exactly `loop_var`, and at least one
+  # such interpolation must be present; anything else returns nil.
+  def unrolled_name(node, loop_var, member)
+    return nil unless node.is_a?(Array)
+    return nil unless [:string_literal, :dyna_symbol].include?(node[0])
+    content = node[1]
+    return nil unless content.is_a?(Array) && content[0] == :string_content
+    out = +""
+    saw_var = false
+    content[1..].each do |part|
+      return nil unless part.is_a?(Array)
+      case part[0]
+      when :@tstring_content
+        out << part[1]
+      when :string_embexpr
+        return nil unless embexpr_var(part) == loop_var
+        saw_var = true
+        out << member
+      else
+        return nil
+      end
+    end
+    saw_var && !out.empty? ? out : nil
+  end
+
+  # Yield each `define_method`/`alias_method` call in a loop body as
+  # [command_name, args_node, block_params_node]. Does not descend into literal
+  # `def`s (those are the extractor's normal business, not codegen).
+  def each_metaprogramming_call(node, &blk)
+    return unless node.is_a?(Array)
+    return if [:def, :defs].include?(node[0])
+    if node[0] == :method_add_block
+      name, args = meta_call_parts(node[1])
+      if name
+        yield name, args, block_params_node(node[2])
+        return
+      end
+    else
+      name, args = meta_call_parts(node)
+      if name
+        yield name, args, nil
+        return
+      end
+    end
+    node.each { |child| each_metaprogramming_call(child, &blk) if child.is_a?(Array) }
+  end
+
+  # [command_name, args_node] when `node` is a `define_method`/`alias_method`
+  # call in either the command (`define_method :x`) or paren
+  # (`define_method(:x)`) form; [nil, nil] otherwise.
+  def meta_call_parts(node)
+    return [nil, nil] unless node.is_a?(Array)
+    case node[0]
+    when :command
+      name = ident_name(node[1])
+      %w[define_method alias_method].include?(name) ? [name, node[2]] : [nil, nil]
+    when :method_add_arg
+      fcall = node[1]
+      return [nil, nil] unless fcall.is_a?(Array) && fcall[0] == :fcall
+      name = ident_name(fcall[1])
+      %w[define_method alias_method].include?(name) ? [name, node[2]] : [nil, nil]
+    else
+      [nil, nil]
+    end
+  end
+
+  # The `[:params, …]` node of a `do`/`{}` block, or nil when it takes none.
+  def block_params_node(block)
+    return nil unless block.is_a?(Array) &&
+                      [:do_block, :brace_block].include?(block[0])
+    block_var = block[1]
+    return nil unless block_var.is_a?(Array) && block_var[0] == :block_var
+    params = block_var[1]
+    params.is_a?(Array) && params[0] == :params ? params : nil
   end
 
   # Models the enumerable `class_eval`/`define_method` codegen loop

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -972,7 +972,12 @@ describe("Ruby extractor file constants", () => {
 describe("Ruby extractor metaprogrammed method surface", () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  type MetaMethod = { name: string; notes?: string; params: { kind: string }[] };
+  type MetaMethod = {
+    name: string;
+    notes?: string;
+    visibility: string;
+    params: { kind: string }[];
+  };
 
   // Returns "<fqn>" -> instance methods, so a test can assert both the
   // generated names and the params lifted off the define_method block.
@@ -985,9 +990,11 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         require "json"
         ex = ApiExtractor.new
         ex.process_file(File.join(${JSON.stringify(dir)}, "meta.rb"), ${JSON.stringify(dir)})
+        ex.dedupe_define_methods!
         out = {}
         (ex.classes.to_a + ex.modules.to_a).each do |fqn, info|
           out[fqn] = info[:instanceMethods]
+          out["#{fqn}.self"] = info[:classMethods]
         end
         puts JSON.generate(out)
       `;
@@ -1049,6 +1056,40 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     expect(appendBefore.notes).toBe("alias");
   });
 
+  it("buckets a `class << self` define_method as a class method", () => {
+    const m = metaMethods(`
+      class Base
+        class << self
+          define_method(:configure) { nil }
+        end
+
+        private
+
+        define_method(:normalize) { nil }
+      end
+    `);
+    expect(m["Base.self"].map((x) => x.name)).toEqual(["configure"]);
+    const normalize = m["Base"].find((x) => x.name === "normalize")!;
+    expect(normalize.visibility).toBe("private");
+  });
+
+  it("keeps the literal def when a branch defines the same name both ways", () => {
+    // rack utils.rb:183 — `define_method(:escape_html, …)` or `def escape_html`
+    // off an `if defined?(…)`; the extractor walks both branches, only one is live.
+    const m = metaMethods(`
+      module Utils
+        if defined?(ERB::Escape)
+          define_method(:escape_html, ERB::Escape.instance_method(:html_escape))
+        else
+          def escape_html(string)
+            CGI.escapeHTML(string.to_s)
+          end
+        end
+      end
+    `);
+    expect(m["Utils"].map((x) => [x.name, x.notes])).toEqual([["escape_html", undefined]]);
+  });
+
   it("skips a define_method whose name cannot be resolved to literals", () => {
     const m = metaMethods(`
       module Unresolvable
@@ -1070,5 +1111,6 @@ describe("Ruby extractor metaprogrammed method surface", () => {
       end
     `);
     expect(m["Unresolvable"] ?? []).toEqual([]);
+    expect(m["Unresolvable.self"] ?? []).toEqual([]);
   });
 });

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -968,3 +968,107 @@ describe("Ruby extractor file constants", () => {
     expect(c["VALID_OPTIONS"]).toEqual({ kind: "expr" });
   });
 });
+
+describe("Ruby extractor metaprogrammed method surface", () => {
+  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+
+  type MetaMethod = { name: string; notes?: string; params: { kind: string }[] };
+
+  // Returns "<fqn>" -> instance methods, so a test can assert both the
+  // generated names and the params lifted off the define_method block.
+  function metaMethods(src: string): Record<string, MetaMethod[]> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meta-rb-"));
+    try {
+      fs.writeFileSync(path.join(dir, "meta.rb"), src);
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        ex = ApiExtractor.new
+        ex.process_file(File.join(${JSON.stringify(dir)}, "meta.rb"), ${JSON.stringify(dir)})
+        out = {}
+        (ex.classes.to_a + ex.modules.to_a).each do |fqn, info|
+          out[fqn] = info[:instanceMethods]
+        end
+        puts JSON.generate(out)
+      `;
+      return JSON.parse(execFileSync("ruby", ["-e", driver], { encoding: "utf-8" }));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("records define_method with a literal name", () => {
+    const m = metaMethods(`
+      module Engine
+        define_method(:railtie_routes_url_helpers) { |include_path_helpers = true| nil }
+        define_method "railtie_helpers_paths" do
+          nil
+        end
+      end
+    `);
+    const names = m["Engine"].map((x) => x.name);
+    expect(names).toContain("railtie_routes_url_helpers");
+    expect(names).toContain("railtie_helpers_paths");
+    const urlHelpers = m["Engine"].find((x) => x.name === "railtie_routes_url_helpers")!;
+    expect(urlHelpers.notes).toBe("define_method");
+    // The block's params are the generated method's params.
+    expect(urlHelpers.params.map((p) => p.kind)).toEqual(["optional"]);
+  });
+
+  it("unrolls a literal-array each loop that interpolates the loop variable", () => {
+    const m = metaMethods(`
+      module ClassMethods
+        [:before, :after, :around].each do |callback|
+          define_method "#{callback}_action" do |*names, &blk|
+            nil
+          end
+
+          define_method "skip_#{callback}_action" do |*names|
+            nil
+          end
+
+          alias_method :"append_#{callback}_action", :"#{callback}_action"
+        end
+      end
+    `);
+    const names = m["ClassMethods"].map((x) => x.name);
+    expect(names).toEqual([
+      "before_action",
+      "after_action",
+      "around_action",
+      "skip_before_action",
+      "skip_after_action",
+      "skip_around_action",
+      "append_before_action",
+      "append_after_action",
+      "append_around_action",
+    ]);
+    const beforeAction = m["ClassMethods"].find((x) => x.name === "before_action")!;
+    expect(beforeAction.params.map((p) => p.kind)).toEqual(["rest", "block"]);
+    const appendBefore = m["ClassMethods"].find((x) => x.name === "append_before_action")!;
+    expect(appendBefore.notes).toBe("alias");
+  });
+
+  it("skips a define_method whose name cannot be resolved to literals", () => {
+    const m = metaMethods(`
+      module Unresolvable
+        SUFFIXES.each do |suffix|
+          define_method "reader_#{suffix}" do
+            nil
+          end
+        end
+
+        [:a, :b].each do |member|
+          define_method "#{member}_#{prefix}" do
+            nil
+          end
+        end
+
+        column_names.each do |name|
+          define_method(name) { nil }
+        end
+      end
+    `);
+    expect(m["Unresolvable"] ?? []).toEqual([]);
+  });
+});

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1056,6 +1056,30 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     expect(appendBefore.notes).toBe("alias");
   });
 
+  it("records both block-less define_method shapes exactly once", () => {
+    // Bare command (action_view/layouts.rb:311's shape) and parenthesized
+    // (rack/utils.rb:183's). The block forms below must not be recorded twice
+    // by the generic descent re-reaching process_command / method_add_arg.
+    const m = metaMethods(`
+      module Shapes
+        define_method :from_proc, &_layout
+        define_method(:from_method, Kernel.instance_method(:inspect))
+        define_method :with_do_block do |a|
+          nil
+        end
+        define_method(:with_brace_block) { |a| nil }
+      end
+    `);
+    expect(m["Shapes"].map((x) => x.name)).toEqual([
+      "from_proc",
+      "from_method",
+      "with_do_block",
+      "with_brace_block",
+    ]);
+    // Only the block forms can supply params; the block-less ones stay empty.
+    expect(m["Shapes"].map((x) => x.params.length)).toEqual([0, 0, 1, 1]);
+  });
+
   it("buckets a `class << self` define_method as a class method", () => {
     const m = metaMethods(`
       class Base


### PR DESCRIPTION
`scripts/api-compare/extract-ruby-api.rb` recorded only literal `def`s, so every
method Rails generates with `define_method` was absent from `rails-api.json` and
the ported TS counterpart read as EXTRA surface rather than as a match.

## What's recorded now

- **Literal-name `define_method`** — `define_method(:railtie_routes_url_helpers) { … }`
  / `define_method "foo" do … end`. The block's parameters become the generated
  method's params, so arity comparison works the same as for a literal `def`.
  Bucketing follows `process_def`: `class << self` and `module_function` make it
  a class method, `private`/`protected` carry through, umbrella scans skip it.
- **Loop-unrolled interpolated names** — a `.each` over a fully literal array
  (`[:before, :after, :around]`, `%w(reverse tidy_bytes)`) whose `define_method`
  / `alias_method` names interpolate the loop variable, emitted one entry per
  generated name. `alias_method` records its `alias_target` so `resolve_aliases!`
  fills in the real param list, as the existing recorder does.
- **Guard arm** — a name that can't be resolved to literals is skipped, never
  guessed: a bare local (`define_method(key)`, `encryption/config.rb:42`), a
  non-literal array member, a second interpolated variable. Only names that
  actually interpolate the loop variable are unrolled, so a loop-invariant
  literal name isn't emitted once per member.
- **Collision rule** — when a literal `def` of the same name already occupies
  the bucket, the `define_method` entry is dropped. Rack's `utils.rb:183`
  defines `escape_html` both ways off an `if defined?(ERB::Escape)` and the
  extractor walks both branches; the literal `def` wins because it carries the
  deps, calls and body digest a metaprogrammed entry can't supply.

All four call shapes are handled: bare-command and parenthesized, each with
and without a block. Only the block forms can supply params. Every arm is
covered by tests in `extract-ruby-api.test.ts`, driven through the real Ripper
parser like the rest of that suite.

## Effect

19 new Ruby methods across the vendored sources, 0 removed — diffed against
`origin/main`'s extractor over the same vendor tree:

| package | added |
| --- | --- |
| `abstractcontroller` | 12 — the `*_action` macros (`callbacks.rb:230`) |
| `activerecord` | 5 — `Encryption::Config#has_*?`, two `#inspect` |
| `activesupport` | 2 — `Multibyte::Chars#reverse!` / `#tidy_bytes!` |

- `api:extra` for `abstractcontroller`: **6 files / 14 novel / 25 total → 5
  files / 2 novel / 19 total**. `actioncontroller` reclassifies one entry from
  novel to moved; every other package is byte-identical (both sides measured
  from a full `API_COMPARE_FORCE=1` rebuild).
- `api:compare` for `callbacks.rb` goes **9/11 → 15/23**. The six new misses are
  `prepend_*_action` and `append_*_action`, which genuinely aren't ported — the
  extractor blind spot was hiding them.
- `api:calls`, `api:calls:wide`, `api:arity`, `api:pins` all still pass, and no
  generated manifest under `eslint/` changed.

## Review follow-up: the bare-command block-less shape

Review asked whether `process_command` lacking a `define_method` arm (so
`define_method :foo, &blk` — no parens, no block — went unrecorded while
`alias_method` was handled in both forms) was intentional. **It wasn't; the arm
is now added.**

The review's reading of the vendor tree is correct and confirmed:
`action_view/layouts.rb:311` is the *only* bare-command block-less instance in
the whole tree, it sits inside `def _write_layout_method`, and `process_def`
never descends into method bodies — so it stays uncaptured either way, which is
the right outcome (`_layout_from_proc` is defined per-including-class at
runtime from the `when Proc` layout branch; attributing it to
`Layouts::ClassMethods` would be wrong). Every other bare-command
`define_method` in vendor carries a `do … end` block and was already handled.

So the arm is inert today — verified by extracting with and without it over the
same vendor tree: `rails-api.json`'s `packages` is **byte-identical** (only
`generatedAt` and `extractorHash`, which hashes the script itself, move). It's
added anyway because the extractor should record the Ruby *shape*, not the
shapes today's pinned Rails happens to use — the tree is re-fetched by
`pnpm vendor:fetch`. Both block-less shapes now have a test asserting they're
recorded exactly once, alongside the block forms, which the descent guard in
`walk` keeps from being double-recorded.

## Note on the story's third acceptance criterion

The twelve `@noRailsEquivalent` tags this story expected to delete are no longer
in the tree — #5332 already relocated the action-callback macros and dropped
them. `pnpm api:extra` reports 80 tags, 80 matched, so there are no stale tags.

Closes-story: ruby-extractor-records-metaprogrammed-methods
