### PR TITLE
refactor(test-helpers): pair second-pool setup with its restore via withSecondPool

### DIFF
--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -190,8 +190,6 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     "priceEstimates",
   ]);
 
-  // The "alternate database" test below needs the arunit2 split; declaring it
-  // at suite scope keeps the primary-database restore paired with the setup.
   withSecondPool();
 
   beforeAll(async () => {

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
  */
-import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base, registerModel, AssociationTypeMismatch, ReadOnlyRecord } from "../index.js";
 import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -37,7 +37,7 @@ import { Computer } from "../test-helpers/models/computer.js";
 import { PublisherArticle, PublisherMagazine } from "../test-helpers/models/publisher.js";
 import { Professor } from "../test-helpers/models/professor.js";
 import { Course } from "../test-helpers/models/course.js";
-import { setupSecondPool, teardownSecondPool } from "../support/setup-second-pool.js";
+import { withSecondPool } from "../support/setup-second-pool.js";
 import { isSqliteRun } from "../support/sqlite-template.js";
 
 // Test-file-local models mirroring the Rails fixture file's inline class
@@ -189,6 +189,10 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     "parrotsTreasures",
     "priceEstimates",
   ]);
+
+  // The "alternate database" test below needs the arunit2 split; declaring it
+  // at suite scope keeps the primary-database restore paired with the setup.
+  withSecondPool();
 
   beforeAll(async () => {
     for (const m of [
@@ -1185,16 +1189,11 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   // `Professor`/`Course` live in the `arunit2` second database. Gated to SQLite
   // like `MultipleDbTest`; un-gating both is its own story.
   it.skipIf(!isSqliteRun())("alternate database", async () => {
-    await setupSecondPool();
     const professor = await Professor.create({ name: "Plum" });
     const course = await Course.create({ name: "Forensics" });
     expect(await (professor as any).courses.count()).toBe(0);
     await expect((professor as any).courses.push(course)).resolves.not.toThrow();
     expect(await (professor as any).courses.count()).toBe(1);
-  });
-
-  afterAll(async () => {
-    if (isSqliteRun()) await teardownSecondPool();
   });
 
   it("habtm scope can unscope", async () => {

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -1,9 +1,9 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import "./index.js";
 import { Base } from "./base.js";
 import { StatementInvalid } from "./errors.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { setupSecondPool, teardownSecondPool } from "./support/setup-second-pool.js";
+import { withSecondPool } from "./support/setup-second-pool.js";
 import { isSqliteRun } from "./support/sqlite-template.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Course } from "./test-helpers/models/course.js";
@@ -18,13 +18,7 @@ describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
   // Rails sets `self.use_transactional_tests = false`; fixtures() pins
   // the schema/fixtures across the file (skips the global per-test reset).
   fixtures({}, { useTransactionalTests: false });
-  beforeAll(async () => {
-    await setupSecondPool();
-  });
-
-  afterAll(async () => {
-    await teardownSecondPool();
-  });
+  withSecondPool();
 
   // Rails: `fixtures :colleges, :courses, :entrants`.
   // Colleges + courses live in arunit2; entrants in the primary pool.
@@ -33,7 +27,7 @@ describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
   // ref("courses", …) which can't cross adapter registries (arunit2 ↔ primary).
   // Seed each set through its model-specific connection via `fixtures()`'
   // caller-supplied `connection` knob. `use_transactional_tests = false`
-  // (Rails). The tables are created by `setupSecondPool` (colleges/courses in
+  // (Rails). The tables are created by `withSecondPool` (colleges/courses in
   // arunit2, entrants in primary), not from the canonical template clone.
   const seedOpts = { useTransactionalTests: false } as const;
   const { colleges } = fixtures(["colleges"], {
@@ -148,7 +142,7 @@ describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
 
   // Rails guards these two with `unless in_memory_db?` (multiple_db_test.rb): its
   // in-memory harness can't give arunit2 a genuinely separate pool, so College
-  // would resolve to Base's connection. setupSecondPool establishes an explicitly
+  // would resolve to Base's connection. withSecondPool establishes an explicitly
   // independent arunit2 pool (its own `:memory:` DB), so the assertions hold and we
   // run them. This differs from the primary-class pair, which stay skipped because
   // `connects_to(arunit/arunit)` is *expected* to share Base's connection — which

--- a/packages/activerecord/src/prepared-statement-status.test.ts
+++ b/packages/activerecord/src/prepared-statement-status.test.ts
@@ -1,9 +1,9 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { IsolatedExecutionState } from "@blazetrails/activesupport";
 import "./index.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { setupSecondPool, teardownSecondPool } from "./support/setup-second-pool.js";
+import { withSecondPool } from "./support/setup-second-pool.js";
 import { isSqliteRun } from "./support/sqlite-template.js";
 import { Course } from "./test-helpers/models/course.js";
 import { Entrant } from "./test-helpers/models/entrant.js";
@@ -18,13 +18,7 @@ function event(): { set: () => void; wait: Promise<void> } {
 
 describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
   fixtures({}, { useTransactionalTests: false });
-  beforeAll(async () => {
-    await setupSecondPool();
-  });
-
-  afterAll(async () => {
-    await teardownSecondPool();
-  });
+  withSecondPool();
 
   it("prepared statement status is thread and instance specific", async () => {
     const courseConn = await Course.leaseConnection();

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -75,8 +75,6 @@ export async function provisionSecondDatabase(): Promise<void> {
  * database ours is shared with every sibling suite in the worker.
  *
  * Fixture data is seeded separately via `useFixtures` in the test file.
- *
- * @internal
  */
 async function setupSecondPool(): Promise<void> {
   registerModel(College);
@@ -100,8 +98,6 @@ async function setupSecondPool(): Promise<void> {
  * Undoes `setupSecondPool`'s primary-database surgery: Rails' two-database
  * split dies with the process, but ours shares one primary database with every
  * sibling suite in the worker, so the dropped tables must be put back.
- *
- * @internal
  */
 async function teardownSecondPool(): Promise<void> {
   await rebuildCanonicalTables(await Base.leaseConnection(), [...ARUNIT2_TABLES, "entrants"]);

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -71,14 +71,12 @@ export async function provisionSecondDatabase(): Promise<void> {
  * The primary copies exist because trails loads one canonical schema into the
  * primary database while Rails' `arunit` never carries these tables. Dropping
  * them is what lets `MultipleDbTest` assert that a `SELECT` on the wrong pool
- * raises; the restore half of {@link withSecondPool} puts them back, because
- * unlike Rails' second database ours is shared with every sibling suite in the
- * worker.
+ * raises; `teardownSecondPool` puts them back, because unlike Rails' second
+ * database ours is shared with every sibling suite in the worker.
  *
  * Fixture data is seeded separately via `useFixtures` in the test file.
  *
- * Module-private on purpose: the surgery is only safe when paired with the
- * restore, so the only way to ask for it is {@link withSecondPool}.
+ * @internal
  */
 async function setupSecondPool(): Promise<void> {
   registerModel(College);
@@ -102,36 +100,22 @@ async function setupSecondPool(): Promise<void> {
  * Undoes `setupSecondPool`'s primary-database surgery: Rails' two-database
  * split dies with the process, but ours shares one primary database with every
  * sibling suite in the worker, so the dropped tables must be put back.
+ *
+ * @internal
  */
 async function teardownSecondPool(): Promise<void> {
   await rebuildCanonicalTables(await Base.leaseConnection(), [...ARUNIT2_TABLES, "entrants"]);
 }
 
 /**
- * Declares the two-database split for the enclosing `describe` (or file): the
- * primary-database surgery runs in a `beforeAll` and is always undone in a
- * matching `afterAll`. Call it at suite scope, next to `fixtures()`.
- *
- * The pairing is the whole point. Rails' `arunit`/`arunit2` split is per
- * process, so it needs no restore; ours shares one primary database with every
- * sibling suite in the worker, and a caller that took the setup without the
- * restore left the schema drift RFC 0070's repair worker exists to paper over.
- * Registering both hooks here makes that impossible to get wrong.
- *
- * A no-op off the sqlite lane, where the arunit2 suites are gated off
- * (`describe.skipIf(!isSqliteRun())`) because no one provisions a second named
- * database on the PG/MySQL servers yet.
- *
  * @internal
  */
 export function withSecondPool(): void {
   beforeAll(async () => {
-    if (!isSqliteRun()) return;
-    await setupSecondPool();
+    if (isSqliteRun()) await setupSecondPool();
   });
 
   afterAll(async () => {
-    if (!isSqliteRun()) return;
-    await teardownSecondPool();
+    if (isSqliteRun()) await teardownSecondPool();
   });
 }

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll } from "vitest";
 import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { registerModel } from "../associations.js";
@@ -8,6 +9,7 @@ import { College } from "../test-helpers/models/college.js";
 import { Entrant } from "../test-helpers/models/entrant.js";
 import { Professor } from "../test-helpers/models/professor.js";
 import { activeLane } from "./connection.js";
+import { isSqliteRun } from "./sqlite-template.js";
 
 /**
  * The tables `schema.rb:1444-1460` creates through the second connection
@@ -69,14 +71,16 @@ export async function provisionSecondDatabase(): Promise<void> {
  * The primary copies exist because trails loads one canonical schema into the
  * primary database while Rails' `arunit` never carries these tables. Dropping
  * them is what lets `MultipleDbTest` assert that a `SELECT` on the wrong pool
- * raises; `teardownSecondPool` puts them back, because unlike Rails' second
- * database ours is shared with every sibling suite in the worker.
+ * raises; the restore half of {@link withSecondPool} puts them back, because
+ * unlike Rails' second database ours is shared with every sibling suite in the
+ * worker.
  *
  * Fixture data is seeded separately via `useFixtures` in the test file.
  *
- * @internal
+ * Module-private on purpose: the surgery is only safe when paired with the
+ * restore, so the only way to ask for it is {@link withSecondPool}.
  */
-export async function setupSecondPool(): Promise<void> {
+async function setupSecondPool(): Promise<void> {
   registerModel(College);
   registerModel(Course);
   registerModel(Entrant);
@@ -98,9 +102,36 @@ export async function setupSecondPool(): Promise<void> {
  * Undoes `setupSecondPool`'s primary-database surgery: Rails' two-database
  * split dies with the process, but ours shares one primary database with every
  * sibling suite in the worker, so the dropped tables must be put back.
+ */
+async function teardownSecondPool(): Promise<void> {
+  await rebuildCanonicalTables(await Base.leaseConnection(), [...ARUNIT2_TABLES, "entrants"]);
+}
+
+/**
+ * Declares the two-database split for the enclosing `describe` (or file): the
+ * primary-database surgery runs in a `beforeAll` and is always undone in a
+ * matching `afterAll`. Call it at suite scope, next to `fixtures()`.
+ *
+ * The pairing is the whole point. Rails' `arunit`/`arunit2` split is per
+ * process, so it needs no restore; ours shares one primary database with every
+ * sibling suite in the worker, and a caller that took the setup without the
+ * restore left the schema drift RFC 0070's repair worker exists to paper over.
+ * Registering both hooks here makes that impossible to get wrong.
+ *
+ * A no-op off the sqlite lane, where the arunit2 suites are gated off
+ * (`describe.skipIf(!isSqliteRun())`) because no one provisions a second named
+ * database on the PG/MySQL servers yet.
  *
  * @internal
  */
-export async function teardownSecondPool(): Promise<void> {
-  await rebuildCanonicalTables(await Base.leaseConnection(), [...ARUNIT2_TABLES, "entrants"]);
+export function withSecondPool(): void {
+  beforeAll(async () => {
+    if (!isSqliteRun()) return;
+    await setupSecondPool();
+  });
+
+  afterAll(async () => {
+    if (!isSqliteRun()) return;
+    await teardownSecondPool();
+  });
 }


### PR DESCRIPTION
`setupSecondPool` mirrors Rails' `arunit`/`arunit2` split by mutating the
*shared* primary database — dropping `colleges`/`courses`/`professors`/
`courses_professors` and rebuilding `entrants`. Rails needs no restore (its two
databases are per-process); ours is shared with every sibling suite in the
vitest worker, so #5255 bolted on a `teardownSecondPool()` that each of the
three callers had to remember to run in an `afterAll`. A fourth caller that
forgot it would reintroduce exactly the schema drift RFC 0070's repair worker
exists to paper over.

This folds both halves into a scoped `withSecondPool()` declared at suite
scope (next to `fixtures()`): it registers the `beforeAll` surgery and the
matching `afterAll` restore itself. `setupSecondPool` / `teardownSecondPool`
become module-private, so the unpaired surgery is now unreachable.

- The three callers (`multiple-db.test.ts`, `prepared-statement-status.test.ts`,
  `associations/has-and-belongs-to-many-associations.test.ts`) drop their
  hand-written `afterAll`.
- The habtm caller previously ran the setup inside the `alternate database`
  test; it now declares `withSecondPool()` at suite scope. No other test in that
  file touches the four tables.
- The sqlite gate moved inside the helper (no-op off the sqlite lane), so
  gating is unchanged: the two arunit2 suites stay
  `describe.skipIf(!isSqliteRun())` and `alternate database` stays
  `it.skipIf(!isSqliteRun())`.
- No test renamed. `test:compare` delta 0.

Local: `multiple-db` (12), `prepared-statement-status` (1), habtm (93 passed,
1 pre-existing skip) all green.

Closes-story: second-pool-avoid-primary-database-surgery
