### PR TITLE
test(migration): port CompositeForeignKeyTest cases

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2568,17 +2568,44 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     } else {
       await this.beginTransaction();
     }
+    // Rails' copy_table/move_table run their DDL through `execute`, so a
+    // rebuild failure (e.g. SQLite's "foreign key mismatch" when a new FK
+    // doesn't match a unique key on the referenced table) surfaces as
+    // StatementInvalid. The rebuild below uses driver.exec directly to manage
+    // savepoint nesting, so translate the raw driver error here to match.
+    const execTranslated = async (sql: string): Promise<void> => {
+      try {
+        await this.driver.exec(sql);
+      } catch (e) {
+        throw this._translateException(e, sql, []);
+      }
+    };
     try {
       await this.disableReferentialIntegrity(async () => {
-        await this.driver.exec(`CREATE TABLE ${qTmp} (${colDefs.join(", ")})`);
-        if (originalColNames.length > 0) {
-          const selectCols = originalColNames.map((n) => quoteColumnName(n)).join(", ");
-          await this.driver.exec(
+        // Rails: move_table(table, atable, temporary: true); move_table(atable, table, &block)
+        // — two copy_table + drop_table pairs, so the *rebuilt* table is created
+        // under its real name. Creating the new definition under a temp name and
+        // renaming it afterwards would make SQLite's DDL errors (e.g. "foreign
+        // key mismatch") name the temp table instead of the real one.
+        const selectCols = originalColNames.map((n) => quoteColumnName(n)).join(", ");
+        const tmpColDefs = originalColNames.map((n) => {
+          const info = tableInfo.find((c) => c.name === n);
+          return `${quoteColumnName(n)} ${info?.type ?? "TEXT"}`;
+        });
+        if (tmpColDefs.length > 0) {
+          await execTranslated(`CREATE TABLE ${qTmp} (${tmpColDefs.join(", ")})`);
+          await execTranslated(
             `INSERT INTO ${qTmp} (${selectCols}) SELECT ${selectCols} FROM ${qTable}`,
           );
         }
-        await this.driver.exec(`DROP TABLE ${qTable}`);
-        await this.driver.exec(`ALTER TABLE ${qTmp} RENAME TO ${quoteColumnName(bareTable)}`);
+        await execTranslated(`DROP TABLE ${qTable}`);
+        await execTranslated(`CREATE TABLE ${qTable} (${colDefs.join(", ")})`);
+        if (tmpColDefs.length > 0) {
+          await execTranslated(
+            `INSERT INTO ${qTable} (${selectCols}) SELECT ${selectCols} FROM ${qTmp}`,
+          );
+          await execTranslated(`DROP TABLE ${qTmp}`);
+        }
       });
 
       // Recreate indexes inside the transaction so failures roll back

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2568,11 +2568,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     } else {
       await this.beginTransaction();
     }
-    // Rails' copy_table/move_table run their DDL through `execute`, so a
-    // rebuild failure (e.g. SQLite's "foreign key mismatch" when a new FK
-    // doesn't match a unique key on the referenced table) surfaces as
-    // StatementInvalid. The rebuild below uses driver.exec directly to manage
-    // savepoint nesting, so translate the raw driver error here to match.
     const execTranslated = async (sql: string): Promise<void> => {
       try {
         await this.driver.exec(sql);
@@ -2582,16 +2577,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     };
     try {
       await this.disableReferentialIntegrity(async () => {
-        // Rails: move_table(table, atable, temporary: true); move_table(atable, table, &block)
-        // — two copy_table + drop_table pairs, so the *rebuilt* table is created
-        // under its real name. Creating the new definition under a temp name and
-        // renaming it afterwards would make SQLite's DDL errors (e.g. "foreign
-        // key mismatch") name the temp table instead of the real one.
         const selectCols = originalColNames.map((n) => quoteColumnName(n)).join(", ");
-        const tmpColDefs = originalColNames.map((n) => {
-          const info = tableInfo.find((c) => c.name === n);
-          return `${quoteColumnName(n)} ${info?.type ?? "TEXT"}`;
-        });
+        const originalTypes = new Map(tableInfo.map((c) => [c.name as string, c.type]));
+        const tmpColDefs = originalColNames.map(
+          (n) => `${quoteColumnName(n)} ${originalTypes.get(n) ?? "TEXT"}`,
+        );
         if (tmpColDefs.length > 0) {
           await execTranslated(`CREATE TABLE ${qTmp} (${tmpColDefs.join(", ")})`);
           await execTranslated(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2578,10 +2578,20 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     try {
       await this.disableReferentialIntegrity(async () => {
         const selectCols = originalColNames.map((n) => quoteColumnName(n)).join(", ");
-        const originalTypes = new Map(tableInfo.map((c) => [c.name as string, c.type]));
-        const tmpColDefs = originalColNames.map(
-          (n) => `${quoteColumnName(n)} ${originalTypes.get(n) ?? "TEXT"}`,
+        // Rails' copy_table builds even the throwaway "a"-prefixed table through
+        // the full create_table machinery. This buffer carries the declared type
+        // verbatim (so storage affinity round-trips exactly, including the
+        // typeless/BLOB-affinity case) but drops NOT NULL/DEFAULT/CHECK/PK: rows
+        // come straight from a table that already satisfied those, so omitting
+        // them can only ever be more permissive, and no INSERT here relies on a
+        // default — both name every column explicitly.
+        const originalTypes = new Map(
+          tableInfo.map((c) => [c.name as string, (c.type as string | null) ?? ""]),
         );
+        const tmpColDefs = originalColNames.map((n) => {
+          const declaredType = originalTypes.get(n) ?? "";
+          return declaredType === "" ? quoteColumnName(n) : `${quoteColumnName(n)} ${declaredType}`;
+        });
         if (tmpColDefs.length > 0) {
           await execTranslated(`CREATE TABLE ${qTmp} (${tmpColDefs.join(", ")})`);
           await execTranslated(

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -15,9 +15,15 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { StatementInvalid } from "../errors.js";
 import type { ReferentialAction } from "../connection-adapters/abstract/schema-definitions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { ambientConnection, withRocketTables } from "../support/rocket-tables.js";
+import {
+  ambientConnection,
+  withCompositeRocketTables,
+  withRocketTables,
+} from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
 import { describeIfSupports } from "../support/supports.js";
+import { dumpTableSchema } from "../support/schema-dumping-helper.js";
+import type { SchemaSource } from "../schema-dumper.js";
 
 // Rails' `unless current_adapter?(:SQLite3Adapter)` guard on the `fk.name`
 // assertions: PRAGMA foreign_key_list exposes no constraint name, so SQLite
@@ -354,6 +360,141 @@ describeIfSupports("foreign_keys", "Migration", () => {
         expect(await conn.foreignKeys("astronauts")).toEqual([]);
 
         await conn.removeForeignKey("astronauts", "rockets", { ifExists: true });
+      });
+    });
+  });
+
+  describe("CompositeForeignKeyTest", () => {
+    fixtures([], { useTransactionalTests: false });
+
+    it("add composite foreign key raises without options", async () => {
+      const conn = await ambientConnection();
+      await withCompositeRocketTables(conn, async () => {
+        const error = await conn.addForeignKey("astronauts", "rockets").then(
+          () => undefined,
+          (err: unknown) => err,
+        );
+
+        expect(error).toBeInstanceOf(StatementInvalid);
+        const message = (error as Error).message;
+        if (adapterType === "postgres") {
+          expect(message).toMatch(
+            /there is no unique constraint matching given keys for referenced table "rockets"/,
+          );
+        } else if (adapterType === "sqlite") {
+          expect(message).toMatch(/foreign key mismatch - "astronauts" referencing "rockets"/);
+        } else {
+          // MariaDB and different versions of MySQL generate different error messages.
+          expect(
+            [
+              /Foreign key constraint is incorrectly formed/i,
+              /Failed to add the foreign key constraint/i,
+              /Cannot add foreign key constraint/i,
+            ].some((pattern) => pattern.test(message)),
+          ).toBe(true);
+        }
+      });
+    });
+
+    it("add composite foreign key infers column", async () => {
+      const conn = await ambientConnection();
+      await withCompositeRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { primaryKey: ["tenant_id", "id"] });
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(fk.column).toEqual(["rocket_tenant_id", "rocket_id"]);
+      });
+    });
+
+    it("add composite foreign key raises if column and primary key sizes mismatch", async () => {
+      const conn = await ambientConnection();
+      await withCompositeRocketTables(conn, async () => {
+        const error = await conn
+          .addForeignKey("astronauts", "rockets", {
+            column: "rocket_id",
+            primaryKey: ["tenant_id", "id"],
+          })
+          .then(
+            () => undefined,
+            (err: unknown) => err,
+          );
+
+        expect(error).toBeInstanceOf(ArgumentError);
+        expect((error as Error).message).toMatch(
+          /:column must reference all the :primary_key columns/,
+        );
+      });
+    });
+
+    it("foreign key exists", async () => {
+      const conn = await ambientConnection();
+      await withCompositeRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { primaryKey: ["tenant_id", "id"] });
+
+        expect(await conn.foreignKeyExists("astronauts", "rockets")).toBe(true);
+        expect(await conn.foreignKeyExists("astronauts", "stars")).toBe(false);
+      });
+    });
+
+    it("foreign key exists by options", async () => {
+      const conn = await ambientConnection();
+      await withCompositeRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { primaryKey: ["tenant_id", "id"] });
+
+        expect(
+          await conn.foreignKeyExists("astronauts", "rockets", {
+            primaryKey: ["tenant_id", "id"],
+          }),
+        ).toBe(true);
+        expect(
+          await conn.foreignKeyExists("astronauts", "rockets", {
+            column: ["rocket_tenant_id", "rocket_id"],
+            primaryKey: ["tenant_id", "id"],
+          }),
+        ).toBe(true);
+
+        expect(
+          await conn.foreignKeyExists("astronauts", "rockets", {
+            primaryKey: ["id", "tenant_id"],
+          }),
+        ).toBe(false);
+        expect(await conn.foreignKeyExists("astronauts", "rockets", { primaryKey: "id" })).toBe(
+          false,
+        );
+        expect(await conn.foreignKeyExists("astronauts", "rockets", { column: "rocket_id" })).toBe(
+          false,
+        );
+      });
+    });
+
+    it("remove foreign key", async () => {
+      const conn = await ambientConnection();
+      await withCompositeRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { primaryKey: ["tenant_id", "id"] });
+        expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+
+        await conn.removeForeignKey("astronauts", "rockets");
+        expect(await conn.foreignKeys("astronauts")).toEqual([]);
+      });
+    });
+
+    it("schema dumping", async () => {
+      const conn = await ambientConnection();
+      await withCompositeRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { primaryKey: ["tenant_id", "id"] });
+
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+
+        // Rails asserts the Ruby DSL line
+        // `add_foreign_key "astronauts", "rockets", column: [...], primary_key: [...]`;
+        // the TS dumper emits the equivalent `ctx.addForeignKey(...)` call with
+        // JSON-formatted arrays.
+        expect(output).toMatch(
+          /\s+await ctx\.addForeignKey\("astronauts", "rockets", \{ column: \["rocket_tenant_id","rocket_id"\], primaryKey: \["tenant_id","id"\] \}\);$/m,
+        );
       });
     });
   });

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -2,8 +2,10 @@
  * Port of the `add_foreign_key` and `remove_foreign_key` halves of
  * `ActiveRecord::Migration::ForeignKeyTest`
  * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330
- * and :393-451, :749-773). The `SchemaDumpingHelper`-driven dumper cases in the
- * same Rails class are still unported.
+ * and :393-451, :749-773) plus all of its sibling
+ * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912). The
+ * `SchemaDumpingHelper`-driven dumper cases in `ForeignKeyTest` are still
+ * unported.
  *
  * Driven by the ambient connection, mirroring Rails'
  * `@connection = ActiveRecord::Base.lease_connection`. The rockets/astronauts
@@ -384,7 +386,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
         } else if (adapterType === "sqlite") {
           expect(message).toMatch(/foreign key mismatch - "astronauts" referencing "rockets"/);
         } else {
-          // MariaDB and different versions of MySQL generate different error messages.
           expect(
             [
               /Foreign key constraint is incorrectly formed/i,
@@ -488,10 +489,9 @@ describeIfSupports("foreign_keys", "Migration", () => {
 
         const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
 
-        // Rails asserts the Ruby DSL line
-        // `add_foreign_key "astronauts", "rockets", column: [...], primary_key: [...]`;
-        // the TS dumper emits the equivalent `ctx.addForeignKey(...)` call with
-        // JSON-formatted arrays.
+        // Deviation: Rails asserts the Ruby DSL line `add_foreign_key "astronauts",
+        // "rockets", column: [...], primary_key: [...]`. The TS dumper emits the
+        // equivalent `ctx.addForeignKey(...)` call with JSON-formatted arrays.
         expect(output).toMatch(
           /\s+await ctx\.addForeignKey\("astronauts", "rockets", \{ column: \["rocket_tenant_id","rocket_id"\], primaryKey: \["tenant_id","id"\] \}\);$/m,
         );

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -385,15 +385,14 @@ describeIfSupports("foreign_keys", "Migration", () => {
           );
         } else if (adapterType === "sqlite") {
           expect(message).toMatch(/foreign key mismatch - "astronauts" referencing "rockets"/);
-        } else {
-          expect(
-            [
-              /Foreign key constraint is incorrectly formed/i,
-              /Failed to add the foreign key constraint/i,
-              /Cannot add foreign key constraint/i,
-            ].some((pattern) => pattern.test(message)),
-          ).toBe(true);
         }
+        // Rails' MySQL/MariaDB branch builds an `.any?` over three message
+        // patterns and then discards the result — it is passed to no assertion
+        // (foreign_key_test.rb:850-856), deliberately, because "MariaDB and
+        // different versions of MySQL generate different error messages". Only
+        // the raise itself is asserted there, so there is nothing to port: an
+        // `expect` here would be a stronger pass condition than Rails', failing
+        // on any MySQL/MariaDB build whose wording is not one of the three.
       });
     });
 

--- a/packages/activerecord/src/support/rocket-tables.ts
+++ b/packages/activerecord/src/support/rocket-tables.ts
@@ -38,3 +38,29 @@ export async function withRocketTables(
     await conn.dropTable("astronauts", "rockets", { ifExists: true });
   }
 }
+
+/**
+ * `ActiveRecord::Migration::CompositeForeignKeyTest`'s setup/teardown,
+ * foreign_key_test.rb:827-842. Same table names as `withRocketTables` but a
+ * composite primary key on `rockets` and the matching pair of integer FK
+ * columns on `astronauts`.
+ */
+export async function withCompositeRocketTables(
+  conn: AbstractAdapter,
+  body: () => Promise<void>,
+): Promise<void> {
+  await conn.createTable("rockets", { primaryKey: ["tenant_id", "id"], force: true }, (t) => {
+    t.integer("tenant_id");
+    t.integer("id");
+  });
+  await conn.createTable("astronauts", { force: true }, (t) => {
+    t.integer("rocket_id");
+    t.integer("rocket_tenant_id");
+  });
+  try {
+    await body();
+  } finally {
+    await conn.dropTable("astronauts", { ifExists: true });
+    await conn.dropTable("rockets", { ifExists: true });
+  }
+}


### PR DESCRIPTION
Ports `ActiveRecord::Migration::CompositeForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:824-912`)
as a sibling `describe("CompositeForeignKeyTest", ...)` under the existing
`Migration` describe in `migration/foreign-key.test.ts`. All 7 cases ported,
names verbatim.

Setup/teardown mirrors the Ruby `setup`/`teardown` blocks via a new
`withCompositeRocketTables` next to the existing `withRocketTables` — the same
rockets/astronauts tables the Rails FK test creates itself, with the composite
primary key on `rockets`.

`test:compare` for `migration/foreign_key_test.rb` goes 22 OK / 50 missing →
28 OK / 44 missing (6, not 7: `test_foreign_key_exists` is also a
`ForeignKeyTest` name, so the two collapse to one entry). `--gates --check`
exits 0.

### Two SQLite adapter fixes fell out of the port

`test_add_composite_foreign_key_raises_without_options` asserts
`StatementInvalid` with a message naming `"astronauts"`. Both halves failed:

- `alterTable`'s table rebuild issued its DDL through `driver.exec` directly
  (to manage savepoint nesting), bypassing exception translation, so the
  failure escaped as a raw `SqliteError`. Rails' `copy_table`/`move_table` run
  through `execute`, so the rebuild DDL is now translated to match.
- The rebuild created the new definition under a temp name and renamed it into
  place, so SQLite's "foreign key mismatch" named `_alter_tmp_astronauts`.
  Rails' `alter_table` is `move_table(table, atable, temporary: true)` then
  `move_table(atable, table, &block)` — two copy+drop pairs, so the *rebuilt*
  table is created under its real name. The rebuild now mirrors that ordering,
  and the new test pins it: reverting to the rename approach fails the message
  assertion.

### Review follow-ups

- The MySQL/MariaDB arm of `test_add_composite_foreign_key_raises_without_options`
  builds an `.any?` over three message patterns and discards it — Rails passes it
  to no assertion (foreign_key_test.rb:850-856), deliberately, since "MariaDB and
  different versions of MySQL generate different error messages". The port no
  longer wraps it in an `expect`: only the raise is asserted there, matching Rails.
- The rebuild buffer now carries each column's declared type **verbatim**,
  including the typeless (BLOB-affinity) case, instead of falling back to `TEXT` —
  that fallback was a real affinity change for a column with no declared type.
  It still drops NOT NULL/DEFAULT/CHECK/PK, which is safe and noted at the call
  site: rows come from a table that already satisfied those, so omitting them is
  strictly more permissive, and both INSERTs name every column explicitly so no
  default is ever consulted.

### Verification

Run locally on all three adapters (isolated compose stack for PG/MySQL):

| adapter | result |
| --- | --- |
| sqlite | 26 passed, 1 skipped |
| postgresql | 27 passed |
| mysql2 | 26 passed, 1 skipped |

The `alterTable` change is SQLite-only, so the sqlite regression sweep also
covers `migration.test.ts`, `schema-dumper.test.ts`,
`schema-dumper.trails.test.ts`, `primary-keys.test.ts`, `defaults.test.ts`,
`adapters/sqlite3/**` (incl. `CopyTableTest`, virtual columns, collation) and
`connection-adapters/sqlite3/**` — all green.

Closes-story: port-migration-composite-foreign-key-cases
