### PR TITLE
feat(api-compare): let an interface's @noRailsEquivalent cover its members

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -286,7 +286,12 @@ report). They therefore share:
   a class, interface, or namespace DECLARATION, where it justifies the
   declared name itself — the only inline form available to an extra that is a
   declaration rather than a member (e.g. a class Rails nests but TS must
-  export as a sibling).
+  export as a sibling). On an `interface` the declaration tag additionally
+  covers every MEMBER: an interface that types a duck-typed collaborator has no
+  Ruby counterpart by construction, so neither can its members, and Ruby writes
+  no such declaration to compare against. Classes are excluded from that spread
+  — a tagged class name is an extractor-shape artifact whose members do have
+  Ruby counterparts.
 - **Grammar** — free prose after the tag; where a key token precedes the
   reason it is em-dash-separated (`@missingRailsCall` takes a Ruby call name
   as that token, `@noRailsEquivalent` takes none); continuation lines with no

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -59,11 +59,14 @@ export interface AbstractPool {
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool::NullConfig
  *
- * @noRailsEquivalent Rails nests this class inside `NullPool` (`class NullPool; class NullConfig`
- *   — connection_pool.rb:14-22), and the Ruby extractor records only the outer `NullPool`. TS
- *   cannot declare a nested class, so it is a sibling export re-attached as `NullPool.NullConfig`
- *   (a static, matching Rails' constant lookup path). Same class, same file, same semantics — an
- *   extractor-shape artifact, not added surface.
+ * Rails nests this class inside `NullPool` (`class NullPool; class NullConfig` —
+ * connection_pool.rb:14-22), and the Ruby extractor records only the outer
+ * `NullPool`. TS cannot declare a nested class, so it is a sibling export
+ * re-attached as `NullPool.NullConfig` (a static, matching Rails' constant
+ * lookup path). Same class, same file, same semantics — an extractor-shape
+ * artifact, not added surface. It carried a `@noRailsEquivalent` tag until that
+ * tag went stale: `api:extra` builds its extra set from MEMBER names only, so
+ * the static never flags and the tag could never match.
  */
 export class NullConfig {
   [key: string]: unknown;

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -9,24 +9,20 @@ import { SignedGlobalID } from "./signed-global-id.js";
 import { validateApp } from "./uri/gid.js";
 import type { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 
-/** Duck-typed model interface; globalid stays AR-agnostic. */
+/**
+ * Duck-typed model interface; globalid stays AR-agnostic.
+ *
+ * @noRailsEquivalent Declares the Active Record surface Rails' BaseLocator
+ * calls duck-typed — `model_class.find gid.model_id` and
+ * `model_class.where(primary_key => ids)` on the ignore_missing path. Ruby
+ * needs no such declaration, so neither the interface nor any member of it has
+ * a Ruby counterpart.
+ */
 export interface LocatorModel {
   name: string;
   primaryKey?: string | string[];
-  /**
-   * Single-id form returns a record; array form returns an ordered array.
-   *
-   * @noRailsEquivalent Member of the duck-typed `LocatorModel` interface, not a
-   * locator method: it declares the Active Record finder Rails' BaseLocator
-   * calls as `model_class.find gid.model_id`. Ruby needs no such declaration.
-   */
+  /** Single-id form returns a record; array form returns an ordered array. */
   find(id: unknown): Promise<unknown> | unknown;
-  /**
-   * @noRailsEquivalent Member of the duck-typed `LocatorModel` interface, not a
-   * locator method: it declares the Active Record relation Rails' BaseLocator
-   * calls as `model_class.where(primary_key => ids)` on the ignore_missing
-   * path. Ruby needs no such declaration.
-   */
   where?(conditions: Record<string, unknown>): {
     toArray?(): Promise<unknown[]> | unknown[];
   };

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1542,6 +1542,27 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     expect(report.tagged.matched).toBe(1);
   });
 
+  it("allows a tagged interface's members without counting or staling the inherited entries", () => {
+    const m = makeManifests();
+    m.ts.packages.activemodel.modules.Shape = {
+      name: "Shape",
+      file: "foo.ts",
+      includes: [],
+      extends: [],
+      // `bar` has a Rails counterpart and never flags as extra; only
+      // `tsOnlyHelper` does. Neither may be reported stale — the one tag is
+      // written on the declaration, so there is nothing per-member to delete.
+      instanceMethods: [method("bar"), method("tsOnlyHelper")],
+      classMethods: [],
+      isInterface: true,
+      noRailsEquivalent: "duck-typed collaborator shape",
+    };
+    const report = run(m);
+    expect(report.packages[0].totalNovel).toBe(0);
+    expect(report.packages[0].totalAllowlisted).toBe(1);
+    expect(report.tagged).toEqual({ total: 0, matched: 1, stale: [] });
+  });
+
   it("does not judge tags of packages this run never scanned", () => {
     const report = buildReport(
       makeManifests("no counterpart").ruby,
@@ -1657,6 +1678,72 @@ describe("collectTaggedEntries", () => {
         reason: "Rails nests this class inside NullPool",
       },
     ]);
+  });
+
+  it("spreads a tagged interface's declaration reason onto its members", () => {
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        globalid: {
+          classes: {},
+          modules: {
+            LocatorModel: {
+              name: "LocatorModel",
+              file: "locator.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("find"), { ...method("where"), noRailsEquivalent: "own" }],
+              classMethods: [],
+              isInterface: true,
+              noRailsEquivalent: "duck-typed collaborator shape",
+            },
+          },
+        },
+      },
+    };
+    expect(collectTaggedEntries(ts)).toEqual([
+      // The member's own tag still wins over the inherited one.
+      { package: "globalid", tsFile: "locator.ts", name: "where", reason: "own" },
+      {
+        package: "globalid",
+        tsFile: "locator.ts",
+        name: "LocatorModel",
+        reason: "duck-typed collaborator shape",
+        inherited: true,
+      },
+      {
+        package: "globalid",
+        tsFile: "locator.ts",
+        name: "find",
+        reason: "duck-typed collaborator shape",
+        inherited: true,
+      },
+    ]);
+  });
+
+  it("does not spread a tagged CLASS declaration's reason onto its members", () => {
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            NullConfig: {
+              name: "NullConfig",
+              file: "connection-pool.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("schemaCache")],
+              classMethods: [],
+              noRailsEquivalent: "Rails nests this class inside NullPool",
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    expect(collectTaggedEntries(ts).map((e) => e.name)).toEqual(["NullConfig"]);
   });
 });
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1501,7 +1501,7 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     expect(pkg.totalNovel).toBe(0);
     expect(pkg.totalAllowlisted).toBe(1);
     expect(pkg.extraFiles).toEqual([]);
-    expect(report.tagged).toEqual({ total: 1, matched: 1, stale: [] });
+    expect(report.tagged).toEqual({ total: 1, matched: 1, inheritedMatched: 0, stale: [] });
     expect(report).not.toHaveProperty("allowlist");
   });
 
@@ -1560,7 +1560,7 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     const report = run(m);
     expect(report.packages[0].totalNovel).toBe(0);
     expect(report.packages[0].totalAllowlisted).toBe(1);
-    expect(report.tagged).toEqual({ total: 0, matched: 1, stale: [] });
+    expect(report.tagged).toEqual({ total: 0, matched: 0, inheritedMatched: 1, stale: [] });
   });
 
   it("does not judge tags of packages this run never scanned", () => {
@@ -1815,6 +1815,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(report.tagged).toEqual({
       total: 1,
       matched: 1,
+      inheritedMatched: 0,
       stale: [],
     });
     expect(report.packages[0].totalAllowlisted).toBe(1);
@@ -1859,7 +1860,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
       { source: "typescript", generatedAt: "", packages: { activerecord: tsPkg } },
       { filterPkg: null, excludeGlobs: [], novelOnly: false, topN: 50 },
     );
-    expect(report.tagged).toEqual({ total: 1, matched: 1, stale: [] });
+    expect(report.tagged).toEqual({ total: 1, matched: 1, inheritedMatched: 0, stale: [] });
     expect(report.packages[0].totalAllowlisted).toBe(1);
     expect(report.packages[0].totalNovel).toBe(0);
   });

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -42,6 +42,8 @@
  *      that no longer flags is STALE and fails the run. The tag is read on
  *      members AND on class / interface / namespace declarations, so an extra
  *      that is a declaration rather than a member still has an inline form.
+ *      On an `interface` the declaration tag additionally covers every member
+ *      — see `collectTaggedEntries`.
  *
  * Manifests are produced by `pnpm api:compare`; if they're missing the
  * script bails with a hint (same convention as `api:moves`).
@@ -279,6 +281,15 @@ export interface TaggedEntry {
   tsFile: string;
   name: string;
   reason: string;
+  /**
+   * True when the entry derives from a tagged `interface` DECLARATION rather
+   * than from a tag written on this name — its members, and the interface's own
+   * name. Such entries allow extra surface like any other, but they are
+   * excluded from the tag total and from the stale check: the interface tag is
+   * written once for the whole shape, so a member of it that happens not to
+   * flag as extra is not a stale tag anyone can delete.
+   */
+  inherited?: boolean;
 }
 
 export function allowKeyOf(e: { package: string; tsFile: string; name: string }): string {
@@ -306,9 +317,21 @@ export function allowKeyOf(e: { package: string; tsFile: string; name: string })
 export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
   const out: TaggedEntry[] = [];
   const seen = new Set<string>();
-  const push = (pkg: string, tsFile: string, name: string, reason: string | undefined): void => {
+  const push = (
+    pkg: string,
+    tsFile: string,
+    name: string,
+    reason: string | undefined,
+    inherited = false,
+  ): void => {
     if (reason === undefined) return;
-    const entry = { package: pkg, tsFile, name, reason };
+    const entry: TaggedEntry = {
+      package: pkg,
+      tsFile,
+      name,
+      reason,
+      ...(inherited ? { inherited } : {}),
+    };
     const key = allowKeyOf(entry);
     if (seen.has(key)) return;
     seen.add(key);
@@ -329,7 +352,26 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
         // LAST on purpose: a member sharing the container's name occupies the
         // same key (see the dedup note above — one key is all the extra set
         // has), so the more specific member reason wins the tie.
-        push(pkg, c.file, c.name, c.noRailsEquivalent);
+        // An interface's own name is not member surface, so it never appears in
+        // the extra set `collectTsFileNames` builds and its entry can never
+        // match — flagged inherited so the stale check doesn't demand its
+        // deletion. The tag is still doing work: it covers the members below.
+        push(pkg, c.file, c.name, c.noRailsEquivalent, c.isInterface === true);
+        // A tagged `interface` covers its MEMBERS as well as its own name. An
+        // interface is type-only: the ones that need the tag exist solely to
+        // declare the shape of a duck-typed collaborator (e.g. globalid's
+        // `LocatorModel`, which types the Active Record surface Rails calls as
+        // `model_class.find gid.model_id`), and Ruby writes no such
+        // declaration at all. So no member of one can have a Ruby counterpart
+        // either, and tagging them one by one would repeat the same reason on
+        // every member of every such interface. Classes are deliberately
+        // excluded: a tagged class name is usually an extractor-shape artifact
+        // (a nested Ruby class TS must export as a sibling) whose members DO
+        // have Ruby counterparts, so inheriting there would mask real drift.
+        // A member's own tag still wins — members are pushed first.
+        if (c.isInterface === true && c.noRailsEquivalent !== undefined) {
+          for (const m of c.instanceMethods) push(pkg, c.file, m.name, c.noRailsEquivalent, true);
+        }
       }
     }
     for (const [file, fns] of Object.entries(tsPkg.fileFunctions ?? {})) {
@@ -1194,11 +1236,11 @@ export function buildReport(
   );
 
   const staleTagged = tagged.filter(
-    (e) => scannedPkgs.has(e.package) && !matchedTagKeys.has(allowKeyOf(e)),
+    (e) => !e.inherited && scannedPkgs.has(e.package) && !matchedTagKeys.has(allowKeyOf(e)),
   );
 
   const taggedSummary: TaggedSummary = {
-    total: tagged.length,
+    total: tagged.filter((e) => !e.inherited).length,
     matched: matchedTagKeys.size,
     stale: staleTagged,
   };

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -421,8 +421,16 @@ interface PackageTotals {
 }
 
 interface TaggedSummary {
+  /** Tags actually WRITTEN in the source — inherited entries excluded. */
   total: number;
+  /** Written tags that matched an extra. */
   matched: number;
+  /**
+   * Extras allowed by an entry inherited from a tagged `interface` declaration
+   * rather than by a tag of their own. Counted apart from `matched` so the two
+   * numbers stay comparable with `total`, which counts written tags only.
+   */
+  inheritedMatched: number;
   stale: TaggedEntry[];
 }
 
@@ -1140,7 +1148,11 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
   );
   console.log(
     `\n${p.dim}@noRailsEquivalent tags: ${report.tagged.total} tag(s), ` +
-      `${report.tagged.matched} matched — allowed extras are subtracted from the counts above.${p.reset}`,
+      `${report.tagged.matched} matched` +
+      (report.tagged.inheritedMatched > 0
+        ? ` (+${report.tagged.inheritedMatched} allowed by a tagged interface declaration)`
+        : "") +
+      ` — allowed extras are subtracted from the counts above.${p.reset}`,
   );
 
   console.log(
@@ -1239,9 +1251,13 @@ export function buildReport(
     (e) => !e.inherited && scannedPkgs.has(e.package) && !matchedTagKeys.has(allowKeyOf(e)),
   );
 
+  const inheritedKeys = new Set(tagged.filter((e) => e.inherited).map(allowKeyOf));
+  const inheritedMatched = [...matchedTagKeys].filter((k) => inheritedKeys.has(k)).length;
+
   const taggedSummary: TaggedSummary = {
     total: tagged.filter((e) => !e.inherited).length,
-    matched: matchedTagKeys.size,
+    matched: matchedTagKeys.size - inheritedMatched,
+    inheritedMatched,
     stale: staleTagged,
   };
   return {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1625,6 +1625,10 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
       "trails-only locator namespace",
     );
     expect(info.modules["seams.ts:Plain"].noRailsEquivalent).toBeUndefined();
+    // extra-surface.ts spreads a declaration tag onto members for interfaces
+    // only, so the kind has to survive into the manifest.
+    expect(info.modules["seams.ts:Quoting"].isInterface).toBe(true);
+    expect(info.modules["seams.ts:Locator"].isInterface).toBeUndefined();
   });
 
   it("keeps a declaration-merged interface's tag when the untagged half is walked first", () => {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1962,6 +1962,7 @@ function extractInterface(
     extends: extendsArr,
     instanceMethods,
     classMethods: [],
+    isInterface: true,
     ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
   };
 }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1409,7 +1409,8 @@ export function hasInternalJsDocTag(node: ts.Node): boolean {
  * Read on members, statements and properties, and on class / interface /
  * namespace declarations (where it lands on `ClassInfo.noRailsEquivalent`) —
  * the latter is the only inline form available to an extra whose declaration
- * is the extra name itself.
+ * is the extra name itself, and on an `interface` it covers the members too
+ * (see `collectTaggedEntries` in extra-surface.ts).
  * Continuation lines belong to the tag and are joined into one line; the prose
  * is otherwise preserved verbatim. An empty reason is a hard error: the tag is
  * the only thing standing between a name and the extra-surface count, so an

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -120,6 +120,13 @@ export interface ClassInfo {
    */
   synthesizedMixin?: boolean;
   /**
+   * TS-side only: this entry came from an `interface` declaration rather than a
+   * `class`, `namespace`, or synthesized module. Interfaces are type-only, so a
+   * container-level `@noRailsEquivalent` on one covers its members too — see
+   * `collectTaggedEntries` in extra-surface.ts.
+   */
+  isInterface?: boolean;
+  /**
    * Reason prose of an `@noRailsEquivalent` tag written on the class /
    * interface / namespace DECLARATION itself, justifying the declared name as
    * deliberate trails-only surface. Members carry their own tag on


### PR DESCRIPTION
## What

`@noRailsEquivalent` on an **interface** declaration now covers that
interface's members, not just its own name.

An interface that exists solely to type a duck-typed collaborator has no Ruby
counterpart *by construction* — Ruby writes no such declaration at all — so no
member of one can have a Ruby counterpart either. Tagging them member by member
repeated the same reason on every member of every such interface, which is what
`globalid/locator.ts` was doing for `LocatorModel.find` / `.where`.

Classes are deliberately excluded from the spread: a tagged class name is
usually an extractor-shape artifact (a nested Ruby class TS must export as a
sibling) whose members **do** have Ruby counterparts, so inheriting there would
mask real drift.

## How

- `extract-ts-api.ts` records `isInterface: true` on entries that came from an
  `interface` declaration (new optional field on `ClassInfo`).
- `collectTaggedEntries` (extra-surface.ts) spreads a tagged interface's
  declaration reason onto its members. A member's own tag still wins.
- Entries derived from the interface declaration — its members, and the
  interface's own name — are flagged `inherited` and excluded from the tag
  total and the stale check. An interface's own name is never member surface
  (`collectTsFileNames` collects members only), so it can never match; and a
  member that happens not to flag as extra is not a stale tag anyone can
  delete.
- Inherited matches are reported apart from `matched`, since `total` counts
  written tags: `77 tag(s), 8 matched (+2 allowed by a tagged interface
  declaration)`.
- `globalid/locator.ts`: the per-member `find` / `where` tags become one tag on
  `LocatorModel`.

## Sweep

The only other interfaces carrying per-member tags are the thenable
`catch` / `finally` augmentations on `Relation`, `CollectionProxy`, and
`BatchEnumerator` — declaration-merged interfaces over ported classes that
*do* have Rails counterparts, so the rule does not cover them and their tags
stay as they are.

## Also: the one pre-existing stale tag

`pnpm api:extra` was already failing on `main` with
`activerecord connection-pool.ts NullConfig` — a tag on a *class* whose name is
a nested-Ruby-class-as-static, which the member-only extra set can never flag.
Its reasoning is kept as prose on the same declaration and the tag is dropped,
which is what the stale message prescribes. `pnpm api:extra` now exits 0.

## Verification

- `pnpm api:extra` exits 0, no stale tags; globalid's allowed count is
  unchanged at 10.
- `pnpm vitest run scripts/api-compare/ packages/globalid` — 831 tests pass.

Closes-story: extra-surface-skip-duck-typed-interface-members
Closes-story: extra-surface-stale-nullconfig-class-tag
