### PR TITLE
fix(mysql): port remove_foreign_key's RESTRICT option stripping

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -72,7 +72,11 @@ import {
   ForeignKeyDefinition,
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
-import type { ColumnOptions, SchemaStatementsLike } from "./abstract/schema-definitions.js";
+import type {
+  ColumnOptions,
+  RemoveForeignKeyOptions,
+  SchemaStatementsLike,
+} from "./abstract/schema-definitions.js";
 import {
   TableDefinition as MysqlTableDefinition,
   Table as MysqlTable,
@@ -251,6 +255,27 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // across dialects.
     const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
     return new MysqlTableDefinition(name, { ...rest, adapter: this });
+  }
+
+  /**
+   * RESTRICT is MySQL's default referential action, so `extractForeignKeyAction`
+   * reflects it back as `undefined` and a lookup keyed on `onDelete: "restrict"`
+   * could never match the live constraint. Drop those keys before resolving.
+   *
+   * Mirrors: `ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#remove_foreign_key`
+   */
+  override async removeForeignKey(
+    fromTable: string,
+    toTableOrOptions?: string | RemoveForeignKeyOptions,
+    options: RemoveForeignKeyOptions = {},
+  ): Promise<void> {
+    const optionsForm = typeof toTableOrOptions === "object" && toTableOrOptions !== null;
+    const opts: RemoveForeignKeyOptions = { ...(optionsForm ? toTableOrOptions : options) };
+    if (opts.onUpdate === "restrict") delete opts.onUpdate;
+    if (opts.onDelete === "restrict") delete opts.onDelete;
+    return optionsForm
+      ? super.removeForeignKey(fromTable, opts)
+      : super.removeForeignKey(fromTable, toTableOrOptions, opts);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -852,7 +852,13 @@ export class SchemaStatements {
     options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
     const adapter = this.adapter as any;
+    // `adapter !== this` keeps the dispatch one-way. When these methods run
+    // mixed into an adapter (`include(AbstractAdapter, SchemaStatements)`),
+    // `this.adapter` is the adapter itself, so an adapter override reaching the
+    // base body through `super` would otherwise be dispatched straight back to
+    // itself.
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.removeForeignKey === "function" &&
       adapter.removeForeignKey !== SchemaStatements.prototype.removeForeignKey
     ) {

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -24,8 +24,6 @@ import { describeIfSupports } from "../support/supports.js";
 // has no name to compare.
 const unlessSqlite3Adapter = adapterType !== "sqlite";
 
-const mysqlRestrictActionReflectsNil = adapterType === "mysql";
-
 describeIfSupports("foreign_keys", "Migration", () => {
   describe("ForeignKeyTest", () => {
     // DDL can't run inside the transactional-fixtures wrapper (PG aborts the
@@ -305,27 +303,15 @@ describeIfSupports("foreign_keys", "Migration", () => {
       });
     });
 
-    // Unreachable on the MySQL family: `extract_foreign_key_action` is overridden
-    // with `super unless specifier == "RESTRICT"` (mysql/schema_statements.rb:224-226),
-    // so the reflected fk stores `on_delete` as nil — the same fact Rails asserts in
-    // test_add_on_delete_restrict_foreign_key. `defined_for?` then compares
-    // `Array(nil)` against `["restrict"]` and never matches, so the removal raises.
-    // Rails leaves the case ungated because its own suite does not run it here,
-    // so the skip is ours, not a ported gate — held in a named boolean so
-    // test-compare records it as an incomparable guard rather than as an adapter
-    // restriction Rails never had.
-    it.skipIf(mysqlRestrictActionReflectsNil)(
-      "remove foreign key with restrict action",
-      async () => {
-        const conn = await ambientConnection();
-        await withRocketTables(conn, async () => {
-          await conn.addForeignKey("astronauts", "rockets", { onDelete: "restrict" });
-          expect((await conn.foreignKeys("astronauts")).length).toBe(1);
-          await conn.removeForeignKey("astronauts", "rockets", { onDelete: "restrict" });
-          expect(await conn.foreignKeys("astronauts")).toEqual([]);
-        });
-      },
-    );
+    it("remove foreign key with restrict action", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { onDelete: "restrict" });
+        expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+        await conn.removeForeignKey("astronauts", "rockets", { onDelete: "restrict" });
+        expect(await conn.foreignKeys("astronauts")).toEqual([]);
+      });
+    });
 
     it("remove foreign key with if exists not set", async () => {
       const conn = await ambientConnection();

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -331,6 +331,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "remove_foreign_key",
+    "call": "delete",
+    "reason": "Ruby's `options.delete(:on_delete)` is the JS `delete opts.onDelete` operator, which is syntax rather than a call the extractor can see."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "remove_index_for_alter",
     "call": "index_name_for_remove",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
#5466 took the `activerecord` gate-mismatch count back to zero, but it did so by
holding the trails-only MySQL skip on `remove foreign key with restrict action`
in a named boolean (`mysqlRestrictActionReflectsNil`) so test-compare records it
as an *incomparable guard* rather than as an adapter restriction Rails never
had. The count is zero; the deviation is still there. This PR removes it.

## The deviation was fixed upstream

The comment justifying the skip argued that MySQL reflects `ON DELETE RESTRICT`
back with `on_delete` nil (`mysql/schema_statements.rb:224-226`), so
`defined_for?` compares `Array(nil)` against `["restrict"]`, never matches, and
the removal raises. That half is correct — Rails asserts exactly that in
`test_add_on_delete_restrict_foreign_key`. What it missed is that Rails already
fixed the *removal* side in b9608a6fa ("Fix removing foreign keys with
`:restrict` action for MySQL", rails/rails#53937):

```ruby
def remove_foreign_key(from_table, to_table = nil, **options)
  # RESTRICT is by default in MySQL.
  options.delete(:on_update) if options[:on_update] == :restrict
  options.delete(:on_delete) if options[:on_delete] == :restrict
  super
end
```

(`mysql/schema_statements.rb:88-93`.) That override is *why* Rails leaves
`test_remove_foreign_key_with_restrict_action` ungated — we were missing the
port, not hitting a latent upstream gap. Porting it onto `AbstractMysqlAdapter`
lets the test run unconditionally, exactly as Rails does, so the boolean and the
skip both go away.

## One dispatch fix was needed to reach `super`

`SchemaStatements#removeForeignKey` dispatches to `this.adapter.removeForeignKey`
when the adapter overrides it. But `SchemaStatements` is also mixed into
`AbstractAdapter` (`include(AbstractAdapter, SchemaStatements)`), where
`this.adapter` *is* the adapter — so an adapter override calling
`super.removeForeignKey` would be dispatched straight back to itself. The guard
now skips that self-dispatch case (`adapter !== this`). The companion-object
path (`schemaStatements()`, where `this.adapter !== this`) is unchanged, which
is the path the SQLite override already relies on.

## Verification

- `test:compare --gates --check` exits 0 (full re-extract); the gate-mismatch
  report is empty.
- `foreign-key.test.ts`: **20/20 on MySQL** (previously 19 + the skip), 20/20 on
  PostgreSQL, 19 + 1 SQLite-gated skip on SQLite.
- `schema-statements-on-adapter.test.ts` + `foreign-key.trails.test.ts` green on
  MySQL (50 total), PostgreSQL (48 with the FK suite) and SQLite — these cover
  the `removeForeignKey` dispatch paths the guard change touches.
- Load-bearing: with the adapter override reverted (test unskipped) the MySQL
  run fails with `ArgumentError: Table 'astronauts' has no foreign key for
  rockets` — the exact failure the old skip was hiding.
- `api:compare`, `api:calls`, `api:calls:wide`, `api:arity`, `api:pins` all
  pass. The wide ratchet flagged `remove_foreign_key` → `delete`, because Ruby's
  `options.delete(:on_delete)` is the `delete` *operator* in TS and not a call
  the extractor can see; baselined with that reason.

Not touched: `api:extra` reports a stale `@noRailsEquivalent` tag on
`NullConfig` in `abstract/connection-pool.ts`. That is pre-existing on `main`
(fallout from #5462 teaching the extractor to honor the tag on class
declarations) and unrelated to this diff.

Closes-story: foreign-key-test-gate-mismatch-hard-zero
