### PR TITLE
fix(nested-attributes): remove the unloaded has_one row displaced by a build

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -519,6 +519,10 @@ export class HasOneAssociation extends SingularAssociation {
    * issue no query at all (`find_target?`) or when the target is already loaded,
    * which keeps the writer synchronous on those paths.
    *
+   * `protected` for the same reason as `buildDisplacementOwnedByCaller`: this is
+   * association-internal bookkeeping, not API surface. The writer lives outside
+   * the class hierarchy and reaches it through its duck-typed handle.
+   *
    * The find deliberately goes through `doAsyncFindTarget` rather than
    * `loadTargetForBuild`: by the time it resolves, the build has already
    * installed the replacement as `this.target`, and `load_target`'s writeback
@@ -526,7 +530,7 @@ export class HasOneAssociation extends SingularAssociation {
    *
    * @internal
    */
-  detachDisplacedForSyncBuild(): Promise<void> | null {
+  protected detachDisplacedForSyncBuild(): Promise<void> | null {
     if (this.loaded) return null;
     if (!this.needsTargetLoadForBuild()) return null;
     return this.findThenDetachDisplaced();

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -268,7 +268,9 @@ export class HasOneAssociation extends SingularAssociation {
    * (builder/has-one.ts, which runs `loadTargetForBuild` and awaits
    * `detachDisplacedTarget`) and the nested-attributes writer
    * (nested-attributes.ts, a synchronous property setter that starts
-   * `detachDisplacedTarget` at assignment and drains it in its `save` wrapper).
+   * `detachDisplacedTarget` — for a loaded target — or
+   * `detachDisplacedForSyncBuild` — for an unloaded one, which runs the leading
+   * `load_target` itself — at assignment, and drains it in its `save` wrapper).
    * Both call `build` on their way through, and without this flag `build` would
    * re-run the load and start a *second*, concurrent removal of the same row.
    *
@@ -499,6 +501,39 @@ export class HasOneAssociation extends SingularAssociation {
       this.target = displaced;
       throw error;
     }
+  }
+
+  /**
+   * The unloaded half of the nested-attributes writer's `remove_target!`.
+   *
+   * Rails' `set_new_record` -> `replace(record, false)` opens with `load_target`
+   * (has_one_association.rb:59-62) on EVERY build, so a build over a *never
+   * loaded* has_one on a persisted owner still discovers the existing row and
+   * removes it. `detachDisplacedTarget` only covers what the caller already had
+   * in memory; this covers the row that only ever existed in the DB.
+   *
+   * The synchronous writer (`pirate.shipAttributes = {...}`) cannot await the
+   * SELECT, so it calls this at assignment — Rails' timing for *issuing* the
+   * query — and parks the returned promise on the owner, draining it in the
+   * `save` wrapper exactly like `detachDisplacedTarget`'s. Null when Rails would
+   * issue no query at all (`find_target?`) or when the target is already loaded,
+   * which keeps the writer synchronous on those paths.
+   *
+   * The find deliberately goes through `doAsyncFindTarget` rather than
+   * `loadTargetForBuild`: by the time it resolves, the build has already
+   * installed the replacement as `this.target`, and `load_target`'s writeback
+   * would clobber it. We need only the displaced record, never the cache.
+   *
+   * @internal
+   */
+  detachDisplacedForSyncBuild(): Promise<void> | null {
+    if (this.loaded) return null;
+    if (!this.needsTargetLoadForBuild()) return null;
+    return this.findThenDetachDisplaced();
+  }
+
+  private async findThenDetachDisplaced(): Promise<void> {
+    await this.detachDisplacedTarget(await this.doAsyncFindTarget());
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -54,6 +54,43 @@ describe("has_one displacement via the synchronous build path", () => {
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
   });
 
+  it("nullifies the displaced row when nested attributes replace an unloaded child", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+
+    // Never load the association: Rails' `build_#{name}` runs `load_target`
+    // regardless, so the writer must discover and detach the row itself.
+    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
+    (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+    await refetched.save();
+
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
+  it("awaits the unloaded displacement removal from the awaitable writer", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+
+    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
+    await (
+      refetched as unknown as { setShipAttributes(a: object): Promise<void> }
+    ).setShipAttributes({ name: "Davy Jones Gold Dagger" });
+
+    // The awaitable writer drains the removal, so the row is detached before
+    // the owner is ever saved — Rails' assignment-time timing.
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
   it("nullifies the displaced row when association(name).build replaces a loaded child", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
     const displaced = (await Ship.create({

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -189,7 +189,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    *
    * @internal
    */
-  override detachDisplacedForSyncBuild(): Promise<void> | null {
+  protected override detachDisplacedForSyncBuild(): Promise<void> | null {
     return null;
   }
 

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -182,6 +182,18 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
+   * No load and no removal, for the same reason as `loadDisplacedForBuild`
+   * above: a through `replace` has no `load_target`, so the nested-attributes
+   * writer must not issue a target SELECT (nor detach a displaced *end* record)
+   * for a has_one_through.
+   *
+   * @internal
+   */
+  override detachDisplacedForSyncBuild(): Promise<void> | null {
+    return null;
+  }
+
+  /**
    * Mirrors Rails `HasOneThroughAssociation#replace` immediate persist to a
    * saved owner. The base `writer` saves the target's foreign key directly,
    * which is wrong for a through (persistence routes through the join model), so

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -919,6 +919,15 @@ export function assignNestedAttributesForOneToOneAssociation(
         // SELECT is issued here, at assignment (Rails' timing), and only its
         // completion is deferred to the same drain — see
         // `HasOneAssociation#detachDisplacedForSyncBuild`.
+        //
+        // Rails reaches `load_target` from `set_new_record`, i.e. just AFTER
+        // `build_record`; this issues it just before. It has to: the load is
+        // gated on `find_target?`, which `build` falsifies by marking the
+        // association loaded, so there is no post-build moment at which the
+        // decision is still observable. The window the swap opens is a build
+        // that throws after a query Rails would not have run —
+        // `assertNestedAttributesAreKnown` above already raised for the
+        // attribute errors that reach this path.
         const unloadedRemoval = assoc.detachDisplacedForSyncBuild?.() ?? null;
         if (unloadedRemoval) parkDisplacedRemoval(record, unloadedRemoval);
         // `HasOneAssociation#build` runs the removal itself for direct callers

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -680,6 +680,7 @@ interface OneToOneAssociation {
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
   detachDisplacedTarget?(displaced: Base | null): Promise<void>;
+  detachDisplacedForSyncBuild?(): Promise<void> | null;
 }
 
 /**
@@ -733,7 +734,18 @@ function detachDisplacedAtAssignment(
 ): void {
   if (!displaced) return;
   if (typeof assoc.detachDisplacedTarget !== "function") return;
-  const settled = assoc.detachDisplacedTarget(displaced).then(
+  parkDisplacedRemoval(record, assoc.detachDisplacedTarget(displaced));
+}
+
+/**
+ * Park an in-flight removal on the owner: capture its rejection so a
+ * never-drained removal cannot surface as an unhandled rejection, and queue it
+ * for the drain that rethrows. See {@link detachDisplacedAtAssignment} for the
+ * full contract.
+ * @internal
+ */
+function parkDisplacedRemoval(record: Base, removal: Promise<void>): void {
+  const settled = removal.then(
     () => null,
     (error: unknown) => error ?? new Error("displaced record removal failed"),
   );
@@ -900,10 +912,15 @@ export function assignNestedAttributesForOneToOneAssociation(
         // Rails' `build_#{name}` → `set_new_record` → `replace(record, false)`
         // removes the displaced target inline (has_one_association.rb:69).
         // Capture it before the build overwrites `assoc.target`, then start that
-        // removal here — see `detachDisplacedAtAssignment`. Rails only removes
-        // what `load_target` surfaced, so an unloaded association displaces
-        // nothing; `detachDisplacedTarget` owns the remaining guards.
+        // removal here — see `detachDisplacedAtAssignment`.
         const displaced = assoc.isLoaded?.() === false ? null : existing;
+        // Rails' `replace` opens with `load_target`, so an association that was
+        // never loaded still discovers the row in the DB and removes it. That
+        // SELECT is issued here, at assignment (Rails' timing), and only its
+        // completion is deferred to the same drain — see
+        // `HasOneAssociation#detachDisplacedForSyncBuild`.
+        const unloadedRemoval = assoc.detachDisplacedForSyncBuild?.() ?? null;
+        if (unloadedRemoval) parkDisplacedRemoval(record, unloadedRemoval);
         // `HasOneAssociation#build` runs the removal itself for direct callers
         // (returning a promise they can await). This writer is synchronous and
         // owns the removal through `detachDisplacedAtAssignment` below, so


### PR DESCRIPTION
Rails' `build_#{name}` → `set_new_record` → `replace(record, false)` opens with
`load_target` (`has_one_association.rb:59-62`) — the guard is `return target
unless load_target || record`, and Ruby always evaluates the left operand — so a
build displaces the existing row even when the association was never loaded.

PR #5442 wired that leading load into `SingularAssociation#build`, but
suppressed it for the nested-attributes writer via
`buildDisplacementOwnedByCaller`, because the writer is a synchronous property
setter (`pirate.shipAttributes = {...}`) that cannot await a SELECT. Result:
assigning nested attributes over an UNLOADED, persisted has_one displaced
nothing — the existing row kept its foreign key. Only the loaded case was
covered.

`HasOneAssociation#detachDisplacedForSyncBuild` now issues that SELECT at
assignment (Rails' timing for the query) and detaches what it finds; only its
*completion* is deferred, through the existing `_pendingDisplacedRemovals` drain
that the `save` wrapper and the awaitable `set#{Name}Attributes` writer already
run. Notes on the shape:

- The find goes through `doAsyncFindTarget`, not `loadTarget`: by the time it
  resolves, the build has installed the replacement as `this.target`, and
  `load_target`'s writeback would clobber it. Only the displaced record is
  wanted, never the cache.
- It is `protected` — association-internal bookkeeping reached through the
  writer's duck-typed handle, exactly like `buildDisplacementOwnedByCaller` — so
  it adds no extra TS API surface (`pnpm api:extra` clean).
- `HasOneThroughAssociation` overrides it to a no-op, matching its existing
  `loadDisplacedForBuild` / `detachDisplacedRecord` overrides: a through
  `replace` has no `load_target` and must never nullify a displaced end record.
- One deliberate ordering deviation, justified at the call site: Rails reaches
  `load_target` just *after* `build_record`, this issues it just *before*. It
  has to — the load is gated on `find_target?`, which `build` falsifies by
  marking the association loaded, so no post-build moment still has the
  decision available. `assertNestedAttributesAreKnown` already raises earlier
  for the attribute errors that reach this path.

## Tests

Two cases added to `has-one-sync-build-displacement.trails.test.ts` — the
synchronous writer drained by `save()`, and the awaitable `setShipAttributes`
writer, which detaches before the owner is ever saved. Both verified failing on
the pre-fix baseline (displaced `pirate_id` still set) and passing after.

`nested-attributes*`, `has-one-associations`, `autosave-association` and
`nested-error` suites pass locally (325 tests); `pnpm api:compare` /
`pnpm api:extra` clean with no manifest churn.

Closes-story: nested-attributes-build-unloaded-has-one-target-not-displaced
