### PR TITLE
feat(api-compare): gate the @missingRailsCall empty-reason contract in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1390,6 +1390,14 @@ jobs:
         # for the advisory arity check, applied by the API comparison step
         # above). Excludes only shrink — delete a converged entry by hand.
         run: pnpm exec tsx scripts/api-compare/lint-arity-excludes.ts
+      - name: Missing-call reasons gate
+        # Enforces the `@missingRailsCall` empty-reason contract (the same
+        # `parseJsdoc` check `api:build` uses) over every JSDoc block under
+        # packages/*/src. Read-only and artifact-free: `api:build` itself is
+        # opt-in and rewrites files, so without this step a hand-authored bare
+        # tag would sit undetected. See the empty-reason bullet in
+        # docs/infrastructure/api-build-stub-generation-plan.md.
+        run: pnpm exec tsx scripts/api-compare/lint-missing-rails-call-reasons.ts
       - name: Body-pins gate
         # Source-hash pinning (RFC 0025). Fails when a pinned pair's normalized
         # Rails body digest drifts from the current vendored source

--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -314,6 +314,17 @@ report). They therefore share:
     allowlist entry into a blessed one, which is exactly the failure mode the
     sibling tag rejects.
 
+  Where each is **enforced in CI** — the parser-level rule only bites if
+  something in CI runs it:
+  - `@noRailsEquivalent`: `noRailsEquivalentReason` runs inside the TS
+    extractor, so every `api:extra` / `api:compare` invocation gates it.
+  - `@missingRailsCall`: `parseJsdoc`'s sole caller is `api:build`, an opt-in
+    developer command with no CI job. `pnpm api:reasons`
+    (`lint-missing-rails-call-reasons.ts`) closes that gap and runs in the
+    Rails API/Test Comparison job: it feeds every JSDoc block under
+    `packages/*/src` through the same `parseJsdoc` check — read-only, no
+    second parser, and with no dependency on the wide call-mismatch artifact.
+
   The placeholder path is unaffected: a generator-authored placeholder is a
   non-empty reason, so it parses, round-trips byte-for-byte via `rawLines`,
   and still drops without a harvest report when the call converges. Reason

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "api:drift": "pnpm tsx scripts/api-compare/drift.ts",
     "api:extra": "pnpm tsx scripts/api-compare/extra-surface.ts",
     "api:build": "pnpm tsx scripts/api-compare/build.ts",
+    "api:reasons": "pnpm tsx scripts/api-compare/lint-missing-rails-call-reasons.ts",
     "api:calls": "pnpm tsx scripts/api-compare/lint-call-mismatches.ts",
     "api:calls:reseed": "API_COMPARE_FORCE=1 pnpm api:compare && pnpm tsx scripts/api-compare/lint-call-mismatches.ts --write",
     "api:calls:wide": "pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts",

--- a/scripts/api-compare/lint-missing-rails-call-reasons.test.ts
+++ b/scripts/api-compare/lint-missing-rails-call-reasons.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { lintFileText, listSourceFiles, main } from "./lint-missing-rails-call-reasons.js";
+
+describe("lintFileText", () => {
+  it("accepts a tag that carries a reason", () => {
+    const text = [
+      "/**",
+      " * @missingRailsCall save! — validations are enforced by the caller.",
+      " */",
+      "function f() {}",
+    ].join("\n");
+    expect(lintFileText("a.ts", text)).toEqual([]);
+  });
+
+  it("rejects a bare tag with a file:line and the parser's message shape", () => {
+    const text = ["", "/**", " * @missingRailsCall save!", " */", "function f() {}"].join("\n");
+    expect(lintFileText("packages/x/src/a.ts", text)).toEqual([
+      "@missingRailsCall needs a reason: packages/x/src/a.ts:3 — state why the " +
+        "Rails call `save!` is not made here.",
+    ]);
+  });
+
+  it("rejects a whitespace-only reason", () => {
+    const text = ["/**", " * @missingRailsCall save! —   ", " */"].join("\n");
+    expect(lintFileText("a.ts", text)).toHaveLength(1);
+  });
+
+  it("reports every offending comment in a file, not just the first", () => {
+    const text = [
+      "/**",
+      " * @missingRailsCall save!",
+      " */",
+      "function f() {}",
+      "/**",
+      " * @missingRailsCall touch",
+      " */",
+      "function g() {}",
+    ].join("\n");
+    expect(lintFileText("a.ts", text)).toHaveLength(2);
+  });
+
+  it("ignores files and comments without the tag", () => {
+    expect(lintFileText("a.ts", "/** plain prose */\nfunction f() {}")).toEqual([]);
+  });
+});
+
+describe("listSourceFiles", () => {
+  it("returns nothing for a directory that does not exist", async () => {
+    expect(await listSourceFiles("/nonexistent-packages-dir")).toEqual([]);
+  });
+});
+
+describe("main", () => {
+  it("passes over the committed tree", async () => {
+    expect(await main()).toBe(0);
+  });
+});

--- a/scripts/api-compare/lint-missing-rails-call-reasons.test.ts
+++ b/scripts/api-compare/lint-missing-rails-call-reasons.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { lintFileText, listSourceFiles, main } from "./lint-missing-rails-call-reasons.js";
 
 describe("lintFileText", () => {
@@ -8,6 +11,17 @@ describe("lintFileText", () => {
       " * @missingRailsCall save! — validations are enforced by the caller.",
       " */",
       "function f() {}",
+    ].join("\n");
+    expect(lintFileText("a.ts", text)).toEqual([]);
+  });
+
+  it("accepts a reason that wraps onto continuation lines", () => {
+    const text = [
+      "/**",
+      " * @missingRailsCall save! — the caller already ran the full",
+      " *   validation chain, so re-running it here would double the",
+      " *   callbacks.",
+      " */",
     ].join("\n");
     expect(lintFileText("a.ts", text)).toEqual([]);
   });
@@ -45,8 +59,39 @@ describe("lintFileText", () => {
 });
 
 describe("listSourceFiles", () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "api-reasons-"));
+    const write = async (rel: string) => {
+      const abs = path.join(dir, rel);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, "");
+    };
+    await write(path.join("activerecord", "src", "base.ts"));
+    await write(path.join("activerecord", "src", "relation", "query-methods.ts"));
+    await write(path.join("activerecord", "src", "base.test.ts"));
+    await write(path.join("activerecord", "src", "README.md"));
+    await write(path.join("activerecord", "src", "dist", "base.ts"));
+    await write(path.join("activerecord", "src", "node_modules", "dep", "index.ts"));
+    await write(path.join("activerecord", "dist", "base.ts"));
+    await write(path.join("arel", "no-src-dir.ts"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("collects nested .ts files under each package's src, tests included", async () => {
+    expect((await listSourceFiles(dir)).map((f) => path.relative(dir, f))).toEqual([
+      path.join("activerecord", "src", "base.test.ts"),
+      path.join("activerecord", "src", "base.ts"),
+      path.join("activerecord", "src", "relation", "query-methods.ts"),
+    ]);
+  });
+
   it("returns nothing for a directory that does not exist", async () => {
-    expect(await listSourceFiles("/nonexistent-packages-dir")).toEqual([]);
+    expect(await listSourceFiles(path.join(dir, "missing"))).toEqual([]);
   });
 });
 

--- a/scripts/api-compare/lint-missing-rails-call-reasons.ts
+++ b/scripts/api-compare/lint-missing-rails-call-reasons.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env npx tsx
+/**
+ * api:reasons — enforce the `@missingRailsCall` empty-reason contract in CI.
+ *
+ * `parseJsdoc` (build.ts) already rejects a bare or whitespace-only tag, but
+ * its only caller is `api:build`, an opt-in developer command with no CI job:
+ * a hand-authored bare tag can sit in the tree undetected until someone
+ * happens to reconcile that file. This lint runs the SAME check over every
+ * JSDoc block under `packages/<pkg>/src`, read-only and with no dependency on the
+ * wide call-mismatch artifact, so the tag is gated like its sibling
+ * `@noRailsEquivalent` (validated by `noRailsEquivalentReason` on every
+ * `api:extra` / `api:compare` run).
+ *
+ * Usage:
+ *   pnpm api:reasons
+ *
+ * Hard rules: no node:* imports, no process.* outside the CLI entry guard.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { ROOT_DIR } from "./config.js";
+import { TAG, parseJsdoc } from "./build.js";
+
+const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
+const SKIP_DIRS = new Set(["node_modules", "dist"]);
+const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
+
+/** Every `.ts` file under `<packages>/<pkg>/src`, sorted for stable output. */
+export async function listSourceFiles(packagesDir: string): Promise<string[]> {
+  const walk = async (dir: string): Promise<string[]> => {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const found = await Promise.all(
+      entries.map(async (entry) => {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) return SKIP_DIRS.has(entry.name) ? [] : walk(abs);
+        return entry.name.endsWith(".ts") ? [abs] : [];
+      }),
+    );
+    return found.flat();
+  };
+  let pkgs;
+  try {
+    pkgs = await fs.readdir(packagesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const perPackage = await Promise.all(
+    pkgs.filter((p) => p.isDirectory()).map((p) => walk(path.join(packagesDir, p.name, "src"))),
+  );
+  return perPackage.flat().sort();
+}
+
+/** Run `parseJsdoc`'s empty-reason check over one file's JSDoc blocks.
+ *  Returns the (possibly empty) list of error messages — never throws, so one
+ *  bad tag doesn't hide the rest. */
+export function lintFileText(fileName: string, text: string): string[] {
+  if (!text.includes(TAG)) return [];
+  const errors: string[] = [];
+  for (const match of text.matchAll(JSDOC_BLOCK)) {
+    const comment = match[0];
+    if (!comment.includes(TAG)) continue;
+    const startLine = text.slice(0, match.index).split("\n").length;
+    try {
+      parseJsdoc(comment, { fileName, startLine });
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+  return errors;
+}
+
+export async function main(): Promise<number> {
+  const files = await listSourceFiles(PACKAGES_DIR);
+  const errors: string[] = [];
+  for (const abs of files) {
+    const text = await fs.readFile(abs, "utf-8");
+    errors.push(...lintFileText(path.relative(ROOT_DIR, abs), text));
+  }
+  if (errors.length > 0) {
+    for (const e of errors) console.error(`api:reasons: ${e}`);
+    console.error(
+      `api:reasons: ${errors.length} tag(s) without a reason — see the empty-reason ` +
+        "contract in docs/infrastructure/api-build-stub-generation-plan.md.",
+    );
+    return 1;
+  }
+  console.log(`api:reasons: ${files.length} file(s) checked, every ${TAG} carries a reason.`);
+  return 0;
+}
+
+async function runAsScript(): Promise<void> {
+  const self = fileURLToPath(import.meta.url);
+  const invoked = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  if (path.resolve(self) !== invoked) return;
+  process.exit(await main());
+}
+
+void runAsScript();

--- a/scripts/api-compare/lint-missing-rails-call-reasons.ts
+++ b/scripts/api-compare/lint-missing-rails-call-reasons.ts
@@ -3,13 +3,12 @@
  * api:reasons — enforce the `@missingRailsCall` empty-reason contract in CI.
  *
  * `parseJsdoc` (build.ts) already rejects a bare or whitespace-only tag, but
- * its only caller is `api:build`, an opt-in developer command with no CI job:
- * a hand-authored bare tag can sit in the tree undetected until someone
- * happens to reconcile that file. This lint runs the SAME check over every
- * JSDoc block under `packages/<pkg>/src`, read-only and with no dependency on the
- * wide call-mismatch artifact, so the tag is gated like its sibling
- * `@noRailsEquivalent` (validated by `noRailsEquivalentReason` on every
- * `api:extra` / `api:compare` run).
+ * its only caller is `api:build`: an opt-in developer command with no CI job,
+ * which also needs the wide call-mismatch artifact and rewrites source files.
+ * This lint runs that same check over every JSDoc block under
+ * `packages/<pkg>/src` — read-only and artifact-free — so the tag is gated
+ * like its sibling `@noRailsEquivalent` (validated by `noRailsEquivalentReason`
+ * on every `api:extra` / `api:compare` run).
  *
  * Usage:
  *   pnpm api:reasons
@@ -27,39 +26,39 @@ const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
 const SKIP_DIRS = new Set(["node_modules", "dist"]);
 const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
 
-/** Every `.ts` file under `<packages>/<pkg>/src`, sorted for stable output. */
+/** Every `.ts` file under `<packagesDir>/<pkg>/src`, sorted for stable output.
+ *  Includes `*.test.ts` (unlike the extractor's `getAllTsFiles`): the contract
+ *  is about what is committed, not about what api-compare measures. */
 export async function listSourceFiles(packagesDir: string): Promise<string[]> {
-  const walk = async (dir: string): Promise<string[]> => {
-    let entries;
-    try {
-      entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
-      return [];
-    }
-    const found = await Promise.all(
-      entries.map(async (entry) => {
-        const abs = path.join(dir, entry.name);
-        if (entry.isDirectory()) return SKIP_DIRS.has(entry.name) ? [] : walk(abs);
-        return entry.name.endsWith(".ts") ? [abs] : [];
-      }),
-    );
-    return found.flat();
-  };
-  let pkgs;
+  let pkgs: string[];
   try {
-    pkgs = await fs.readdir(packagesDir, { withFileTypes: true });
+    pkgs = (await fs.readdir(packagesDir, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
   } catch {
     return [];
   }
   const perPackage = await Promise.all(
-    pkgs.filter((p) => p.isDirectory()).map((p) => walk(path.join(packagesDir, p.name, "src"))),
+    pkgs.map(async (pkg) => {
+      const srcDir = path.join(packagesDir, pkg, "src");
+      let names: string[];
+      try {
+        names = await fs.readdir(srcDir, { recursive: true });
+      } catch {
+        return [];
+      }
+      return names
+        .filter((name) => name.endsWith(".ts"))
+        .filter((name) => !name.split(path.sep).some((seg) => SKIP_DIRS.has(seg)))
+        .map((name) => path.join(srcDir, name));
+    }),
   );
   return perPackage.flat().sort();
 }
 
-/** Run `parseJsdoc`'s empty-reason check over one file's JSDoc blocks.
- *  Returns the (possibly empty) list of error messages — never throws, so one
- *  bad tag doesn't hide the rest. */
+/** Run `parseJsdoc`'s empty-reason check over one file's JSDoc blocks, and
+ *  return the resulting error messages. Each block is parsed independently so
+ *  one bare tag doesn't hide the rest of the file. */
 export function lintFileText(fileName: string, text: string): string[] {
   if (!text.includes(TAG)) return [];
   const errors: string[] = [];
@@ -78,13 +77,14 @@ export function lintFileText(fileName: string, text: string): string[] {
 
 export async function main(): Promise<number> {
   const files = await listSourceFiles(PACKAGES_DIR);
+  // Sequential: the tree is ~3k files, and fanning every read out at once
+  // risks EMFILE for no measurable win (the whole pass is ~1s).
   const errors: string[] = [];
   for (const abs of files) {
-    const text = await fs.readFile(abs, "utf-8");
-    errors.push(...lintFileText(path.relative(ROOT_DIR, abs), text));
+    errors.push(...lintFileText(path.relative(ROOT_DIR, abs), await fs.readFile(abs, "utf-8")));
   }
   if (errors.length > 0) {
-    for (const e of errors) console.error(`api:reasons: ${e}`);
+    for (const error of errors) console.error(`api:reasons: ${error}`);
     console.error(
       `api:reasons: ${errors.length} tag(s) without a reason — see the empty-reason ` +
         "contract in docs/infrastructure/api-build-stub-generation-plan.md.",


### PR DESCRIPTION
`parseJsdoc` rejects a bare or whitespace-only `@missingRailsCall` (#5460), but
its only caller is `api:build` — an opt-in developer command with no CI job that
also needs the `--wide-calls` artifact and rewrites files. So, unlike its
sibling `@noRailsEquivalent` (gated by `noRailsEquivalentReason` on every
`api:extra` / `api:compare` run), a hand-authored bare tag could sit in the tree
undetected.

This adds `pnpm api:reasons`
(`scripts/api-compare/lint-missing-rails-call-reasons.ts`): it walks every `.ts`
file under `packages/*/src`, feeds each JSDoc block containing the tag through
the **same** `parseJsdoc` check (no second parser, same
`<tag> needs a reason: <file>:<line> — ...` message), and reports every offender
rather than the first. Read-only and artifact-free, so it runs as one more step
in the `Rails API/Test Comparison` job alongside the other api-compare gates.

Zero bare tags exist today (3048 files checked, clean) — this is drift
prevention.

**Scope is deliberately wider than api-compare's.** The walk covers every
directory under `packages/`, not the api-compare-filtered `PACKAGES` set from
`config.ts`, and includes `*.test.ts` (which the extractor's `getAllTsFiles`
skips). The contract is about what is committed, not about what api-compare
measures: a bare tag in an uncovered package or a test file is just as
unjustified, and the check is cheap (~0.6s for the whole tree).

`fs.readdir(..., { recursive: true })` needs Node ≥18.11; CI pins Node 24 via
`setup-pnpm`'s default, so this adds no new floor.

Also records in the empty-reason bullet of
`docs/infrastructure/api-build-stub-generation-plan.md` where each tag of the
family is enforced in CI.

Closes-story: enforce-missing-rails-call-reason-in-ci
