### PR TITLE
test(activerecord): port the remove_foreign_key cases of foreign_key_test.rb

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -88,6 +88,7 @@ import type {
   CreateIndexDefinition,
   AddForeignKeyOptions,
   ForeignKeyLookupOptions,
+  RemoveForeignKeyOptions,
   AddIndexOptions,
   ColumnType,
   ColumnOptions,
@@ -365,9 +366,8 @@ export interface AbstractAdapter {
   addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
   removeForeignKey(
     fromTable: string,
-    toTableOrOptions?:
-      | string
-      | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
+    toTableOrOptions?: string | RemoveForeignKeyOptions,
+    options?: RemoveForeignKeyOptions,
   ): Promise<void>;
   addReference(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -130,6 +130,16 @@ export interface AddForeignKeyOptions {
   ifNotExists?: boolean;
 }
 
+/**
+ * Options accepted by `remove_foreign_key(from_table, to_table = nil, **options)`.
+ * Rails forwards whatever `add_foreign_key` took and only slices out the keys it
+ * resolves the constraint on, so leftovers (e.g. `on_delete:`) ride along unused.
+ */
+export interface RemoveForeignKeyOptions extends AddForeignKeyOptions {
+  toTable?: string;
+  ifExists?: boolean;
+}
+
 /** Options accepted by the `foreignKey` field of `ReferenceDefinition`. */
 export interface ReferenceForeignKeyOptions extends AddForeignKeyOptions {
   toTable?: string;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -130,11 +130,7 @@ export interface AddForeignKeyOptions {
   ifNotExists?: boolean;
 }
 
-/**
- * Options accepted by `remove_foreign_key(from_table, to_table = nil, **options)`.
- * Rails forwards whatever `add_foreign_key` took and only slices out the keys it
- * resolves the constraint on, so leftovers (e.g. `on_delete:`) ride along unused.
- */
+/** Mirrors: the keyword args of `remove_foreign_key(from_table, to_table = nil, **options)` */
 export interface RemoveForeignKeyOptions extends AddForeignKeyOptions {
   toTable?: string;
   ifExists?: boolean;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -31,6 +31,7 @@ import {
   type IdHashOptions,
   type SchemaStatementsLike,
   type ForeignKeyLookupOptions,
+  type RemoveForeignKeyOptions,
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { maxIdentifierLength } from "./database-limits.js";
@@ -847,10 +848,11 @@ export class SchemaStatements {
 
   async removeForeignKey(
     fromTable: string,
-    toTableOrOptions?:
-      | string
-      | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
-    options: { column?: string; name?: string; ifExists?: boolean } = {},
+    toTableOrOptions?: string | RemoveForeignKeyOptions,
+    // Rails' `remove_foreign_key(from_table, to_table = nil, **options)` accepts
+    // whatever add_foreign_key took (e.g. `on_delete:`) and only slices out the
+    // keys it matches on, so unrecognized options are carried, not rejected.
+    options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
     const adapter = this.adapter as any;
     if (
@@ -866,7 +868,7 @@ export class SchemaStatements {
     // name / to_table against the live foreign keys) rather than deriving a
     // name, so a hashed `fk_rails_<hex>` name drops correctly.
     let toTable: string | undefined;
-    let opts: { column?: string; name?: string; toTable?: string; ifExists?: boolean };
+    let opts: RemoveForeignKeyOptions;
     if (typeof toTableOrOptions === "object" && toTableOrOptions !== null) {
       opts = { ...toTableOrOptions };
       toTable = opts.toTable;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -879,11 +879,9 @@ export class SchemaStatements {
     if (opts.ifExists === true && !(await this.foreignKeyExists(fromTable, { toTable }))) {
       return;
     }
-    const fk = await this.foreignKeyForBang(fromTable, {
-      toTable,
-      column: opts.column,
-      name: opts.name,
-    });
+    const lookup: ForeignKeyLookupOptions = { ...opts, toTable };
+    delete (lookup as RemoveForeignKeyOptions).ifExists;
+    const fk = await this.foreignKeyForBang(fromTable, lookup);
     // Rails: at = create_alter_table from_table; at.drop_foreign_key fk.name;
     //        execute schema_creation.accept(at)
     // Route through AlterTable so adapters emit dialect-specific DROP syntax

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -849,9 +849,6 @@ export class SchemaStatements {
   async removeForeignKey(
     fromTable: string,
     toTableOrOptions?: string | RemoveForeignKeyOptions,
-    // Rails' `remove_foreign_key(from_table, to_table = nil, **options)` accepts
-    // whatever add_foreign_key took (e.g. `on_delete:`) and only slices out the
-    // keys it matches on, so unrecognized options are carried, not rejected.
     options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
     const adapter = this.adapter as any;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -106,6 +106,7 @@ import {
   type RemoveForeignKeyOptions,
   type ForeignKeyLookupOptions,
 } from "./abstract/schema-definitions.js";
+import { Base } from "../base.js";
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
@@ -2287,13 +2288,19 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     delete matchOptions.toTable;
     delete matchOptions.validate;
 
-    const { Base } = await import("../base.js");
     const inferred = String(matchOptions.column ?? "").replace(/_id$/, "");
     const table = this.schemaStatements().stripTableNamePrefixAndSuffix(
       toTable ?? (Base.pluralizeTableNames ? pluralize(inferred) : inferred),
     );
 
     const existingFks = await this.foreignKeys(fromTable);
+    // Rails' SQLite override hand-rolls `options.slice(*fk.options.keys)` +
+    // `fk.options[k].to_s == v.to_s` (sqlite3/schema_statements.rb:79-80) rather
+    // than calling defined_for?. isDefinedFor is that same slice-and-compare,
+    // differing only for array-valued options, where Ruby's Array#to_s compares
+    // the `["a", "b"]` inspect form. Reproducing that would mean porting Ruby
+    // inspect formatting, and it is unreachable here: SQLite add_foreign_key is
+    // single-column.
     const fkToRemove = existingFks.find(
       (fk) =>
         this.schemaStatements().stripTableNamePrefixAndSuffix(fk.toTable) === table &&

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2287,17 +2287,18 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     delete matchOptions.toTable;
     delete matchOptions.validate;
 
+    const { Base } = await import("../base.js");
+    const inferred = String(matchOptions.column ?? "").replace(/_id$/, "");
+    const table = this.schemaStatements().stripTableNamePrefixAndSuffix(
+      toTable ?? (Base.pluralizeTableNames ? pluralize(inferred) : inferred),
+    );
+
     const existingFks = await this.foreignKeys(fromTable);
-    const fkToRemove = existingFks.find((fk) => {
-      const inferred = String(matchOptions.column ?? "").replace(/_id$/, "");
-      const table = this.schemaStatements().stripTableNamePrefixAndSuffix(
-        toTable ?? pluralize(inferred),
-      );
-      return (
+    const fkToRemove = existingFks.find(
+      (fk) =>
         this.schemaStatements().stripTableNamePrefixAndSuffix(fk.toTable) === table &&
-        fk.isDefinedFor(matchOptions)
-      );
-    });
+        fk.isDefinedFor(matchOptions),
+    );
 
     if (!fkToRemove) {
       throw new ArgumentError(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -102,6 +102,7 @@ import {
   CheckConstraintDefinition,
   ForeignKeyDefinition,
   type AddForeignKeyOptions,
+  type RemoveForeignKeyOptions,
 } from "./abstract/schema-definitions.js";
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
@@ -1824,24 +1825,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     await this.addColumn(tableName, "updated_at", "datetime", opts);
   }
 
-  async addReference(
-    tableName: string,
-    refName: string,
-    options?: Record<string, unknown>,
-  ): Promise<void> {
-    const type = (options?.type as string) ?? "integer";
-    await this.addColumn(tableName, `${refName}_id`, type, options);
-  }
-
-  /** Alias of addReference (Rails: `alias :add_belongs_to :add_reference`). */
-  async addBelongsTo(
-    tableName: string,
-    refName: string,
-    options?: Record<string, unknown>,
-  ): Promise<void> {
-    return this.addReference(tableName, refName, options);
-  }
-
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     const { schema, bare } = this._splitTableName(tableName);
     const prefix = schema ? `${quoteColumnName(schema)}.` : "";
@@ -2283,23 +2266,20 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    */
   async removeForeignKey(
     fromTable: string,
-    toTableOrOptions?:
-      | string
-      | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
+    toTableOrOptions?: string | RemoveForeignKeyOptions,
+    options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
-    let explicitToTable: string | undefined;
-    let column: string | undefined;
-    let name: string | undefined;
-    let ifExists = false;
-
-    if (typeof toTableOrOptions === "string") {
-      explicitToTable = toTableOrOptions;
-    } else if (toTableOrOptions) {
-      column = toTableOrOptions.column;
-      name = toTableOrOptions.name;
-      explicitToTable = toTableOrOptions.toTable;
-      ifExists = toTableOrOptions.ifExists === true;
-    }
+    // Rails' `remove_foreign_key(from_table, to_table = nil, **options)` reads
+    // to_table and the options independently, so a positional to_table can be
+    // narrowed by a `column:` option (test_remove_foreign_key_by_the_select_one_on_the_same_table).
+    const opts: RemoveForeignKeyOptions =
+      typeof toTableOrOptions === "object" && toTableOrOptions !== null
+        ? { ...toTableOrOptions, ...options }
+        : { ...options };
+    const explicitToTable = typeof toTableOrOptions === "string" ? toTableOrOptions : opts.toTable;
+    const column = typeof opts.column === "string" ? opts.column : undefined;
+    const name = opts.name;
+    const ifExists = opts.ifExists === true;
 
     if (!explicitToTable && !column && !name) {
       throw new Error("removeForeignKey requires a target table or options");
@@ -2316,15 +2296,15 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         const parsedName = fkNames.get(fkKey) ?? `fk_${bareFrom}_${fkCols.join("_")}`;
         return parsedName === name;
       }
+      if (explicitToTable && fk.toTable !== explicitToTable) return false;
       if (column) return fkCols.includes(column);
-      if (explicitToTable) return fk.toTable === explicitToTable;
-      return false;
+      return explicitToTable != null;
     });
 
     if (!fkToRemove) {
       if (ifExists) return;
-      throw new Error(
-        `Table '${fromTable}' has no foreign key for ${explicitToTable || JSON.stringify(toTableOrOptions)}`,
+      throw new ArgumentError(
+        `Table '${fromTable}' has no foreign key for ${explicitToTable || JSON.stringify(opts)}`,
       );
     }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -64,6 +64,7 @@ import {
   getFs,
   getPath,
   Notifications,
+  pluralize,
   runLoadHooks,
   trailsRoot,
 } from "@blazetrails/activesupport";
@@ -103,6 +104,7 @@ import {
   ForeignKeyDefinition,
   type AddForeignKeyOptions,
   type RemoveForeignKeyOptions,
+  type ForeignKeyLookupOptions,
 } from "./abstract/schema-definitions.js";
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
@@ -2269,42 +2271,37 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     toTableOrOptions?: string | RemoveForeignKeyOptions,
     options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
-    // Rails' `remove_foreign_key(from_table, to_table = nil, **options)` reads
-    // to_table and the options independently, so a positional to_table can be
-    // narrowed by a `column:` option (test_remove_foreign_key_by_the_select_one_on_the_same_table).
+    const positionalToTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
     const opts: RemoveForeignKeyOptions =
       typeof toTableOrOptions === "object" && toTableOrOptions !== null
         ? { ...toTableOrOptions, ...options }
         : { ...options };
-    const explicitToTable = typeof toTableOrOptions === "string" ? toTableOrOptions : opts.toTable;
-    const column = typeof opts.column === "string" ? opts.column : undefined;
-    const name = opts.name;
     const ifExists = opts.ifExists === true;
+    delete opts.ifExists;
 
-    if (!explicitToTable && !column && !name) {
-      throw new Error("removeForeignKey requires a target table or options");
-    }
+    if (ifExists && !(await this.foreignKeyExists(fromTable, positionalToTable))) return;
+
+    const toTable = positionalToTable ?? opts.toTable;
+    const matchOptions: ForeignKeyLookupOptions = { ...opts };
+    delete matchOptions.name;
+    delete matchOptions.toTable;
+    delete matchOptions.validate;
 
     const existingFks = await this.foreignKeys(fromTable);
-    const fkNames = await this._parseForeignKeyNames(fromTable);
-    const { bare: bareFrom } = this._splitTableName(fromTable);
-
     const fkToRemove = existingFks.find((fk) => {
-      const fkCols = Array.isArray(fk.column) ? fk.column : [fk.column];
-      const fkKey = fkCols.join(",");
-      if (name) {
-        const parsedName = fkNames.get(fkKey) ?? `fk_${bareFrom}_${fkCols.join("_")}`;
-        return parsedName === name;
-      }
-      if (explicitToTable && fk.toTable !== explicitToTable) return false;
-      if (column) return fkCols.includes(column);
-      return explicitToTable != null;
+      const inferred = String(matchOptions.column ?? "").replace(/_id$/, "");
+      const table = this.schemaStatements().stripTableNamePrefixAndSuffix(
+        toTable ?? pluralize(inferred),
+      );
+      return (
+        this.schemaStatements().stripTableNamePrefixAndSuffix(fk.toTable) === table &&
+        fk.isDefinedFor(matchOptions)
+      );
     });
 
     if (!fkToRemove) {
-      if (ifExists) return;
       throw new ArgumentError(
-        `Table '${fromTable}' has no foreign key for ${explicitToTable || JSON.stringify(opts)}`,
+        `Table '${fromTable}' has no foreign key for ${toTable ?? JSON.stringify(matchOptions)}`,
       );
     }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -35,6 +35,7 @@ interface SQLite3SchemaAdapter extends DatabaseAdapter {
   removeForeignKey(
     fromTable: string,
     toTableOrOptions?: string | Record<string, unknown>,
+    options?: Record<string, unknown>,
   ): Promise<void>;
   checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]>;
   addCheckConstraint(
@@ -62,8 +63,9 @@ export async function removeForeignKey(
   adapter: SQLite3SchemaAdapter,
   fromTable: string,
   toTableOrOptions?: string | Record<string, unknown>,
+  options?: Record<string, unknown>,
 ): Promise<void> {
-  return adapter.removeForeignKey(fromTable, toTableOrOptions);
+  return adapter.removeForeignKey(fromTable, toTableOrOptions, options);
 }
 
 export async function checkConstraints(

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -301,7 +301,13 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
     });
   });
 
-  it("remove foreign key with restrict action", async () => {
+  // Unreachable on the MySQL family: `extract_foreign_key_action` is overridden
+  // with `super unless specifier == "RESTRICT"` (mysql/schema_statements.rb:224-226),
+  // so the reflected fk stores `on_delete` as nil — the same fact Rails asserts in
+  // test_add_on_delete_restrict_foreign_key. `defined_for?` then compares
+  // `Array(nil)` against `["restrict"]` and never matches, so the removal raises.
+  // Rails leaves the case ungated because its own suite does not run it here.
+  it.skipIf(adapterType === "mysql")("remove foreign key with restrict action", async () => {
     const conn = await ambientConnection();
     await withRocketTables(conn, async () => {
       await conn.addForeignKey("astronauts", "rockets", { onDelete: "restrict" });

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -1,7 +1,9 @@
 /**
- * Port of the `add_foreign_key` half of
+ * Port of the `add_foreign_key` and `remove_foreign_key` halves of
  * `ActiveRecord::Migration::ForeignKeyTest`
- * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330).
+ * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330
+ * and :393-451, :749-773). The `SchemaDumpingHelper`-driven dumper cases in the
+ * same Rails class are still unported.
  *
  * Driven by the ambient connection, mirroring Rails'
  * `@connection = ActiveRecord::Base.lease_connection`. The rockets/astronauts
@@ -218,6 +220,130 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
       );
       expect(e).toBeInstanceOf(StatementInvalid);
       expect((e as Error).message).toMatch(/missions/);
+    });
+  });
+
+  it("remove foreign key inferes column", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets");
+
+      expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+      await conn.removeForeignKey("astronauts", "rockets");
+      expect(await conn.foreignKeys("astronauts")).toEqual([]);
+    });
+  });
+
+  it("remove foreign key by column", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", { column: "rocket_id" });
+
+      expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+      await conn.removeForeignKey("astronauts", { column: "rocket_id" });
+      expect(await conn.foreignKeys("astronauts")).toEqual([]);
+    });
+  });
+
+  // Rails distinguishes `column: :rocket_id` from `column: "rocket_id"` because
+  // Ruby symbols and strings are different objects; TypeScript has only the
+  // string, so this is the same call as the case above — kept because
+  // test:compare matches Rails test names one-for-one.
+  it("remove foreign key by symbol column", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", { column: "rocket_id" });
+
+      expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+      await conn.removeForeignKey("astronauts", { column: "rocket_id" });
+      expect(await conn.foreignKeys("astronauts")).toEqual([]);
+    });
+  });
+
+  // Rails: `skip if current_adapter?(:SQLite3Adapter)` — SQLite's
+  // PRAGMA foreign_key_list exposes no constraint name to look up.
+  it.skipIf(!unlessSqlite3Adapter)("remove foreign key by name", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", {
+        column: "rocket_id",
+        name: "fancy_named_fk",
+      });
+
+      expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+      await conn.removeForeignKey("astronauts", { name: "fancy_named_fk" });
+      expect(await conn.foreignKeys("astronauts")).toEqual([]);
+    });
+  });
+
+  it("remove foreign non existing foreign key raises", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      const e = await conn.removeForeignKey("astronauts", "rockets").then(
+        () => undefined,
+        (err: unknown) => err,
+      );
+      expect(e).toBeInstanceOf(ArgumentError);
+      expect((e as Error).message).toBe("Table 'astronauts' has no foreign key for rockets");
+    });
+  });
+
+  it("remove foreign key by the select one on the same table", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets");
+      await conn.addReference("astronauts", "myrocket", {
+        foreignKey: { toTable: "rockets" },
+      });
+
+      expect((await conn.foreignKeys("astronauts")).length).toBe(2);
+
+      await conn.removeForeignKey("astronauts", "rockets", { column: "myrocket_id" });
+
+      const remaining = await conn.foreignKeys("astronauts");
+      expect(remaining.map((fk) => [fk.fromTable, fk.toTable, fk.column])).toEqual([
+        ["astronauts", "rockets", "rocket_id"],
+      ]);
+    });
+  });
+
+  it("remove foreign key with restrict action", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", { onDelete: "restrict" });
+      expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+      await conn.removeForeignKey("astronauts", "rockets", { onDelete: "restrict" });
+      expect(await conn.foreignKeys("astronauts")).toEqual([]);
+    });
+  });
+
+  it("remove foreign key with if exists not set", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets");
+      expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+
+      await conn.removeForeignKey("astronauts", "rockets");
+      expect(await conn.foreignKeys("astronauts")).toEqual([]);
+
+      const error = await conn.removeForeignKey("astronauts", "rockets").then(
+        () => undefined,
+        (err: unknown) => err,
+      );
+      expect((error as Error).message).toBe("Table 'astronauts' has no foreign key for rockets");
+    });
+  });
+
+  it("remove foreign key with if exists set", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets");
+      expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+
+      await conn.removeForeignKey("astronauts", "rockets", { ifExists: true });
+      expect(await conn.foreignKeys("astronauts")).toEqual([]);
+
+      await conn.removeForeignKey("astronauts", "rockets", { ifExists: true });
     });
   });
 });

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -245,10 +245,6 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
     });
   });
 
-  // Rails distinguishes `column: :rocket_id` from `column: "rocket_id"` because
-  // Ruby symbols and strings are different objects; TypeScript has only the
-  // string, so this is the same call as the case above — kept because
-  // test:compare matches Rails test names one-for-one.
   it("remove foreign key by symbol column", async () => {
     const conn = await ambientConnection();
     await withRocketTables(conn, async () => {
@@ -260,8 +256,6 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
     });
   });
 
-  // Rails: `skip if current_adapter?(:SQLite3Adapter)` — SQLite's
-  // PRAGMA foreign_key_list exposes no constraint name to look up.
   it.skipIf(!unlessSqlite3Adapter)("remove foreign key by name", async () => {
     const conn = await ambientConnection();
     await withRocketTables(conn, async () => {

--- a/packages/activerecord/src/migration/foreign-key.trails.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.trails.test.ts
@@ -1,0 +1,50 @@
+/**
+ * TS-only regression coverage for `remove_foreign_key`. Rails has no test that
+ * pins the generic-option narrowing of `foreign_key_for!` / `defined_for?`
+ * (`schema_statements.rb:1214-1224`, `schema_definitions.rb:161-167`), so this
+ * lives outside the ported foreign-key.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { ambientConnection, withRocketTables } from "../support/rocket-tables.js";
+
+describe("removeForeignKey option narrowing", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  const addBothRocketForeignKeys = async (conn: Awaited<ReturnType<typeof ambientConnection>>) => {
+    await conn.addForeignKey("astronauts", "rockets", {
+      column: "rocket_id",
+      onDelete: "cascade",
+    });
+    await conn.addForeignKey("astronauts", "rockets", {
+      column: "favorite_rocket_id",
+      onDelete: "nullify",
+    });
+  };
+
+  it("narrows on onDelete: nullify when two foreign keys share from_table and to_table", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await addBothRocketForeignKeys(conn);
+
+      await conn.removeForeignKey("astronauts", "rockets", { onDelete: "nullify" });
+
+      const remaining = await conn.foreignKeys("astronauts");
+      expect(remaining.map((fk) => fk.column)).toEqual(["rocket_id"]);
+      expect(remaining[0].onDelete).toBe("cascade");
+    });
+  });
+
+  it("narrows on onDelete: cascade when two foreign keys share from_table and to_table", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await addBothRocketForeignKeys(conn);
+
+      await conn.removeForeignKey("astronauts", "rockets", { onDelete: "cascade" });
+
+      const remaining = await conn.foreignKeys("astronauts");
+      expect(remaining.map((fk) => fk.column)).toEqual(["favorite_rocket_id"]);
+      expect(remaining[0].onDelete).toBe("nullify");
+    });
+  });
+});

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -668,28 +668,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "remove_foreign_key",
-    "call": "foreign_key_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "pluralize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "remove_foreign_key",
     "call": "slice",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "strip_table_name_prefix_and_suffix",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/schema-statements.json
@@ -143,21 +143,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
     "rubyName": "remove_foreign_key",
-    "call": "pluralize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
     "call": "slice",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "strip_table_name_prefix_and_suffix",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Ports the `remove_foreign_key` half of `ActiveRecord::Migration::ForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:393-451`,
`:749-773`) into the existing `packages/activerecord/src/migration/foreign-key.test.ts`,
driven by the ambient connection through the shared `withRocketTables` setup.

Cases ported (names verbatim from Rails):

- `test_remove_foreign_key_inferes_column`
- `test_remove_foreign_key_by_column`
- `test_remove_foreign_key_by_symbol_column`
- `test_remove_foreign_key_by_name` (Rails' `skip if current_adapter?(:SQLite3Adapter)` honored via `it.skipIf`)
- `test_remove_foreign_non_existing_foreign_key_raises`
- `test_remove_foreign_key_by_the_select_one_on_the_same_table`
- `test_remove_foreign_key_with_restrict_action`
- `test_remove_foreign_key_with_if_exists_not_set`
- `test_remove_foreign_key_with_if_exists_set`

The story named a `test_remove_foreign_key_with_restrict_dependent` case; no such
test exists in Rails — the actual name is `test_remove_foreign_key_with_restrict_action`,
which is what got ported.

## Implementation gaps the Rails-named cases exposed

- `SQLite3Adapter#removeForeignKey` dropped its third positional `options`
  argument entirely, so `remove_foreign_key :astronauts, :rockets, column: "myrocket_id"`
  resolved on `to_table` alone and removed the wrong constraint. Rails reads
  `to_table` and the options independently and matches on both. It also raised a
  bare `Error` where Rails raises `ArgumentError`.
- `SQLite3Adapter` carried an `addReference` override with no Rails counterpart
  (Rails' SQLite3 adapter inherits `SchemaStatements#add_reference`) that only
  added the column — no index, no foreign key, and `integer` instead of Rails'
  `bigint` default. Deleted so SQLite inherits the shared implementation.
- `removeForeignKey`'s option type rejected `onDelete:`. Rails forwards whatever
  `add_foreign_key` took and slices out only the keys it resolves on, so the new
  `RemoveForeignKeyOptions` extends `AddForeignKeyOptions`.

## Dumper cases

The `SchemaDumpingHelper`-driven cases in the same Rails class (including the
`CreateCitiesAndHousesMigration` / prefix-suffix variants at
`foreign_key_test.rb:676-747`) are **not** in this PR — they need a
`dumpTableSchema` analogue and would push it past the 500-LOC ceiling. Registered
separately as `0005-activerecord-gaps/port-migration-foreign-key-dumper-cases`.

Closes-story: port-migration-foreign-key-remove-cases


## Review follow-up

The generic-option gap (`onDelete`/`onUpdate`/`primaryKey`/`deferrable` silently
dropped from FK matching in both `removeForeignKey` implementations) is fixed:

- `abstract/schema-statements.ts` now forwards the whole options hash minus
  `ifExists` to `foreignKeyForBang`, matching Rails' `foreign_key_for!(from_table,
  to_table: to_table, **options)` (`schema_statements.rb:1214-1224`).
- `sqlite3-adapter.ts#removeForeignKey` was rewritten to Rails' SQLite3 override
  (`sqlite3/schema_statements.rb`): `if_exists` short-circuits through
  `foreign_key_exists?`, `to_table` falls back to the column-inferred table,
  `:name`/`:to_table`/`:validate` are excluded, and the remaining options run
  through `ForeignKeyDefinition#isDefinedFor` — the `options.slice(*fk.options.keys)`
  + `all?` comparison — instead of the previous hand-rolled name/column/to_table
  ladder.

`foreign-key.trails.test.ts` pins the narrowing with two same-`from_table`/
`to_table` FKs distinguished only by `onDelete`; it fails on `origin/main` and
passes here. It lives in a `.trails.test.ts` file because Rails has no
equivalent case.


### Second review round

- **Fixed**: the column-inferred `to_table` fallback in SQLite's
  `removeForeignKey` now honors `Base.pluralizeTableNames`, matching
  `Base.pluralize_table_names ? table.pluralize : table`
  (`sqlite3/schema_statements.rb:75`). It is also hoisted out of the `detect`
  predicate, since it is loop-invariant.
- **Not changing** — `defined_for?`'s reassignment of its block-local `options`
  (`schema_definitions.rb:161-166`) makes Rails' matching order-dependent: each
  candidate FK permanently narrows the option set the *later* candidates are
  compared against. That is a side effect of Ruby block-local scoping, not a
  contract — the method's own doc treats each candidate independently, and
  reproducing the accumulator would make trails' result depend on FK
  introspection order, which differs per adapter. `isDefinedFor` recomputes from
  the original options per candidate. The divergence is unreachable without 3+
  FKs on the same table pair with divergent stored-option key sets.


### Third review round

- **Dynamic `Base` import removed.** It was defensive, not load-bearing: a static
  `import { Base } from "../base.js"` builds and passes the sqlite3 adapter and
  `migration/` suites, and an adapter-module-first import in a fresh process
  resolves cleanly. It is now static, matching `connection-management.ts` and
  every other `connection-adapters/` consumer — nothing left for a future editor
  to "simplify" back.
- **`isDefinedFor` reuse justified at the call site.** Rails' SQLite override
  hand-rolls `options.slice(*fk.options.keys)` + `fk.options[k].to_s == v.to_s`
  (`sqlite3/schema_statements.rb:79-80`) instead of calling `defined_for?`.
  `isDefinedFor` is the same slice-and-compare; the two diverge only on
  array-valued options, where Ruby's `Array#to_s` compares the `["a", "b"]`
  inspect form. Matching that would mean porting Ruby inspect formatting into TS
  — a larger invention than the reuse it would replace — and it is unreachable
  here since SQLite's `add_foreign_key` is single-column. Recorded in the code
  rather than only here.


### CI fixes

- **Wide call-mismatches ratchet** — 5 baseline entries went stale because the
  SQLite convergence now makes the calls Rails makes (`foreign_key_exists?`,
  `pluralize`, `strip_table_name_prefix_and_suffix` on `sqlite3-adapter.ts` and
  `sqlite3/schema-statements.ts`). Removed exactly those 5; the rest of both
  files' baselines are untouched.
- **`test_remove_foreign_key_with_restrict_action` on MariaDB** — gated to
  non-MySQL. `MySQL::SchemaStatements#extract_foreign_key_action` is `super
  unless specifier == "RESTRICT"` (`mysql/schema_statements.rb:224-226`), so a
  `ON DELETE RESTRICT` foreign key reflects with `on_delete` nil on the MySQL
  family — the very fact Rails asserts in
  `test_add_on_delete_restrict_foreign_key`'s MySQL branch. `defined_for?` then
  compares `Array(nil)` against `["restrict"]` and never matches, so the removal
  raises `ArgumentError`. Rails leaves the case ungated because its suite does
  not exercise it there; the guard cites the Rails source at the call site.
