### PR TITLE
test(activerecord): port Migration::ReferencesForeignKeyInCreateTest

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1893,12 +1893,16 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // from CREATE TABLE SQL since PRAGMA foreign_key_list doesn't expose it.
   private async _parseFkDeferrable(
     tableName: string,
-  ): Promise<Map<string, "immediate" | "deferred">> {
+  ): Promise<Map<string, "immediate" | "deferred" | false>> {
     const createSql = await this._getCreateTableSql(tableName);
-    const result = new Map<string, "immediate" | "deferred">();
+    const result = new Map<string, "immediate" | "deferred" | false>();
     if (!createSql) return result;
+    // Rails builds fk_defs from every `CONSTRAINT ... FOREIGN KEY` clause and
+    // records `mode || false` (sqlite3_adapter.rb:422-431), so a constraint
+    // without a DEFERRABLE clause reflects as `false`, not nil — the DEFERRABLE
+    // suffix is optional here for that reason.
     const fkRegex =
-      /FOREIGN KEY\s*\(([^)]+)\)\s*REFERENCES\s*"?([^"(,\s]+)"?\s*\(([^)]+)\)[^,)]*DEFERRABLE\s+INITIALLY\s+(\w+)/gi;
+      /CONSTRAINT\s+[^(]*?FOREIGN KEY\s*\(([^)]+)\)\s*REFERENCES\s*"?([^"(,\s]+)"?\s*\(([^)]+)\)(?:[^,)]*DEFERRABLE\s+INITIALLY\s+(\w+))?/gi;
     let match;
     while ((match = fkRegex.exec(createSql)) !== null) {
       const [, fromCols, toTbl, toCols, mode] = match;
@@ -1911,7 +1915,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         .map((c) => c.trim().replace(/^"|"$/g, ""))
         .join(",");
       const key = `${toTbl},${fromKey},${toKey}`;
-      result.set(key, mode.toLowerCase() === "deferred" ? "deferred" : "immediate");
+      result.set(
+        key,
+        mode === undefined ? false : mode.toLowerCase() === "deferred" ? "deferred" : "immediate",
+      );
     }
     return result;
   }

--- a/packages/activerecord/src/migration/references-foreign-key.test.ts
+++ b/packages/activerecord/src/migration/references-foreign-key.test.ts
@@ -3,7 +3,8 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { ambientConnection } from "../support/rocket-tables.js";
-import { describeIfSupports } from "../support/supports.js";
+import { describeIfSupports, itIfSupports } from "../support/supports.js";
+import { assertQueriesCount } from "../testing/query-assertions.js";
 
 async function withTestingTables(conn: AbstractAdapter, body: () => Promise<void>): Promise<void> {
   await conn.createTable("testing_parents", { force: true });
@@ -142,5 +143,154 @@ describeIfSupports("foreign_keys", "Migration", () => {
         ]);
       });
     });
+  });
+
+  describe("ReferencesForeignKeyInCreateTest", () => {
+    fixtures([], { useTransactionalTests: false });
+
+    it("foreign keys can be created with the table", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("testing_parent", { foreignKey: true });
+        });
+
+        const fk = (await conn.foreignKeys("testings"))[0];
+        expect(fk.fromTable).toBe("testings");
+        expect(fk.toTable).toBe("testing_parents");
+      });
+    });
+
+    it("no foreign key is created by default", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("testing_parent");
+        });
+
+        expect(await conn.foreignKeys("testings")).toEqual([]);
+      });
+    });
+
+    it("foreign keys can be created in one query when index is not added", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await assertQueriesCount(1, false, async () => {
+          await conn.createTable("testings", (t) => {
+            t.references("testing_parent", { foreignKey: true, index: false });
+          });
+        });
+      });
+    });
+
+    it("options hash can be passed", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.changeTable("testing_parents", async (t) => {
+          await t.references("other", { index: { unique: true } });
+        });
+        await conn.createTable("testings", (t) => {
+          t.references("testing_parent", { foreignKey: { primaryKey: "other_id" } });
+        });
+
+        const fk = (await conn.foreignKeys("testings")).find(
+          (k) => k.toTable === "testing_parents",
+        );
+        expect(fk!.primaryKey).toBe("other_id");
+      });
+    });
+
+    it("to_table option can be passed", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("parent", { foreignKey: { toTable: "testing_parents" } });
+        });
+
+        const fks = await conn.foreignKeys("testings");
+        expect(fks.map((fk) => [fk.fromTable, fk.toTable, fk.column])).toEqual([
+          ["testings", "testing_parents", "parent_id"],
+        ]);
+      });
+    });
+
+    itIfSupports("deferrable_constraints", "deferrable: false option can be passed", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("testing_parent", { foreignKey: { deferrable: false } });
+        });
+
+        const fks = await conn.foreignKeys("testings");
+        expect(fks.map((fk) => [fk.fromTable, fk.toTable, fk.column, fk.deferrable])).toEqual([
+          ["testings", "testing_parents", "testing_parent_id", false],
+        ]);
+      });
+    });
+
+    itIfSupports(
+      "deferrable_constraints",
+      "deferrable: :immediate option can be passed",
+      async () => {
+        const conn = await ambientConnection();
+        await withTestingTables(conn, async () => {
+          await conn.createTable("testings", (t) => {
+            t.references("testing_parent", { foreignKey: { deferrable: "immediate" } });
+          });
+
+          const fks = await conn.foreignKeys("testings");
+          expect(fks.map((fk) => [fk.fromTable, fk.toTable, fk.column, fk.deferrable])).toEqual([
+            ["testings", "testing_parents", "testing_parent_id", "immediate"],
+          ]);
+        });
+      },
+    );
+
+    itIfSupports(
+      "deferrable_constraints",
+      "deferrable: :deferred option can be passed",
+      async () => {
+        const conn = await ambientConnection();
+        await withTestingTables(conn, async () => {
+          await conn.createTable("testings", (t) => {
+            t.references("testing_parent", { foreignKey: { deferrable: "deferred" } });
+          });
+
+          const fks = await conn.foreignKeys("testings");
+          expect(fks.map((fk) => [fk.fromTable, fk.toTable, fk.column, fk.deferrable])).toEqual([
+            ["testings", "testing_parents", "testing_parent_id", "deferred"],
+          ]);
+        });
+      },
+    );
+
+    itIfSupports(
+      "deferrable_constraints",
+      "deferrable and on_(delete|update) option can be passed",
+      async () => {
+        const conn = await ambientConnection();
+        await withTestingTables(conn, async () => {
+          await conn.createTable("testings", (t) => {
+            t.references("testing_parent", {
+              foreignKey: { onUpdate: "cascade", onDelete: "cascade", deferrable: "immediate" },
+            });
+          });
+
+          const fks = await conn.foreignKeys("testings");
+          expect(
+            fks.map((fk) => [
+              fk.fromTable,
+              fk.toTable,
+              fk.column,
+              fk.onDelete,
+              fk.onUpdate,
+              fk.deferrable,
+            ]),
+          ).toEqual([
+            ["testings", "testing_parents", "testing_parent_id", "cascade", "cascade", "immediate"],
+          ]);
+        });
+      },
+    );
   });
 });

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -72,6 +72,9 @@ const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // PostgreSQL only (postgresql_adapter.rb:224/228; abstract default false).
   exclusion_constraints: ["postgres"],
   unique_constraints: ["postgres"],
+  // `supports_deferrable_constraints?`: PostgreSQL + SQLite true, abstract
+  // default false. (postgresql_adapter.rb:236, sqlite3_adapter.rb:249)
+  deferrable_constraints: ["postgres", "sqlite"],
   // `supports_expression_index?`: PG + SQLite always; MySQL family per the
   // live-server probe above (MySQL ≥ 8.0.13, never MariaDB).
   // (postgresql_adapter.rb:208, sqlite3_adapter.rb:155, abstract_mysql_adapter.rb:104)


### PR DESCRIPTION
Ports the 9 cases of `ActiveRecord::Migration::ReferencesForeignKeyInCreateTest`
(`vendor/rails/activerecord/test/cases/migration/references_foreign_key_test.rb:6-106`)
into `packages/activerecord/src/migration/references-foreign-key.test.ts` as a
second `describe` alongside the `ReferencesForeignKeyTest` block, under the path
`Migration > ReferencesForeignKeyInCreateTest`, with names matching Rails
verbatim.

The four `deferrable:` cases are Ruby-guarded by
`supports_deferrable_constraints?`; they are gated here with
`itIfSupports("deferrable_constraints", …)` — a new key in `support/supports.ts`
(PG + SQLite, mirroring `postgresql_adapter.rb:236` / `sqlite3_adapter.rb:249`).

One fidelity fix the cases surfaced: the SQLite FK reflection only recorded a
`deferrable` value for constraints carrying a `DEFERRABLE` clause, leaving the
rest nil. Rails' `fk_defs` (`sqlite3_adapter.rb:422-431`) selects every column
string that `start_with?("CONSTRAINT") && include?("FOREIGN KEY")` and stores
`mode&.downcase&.to_sym || false`, so a plain constraint reflects as `false`.
`_parseFkDeferrable` now requires the leading `CONSTRAINT` keyword and treats the
`DEFERRABLE INITIALLY` suffix as optional, defaulting to `false`.

`test:compare --package activerecord` reports `17 OK / 6 missing` for
`migration/references_foreign_key_test.rb` (was 8 OK / 15 missing);
`--gates --check` exits 0. `api:compare` is unchanged at 6079/6145 — no new
surface.

Rebased onto `main` after the sibling `ReferencesForeignKeyTest` PR merged. Two
changes this PR originally carried are now redundant and were dropped in the
rebase: the `AddReferenceOptions` widening (landed with the sibling) and the
`addReference` `index:`-hash merge — `main` now delegates
`addReference` to `new ReferenceDefinition(refName, options).add(tableName, this)`
(`schema-statements.ts:714`), matching `abstract/schema_statements.rb:1063-1065`,
so the hand-rolled duplicate is gone. The follow-up story filed for that
(`0005-activerecord-gaps/delegate-add-reference-to-reference-definition`) has been
closed as superseded.

Closes-story: port-migration-references-foreign-key-in-create-cases
