### PR TITLE
fix(activerecord): remove the has_one row displaced by association(name).build

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -76,7 +76,7 @@ export class HasOne extends SingularAssociation {
           // `detachDisplacedTarget` is a no-op, so the proxy passed as
           // `displaced` here is inert.
           return assoc.loadTargetForBuild().then((displaced: unknown) => {
-            const record = assoc.build(...args);
+            const record = buildOwningDisplacement(assoc, args);
             return assoc.detachDisplacedTarget(displaced, record).then(() => record);
           });
         }
@@ -88,7 +88,7 @@ export class HasOne extends SingularAssociation {
         // synchronous return (the shape the STI-build tests assert).
         const displaced =
           typeof assoc.isLoaded === "function" && assoc.isLoaded() ? assoc.target : null;
-        const record = assoc.build(...args);
+        const record = buildOwningDisplacement(assoc, args);
         if (displaced && typeof assoc.detachDisplacedTarget === "function") {
           return assoc.detachDisplacedTarget(displaced, record).then(() => record);
         }
@@ -246,5 +246,24 @@ export class HasOne extends SingularAssociation {
         }
       });
     }
+  }
+}
+
+/**
+ * Run `association.build` with the association's own displaced-record removal
+ * suppressed: this accessor awaits `detachDisplacedTarget` itself (with Rails'
+ * target-on-failure semantics), and a second, concurrent removal of the same
+ * row would double-destroy it. `HasOneAssociation#build` keeps the removal for
+ * the direct `record.association(name).build(...)` callers, which have no other
+ * hook to run it from.
+ *
+ * @internal
+ */
+function buildOwningDisplacement(assoc: any, args: unknown[]): any {
+  assoc.buildSkipsDisplacementRemoval = true;
+  try {
+    return assoc.build(...args);
+  } finally {
+    assoc.buildSkipsDisplacementRemoval = false;
   }
 }

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -260,10 +260,10 @@ export class HasOne extends SingularAssociation {
  * @internal
  */
 function buildOwningDisplacement(assoc: any, args: unknown[]): any {
-  assoc.buildSkipsDisplacementRemoval = true;
+  assoc.buildDisplacementOwnedByCaller = true;
   try {
     return assoc.build(...args);
   } finally {
-    assoc.buildSkipsDisplacementRemoval = false;
+    assoc.buildDisplacementOwnedByCaller = false;
   }
 }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -263,13 +263,14 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   /**
-   * Set by the callers that own the displaced record's removal themselves — the
-   * `build#{name}` accessor (builder/has-one.ts, which awaits
+   * Set by the callers that own Rails' leading `load_target` and the
+   * `remove_target!` that follows it themselves — the `build#{name}` accessor
+   * (builder/has-one.ts, which runs `loadTargetForBuild` and awaits
    * `detachDisplacedTarget`) and the nested-attributes writer
-   * (nested-attributes.ts, which starts `detachDisplacedRecord` at assignment
-   * and drains it in its `save` wrapper). Both call `build` on their way through,
-   * and without this flag `build` would start a *second*, concurrent removal of
-   * the same row.
+   * (nested-attributes.ts, a synchronous property setter that starts
+   * `detachDisplacedRecord` at assignment and drains it in its `save` wrapper).
+   * Both call `build` on their way through, and without this flag `build` would
+   * re-run the load and start a *second*, concurrent removal of the same row.
    *
    * `protected` because it is association-internal bookkeeping, not API surface;
    * the two callers reach it through their existing duck-typed handles on the
@@ -277,7 +278,25 @@ export class HasOneAssociation extends SingularAssociation {
    *
    * @internal
    */
-  protected buildSkipsDisplacementRemoval = false;
+  protected buildDisplacementOwnedByCaller = false;
+
+  /**
+   * Rails' `set_new_record` → `replace(record, false)` opens with `load_target`
+   * (has_one_association.rb:59-62): the guard is `return target unless
+   * load_target || record`, and Ruby always evaluates the left operand, so
+   * EVERY build queries for an existing target before deciding whether to
+   * displace it — a never-loaded association included. `needsTargetLoadForBuild`
+   * is Rails' `find_target?`, so the query runs exactly when Rails' would (a
+   * persisted / FK-present owner whose target isn't loaded), and returning it
+   * here is what makes `association(name).build(...)` awaitable on that path.
+   *
+   * @internal
+   */
+  protected override loadDisplacedForBuild(): Promise<unknown> | null {
+    if (this.buildDisplacementOwnedByCaller) return null;
+    if (!this.needsTargetLoadForBuild()) return null;
+    return this.loadTargetForBuild();
+  }
 
   /**
    * `build_#{name}` and `association(:name).build` are the same Rails method,
@@ -299,7 +318,7 @@ export class HasOneAssociation extends SingularAssociation {
     displaced: Base | null,
     record: Base | null,
   ): Promise<void> | null {
-    if (this.buildSkipsDisplacementRemoval) return null;
+    if (this.buildDisplacementOwnedByCaller) return null;
     if (!displaced || sameRecord(displaced, record)) return null;
     // A displaced record that was never persisted keys no row: `remove_target!`'s
     // in-memory half already ran in `setNewRecord`, and its `target.save` is

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -263,6 +263,50 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   /**
+   * Set by the callers that own the displaced record's removal themselves — the
+   * `build#{name}` accessor (builder/has-one.ts, which awaits
+   * `detachDisplacedTarget`) and the nested-attributes writer
+   * (nested-attributes.ts, which starts `detachDisplacedRecord` at assignment
+   * and drains it in its `save` wrapper). Both call `build` on their way through,
+   * and without this flag `build` would start a *second*, concurrent removal of
+   * the same row.
+   *
+   * @internal
+   */
+  buildSkipsDisplacementRemoval = false;
+
+  /**
+   * `build_#{name}` and `association(:name).build` are the same Rails method,
+   * and both run `set_new_record` → `replace(record, false)` → `remove_target!`
+   * (has_one_association.rb:87-93, 59-69): the displaced row's foreign key is
+   * nullified (or the row destroyed/deleted per `:dependent`) inline. Our
+   * `setNewRecord` is synchronous and does only the in-memory half, so a direct
+   * `record.association("ship").build({...})` over a loaded, persisted target
+   * used to leave that row attached in the DB. Returning the removal here makes
+   * `build` hand the caller a promise to `await` — the only way a synchronous
+   * return can expose an inline write in JS.
+   *
+   * `detachDisplacedTarget` supplies the remaining guards (a different,
+   * non-destroyed record) and Rails' target-on-failure semantics.
+   *
+   * @internal
+   */
+  protected override detachDisplacedOnBuild(
+    displaced: Base | null,
+    record: Base | null,
+  ): Promise<void> | null {
+    if (this.buildSkipsDisplacementRemoval) return null;
+    if (!displaced || sameRecord(displaced, record)) return null;
+    // A displaced record that was never persisted keys no row: `remove_target!`'s
+    // in-memory half already ran in `setNewRecord`, and its `target.save` is
+    // gated on `target.persisted?` (has_one_association.rb:108). Returning null
+    // keeps repeated `build`s (the common `assoc.build()` twice shape)
+    // synchronous.
+    if ((displaced as { isPersisted?: () => boolean }).isPersisted?.() !== true) return null;
+    return this.detachDisplacedTarget(displaced, record);
+  }
+
+  /**
    * Whether a `build#{name}` accessor call must first run Rails'
    * `load_target` — mirrors `HasOneAssociation#set_new_record` →
    * `replace(record, false)`, whose leading `load_target`

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -271,9 +271,13 @@ export class HasOneAssociation extends SingularAssociation {
    * and without this flag `build` would start a *second*, concurrent removal of
    * the same row.
    *
+   * `protected` because it is association-internal bookkeeping, not API surface;
+   * the two callers reach it through their existing duck-typed handles on the
+   * association (both live outside the class hierarchy).
+   *
    * @internal
    */
-  buildSkipsDisplacementRemoval = false;
+  protected buildSkipsDisplacementRemoval = false;
 
   /**
    * `build_#{name}` and `association(:name).build` are the same Rails method,

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -924,10 +924,10 @@ describe("HasOneAssociationsTest", () => {
   it("association keys bypass attribute protection", async () => {
     const car = (await Car.create({ name: "honda" })) as any;
 
-    let bulb = car.association("bulb").build();
+    let bulb = await car.association("bulb").build();
     expect(bulb.car_id).toBe(Number(car.id));
 
-    bulb = car.association("bulb").build({ car_id: Number(car.id) + 1 });
+    bulb = await car.association("bulb").build({ car_id: Number(car.id) + 1 });
     expect(bulb.car_id).toBe(Number(car.id));
 
     bulb = await car.association("bulb").create();
@@ -939,9 +939,9 @@ describe("HasOneAssociationsTest", () => {
 
   it("association protect foreign key", async () => {
     const pirate = await Pirate.create({ catchphrase: "Don' botharrr talkin' like one, savvy?" });
-    let ship = (pirate.association("ship") as any).build();
+    let ship = await (pirate.association("ship") as any).build();
     expect(ship.pirate_id).toBe(Number(pirate.id));
-    ship = (pirate.association("ship") as any).build({ pirate_id: Number(pirate.id) + 1 });
+    ship = await (pirate.association("ship") as any).build({ pirate_id: Number(pirate.id) + 1 });
     expect(ship.pirate_id).toBe(Number(pirate.id));
     ship = await (pirate.association("ship") as any).create({ name: "s1" });
     expect(ship.pirate_id).toBe(Number(pirate.id));
@@ -1017,7 +1017,7 @@ describe("HasOneAssociationsTest", () => {
 
   it("has one assignment dont trigger save on change of same object", async () => {
     const pirate = await Pirate.create({ catchphrase: "Don' botharrr talkin' like one, savvy?" });
-    const ship = (pirate.association("ship") as any).build({ name: "old name" });
+    const ship = await (pirate.association("ship") as any).build({ name: "old name" });
     await ship.save();
 
     ship.name = "new name";
@@ -1031,7 +1031,7 @@ describe("HasOneAssociationsTest", () => {
 
   it("has one assignment triggers save on change on replacing object", async () => {
     const pirate = await Pirate.create({ catchphrase: "Don' botharrr talkin' like one, savvy?" });
-    const ship = (pirate.association("ship") as any).build({ name: "old name" });
+    const ship = await (pirate.association("ship") as any).build({ name: "old name" });
     await ship.save();
 
     const newShip = await Ship.create({ name: "new name" });

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -94,6 +94,24 @@ describe("has_one displacement via the synchronous build path", () => {
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
   });
 
+  it("raises from the record construction before issuing the displacement query", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    });
+
+    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
+    const assoc = (
+      refetched as unknown as { association(n: string): { build(a: object): unknown } }
+    ).association("ship");
+
+    // Rails is `build_record(...)` then `set_new_record` → `load_target`, so a
+    // bad attribute raises before anything is queried or displaced. A
+    // synchronous throw (not a rejected promise) is what proves the ordering.
+    expect(() => assoc.build({ bogus_attribute: 1 })).toThrow();
+  });
+
   it("returns the built record synchronously when no query would run", async () => {
     // A new-record owner keys no row, so Rails' `find_target?` is false and
     // `load_target` queries nothing — the build stays fully in memory.

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -73,8 +73,31 @@ describe("has_one displacement via the synchronous build path", () => {
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
   });
 
-  it("returns the built record synchronously when nothing is displaced", async () => {
+  it("nullifies the displaced row when association(name).build replaces an unloaded child", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+
+    // Never load the association: Rails' `replace` guard is `return target
+    // unless load_target || record`, whose left operand always runs, so the
+    // build discovers the row itself.
+    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
+    const assoc = (
+      refetched as unknown as { association(n: string): { build(a: object): unknown } }
+    ).association("ship");
+    const built = (await assoc.build({ name: "Davy Jones Gold Dagger" })) as Base;
+
+    expect((built as unknown as { name: string }).name).toBe("Davy Jones Gold Dagger");
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
+  it("returns the built record synchronously when no query would run", async () => {
+    // A new-record owner keys no row, so Rails' `find_target?` is false and
+    // `load_target` queries nothing — the build stays fully in memory.
+    const pirate = new (Pirate as unknown as new () => Base)();
     const assoc = (
       pirate as unknown as { association(n: string): { build(a: object): unknown } }
     ).association("ship");

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -11,7 +11,9 @@
  * `assoc.build()`, which nested attributes calls directly, the nested-attributes
  * writer uses `detachDisplacedRecord` — starting the removal inline at
  * assignment and awaiting it in its `save` wrapper before the replacement is
- * inserted.
+ * inserted. A *direct* `record.association(name).build(...)` has no such
+ * wrapper, so `HasOneAssociation#build` runs the removal itself and returns the
+ * record wrapped in that promise for the caller to `await`.
  *
  * Rails' own `test_should_replace_an_existing_record_if_there_is_no_id`
  * (nested_attributes_test.rb:288) asserts only in-memory state and never saves
@@ -50,5 +52,36 @@ describe("has_one displacement via the synchronous build path", () => {
 
     const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
+  it("nullifies the displaced row when association(name).build replaces a loaded child", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    const assoc = (
+      pirate as unknown as { association(n: string): { build(a: object): unknown } }
+    ).association("ship");
+    const built = (await assoc.build({ name: "Davy Jones Gold Dagger" })) as Base;
+
+    expect((built as unknown as { name: string }).name).toBe("Davy Jones Gold Dagger");
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
+  it("returns the built record synchronously when nothing is displaced", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const assoc = (
+      pirate as unknown as { association(n: string): { build(a: object): unknown } }
+    ).association("ship");
+
+    const built = assoc.build({ name: "Black Pearl" });
+
+    expect(built).not.toBeInstanceOf(Promise);
+    expect((built as { name: string }).name).toBe("Black Pearl");
   });
 });

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -154,6 +154,20 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
+   * A through `build` displaces nothing: Rails'
+   * `HasOneThroughAssociation#replace` has no `load_target`/`remove_target!`
+   * (has_one_through_association.rb:15-42) — the join row, not the end record,
+   * carries the association, and displacement is `createThroughRecord` /
+   * `persistReplace`'s job. Same reason as `detachDisplacedTarget` above; this
+   * also keeps `build`'s return synchronous for the through builders.
+   *
+   * @internal
+   */
+  protected override detachDisplacedOnBuild(): Promise<void> | null {
+    return null;
+  }
+
+  /**
    * No-op for the same reason as `detachDisplacedTarget` above: the
    * nested-attributes displacement path must not nullify/destroy a displaced
    * *end* record of a through association.

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -168,6 +168,20 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
+   * No load either: `HasOneThroughAssociation#replace` has no `load_target`
+   * (has_one_through_association.rb:9-13) — Rails loads the *through* proxy
+   * from `create_through_record` (:15-19), which our `build#{name}` accessor
+   * drives via `loadTargetForBuild`. Building through `association(name).build`
+   * must not issue that join-model SELECT here, so return null and keep the
+   * synchronous return the through builders expect.
+   *
+   * @internal
+   */
+  protected override loadDisplacedForBuild(): Promise<unknown> | null {
+    return null;
+  }
+
+  /**
    * No-op for the same reason as `detachDisplacedTarget` above: the
    * nested-attributes displacement path must not nullify/destroy a displaced
    * *end* record of a through association.
@@ -386,7 +400,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
       // duplicate. So queue this association's own deferred `createThroughRecord`,
       // whose `persistReplace` resets the through proxy and re-reads the join row
       // from the DB, then reconciles (update existing / create when absent).
-      throughProxy.build?.(attrs);
+      buildThroughProxyRecord(throughProxy, attrs);
       if (!((this.owner as any).isNewRecord?.() ?? true)) {
         if (this._pendingReplace) {
           this._pendingReplace.record = record;
@@ -526,7 +540,7 @@ async function createThroughRecord(
         await throughRecord.update?.(attrs);
       }
     } else if ((assoc.owner as any).isNewRecord?.() || !save) {
-      throughProxy.build?.(attrs);
+      buildThroughProxyRecord(throughProxy, attrs);
     } else {
       await throughProxy.create?.(attrs);
     }
@@ -761,4 +775,24 @@ export async function findTarget(
   if (fkValue === null || fkValue === undefined) return null;
   const targetModel = resolveAssocClass(throughRecord, sourceName, className);
   return targetModel.findBy({ [targetModel.primaryKey as string]: fkValue });
+}
+
+/**
+ * Build the join record on the through proxy without its own `load_target` /
+ * `remove_target!`: a has_one through proxy is itself a has_one association, and
+ * Rails' `create_through_record` (has_one_through_association.rb:15-40) — not
+ * `SingularAssociation#build` — owns the join row's displacement, loading the
+ * proxy and updating/destroying the existing row. Letting the proxy's own build
+ * query here would both duplicate that load and make this synchronous
+ * reconstruction return a promise.
+ *
+ * @internal
+ */
+function buildThroughProxyRecord(throughProxy: any, attrs: Record<string, unknown>): void {
+  throughProxy.buildDisplacementOwnedByCaller = true;
+  try {
+    throughProxy.build?.(attrs);
+  } finally {
+    throughProxy.buildDisplacementOwnedByCaller = false;
+  }
 }

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -284,7 +284,11 @@ describe("HasOneThroughAssociationsTest", () => {
     // be cleared afterward: a later independent write to `currentMembership` on
     // the SAME instance must still autosave, not be silently skipped forever.
     const laterClub = await Club.create({ name: "Later Club" });
-    const newMembership = (refetched.association("currentMembership") as any).build({
+    // `currentMembership`'s target is loaded and persisted here, so `build`
+    // displaces it: Rails' `set_new_record` → `replace(record, false)` runs
+    // `remove_target!` inline, and our `build` returns the record wrapped in
+    // that removal's promise.
+    const newMembership = await (refetched.association("currentMembership") as any).build({
       club: laterClub,
     });
     expect(await refetched.save()).toBe(true);

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -59,19 +59,31 @@ export class SingularAssociation extends Association {
     this.replace(record);
   }
 
-  // has_one widens the return to a Promise when the freshly built record
-  // displaces a loaded, persisted target: Rails' `set_new_record` →
-  // `replace(record, false)` removes that row inline (`remove_target!`), and a
-  // synchronous JS return has no other way to expose the write for `await`.
+  // has_one widens the return to a Promise: Rails' `set_new_record` →
+  // `replace(record, false)` opens with `load_target` (the `unless load_target
+  // || record` guard, has_one_association.rb:62, always evaluates its left
+  // operand) and then removes the displaced row inline (`remove_target!`), and a
+  // synchronous JS return has no other way to expose either query for `await`.
   // belongs_to keeps the plain synchronous return — its `set_new_record` only
   // writes the owner's foreign key in memory.
   build(
     attributes?: Record<string, unknown>,
     block?: (record: Base) => void,
   ): Base | null | Promise<Base | null> {
-    // Rails' `set_new_record` → `replace(record, false)` opens with
-    // `load_target`, so only an ALREADY-loaded target can be displaced here (the
-    // `build#{name}` accessor, which can await, runs the load itself).
+    // Rails' `load_target` runs on EVERY build, so a persisted owner whose
+    // target has never been loaded still discovers (and displaces) the row in
+    // the DB. That query has to precede the in-memory build, which overwrites
+    // the target — hence the load-first branch rather than a load inside
+    // `detachDisplacedOnBuild`.
+    const load = this.loadDisplacedForBuild();
+    if (load) return load.then(() => this.buildAfterDisplacementLoad(attributes, block));
+    return this.buildAfterDisplacementLoad(attributes, block);
+  }
+
+  private buildAfterDisplacementLoad(
+    attributes?: Record<string, unknown>,
+    block?: (record: Base) => void,
+  ): Base | null | Promise<Base | null> {
     const displaced = this.loaded ? this.target : null;
     const record = this.buildRecord(attributes);
     if (record) {
@@ -83,6 +95,19 @@ export class SingularAssociation extends Association {
     }
     const removal = this.detachDisplacedOnBuild(displaced, record);
     return removal ? removal.then(() => record) : record;
+  }
+
+  /**
+   * Rails' leading `load_target` (has_one_association.rb:59-62), when it would
+   * actually query — null otherwise, which is always the case for belongs_to
+   * (`BelongsToAssociation#replace` neither loads nor removes anything).
+   * Overridden by has_one; the promise returned here is what makes `build`
+   * awaitable for the direct `record.association(name).build(...)` caller.
+   *
+   * @internal
+   */
+  protected loadDisplacedForBuild(): Promise<unknown> | null {
+    return null;
   }
 
   /**

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -59,7 +59,20 @@ export class SingularAssociation extends Association {
     this.replace(record);
   }
 
-  build(attributes?: Record<string, unknown>, block?: (record: Base) => void): Base | null {
+  // has_one widens the return to a Promise when the freshly built record
+  // displaces a loaded, persisted target: Rails' `set_new_record` →
+  // `replace(record, false)` removes that row inline (`remove_target!`), and a
+  // synchronous JS return has no other way to expose the write for `await`.
+  // belongs_to keeps the plain synchronous return — its `set_new_record` only
+  // writes the owner's foreign key in memory.
+  build(
+    attributes?: Record<string, unknown>,
+    block?: (record: Base) => void,
+  ): Base | null | Promise<Base | null> {
+    // Rails' `set_new_record` → `replace(record, false)` opens with
+    // `load_target`, so only an ALREADY-loaded target can be displaced here (the
+    // `build#{name}` accessor, which can await, runs the load itself).
+    const displaced = this.loaded ? this.target : null;
     const record = this.buildRecord(attributes);
     if (record) {
       // Rails yields the freshly built record before it's set as the new
@@ -68,7 +81,25 @@ export class SingularAssociation extends Association {
       if (block) block(record);
       this.setNewRecord(record);
     }
-    return record;
+    const removal = this.detachDisplacedOnBuild(displaced, record);
+    return removal ? removal.then(() => record) : record;
+  }
+
+  /**
+   * The DB half of the `remove_target!` Rails' has_one `set_new_record` runs
+   * inline — null when there is nothing to remove, which is always the case for
+   * belongs_to (`BelongsToAssociation#replace` only writes the owner's foreign
+   * key in memory). Overridden by has_one, where the returned promise both
+   * performs the removal and is what widens `build`'s return so a direct
+   * `record.association(name).build(...)` caller can `await` the write.
+   *
+   * @internal
+   */
+  protected detachDisplacedOnBuild(
+    _displaced: Base | null,
+    _record: Base | null,
+  ): Promise<void> | null {
+    return null;
   }
 
   async forceReloadReader(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -70,29 +70,27 @@ export class SingularAssociation extends Association {
     attributes?: Record<string, unknown>,
     block?: (record: Base) => void,
   ): Base | null | Promise<Base | null> {
-    // Rails' `load_target` runs on EVERY build, so a persisted owner whose
-    // target has never been loaded still discovers (and displaces) the row in
-    // the DB. That query has to precede the in-memory build, which overwrites
-    // the target — hence the load-first branch rather than a load inside
-    // `detachDisplacedOnBuild`.
+    // Rails is `record = build_record(attributes, &block); set_new_record(record)`
+    // (singular_association.rb:29-33): construction — and the raise a bad
+    // attribute produces — happens BEFORE `set_new_record` reaches `load_target`,
+    // so an invalid build never queries. Keep that order here.
+    const record = this.buildRecord(attributes);
+    // Rails yields the freshly built record before it's set as the new target
+    // (`build_record(attributes, &block)`), so a passed block can mutate
+    // persisted attributes (e.g. `build_bulb { |b| b.color = ... }`).
+    if (record && block) block(record);
+    // `set_new_record` → `replace(record, false)` runs `load_target` on EVERY
+    // build, so a persisted owner whose target has never been loaded still
+    // discovers (and displaces) the row in the DB. The load has to precede
+    // `setNewRecord`, which overwrites the target and marks it loaded.
     const load = this.loadDisplacedForBuild();
-    if (load) return load.then(() => this.buildAfterDisplacementLoad(attributes, block));
-    return this.buildAfterDisplacementLoad(attributes, block);
+    if (load) return load.then(() => this.setNewRecordDisplacing(record));
+    return this.setNewRecordDisplacing(record);
   }
 
-  private buildAfterDisplacementLoad(
-    attributes?: Record<string, unknown>,
-    block?: (record: Base) => void,
-  ): Base | null | Promise<Base | null> {
+  private setNewRecordDisplacing(record: Base | null): Base | null | Promise<Base | null> {
     const displaced = this.loaded ? this.target : null;
-    const record = this.buildRecord(attributes);
-    if (record) {
-      // Rails yields the freshly built record before it's set as the new
-      // target (`build_record(attributes, &block)`), so a passed block can
-      // mutate persisted attributes (e.g. `build_bulb { |b| b.color = ... }`).
-      if (block) block(record);
-      this.setNewRecord(record);
-    }
+    if (record) this.setNewRecord(record);
     const removal = this.detachDisplacedOnBuild(displaced, record);
     return removal ? removal.then(() => record) : record;
   }

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -83,16 +83,15 @@ export class SingularAssociation extends Association {
     // build, so a persisted owner whose target has never been loaded still
     // discovers (and displaces) the row in the DB. The load has to precede
     // `setNewRecord`, which overwrites the target and marks it loaded.
+    const setNewRecord = (): Base | null | Promise<Base | null> => {
+      const displaced = this.loaded ? this.target : null;
+      if (record) this.setNewRecord(record);
+      const removal = this.detachDisplacedOnBuild(displaced, record);
+      return removal ? removal.then(() => record) : record;
+    };
     const load = this.loadDisplacedForBuild();
-    if (load) return load.then(() => this.setNewRecordDisplacing(record));
-    return this.setNewRecordDisplacing(record);
-  }
-
-  private setNewRecordDisplacing(record: Base | null): Base | null | Promise<Base | null> {
-    const displaced = this.loaded ? this.target : null;
-    if (record) this.setNewRecord(record);
-    const removal = this.detachDisplacedOnBuild(displaced, record);
-    return removal ? removal.then(() => record) : record;
+    if (load) return load.then(setNewRecord);
+    return setNewRecord();
   }
 
   /**

--- a/packages/activerecord/src/associations/sti-owner-through-foreign-key.test.ts
+++ b/packages/activerecord/src/associations/sti-owner-through-foreign-key.test.ts
@@ -79,7 +79,7 @@ describe("STI owner has_one — declaring-class owner FK", () => {
         association: (n: string) => { build: (a: Record<string, unknown>) => VerySpecialComment };
       }
     ).association("verySpecialComment");
-    const built = assoc.build({ body: "built sti has_one" });
+    const built = await assoc.build({ body: "built sti has_one" });
 
     expect(Number(built._readAttribute("post_id"))).toBe(Number(post.id));
   });

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -658,8 +658,8 @@ function assertNestedAttributesAreKnown(
 interface OneToOneAssociation {
   target: Base | null;
   build(attrs: Record<string, unknown>): Base | null | Promise<Base | null>;
-  /** has_one only — see `HasOneAssociation#buildSkipsDisplacementRemoval`. */
-  buildSkipsDisplacementRemoval?: boolean;
+  /** has_one only — see `HasOneAssociation#buildDisplacementOwnedByCaller`. */
+  buildDisplacementOwnedByCaller?: boolean;
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
   detachDisplacedRecord?(displaced: Base | null): Promise<void>;
@@ -843,12 +843,12 @@ export function assignNestedAttributesForOneToOneAssociation(
         // owns the removal through `detachDisplacedAtAssignment` below, so
         // suppress the association's own — two concurrent removals of the same
         // row would double-destroy it under `dependent: :destroy`.
-        assoc.buildSkipsDisplacementRemoval = true;
+        assoc.buildDisplacementOwnedByCaller = true;
         try {
           // Never a promise with the flag set — `void` states that statically.
           void assoc.build(assignable);
         } finally {
-          assoc.buildSkipsDisplacementRemoval = false;
+          assoc.buildDisplacementOwnedByCaller = false;
         }
         detachDisplacedAtAssignment(record, assoc, displaced);
       }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -657,7 +657,9 @@ function assertNestedAttributesAreKnown(
  */
 interface OneToOneAssociation {
   target: Base | null;
-  build(attrs: Record<string, unknown>): Base | null;
+  build(attrs: Record<string, unknown>): Base | null | Promise<Base | null>;
+  /** has_one only — see `HasOneAssociation#buildSkipsDisplacementRemoval`. */
+  buildSkipsDisplacementRemoval?: boolean;
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
   detachDisplacedRecord?(displaced: Base | null): Promise<void>;
@@ -836,7 +838,18 @@ export function assignNestedAttributesForOneToOneAssociation(
         // what `load_target` surfaced, so an unloaded association displaces
         // nothing; `detachDisplacedRecord` owns the remaining guards.
         const displaced = assoc.isLoaded?.() === false ? null : existing;
-        assoc.build(assignable);
+        // `HasOneAssociation#build` runs the removal itself for direct callers
+        // (returning a promise they can await). This writer is synchronous and
+        // owns the removal through `detachDisplacedAtAssignment` below, so
+        // suppress the association's own — two concurrent removals of the same
+        // row would double-destroy it under `dependent: :destroy`.
+        assoc.buildSkipsDisplacementRemoval = true;
+        try {
+          // Never a promise with the flag set — `void` states that statically.
+          void assoc.build(assignable);
+        } finally {
+          assoc.buildSkipsDisplacementRemoval = false;
+        }
         detachDisplacedAtAssignment(record, assoc, displaced);
       }
     }

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -919,8 +919,15 @@ describe("DefaultScopingTest", () => {
       expect(Number(assigned._readAttribute("post_id"))).toBe(Number(post.id));
 
       // Association#buildRecord sets the declaring-class FK on the built target.
-      const built = post.association("verySpecialComment").build({ body: "built sti has_one" });
-      expect(Number(built._readAttribute("post_id"))).toBe(Number(post.id));
+      // Build on an owner with no comment: Rails' `build` runs `load_target` +
+      // `remove_target!`, and nullifying a displaced comment's `post_id` would
+      // hit the column's NOT NULL constraint rather than exercise the FK
+      // derivation this asserts.
+      const builder = (await SpecialPost.create({ title: "sti builder", body: "x" })) as any;
+      const built = await builder
+        .association("verySpecialComment")
+        .build({ body: "built sti has_one" });
+      expect(Number(built._readAttribute("post_id"))).toBe(Number(builder.id));
     });
   });
 


### PR DESCRIPTION
## What

`record.association("ship").build({...})` on a has_one left the displaced row
attached. `setNewRecord` does only the in-memory nullify, and PR #5290 (which
retired `_displacedRecords`) moved the DB half to the callers that can `await` —
the `build#{Name}` / `create#{Name}` accessors and the nested-attributes writer.
The direct `association(name).build` entry point had no such caller.

Rails does both halves inline: `set_new_record` → `replace(record, false)`
(`has_one_association.rb:87-93`), whose guard is `return target unless
load_target || record` (:62) — Ruby always evaluates the left operand, so **every**
build first queries for an existing target (`find_target?`), then
`remove_target!` nullifies it, or destroys/deletes it per `:dependent`
(:59-69, 95-115).

## How

`SingularAssociation#build` gains two `@internal`, `protected` hooks:

- `loadDisplacedForBuild` — Rails' leading `load_target`. `HasOneAssociation`
  routes it through the same `needsTargetLoadForBuild` (`find_target?`) /
  `loadTargetForBuild` machinery the `build#{Name}` accessor already uses, so
  the query runs exactly when Rails' would — including on a **fresh,
  never-loaded** owner, the case the first revision of this PR missed.
- `detachDisplacedOnBuild` — the `remove_target!` that follows, via
  `detachDisplacedTarget` (its guards: a different, non-destroyed record; plus
  the `target.persisted?` gate at :108).

Both return `null` in the base — belongs_to's `replace` neither loads nor
removes — and in has_one_through, whose `replace` has no `load_target` /
`remove_target!` at all (`has_one_through_association.rb:9-13`); its join row is
loaded and reconciled by `createThroughRecord` / `persistReplace`.

So `build` returns a Promise resolving to the record whenever Rails would issue
a query, and stays synchronous when Rails would not (a new-record owner, or a
loaded association displacing nothing / displacing a never-persisted record).
Nothing is queued for the owner's `save()`.

`buildDisplacementOwnedByCaller` suppresses both hooks for the three callers
that already own the load and the removal: the `build#{Name}` accessor
(`loadTargetForBuild` + `detachDisplacedTarget`), the nested-attributes writer
(a synchronous property setter, which starts `detachDisplacedRecord` at
assignment and drains it in its `save` wrapper), and the through machinery's own
`throughProxy.build` in `constructThroughRecordInMemory`.

## Tests

`has-one-sync-build-displacement.trails.test.ts` covers the loaded and the
unloaded displaced target (each verified failing on its respective baseline —
`expected 959118196 to be null`), plus a guard that a build needing no query
keeps its synchronous return.

Call sites that now cross a query boundary gained an `await`: five direct
`association(name).build` calls in `has-one-associations.test.ts`, one in
`sti-owner-through-foreign-key.test.ts`, one in
`has-one-through-associations.test.ts`, and one in `default-scoping.test.ts`.
No test was renamed. The last one also moves its build to a fresh owner:
nullifying the displaced comment's `post_id` hits that column's NOT NULL
constraint, which is not what the assertion is about.

## Parity gates

- `pnpm api:compare` exits 0; `pnpm api:extra` activerecord novel count is
  unchanged at 579 — every new member is protected, so none reaches the API
  surface.
- `pnpm test:compare`: activerecord 7787/7787 tests (100%), 321/321 files,
  0 misplaced.

Closes-story: has-one-direct-association-build-leaves-displaced-row-attached
