### PR TITLE
feat(api-compare): reject a bare @missingRailsCall tag

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -320,7 +320,7 @@ report). They therefore share:
 Two things are deliberately **not** shared, and the difference is load-bearing:
 
 - **Reader.** `@noRailsEquivalent` is read through `ts.getJSDocTags`
-  (`noRailsEquivalentReason` in `extract-ts-api.ts:1388`), the same pass that
+  (`noRailsEquivalentReason` in `extract-ts-api.ts:1390`), the same pass that
   already reads `@internal`, because the extractor only needs the flattened
   prose. `@missingRailsCall` is read by `parseJsdoc`'s line regex over the raw
   comment text (`TAG_LINE`, `build.ts:78`) because `api:build` must **write**

--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -312,7 +312,10 @@ report). They therefore share:
 
   The placeholder path is unaffected: a generator-authored placeholder is a
   non-empty reason, so it parses, round-trips byte-for-byte via `rawLines`,
-  and still drops without a harvest report when the call converges.
+  and still drops without a harvest report when the call converges. Reason
+  precedence (3a) falls back to the placeholder if a curated baseline row's
+  `reason` is ever blank, so the generator can never write a tag its own
+  parser would reject on the next run.
 
 Two things are deliberately **not** shared, and the difference is load-bearing:
 

--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -293,6 +293,26 @@ report). They therefore share:
 - **Only-shrink gating** — a tag whose condition no longer holds (the call is
   now made; the extra is no longer extra) fails the run exactly as a stale
   JSON row does today, and the fix is deleting the tag next to the code.
+- **Empty-reason handling — a tag with no reason is a hard error, for both
+  tags.** This is the single statement of the family's empty-reason contract;
+  neither tag's reader has a permissive mode.
+  - `@noRailsEquivalent`: raised at extraction time by
+    `noRailsEquivalentReason` (`extract-ts-api.ts:1356`). The tag is the only
+    thing standing between a name and the extra-surface count, so an
+    unjustified one would suppress drift with no argument for it.
+  - `@missingRailsCall`: raised by `parseJsdoc` (`build.ts`), with the same
+    `<tag> needs a reason: <file>:<line> — <what to write>` message shape. A
+    bare tag in the tree is necessarily **hand-authored**: the generator
+    always writes a reason — either the curated baseline row's prose or a
+    placeholder (`unported (api:build stub)` / the wide `DEFAULT_REASON`) —
+    so there is no generated bare tag to protect. Backfilling a hand-written
+    bare tag with a placeholder would silently convert an unjustified
+    allowlist entry into a blessed one, which is exactly the failure mode the
+    sibling tag rejects.
+
+  The placeholder path is unaffected: a generator-authored placeholder is a
+  non-empty reason, so it parses, round-trips byte-for-byte via `rawLines`,
+  and still drops without a harvest report when the call converges.
 
 Two things are deliberately **not** shared, and the difference is load-bearing:
 
@@ -305,15 +325,10 @@ Two things are deliberately **not** shared, and the difference is load-bearing:
   round-trips byte-for-byte, which is what makes a re-run with no diff a no-op.
   A flattened AST read cannot reproduce the original wrapping, so the two
   readers stay distinct.
-- **Empty-reason handling.** An empty `@noRailsEquivalent` reason is a hard
-  extraction-time error (`extract-ts-api.ts:1356`): the tag is the only thing
-  standing between a name and the extra-surface count, so an unjustified one
-  would suppress drift with no argument for it.
-  `@missingRailsCall` parses a bare tag as `reason: ""` (`build.ts:97`) —
-  reconcile then fills the reason from the curated baseline row or the
-  placeholder, so an empty one is an input state, not an error. Nothing in
-  this section changes that; tightening it would be a change to `api:build`,
-  which RFC 0080 lists as a non-goal.
+- **Where the error is raised.** `@noRailsEquivalent` fails during extraction;
+  `@missingRailsCall` fails when `api:build` parses the block it is about to
+  rewrite, because nothing else reads that tag. Same contract (above), two
+  entry points.
 
 ### `@noRailsEquivalent` vs `@internal`
 

--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -297,7 +297,7 @@ report). They therefore share:
   tags.** This is the single statement of the family's empty-reason contract;
   neither tag's reader has a permissive mode.
   - `@noRailsEquivalent`: raised at extraction time by
-    `noRailsEquivalentReason` (`extract-ts-api.ts:1356`). The tag is the only
+    `noRailsEquivalentReason` (`extract-ts-api.ts:1398`). The tag is the only
     thing standing between a name and the extra-surface count, so an
     unjustified one would suppress drift with no argument for it.
   - `@missingRailsCall`: raised by `parseJsdoc` (`build.ts`), with the same
@@ -320,7 +320,7 @@ report). They therefore share:
 Two things are deliberately **not** shared, and the difference is load-bearing:
 
 - **Reader.** `@noRailsEquivalent` is read through `ts.getJSDocTags`
-  (`noRailsEquivalentReason` in `extract-ts-api.ts:1352`), the same pass that
+  (`noRailsEquivalentReason` in `extract-ts-api.ts:1388`), the same pass that
   already reads `@internal`, because the extractor only needs the flattened
   prose. `@missingRailsCall` is read by `parseJsdoc`'s line regex over the raw
   comment text (`TAG_LINE`, `build.ts:78`) because `api:build` must **write**

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -48,6 +48,12 @@ describe("parseJsdoc", () => {
     );
   });
 
+  it("rejects a reason that is only whitespace after the em-dash", () => {
+    expect(() => parseJsdoc("/**\n * @missingRailsCall merge! —   \n */")).toThrow(
+      "@missingRailsCall needs a reason",
+    );
+  });
+
   it("accepts the generator's placeholder reason", () => {
     const { entries } = parseJsdoc(`/**\n * @missingRailsCall a — ${DEFAULT_TAG_REASON}\n */`);
     expect(entries[0]!.reason).toBe(DEFAULT_TAG_REASON);

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -29,6 +29,24 @@ describe("parseJsdoc", () => {
     expect(rest.join("\n")).toContain("Mirrors Rails");
     expect(rest.join("\n")).not.toContain("@missingRailsCall");
   });
+
+  it("rejects a bare tag with a file:line message", () => {
+    const comment = [
+      "/**",
+      " * Mirrors Rails `Base.all`.",
+      " * @missingRailsCall merge!",
+      " */",
+    ].join("\n");
+    expect(() => parseJsdoc(comment, { fileName: "foo.ts", startLine: 10 })).toThrow(
+      /@missingRailsCall needs a reason: foo\.ts:12 — state why the Rails call `merge!`/,
+    );
+  });
+
+  it("rejects a tag whose em-dash carries no prose", () => {
+    expect(() => parseJsdoc("/**\n * @missingRailsCall merge! — \n */")).toThrow(
+      /@missingRailsCall needs a reason/,
+    );
+  });
 });
 
 describe("reconcile", () => {
@@ -152,5 +170,19 @@ describe("reconcileFileText", () => {
     expect(text!).not.toContain("@missingRailsCall");
     expect(text!).not.toContain("/**");
     expect(text!).toContain("  bar(): void {}");
+  });
+
+  it("rejects a hand-authored bare tag, naming the tag's own line", () => {
+    const src = [
+      "export class Foo {",
+      "  /**",
+      "   * @missingRailsCall bare_call",
+      "   */",
+      "  bar(): void {}",
+      "}",
+    ].join("\n");
+    expect(() => reconcileFileText("foo.ts", src, new Map(), () => "x")).toThrow(
+      /@missingRailsCall needs a reason: foo\.ts:3 —/,
+    );
   });
 });

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -42,10 +42,15 @@ describe("parseJsdoc", () => {
     );
   });
 
-  it("rejects a tag whose em-dash carries no prose", () => {
+  it("rejects a tag whose em-dash carries no prose, with no location when unknown", () => {
     expect(() => parseJsdoc("/**\n * @missingRailsCall merge! — \n */")).toThrow(
-      /@missingRailsCall needs a reason/,
+      "@missingRailsCall needs a reason: — state why the Rails call `merge!` is not made here.",
     );
+  });
+
+  it("accepts the generator's placeholder reason", () => {
+    const { entries } = parseJsdoc(`/**\n * @missingRailsCall a — ${DEFAULT_TAG_REASON}\n */`);
+    expect(entries[0]!.reason).toBe(DEFAULT_TAG_REASON);
   });
 });
 
@@ -59,6 +64,11 @@ describe("reconcile", () => {
     expect(r.dropped).toEqual([]);
     const r2 = reconcile(entries, new Set(), reasonFor);
     expect(r2.dropped.map((e) => e.call)).toEqual(["a"]);
+  });
+
+  it("falls back to the placeholder when a curated reason is blank", () => {
+    const r = reconcile([], new Set(["a"]), () => "  ");
+    expect(r.added[0]!.reason).toBe(DEFAULT_TAG_REASON);
   });
 });
 

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -14,6 +14,8 @@
  *     harvested to stdout, never destroyed unseen);
  *   - existing tags that still apply are kept byte-for-byte (idempotent:
  *     a second run produces zero edits);
+ *   - a tag with no reason fails the run (see the empty-reason contract in
+ *     docs/infrastructure/api-build-stub-generation-plan.md);
  *   - reasons for newly-added tags migrate from the committed baselines
  *     (call-mismatches-wide-exclude/, call-mismatches-exclude.json).
  *
@@ -131,11 +133,11 @@ export function parseJsdoc(
   for (const entry of entries) {
     if (entry.reason !== "") continue;
     const at = origin
-      ? `${origin.fileName}:${origin.startLine + (tagLineOf.get(entry) ?? 0)}`
-      : entry.call;
+      ? ` ${origin.fileName}:${origin.startLine + (tagLineOf.get(entry) ?? 0)}`
+      : "";
     throw new Error(
-      `${TAG} needs a reason: ${at} — state why the Rails call \`${entry.call}\` ` +
-        "is not made here.",
+      `${TAG} needs a reason:${at} — state why the Rails call ` +
+        `\`${entry.call}\` is not made here.`,
     );
   }
   return { rest, entries };
@@ -159,7 +161,9 @@ export function reconcile(
   for (const call of [...expected].sort()) {
     const have = byCall.get(call);
     if (have) kept.push(have);
-    else added.push({ call, reason: reasonFor(call), rawLines: [] });
+    // A blank curated reason would emit a tag this tool's own parser rejects
+    // on the next run; the placeholder keeps the generated path round-trippable.
+    else added.push({ call, reason: reasonFor(call).trim() || DEFAULT_TAG_REASON, rawLines: [] });
   }
   const dropped = existing.filter((e) => !expected.has(e.call));
   return { kept, added, dropped };
@@ -378,17 +382,22 @@ async function main(argv: string[]): Promise<number> {
     } catch {
       continue; // expected TS file not ported yet — stub phase, not this slice
     }
-    const {
-      text: next,
-      harvested,
-      unmatched,
-    } = reconcileFileText(
-      tsFile,
-      text,
-      expectations,
-      (rubyName, call) =>
-        reasons.get(keyOf({ package: pkg, tsFile, rubyName, call })) ?? DEFAULT_TAG_REASON,
-    );
+    let reconciled;
+    try {
+      reconciled = reconcileFileText(
+        // Repo-relative so an unjustified-tag error names a path the operator
+        // can open; the artifact key stays `tsFile`.
+        path.relative(ROOT_DIR, abs),
+        text,
+        expectations,
+        (rubyName, call) =>
+          reasons.get(keyOf({ package: pkg, tsFile, rubyName, call })) ?? DEFAULT_TAG_REASON,
+      );
+    } catch (err) {
+      console.error(`api:build: ${err instanceof Error ? err.message : String(err)}`);
+      return 1;
+    }
+    const { text: next, harvested, unmatched } = reconciled;
     for (const h of harvested) {
       console.log(`harvested (${tsFile} ${h.tsName} ${h.entry.call}): ${h.entry.reason}`);
     }

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -83,19 +83,40 @@ const TAG_LINE = /^\s*\*?\s*@missingRailsCall\s+(\S+)(?:\s+—\s?(.*))?$/;
 // run: core.ts initInternals).
 const ANY_TAG_LINE = /^\s*\*?\s?@\S/;
 
+/** Where a JSDoc comment starts, so an empty-reason error can name a
+ *  `file:line` the way `noRailsEquivalentReason` does. */
+export interface JsdocOrigin {
+  fileName: string;
+  /** 1-based line of the comment's first line in `fileName`. */
+  startLine: number;
+}
+
 /** Parse a JSDoc comment's text (including delimiters) into its non-tag lines
  *  and its `@missingRailsCall` entries. Continuation lines (not starting a new
- *  `@` tag) attach to the preceding entry. */
-export function parseJsdoc(comment: string): { rest: string[]; entries: TagEntry[] } {
+ *  `@` tag) attach to the preceding entry.
+ *
+ *  An empty reason is a hard error, matching `@noRailsEquivalent` (RFC 0080):
+ *  every tag in the tree is written with a reason — the generator always emits
+ *  the curated baseline row's prose or a placeholder — so a bare tag is
+ *  necessarily hand-authored, and backfilling it with a placeholder would turn
+ *  an unjustified allowlist entry into a silently blessed one. The family's
+ *  empty-reason contract is stated in
+ *  docs/infrastructure/api-build-stub-generation-plan.md. */
+export function parseJsdoc(
+  comment: string,
+  origin?: JsdocOrigin,
+): { rest: string[]; entries: TagEntry[] } {
   const lines = comment.split("\n");
   const rest: string[] = [];
   const entries: TagEntry[] = [];
+  const tagLineOf = new Map<TagEntry, number>();
   let open: TagEntry | null = null;
-  for (const line of lines) {
+  for (const [index, line] of lines.entries()) {
     const m = line.match(TAG_LINE);
     if (m) {
       open = { call: m[1]!, reason: m[2] ?? "", rawLines: [line] };
       entries.push(open);
+      tagLineOf.set(open, index);
       continue;
     }
     const closes = line.trim() === "*/" || line.trim().endsWith("*/");
@@ -106,6 +127,16 @@ export function parseJsdoc(comment: string): { rest: string[]; entries: TagEntry
     }
     open = null;
     rest.push(line);
+  }
+  for (const entry of entries) {
+    if (entry.reason !== "") continue;
+    const at = origin
+      ? `${origin.fileName}:${origin.startLine + (tagLineOf.get(entry) ?? 0)}`
+      : entry.call;
+    throw new Error(
+      `${TAG} needs a reason: ${at} — state why the Rails call \`${entry.call}\` ` +
+        "is not made here.",
+    );
   }
   return { rest, entries };
 }
@@ -250,7 +281,15 @@ export function reconcileFileText(
       if (exp || (comment && comment.includes(TAG))) {
         const lineStart = text.lastIndexOf("\n", node.getStart(sf)) + 1;
         const indent = text.slice(lineStart, node.getStart(sf)).match(/^\s*/)?.[0] ?? "";
-        const { rest, entries } = parseJsdoc(comment ?? "");
+        const { rest, entries } = parseJsdoc(
+          comment ?? "",
+          jsdocRange
+            ? {
+                fileName,
+                startLine: sf.getLineAndCharacterOfPosition(jsdocRange.pos).line + 1,
+              }
+            : undefined,
+        );
         const expected = exp?.calls ?? new Set<string>();
         const r = reconcile(entries, expected, (c) =>
           exp ? reasonFor(exp.rubyName, c) : DEFAULT_TAG_REASON,

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -116,7 +116,11 @@ export function parseJsdoc(
   for (const [index, line] of lines.entries()) {
     const m = line.match(TAG_LINE);
     if (m) {
-      open = { call: m[1]!, reason: m[2] ?? "", rawLines: [line] };
+      // Trimmed at capture: `TAG_LINE` absorbs only one space after the
+      // em-dash, so trailing whitespace would otherwise read as a non-empty
+      // reason and slide past the empty-reason gate below. `rawLines` keeps
+      // the line verbatim, so idempotency is unaffected.
+      open = { call: m[1]!, reason: (m[2] ?? "").trim(), rawLines: [line] };
       entries.push(open);
       tagLineOf.set(open, index);
       continue;

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1384,6 +1384,8 @@ export function hasInternalJsDocTag(node: ts.Node): boolean {
  * is otherwise preserved verbatim. An empty reason is a hard error: the tag is
  * the only thing standing between a name and the extra-surface count, so an
  * unjustified one would suppress drift with no argument for it (RFC 0080).
+ * The family's empty-reason contract (shared with `@missingRailsCall`) is
+ * stated in docs/infrastructure/api-build-stub-generation-plan.md.
  */
 export function noRailsEquivalentReason(node: ts.Node): string | undefined {
   for (const tag of ts.getJSDocTags(node)) {


### PR DESCRIPTION
Resolves the empty-reason asymmetry PR #5412 documented but left open:
`@noRailsEquivalent` rejects an unjustified tag, `@missingRailsCall` silently
backfilled one with a placeholder.

**Decision: a bare `@missingRailsCall` is an error.** Every tag the generator
writes carries a reason — either the curated baseline row's prose or a
placeholder (`unported (api:build stub)` / the wide `DEFAULT_REASON`) — so a
bare tag in the tree is necessarily hand-authored. Backfilling it turned an
allowlist entry with no argument into a blessed one, exactly what the sibling
tag exists to prevent.

- `parseJsdoc` now throws on an empty reason with the same
  `<tag> needs a reason: <file>:<line> — <what to write>` shape as
  `noRailsEquivalentReason`. It takes an optional `JsdocOrigin` so
  `reconcileFileText` can name the tag's own line.
- `api:build` catches the throw and exits 1 with the message on stderr, like
  its other gate failures, and passes the repo-relative path so the location
  is openable.
- The generator's placeholder path is untouched: a placeholder is a non-empty
  reason, so it parses, round-trips byte-for-byte via `rawLines`, and still
  drops without a harvest report on convergence. No bare tags exist in the
  tree today (`grep`: 0), so nothing is retro-broken. `reconcile` also falls
  back to the placeholder if a curated baseline reason is ever blank, so the
  generator can never write a tag its own parser would reject.
- The family's empty-reason contract is now stated once, in the
  `Sibling tag: @noRailsEquivalent` section of
  `docs/infrastructure/api-build-stub-generation-plan.md`; both code sites
  point at it. What stays "deliberately not shared" is only *where* the error
  is raised (extraction vs `api:build`).

Closes-story: missing-rails-call-empty-reason-contract
