### PR TITLE
test(compare): stop skipping the migration test directory

### DIFF
--- a/packages/activerecord/src/migration/exclusion-constraint.test.ts
+++ b/packages/activerecord/src/migration/exclusion-constraint.test.ts
@@ -12,16 +12,13 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import {
-  describeIfPg,
-  PostgreSQLAdapter,
-  PG_TEST_URL,
-} from "../adapters/postgresql/test-helper.js";
+import { PostgreSQLAdapter, PG_TEST_URL } from "../adapters/postgresql/test-helper.js";
+import { describeIfSupports } from "../support/supports.js";
 import { rebuildCanonicalTables } from "../support/canonical-schema.js";
 
 const EXPRESSION = "daterange(start_date, end_date) WITH &&";
 
-describeIfPg("ActiveRecord::Migration", () => {
+describeIfSupports("exclusion_constraints", "Migration", () => {
   let connection: PostgreSQLAdapter;
 
   beforeEach(async () => {

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -8,20 +8,21 @@
  * setup/teardown is shared with schema-statements-on-adapter.test.ts via
  * `withRocketTables`.
  */
-import { describe, it, expect } from "vitest";
+import { it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { StatementInvalid } from "../errors.js";
 import type { ReferentialAction } from "../connection-adapters/abstract/schema-definitions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { ambientConnection, withRocketTables } from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
+import { describeIfSupports } from "../support/supports.js";
 
 // Rails' `unless current_adapter?(:SQLite3Adapter)` guard on the `fk.name`
 // assertions: PRAGMA foreign_key_list exposes no constraint name, so SQLite
 // has no name to compare.
 const unlessSqlite3Adapter = adapterType !== "sqlite";
 
-describe("ActiveRecord::Migration::ForeignKeyTest", () => {
+describeIfSupports("foreign_keys", "ActiveRecord::Migration::ForeignKeyTest", () => {
   // DDL can't run inside the transactional-fixtures wrapper (PG aborts the
   // outer transaction on a failed statement), matching the schema-statements
   // suite's setup.

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -7,14 +7,11 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import {
-  describeIfPg,
-  PostgreSQLAdapter,
-  PG_TEST_URL,
-} from "../adapters/postgresql/test-helper.js";
+import { PostgreSQLAdapter, PG_TEST_URL } from "../adapters/postgresql/test-helper.js";
+import { describeIfSupports } from "../support/supports.js";
 import { rebuildCanonicalTables } from "../support/canonical-schema.js";
 
-describeIfPg("ActiveRecord::Migration", () => {
+describeIfSupports("unique_constraints", "Migration", () => {
   let connection: PostgreSQLAdapter;
 
   beforeEach(async () => {

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -49,7 +49,6 @@ SKIP_PATTERNS = [
   /\/test_case\.rb$/,
   /\/abstract_unit\.rb$/,
   /\/config\.rb$/,
-  /\/migration\//,  # Migration test infrastructure (not test cases themselves)
 ]
 
 # Is `name` an assertion call? Matched by PREFIX (not a fixed list), the twin of

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -41,7 +41,12 @@ rescue JSON::ParserError => e
         "If you set it manually, re-run via `TEST_PATHS_JSON=$(pnpm -s vendor:fetch --print-test-paths)`."
 end
 
-# Files/directories to skip (infrastructure, not actual tests)
+# Files/directories to skip (infrastructure, not actual tests).
+#
+# Match FILES, not directories: `test/cases/migration/` looks like a support
+# tree but is ~20 real test files, and skipping the whole directory silently
+# demoted every ported case there to a TS-only "extra". Its one infrastructure
+# file, migration/helper.rb, is already covered by the /helper\.rb$/ entry.
 SKIP_PATTERNS = [
   /\/helper\.rb$/,
   /\/support\//,


### PR DESCRIPTION
`scripts/test-compare/extract-ruby-tests.rb` skipped everything matching
`/\/migration\//`, commented "Migration test infrastructure (not test cases
themselves)". That was wrong: `vendor/rails/activerecord/test/cases/migration/`
is ~20 real test files (`foreign_key_test.rb`, `change_schema_test.rb`,
`index_test.rb`, …). The genuine infrastructure there is `helper.rb`, already
covered by the existing `/\/helper\.rb$/` pattern.

Consequence of the skip: every case ported out of that directory was invisible
to `test:compare` — counted as a TS-only extra instead of a matched pair, and
the missing cases never showed as missing.

## Effect on the baseline

| | before | after |
| --- | --- | --- |
| activerecord files | 321 | 342 |
| activerecord tests | 7787/7787 (100%) | 7824/8327 (94%) |

The drop is a one-time measurement correction — those cases were always
missing, just unmeasured. `migration/foreign-key.test.ts`,
`unique-constraint.test.ts`, `exclusion-constraint.test.ts`,
`command-recorder.test.ts` and friends now match against their Rails files
instead of sitting in the extras bucket.

## Gate fixes (required for green CI)

activerecord's gate-mismatch check is a hard zero, and the newly-visible pairs
tripped 29. Re-gated the three affected suites to the Rails-side predicate:

- `unique-constraint.test.ts`: `describeIfPg` → `describeIfSupports("unique_constraints", "Migration", …)`
- `exclusion-constraint.test.ts`: `describeIfPg` → `describeIfSupports("exclusion_constraints", "Migration", …)`
- `foreign-key.test.ts`: bare `describe` → `describeIfSupports("foreign_keys", …)` (`foreign_keys` is supported on all three backends, so nothing changes about when it runs)

Renaming the two outer describes to `Migration` also matches Rails' ancestor
path (`Migration > UniqueConstraintTest`), clearing 18 of the 29 wrong-describe
entries. The remaining 11 are `foreign-key.test.ts`'s single flat
`ActiveRecord::Migration::ForeignKeyTest` describe — splitting it in two
reindents the whole file, so it is registered separately as
`0005-activerecord-gaps/fix-foreign-key-test-describe-path`.

`pnpm test:compare --gates --check` exits 0.

Closes-story: unskip-migration-dir-in-test-compare

## Verification

- `pnpm test:compare --package activerecord --gates --check` → exit 0.
- The three re-gated suites, on the postgres lane
  (`ARCONN=postgresql`, isolated compose project): 29/29 pass.
  On the sqlite lane: foreign-key 11/11 pass, the two PG-only suites skip.
- `pnpm vitest run scripts/test-compare` → 146/146 pass.

Note on the two constraint suites: `describeIfPg` was a *server-reachability*
probe, so they used to run in all three lanes whenever a PG server happened to
be up — running identical PG-only assertions three times. `describeIfSupports`
keys on the active lane, so they now run once, on the postgres lane, which is
what Rails' `supports_unique_constraints?` guard means.
