### PR TITLE
refactor(api-compare): drop the duplicate allowlist report key

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1448,7 +1448,6 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     expect(pkg.totalAllowlisted).toBe(1);
     expect(pkg.extraFiles).toEqual([]);
     expect(report.tagged).toEqual({ total: 1, matched: 1, stale: [] });
-    // `tagged` is the only summary key: the retired `allowlist` alias is gone.
     expect(report).not.toHaveProperty("allowlist");
   });
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1448,8 +1448,8 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     expect(pkg.totalAllowlisted).toBe(1);
     expect(pkg.extraFiles).toEqual([]);
     expect(report.tagged).toEqual({ total: 1, matched: 1, stale: [] });
-    // `allowlist` is the retained stats-DB key, now fed solely by tags.
-    expect(report.allowlist).toEqual(report.tagged);
+    // `tagged` is the only summary key: the retired `allowlist` alias is gone.
+    expect(report).not.toHaveProperty("allowlist");
   });
 
   it("reports the tagged extra as novel when the tag is absent", () => {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -355,7 +355,7 @@ interface PackageTotals {
   extraFiles: ExtraFile[];
 }
 
-interface AllowlistSummary {
+interface TaggedSummary {
   total: number;
   matched: number;
   stale: TaggedEntry[];
@@ -365,14 +365,8 @@ interface Report {
   generatedAt: string;
   packages: PackageTotals[];
   topN: ExtraFile[];
-  /**
-   * Retained key name for the stats-DB consumer. Since RFC 0080 retired
-   * extra-surface-allow.json it is fed solely by `@noRailsEquivalent` tags,
-   * and is identical to `tagged`.
-   */
-  allowlist: AllowlistSummary;
   /** `@noRailsEquivalent` tags found in the TS manifest. */
-  tagged: AllowlistSummary;
+  tagged: TaggedSummary;
 }
 
 const HELP = `extra-surface — TS files with public API exceeding their Rails counterpart
@@ -1161,7 +1155,7 @@ export function buildReport(
     (e) => scannedPkgs.has(e.package) && !matchedTagKeys.has(allowKeyOf(e)),
   );
 
-  const taggedSummary: AllowlistSummary = {
+  const taggedSummary: TaggedSummary = {
     total: tagged.length,
     matched: matchedTagKeys.size,
     stale: staleTagged,
@@ -1170,7 +1164,6 @@ export function buildReport(
     generatedAt: new Date().toISOString(),
     packages,
     topN: allExtras.slice(0, opts.topN),
-    allowlist: taggedSummary,
     tagged: taggedSummary,
   };
 }


### PR DESCRIPTION
## What

Drops the duplicate `allowlist` key from the `extra-surface --json` report,
leaving `tagged` as the single summary, and renames `AllowlistSummary` →
`TaggedSummary`.

## Consumer finding (acceptance criterion 1)

The stats pipeline does **not** read either key. `scripts/sync-stats/sync.ts`
ingests api-compare numbers by parsing the CI job's log output into
`api_compare_stats` / `api_compare_privates_stats`; it never invokes
`pnpm api:extra` and contains no reference to `extra-surface`. The stats DB
schema has no allowlist/tagged/extra columns either. In-repo, the only reader
of `report.allowlist` was `extra-surface.test.ts`. So the compatibility alias
left in place by #5399 has no consumer and can be removed without a
coordinated migration.

## Notes

- Per-package counts (`totalExtras`, `totalAllowlisted`, `totalNovel`,
  `totalMoved`) are untouched.
- `extra-surface.test.ts` now pins the decision with
  `expect(report).not.toHaveProperty("allowlist")`.

Closes-story: drop-duplicate-allowlist-report-key
