### PR TITLE
feat(api-compare): honor @noRailsEquivalent on class declarations

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -282,7 +282,11 @@ that known, and why?" — for two different gates (`api:calls` /
 report). They therefore share:
 
 - **Placement** — leading JSDoc on the declaration (class/module member,
-  getter, or top-level function).
+  getter, or top-level function). `@noRailsEquivalent` additionally reads on
+  a class, interface, or namespace DECLARATION, where it justifies the
+  declared name itself — the only inline form available to an extra that is a
+  declaration rather than a member (e.g. a class Rails nests but TS must
+  export as a sibling).
 - **Grammar** — free prose after the tag; where a key token precedes the
   reason it is em-dash-separated (`@missingRailsCall` takes a Ruby call name
   as that token, `@noRailsEquivalent` takes none); continuation lines with no

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -58,6 +58,12 @@ export interface AbstractPool {
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool::NullConfig
+ *
+ * @noRailsEquivalent Rails nests this class inside `NullPool` (`class NullPool; class NullConfig`
+ *   — connection_pool.rb:14-22), and the Ruby extractor records only the outer `NullPool`. TS
+ *   cannot declare a nested class, so it is a sibling export re-attached as `NullPool.NullConfig`
+ *   (a static, matching Rails' constant lookup path). Same class, same file, same semantics — an
+ *   extractor-shape artifact, not added surface.
  */
 export class NullConfig {
   [key: string]: unknown;
@@ -110,13 +116,6 @@ const ADAPTER_PROXY_PROBE_KEYS = new Set<string>([
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool
  */
 export class NullPool implements AbstractPool {
-  /**
-   * @noRailsEquivalent Rails nests this class inside `NullPool` (`class NullPool; class NullConfig`
-   *   — connection_pool.rb:14-22), and the Ruby extractor records only the outer `NullPool`. TS
-   *   cannot declare a nested class, so it is a sibling export re-attached as `NullPool.NullConfig`
-   *   (a static, matching Rails' constant lookup path). Same class, same file, same semantics — an
-   *   extractor-shape artifact, not added surface.
-   */
   static readonly NullConfig = NullConfig;
   static readonly NULL_CONFIG = NULL_CONFIG;
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1480,6 +1480,14 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     expect(report.tagged.matched).toBe(1);
   });
 
+  it("reports a class-declaration tag on a name that does not flag as extra surface as stale", () => {
+    const m = makeManifests("no counterpart");
+    m.ts.packages.activemodel.classes.Foo.noRailsEquivalent = "no counterpart";
+    const report = run(m);
+    expect(report.tagged.stale.map((e) => e.name)).toEqual(["Foo"]);
+    expect(report.tagged.matched).toBe(1);
+  });
+
   it("does not judge tags of packages this run never scanned", () => {
     const report = buildReport(
       makeManifests("no counterpart").ruby,

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1529,6 +1529,45 @@ describe("collectTaggedEntries", () => {
       },
     ]);
   });
+
+  it("collects a tag written on the class declaration itself", () => {
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            NullConfig: {
+              name: "NullConfig",
+              file: "connection-pool.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [],
+              noRailsEquivalent: "Rails nests this class inside NullPool",
+            },
+            NullPool: {
+              name: "NullPool",
+              file: "connection-pool.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [method("NullConfig")],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    expect(collectTaggedEntries(ts)).toEqual([
+      {
+        package: "activerecord",
+        tsFile: "connection-pool.ts",
+        name: "NullConfig",
+        reason: "Rails nests this class inside NullPool",
+      },
+    ]);
+  });
 });
 
 describe("@noRailsEquivalent — extractor to report", () => {
@@ -1604,6 +1643,48 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(report.packages[0].totalAllowlisted).toBe(1);
     expect(report.packages[0].totalNovel).toBe(0);
     expect(report.packages[0].extraFiles).toEqual([]);
+  });
+
+  it("carries a tag written on a class DECLARATION through to the Allowed totals", () => {
+    // The live NullPool/NullConfig shape: Rails nests the class, TS exports it
+    // as a sibling and re-attaches it as a static, so the extra name is the
+    // class's own — and the declaration is the only place to justify it.
+    const tsPkg = extract({
+      "connection-pool.ts": `
+        /** @noRailsEquivalent Rails nests this class inside NullPool; TS cannot */
+        export class NullConfig {}
+
+        export class NullPool {
+          static readonly NullConfig = NullConfig;
+
+          schemaCache(): void {}
+        }
+      `,
+    });
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            "ActiveRecord::ConnectionAdapters::NullPool": rubyClass({
+              name: "NullPool",
+              file: "connection_pool.rb",
+              instance: [method("schema_cache")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(
+      ruby,
+      { source: "typescript", generatedAt: "", packages: { activerecord: tsPkg } },
+      { filterPkg: null, excludeGlobs: [], novelOnly: false, topN: 50 },
+    );
+    expect(report.tagged).toEqual({ total: 1, matched: 1, stale: [] });
+    expect(report.packages[0].totalAllowlisted).toBe(1);
+    expect(report.packages[0].totalNovel).toBe(0);
   });
 });
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1538,6 +1538,34 @@ describe("collectTaggedEntries", () => {
     ]);
   });
 
+  it("keeps the member's reason when a member shares the container's name", () => {
+    // Both spellings occupy the one key the extra set has for the name, so
+    // only one reason can be reported; the member's is the specific one.
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [{ ...method("Foo"), noRailsEquivalent: "the member reason" }],
+              noRailsEquivalent: "the declaration reason",
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    expect(collectTaggedEntries(ts)).toEqual([
+      { package: "activerecord", tsFile: "foo.ts", name: "Foo", reason: "the member reason" },
+    ]);
+  });
+
   it("collects a tag written on the class declaration itself", () => {
     const ts: ApiManifest = {
       source: "typescript",

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -39,7 +39,9 @@
  *      `@noRailsEquivalent <reason>` JSDoc tag counts as `Allowed` rather
  *      than extra. Since RFC 0080 the tag is the ONLY such source — the
  *      former extra-surface-allow.json sidecar is gone — and a tag on a name
- *      that no longer flags is STALE and fails the run.
+ *      that no longer flags is STALE and fails the run. The tag is read on
+ *      members AND on class / interface / namespace declarations, so an extra
+ *      that is a declaration rather than a member still has an inline form.
  *
  * Manifests are produced by `pnpm api:compare`; if they're missing the
  * script bails with a hint (same convention as `api:moves`).
@@ -293,24 +295,31 @@ export function allowKeyOf(e: { package: string; tsFile: string; name: string })
 export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
   const out: TaggedEntry[] = [];
   const seen = new Set<string>();
-  const push = (pkg: string, tsFile: string, m: MethodInfo): void => {
-    if (m.noRailsEquivalent === undefined) return;
-    const entry = { package: pkg, tsFile, name: m.name, reason: m.noRailsEquivalent };
+  const push = (pkg: string, tsFile: string, name: string, reason: string | undefined): void => {
+    if (reason === undefined) return;
+    const entry = { package: pkg, tsFile, name, reason };
     const key = allowKeyOf(entry);
     if (seen.has(key)) return;
     seen.add(key);
     out.push(entry);
   };
+  const pushMethod = (pkg: string, tsFile: string, m: MethodInfo): void =>
+    push(pkg, tsFile, m.name, m.noRailsEquivalent);
   for (const [pkg, tsPkg] of Object.entries(ts.packages)) {
     for (const container of [tsPkg.classes, tsPkg.modules]) {
       for (const c of Object.values(container) as ClassInfo[]) {
         if (!c.file || c.reExportedFrom) continue;
-        for (const m of c.instanceMethods) push(pkg, c.file, m);
-        for (const m of c.classMethods) push(pkg, c.file, m);
+        // The container's OWN name, tagged on the class/interface/namespace
+        // declaration itself — the only inline form available to an extra that
+        // is a declaration rather than a member (e.g. a class TS must export as
+        // a sibling because it cannot nest, re-attached as a static property).
+        push(pkg, c.file, c.name, c.noRailsEquivalent);
+        for (const m of c.instanceMethods) pushMethod(pkg, c.file, m);
+        for (const m of c.classMethods) pushMethod(pkg, c.file, m);
       }
     }
     for (const [file, fns] of Object.entries(tsPkg.fileFunctions ?? {})) {
-      for (const fn of fns) push(pkg, file, fn);
+      for (const fn of fns) pushMethod(pkg, file, fn);
     }
   }
   return out;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -291,6 +291,15 @@ export function allowKeyOf(e: { package: string; tsFile: string; name: string })
  * Keys are deduped: one declaration reaches many hosts (the mixin object, the
  * install site, the auto-synthesized file module), so the same key arrives
  * repeatedly and would otherwise inflate the tag total.
+ *
+ * The key space is shared across declaration kinds by necessity, not accident:
+ * it must equal the key the extra set uses, and `collectTsFileNames` collapses
+ * a file's public surface to a Set of bare NAMES. A static and an instance
+ * method called `helper`, or a class and a member both called `Foo`, are one
+ * extra with one allowed/novel verdict, so at most one reason can ever be
+ * reported for them — namespacing a kind's key would simply stop it matching.
+ * The tie-break is first-push-wins, and members are pushed before the
+ * container so the more specific reason is the one kept.
  */
 export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
   const out: TaggedEntry[] = [];
@@ -309,13 +318,16 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
     for (const container of [tsPkg.classes, tsPkg.modules]) {
       for (const c of Object.values(container) as ClassInfo[]) {
         if (!c.file || c.reExportedFrom) continue;
+        for (const m of c.instanceMethods) pushMethod(pkg, c.file, m);
+        for (const m of c.classMethods) pushMethod(pkg, c.file, m);
         // The container's OWN name, tagged on the class/interface/namespace
         // declaration itself — the only inline form available to an extra that
         // is a declaration rather than a member (e.g. a class TS must export as
         // a sibling because it cannot nest, re-attached as a static property).
+        // LAST on purpose: a member sharing the container's name occupies the
+        // same key (see the dedup note above — one key is all the extra set
+        // has), so the more specific member reason wins the tie.
         push(pkg, c.file, c.name, c.noRailsEquivalent);
-        for (const m of c.instanceMethods) pushMethod(pkg, c.file, m);
-        for (const m of c.classMethods) pushMethod(pkg, c.file, m);
       }
     }
     for (const [file, fns] of Object.entries(tsPkg.fileFunctions ?? {})) {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1558,6 +1558,93 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(rel.instanceMethods.find((m) => m.name === "where")!.noRailsEquivalent).toBeUndefined();
   });
 
+  it("records the reason on a tagged class declaration", () => {
+    const info = extractFromFiles("/p", {
+      "connection-pool.ts": `
+        /** @noRailsEquivalent Rails nests this class inside NullPool; TS cannot */
+        export class NullConfig {}
+
+        export class NullPool {}
+      `,
+    });
+    expect(info.classes["connection-pool.ts:NullConfig"].noRailsEquivalent).toBe(
+      "Rails nests this class inside NullPool; TS cannot",
+    );
+    expect(info.classes["connection-pool.ts:NullPool"].noRailsEquivalent).toBeUndefined();
+  });
+
+  it("records the reason on a tagged interface and namespace declaration", () => {
+    const info = extractFromFiles("/p", {
+      "seams.ts": `
+        /** @noRailsEquivalent structural seam, no Rails counterpart */
+        export interface Quoting {}
+
+        /** @noRailsEquivalent trails-only locator namespace */
+        export namespace Locator {}
+
+        export interface Plain {}
+      `,
+    });
+    expect(info.modules["seams.ts:Quoting"].noRailsEquivalent).toBe(
+      "structural seam, no Rails counterpart",
+    );
+    expect(info.modules["seams.ts:Locator"].noRailsEquivalent).toBe(
+      "trails-only locator namespace",
+    );
+    expect(info.modules["seams.ts:Plain"].noRailsEquivalent).toBeUndefined();
+  });
+
+  it("keeps a declaration-merged interface's tag when the untagged half is walked first", () => {
+    const info = extractFromFiles("/p", {
+      "seams.ts": `
+        export interface Quoting {
+          quote(value: unknown): string;
+        }
+
+        /** @noRailsEquivalent structural seam, no Rails counterpart */
+        export interface Quoting {
+          quoteAsync(value: unknown): Promise<string>;
+        }
+      `,
+    });
+    expect(info.modules["seams.ts:Quoting"].noRailsEquivalent).toBe(
+      "structural seam, no Rails counterpart",
+    );
+  });
+
+  it("throws when a class declaration's tag carries no reason", () => {
+    expect(() =>
+      extractFromFiles("/p", {
+        "connection-pool.ts": `
+          /** @noRailsEquivalent */
+          export class NullConfig {}
+        `,
+      }),
+    ).toThrow(/@noRailsEquivalent needs a reason/);
+  });
+
+  it("throws when an interface declaration's tag carries no reason", () => {
+    expect(() =>
+      extractFromFiles("/p", {
+        "seams.ts": `
+          /** @noRailsEquivalent */
+          export interface Quoting {}
+        `,
+      }),
+    ).toThrow(/@noRailsEquivalent needs a reason/);
+  });
+
+  it("throws when a namespace declaration's tag carries no reason", () => {
+    expect(() =>
+      extractFromFiles("/p", {
+        "seams.ts": `
+          /** @noRailsEquivalent */
+          export namespace Locator {}
+        `,
+      }),
+    ).toThrow(/@noRailsEquivalent needs a reason/);
+  });
+
   it("throws when the tag carries no reason", () => {
     expect(() =>
       extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -480,6 +480,10 @@ export function extractFromProgram(
           for (const e of extracted.extends) {
             if (!existing.extends.includes(e)) existing.extends.push(e);
           }
+          // A declaration-merged interface only needs the tag on ONE of its
+          // declarations; without this the reason is lost whenever the tagged
+          // half is not the first one walked.
+          existing.noRailsEquivalent ??= extracted.noRailsEquivalent;
         } else {
           info.modules[modKey] = extracted;
         }
@@ -1380,6 +1384,10 @@ export function hasInternalJsDocTag(node: ts.Node): boolean {
  * the tag is absent. Unlike `@internal` (which removes the method from the
  * compared surface), this tag keeps the method counted and justifies it as
  * deliberate trails-only surface — extra-surface.ts reports it as allowlisted.
+ * Read on members, statements and properties, and on class / interface /
+ * namespace declarations (where it lands on `ClassInfo.noRailsEquivalent`) —
+ * the latter is the only inline form available to an extra whose declaration
+ * is the extra name itself.
  * Continuation lines belong to the tag and are joined into one line; the prose
  * is otherwise preserved verbatim. An empty reason is a hard error: the tag is
  * the only thing standing between a name and the extra-surface count, so an
@@ -1802,6 +1810,8 @@ export function extractClass(
     method.calls = [...merged].sort();
   }
 
+  const noRailsEquivalent = noRailsEquivalentReason(node);
+
   return {
     name,
     superclass,
@@ -1810,6 +1820,7 @@ export function extractClass(
     extends: extendsArr,
     instanceMethods,
     classMethods,
+    ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
   };
 }
 
@@ -1881,6 +1892,8 @@ function extractInterface(
     }
   }
 
+  const noRailsEquivalent = noRailsEquivalentReason(node);
+
   return {
     name,
     file,
@@ -1888,6 +1901,7 @@ function extractInterface(
     extends: extendsArr,
     instanceMethods,
     classMethods: [],
+    ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
   };
 }
 
@@ -1951,6 +1965,8 @@ function extractNamespace(
     }
   }
 
+  const noRailsEquivalent = noRailsEquivalentReason(node);
+
   return {
     name,
     file,
@@ -1958,6 +1974,7 @@ function extractNamespace(
     extends: [],
     instanceMethods,
     classMethods: [],
+    ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
   };
 }
 

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -55,7 +55,11 @@ export const SCHEMA_VERSION_BASE = 8;
  * input when it can change WITHOUT any per-method field changing; every one
  * added so far has shipped alongside the per-method field its consumer reads
  * (`synthesizedMixin` pairs with `declaredIn`), so registering the method-side
- * key already evicts entries predating the pair. Extending the token to
+ * key already evicts entries predating the pair. The one exception is
+ * `ClassInfo.noRailsEquivalent` (a tag on the class/interface/namespace
+ * DECLARATION), which can appear with no per-method field changing; it is
+ * covered by input (2) alone — the extractor edit that introduced it changed
+ * the source hashes, evicting every entry predating it. Extending the token to
  * entity-level fields is tracked separately — see the
  * `extractor-schema-entity-level-fields` story.
  */

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -119,6 +119,14 @@ export interface ClassInfo {
    * consult `MethodInfo.declaredIn`. See extract-ts-api.ts.
    */
   synthesizedMixin?: boolean;
+  /**
+   * Reason prose of an `@noRailsEquivalent` tag written on the class /
+   * interface / namespace DECLARATION itself, justifying the declared name as
+   * deliberate trails-only surface. Members carry their own tag on
+   * `MethodInfo.noRailsEquivalent`; this is the container-level form, needed
+   * for extras that are declarations rather than members (RFC 0080).
+   */
+  noRailsEquivalent?: string;
 }
 
 export interface PackageInfo {


### PR DESCRIPTION
`@noRailsEquivalent` was only read at member, statement and property emit
sites. A tag written on a class declaration was silently ignored — the
failure found in #5343, where `NullConfig` in
`connection-adapters/abstract/connection-pool.ts` had to be justified on the
static property `NullPool.NullConfig` instead of on the class it describes.

## What changed

- `noRailsEquivalentReason` is now called on class, interface and namespace
  declarations; the reason lands on `ClassInfo.noRailsEquivalent`.
- `collectTaggedEntries` pushes a container-level entry keyed by the declared
  name, alongside the member entries it already collected.
- A declaration-merged interface keeps its tag whichever half carries it.
- `NullConfig`'s justification moved onto the class declaration.
- Docs: the placement note in `api-build-stub-generation-plan.md`, and the
  `extractor-schema.ts` invariant that this is the first entity-level field
  with no paired per-method field (safe via the source-hash backstop, which
  the extractor edit itself trips).

The empty-reason guard (`@noRailsEquivalent needs a reason`) and the
truncated-reason guard extend to the new sites for free — both live inside
`noRailsEquivalentReason` — and there are tests for each new declaration kind.

## Verification

`pnpm api:extra --package activerecord` reports
`connection-adapters/abstract/connection-pool.ts` at **0 novel** with the tag
counted and not stale. Removing the new container-level push (negative
control) puts it back to **1 novel**, so the class-declaration read is
load-bearing. Full run: 80 tags, 80 matched, 0 stale. The only-shrink gate
holds at the new site too: a class-declaration tag on a name that no longer
flags is reported STALE (covered by a test).

## Blocker audit for `retire-extra-surface-allow-json`

That JSON is already gone (#5399), so there is no entry list left to audit.
Auditing the equivalent question — extras with no inline form — the answer is
none: every extra name comes from `collectTsFileNames`, which only walks
`instanceMethods` / `classMethods` / `fileFunctions`, so an extra is always a
`MethodInfo` and always has a member-side tag site. `NullConfig` was the one
case where that site was the wrong place to argue the point, and it now has
the right one. Type aliases are not extracted at all and can never surface as
extras, so they need no tag site.

Closes-story: no-rails-equivalent-tag-on-class-declarations
