### PR TITLE
test(api-compare): pin the MethodInfo emit-site inventory

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -22,6 +22,7 @@ import {
   packageFingerprint,
   tsLiteralValue,
 } from "./extract-ts-api.js";
+import { collectTsFileNames } from "./extra-surface.js";
 import { overlappingSubDirs, packageSrcDir } from "./config.js";
 import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
@@ -1668,17 +1669,12 @@ describe("sub-package de-overlap", () => {
 /**
  * Every `MethodInfo` emit site in the extractor, pinned in one fixture.
  *
- * Adding a per-method declaration-derived field (`@missingRailsCall` is the
- * obvious next one) means visiting every site that must copy it. There is no
- * mechanical way to enumerate those sites from the source, so PR #5358 found
- * them one review round at a time and guessed wrong twice. This fixture tags
- * EVERY declaration the extractor can reach and asserts, per emitted entry,
- * whether the tag came through — so a new field with a missed site fails here
- * instead of in review.
- *
- * The rule (see the emit-site comment block in extract-ts-api.ts): an entry
- * must carry declaration-derived metadata iff `collectTsFileNames`
- * (extra-surface.ts) counts it as the file's own surface.
+ * Adding a per-method declaration-derived field means visiting every site that
+ * must copy it, and there is no mechanical way to enumerate those sites from
+ * the source — PR #5358 found them one review round at a time and guessed
+ * wrong twice. This fixture tags EVERY declaration the extractor can reach, so
+ * a new field with a missed site fails here instead of in review. The rule it
+ * encodes lives in the extract-ts-api.ts module comment.
  */
 const EMIT_SITE_FIXTURE: Record<string, string> = {
   "mixin-base.ts": `
@@ -1771,7 +1767,7 @@ interface EmitEntry {
   /** Container key, or `<fileFunctions>` for the per-file function list. */
   container: string;
   name: string;
-  /** Does `collectTsFileNames` count this entry as `emit-sites.ts`'s surface? */
+  /** Does `collectTsFileNames` count this entry as the file's own surface? */
   counted: boolean;
   /** Did the declaration's `@noRailsEquivalent` tag reach this entry? */
   hasReason: boolean;
@@ -1779,9 +1775,10 @@ interface EmitEntry {
 
 /**
  * Flatten every entry the extractor emitted for `file`, tagging each with the
- * `collectTsFileNames` counted-ness that decides whether it must carry
- * declaration-derived metadata. Mirrors that function's filter deliberately:
- * if the two drift, this fixture's expectations stop meaning what they say.
+ * counted-ness that decides whether it must carry declaration-derived
+ * metadata. `collectTsFileNames` only exposes a per-file name Set, so the
+ * filter is restated here for per-entry granularity; the drift that invites is
+ * caught by the cross-check test below.
  */
 function emitInventory(info: PackageInfo, file: string): EmitEntry[] {
   const out: EmitEntry[] = [];
@@ -1799,8 +1796,8 @@ function emitInventory(info: PackageInfo, file: string): EmitEntry[] {
     for (const m of c.classMethods) push(key, m, skipForeign);
   }
   for (const m of info.fileFunctions[file] ?? []) push("<fileFunctions>", m, false);
-  // Plain code-unit ordering, not localeCompare: the expected table below is
-  // written out by hand and must not shift with the host's collation.
+  // Code-unit ordering, not localeCompare: the hand-written table below must
+  // not shift with the host's collation.
   return out.sort((a, b) => {
     const ka = `${a.container}#${a.name}`;
     const kb = `${b.container}#${b.name}`;
@@ -1809,18 +1806,18 @@ function emitInventory(info: PackageInfo, file: string): EmitEntry[] {
 }
 
 /**
- * The pinned inventory. Every entry below has a tagged declaration behind it
- * except the three noted:
+ * The pinned inventory. Every entry has a tagged declaration behind it and so
+ * expects `hasReason: true`, except four:
  *
- * - `<fileFunctions>#Attributes` — the mixin factory itself, left untagged so
- *   an untagged counted site is represented too.
+ * - `<fileFunctions>#Attributes` — the mixin factory, left untagged so an
+ *   untagged counted site is represented too.
  * - `<fileFunctions>#aliasTarget` / `#shorthandRef` — `extractFileLocalHelpers`
- *   output, always `internal: true`, so not counted and never metadata-bearing.
+ *   output, always `internal: true`, so uncounted and never metadata-bearing.
  * - `Attributes__mixin#constructor` — synthesized from the factory's construct
  *   signature; counted, but there is no member declaration to read a tag off.
  * - `<fileFunctions>#renamedExport` — an untagged `export { x as y }` alias
- *   deliberately drops the declaration's reason: the reason justifies the
- *   declared spelling, not the alias. `#taggedAlias` is the tagged form.
+ *   drops the declaration's reason: the reason justifies the declared
+ *   spelling, not the alias. `#taggedAlias` is the tagged form.
  */
 const EMIT_SITE_INVENTORY: EmitEntry[] = [
   { container: "<fileFunctions>", name: "Attributes", counted: true, hasReason: false },
@@ -1866,30 +1863,26 @@ const EMIT_SITE_INVENTORY: EmitEntry[] = [
 describe("extract-ts-api — MethodInfo emit-site inventory", () => {
   it("pins every emit site and whether declaration-derived metadata reaches it", () => {
     const info = extractFromFiles("/p", EMIT_SITE_FIXTURE);
-    // An exact match, not a superset: a NEW emit site shows up here as an
-    // unexpected entry, which is the whole point of the fixture.
+    // Exact match, not a superset: a NEW emit site shows up as an unexpected
+    // entry, and a field that misses an existing site flips `hasReason`.
     expect(emitInventory(info, "emit-sites.ts")).toEqual(EMIT_SITE_INVENTORY);
   });
 
-  it("keeps declaration-derived metadata off entries collectTsFileNames does not count", () => {
+  it("agrees with collectTsFileNames about which entries the file owns", () => {
     const info = extractFromFiles("/p", EMIT_SITE_FIXTURE);
-    // A tag on an uncounted entry can never match its file's Rails surface —
-    // it reads as a stale allowlist entry on top of the correct match on the
-    // declaring file. See the `__mixin` foreign-member case in #5358.
-    const leaked = emitInventory(info, "emit-sites.ts").filter((e) => !e.counted && e.hasReason);
-    expect(leaked).toEqual([]);
-  });
-
-  it("carries the tag onto every counted entry whose declaration has one", () => {
-    const info = extractFromFiles("/p", EMIT_SITE_FIXTURE);
-    const missing = emitInventory(info, "emit-sites.ts").filter(
-      (e) =>
-        e.counted &&
-        !e.hasReason &&
-        !(e.container === "<fileFunctions>" && e.name === "Attributes") &&
-        !(e.container === "<fileFunctions>" && e.name === "renamedExport") &&
-        !(e.container.endsWith("__mixin") && e.name === "constructor"),
+    const file = "emit-sites.ts";
+    const counted = new Set(
+      emitInventory(info, file)
+        .filter((e) => e.counted)
+        .map((e) => e.name),
     );
-    expect(missing).toEqual([]);
+    expect(counted).toEqual(
+      collectTsFileNames(
+        file,
+        Object.values(info.classes),
+        Object.values(info.modules),
+        info.fileFunctions[file],
+      ),
+    );
   });
 });

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1664,3 +1664,232 @@ describe("sub-package de-overlap", () => {
     expect(Object.keys(deOverlapped.classes)).toEqual(["parent.ts:Parent"]);
   });
 });
+
+/**
+ * Every `MethodInfo` emit site in the extractor, pinned in one fixture.
+ *
+ * Adding a per-method declaration-derived field (`@missingRailsCall` is the
+ * obvious next one) means visiting every site that must copy it. There is no
+ * mechanical way to enumerate those sites from the source, so PR #5358 found
+ * them one review round at a time and guessed wrong twice. This fixture tags
+ * EVERY declaration the extractor can reach and asserts, per emitted entry,
+ * whether the tag came through — so a new field with a missed site fails here
+ * instead of in review.
+ *
+ * The rule (see the emit-site comment block in extract-ts-api.ts): an entry
+ * must carry declaration-derived metadata iff `collectTsFileNames`
+ * (extra-surface.ts) counts it as the file's own surface.
+ */
+const EMIT_SITE_FIXTURE: Record<string, string> = {
+  "mixin-base.ts": `
+    export class MixinBase {
+      /** @noRailsEquivalent mixin foreign member */
+      foreign(): void {}
+    }
+  `,
+  "iface-base.ts": `
+    export interface IfaceBase {
+      /** @noRailsEquivalent interface extends-resolved member */
+      inherited(): void;
+    }
+  `,
+  "emit-sites.ts": `
+    import { MixinBase } from "./mixin-base.js";
+    import type { IfaceBase } from "./iface-base.js";
+
+    export class Widget {
+      /** @noRailsEquivalent class constructor */
+      constructor() {}
+
+      /** @noRailsEquivalent class method */
+      render(): void {}
+
+      /** @noRailsEquivalent class getter */
+      get sizeRead(): number { return 1; }
+
+      /** @noRailsEquivalent class setter */
+      set sizeWrite(value: number) {}
+
+      /** @noRailsEquivalent class property */
+      label: string = "";
+
+      /** @noRailsEquivalent class static method */
+      static build(): void {}
+    }
+
+    /** @noRailsEquivalent top-level exported function */
+    export function topLevel(): void {}
+
+    /** @noRailsEquivalent export-list alias target */
+    export function renameSource(): void {}
+    export { renameSource as renamedExport };
+
+    /** @noRailsEquivalent export-list alias own reason */
+    export { renameSource as taggedAlias };
+
+    /** @noRailsEquivalent object-literal shorthand target */
+    function shorthandRef(): void {}
+
+    function aliasTarget(): void {}
+
+    const NS = {
+      /** @noRailsEquivalent object-literal alias target */
+      target: aliasTarget,
+    };
+
+    export const Registry = {
+      /** @noRailsEquivalent object-literal inline method */
+      inline(): void {},
+      shorthandRef,
+      aliasRef: NS.target,
+    };
+
+    export namespace Locator {
+      /** @noRailsEquivalent namespace function */
+      export function findIt(): void {}
+
+      /** @noRailsEquivalent namespace const */
+      export const findConst = (): void => {};
+    }
+
+    export interface Quoting extends IfaceBase {
+      /** @noRailsEquivalent interface method signature */
+      quoteAsync(value: unknown): Promise<string>;
+    }
+
+    export function Attributes(Base: typeof MixinBase) {
+      class M extends Base {
+        /** @noRailsEquivalent mixin own member */
+        ownMember(): void {}
+      }
+      return M;
+    }
+  `,
+};
+
+interface EmitEntry {
+  /** Container key, or `<fileFunctions>` for the per-file function list. */
+  container: string;
+  name: string;
+  /** Does `collectTsFileNames` count this entry as `emit-sites.ts`'s surface? */
+  counted: boolean;
+  /** Did the declaration's `@noRailsEquivalent` tag reach this entry? */
+  hasReason: boolean;
+}
+
+/**
+ * Flatten every entry the extractor emitted for `file`, tagging each with the
+ * `collectTsFileNames` counted-ness that decides whether it must carry
+ * declaration-derived metadata. Mirrors that function's filter deliberately:
+ * if the two drift, this fixture's expectations stop meaning what they say.
+ */
+function emitInventory(info: PackageInfo, file: string): EmitEntry[] {
+  const out: EmitEntry[] = [];
+  const push = (container: string, m: MethodInfo, skipForeign: boolean): void => {
+    const counted =
+      m.internal !== true &&
+      !m.name.startsWith("_") &&
+      !(skipForeign && m.declaredIn !== undefined);
+    out.push({ container, name: m.name, counted, hasReason: m.noRailsEquivalent !== undefined });
+  };
+  for (const [key, c] of Object.entries({ ...info.classes, ...info.modules })) {
+    if (c.file !== file) continue;
+    const skipForeign = c.synthesizedMixin === true;
+    for (const m of c.instanceMethods) push(key, m, skipForeign);
+    for (const m of c.classMethods) push(key, m, skipForeign);
+  }
+  for (const m of info.fileFunctions[file] ?? []) push("<fileFunctions>", m, false);
+  // Plain code-unit ordering, not localeCompare: the expected table below is
+  // written out by hand and must not shift with the host's collation.
+  return out.sort((a, b) => {
+    const ka = `${a.container}#${a.name}`;
+    const kb = `${b.container}#${b.name}`;
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+}
+
+/**
+ * The pinned inventory. Every entry below has a tagged declaration behind it
+ * except the three noted:
+ *
+ * - `<fileFunctions>#Attributes` — the mixin factory itself, left untagged so
+ *   an untagged counted site is represented too.
+ * - `<fileFunctions>#aliasTarget` / `#shorthandRef` — `extractFileLocalHelpers`
+ *   output, always `internal: true`, so not counted and never metadata-bearing.
+ * - `Attributes__mixin#constructor` — synthesized from the factory's construct
+ *   signature; counted, but there is no member declaration to read a tag off.
+ * - `<fileFunctions>#renamedExport` — an untagged `export { x as y }` alias
+ *   deliberately drops the declaration's reason: the reason justifies the
+ *   declared spelling, not the alias. `#taggedAlias` is the tagged form.
+ */
+const EMIT_SITE_INVENTORY: EmitEntry[] = [
+  { container: "<fileFunctions>", name: "Attributes", counted: true, hasReason: false },
+  { container: "<fileFunctions>", name: "aliasTarget", counted: false, hasReason: false },
+  { container: "<fileFunctions>", name: "renameSource", counted: true, hasReason: true },
+  { container: "<fileFunctions>", name: "renamedExport", counted: true, hasReason: false },
+  { container: "<fileFunctions>", name: "shorthandRef", counted: false, hasReason: false },
+  { container: "<fileFunctions>", name: "taggedAlias", counted: true, hasReason: true },
+  { container: "<fileFunctions>", name: "topLevel", counted: true, hasReason: true },
+  {
+    container: "emit-sites.ts:Attributes__mixin",
+    name: "constructor",
+    counted: true,
+    hasReason: false,
+  },
+  {
+    container: "emit-sites.ts:Attributes__mixin",
+    name: "foreign",
+    counted: false,
+    hasReason: false,
+  },
+  {
+    container: "emit-sites.ts:Attributes__mixin",
+    name: "ownMember",
+    counted: true,
+    hasReason: true,
+  },
+  { container: "emit-sites.ts:Locator", name: "findConst", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Locator", name: "findIt", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Quoting", name: "inherited", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Quoting", name: "quoteAsync", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Registry", name: "aliasRef", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Registry", name: "inline", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Registry", name: "shorthandRef", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Widget", name: "build", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Widget", name: "constructor", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Widget", name: "label", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Widget", name: "render", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Widget", name: "sizeRead", counted: true, hasReason: true },
+  { container: "emit-sites.ts:Widget", name: "sizeWrite", counted: true, hasReason: true },
+];
+
+describe("extract-ts-api — MethodInfo emit-site inventory", () => {
+  it("pins every emit site and whether declaration-derived metadata reaches it", () => {
+    const info = extractFromFiles("/p", EMIT_SITE_FIXTURE);
+    // An exact match, not a superset: a NEW emit site shows up here as an
+    // unexpected entry, which is the whole point of the fixture.
+    expect(emitInventory(info, "emit-sites.ts")).toEqual(EMIT_SITE_INVENTORY);
+  });
+
+  it("keeps declaration-derived metadata off entries collectTsFileNames does not count", () => {
+    const info = extractFromFiles("/p", EMIT_SITE_FIXTURE);
+    // A tag on an uncounted entry can never match its file's Rails surface —
+    // it reads as a stale allowlist entry on top of the correct match on the
+    // declaring file. See the `__mixin` foreign-member case in #5358.
+    const leaked = emitInventory(info, "emit-sites.ts").filter((e) => !e.counted && e.hasReason);
+    expect(leaked).toEqual([]);
+  });
+
+  it("carries the tag onto every counted entry whose declaration has one", () => {
+    const info = extractFromFiles("/p", EMIT_SITE_FIXTURE);
+    const missing = emitInventory(info, "emit-sites.ts").filter(
+      (e) =>
+        e.counted &&
+        !e.hasReason &&
+        !(e.container === "<fileFunctions>" && e.name === "Attributes") &&
+        !(e.container === "<fileFunctions>" && e.name === "renamedExport") &&
+        !(e.container.endsWith("__mixin") && e.name === "constructor"),
+    );
+    expect(missing).toEqual([]);
+  });
+});

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -3,6 +3,31 @@
  * Extracts the public API surface from our TypeScript packages.
  * Uses the TypeScript Compiler API.
  * Outputs output/ts-api.json
+ *
+ * ## Adding a per-method field derived from a declaration
+ *
+ * A `MethodInfo` is constructed in ~10 places here (class members, the
+ * `__mixin` synthesis, the named-export list, object literals, file-local
+ * helpers, interface signatures, interface `extends`-resolved members,
+ * namespace functions and consts, top-level functions). Whether a
+ * declaration-derived field (`internal`, `noRailsEquivalent`, …) must be
+ * copied at a given site is decided by ONE thing: whether
+ * `collectTsFileNames` (extra-surface.ts) counts that entry as the file's
+ * own surface. That function is the authority — read it, don't reason by
+ * analogy.
+ *
+ * - counted → the site MUST read the declaration's metadata.
+ * - not counted → it MUST NOT: the copied value can never match this file's
+ *   Rails surface, so it reads as stale on top of the correct match on the
+ *   declaring file. Only two populations are uncounted: `__mixin` members
+ *   carrying `declaredIn` (skipped via `synthesizedMixin`) and
+ *   `extractFileLocalHelpers` output (always `internal: true`).
+ *
+ * Interface `extends`-resolved members are the trap: they carry no
+ * `declaredIn`, so they ARE counted — the `__mixin` analogy gets it backwards.
+ *
+ * The full inventory is pinned by "MethodInfo emit-site inventory" in
+ * extract-ts-api.test.ts; extend that fixture when you add a field.
  */
 
 import * as ts from "typescript";

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -6,15 +6,11 @@
  *
  * ## Adding a per-method field derived from a declaration
  *
- * A `MethodInfo` is constructed in ~10 places here (class members, the
- * `__mixin` synthesis, the named-export list, object literals, file-local
- * helpers, interface signatures, interface `extends`-resolved members,
- * namespace functions and consts, top-level functions). Whether a
+ * A `MethodInfo` is constructed in ~10 places here. Whether a
  * declaration-derived field (`internal`, `noRailsEquivalent`, …) must be
  * copied at a given site is decided by ONE thing: whether
- * `collectTsFileNames` (extra-surface.ts) counts that entry as the file's
- * own surface. That function is the authority — read it, don't reason by
- * analogy.
+ * `collectTsFileNames` (extra-surface.ts) counts that entry as the file's own
+ * surface. That function is the authority — read it, don't reason by analogy.
  *
  * - counted → the site MUST read the declaration's metadata.
  * - not counted → it MUST NOT: the copied value can never match this file's


### PR DESCRIPTION
## What

Pins the `MethodInfo` emit-site inventory in `scripts/api-compare/extract-ts-api.ts` with a coverage test, plus a module comment stating the rule that decides each site.

PR #5358 wired `@noRailsEquivalent` through the extractor and took five review rounds, each finding one more emit site the tag didn't reach. Whether a declaration-derived field must be copied at a site depends on one thing: whether `collectTsFileNames` (`extra-surface.ts`) counts that entry as the file's own surface. There was no mechanical way to enumerate the sites, so completeness was asserted from grep and was wrong twice.

## How

- **`extract-ts-api.ts`** — module JSDoc block stating the counted-vs-not rule, naming `collectTsFileNames` as the authority, listing the only two uncounted populations (`__mixin` members with `declaredIn`, `extractFileLocalHelpers` output), and calling out the interface `extends`-resolved trap (no `declaredIn` → counted; the `__mixin` analogy gets it backwards).
- **`extract-ts-api.test.ts`** — one fixture tagging every reachable declaration across every emit path: class method / getter / setter / property / static / constructor, top-level function, export-list alias (tagged and untagged), object-literal inline / shorthand / property alias, namespace function and const, interface method signature, interface `extends`-resolved member, `__mixin` own and foreign member, file-local helper. `emitInventory` flattens the result and tags each entry with its counted-ness; the inventory is asserted exactly, so a NEW emit site fails as an unexpected entry and a field that misses an existing site flips that entry's `hasReason`.
- A second test holds `emitInventory`'s restatement of the counted-vs-not filter to the real rule by comparing its counted names against `collectTsFileNames` itself — otherwise the fixture's `counted` column could silently drift out of agreement with the authority it claims to encode.

Four documented `hasReason: false` entries: the untagged mixin factory itself, the two `extractFileLocalHelpers` outputs (uncounted, so metadata must NOT reach them), the synthesized `__mixin` constructor (no member declaration to read), and an untagged `export { x as y }` alias (the reason justifies the declared spelling, not the alias — `taggedAlias` covers the tagged form).

No behavior change — this is a guard for the NEXT per-method field (`@missingRailsCall` from #5229 is the obvious candidate).

## Test

`pnpm vitest run scripts/api-compare/extract-ts-api.test.ts` — 97 passed.

Both tests were mutation-checked: dropping `...tagged` from the class-getter emit site fails the inventory table on `sizeRead`, and loosening `emitInventory`'s foreign-member filter fails the `collectTsFileNames` cross-check.

Closes-story: pin-methodinfo-emit-site-inventory
