### PR TITLE
refactor(migration): split a per-run Migrator out of MigrationContext

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1066,8 +1066,10 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(adapter, [proxy], { environment: "test" });
     await migrator.up().catch(() => {});
     const env = await im.get("environment");
-    // Environment should NOT be stored when migration fails
-    expect(env).toBeNull();
+    // Rails stamps the environment in `record_environment` BEFORE running the
+    // migrations, so a failing migration still leaves it recorded
+    // (migration_test.rb:697-711).
+    expect(env).toBe("test");
   });
 
   it("internal metadata stores environment when other data exists", async () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2056,9 +2056,9 @@ export class Migrator {
   private _internalMetadata: InternalMetadata;
   private _environment: string;
   private _strategy: ExecutionStrategy;
-  private _options: MigratorOptions;
-  private _direction: "up" | "down";
-  private _targetVersion: number | string | null;
+  private readonly _options: MigratorOptions;
+  private readonly _direction: "up" | "down";
+  private readonly _targetVersion: number | string | null;
   verbose = true;
 
   constructor(
@@ -2202,9 +2202,9 @@ export class Migrator {
    *
    * @internal
    */
-  async up(targetVersion?: number | string | null): Promise<void> {
+  async up(targetVersion?: number | string | null): Promise<MigrationProxy[]> {
     const migrator = this._forRun("up", targetVersion ?? null);
-    await migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
+    return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
   /**
@@ -2214,9 +2214,9 @@ export class Migrator {
    *
    * @internal
    */
-  async down(targetVersion?: number | string | null): Promise<void> {
+  async down(targetVersion?: number | string | null): Promise<MigrationProxy[]> {
     const migrator = this._forRun("down", targetVersion ?? null);
-    await migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
+    return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2028,6 +2028,25 @@ export interface MigrationProxy {
   loadMigration?(): Promise<MigrationLike>;
 }
 
+/**
+ * Construction-time options. `direction` / `targetVersion` are the per-run
+ * state Rails' `Migrator` holds as `@direction` / `@target_version`; a Migrator
+ * built without them is the long-lived, MigrationContext-shaped instance
+ * (Rails' `MigrationContext#open`).
+ */
+type MigratorOptions = {
+  environment?: string;
+  strategy?: ExecutionStrategy;
+  /**
+   * Set to false when the db_config opts out of metadata storage
+   * (Rails' `use_metadata_table: false`). environment stamping is a
+   * no-op / raises in `environment:set` when this is false.
+   */
+  internalMetadataEnabled?: boolean;
+  direction?: "up" | "down";
+  targetVersion?: number | string | null;
+};
+
 export class Migrator {
   static validateMigrationTimestamps = false;
 
@@ -2037,22 +2056,19 @@ export class Migrator {
   private _internalMetadata: InternalMetadata;
   private _environment: string;
   private _strategy: ExecutionStrategy;
+  private _options: MigratorOptions;
+  private _direction: "up" | "down";
+  private _targetVersion: number | string | null;
   verbose = true;
 
   constructor(
     adapter: DatabaseAdapter,
     migrations: MigrationProxy[],
-    options: {
-      environment?: string;
-      strategy?: ExecutionStrategy;
-      /**
-       * Set to false when the db_config opts out of metadata storage
-       * (Rails' `use_metadata_table: false`). environment stamping is a
-       * no-op / raises in `environment:set` when this is false.
-       */
-      internalMetadataEnabled?: boolean;
-    } = {},
+    options: MigratorOptions = {},
   ) {
+    this._options = options;
+    this._direction = options.direction ?? "up";
+    this._targetVersion = options.targetVersion ?? null;
     this._adapter = adapter;
     this._schemaMigration = new SchemaMigration(adapter);
     this._internalMetadata = new InternalMetadata(adapter, {
@@ -2074,6 +2090,22 @@ export class Migrator {
 
   get migrations(): MigrationProxy[] {
     return [...this._migrations];
+  }
+
+  /**
+   * Build the per-run Migrator Rails constructs for every `run` / `up` / `down`
+   * (`Migrator.new(direction, migrations, schema_migration, internal_metadata,
+   * target_version)`), carrying the direction and target version as
+   * construction state instead of threading them through each call.
+   */
+  private _forRun(direction: "up" | "down", targetVersion: number | string | null): Migrator {
+    const migrator = new Migrator(this._adapter, this._migrations, {
+      ...this._options,
+      direction,
+      targetVersion,
+    });
+    migrator.verbose = this.verbose;
+    return migrator;
   }
 
   // Rails: MIGRATOR_SALT = 2053462845 (Zlib.crc32("googol"))
@@ -2171,10 +2203,8 @@ export class Migrator {
    * @internal
    */
   async up(targetVersion?: number | string | null): Promise<void> {
-    await this._withAdvisoryLock(async () => {
-      await this._ensureSchemaTable();
-      await this._migrateUp(targetVersion ?? null);
-    });
+    const migrator = this._forRun("up", targetVersion ?? null);
+    await migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
   /**
@@ -2185,10 +2215,8 @@ export class Migrator {
    * @internal
    */
   async down(targetVersion?: number | string | null): Promise<void> {
-    await this._withAdvisoryLock(async () => {
-      await this._ensureSchemaTable();
-      await this._migrateDown(targetVersion ?? null);
-    });
+    const migrator = this._forRun("down", targetVersion ?? null);
+    await migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
   /**
@@ -2238,18 +2266,19 @@ export class Migrator {
   /**
    * @internal Mirrors: ActiveRecord::Migrator#run_without_lock
    *
-   * Signature differs from Rails: Rails reads `@direction`/`@target_version` from
-   * per-invocation instance state; TS takes them as explicit params.
+   * Reads the direction and target version this Migrator was constructed with,
+   * as Rails does with `@direction` / `@target_version`.
    *
    * The already-applied guards replicate the skip logic in Rails'
    * `execute_migration_in_transaction` (migration.rb:1528-1530), which checks
    * `migrated.include?(migration.version)` before running. Our `_runMigration`
    * doesn't carry that check, so the guard lives here instead.
    */
-  async runWithoutLock(
-    direction: "up" | "down",
-    targetVersion: string | number,
-  ): Promise<string | undefined> {
+  async runWithoutLock(): Promise<string | undefined> {
+    // Rails' `Migrator#run` is only ever built with a target version; a nil one
+    // finds no migration and raises, so mirror that rather than treating it as
+    // "run everything".
+    const targetVersion = this._targetVersion ?? "";
     await this._ensureSchemaTable();
     let key: string;
     try {
@@ -2259,21 +2288,40 @@ export class Migrator {
     }
     const proxy = this._migrations.find((m) => m.version === key);
     if (!proxy) throw new UnknownMigrationVersionError(targetVersion);
+    await this.recordEnvironment();
     const applied = await this._appliedVersions();
-    if (direction === "up" && applied.has(key)) return undefined;
-    if (direction === "down" && !applied.has(key)) return undefined;
-    await this._runMigration(proxy, direction);
+    if (this.isUp() && applied.has(key)) return undefined;
+    if (this.isDown() && !applied.has(key)) return undefined;
+    await this._runMigration(proxy, this._direction);
     return proxy.version;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#migrate_without_lock */
-  async migrateWithoutLock(targetVersion?: number | string | null): Promise<void> {
+  async migrateWithoutLock(): Promise<MigrationProxy[]> {
+    // isInvalidTarget() is only ever true for a non-null target version.
+    if (this.isInvalidTarget()) {
+      throw new UnknownMigrationVersionError(this._targetVersion ?? "");
+    }
     await this._ensureSchemaTable();
-    await this._migrateUp(targetVersion ?? null);
+    await this.recordEnvironment();
+    return this.isDown()
+      ? this._migrateDown(this._targetVersion)
+      : this._migrateUp(this._targetVersion);
+  }
+
+  /** @internal Mirrors: ActiveRecord::Migrator#up? */
+  isUp(): boolean {
+    return this._direction === "up";
+  }
+
+  /** @internal Mirrors: ActiveRecord::Migrator#down? */
+  isDown(): boolean {
+    return this._direction === "down";
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#record_environment */
   async recordEnvironment(): Promise<void> {
+    if (this.isDown()) return;
     if (this._internalMetadata.enabled) {
       await this._ensureSchemaTable();
       await this._internalMetadata.set("environment", this._environment);
@@ -2287,14 +2335,9 @@ export class Migrator {
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#invalid_target? */
-  isInvalidTarget(targetVersion?: string | number | null): boolean {
-    if (targetVersion === null || targetVersion === undefined) return false;
-    try {
-      const key = String(BigInt(targetVersion));
-      return !this._migrations.some((m) => m.version === key);
-    } catch {
-      return true;
-    }
+  isInvalidTarget(): boolean {
+    if (this._targetVersion === null) return false;
+    return this._invalidTarget(this._targetVersion);
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction */
@@ -2737,7 +2780,8 @@ export class Migrator {
    * scoped to `target_version` and calls `#run`).
    */
   async run(direction: "up" | "down", targetVersion: number | string): Promise<string | undefined> {
-    return this._withAdvisoryLock(() => this.runWithoutLock(direction, targetVersion));
+    const migrator = this._forRun(direction, targetVersion);
+    return migrator._withAdvisoryLock(() => migrator.runWithoutLock());
   }
 
   private async _migrateUp(

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2093,19 +2093,16 @@ export class Migrator {
   }
 
   /**
-   * Build the per-run Migrator Rails constructs for every `run` / `up` / `down`
-   * (`Migrator.new(direction, migrations, schema_migration, internal_metadata,
-   * target_version)`), carrying the direction and target version as
-   * construction state instead of threading them through each call.
+   * Options for the per-run Migrator `run` / `up` / `down` each construct
+   * (Rails' `Migrator.new(direction, migrations, schema_migration,
+   * internal_metadata, target_version)`). The `new Migrator(...)` call itself
+   * stays inline at all three sites, as Rails writes it.
    */
-  private _forRun(direction: "up" | "down", targetVersion: number | string | null): Migrator {
-    const migrator = new Migrator(this._adapter, this._migrations, {
-      ...this._options,
-      direction,
-      targetVersion,
-    });
-    migrator.verbose = this.verbose;
-    return migrator;
+  private _runOptions(
+    direction: "up" | "down",
+    targetVersion: number | string | null,
+  ): MigratorOptions {
+    return { ...this._options, direction, targetVersion };
   }
 
   // Rails: MIGRATOR_SALT = 2053462845 (Zlib.crc32("googol"))
@@ -2203,7 +2200,12 @@ export class Migrator {
    * @internal
    */
   async up(targetVersion?: number | string | null): Promise<MigrationProxy[]> {
-    const migrator = this._forRun("up", targetVersion ?? null);
+    const migrator = new Migrator(
+      this._adapter,
+      this._migrations,
+      this._runOptions("up", targetVersion ?? null),
+    );
+    migrator.verbose = this.verbose;
     return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
@@ -2215,7 +2217,12 @@ export class Migrator {
    * @internal
    */
   async down(targetVersion?: number | string | null): Promise<MigrationProxy[]> {
-    const migrator = this._forRun("down", targetVersion ?? null);
+    const migrator = new Migrator(
+      this._adapter,
+      this._migrations,
+      this._runOptions("down", targetVersion ?? null),
+    );
+    migrator.verbose = this.verbose;
     return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
@@ -2780,7 +2787,12 @@ export class Migrator {
    * scoped to `target_version` and calls `#run`).
    */
   async run(direction: "up" | "down", targetVersion: number | string): Promise<string | undefined> {
-    const migrator = this._forRun(direction, targetVersion);
+    const migrator = new Migrator(
+      this._adapter,
+      this._migrations,
+      this._runOptions(direction, targetVersion),
+    );
+    migrator.verbose = this.verbose;
     return migrator._withAdvisoryLock(() => migrator.runWithoutLock());
   }
 

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -7,6 +7,7 @@ import {
   CheckPending,
   PendingMigrationError,
   ConcurrentMigrationError,
+  UnknownMigrationVersionError,
   EnvironmentMismatchError,
   NoEnvironmentInSchemaError,
   ProtectedEnvironmentError,
@@ -71,6 +72,25 @@ describe("Migrator trails extensions", () => {
     await migrator.up();
     const env = await migrator.internalMetadata.get("environment");
     expect(env).toBe("test");
+  });
+
+  it("up and down raise UnknownMigrationVersionError for an unknown target", async () => {
+    // Rails routes both through a per-run Migrator whose migrate_without_lock
+    // starts with `raise UnknownMigrationVersionError if invalid_target?`
+    // (migration.rb:1503-1505); target 0 stays valid.
+    const list = (): MigrationProxy[] => [makeMigration("1", "M1"), makeMigration("2", "M2")];
+    await expect(new Migrator(adapter, list()).up(3)).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(new Migrator(adapter, list()).down(3)).rejects.toThrow(
+      UnknownMigrationVersionError,
+    );
+    await expect(new Migrator(adapter, list()).down(0)).resolves.toEqual([]);
+  });
+
+  it("down does not stamp the environment", async () => {
+    // Rails' record_environment returns early when down? (migration.rb:1511).
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")], { environment: "test" });
+    await migrator.down();
+    expect(await migrator.internalMetadata.get("environment")).toBeNull();
   });
 
   it("checkEnvironment raises NoEnvironmentInSchemaError when no environment stored", async () => {

--- a/scripts/api-compare/arity-exclude.json
+++ b/scripts/api-compare/arity-exclude.json
@@ -22,11 +22,5 @@
     "rubyFile": "database_configurations/url_config.rb",
     "rubyName": "build_url_hash",
     "reason": "Ruby reads `@url`, but the TS port must run BEFORE `super(...)` in the UrlConfig constructor — its result is merged into the configuration hash passed up to HashConfig, and `this` is unavailable before `super`. The url therefore has to be threaded in as a parameter."
-  },
-  {
-    "package": "activerecord",
-    "rubyFile": "migration.rb",
-    "rubyName": "run_without_lock",
-    "reason": "Rails' Migrator holds `@direction` / `@target_version` as construction-time ivars; trails' MigrationContext keeps one long-lived instance and passes both per call. Converging means splitting a per-run Migrator out of MigrationContext, which is a structural port well beyond an arity fix."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -289,20 +289,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "migrate_without_lock",
-    "call": "invalid_target?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "migrate_without_lock",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "migration_files",
     "call": "flat_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -424,13 +410,6 @@
     "tsFile": "migration.ts",
     "rubyName": "record_environment",
     "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "record_environment",
-    "call": "down?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Rails builds a fresh `Migrator` for every `run` / `up` / `down`, holding
`@direction` and `@target_version` as construction-time ivars
(`migration.rb:1418`). trails kept one long-lived instance and threaded both
through every call, so `run_without_lock`, `migrate_without_lock` and
`invalid_target?` all diverged from their zero-arg Rails signatures — hence the
`run_without_lock` arity exclusion added in #5340.

## What changed

- `Migrator` now carries `direction` / `targetVersion` as readonly construction
  state. A Migrator built without them is the long-lived,
  MigrationContext-shaped instance (Rails' `MigrationContext#open`).
- `run` / `up` / `down` build a per-run Migrator via `_forRun` — trails' single
  merged class standing in for Rails'
  `Migrator.new(direction, migrations, schema_migration, internal_metadata, target_version)`
  — and drive it under the advisory lock.
- `runWithoutLock()`, `migrateWithoutLock()` and `isInvalidTarget()` are now
  zero-arg and read that state, matching Rails.
- Adds `isUp()` / `isDown()` (Rails' `up?` / `down?`). `api:extra` reports 0
  novel extras.
- `recordEnvironment()` moves to where Rails calls it — before the migrations
  run (`migration.rb:1500`, `:1512`) and skipped when heading down
  (`return if down?`).
- `up` / `down` return the ran migrations, as Rails' `MigrationContext#up` /
  `#down` return `Migrator#migrate`'s value. Widening `Promise<void>` →
  `Promise<MigrationProxy[]>` is source-compatible for existing callers.

## Behaviour changes

- `up` / `down` with an unknown target version now raise
  `UnknownMigrationVersionError`, as Rails' `migrate_without_lock` does
  (`invalid_target?`); target `0` stays valid. Covered by a new
  `migrator.trails.test.ts` case, which fails on baseline.
- `internal metadata stores environment when migration fails` asserted the
  environment was *not* stored. Rails'
  `test_internal_metadata_stores_environment_when_migration_fails`
  (migration_test.rb:697-711) asserts the opposite — `record_environment` runs
  before the migrations, so a failure still leaves it stamped. The assertion now
  matches Rails; the test name is unchanged.

## Left for a follow-up story

`Migrator#migrate` still inlines its dispatch instead of delegating to
`up` / `down` the way `MigrationContext#migrate` does, so `target == current`
is a no-op in trails where Rails runs any unapplied lower version. Converging it
means modelling Rails' `&block` as the per-run Migrator's migration list rather
than as a parameter (a `filter` param on `up`/`down` would *create* an arity
mismatch, since api-compare doesn't count Ruby block params). Registered as
`0051-migration-schema-statements-fidelity/converge-migrationcontext-migrate-dispatch-onto-up-down`.

## Verification

`api:compare` reports no arity mismatches for `migration.rb`, so the
`run_without_lock` entry is removed from `arity-exclude.json`. Migration,
migrator, schema, tasks, CLI and trailties db suites pass (628 tests); no test
renames.

Closes-story: split-per-run-migrator-out-of-migration-context
