### PR TITLE
fix(schema-statements): fall back to tables.include? when table_exists? hits NotImplementedError

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -571,6 +571,7 @@ describe("tableExists NotImplementedError fallback", () => {
     const ss = makeStatements({ quote: (v: string) => `'${v}'`, execute });
 
     expect(await ss.tableExists("")).toBe(false);
+    expect(await ss.tableExists("   ")).toBe(false);
     expect(execute).not.toHaveBeenCalled();
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -564,3 +564,30 @@ describe("distinctRelationForPrimaryKey", () => {
     expect(whereBang).not.toHaveBeenCalled();
   });
 });
+
+describe("tableExists NotImplementedError fallback", () => {
+  it("returns false for a blank table name without querying", async () => {
+    const execute = vi.fn().mockResolvedValue([]);
+    const ss = makeStatements({ quote: (v: string) => `'${v}'`, execute });
+
+    expect(await ss.tableExists("")).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("falls back to tables.include? when the data-source path is not implemented", async () => {
+    const ss = makeStatements({ adapterName: "fake" as any, quote: (v: string) => `'${v}'` });
+    vi.spyOn(ss, "tables").mockResolvedValue(["posts", "comments"]);
+
+    expect(await ss.tableExists("posts")).toBe(true);
+    expect(await ss.tableExists("widgets")).toBe(false);
+  });
+
+  it("propagates errors other than NotImplementedError", async () => {
+    const ss = makeStatements({
+      quote: (v: string) => `'${v}'`,
+      execute: vi.fn().mockRejectedValue(new Error("connection lost")),
+    });
+
+    await expect(ss.tableExists("posts")).rejects.toThrow("connection lost");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -588,32 +588,45 @@ export class SchemaStatements {
   }
 
   async tableExists(tableName: string): Promise<boolean> {
-    // Rails' data_source_exists? embeds the table name via quote() — an escaped
-    // SQL string literal, not raw interpolation (data_source_sql, schema_statements.rb).
-    // A value containing quotes/operators is escaped to a literal that matches
-    // nothing and returns false instead of producing broken SQL.
-    const quoted = this.adapter.quote(tableName);
-    let rows: Record<string, unknown>[];
-    switch (this.adapterName) {
-      case "sqlite":
-        rows = await this.adapter.execute(
-          `SELECT name FROM sqlite_master WHERE type='table' AND name=${quoted}`,
-        );
-        break;
-      case "postgres":
-        // Rails' PG data_source_sql scopes to ANY (current_schemas(false))
-        // (the active search_path), not a hardcoded 'public'.
-        rows = await this.adapter.execute(
-          `SELECT 1 FROM information_schema.tables WHERE table_schema = ANY (current_schemas(false)) AND table_name = ${quoted} LIMIT 1`,
-        );
-        break;
-      case "mysql":
-        rows = await this.adapter.execute(
-          `SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${quoted} LIMIT 1`,
-        );
-        break;
+    // Rails guards on `table_name.present?` and returns nil otherwise; the
+    // boolean return type makes that false here.
+    if (!tableName) return false;
+    try {
+      // Rails' data_source_exists? embeds the table name via quote() — an escaped
+      // SQL string literal, not raw interpolation (data_source_sql, schema_statements.rb).
+      // A value containing quotes/operators is escaped to a literal that matches
+      // nothing and returns false instead of producing broken SQL.
+      const quoted = this.adapter.quote(tableName);
+      let rows: Record<string, unknown>[];
+      switch (this.adapterName) {
+        case "sqlite":
+          rows = await this.adapter.execute(
+            `SELECT name FROM sqlite_master WHERE type='table' AND name=${quoted}`,
+          );
+          break;
+        case "postgres":
+          // Rails' PG data_source_sql scopes to ANY (current_schemas(false))
+          // (the active search_path), not a hardcoded 'public'.
+          rows = await this.adapter.execute(
+            `SELECT 1 FROM information_schema.tables WHERE table_schema = ANY (current_schemas(false)) AND table_name = ${quoted} LIMIT 1`,
+          );
+          break;
+        case "mysql":
+          rows = await this.adapter.execute(
+            `SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${quoted} LIMIT 1`,
+          );
+          break;
+        default:
+          // Rails' abstract data_source_sql raises NotImplementedError; the
+          // rescue arm below degrades to tables.include?.
+          // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
+          throw new NotImplementedError("#data_source_sql is not implemented");
+      }
+      return rows.length > 0;
+    } catch (error) {
+      if (!(error instanceof NotImplementedError)) throw error;
+      return (await this.tables()).includes(String(tableName));
     }
-    return rows.length > 0;
   }
 
   async columnExists(
@@ -1453,6 +1466,11 @@ export class SchemaStatements {
           `SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' ORDER BY table_name`,
         );
         return (rows as any[]).map((r: any) => r.name ?? r.TABLE_NAME);
+      default:
+        // Rails' abstract #tables goes through data_source_sql, which raises
+        // NotImplementedError for an adapter that does not define it.
+        // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
+        throw new NotImplementedError("#tables is not implemented");
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -39,7 +39,7 @@ import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
-import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
+import { singularize, pluralize, getCrypto, isPresent } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 import { Utils as PgUtils } from "../postgresql/utils.js";
 import { indexes as sqliteIndexes } from "../sqlite3/schema-statements.js";
@@ -588,9 +588,7 @@ export class SchemaStatements {
   }
 
   async tableExists(tableName: string): Promise<boolean> {
-    // Rails guards on `table_name.present?` and returns nil otherwise; the
-    // boolean return type makes that false here.
-    if (!tableName) return false;
+    if (!isPresent(tableName)) return false;
     try {
       // Rails' data_source_exists? embeds the table name via quote() — an escaped
       // SQL string literal, not raw interpolation (data_source_sql, schema_statements.rb).
@@ -617,8 +615,6 @@ export class SchemaStatements {
           );
           break;
         default:
-          // Rails' abstract data_source_sql raises NotImplementedError; the
-          // rescue arm below degrades to tables.include?.
           // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
           throw new NotImplementedError("#data_source_sql is not implemented");
       }
@@ -1467,8 +1463,6 @@ export class SchemaStatements {
         );
         return (rows as any[]).map((r: any) => r.name ?? r.TABLE_NAME);
       default:
-        // Rails' abstract #tables goes through data_source_sql, which raises
-        // NotImplementedError for an adapter that does not define it.
         // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
         throw new NotImplementedError("#tables is not implemented");
     }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -702,13 +702,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "table_exists?",
-    "call": "tables",
-    "reason": "Newly comparable (RFC 0072 arity sweep): Rails calls `tables` only from the `rescue NotImplementedError` fallback arm; trails' tableExists issues the data-source query per adapter and has no such fallback. Pre-existing gap — converge by porting the rescue arm."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "tables",
     "call": "data_source_sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -689,13 +689,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "table_exists?",
-    "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "table_exists?",
     "call": "query_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Ports the `rescue NotImplementedError` arm of Rails'
`table_exists?` (`schema_statements.rb:59-63`):

```ruby
def table_exists?(table_name)
  query_values(data_source_sql(table_name, type: "BASE TABLE"), "SCHEMA").any? if table_name.present?
rescue NotImplementedError
  tables.include?(table_name.to_s)
end
```

- `tableExists` guards on `isPresent(tableName)` (Rails' `if table_name.present?`)
  and wraps the data-source query, degrading to `tables().includes(...)` on
  `NotImplementedError`. Other errors propagate unchanged.
- The adapter `switch` gains a `default:` that raises `NotImplementedError`,
  matching Rails' abstract `data_source_sql`; previously an adapter outside the
  three known names left `rows` undefined and crashed with a `TypeError`.
- `tables()` gains the same `default:` arm so the fallback path is well-defined.
- Drops two now-converged wide-exclude entries: `table_exists? -> tables` and
  `table_exists? -> include?` (the fallback arm makes both calls).

Closes-story: table-exists-notimplementederror-tables-fallback
