### PR TITLE
fix(api-compare): detect a line-leading prose tag in a @noRailsEquivalent reason

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -315,6 +315,16 @@ Two things are deliberately **not** shared, and the difference is load-bearing:
   this section changes that; tightening it would be a change to `api:build`,
   which RFC 0080 lists as a non-goal.
 
+- **Tag order after the reason.** Because the reason wraps freely, a bare
+  `@word` in its prose is parsed as a real tag and truncates the reason —
+  fatally so for `@internal`, which drops the declaration from the compared
+  surface. The extractor therefore rejects any tag after `@noRailsEquivalent`
+  that is not one of the structural, signature-documenting tags (`@param`,
+  `@returns`, `@throws`, `@example`, `@see`, `@template`, …). Deliberate tags
+  outside that set — `@internal` above all — must be written **above**
+  `@noRailsEquivalent`, which is how the tree already writes them (see
+  `schema-cache.ts` `recordTouchedTables`).
+
 ### `@noRailsEquivalent` vs `@internal`
 
 Different claims, deliberately kept distinct:

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1583,6 +1583,36 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     ).toThrow(/truncated by a bare `@internal`/);
   });
 
+  it("throws when a prose tag name wraps onto the start of a continuation line", () => {
+    expect(() =>
+      extractFromSource(`
+        class Foo {
+          /**
+           * @noRailsEquivalent wiring seam; the method is real Rails-facing
+           * @internal is the wrong tool here because callers depend on it.
+           */
+          initializeAssociations(): void {}
+        }
+      `),
+    ).toThrow(/truncated by a bare `@internal`/);
+  });
+
+  it("accepts a deliberate @internal placed above @noRailsEquivalent", () => {
+    const foo = extractFromSource(`
+      class Foo {
+        /**
+         * @internal
+         *
+         * @noRailsEquivalent test-harness ledger with no Rails counterpart
+         */
+        recordTouchedTables(): void {}
+      }
+    `);
+    expect(
+      foo.instanceMethods.find((m) => m.name === "recordTouchedTables")!.noRailsEquivalent,
+    ).toBe("test-harness ledger with no Rails counterpart");
+  });
+
   it("accepts a following tag that starts its own line", () => {
     const foo = extractFromSource(`
       class Foo {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1594,7 +1594,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
           initializeAssociations(): void {}
         }
       `),
-    ).toThrow(/truncated by a bare `@internal`/);
+    ).toThrow(/truncated by a bare `@internal`.*move it above `@noRailsEquivalent`/s);
   });
 
   it("accepts a deliberate @internal placed above @noRailsEquivalent", () => {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1399,13 +1399,14 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
     }
     const sf = node.getSourceFile();
     const line = sf.getLineAndCharacterOfPosition(tag.getStart()).line + 1;
-    const inlineTag = inlineTagAfter(tag);
-    if (inlineTag !== undefined) {
+    const proseTag = proseTagAfter(tag);
+    if (proseTag !== undefined) {
       throw new Error(
-        `@noRailsEquivalent reason is truncated by a bare \`@${inlineTag}\` in its ` +
+        `@noRailsEquivalent reason is truncated by a bare \`@${proseTag}\` in its ` +
           `prose: ${sf.fileName}:${line} — TypeScript parses it as a real JSDoc tag, ` +
           "so the reason is cut short and the declaration can drop out of the " +
-          "compared surface entirely. Reword the prose to avoid the tag form.",
+          "compared surface entirely. Reword the prose to avoid the tag form" +
+          ", or — for a deliberate tag — move it above `@noRailsEquivalent`.",
       );
     }
     return reason;
@@ -1414,28 +1415,56 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
 }
 
 /**
- * Name of the first JSDoc tag that follows `tag` in the same comment while
- * starting mid-line — i.e. a bare `@word` written inside reason prose rather
- * than a deliberate tag on its own line. TypeScript parses either shape as a
- * real tag, which silently truncates the reason (and, for `@internal`, drops
- * the declaration from the extracted surface). Returns undefined when every
- * following tag starts its own line: a line-leading tag can't be told apart
- * from a deliberate one, and `@internal` next to `@noRailsEquivalent` is a real
- * pairing in the tree (schema-cache.ts `recordTouchedTables`), so only the
- * mid-line shape is judged a mistake.
+ * Tags a deliberate JSDoc block may legitimately carry *after*
+ * `@noRailsEquivalent`: the structural ones that document the signature and
+ * conventionally trail the description. Every other tag name after the reason
+ * is prose that TypeScript mis-parsed — see `proseTagAfter`.
  */
-function inlineTagAfter(tag: ts.JSDocTag): string | undefined {
+const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT = new Set([
+  "param",
+  "returns",
+  "return",
+  "throws",
+  "example",
+  "see",
+  "template",
+  "typeParam",
+  "yields",
+  "defaultValue",
+  "remarks",
+  "deprecated",
+]);
+
+/**
+ * Name of the first JSDoc tag that follows `tag` in the same comment and is a
+ * bare `@word` from the reason prose rather than a deliberate tag. TypeScript
+ * parses either shape as a real tag, which silently truncates the reason (and,
+ * for `@internal`, drops the declaration from the extracted surface).
+ *
+ * A mid-line tag is prose by construction. A *line-leading* one is textually
+ * identical to a deliberate tag, so it is judged by name: the structural tags
+ * in `TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT` are accepted, and anything else
+ * — `@internal` above all — is prose that wrapped onto a continuation line.
+ * That makes tag order load-bearing: a deliberate `@internal` must precede
+ * `@noRailsEquivalent`, as schema-cache.ts `recordTouchedTables` already
+ * writes it.
+ */
+function proseTagAfter(tag: ts.JSDocTag): string | undefined {
   const jsDoc = tag.parent;
   if (!ts.isJSDoc(jsDoc) || jsDoc.tags === undefined) return undefined;
   const text = jsDoc.getSourceFile().text;
   for (const other of jsDoc.tags) {
     if (other.getStart() <= tag.getStart()) continue;
-    let i = other.getStart() - 1;
-    while (i >= 0 && text[i] !== "\n") {
+    const name = other.tagName.text;
+    let lineLeading = true;
+    for (let i = other.getStart() - 1; i >= 0 && text[i] !== "\n"; i--) {
       const ch = text[i];
-      if (ch !== " " && ch !== "\t" && ch !== "*") return other.tagName.text;
-      i--;
+      if (ch !== " " && ch !== "\t" && ch !== "*") {
+        lineLeading = false;
+        break;
+      }
     }
+    if (!lineLeading || !TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT.has(name)) return name;
   }
   return undefined;
 }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1402,11 +1402,14 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
     const proseTag = proseTagAfter(tag);
     if (proseTag !== undefined) {
       throw new Error(
-        `@noRailsEquivalent reason is truncated by a bare \`@${proseTag}\` in its ` +
+        `@noRailsEquivalent reason is truncated by a bare \`@${proseTag.name}\` in its ` +
           `prose: ${sf.fileName}:${line} — TypeScript parses it as a real JSDoc tag, ` +
           "so the reason is cut short and the declaration can drop out of the " +
           "compared surface entirely. Reword the prose to avoid the tag form" +
-          ", or — for a deliberate tag — move it above `@noRailsEquivalent`.",
+          (proseTag.lineLeading
+            ? `, or — if the \`@${proseTag.name}\` is deliberate — move it above ` +
+              "`@noRailsEquivalent`, which every deliberate tag of its kind must precede."
+            : "."),
       );
     }
     return reason;
@@ -1436,10 +1439,10 @@ const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT = new Set([
 ]);
 
 /**
- * Name of the first JSDoc tag that follows `tag` in the same comment and is a
- * bare `@word` from the reason prose rather than a deliberate tag. TypeScript
- * parses either shape as a real tag, which silently truncates the reason (and,
- * for `@internal`, drops the declaration from the extracted surface).
+ * The first JSDoc tag that follows `tag` in the same comment and is a bare
+ * `@word` from the reason prose rather than a deliberate tag. TypeScript parses
+ * either shape as a real tag, which silently truncates the reason (and, for
+ * `@internal`, drops the declaration from the extracted surface).
  *
  * A mid-line tag is prose by construction. A *line-leading* one is textually
  * identical to a deliberate tag, so it is judged by name: the structural tags
@@ -1447,26 +1450,31 @@ const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT = new Set([
  * — `@internal` above all — is prose that wrapped onto a continuation line.
  * That makes tag order load-bearing: a deliberate `@internal` must precede
  * `@noRailsEquivalent`, as schema-cache.ts `recordTouchedTables` already
- * writes it.
+ * writes it. `lineLeading` rides along so the caller can point at the fix that
+ * actually applies.
  */
-function proseTagAfter(tag: ts.JSDocTag): string | undefined {
+function proseTagAfter(tag: ts.JSDocTag): { name: string; lineLeading: boolean } | undefined {
   const jsDoc = tag.parent;
   if (!ts.isJSDoc(jsDoc) || jsDoc.tags === undefined) return undefined;
   const text = jsDoc.getSourceFile().text;
   for (const other of jsDoc.tags) {
     if (other.getStart() <= tag.getStart()) continue;
     const name = other.tagName.text;
-    let lineLeading = true;
-    for (let i = other.getStart() - 1; i >= 0 && text[i] !== "\n"; i--) {
-      const ch = text[i];
-      if (ch !== " " && ch !== "\t" && ch !== "*") {
-        lineLeading = false;
-        break;
-      }
+    const lineLeading = isLineLeading(text, other.getStart());
+    if (!lineLeading || !TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT.has(name)) {
+      return { name, lineLeading };
     }
-    if (!lineLeading || !TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT.has(name)) return name;
   }
   return undefined;
+}
+
+/** True when only comment-frame padding (`*`, spaces, tabs) precedes `pos` on its line. */
+function isLineLeading(text: string, pos: number): boolean {
+  for (let i = pos - 1; i >= 0 && text[i] !== "\n"; i--) {
+    const ch = text[i];
+    if (ch !== " " && ch !== "\t" && ch !== "*") return false;
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
A prose `@internal` that wrapped onto the **start** of a continuation line
inside a `@noRailsEquivalent` reason was undetected: PR 5393 only caught the
mid-line shape, and a line-leading tag is textually identical to a deliberate
one.

Resolved by making tag order load-bearing. `proseTagAfter` (was
`inlineTagAfter`) now judges a line-leading tag by name: the structural JSDoc
tags that conventionally trail a description (`@param`, `@returns`, `@throws`,
`@example`, …) are accepted after `@noRailsEquivalent`; anything else —
`@internal` above all — is prose that wrapped, and is reported with
`file:line`. The error hint is tailored to the shape it found: reword the prose
for a mid-line tag, or move a deliberate one above `@noRailsEquivalent`.

That ordering rule is how the one real pairing in the tree (`schema-cache.ts`
`recordTouchedTables`) is already written, so no source changes were needed;
`pnpm api:compare` runs clean over the whole tree. The rule is documented
alongside the rest of the tag's semantics in
`docs/infrastructure/api-build-stub-generation-plan.md`.

Regression tests cover both shapes: the wrapped prose tag throws with the
move-it-above hint, and `@internal` above `@noRailsEquivalent` extracts with
its reason intact.

Closes-story: line-leading-prose-tag-in-no-rails-equivalent-reason-undetected
