### PR TITLE
refactor(activerecord): share one target between a collection association and its proxy

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1303,9 +1303,23 @@ export async function _loadSingularThroughViaDisableJoinsScope(
  */
 export function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
   const holder = record._associationInstances.get(assocName) as
-    | { _setTargetFromLoader(t: Base | Base[] | null): void; _loaderWritebackSuppressed?: number }
+    | {
+        _setTargetFromLoader(t: Base | Base[] | null): void;
+        _loaderWritebackSuppressed?: number;
+        isCollection?(): boolean;
+        _mergeLoaderResults?(rows: Base[]): void;
+      }
     | undefined;
   if (!holder || holder._loaderWritebackSuppressed) return;
+  // A collection holder's target IS the canonical CollectionProxy's array, and
+  // Rails assigns `@target = merge_target_lists(find_target, target)` — never
+  // the raw rows. Writing them straight through here would drop the in-memory
+  // built/pushed records the loader's caller is about to merge them with
+  // (Rails' `load_target`, collection_association.rb:50).
+  if (holder.isCollection?.()) {
+    holder._mergeLoaderResults?.((result ?? []) as Base[]);
+    return;
+  }
   holder._setTargetFromLoader(result as Base | Base[] | null);
 }
 
@@ -2029,15 +2043,10 @@ export function association<T extends Base = Base>(
       if (preloaded != null) {
         const records = Array.isArray(preloaded) ? preloaded : [preloaded];
         existing._hydrateFromPreload(records as T[]);
-      } else {
-        // Hydrate from an AssociationInstance loaded via asyncLoadTarget()
-        const instance = record._associationInstances.get(assocName);
-        if (instance?.loaded && instance._loadedViaAsync && instance.isCollection?.()) {
-          const target = instance.target;
-          const records = Array.isArray(target) ? target : target != null ? [target] : [];
-          existing._hydrateFromPreload(records as T[]);
-        }
       }
+      // A collection `AssociationInstance` no longer needs hydrating from:
+      // `CollectionAssociation#target` IS this proxy's target, so an
+      // `asyncLoadTarget()` load has already landed here.
     }
     return existing;
   }
@@ -2083,20 +2092,27 @@ export function association<T extends Base = Base>(
     }
   )._create(record, assocName, assocDef) as CollectionProxy<T> & {
     _hydrateFromPreload: (records: T[]) => void;
+    _adoptSharedTarget: (records: Base[], loaded: boolean) => void;
   };
 
-  // Hydrate from preloaded data or from an asyncLoadTarget()-loaded AssociationInstance
+  // Take over the OO association's in-memory target — the SAME array object, so
+  // any reference a caller already holds keeps pointing at the live store. Until
+  // this moment the OO instance was the only surface and wrote there directly
+  // (its `target`/`loaded` accessors fall back to the inherited store while no
+  // proxy exists); from here on both surfaces read and write this proxy.
+  // Read the RAW store, not `instance.target`: this proxy is not in
+  // `_collectionProxies` yet, so the accessor would still see "no proxy".
+  const instance = record._associationInstances.get(assocName);
+  if (instance?.isCollection?.()) {
+    const raw = instance._rawTarget;
+    proxy._adoptSharedTarget(Array.isArray(raw) ? raw : [], instance._rawLoaded);
+  }
+
+  // Preloaded data wins over whatever the OO instance had.
   const preloaded = _preloadedHolderTarget(record, assocName)?.value;
   if (preloaded != null) {
     const records = Array.isArray(preloaded) ? preloaded : [preloaded];
     proxy._hydrateFromPreload(records as T[]);
-  } else {
-    const instance = record._associationInstances.get(assocName);
-    if (instance?.loaded && instance._loadedViaAsync && instance.isCollection?.()) {
-      const target = instance.target;
-      const records = Array.isArray(target) ? target : target != null ? [target] : [];
-      proxy._hydrateFromPreload(records as T[]);
-    }
   }
 
   const wrapped = wrapCollectionProxy<T>(proxy);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1311,11 +1311,6 @@ export function syncToAssociationInstance(record: Base, assocName: string, resul
       }
     | undefined;
   if (!holder || holder._loaderWritebackSuppressed) return;
-  // A collection holder's target IS the canonical CollectionProxy's array, and
-  // Rails assigns `@target = merge_target_lists(find_target, target)` — never
-  // the raw rows. Writing them straight through here would drop the in-memory
-  // built/pushed records the loader's caller is about to merge them with
-  // (Rails' `load_target`, collection_association.rb:50).
   if (holder.isCollection?.()) {
     holder._mergeLoaderResults?.((result ?? []) as Base[]);
     return;
@@ -2044,9 +2039,6 @@ export function association<T extends Base = Base>(
         const records = Array.isArray(preloaded) ? preloaded : [preloaded];
         existing._hydrateFromPreload(records as T[]);
       }
-      // A collection `AssociationInstance` no longer needs hydrating from:
-      // `CollectionAssociation#target` IS this proxy's target, so an
-      // `asyncLoadTarget()` load has already landed here.
     }
     return existing;
   }
@@ -2095,20 +2087,12 @@ export function association<T extends Base = Base>(
     _adoptSharedTarget: (records: Base[], loaded: boolean) => void;
   };
 
-  // Take over the OO association's in-memory target — the SAME array object, so
-  // any reference a caller already holds keeps pointing at the live store. Until
-  // this moment the OO instance was the only surface and wrote there directly
-  // (its `target`/`loaded` accessors fall back to the inherited store while no
-  // proxy exists); from here on both surfaces read and write this proxy.
-  // Read the RAW store, not `instance.target`: this proxy is not in
-  // `_collectionProxies` yet, so the accessor would still see "no proxy".
   const instance = record._associationInstances.get(assocName);
   if (instance?.isCollection?.()) {
     const raw = instance._rawTarget;
     proxy._adoptSharedTarget(Array.isArray(raw) ? raw : [], instance._rawLoaded);
   }
 
-  // Preloaded data wins over whatever the OO instance had.
   const preloaded = _preloadedHolderTarget(record, assocName)?.value;
   if (preloaded != null) {
     const records = Array.isArray(preloaded) ? preloaded : [preloaded];

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -27,17 +27,9 @@ export class Association {
   owner: Base;
   readonly reflection: AssociationDefinition;
   readonly disableJoins: boolean;
-  /**
-   * Backing store for `loaded` / `target`. These are accessors rather than
-   * plain fields so `CollectionAssociation` can override them and delegate to
-   * the canonical `CollectionProxy` — Rails keeps a single `@target` on the
-   * association and has `CollectionProxy` forward to it; trails inverts the
-   * ownership (RFC 0022 makes the proxy canonical) but the invariant is the
-   * same: ONE in-memory target per association, not two.
-   * @internal
-   */
+  /** @internal */
   protected _targetStore: Base | Base[] | null = null;
-  /** @internal Backing store for `loaded`. See {@link _targetStore}. */
+  /** @internal */
   protected _loadedStore = false;
 
   get loaded(): boolean {
@@ -56,18 +48,12 @@ export class Association {
     this._targetStore = value;
   }
 
-  /**
-   * The un-delegated backing store, for the few callers that must NOT trip a
-   * subclass's proxy delegation — notably `association()`'s proxy factory,
-   * which would otherwise recurse (proxy lookup → `target` getter → proxy
-   * lookup) while the proxy is still being built.
-   * @internal
-   */
+  /** @internal */
   get _rawTarget(): Base | Base[] | null {
     return this._targetStore;
   }
 
-  /** @internal See {@link _rawTarget}. */
+  /** @internal */
   get _rawLoaded(): boolean {
     return this._loadedStore;
   }
@@ -214,16 +200,7 @@ export class Association {
     this._staleStateSnapshotted = true;
   }
 
-  /**
-   * Whether `loadedBang` has taken its `@stale_state` snapshot since the last
-   * `reset`. A collection's `loaded` flag lives on the shared `CollectionProxy`
-   * (see `CollectionAssociation`), which flips it without going through
-   * `loadedBang`, so the snapshot `isStaleTarget` diffs against can be missing
-   * — and a missing one reads as "stale". Lets `record.association(name)` fill
-   * that gap in without *re*-snapshotting a real load-time capture, which
-   * would mask genuine staleness.
-   * @internal
-   */
+  /** @internal */
   get _staleStateIsSnapshotted(): boolean {
     return this._staleStateSnapshotted;
   }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -27,8 +27,51 @@ export class Association {
   owner: Base;
   readonly reflection: AssociationDefinition;
   readonly disableJoins: boolean;
-  loaded: boolean;
-  target: Base | Base[] | null;
+  /**
+   * Backing store for `loaded` / `target`. These are accessors rather than
+   * plain fields so `CollectionAssociation` can override them and delegate to
+   * the canonical `CollectionProxy` — Rails keeps a single `@target` on the
+   * association and has `CollectionProxy` forward to it; trails inverts the
+   * ownership (RFC 0022 makes the proxy canonical) but the invariant is the
+   * same: ONE in-memory target per association, not two.
+   * @internal
+   */
+  protected _targetStore: Base | Base[] | null = null;
+  /** @internal Backing store for `loaded`. See {@link _targetStore}. */
+  protected _loadedStore = false;
+
+  get loaded(): boolean {
+    return this._loadedStore;
+  }
+
+  set loaded(value: boolean) {
+    this._loadedStore = value;
+  }
+
+  get target(): Base | Base[] | null {
+    return this._targetStore;
+  }
+
+  set target(value: Base | Base[] | null) {
+    this._targetStore = value;
+  }
+
+  /**
+   * The un-delegated backing store, for the few callers that must NOT trip a
+   * subclass's proxy delegation — notably `association()`'s proxy factory,
+   * which would otherwise recurse (proxy lookup → `target` getter → proxy
+   * lookup) while the proxy is still being built.
+   * @internal
+   */
+  get _rawTarget(): Base | Base[] | null {
+    return this._targetStore;
+  }
+
+  /** @internal See {@link _rawTarget}. */
+  get _rawLoaded(): boolean {
+    return this._loadedStore;
+  }
+
   /**
    * True when `target` was set by an *explicit* assignment / inverse-of seed
    * (the writer paths routed through `_cacheSingularTarget`), as opposed to a
@@ -82,6 +125,7 @@ export class Association {
   _loaderWritebackSuppressed = 0;
 
   private _staleState: unknown = undefined;
+  private _staleStateSnapshotted = false;
   /**
    * Memoized result of `scope()` — Rails' `@association_scope`
    * (association.rb:300-308). Built lazily on first access; reset by
@@ -97,8 +141,6 @@ export class Association {
     this.owner = owner;
     this.reflection = reflection;
     this.disableJoins = reflection.options.disableJoins || false;
-    this.loaded = false;
-    this.target = null;
 
     // Rails' `check_validity! → klass → compute_class` raises NameError
     // synchronously in the constructor, so `record.association(:name)` itself
@@ -169,6 +211,21 @@ export class Association {
   loadedBang(): void {
     this.loaded = true;
     this._staleState = this.staleState();
+    this._staleStateSnapshotted = true;
+  }
+
+  /**
+   * Whether `loadedBang` has taken its `@stale_state` snapshot since the last
+   * `reset`. A collection's `loaded` flag lives on the shared `CollectionProxy`
+   * (see `CollectionAssociation`), which flips it without going through
+   * `loadedBang`, so the snapshot `isStaleTarget` diffs against can be missing
+   * — and a missing one reads as "stale". Lets `record.association(name)` fill
+   * that gap in without *re*-snapshotting a real load-time capture, which
+   * would mask genuine staleness.
+   * @internal
+   */
+  get _staleStateIsSnapshotted(): boolean {
+    return this._staleStateSnapshotted;
   }
 
   isStaleTarget(): boolean {
@@ -179,6 +236,7 @@ export class Association {
     this.loaded = false;
     this.target = null;
     this._staleState = undefined;
+    this._staleStateSnapshotted = false;
     this._explicitTarget = false;
     this._loadedFromPreload = false;
     this._loadedViaAsync = false;

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -32,8 +32,17 @@ export interface ReplacePlan {
  *
  * Mirrors: ActiveRecord::Associations::CollectionAssociation
  */
+/**
+ * The slice of `CollectionProxy` the shared-target delegation needs.
+ * @internal
+ */
+interface SharedTargetStore {
+  _sharedTarget: Base[];
+  _sharedLoaded: boolean;
+  _sharedReplacedOrAddedTargets: Set<Base>;
+}
+
 export class CollectionAssociation extends Association {
-  declare target: Base[];
   // A `null` entry is a placeholder for a rejected new record, preserving the
   // 1:1 ordering with the assigned attributes collection (Rails
   // nested_attributes.rb:487-547).
@@ -58,10 +67,84 @@ export class CollectionAssociation extends Association {
   // `CollectionProxy`.
   _namedScopeRelations?: Map<string, unknown>;
 
+  /**
+   * Off until the constructor has finished, so the base `Association`
+   * constructor and our own `this.target = []` seed write to the inherited
+   * backing store instead of building — and immediately clearing — the
+   * canonical `CollectionProxy`.
+   */
+  private _sharedTargetEnabled = false;
+
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
     this.target = [];
+    this._sharedTargetEnabled = true;
   }
+
+  /**
+   * The canonical `CollectionProxy` backing this association's target — the one
+   * already cached on the owner, if any. Deliberately a plain cache *lookup*
+   * rather than `association()`: building a proxy here would be re-entrant
+   * (the proxy constructor resolves through-scopes that read back through this
+   * association) and would make an OO-only path fail wherever proxy
+   * construction can't run at all. Until a proxy exists there is no second
+   * store to keep coherent, so the inherited one serves; `association()` hands
+   * that very array to the proxy it builds (`_adoptSharedTarget`), so no
+   * reference a caller already holds goes stale.
+   */
+  private _sharedStore(): SharedTargetStore | null {
+    if (!this._sharedTargetEnabled) return null;
+    return (
+      (this.owner._collectionProxies.get(this.reflection.name) as SharedTargetStore | undefined) ??
+      null
+    );
+  }
+
+  /**
+   * One target, two surfaces. Rails' `CollectionProxy` forwards `target` /
+   * `loaded` to its `@association`; trails inverts the ownership (the proxy is
+   * the canonical has_many store per RFC 0022) so the OO association forwards
+   * the other way. Either direction gives the invariant that matters: a record
+   * added through `add_to_target` / `replace_on_target` is visible to every
+   * reader that goes through the proxy, and vice versa, with no sync step.
+   */
+  override get target(): Base[] {
+    const store = this._sharedStore();
+    return store ? store._sharedTarget : (this._targetStore as Base[]);
+  }
+
+  override set target(records: Base | Base[] | null) {
+    // `Association#reset` assigns `null`; a collection's empty target is `[]`.
+    const value = Array.isArray(records) ? records : records == null ? [] : [records];
+    const store = this._sharedStore();
+    if (store) store._sharedTarget = value;
+    else this._targetStore = value;
+  }
+
+  override get loaded(): boolean {
+    const store = this._sharedStore();
+    return store ? store._sharedLoaded : this._loadedStore;
+  }
+
+  override set loaded(value: boolean) {
+    const store = this._sharedStore();
+    if (store) store._sharedLoaded = value;
+    else this._loadedStore = value;
+  }
+
+  /**
+   * Rails' `@replaced_or_added_targets` (a `Set.new.compare_by_identity`), the
+   * other half of `replace_on_target`'s state: it decides whether a re-added
+   * record replaces in place or appends. It has to travel with the target —
+   * two sets over one array means a record added via the proxy and then via
+   * `add_to_target` lands twice.
+   * @internal
+   */
+  get _replacedOrAddedTargets(): Set<Base> {
+    return this._sharedStore()?._sharedReplacedOrAddedTargets ?? this._replacedOrAddedTargetsStore;
+  }
+
+  private _replacedOrAddedTargetsStore = new Set<Base>();
 
   /**
    * Implements the writer method, e.g. foo.items= for Foo.has_many :items.
@@ -1125,6 +1208,21 @@ export class CollectionAssociation extends Association {
   }
 
   /**
+   * The collection form of `_setTargetFromLoader`: fold a loader's rows into
+   * the shared target the way Rails' `load_target` does — `@target =
+   * merge_target_lists(find_target, target); loaded!` — rather than
+   * overwriting, which would discard in-memory builds. `loaded!` is what
+   * snapshots `@stale_state`, and `association_scope` reads that snapshot to
+   * decide whether its memoized scope was built from a since-changed foreign
+   * key, so it has to happen on every load, not just the proxy's own.
+   * @internal
+   */
+  _mergeLoaderResults(rows: Base[]): void {
+    this.target = this.mergeTargetLists(rows, this.target);
+    this.loadedBang();
+  }
+
+  /**
    * Merge persisted records from DB with in-memory target records.
    * Preserves order of persisted, deduplicates, and keeps
    * attribute changes from in-memory versions.
@@ -1315,7 +1413,14 @@ function beginReplaceOnTarget(
   skipCallbacks: boolean,
   replace: boolean,
 ): number | null {
-  const index = replace ? assoc.target.indexOf(record) : -1;
+  // Rails: `index = @target.index(record) if replace && (!record.new_record? ||
+  // @replaced_or_added_targets.include?(record))` (collection_association.rb:478).
+  // The bare `indexOf` this used to be both ignored that guard and matched by
+  // JS reference instead of `Core#==`.
+  const index =
+    replace && (!record.isNewRecord() || assoc._replacedOrAddedTargets.has(record))
+      ? indexInTarget(assoc, record)
+      : -1;
   if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
   assoc.setInverseInstance(record);
   (assoc as any)._associationIds = null;
@@ -1334,13 +1439,28 @@ function finishReplaceOnTarget(
   index: number,
 ): Base {
   const target = assoc.target;
-  if (index !== -1) {
-    target[index] = record;
+  // Rails re-runs `@target.index(record)` after the `yield` — the block (a
+  // save) can have added the record to `@replaced_or_added_targets` in between.
+  let at = index;
+  if (at === -1 && assoc._replacedOrAddedTargets.has(record)) at = indexInTarget(assoc, record);
+  if (at !== -1 || record.isNewRecord()) assoc._replacedOrAddedTargets.add(record);
+  if (at !== -1) {
+    target[at] = record;
   } else {
     target.push(record);
   }
   if (!skipCallbacks) callback(assoc, "afterAdd", record);
   return record;
+}
+
+/**
+ * Ruby's `@target.index(record)` inside `replace_on_target`: `Core#==`, not JS
+ * reference identity, so a re-fetched persisted record dedups against the one
+ * already buffered.
+ * @internal
+ */
+function indexInTarget(assoc: CollectionAssociation, record: Base): number {
+  return assoc.target.findIndex((r) => r === record || r.isEqual(record));
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -23,6 +23,13 @@ export interface ReplacePlan {
   wasLoaded: boolean;
 }
 
+/** @internal */
+interface SharedTargetStore {
+  _sharedTarget: Base[];
+  _sharedLoaded: boolean;
+  _sharedReplacedOrAddedTargets: Set<Base>;
+}
+
 /**
  * Base class for has_many and has_and_belongs_to_many associations.
  *
@@ -32,16 +39,6 @@ export interface ReplacePlan {
  *
  * Mirrors: ActiveRecord::Associations::CollectionAssociation
  */
-/**
- * The slice of `CollectionProxy` the shared-target delegation needs.
- * @internal
- */
-interface SharedTargetStore {
-  _sharedTarget: Base[];
-  _sharedLoaded: boolean;
-  _sharedReplacedOrAddedTargets: Set<Base>;
-}
-
 export class CollectionAssociation extends Association {
   // A `null` entry is a placeholder for a rejected new record, preserving the
   // 1:1 ordering with the assigned attributes collection (Rails
@@ -67,12 +64,6 @@ export class CollectionAssociation extends Association {
   // `CollectionProxy`.
   _namedScopeRelations?: Map<string, unknown>;
 
-  /**
-   * Off until the constructor has finished, so the base `Association`
-   * constructor and our own `this.target = []` seed write to the inherited
-   * backing store instead of building — and immediately clearing — the
-   * canonical `CollectionProxy`.
-   */
   private _sharedTargetEnabled = false;
 
   constructor(owner: Base, definition: AssociationDefinition) {
@@ -82,15 +73,11 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * The canonical `CollectionProxy` backing this association's target — the one
-   * already cached on the owner, if any. Deliberately a plain cache *lookup*
-   * rather than `association()`: building a proxy here would be re-entrant
-   * (the proxy constructor resolves through-scopes that read back through this
-   * association) and would make an OO-only path fail wherever proxy
-   * construction can't run at all. Until a proxy exists there is no second
-   * store to keep coherent, so the inherited one serves; `association()` hands
-   * that very array to the proxy it builds (`_adoptSharedTarget`), so no
-   * reference a caller already holds goes stale.
+   * A cache *lookup*, never a build: constructing a proxy here would be
+   * re-entrant (its constructor resolves through-scopes that read back through
+   * this association). Until one exists there is no second store to keep
+   * coherent, and `association()` hands the proxy this very array
+   * (`_adoptSharedTarget`), so no reference already handed out goes stale.
    */
   private _sharedStore(): SharedTargetStore | null {
     if (!this._sharedTargetEnabled) return null;
@@ -101,12 +88,10 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * One target, two surfaces. Rails' `CollectionProxy` forwards `target` /
-   * `loaded` to its `@association`; trails inverts the ownership (the proxy is
-   * the canonical has_many store per RFC 0022) so the OO association forwards
-   * the other way. Either direction gives the invariant that matters: a record
-   * added through `add_to_target` / `replace_on_target` is visible to every
-   * reader that goes through the proxy, and vice versa, with no sync step.
+   * Rails' `CollectionProxy` forwards `target`/`loaded` to its `@association`;
+   * trails inverts the ownership (RFC 0022 makes the proxy the canonical
+   * has_many store) so the association forwards the other way. Either
+   * direction gives the one invariant that matters: ONE in-memory target.
    */
   override get target(): Base[] {
     const store = this._sharedStore();
@@ -133,11 +118,9 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * Rails' `@replaced_or_added_targets` (a `Set.new.compare_by_identity`), the
-   * other half of `replace_on_target`'s state: it decides whether a re-added
-   * record replaces in place or appends. It has to travel with the target —
-   * two sets over one array means a record added via the proxy and then via
-   * `add_to_target` lands twice.
+   * Rails' `@replaced_or_added_targets`, the other half of
+   * `replace_on_target`'s state — it has to travel with the target, since two
+   * sets over one array double-append.
    * @internal
    */
   get _replacedOrAddedTargets(): Set<Base> {
@@ -1208,13 +1191,9 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * The collection form of `_setTargetFromLoader`: fold a loader's rows into
-   * the shared target the way Rails' `load_target` does — `@target =
-   * merge_target_lists(find_target, target); loaded!` — rather than
-   * overwriting, which would discard in-memory builds. `loaded!` is what
-   * snapshots `@stale_state`, and `association_scope` reads that snapshot to
-   * decide whether its memoized scope was built from a since-changed foreign
-   * key, so it has to happen on every load, not just the proxy's own.
+   * The collection form of `_setTargetFromLoader`, mirroring Rails'
+   * `load_target`: `@target = merge_target_lists(find_target, target);
+   * loaded!`. Overwriting instead would discard in-memory builds.
    * @internal
    */
   _mergeLoaderResults(rows: Base[]): void {
@@ -1415,8 +1394,6 @@ function beginReplaceOnTarget(
 ): number | null {
   // Rails: `index = @target.index(record) if replace && (!record.new_record? ||
   // @replaced_or_added_targets.include?(record))` (collection_association.rb:478).
-  // The bare `indexOf` this used to be both ignored that guard and matched by
-  // JS reference instead of `Core#==`.
   const index =
     replace && (!record.isNewRecord() || assoc._replacedOrAddedTargets.has(record))
       ? indexInTarget(assoc, record)

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -188,10 +188,7 @@ function assertValidLimit(n: number): void {
   }
 }
 
-/**
- * The owner's `Association` wrapper, as far as staleness handling needs it.
- * @internal
- */
+/** @internal */
 interface StaleWrapper {
   isStaleTarget?: () => boolean;
   resetScope?: () => void;
@@ -253,15 +250,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return this._target;
   }
 
-  /**
-   * @internal The single in-memory target this proxy shares with its OO
-   * `CollectionAssociation` (`record.association(name)`), whose `target` /
-   * `loaded` accessors read and write through here. Rails has one `@target`
-   * per association with the proxy forwarding to it; trails makes the proxy
-   * the owner of that store (RFC 0022) and the OO object the forwarder, so
-   * `replace_on_target` / `add_to_target` land in the array every reader
-   * consults instead of a parallel mirror.
-   */
+  /** @internal */
   get _sharedTarget(): T[] {
     return this._target;
   }
@@ -270,17 +259,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._target = records;
   }
 
-  /**
-   * @internal Rails' `@replaced_or_added_targets` — part of the same store as
-   * `_sharedTarget`, since `replace_on_target`'s dedup rule reads both. The OO
-   * `CollectionAssociation` shares this set so a record added through one
-   * surface is not appended a second time through the other.
-   */
+  /** @internal */
   get _sharedReplacedOrAddedTargets(): Set<T> {
     return this._replacedOrAddedTargets;
   }
 
-  /** @internal Loaded flag for the shared target. See {@link _sharedTarget}. */
+  /** @internal */
   get _sharedLoaded(): boolean {
     return this._targetLoaded;
   }
@@ -289,12 +273,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._targetLoaded = value;
   }
 
-  /**
-   * @internal Take over the target the OO `CollectionAssociation` was holding
-   * before this proxy existed, keeping the array identity so references
-   * handed out earlier stay live. Called once, from `association()`, right
-   * after construction.
-   */
+  /** @internal */
   _adoptSharedTarget(records: T[], loaded: boolean): void {
     this._target = records;
     this._targetLoaded = loaded;
@@ -973,12 +952,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (!(wrapper?.isStaleTarget?.() ?? false)) return this._target;
       // Stale (owner FK changed since load): fall through to re-query. Clear
       // the CP's cached target so the stale records don't survive
-      // `merge_target_lists`. Clearing `_targetLoaded` also clears the
-      // wrapper's `loaded` (one shared flag), which would leave
-      // `Association#association_scope` no longer *seeing* the staleness and
-      // happily reusing its cached JOIN scope built from the old foreign key —
-      // so drop that memo explicitly, exactly as Rails' `reload` does
-      // (`reset; reset_scope; load_target`, association.rb:72).
+      // `merge_target_lists`; drop the wrapper's memoized association scope
+      // too, as Rails' `reload` does (`reset; reset_scope; load_target`,
+      // association.rb:72), since the shared `loaded` flag this clears is what
+      // `Association#association_scope` used to read the staleness from.
       this._target = [];
       this._targetLoaded = false;
       wrapper?.resetScope?.();
@@ -987,9 +964,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._target = this._mergeTargetLists(results);
     this._targetLoaded = true;
     // Snapshot the owner's `@stale_state` NOW (while owner FKs still reflect
-    // the load time). The wrapper shares this proxy's `loaded` flag but not
-    // `@stale_state`, and letting the snapshot happen later — after a FK
-    // change — would capture the wrong state and mask the staleness.
+    // the load time). Letting it happen later — after a FK change — would
+    // capture the wrong state and mask the staleness.
     this._staleWrapper()?.loadedBang?.();
     return this._target;
   }
@@ -2572,11 +2548,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (assocInstance) {
       assocInstance._associationIds = null;
       // Rails' `insert_record` ends in `reset_scope` (collection_association.rb),
-      // which drops the memoized `@association_scope` — NOT `reset`, which would
-      // also drop `@target`. trails used to call the full `reset` here to stop
-      // the OO instance serving a stale copy of the target; now that the two
-      // surfaces share one array there is no copy to go stale, and resetting it
-      // would discard the very record we just added.
+      // which drops the memoized `@association_scope` — NOT `reset`, which now
+      // shares one array with this proxy and would discard the record just added.
       if (typeof assocInstance.resetScope === "function") {
         assocInstance.resetScope();
       }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -188,6 +188,16 @@ function assertValidLimit(n: number): void {
   }
 }
 
+/**
+ * The owner's `Association` wrapper, as far as staleness handling needs it.
+ * @internal
+ */
+interface StaleWrapper {
+  isStaleTarget?: () => boolean;
+  resetScope?: () => void;
+  loadedBang?: () => void;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /** @internal */
@@ -241,6 +251,53 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   get target(): T[] {
     return this._target;
+  }
+
+  /**
+   * @internal The single in-memory target this proxy shares with its OO
+   * `CollectionAssociation` (`record.association(name)`), whose `target` /
+   * `loaded` accessors read and write through here. Rails has one `@target`
+   * per association with the proxy forwarding to it; trails makes the proxy
+   * the owner of that store (RFC 0022) and the OO object the forwarder, so
+   * `replace_on_target` / `add_to_target` land in the array every reader
+   * consults instead of a parallel mirror.
+   */
+  get _sharedTarget(): T[] {
+    return this._target;
+  }
+
+  set _sharedTarget(records: T[]) {
+    this._target = records;
+  }
+
+  /**
+   * @internal Rails' `@replaced_or_added_targets` — part of the same store as
+   * `_sharedTarget`, since `replace_on_target`'s dedup rule reads both. The OO
+   * `CollectionAssociation` shares this set so a record added through one
+   * surface is not appended a second time through the other.
+   */
+  get _sharedReplacedOrAddedTargets(): Set<T> {
+    return this._replacedOrAddedTargets;
+  }
+
+  /** @internal Loaded flag for the shared target. See {@link _sharedTarget}. */
+  get _sharedLoaded(): boolean {
+    return this._targetLoaded;
+  }
+
+  set _sharedLoaded(value: boolean) {
+    this._targetLoaded = value;
+  }
+
+  /**
+   * @internal Take over the target the OO `CollectionAssociation` was holding
+   * before this proxy existed, keeping the array identity so references
+   * handed out earlier stay live. Called once, from `association()`, right
+   * after construction.
+   */
+  _adoptSharedTarget(records: T[], loaded: boolean): void {
+    this._target = records;
+    this._targetLoaded = loaded;
   }
 
   /**
@@ -916,21 +973,24 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (!(wrapper?.isStaleTarget?.() ?? false)) return this._target;
       // Stale (owner FK changed since load): fall through to re-query. Clear
       // the CP's cached target so the stale records don't survive
-      // `merge_target_lists`; leave the wrapper's loaded/stale marker intact so
-      // `Association#association_scope` sees the staleness and rebuilds its
-      // cached JOIN scope from the new foreign key (association.ts:241).
+      // `merge_target_lists`. Clearing `_targetLoaded` also clears the
+      // wrapper's `loaded` (one shared flag), which would leave
+      // `Association#association_scope` no longer *seeing* the staleness and
+      // happily reusing its cached JOIN scope built from the old foreign key —
+      // so drop that memo explicitly, exactly as Rails' `reload` does
+      // (`reset; reset_scope; load_target`, association.rb:72).
       this._target = [];
       this._targetLoaded = false;
+      wrapper?.resetScope?.();
     }
     const results = await this._execLoad();
     this._target = this._mergeTargetLists(results);
     this._targetLoaded = true;
-    // Eagerly sync the Association instance NOW (while owner FKs still reflect
-    // the load time). Without this, syncAssociationInstance fires later — after
-    // a FK change — snapshotting the wrong stale state into loadedBang.
-    if (typeof (this._record as any).association === "function") {
-      (this._record as any).association(this._assocName);
-    }
+    // Snapshot the owner's `@stale_state` NOW (while owner FKs still reflect
+    // the load time). The wrapper shares this proxy's `loaded` flag but not
+    // `@stale_state`, and letting the snapshot happen later — after a FK
+    // change — would capture the wrong state and mask the staleness.
+    this._staleWrapper()?.loadedBang?.();
     return this._target;
   }
 
@@ -1018,11 +1078,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * The owner's Association wrapper for this proxy, used to consult
    * `isStaleTarget()` (Rails `Association#stale_target?`) so a cached target is
-   * re-queried after the owner's foreign key changes.
+   * re-queried after the owner's foreign key changes, and to drop its memoized
+   * association scope when that happens.
    */
-  private _staleWrapper(): { isStaleTarget?: () => boolean } | undefined {
+  private _staleWrapper(): StaleWrapper | undefined {
     const rec = this._record as unknown as {
-      association?: (n: string) => { isStaleTarget?: () => boolean };
+      association?: (n: string) => StaleWrapper;
     };
     return typeof rec.association === "function" ? rec.association(this._assocName) : undefined;
   }
@@ -2510,13 +2571,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const assocInstance = (this._record as any)._associationInstances?.get(this._assocName);
     if (assocInstance) {
       assocInstance._associationIds = null;
-      // Mirrors Rails' `reset_scope` after insert_record — without it an
-      // instance that was previously loaded via the `record.collectionIds`
-      // reader keeps `loaded`/`target` from the pre-push fetch and returns
-      // stale data on the next read.
-      if (typeof assocInstance.reset === "function") {
-        assocInstance.reset();
+      // Rails' `insert_record` ends in `reset_scope` (collection_association.rb),
+      // which drops the memoized `@association_scope` — NOT `reset`, which would
+      // also drop `@target`. trails used to call the full `reset` here to stop
+      // the OO instance serving a stale copy of the target; now that the two
+      // surfaces share one array there is no copy to go stale, and resetting it
+      // would discard the very record we just added.
+      if (typeof assocInstance.resetScope === "function") {
+        assocInstance.resetScope();
       }
+      assocInstance._namedScopeRelations = undefined;
     }
   }
 

--- a/packages/activerecord/src/associations/collection-shared-target.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-shared-target.trails.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Trails-only: Rails keeps ONE `@target` per collection association and
+ * `CollectionProxy` forwards to it. Trails split the store in two — the
+ * user-facing `CollectionProxy` (`record._collectionProxies`, RFC 0022's
+ * canonical has_many store) and the OO `CollectionAssociation`
+ * (`record._associationInstances`), each with its own array and loaded flag —
+ * so `add_to_target` / `replace_on_target` landed in a mirror no reader
+ * consulted. These tests pin the unified store from both surfaces. Rails has no
+ * equivalent test: it has nothing to unify.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Category } from "../test-helpers/models/category.js";
+import { Categorization } from "../test-helpers/models/categorization.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+
+/** `author.posts` / `author.association("posts")`, typed for these tests. */
+interface AuthorWithCollections {
+  id: unknown;
+  posts: ProxyLike;
+  categories: { toArray(): Promise<unknown[]> };
+  association(name: string): CollectionAssociationLike & { target: unknown[] };
+}
+
+const withCollections = (author: Author): AuthorWithCollections =>
+  author as unknown as AuthorWithCollections;
+
+interface CollectionAssociationLike {
+  target: Post[];
+  loaded: boolean;
+  isLoaded(): boolean;
+  loadedBang(): void;
+  reset(): void;
+  addToTarget(record: Post, skipCallbacks?: boolean): Post;
+}
+
+interface ProxyLike {
+  target: Post[];
+  loaded: boolean;
+  build(attrs?: Record<string, unknown>): Post;
+  toArray(): Promise<Post[]>;
+  size(): Promise<number>;
+}
+
+describe("collection association and CollectionProxy share one target", () => {
+  const { authors } = fixtures(["authors", "posts", "categories", "categorizations"]);
+
+  beforeAll(() => {
+    registerModel(Author);
+    registerModel(Post);
+    registerModel(Category);
+    registerModel(Categorization);
+  });
+
+  it("the OO association and the proxy hold the same target array", async () => {
+    const author = withCollections(await Author.find(authors("david").id));
+    const proxy = author.posts;
+    const assoc = author.association("posts");
+
+    expect(assoc.target).toBe(proxy.target);
+    await proxy.toArray();
+    expect(assoc.target).toBe(proxy.target);
+    expect(assoc.target.length).toBeGreaterThan(0);
+  });
+
+  it("addToTarget on the association is visible through the proxy", async () => {
+    const author = withCollections(await Author.find(authors("david").id));
+    const proxy = author.posts;
+    const assoc = author.association("posts");
+
+    const built = Post.new({ title: "shared", body: "target" });
+    assoc.addToTarget(built);
+
+    expect(proxy.target).toContain(built);
+    // `size` on an unloaded collection is the DB count plus the buffered new
+    // records — so the OO-side add has to show up in that count too.
+    const persisted = (await Post.where({ author_id: author.id }).count()) as number;
+    expect(await proxy.size()).toBe(persisted + 1);
+  });
+
+  it("build on the proxy is visible through the association", async () => {
+    const author = withCollections(await Author.find(authors("david").id));
+    const proxy = author.posts;
+    const assoc = author.association("posts");
+
+    const built = proxy.build({ title: "from proxy", body: "body" });
+
+    expect(assoc.target).toContain(built);
+  });
+
+  it("adding the same record through both surfaces appends it once", async () => {
+    const author = withCollections(await Author.find(authors("david").id));
+    const proxy = author.posts;
+    const assoc = author.association("posts");
+
+    const built = proxy.build({ title: "once", body: "only" });
+    const before = assoc.target.length;
+    assoc.addToTarget(built);
+
+    expect(assoc.target.length).toBe(before);
+    expect(assoc.target.filter((r) => r === built).length).toBe(1);
+  });
+
+  it("loadedness is one flag, not two", async () => {
+    const author = withCollections(await Author.find(authors("david").id));
+    const proxy = author.posts;
+    const assoc = author.association("posts");
+
+    expect(proxy.loaded).toBe(false);
+    expect(assoc.isLoaded()).toBe(false);
+
+    await proxy.toArray();
+    expect(proxy.loaded).toBe(true);
+    expect(assoc.isLoaded()).toBe(true);
+
+    assoc.reset();
+    expect(proxy.loaded).toBe(false);
+    expect(proxy.target).toEqual([]);
+  });
+
+  it("a has_many :through shares its target with its proxy too", async () => {
+    const author = withCollections(await Author.find(authors("david").id));
+    const proxy = author.categories;
+    const assoc = author.association("categories");
+
+    const loaded = await proxy.toArray();
+    expect(assoc.target).toEqual(loaded);
+  });
+});

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -41,23 +41,7 @@ function buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationIn
 }
 
 function syncAssociationInstance(this: Base, name: string, instance: AssociationInstance): void {
-  // A collection instance shares its target array and loaded flag with the
-  // canonical CollectionProxy (see CollectionAssociation's `target`/`loaded`
-  // accessors), so there is nothing to copy — and copying would be actively
-  // wrong: the `_setTargetFromLoader` arm below would mark a merely-populated
-  // proxy loaded. Preload hydration for collections happens inside the proxy
-  // factory (`association()` in associations.ts), which the accessors reach.
-  //
-  // The one thing that is NOT shared is `@stale_state`: the proxy flips the
-  // shared loaded flag directly, so `loadedBang` — which takes the snapshot
-  // `isStaleTarget` diffs against — may never have run. Fill it in here, but
-  // only when it is genuinely missing: `CollectionProxy#load` re-snapshots at
-  // its own load point, and re-capturing after a foreign-key change would
-  // reset the detector and mask real staleness.
   if (instance.isCollection()) {
-    // Read `_collectionProxies` directly rather than `instance.isLoaded()`:
-    // the delegating getter would *build* the proxy, and this runs while the
-    // proxy's own constructor may be resolving its through-scope.
     const proxy = this._collectionProxies.get(name) as { loaded?: boolean } | undefined;
     if (proxy?.loaded === true && !instance._staleStateIsSnapshotted) instance.loadedBang();
     return;
@@ -159,10 +143,6 @@ export function association(this: Base, name: string): AssociationInstance {
   }
 
   const instance = buildAssociationInstance.call(this, assocDef);
-  // Cache before syncing: a collection's sync reaches the CollectionProxy,
-  // whose constructor can call back into `association(name)` while building a
-  // through-scope. Without the instance in the map that re-entry builds a
-  // second one and recurses.
   this._associationInstances.set(name, instance);
   syncAssociationInstance.call(this, name, instance);
   return instance;

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -41,7 +41,11 @@ function buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationIn
 }
 
 function syncAssociationInstance(this: Base, name: string, instance: AssociationInstance): void {
-  if (instance.isCollection()) {
+  // Optional call: `_associationInstances` also holds minimal ad-hoc holders
+  // for undeclared inverses (`associations.ts`'s literal, seed-association-cache)
+  // that implement only `target` / `isLoaded` / `setTarget`. Those are singular
+  // by construction, so falling through is right.
+  if ((instance as { isCollection?(): boolean }).isCollection?.()) {
     const proxy = this._collectionProxies.get(name) as { loaded?: boolean } | undefined;
     if (proxy?.loaded === true && !instance._staleStateIsSnapshotted) instance.loadedBang();
     return;

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -41,6 +41,27 @@ function buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationIn
 }
 
 function syncAssociationInstance(this: Base, name: string, instance: AssociationInstance): void {
+  // A collection instance shares its target array and loaded flag with the
+  // canonical CollectionProxy (see CollectionAssociation's `target`/`loaded`
+  // accessors), so there is nothing to copy — and copying would be actively
+  // wrong: the `_setTargetFromLoader` arm below would mark a merely-populated
+  // proxy loaded. Preload hydration for collections happens inside the proxy
+  // factory (`association()` in associations.ts), which the accessors reach.
+  //
+  // The one thing that is NOT shared is `@stale_state`: the proxy flips the
+  // shared loaded flag directly, so `loadedBang` — which takes the snapshot
+  // `isStaleTarget` diffs against — may never have run. Fill it in here, but
+  // only when it is genuinely missing: `CollectionProxy#load` re-snapshots at
+  // its own load point, and re-capturing after a foreign-key change would
+  // reset the detector and mask real staleness.
+  if (instance.isCollection()) {
+    // Read `_collectionProxies` directly rather than `instance.isLoaded()`:
+    // the delegating getter would *build* the proxy, and this runs while the
+    // proxy's own constructor may be resolving its through-scope.
+    const proxy = this._collectionProxies.get(name) as { loaded?: boolean } | undefined;
+    if (proxy?.loaded === true && !instance._staleStateIsSnapshotted) instance.loadedBang();
+    return;
+  }
   // Reads the loaded target through the association cache
   // (`Base#_associationCache`): a loaded collection proxy's canonical target
   // array or a loaded singular holder's target. A cached "nil association"
@@ -138,8 +159,12 @@ export function association(this: Base, name: string): AssociationInstance {
   }
 
   const instance = buildAssociationInstance.call(this, assocDef);
-  syncAssociationInstance.call(this, name, instance);
+  // Cache before syncing: a collection's sync reaches the CollectionProxy,
+  // whose constructor can call back into `association(name)` while building a
+  // through-scope. Without the instance in the map that re-entry builds a
+  // second one and recurses.
   this._associationInstances.set(name, instance);
+  syncAssociationInstance.call(this, name, instance);
   return instance;
 }
 

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -39,7 +39,16 @@ import { RecordInvalid } from "../validations.js";
  * Mirrors: ActiveRecord::Associations::SingularAssociation
  */
 export class SingularAssociation extends Association {
-  declare target: Base | null;
+  // Narrows the inherited accessor pair to the singular shape. A `declare`
+  // field would shadow the base accessors (TS2610) now that `Association`
+  // backs `target` with a getter/setter so collections can delegate theirs.
+  override get target(): Base | null {
+    return super.target as Base | null;
+  }
+
+  override set target(value: Base | Base[] | null) {
+    super.target = value;
+  }
 
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -39,9 +39,6 @@ import { RecordInvalid } from "../validations.js";
  * Mirrors: ActiveRecord::Associations::SingularAssociation
  */
 export class SingularAssociation extends Association {
-  // Narrows the inherited accessor pair to the singular shape. A `declare`
-  // field would shadow the base accessors (TS2610) now that `Association`
-  // backs `target` with a getter/setter so collections can delegate theirs.
   override get target(): Base | null {
     return super.target as Base | null;
   }


### PR DESCRIPTION
Rails keeps a single `@target` per collection association, with `CollectionProxy`
forwarding to it. trails kept two: the user-facing `CollectionProxy`
(`record._collectionProxies`, RFC 0022's canonical has_many store — consulted by
`size`/`load`, autosave, and the through build/delete paths) and the OO
`CollectionAssociation` (`record._associationInstances`), each with its own array
and loaded flag. `add_to_target` / `replace_on_target` mutated the OO mirror,
invisible to every reader that goes through the proxy.

## What changed

`CollectionAssociation` now backs `target` / `loaded` — and
`@replaced_or_added_targets`, the other half of `replace_on_target`'s state —
with the canonical proxy:

- `Association` exposes `target` / `loaded` as accessors (backed by protected
  fields) so the collection subclass can override them. `SingularAssociation`
  narrows via accessors instead of a shadowing `declare` field.
- The delegation is a plain `_collectionProxies` **lookup**, never a build:
  constructing a proxy from here would be re-entrant (its constructor resolves
  through-scopes that read back through the association) and would break
  OO-only paths where `CollectionProxy` isn't registered at all.
- Until a proxy exists there is no second store, so the inherited one serves;
  `association()` then hands the proxy that very array (`_adoptSharedTarget` —
  same object, so references already handed out stay live).

## Falling out of the unification

Four places were compensating for the split store and had to converge on Rails:

| Changed | Rails |
|---|---|
| `syncToAssociationInstance` → `_mergeLoaderResults` | `load_target`: `@target = merge_target_lists(find_target, target); loaded!` — never the raw rows, which would drop in-memory builds |
| `beginReplaceOnTarget` index guard | `replace_on_target:441`: `if replace && (!record.new_record? \|\| @replaced_or_added_targets.include?(record))`, matched by `Core#==`; the bare `indexOf` had drifted |
| `_invalidateAssociationIds` → `resetScope` | `insert_record` ends in `reset_scope` (`@association_scope = nil`), not the full `reset` that would now discard the record just added |
| `CollectionProxy#load` stale branch | `reload` = `reset; reset_scope; load_target` (`association.rb:72`) — the shared `loaded` flag no longer doubles as the staleness signal |

Not widened here: neither `finishReplaceOnTarget` nor the proxy's
`_commitToTarget` ports Rails' `@_was_loaded` flag or its
`elsif @_was_loaded || !loaded?` append guard. That gap predates this PR; both
trails copies now at least agree with each other.

`_pushThrough` is deliberately untouched — rerouting it is the dependent story
this one unblocks.

## Verification

`collection-shared-target.trails.test.ts` pins the shared store from both
surfaces (same array identity, cross-surface visibility of `addToTarget` /
`build`, single-fire dedup, one loaded flag, has_many :through). 5 of its 6
cases fail on `origin/main`.

- All 87 suites under `src/associations/` pass (1957 tests), plus autosave /
  nested-attributes / counter-cache / association-cache and root suites for
  base, relations, persistence, transactions, strict-loading, inheritance and
  HABTM destroy order (1421 tests).
- `api:compare` delta, measured with a full rebuild on both sides of
  `origin/main`: methods `7718/7813` and `11725/17544` unchanged; arity
  `7475/7558` → `7478/7561` (+3 compared, +3 matching, no new mismatches).
- `test:compare` delta: `14620/21663`, `754/1023` files — unchanged.

Closes-story: share-collection-association-target-with-proxy
