### PR TITLE
ci(vendor): run vendor/sources.test.ts on vendor source changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,14 @@ jobs:
           # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
           # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
           # to the root config must still run the guard.
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$)'
+          # vendor/sources.test.ts asserts an exact set over SOURCES, so it
+          # rots the moment vendor/sources.ts gains or renames a source — the
+          # failures #5347 found had sat unnoticed since #1621. It runs on
+          # this gate, so name its inputs here: without them a PR that edits
+          # only vendor/sources.ts would skip the only job asserting on it.
+          # (vendor/fetch.test.ts stays unrun — it needs a fetched vendor/
+          # tree; story run-vendor-fetch-tests-in-ci.)
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -710,6 +717,7 @@ jobs:
           scripts/rails-file-structure-mixins.test.ts
           scripts/deprecated-manifest-diff.test.ts
           scripts/ci-suite-coverage.test.ts
+          vendor/sources.test.ts
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack
   # (~27 s), actionview (~26 s), tse-compiler (~22 s), and the DX type tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,6 @@ jobs:
           # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
           # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
           # to the root config must still run the guard.
-          # vendor/sources.test.ts asserts an exact set over SOURCES, so it
-          # rots the moment vendor/sources.ts gains or renames a source — the
-          # failures #5347 found had sat unnoticed since #1621. It runs on
-          # this gate, so name its inputs here: without them a PR that edits
-          # only vendor/sources.ts would skip the only job asserting on it.
-          # (vendor/fetch.test.ts stays unrun — it needs a fetched vendor/
-          # tree; story run-vendor-fetch-tests-in-ci.)
           UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,11 @@ jobs:
           # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
           # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
           # to the root config must still run the guard.
+          # vendor/fetch.ts is gated here but asserted over by nothing that
+          # runs yet: vendor/fetch.test.ts is KNOWN_UNRUN (needs a fetched
+          # vendor/ tree — story run-vendor-fetch-tests-in-ci). It is NOT in
+          # ci-suite-coverage's GATE_INPUTS, which lists only what
+          # vendor/sources.test.ts actually reads.
           UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,11 +201,6 @@ jobs:
           # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
           # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
           # to the root config must still run the guard.
-          # vendor/fetch.ts is gated here but asserted over by nothing that
-          # runs yet: vendor/fetch.test.ts is KNOWN_UNRUN (needs a fetched
-          # vendor/ tree — story run-vendor-fetch-tests-in-ci). It is NOT in
-          # ci-suite-coverage's GATE_INPUTS, which lists only what
-          # vendor/sources.test.ts actually reads.
           UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -35,7 +35,11 @@ const KNOWN_UNRUN: Record<string, string> = {
 // of these declares or renames a source; matching the test file alone is not
 // enough, because the file that drifts is the one it asserts over.
 const GATE_INPUTS: Record<string, string[]> = {
-  UNIT_TESTS_PKGS_RE: ["vendor/sources.ts", "vendor/sources.lock.json", "vendor/fetch.ts"],
+  UNIT_TESTS_PKGS_RE: [
+    "vendor/sources.ts",
+    "vendor/sources.lock.json",
+    "scripts/api-compare/config.ts",
+  ],
 };
 
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -30,6 +30,14 @@ const KNOWN_UNRUN: Record<string, string> = {
   "vendor/fetch.test.ts": "run-vendor-fetch-tests-in-ci",
 };
 
+// Non-test inputs whose change must re-run a suite CI names. vendor/
+// sources.test.ts asserts exact sets over SOURCES, so it rots the moment one
+// of these declares or renames a source; matching the test file alone is not
+// enough, because the file that drifts is the one it asserts over.
+const GATE_INPUTS: Record<string, string[]> = {
+  UNIT_TESTS_PKGS_RE: ["vendor/sources.ts", "vendor/sources.lock.json", "vendor/fetch.ts"],
+};
+
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
 
 async function collectTestFiles(dir: string, acc: string[]): Promise<string[]> {
@@ -99,6 +107,13 @@ function unitTestsJob(yml: string): string {
   return lines.slice(start, end === -1 ? undefined : end).join("\n");
 }
 
+/** The changed-path regex a gate name resolves to in the `changes` job. */
+function gateRegex(yml: string, name: string): RegExp {
+  const source = yml.match(new RegExp(`${name}='([^']+)'`))?.[1];
+  if (source === undefined) throw new Error(`no ${name} in ci.yml`);
+  return new RegExp(source);
+}
+
 describe("CI runs every tooling test suite", () => {
   it("covers each scripts/eslint/vendor test file with a ci.yml vitest filter", async () => {
     const yml = await readFile(CI_YML, "utf8");
@@ -126,9 +141,7 @@ describe("CI runs every tooling test suite", () => {
   // exactly when it is the thing that changed.
   it("matches every unit-tests filter against the gate that runs the job", async () => {
     const yml = await readFile(CI_YML, "utf8");
-    const gateSource = yml.match(/UNIT_TESTS_PKGS_RE='([^']+)'/)?.[1];
-    expect(gateSource).toBeDefined();
-    const gate = new RegExp(gateSource as string);
+    const gate = gateRegex(yml, "UNIT_TESTS_PKGS_RE");
 
     const filters = ciVitestFilters(unitTestsJob(yml));
     expect(filters.length).toBeGreaterThan(5);
@@ -138,6 +151,16 @@ describe("CI runs every tooling test suite", () => {
       (f) => !gate.test(f.endsWith(".ts") ? f : `${f.replace(/\/?$/, "/")}probe.test.ts`),
     );
     expect(ungated).toEqual([]);
+  });
+
+  it("matches each gate against the non-test inputs its suites assert over", async () => {
+    const yml = await readFile(CI_YML, "utf8");
+    const unmatched: string[] = [];
+    for (const [name, inputs] of Object.entries(GATE_INPUTS)) {
+      const gate = gateRegex(yml, name);
+      unmatched.push(...inputs.filter((input) => !gate.test(input)));
+    }
+    expect(unmatched).toEqual([]);
   });
 
   it("keeps KNOWN_UNRUN free of entries CI already runs", async () => {

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -28,7 +28,6 @@ const KNOWN_UNRUN: Record<string, string> = {
   // vendor/fetch.test.ts fails outside a freshly fetched vendor/ tree.
   // Story: run-vendor-fetch-tests-in-ci.
   "vendor/fetch.test.ts": "run-vendor-fetch-tests-in-ci",
-  "vendor/sources.test.ts": "run-vendor-fetch-tests-in-ci",
 };
 
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -34,6 +34,13 @@ const KNOWN_UNRUN: Record<string, string> = {
 // sources.test.ts asserts exact sets over SOURCES, so it rots the moment one
 // of these declares or renames a source; matching the test file alone is not
 // enough, because the file that drifts is the one it asserts over.
+//
+// vendor/fetch.ts is in UNIT_TESTS_PKGS_RE but deliberately NOT here:
+// vendor/sources.test.ts never reads it. It is gated for vendor/fetch.test.ts,
+// still KNOWN_UNRUN above. This note lives here rather than in ci.yml because
+// the changes job's inline `run:` script is ~200 bytes under a hard Actions
+// size limit — pushing it over makes the whole workflow fail at startup, with
+// no jobs and no checks reported at all.
 const GATE_INPUTS: Record<string, string[]> = {
   UNIT_TESTS_PKGS_RE: [
     "vendor/sources.ts",


### PR DESCRIPTION
`vendor/sources.test.ts` asserts exact sets over `SOURCES`, so it rots the
moment `vendor/sources.ts` gains or renames a source. #5347 found four
assertions that had been wrong since #1621 — nothing ran the suite: it sat on
`ci-suite-coverage`'s `KNOWN_UNRUN` list, and no CI vitest invocation named
`vendor/*.test.ts`.

## Change

- `unit-tests` runs `vendor/sources.test.ts` (no fetched `vendor/` tree, no
  Ruby, ~30 ms), and it leaves `KNOWN_UNRUN`. `vendor/fetch.test.ts` stays —
  it needs a freshly fetched tree (story `run-vendor-fetch-tests-in-ci`).
- `UNIT_TESTS_PKGS_RE` now matches `vendor/sources.ts`,
  `vendor/sources.lock.json`, `vendor/sources.test.ts` and `vendor/fetch.ts`,
  so editing a source declaration flips `unit_tests_affected`. Push to `main`
  / schedule / dispatch already force it true via `force_all_affected`.
- `GATE_INPUTS` lists only what `vendor/sources.test.ts` actually reads:
  `vendor/sources.ts`, `vendor/sources.lock.json`, and
  `scripts/api-compare/config.ts` (imported at `sources.test.ts:114` for the
  `apiComparePackages` assertions). `vendor/fetch.ts` is gated in ci.yml but
  deliberately absent from `GATE_INPUTS` — the suite never touches it; it is
  gated for `vendor/fetch.test.ts`, still `KNOWN_UNRUN`; the note explaining
  that lives in the test file, not ci.yml (see below).
- New `ci-suite-coverage` case: each gate must match the **non-test inputs**
  its suites assert over (`GATE_INPUTS`). The existing gate test only checked
  the vitest *filters* — a filter naming `vendor/sources.test.ts` while the
  gate ignored `vendor/sources.ts` would still be dead exactly when the source
  drifts. That was the rot vector; it is now a failing test rather than a
  convention.

## Verification

- `pnpm vitest run scripts/ci-suite-coverage.test.ts vendor/sources.test.ts` —
  25 passed. Removing `api-compare` from the gate fails the new case, so the
  added input has teeth.
- Drift demo A (the gate): deleting the `vendor/…` clause from
  `UNIT_TESTS_PKGS_RE` fails 2 `ci-suite-coverage` tests, including the new
  one. Restored and re-verified green.
- Drift demo B (the expectations): renaming `actionpackversion` in
  `vendor/sources.test.ts`'s expected sets fails 2 tests — the class of defect
  #5347 fixed, now caught by CI.
- This PR edits `.github/workflows/ci.yml` (`INFRA_RE`), so
  `unit_tests_affected` is true here and the newly wired suite runs in this
  very run.

## Why no ci.yml comment

An earlier revision documented the `vendor/` clause with a 5-line comment in the
`changes` job. That made **the entire workflow fail at startup** — a 0s
`push`-event run with zero jobs, `no checks reported on the branch`, and no
`pull_request` run created at all. The YAML is valid; the cause is a hard
Actions size limit on that job's inline `run:` script, which `main` already sits
just under. Bisected with single-hunk scratch branches off `main`:

| filter-step `run:` size | starts? |
| --- | --- |
| 20,625 B (`main`) | yes |
| 20,695 B (this PR's two code hunks) | yes |
| 20,919 B (+ the 5-line comment) | **no** |
| 20,991 B (earlier head) | **no** |

So the prose moved to `GATE_INPUTS` in `scripts/ci-suite-coverage.test.ts`, where
it costs no workflow bytes, and it records the ceiling for whoever edits this
block next. Anyone adding to the `changes` job should measure first:

```
python3 -c "import yaml;d=yaml.safe_load(open('.github/workflows/ci.yml'));print(len([s for s in d['jobs']['changes']['steps'] if s.get('id')=='filter'][0]['run']))"
```

Closes-story: ci-vendor-sources-tests-path-filter-rot
