### PR TITLE
feat(api-compare): treat set#{Name} as the port of Rails' #{name}= writer

### DIFF
--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -22,7 +22,7 @@ matches the first candidate present in the target file), not a call expression.
 | `has_*?` / `supports_*?` / `can_*?` / `should_*?` / `needs_*?` / `includes_*?` / `responds_*?` / `allows_*?` / `uses_*?` | camel form + `is*` fallback          | `has_attribute?` → `hasAttribute` or `isHasAttribute` |
 | `include?` / `member?` / `exclude?`                                                                                      | `is*` / camel / native JS spelling   | `include?` → `isInclude` or `include` or `includes`   |
 | `name!` (bang)                                                                                                           | `*Bang` suffix                       | `save!` → `saveBang`                                  |
-| `name=` (setter)                                                                                                         | bare camel name                      | `table_name=` → `tableName`                           |
+| `name=` (setter)                                                                                                         | bare camel name, `set*` fallback     | `table_name=` → `tableName` or `setTableName`         |
 | `initialize` / `new`                                                                                                     | `constructor`                        | `initialize` → `constructor`                          |
 | `to_s` / `to_str`                                                                                                        | `toString`                           | `to_s` → `toString`                                   |
 | `to_json`                                                                                                                | `toJSON`                             | `to_json` → `toJSON`                                  |
@@ -37,6 +37,16 @@ name collides with a macro (e.g. `isHasOne()` alongside the `Model.hasOne`
 declaration). Leading underscores and runs of underscores collapse like a single
 underscore (`visit__regexp` → `visitRegexp`), and underscore-before-capital
 collapses too (`visit_Arel_Nodes_X` → `visitArelNodesX`).
+
+Setter-form details: a Ruby `name=` writer matches the bare camel accessor
+first, and `set#{Name}` second. The `set*` fallback covers writers whose Rails
+body blocks on I/O — `has_one`'s `#{name}=` removes and persists the displaced
+target inline — which a synchronous JS property setter cannot express. There the
+promise-returning `setAccount` **is** the port of `account=`, and the sync `=`
+setter remains only as the faithful in-memory path on an unpersisted owner plus a
+shim steering persisted-owner callers to the awaitable writer. Underscore-prefixed
+writers (`_reflections=`) are `class_attribute` storage slots, never blocking
+writers, so they get no `set*` candidate.
 
 ## Operators
 

--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -42,9 +42,10 @@ Setter-form details: a Ruby `name=` writer matches the bare camel accessor
 first, and `set#{Name}` second. The `set*` fallback covers writers whose Rails
 body blocks on I/O — `has_one`'s `#{name}=` removes and persists the displaced
 target inline — which a synchronous JS property setter cannot express. There the
-promise-returning `setAccount` **is** the port of `account=`, and the sync `=`
-setter remains only as the faithful in-memory path on an unpersisted owner plus a
-shim steering persisted-owner callers to the awaitable writer. Underscore-prefixed
+promise-returning `setAccount` **is** the port of `account=`. Both spellings are
+supported and both score as the port — the candidate list is a fallback chain, not
+a migration: a sync accessor alone still matches, as it always did.
+Underscore-prefixed
 writers (`_reflections=`) are `class_attribute` storage slots, never blocking
 writers, so they get no `set*` candidate.
 

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -102,9 +102,12 @@ export class HasOne extends SingularAssociation {
   static override defineWriters(mixin: object, name: string): void {
     if (!mixin || typeof mixin !== "object") return;
     const cap = name.charAt(0).toUpperCase() + name.slice(1);
-    // Ergonomic awaitable setter (`await firm.setAccount(x)` /
-    // `await firm.setAccount(null)`), the RFC-sanctioned alternative to the
-    // racy native `firm.account = x` property setter defined below. Generated
+    // `set${cap}` IS the port of Rails' `#{name}=` writer: that writer removes
+    // and persists the displaced target inline (has_one_association.rb:59-84),
+    // blocking I/O a synchronous JS property setter cannot express but a
+    // promise-returning method can. api:compare scores it as such —
+    // `rubyMethodToTs` offers `set#{Name}` as a candidate for `name=`
+    // (scripts/api-compare/conventions.ts). Generated
     // here — beside that setter, unconditionally (including polymorphic
     // has_one) — rather than in `defineConstructors`, which Rails skips for
     // polymorphic; the sugar must exist wherever the `=` setter does. A thin
@@ -128,13 +131,18 @@ export class HasOne extends SingularAssociation {
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, name, {
       get: existing?.get,
-      // A JS property setter cannot `await`. On an *unpersisted* owner Rails'
-      // assignment is in-memory too, so `syncWrite` sets the FK/inverse and
-      // lets autosave persist at the owner's first `save()`. On a *persisted*
-      // owner `syncWrite` throws (`HasOnePersistedAssignmentError`): Rails
-      // persists the displacement inline at assignment, which needs `await`.
-      // Callers use `await owner.set#{Name}(value)` (the `set${cap}` sugar
-      // above) or `await record.association(name).writer(value)` (RFC 0068).
+      // The `=` setter exists because Rails defines `#{name}=` and dropping it
+      // would report that method missing — but it is NOT the co-equal writer.
+      // It is faithful on exactly one branch: an *unpersisted* owner, where
+      // Rails' assignment is in-memory too, so `syncWrite` sets the FK/inverse
+      // and lets autosave persist at the owner's first `save()`. On a
+      // *persisted* owner it degrades to a deprecation shim: `syncWrite` throws
+      // `HasOnePersistedAssignmentError` — a deliberate DEVIATION, since Rails
+      // raises nothing there and simply persists the displacement inline, which
+      // needs `await`. Throwing steers the caller to the awaitable port rather
+      // than silently skipping the write. Callers use
+      // `await owner.set#{Name}(value)` (the `set${cap}` port above) or
+      // `await record.association(name).writer(value)` (RFC 0068).
       set(this: { association(n: string): { syncWrite(v: unknown): void } }, value: unknown) {
         this.association(name).syncWrite(value);
       },

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -132,16 +132,18 @@ export class HasOne extends SingularAssociation {
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, name, {
       get: existing?.get,
-      // The `=` setter exists because Rails defines `#{name}=` and dropping it
-      // would report that method missing — but it is NOT the co-equal writer.
-      // It is faithful on exactly one branch: an *unpersisted* owner, where
-      // Rails' assignment is in-memory too, so `syncWrite` sets the FK/inverse
-      // and lets autosave persist at the owner's first `save()`. On a
-      // *persisted* owner it degrades to a deprecation shim: `syncWrite` throws
-      // `HasOnePersistedAssignmentError` — a deliberate DEVIATION, since Rails
-      // raises nothing there and simply persists the displacement inline, which
-      // needs `await`. Throwing steers the caller to the awaitable port rather
-      // than silently skipping the write. Callers use
+      // The synchronous path, supported alongside `set${cap}` — Rails defines
+      // `#{name}=`, so this stays. It is fully faithful on the branch where
+      // Rails does no I/O either: an *unpersisted* owner, where Rails'
+      // assignment is in-memory too, so `syncWrite` sets the FK/inverse and
+      // lets autosave persist at the owner's first `save()`.
+      //
+      // On a *persisted* owner Rails persists the displacement inline, which
+      // needs `await` — unreachable from a JS property setter. `syncWrite`
+      // therefore throws `HasOnePersistedAssignmentError`, a deliberate
+      // DEVIATION (Rails raises nothing there): the alternative is accepting
+      // the assignment and silently skipping the write, so the throw is a guard
+      // against data loss, not a deprecation. Persisted-owner callers use
       // `await owner.set#{Name}(value)` (the `set${cap}` port above) or
       // `await record.association(name).writer(value)` (RFC 0068).
       set(this: { association(n: string): { syncWrite(v: unknown): void } }, value: unknown) {

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -107,10 +107,11 @@ export class HasOne extends SingularAssociation {
     // blocking I/O a synchronous JS property setter cannot express but a
     // promise-returning method can. api:compare scores it as such —
     // `rubyMethodToTs` offers `set#{Name}` as a candidate for `name=`
-    // (scripts/api-compare/conventions.ts). Generated
-    // here — beside that setter, unconditionally (including polymorphic
-    // has_one) — rather than in `defineConstructors`, which Rails skips for
-    // polymorphic; the sugar must exist wherever the `=` setter does. A thin
+    // (scripts/api-compare/conventions.ts).
+    //
+    // Generated here — beside the `=` setter below, unconditionally (including
+    // polymorphic has_one) — rather than in `defineConstructors`, which Rails
+    // skips for polymorphic; the writer must exist wherever `=` does. A thin
     // delegation to the association-level `writer`, whose has_one /
     // has_one_through overrides run the Rails-faithful immediate replace/persist
     // and whose returned promise rejects (`RecordNotSaved`) at the call site.

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "scoping.ts",
-    "rubyName": "ignore_default_scope=",
-    "call": "set_ignore_default_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping.ts",
     "rubyName": "populate_with_current_scope_attributes",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -113,7 +113,13 @@ describe("rubyMethodToTs", () => {
   });
 
   it("strips the trailing `=` from setter methods", () => {
-    expect(rubyMethodToTs("name=")).toEqual(["name"]);
+    expect(rubyMethodToTs("name=")).toEqual(["name", "setName"]);
+  });
+
+  it("orders the setX candidate after the bare accessor for setter methods", () => {
+    expect(rubyMethodToTs("table_name=")).toEqual(["tableName", "setTableName"]);
+    // Underscore-prefixed storage slots get no `setX` candidate at all.
+    expect(rubyMethodToTs("_load_from=")).toEqual(["_loadFrom"]);
   });
 
   it("camelCases capitalized snake-case visit method names", () => {

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -753,9 +753,10 @@ Setter-form details: a Ruby \`name=\` writer matches the bare camel accessor
 first, and \`set#{Name}\` second. The \`set*\` fallback covers writers whose Rails
 body blocks on I/O — \`has_one\`'s \`#{name}=\` removes and persists the displaced
 target inline — which a synchronous JS property setter cannot express. There the
-promise-returning \`setAccount\` **is** the port of \`account=\`, and the sync \`=\`
-setter remains only as the faithful in-memory path on an unpersisted owner plus a
-shim steering persisted-owner callers to the awaitable writer. Underscore-prefixed
+promise-returning \`setAccount\` **is** the port of \`account=\`. Both spellings are
+supported and both score as the port — the candidate list is a fallback chain, not
+a migration: a sync accessor alone still matches, as it always did.
+Underscore-prefixed
 writers (\`_reflections=\`) are \`class_attribute\` storage slots, never blocking
 writers, so they get no \`set*\` candidate.
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -637,7 +637,18 @@ export function rubyMethodToTsIgnoringSkip(name: string): string[] | null {
 
   if (name.endsWith("=")) {
     const base = name.slice(0, -1);
-    return [snakeToCamel(base)];
+    const camel = snakeToCamel(base);
+    // `setX` is offered *after* the bare camel name so plain-value writers
+    // (`table_name=`, `_reflections=`) keep matching the accessor they always
+    // matched. It exists for writers whose Rails body blocks on I/O — has_one's
+    // `#{name}=` persists the displacement inline (has_one_association.rb:59-84)
+    // — which a synchronous JS property setter cannot express; the awaitable
+    // `set#{Name}` is the faithful rendering there (RFC 0068).
+    // Underscore-prefixed writers are `class_attribute` storage slots
+    // (`_reflections=`), never blocking writers — offering `set_reflections`
+    // there would only be a nonsense candidate, so they keep the bare form.
+    if (camel.startsWith("_")) return [camel];
+    return [camel, "set" + camel.charAt(0).toUpperCase() + camel.slice(1)];
   }
 
   return [snakeToCamel(name)];
@@ -722,7 +733,7 @@ matches the first candidate present in the target file), not a call expression.
 | ${predicatePrefixes} | camel form + \`is*\` fallback | \`has_attribute?\` → ${example("has_attribute?")} |
 | ${containmentPredicates} | \`is*\` / camel / native JS spelling | \`include?\` → ${example("include?")} |
 | \`name!\` (bang) | \`*Bang\` suffix | \`save!\` → ${example("save!")} |
-| \`name=\` (setter) | bare camel name | \`table_name=\` → ${example("table_name=")} |
+| \`name=\` (setter) | bare camel name, \`set*\` fallback | \`table_name=\` → ${example("table_name=")} |
 | \`initialize\` / \`new\` | \`constructor\` | \`initialize\` → ${example("initialize")} |
 | \`to_s\` / \`to_str\` | \`toString\` | \`to_s\` → ${example("to_s")} |
 | \`to_json\` | \`toJSON\` | \`to_json\` → ${example("to_json")} |
@@ -737,6 +748,16 @@ name collides with a macro (e.g. \`isHasOne()\` alongside the \`Model.hasOne\`
 declaration). Leading underscores and runs of underscores collapse like a single
 underscore (\`visit__regexp\` → \`visitRegexp\`), and underscore-before-capital
 collapses too (\`visit_Arel_Nodes_X\` → \`visitArelNodesX\`).
+
+Setter-form details: a Ruby \`name=\` writer matches the bare camel accessor
+first, and \`set#{Name}\` second. The \`set*\` fallback covers writers whose Rails
+body blocks on I/O — \`has_one\`'s \`#{name}=\` removes and persists the displaced
+target inline — which a synchronous JS property setter cannot express. There the
+promise-returning \`setAccount\` **is** the port of \`account=\`, and the sync \`=\`
+setter remains only as the faithful in-memory path on an unpersisted owner plus a
+shim steering persisted-owner callers to the awaitable writer. Underscore-prefixed
+writers (\`_reflections=\`) are \`class_attribute\` storage slots, never blocking
+writers, so they get no \`set*\` candidate.
 
 ## Operators
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -638,16 +638,16 @@ export function rubyMethodToTsIgnoringSkip(name: string): string[] | null {
   if (name.endsWith("=")) {
     const base = name.slice(0, -1);
     const camel = snakeToCamel(base);
-    // `setX` is offered *after* the bare camel name so plain-value writers
-    // (`table_name=`, `_reflections=`) keep matching the accessor they always
-    // matched. It exists for writers whose Rails body blocks on I/O — has_one's
-    // `#{name}=` persists the displacement inline (has_one_association.rb:59-84)
-    // — which a synchronous JS property setter cannot express; the awaitable
-    // `set#{Name}` is the faithful rendering there (RFC 0068).
     // Underscore-prefixed writers are `class_attribute` storage slots
-    // (`_reflections=`), never blocking writers — offering `set_reflections`
-    // there would only be a nonsense candidate, so they keep the bare form.
+    // (`_reflections=`), never blocking writers — `set_reflections` would only
+    // be a nonsense candidate, so they keep the bare form alone.
     if (camel.startsWith("_")) return [camel];
+    // `setX` is offered *after* the bare camel name so plain-value writers
+    // (`table_name=`) keep matching the accessor they always matched. It exists
+    // for writers whose Rails body blocks on I/O — has_one's `#{name}=`
+    // persists the displacement inline (has_one_association.rb:59-84) — which a
+    // synchronous JS property setter cannot express; the awaitable `set#{Name}`
+    // is the faithful rendering there (RFC 0068).
     return [camel, "set" + camel.charAt(0).toUpperCase() + camel.slice(1)];
   }
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1919,12 +1919,13 @@ describe("buildReport — TS files with no Rails counterpart", () => {
     });
     const files = report.packages[0].extraFiles;
     expect(files.map((f) => f.tsFile)).toEqual(["ar-config.ts"]);
-    // `foo=` maps to `foo`, so the `setX` re-spelling is novel and the reader
-    // is moved (base.ts owns it) — the whole file is measured, not skipped.
+    // `foo=` maps to `foo` first and `setFoo` second, so both spellings are
+    // moved (base.rb's `foo=` owns them) — the whole file is measured, not
+    // skipped.
     expect(files[0].rubyFile).toBeNull();
     expect(files[0].extras.map((e) => [e.name, e.kind])).toEqual([
-      ["setFoo", "novel"],
       ["foo", "moved"],
+      ["setFoo", "moved"],
     ]);
   });
 
@@ -1940,7 +1941,7 @@ describe("buildReport — TS files with no Rails counterpart", () => {
     expect(pkg.totalExtras).toBe(2);
     expect(pkg.noCounterpartFiles).toBe(1);
     expect(pkg.noCounterpartExtras).toBe(2);
-    expect(pkg.noCounterpartNovel).toBe(1);
+    expect(pkg.noCounterpartNovel).toBe(0);
   });
 
   it("treats a Ruby file known only by its file-level constants as a counterpart", () => {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -850,11 +850,13 @@ export function isTestSupportFile(tsFile: string): boolean {
  *
  * These files are scored with an EMPTY allowed set — there is no Rails file to
  * take allowed names from — so every public name lands as an extra, classed
- * novel vs moved against the package-wide Rails candidates like any other. In
- * particular the umbrella-config attribution `compare.ts` applies (crediting
- * `setProtocolAdapters` to `ActiveRecord.protocol_adapters=` as a *move*) is
- * deliberately NOT mirrored here: `rubyMethodToTs` maps `foo=` to `foo`, so the
- * `setX` spelling is novel surface, which is the finding, not noise to absorb.
+ * novel vs moved against the package-wide Rails candidates like any other —
+ * including the `setX` spelling of a Ruby `foo=` writer, which `rubyMethodToTs`
+ * now offers as a candidate after the bare `foo` accessor, so
+ * `setProtocolAdapters` lands as a *move* against `ActiveRecord.protocol_adapters=`
+ * rather than as novel. The name is still reported; only its classification
+ * changed, and it changed because a promise-returning `setX` is the faithful
+ * rendering of a Rails writer that blocks on I/O (RFC 0068).
  */
 export function uncoveredTsFiles(
   coveredTsFiles: Set<string>,


### PR DESCRIPTION
Treats the awaitable `set#{Name}` writer as the api:compare port of Rails'
`#{name}=`, instead of scoring it as extra TS-only surface.

## Why

Rails' `has_one` writer blocks inline on `remove_target!` + `save`
(`has_one_association.rb:59-84`). A synchronous JS property setter cannot
express blocking I/O; a promise-returning method can. So `setAccount` is the
*more* faithful rendering of `account=`, and the sync `=` setter is faithful
only on the branch where Rails does no I/O either (unpersisted owner —
`syncWrite`).

Both spellings are supported and both score as the port. The candidate list is a
fallback chain, not a migration: a setting that is synchronous in Ruby stays a
plain JS property setter and matches on the bare camel name exactly as before;
anything that needs to `await` may be a `setX` method and now matches too. This
is a general convention across every package, not a has_one carve-out.

## Changes

- `rubyMethodToTs` returns `set#{Cap}` as a second candidate for Ruby `name=`,
  ordered **after** the bare camel name so plain-value writers (`table_name=`,
  `_reflections=`) keep matching the accessor they always matched.
  Underscore-prefixed writers are `class_attribute` storage slots, never
  blocking writers, so they get no `set*` candidate at all.
- `explainConventions()` documents the new candidate; `docs/ruby-ts-conventions.md`
  regenerated and `conventions-doc.ts --check` passes.
- The now-stale rationale in `extra-surface.ts` (which asserted `setX` is
  deliberately novel) updated to match.
- The `=` setter's role recorded at the call site in `builder/has-one.ts`: it is
  the synchronous path, supported alongside `set${cap}`, and fully faithful on
  the unpersisted-owner branch where Rails does no I/O either. Its
  `HasOnePersistedAssignmentError` throw on a persisted owner is called out as a
  deliberate deviation (Rails raises nothing there) — a guard against accepting
  an assignment and silently skipping the write, not a deprecation.

## Accounting

`missing`/`ported` totals are unchanged (`account=` was already matched by the
bare `account` accessor). The move is entirely in extra surface:

| package | novel | moved | total |
| --- | --- | --- | --- |
| activerecord | 574 → **547** | 1073 → **1093** | 1647 → **1640** |
| activesupport | 275 → **270** | 402 → **407** | 677 → 677 |
| actionview | 40 → **35** | 72 → **73** | 112 → **108** |
| rack | 44 → **40** | 64 → 64 | 108 → **104** |
| actiondispatch | 187 → **186** | 182 → 182 | 369 → **368** |

Every reclassified name was inspected: they are all `setX` spellings of a real
Ruby `x=` writer (`setFullSanitizer` ↔ `full_sanitizer=`, `setClientMinMessages`
↔ `client_min_messages=`, `setSchemaSearchPath` ↔ `schema_search_path=`,
`ar-config.ts` 18 novel → 1). No unrelated Rails writer started matching a `setX`
that was never intended as its port.

One wide-call-ratchet entry converged and was removed
(`scoping.ts` `ignore_default_scope=` → `set_ignore_default_scope`); the
baseline only shrinks.

Closes-story: awaitable-writer-is-the-port-of-rails-writer
