### PR TITLE
fix(migration): return null from lastStoredEnvironment at version 0

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2997,12 +2997,13 @@ export class Migrator {
     // MigrationContext#last_stored_environment short-circuits on
     // `internal_metadata.enabled?` before the table_exists? read.
     if (!this._internalMetadata.enabled) return null;
+    // Rails guards on current_version == 0 BEFORE the table_exists? read: an
+    // unmigrated database is unstamped even when ar_internal_metadata exists
+    // and carries an environment row.
+    if ((await this.currentVersionReadOnly()) === 0) return null;
     const noEnvMsg =
       "Environment data not found in the schema. To resolve this issue, run: bin/rails db:environment:set";
     if (!(await this._internalMetadata.tableExists())) {
-      // Rails: return nil when current_version == 0 (no migrations applied yet).
-      // When migrations are present but the metadata table is absent, raise.
-      if ((await this.currentVersionReadOnly()) === 0) return null;
       throw new NoEnvironmentInSchemaError(noEnvMsg);
     }
     const environment = await this._internalMetadata.get("environment");

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2997,9 +2997,6 @@ export class Migrator {
     // MigrationContext#last_stored_environment short-circuits on
     // `internal_metadata.enabled?` before the table_exists? read.
     if (!this._internalMetadata.enabled) return null;
-    // Rails guards on current_version == 0 BEFORE the table_exists? read: an
-    // unmigrated database is unstamped even when ar_internal_metadata exists
-    // and carries an environment row.
     if ((await this.currentVersionReadOnly()) === 0) return null;
     const noEnvMsg =
       "Environment data not found in the schema. To resolve this issue, run: bin/rails db:environment:set";

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -106,6 +106,18 @@ describe("Migrator trails extensions", () => {
     await expect(migrator.checkProtectedEnvironments()).rejects.toThrow(ProtectedEnvironmentError);
   });
 
+  it("lastStoredEnvironment returns null at version 0 even when metadata is stamped", async () => {
+    const metadata = new InternalMetadata(adapter);
+    await metadata.createTable();
+    await metadata.set("environment", "production");
+
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")], {
+      environment: "production",
+    });
+    await expect(migrator.lastStoredEnvironment()).resolves.toBeNull();
+    await expect(migrator.checkProtectedEnvironments()).resolves.toBeUndefined();
+  });
+
   it("checkProtectedEnvironments passes for development", async () => {
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")], {
       environment: "development",

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1144,6 +1144,10 @@ export class CreatePosts extends Migration {
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
       const migrator = new Migrator(adapter, []);
+      // Rails' last_stored_environment returns nil at current_version == 0, so
+      // record a version (as database_tasks_test.rb does) to make the DB stamped.
+      await migrator.schemaMigration.createTable();
+      await migrator.schemaMigration.createVersion("1");
       await migrator.internalMetadata.createTable();
       await migrator.internalMetadata.set("environment", "production");
     } finally {
@@ -1184,6 +1188,10 @@ export class CreatePosts extends Migration {
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
       const migrator = new Migrator(adapter, []);
+      // Rails' last_stored_environment returns nil at current_version == 0, so
+      // record a version (as database_tasks_test.rb does) to make the DB stamped.
+      await migrator.schemaMigration.createTable();
+      await migrator.schemaMigration.createVersion("1");
       await migrator.internalMetadata.createTable();
       await migrator.internalMetadata.set("environment", "staging");
     } finally {
@@ -1216,6 +1224,10 @@ export class CreatePosts extends Migration {
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
       const migrator = new Migrator(adapter, []);
+      // Rails' last_stored_environment returns nil at current_version == 0, so
+      // record a version (as database_tasks_test.rb does) to make the DB stamped.
+      await migrator.schemaMigration.createTable();
+      await migrator.schemaMigration.createVersion("1");
       await migrator.internalMetadata.createTable();
       await migrator.internalMetadata.set("environment", "production");
     } finally {
@@ -1263,6 +1275,8 @@ export class CreatePosts extends Migration {
       expect(await migrator.internalMetadata.tableExists()).toBe(false);
 
       // After stamping as production, both calls reflect the protected state.
+      await migrator.schemaMigration.createTable();
+      await migrator.schemaMigration.createVersion("1");
       await migrator.internalMetadata.createTable();
       await migrator.internalMetadata.set("environment", "production");
       expect(await migrator.protectedEnvironment()).toBe(true);


### PR DESCRIPTION
Rails' `MigrationContext#last_stored_environment` (migration.rb:1348) returns
`nil` when `current_version == 0` **before** consulting
`internal_metadata.table_exists?`. Trails only applied the version-0 check in
the table-absent branch, so a database stamped with a protected environment but
with zero applied migrations raised `ProtectedEnvironmentError` where Rails
passes.

Reorders the guard to match Rails and adds a regression test covering the
stamped-metadata-at-version-0 case.

Closes-story: last-stored-environment-missing-version-zero-guard
