### PR TITLE
refactor(api-compare): drop the unused AMBIENT_RAILTIE_MIXINS.methods arm

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1042,12 +1042,12 @@ describe("buildReport — novel vs moved classification", () => {
     expect(f!.extras.map((e) => e.name)).toContain("unportedMethod");
   });
 
-  it("folds a ported mirror of an unported mixin method back into allowed (PORTED_UNPORTED_MIXIN_METHODS)", () => {
+  it("folds a ported mirror of an unported mixin method back into allowed (PORTED_METHODS_FROM_UNPORTED_MIXINS)", () => {
     // ActiveRecord::AssociationNotFoundError `include DidYouMean::Correctable`,
     // whose source (core_ext/name_error.rb) is unported — so walkMixin skips it
     // and `detailedMessage` would show as a "moved" extra. We ported
     // detailed_message inline (associations/errors.ts), so
-    // PORTED_UNPORTED_MIXIN_METHODS must fold it back into allowed while a
+    // PORTED_METHODS_FROM_UNPORTED_MIXINS must fold it back into allowed while a
     // genuinely-extra name stays flagged.
     const ruby: ApiManifest = {
       source: "ruby",
@@ -1111,7 +1111,7 @@ describe("buildReport — novel vs moved classification", () => {
     // on_load(:action_controller) { include … }); its source
     // controller_runtime.rb is unported, so the ported process_action /
     // cleanup_view_runtime / append_info_to_payload mirrors would show as moved
-    // extras without the PORTED_UNPORTED_MIXIN_METHODS["ActiveRecord::Railtie"]
+    // extras without the PORTED_METHODS_FROM_UNPORTED_MIXINS["ActiveRecord::Railtie"]
     // fold-back. Guards the exact host FQN + method names against a typo.
     const ruby: ApiManifest = {
       source: "ruby",

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -101,10 +101,11 @@ interface RubyEntity {
 
 /**
  * Mixins a host class gains at *runtime* via a gem's railtie
- * `ActiveSupport.on_load(:active_record)` block rather than a lexical `include`
- * in the host's own source. The static Ruby extractor only sees `include`s
- * written inside the class/module body, so a railtie-injected mixin never
- * lands in the host's `includes` array and its faithful TS ports look novel.
+ * `ActiveSupport.on_load(:active_record)` block rather than a lexical
+ * `include` in the host's own source. The static Ruby extractor only sees
+ * `include`s written inside the class/module body, so a railtie-injected mixin
+ * never lands in the host's `includes` array and its faithful TS ports look
+ * novel.
  *
  * `includes` are resolved against the *cross-package* module map (every
  * package's extracted modules), so a mixin defined in a different gem —
@@ -112,7 +113,7 @@ interface RubyEntity {
  * `ActiveRecord::Base` (activerecord package) by globalid's railtie — still
  * contributes its instance methods to the host's allowed set.
  */
-const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[] }> = {
+const AMBIENT_RAILTIE_MIXINS: Record<string, { includes: string[] }> = {
   "ActiveRecord::Base": {
     includes: ["GlobalID::Identification"],
   },
@@ -650,10 +651,7 @@ function collectAllowedNames(
     for (const inc of info.includes ?? []) walkMixin(inc, fqn);
     for (const ext of info.extends ?? []) walkMixin(ext, fqn);
 
-    const ambient = AMBIENT_RAILTIE_MIXINS[fqn];
-    if (ambient) {
-      for (const inc of ambient.includes ?? []) walkMixin(inc, fqn);
-    }
+    for (const inc of AMBIENT_RAILTIE_MIXINS[fqn]?.includes ?? []) walkMixin(inc, fqn);
 
     for (const name of PORTED_UNPORTED_MIXIN_METHODS[fqn] ?? []) addRubyName(name);
   }

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -100,7 +100,7 @@ interface RubyEntity {
 }
 
 /**
- * Mixins (and methods) a host class gains at *runtime* via a gem's railtie
+ * Mixins a host class gains at *runtime* via a gem's railtie
  * `ActiveSupport.on_load(:active_record)` block rather than a lexical `include`
  * in the host's own source. The static Ruby extractor only sees `include`s
  * written inside the class/module body, so a railtie-injected mixin never
@@ -111,28 +111,8 @@ interface RubyEntity {
  * e.g. `GlobalID::Identification` (globalid package) included into
  * `ActiveRecord::Base` (activerecord package) by globalid's railtie — still
  * contributes its instance methods to the host's allowed set.
- *
- * `methods` are raw Ruby method names the railtie surface implies but which
- * have no static `def` anywhere (so they can't be reached via a module). It is
- * only for that Ruby-extractor blind spot: Rails really does gain the method,
- * the extractor just can't see it. A trails-only method with no Rails
- * counterpart is NOT that case and does not belong here — either it is
- * permanently unportable, which a `@noRailsEquivalent` tag on its own
- * declaration records (RFC 0080), or it is unconverged work, which stays
- * unsuppressed so this report keeps flagging it.
- *
- * `ActiveRecord::Base` previously listed `find_global_id` /
- * `find_signed_global_id[!]` here. It was the wrong bucket both ways: globalid's
- * railtie includes only `GlobalID::Identification`
- * (globalid/lib/global_id/railtie.rb:35), and Rails callers reach the finders
- * through `GlobalID::Locator.locate` / `locate_signed`
- * (globalid/lib/global_id/locator.rb:23,:84), so there is no ambient Ruby
- * method to be blind to — trails' model-side class methods are an invention with
- * no callers. They are deliberately untagged so `api:extra` reports them until
- * they are removed. No entry needs `methods` today; the field stays because the
- * blind spot it covers is a property of the Ruby extractor, not of any one gem.
  */
-const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[]; methods?: string[] }> = {
+const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[] }> = {
   "ActiveRecord::Base": {
     includes: ["GlobalID::Identification"],
   },
@@ -145,10 +125,9 @@ const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[]; methods?: st
  * compare.ts:507) and the faithful TS ports look like unexplained "moved"
  * extras. We DID port these methods, just as standalone mirrors that don't go
  * through the unported module, so list them here keyed by the Ruby host FQN to
- * fold the ported names back into the host's allowed set. Applied like
- * `AMBIENT_RAILTIE_MIXINS.methods` (raw Ruby names → `addRubyName`), but the
- * justification is a source-unported *lexical* include rather than a railtie
- * `on_load` injection.
+ * fold the ported names back into the host's allowed set (raw Ruby names →
+ * `addRubyName`). The justification is a source-unported *lexical* include
+ * rather than a railtie `on_load` injection.
  *
  *   - `ActiveRecord::Railtie` re-exports `Railties::ControllerRuntime`
  *     (railtie.rb:267 — `on_load(:action_controller) { include … }`); the port
@@ -674,7 +653,6 @@ function collectAllowedNames(
     const ambient = AMBIENT_RAILTIE_MIXINS[fqn];
     if (ambient) {
       for (const inc of ambient.includes ?? []) walkMixin(inc, fqn);
-      for (const name of ambient.methods ?? []) addRubyName(name);
     }
 
     for (const name of PORTED_UNPORTED_MIXIN_METHODS[fqn] ?? []) addRubyName(name);

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -143,7 +143,7 @@ const AMBIENT_RAILTIE_MIXINS: Record<string, { includes: string[] }> = {
  *     machinery with no JS analog). Keyed on one host class since `allowed` is
  *     unioned per-file across every entity in errors.rb.
  */
-const PORTED_UNPORTED_MIXIN_METHODS: Record<string, string[]> = {
+const PORTED_METHODS_FROM_UNPORTED_MIXINS: Record<string, string[]> = {
   "ActiveRecord::Railtie": ["process_action", "cleanup_view_runtime", "append_info_to_payload"],
   "ActiveRecord::AssociationNotFoundError": ["detailed_message"],
 };
@@ -653,7 +653,7 @@ function collectAllowedNames(
 
     for (const inc of AMBIENT_RAILTIE_MIXINS[fqn]?.includes ?? []) walkMixin(inc, fqn);
 
-    for (const name of PORTED_UNPORTED_MIXIN_METHODS[fqn] ?? []) addRubyName(name);
+    for (const name of PORTED_METHODS_FROM_UNPORTED_MIXINS[fqn] ?? []) addRubyName(name);
   }
   return allowed;
 }


### PR DESCRIPTION
`AMBIENT_RAILTIE_MIXINS.methods` had zero entries after #5368 removed its only
user. Deletes the field, its type member, and the `for (const name of
ambient.methods ?? []) addRubyName(name)` consumer loop, plus the doc-comment
paragraphs that described it. With `includes` now the only member, it becomes
required and the lookup collapses to a single statement.

The `includes` arm is untouched in behavior — it is load-bearing
(`ActiveRecord::Base` gains `GlobalID::Identification` via globalid's railtie,
invisible to the static Ruby extractor). The raw-Ruby-name → `addRubyName`
mechanism itself survives via the sibling constant just below, which is in use,
so a future railtie-injected `def`-less method has a live precedent to follow.

Also renames that sibling `PORTED_UNPORTED_MIXIN_METHODS` →
`PORTED_METHODS_FROM_UNPORTED_MIXINS` (a single mechanical rename, noted here
per the CLAUDE.md exception). The old name read as the self-contradictory
"ported unported"; the two words in fact qualify different nouns — *we ported
the methods*, while the *mixin's source file* is unported. Identifier-only:
2 call sites in `extra-surface.ts` and 3 references in `extra-surface.test.ts`
(one test title's trailing parenthetical, which names the identifier — this
file is api-compare tooling with no Rails counterpart, so it is not part of
`test:compare`'s Rails-test matching).

Verification: `pnpm api:compare && pnpm api:extra` run on `main` and on this
branch (manifests regenerated for both — `api:extra` reads build state, not the
commit) produce byte-identical reports apart from the generation timestamp. The
one pre-existing STALE-tag failure (`connection-pool.ts NullConfig`) reproduces
unchanged on `main`. `extra-surface.test.ts` passes (47/47).

Closes-story: retire-unused-ambient-railtie-mixins-methods-arm
