### PR TITLE
refactor(sqlite3): build alterTable rebuild DDL through schemaCreation

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -103,6 +103,7 @@ import {
   CheckConstraintDefinition,
   ForeignKeyDefinition,
   type AddForeignKeyOptions,
+  type ColumnType,
   type RemoveForeignKeyOptions,
   type ForeignKeyLookupOptions,
 } from "./abstract/schema-definitions.js";
@@ -2460,34 +2461,51 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       .map((c) => c.name);
     const compositePk = pkColumns.length > 1;
 
-    const existingCollations = await this._parseCollationsFromTableSql(tableName);
-    const colDefs = colNames.map((name) => {
-      const col = columns[name];
-      let def = `${quoteColumnName(name)} ${col.type ?? "TEXT"}`;
-      const collation = col.collation === undefined ? existingCollations.get(name) : col.collation;
-      if (collation) def += ` COLLATE ${quoteColumnName(String(collation))}`;
-      if (col.generatedAs) {
-        def += ` GENERATED ALWAYS AS (${col.generatedAs})${col.generatedStored ? " STORED" : " VIRTUAL"}`;
-      }
-      if (!compositePk && col.pk) def += " PRIMARY KEY";
-      if (col.notnull) def += " NOT NULL";
-      if (col.dflt_value !== null && col.dflt_value !== undefined) {
-        def += ` DEFAULT ${col.dflt_value}`;
-      }
-      return def;
+    // Rails' copy_table populates a real TableDefinition (`@definition.column`,
+    // `definition.foreign_key`, `definition.check_constraint`) and hands it to
+    // create_table, so the rebuild emits through schema_creation exactly like
+    // any other CREATE TABLE (sqlite3_adapter.rb:598-640). Build the same
+    // definition here instead of concatenating column/FK/CHECK SQL by hand.
+    const definition = new SQLite3TableDefinition(tableName, {
+      id: false,
+      adapter: this,
+      ...(compositePk ? { primaryKey: pkColumns } : {}),
     });
-    if (compositePk) {
-      colDefs.push(`PRIMARY KEY(${pkColumns.map((n) => quoteColumnName(n)).join(", ")})`);
+
+    const existingCollations = await this._parseCollationsFromTableSql(tableName);
+    for (const name of colNames) {
+      const col = columns[name];
+      const options: Record<string, unknown> = {};
+      const collation = col.collation === undefined ? existingCollations.get(name) : col.collation;
+      if (collation) options.collation = String(collation);
+      if (col.generatedAs) {
+        options.as = col.generatedAs;
+        options.stored = Boolean(col.generatedStored);
+      }
+      // Rails passes `primary_key: column_name == from_primary_key`, which is
+      // never true for a composite key (from_primary_key is an Array there).
+      if (!compositePk && col.pk) options.primaryKey = true;
+      if (col.notnull) options.null = false;
+      if (col.dflt_value !== null && col.dflt_value !== undefined) {
+        // `dflt_value` is already a quoted SQL literal (PRAGMA hands it back
+        // verbatim, and the callers that rewrite it run it through
+        // quoteDefault first), so carry it as a callable default — the same
+        // vehicle Rails' copy_table uses for `-> { column.default_function }`,
+        // which quote_default_expression emits without re-quoting.
+        const literal = String(col.dflt_value);
+        options.default = () => literal;
+      }
+      definition.column(name, String(col.type ?? "TEXT") as ColumnType, options);
+      // PRAGMA reports the declared SQL type, not an AR type name, so pin it
+      // rather than letting the visitor resolve it through typeToSql: that is
+      // how the rebuild round-trips storage affinity exactly.
+      definition.columns[definition.columns.length - 1].sqlType = String(col.type ?? "TEXT");
     }
 
     // Preserve foreign keys and check constraints across the rebuild.
     // Rails: alter_table(table_name, foreign_keys(...), check_constraints(...))
     const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
     const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
-
-    // PRAGMA foreign_key_list doesn't expose constraint names, but the
-    // CREATE TABLE DDL does. Parse names so they survive the rebuild.
-    const fkNames = await this._parseForeignKeyNames(tableName);
 
     for (const fk of fks) {
       const cols = Array.isArray(fk.column)
@@ -2496,21 +2514,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
           ? fk.column.split(",").map((c) => c.trim())
           : [fk.column];
       if (!cols.every((c) => colNames.includes(c))) continue;
-      const pks = Array.isArray(fk.primaryKey)
-        ? fk.primaryKey
-        : fk.primaryKey.includes(",")
-          ? fk.primaryKey.split(",").map((c) => c.trim())
-          : [fk.primaryKey];
-      const colList = cols.map((c) => quoteColumnName(c)).join(", ");
-      const pkList = pks.map((c) => quoteColumnName(c)).join(", ");
-      let fkSql = "";
-      const fkKey = cols.join(",");
-      const fkName = fkNames.get(fkKey) ?? `fk_${bareTable}_${cols.join("_")}`;
-      fkSql += `CONSTRAINT ${quoteColumnName(fkName)} `;
-      fkSql += `FOREIGN KEY(${colList}) REFERENCES ${quoteTableName(fk.toTable)}(${pkList})`;
-      if (fk.onDelete) fkSql += ` ON DELETE ${normalizeReferentialAction(fk.onDelete)}`;
-      if (fk.onUpdate) fkSql += ` ON UPDATE ${normalizeReferentialAction(fk.onUpdate)}`;
-      colDefs.push(fkSql);
+      // Push the reflected definition rather than re-deriving one: foreignKeys()
+      // already resolved the constraint name out of the CREATE TABLE DDL (PRAGMA
+      // foreign_key_list doesn't expose it), and Rails' caller block likewise
+      // reuses the introspected fk's options.
+      definition.foreignKeys.push(fk);
     }
 
     const removedColumns = tableInfo
@@ -2523,32 +2531,15 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         new RegExp(`\\b${col.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(chk.expression),
       );
       if (referencesRemovedCol) continue;
-      colDefs.push(`CONSTRAINT ${quoteColumnName(chk.name)} CHECK (${chk.expression})`);
+      definition.checkConstraints.push(chk);
     }
 
-    // Apply any extra definitions (e.g. new FK/check from add operations)
-    if (extraDefinition) {
-      const { TableDefinition } = await import("./abstract/schema-definitions.js");
-      const tmpDef = new TableDefinition(bareTable);
-      extraDefinition(tmpDef);
-      for (const fkDef of tmpDef.foreignKeys) {
-        let fkSql = "";
-        if (fkDef.name) fkSql += `CONSTRAINT ${quoteColumnName(fkDef.name)} `;
-        const fkDefCols = (Array.isArray(fkDef.column) ? fkDef.column : [fkDef.column])
-          .map((c) => quoteColumnName(c))
-          .join(", ");
-        const fkDefPks = (Array.isArray(fkDef.primaryKey) ? fkDef.primaryKey : [fkDef.primaryKey])
-          .map((c) => quoteColumnName(c))
-          .join(", ");
-        fkSql += `FOREIGN KEY(${fkDefCols}) REFERENCES ${quoteTableName(fkDef.toTable)}(${fkDefPks})`;
-        if (fkDef.onDelete) fkSql += ` ON DELETE ${normalizeReferentialAction(fkDef.onDelete)}`;
-        if (fkDef.onUpdate) fkSql += ` ON UPDATE ${normalizeReferentialAction(fkDef.onUpdate)}`;
-        colDefs.push(fkSql);
-      }
-      for (const chkDef of tmpDef.checkConstraints) {
-        colDefs.push(`CONSTRAINT ${quoteColumnName(chkDef.name)} CHECK (${chkDef.expression})`);
-      }
-    }
+    // Rails: `yield definition if block_given?` at the tail of copy_table's
+    // create_table block — this is where add_foreign_key / add_check_constraint
+    // contribute their new constraint.
+    extraDefinition?.(definition);
+
+    const createTableSql = await this.schemaCreation.accept(definition);
 
     // Generated columns can't be inserted into — exclude them from the copy
     // (Rails: columns_to_copy rejects columns with an :as option,
@@ -2599,7 +2590,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
           );
         }
         await execTranslated(`DROP TABLE ${qTable}`);
-        await execTranslated(`CREATE TABLE ${qTable} (${colDefs.join(", ")})`);
+        await execTranslated(createTableSql);
         if (tmpColDefs.length > 0) {
           await execTranslated(
             `INSERT INTO ${qTable} (${selectCols}) SELECT ${selectCols} FROM ${qTmp}`,
@@ -3214,23 +3205,6 @@ export class SQLite3Integer {
     const v = BigInt(value);
     return v >= SQLite3Integer.MIN && v <= SQLite3Integer.MAX;
   }
-}
-
-const REFERENTIAL_ACTION_MAP: Record<string, string> = {
-  nullify: "SET NULL",
-  cascade: "CASCADE",
-  restrict: "RESTRICT",
-};
-
-function normalizeReferentialAction(action: string): string {
-  const sql = REFERENTIAL_ACTION_MAP[action];
-  if (sql === undefined) {
-    throw new ArgumentError(
-      `'${action}' is not supported for :on_update or :on_delete.\n` +
-        `Supported values are: :nullify, :cascade, :restrict\n`,
-    );
-  }
-  return sql;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2386,7 +2386,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     modify: (columns: Record<string, Record<string, unknown>>) => void,
     overrideForeignKeys?: ForeignKeyDefinition[],
     overrideCheckConstraints?: CheckConstraintDefinition[],
-    extraDefinition?: (def: import("./abstract/schema-definitions.js").TableDefinition) => void,
+    extraDefinition?: (definition: SQLite3TableDefinition) => void,
   ): Promise<void> {
     await this.ensureConnected();
     const { schema, bare: bareTable } = this._splitTableName(tableName);
@@ -2461,11 +2461,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       .map((c) => c.name);
     const compositePk = pkColumns.length > 1;
 
-    // Rails' copy_table populates a real TableDefinition (`@definition.column`,
-    // `definition.foreign_key`, `definition.check_constraint`) and hands it to
-    // create_table, so the rebuild emits through schema_creation exactly like
-    // any other CREATE TABLE (sqlite3_adapter.rb:598-640). Build the same
-    // definition here instead of concatenating column/FK/CHECK SQL by hand.
     const definition = new SQLite3TableDefinition(tableName, {
       id: false,
       adapter: this,
@@ -2482,24 +2477,19 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         options.as = col.generatedAs;
         options.stored = Boolean(col.generatedStored);
       }
-      // Rails passes `primary_key: column_name == from_primary_key`, which is
-      // never true for a composite key (from_primary_key is an Array there).
       if (!compositePk && col.pk) options.primaryKey = true;
       if (col.notnull) options.null = false;
       if (col.dflt_value !== null && col.dflt_value !== undefined) {
-        // `dflt_value` is already a quoted SQL literal (PRAGMA hands it back
-        // verbatim, and the callers that rewrite it run it through
-        // quoteDefault first), so carry it as a callable default — the same
-        // vehicle Rails' copy_table uses for `-> { column.default_function }`,
-        // which quote_default_expression emits without re-quoting.
         const literal = String(col.dflt_value);
         options.default = () => literal;
       }
-      definition.column(name, String(col.type ?? "TEXT") as ColumnType, options);
-      // PRAGMA reports the declared SQL type, not an AR type name, so pin it
-      // rather than letting the visitor resolve it through typeToSql: that is
-      // how the rebuild round-trips storage affinity exactly.
-      definition.columns[definition.columns.length - 1].sqlType = String(col.type ?? "TEXT");
+      const sqlType = String(col.type ?? "TEXT");
+      const columnDefinition = definition.newColumnDefinition(name, sqlType as ColumnType, options);
+      // PRAGMA reports the declared SQL type, not an AR type name, so pin it here
+      // rather than let the visitor resolve it through typeToSql — that is what
+      // round-trips storage affinity exactly.
+      columnDefinition.sqlType = sqlType;
+      definition.columns.push(columnDefinition);
     }
 
     // Preserve foreign keys and check constraints across the rebuild.
@@ -2514,10 +2504,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
           ? fk.column.split(",").map((c) => c.trim())
           : [fk.column];
       if (!cols.every((c) => colNames.includes(c))) continue;
-      // Push the reflected definition rather than re-deriving one: foreignKeys()
-      // already resolved the constraint name out of the CREATE TABLE DDL (PRAGMA
-      // foreign_key_list doesn't expose it), and Rails' caller block likewise
-      // reuses the introspected fk's options.
       definition.foreignKeys.push(fk);
     }
 
@@ -2534,9 +2520,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       definition.checkConstraints.push(chk);
     }
 
-    // Rails: `yield definition if block_given?` at the tail of copy_table's
-    // create_table block — this is where add_foreign_key / add_check_constraint
-    // contribute their new constraint.
     extraDefinition?.(definition);
 
     const createTableSql = await this.schemaCreation.accept(definition);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2487,8 +2487,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       const columnDefinition = definition.newColumnDefinition(name, sqlType as ColumnType, options);
       // PRAGMA reports the declared SQL type, not an AR type name, so pin it here
       // rather than let the visitor resolve it through typeToSql — that is what
-      // round-trips storage affinity exactly.
-      columnDefinition.sqlType = sqlType;
+      // round-trips storage affinity exactly. Not when newColumnDefinition flipped
+      // the type to :primary_key though (an integer/bigint PK with no default):
+      // visit_ColumnDefinition then skips add_column_options! entirely and the
+      // whole constraint rides on type_to_sql(:primary_key), so pinning the
+      // declared text over it would silently drop the PRIMARY KEY. Rails' `||=`
+      // has the same effect (abstract/schema_creation.rb:34).
+      if (columnDefinition.type !== "primary_key") columnDefinition.sqlType = sqlType;
       definition.columns.push(columnDefinition);
     }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -175,4 +175,18 @@ describe("SQLite3Adapter table-rebuild cluster", () => {
       .all() as any[];
     expect(tables.map((t: any) => t.name)).not.toContain("src");
   });
+
+  // --- alterTable ---
+
+  it("alterTable keeps the primary key of a lowercase integer-like declared type", async () => {
+    // PRAGMA table_info normalizes a declared `integer` to `INTEGER` but leaves
+    // `bigint` verbatim, so hand-written DDL is the one way the rebuild sees an
+    // AR-spelled integer-like type — the shape that makes newColumnDefinition
+    // flip the column to :primary_key, where the constraint rides entirely on
+    // type_to_sql(:primary_key).
+    await db.exec('CREATE TABLE "users" ("id" bigint PRIMARY KEY, "name" TEXT)');
+    await db.removeColumn("users", "name");
+    const pk = (await (db as any).tableInfo("users")).filter((c: any) => Number(c.pk) > 0);
+    expect(pk.map((c: any) => c.name)).toEqual(["id"]);
+  });
 });


### PR DESCRIPTION
Root cause of two of the four fidelity patches in #5307.

`AbstractSQLite3Adapter#alterTable` rebuilt the table by string-concatenating
column, FK and CHECK SQL. Rails' `alter_table` → `move_table` → `copy_table`
(`sqlite3_adapter.rb:593-640`) instead populates a real `TableDefinition`
(`@definition.column`, `definition.foreign_key`, `definition.check_constraint`)
and hands it to `create_table`, so every rebuild goes through `schema_creation`
like any other CREATE TABLE.

- Build a `SQLite3TableDefinition` (id: false, composite PK when reflected),
  add the columns, push the preserved FKs and CHECK constraints onto it, then
  run the caller block — Rails' `yield definition`, which is where
  `add_foreign_key` / `add_check_constraint` contribute their new constraint —
  and emit with `schemaCreation.accept(...)`. The throwaway extra
  `TableDefinition` the old extra-definition path built and re-serialized by
  hand is gone.
- PRAGMA reports the declared SQL type rather than an AR type name, so the
  ColumnDefinition's `sqlType` is pinned instead of resolved through
  `typeToSql`; storage affinity still round-trips exactly. The pin is skipped
  when `newColumnDefinition` flipped the column to the `primary_key`
  pseudo-type, matching Rails' `o.sql_type ||= type_to_sql(...)` — see below.
- `REFERENTIAL_ACTION_MAP` / `normalizeReferentialAction` are deleted.
  Referential-action rendering and validation (the `ArgumentError` on an
  unsupported `on_delete` / `on_update`) now exist only in
  `SchemaCreation#actionSql`.
- The missing-table guard from #5307 stays, with its existing comment: our
  rebuild reads PRAGMA directly rather than going through
  `primary_key(from)` → `table_structure`, so the natural path never raises it.
- Side effect: the rebuild now preserves `DEFERRABLE INITIALLY ...` on
  foreign keys, which the hand-rolled path silently dropped.

## Review finding: PRIMARY KEY loss when the sqlType pin overrides the flip

Confirmed reachable and fixed in a5bbd32, with a regression test.

`newColumnDefinition` flips an integer-like PK with no default to the
`primary_key` pseudo-type, and `visitColumnDefinition` then skips
`addColumnOptionsBang` entirely — the constraint rides entirely on
`typeToSql("primary_key")`. Pinning the PRAGMA-declared text over that emitted
a bare `"id" <type>` and dropped the PRIMARY KEY with no error.

The reviewer suspected PRAGMA's uppercase readback masked it. Half true:
`PRAGMA table_info` normalizes a declared `integer` to `INTEGER`, but it leaves
`bigint` verbatim, so `CREATE TABLE "users" ("id" bigint PRIMARY KEY, ...)`
followed by any rebuild really did produce
`CREATE TABLE "users" ("id" bigint, ...)`. Fix: pin the declared type only when
the definition did not flip it. That column now rebuilds as
`"id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL` — what Rails' `copy_table`
emits for the same input. `sqlite3-copy-table.test.ts` covers it and fails on
the pre-fix code (`expected [] to deeply equal [ 'id' ]`).

Green locally on SQLite: `migration/foreign-key.test.ts`,
`sqlite3-copy-table.test.ts`, `abstract/schema-statements-on-adapter.test.ts`,
`schema-dumper.test.ts` (+ trails), `migration.test.ts`, the whole
`adapters/sqlite3/` and `connection-adapters/sqlite3/` trees,
`invertible-migration`, `inheritance`, `locking`, `persistence`,
`transactions`, `hot-compatibility`, `reserved-word`, `schema-cache`.

Closes-story: sqlite-alter-table-hand-rolls-fk-sql-instead-of-schema-creation
