### PR TITLE
fix(schema-definitions): gate ReferenceDefinition foreign table pluralization on pluralizeTableNames

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import {
   ForeignKeyDefinition,
   CheckConstraintDefinition,
-  TableDefinition,
   ReferenceDefinition,
+  TableDefinition,
   type ReferenceDefinitionConnection,
 } from "./schema-definitions.js";
 import { SchemaDumper } from "../../schema-dumper.js";
+import { Base } from "../../base.js";
 
 const originalFkPattern = SchemaDumper.fkIgnorePattern;
 const originalChkPattern = SchemaDumper.chkIgnorePattern;
@@ -153,5 +154,32 @@ describe("ReferenceDefinition#add", () => {
     await new ReferenceDefinition("user", { index: false }).add("taggings", connection);
 
     expect(calls.map((c) => c[0])).toEqual(["addColumn"]);
+  });
+});
+
+describe("ReferenceDefinition#foreign_table_name", () => {
+  const originalPluralize = Base.pluralizeTableNames;
+
+  afterEach(() => {
+    Base.pluralizeTableNames = originalPluralize;
+  });
+
+  it("targets the singular table when Base.pluralizeTableNames is false", () => {
+    Base.pluralizeTableNames = false;
+    const ref = new ReferenceDefinition("user", { foreignKey: true, index: false });
+    const td = new TableDefinition("posts", { id: false });
+    ref.addTo(td);
+    expect(td.foreignKeys[0].toTable).toBe("user");
+  });
+
+  it("still honors an explicit toTable when pluralizeTableNames is false", () => {
+    Base.pluralizeTableNames = false;
+    const ref = new ReferenceDefinition("author", {
+      foreignKey: { toTable: "accounts" },
+      index: false,
+    });
+    const td = new TableDefinition("posts", { id: false });
+    ref.addTo(td);
+    expect(td.foreignKeys[0].toTable).toBe("accounts");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -5,6 +5,7 @@ import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { globalTableNamePrefix, globalTableNameSuffix } from "./table-name-options.js";
+import { Base } from "../../base.js";
 
 /**
  * @internal Shared identifier guard for MySQL bare-identifier emission
@@ -805,7 +806,7 @@ export class ReferenceDefinition {
   /** @internal */
   private foreignTableName(): string {
     const fkOpts = this.foreignKeyOptions();
-    return fkOpts.toTable ?? pluralize(this.name);
+    return fkOpts.toTable ?? (Base.pluralizeTableNames ? pluralize(this.name) : this.name);
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary

`ReferenceDefinition#foreignTableName` unconditionally pluralized the reference
name, so with `Base.pluralizeTableNames = false` a `references :user,
foreign_key: true` emitted a foreign key pointing at `users` — a table that does
not exist. Rails gates that pluralization on the flag
(`schema_definitions.rb:293-297`).

Since PR #5485 this is the single shared implementation for `create_table`'s
`t.references`, `change_table`'s `t.references`, and top-level `add_reference`,
so the fix covers all three.

An explicit `toTable` in `foreignKeyOptions` still wins, matching Ruby's
`fetch(:to_table) { ... }` block-default semantics.

## Tests

Two regression tests in `schema-definitions.trails.test.ts` (Rails has no direct
test for this path); both restore the global `Base.pluralizeTableNames` in
`afterEach`. The singular-table one fails on baseline (`users` vs `user`).

`api:compare` and `test:compare` deltas non-negative; `test:compare --gates
--check` exits 0. `migration/`, `connection-adapters/abstract/`, and
`invertible-migration` suites green.

Closes-story: reference-definition-foreign-table-name-honors-pluralize-table-names
