### PR TITLE
test(activerecord): port the SchemaDumpingHelper cases of ForeignKeyTest

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -134,6 +134,7 @@ import {
   setVerboseQueryLogs as _setVerboseQueryLogs,
 } from "./log-subscriber.js";
 import { registerMigrationArConfig } from "./migration.js";
+import { registerTableNameOptions } from "./connection-adapters/abstract/table-name-options.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 import * as LockingOptimistic from "./locking/optimistic.js";
 import * as LockingPessimistic from "./locking/pessimistic.js";
@@ -5179,6 +5180,15 @@ _setSuperValidates(Model.validates);
     });
   }
 }
+
+registerTableNameOptions({
+  get tableNamePrefix() {
+    return Base._tableNamePrefix;
+  },
+  get tableNameSuffix() {
+    return Base._tableNameSuffix;
+  },
+});
 
 registerMigrationArConfig({
   get tableNamePrefix() {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -4,6 +4,7 @@ import type { Column } from "../column.js";
 import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { SchemaDumper } from "../../schema-dumper.js";
+import { globalTableNamePrefix, globalTableNameSuffix } from "./table-name-options.js";
 
 /**
  * @internal Shared identifier guard for MySQL bare-identifier emission
@@ -1139,8 +1140,8 @@ export class TableDefinition {
     // table_name_prefix/suffix to to_table, then route the column/name defaults
     // through the adapter's foreign_key_options (SHA256 `fk_rails_<hex>` name).
     const adapter = this._adapter as Partial<ForeignKeyOptionsAdapter>;
-    const prefix = adapter.tableNamePrefix ?? "";
-    const suffix = adapter.tableNameSuffix ?? "";
+    const prefix = adapter.tableNamePrefix ?? globalTableNamePrefix();
+    const suffix = adapter.tableNameSuffix ?? globalTableNameSuffix();
     const prefixedToTable = `${prefix}${toTable}${suffix}`;
     const opts = this._foreignKeyOptions(prefixedToTable, options);
     return new ForeignKeyDefinition(
@@ -1181,8 +1182,8 @@ export class TableDefinition {
     // trails schema-qualifier) before singularizing, so a prefixed to_table
     // still yields the bare `<singular>_<pk>` default column.
     const columnFor = (pk: string): string => {
-      const prefix = adapter.tableNamePrefix ?? "";
-      const suffix = adapter.tableNameSuffix ?? "";
+      const prefix = adapter.tableNamePrefix ?? globalTableNamePrefix();
+      const suffix = adapter.tableNameSuffix ?? globalTableNameSuffix();
       let base = toTable.replace(/^.*\./, "");
       if (prefix || suffix) {
         const stripped = base.match(new RegExp(`^${prefix}(.+)${suffix}$`));

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -43,6 +43,7 @@ import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 import { Utils as PgUtils } from "../postgresql/utils.js";
 import { indexes as sqliteIndexes } from "../sqlite3/schema-statements.js";
+import { globalTableNamePrefix, globalTableNameSuffix } from "./table-name-options.js";
 
 export { assertSchemaAdapter } from "./assert-schema-adapter.js";
 
@@ -2426,16 +2427,16 @@ export class SchemaStatements {
 
   /**
    * @internal
-   * Diverges from Rails: Rails reads `Base.table_name_prefix` / `Base.table_name_suffix`
-   * (model-class globals). Importing Base here creates a circular dependency
-   * (base.ts → connection-adapters/abstract/connection-handler.ts). Instead, we read from
-   * the adapter, which callers can populate from `Base.tableNamePrefix` at the connection
-   * layer if needed.
+   * Rails reads `Base.table_name_prefix` / `Base.table_name_suffix` (model-class
+   * globals). Importing Base here creates a circular dependency
+   * (base.ts → connection-adapters/abstract/connection-handler.ts), so the globals
+   * arrive through the `table-name-options` registry Base populates at load; an
+   * adapter-level override still wins.
    */
   stripTableNamePrefixAndSuffix(tableName: string): string {
     const adapter = this.adapter as any;
-    const prefix: string = adapter.tableNamePrefix ?? "";
-    const suffix: string = adapter.tableNameSuffix ?? "";
+    const prefix: string = adapter.tableNamePrefix ?? globalTableNamePrefix();
+    const suffix: string = adapter.tableNameSuffix ?? globalTableNameSuffix();
     const str = String(tableName);
     if (prefix || suffix) {
       const re = new RegExp(`^${prefix}(.+)${suffix}$`);

--- a/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
@@ -1,0 +1,32 @@
+/**
+ * No Rails counterpart file. Rails' schema-definition code reads
+ * `ActiveRecord::Base.table_name_prefix` / `.table_name_suffix` directly
+ * (e.g. `TableDefinition#new_foreign_key_definition`,
+ * schema_definitions.rb:575-581). Importing `Base` from the connection-adapter
+ * layer is a cycle (base.ts → connection-handler.ts → adapters), so `Base`
+ * registers itself here at load and the adapter layer reads the globals through
+ * this indirection.
+ */
+
+/** @internal */
+export interface TableNameOptionsSource {
+  readonly tableNamePrefix: string;
+  readonly tableNameSuffix: string;
+}
+
+let _source: TableNameOptionsSource | null = null;
+
+/** @internal */
+export function registerTableNameOptions(source: TableNameOptionsSource): void {
+  _source = source;
+}
+
+/** @internal */
+export function globalTableNamePrefix(): string {
+  return _source?.tableNamePrefix ?? "";
+}
+
+/** @internal */
+export function globalTableNameSuffix(): string {
+  return _source?.tableNameSuffix ?? "";
+}

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -1,11 +1,9 @@
 /**
- * Port of the `add_foreign_key` and `remove_foreign_key` halves of
- * `ActiveRecord::Migration::ForeignKeyTest`
- * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330
- * and :393-451, :749-773) plus all of its sibling
- * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912). The
- * `SchemaDumpingHelper`-driven dumper cases in `ForeignKeyTest` are still
- * unported.
+ * Port of the `add_foreign_key`, `remove_foreign_key` and `SchemaDumpingHelper`
+ * halves of `ActiveRecord::Migration::ForeignKeyTest`
+ * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330,
+ * :393-451, :643-747 and :749-773) plus all of its sibling
+ * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912).
  *
  * Driven by the ambient connection, mirroring Rails'
  * `@connection = ActiveRecord::Base.lease_connection`. The rockets/astronauts
@@ -26,11 +24,49 @@ import { adapterType } from "../test-adapter.js";
 import { describeIfSupports } from "../support/supports.js";
 import { dumpTableSchema } from "../support/schema-dumping-helper.js";
 import type { SchemaSource } from "../schema-dumper.js";
+import { Base } from "../base.js";
+import { Migration } from "../migration.js";
+import { SchemaDumper } from "../schema-dumper.js";
 
 // Rails' `unless current_adapter?(:SQLite3Adapter)` guard on the `fk.name`
 // assertions: PRAGMA foreign_key_list exposes no constraint name, so SQLite
 // has no name to compare.
 const unlessSqlite3Adapter = adapterType !== "sqlite";
+
+/** Rails' `silence_stream($stdout) { migration.migrate(...) }`. */
+class SilentMigration extends Migration {
+  write(): void {}
+}
+
+class CreateCitiesAndHousesMigration extends SilentMigration {
+  async change(): Promise<void> {
+    await this.createTable("cities", () => {});
+
+    await this.createTable("houses", (t) => {
+      t.references("city");
+    });
+    await this.addForeignKey("houses", "cities", { column: "city_id" });
+
+    // remove and re-add to test that schema is updated and not accidentally cached
+    await this.removeForeignKey("houses", "cities");
+    await this.addForeignKey("houses", "cities", { column: "city_id", onDelete: "cascade" });
+  }
+}
+
+class CreateSchoolsAndClassesMigration extends SilentMigration {
+  async change(): Promise<void> {
+    // Both tables are dropped by the migration's own `migrate("down")` in each
+    // case's ensure block, which the rule can't see from here.
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await this.createTable("schools");
+
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await this.createTable("classes", (t) => {
+      t.references("school");
+    });
+    await this.addForeignKey("classes", "schools", { validate: true });
+  }
+}
 
 describeIfSupports("foreign_keys", "Migration", () => {
   describe("ForeignKeyTest", () => {
@@ -349,6 +385,119 @@ describeIfSupports("foreign_keys", "Migration", () => {
 
         await conn.removeForeignKey("astronauts", "rockets", { ifExists: true });
       });
+    });
+
+    it("schema dumping", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets");
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+        expect(output).toMatch(/\s+await ctx\.addForeignKey\("astronauts", "rockets"\);$/m);
+      });
+    });
+
+    it("schema dumping with options", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        // Rails' SQLite3 branch expects no `name:` because its `foreign_keys`
+        // reads PRAGMA foreign_key_list, which drops the CONSTRAINT name
+        // (sqlite3_adapter.rb:417-451). trails' SQLite `foreignKeys` additionally
+        // parses the CREATE TABLE DDL and recovers the real name, so the dump
+        // carries `name: "fk_name"` on every adapter and the branch collapses.
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "fk_test_has_fk");
+        expect(output).toMatch(
+          /\s+await ctx\.addForeignKey\("fk_test_has_fk", "fk_test_has_pk", \{ column: "fk_id", primaryKey: "pk_id", name: "fk_name" \}\);$/m,
+        );
+      });
+    });
+
+    it("schema dumping with custom fk ignore pattern", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        const originalPattern = SchemaDumper.fkIgnorePattern;
+        SchemaDumper.fkIgnorePattern = /^ignored_/;
+        await conn.addForeignKey("astronauts", "rockets", {
+          name: "ignored_fk_astronauts_rockets",
+        });
+
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+        expect(output).toMatch(/\s+await ctx\.addForeignKey\("astronauts", "rockets"\);$/m);
+
+        SchemaDumper.fkIgnorePattern = originalPattern;
+      });
+    });
+
+    it("schema dumping on delete and on update options", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          onDelete: "nullify",
+          onUpdate: "cascade",
+        });
+
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+        expect(output).toMatch(
+          /\s+await ctx\.addForeignKey\("astronauts",.+onUpdate: "cascade",.+onDelete: "nullify" \}\);$/m,
+        );
+      });
+    });
+
+    it("add foreign key is reversible", async () => {
+      const conn = await ambientConnection();
+      await conn.dropTable("cities", "houses", { ifExists: true });
+
+      try {
+        const migration = new CreateCitiesAndHousesMigration();
+        await migration.migrate("up");
+        expect((await conn.foreignKeys("houses")).length).toBe(1);
+        await migration.migrate("down");
+      } finally {
+        await conn.dropTable("cities", "houses", { ifExists: true });
+      }
+    });
+
+    it("foreign key constraint is not cached incorrectly", async () => {
+      const conn = await ambientConnection();
+      await conn.dropTable("cities", "houses", { ifExists: true });
+
+      try {
+        const migration = new CreateCitiesAndHousesMigration();
+        await migration.migrate("up");
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "houses");
+        expect(output).toMatch(
+          /\s+await ctx\.addForeignKey\("houses",.+onDelete: "cascade" \}\);$/m,
+        );
+        await migration.migrate("down");
+      } finally {
+        await conn.dropTable("cities", "houses", { ifExists: true });
+      }
+    });
+
+    it("add foreign key with prefix", async () => {
+      Base.tableNamePrefix = "p_";
+      const migration = new CreateSchoolsAndClassesMigration();
+      try {
+        await migration.migrate("up");
+        const conn = await ambientConnection();
+        expect((await conn.foreignKeys("p_classes")).length).toBe(1);
+      } finally {
+        await migration.migrate("down");
+        Base.tableNamePrefix = "";
+      }
+    });
+
+    it("add foreign key with suffix", async () => {
+      Base.tableNameSuffix = "_s";
+      const migration = new CreateSchoolsAndClassesMigration();
+      try {
+        await migration.migrate("up");
+        const conn = await ambientConnection();
+        expect((await conn.foreignKeys("classes_s")).length).toBe(1);
+      } finally {
+        await migration.migrate("down");
+        Base.tableNameSuffix = "";
+      }
     });
   });
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -1092,12 +1092,29 @@ export class SchemaDumper {
       validate?: boolean;
     };
     const fkIgnorePattern = (this.constructor as typeof SchemaDumper).fkIgnorePattern;
+    // Rails' `@connection.foreign_key_column_for(to_table, "id")` — the column
+    // whose match makes the dump omit `column:`. A bare SchemaSource lacks the
+    // schema-statement mixin, and with no inference to compare against the
+    // option is emitted rather than guessed at.
+    const columnFor = (host as { foreignKeyColumnFor?: (t: string, c: string) => string })
+      .foreignKeyColumnFor;
+    // Rails sorts the emitted statements (`add_foreign_key_statements.sort`),
+    // so the dump order does not follow introspection order.
+    const statements: string[] = [];
     for (const fk of fks as Fk[]) {
       const fromExpr = JSON.stringify(this.removePrefixAndSuffix(fk.fromTable ?? tableName));
       const toExpr = JSON.stringify(this.removePrefixAndSuffix(fk.toTable));
       const opts: string[] = [];
-      if (fk.column) opts.push(`column: ${JSON.stringify(fk.column)}`);
-      if (fk.primaryKey) opts.push(`primaryKey: ${JSON.stringify(fk.primaryKey)}`);
+      const inferredColumn = columnFor ? columnFor.call(host, fk.toTable, "id") : undefined;
+      if (fk.column && fk.column !== inferredColumn) {
+        opts.push(`column: ${JSON.stringify(fk.column)}`);
+      }
+      const isCustomPrimaryKey =
+        "isCustomPrimaryKey" in (fk as object)
+          ? (fk as unknown as { isCustomPrimaryKey: boolean }).isCustomPrimaryKey
+          : fk.primaryKey != null && fk.primaryKey !== "id";
+      if (isCustomPrimaryKey && fk.primaryKey)
+        opts.push(`primaryKey: ${JSON.stringify(fk.primaryKey)}`);
       // Mirrors Rails' export_name_on_schema_dump? — delegate to FK object when available
       // (ForeignKeyDefinition incorporates the fk_rails_ ignore-pattern check), else fall back.
       const exportName =
@@ -1111,8 +1128,10 @@ export class SchemaDumper {
         opts.push(`deferrable: ${JSON.stringify(fk.deferrable)}`);
       if (fk.validate === false) opts.push("validate: false");
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
-      lines.push(`  await ctx.addForeignKey(${fromExpr}, ${toExpr}${optStr});`);
+      statements.push(`  await ctx.addForeignKey(${fromExpr}, ${toExpr}${optStr});`);
     }
+    statements.sort();
+    lines.push(...statements);
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-dumper.json
@@ -73,13 +73,6 @@
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "foreign_keys",
-    "call": "foreign_key_column_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "foreign_keys",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Ports the `SchemaDumpingHelper`-driven cases of
`ActiveRecord::Migration::ForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:643-747`)
into the existing `packages/activerecord/src/migration/foreign-key.test.ts`,
reusing `withRocketTables` and the existing `dumpTableSchema` helper — no
bespoke tables, no new adapter.

Cases ported (names verbatim from Rails): `schema_dumping`,
`schema_dumping_with_options`, `schema_dumping_with_custom_fk_ignore_pattern`,
`schema_dumping_on_delete_and_on_update_options`,
`add_foreign_key_is_reversible`, `foreign_key_constraint_is_not_cached_incorrectly`,
`add_foreign_key_with_prefix`, `add_foreign_key_with_suffix`.

## Fidelity fixes the ported cases surfaced

1. **`SchemaDumper#foreignKeys` over-emitted options.** Rails
   (`schema_dumper.rb:316-346`) omits `column:` when it equals
   `foreign_key_column_for(to_table, "id")`, omits `primary_key:` unless
   `custom_primary_key?`, and sorts the emitted statements. trails emitted
   both unconditionally and in introspection order, so
   `add_foreign_key "astronauts", "rockets"` dumped as
   `addForeignKey("astronauts", "rockets", { column: "rocket_id", primaryKey: "id" })`.

2. **`table_name_prefix` / `table_name_suffix` never reached the adapter layer.**
   Rails' `TableDefinition#new_foreign_key_definition` reads
   `ActiveRecord::Base.table_name_prefix` directly; trails read it off the
   adapter, which nothing ever populated, so a prefixed migration emitted
   `REFERENCES <bare_table>` and blew up with "no such table". `Base` now
   registers the globals through a small leaf module
   (`connection-adapters/abstract/table-name-options.ts`) that the adapter layer
   can import without the `base.ts` cycle; an adapter-level override still wins.

## Deviations (justified at the call sites)

- `schema_dumping_with_options`: Rails' SQLite branch expects **no** `name:`
  because `PRAGMA foreign_key_list` drops the CONSTRAINT name
  (`sqlite3_adapter.rb:417-451`). trails' SQLite `foreignKeys` additionally
  parses the CREATE TABLE DDL and recovers the real name, so the dump carries
  `name: "fk_name"` on all three adapters and the adapter branch collapses to a
  single assertion.
- The `unless current_adapter?(:SQLite3Adapter)` guards on the pre-existing
  `add_foreign_key` cases are untouched.

## Verification

- All 28 cases in the file (11 add + 7 remove from main, + these 8) green on
  **sqlite3, PostgreSQL and MySQL 8** after the rebase (isolated compose stack).
- Regression sweep green on all three adapters for the dumper-adjacent suites:
  `schema-dumper.test.ts`, `schema-dumper.trails.test.ts`,
  `support/schema-dumping-helper.test.ts`,
  `migration/schema-statements-on-adapter.test.ts`, `invertible-migration.test.ts`,
  `adapters/postgresql/schema.test.ts`,
  `adapters/postgresql/deferred-constraints.test.ts`,
  `adapters/abstract-mysql-adapter/schema.test.ts`.
- `pnpm typecheck` and `eslint` clean.
- **`test:compare` delta: +7 (strictly positive).** Measured against
  `origin/main` at `cc2f7c231`:

  | | main | this PR |
  |---|---|---|
  | `migration/foreign_key_test.rb` OK | 22 | **29** |
  | missing | 50 | **43** |
  | wrong describe | 0 | **0** |
  | extra (TS only) | 0 | 0 |
  | activerecord package OK | 7833 | **7840** |

  (An earlier revision of this description noted a "wrong describe" count on
  this file. #5457 nested the suite under a `Migration` describe and cleared it
  on both sides; these 8 cases were re-nested with it during the rebase.)
- **Gate check green.** `test-compare.ts --gates --check` exits 0. It was
  briefly red on this PR while main carried two `wrong-gate` entries on #5450's
  cases; #5466 converged them upstream and no change here was involved.
- **`api:compare` / `api:extra` delta: 0 (non-negative).** No method added,
  removed, or renamed; the new leaf module is entirely `@internal`, so it
  contributes no counted surface. Data layer holds at 7718/7813 (98.8%).
  The wide call-mismatch ratchet needed one converged entry removed
  (`schema-dumper.ts foreign_keys foreign_key_column_for`) — the dumper now
  makes that call per `schema_dumper.rb:324`; ratchet is `OK (4820 baselined)`.
- No stubs: `write(): void {}` is the `silence_stream` analogue used by
  `invertible-migration.test.ts`, and `createTable("cities", () => {})` mirrors
  Rails' `create_table("cities") { |t| }`.

Closes-story: port-migration-foreign-key-dumper-cases
