### PR TITLE
feat(activerecord): thread pluralize_table_names and conditional options through references

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -5188,6 +5188,9 @@ registerTableNameOptions({
   get tableNameSuffix() {
     return Base._tableNameSuffix;
   },
+  get pluralizeTableNames() {
+    return Base.pluralizeTableNames;
+  },
 });
 
 registerMigrationArConfig({

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -4,8 +4,11 @@ import type { Column } from "../column.js";
 import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { globalTableNamePrefix, globalTableNameSuffix } from "./table-name-options.js";
-import { Base } from "../../base.js";
+import {
+  globalPluralizeTableNames,
+  globalTableNamePrefix,
+  globalTableNameSuffix,
+} from "./table-name-options.js";
 
 /**
  * @internal Shared identifier guard for MySQL bare-identifier emission
@@ -806,7 +809,7 @@ export class ReferenceDefinition {
   /** @internal */
   private foreignTableName(): string {
     const fkOpts = this.foreignKeyOptions();
-    return fkOpts.toTable ?? (Base.pluralizeTableNames ? pluralize(this.name) : this.name);
+    return fkOpts.toTable ?? (globalPluralizeTableNames() ? pluralize(this.name) : this.name);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -45,7 +45,11 @@ import { singularize, pluralize, getCrypto, isPresent } from "@blazetrails/activ
 import { SchemaDumper } from "./schema-dumper.js";
 import { Utils as PgUtils } from "../postgresql/utils.js";
 import { indexes as sqliteIndexes } from "../sqlite3/schema-statements.js";
-import { globalTableNamePrefix, globalTableNameSuffix } from "./table-name-options.js";
+import {
+  globalPluralizeTableNames,
+  globalTableNamePrefix,
+  globalTableNameSuffix,
+} from "./table-name-options.js";
 
 export { assertSchemaAdapter } from "./assert-schema-adapter.js";
 
@@ -731,28 +735,30 @@ export class SchemaStatements {
     options: {
       polymorphic?: boolean;
       foreignKey?: boolean | { toTable?: string; column?: string };
+      ifExists?: boolean;
+      ifNotExists?: boolean;
     } = {},
   ): Promise<void> {
-    // Mirrors Rails remove_reference (schema_statements.rb): when `foreign_key`
-    // is given, drop the constraint BEFORE the column, otherwise MySQL/MariaDB
-    // refuses to drop the column's index while the FK still needs it. This is
-    // the inverse `add_reference ... foreign_key:` records (CommandRecorder
-    // passes the same args through), so it has to undo the FK the forward call
-    // created.
+    const conditionalOptions: { ifExists?: boolean; ifNotExists?: boolean } = {};
+    if (options.ifExists !== undefined) conditionalOptions.ifExists = options.ifExists;
+    if (options.ifNotExists !== undefined) conditionalOptions.ifNotExists = options.ifNotExists;
     if (options.foreignKey) {
       const fkOptions =
         typeof options.foreignKey === "object"
-          ? { ...options.foreignKey }
-          : { toTable: pluralize(refName) };
+          ? { ...options.foreignKey, ...conditionalOptions }
+          : {
+              toTable: globalPluralizeTableNames() ? pluralize(refName) : refName,
+              ...conditionalOptions,
+            };
       if ((fkOptions as { column?: string }).column == null) {
         (fkOptions as { column?: string }).column = `${refName}_id`;
       }
       await this.removeForeignKey(tableName, fkOptions);
     }
+    await this.removeColumn(tableName, `${refName}_id`, undefined, conditionalOptions);
     if (options.polymorphic) {
-      await this.removeColumn(tableName, `${refName}_type`);
+      await this.removeColumn(tableName, `${refName}_type`, undefined, conditionalOptions);
     }
-    await this.removeColumn(tableName, `${refName}_id`);
   }
 
   /** Alias of removeReference (Rails: `alias :remove_belongs_to :remove_reference`). */
@@ -762,6 +768,8 @@ export class SchemaStatements {
     options: {
       polymorphic?: boolean;
       foreignKey?: boolean | { toTable?: string; column?: string };
+      ifExists?: boolean;
+      ifNotExists?: boolean;
     } = {},
   ): Promise<void> {
     return this.removeReference(tableName, refName, options);

--- a/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
@@ -12,6 +12,7 @@
 export interface TableNameOptionsSource {
   readonly tableNamePrefix: string;
   readonly tableNameSuffix: string;
+  readonly pluralizeTableNames: boolean;
 }
 
 let _source: TableNameOptionsSource | null = null;
@@ -29,4 +30,9 @@ export function globalTableNamePrefix(): string {
 /** @internal */
 export function globalTableNameSuffix(): string {
   return _source?.tableNameSuffix ?? "";
+}
+
+/** @internal */
+export function globalPluralizeTableNames(): boolean {
+  return _source?.pluralizeTableNames ?? true;
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1714,6 +1714,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       });
       return;
     }
+    if (options?.ifNotExists === true && (await this.columnExists(tableName, columnName))) {
+      return;
+    }
     const sqlType = baseType;
     let sql = `ALTER TABLE ${quoteTableName(tableName)} ADD COLUMN ${quoteColumnName(columnName)} ${sqlType}`;
     if (options?.collation) sql += ` COLLATE ${quoteColumnName(String(options.collation))}`;

--- a/packages/activerecord/src/migration/references-foreign-key.test.ts
+++ b/packages/activerecord/src/migration/references-foreign-key.test.ts
@@ -5,6 +5,22 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { ambientConnection } from "../support/rocket-tables.js";
 import { describeIfSupports, itIfSupports } from "../support/supports.js";
 import { assertQueriesCount } from "../testing/query-assertions.js";
+import { Base } from "../base.js";
+import { Migration } from "../migration.js";
+
+class CreateDogsMigration extends Migration {
+  write(): void {}
+
+  async change(): Promise<void> {
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await this.createTable("dog_owners");
+
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await this.createTable("dogs", (t) => {
+      t.references("dog_owner", { foreignKey: true });
+    });
+  }
+}
 
 async function withTestingTables(conn: AbstractAdapter, body: () => Promise<void>): Promise<void> {
   await conn.createTable("testing_parents", { force: true });
@@ -155,6 +171,81 @@ describeIfSupports("foreign_keys", "Migration", () => {
           ["testings", "testing_parents", "parent2_id"],
         ]);
       });
+    });
+
+    it("foreign key methods respect pluralize_table_names", async () => {
+      const conn = await ambientConnection();
+      const originalPluralizeTableNames = Base.pluralizeTableNames;
+      Base.pluralizeTableNames = false;
+      try {
+        await withTestingTables(conn, async () => {
+          await conn.createTable("testing");
+          await conn.changeTable("testing_parents", async (t) => {
+            await t.references("testing", { foreignKey: true });
+          });
+
+          const fk = (await conn.foreignKeys("testing_parents"))[0];
+          expect(fk.fromTable).toBe("testing_parents");
+          expect(fk.toTable).toBe("testing");
+
+          const before = (await conn.foreignKeys("testing_parents")).length;
+          await conn.removeReference("testing_parents", "testing", { foreignKey: true });
+          expect((await conn.foreignKeys("testing_parents")).length).toBe(before - 1);
+        });
+      } finally {
+        Base.pluralizeTableNames = originalPluralizeTableNames;
+        await conn.dropTable("testing", { ifExists: true });
+      }
+    });
+
+    it("remove_reference responds to if_exists option", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings");
+
+        await expect(
+          conn.removeReference("testings", "nonexistent", { foreignKey: true, ifExists: true }),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    it("add_reference responds to if_not_exists option", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("testing", { foreignKey: true });
+        });
+
+        await expect(
+          conn.addReference("testings", "testing", { foreignKey: true, ifNotExists: true }),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    it("references foreign key with prefix", async () => {
+      const conn = await ambientConnection();
+      Base.tableNamePrefix = "p_";
+      const migration = new CreateDogsMigration();
+      try {
+        await migration.migrate("up");
+        expect((await conn.foreignKeys("p_dogs")).length).toBe(1);
+      } finally {
+        await migration.migrate("down");
+        Base.tableNamePrefix = "";
+      }
+    });
+
+    it("references foreign key with suffix", async () => {
+      const conn = await ambientConnection();
+      Base.tableNameSuffix = "_s";
+      const migration = new CreateDogsMigration();
+      try {
+        await migration.migrate("up");
+        expect((await conn.foreignKeys("dogs_s")).length).toBe(1);
+      } finally {
+        await migration.migrate("down");
+        Base.tableNameSuffix = "";
+      }
     });
   });
 


### PR DESCRIPTION
Ports the five cases of `ActiveRecord::Migration::ReferencesForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/references_foreign_key_test.rb:187-254`)
that #5480 deliberately left out, closing the implementation gap each one needed.

## Implementation

- **`pluralize_table_names`** — `ReferenceDefinition#foreignTableName` and
  `removeReference` unconditionally pluralized the reference name to get the FK's
  target table. Rails consults `Base.pluralize_table_names` first
  (`schema_definitions.rb:297-301`, `schema_statements.rb:1086`).
- **`if_exists` / `if_not_exists`** — `removeReference` now threads the pair onto
  the foreign-key call and both column removals, matching
  `options.slice(:if_exists, :if_not_exists)` (`schema_statements.rb:1083`).
  `addReference` needed nothing: it already routes through
  `ReferenceDefinition#add`, whose `conditional_options` reach the column, index
  and FK calls.
- **`table_name_prefix` / `table_name_suffix`** — three sites read the
  prefix/suffix only off the adapter, a trails-only carrier that nothing in the
  library populates: `TableDefinition#newForeignKeyDefinition`, its
  `foreignKeyOptions` fallback, and `stripTableNamePrefixAndSuffix`. Rails reads
  `ActiveRecord::Base` at all three (`schema_definitions.rb:575-581`,
  `schema_statements.rb:1749-1753`), so each now falls back to
  `Base.tableNamePrefix` / `tableNameSuffix`; the adapter-carried pair still wins
  when set. Without this a prefixed migration's `t.references ..., foreign_key: true`
  points at the unprefixed table.
- **SQLite3 `addColumn`** — its override skipped the abstract `if_not_exists`
  short-circuit (`build_add_column_definition`, `schema_statements.rb:654-655`),
  which is what made `add_reference responds to if_not_exists option` fail with
  `duplicate column name`. The override now reproduces it **on the non-rebuild
  branch only**: Rails' SQLite3 `add_column` (`sqlite3_adapter.rb:338-347`)
  reaches that guard solely via `super`, so the `invalid_alter_table_type?`
  branch — which calls `alter_table` directly — never checks `if_not_exists`.
  Guarding before the branch would have made trails more lenient than Rails for
  rebuild-requiring column types.
- **`removeReference` column order** — Rails drops `#{ref}_id` before
  `#{ref}_type`; trails had them reversed.

## Parity

Against `origin/main` (8d8e2b922):

- `test:compare` activerecord: 7847 → 7852 matched (+5), TS-only extra 1039 → 1039.
  `migration/references_foreign_key_test.rb` goes 8/23 → 13/23 matched, 0 extra.
- `api:compare`: unchanged — data layer 7718/7813, overall 11725/17544,
  arity 7474/7557.
- `--gates --check` and `api:compare --check` both exit 0; `typecheck` clean.

Closes-story: port-migration-references-foreign-key-naming-and-conditional-cases
