### PR TITLE
fix(postgresql): derive sequenceNameFromParts budget from maxIdentifierLength

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -6,6 +6,7 @@ interface FakeOptions {
   logger?: { warn: (msg: string) => void };
   schemaQuery?: (sql: string) => Promise<Record<string, unknown>[]>;
   queryValue?: (sql: string) => Promise<unknown>;
+  maxIdentifierLength?: number;
 }
 
 function makeAdapter(options: FakeOptions = {}) {
@@ -44,6 +45,7 @@ function makeAdapter(options: FakeOptions = {}) {
       return options.queryValue ? await options.queryValue(text) : null;
     }),
     getDatabaseVersion: vi.fn(async () => 160000),
+    maxIdentifierLength: () => options.maxIdentifierLength ?? 63,
   };
   return { adapter: adapter as unknown as DatabaseAdapter, sql };
 }
@@ -188,5 +190,34 @@ describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
     const ss = new PostgreSQLSchemaStatements(adapter);
     await ss.resetPkSequenceBang("things", "id", "public.things_id_seq");
     expect(sql.at(-1)).toContain(`SELECT setval('"public"."things_id_seq"', 1, false)`);
+  });
+});
+
+// PostgreSQL's identifier limit is NAMEDATALEN - 1, and NAMEDATALEN is a
+// compile-time constant: `max_identifier_length` is the real server value, not
+// necessarily 63. sequenceNameFromParts is what newColumnFromField compares a
+// column's nextval() default against to decide `serial:`, so a budget that
+// ignores the server value mis-detects serial columns and changes the dump.
+describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", () => {
+  it("truncates against the server's maxIdentifierLength, not a hardcoded 63", () => {
+    const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    const name = ss.sequenceNameFromParts("a".repeat(40), "b".repeat(10), "seq");
+    expect(name).toBe(`${"a".repeat(16)}_${"b".repeat(10)}_seq`);
+    expect(name.length).toBe(31);
+  });
+
+  it("splits the overage across column and table under a short limit", () => {
+    const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    const name = ss.sequenceNameFromParts("a".repeat(40), "b".repeat(30), "seq");
+    expect(name).toBe(`${"a".repeat(13)}_${"b".repeat(13)}_seq`);
+    expect(name.length).toBe(31);
+  });
+
+  it("leaves names within the limit untouched", () => {
+    const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    expect(ss.sequenceNameFromParts("things", "id", "seq")).toBe("things_id_seq");
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -193,11 +193,6 @@ describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
   });
 });
 
-// PostgreSQL's identifier limit is NAMEDATALEN - 1, and NAMEDATALEN is a
-// compile-time constant: `max_identifier_length` is the real server value, not
-// necessarily 63. sequenceNameFromParts is what newColumnFromField compares a
-// column's nextval() default against to decide `serial:`, so a budget that
-// ignores the server value mis-detects serial columns and changes the dump.
 describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", () => {
   it("truncates against the server's maxIdentifierLength, not a hardcoded 63", () => {
     const { adapter } = makeAdapter({ maxIdentifierLength: 31 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1910,13 +1910,14 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   /** @internal */
   sequenceNameFromParts(tableName: string, columnName: string, suffix: string): string {
-    const maxLen = this.pg.maxIdentifierLength();
+    const maxIdentifierLength = this.pg.maxIdentifierLength();
     const [, unqualifiedTable] = this.pg.extractSchemaQualifiedName(tableName);
-    let overLength = unqualifiedTable.length + columnName.length + suffix.length + 2 - maxLen;
+    let overLength =
+      unqualifiedTable.length + columnName.length + suffix.length + 2 - maxIdentifierLength;
     let col = columnName;
     let tbl = unqualifiedTable;
     if (overLength > 0) {
-      const colMaxLen = Math.floor((maxLen - suffix.length - 2) / 2);
+      const colMaxLen = Math.floor((maxIdentifierLength - suffix.length - 2) / 2);
       const newColLen = Math.min(colMaxLen, col.length);
       overLength -= col.length - newColLen;
       // Mirrors Ruby's `column_name[0, column_name_length - [over_length, 0].min]`:

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -58,6 +58,7 @@ interface PgSchemaAdapter {
   supportsIdentityColumns(): boolean;
   supportsVirtualColumns(): boolean;
   extractSchemaQualifiedName(string: string): [string | null, string];
+  maxIdentifierLength(): number;
   getDatabaseVersion(): Promise<number>;
   supportsIndexInclude(): boolean;
   dataSourceSql(name?: string | null, options?: { type?: string }): string;
@@ -1909,7 +1910,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   /** @internal */
   sequenceNameFromParts(tableName: string, columnName: string, suffix: string): string {
-    const maxLen = 63;
+    const maxLen = this.pg.maxIdentifierLength();
     const [, unqualifiedTable] = this.pg.extractSchemaQualifiedName(tableName);
     let overLength = unqualifiedTable.length + columnName.length + suffix.length + 2 - maxLen;
     let col = columnName;


### PR DESCRIPTION
Rails computes `sequence_name_from_parts`' truncation budget from
`max_identifier_length`
(`postgresql/schema_statements.rb:1007-1021`), a `SHOW`-backed server value.
trails hardcoded `const maxLen = 63` — the default `NAMEDATALEN - 1`, but
PostgreSQL can be compiled with a different `NAMEDATALEN`.

`converge-pg-max-identifier-length-sync` (#4810) already made
`maxIdentifierLength()` synchronous, so the helper reads the real value with no
async plumbing.

This is not cosmetic: `sequenceNameFromParts` is what `newColumnFromField`
compares a column's `nextval(...)` default against to decide whether a column is
`serial:`, so a wrong budget mis-detects serial columns on a non-default server
and changes the dumped schema.

Rails has no test for this helper, so the regression tests land in
`schema-statements-class.trails.test.ts`. Both truncation tests fail against the
hardcoded 63 (verified) and pass after the fix.

Closes-story: pg-sequence-name-from-parts-hardcodes-63
