### PR TITLE
refactor(mysql): drop the invented _mysqlFkAction indirection

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -83,7 +83,6 @@ import {
   newColumnFromField,
   quotedScope,
   tableAliasLength as mysqlTableAliasLength,
-  extractForeignKeyAction as mysqlExtractForeignKeyAction,
 } from "./mysql/schema-statements.js";
 import type { Column as MysqlColumn } from "./mysql/column.js";
 import { TypeMap } from "../type/type-map.js";
@@ -1069,15 +1068,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     void tableName;
     return [];
-  }
-
-  protected _mysqlFkAction(
-    rule: string | null | undefined,
-  ): "cascade" | "nullify" | "restrict" | undefined {
-    // MySQL::SchemaStatements#extract_foreign_key_action overrides the abstract
-    // one with `super unless specifier == "RESTRICT"` (mysql/schema_statements.rb:225)
-    // — RESTRICT is MySQL's default, so it reports as nil (foreign_key_test.rb:267).
-    return mysqlExtractForeignKeyAction((rule ?? "").toUpperCase());
   }
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -374,7 +374,6 @@ describe("MySQL::SchemaStatements", () => {
     expect(fks[0].primaryKey).toBe("id");
     expect(fks[0].toTable).toBe("rockets");
     expect(fks[0].onDelete).toBe("cascade");
-    // RESTRICT is MySQL's default and reports as nil (foreign_key_test.rb:267).
     expect(fks[0].onUpdate).toBeUndefined();
   });
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -31,14 +31,7 @@ function fkHost(rows: Record<string, unknown>[]) {
   return {
     schemaQuery: async () => rows,
     quote,
-    _mysqlFkAction: (action: string) =>
-      action === "CASCADE"
-        ? "cascade"
-        : action === "SET NULL"
-          ? "nullify"
-          : action === "RESTRICT"
-            ? "restrict"
-            : undefined,
+    extractForeignKeyAction,
   };
 }
 
@@ -381,6 +374,8 @@ describe("MySQL::SchemaStatements", () => {
     expect(fks[0].primaryKey).toBe("id");
     expect(fks[0].toTable).toBe("rockets");
     expect(fks[0].onDelete).toBe("cascade");
+    // RESTRICT is MySQL's default and reports as nil (foreign_key_test.rb:267).
+    expect(fks[0].onUpdate).toBeUndefined();
   });
 
   it("test_add_composite_foreign_key_infers_column", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -554,6 +554,7 @@ export function parseMysqlName(name: string): { schema?: string; table: string }
 interface ForeignKeysHost {
   schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
   quote(value: unknown): string;
+  /** @internal */
   extractForeignKeyAction(specifier: string): "cascade" | "nullify" | undefined;
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -554,7 +554,7 @@ export function parseMysqlName(name: string): { schema?: string; table: string }
 interface ForeignKeysHost {
   schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
   quote(value: unknown): string;
-  _mysqlFkAction(action: string): "cascade" | "nullify" | "restrict" | undefined;
+  extractForeignKeyAction(specifier: string): "cascade" | "nullify" | "restrict" | undefined;
 }
 
 /** @internal
@@ -601,8 +601,8 @@ export async function foreignKeys(
     const first = group[0];
     const toTable = unquoteIdentifier(first.to_table as string) as string;
     const fkName = first.name as string;
-    const onDelete = this._mysqlFkAction(first.on_delete as string);
-    const onUpdate = this._mysqlFkAction(first.on_update as string);
+    const onDelete = this.extractForeignKeyAction(first.on_delete as string);
+    const onUpdate = this.extractForeignKeyAction(first.on_update as string);
     const column =
       group.length === 1
         ? (unquoteIdentifier(first.column as string) as string)

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -554,7 +554,7 @@ export function parseMysqlName(name: string): { schema?: string; table: string }
 interface ForeignKeysHost {
   schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
   quote(value: unknown): string;
-  extractForeignKeyAction(specifier: string): "cascade" | "nullify" | "restrict" | undefined;
+  extractForeignKeyAction(specifier: string): "cascade" | "nullify" | undefined;
 }
 
 /** @internal

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -56,6 +56,7 @@ import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
 import { abandonRawSocket } from "./abandon-raw-socket.js";
 import {
   foreignKeys as mysqlForeignKeys,
+  extractForeignKeyAction as mysqlExtractForeignKeyAction,
   indexes as mysqlIndexes,
   parseMysqlName as mysqlParseName,
   MysqlSchemaStatements,
@@ -1836,13 +1837,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   /** Delegates to {@link mysqlForeignKeys} in `mysql/schema-statements.ts`. */
   override async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    // `_mysqlFkAction` is protected on AbstractMysqlAdapter, so bind a public
-    // host surface rather than handing `this` straight to the standalone helper.
     return mysqlForeignKeys.call(
       {
         schemaQuery: this.schemaQuery.bind(this),
         quote: this.quote.bind(this),
-        _mysqlFkAction: this._mysqlFkAction.bind(this),
+        extractForeignKeyAction: mysqlExtractForeignKeyAction,
       },
       tableName,
     );


### PR DESCRIPTION
Removes the trails-invented `_mysqlFkAction` indirection surfaced by
`foreign_key_test.rb:267` in #5307.

Rails models this as `MySQL::SchemaStatements#extract_foreign_key_action`
(`mysql/schema_statements.rb:225`), which trails already ports as the standalone
in `connection-adapters/mysql/schema-statements.ts`. #5307 made `_mysqlFkAction`
delegate to it but left the wrapper in place.

- `_mysqlFkAction` is gone from `AbstractMysqlAdapter`; the `ForeignKeysHost`
  interface and the FK-reading path now name `extractForeignKeyAction`, and
  `mysql2-adapter.ts` passes the ported helper straight into the bound host
  (no protected-visibility workaround needed).
- The `fkHost` stub in `mysql/schema-statements.test.ts` uses the real
  `extractForeignKeyAction` instead of an inline mapping that still returned
  `"restrict"` for `"RESTRICT"` — the pre-#5307 behaviour — so the unit test
  would now catch a regression. Added an `onUpdate` assertion so RESTRICT → nil
  is actually exercised.

Also drops the `(rule ?? "").toUpperCase()` normalization the wrapper carried:
Rails passes `row["on_delete"]` through unchanged, and `information_schema`
yields uppercase rules.

Closes-story: remove-invented-mysql-fk-action-indirection
