### PR TITLE
test(activerecord): resolve :arunit named configs instead of call-site workarounds

### DIFF
--- a/packages/activerecord/src/primary-class.test.ts
+++ b/packages/activerecord/src/primary-class.test.ts
@@ -108,14 +108,10 @@ describe("PrimaryClassTest", () => {
     expect(ApplicationRecord.abstractClass).toBe(true);
   });
 
-  // Both tests are gated behind Rails' `unless in_memory_db?`
-  // (primary_class_test.rb): re-establishing an in-memory pool would discard
-  // its schema.
   it.skipIf(inMemoryDb())(
     "application record shares a connection with active record by default",
     async () => {
       (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
-      const original = Base.connectionDbConfig();
       try {
         const pools = ApplicationRecord.connectsTo({
           database: { writing: "arunit", reading: "arunit" },
@@ -127,7 +123,7 @@ describe("PrimaryClassTest", () => {
         expect(await ApplicationRecord.leaseConnection()).toBe(await Base.leaseConnection());
       } finally {
         ApplicationRecord.removeConnection();
-        await Base.establishConnection(original);
+        await Base.establishConnection("arunit");
       }
     },
   );
@@ -136,7 +132,6 @@ describe("PrimaryClassTest", () => {
     "application record shares a connection with the primary abstract class if set",
     async () => {
       PrimaryAppRecord.primaryAbstractClass();
-      const original = Base.connectionDbConfig();
       try {
         const pools = PrimaryAppRecord.connectsTo({
           database: { writing: "arunit", reading: "arunit" },
@@ -149,7 +144,7 @@ describe("PrimaryClassTest", () => {
         expect(await PrimaryAppRecord.leaseConnection()).toBe(await Base.leaseConnection());
       } finally {
         PrimaryAppRecord.removeConnection();
-        await Base.establishConnection(original);
+        await Base.establishConnection("arunit");
       }
     },
   );

--- a/packages/activerecord/src/primary-class.test.ts
+++ b/packages/activerecord/src/primary-class.test.ts
@@ -110,17 +110,15 @@ describe("PrimaryClassTest", () => {
 
   // Both tests are gated behind Rails' `unless in_memory_db?`
   // (primary_class_test.rb): re-establishing an in-memory pool would discard
-  // its schema. Rails passes `:arunit`; the trails harness registers no named
-  // configurations, so the current db config stands in for that lookup.
+  // its schema.
   it.skipIf(inMemoryDb())(
     "application record shares a connection with active record by default",
     async () => {
       (globalThis as Record<string, unknown>)["ApplicationRecord"] = ApplicationRecord;
       const original = Base.connectionDbConfig();
       try {
-        const arunit = original as unknown as Record<string, unknown>;
         const pools = ApplicationRecord.connectsTo({
-          database: { writing: arunit, reading: arunit },
+          database: { writing: "arunit", reading: "arunit" },
         });
         await Promise.all(pools.map((p) => p.adapterReady));
 
@@ -140,9 +138,8 @@ describe("PrimaryClassTest", () => {
       PrimaryAppRecord.primaryAbstractClass();
       const original = Base.connectionDbConfig();
       try {
-        const arunit = original as unknown as Record<string, unknown>;
         const pools = PrimaryAppRecord.connectsTo({
-          database: { writing: arunit, reading: arunit },
+          database: { writing: "arunit", reading: "arunit" },
         });
         await Promise.all(pools.map((p) => p.adapterReady));
 

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -573,8 +573,6 @@ describe("QueryCacheTest", () => {
     });
   });
 
-  // Rails skips this in-memory ("In-Memory DB can't test for using a not
-  // connected connection"): re-establishing the pool would discard the schema.
   it.skipIf(inMemoryDb())("cache is available when using a not connected connection", async () => {
     const dbConfig = Base.connectionDbConfig();
     const originalConnection = Base.removeConnection();

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -579,14 +579,6 @@ describe("QueryCacheTest", () => {
     const dbConfig = Base.connectionDbConfig();
     const originalConnection = Base.removeConnection();
 
-    // Rails' `cache` block-helper only engages when `connected? ||
-    // !configurations.empty?` — its harness (ARTest.connect) populates
-    // `Base.configurations` from config.yml, so the not-connected branch still
-    // caches. The trails harness establishes connections without registering
-    // configurations, so supply that precondition here and restore after.
-    const priorConfigurations = Base.configurations();
-    Base.configurations({ arunit: dbConfig.configuration });
-
     await Base.establishConnection(dbConfig);
     expect(Task.isConnectedQ()).toBe(false);
 
@@ -600,7 +592,6 @@ describe("QueryCacheTest", () => {
         });
       });
     } finally {
-      Base.configurations(priorConfigurations);
       await Base.establishConnection(originalConnection);
     }
   });


### PR DESCRIPTION
The harness half of this story is already in place: `support/connection.ts`
`connect()` builds all three ARTest named entries (`arunit`, `arunit2`,
`arunit_without_prepared_statements`) via `testConfigurationHashes()` /
`expandConfig()`, assigns them to `Base.configurations`, and establishes the
primary pool by name (`Base.establishConnection("arunit")`), mirroring
`connection.rb:22-38`.

What was left were the two PR #5088 call-site workarounds, both removed here:

- `query-cache.test.ts` — "cache is available when using a not connected
  connection" no longer hand-assigns and restores `Base.configurations` to
  satisfy Rails' `connected? || !configurations.empty?` gate
  (`query_cache.rb:10`); the harness-registered configs already satisfy it.
- `primary-class.test.ts` — both "application record shares a connection …"
  tests pass `"arunit"` to `connectsTo`, as Rails passes `:arunit`, instead of
  threading the current `connectionDbConfig()` hash through.

Both files pass locally on the default (sqlite) lane; neither test is skipped
there, so the named-config resolution path is genuinely exercised.

Closes-story: harness-register-arunit-named-configurations
