### PR TITLE
fix(api-compare): let a nested Ruby class feed its file's extra-surface allow-set

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -682,16 +682,7 @@ export const ABSTRACT_COLUMN_METHOD_NAMES: readonly string[] = [
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractAdapter implements Quoting {
-  /**
-   * @noRailsEquivalent `AbstractAdapter::Version` is a real Rails nested class
-   *   (abstract_adapter.rb:243); `static
-   *   readonly Version = Version` is the TS spelling of that nested Ruby constant, so this is public
-   *   Rails API parity, not drift. It reads as extra surface only because extra-surface skips nested
-   *   Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still
-   *   counting the TS nested class. Nothing to converge. AbstractMysqlAdapter's redundant re-pin of
-   *   the same constant was deleted rather than allowlisted — JS statics are inherited, so it
-   *   shadowed nothing and had no readers.
-   */
+  /** The TS spelling of Rails' nested `AbstractAdapter::Version` (abstract_adapter.rb:243). */
   static readonly Version = Version;
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -682,7 +682,6 @@ export const ABSTRACT_COLUMN_METHOD_NAMES: readonly string[] = [
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractAdapter implements Quoting {
-  /** The TS spelling of Rails' nested `AbstractAdapter::Version` (abstract_adapter.rb:243). */
   static readonly Version = Version;
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -110,11 +110,6 @@ const ADAPTER_PROXY_PROBE_KEYS = new Set<string>([
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool
  */
 export class NullPool implements AbstractPool {
-  /**
-   * Rails nests this class inside `NullPool` (`class NullPool; class NullConfig`
-   * — connection_pool.rb:14-22). TS cannot declare a nested class, so it is a
-   * sibling export re-attached here, matching Rails' constant lookup path.
-   */
   static readonly NullConfig = NullConfig;
   static readonly NULL_CONFIG = NULL_CONFIG;
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -111,11 +111,9 @@ const ADAPTER_PROXY_PROBE_KEYS = new Set<string>([
  */
 export class NullPool implements AbstractPool {
   /**
-   * @noRailsEquivalent Rails nests this class inside `NullPool` (`class NullPool; class NullConfig`
-   *   — connection_pool.rb:14-22), and the Ruby extractor records only the outer `NullPool`. TS
-   *   cannot declare a nested class, so it is a sibling export re-attached as `NullPool.NullConfig`
-   *   (a static, matching Rails' constant lookup path). Same class, same file, same semantics — an
-   *   extractor-shape artifact, not added surface.
+   * Rails nests this class inside `NullPool` (`class NullPool; class NullConfig`
+   * — connection_pool.rb:14-22). TS cannot declare a nested class, so it is a
+   * sibling export re-attached here, matching Rails' constant lookup path.
    */
   static readonly NullConfig = NullConfig;
   static readonly NULL_CONFIG = NULL_CONFIG;

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -261,6 +261,61 @@ describe("buildReport — novel vs moved classification", () => {
     ]);
   });
 
+  it("a Ruby class nested in the matched file contributes its constant and methods to the allow-set", () => {
+    // Rails outer.rb: `class Outer; class Inner; def inner_only; end; end; end`.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Outer": rubyClass({
+              name: "Outer",
+              file: "outer.rb",
+              instance: [method("bar")],
+            }),
+            "ActiveModel::Outer::Inner": rubyClass({
+              name: "Inner",
+              file: "outer.rb",
+              instance: [method("inner_only")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    // TS outer.ts: `Outer` carrying the nested constant as a static, plus the
+    // nested class's own method and one genuinely novel helper.
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Outer: {
+              name: "Outer",
+              file: "outer.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("bar"), method("innerOnly"), method("tsOnlyHelper")],
+              classMethods: [method("Inner")],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const pkg = report.packages[0];
+    expect(pkg.extraFiles).toHaveLength(1);
+    expect(pkg.extraFiles[0].extras.map((e) => e.name)).toEqual(["tsOnlyHelper"]);
+  });
+
   it("a TS public method mirroring a Rails-PRIVATE method is not extra surface", () => {
     // Rails foo.rb has private `same_file_secret`; baz.rb has private
     // `other_file_secret`. TS foo.ts exposes both publicly plus a true novel.
@@ -560,10 +615,11 @@ describe("buildReport — novel vs moved classification", () => {
     expect(f!.extras.map((e) => e.name)).toContain("pgOnlyMethod");
   });
 
-  it("skips nested classes sharing a file with a shorter-named parent (matches compare.ts)", () => {
-    // Nested Preloader::Association::LoaderQuery in association.rb is an
-    // impl detail; its `nestedHelper` must NOT count as allowed for the
-    // matched TS file. Per compare.ts:738-755.
+  it("a nested class sharing a file with a shorter-named parent is not its own counterpart file", () => {
+    // Nested Preloader::Association::LoaderQuery in association.rb never
+    // becomes a Rails counterpart *file* of its own (per compare.ts:738-755),
+    // but it is surface association.rb declares, so its `nested_helper` joins
+    // that file's allow-set.
     const ruby: ApiManifest = {
       source: "ruby",
       generatedAt: "",
@@ -610,10 +666,9 @@ describe("buildReport — novel vs moved classification", () => {
       novelOnly: false,
       topN: 50,
     });
-    const f = report.packages[0].extraFiles.find((x) => x.tsFile === "preloader/association.ts");
-    expect(f).toBeDefined();
-    // primaryMethod allowed; nestedHelper flagged (nested class is skipped).
-    expect(f!.extras.map((e) => e.name)).toEqual(["nestedHelper"]);
+    // No file scored at all: both names are allowed, and the nested class did
+    // not spawn a second counterpart file of its own.
+    expect(report.packages[0].extraFiles).toEqual([]);
   });
 
   it("admits scanned umbrella module config (Base class methods) over novel ports", () => {

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -262,7 +262,6 @@ describe("buildReport — novel vs moved classification", () => {
   });
 
   it("a Ruby class nested in the matched file contributes its constant and methods to the allow-set", () => {
-    // Rails outer.rb: `class Outer; class Inner; def inner_only; end; end; end`.
     const ruby: ApiManifest = {
       source: "ruby",
       generatedAt: "",
@@ -284,8 +283,6 @@ describe("buildReport — novel vs moved classification", () => {
         },
       },
     };
-    // TS outer.ts: `Outer` carrying the nested constant as a static, plus the
-    // nested class's own method and one genuinely novel helper.
     const ts: ApiManifest = {
       source: "typescript",
       generatedAt: "",
@@ -297,8 +294,16 @@ describe("buildReport — novel vs moved classification", () => {
               file: "outer.ts",
               includes: [],
               extends: [],
-              instanceMethods: [method("bar"), method("innerOnly"), method("tsOnlyHelper")],
+              instanceMethods: [method("bar"), method("tsOnlyHelper")],
               classMethods: [method("Inner")],
+            },
+            Inner: {
+              name: "Inner",
+              file: "outer.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("innerOnly")],
+              classMethods: [],
             },
           },
           modules: {},
@@ -616,10 +621,6 @@ describe("buildReport — novel vs moved classification", () => {
   });
 
   it("a nested class sharing a file with a shorter-named parent is not its own counterpart file", () => {
-    // Nested Preloader::Association::LoaderQuery in association.rb never
-    // becomes a Rails counterpart *file* of its own (per compare.ts:738-755),
-    // but it is surface association.rb declares, so its `nested_helper` joins
-    // that file's allow-set.
     const ruby: ApiManifest = {
       source: "ruby",
       generatedAt: "",
@@ -666,8 +667,6 @@ describe("buildReport — novel vs moved classification", () => {
       novelOnly: false,
       topN: 50,
     });
-    // No file scored at all: both names are allowed, and the nested class did
-    // not spawn a second counterpart file of its own.
     expect(report.packages[0].extraFiles).toEqual([]);
   });
 

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -843,11 +843,13 @@ function buildPackageReport(
     moduleFqnByShort.set(short, list);
   }
 
-  // compare.ts's nested-class filter (compare.ts:738-755) says a class nested
-  // in another class in the same file is not a Rails counterpart *file* of its
-  // own. That's a statement about file matching only: the nested class is
-  // still surface the enclosing file declares, so it enters that file's
-  // allow-set flagged `nestedInEnclosingClass` rather than being dropped.
+  // compare.ts drops a class nested in a same-file parent from `allRuby`
+  // outright (compare.ts:1321-1339), so its methods never count toward the
+  // coverage denominator. Extra surface is the inverse question and needs the
+  // opposite answer: the nested class IS surface the enclosing file declares,
+  // so counting the TS port of it as drift is wrong. It therefore enters the
+  // file's allow-set flagged `nestedInEnclosingClass` rather than being
+  // dropped — deliberately NOT mirroring compare.ts's use of the same filter.
   const classFqnsPerFile = new Map<string, Set<string>>();
   for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
     if (!info.file) continue;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -93,14 +93,8 @@ import { manifestIsStale } from "./build-freshness.js";
 interface RubyEntity {
   fqn: string;
   info: ClassInfo;
-  /**
-   * True when this class is declared *inside* another class in the same Ruby
-   * file (`class Outer; class Inner`). The nested constant itself is surface
-   * Rails declares, so the enclosing TS class may legitimately carry a member
-   * of that name — either a real nested class or the `static Inner = Inner`
-   * spelling trails uses for a sibling-exported port.
-   */
-  nested?: boolean;
+  /** Declared inside another class in the same Ruby file (`class Outer; class Inner`). */
+  nestedInEnclosingClass?: boolean;
 }
 
 /**
@@ -643,12 +637,11 @@ function collectAllowedNames(
     for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
   };
 
-  for (const { fqn, info, nested } of entities) {
-    // A class nested in an enclosing class is a constant on that enclosing
-    // class, so the enclosing TS class carrying a member of the same name is
-    // the faithful port — whether spelled as a real nested class or as
-    // `static readonly Inner = Inner` re-attaching a sibling export.
-    if (nested) {
+  for (const { fqn, info, nestedInEnclosingClass } of entities) {
+    // A nested class is a constant ON its enclosing class, so a member of that
+    // name is the faithful port — spelled either as a real TS nested class or
+    // as `static readonly Inner = Inner` re-attaching a sibling export.
+    if (nestedInEnclosingClass) {
       const short = fqn.split("::").pop();
       if (short) for (const c of rubyConstantCandidates(short)) allowed.add(c);
     }
@@ -850,13 +843,11 @@ function buildPackageReport(
     moduleFqnByShort.set(short, list);
   }
 
-  // A class declared inside another class in the same Ruby file (e.g.
-  // `Preloader::Association::LoaderQuery` in `preloader/association.rb`,
-  // `NullPool::NullConfig` in `abstract/connection_pool.rb`) is not a Rails
-  // counterpart *file* of its own — that's what compare.ts's nested-class
-  // filter encodes. It IS Rails-declared surface inside the enclosing class's
-  // file, so it enters that file's allow-set flagged `nested` (see
-  // `RubyEntity.nested`) rather than being dropped.
+  // compare.ts's nested-class filter (compare.ts:738-755) says a class nested
+  // in another class in the same file is not a Rails counterpart *file* of its
+  // own. That's a statement about file matching only: the nested class is
+  // still surface the enclosing file declares, so it enters that file's
+  // allow-set flagged `nestedInEnclosingClass` rather than being dropped.
   const classFqnsPerFile = new Map<string, Set<string>>();
   for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
     if (!info.file) continue;
@@ -864,7 +855,7 @@ function buildPackageReport(
     set.add(fqn);
     classFqnsPerFile.set(info.file, set);
   }
-  const enclosingClassInFile = (fqn: string, file: string): boolean => {
+  const hasEnclosingClassInFile = (fqn: string, file: string): boolean => {
     const siblings = classFqnsPerFile.get(file);
     if (!siblings) return false;
     const parts = fqn.split("::");
@@ -877,7 +868,11 @@ function buildPackageReport(
   const rubyFiles = new Map<string, RubyEntity[]>();
   for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
     if (!info.file) continue;
-    pushTo(rubyFiles, info.file, { fqn, info, nested: enclosingClassInFile(fqn, info.file) });
+    pushTo(rubyFiles, info.file, {
+      fqn,
+      info,
+      nestedInEnclosingClass: hasEnclosingClassInFile(fqn, info.file),
+    });
   }
   for (const [fqn, info] of Object.entries(rubyPkg.modules) as [string, ClassInfo][]) {
     if (!info.file) continue;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -93,6 +93,14 @@ import { manifestIsStale } from "./build-freshness.js";
 interface RubyEntity {
   fqn: string;
   info: ClassInfo;
+  /**
+   * True when this class is declared *inside* another class in the same Ruby
+   * file (`class Outer; class Inner`). The nested constant itself is surface
+   * Rails declares, so the enclosing TS class may legitimately carry a member
+   * of that name — either a real nested class or the `static Inner = Inner`
+   * spelling trails uses for a sibling-exported port.
+   */
+  nested?: boolean;
 }
 
 /**
@@ -635,7 +643,15 @@ function collectAllowedNames(
     for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
   };
 
-  for (const { fqn, info } of entities) {
+  for (const { fqn, info, nested } of entities) {
+    // A class nested in an enclosing class is a constant on that enclosing
+    // class, so the enclosing TS class carrying a member of the same name is
+    // the faithful port — whether spelled as a real nested class or as
+    // `static readonly Inner = Inner` re-attaching a sibling export.
+    if (nested) {
+      const short = fqn.split("::").pop();
+      if (short) for (const c of rubyConstantCandidates(short)) allowed.add(c);
+    }
     addMethods(info.instanceMethods);
     addMethods(info.classMethods);
     for (const inc of info.includes ?? []) walkMixin(inc, fqn);
@@ -834,26 +850,34 @@ function buildPackageReport(
     moduleFqnByShort.set(short, list);
   }
 
-  // Match compare.ts's nested-class filter: for each file, keep only the
-  // shortest-named class as the "primary" and skip nested classes that
-  // share the same file (e.g. `Preloader::Association::LoaderQuery` in
-  // `preloader/association.rb` is an implementation detail — its methods
-  // shouldn't inflate the parent file's allowed-name set).
-  const primaryClassPerFile = new Map<string, string>();
+  // A class declared inside another class in the same Ruby file (e.g.
+  // `Preloader::Association::LoaderQuery` in `preloader/association.rb`,
+  // `NullPool::NullConfig` in `abstract/connection_pool.rb`) is not a Rails
+  // counterpart *file* of its own — that's what compare.ts's nested-class
+  // filter encodes. It IS Rails-declared surface inside the enclosing class's
+  // file, so it enters that file's allow-set flagged `nested` (see
+  // `RubyEntity.nested`) rather than being dropped.
+  const classFqnsPerFile = new Map<string, Set<string>>();
   for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
     if (!info.file) continue;
-    const existing = primaryClassPerFile.get(info.file);
-    if (!existing || fqn.split("::").length < existing.split("::").length) {
-      primaryClassPerFile.set(info.file, fqn);
-    }
+    const set = classFqnsPerFile.get(info.file) ?? new Set<string>();
+    set.add(fqn);
+    classFqnsPerFile.set(info.file, set);
   }
+  const enclosingClassInFile = (fqn: string, file: string): boolean => {
+    const siblings = classFqnsPerFile.get(file);
+    if (!siblings) return false;
+    const parts = fqn.split("::");
+    for (let i = parts.length - 1; i > 0; i--) {
+      if (siblings.has(parts.slice(0, i).join("::"))) return true;
+    }
+    return false;
+  };
 
   const rubyFiles = new Map<string, RubyEntity[]>();
   for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
     if (!info.file) continue;
-    const primary = primaryClassPerFile.get(info.file);
-    if (primary && primary !== fqn && fqn.startsWith(primary + "::")) continue;
-    pushTo(rubyFiles, info.file, { fqn, info });
+    pushTo(rubyFiles, info.file, { fqn, info, nested: enclosingClassInFile(fqn, info.file) });
   }
   for (const [fqn, info] of Object.entries(rubyPkg.modules) as [string, ClassInfo][]) {
     if (!info.file) continue;


### PR DESCRIPTION
`extra-surface.ts` dropped a nested Ruby class (`class Outer; class Inner`)
from its file's allowed-name set while `collectTsFileNames` still counted the
TS port of that nested class, so every faithful nested port scored as extra
surface.

The nested-class filter's real job is *file matching* — a nested class must not
be reported as a Rails counterpart file of its own — so this changes the
allow-set construction only, not the file matching. A class whose enclosing
class lives in the same `.rb` now contributes its constant name and its methods
to that file's allow-set, which covers both spellings of the port: a real TS
nested class, and the `static readonly Inner = Inner` re-attachment of a
sibling export declared in the same TS file.

Deletes the two `@noRailsEquivalent` tags that existed only to paper over the
bug — `AbstractAdapter.Version` (abstract_adapter.rb:243) and
`NullPool.NullConfig` (connection_pool.rb:14-22). Tags: 80 -> 78, all matched,
no stale tags.

Every nested-class family the story named now scores clean: `StatementPool`
(x3 adapters), `JoinDependency::Aliases`, `Preloader::LoaderQuery`,
`StatementCache::Substitute`, `SQLite3Integer`, `OID::Bit::Data`,
`AbstractAdapter::Version`.

## totalExtras before/after

Both columns measured on the same build, with the two tags already deleted, so
the delta isolates the comparator change.

| Package | Before | After |
| --- | --- | --- |
| activerecord | 1712 | 1669 |
| activesupport | 684 | 677 |
| actiondispatch | 419 | 369 |
| trailties | 248 | 244 |
| activemodel | 285 | 280 |
| arel | 233 | 230 |
| actioncontroller | 142 | 141 |
| rack | 122 | 108 |
| activerecord-test-support | 53 | 53 |
| actionview | 130 | 114 |
| globalid | 17 | 17 |
| abstractcontroller | 19 | 19 |
| actionpackversion | 1 | 1 |
| did-you-mean | 0 | 0 |
| **total** | **4065** | **3922** |

143 fewer extras (-3.5%).

## Verification

- `pnpm api:compare && pnpm api:extra` green (fresh `pnpm build` first, so the
  totals are a trustworthy baseline).
- `pnpm vitest run scripts/api-compare` — 618 passed.
- Both new test cases fail against `origin/main`'s `extra-surface.ts` and pass
  with the fix.

Closes-story: extra-surface-nested-ruby-class-allow-set-gap
