### PR TITLE
test(activerecord): un-gate the arunit2 second-database suites on PG/MySQL

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -21,8 +21,6 @@ export { withDbWarningsAction } from "../../support/with-db-warnings-action.js";
 // deliberately build a second, differently configured adapter.
 export const MYSQL_TEST_URL = mysqlUrl();
 
-export { databaseName } from "../../support/arunit2-config.js";
-
 /**
  * ARTest models the AR suite as two databases — `arunit` (primary) and
  * `arunit2` — and reads both names from `ARTest.test_configuration_hashes`.

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -4,7 +4,6 @@ import { Base } from "./base.js";
 import { StatementInvalid } from "./errors.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { withSecondPool } from "./support/setup-second-pool.js";
-import { isSqliteRun } from "./support/sqlite-template.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Course } from "./test-helpers/models/course.js";
 import { College } from "./test-helpers/models/college.js";
@@ -12,9 +11,9 @@ import { Entrant } from "./test-helpers/models/entrant.js";
 import { Bird } from "./test-helpers/models/bird.js";
 
 // Rails runs MultipleDbTest against two real databases (arunit / arunit2), as
-// does trails now that `connect` establishes ARUnit2Model on a provisioned
-// arunit2. Un-gating this suite for PG/MySQL is its own story.
-describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
+// does trails on every lane: `connect` establishes ARUnit2Model on arunit2 and
+// `provisionSecondDatabase` creates that database before any suite runs.
+describe("MultipleDbTest", () => {
   // Rails sets `self.use_transactional_tests = false`; fixtures() pins
   // the schema/fixtures across the file (skips the global per-test reset).
   fixtures({}, { useTransactionalTests: false });

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -10,9 +10,6 @@ import { College } from "./test-helpers/models/college.js";
 import { Entrant } from "./test-helpers/models/entrant.js";
 import { Bird } from "./test-helpers/models/bird.js";
 
-// Rails runs MultipleDbTest against two real databases (arunit / arunit2), as
-// does trails on every lane: `connect` establishes ARUnit2Model on arunit2 and
-// `provisionSecondDatabase` creates that database before any suite runs.
 describe("MultipleDbTest", () => {
   // Rails sets `self.use_transactional_tests = false`; fixtures() pins
   // the schema/fixtures across the file (skips the global per-test reset).
@@ -141,11 +138,12 @@ describe("MultipleDbTest", () => {
 
   // Rails guards these two with `unless in_memory_db?` (multiple_db_test.rb): its
   // in-memory harness can't give arunit2 a genuinely separate pool, so College
-  // would resolve to Base's connection. withSecondPool establishes an explicitly
-  // independent arunit2 pool (its own `:memory:` DB), so the assertions hold and we
-  // run them. This differs from the primary-class pair, which stay skipped because
-  // `connects_to(arunit/arunit)` is *expected* to share Base's connection — which
-  // independent in-memory DBs can't do.
+  // would resolve to Base's connection. trails' arunit2 is always a genuinely
+  // separate pool — a provisioned database on PG/MySQL, its own `:memory:` DB on
+  // sqlite — so the assertions hold and we run them. This differs from the
+  // primary-class pair, which stay skipped because `connects_to(arunit/arunit)`
+  // is *expected* to share Base's connection — which independent in-memory DBs
+  // can't do.
   it("count on custom connection", async () => {
     expect(await ARUnit2Model.leaseConnection()).toBe(await College.leaseConnection());
     expect(await Base.leaseConnection()).not.toBe(await College.leaseConnection());

--- a/packages/activerecord/src/prepared-statement-status.test.ts
+++ b/packages/activerecord/src/prepared-statement-status.test.ts
@@ -4,7 +4,6 @@ import "./index.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { withSecondPool } from "./support/setup-second-pool.js";
-import { isSqliteRun } from "./support/sqlite-template.js";
 import { Course } from "./test-helpers/models/course.js";
 import { Entrant } from "./test-helpers/models/entrant.js";
 
@@ -16,7 +15,7 @@ function event(): { set: () => void; wait: Promise<void> } {
   return { set, wait };
 }
 
-describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
+describe("PreparedStatementStatusTest", () => {
   fixtures({}, { useTransactionalTests: false });
   withSecondPool();
 

--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -1,21 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  arunitDatabaseNames,
-  databaseName,
-  resolveSecondDatabaseConfig,
-} from "./arunit2-config.js";
-
-/** A stub env reader backed by a fixed map (no ambient env mutation). */
-function reader(env: Record<string, string | undefined>): (key: string) => string | undefined {
-  return (key) => env[key];
-}
+import { arunitDatabaseNames } from "./arunit2-config.js";
 
 describe("arunit2-config", () => {
-  it("databaseName strips the leading slash from the URL path", () => {
-    expect(databaseName("mysql://root@localhost:3306/rails_js_test")).toBe("rails_js_test");
-    expect(databaseName("postgres://localhost/ar_test")).toBe("ar_test");
-  });
-
   it("arunitDatabaseNames suffixes the primary database name", () => {
     expect(arunitDatabaseNames("rails_js_test")).toEqual({
       arunit: "rails_js_test_arunit",
@@ -23,53 +9,10 @@ describe("arunit2-config", () => {
     });
   });
 
-  it("resolves Postgres when ARCONN names the postgresql connection", () => {
-    expect(
-      resolveSecondDatabaseConfig(
-        reader({ ARCONN: "postgresql", PGHOST: "db.example", PGDATABASE: "ar_test" }),
-      ),
-    ).toEqual({
-      adapter: "postgres",
-      config: "postgres://postgres@db.example:5432/ar_test_arunit2",
-    });
-  });
-
-  it("resolves MySQL when ARCONN names the mysql2 connection", () => {
-    expect(resolveSecondDatabaseConfig(reader({ ARCONN: "mysql2" }))).toEqual({
-      adapter: "mysql",
-      config: "mysql://root@localhost:3306/rails_js_test_arunit2",
-    });
-  });
-
-  it("carries MYSQL_SOCK into the arunit2 connection", () => {
-    // Rails puts the socket in mysql2.arunit2 as well as mysql2.arunit
-    // (config.example.yml:37-39) before ARUnit2Model.establish_connection
-    // :arunit2 (connection.rb:33), so the second database must reach the
-    // socket too — not just the primary.
-    expect(
-      resolveSecondDatabaseConfig(reader({ ARCONN: "mysql2", MYSQL_SOCK: "/tmp/m.sock" })).config,
-    ).toBe("mysql://root@localhost:3306/rails_js_test_arunit2?socketPath=%2Ftmp%2Fm.sock");
-  });
-
   it("carries the worker isolation slot into the arunit2 database name", () => {
-    expect(resolveSecondDatabaseConfig(reader({ ARCONN: "mysql2", AR_DB_SLOT: "3" })).config).toBe(
-      "mysql://root@localhost:3306/rails_js_test_3_arunit2",
-    );
-  });
-
-  it("ignores connection sub-settings when ARCONN does not select that backend", () => {
-    // The whole point of the ARCONN split: a PG host in the environment must
-    // not drag the second database onto Postgres.
-    expect(
-      resolveSecondDatabaseConfig(reader({ PGHOST: "db.example", MYSQL_HOST: "mysql.example" }))
-        .adapter,
-    ).toBe("sqlite");
-  });
-
-  it("falls back to a separate in-memory SQLite pool when ARCONN is unset", () => {
-    expect(resolveSecondDatabaseConfig(reader({}))).toEqual({
-      adapter: "sqlite",
-      config: { adapter: "sqlite3", database: ":memory:", pool: 1 },
-    });
+    // The slot is already baked into the primary database name by the
+    // sub-settings, so the derived arunit2 name inherits it and parallel
+    // workers never share a second database.
+    expect(arunitDatabaseNames("rails_js_test_3").arunit2).toBe("rails_js_test_3_arunit2");
   });
 });

--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -10,9 +10,6 @@ describe("arunit2-config", () => {
   });
 
   it("carries the worker isolation slot into the arunit2 database name", () => {
-    // The slot is already baked into the primary database name by the
-    // sub-settings, so the derived arunit2 name inherits it and parallel
-    // workers never share a second database.
     expect(arunitDatabaseNames("rails_js_test_3").arunit2).toBe("rails_js_test_3_arunit2");
   });
 });

--- a/packages/activerecord/src/support/arunit2-config.ts
+++ b/packages/activerecord/src/support/arunit2-config.ts
@@ -15,32 +15,19 @@
  * work — off the shared primary database whose canonical tables parallel
  * workers create and drop.
  *
- * Hard rules (RFC 0023): no `node:*` imports, no `process.*` — environment
- * reads go through activesupport's `getEnv`; async fs only (none needed here).
+ * The *connection names* are already first-class: `support/connection.ts`
+ * publishes `arunit`, `arunit2` and `arunit_without_prepared_statements` as
+ * named entries on `Base.configurations`, and `connect` establishes both pools
+ * by name (`connection.rb:32-33`). Only the *database names* stay
+ * suffix-derived, because they must carry the per-worker isolation slot that
+ * Rails' static `config.yml` has no equivalent of — a checked-in name would
+ * collide across parallel workers.
  *
  * @internal
  */
 
-import { getEnv } from "@blazetrails/activesupport";
-import {
-  mysqlSettings,
-  postgresSettings,
-  settingsUrl,
-  withDatabase,
-  type EnvReader,
-  type TestAdapterName,
-} from "./config.js";
-import { activeLane } from "./connection.js";
-
-export type { TestAdapterName };
-
 const ARUNIT_SUFFIX = "_arunit";
 const ARUNIT2_SUFFIX = "_arunit2";
-
-/** The database component of a connection URL (`scheme://host/foo` → `foo`). */
-export function databaseName(url: string): string {
-  return new URL(url).pathname.replace(/^\//, "");
-}
 
 /**
  * The config-derived `arunit` / `arunit2` database names for a primary
@@ -53,49 +40,4 @@ export function arunitDatabaseNames(primaryDatabase: string): {
 } {
   const base = primaryDatabase;
   return { arunit: `${base}${ARUNIT_SUFFIX}`, arunit2: `${base}${ARUNIT2_SUFFIX}` };
-}
-
-/** A config accepted by `Model.establishConnection` (URL string or hash). */
-export type SecondDatabaseConfig = string | { adapter: string; database: string; pool: number };
-
-export interface ResolvedSecondDatabase {
-  adapter: TestAdapterName;
-  config: SecondDatabaseConfig;
-}
-
-/**
- * Resolve the second-database (`arunit2`) connection config for the adapter the
- * current worker is running against, from the same `ARCONN` + sub-settings
- * the primary harness uses. On sqlite the
- * two databases are separate in-memory pools (a server-less analog of the
- * `arunit` / `arunit2` split); on Postgres/MySQL the config points at the
- * derived `arunit2` database on the shared server.
- *
- * Status: the sole runtime caller (`setupSecondPool`) only runs on the sqlite
- * lane today — `MultipleDbTest` is `describe.skipIf(!isSqliteRun())` because no
- * one provisions a second named database on the PG/MySQL servers yet. The
- * Postgres/MySQL branches here are therefore groundwork: exercised by this
- * file's unit tests and ready for the un-gating + `CREATE DATABASE`
- * provisioning tracked in its own story, not yet live on a PG/MySQL run.
- *
- * `read` is injectable so tests can exercise each adapter branch without
- * mutating the ambient environment; it defaults to activesupport's `getEnv`.
- * Selection keys off `ARCONN` — the same signal the primary harness uses.
- */
-export function resolveSecondDatabaseConfig(read: EnvReader = getEnv): ResolvedSecondDatabase {
-  const lane = activeLane(read);
-  if (lane === "postgres") {
-    const settings = postgresSettings(read);
-    const { arunit2 } = arunitDatabaseNames(settings.database);
-    return {
-      adapter: "postgres",
-      config: settingsUrl("postgres", withDatabase(settings, arunit2)),
-    };
-  }
-  if (lane === "mysql") {
-    const settings = mysqlSettings(read);
-    const { arunit2 } = arunitDatabaseNames(settings.database);
-    return { adapter: "mysql", config: settingsUrl("mysql", withDatabase(settings, arunit2)) };
-  }
-  return { adapter: "sqlite", config: { adapter: "sqlite3", database: ":memory:", pool: 1 } };
 }

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -9,7 +9,6 @@ import { College } from "../test-helpers/models/college.js";
 import { Entrant } from "../test-helpers/models/entrant.js";
 import { Professor } from "../test-helpers/models/professor.js";
 import { activeLane } from "./connection.js";
-import { isSqliteRun } from "./sqlite-template.js";
 
 /**
  * The tables `schema.rb:1444-1460` creates through the second connection
@@ -107,11 +106,6 @@ async function teardownSecondPool(): Promise<void> {
  * @internal
  */
 export function withSecondPool(): void {
-  beforeAll(async () => {
-    if (isSqliteRun()) await setupSecondPool();
-  });
-
-  afterAll(async () => {
-    if (isSqliteRun()) await teardownSecondPool();
-  });
+  beforeAll(setupSecondPool);
+  afterAll(teardownSecondPool);
 }


### PR DESCRIPTION
`arunit2` was already provisioned on every lane — `provisionSecondDatabase`
(`support/setup-second-pool.ts`, run from the worker bootstrap
`test-setup-dy.ts`) issues the `CREATE DATABASE` off the primary connection and
lays `schema.rb:1444-1462`'s tables, and `connect` establishes
`ARUnit2Model` on the named `arunit2` entry. What remained was the sqlite
gating in front of it.

- `MultipleDbTest` loses `describe.skipIf(!isSqliteRun())`.
- `PreparedStatementStatusTest` loses the same gate (same root cause, not gated
  in Rails).
- `withSecondPool` no longer no-ops off sqlite, so its
  `beforeAll`/`afterAll` run on all three lanes.
- `resolveSecondDatabaseConfig` had no runtime callers left — the live path
  builds `arunit2` from the named test-configuration entries in
  `support/connection.ts` — so it and the unused `databaseName` helper (plus its
  re-export from the MySQL test helper) are removed, and the module doc drops
  the stale "tracked in its own story" note.

**Named-connection decision (AC3):** `arunit` / `arunit2` /
`arunit_without_prepared_statements` are *already* first-class named entries on
`Base.configurations`, and both pools are established by name as
`connection.rb:32-33` does. Only the *database names* stay suffix-derived,
because they must carry the per-worker isolation slot that Rails' static
`config.yml` has no equivalent of — a checked-in name would collide across
parallel workers. Recorded in the `arunit2-config.ts` module doc.

## Verification

`multiple-db`, `prepared-statement-status` and
`has-and-belongs-to-many-associations` (the third `withSecondPool` caller, which
previously got a no-op setup off sqlite) all pass on sqlite, Postgres and MySQL
against an isolated local compose stack.

Closes-story: provision-arunit2-second-database-on-pg-mysql
