### PR TITLE
test(test-helpers): converge harness credentials with config.example.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1087,9 +1087,14 @@ jobs:
       postgres:
         image: postgres:17
         env:
-          POSTGRES_DB: rails_js_test
+          POSTGRES_DB: activerecord_unittest
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          # Rails' postgresql: entries carry no credential at all
+          # (config.example.yml:74-81) and its rake db:postgresql:build runs
+          # createdb as the local user. trust reproduces that over TCP: the
+          # passwordless `rails` role provisioned below can connect without a
+          # password. The container is throwaway per-run.
+          POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_INITDB_ARGS: "--no-sync"
         ports:
           - 5432:5432
@@ -1105,6 +1110,17 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
+      # Mirrors rake db:mysql:build_user / db:postgresql:build
+      # (activerecord/Rakefile:227-241,258-262): the suite connects as Rails'
+      # own `rails` user, not as the image superuser. CREATEDB (rather than
+      # Rails' plain GRANT) is what trails adds — each vitest worker creates its
+      # own AR_DB_SLOT copy of the database, which Rails' single-database run
+      # never needs.
+      - name: Provision Rails' test role
+        run: |
+          psql -h localhost -U postgres -d activerecord_unittest \
+            -c "CREATE ROLE rails LOGIN CREATEDB SUPERUSER" \
+            -c "ALTER DATABASE activerecord_unittest OWNER TO rails"
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a
@@ -1116,9 +1132,9 @@ jobs:
           ARCONN: postgresql
           PGHOST: localhost
           PGPORT: "5432"
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGDATABASE: rails_js_test
+          # PGDATABASE is deliberately unset: the database comes from
+          # ARTest.expand_config (test/support/config.rb:28-34), not libpq's env.
+          PGUSER: rails
           # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
           # worker count and the slot-DB pool from the runner's vCPU count.
       # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
@@ -1129,7 +1145,7 @@ jobs:
       - if: ${{ matrix.shard == 1 }}
         run: pnpm vitest run packages/activerecord-cli
         env:
-          PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
+          PG_TEST_URL: postgres://rails@localhost:5432/activerecord_unittest
 
   mysql-tests:
     name: Active Record MySQL Tests
@@ -1150,7 +1166,7 @@ jobs:
       mysql:
         image: mysql:8
         env:
-          MYSQL_DATABASE: rails_js_test
+          MYSQL_DATABASE: activerecord_unittest
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         ports:
           - 3306:3306
@@ -1174,6 +1190,20 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
+      # rake db:mysql:build_user (activerecord/Rakefile:227-235): CREATE USER
+      # with no IDENTIFIED BY — Rails' `rails` user has no password — then
+      # GRANT. Rails grants on the test database plus
+      # inexistent_activerecord_unittest; trails grants globally instead because
+      # each vitest worker creates its own AR_DB_SLOT copy of the database,
+      # which Rails' single-database run never needs.
+      - name: Provision Rails' test user
+        run: |
+          mysql -h 127.0.0.1 -uroot -e "
+            CREATE USER IF NOT EXISTS 'rails'@'%';
+            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%';
+            CREATE USER IF NOT EXISTS 'rails'@'localhost';
+            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'localhost';
+            FLUSH PRIVILEGES;"
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a
@@ -1185,13 +1215,11 @@ jobs:
           ARCONN: mysql2
           MYSQL_HOST: localhost
           MYSQL_PORT: "3306"
-          MYSQL_USER: root
-          MYSQL_DATABASE: rails_js_test
           # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
           # worker count and the slot-DB pool from the runner's vCPU count.
       - run: pnpm vitest run packages/activerecord-cli
         env:
-          MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
+          MYSQL_TEST_URL: mysql://rails@localhost:3306/activerecord_unittest
 
   # MariaDB stand-in runner. mysql-tests is temporarily disabled (see above);
   # this provides MySQL/MariaDB-family coverage via the mysql2 adapter against
@@ -1226,7 +1254,7 @@ jobs:
       mariadb:
         image: mariadb:11
         env:
-          MARIADB_DATABASE: rails_js_test
+          MARIADB_DATABASE: activerecord_unittest
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
         ports:
           - 3306:3306
@@ -1242,6 +1270,20 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
+      # rake db:mysql:build_user (activerecord/Rakefile:227-235): CREATE USER
+      # with no IDENTIFIED BY — Rails' `rails` user has no password — then
+      # GRANT. Rails grants on the test database plus
+      # inexistent_activerecord_unittest; trails grants globally instead because
+      # each vitest worker creates its own AR_DB_SLOT copy of the database,
+      # which Rails' single-database run never needs.
+      - name: Provision Rails' test user
+        run: |
+          mysql -h 127.0.0.1 -uroot -e "
+            CREATE USER IF NOT EXISTS 'rails'@'%';
+            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%';
+            CREATE USER IF NOT EXISTS 'rails'@'localhost';
+            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'localhost';
+            FLUSH PRIVILEGES;"
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a
@@ -1253,15 +1295,13 @@ jobs:
           ARCONN: mysql2
           MYSQL_HOST: localhost
           MYSQL_PORT: "3306"
-          MYSQL_USER: root
-          MYSQL_DATABASE: rails_js_test
           # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
           # worker count and the slot-DB pool from the runner's vCPU count.
       # CLI E2E is not sharded — run it once, on shard 1 only.
       - if: ${{ matrix.shard == 1 }}
         run: pnpm vitest run packages/activerecord-cli
         env:
-          MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
+          MYSQL_TEST_URL: mysql://rails@localhost:3306/activerecord_unittest
 
   website:
     name: Website

--- a/README.md
+++ b/README.md
@@ -253,29 +253,33 @@ Which backend runs is selected by `ARCONN`, naming a connection exactly as
 Rails' `test/config.yml` does — never by the presence of a connection detail.
 Connection _details_ come from discrete sub-setting env vars.
 
-| Backend          | How to run locally                  | Connection sub-settings                                                               |
-| ---------------- | ----------------------------------- | ------------------------------------------------------------------------------------- |
-| SQLite (default) | `pnpm vitest run`                   | (none)                                                                                |
-| PostgreSQL       | `ARCONN=postgresql pnpm vitest run` | `PGHOST` `PGPORT` `PGUSER` `PGPASSWORD` `PGDATABASE`                                  |
-| MySQL/MariaDB    | `ARCONN=mysql2 pnpm vitest run`     | `MYSQL_HOST` `MYSQL_PORT` `MYSQL_SOCK` `MYSQL_USER` `MYSQL_PASSWORD` `MYSQL_DATABASE` |
+| Backend          | How to run locally                  | Connection sub-settings                 |
+| ---------------- | ----------------------------------- | --------------------------------------- |
+| SQLite (default) | `pnpm vitest run`                   | (none)                                  |
+| PostgreSQL       | `ARCONN=postgresql pnpm vitest run` | `PGHOST` `PGPORT` `PGUSER` `PGPASSWORD` |
+| MySQL/MariaDB    | `ARCONN=mysql2 pnpm vitest run`     | `MYSQL_HOST` `MYSQL_PORT` `MYSQL_SOCK`  |
 
-Every sub-setting has a working default (`localhost`, the stock port, and the
-`rails_js_test` database), so a local server on default ports needs only
-`ARCONN`. An empty value counts as unset. `ARCONN=sqlite3_mem` selects the pure
-`:memory:` lane.
+These are exactly the keys Rails interpolates
+(`vendor/rails/activerecord/test/config.example.yml:12-20`), plus the `PG*` set
+its `postgresql:` entries leave to libpq by carrying no connection fields
+(`config.example.yml:74-81`). Each has a working default (`localhost` and the
+stock port), so a local server on default ports needs only `ARCONN`. An empty
+value counts as unset. `ARCONN=sqlite3_mem` selects the pure `:memory:` lane.
 
-Defaults are a trails choice matching what CI provisions, not Rails parity:
-Rails hard-codes `username: rails` and interpolates only host/port/socket
-(`vendor/rails/activerecord/test/config.example.yml`). `ARCONN` selecting the
-backend is the part that mirrors Rails.
+The **credential and database name are not env-driven**, because Rails' are not:
+the harness connects as `username: rails` with no password
+(`config.example.yml:4,24`) to `activerecord_unittest`, the name
+`ARTest.expand_config` fills in (`test/support/config.rb:28-34`).
+`docker-compose.yml` and the CI service containers provision that user the way
+`rake db:mysql:build_user` does (`activerecord/Rakefile:227-235`) — so
+`docker compose up` is all a local run needs. On Postgres, Rails' entries carry
+no credential at all, so `PGUSER` / `PGPASSWORD` stay unset unless you set them
+and `pg` resolves libpq's own defaults.
 
-That divergence is **accepted permanently** rather than closed by provisioning a
-`rails` user: nothing under test observes the credential's value, adopting
-Rails' literal would need a user provisioned in CI, `docker-compose.yml`, and
-every contributor's local server, and the credential already has to stay
-configurable (CI sets it, and `AR_DB_SLOT` rewrites the database per worker).
-The full reasoning lives in the deviations note atop
-`packages/activerecord/src/support/config.ts`.
+The one addition with no Rails counterpart is `AR_DB_SLOT`: Rails runs one
+database, trails runs parallel vitest workers and gives each an `_N`-suffixed
+copy (`activerecord_unittest_2`, `_3`, …). That is why the provisioned user
+carries `CREATEDB` / a global `GRANT` where Rails grants on one database.
 
 The `SchemaAdapter` wrapper auto-creates tables from model attribute definitions, so tests don't need manual DDL.
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ Rails hard-codes `username: rails` and interpolates only host/port/socket
 (`vendor/rails/activerecord/test/config.example.yml`). `ARCONN` selecting the
 backend is the part that mirrors Rails.
 
+That divergence is **accepted permanently** rather than closed by provisioning a
+`rails` user: nothing under test observes the credential's value, adopting
+Rails' literal would need a user provisioned in CI, `docker-compose.yml`, and
+every contributor's local server, and the credential already has to stay
+configurable (CI sets it, and `AR_DB_SLOT` rewrites the database per worker).
+The full reasoning lives in the deviations note atop
+`packages/activerecord/src/support/config.ts`.
+
 The `SchemaAdapter` wrapper auto-creates tables from model attribute definitions, so tests don't need manual DDL.
 
 ## Project Structure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,13 @@ services:
     ports:
       - "${PG_PORT:-25432}:5432"
     environment:
-      POSTGRES_DB: rails_js_test
+      POSTGRES_DB: activerecord_unittest
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      # Rails' postgresql: entries carry no credential (config.example.yml:74-81),
+      # so the `rails` role created by the init script below has no password.
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - ./scripts/db-init/postgres:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
@@ -18,8 +22,10 @@ services:
     ports:
       - "${MYSQL_PORT:-13306}:3306"
     environment:
-      MYSQL_DATABASE: rails_js_test
+      MYSQL_DATABASE: activerecord_unittest
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    volumes:
+      - ./scripts/db-init/mysql:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 2s

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "vitest",
     "test:types": "vitest run --config vitest.dx-tests.config.ts",
     "test:types:virtualized": "tsc -b packages/activerecord-cli && node packages/activerecord-cli/dist/tsc-wrapper/cli.js -p packages/activerecord/virtualized-dx-tests/tsconfig.json",
-    "test:db": "ARCONN=postgresql PGHOST=localhost PGPORT=25432 PGUSER=postgres PGPASSWORD=postgres PGDATABASE=rails_js_test MYSQL_HOST=localhost MYSQL_PORT=13306 MYSQL_USER=root MYSQL_DATABASE=rails_js_test vitest run",
+    "test:db": "ARCONN=postgresql PGHOST=localhost PGPORT=25432 PGUSER=rails MYSQL_HOST=127.0.0.1 MYSQL_PORT=13306 vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",
     "api:compare": "bash scripts/api-compare/run.sh",

--- a/packages/activerecord/src/adapters/postgresql/pinned-query-serializer.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/pinned-query-serializer.trails.test.ts
@@ -23,7 +23,7 @@ interface SerializerHarness {
 
 function makeAdapter(): { adapter: SerializerHarness; pinned: { query: () => Promise<unknown> } } {
   const adapter = new PostgreSQLAdapter(
-    "postgres://localhost:5432/rails_js_test",
+    "postgres://localhost:5432/activerecord_unittest",
   ) as unknown as SerializerHarness;
   // A minimal fake pinned client. The `_rawConnection` setter registers a
   // dealloc serializer closure over it but never invokes it here.

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -913,7 +913,7 @@ async function establishWithConfig(
   // Mirror Rails' db_config_handler (database_configurations.rb:65-70):
   // `url ? UrlConfig.new(env, name, url, config) : HashConfig.new(...)`.
   // A UrlConfig parses the URL into its hash and surfaces the database name
-  // living in the path — e.g. the per-worker slot DB `rails_js_test_2` that
+  // living in the path — e.g. the per-worker slot DB `activerecord_unittest_2` that
   // test-setup-worker-db.ts suffixes on — natively via the URL fallback
   // (url-config.ts), so `connectionDbConfig().database` is no longer undefined.
   //

--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -3,13 +3,13 @@ import { arunitDatabaseNames } from "./arunit2-config.js";
 
 describe("arunit2-config", () => {
   it("arunitDatabaseNames suffixes the primary database name", () => {
-    expect(arunitDatabaseNames("rails_js_test")).toEqual({
-      arunit: "rails_js_test_arunit",
-      arunit2: "rails_js_test_arunit2",
+    expect(arunitDatabaseNames("activerecord_unittest")).toEqual({
+      arunit: "activerecord_unittest_arunit",
+      arunit2: "activerecord_unittest_arunit2",
     });
   });
 
   it("carries the worker isolation slot into the arunit2 database name", () => {
-    expect(arunitDatabaseNames("rails_js_test_3").arunit2).toBe("rails_js_test_3_arunit2");
+    expect(arunitDatabaseNames("activerecord_unittest_3").arunit2).toBe("activerecord_unittest_3_arunit2");
   });
 });

--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -10,6 +10,8 @@ describe("arunit2-config", () => {
   });
 
   it("carries the worker isolation slot into the arunit2 database name", () => {
-    expect(arunitDatabaseNames("activerecord_unittest_3").arunit2).toBe("activerecord_unittest_3_arunit2");
+    expect(arunitDatabaseNames("activerecord_unittest_3").arunit2).toBe(
+      "activerecord_unittest_3_arunit2",
+    );
   });
 });

--- a/packages/activerecord/src/support/arunit2-config.ts
+++ b/packages/activerecord/src/support/arunit2-config.ts
@@ -33,6 +33,13 @@ const ARUNIT2_SUFFIX = "_arunit2";
  * The config-derived `arunit` / `arunit2` database names for a primary
  * database. Both are the primary database name plus a fixed suffix, mirroring
  * how `ARTest.test_configuration_hashes` exposes two named databases.
+ *
+ * Rails' own pair is `activerecord_unittest` / `activerecord_unittest2` — the
+ * second is the first plus `"2"` (`test/support/config.rb:28`). trails cannot
+ * spell it that way because the primary name already carries the per-worker
+ * `AR_DB_SLOT` suffix: appending `"2"` to slot 3's `activerecord_unittest_3`
+ * yields `activerecord_unittest_32`, which is slot 32's database. The `_arunit`
+ * / `_arunit2` suffixes keep the pair collision-free per slot.
  */
 export function arunitDatabaseNames(primaryDatabase: string): {
   arunit: string;

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -42,18 +42,29 @@ describe("config", () => {
   });
 
   it("reads Postgres details from libpq's env vars, with defaults", () => {
+    // Rails' postgresql: entries carry no connection fields at all
+    // (config.example.yml:74-81), so there is no credential to default: an
+    // unset PGUSER stays unset and pg resolves libpq's own default. The
+    // database comes from expand_config (support/config.rb:28-34), not from
+    // PGDATABASE — an entry's own database beats libpq's env in Rails too.
     expect(postgresSettings(reader({}))).toEqual({
       host: "localhost",
       port: 5432,
-      user: "postgres",
+      user: undefined,
       password: undefined,
-      database: "rails_js_test",
+      database: "activerecord_unittest",
     });
     expect(
       postgresSettings(
         reader({ PGHOST: "db", PGPORT: "6543", PGUSER: "u", PGPASSWORD: "p", PGDATABASE: "d" }),
       ),
-    ).toEqual({ host: "db", port: 6543, user: "u", password: "p", database: "d" });
+    ).toEqual({
+      host: "db",
+      port: 6543,
+      user: "u",
+      password: "p",
+      database: "activerecord_unittest",
+    });
   });
 
   it("reads MySQL details from the sub-settings config.example.yml interpolates", () => {
@@ -64,21 +75,20 @@ describe("config", () => {
     ).toEqual({
       host: "db",
       port: 3307,
-      user: "root",
-      password: undefined,
-      database: "rails_js_test",
+      // config.example.yml:4,24 hard-code `username: rails` with no password.
+      user: "rails",
+      database: "activerecord_unittest",
       socket: "/tmp/mysql.sock",
     });
   });
 
-  it("interpolates exactly the accepted sub-setting key set, and no more", () => {
-    // The accepted deviation from config.example.yml, made executable: Rails
-    // interpolates only MYSQL_HOST/MYSQL_PORT/MYSQL_SOCK and hard-codes
-    // `username: rails`; trails also interpolates the credential and database
-    // name, and the postgresql lane reads libpq's own PG* set because Rails'
-    // `postgresql:` entries carry no fields precisely so libpq resolves them
-    // (config.example.yml:74-81). Widening this set again is a decision, not a
-    // detail — see the deviations note in config.ts.
+  it("interpolates exactly the sub-setting key set config.example.yml interpolates", () => {
+    // Rails interpolates only MYSQL_HOST/MYSQL_PORT/MYSQL_SOCK
+    // (config.example.yml:12-20) and hard-codes the credential and database;
+    // its postgresql: entries carry no fields so libpq reads PG* itself
+    // (config.example.yml:74-81). AR_DB_SLOT is the one trails addition — the
+    // per-worker database copy Rails has no analogue for. Re-widening this set
+    // is a decision, not a detail.
     const seen: string[] = [];
     const recording = (env: Record<string, string>) => (key: string) => {
       seen.push(key);
@@ -87,40 +97,30 @@ describe("config", () => {
 
     mysqlSettings(recording({}));
     expect(new Set(seen)).toEqual(
-      new Set([
-        "MYSQL_HOST",
-        "MYSQL_PORT",
-        "MYSQL_USER",
-        "MYSQL_PASSWORD",
-        "MYSQL_DATABASE",
-        "MYSQL_SOCK",
-        "AR_DB_SLOT",
-      ]),
+      new Set(["MYSQL_HOST", "MYSQL_PORT", "MYSQL_SOCK", "AR_DB_SLOT"]),
     );
 
     seen.length = 0;
     postgresSettings(recording({}));
     expect(new Set(seen)).toEqual(
-      new Set(["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGDATABASE", "AR_DB_SLOT"]),
+      new Set(["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "AR_DB_SLOT"]),
     );
   });
 
   it("suffixes the database with the worker isolation slot above slot 1", () => {
-    expect(postgresSettings(reader({ AR_DB_SLOT: "1" })).database).toBe("rails_js_test");
-    expect(postgresSettings(reader({ AR_DB_SLOT: "4" })).database).toBe("rails_js_test_4");
-    expect(mysqlSettings(reader({ AR_DB_SLOT: "2" })).database).toBe("rails_js_test_2");
+    expect(postgresSettings(reader({ AR_DB_SLOT: "1" })).database).toBe("activerecord_unittest");
+    expect(postgresSettings(reader({ AR_DB_SLOT: "4" })).database).toBe("activerecord_unittest_4");
+    expect(mysqlSettings(reader({ AR_DB_SLOT: "2" })).database).toBe("activerecord_unittest_2");
   });
 
   it("treats an empty sub-setting as unset rather than as an empty value", () => {
     // CI routinely sets a var to "" to mean "no value". Taking that literally
-    // yields user: "" and the server answers `Access denied for user ''`.
-    const settings = mysqlSettings(
-      reader({ MYSQL_USER: "", MYSQL_HOST: "", MYSQL_DATABASE: "", MYSQL_SOCK: "" }),
-    );
-    expect(settings.user).toBe("root");
+    // yields host: "" / user: "" and the server answers `Access denied for
+    // user ''`.
+    const settings = mysqlSettings(reader({ MYSQL_HOST: "", MYSQL_SOCK: "" }));
     expect(settings.host).toBe("localhost");
-    expect(settings.database).toBe("rails_js_test");
     expect(settings.socket).toBeUndefined();
+    expect(postgresSettings(reader({ PGUSER: "", PGPASSWORD: "" })).user).toBeUndefined();
   });
 
   it("raises on a malformed slot rather than sharing the base database", () => {
@@ -146,7 +146,7 @@ describe("config", () => {
     // driver, which attempts the socket rather than falling back to TCP.
     const settings = mysqlSettings(reader({ MYSQL_SOCK: "/tmp/mysql.sock" }));
     expect(settingsUrl("mysql", settings)).toBe(
-      "mysql://root@localhost:3306/rails_js_test?socketPath=%2Ftmp%2Fmysql.sock",
+      "mysql://rails@localhost:3306/activerecord_unittest?socketPath=%2Ftmp%2Fmysql.sock",
     );
   });
 
@@ -159,7 +159,7 @@ describe("config", () => {
     // real socket, as was the empty-authority + host= form emitted here.
     const settings = postgresSettings(reader({ PGHOST: "/var/run/postgresql" }));
     expect(settingsUrl("postgres", settings)).toBe(
-      "postgres://postgres@/rails_js_test?host=%2Fvar%2Frun%2Fpostgresql&port=5432",
+      "postgres:///activerecord_unittest?host=%2Fvar%2Frun%2Fpostgresql&port=5432",
     );
   });
 
@@ -171,10 +171,13 @@ describe("config", () => {
   });
 
   it("renders settings as a URL, encoding credentials", () => {
-    expect(mysqlUrl(reader({}))).toBe("mysql://root@localhost:3306/rails_js_test");
-    expect(postgresUrl(reader({ PGPASSWORD: "p@ss word" }))).toBe(
-      "postgres://postgres:p%40ss%20word@localhost:5432/rails_js_test",
+    expect(mysqlUrl(reader({}))).toBe("mysql://rails@localhost:3306/activerecord_unittest");
+    expect(postgresUrl(reader({ PGUSER: "u", PGPASSWORD: "p@ss word" }))).toBe(
+      "postgres://u:p%40ss%20word@localhost:5432/activerecord_unittest",
     );
+    // No PGUSER means no userinfo at all, so pg resolves libpq's default user
+    // rather than seeing an empty username.
+    expect(postgresUrl(reader({}))).toBe("postgres://localhost:5432/activerecord_unittest");
   });
 
   it("withDatabase repoints settings at another database on the same server", () => {
@@ -185,10 +188,8 @@ describe("config", () => {
   it("driverConfig emits Rails' username and socket spellings only", () => {
     // Both keys are Rails' canonical spelling — the adapters map them to the
     // driver-native `user` / `socketPath`.
-    const config = driverConfig(
-      mysqlSettings(reader({ MYSQL_USER: "u", MYSQL_PASSWORD: "p", MYSQL_SOCK: "/tmp/m.sock" })),
-    );
-    expect(config.username).toBe("u");
+    const config = driverConfig(mysqlSettings(reader({ MYSQL_SOCK: "/tmp/m.sock" })));
+    expect(config.username).toBe("rails");
     expect(config).not.toHaveProperty("user");
     expect(config.socket).toBe("/tmp/m.sock");
     expect(config).not.toHaveProperty("socketPath");

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -71,6 +71,40 @@ describe("config", () => {
     });
   });
 
+  it("interpolates exactly the accepted sub-setting key set, and no more", () => {
+    // The accepted deviation from config.example.yml, made executable: Rails
+    // interpolates only MYSQL_HOST/MYSQL_PORT/MYSQL_SOCK and hard-codes
+    // `username: rails`; trails also interpolates the credential and database
+    // name, and the postgresql lane reads libpq's own PG* set because Rails'
+    // `postgresql:` entries carry no fields precisely so libpq resolves them
+    // (config.example.yml:74-81). Widening this set again is a decision, not a
+    // detail — see the deviations note in config.ts.
+    const seen: string[] = [];
+    const recording = (env: Record<string, string>) => (key: string) => {
+      seen.push(key);
+      return env[key];
+    };
+
+    mysqlSettings(recording({}));
+    expect(new Set(seen)).toEqual(
+      new Set([
+        "MYSQL_HOST",
+        "MYSQL_PORT",
+        "MYSQL_USER",
+        "MYSQL_PASSWORD",
+        "MYSQL_DATABASE",
+        "MYSQL_SOCK",
+        "AR_DB_SLOT",
+      ]),
+    );
+
+    seen.length = 0;
+    postgresSettings(recording({}));
+    expect(new Set(seen)).toEqual(
+      new Set(["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGDATABASE", "AR_DB_SLOT"]),
+    );
+  });
+
   it("suffixes the database with the worker isolation slot above slot 1", () => {
     expect(postgresSettings(reader({ AR_DB_SLOT: "1" })).database).toBe("rails_js_test");
     expect(postgresSettings(reader({ AR_DB_SLOT: "4" })).database).toBe("rails_js_test_4");

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -41,7 +41,7 @@ describe("config", () => {
     );
   });
 
-  it("reads Postgres details from libpq's env vars, with defaults", () => {
+  it("reads Postgres details from libpq's env vars, defaulting no credential", () => {
     // Rails' postgresql: entries carry no connection fields at all
     // (config.example.yml:74-81), so there is no credential to default: an
     // unset PGUSER stays unset and pg resolves libpq's own default. The

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -26,7 +26,7 @@
  *     `PGPASSWORD` / `PGDATABASE` for the postgresql lane (Rails' `postgresql:`
  *     entries carry no host at all, deferring to libpq's own env).
  *
- * ## Deviations from `config.example.yml` — ACCEPTED PERMANENTLY
+ * ## Deviations from `config.example.yml` — accepted permanently (decision record)
  *
  * Rails interpolates ONLY `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK` from the
  * environment and hard-codes the rest — notably `username: rails` on both
@@ -54,14 +54,21 @@
  *     explicit fallbacks (`postgres` / `rails_js_test`) are a trails addition,
  *     and they are what libpq would otherwise resolve from the local role.
  *   - Rails' `rails` user is an artifact of Rails' own CI images, not a
- *     behaviour the port reproduces: no adapter, task, or assertion observes the
- *     credential's *value*. Adopting it would mean provisioning a user in three
- *     places (CI service containers, `docker-compose.yml`, and every
- *     contributor's local server) to buy no fidelity in anything under test.
+ *     behaviour the port reproduces. Audited: the only places the credential's
+ *     *value* is observed are the harness-config tests that spell a whole
+ *     rendered URL (`config.test.ts`, `arunit2-config.test.ts`) — no adapter,
+ *     task, or suite assertion reads it. Adopting Rails' literal would mean
+ *     provisioning a user in three places (CI service containers,
+ *     `docker-compose.yml`, and every contributor's local server) to buy no
+ *     fidelity in anything under test.
  *   - Configurability is already depended on: CI sets `MYSQL_USER` / `PGUSER` /
  *     `PGPASSWORD` / `*_DATABASE` explicitly, `AR_DB_SLOT` rewrites the database
  *     name per worker, and local servers (Homebrew postgres, socket MySQL) have
  *     no common credential to hard-code.
+ *
+ * The accepted key set is pinned by a test (`config.test.ts`, "interpolates
+ * exactly the accepted sub-setting key set"), so widening it later has to be a
+ * decision rather than a drift.
  *
  * So: the ARCONN-selects / sub-settings-describe *split* is Rails parity; the
  * particular set of interpolated keys and their defaults is a settled trails

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -20,60 +20,39 @@
  *   - **Which backend runs** is chosen by `ARCONN`, naming a key of the
  *     `connections:` hash (`test/support/connection.rb:10,14-19`). Nothing
  *     else selects a backend — there is no "is this env var set?" sniffing.
- *   - **How to reach it** comes from discrete sub-setting env vars interpolated
- *     into that connection's entry: `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK`
- *     for the mysql2 lane, and libpq's `PGHOST` / `PGPORT` / `PGUSER` /
- *     `PGPASSWORD` / `PGDATABASE` for the postgresql lane (Rails' `postgresql:`
- *     entries carry no host at all, deferring to libpq's own env).
+ *   - **How to reach it** comes from the connection entry itself, over which
+ *     Rails interpolates exactly three env vars: `MYSQL_HOST` / `MYSQL_PORT` /
+ *     `MYSQL_SOCK` (`config.example.yml:12-20`). The postgresql entries carry
+ *     no connection fields at all (`config.example.yml:74-81`), leaving libpq
+ *     to resolve `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD` itself.
  *
- * ## Deviations from `config.example.yml` — accepted permanently (decision record)
+ * ## Credentials and database names: converged with `config.example.yml`
  *
- * Rails interpolates ONLY `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK` from the
- * environment and hard-codes the rest — notably `username: rails` on both
- * `mysql2.arunit` and `mysql2.arunit2` (`config.example.yml:4,24`), because
- * Rails' own CI provisions a `rails` user.
+ * Both come straight from Rails, not from the environment:
  *
- * trails makes the credential and database name env-driven too
- * (`MYSQL_USER` / `MYSQL_PASSWORD` / `MYSQL_DATABASE`, and the `PG*` set), and
- * defaults them to `root` / `postgres` / `rails_js_test` — the users and
- * database the containers in `.github/workflows/ci.yml` and `docker-compose.yml`
- * actually provision. Hard-coding Rails' `rails` user would not authenticate
- * against them.
+ *   - `username: rails`, no password, on `mysql2.arunit` and `mysql2.arunit2`
+ *     (`config.example.yml:4,24`) — see {@link MYSQL_USERNAME}. The user is
+ *     provisioned the way `db:mysql:build_user` provisions it
+ *     (`activerecord/Rakefile:227-235`): `CREATE USER` with no `IDENTIFIED BY`,
+ *     then `GRANT ALL PRIVILEGES`, done here by the container init scripts in
+ *     `.github/workflows/ci.yml` and `docker-compose.yml`.
+ *   - `database: activerecord_unittest`, which `ARTest.expand_config` fills in
+ *     for every entry that carries none (`test/support/config.rb:28-34`) — see
+ *     {@link ARUNIT_DATABASE}.
+ *   - The postgresql lane hard-codes no credential, exactly as Rails' entries
+ *     do not: `PGUSER` / `PGPASSWORD` stay unset unless the environment carries
+ *     them, and `pg` then resolves libpq's defaults.
  *
- * This was weighed against the alternative — provision a `rails` user in the
- * containers so the harness could adopt Rails' literal credential and shrink to
- * Rails' three interpolated keys — and deliberately kept. The reasoning, so it
- * is not re-derived:
- *
- *   - The `PG*` half is not a deviation in substance. Rails' `postgresql:`
- *     entries carry no connection fields precisely so libpq resolves them from
- *     `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD` / `PGDATABASE`
- *     (`config.example.yml:74-81`). trails reads the same variables because it
- *     must *materialize* concrete values — it renders a URL for `pg` and for the
- *     CLI's `--database-url` rather than handing libpq an empty config. Only the
- *     explicit fallbacks (`postgres` / `rails_js_test`) are a trails addition,
- *     and they are what libpq would otherwise resolve from the local role.
- *   - Rails' `rails` user is an artifact of Rails' own CI images, not a
- *     behaviour the port reproduces. Audited: the only places the credential's
- *     *value* is observed are the harness-config tests that spell a whole
- *     rendered URL (`config.test.ts`, `arunit2-config.test.ts`) — no adapter,
- *     task, or suite assertion reads it. Adopting Rails' literal would mean
- *     provisioning a user in three places (CI service containers,
- *     `docker-compose.yml`, and every contributor's local server) to buy no
- *     fidelity in anything under test.
- *   - Configurability is already depended on: CI sets `MYSQL_USER` / `PGUSER` /
- *     `PGPASSWORD` / `*_DATABASE` explicitly, `AR_DB_SLOT` rewrites the database
- *     name per worker, and local servers (Homebrew postgres, socket MySQL) have
- *     no common credential to hard-code.
- *
- * The accepted key set is pinned by a test (`config.test.ts`, "interpolates
- * exactly the accepted sub-setting key set"), so widening it later has to be a
+ * `MYSQL_USER` / `MYSQL_PASSWORD` / `MYSQL_DATABASE` / `PGDATABASE` are
+ * therefore NOT read — Rails interpolates none of them, and an entry's own
+ * `database` beats libpq's env in Rails too. The exact key set each lane reads
+ * is pinned by a test (`config.test.ts`, "interpolates exactly the sub-setting
+ * key set config.example.yml interpolates"), so re-widening it has to be a
  * decision rather than a drift.
  *
- * So: the ARCONN-selects / sub-settings-describe *split* is Rails parity; the
- * particular set of interpolated keys and their defaults is a settled trails
- * choice. Anything relying on Rails' literal credential must set `MYSQL_USER`
- * itself. Revisit only if a test ever needs to assert the credential itself.
+ * The one addition with no Rails counterpart is {@link SLOT_ENV}: Rails runs
+ * one database, trails runs parallel vitest workers and gives each its own
+ * `_N`-suffixed copy of it.
  *
  * trails previously collapsed both into a single `PG_TEST_URL` /
  * `MYSQL_TEST_URL` URL string, which made backend selection a side effect of
@@ -139,7 +118,8 @@ function intSetting(read: EnvReader, key: string, fallback: number): number {
 export interface ServerSettings {
   host: string;
   port: number;
-  user: string;
+  /** Absent on the postgresql lane unless `PGUSER` is set — Rails' entries carry none. */
+  user?: string;
   password?: string;
   database: string;
   /** Unix socket path (`MYSQL_SOCK`); mysql2 prefers it over host/port when set. */
@@ -170,38 +150,59 @@ function applySlot(database: string, read: EnvReader): string {
 }
 
 /**
- * PostgreSQL connection details from libpq's standard env vars — the ones
- * Rails' `postgresql:` entries rely on by carrying no host of their own. Reading
- * them is the parity path; only the explicit defaults (`postgres` /
- * `rails_js_test`) are a trails choice, matching what CI provisions. Accepted
- * permanently — see the deviations note in the module doc.
+ * The `arunit` database name `ARTest.expand_config` fills in when a connection
+ * entry carries none — which is every mysql2 and postgresql entry
+ * (`test/support/config.rb:28-31`, `config.example.yml:2-40,74-81`).
+ */
+export const ARUNIT_DATABASE = "activerecord_unittest";
+
+/**
+ * The credential `config.example.yml` hard-codes on both `mysql2.arunit` and
+ * `mysql2.arunit2` (`config.example.yml:4,24`), provisioned by
+ * `db:mysql:build_user` (`activerecord/Rakefile:227-235`) — `CREATE USER`, no
+ * `IDENTIFIED BY`, hence no password.
+ */
+export const MYSQL_USERNAME = "rails";
+
+/**
+ * PostgreSQL connection details.
+ *
+ * Rails' `postgresql:` entries carry no connection fields at all
+ * (`config.example.yml:74-81`) — no host, port, or credential — so libpq
+ * resolves them from its own `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD`.
+ * Reading those here is that same deferral, not an interpolation of trails'
+ * own: they are the driver's env contract. `user` and `password` are left
+ * unset when the environment carries none, so `pg` applies libpq's defaults
+ * exactly as it would for Rails.
+ *
+ * The database is NOT read from `PGDATABASE`: `expand_config` fills the entry's
+ * `database` in (`support/config.rb:31-34`), and an explicit config value beats
+ * libpq's env in Rails too.
  */
 export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
   return {
     host: present(read, "PGHOST") ?? "localhost",
     port: intSetting(read, "PGPORT", 5432),
-    user: present(read, "PGUSER") ?? "postgres",
+    user: present(read, "PGUSER"),
     password: present(read, "PGPASSWORD"),
-    database: applySlot(present(read, "PGDATABASE") ?? "rails_js_test", read),
+    database: applySlot(ARUNIT_DATABASE, read),
   };
 }
 
 /**
  * MySQL/MariaDB connection details.
  *
- * `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK` mirror the keys Rails interpolates
- * (`config.example.yml:12-19`). The credential and database name are a trails
- * extension defaulting to what CI provisions — Rails hard-codes
- * `username: rails` instead. Accepted permanently (no test observes the
- * credential's value); see the deviations note in the module doc.
+ * Exactly the three keys Rails interpolates — `MYSQL_HOST` / `MYSQL_PORT` /
+ * `MYSQL_SOCK` (`config.example.yml:12-20`) — over the hard-coded
+ * `username: rails` (`config.example.yml:4,24`) and the `expand_config`
+ * database. The credential is not env-driven because Rails' is not.
  */
 export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
   return {
     host: present(read, "MYSQL_HOST") ?? "localhost",
     port: intSetting(read, "MYSQL_PORT", 3306),
-    user: present(read, "MYSQL_USER") ?? "root",
-    password: present(read, "MYSQL_PASSWORD"),
-    database: applySlot(present(read, "MYSQL_DATABASE") ?? "rails_js_test", read),
+    user: MYSQL_USERNAME,
+    database: applySlot(ARUNIT_DATABASE, read),
     socket: present(read, "MYSQL_SOCK"),
   };
 }
@@ -226,8 +227,8 @@ export function driverConfig(settings: ServerSettings): Record<string, unknown> 
   return {
     host,
     port,
-    username: user,
     database,
+    ...(user === undefined ? {} : { username: user }),
     ...(password === undefined ? {} : { password }),
     ...(socket === undefined ? {} : { socket }),
   };
@@ -239,6 +240,10 @@ export function withDatabase(settings: ServerSettings, database: string): Server
 }
 
 function credentials({ user, password }: ServerSettings): string {
+  // No user at all is libpq's own default path (Rails' postgresql: entries carry
+  // no credential): the URL must then carry no authority userinfo either, or the
+  // driver sees an empty username instead of resolving the OS user.
+  if (user === undefined) return "";
   const auth = encodeURIComponent(user);
   return password ? `${auth}:${encodeURIComponent(password)}@` : `${auth}@`;
 }

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -26,7 +26,7 @@
  *     `PGPASSWORD` / `PGDATABASE` for the postgresql lane (Rails' `postgresql:`
  *     entries carry no host at all, deferring to libpq's own env).
  *
- * ## Deviations from `config.example.yml` (deliberate, not parity)
+ * ## Deviations from `config.example.yml` — ACCEPTED PERMANENTLY
  *
  * Rails interpolates ONLY `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK` from the
  * environment and hard-codes the rest — notably `username: rails` on both
@@ -36,12 +36,37 @@
  * trails makes the credential and database name env-driven too
  * (`MYSQL_USER` / `MYSQL_PASSWORD` / `MYSQL_DATABASE`, and the `PG*` set), and
  * defaults them to `root` / `postgres` / `rails_js_test` — the users and
- * database the containers in `.github/workflows/ci.yml` actually provision.
- * Hard-coding Rails' `rails` user would not authenticate against them.
+ * database the containers in `.github/workflows/ci.yml` and `docker-compose.yml`
+ * actually provision. Hard-coding Rails' `rails` user would not authenticate
+ * against them.
+ *
+ * This was weighed against the alternative — provision a `rails` user in the
+ * containers so the harness could adopt Rails' literal credential and shrink to
+ * Rails' three interpolated keys — and deliberately kept. The reasoning, so it
+ * is not re-derived:
+ *
+ *   - The `PG*` half is not a deviation in substance. Rails' `postgresql:`
+ *     entries carry no connection fields precisely so libpq resolves them from
+ *     `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD` / `PGDATABASE`
+ *     (`config.example.yml:74-81`). trails reads the same variables because it
+ *     must *materialize* concrete values — it renders a URL for `pg` and for the
+ *     CLI's `--database-url` rather than handing libpq an empty config. Only the
+ *     explicit fallbacks (`postgres` / `rails_js_test`) are a trails addition,
+ *     and they are what libpq would otherwise resolve from the local role.
+ *   - Rails' `rails` user is an artifact of Rails' own CI images, not a
+ *     behaviour the port reproduces: no adapter, task, or assertion observes the
+ *     credential's *value*. Adopting it would mean provisioning a user in three
+ *     places (CI service containers, `docker-compose.yml`, and every
+ *     contributor's local server) to buy no fidelity in anything under test.
+ *   - Configurability is already depended on: CI sets `MYSQL_USER` / `PGUSER` /
+ *     `PGPASSWORD` / `*_DATABASE` explicitly, `AR_DB_SLOT` rewrites the database
+ *     name per worker, and local servers (Homebrew postgres, socket MySQL) have
+ *     no common credential to hard-code.
  *
  * So: the ARCONN-selects / sub-settings-describe *split* is Rails parity; the
- * particular set of interpolated keys and their defaults is a trails choice.
- * Anything relying on Rails' literal credential must set `MYSQL_USER` itself.
+ * particular set of interpolated keys and their defaults is a settled trails
+ * choice. Anything relying on Rails' literal credential must set `MYSQL_USER`
+ * itself. Revisit only if a test ever needs to assert the credential itself.
  *
  * trails previously collapsed both into a single `PG_TEST_URL` /
  * `MYSQL_TEST_URL` URL string, which made backend selection a side effect of
@@ -139,9 +164,10 @@ function applySlot(database: string, read: EnvReader): string {
 
 /**
  * PostgreSQL connection details from libpq's standard env vars — the ones
- * Rails' `postgresql:` entries rely on by carrying no host of their own. The
- * defaults (`postgres` / `rails_js_test`) are a trails choice matching what CI
- * provisions; see the deviations note in the module doc.
+ * Rails' `postgresql:` entries rely on by carrying no host of their own. Reading
+ * them is the parity path; only the explicit defaults (`postgres` /
+ * `rails_js_test`) are a trails choice, matching what CI provisions. Accepted
+ * permanently — see the deviations note in the module doc.
  */
 export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
   return {
@@ -159,7 +185,8 @@ export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
  * `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK` mirror the keys Rails interpolates
  * (`config.example.yml:12-19`). The credential and database name are a trails
  * extension defaulting to what CI provisions — Rails hard-codes
- * `username: rails` instead. See the deviations note in the module doc.
+ * `username: rails` instead. Accepted permanently (no test observes the
+ * credential's value); see the deviations note in the module doc.
  */
 export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
   return {

--- a/packages/activerecord/src/test-fixtures/use-transactional-tests.test.ts
+++ b/packages/activerecord/src/test-fixtures/use-transactional-tests.test.ts
@@ -7,7 +7,7 @@
  *   pnpm vitest run packages/activerecord/src/test-fixtures/use-transactional-tests.test.ts
  *
  * With PG:
- *   ARCONN=postgresql PGHOST=localhost PGPORT=5432 PGDATABASE=rails_test \
+ *   ARCONN=postgresql PGHOST=localhost PGPORT=5432 PGUSER=rails \
  *     pnpm vitest run packages/activerecord/src/test-fixtures/use-transactional-tests.test.ts
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -16,7 +16,7 @@
  *     safe — no other worker shares this file path)
  *   - PG/MySQL slot >1 (AR_PG_EXCLUSIVE_DB / AR_MYSQL_EXCLUSIVE_DB set by
  *     test-setup-worker-db.ts) → reconstructFromSchema; the worker owns its
- *     own suffixed DB (rails_js_test_N), so purge+load is safe.
+ *     own suffixed DB (activerecord_unittest_N), so purge+load is safe.
  *   - PG/MySQL slot 1 → loadSchema (base URL unchanged; the advisory-lock
  *     bootstrap pg.Client / GET_LOCK connection lives in the same DB as the
  *     worker pool, so DROP DATABASE fails with PG error 55006 and releasing

--- a/scripts/db-init/mysql/01-rails-user.sql
+++ b/scripts/db-init/mysql/01-rails-user.sql
@@ -1,0 +1,17 @@
+-- Rails' `rails` test user, as `rake db:mysql:build_user` provisions it
+-- (vendor/rails/activerecord/Rakefile:227-235): CREATE USER with no
+-- IDENTIFIED BY, so the user has no password — which is what
+-- `username: rails` in test/config.example.yml:4,24 connects as.
+--
+-- Rails grants on the test database plus inexistent_activerecord_unittest;
+-- this grants globally instead, because each vitest worker creates its own
+-- AR_DB_SLOT copy of the database (activerecord_unittest_2, _3, …) and
+-- Rails' single-database run never needs that.
+CREATE USER IF NOT EXISTS 'rails'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%';
+-- MYSQL_SOCK is a first-class sub-setting here (config.example.yml:18-19), and
+-- a socket connection authenticates as 'rails'@'localhost', which '%' does not
+-- cover. Rails' rake task grants only '%' because its own runs are over TCP.
+CREATE USER IF NOT EXISTS 'rails'@'localhost';
+GRANT ALL PRIVILEGES ON *.* TO 'rails'@'localhost';
+FLUSH PRIVILEGES;

--- a/scripts/db-init/postgres/01-rails-role.sql
+++ b/scripts/db-init/postgres/01-rails-role.sql
@@ -1,0 +1,11 @@
+-- Rails' `postgresql:` connection entries carry no credential at all
+-- (vendor/rails/activerecord/test/config.example.yml:74-81) — `rake
+-- db:postgresql:build` (Rakefile:258-262) just runs createdb as the local
+-- user. This role is the container equivalent: a passwordless `rails` role,
+-- reachable because the container runs with POSTGRES_HOST_AUTH_METHOD=trust.
+--
+-- CREATEDB is what trails adds on top of Rails' setup: each vitest worker
+-- creates its own AR_DB_SLOT copy of the database (activerecord_unittest_2,
+-- _3, …), which Rails' single-database run never needs.
+CREATE ROLE rails LOGIN CREATEDB SUPERUSER;
+ALTER DATABASE activerecord_unittest OWNER TO rails;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -343,7 +343,7 @@ export default defineConfig({
     },
     projects: [
       {
-        // All activerecord tests. Each fork gets its own database (rails_js_test_N
+        // All activerecord tests. Each fork gets its own database (activerecord_unittest_N
         // for PG/MySQL, provisioned via AR_DB_FORKS) so files can run in parallel.
         // SQLite is file-backed too: globalSetup builds one on-disk template and
         // each fork restores it into its own private `.sqlite` clone stamped into


### PR DESCRIPTION
> **Direction changed mid-PR.** This PR originally *accepted* the deviation as
> permanent (commits `d516389a8` / `35c7bd607`). That decision was reversed: it
> now eliminates the deviation instead, which is a real behaviour change to the
> driver config, the CI service containers, and `docker-compose.yml`. The title
> and description below describe the current diff.

Resolves the open question in RFC 0071 by **converging** on
`test/config.example.yml`: the harness now uses Rails' hard-coded credential and
database name, and interpolates only the keys Rails interpolates. The `rails`
user is provisioned the way Rails provisions it.

## What Rails does

- `username: rails`, no password, on `mysql2.arunit` and `mysql2.arunit2`
  (`config.example.yml:4,24`), created by `rake db:mysql:build_user`
  (`activerecord/Rakefile:227-235`) — `CREATE USER` with no `IDENTIFIED BY`.
- Exactly three interpolated keys: `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK`
  (`config.example.yml:12-20`).
- `postgresql:` entries carry **no connection fields at all**
  (`config.example.yml:74-81`) — no host, no credential — so libpq resolves
  `PG*` itself.
- `database: activerecord_unittest`, filled in by `ARTest.expand_config`
  (`test/support/config.rb:28-34`) for every entry that carries none.

## What changed

- `support/config.ts` — mysql2 reads only `MYSQL_HOST` / `MYSQL_PORT` /
  `MYSQL_SOCK` over `username: rails` (no password). Postgres hard-codes no
  credential: `PGUSER` / `PGPASSWORD` stay unset unless the environment carries
  them, `ServerSettings.user` became optional, and a settings-derived URL then
  emits no userinfo at all so `pg` resolves libpq's defaults instead of seeing
  an empty username. Database is `activerecord_unittest` for both lanes;
  `MYSQL_USER` / `MYSQL_PASSWORD` / `MYSQL_DATABASE` / `PGDATABASE` are no
  longer read.
- **Provisioning** — `scripts/db-init/{mysql,postgres}/` init scripts for
  `docker-compose.yml`, and a provisioning step in each of the three CI jobs.
  Postgres runs with `POSTGRES_HOST_AUTH_METHOD=trust` so the passwordless
  `rails` role can connect over TCP, mirroring Rails' credential-less entries.
- Test/CI env, `test:db`, and the local-run doc recipes drop the removed keys.

## Deliberate additions over Rails' setup, each noted at its call site

- `AR_DB_SLOT` stays: Rails runs one database, trails gives each vitest worker
  an `_N`-suffixed copy. That is also why the provisioned user carries
  `CREATEDB` / a global `GRANT` where Rails grants on one database.
- `'rails'@'localhost'` is granted alongside `'rails'@'%'`, because `MYSQL_SOCK`
  is a first-class sub-setting here and a socket connection authenticates as
  `localhost`, which `%` does not cover. Rails' rake task grants only `%`.
- `arunit2-config` keeps its `_arunit` / `_arunit2` suffixes rather than Rails'
  `activerecord_unittest2`: the primary name already carries the slot suffix, so
  Rails' "+2" rule would turn slot 3 into `activerecord_unittest_32` — slot 32's
  database.

## Verification

Ran against real converged containers (`docker compose` with the new init
scripts), connecting as `rails`:

- **Postgres** — `support/` + `adapters/postgresql/`: 1138 passed. The `rails`
  role created the slot DBs, the template DB, and the `_arunit2` pair.
- **MySQL** — `support/`: 193 passed, slot DBs `_2`/`_3`/`_4` created.
- The handful of failures in those runs were environmental, each confirmed by
  isolated re-run: `pg-template` was two concurrent PG runs clobbering the
  shared template DB, and `drop-all-tables` was DDL timeouts on a local
  `mysql:8` without CI's tmpfs mount — it passes with raised timeouts (40s of
  DDL) and clean on PG.
- Key-set pinning test updated to Rails' three keys; verified it still fails
  when an extra read is added.

The story asked to decide one of two outcomes and write it down. It is resolved
by taking the convergence branch of that choice, not the accept branch.

Closes-story: test-harness-credential-defaults-diverge-from-config-example
