### PR TITLE
refactor(tasks): route migrate through the migration connection pool

### DIFF
--- a/packages/activerecord-cli/src/db-migrate.test.ts
+++ b/packages/activerecord-cli/src/db-migrate.test.ts
@@ -51,14 +51,21 @@ describe("DbMigrateTest", () => {
   it("db:migrate calls migrate with no args", async () => {
     DatabaseConfigurations.defaultEnv = "development";
     expect(await run(["db:migrate"], await makeFakeProject())).toBe(0);
-    expect(migrateSpy).toHaveBeenCalledWith(undefined);
+    expect(migrateSpy).toHaveBeenCalledWith(undefined, { skipInitialize: true });
   });
 
   it("db:migrate --version passes version string", async () => {
+    // `--version` is the CLI spelling of Rails' `VERSION=x rake db:migrate`, so
+    // it reaches `migrate` through `targetVersion()` rather than as an argument.
+    let seenTargetVersion: number | null = null;
+    migrateSpy.mockImplementation(async () => {
+      seenTargetVersion = DatabaseTasks.targetVersion();
+    });
     expect(await run(["db:migrate", "--version", "20240101000000"], await makeFakeProject())).toBe(
       0,
     );
-    expect(migrateSpy).toHaveBeenCalledWith("20240101000000");
+    expect(seenTargetVersion).toBe(20240101000000);
+    expect(DatabaseTasks.targetVersion()).toBeNull();
   });
 
   it("db:migrate calls Migrator.discoverMigrations before migrate", async () => {

--- a/packages/activerecord-cli/src/db-migrate.test.ts
+++ b/packages/activerecord-cli/src/db-migrate.test.ts
@@ -10,10 +10,27 @@ const config = { development: { adapter: "sqlite3", database: ":memory:", pool: 
 export default config;
 `;
 
+const FAKE_MULTI_DB_CONFIG = `
+const config = {
+  development: {
+    primary: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+    animals: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+  },
+};
+export default config;
+`;
+
 async function makeFakeProject(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "ar-db-migrate-"));
   await mkdir(join(dir, "config"), { recursive: true });
   await writeFile(join(dir, "config", "database.ts"), FAKE_CONFIG, "utf8");
+  return dir;
+}
+
+async function makeMultiDbFakeProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "ar-db-migrate-multi-"));
+  await mkdir(join(dir, "config"), { recursive: true });
+  await writeFile(join(dir, "config", "database.ts"), FAKE_MULTI_DB_CONFIG, "utf8");
   return dir;
 }
 
@@ -72,6 +89,16 @@ describe("DbMigrateTest", () => {
     const discoverSpy = vi.spyOn(Migrator, "discoverMigrations").mockReturnValue([]);
     expect(await run(["db:migrate"], await makeFakeProject())).toBe(0);
     expect(discoverSpy).toHaveBeenCalled();
+  });
+
+  it("db:migrate takes the multi-database path when the env has several configs", async () => {
+    // `migrateAll`'s multi-db branch never touches the ambient pool `dbMigrate`
+    // opens — it drives each config through its own `withTemporaryConnection`,
+    // so the single-primary fast path (and with it `migrate`) is never reached.
+    DatabaseConfigurations.defaultEnv = "development";
+    expect(await run(["db:migrate"], await makeMultiDbFakeProject())).toBe(0);
+    expect(DatabaseTasks.configsFor("development")).toHaveLength(2);
+    expect(migrateSpy).not.toHaveBeenCalled();
   });
 
   it("db:migrate exits 1 on missing config", async () => {

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from "path";
-import { getFsAsync } from "@blazetrails/activesupport";
+import { getEnv, getFsAsync, setEnv } from "@blazetrails/activesupport";
 import {
   DatabaseTasks,
   DatabaseConfigurations,
@@ -123,15 +123,29 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
   await tryLoadModels(cwd);
   loadMigrations(cwd);
 
+  // Rails' `rake db:migrate` (railties/databases.rake:89) takes its target from
+  // `ENV["VERSION"]`, which `migrate_all` reads back through `target_version`;
+  // `--version` is the CLI spelling of that env var, not an extra argument.
   const version = flagValue(args, "--version");
+  const previousVersion = getEnv("TRAILS_MIGRATION_VERSION");
+  if (version !== undefined) setEnv("TRAILS_MIGRATION_VERSION", version);
+  // `db:migrate` depends on `load_config: :environment` (databases.rake:22, :89),
+  // so app boot has already established Base's connection by the time
+  // `migrate_all` reaches its single-primary fast path. The CLI has no boot
+  // step, so open that ambient connection here.
+  const dbConfig = DatabaseTasks.databaseConfiguration?.findDbConfig(DatabaseTasks.env);
   try {
-    await DatabaseTasks.withTemporaryPoolForEach(DatabaseTasks.env, async () => {
-      await DatabaseTasks.migrate(version);
-    });
+    if (dbConfig) {
+      await DatabaseTasks.withTemporaryPool(dbConfig, () => DatabaseTasks.migrateAll());
+    } else {
+      await DatabaseTasks.migrateAll();
+    }
     return 0;
   } catch (err) {
     console.error(`ar: db:migrate failed — ${String(err)}`);
     return 1;
+  } finally {
+    if (version !== undefined) setEnv("TRAILS_MIGRATION_VERSION", previousVersion);
   }
 }
 

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -124,13 +124,8 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
   loadMigrations(cwd);
 
   const version = flagValue(args, "--version");
-  const env = DatabaseTasks.env;
-  if (DatabaseTasks.configsFor(env).length === 0) {
-    console.error(`ar: no database configuration found for environment "${env}"`);
-    return 1;
-  }
   try {
-    await DatabaseTasks.withTemporaryPoolForEach(env, async () => {
+    await DatabaseTasks.withTemporaryPoolForEach(DatabaseTasks.env, async () => {
       await DatabaseTasks.migrate(version);
     });
     return 0;

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -124,8 +124,20 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
   loadMigrations(cwd);
 
   const version = flagValue(args, "--version");
+  const configs = DatabaseTasks.configsFor(DatabaseTasks.env);
+  if (configs.length === 0) {
+    console.error(`ar: no database configuration found for environment "${DatabaseTasks.env}"`);
+    return 1;
+  }
+  const config = configs.find((c) => c.name === "primary") ?? configs[0];
   try {
-    await DatabaseTasks.migrate(version);
+    // `migrate` routes through the migration connection pool (Rails
+    // tasks/database_tasks.rb:262-283), so the caller picks the database —
+    // mirroring `with_temporary_connection(db_config) { migrate(...) }` in
+    // `migrate_all` (:254).
+    await DatabaseTasks.withTemporaryPool(config, async () => {
+      await DatabaseTasks.migrate(version);
+    });
     return 0;
   } catch (err) {
     console.error(`ar: db:migrate failed — ${String(err)}`);

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -124,18 +124,13 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
   loadMigrations(cwd);
 
   const version = flagValue(args, "--version");
-  const configs = DatabaseTasks.configsFor(DatabaseTasks.env);
-  if (configs.length === 0) {
-    console.error(`ar: no database configuration found for environment "${DatabaseTasks.env}"`);
+  const env = DatabaseTasks.env;
+  if (DatabaseTasks.configsFor(env).length === 0) {
+    console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;
   }
-  const config = configs.find((c) => c.name === "primary") ?? configs[0];
   try {
-    // `migrate` routes through the migration connection pool (Rails
-    // tasks/database_tasks.rb:262-283), so the caller picks the database —
-    // mirroring `with_temporary_connection(db_config) { migrate(...) }` in
-    // `migrate_all` (:254).
-    await DatabaseTasks.withTemporaryPool(config, async () => {
+    await DatabaseTasks.withTemporaryPoolForEach(env, async () => {
       await DatabaseTasks.migrate(version);
     });
     return 0;

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -786,13 +786,6 @@ function databaseTasksMigrationTestCase(): MigrationTestCase {
     const ambient = ambientPoolConfiguration();
     const sourceFile = String(ambient.database);
     await Base.establishConnection({ ...ambient, database: ":memory:", pool: 1 });
-    // Rails leaves the ambient `arunit` configurations in place while the
-    // connection is `:memory:`; trails' `migrate` picks its pool by comparing
-    // the config's database to the pool's, so the ambient shape is carried
-    // over with the connected database substituted in.
-    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      [DatabaseTasks.env]: { ...ambient, database: ":memory:" },
-    });
     await backupIntoConnection(sourceFile);
   });
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -303,17 +303,9 @@ export class DatabaseTasks {
       adapter.schemaCache?.clear();
     };
 
-    // Rails routes solely through `migration_connection_pool`
-    // (tasks/database_tasks.rb:262-283): no configurations lookup, no early
-    // return, and no comparison of the config's database to the pool's. The
-    // caller (`with_temporary_connection`, `db_configs_with_versions`) is what
-    // selects which database gets migrated.
     const pool = await this.migrationConnectionPool();
     if (!pool) throw new ConnectionNotDefined("No connection pool for the migration connection");
 
-    // Rails: `initialize_database(migration_connection_pool.db_config)` — the
-    // pool's OWN config object, so the temporary pool it opens resolves to the
-    // established pool rather than a second one.
     if (!skipInitialize) await initializeDatabase(pool.dbConfig);
     await runMigration(await pool.leaseConnection());
   }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -269,12 +269,6 @@ export class DatabaseTasks {
     const effectiveVersion = typeof raw === "string" ? raw.trim() || null : raw;
     this.checkTargetVersion(effectiveVersion ?? undefined);
 
-    if (!this.databaseConfiguration) return;
-    const configs = this.configsFor(this._normalizeEnv());
-    if (configs.length === 0) return;
-
-    const config = configs.find((c) => c.name === "primary") ?? configs[0];
-
     const { Migrator, Migration } = await import("../migration.js");
     const scope = getEnv("SCOPE");
     const verbose = isVerbose();
@@ -309,37 +303,19 @@ export class DatabaseTasks {
       adapter.schemaCache?.clear();
     };
 
-    // Pool path: check whether the Base pool is connected to this config's database.
-    // When pool and config point to different known databases (multi-db scenario),
-    // route through withTemporaryConnection so the owned adapter is properly closed.
-    // "database unknown on either side" means a URL-only config or no database
-    // restriction — treat as matching so the established pool is reused.
-    const { Base } = await import("../base.js");
-    this._baseClass = Base;
-    let pool: ConnectionPool | undefined;
-    try {
-      pool = Base.connectionPool();
-    } catch (error) {
-      if (!(error instanceof ConnectionNotDefined)) throw error;
-      // No pool — fall through to withTemporaryConnection.
-    }
-    // Use the pool when: pool is present AND databases are equal, or either side
-    // is unknown (URL-only config / pool established without an explicit database).
-    if (
-      pool &&
-      (!pool.dbConfig.database || !config.database || config.database === pool.dbConfig.database)
-    ) {
-      // Rails: `initialize_database(migration_connection_pool.db_config)`
-      // (tasks/database_tasks.rb:268) — the pool's OWN config object, so the
-      // temporary pool it opens resolves to the established pool rather than a
-      // second one.
-      if (!skipInitialize) await initializeDatabase(pool.dbConfig);
-      await runMigration(await pool.leaseConnection());
-    } else {
-      // Multi-db or no pool: withTemporaryConnection scopes the adapter lifecycle.
-      if (!skipInitialize) await initializeDatabase(config);
-      await this.withTemporaryConnection(config, runMigration);
-    }
+    // Rails routes solely through `migration_connection_pool`
+    // (tasks/database_tasks.rb:262-283): no configurations lookup, no early
+    // return, and no comparison of the config's database to the pool's. The
+    // caller (`with_temporary_connection`, `db_configs_with_versions`) is what
+    // selects which database gets migrated.
+    const pool = await this.migrationConnectionPool();
+    if (!pool) throw new ConnectionNotDefined("No connection pool for the migration connection");
+
+    // Rails: `initialize_database(migration_connection_pool.db_config)` — the
+    // pool's OWN config object, so the temporary pool it opens resolves to the
+    // established pool rather than a second one.
+    if (!skipInitialize) await initializeDatabase(pool.dbConfig);
+    await runMigration(await pool.leaseConnection());
   }
 
   /** Roll back the last N migrations (default 1). Mirrors `db:rollback`. */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -304,8 +304,6 @@ export class DatabaseTasks {
     };
 
     const pool = await this.migrationConnectionPool();
-    if (!pool) throw new ConnectionNotDefined("No connection pool for the migration connection");
-
     if (!skipInitialize) await initializeDatabase(pool.dbConfig);
     await runMigration(await pool.leaseConnection());
   }
@@ -1154,11 +1152,8 @@ export class DatabaseTasks {
     }
   }
 
-  static async migrationConnectionPool(): Promise<ConnectionPool | null> {
-    const { Base } = await import("../base.js");
-    this._baseClass = Base;
-    const fn = (Base as unknown as { connectionPool?: () => ConnectionPool }).connectionPool;
-    return fn ? fn.call(Base) : null;
+  static async migrationConnectionPool(): Promise<ConnectionPool> {
+    return (await this.migrationClass()).connectionPool();
   }
 
   static async schemaUpToDate(


### PR DESCRIPTION
## What

`DatabaseTasks.migrate` now resolves its pool the way Rails does — through the
migration connection pool — instead of comparing database strings against
`databaseConfiguration`.

Rails (`vendor/rails/activerecord/lib/active_record/tasks/database_tasks.rb:262-283`)
runs `migration_connection_pool.migration_context.migrate` unconditionally and
reads `db_config` off that same pool for `initialize_database`. There is no
configurations lookup, no early return, and no database-string routing.

trails had all three: an `if (!this.databaseConfiguration) return` gate, a
`configsFor(env)` lookup, and a `config.database === pool.dbConfig.database`
comparison choosing between the established pool and `withTemporaryConnection`.
The consequence (surfaced in #5299) was that callers had to install a
`databaseConfiguration` whose database string matched the connected pool, or
`migrate()` silently no-oped / migrated a *different* database.

## Changes

- `migrate` leases from `migrationConnectionPool()` and initializes from
  `pool.dbConfig`; the early return, the config lookup and the string routing
  are gone. Choosing *which* database gets migrated is the caller's job now, as
  in Rails.
- `migrationConnectionPool()` is now literally `migration_class.connection_pool`
  (:537-539) and non-nullable. It never returned `null` for an unestablished
  connection — `Base.connectionPool()` raises `ConnectionNotDefined` — so the
  defensive `fn ? … : null` branch was unreachable.
- `databaseTasksMigrationTestCase()` no longer synthesizes a
  `DatabaseConfigurations` to make `migrate()` reach the connected pool.
- `ar db:migrate` calls `DatabaseTasks.migrateAll()`, matching
  `rake db:migrate` (`railties/databases.rake:89`), so the single-primary fast
  path and `dbConfigsWithVersions`' per-config version dispatch are back in
  play. `--version` is threaded as Rails threads it — written to
  `TRAILS_MIGRATION_VERSION` for the duration of the call and read back via
  `targetVersion()`, since `migrate_all` takes no version argument.

## The CLI's ambient connection

`db:migrate` depends on `load_config: :environment` (`databases.rake:22`), so in
Rails the app boot has already established `Base`'s connection by the time
`migrate_all` reaches `migration_connection_pool`. The `ar` CLI has no boot
step, and `initializeDatabase` only opens a scoped `withTemporaryConnection`
(`database-tasks.ts:1462`) that closes before the fast path runs — so
`dbMigrate` opens that ambient pool itself via `withTemporaryPool(dbConfig, …)`
around `migrateAll()`. With no config for the env it just calls `migrateAll()`,
which no-ops exactly as Rails' does with an empty `db_configs`.

### Why the wrap is unconditional

Rails' ambient connection does not depend on the config count — `load_config`
depends on `:environment` whether the env has one database or five, so `Base` is
connected before `migrate_all` branches. Gating the wrap on
`configs.length === 1` would duplicate `migrateAll`'s own
`size == 1 && primary?` check in the caller to save a connection Rails also
holds open, so it stays unconditional and the multi-db branch is covered by a
test instead.

## Testing

`database-tasks.test.ts`, `migration.test.ts`, `migrator.test.ts` and the whole
`activerecord-cli` suite pass locally (352 tests), including the sqlite
happy-path E2E that drives `ar db:migrate` end to end. `db-migrate.test.ts`
assertions follow the new call shape (`migrate(undefined, { skipInitialize: true })`
from the fast path; `--version` observed through `targetVersion()` and asserted
restored afterwards), plus a new case covering the multi-database branch — two
`development` configs, asserting `migrate` is never called (the fast path is
skipped) and that two configs really resolved, so it can't pass vacuously on an
empty config set. No existing test names changed.

## Review follow-ups

All three findings from review are fixed:

- **Dead null-check on `migrationConnectionPool()`** — gone; the method is
  non-nullable and the real `ConnectionNotDefined` surfaces from
  `connectionPool()`.
- **Invented empty-configs guard in `dbMigrate`** — dropped; no configs is a
  silent no-op, as in `migrate_all`.
- **`dbMigrate` reimplemented `migrate_all`** — now calls `migrateAll()`. I had
  deferred this to a story on the grounds that `--version` needed its own
  contract change; the `VERSION`-env threading turned out to be the faithful
  spelling and small enough to land here, so the story
  (`cli-db-migrate-should-call-migrate-all`) is closed as superseded by this PR.

Closes-story: migrate-pool-routing-via-database-configuration
