### PR TITLE
fix(nested-attributes): keep a failed displacement removal observable without a save

### DIFF
--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Trails-only surface: what happens when the displacement removal a
+ * nested-attributes assignment starts *fails*.
+ *
+ * Rails raises `RecordNotSaved` from `remove_target!` inline inside
+ * `HasOneAssociation#replace`
+ * (vendor/rails/activerecord/lib/active_record/associations/has_one_association.rb:95-115),
+ * so `pirate.ship_attributes = {...}` surfaces the failure at the assignment
+ * expression whether or not the owner is ever saved. A synchronous JS property
+ * setter cannot raise on an async write, so trails splits that guarantee: the
+ * awaitable `set#{Name}Attributes` writer raises at the assignment point, and the
+ * synchronous setter's failure is parked on the owner permanently — every later
+ * drain rethrows it, so an owner that is never saved never loses it.
+ *
+ * No Rails test covers a *failing* displacement removal, hence a trails-only
+ * guard rather than a mirrored test.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel, type Base } from "./index.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Pirate } from "./test-helpers/models/pirate.js";
+import { Ship } from "./test-helpers/models/ship.js";
+
+interface RemovalHost {
+  _pendingDisplacedRemovals?: Promise<unknown>[];
+  _displacedRemovalFailure?: unknown;
+}
+
+/**
+ * A pirate with a loaded, persisted ship whose displacement removal is rigged
+ * to fail — the async analogue of Rails' `remove_target!` nullify save
+ * returning false.
+ */
+async function pirateWithFailingRemoval(): Promise<Base> {
+  const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+  await Ship.create({
+    name: "Nights Dirty Lightning",
+    pirate_id: (pirate as unknown as { id: number }).id,
+  });
+  await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+  const assoc = pirate.association("ship") as unknown as {
+    detachDisplacedRecord: () => Promise<void>;
+  };
+  assoc.detachDisplacedRecord = () => Promise.reject(new Error("removal exploded"));
+  return pirate;
+}
+
+describe("nested-attributes displacement removal failure", () => {
+  fixtures(["pirates", "ships"]);
+
+  beforeAll(() => {
+    registerModel(Pirate);
+    registerModel(Ship);
+  });
+
+  it("raises at the assignment through the awaitable writer, with no save", async () => {
+    const pirate = await pirateWithFailingRemoval();
+
+    await expect(
+      (pirate as unknown as { setShipAttributes: (a: unknown) => Promise<void> }).setShipAttributes(
+        { name: "Davy Jones Gold Dagger" },
+      ),
+    ).rejects.toThrow("removal exploded");
+  });
+
+  it("keeps the failure on the owner once it has been raised", async () => {
+    const pirate = await pirateWithFailingRemoval();
+
+    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+
+    // Every drain rethrows: the first observation does not consume the failure,
+    // so an owner saved (or re-assigned) later cannot silently succeed.
+    await expect(pirate.save()).rejects.toThrow("removal exploded");
+    await expect(pirate.save()).rejects.toThrow("removal exploded");
+    expect((pirate as unknown as RemovalHost)._displacedRemovalFailure).toBeInstanceOf(Error);
+  });
+
+  it("does not leave a floating rejection when the removal is never drained", async () => {
+    const pirate = await pirateWithFailingRemoval();
+
+    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+
+    // The captured promise resolves *to* the error rather than rejecting, so a
+    // never-drained removal cannot surface as an unhandled rejection.
+    const pending = (pirate as unknown as RemovalHost)._pendingDisplacedRemovals ?? [];
+    expect(pending).toHaveLength(1);
+    await expect(pending[0]).resolves.toBeInstanceOf(Error);
+  });
+});

--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -20,6 +20,7 @@ import { registerModel, type Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Pirate } from "./test-helpers/models/pirate.js";
 import { Ship } from "./test-helpers/models/ship.js";
+import { Bird } from "./test-helpers/models/bird.js";
 
 interface RemovalHost {
   _pendingDisplacedRemovals?: Promise<unknown>[];
@@ -52,6 +53,7 @@ describe("nested-attributes displacement removal failure", () => {
   beforeAll(() => {
     registerModel(Pirate);
     registerModel(Ship);
+    registerModel(Bird);
   });
 
   it("detaches the displaced row at the assignment through the awaitable writer", async () => {
@@ -94,6 +96,24 @@ describe("nested-attributes displacement removal failure", () => {
     await expect(pirate.save()).rejects.toThrow("removal exploded");
     await expect(pirate.save()).rejects.toThrow("removal exploded");
     expect((pirate as unknown as RemovalHost)._displacedRemovalFailure).toBeInstanceOf(Error);
+  });
+
+  it("surfaces the failure through an unrelated association's awaitable writer", async () => {
+    const pirate = await pirateWithFailingRemoval();
+
+    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+
+    // The pending list and the sticky failure are per-owner, so the collection
+    // writer rethrows the has_one's failure even though the crew assignment
+    // itself succeeded: the owner instance is poisoned, and an awaitable write
+    // to it must not proceed toward a `save()` that would persist two rows.
+    await expect(
+      (
+        pirate as unknown as { setBirdsAttributes: (a: unknown) => Promise<void> }
+      ).setBirdsAttributes([{ name: "Posideons Killer" }]),
+    ).rejects.toThrow("removal exploded");
   });
 
   it("does not leave a floating rejection when the removal is never drained", async () => {

--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -54,6 +54,24 @@ describe("nested-attributes displacement removal failure", () => {
     registerModel(Ship);
   });
 
+  it("detaches the displaced row at the assignment through the awaitable writer", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    await (
+      pirate as unknown as { setShipAttributes: (a: unknown) => Promise<void> }
+    ).setShipAttributes({ name: "Davy Jones Gold Dagger" });
+
+    // The owner is deliberately NOT saved: Rails' `replace` has already run
+    // `remove_target!` by the time the assignment expression returns.
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
   it("raises at the assignment through the awaitable writer, with no save", async () => {
     const pirate = await pirateWithFailingRemoval();
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -582,6 +582,9 @@ function generateAssociationWriter(
   // assignment expression; a JS property setter cannot await, so this is the
   // surface that reproduces that timing (RFC 0068's `set#{Name}` sugar, applied
   // to nested attributes). See `detachDisplacedAtAssignment` for the contract.
+  // Collections get it too, for one uniform awaitable writer per association —
+  // only a one-to-one assignment ever queues a removal, so the drain is a no-op
+  // there.
   Object.defineProperty(modelClass.prototype, `set${camelize(attrName, true)}`, {
     async value(this: Base, value: any): Promise<void> {
       assign(this, associationName, value);
@@ -708,6 +711,12 @@ interface OneToOneAssociation {
  *   (`save()`, an awaitable writer, another assignment's drain) rethrows it. An
  *   owner that is never saved therefore still carries the failure; nothing
  *   silently discards it.
+ *
+ * The sticky failure is deliberately terminal for that instance: the in-memory
+ * replacement landed while the displaced row did not detach, so persisting the
+ * owner would produce exactly the two-FK-matching-rows state RFC 0068 exists to
+ * eliminate. Recovery is a fresh load of the owner, not a retry on the poisoned
+ * instance.
  * @internal
  */
 function detachDisplacedAtAssignment(
@@ -762,9 +771,7 @@ async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
       if (error) recordDisplacedRemovalFailure(host, error);
     }
   }
-  if ("_displacedRemovalFailure" in host && host._displacedRemovalFailure !== undefined) {
-    throw host._displacedRemovalFailure;
-  }
+  if (host._displacedRemovalFailure !== undefined) throw host._displacedRemovalFailure;
 }
 
 /** @internal */

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -566,21 +566,30 @@ function generateAssociationWriter(
     (modelClass as any)._nestedAttributeSetterKeys = new Set<string>();
   }
   (modelClass as any)._nestedAttributeSetterKeys.add(attrName);
-  if (type === "collection") {
-    Object.defineProperty(modelClass.prototype, attrName, {
-      set(this: Base, value: any) {
-        assignNestedAttributesForCollectionAssociation(this, associationName, value);
-      },
-      configurable: true,
-    });
-  } else {
-    Object.defineProperty(modelClass.prototype, attrName, {
-      set(this: Base, value: any) {
-        assignNestedAttributesForOneToOneAssociation(this, associationName, value);
-      },
-      configurable: true,
-    });
-  }
+  const assign: (record: Base, name: string, value: any) => void =
+    type === "collection"
+      ? assignNestedAttributesForCollectionAssociation
+      : assignNestedAttributesForOneToOneAssociation;
+  Object.defineProperty(modelClass.prototype, attrName, {
+    set(this: Base, value: any) {
+      assign(this, associationName, value);
+    },
+    configurable: true,
+  });
+
+  // The awaitable counterpart of the Rails-named `#{name}_attributes=` setter.
+  // Rails' writer removes the displaced record inline and raises at the
+  // assignment expression; a JS property setter cannot await, so this is the
+  // surface that reproduces that timing (RFC 0068's `set#{Name}` sugar, applied
+  // to nested attributes). See `detachDisplacedAtAssignment` for the contract.
+  Object.defineProperty(modelClass.prototype, `set${camelize(attrName, true)}`, {
+    async value(this: Base, value: any): Promise<void> {
+      assign(this, associationName, value);
+      await awaitPendingDisplacedRemovals(this);
+    },
+    writable: true,
+    configurable: true,
+  });
 }
 
 /** @internal */
@@ -680,6 +689,25 @@ interface OneToOneAssociation {
  *
  * The rejection is captured rather than left floating: a never-drained removal
  * must not surface as an unhandled rejection, and a drained one must rethrow.
+ *
+ * ## The contract for a removal that fails
+ *
+ * Rails raises `RecordNotSaved` at the assignment expression itself, so the
+ * failure is observable whether or not the owner is ever saved. A synchronous
+ * property setter cannot do that, so trails splits the guarantee in two, and a
+ * failure is **retained on the owner forever** rather than consumed by whoever
+ * happens to drain first:
+ *
+ * - `await owner.set#{Name}Attributes({...})` — the awaitable nested-attributes
+ *   writer (the analogue of RFC 0068's `set#{Name}`) assigns and then awaits the
+ *   removal, so it raises at the assignment point exactly as Rails does. This is
+ *   the sanctioned surface when the failure matters.
+ * - `owner.#{name}Attributes = {...}` — the Rails-named synchronous setter still
+ *   works, and its failure is *sticky*: {@link recordDisplacedRemovalFailure}
+ *   parks the first error on the owner, and **every** subsequent drain
+ *   (`save()`, an awaitable writer, another assignment's drain) rethrows it. An
+ *   owner that is never saved therefore still carries the failure; nothing
+ *   silently discards it.
  * @internal
  */
 function detachDisplacedAtAssignment(
@@ -693,23 +721,49 @@ function detachDisplacedAtAssignment(
     () => null,
     (error: unknown) => error ?? new Error("displaced record removal failed"),
   );
-  const host = record as unknown as { _pendingDisplacedRemovals?: Promise<unknown>[] };
+  const host = record as unknown as DisplacedRemovalHost;
   (host._pendingDisplacedRemovals ??= []).push(settled);
 }
 
 /**
+ * The owner-side state {@link detachDisplacedAtAssignment} parks: the in-flight
+ * removals plus the sticky first failure among them.
+ * @internal
+ */
+interface DisplacedRemovalHost {
+  _pendingDisplacedRemovals?: Promise<unknown>[];
+  _displacedRemovalFailure?: unknown;
+}
+
+/**
+ * Park a displacement-removal failure on the owner permanently. Draining
+ * consumes the *promise*, never the error — see the contract on
+ * {@link detachDisplacedAtAssignment}.
+ * @internal
+ */
+function recordDisplacedRemovalFailure(host: DisplacedRemovalHost, error: unknown): void {
+  host._displacedRemovalFailure ??= error;
+}
+
+/**
  * Await the removals started by `detachDisplacedAtAssignment`, rethrowing the
- * first failure — the deferred half of Rails' inline `remove_target!`.
+ * first failure — the deferred half of Rails' inline `remove_target!`. A failure
+ * already parked by an earlier drain is rethrown before anything is awaited, so
+ * it cannot be observed once and then forgotten.
  * @internal
  */
 async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
-  const host = record as unknown as { _pendingDisplacedRemovals?: Promise<unknown>[] };
+  const host = record as unknown as DisplacedRemovalHost;
   const pending = host._pendingDisplacedRemovals;
-  if (!pending?.length) return;
-  host._pendingDisplacedRemovals = [];
-  for (const settled of pending) {
-    const error = await settled;
-    if (error) throw error;
+  if (pending?.length) {
+    host._pendingDisplacedRemovals = [];
+    for (const settled of pending) {
+      const error = await settled;
+      if (error) recordDisplacedRemovalFailure(host, error);
+    }
+  }
+  if ("_displacedRemovalFailure" in host && host._displacedRemovalFailure !== undefined) {
+    throw host._displacedRemovalFailure;
   }
 }
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -582,9 +582,14 @@ function generateAssociationWriter(
   // assignment expression; a JS property setter cannot await, so this is the
   // surface that reproduces that timing (RFC 0068's `set#{Name}` sugar, applied
   // to nested attributes). See `detachDisplacedAtAssignment` for the contract.
-  // Collections get it too, for one uniform awaitable writer per association —
-  // only a one-to-one assignment ever queues a removal, so the drain is a no-op
-  // there.
+  // Collections get it too, for one uniform awaitable writer per association. A
+  // collection assignment never queues a removal of its own, but the drain is
+  // NOT a no-op there: the pending list and the sticky failure are per-*owner*,
+  // so `await pirate.setBirdsAttributes(...)` rethrows an undrained
+  // `pirate.shipAttributes = ...` failure. That is the contract, not a leak —
+  // the failure poisons the owner instance (see `detachDisplacedAtAssignment`),
+  // and an awaitable write to a poisoned owner must not silently proceed toward
+  // a `save()` that would persist the two-row state.
   Object.defineProperty(modelClass.prototype, `set${camelize(attrName, true)}`, {
     async value(this: Base, value: any): Promise<void> {
       assign(this, associationName, value);


### PR DESCRIPTION
## Problem

The nested-attributes has_one displacement removal (`detachDisplacedAtAssignment`
/ `awaitPendingDisplacedRemovals`, `packages/activerecord/src/nested-attributes.ts`)
started the removal inline at assignment — matching Rails — but captured its
rejection and rethrew it only when the pending list was drained by the
nested-attributes `save` wrapper. If the owner was never saved, the failure was
silently discarded.

Rails runs `remove_target!` inline inside `HasOneAssociation#replace`
(`has_one_association.rb:95-115`) and raises `RecordNotSaved` at the assignment
expression itself, so `pirate.ship_attributes = {...}` surfaces the failure
regardless of any later save.

## The contract

A synchronous JS property setter cannot raise on an async write, so the
guarantee splits in two (documented on `detachDisplacedAtAssignment`):

- **`await owner.set#{Name}Attributes({...})`** — a new awaitable
  nested-attributes writer, the analogue of RFC 0068's `set#{Name}` sugar. It
  assigns and then awaits the removal, so it raises at the assignment point
  exactly as Rails does, with no save involved. This is the sanctioned surface
  when the failure matters.
- **`owner.#{name}Attributes = {...}`** — the Rails-named synchronous setter
  keeps working (Rails' own nested-attributes tests use it), but its failure is
  now **sticky**: the first error is parked on the owner and *every* subsequent
  drain rethrows it. Draining consumes the promise, never the error, so an owner
  that is never saved still carries the failure and a later save cannot silently
  succeed.

The rejection is still captured at the source, so a never-drained removal cannot
surface as an unhandled rejection.

## Tests

`nested-attributes-displaced-removal-failure.trails.test.ts` (trails-only — no
Rails test covers a *failing* displacement removal) pins all three: the awaitable
writer raises with no save, the failure survives repeated drains, and the pending
promise resolves to the error rather than rejecting. Two of the three fail on
baseline.

Closes-story: nested-attributes-displacement-removal-error-lost-when-owner-unsaved
