### PR TITLE
test(migration): cover ReferenceDefinition#add

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -3,6 +3,8 @@ import {
   ForeignKeyDefinition,
   CheckConstraintDefinition,
   TableDefinition,
+  ReferenceDefinition,
+  type ReferenceDefinitionConnection,
 } from "./schema-definitions.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
@@ -67,5 +69,89 @@ describe("TableDefinition#remove_column", () => {
     const t = td();
     t.removeColumn("nonexistent");
     expect(t.columns.map((c) => c.name)).toEqual(["id", "name", "rocket_id"]);
+  });
+});
+
+describe("ReferenceDefinition#add", () => {
+  type Call = [string, ...unknown[]];
+
+  const recorder = (): { calls: Call[]; connection: ReferenceDefinitionConnection } => {
+    const calls: Call[] = [];
+    return {
+      calls,
+      connection: {
+        async addColumn(tableName, columnName, type, options) {
+          calls.push(["addColumn", tableName, columnName, type, options]);
+        },
+        async addIndex(tableName, columns, options) {
+          calls.push(["addIndex", tableName, columns, options]);
+        },
+        async addForeignKey(fromTable, toTable, options) {
+          calls.push(["addForeignKey", fromTable, toTable, options]);
+        },
+      },
+    };
+  };
+
+  it("adds the column, index and foreign key in Rails' order", async () => {
+    const { calls, connection } = recorder();
+    await new ReferenceDefinition("user", { foreignKey: true }).add("taggings", connection);
+
+    expect(calls.map((c) => c[0])).toEqual(["addColumn", "addIndex", "addForeignKey"]);
+    expect(calls[0].slice(1, 4)).toEqual(["taggings", "user_id", "bigint"]);
+    expect(calls[1][2]).toEqual(["user_id"]);
+    expect(calls[2][2]).toBe("users");
+    expect(calls[2][3]).toMatchObject({ column: "user_id" });
+  });
+
+  it("adds a polymorphic reference type-column first and names its index", async () => {
+    const { calls, connection } = recorder();
+    await new ReferenceDefinition("taggable", { polymorphic: true }).add("taggings", connection);
+
+    expect(calls.map((c) => c[2])).toEqual([
+      "taggable_type",
+      "taggable_id",
+      ["taggable_type", "taggable_id"],
+    ]);
+    expect(calls[2][3]).toMatchObject({ name: "index_taggings_on_taggable" });
+  });
+
+  it("merges an index options hash", async () => {
+    const { calls, connection } = recorder();
+    await new ReferenceDefinition("user", { index: { unique: true, name: "my_index" } }).add(
+      "taggings",
+      connection,
+    );
+
+    expect(calls[1][3]).toMatchObject({ unique: true, name: "my_index" });
+  });
+
+  it("passes ifNotExists through to the index and foreign key options", async () => {
+    const { calls, connection } = recorder();
+    await new ReferenceDefinition("user", { foreignKey: true, ifNotExists: true }).add(
+      "taggings",
+      connection,
+    );
+
+    expect(calls[1][3]).toMatchObject({ ifNotExists: true });
+    expect(calls[2][3]).toMatchObject({ ifNotExists: true });
+  });
+
+  it("merges a polymorphic options hash into the type column", async () => {
+    const { calls, connection } = recorder();
+    await new ReferenceDefinition("taggable", {
+      polymorphic: { null: false },
+      index: false,
+    }).add("taggings", connection);
+
+    expect(calls[0][2]).toBe("taggable_type");
+    expect(calls[0][4]).toMatchObject({ null: false });
+  });
+
+  it("skips the index when index is false", async () => {
+    const { calls, connection } = recorder();
+    await new ReferenceDefinition("user", { index: false }).add("taggings", connection);
+
+    expect(calls.map((c) => c[0])).toEqual(["addColumn"]);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -509,7 +509,7 @@ export interface AddIndexOptions {
 }
 
 export interface AddReferenceOptions extends Omit<ColumnOptions, "index"> {
-  polymorphic?: boolean;
+  polymorphic?: boolean | Record<string, unknown>;
   foreignKey?: boolean | ReferenceForeignKeyOptions;
   type?: ColumnType;
   index?: boolean | AddIndexOptions;


### PR DESCRIPTION
**Rewritten after rebase.** The delegation this PR originally implemented was
landed independently by #5480 (`test(activerecord): port
Migration::ReferencesForeignKeyTest core cases`), which shipped
`ReferenceDefinition#add`, `ReferenceDefinitionConnection`, the one-line
`SchemaStatements#addReference` delegate, and the `ArgumentError` change —
character-for-character what this branch had. That work is now dropped from
here rather than duplicated.

What remains is the part #5480 did not bring:

## Changes

- **Six `ReferenceDefinition#add` cases** in `schema-definitions.trails.test.ts`.
  #5480 added `#add` but no direct coverage of it; the behavior was only
  exercised indirectly. These pin, against a plain recorder double implementing
  `ReferenceDefinitionConnection` (no bespoke tables, no DB):
  - call order — `addColumn`* → `addIndex` if `index` → `addForeignKey` if
    `foreignKey` (`schema_definitions.rb:219-231`)
  - polymorphic `_type`-before-`_id` column ordering and the
    `index_<table>_on_<ref>` index name (`schema_definitions.rb:259-274`)
  - `index:` options-hash merge
  - a `polymorphic:` options hash reaching the type column
  - `ifNotExists` propagating to *both* index and foreign-key options
    (`schema_definitions.rb:267, 276-277`)
  - `index: false` suppressing the index
- **`AddReferenceOptions.polymorphic` widened to `boolean | Record<string,
  unknown>`.** `ReferenceDefinition` already stores and reads the hash form —
  `polymorphicOptions()` calls `asOptions(this.polymorphic)`, mirroring Ruby's
  `as_options(polymorphic)` (`schema_definitions.rb:259`) — but the public
  option type only admitted `boolean`, so `t.references :taggable, polymorphic:
  { null: false }` was a type error despite working at runtime. The new test
  covers it.

## Verification

- `pnpm typecheck` clean.
- 11 tests pass in `schema-definitions.trails.test.ts`. The six new cases pass
  against `#add` as merged, independently confirming #5480's implementation.
- `test:compare --gates --check` exits 0.

Note: the wide call-mismatch ratchet currently reports 7 NEW entries on
`origin/main` (`table_exists?` → `include?`/`tables`, `migrate_without_lock`,
`record_environment`, `ignore_default_scope=`, `database-tasks` `migrate`).
None are in files this diff touches; they arrived with #5486/#5481 and are not
addressed here.
