### PR TITLE
feat(api-compare): carry a mixin inner-class constructor's JSDoc onto its __mixin entry

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1569,6 +1569,28 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(ctor.internal).toBeUndefined();
   });
 
+  it("inherits a foreign base constructor's visibility onto the synthesized __mixin entry", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `
+        export class Base {
+          protected constructor() {}
+        }
+      `,
+      "attributes.ts": `
+        import { Base } from "./base.js";
+        export function Attributes(B: typeof Base) {
+          class M extends B {}
+          return M;
+        }
+      `,
+    });
+    const ctor = info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+      (m) => m.name === "constructor",
+    )!;
+    expect(ctor.visibility).toBe("protected");
+    expect(ctor.internal).toBe(true);
+  });
+
   it("records the reason on tagged namespace members", () => {
     const info = extractFromFiles("/p", {
       "locator.ts": `

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1569,12 +1569,15 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(ctor.noRailsEquivalent).toBeUndefined();
     expect(ctor.internal).toBeUndefined();
     expect(ctor.declaredIn).toBe("base.ts");
+    expect(ctor.line).toBe(4);
   });
 
   it("inherits a foreign base constructor's visibility onto the synthesized __mixin entry", () => {
     const info = extractFromFiles("/p", {
       "base.ts": `
         export class Base {
+          readonly tag = "base";
+
           protected constructor() {}
         }
       `,
@@ -1592,6 +1595,8 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(ctor.visibility).toBe("protected");
     expect(ctor.internal).toBe(true);
     expect(ctor.declaredIn).toBe("base.ts");
+    // Line 5 of base.ts, not line 3 — the factory's line in attributes.ts.
+    expect(ctor.line).toBe(5);
   });
 
   it("records the reason on tagged namespace members", () => {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1904,6 +1904,9 @@ const EMIT_SITE_FIXTURE: Record<string, string> = {
 
     export function Attributes(Base: typeof MixinBase) {
       class M extends Base {
+        /** @noRailsEquivalent mixin constructor */
+        constructor(...args: any[]) { super(...args); }
+
         /** @noRailsEquivalent mixin own member */
         ownMember(): void {}
       }
@@ -1956,14 +1959,12 @@ function emitInventory(info: PackageInfo, file: string): EmitEntry[] {
 
 /**
  * The pinned inventory. Every entry has a tagged declaration behind it and so
- * expects `hasReason: true`, except four:
+ * expects `hasReason: true`, except three:
  *
  * - `<fileFunctions>#Attributes` — the mixin factory, left untagged so an
  *   untagged counted site is represented too.
  * - `<fileFunctions>#aliasTarget` / `#shorthandRef` — `extractFileLocalHelpers`
  *   output, always `internal: true`, so uncounted and never metadata-bearing.
- * - `Attributes__mixin#constructor` — synthesized from the factory's construct
- *   signature; counted, but there is no member declaration to read a tag off.
  * - `<fileFunctions>#renamedExport` — an untagged `export { x as y }` alias
  *   drops the declaration's reason: the reason justifies the declared
  *   spelling, not the alias. `#taggedAlias` is the tagged form.
@@ -1980,7 +1981,7 @@ const EMIT_SITE_INVENTORY: EmitEntry[] = [
     container: "emit-sites.ts:Attributes__mixin",
     name: "constructor",
     counted: true,
-    hasReason: false,
+    hasReason: true,
   },
   {
     container: "emit-sites.ts:Attributes__mixin",

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1527,6 +1527,48 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     ).toBe("JS-only lifecycle hook");
   });
 
+  it("records the reason on a synthesized __mixin constructor", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new () => object) {
+          class M extends Base {
+            /** @noRailsEquivalent JS constructors take no Ruby-style block */
+            constructor() { super(); }
+          }
+          return M;
+        }
+      `,
+    });
+    const ctor = info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+      (m) => m.name === "constructor",
+    )!;
+    expect(ctor.noRailsEquivalent).toBe("JS constructors take no Ruby-style block");
+    expect(ctor.line).toBe(5);
+  });
+
+  it("leaves a synthesized __mixin constructor bare when the inner class declares none", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `
+        export class Base {
+          /** @noRailsEquivalent JS-only wiring */
+          constructor() {}
+        }
+      `,
+      "attributes.ts": `
+        import { Base } from "./base.js";
+        export function Attributes(B: typeof Base) {
+          class M extends B {}
+          return M;
+        }
+      `,
+    });
+    const ctor = info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+      (m) => m.name === "constructor",
+    )!;
+    expect(ctor.noRailsEquivalent).toBeUndefined();
+    expect(ctor.internal).toBeUndefined();
+  });
+
   it("records the reason on tagged namespace members", () => {
     const info = extractFromFiles("/p", {
       "locator.ts": `

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1544,6 +1544,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     )!;
     expect(ctor.noRailsEquivalent).toBe("JS constructors take no Ruby-style block");
     expect(ctor.line).toBe(5);
+    expect(ctor.declaredIn).toBeUndefined();
   });
 
   it("leaves a synthesized __mixin constructor bare when the inner class declares none", () => {
@@ -1567,6 +1568,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     )!;
     expect(ctor.noRailsEquivalent).toBeUndefined();
     expect(ctor.internal).toBeUndefined();
+    expect(ctor.declaredIn).toBe("base.ts");
   });
 
   it("inherits a foreign base constructor's visibility onto the synthesized __mixin entry", () => {
@@ -1589,6 +1591,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     )!;
     expect(ctor.visibility).toBe("protected");
     expect(ctor.internal).toBe(true);
+    expect(ctor.declaredIn).toBe("base.ts");
   });
 
   it("records the reason on tagged namespace members", () => {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -700,18 +700,19 @@ export function extractFromProgram(
       // so its `constructor` reaches this entry only through the construct
       // signature's declaration. Split the same way as the property loop
       // above: visibility comes off whichever declaration the signature
-      // resolves to, near or foreign, while only the JSDoc reason is gated on
-      // the declaration living in THIS file. An implicit constructor resolves
-      // to no declaration at all, and that entry stays bare.
+      // resolves to, a foreign one is marked `declaredIn` so `collectTsFileNames`
+      // skips it as another file's surface, and only the JSDoc reason is gated
+      // on the declaration living in THIS file. An implicit constructor
+      // resolves to no declaration at all, and that entry stays bare.
       if (constructSigs.length > 0) {
         const sigDecl = constructSigs[0].getDeclaration();
         const ctorDecl =
           sigDecl !== undefined && ts.isConstructorDeclaration(sigDecl) ? sigDecl : undefined;
-        const ownCtor =
-          ctorDecl !== undefined &&
-          path.relative(srcDir, ctorDecl.getSourceFile().fileName).replace(/\\/g, "/") === relPath
-            ? ctorDecl
+        const ctorDeclFile =
+          ctorDecl !== undefined
+            ? path.relative(srcDir, ctorDecl.getSourceFile().fileName).replace(/\\/g, "/")
             : undefined;
+        const ownCtor = ctorDeclFile === relPath ? ctorDecl : undefined;
         const ctorVisibility = ctorDecl !== undefined ? memberVisibility(ctorDecl) : "public";
         const ctorReason = ownCtor !== undefined ? noRailsEquivalentReason(ownCtor) : undefined;
         const ctorNode = ownCtor ?? node;
@@ -723,6 +724,9 @@ export function extractFromProgram(
           line:
             ctorNode.getSourceFile().getLineAndCharacterOfPosition(ctorNode.getStart()).line + 1,
           file: relPath,
+          ...(ctorDeclFile !== undefined && ctorDeclFile !== relPath
+            ? { declaredIn: ctorDeclFile }
+            : {}),
           ...(ctorVisibility !== "public" ? { internal: true } : {}),
           ...(ctorReason !== undefined ? { noRailsEquivalent: ctorReason } : {}),
         });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -698,20 +698,21 @@ export function extractFromProgram(
 
       // Add constructor. The inner class is invisible to the top-level walker,
       // so its `constructor` reaches this entry only through the construct
-      // signature's declaration. When the inner class declares one in THIS
-      // file, that declaration IS the entry's member declaration and carries
-      // its JSDoc; otherwise (implicit constructor, or one inherited from a
-      // base in another file) there is no declaration here to read, and the
-      // entry stays bare — same reason foreign members above skip their tag.
+      // signature's declaration. Split the same way as the property loop
+      // above: visibility comes off whichever declaration the signature
+      // resolves to, near or foreign, while only the JSDoc reason is gated on
+      // the declaration living in THIS file. An implicit constructor resolves
+      // to no declaration at all, and that entry stays bare.
       if (constructSigs.length > 0) {
-        const ctorDecl = constructSigs[0].getDeclaration();
+        const sigDecl = constructSigs[0].getDeclaration();
+        const ctorDecl =
+          sigDecl !== undefined && ts.isConstructorDeclaration(sigDecl) ? sigDecl : undefined;
         const ownCtor =
           ctorDecl !== undefined &&
-          ts.isConstructorDeclaration(ctorDecl) &&
           path.relative(srcDir, ctorDecl.getSourceFile().fileName).replace(/\\/g, "/") === relPath
             ? ctorDecl
             : undefined;
-        const ctorVisibility = ownCtor !== undefined ? memberVisibility(ownCtor) : "public";
+        const ctorVisibility = ctorDecl !== undefined ? memberVisibility(ctorDecl) : "public";
         const ctorReason = ownCtor !== undefined ? noRailsEquivalentReason(ownCtor) : undefined;
         const ctorNode = ownCtor ?? node;
         mixinMethods.push({

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -696,15 +696,34 @@ export function extractFromProgram(
         });
       }
 
-      // Add constructor
+      // Add constructor. The inner class is invisible to the top-level walker,
+      // so its `constructor` reaches this entry only through the construct
+      // signature's declaration. When the inner class declares one in THIS
+      // file, that declaration IS the entry's member declaration and carries
+      // its JSDoc; otherwise (implicit constructor, or one inherited from a
+      // base in another file) there is no declaration here to read, and the
+      // entry stays bare — same reason foreign members above skip their tag.
       if (constructSigs.length > 0) {
+        const ctorDecl = constructSigs[0].getDeclaration();
+        const ownCtor =
+          ctorDecl !== undefined &&
+          ts.isConstructorDeclaration(ctorDecl) &&
+          path.relative(srcDir, ctorDecl.getSourceFile().fileName).replace(/\\/g, "/") === relPath
+            ? ctorDecl
+            : undefined;
+        const ctorInternal = ownCtor !== undefined && hasInternalJsDocTag(ownCtor);
+        const ctorReason = ownCtor !== undefined ? noRailsEquivalentReason(ownCtor) : undefined;
+        const ctorNode = ownCtor ?? node;
         mixinMethods.push({
           name: "constructor",
           visibility: "public",
           params: [],
           isStatic: false,
-          line: node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1,
+          line:
+            ctorNode.getSourceFile().getLineAndCharacterOfPosition(ctorNode.getStart()).line + 1,
           file: relPath,
+          ...(ctorInternal ? { internal: true } : {}),
+          ...(ctorReason !== undefined ? { noRailsEquivalent: ctorReason } : {}),
         });
       }
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -711,18 +711,18 @@ export function extractFromProgram(
           path.relative(srcDir, ctorDecl.getSourceFile().fileName).replace(/\\/g, "/") === relPath
             ? ctorDecl
             : undefined;
-        const ctorInternal = ownCtor !== undefined && hasInternalJsDocTag(ownCtor);
+        const ctorVisibility = ownCtor !== undefined ? memberVisibility(ownCtor) : "public";
         const ctorReason = ownCtor !== undefined ? noRailsEquivalentReason(ownCtor) : undefined;
         const ctorNode = ownCtor ?? node;
         mixinMethods.push({
           name: "constructor",
-          visibility: "public",
+          visibility: ctorVisibility,
           params: [],
           isStatic: false,
           line:
             ctorNode.getSourceFile().getLineAndCharacterOfPosition(ctorNode.getStart()).line + 1,
           file: relPath,
-          ...(ctorInternal ? { internal: true } : {}),
+          ...(ctorVisibility !== "public" ? { internal: true } : {}),
           ...(ctorReason !== undefined ? { noRailsEquivalent: ctorReason } : {}),
         });
       }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -700,8 +700,9 @@ export function extractFromProgram(
       // so its `constructor` reaches this entry only through the construct
       // signature's declaration. Split the same way as the property loop
       // above: visibility comes off whichever declaration the signature
-      // resolves to, a foreign one is marked `declaredIn` so `collectTsFileNames`
-      // skips it as another file's surface, and only the JSDoc reason is gated
+      // resolves to — its line points into that file too — a foreign one is
+      // marked `declaredIn` so `collectTsFileNames` skips it as another file's
+      // surface, and only the JSDoc reason is gated
       // on the declaration living in THIS file. An implicit constructor
       // resolves to no declaration at all, and that entry stays bare.
       if (constructSigs.length > 0) {
@@ -715,7 +716,7 @@ export function extractFromProgram(
         const ownCtor = ctorDeclFile === relPath ? ctorDecl : undefined;
         const ctorVisibility = ctorDecl !== undefined ? memberVisibility(ctorDecl) : "public";
         const ctorReason = ownCtor !== undefined ? noRailsEquivalentReason(ownCtor) : undefined;
-        const ctorNode = ownCtor ?? node;
+        const ctorNode = ctorDecl ?? node;
         mixinMethods.push({
           name: "constructor",
           visibility: ctorVisibility,


### PR DESCRIPTION
The synthesized `constructor` entry for a `__mixin` module was emitted from the factory's construct signature with no declaration behind it, so no declaration-derived field (`internal`, `noRailsEquivalent`, and the upcoming `@missingRailsCall`) could ever reach it — while `collectTsFileNames` still counted it as the file's own surface.

Resolution (1) from the story. The entry now splits its metadata exactly the way the property loop above it does:

- **Visibility** comes off whichever declaration the construct signature resolves to, near or foreign — `memberVisibility` takes any `ts.ClassElement` and has no same-file requirement, so a `private`/`protected` constructor inherited from a base in another file is reported as such rather than flattened to `public`.
- **`declaredIn`** is set when that declaration lives in another file, so `collectTsFileNames` skips it as the base file's surface instead of counting it here.
- **The `@noRailsEquivalent` reason** is gated on the declaration living in THIS file, because a reason justifies the declared spelling and would read as stale on top of its correct match on the base file.
- **The line** points at that declaration too, in its own file — only an implicit constructor falls back to the factory's line.

An implicit constructor resolves to no declaration at all; that entry stays bare and counted, as before.

On `declaredIn` I initially held it back, on the theory that it would move mixin constructors from counted to uncounted and so change which entries a file owns. Measured, that theory is wrong: 12 of the repo's 22 `__mixin#constructor` entries gain `declaredIn` (all resolving to `base.ts`), and both `pnpm api:compare` (`Overall: 11725/17544`, `files: 773/1028`, unchanged) and `pnpm api:extra` are byte-identical before and after — none of those 12 were contributing counted extra surface. With no observable movement, mirroring the property loop is the right call, so the field is now set.

Tests:

- `EMIT_SITE_INVENTORY` loses the exception: the fixture's mixin declares a tagged constructor and the pinned entry flips to `hasReason: true`.
- Three new unit tests pin each arm, each asserting `declaredIn` — a tagged own constructor carries its reason and line and has no `declaredIn`; a `public` foreign base constructor yields a bare entry marked `declaredIn: "base.ts"` rather than picking up the base's tag; a `protected` foreign base constructor lands as `visibility: "protected"` / `internal: true` / `declaredIn: "base.ts"`, which distinguishes inherited-as-public from forced-to-public. Both foreign cases assert `line`, at a base-file line that cannot coincide with the factory's.

The one `NullConfig` stale-tag failure from `pnpm api:extra` is pre-existing — it reproduces identically on a detached `origin/main` worktree.

Closes-story: mixin-constructor-entry-cannot-carry-declaration-metadata
