### PR TITLE
fix(migration): write via the stdout shim instead of Migration.logger

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2799,10 +2799,6 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    // Rails emits these banners from Migration#migrate (`migration.rb:964`),
-    // which this Migrator bypasses by driving the execution strategy directly.
-    this._announce(proxy, direction === "up" ? "migrating" : "reverting");
-
     const migration = await proxy.migration();
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
@@ -2810,9 +2806,13 @@ export class Migrator {
     // would leave schema_migrations out of sync.
     try {
       await this._ddlTransaction(migration, async () => {
+        // Rails emits these banners from Migration#migrate (`migration.rb:964`),
+        // which this Migrator bypasses by driving the execution strategy
+        // directly. They belong inside the ddl_transaction because Rails calls
+        // migration.migrate from within it (`migration.rb:1534`).
+        this._announce(proxy, direction === "up" ? "migrating" : "reverting");
         // Rails benchmarks exec_migration alone (`migration.rb:973`) and emits
-        // the completion banner from Migration#migrate — i.e. before
-        // record_version_state_after_migrating runs (`migration.rb:1534`).
+        // the completion banner before record_version_state_after_migrating.
         const start = Date.now();
         await this._strategy.exec(direction, migration, this._adapter);
         const elapsed = ((Date.now() - start) / 1000).toFixed(4);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -273,11 +273,11 @@ function writeMigrationMessage(verbose: boolean, text = ""): void {
   }
 }
 
-/** @internal The body of `Migration#announce` (`migration.rb:1005`). */
-function announceMigrationMessage(verbose: boolean, header: string, message: string): void {
+/** @internal The banner `Migration#announce` (`migration.rb:1005`) hands to `write`. */
+function announceMigrationText(header: string, message: string): string {
   const text = `${header}: ${message}`;
   const pad = Math.max(0, 75 - text.length);
-  writeMigrationMessage(verbose, `== ${text} ${"=".repeat(pad)}`);
+  return `== ${text} ${"=".repeat(pad)}`;
 }
 
 /**
@@ -1279,7 +1279,7 @@ export abstract class Migration {
   }
 
   announce(message: string): void {
-    announceMigrationMessage(this.verbose, `${this.version} ${this.name}`, message);
+    this.write(announceMigrationText(`${this.version} ${this.name}`, message));
   }
 
   say(message: string, subitem = false): void {
@@ -2839,7 +2839,10 @@ export class Migrator {
 
   /** @internal Rails: `MigrationProxy` delegates `announce`/`write` to the migration. */
   private _announce(proxy: MigrationProxy, message: string): void {
-    announceMigrationMessage(this.verbose, `${proxy.version} ${proxy.name}`, message);
+    writeMigrationMessage(
+      this.verbose,
+      announceMigrationText(`${proxy.version} ${proxy.name}`, message),
+    );
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2802,9 +2802,11 @@ export class Migrator {
     // Rails emits these banners from Migration#migrate (`migration.rb:964`),
     // which this Migrator bypasses by driving the execution strategy directly.
     this._announce(proxy, direction === "up" ? "migrating" : "reverting");
-    const start = Date.now();
 
     const migration = await proxy.migration();
+    // Rails benchmarks exec_migration only (`migration.rb:973`), so the timer
+    // starts after the migration is loaded.
+    const start = Date.now();
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
     // atomically. Without this, a committed migration + failed stamp

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2804,16 +2804,20 @@ export class Migrator {
     this._announce(proxy, direction === "up" ? "migrating" : "reverting");
 
     const migration = await proxy.migration();
-    // Rails benchmarks exec_migration only (`migration.rb:973`), so the timer
-    // starts after the migration is loaded.
-    const start = Date.now();
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
     // atomically. Without this, a committed migration + failed stamp
     // would leave schema_migrations out of sync.
     try {
       await this._ddlTransaction(migration, async () => {
+        // Rails benchmarks exec_migration alone (`migration.rb:973`) and emits
+        // the completion banner from Migration#migrate — i.e. before
+        // record_version_state_after_migrating runs (`migration.rb:1534`).
+        const start = Date.now();
         await this._strategy.exec(direction, migration, this._adapter);
+        const elapsed = ((Date.now() - start) / 1000).toFixed(4);
+        this._announce(proxy, `${direction === "up" ? "migrated" : "reverted"} (${elapsed}s)`);
+        writeMigrationMessage(this.verbose);
         if (direction === "up") {
           await this._schemaMigration.recordVersion(proxy.version);
           if (this._internalMetadata.enabled) {
@@ -2831,10 +2835,6 @@ export class Migrator {
       const msg = `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\n${e instanceof Error ? e.message : e}`;
       throw Object.assign(new Error(msg), { cause: e });
     }
-
-    const elapsed = ((Date.now() - start) / 1000).toFixed(4);
-    this._announce(proxy, `${direction === "up" ? "migrated" : "reverted"} (${elapsed}s)`);
-    writeMigrationMessage(this.verbose);
   }
 
   /** @internal Rails: `MigrationProxy` delegates `announce`/`write` to the migration. */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1,11 +1,11 @@
 import {
   getFs,
   getPath,
-  Logger,
   getEnv,
   camelize,
   underscore,
   humanize,
+  stdout,
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -258,6 +258,29 @@ export class EnvironmentStorageError extends MigrationError {
 }
 
 /**
+ * @internal The body of `Migration#write` (`migration.rb:1001`), lifted to a
+ * free function so the `verbose` gate exists in exactly one place. Rails puts
+ * migration output on `$stdout` via `Kernel#puts`; `stdout` is the
+ * activesupport shim standing in for `$stdout` — no logger is involved.
+ *
+ * The Migrator needs it too: unlike Rails, where `Migration#migrate` announces
+ * its own banners, trails' Migrator drives the execution strategy directly and
+ * its migrations may be bare `{ up, down }` proxies with no `announce`.
+ */
+function writeMigrationMessage(verbose: boolean, text = ""): void {
+  if (verbose) {
+    stdout.write(`${text}\n`);
+  }
+}
+
+/** @internal The body of `Migration#announce` (`migration.rb:1005`). */
+function announceMigrationMessage(verbose: boolean, header: string, message: string): void {
+  const text = `${header}: ${message}`;
+  const pad = Math.max(0, 75 - text.length);
+  writeMigrationMessage(verbose, `== ${text} ${"=".repeat(pad)}`);
+}
+
+/**
  * Migration — base class for database migrations.
  *
  * Mirrors: ActiveRecord::Migration
@@ -279,7 +302,6 @@ export abstract class Migration {
   static delegate: DatabaseAdapter | null = null;
   private _version?: string;
   verbose = true;
-  static logger: Logger = new Logger();
   private static _disableDdlTransaction = false;
 
   /** Return the normalized adapter name from the configured adapter. */
@@ -1253,15 +1275,11 @@ export abstract class Migration {
   // --- Logging (Rails: Migration#write, #announce, #say, #say_with_time, #suppress_messages) ---
 
   write(text = ""): void {
-    if (this.verbose) {
-      Migration.logger.info(text);
-    }
+    writeMigrationMessage(this.verbose, text);
   }
 
   announce(message: string): void {
-    const text = `${this.version} ${this.name}: ${message}`;
-    const pad = Math.max(0, 75 - text.length);
-    this.write(`== ${text} ${"=".repeat(pad)}`);
+    announceMigrationMessage(this.verbose, `${this.version} ${this.name}`, message);
   }
 
   say(message: string, subitem = false): void {
@@ -2781,10 +2799,10 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    if (this.verbose) {
-      const action = direction === "up" ? "migrating" : "reverting";
-      Migration.logger.info(`== ${proxy.version} ${proxy.name}: ${action} ==`);
-    }
+    // Rails emits these banners from Migration#migrate (`migration.rb:964`),
+    // which this Migrator bypasses by driving the execution strategy directly.
+    this._announce(proxy, direction === "up" ? "migrating" : "reverting");
+    const start = Date.now();
 
     const migration = await proxy.migration();
     // Rails wraps both the migration execution AND the version
@@ -2812,10 +2830,14 @@ export class Migrator {
       throw Object.assign(new Error(msg), { cause: e });
     }
 
-    if (this.verbose) {
-      const action = direction === "up" ? "migrated" : "reverted";
-      Migration.logger.info(`== ${proxy.version} ${proxy.name}: ${action} ==`);
-    }
+    const elapsed = ((Date.now() - start) / 1000).toFixed(4);
+    this._announce(proxy, `${direction === "up" ? "migrated" : "reverted"} (${elapsed}s)`);
+    writeMigrationMessage(this.verbose);
+  }
+
+  /** @internal Rails: `MigrationProxy` delegates `announce`/`write` to the migration. */
+  private _announce(proxy: MigrationProxy, message: string): void {
+    announceMigrationMessage(this.verbose, `${proxy.version} ${proxy.name}`, message);
   }
 
   /**

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -1,9 +1,8 @@
 // Faithful port of vendor/rails/activerecord/test/cases/migrator_test.rb
-import { describe, it, expect, beforeEach } from "vitest";
-import { Logger } from "@blazetrails/activesupport";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { stdout } from "@blazetrails/activesupport";
 import {
   Migrator,
-  Migration,
   DuplicateMigrationVersionError,
   UnknownMigrationVersionError,
 } from "./migration.js";
@@ -427,8 +426,13 @@ describe("MigratorTest", () => {
 
   it("migrator verbosity", async () => {
     const lines: string[] = [];
-    const origLogger = Migration.logger;
-    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+    // Rails counts messages via `Migration.message_count`, which its test
+    // helper increments from an overridden `write`. Here the equivalent seam
+    // is the stdout shim `write` puts to.
+    const spy = vi.spyOn(stdout, "write").mockImplementation((chunk) => {
+      lines.push(chunk);
+      return true;
+    });
     try {
       const { migrations } = sensors(3);
 
@@ -444,14 +448,16 @@ describe("MigratorTest", () => {
       await downMigrator.migrate(0);
       expect(lines.length).not.toBe(0);
     } finally {
-      Migration.logger = origLogger;
+      spy.mockRestore();
     }
   });
 
   it("migrator verbosity off", async () => {
     const lines: string[] = [];
-    const origLogger = Migration.logger;
-    Migration.logger = new Logger({ write: (s) => lines.push(s) });
+    const spy = vi.spyOn(stdout, "write").mockImplementation((chunk) => {
+      lines.push(chunk);
+      return true;
+    });
     try {
       const { migrations } = sensors(3);
 
@@ -465,7 +471,7 @@ describe("MigratorTest", () => {
       await downMigrator.migrate(0);
       expect(lines.length).toBe(0);
     } finally {
-      Migration.logger = origLogger;
+      spy.mockRestore();
     }
   });
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -269,7 +269,7 @@ export class DatabaseTasks {
     const effectiveVersion = typeof raw === "string" ? raw.trim() || null : raw;
     this.checkTargetVersion(effectiveVersion ?? undefined);
 
-    const { Migrator, Migration } = await import("../migration.js");
+    const { Migrator } = await import("../migration.js");
     const scope = getEnv("SCOPE");
     const verbose = isVerbose();
 
@@ -294,7 +294,10 @@ export class DatabaseTasks {
       }
       const ran = await migrator.migrate(effectiveVersion ?? null, filter);
       if (scope && scope.trim() !== "" && ran.length === 0 && verbose) {
-        Migration.logger.info(`No migrations ran. (using ${scope} scope)`);
+        // Rails: `Migration.write("No migrations ran. ...")` — write puts to
+        // $stdout (`migration.rb:1001`); `verbose` here is the gate Migration
+        // #write applies. `stdout` is the activesupport $stdout shim.
+        stdout.write(`No migrations ran. (using ${scope} scope)\n`);
       }
       // Rails: `migration_connection_pool.schema_cache.clear!` — drop the
       // reflected schema so post-migration introspection re-reads the

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -590,8 +590,8 @@ async function withMigratorForDb(
   // Migration output goes to stdout (Rails' Migration#write is `puts`), so the
   // per-database prefix is applied by swapping in a stdout-wrapping process
   // adapter for the duration of the run.
-  const prevAdapter = getProcessAdapter();
-  if (ctx.prefix) {
+  const prevAdapter = ctx.prefix ? getProcessAdapter() : null;
+  if (prevAdapter) {
     registerProcessAdapter({
       ...prevAdapter,
       stdout: {
@@ -612,7 +612,7 @@ async function withMigratorForDb(
     await operation(migrator);
     if (opts?.afterOutput) await opts.afterOutput(migrator);
   } finally {
-    if (ctx.prefix) registerProcessAdapter(prevAdapter);
+    if (prevAdapter) registerProcessAdapter(prevAdapter);
   }
   if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.raw, ctx.config);
 }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
-import { getFsAsync, getPathAsync, Logger } from "@blazetrails/activesupport";
-import { env, setExitCode, stdout } from "@blazetrails/activesupport/process-adapter";
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import {
+  env,
+  setExitCode,
+  getProcessAdapter,
+  registerProcessAdapter,
+} from "@blazetrails/activesupport/process-adapter";
 import {
   loadDatabaseConfig,
   loadAllDatabaseConfigs,
@@ -13,7 +18,6 @@ import { discoverMigrations } from "../migration-loader.js";
 import {
   DatabaseTasks,
   HashConfig,
-  Migration,
   Migrator,
   DatabaseAlreadyExists,
   NoDatabaseError,
@@ -583,17 +587,32 @@ async function withMigratorForDb(
     environment: ctx.config.envName,
     internalMetadataEnabled: ctx.config.useMetadataTable,
   });
-  const prevLogger = Migration.logger;
+  // Migration output goes to stdout (Rails' Migration#write is `puts`), so the
+  // per-database prefix is applied by swapping in a stdout-wrapping process
+  // adapter for the duration of the run.
+  const prevAdapter = getProcessAdapter();
   if (ctx.prefix) {
-    Migration.logger = new Logger({
-      write: (s) => stdout.write(`${ctx.prefix}${s}`),
+    registerProcessAdapter({
+      ...prevAdapter,
+      stdout: {
+        write: (chunk) => prevAdapter.stdout.write(`${ctx.prefix}${chunk}`),
+        get isTTY() {
+          return prevAdapter.stdout.isTTY;
+        },
+        get columns() {
+          return prevAdapter.stdout.columns;
+        },
+        get rows() {
+          return prevAdapter.stdout.rows;
+        },
+      },
     });
   }
   try {
     await operation(migrator);
     if (opts?.afterOutput) await opts.afterOutput(migrator);
   } finally {
-    Migration.logger = prevLogger;
+    if (ctx.prefix) registerProcessAdapter(prevAdapter);
   }
   if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.raw, ctx.config);
 }

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -2,8 +2,8 @@ import type { VirtualFS } from "./virtual-fs.js";
 import type { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VfsModelGenerator, VfsMigrationGenerator, VfsAppGenerator } from "./vfs-generator.js";
 import type { MigrationProxy, MigrationLike } from "@blazetrails/activerecord/migration";
-import { Migration, Migrator } from "@blazetrails/activerecord/migration";
-import { camelize, Logger } from "@blazetrails/activesupport";
+import { Migrator } from "@blazetrails/activerecord/migration";
+import { camelize, registerProcessAdapter, type ProcessAdapter } from "@blazetrails/activesupport";
 
 export interface CliResult {
   success: boolean;
@@ -128,6 +128,38 @@ export function dropUserTables(adapter: SqlJsAdapter, getTables: () => string[])
   return tables.length;
 }
 
+let stdoutSink: (chunk: string) => void = () => {};
+
+/** Minimal ProcessAdapter so the activesupport `stdout` shim works in the browser. */
+const browserProcessAdapter: ProcessAdapter = {
+  envSnapshot: () => ({}),
+  argvSnapshot: () => [],
+  cwd: () => "/",
+  chdir: () => {},
+  platform: () => "browser",
+  setEnv: () => {},
+  exit: () => {
+    throw new Error("exit() is not supported in the browser CLI");
+  },
+  setExitCode: () => {},
+  onSignal: () => () => {},
+  stdout: {
+    write: (chunk) => {
+      stdoutSink(chunk);
+      return true;
+    },
+    isTTY: false,
+  },
+  stderr: {
+    write: (chunk) => {
+      stdoutSink(chunk);
+      return true;
+    },
+    isTTY: false,
+  },
+  stdin: { isTTY: false, read: async () => null },
+};
+
 export function createTrailCLI(deps: TrailCliDeps) {
   const { vfs, adapter } = deps;
   const output: string[] = [];
@@ -142,12 +174,15 @@ export function createTrailCLI(deps: TrailCliDeps) {
       return;
     }
     const migrator = new Migrator(adapter, proxies);
-    const prevLogger = Migration.logger;
-    Migration.logger = new Logger({ write: (s) => log(s.replace(/\n$/, "")) });
+    // Migration output goes to stdout (Rails' Migration#write is `puts`), and
+    // the browser has no process — so the shim's stdout is pointed at this
+    // CLI's output buffer for the duration of the run.
+    registerProcessAdapter(browserProcessAdapter);
+    stdoutSink = (chunk) => log(chunk.replace(/\n$/, ""));
     try {
       await fn(migrator);
     } finally {
-      Migration.logger = prevLogger;
+      stdoutSink = () => {};
     }
   }
 

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -3,7 +3,13 @@ import type { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VfsModelGenerator, VfsMigrationGenerator, VfsAppGenerator } from "./vfs-generator.js";
 import type { MigrationProxy, MigrationLike } from "@blazetrails/activerecord/migration";
 import { Migrator } from "@blazetrails/activerecord/migration";
-import { camelize, registerProcessAdapter, type ProcessAdapter } from "@blazetrails/activesupport";
+import {
+  camelize,
+  getProcessAdapter,
+  processAdapterConfig,
+  registerProcessAdapter,
+  type ProcessAdapter,
+} from "@blazetrails/activesupport";
 
 export interface CliResult {
   success: boolean;
@@ -176,13 +182,16 @@ export function createTrailCLI(deps: TrailCliDeps) {
     const migrator = new Migrator(adapter, proxies);
     // Migration output goes to stdout (Rails' Migration#write is `puts`), and
     // the browser has no process — so the shim's stdout is pointed at this
-    // CLI's output buffer for the duration of the run.
+    // CLI's output buffer for the duration of the run. Any adapter the host
+    // already registered (e.g. the Node one under test) is restored after.
+    const prevAdapter = processAdapterConfig.adapter === null ? null : getProcessAdapter();
     registerProcessAdapter(browserProcessAdapter);
     stdoutSink = (chunk) => log(chunk.replace(/\n$/, ""));
     try {
       await fn(migrator);
     } finally {
       stdoutSink = () => {};
+      if (prevAdapter) registerProcessAdapter(prevAdapter);
     }
   }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
@@ -254,13 +254,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migrate",
-    "call": "write",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "migrate_all",
     "call": "configurations",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `Migration#write` is `puts(text) if verbose` (`migration.rb:1001`) —
migration output goes to `$stdout`, never through a logger. trails routed it
through `Migration.logger`, and the Migrator emitted its own banners with two
extra `Migration.logger.info` calls that duplicated the `verbose` gate.

- `Migration#write` now writes to the activesupport `stdout` shim (our `$stdout`
  analogue). The gate lives in one `@internal` free function that both
  `Migration#write` and the Migrator share, since Migrator migrations may be
  bare `{ up, down }` proxies with no `announce`.
- `Migrator#_runMigration`'s two banner sites go through `announce`/`write`,
  so the banners now match Rails' `== 1 Foo: migrating =====…` padding and the
  `migrated (0.0000s)` + blank-line completion form emitted by
  `Migration#migrate` (`migration.rb:964`).
- `DatabaseTasks` "No migrations ran." now puts to stdout, matching
  `database_tasks.rb:277`'s `Migration.write(...)`.
- **`Migration.logger` removed** — it has no Rails counterpart. Its two external
  consumers redirected migration output by swapping the logger; they now swap
  the stdout sink instead: `trailties db` wraps the current process adapter to
  prefix each chunk, and the website browser CLI registers a minimal
  `ProcessAdapter` (the browser has no process, so the shim needed one anyway).
- `migrator.test.ts`'s two verbosity tests spy on the `stdout` shim — the
  analogue of Rails' `Migration.message_count`, which its helper increments from
  an overridden `write`. Test names unchanged.

Closes-story: migration-write-uses-logger-not-puts
