### PR TITLE
fix(test): cancel only the test's own backend in pg transaction test

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -129,8 +129,13 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.beginDbTransaction();
         await adapter.execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE");
-        // `other` blocks on `adapter`'s row; a third connection cancels it via
-        // pg_stat_activity (mirrors Rails). Handler attached at creation (vitest).
+        // `other` blocks on `adapter`'s row; a third connection cancels it by
+        // pid. Rails cancels its own session's thread; matching a
+        // pg_stat_activity query pattern would cancel sibling workers' `FOR
+        // UPDATE` queries on the shared CI database.
+        const otherRows = await other.execute("SELECT pg_backend_pid() AS pid");
+        const otherPid = (otherRows[0] as { pid: number }).pid;
+        // Handler attached at creation (vitest fails on unhandled rejections).
         let blockedError: unknown;
         const blocked = other
           .execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE")
@@ -140,12 +145,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         await new Promise<void>((r) => setTimeout(r, 200));
         const canceler = new PostgreSQLAdapter(PG_TEST_URL);
         try {
-          // Assert the cancel matched, else a no-op leaves `blocked` to timeout.
-          const sent = await canceler.execute(
-            "SELECT pg_cancel_backend(pid) AS ok FROM pg_stat_activity " +
-              "WHERE state = 'active' AND query LIKE '% FOR UPDATE'",
-          );
-          expect(sent.length).toBe(1);
+          // Assert the cancel landed, else a no-op leaves `blocked` to timeout.
+          const sent = await canceler.execute("SELECT pg_cancel_backend(?) AS ok", [otherPid]);
+          expect((sent[0] as { ok: boolean }).ok).toBe(true);
           await blocked;
           expect(blockedError).toBeInstanceOf(QueryCanceled);
         } finally {

--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -129,23 +129,33 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.beginDbTransaction();
         await adapter.execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE");
-        // `other` blocks on `adapter`'s row; a third connection cancels it by
-        // pid. Rails cancels its own session's thread; matching a
-        // pg_stat_activity query pattern would cancel sibling workers' `FOR
-        // UPDATE` queries on the shared CI database.
         const otherRows = await other.execute("SELECT pg_backend_pid() AS pid");
         const otherPid = (otherRows[0] as { pid: number }).pid;
-        // Handler attached at creation (vitest fails on unhandled rejections).
         let blockedError: unknown;
         const blocked = other
           .execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE")
           .catch((e) => {
             blockedError = e;
           });
-        await new Promise<void>((r) => setTimeout(r, 200));
         const canceler = new PostgreSQLAdapter(PG_TEST_URL);
         try {
-          // Assert the cancel landed, else a no-op leaves `blocked` to timeout.
+          // Under vitest's 5s default testTimeout, so a stuck poll fails the
+          // `waiting` assertion instead of dying as an opaque test timeout.
+          const deadline = Date.now() + 3000;
+          let waiting = false;
+          while (Date.now() < deadline) {
+            const rows = await canceler.execute(
+              "SELECT 1 AS n FROM pg_stat_activity " +
+                "WHERE pid = ? AND state = 'active' AND wait_event_type = 'Lock'",
+              [otherPid],
+            );
+            if (rows.length === 1) {
+              waiting = true;
+              break;
+            }
+            await new Promise<void>((r) => setTimeout(r, 50));
+          }
+          expect(waiting).toBe(true);
           const sent = await canceler.execute("SELECT pg_cancel_backend(?) AS ok", [otherPid]);
           expect((sent[0] as { ok: boolean }).ok).toBe(true);
           await blocked;


### PR DESCRIPTION
`transaction.test.ts` cancelled the blocked query by pattern-matching
`pg_stat_activity`:

```sql
SELECT pg_cancel_backend(pid) FROM pg_stat_activity
WHERE state = 'active' AND query LIKE '% FOR UPDATE'
```

On the shared CI database that can cancel a **sibling vitest worker's**
in-flight `FOR UPDATE` query. Observed on #5119 (run 29976288962, PG shard 2):
every test file passed but the job failed on a run-end vitest
`Unhandled Rejection: QueryCanceled: canceling statement due to user request`
attributed to no test.

Rails' equivalent cancels only its own session's thread. This captures
`pg_backend_pid()` from the `other` connection before it blocks and cancels
that pid — the idiom already used by the sibling "raises Interrupt when
canceling statement via interrupt" test above.

## Keeping the guard as strong as the one it replaces

Cancelling by pid after the old fixed 200 ms sleep would have been a *weaker*
guard: `pg_cancel_backend` returns `true` for an idle backend, so if `other`
had not yet reached the lock the cancel would no-op and leave `blocked`
pending until the test timed out. The pattern match, for all its
cross-worker damage, at least proved a real `FOR UPDATE` was active.

So the fixed sleep is replaced by a poll on `pg_stat_activity` for **our own
pid's** `Lock` wait, asserted before cancelling. That restores the "a really
blocked query was cancelled" guarantee while staying scoped to this test's
backend. The poll deadline is 3 s, under vitest's 5 s default `testTimeout`,
so a stuck poll fails the `waiting` assertion rather than dying as an opaque
timeout. Dropping the unconditional sleep also makes the test faster.

Verified against an isolated PG stack: 6/6 pass.

Closes-story: pg-cancel-backend-pattern-cancels-sibling-workers
