### PR TITLE
test(activerecord): port Migration::ReferencesForeignKeyTest core cases

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -664,6 +664,18 @@ export interface ColumnMethods {
   ): unknown;
 }
 
+/** @internal */
+export interface ReferenceDefinitionConnection {
+  addColumn(
+    tableName: string,
+    columnName: string,
+    type: ColumnType,
+    options?: ColumnOptions,
+  ): Promise<void>;
+  addIndex(tableName: string, columnNames: string[], options?: AddIndexOptions): Promise<void>;
+  addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
+}
+
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ReferenceDefinition
  */
@@ -699,6 +711,22 @@ export class ReferenceDefinition {
     this.type = options.type ?? "bigint";
     const { polymorphic: _, foreignKey: _fk, index: _idx, type: _t, ...rest } = options;
     this.options = rest;
+  }
+
+  async add(tableName: string, connection: ReferenceDefinitionConnection): Promise<void> {
+    for (const [colName, colType, colOpts] of this._columns()) {
+      await connection.addColumn(tableName, colName, colType, colOpts);
+    }
+    if (this.index) {
+      await connection.addIndex(tableName, this.columnNames(), this.indexOptions(tableName));
+    }
+    if (this.foreignKey) {
+      await connection.addForeignKey(
+        tableName,
+        this.foreignTableName(),
+        this.foreignKeyOptions() as AddForeignKeyOptions,
+      );
+    }
   }
 
   addTo(table: TableDefinition): void {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -508,11 +508,11 @@ export interface AddIndexOptions {
   algorithm?: string;
 }
 
-export interface AddReferenceOptions extends ColumnOptions {
+export interface AddReferenceOptions extends Omit<ColumnOptions, "index"> {
   polymorphic?: boolean;
-  foreignKey?: boolean;
+  foreignKey?: boolean | ReferenceForeignKeyOptions;
   type?: ColumnType;
-  index?: boolean;
+  index?: boolean | AddIndexOptions;
   ifExists?: boolean;
   ifNotExists?: boolean;
 }
@@ -686,7 +686,7 @@ export class ReferenceDefinition {
     } = {},
   ) {
     if (options.polymorphic && options.foreignKey) {
-      throw new Error("Cannot add a foreign key to a polymorphic relation");
+      throw new ArgumentError("Cannot add a foreign key to a polymorphic relation");
     }
     this.name = name;
     this.polymorphic = options.polymorphic ?? false;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -702,7 +702,7 @@ export class SchemaStatements {
       polymorphic?: boolean;
       foreignKey?: boolean | { toTable?: string; column?: string };
       type?: ColumnType;
-      index?: boolean;
+      index?: boolean | AddIndexOptions;
     } = {},
   ): Promise<void> {
     // Mirrors ReferenceDefinition#initialize (schema_definitions.rb:214-216):
@@ -721,7 +721,11 @@ export class SchemaStatements {
     }
     if (options.index !== false) {
       const cols = options.polymorphic ? [`${refName}_id`, `${refName}_type`] : [`${refName}_id`];
-      await this.addIndex(tableName, cols);
+      // ReferenceDefinition#index_options (schema_definitions.rb:266-274):
+      // `index:` given as a hash carries real index options (`unique:`, `name:`,
+      // …), not just an on/off flag.
+      const indexOptions = typeof options.index === "object" ? options.index : {};
+      await this.addIndex(tableName, cols, indexOptions);
     }
     if (options.foreignKey) {
       // Mirrors ReferenceDefinition#add: `connection.add_foreign_key(table_name,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -26,6 +26,8 @@ import {
   assertCompositeForeignKeyArity,
   type AddForeignKeyOptions,
   type AddIndexOptions,
+  type AddReferenceOptions,
+  ReferenceDefinition,
   type ColumnType,
   type ColumnOptions,
   type IdHashOptions,
@@ -698,59 +700,16 @@ export class SchemaStatements {
   async addReference(
     tableName: string,
     refName: string,
-    options: ColumnOptions & {
-      polymorphic?: boolean;
-      foreignKey?: boolean | { toTable?: string; column?: string };
-      type?: ColumnType;
-      index?: boolean | AddIndexOptions;
-    } = {},
+    options: AddReferenceOptions = {},
   ): Promise<void> {
-    // Mirrors ReferenceDefinition#initialize (schema_definitions.rb:214-216):
-    // a foreign key can't target a polymorphic (type-tagged) reference.
-    if (options.polymorphic && options.foreignKey) {
-      throw new ArgumentError("Cannot add a foreign key to a polymorphic relation");
-    }
-    // Rails' ReferenceDefinition defaults `type: :bigint`
-    // (schema_definitions.rb:204), matching the default `bigint` primary key a
-    // referenced table gets — so a reference column lines up with the PK it
-    // points at.
-    const colType = options.type ?? "bigint";
-    await this.addColumn(tableName, `${refName}_id`, colType, options);
-    if (options.polymorphic) {
-      await this.addColumn(tableName, `${refName}_type`, "string", options);
-    }
-    if (options.index !== false) {
-      const cols = options.polymorphic ? [`${refName}_id`, `${refName}_type`] : [`${refName}_id`];
-      // ReferenceDefinition#index_options (schema_definitions.rb:266-274):
-      // `index:` given as a hash carries real index options (`unique:`, `name:`,
-      // …), not just an on/off flag.
-      const indexOptions = typeof options.index === "object" ? options.index : {};
-      await this.addIndex(tableName, cols, indexOptions);
-    }
-    if (options.foreignKey) {
-      // Mirrors ReferenceDefinition#add: `connection.add_foreign_key(table_name,
-      // foreign_table_name, **foreign_key_options)`. foreign_table_name defaults
-      // to the pluralized reference name; foreign_key_options carries the
-      // `<ref>_id` column and, when `foreign_key:` is a hash, its `to_table`.
-      const fkOptions = typeof options.foreignKey === "object" ? options.foreignKey : {};
-      const toTable = (fkOptions as { toTable?: string }).toTable ?? pluralize(refName);
-      await this.addForeignKey(tableName, toTable, {
-        ...(fkOptions as Record<string, unknown>),
-        column: `${refName}_id`,
-      });
-    }
+    await new ReferenceDefinition(refName, options).add(tableName, this);
   }
 
   /** Alias of addReference (Rails: `alias :add_belongs_to :add_reference`). */
   async addBelongsTo(
     tableName: string,
     refName: string,
-    options: ColumnOptions & {
-      polymorphic?: boolean;
-      foreignKey?: boolean | { toTable?: string; column?: string };
-      type?: ColumnType;
-      index?: boolean;
-    } = {},
+    options: AddReferenceOptions = {},
   ): Promise<void> {
     return this.addReference(tableName, refName, options);
   }

--- a/packages/activerecord/src/migration/references-foreign-key.test.ts
+++ b/packages/activerecord/src/migration/references-foreign-key.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Port of `ActiveRecord::Migration::ReferencesForeignKeyTest`
+ * (vendor/rails/activerecord/test/cases/migration/references_foreign_key_test.rb:110-269).
+ *
+ * The sibling `ReferencesForeignKeyInCreateTest` class in the same Rails file,
+ * plus the `pluralize_table_names` / `if_exists` / `if_not_exists` /
+ * `table_name_prefix` / `table_name_suffix` cases of this class, are still
+ * unported — they need `ReferenceDefinition` to thread `Base.pluralize_table_names`
+ * and the conditional options through, which is separate work.
+ *
+ * Driven by the ambient connection, mirroring Rails'
+ * `@connection = ActiveRecord::Base.lease_connection`.
+ */
+import { describe, it, expect } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { ambientConnection } from "../support/rocket-tables.js";
+import { describeIfSupports } from "../support/supports.js";
+
+/**
+ * The class' `setup`/`teardown` (references_foreign_key_test.rb:113-121).
+ * `testings` / `testing_parents` are not canonical-schema tables in Rails
+ * either — the suite creates and drops them itself.
+ */
+async function withTestingTables(conn: AbstractAdapter, body: () => Promise<void>): Promise<void> {
+  await conn.createTable("testing_parents", { force: true });
+  try {
+    await body();
+  } finally {
+    await conn.dropTable("testings", "testing_parents", { ifExists: true });
+  }
+}
+
+describeIfSupports("foreign_keys", "Migration", () => {
+  describe("ReferencesForeignKeyTest", () => {
+    // DDL can't run inside the transactional-fixtures wrapper (PG aborts the
+    // outer transaction on a failed statement).
+    fixtures([], { useTransactionalTests: false });
+
+    it("foreign keys cannot be added to polymorphic relations when creating the table", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          expect(() =>
+            t.references("testing_parent", { polymorphic: true, foreignKey: true }),
+          ).toThrow(ArgumentError);
+        });
+      });
+    });
+
+    it("foreign keys can be created while changing the table", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings");
+        await conn.changeTable("testings", async (t) => {
+          await t.references("testing_parent", { foreignKey: true });
+        });
+
+        const fk = (await conn.foreignKeys("testings"))[0];
+        expect(fk.fromTable).toBe("testings");
+        expect(fk.toTable).toBe("testing_parents");
+      });
+    });
+
+    it("foreign keys are not added by default when changing the table", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings");
+        await conn.changeTable("testings", async (t) => {
+          await t.references("testing_parent");
+        });
+
+        expect(await conn.foreignKeys("testings")).toEqual([]);
+      });
+    });
+
+    it("foreign keys accept options when changing the table", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.changeTable("testing_parents", async (t) => {
+          await t.references("other", { index: { unique: true } });
+        });
+        await conn.createTable("testings");
+        await conn.changeTable("testings", async (t) => {
+          await t.references("testing_parent", { foreignKey: { primaryKey: "other_id" } });
+        });
+
+        const fk = (await conn.foreignKeys("testings")).find(
+          (k) => k.toTable === "testing_parents",
+        );
+        expect(fk!.primaryKey).toBe("other_id");
+      });
+    });
+
+    it("foreign keys cannot be added to polymorphic relations when changing the table", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings");
+        await conn.changeTable("testings", async (t) => {
+          await expect(
+            t.references("testing_parent", { polymorphic: true, foreignKey: true }),
+          ).rejects.toThrow(ArgumentError);
+        });
+      });
+    });
+
+    it("foreign key column can be removed", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("testing_parent", { index: true, foreignKey: true });
+        });
+
+        const before = (await conn.foreignKeys("testings")).length;
+        await conn.removeReference("testings", "testing_parent", { foreignKey: true });
+        expect((await conn.foreignKeys("testings")).length).toBe(before - 1);
+      });
+    });
+
+    it("removing column removes foreign key", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("testing_parent", { index: true, foreignKey: true });
+        });
+
+        const before = (await conn.foreignKeys("testings")).length;
+        await conn.removeColumn("testings", "testing_parent_id");
+        expect((await conn.foreignKeys("testings")).length).toBe(before - 1);
+      });
+    });
+
+    it("multiple foreign keys can be added to the same table", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("parent1", { foreignKey: { toTable: "testing_parents" } });
+          t.references("parent2", { foreignKey: { toTable: "testing_parents" } });
+          t.references("self_join", { foreignKey: { toTable: "testings" } });
+        });
+
+        const fks = (await conn.foreignKeys("testings")).sort((a, b) =>
+          String(a.column).localeCompare(String(b.column)),
+        );
+
+        expect(fks.map((fk) => [fk.fromTable, fk.toTable, fk.column])).toEqual([
+          ["testings", "testing_parents", "parent1_id"],
+          ["testings", "testing_parents", "parent2_id"],
+          ["testings", "testings", "self_join_id"],
+        ]);
+      });
+    });
+
+    it("multiple foreign keys can be removed to the selected one", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("parent1", { foreignKey: { toTable: "testing_parents" } });
+          t.references("parent2", { foreignKey: { toTable: "testing_parents" } });
+        });
+
+        const before = (await conn.foreignKeys("testings")).length;
+        await conn.removeReference("testings", "parent1", {
+          foreignKey: { toTable: "testing_parents" },
+        });
+        expect((await conn.foreignKeys("testings")).length).toBe(before - 1);
+
+        const fks = (await conn.foreignKeys("testings")).sort((a, b) =>
+          String(a.column).localeCompare(String(b.column)),
+        );
+
+        expect(fks.map((fk) => [fk.fromTable, fk.toTable, fk.column])).toEqual([
+          ["testings", "testing_parents", "parent2_id"],
+        ]);
+      });
+    });
+  });
+});

--- a/packages/activerecord/src/migration/references-foreign-key.test.ts
+++ b/packages/activerecord/src/migration/references-foreign-key.test.ts
@@ -1,16 +1,3 @@
-/**
- * Port of `ActiveRecord::Migration::ReferencesForeignKeyTest`
- * (vendor/rails/activerecord/test/cases/migration/references_foreign_key_test.rb:110-269).
- *
- * The sibling `ReferencesForeignKeyInCreateTest` class in the same Rails file,
- * plus the `pluralize_table_names` / `if_exists` / `if_not_exists` /
- * `table_name_prefix` / `table_name_suffix` cases of this class, are still
- * unported — they need `ReferenceDefinition` to thread `Base.pluralize_table_names`
- * and the conditional options through, which is separate work.
- *
- * Driven by the ambient connection, mirroring Rails'
- * `@connection = ActiveRecord::Base.lease_connection`.
- */
 import { describe, it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
@@ -18,11 +5,6 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { ambientConnection } from "../support/rocket-tables.js";
 import { describeIfSupports } from "../support/supports.js";
 
-/**
- * The class' `setup`/`teardown` (references_foreign_key_test.rb:113-121).
- * `testings` / `testing_parents` are not canonical-schema tables in Rails
- * either — the suite creates and drops them itself.
- */
 async function withTestingTables(conn: AbstractAdapter, body: () => Promise<void>): Promise<void> {
   await conn.createTable("testing_parents", { force: true });
   try {
@@ -34,8 +16,6 @@ async function withTestingTables(conn: AbstractAdapter, body: () => Promise<void
 
 describeIfSupports("foreign_keys", "Migration", () => {
   describe("ReferencesForeignKeyTest", () => {
-    // DDL can't run inside the transactional-fixtures wrapper (PG aborts the
-    // outer transaction on a failed statement).
     fixtures([], { useTransactionalTests: false });
 
     it("foreign keys cannot be added to polymorphic relations when creating the table", async () => {

--- a/packages/activerecord/src/migration/references-foreign-key.test.ts
+++ b/packages/activerecord/src/migration/references-foreign-key.test.ts
@@ -98,19 +98,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
       });
     });
 
-    it("removing column removes foreign key", async () => {
-      const conn = await ambientConnection();
-      await withTestingTables(conn, async () => {
-        await conn.createTable("testings", (t) => {
-          t.references("testing_parent", { index: true, foreignKey: true });
-        });
-
-        const before = (await conn.foreignKeys("testings")).length;
-        await conn.removeColumn("testings", "testing_parent_id");
-        expect((await conn.foreignKeys("testings")).length).toBe(before - 1);
-      });
-    });
-
     it("multiple foreign keys can be added to the same table", async () => {
       const conn = await ambientConnection();
       await withTestingTables(conn, async () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -3,49 +3,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "add",
-    "call": "add_foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add",
-    "call": "add_index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add",
     "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add",
-    "call": "foreign_key_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add",
-    "call": "index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add",
-    "call": "index_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -23,13 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_reference",
-    "call": "add",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_timestamps",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Ports the create/change/remove cases of
`ActiveRecord::Migration::ReferencesForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/references_foreign_key_test.rb:110-269`)
into `packages/activerecord/src/migration/references-foreign-key.test.ts`, under
the two-level describe path `Migration > ReferencesForeignKeyTest` established
by #5457 for the neighbouring `foreign_key_test.rb` suite.

`test:compare` for `migration/references_foreign_key_test.rb` goes from
`0 OK / 23 missing` to `8 OK / 15 missing`, with 0 wrong-describe.

### Fidelity fix the ported cases surfaced

Rails' `add_reference` is one line (`abstract/schema_statements.rb:1063-1065`):

```ruby
def add_reference(table_name, ref_name, **options)
  ReferenceDefinition.new(ref_name, **options).add(table_name, self)
end
```

trails already had a faithful `ReferenceDefinition` — including
`index_options`, `polymorphic_options`, `conditional_options` and
`polymorphic_index_name` — but only the `add_to` (table-definition) half of the
pair; `SchemaStatements#addReference` reimplemented the connection-side half by
hand, and that copy had drifted from the class it duplicated:

- it ignored an `index:` options hash, always adding a plain index, so
  `index: { unique: true }` produced a non-unique index (SQLite then refuses a
  foreign key targeting that column — this is what "foreign keys accept options
  when changing the table" trips over);
- it never applied `polymorphic_index_name`;
- it passed the full column options to the polymorphic `_type` column instead of
  `polymorphic_options`;
- it raised a bare `Error` rather than `ArgumentError` for a polymorphic
  reference with a foreign key (`abstract/schema_definitions.rb:214-216`), which
  the two "cannot be added to polymorphic relations" cases assert.

So this ports the missing `ReferenceDefinition#add` (the connection-side twin of
the existing `addTo`) and makes `addReference` delegate to it, deleting the
divergent copy.

`api:compare` is unchanged at 6079/6145 methods with no new extra surface —
`add` matches Rails, and the `ReferenceDefinitionConnection` host interface is
`@internal`. Porting `add` converged 7 wide call-mismatch baseline entries
(`add` → `add_index` / `add_foreign_key` / `index_options` / …, and
`add_reference` → `add`); since that ratchet only shrinks, those entries are
removed here.

### One case left unported (MySQL dispatch gap)

`removing column removes foreign key` (`rb:180-186`) is **not** in this PR. It
fails on MySQL/MariaDB with `ER_FK_COLUMN_CANNOT_DROP`, because Rails'
`MySQL::SchemaStatements#remove_column` (`mysql/schema_statements.rb:77-82`)
drops the FK before the column and trails can't reach that override: Rails does
`include MySQL::SchemaStatements` on `AbstractMysqlAdapter`, whereas trails only
does `include(AbstractAdapter, SchemaStatements)` — `MysqlSchemaStatements` is
never mixed onto an adapter prototype, so `conn.removeColumn(...)` always
resolves to the base.

Porting the 4-line override alone does not fix it (verified locally against
MariaDB: the failure is unchanged), and putting a `removeColumn` on
`AbstractMysqlAdapter` instead recurses, since
`SchemaStatements#removeColumn` delegates back to `adapter.removeColumn`
whenever the adapter defines one. Rails runs this case unguarded on every
adapter, so gating it in trails would be a fidelity lie. Filed as
`mysql-schema-statements-overrides-unreachable-on-adapter` with the full
diagnosis.

The other 8 cases are verified green on sqlite3, postgresql and mysql2 locally.

### Scope

The file's remaining 14 cases are registered as follow-up stories rather than
fanned out here:

- `port-migration-references-foreign-key-in-create-cases` — the 9
  `ReferencesForeignKeyInCreateTest` cases (`rb:6-106`), including the four
  `supports_deferrable_constraints?`-gated ones.
- `mysql-schema-statements-overrides-unreachable-on-adapter` — the case above.
- `port-migration-references-foreign-key-naming-and-conditional-cases` — the 5
  cases of this class that need implementation work first:
  `pluralize_table_names` in `foreign_table_name`, `if_exists` / `if_not_exists`
  threading via `conditional_options`, and `table_name_prefix` /
  `table_name_suffix` through a migration.

Closes-story: port-migration-references-foreign-key-cases
