### PR TITLE
test(activerecord): pin the deferred has_one create load-error re-raise

### DIFF
--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -608,7 +608,6 @@ describe("HasOneAssociationsTest", () => {
     association.loadTargetForBuild = () => Promise.reject(loadError);
 
     await expect(found.createAccount({ credit_limit: 70 })).rejects.toBe(loadError);
-    // The build/save itself succeeded — only the deferred load error is fatal.
     expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);
   });
 

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -6,7 +6,7 @@
  * have been replaced with the real Rails `Company`/`Firm`/`DependentFirm`/
  * `Account` models and the `companies`/`accounts` fixtures. No `defineSchema`.
  */
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { ArgumentError, I18n, UnknownAttributeError } from "@blazetrails/activemodel";
 import { throwAbort } from "@blazetrails/activesupport";
 import {
@@ -605,7 +605,7 @@ describe("HasOneAssociationsTest", () => {
     const association = found.association("account");
     expect(association.isLoaded()).toBe(false);
     const loadError = new Error("connection lost while loading the displaced target");
-    association.loadTargetForBuild = () => Promise.reject(loadError);
+    vi.spyOn(association, "loadTargetForBuild").mockRejectedValue(loadError);
 
     await expect(found.createAccount({ credit_limit: 70 })).rejects.toBe(loadError);
     expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -590,6 +590,28 @@ describe("HasOneAssociationsTest", () => {
     expect((await readHasOne(firm, "account")).id).toBe(created.id);
   });
 
+  // Trails deviation guard (no Rails counterpart, RFC 0068 story
+  // has-one-create-deferred-load-error-reraise-untested): the displaced-target
+  // load has to run BEFORE `super._createRecord` (it must precede the new
+  // record's FK write), but Rails reaches `load_target` only from
+  // `set_new_record`, i.e. *after* `build_record` (singular_association.rb:63-68).
+  // So `_createRecord` defers the load error and re-raises it once the build has
+  // succeeded. A build-time failure hides it (covered by "create with inexistent
+  // foreign key failing"); this pins the other branch — build succeeds, load
+  // error still propagates out of `create#{name}`.
+  it("create re-raises a deferred target-load error after a successful build", async () => {
+    const company = (await Company.create({ name: "DeferredLoadCo" })) as any;
+    const found = (await Company.find(company.id)) as any;
+    const association = found.association("account");
+    expect(association.isLoaded()).toBe(false);
+    const loadError = new Error("connection lost while loading the displaced target");
+    association.loadTargetForBuild = () => Promise.reject(loadError);
+
+    await expect(found.createAccount({ credit_limit: 70 })).rejects.toBe(loadError);
+    // The build/save itself succeeded — only the deferred load error is fatal.
+    expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);
+  });
+
   // Same root cause on the build path: `set_new_record` → `replace(record, false)`
   // still runs `remove_target!` on the loaded target (has_one_association.rb:69),
   // whose else-branch nullifies+saves the old row even though the new record is


### PR DESCRIPTION
Pins the previously-untested branch of the deferred load-error re-raise on the
has_one `create#{name}` path.

`HasOneAssociation#_createRecord` must run the displaced-target load BEFORE
`super._createRecord` (it has to precede the new record's FK write), but Rails
reaches `load_target` only from `set_new_record`, i.e. after `build_record`
(`singular_association.rb:63-68`). So `loadDisplacedTargetForCreate` returns
`[displaced, loadError]` and `_createRecord` re-raises `loadError` only once the
build/save succeeded.

The build-fails branch was already covered by `create with inexistent foreign key
failing`. The build-succeeds branch — load error propagates out of
`create#{name}` — was reasoned from Rails source only, with nothing pinning it.

This adds one trails deviation guard next to the sibling RFC 0068 guards in
`has-one-associations.test.ts`: stub the association's `loadTargetForBuild` to
reject with a non-`RecordNotFound` error on a persisted owner with an unloaded
target, assert `createAccount` rejects with exactly that error, and assert the
account row was still created (proving the build itself succeeded).

Verified the test fails when `if (loadError) throw loadError;` is removed from
`_createRecord`. has_one and has_one_through suites green.

Closes-story: has-one-create-deferred-load-error-reraise-untested
