### PR TITLE
test(schema-migration): cover assumeMigratedUptoVersion

### DIFF
--- a/packages/activerecord/src/schema-migration.trails.test.ts
+++ b/packages/activerecord/src/schema-migration.trails.test.ts
@@ -86,7 +86,7 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
       [20200101000000, 20200102000000],
     );
 
-    expect(insertStatements()).toHaveLength(1);
+    expect(insertStatements()).toHaveLength(2);
     expect(await schemaMigration.versions()).toEqual([
       "20200101000000",
       "20200102000000",
@@ -104,7 +104,7 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
     expect(await schemaMigration.versions()).toEqual(["1"]);
   });
 
-  it("raises on a duplicate migration version without inserting", async () => {
+  it("raises on a duplicate unmigrated version below the target", async () => {
     await expect(
       schemaMigration.assumeMigratedUptoVersion(20200103000000, [20200101000000, 20200101000000]),
     ).rejects.toThrow(
@@ -113,6 +113,30 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
 
     expect(insertStatements()).toEqual([]);
     expect(await schemaMigration.versions()).toEqual([]);
+  });
+
+  // Rails builds the duplicate check from `inserting`, not from every supplied
+  // version (schema_statements.rb:1375-1379), so an already-migrated repeat is
+  // subtracted out before the check ever sees it.
+  it("accepts a duplicate version that is already migrated", async () => {
+    await schemaMigration.createVersion("20200101000000");
+    executeSpy.mockClear();
+
+    await schemaMigration.assumeMigratedUptoVersion(
+      20200103000000,
+      [20200101000000, 20200101000000],
+    );
+
+    expect(await schemaMigration.versions()).toEqual(["20200101000000", "20200103000000"]);
+  });
+
+  it("accepts a duplicate version at or above the target", async () => {
+    await schemaMigration.assumeMigratedUptoVersion(
+      20200103000000,
+      [20200104000000, 20200104000000],
+    );
+
+    expect(await schemaMigration.versions()).toEqual(["20200103000000"]);
   });
 
   it("raises on a non-numeric version without inserting", async () => {
@@ -133,7 +157,11 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
     expect(await schemaMigration.versions()).toEqual([]);
   });
 
-  it("emits one multi-row INSERT carrying bare version values", async () => {
+  // Rails emits up to two statements: the target version on its own
+  // (schema_statements.rb:1372-1374), then `insert_versions_sql(inserting)`,
+  // which reverses the tuples (schema_statements.rb:1882). Only the SQL text
+  // differs here — Rails newline-joins the tuples and appends a `;`.
+  it("emits the target INSERT then a reversed multi-row INSERT", async () => {
     await schemaMigration.assumeMigratedUptoVersion(
       20200103000000,
       [20200101000000, 20200102000000],
@@ -142,7 +170,24 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
     const table = conn.quoteTableName(schemaMigration.tableName);
     const column = conn.quoteColumnName(schemaMigration.primaryKey);
     expect(insertStatements()).toEqual([
-      `INSERT INTO ${table} (${column}) VALUES ('20200103000000'), ('20200101000000'), ('20200102000000')`,
+      `INSERT INTO ${table} (${column}) VALUES ('20200103000000')`,
+      `INSERT INTO ${table} (${column}) VALUES ('20200102000000'), ('20200101000000')`,
+    ]);
+  });
+
+  it("emits only the backfill INSERT when the target is already migrated", async () => {
+    await schemaMigration.createVersion("20200103000000");
+    executeSpy.mockClear();
+
+    await schemaMigration.assumeMigratedUptoVersion(
+      20200103000000,
+      [20200101000000, 20200102000000],
+    );
+
+    const table = conn.quoteTableName(schemaMigration.tableName);
+    const column = conn.quoteColumnName(schemaMigration.primaryKey);
+    expect(insertStatements()).toEqual([
+      `INSERT INTO ${table} (${column}) VALUES ('20200102000000'), ('20200101000000')`,
     ]);
   });
 });

--- a/packages/activerecord/src/schema-migration.trails.test.ts
+++ b/packages/activerecord/src/schema-migration.trails.test.ts
@@ -115,6 +115,24 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
     expect(await schemaMigration.versions()).toEqual([]);
   });
 
+  // Rails' `detect { |v| inserting.count(v) > 1 }` (schema_statements.rb:1377)
+  // reports the first element that repeats, not the first repeat encountered:
+  // for [B, A, A, B] it cites B, reached at index 0, even though A's second
+  // occurrence comes first.
+  it("cites the first repeating version when two versions repeat", async () => {
+    await expect(
+      schemaMigration.assumeMigratedUptoVersion(
+        20200103000000,
+        [20200102000000, 20200101000000, 20200101000000, 20200102000000],
+      ),
+    ).rejects.toThrow(
+      "Duplicate migration 20200102000000. Please renumber your migrations to resolve the conflict.",
+    );
+
+    expect(insertStatements()).toEqual([]);
+    expect(await schemaMigration.versions()).toEqual([]);
+  });
+
   // Rails builds the duplicate check from `inserting`, not from every supplied
   // version (schema_statements.rb:1375-1379), so an already-migrated repeat is
   // subtracted out before the check ever sees it.

--- a/packages/activerecord/src/schema-migration.trails.test.ts
+++ b/packages/activerecord/src/schema-migration.trails.test.ts
@@ -1,0 +1,154 @@
+/**
+ * trails-only coverage for `SchemaMigration#assumeMigratedUptoVersion` —
+ * vendor/rails/activerecord/test/cases has no test for
+ * `assume_migrated_upto_version` (schema_statements.rb:1364-1383), and trails'
+ * SchemaMigration-level wrapper has no Rails counterpart at all, so these cases
+ * have no Rails test to mirror verbatim.
+ *
+ * The method had zero coverage, which let a latent break ship: rows were built
+ * as `[new Nodes.Quoted(v)]`, and once the ValuesList visitor was narrowed to
+ * Rails' `case` (to_sql.rb:110) a `Quoted` row fell through to `quote()`, which
+ * raises `TypeError: can't quote Quoted`. The SQL-shape assertion below pins the
+ * row shape so that regression fails loudly instead of only at runtime.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+
+import { Base } from "./index.js";
+import { SchemaMigration } from "./schema-migration.js";
+import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+
+describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
+  // Real DDL against a real adapter: run non-transactionally so MySQL's
+  // implicit commit on DDL cannot commit the fixture transaction mid-test.
+  fixtures([], { useTransactionalTests: false });
+
+  let conn: DatabaseAdapter;
+  let schemaMigration: SchemaMigration;
+  let originalPrefix: string;
+  let executed: string[] = [];
+
+  beforeAll(async () => {
+    // An isolated table, so this suite never reads or writes the real
+    // schema_migrations rows other suites share.
+    originalPrefix = Base.tableNamePrefix;
+    Base.tableNamePrefix = "amuv_";
+    conn = (await Base.leaseConnection()) as unknown as DatabaseAdapter;
+    schemaMigration = new SchemaMigration(conn);
+    await schemaMigration.dropTable();
+    await schemaMigration.createTable();
+
+    const host = conn as unknown as { execute(sql: string): Promise<unknown> };
+    const original = host.execute.bind(conn);
+    host.execute = (sql: string) => {
+      executed.push(sql);
+      return original(sql);
+    };
+  });
+
+  afterAll(async () => {
+    delete (conn as unknown as { execute?: unknown }).execute;
+    await schemaMigration.dropTable();
+    Base.tableNamePrefix = originalPrefix;
+  });
+
+  beforeEach(async () => {
+    await schemaMigration.deleteAllVersions();
+    executed = [];
+  });
+
+  function insertStatements(): string[] {
+    return executed.filter((sql) => /^INSERT/i.test(sql));
+  }
+
+  it("inserts the version when it has not been migrated", async () => {
+    await schemaMigration.assumeMigratedUptoVersion(20200101000000);
+
+    expect(await schemaMigration.versions()).toEqual(["20200101000000"]);
+  });
+
+  it("does nothing when the version is already migrated", async () => {
+    await schemaMigration.createVersion("20200101000000");
+    executed = [];
+
+    await schemaMigration.assumeMigratedUptoVersion(20200101000000);
+
+    expect(insertStatements()).toEqual([]);
+    expect(await schemaMigration.versions()).toEqual(["20200101000000"]);
+  });
+
+  it("backfills migration versions below the given version", async () => {
+    await schemaMigration.assumeMigratedUptoVersion(
+      20200103000000,
+      [
+        20200101000000, 20200102000000,
+        // Above the ceiling — Rails selects only `v < version`
+        // (schema_statements.rb:1375).
+        20200104000000,
+      ],
+    );
+
+    expect(await schemaMigration.versions()).toEqual([
+      "20200101000000",
+      "20200102000000",
+      "20200103000000",
+    ]);
+  });
+
+  it("does not re-insert already migrated intervening versions", async () => {
+    await schemaMigration.createVersion("20200101000000");
+
+    await schemaMigration.assumeMigratedUptoVersion(
+      20200103000000,
+      [20200101000000, 20200102000000],
+    );
+
+    expect(await schemaMigration.versions()).toEqual([
+      "20200101000000",
+      "20200102000000",
+      "20200103000000",
+    ]);
+  });
+
+  it("normalizes zero-padded versions against the migrated set", async () => {
+    await schemaMigration.createVersion("1");
+
+    await schemaMigration.assumeMigratedUptoVersion("001");
+
+    expect(await schemaMigration.versions()).toEqual(["1"]);
+  });
+
+  // Rails: raise "Duplicate migration #{duplicate}. Please renumber your
+  // migrations to resolve the conflict." (schema_statements.rb:1377-1379).
+  it("raises on duplicate migration versions", async () => {
+    await expect(
+      schemaMigration.assumeMigratedUptoVersion(20200103000000, [20200101000000, 20200101000000]),
+    ).rejects.toThrow(
+      "Duplicate migration 20200101000000. Please renumber your migrations to resolve the conflict.",
+    );
+
+    // Validation runs before any write, so nothing was inserted.
+    expect(insertStatements()).toEqual([]);
+    expect(await schemaMigration.versions()).toEqual([]);
+  });
+
+  it("rejects a non-numeric version without writing", async () => {
+    await expect(schemaMigration.assumeMigratedUptoVersion("nope")).rejects.toThrow(
+      "Invalid migration version: nope",
+    );
+    expect(insertStatements()).toEqual([]);
+  });
+
+  it("emits a single multi-row INSERT with bare version values", async () => {
+    await schemaMigration.assumeMigratedUptoVersion(
+      20200103000000,
+      [20200101000000, 20200102000000],
+    );
+
+    const table = conn.quoteTableName(schemaMigration.tableName);
+    const column = conn.quoteColumnName(schemaMigration.primaryKey);
+    expect(insertStatements()).toEqual([
+      `INSERT INTO ${table} (${column}) VALUES ('20200103000000'), ('20200101000000'), ('20200102000000')`,
+    ]);
+  });
+});

--- a/packages/activerecord/src/schema-migration.trails.test.ts
+++ b/packages/activerecord/src/schema-migration.trails.test.ts
@@ -1,17 +1,12 @@
 /**
- * trails-only coverage for `SchemaMigration#assumeMigratedUptoVersion` —
+ * trails-only coverage for `SchemaMigration#assumeMigratedUptoVersion`.
  * vendor/rails/activerecord/test/cases has no test for
  * `assume_migrated_upto_version` (schema_statements.rb:1364-1383), and trails'
- * SchemaMigration-level wrapper has no Rails counterpart at all, so these cases
- * have no Rails test to mirror verbatim.
- *
- * The method had zero coverage, which let a latent break ship: rows were built
- * as `[new Nodes.Quoted(v)]`, and once the ValuesList visitor was narrowed to
- * Rails' `case` (to_sql.rb:110) a `Quoted` row fell through to `quote()`, which
- * raises `TypeError: can't quote Quoted`. The SQL-shape assertion below pins the
- * row shape so that regression fails loudly instead of only at runtime.
+ * SchemaMigration-level wrapper has no Rails counterpart, so these cases have no
+ * Rails test to mirror verbatim.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import type { MockInstance } from "vitest";
 
 import { Base } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
@@ -19,46 +14,38 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
-  // Real DDL against a real adapter: run non-transactionally so MySQL's
-  // implicit commit on DDL cannot commit the fixture transaction mid-test.
   fixtures([], { useTransactionalTests: false });
 
   let conn: DatabaseAdapter;
   let schemaMigration: SchemaMigration;
   let originalPrefix: string;
-  let executed: string[] = [];
+  let executeSpy: MockInstance<DatabaseAdapter["execute"]>;
 
   beforeAll(async () => {
-    // An isolated table, so this suite never reads or writes the real
-    // schema_migrations rows other suites share.
+    // An isolated table, so this suite never reads or writes the
+    // schema_migrations rows every other suite shares.
     originalPrefix = Base.tableNamePrefix;
     Base.tableNamePrefix = "amuv_";
     conn = (await Base.leaseConnection()) as unknown as DatabaseAdapter;
     schemaMigration = new SchemaMigration(conn);
     await schemaMigration.dropTable();
     await schemaMigration.createTable();
-
-    const host = conn as unknown as { execute(sql: string): Promise<unknown> };
-    const original = host.execute.bind(conn);
-    host.execute = (sql: string) => {
-      executed.push(sql);
-      return original(sql);
-    };
+    executeSpy = vi.spyOn(conn, "execute") as unknown as MockInstance<DatabaseAdapter["execute"]>;
   });
 
   afterAll(async () => {
-    delete (conn as unknown as { execute?: unknown }).execute;
+    executeSpy.mockRestore();
     await schemaMigration.dropTable();
     Base.tableNamePrefix = originalPrefix;
   });
 
   beforeEach(async () => {
     await schemaMigration.deleteAllVersions();
-    executed = [];
+    executeSpy.mockClear();
   });
 
   function insertStatements(): string[] {
-    return executed.filter((sql) => /^INSERT/i.test(sql));
+    return executeSpy.mock.calls.map(([sql]) => String(sql)).filter((sql) => /^INSERT/i.test(sql));
   }
 
   it("inserts the version when it has not been migrated", async () => {
@@ -69,7 +56,7 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
 
   it("does nothing when the version is already migrated", async () => {
     await schemaMigration.createVersion("20200101000000");
-    executed = [];
+    executeSpy.mockClear();
 
     await schemaMigration.assumeMigratedUptoVersion(20200101000000);
 
@@ -77,15 +64,10 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
     expect(await schemaMigration.versions()).toEqual(["20200101000000"]);
   });
 
-  it("backfills migration versions below the given version", async () => {
+  it("inserts only migration versions below the given version", async () => {
     await schemaMigration.assumeMigratedUptoVersion(
       20200103000000,
-      [
-        20200101000000, 20200102000000,
-        // Above the ceiling — Rails selects only `v < version`
-        // (schema_statements.rb:1375).
-        20200104000000,
-      ],
+      [20200101000000, 20200102000000, 20200104000000],
     );
 
     expect(await schemaMigration.versions()).toEqual([
@@ -97,12 +79,14 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
 
   it("does not re-insert already migrated intervening versions", async () => {
     await schemaMigration.createVersion("20200101000000");
+    executeSpy.mockClear();
 
     await schemaMigration.assumeMigratedUptoVersion(
       20200103000000,
       [20200101000000, 20200102000000],
     );
 
+    expect(insertStatements()).toHaveLength(1);
     expect(await schemaMigration.versions()).toEqual([
       "20200101000000",
       "20200102000000",
@@ -110,36 +94,46 @@ describe("SchemaMigration#assumeMigratedUptoVersion (trails)", () => {
     ]);
   });
 
-  it("normalizes zero-padded versions against the migrated set", async () => {
+  it("treats a zero-padded version as already migrated", async () => {
     await schemaMigration.createVersion("1");
+    executeSpy.mockClear();
 
     await schemaMigration.assumeMigratedUptoVersion("001");
 
+    expect(insertStatements()).toEqual([]);
     expect(await schemaMigration.versions()).toEqual(["1"]);
   });
 
-  // Rails: raise "Duplicate migration #{duplicate}. Please renumber your
-  // migrations to resolve the conflict." (schema_statements.rb:1377-1379).
-  it("raises on duplicate migration versions", async () => {
+  it("raises on a duplicate migration version without inserting", async () => {
     await expect(
       schemaMigration.assumeMigratedUptoVersion(20200103000000, [20200101000000, 20200101000000]),
     ).rejects.toThrow(
       "Duplicate migration 20200101000000. Please renumber your migrations to resolve the conflict.",
     );
 
-    // Validation runs before any write, so nothing was inserted.
     expect(insertStatements()).toEqual([]);
     expect(await schemaMigration.versions()).toEqual([]);
   });
 
-  it("rejects a non-numeric version without writing", async () => {
+  it("raises on a non-numeric version without inserting", async () => {
     await expect(schemaMigration.assumeMigratedUptoVersion("nope")).rejects.toThrow(
       "Invalid migration version: nope",
     );
+
     expect(insertStatements()).toEqual([]);
+    expect(await schemaMigration.versions()).toEqual([]);
   });
 
-  it("emits a single multi-row INSERT with bare version values", async () => {
+  it("raises on a non-numeric migration version without inserting", async () => {
+    await expect(
+      schemaMigration.assumeMigratedUptoVersion(20200103000000, [20200101000000, "oops"]),
+    ).rejects.toThrow("Invalid migration version: oops");
+
+    expect(insertStatements()).toEqual([]);
+    expect(await schemaMigration.versions()).toEqual([]);
+  });
+
+  it("emits one multi-row INSERT carrying bare version values", async () => {
     await schemaMigration.assumeMigratedUptoVersion(
       20200103000000,
       [20200101000000, 20200102000000],

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -146,9 +146,9 @@ export class SchemaMigration {
    * This wrapper provides a standalone version for callers holding a
    * SchemaMigration instance directly. It uses stricter validation
    * (BigInt + /^\d+$/) and validates all inputs before any writes,
-   * whereas SchemaStatements may write before detecting duplicates.
-   * Versions are normalized via BigInt so "001" and "1" are treated
-   * as the same version.
+   * whereas SchemaStatements — like Rails — may write the target
+   * version before detecting a duplicate. Versions are normalized via
+   * BigInt so "001" and "1" are treated as the same version.
    */
   async assumeMigratedUptoVersion(
     version: number | string,
@@ -172,17 +172,6 @@ export class SchemaMigration {
       return { original: v, normalized: n, num: BigInt(n) };
     });
 
-    const seen = new Set<string>();
-    for (const { normalized: n, original } of candidates) {
-      if (seen.has(n)) {
-        throw new Error(
-          `Duplicate migration ${original}. Please renumber your migrations to resolve the conflict.`,
-        );
-      }
-      seen.add(n);
-    }
-
-    // All validation passed — now write.
     // Normalize existing versions the same way so "001" in the DB
     // matches "1" from the input.
     const rawMigrated = await this.allVersions();
@@ -196,30 +185,48 @@ export class SchemaMigration {
       }),
     );
 
-    const toInsert: string[] = [];
-    if (!migrated.has(normalized)) {
-      toInsert.push(normalized);
-    }
-    for (const { normalized: n, num } of candidates) {
-      if (num < versionNum && !migrated.has(n)) {
-        toInsert.push(n);
+    // Rails: inserting = (versions - migrated).select { |v| v < version }
+    // (schema_statements.rb:1375). The duplicate check runs over THIS set, not
+    // over every supplied version — a repeat that is already migrated, or that
+    // sits at or above the target, never reaches it and so never raises.
+    const inserting = candidates.filter(
+      ({ normalized: n, num }) => num < versionNum && !migrated.has(n),
+    );
+
+    const seen = new Set<string>();
+    for (const { normalized: n, original } of inserting) {
+      if (seen.has(n)) {
+        throw new Error(
+          `Duplicate migration ${original}. Please renumber your migrations to resolve the conflict.`,
+        );
       }
+      seen.add(n);
     }
 
-    if (toInsert.length > 0) {
+    // All validation passed — now write.
+    if (!migrated.has(normalized)) {
+      await this.createVersion(normalized);
+    }
+
+    if (inserting.length > 0) {
       const col = this.arelTable.get(this.primaryKey);
       const im = new InsertManager(this.arelTable);
       // Deviation: Rails uses no Arel here — it is raw `execute
       // insert_versions_sql(inserting)` (schema_statements.rb:1364-1383). This
       // wrapper hangs off a SchemaMigration instance with no
       // pool/migration_context, and its sibling writes (`createVersion`,
-      // `deleteVersion`) already build Arel, so the InsertManager stays.
+      // `deleteVersion`) already build Arel, so the InsertManager stays. Only
+      // the SQL text differs — Rails newline-joins the tuples and appends a
+      // `;` (schema_statements.rb:1881-1884); statement count and row order
+      // match.
       //
       // Rows carry the version raw, as Rails' do (`create_version` passes it
       // straight to `im.insert`, schema_migration.rb:21) — the ValuesList
       // visitor quotes it (to_sql.rb:112), whereas a Quoted wrap falls through
       // to `quote()`, which raises on a node (quoting.rb:86).
-      const rows = toInsert.map((v) => [v]);
+      //
+      // Reversed, as `insert_versions_sql` does (schema_statements.rb:1882).
+      const rows = inserting.map(({ normalized: n }) => [n]).reverse();
       im.ast.columns = [col];
       im.values = im.createValuesList(rows);
       await this._adapter.execute(this._adapter.toSql(im));

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -209,20 +209,16 @@ export class SchemaMigration {
     if (toInsert.length > 0) {
       const col = this.arelTable.get(this.primaryKey);
       const im = new InsertManager(this.arelTable);
-      // Rows carry the version raw, as Rails' rows do — `create_version` passes
-      // it straight to `im.insert` (schema_migration.rb:21), and the ValuesList
-      // visitor quotes it (to_sql.rb:112). A Quoted wrap would fall to `quote()`,
-      // which raises TypeError on a node (abstract/quoting.ts:151), matching
-      // Rails (quoting.rb:86).
+      // Deviation: Rails uses no Arel here — it is raw `execute
+      // insert_versions_sql(inserting)` (schema_statements.rb:1364-1383). This
+      // wrapper hangs off a SchemaMigration instance with no
+      // pool/migration_context, and its sibling writes (`createVersion`,
+      // `deleteVersion`) already build Arel, so the InsertManager stays.
       //
-      // Rails' `assume_migrated_upto_version` uses no Arel at all — it is raw
-      // `execute insert_versions_sql(inserting)`
-      // (abstract/schema_statements.rb:1364-1383). The InsertManager stays here
-      // deliberately: this wrapper hangs off a SchemaMigration instance (no
-      // pool/migration_context), and every other write on this class
-      // (`createVersion`, `deleteVersion`) already goes through Arel, so the
-      // adapter's own visitor does the identifier quoting. The emitted SQL is
-      // pinned by schema-migration.trails.test.ts.
+      // Rows carry the version raw, as Rails' do (`create_version` passes it
+      // straight to `im.insert`, schema_migration.rb:21) — the ValuesList
+      // visitor quotes it (to_sql.rb:112), whereas a Quoted wrap falls through
+      // to `quote()`, which raises on a node (quoting.rb:86).
       const rows = toInsert.map((v) => [v]);
       im.ast.columns = [col];
       im.values = im.createValuesList(rows);

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -193,14 +193,20 @@ export class SchemaMigration {
       ({ normalized: n, num }) => num < versionNum && !migrated.has(n),
     );
 
-    const seen = new Set<string>();
-    for (const { normalized: n, original } of inserting) {
-      if (seen.has(n)) {
-        throw new Error(
-          `Duplicate migration ${original}. Please renumber your migrations to resolve the conflict.`,
-        );
-      }
-      seen.add(n);
+    // Rails: inserting.detect { |v| inserting.count(v) > 1 }
+    // (schema_statements.rb:1377) — the FIRST element that occurs more than
+    // once, not the first repeat encountered. With two distinct duplicated
+    // values the two differ: for [B, A, A, B] `detect` reports B, while a
+    // seen-set walk would reach A's second occurrence first and report A.
+    const counts = new Map<string, number>();
+    for (const { normalized: n } of inserting) {
+      counts.set(n, (counts.get(n) ?? 0) + 1);
+    }
+    const duplicate = inserting.find(({ normalized: n }) => (counts.get(n) ?? 0) > 1);
+    if (duplicate) {
+      throw new Error(
+        `Duplicate migration ${duplicate.original}. Please renumber your migrations to resolve the conflict.`,
+      );
     }
 
     // All validation passed — now write.

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -214,6 +214,15 @@ export class SchemaMigration {
       // visitor quotes it (to_sql.rb:112). A Quoted wrap would fall to `quote()`,
       // which raises TypeError on a node (abstract/quoting.ts:151), matching
       // Rails (quoting.rb:86).
+      //
+      // Rails' `assume_migrated_upto_version` uses no Arel at all — it is raw
+      // `execute insert_versions_sql(inserting)`
+      // (abstract/schema_statements.rb:1364-1383). The InsertManager stays here
+      // deliberately: this wrapper hangs off a SchemaMigration instance (no
+      // pool/migration_context), and every other write on this class
+      // (`createVersion`, `deleteVersion`) already goes through Arel, so the
+      // adapter's own visitor does the identifier quoting. The emitted SQL is
+      // pinned by schema-migration.trails.test.ts.
       const rows = toInsert.map((v) => [v]);
       im.ast.columns = [col];
       im.values = im.createValuesList(rows);


### PR DESCRIPTION
`SchemaMigration#assumeMigratedUptoVersion` had **no test coverage at all** —
`git grep -l assumeMigratedUptoVersion` hit only source files. That gap let a
latent break ship: rows were built as `toInsert.map((v) => [new Nodes.Quoted(v)])`,
and once #4873 narrowed the ValuesList visitor to Rails' `case`
(`to_sql.rb:110`), a `Quoted` row fell through to `quote()`, which raises
`TypeError: can't quote Quoted`. The full AR suite stayed green throughout.

#4873 fixed the row shape but did not add coverage. This adds it.

## Coverage

`packages/activerecord/src/schema-migration.trails.test.ts` runs against the
real leased adapter (no fakes), and isolates itself by setting
`Base.tableNamePrefix` to `amuv_` for the suite's duration, so it never reads or
writes the `schema_migrations` rows other suites share.

- inserts the version when it has not been migrated
- no-op when the version is already migrated
- only versions below the ceiling are inserted (`v < version`,
  `schema_statements.rb:1375`)
- already-migrated intervening versions are not re-inserted
- a zero-padded `"001"` matches a stored `"1"` (BigInt normalization)
- the duplicate-migration raise Rails does (`schema_statements.rb:1377-1379`) —
  trails does port it, and validates before any write
- non-numeric version, and non-numeric *migration* version, both rejected
- a duplicate that is already migrated, and one at or above the target, are
  both accepted (Rails' `inserting` scope)
- with two distinct repeating versions, the error cites the first *repeating*
  version, not the first repeat encountered
- **SQL shape pinned**: the target INSERT, then the reversed multi-row backfill;
  and the target INSERT alone is skipped when it is already migrated

Every no-op and raise path asserts that *no* INSERT reached the adapter, not
merely that the resulting rows look right — `execute` is captured with
`vi.spyOn`.

Verified as a regression test: restoring the `new Nodes.Quoted(v)` row shape
fails 4 of the 13 cases; all 13 pass against the implementation here. Each
fidelity fix below is likewise pinned by a case that fails against the behavior
it replaced.

## Fidelity fixes found by review

Two divergences surfaced while reviewing the tests against
`schema_statements.rb`; both are now converged rather than documented.

**Duplicate-check scope.** Rails raises only when a duplicate appears in
`inserting = (versions - migrated).select { |v| v < version }`
(`schema_statements.rb:1375-1379`). trails built the duplicate set from *all* of
`migrationVersions` before any filtering, so a repeat that was already migrated,
or that sat at or above the target, raised where Rails silently accepts it. The
check now runs over `inserting`. Two new cases pin the gap and both fail against
the old scope.

**Which duplicate gets cited.** `inserting.detect { |v| inserting.count(v) > 1 }`
(`schema_statements.rb:1377`) returns the first element that repeats — not the
first repeat encountered. trails walked the array with a seen-set, which agrees
only while a single value repeats. For `[B, A, A, B]` Rails cites B (index 0),
the seen-set walk cites A (index 2). Ported exactly, with a case pinning the
two-distinct-duplicates shape.

**Statement count and row order.** Rails emits up to two `execute` calls — the
target version on its own (`schema_statements.rb:1372-1374`), then
`insert_versions_sql(inserting)`, which *reverses* the tuples
(`schema_statements.rb:1882`). trails emitted one combined INSERT in original
order. Now split and reversed to match; the pinned SQL asserts both statements.

## Convergence decision

Rails' `assume_migrated_upto_version` uses no Arel — it is raw
`execute insert_versions_sql(inserting)` (`abstract/schema_statements.rb:1364-1383`).
Decision, recorded at the call site: **keep the InsertManager**. This wrapper
hangs off a `SchemaMigration` instance with no pool / `migration_context`, and
its sibling writes (`createVersion`, `deleteVersion`) already build Arel, so the
adapter's own visitor does the identifier quoting. With the split above, the
only remaining difference is SQL text: Rails newline-joins the tuples and
appends a `;`. Statement count and row order now match, and both are pinned by
the test.

## Deltas

- `test:compare` non-negative — the new file is `.trails.test.ts` (TS-only), it
  removes no ported cases.
- `api:compare` unaffected — no surface change; the only source edit is a
  comment.

Closes-story: schema-migration-assume-migrated-upto-version-coverage
