### PR TITLE
fix(ci): wire MYSQL_TEST_URL into the activerecord-cli E2E runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1188,9 +1188,9 @@ jobs:
           MYSQL_DATABASE: rails_js_test
           # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
           # worker count and the slot-DB pool from the runner's vCPU count.
-      # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
-      # covers the SQLite E2E until a mysql suite lands and can be wired up.
       - run: pnpm vitest run packages/activerecord-cli
+        env:
+          MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
 
   # MariaDB stand-in runner. mysql-tests is temporarily disabled (see above);
   # this provides MySQL/MariaDB-family coverage via the mysql2 adapter against
@@ -1256,11 +1256,11 @@ jobs:
           MYSQL_DATABASE: rails_js_test
           # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
           # worker count and the slot-DB pool from the runner's vCPU count.
-      # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
-      # covers the SQLite E2E until a mysql suite lands and can be wired up.
       # CLI E2E is not sharded — run it once, on shard 1 only.
       - if: ${{ matrix.shard == 1 }}
         run: pnpm vitest run packages/activerecord-cli
+        env:
+          MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
 
   website:
     name: Website

--- a/packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts
+++ b/packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts
@@ -106,13 +106,14 @@ export default config;
     expect(versionLines.join("\n")).toContain(`Current version: ${version}`);
 
     // 8. ar db:migrate:status
-    const statusLines: string[] = [];
-    vi.spyOn(console, "log").mockImplementation(
-      (...args) => void statusLines.push(args.map(String).join(" ")),
-    );
+    const statusChunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      statusChunks.push(String(chunk));
+      return true;
+    });
     const statusCode = await run(["db:migrate:status"], tmpDir);
     expect(statusCode, "ar db:migrate:status should exit 0").toBe(0);
-    const statusText = statusLines.join("\n");
+    const statusText = statusChunks.join("");
     expect(statusText).toContain("up");
     expect(statusText).toContain(version);
   });


### PR DESCRIPTION
The mysql-happy-path CLI E2E is gated on `MYSQL_TEST_URL`, which no CI job ever set — so it silently skipped in every job while the mysql/maria jobs carried a stale comment claiming no such suite existed.

- Set `MYSQL_TEST_URL` on the `activerecord-cli` step in both the mysql job and the maria job (shard 1), mirroring how the postgres job wires `PG_TEST_URL`.
- Replaced the stale "no mysql-happy-path E2E exists yet" comments.
- Running the suite for the first time surfaced a real bug in it: it captured `db:migrate:status` through `console.log`, but `migrateStatus` writes to stdout, so it asserted against an empty string. Now captures the stream the way the sqlite/postgres suites do.

Verified green locally against `mariadb:11`.

Closes-story: wire-mysql-connection-for-cli-e2e
