### PR TITLE
fix(activesupport): route Logger's default output through the stdout shim

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } fr
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { stdout } from "@blazetrails/activesupport";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
@@ -776,11 +777,8 @@ function databaseTasksMigrationTestCase(): MigrationTestCase {
   beforeEach(async () => {
     if (skipMigrationTestCase) return;
     stdoutChunks = [];
-    // `Migration.logger` writes straight to `process.stdout` (activesupport
-    // logger.ts:64), so the capture has to sit there rather than on the
-    // activesupport `stdout` shim — both funnel through this write.
-    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    stdoutSpy = vi.spyOn(stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(chunk);
       return true;
     });
     const ambient = ambientPoolConfiguration();

--- a/packages/activesupport/src/logger.trails.test.ts
+++ b/packages/activesupport/src/logger.trails.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Logger } from "./logger.js";
+import {
+  __INTERNAL_resetProcessAdapter_TEST_ONLY,
+  registerProcessAdapter,
+  type ProcessAdapter,
+} from "./process-adapter.js";
+
+function makeCapturingAdapter(): { adapter: ProcessAdapter; written: string[] } {
+  const written: string[] = [];
+  const stream = {
+    write: (chunk: string) => {
+      written.push(chunk);
+      return true;
+    },
+    isTTY: false,
+  };
+  const adapter: ProcessAdapter = {
+    envSnapshot: () => ({}),
+    argvSnapshot: () => [],
+    cwd: () => "/capture",
+    chdir: () => {},
+    platform: () => "capture",
+    setEnv: () => {},
+    exit: () => {
+      throw new Error("exit");
+    },
+    setExitCode: () => {},
+    onSignal: () => () => {},
+    stdout: stream,
+    stderr: stream,
+    stdin: { isTTY: false, read: async () => null },
+  };
+  return { adapter, written };
+}
+
+describe("Logger default output", () => {
+  afterEach(() => {
+    __INTERNAL_resetProcessAdapter_TEST_ONLY();
+  });
+
+  it("routes through the registered process adapter", () => {
+    const { adapter, written } = makeCapturingAdapter();
+    registerProcessAdapter(adapter);
+
+    new Logger().info("== 1 Foo: migrating ==");
+
+    expect(written.join("")).toBe("== 1 Foo: migrating ==\n");
+  });
+
+  it("routes through an adapter registered after the logger was built", () => {
+    const logger = new Logger();
+    const { adapter, written } = makeCapturingAdapter();
+    registerProcessAdapter(adapter);
+
+    logger.info("late");
+
+    expect(written.join("")).toBe("late\n");
+  });
+});

--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -2,6 +2,7 @@
  * Logger and TaggedLogging — mirroring ActiveSupport's logging API.
  */
 
+import { stdout } from "./process-adapter.js";
 import { Temporal } from "./temporal.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "fatal" | "unknown";
@@ -27,6 +28,12 @@ const LEVEL_NAMES: Record<number, LogLevel> = {
 export interface LoggerOutput {
   write(s: string): void;
 }
+
+const defaultOutput: LoggerOutput = {
+  write: (s) => {
+    stdout.write(s);
+  },
+};
 
 /**
  * ActiveSupport::Logger — a structured logger with level filtering, silence blocks,
@@ -61,7 +68,7 @@ export class Logger {
   static readonly FATAL = 4;
   static readonly UNKNOWN = 5;
 
-  constructor(output: LoggerOutput | null = { write: (s) => process.stdout.write(s) }) {
+  constructor(output: LoggerOutput | null = defaultOutput) {
     this.output = output;
   }
 


### PR DESCRIPTION
`Logger`'s default sink wrote straight to `process.stdout` (`logger.ts:64`), bypassing the activesupport process-adapter shim that `DatabaseTasks.migrateStatus` and every other output path use. A host registering a custom `ProcessAdapter` got migration progress (`== 1 Foo: migrating ==`) on the real stdout while everything else was redirected.

The default sink now dispatches through `stdout` from `process-adapter.ts` on **each write** rather than capturing a stream reference, so an adapter registered after a `Logger` was constructed still captures its output. No `process.*` reference remains in `logger.ts`.

`database-tasks.test.ts`'s migration capture helper moves off `vi.spyOn(process.stdout, "write")` onto the shim; its existing `toContain("migrating")` assertions still pass, which is the end-to-end proof that migration logger output now reaches the shim.

New `logger.trails.test.ts` registers a capturing `ProcessAdapter` and asserts the default `Logger` writes land in it — both for a logger built after registration and one built before. Both fail on baseline (output goes to the real stdout, capture array empty).

Closes-story: migration-logger-bypasses-stdout-adapter