### PR TITLE
chore(api-compare): drop the stale @noRailsEquivalent tag on NullConfig

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -59,11 +59,9 @@ export interface AbstractPool {
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool::NullConfig
  *
- * @noRailsEquivalent Rails nests this class inside `NullPool` (`class NullPool; class NullConfig`
- *   — connection_pool.rb:14-22), and the Ruby extractor records only the outer `NullPool`. TS
- *   cannot declare a nested class, so it is a sibling export re-attached as `NullPool.NullConfig`
- *   (a static, matching Rails' constant lookup path). Same class, same file, same semantics — an
- *   extractor-shape artifact, not added surface.
+ * Rails nests this class inside `NullPool` (connection_pool.rb:14-22). TS cannot declare a nested
+ * class, so it is a sibling export re-attached as `static readonly NullPool.NullConfig`, matching
+ * Rails' constant lookup path.
  */
 export class NullConfig {
   [key: string]: unknown;


### PR DESCRIPTION
`pnpm api:extra` failed on `main` with one stale `@noRailsEquivalent` tag:

    activerecord  connection-adapters/abstract/connection-pool.ts  NullConfig

**Verdict: delete the tag.** The shape it argued for is already handled.

The tag claimed the Ruby extractor records only the outer `NullPool`, so the
sibling-export-plus-static spelling counted as added surface. That is no longer
true on either side:

- `rails-api.json` records `ActiveRecord::ConnectionAdapters::NullPool::NullConfig`
  as its own class entry, flagged `nestedInEnclosingClass`.
- `collectAllowedNames` (scripts/api-compare/extra-surface.ts) admits a nested
  class's short name as a constant on its enclosing class, precisely so that
  `static readonly NullConfig = NullConfig` reads as the faithful port.

So `NullConfig` can never appear in the extra set, and the tag can never match.
The class-level tag support added in #5462 is unaffected — this is one stale
occupant, not a defect in the mechanism.

The explanation of *why* the class is a sibling export is still useful at the
call site, so it stays as plain prose in the JSDoc rather than as a tag.

`pnpm api:extra` now exits 0.

Closes-story: extra-surface-stale-nullconfig-class-tag
