### PR TITLE
docs(api-compare): audit @noRailsEquivalent tags for convergeable surface

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1463,13 +1463,14 @@ export class AbstractAdapter implements Quoting {
   }
 
   /**
-   * @noRailsEquivalent Rails gains these bodies with `include SchemaStatements` on the adapter, so
-   *   there is no
-   *   accessor to mirror. The schema-statement surface is far too large for the repo's `this`-typed
-   *   module-mixin pattern to stay readable, so trails keeps it in a companion class;
-   *   `schemaStatements(host?)` is the accessor that returns it bound to a host adapter. It is the TS
-   *   stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to return the
-   *   MySQL companion the same way Rails includes `MySQL::SchemaStatements`.
+   * @noRailsEquivalent PERMANENT. Rails gains these bodies with `include SchemaStatements` on the
+   *   adapter, so there is no accessor to mirror. Permanent because TypeScript has no `include`:
+   *   the repo's substitute is a `this`-typed function assigned per method, and
+   *   abstract/schema_statements.rb defines 76 of them — that many hand-assigned statics is not a
+   *   readable class, and no future port removes the limitation. trails therefore keeps the module
+   *   as a companion class and `schemaStatements(host?)` returns it bound to a host adapter. It is
+   *   the TS stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to
+   *   return the MySQL companion the same way Rails includes `MySQL::SchemaStatements`.
    */
   schemaStatements(host?: AbstractAdapter): SchemaStatements {
     return new SchemaStatements((host ?? this) as unknown as AbstractAdapter);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -58,15 +58,6 @@ export interface AbstractPool {
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool::NullConfig
- *
- * Rails nests this class inside `NullPool` (`class NullPool; class NullConfig` —
- * connection_pool.rb:14-22), and the Ruby extractor records only the outer
- * `NullPool`. TS cannot declare a nested class, so it is a sibling export
- * re-attached as `NullPool.NullConfig` (a static, matching Rails' constant
- * lookup path). Same class, same file, same semantics — an extractor-shape
- * artifact, not added surface. It carried a `@noRailsEquivalent` tag until that
- * tag went stale: `api:extra` builds its extra set from MEMBER names only, so
- * the static never flags and the tag could never match.
  */
 export class NullConfig {
   [key: string]: unknown;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4553,13 +4553,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * @noRailsEquivalent Rails gains these bodies with `include SchemaStatements` on the adapter, so
-   *   there is no
-   *   accessor to mirror. The schema-statement surface is far too large for the repo's `this`-typed
-   *   module-mixin pattern to stay readable, so trails keeps it in a companion class;
-   *   `schemaStatements(host?)` is the accessor that returns it bound to a host adapter. It is the TS
-   *   stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to return the
-   *   MySQL companion the same way Rails includes `MySQL::SchemaStatements`.
+   * @noRailsEquivalent PERMANENT. Rails gains these bodies with `include SchemaStatements` on the
+   *   adapter, so there is no accessor to mirror. Permanent because TypeScript has no `include`:
+   *   the repo's substitute is a `this`-typed function assigned per method, and
+   *   abstract/schema_statements.rb defines 76 of them — that many hand-assigned statics is not a
+   *   readable class, and no future port removes the limitation. trails therefore keeps the module
+   *   as a companion class and `schemaStatements(host?)` returns it bound to a host adapter. It is
+   *   the TS stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to
+   *   return the MySQL companion the same way Rails includes `MySQL::SchemaStatements`.
    */
   override schemaStatements(host?: DatabaseAdapter): SchemaStatements {
     return new PostgreSQLSchemaStatements((host ?? this) as unknown as DatabaseAdapter);


### PR DESCRIPTION
Audits every `@noRailsEquivalent` tag against the test PR #5367 established: a
tag is permanent only if it records a language- or runtime-level fact that no
port can remove. Anything recording unfinished porting, a fixable collision, a
trails architectural choice, or a comparator gap is convergeable.

**Result: 42 of 79 tags (53%) are convergeable.** The migrated tag population
was not a record of permanent divergence.

### Where the deliverable lives

The audit is work tracking, so it lives in the **tasks repo**, not in trails
`docs/`:

- **[`rfcs/0080-api-compare-jsdoc-metadata/tag-audit.md`]** — full
  classification, with a `vendor/rails` `file:line` behind every finding,
  linked from the RFC README.
- **Ten registered stories** carrying the actionable half — nine on RFC 0072,
  one on RFC 0080. These are the deliverable; they are already on `main` in the
  tasks repo and schedulable independently of this PR.

Three shipped while this PR was in review, which is the audit working as
intended: **#5467** (interface tags cover their members — collapsed
`LocatorModel.find`/`.where`, and deleted the stale `NullConfig` tag) and
**#5471** (ported `constantize`, retired globalid's model finder).

### What this PR changes (16+/23-)

Everything else lands as its own story, so the code here is only what the audit
itself settled:

- **Tighten both `schemaStatements` reasons.** The story left this "debatable";
  decided permanent. The reasons said what the accessor was, not why it was
  permanent — they now name the cause: TS has no `include`, the repo's
  substitute is a `this`-typed function per method, and
  `abstract/schema_statements.rb` defines 76 of them.
- **Delete the `NullConfig` tag-history prose.** #5467 removed the tag itself
  and left a comment narrating a tag that no longer exists plus an extractor
  detail that belongs in `extra-surface.ts`. The `Mirrors:` line already says
  what the class is.

`pnpm api:compare` and `pnpm api:extra` both exit 0 — 76 tags, 76 matched, 0
stale.

### One correction the audit made to itself

The audit originally attributed the `NullConfig` staleness to #5458 closing the
nested-Ruby-class allow-set gap. #5467 landed the narrower and permanent
reason: `collectTsFileNames` builds the extra set from **member** surface, so an
entry for a re-attached sibling class never appears there and the tag could
never have matched, before or after #5458. The audit doc records the correction.

Closes-story: audit-existing-tags-for-convergeable-surface
