### PR TITLE
refactor(has-one): converge the two displaced-removal helpers into one

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -77,7 +77,7 @@ export class HasOne extends SingularAssociation {
           // `displaced` here is inert.
           return assoc.loadTargetForBuild().then((displaced: unknown) => {
             const record = buildOwningDisplacement(assoc, args);
-            return assoc.detachDisplacedTarget(displaced, record).then(() => record);
+            return assoc.detachDisplacedTarget(displaced).then(() => record);
           });
         }
         // The target may already be loaded (so `needsTargetLoadForBuild` is
@@ -90,7 +90,7 @@ export class HasOne extends SingularAssociation {
           typeof assoc.isLoaded === "function" && assoc.isLoaded() ? assoc.target : null;
         const record = buildOwningDisplacement(assoc, args);
         if (displaced && typeof assoc.detachDisplacedTarget === "function") {
-          return assoc.detachDisplacedTarget(displaced, record).then(() => record);
+          return assoc.detachDisplacedTarget(displaced).then(() => record);
         }
         return record;
       },

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -268,7 +268,7 @@ export class HasOneAssociation extends SingularAssociation {
    * (builder/has-one.ts, which runs `loadTargetForBuild` and awaits
    * `detachDisplacedTarget`) and the nested-attributes writer
    * (nested-attributes.ts, a synchronous property setter that starts
-   * `detachDisplacedRecord` at assignment and drains it in its `save` wrapper).
+   * `detachDisplacedTarget` at assignment and drains it in its `save` wrapper).
    * Both call `build` on their way through, and without this flag `build` would
    * re-run the load and start a *second*, concurrent removal of the same row.
    *
@@ -326,7 +326,7 @@ export class HasOneAssociation extends SingularAssociation {
     // keeps repeated `build`s (the common `assoc.build()` twice shape)
     // synchronous.
     if ((displaced as { isPersisted?: () => boolean }).isPersisted?.() !== true) return null;
-    return this.detachDisplacedTarget(displaced, record);
+    return this.detachDisplacedTarget(displaced);
   }
 
   /**
@@ -423,7 +423,7 @@ export class HasOneAssociation extends SingularAssociation {
     // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
     // now the freshly created record; detach the displaced (previously attached)
     // one, matching `remove_target!` inside Rails' `replace`.
-    await this.detachDisplacedTarget(displaced, record);
+    await this.detachDisplacedTarget(displaced);
     return record;
   }
 
@@ -459,59 +459,46 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   /**
-   * Detach the record displaced by a `create#{name}` / `build#{name}` over an
-   * already-**loaded** has_one target — the awaitable analog of the
-   * `remove_target!` Rails runs inside `HasOneAssociation#replace`
-   * (has_one_association.rb:69) whenever another record is assigned. Nullifies
-   * the displaced record's foreign key (or destroys/deletes it per
-   * `:dependent`). Our sync `replace`/`setNewRecord` cannot `await` that removal,
-   * so the async create/build accessors run it here after materializing the
-   * replacement. A no-op unless a *different*, non-destroyed record was loaded.
+   * The single awaitable analog of the `remove_target!` Rails runs inside
+   * `HasOneAssociation#replace` (has_one_association.rb:69) whenever another
+   * record is assigned: nullify the displaced record's foreign key (or
+   * destroy/delete it per `:dependent`). Our sync `replace`/`setNewRecord`
+   * cannot `await` that write, so every caller that materializes a replacement
+   * — the `build#{name}` / `create#{name}` accessors, `association(name).build`,
+   * and the nested-attributes writer — runs it here, *after* the replacement is
+   * already cached as `this.target`. A no-op unless a *different*,
+   * non-destroyed record was displaced.
+   *
+   * The removal names `displaced` explicitly instead of parking it on
+   * `this.target` for the duration: the nested-attributes property setter is
+   * synchronous and returns to its caller mid-removal, so a parked target would
+   * be briefly observable as `assoc.target` reverting to the displaced record
+   * (Rails' own nested-attributes tests read the new target right after the
+   * assignment). Rails' target-on-failure semantics — `self.target = record`
+   * runs only after the transaction block, so a raising `remove_target!` (e.g.
+   * a failed nullify save, has_one_association.rb:102-108) leaves the OLD
+   * record cached — are preserved by restoring the target in the `catch`
+   * instead, which is observable at exactly the same moment the caller sees the
+   * error.
+   *
+   * No `isPersisted` pre-screen: Rails' `remove_target!` gates on persistence
+   * only inside its `:destroy` and nullify arms; the `:delete` arm calls
+   * `target.delete` unconditionally, and `Persistence#delete` still marks the
+   * record destroyed and freezes it when the row does not exist
+   * (persistence.rb:439-444). Let `removeTargetBang`'s arms make that call.
    *
    * @internal
    */
-  async detachDisplacedTarget(displaced: Base | null, replacement: Base | null): Promise<void> {
-    if (!displaced) return;
-    if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
-    if (sameRecord(displaced, replacement)) return;
-    // Mirror Rails' `HasOneAssociation#replace`, where `self.target = record` runs
-    // only after the transaction block: if `remove_target!` raises (e.g. a failed
-    // nullify save, which restores the old record's owner attributes before
-    // raising — has_one_association.rb:102-108), the cached target stays the OLD
-    // record. So point the target at `displaced` across the removal and only
-    // promote the `replacement` on success — a throw leaves `displaced` cached.
-    this.target = displaced;
-    await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
-    this.target = replacement;
-  }
-
-  /**
-   * `remove_target!` for a record displaced by the *synchronous* `assoc.build()`
-   * path (nested attributes), run without disturbing `this.target`.
-   *
-   * `detachDisplacedTarget` parks the target on `displaced` for the duration of
-   * the removal to reproduce Rails' target-on-failure semantics — safe for the
-   * `build#{name}` accessors, whose callers `await` before observing anything.
-   * The nested-attributes writer is a synchronous property setter: it returns to
-   * the caller while this removal is still in flight, so a parked target would
-   * be visible as `assoc.target` briefly reverting to the displaced record.
-   * Name the record instead and leave the cached target alone.
-   *
-   * The parked target is the ONLY intended difference: the guards below
-   * deliberately match `detachDisplacedTarget`'s, and neither pre-screens
-   * `isPersisted`. Rails' `remove_target!` gates on persistence only inside its
-   * `:destroy` and nullify arms; the `:delete` arm calls `target.delete`
-   * unconditionally, and `Persistence#delete` still marks the record destroyed
-   * and freezes it when the row does not exist (persistence.rb:439-444). Let
-   * `removeTargetBang`'s arms make that call.
-   *
-   * @internal
-   */
-  async detachDisplacedRecord(displaced: Base | null): Promise<void> {
+  async detachDisplacedTarget(displaced: Base | null): Promise<void> {
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, this.target)) return;
-    await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "", displaced);
+    try {
+      await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "", displaced);
+    } catch (error) {
+      this.target = displaced;
+      throw error;
+    }
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {
@@ -613,7 +600,7 @@ export class HasOneAssociation extends SingularAssociation {
    * an `await` this synchronous method cannot issue, so every caller that can
    * displace a persisted record issues it itself — `detachDisplacedTarget` from
    * the `build#{name}` / `create#{name}` accessors (builder/has-one.ts,
-   * `_createRecord`), `detachDisplacedRecord` from the nested-attributes writer
+   * `_createRecord`), and the same method from the nested-attributes writer
    * (nested-attributes.ts, `detachDisplacedAtAssignment`). Nothing is queued
    * here: a queue drained at the owner's `save` would defer a write Rails makes
    * at assignment, and would double-remove records the awaiting callers have
@@ -728,10 +715,12 @@ async function preloadDestroyInverseBelongsTo(
 async function removeTargetBang(
   assoc: HasOneAssociation,
   method: string,
-  // Rails' `remove_target!` always acts on `self.target`. The nested-attributes
-  // displacement path removes a record while `assoc.target` is already the
-  // replacement (it must not flip the cached target back mid-await, which is
-  // observable to synchronous readers), so it names the record explicitly.
+  // Rails' `remove_target!` always acts on `self.target`, which is still the
+  // displaced record inside `replace`'s transaction (persistImmediate keeps that
+  // shape, so it takes the default). Every deferred displacement path instead
+  // removes a record while `assoc.target` is already the replacement — flipping
+  // the cached target back mid-await is observable to synchronous readers — so
+  // `detachDisplacedTarget` names the record explicitly.
   target: Base | null = assoc.target,
 ): Promise<void> {
   if (!target) return;

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -21,7 +21,7 @@
  * guard rather than a change to the mirrored test.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, type Base } from "../index.js";
+import { registerModel, RecordNotSaved, type Base } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Pirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
@@ -110,6 +110,29 @@ describe("has_one displacement via the synchronous build path", () => {
     // bad attribute raises before anything is queried or displaced. A
     // synchronous throw (not a rejected promise) is what proves the ordering.
     expect(() => assoc.build({ bogus_attribute: 1 })).toThrow();
+  });
+
+  it("leaves the displaced record cached when its removal fails", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    });
+
+    const displaced = (await (pirate as unknown as { ship: Promise<Base | null> }).ship) as Base;
+    // An invalid displaced record makes `remove_target!`'s nullify save return
+    // false, which raises RecordNotSaved (has_one_association.rb:102-108).
+    (displaced as unknown as { name: string | null }).name = null;
+
+    await expect(
+      (pirate as unknown as { buildShip(a: object): Promise<Base> }).buildShip({
+        name: "Davy Jones Gold Dagger",
+      }),
+    ).rejects.toThrow(RecordNotSaved);
+
+    // Rails reaches `self.target = record` only after the transaction block, so
+    // a raising `remove_target!` leaves the OLD record cached.
+    expect(pirate.association("ship").target).toBe(displaced);
   });
 
   it("returns the built record synchronously when no query would run", async () => {

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -9,7 +9,7 @@
  * caller that can displace a persisted record issues the DB half itself. The
  * `build#{Name}` / `create#{Name}` accessors use `detachDisplacedTarget`. For
  * `assoc.build()`, which nested attributes calls directly, the nested-attributes
- * writer uses `detachDisplacedRecord` — starting the removal inline at
+ * writer calls the same method — starting the removal inline at
  * assignment and awaiting it in its `save` wrapper before the replacement is
  * inserted. A *direct* `record.association(name).build(...)` has no such
  * wrapper, so `HasOneAssociation#build` runs the removal itself and returns the

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -182,17 +182,6 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
-   * No-op for the same reason as `detachDisplacedTarget` above: the
-   * nested-attributes displacement path must not nullify/destroy a displaced
-   * *end* record of a through association.
-   *
-   * @internal
-   */
-  override async detachDisplacedRecord(): Promise<void> {
-    // no-op — see JSDoc
-  }
-
-  /**
    * Mirrors Rails `HasOneThroughAssociation#replace` immediate persist to a
    * saved owner. The base `writer` saves the target's foreign key directly,
    * which is wrong for a through (persistence routes through the join model), so

--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -41,9 +41,9 @@ async function pirateWithFailingRemoval(): Promise<Base> {
   await (pirate as unknown as { ship: Promise<Base | null> }).ship;
 
   const assoc = pirate.association("ship") as unknown as {
-    detachDisplacedRecord: () => Promise<void>;
+    detachDisplacedTarget: () => Promise<void>;
   };
-  assoc.detachDisplacedRecord = () => Promise.reject(new Error("removal exploded"));
+  assoc.detachDisplacedTarget = () => Promise.reject(new Error("removal exploded"));
   return pirate;
 }
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -679,7 +679,7 @@ interface OneToOneAssociation {
   buildDisplacementOwnedByCaller?: boolean;
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
-  detachDisplacedRecord?(displaced: Base | null): Promise<void>;
+  detachDisplacedTarget?(displaced: Base | null): Promise<void>;
 }
 
 /**
@@ -689,7 +689,7 @@ interface OneToOneAssociation {
  * Rails runs the removal inline inside `HasOneAssociation#replace`
  * (has_one_association.rb:69) — the nested-attributes writer is a synchronous
  * property setter (`pirate.shipAttributes = {...}`), so it cannot `await` the
- * nullify save. It CAN issue it: `detachDisplacedRecord` is kicked off here,
+ * nullify save. It CAN issue it: `detachDisplacedTarget` is kicked off here,
  * inline at assignment exactly as in Rails, and only its *completion* is
  * deferred — to the nested-attributes `save` wrapper, which drains this list
  * before the parent (and its autosaved new target) is persisted. That keeps
@@ -732,8 +732,8 @@ function detachDisplacedAtAssignment(
   displaced: Base | null,
 ): void {
   if (!displaced) return;
-  if (typeof assoc.detachDisplacedRecord !== "function") return;
-  const settled = assoc.detachDisplacedRecord(displaced).then(
+  if (typeof assoc.detachDisplacedTarget !== "function") return;
+  const settled = assoc.detachDisplacedTarget(displaced).then(
     () => null,
     (error: unknown) => error ?? new Error("displaced record removal failed"),
   );
@@ -902,7 +902,7 @@ export function assignNestedAttributesForOneToOneAssociation(
         // Capture it before the build overwrites `assoc.target`, then start that
         // removal here — see `detachDisplacedAtAssignment`. Rails only removes
         // what `load_target` surfaced, so an unloaded association displaces
-        // nothing; `detachDisplacedRecord` owns the remaining guards.
+        // nothing; `detachDisplacedTarget` owns the remaining guards.
         const displaced = assoc.isLoaded?.() === false ? null : existing;
         // `HasOneAssociation#build` runs the removal itself for direct callers
         // (returning a promise they can await). This writer is synchronous and


### PR DESCRIPTION
Rails has one removal entry point for a displaced has_one: the private
`remove_target!` (`has_one_association.rb:95-115`), called from `replace` (:69).
trails had two public methods doing that job — `detachDisplacedTarget` and
`detachDisplacedRecord` — with identical guards, differing only in whether the
displaced record was parked on `this.target` for the duration of the removal.

Parking existed to reproduce Rails' target-on-failure semantics (`self.target =
record` runs only after the transaction block, so a raising `remove_target!`
leaves the OLD record cached). But parking is unsafe for the synchronous
nested-attributes writer, which returns to its caller mid-removal — the parked
target is briefly observable as `assoc.target` reverting to the displaced
record — and it is unnecessary for the awaitable accessors: the invariant only
requires the old record to be cached *once the failure surfaces*.

So this converges both into one `detachDisplacedTarget(displaced)` that always
names the removed record explicitly (never parks) and restores
`this.target = displaced` in a `catch` before rethrowing — observable at exactly
the moment the caller sees the error. Every call site already has the
replacement cached as `this.target` before calling, so the old `replacement`
parameter and the trailing promotion were both redundant. The has_one_through
no-op override of the removed method goes away too.

New coverage: the target-on-failure invariant parking used to provide was
untested, so `has-one-sync-build-displacement.trails.test.ts` now pins it — a
`build#{Name}` over a displaced record whose nullify save fails rejects with
`RecordNotSaved` and leaves that record cached. Verified to fail without the
`catch`.

- `pnpm api:extra` activerecord novel: **579 -> 577**; no new allowlist entries.
- Passing: `has-one-associations.test.ts` (incl. the target-on-failure
  "replacement failure due to existing record should raise error"),
  `nested-attributes-displaced-removal-failure.trails.test.ts`,
  `has-one-sync-build-displacement.trails.test.ts`, `nested-attributes.test.ts`,
  `has-one-through-associations.test.ts`, `autosave-association.test.ts`.

Closes-story: converge-two-detach-displaced-helpers-into-remove-target
