### PR TITLE
fix(mysql): include MySQL::SchemaStatements on the adapter so its overrides win

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -87,7 +87,9 @@ import {
   newColumnFromField,
   quotedScope,
   tableAliasLength as mysqlTableAliasLength,
+  MysqlSchemaStatements,
 } from "./mysql/schema-statements.js";
+import { include } from "@blazetrails/activesupport";
 import type { Column as MysqlColumn } from "./mysql/column.js";
 import { TypeMap } from "../type/type-map.js";
 import {
@@ -2224,3 +2226,12 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
     return `a${++this._counter}`;
   }
 }
+
+// Rails: `include MySQL::SchemaStatements` in the AbstractMysqlAdapter class
+// body (abstract_mysql_adapter.rb:19), so the MySQL overrides win over the base
+// SchemaStatements on the adapter itself — not just on the companion returned by
+// `schemaStatements()`. Applied here at module scope rather than inside the class
+// because trails keeps the module in a companion class; `include()` copies its
+// own prototype descriptors and leaves class-body methods (which sit above every
+// mixin in Ruby's ancestry) untouched.
+include(AbstractMysqlAdapter, MysqlSchemaStatements);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -2227,11 +2227,5 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
   }
 }
 
-// Rails: `include MySQL::SchemaStatements` in the AbstractMysqlAdapter class
-// body (abstract_mysql_adapter.rb:19), so the MySQL overrides win over the base
-// SchemaStatements on the adapter itself — not just on the companion returned by
-// `schemaStatements()`. Applied here at module scope rather than inside the class
-// because trails keeps the module in a companion class; `include()` copies its
-// own prototype descriptors and leaves class-body methods (which sit above every
-// mixin in Ruby's ancestry) untouched.
+// Rails: `include MySQL::SchemaStatements` (abstract_mysql_adapter.rb:19).
 include(AbstractMysqlAdapter, MysqlSchemaStatements);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -433,10 +433,6 @@ export class SchemaStatements {
     // reference it are dropped instead of left dangling; delegate when the
     // adapter supplies its own removeColumn (mirrors renameColumn's gate).
     const adapter = this.adapter as any;
-    // `adapter !== this` keeps the dispatch one-way: when these methods run
-    // mixed into an adapter (MySQL's `include MySQL::SchemaStatements`),
-    // `this.adapter` is the adapter itself, so an override reaching this body
-    // through `super` would otherwise be dispatched straight back to itself.
     if (
       adapter !== (this as unknown) &&
       typeof adapter.removeColumn === "function" &&

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -433,7 +433,12 @@ export class SchemaStatements {
     // reference it are dropped instead of left dangling; delegate when the
     // adapter supplies its own removeColumn (mirrors renameColumn's gate).
     const adapter = this.adapter as any;
+    // `adapter !== this` keeps the dispatch one-way: when these methods run
+    // mixed into an adapter (MySQL's `include MySQL::SchemaStatements`),
+    // `this.adapter` is the adapter itself, so an override reaching this body
+    // through `super` would otherwise be dispatched straight back to itself.
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.removeColumn === "function" &&
       adapter.removeColumn !== SchemaStatements.prototype.removeColumn
     ) {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -63,6 +63,24 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     await this.adapter.execute(await this.schemaCreation.accept(createDef));
   }
 
+  /**
+   * MySQL refuses to drop a column that a foreign key references
+   * (ER_FK_COLUMN_CANNOT_DROP), so drop the key first.
+   *
+   * Mirrors: MySQL::SchemaStatements#remove_column
+   */
+  override async removeColumn(
+    tableName: string,
+    columnName: string,
+    type?: string,
+    options: { ifExists?: boolean } = {},
+  ): Promise<void> {
+    if (await this.foreignKeyExists(tableName, { column: columnName })) {
+      await this.removeForeignKey(tableName, { column: columnName });
+    }
+    return super.removeColumn(tableName, columnName, type, options);
+  }
+
   override async dropTable(
     ...args:
       | [string, ...string[]]
@@ -71,7 +89,9 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     const last = args[args.length - 1];
     const hasOpts = last !== null && last !== undefined && typeof last === "object";
     const opts = (hasOpts ? last : {}) as { temporary?: boolean };
-    if (opts.temporary) {
+    // `this.adapter !== this` keeps the delegation one-way once this body is
+    // mixed onto the adapter itself (see removeColumn).
+    if (opts.temporary && (this.adapter as unknown) !== (this as unknown)) {
       return (
         this.adapter as unknown as { dropTable(...args: unknown[]): Promise<void> }
       ).dropTable(...(args as unknown[]));

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -63,12 +63,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     await this.adapter.execute(await this.schemaCreation.accept(createDef));
   }
 
-  /**
-   * MySQL refuses to drop a column that a foreign key references
-   * (ER_FK_COLUMN_CANNOT_DROP), so drop the key first.
-   *
-   * Mirrors: MySQL::SchemaStatements#remove_column
-   */
+  /** Mirrors: MySQL::SchemaStatements#remove_column */
   override async removeColumn(
     tableName: string,
     columnName: string,
@@ -89,9 +84,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     const last = args[args.length - 1];
     const hasOpts = last !== null && last !== undefined && typeof last === "object";
     const opts = (hasOpts ? last : {}) as { temporary?: boolean };
-    // `this.adapter !== this` keeps the delegation one-way once this body is
-    // mixed onto the adapter itself (see removeColumn).
-    if (opts.temporary && (this.adapter as unknown) !== (this as unknown)) {
+    if (opts.temporary) {
       return (
         this.adapter as unknown as { dropTable(...args: unknown[]): Promise<void> }
       ).dropTable(...(args as unknown[]));

--- a/packages/activerecord/src/migration/references-foreign-key.test.ts
+++ b/packages/activerecord/src/migration/references-foreign-key.test.ts
@@ -98,6 +98,19 @@ describeIfSupports("foreign_keys", "Migration", () => {
       });
     });
 
+    it("removing column removes foreign key", async () => {
+      const conn = await ambientConnection();
+      await withTestingTables(conn, async () => {
+        await conn.createTable("testings", (t) => {
+          t.references("testing_parent", { index: true, foreignKey: true });
+        });
+
+        const before = (await conn.foreignKeys("testings")).length;
+        await conn.removeColumn("testings", "testing_parent_id");
+        expect((await conn.foreignKeys("testings")).length).toBe(before - 1);
+      });
+    });
+
     it("multiple foreign keys can be added to the same table", async () => {
       const conn = await ambientConnection();
       await withTestingTables(conn, async () => {


### PR DESCRIPTION
## What

Rails' `AbstractMysqlAdapter` does `include MySQL::SchemaStatements`
(`abstract_mysql_adapter.rb:19`), so the MySQL module's overrides win over the
base `SchemaStatements` **on the adapter itself**. trails only mixed the base
`SchemaStatements` onto `AbstractAdapter`; `MysqlSchemaStatements` was never on
any adapter prototype and was reachable only through the `schemaStatements()`
companion accessor that `Migration` routes through. Every override was silently
bypassed on the `conn.someSchemaMethod(...)` path.

- `include(AbstractMysqlAdapter, MysqlSchemaStatements)` — `include()` copies the
  companion's own prototype descriptors and leaves class-body methods untouched,
  matching Ruby's ancestry (class body > included module > superclass module).
- Ported `MySQL::SchemaStatements#remove_column`
  (`mysql/schema_statements.rb:77-82`): drop a referencing foreign key first, then
  `super`.
- Gated the base `removeColumn` delegation (and the MySQL `dropTable` temporary
  delegation) on `adapter !== this`, the same one-way guard `removeForeignKey`
  already uses — otherwise a mixed-in override reaching the base body through
  `super` is dispatched straight back to itself and recurses.

## Test

Adds the Rails case `"removing column removes foreign key"`
(`references_foreign_key_test.rb:183-190`) to
`migration/references-foreign-key.test.ts`, with no adapter guard (Rails has
none). Verified locally: fails on baseline with `ER_FK_COLUMN_CANNOT_DROP`,
passes after, on sqlite3 / postgresql / mysql2.

Audit of the other overrides that become reachable: `addIndex` and
`schemaCreation` are both already defined in the `AbstractMysqlAdapter` class
body, so the include does not change their resolution (class body wins, as in
Ruby). `dropTable` likewise stays the `Mysql2Adapter` class-body method.

`pnpm test:compare --package activerecord --gates --check` exits 0.

Closes-story: mysql-schema-statements-overrides-unreachable-on-adapter
