### PR TITLE
test(postgresql): isolate the inline samples/bits tables per suite

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -92,6 +92,23 @@ export async function withNativeDatabaseTypeOverrides<T>(
 export { PostgreSQLAdapter };
 
 /**
+ * Suffixes an inline DDL table name so concurrent suites cannot drop each
+ * other's copy of it.
+ *
+ * Rails creates `samples`/`bits` inline in each transaction test's `setup`
+ * (transaction_test.rb, transaction_nested_test.rb) and runs single-process, so
+ * the shared name is harmless there. Trails forks 6 vitest workers onto ONE
+ * shared CI database, and vitest puts these two files in different workers: one
+ * file's `afterEach` `DROP TABLE IF EXISTS samples` can drop the table the
+ * other file is mid-test against, surfacing as 42P01 on an innocent test. A
+ * per-suite physical name keeps the DDL isolated; the Rails-facing surface
+ * (test names, the columns, the semantics) is untouched.
+ */
+export function suiteTable(name: string, suite: string): string {
+  return `${name}_${suite}`;
+}
+
+/**
  * Mirrors Rails' SQLSubscriber test helper from activerecord/test/cases/helper.rb.
  * Records sql.active_record notifications so tests can assert on payload fields.
  */

--- a/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
@@ -15,11 +15,12 @@
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, suiteTable } from "./test-helper.js";
+import { SerializationFailure, Deadlocked } from "../../errors.js";
 
-// See suiteTable: cross-worker DDL isolation for Rails' inline `samples`/`bits`.
+// Rails' inline `samples`/`bits`, renamed per suite — see suiteTable for why the
+// shared names race across vitest workers on the one CI database.
 const SAMPLES = suiteTable("samples", "transaction_nested");
 const BITS = suiteTable("bits", "transaction_nested");
-import { SerializationFailure, Deadlocked } from "../../errors.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
@@ -14,7 +14,11 @@
  * from the aborted state — see assertConnectionRecovers.
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, suiteTable } from "./test-helper.js";
+
+// See suiteTable: cross-worker DDL isolation for Rails' inline `samples`/`bits`.
+const SAMPLES = suiteTable("samples", "transaction_nested");
+const BITS = suiteTable("bits", "transaction_nested");
 import { SerializationFailure, Deadlocked } from "../../errors.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -29,20 +33,20 @@ describeIfPg("PostgreSQLAdapter", () => {
   describe("PostgreSQLTransactionNestedTest", () => {
     // Mirrors Rails' setup (samples + bits, value col); created post-reset.
     beforeEach(async () => {
-      await adapter.exec("DROP TABLE IF EXISTS samples, bits");
-      await adapter.exec("CREATE TABLE samples (id int PRIMARY KEY, value integer)");
-      await adapter.exec("CREATE TABLE bits (id int PRIMARY KEY, value integer)");
-      await adapter.execute("INSERT INTO samples VALUES (1, 0), (2, 0)");
-      await adapter.execute("INSERT INTO bits VALUES (1, 0)");
+      await adapter.exec(`DROP TABLE IF EXISTS ${SAMPLES}, ${BITS}`);
+      await adapter.exec(`CREATE TABLE ${SAMPLES} (id int PRIMARY KEY, value integer)`);
+      await adapter.exec(`CREATE TABLE ${BITS} (id int PRIMARY KEY, value integer)`);
+      await adapter.execute(`INSERT INTO ${SAMPLES} VALUES (1, 0), (2, 0)`);
+      await adapter.execute(`INSERT INTO ${BITS} VALUES (1, 0)`);
     });
     afterEach(async () => {
-      await adapter.exec("DROP TABLE IF EXISTS samples, bits");
+      await adapter.exec(`DROP TABLE IF EXISTS ${SAMPLES}, ${BITS}`);
     });
 
     // Mirrors make_parent_transaction_dirty (Bit.take): reads `bits`, not the
     // contended `samples` rows.
     async function makeParentTransactionDirty(conn: PostgreSQLAdapter): Promise<void> {
-      await conn.execute("SELECT * FROM bits LIMIT 1");
+      await conn.execute(`SELECT * FROM ${BITS} LIMIT 1`);
     }
 
     // Serializable parent on each connection, dirty each, savepoint on
@@ -52,12 +56,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       await other.beginIsolatedDbTransaction("serializable");
       await makeParentTransactionDirty(other);
-      await other.execute("SELECT sum(value) FROM samples");
+      await other.execute(`SELECT sum(value) FROM ${SAMPLES}`);
       await adapter.beginIsolatedDbTransaction("serializable");
       await makeParentTransactionDirty(adapter);
-      await adapter.execute("SELECT sum(value) FROM samples");
+      await adapter.execute(`SELECT sum(value) FROM ${SAMPLES}`);
       await adapter.createSavepoint("sp1");
-      await other.execute("UPDATE samples SET value = 1 WHERE id = 1");
+      await other.execute(`UPDATE ${SAMPLES} SET value = 1 WHERE id = 1`);
       await other.commitDbTransaction();
       return other;
     }
@@ -70,11 +74,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       await makeParentTransactionDirty(other);
       await adapter.createSavepoint("sp1");
       await other.createSavepoint("sp1");
-      await adapter.execute("UPDATE samples SET value = 1 WHERE id = 1");
-      await other.execute("UPDATE samples SET value = 2 WHERE id = 2");
+      await adapter.execute(`UPDATE ${SAMPLES} SET value = 1 WHERE id = 1`);
+      await other.execute(`UPDATE ${SAMPLES} SET value = 2 WHERE id = 2`);
       const [r1, r2] = await Promise.allSettled([
-        adapter.execute("UPDATE samples SET value = 3 WHERE id = 2"),
-        other.execute("UPDATE samples SET value = 4 WHERE id = 1"),
+        adapter.execute(`UPDATE ${SAMPLES} SET value = 3 WHERE id = 2`),
+        other.execute(`UPDATE ${SAMPLES} SET value = 4 WHERE id = 1`),
       ]);
       const errs = [r1, r2].filter((r) => r.status === "rejected");
       return errs.length === 1 && errs[0].reason instanceof Deadlocked;
@@ -84,18 +88,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     // transaction commits and persists (fails if state was left stuck).
     async function assertConnectionRecovers(): Promise<void> {
       await adapter.beginDbTransaction();
-      await adapter.execute("UPDATE samples SET value = 7 WHERE id = 2");
+      await adapter.execute(`UPDATE ${SAMPLES} SET value = 7 WHERE id = 2`);
       await adapter.commitDbTransaction();
-      const rows = await adapter.execute("SELECT value FROM samples WHERE id = 2");
+      const rows = await adapter.execute(`SELECT value FROM ${SAMPLES} WHERE id = 2`);
       expect((rows[0] as { value: number }).value).toBe(7);
     }
 
     it("unserializable transaction raises SerializationFailure inside nested SavepointTransaction", async () => {
       const other = await serializationConflict();
       try {
-        await expect(adapter.execute("UPDATE samples SET value = 2 WHERE id = 1")).rejects.toThrow(
-          SerializationFailure,
-        );
+        await expect(
+          adapter.execute(`UPDATE ${SAMPLES} SET value = 2 WHERE id = 1`),
+        ).rejects.toThrow(SerializationFailure);
       } finally {
         await adapter.rollbackDbTransaction().catch(() => {});
         await other.rollbackDbTransaction().catch(() => {});
@@ -106,9 +110,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("SerializationFailure inside nested SavepointTransaction is recoverable", async () => {
       const other = await serializationConflict();
       try {
-        await expect(adapter.execute("UPDATE samples SET value = 2 WHERE id = 1")).rejects.toThrow(
-          SerializationFailure,
-        );
+        await expect(
+          adapter.execute(`UPDATE ${SAMPLES} SET value = 2 WHERE id = 1`),
+        ).rejects.toThrow(SerializationFailure);
       } finally {
         await adapter.rollbackDbTransaction().catch(() => {});
         await other.rollbackDbTransaction().catch(() => {});

--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -7,10 +7,11 @@
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, suiteTable } from "./test-helper.js";
-
-// See suiteTable: cross-worker DDL isolation for Rails' inline `samples` table.
-const SAMPLES = suiteTable("samples", "transaction");
 import { SerializationFailure, Deadlocked, LockWaitTimeout, QueryCanceled } from "../../errors.js";
+
+// Rails' inline `samples`, renamed per suite — see suiteTable for why the
+// shared name races across vitest workers on the one CI database.
+const SAMPLES = suiteTable("samples", "transaction");
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -6,7 +6,10 @@
  * instances coordinating real conflicts), the idiom for `adapters/postgresql/`.
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, suiteTable } from "./test-helper.js";
+
+// See suiteTable: cross-worker DDL isolation for Rails' inline `samples` table.
+const SAMPLES = suiteTable("samples", "transaction");
 import { SerializationFailure, Deadlocked, LockWaitTimeout, QueryCanceled } from "../../errors.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -22,12 +25,12 @@ describeIfPg("PostgreSQLAdapter", () => {
     // Mirrors Rails' setup/teardown (samples table, value column). Created in
     // beforeEach — after the global reset (cases/helper.ts drops all tables).
     beforeEach(async () => {
-      await adapter.exec("DROP TABLE IF EXISTS samples");
-      await adapter.exec("CREATE TABLE samples (id int PRIMARY KEY, value integer)");
-      await adapter.execute("INSERT INTO samples VALUES (1, 0), (2, 0)");
+      await adapter.exec(`DROP TABLE IF EXISTS ${SAMPLES}`);
+      await adapter.exec(`CREATE TABLE ${SAMPLES} (id int PRIMARY KEY, value integer)`);
+      await adapter.execute(`INSERT INTO ${SAMPLES} VALUES (1, 0), (2, 0)`);
     });
     afterEach(async () => {
-      await adapter.exec("DROP TABLE IF EXISTS samples");
+      await adapter.exec(`DROP TABLE IF EXISTS ${SAMPLES}`);
     });
 
     it("raises SerializationFailure when a serialization failure occurs", async () => {
@@ -37,13 +40,13 @@ describeIfPg("PostgreSQLAdapter", () => {
         await other.beginIsolatedDbTransaction("serializable");
         // Both read the same set, then write based on it — the second writer
         // raises serialization_failure.
-        await adapter.execute("SELECT sum(value) FROM samples");
-        await other.execute("SELECT sum(value) FROM samples");
-        await other.execute("UPDATE samples SET value = 1 WHERE id = 1");
+        await adapter.execute(`SELECT sum(value) FROM ${SAMPLES}`);
+        await other.execute(`SELECT sum(value) FROM ${SAMPLES}`);
+        await other.execute(`UPDATE ${SAMPLES} SET value = 1 WHERE id = 1`);
         await other.commitDbTransaction();
-        await expect(adapter.execute("UPDATE samples SET value = 2 WHERE id = 1")).rejects.toThrow(
-          SerializationFailure,
-        );
+        await expect(
+          adapter.execute(`UPDATE ${SAMPLES} SET value = 2 WHERE id = 1`),
+        ).rejects.toThrow(SerializationFailure);
       } finally {
         await adapter.rollbackDbTransaction().catch(() => {});
         await other.rollbackDbTransaction().catch(() => {});
@@ -88,12 +91,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.beginDbTransaction();
         await other.beginDbTransaction();
-        await adapter.execute("UPDATE samples SET value = 1 WHERE id = 1");
-        await other.execute("UPDATE samples SET value = 2 WHERE id = 2");
+        await adapter.execute(`UPDATE ${SAMPLES} SET value = 1 WHERE id = 1`);
+        await other.execute(`UPDATE ${SAMPLES} SET value = 2 WHERE id = 2`);
         // Each now waits on the row the other holds — deadlock; PG aborts one.
         const [r1, r2] = await Promise.allSettled([
-          adapter.execute("UPDATE samples SET value = 3 WHERE id = 2"),
-          other.execute("UPDATE samples SET value = 4 WHERE id = 1"),
+          adapter.execute(`UPDATE ${SAMPLES} SET value = 3 WHERE id = 2`),
+          other.execute(`UPDATE ${SAMPLES} SET value = 4 WHERE id = 1`),
         ]);
         const errs = [r1, r2].filter((r) => r.status === "rejected");
         expect(errs).toHaveLength(1);
@@ -113,10 +116,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       try {
         await adapter.beginDbTransaction();
-        await adapter.execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE");
+        await adapter.execute(`SELECT * FROM ${SAMPLES} WHERE id = 1 FOR UPDATE`);
         await other.execute("SET lock_timeout = '100ms'");
         await expect(
-          other.execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE"),
+          other.execute(`SELECT * FROM ${SAMPLES} WHERE id = 1 FOR UPDATE`),
         ).rejects.toThrow(LockWaitTimeout);
       } finally {
         await adapter.rollbackDbTransaction().catch(() => {});
@@ -128,12 +131,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       try {
         await adapter.beginDbTransaction();
-        await adapter.execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE");
+        await adapter.execute(`SELECT * FROM ${SAMPLES} WHERE id = 1 FOR UPDATE`);
         const otherRows = await other.execute("SELECT pg_backend_pid() AS pid");
         const otherPid = (otherRows[0] as { pid: number }).pid;
         let blockedError: unknown;
         const blocked = other
-          .execute("SELECT * FROM samples WHERE id = 1 FOR UPDATE")
+          .execute(`SELECT * FROM ${SAMPLES} WHERE id = 1 FOR UPDATE`)
           .catch((e) => {
             blockedError = e;
           });


### PR DESCRIPTION
## Problem

`transaction.test.ts` and `transaction-nested.test.ts` each `CREATE TABLE samples`
in `beforeEach` and `DROP TABLE IF EXISTS samples` in `afterEach`, against the
**shared** CI database. Vitest assigns each file to a different worker, so the
two run concurrently: one file's teardown DROP can remove the table the other
file is mid-test against, surfacing as `42P01 relation "samples" does not exist`
on a test that did nothing wrong. Same class of cross-worker interference as
#5437 (which fixed the `pg_cancel_backend` half of the hazard in this same file
pair); this is the remaining DDL half.

## Fix

The table is faithful — Rails' `transaction_test.rb` also creates `samples`
inline in `setup`; it runs single-process, so the shared name is harmless there.
So the fix is worker isolation, not moving `samples` into the canonical schema:
each suite gets its own physical table name via a documented `suiteTable()`
helper in `adapters/postgresql/test-helper.ts` (`samples_transaction`,
`samples_transaction_nested`, `bits_transaction_nested`). Rails-facing surface —
test names, columns, semantics — is unchanged.

Verified against a local PG 17: both files, 10 tests pass.

Closes-story: pg-samples-table-ddl-races-between-worker-files
