### PR TITLE
test(connection-adapters): ride the ambient config instead of hardcoded :memory:

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1913,11 +1913,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     };
     m.registerType(/decimal/i, undefined, registerDecimal);
     m.registerType(/numeric/i, undefined, registerDecimal);
-    m.registerType(/clob/i, undefined, (sqlType: string) => {
-      const meta = /\(.*\)/.exec(sqlType)?.[0] ?? "";
-      return m.lookup(`text${meta}`);
-    });
-    m.registerType(/number/i, undefined, registerDecimal);
+    m.aliasType(/clob/i, "text");
+    m.aliasType(/number/i, "decimal");
     m.registerType("json", new JsonType());
 
     // MySQL-specific overrides (mirrors MySQL's initialize_type_map additions).

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1913,6 +1913,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     };
     m.registerType(/decimal/i, undefined, registerDecimal);
     m.registerType(/numeric/i, undefined, registerDecimal);
+    m.registerType(/clob/i, undefined, (sqlType: string) => {
+      const meta = /\(.*\)/.exec(sqlType)?.[0] ?? "";
+      return m.lookup(`text${meta}`);
+    });
+    m.registerType(/number/i, undefined, registerDecimal);
     m.registerType("json", new JsonType());
 
     // MySQL-specific overrides (mirrors MySQL's initialize_type_map additions).

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -40,9 +40,6 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("establish connection using 3 levels config", async () => {
-    // Rails (connection_handler_test.rb:34-63) establishes all three named
-    // configs out of a 3-level hash and asserts each pool's db_config.database
-    // is the file path that config named.
     const configs = new DatabaseConfigurations({
       default_env: {
         readonly: { adapter: "sqlite3", database: "test/db/readonly.sqlite3" },
@@ -56,11 +53,6 @@ describe("ConnectionHandlerTest", () => {
     });
     DatabaseConfigurations.defaultEnv = "default_env";
 
-    // Rails passes the bare symbol and lets establish_connection resolve it via
-    // find_db_config. Resolved explicitly here: trails' DatabaseConfig
-    // `forCurrentEnv` does not see `DatabaseConfigurations.defaultEnv`, so
-    // findDbConfig misses the 3-level entries — a wiring divergence of its own,
-    // not something this test should encode.
     for (const name of ["primary", "readonly"]) {
       handler.establishConnection(configs.configsFor({ envName: "default_env", name })[0], {
         owner: name,
@@ -284,9 +276,6 @@ describe("ConnectionHandlerTest", () => {
     try {
       class Klass2 extends Base {}
 
-      // Rails: klass2.establish_connection(
-      //   ActiveRecord::Base.connection_pool.db_config.configuration_hash)
-      // — the ambient lane config, not a private `:memory:` database.
       const baseConfig = new HashConfig("development", "primary", ambientPoolConfiguration());
       const ownConfig = new HashConfig("development", "Klass2", ambientPoolConfiguration());
 

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -3,6 +3,7 @@ import { ConnectionHandler } from "./abstract/connection-handler.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
+import { ambientPoolConfiguration } from "../test-adapter.js";
 
 // Mirrors ActiveRecord::TestFixtures#setup_shared_connection_pool (test_fixtures.rb:220).
 // For each shard in each pool manager, replaces every non-writing role's pool
@@ -39,13 +40,45 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("establish connection using 3 levels config", async () => {
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
+    // Rails (connection_handler_test.rb:34-63) establishes all three named
+    // configs out of a 3-level hash and asserts each pool's db_config.database
+    // is the file path that config named.
+    const configs = new DatabaseConfigurations({
+      default_env: {
+        readonly: { adapter: "sqlite3", database: "test/db/readonly.sqlite3" },
+        primary: { adapter: "sqlite3", database: "test/db/primary.sqlite3" },
+      },
+      another_env: {
+        readonly: { adapter: "sqlite3", database: "test/db/bad-readonly.sqlite3" },
+        primary: { adapter: "sqlite3", database: "test/db/bad-primary.sqlite3" },
+      },
+      common: { adapter: "sqlite3", database: "test/db/common.sqlite3" },
     });
-    const pool = handler.establishConnection(config);
-    expect(pool).toBeTruthy();
-    expect(pool.dbConfig.adapter).toBe("sqlite3");
+    DatabaseConfigurations.defaultEnv = "default_env";
+
+    // Rails passes the bare symbol and lets establish_connection resolve it via
+    // find_db_config. Resolved explicitly here: trails' DatabaseConfig
+    // `forCurrentEnv` does not see `DatabaseConfigurations.defaultEnv`, so
+    // findDbConfig misses the 3-level entries — a wiring divergence of its own,
+    // not something this test should encode.
+    for (const name of ["primary", "readonly"]) {
+      handler.establishConnection(configs.configsFor({ envName: "default_env", name })[0], {
+        owner: name,
+      });
+    }
+    handler.establishConnection(configs.configsFor({ envName: "common" })[0], { owner: "common" });
+
+    const readonlyPool = handler.retrieveConnectionPool("readonly");
+    expect(readonlyPool).toBeTruthy();
+    expect(readonlyPool!.dbConfig.database).toBe("test/db/readonly.sqlite3");
+
+    const primaryPool = handler.retrieveConnectionPool("primary");
+    expect(primaryPool).toBeTruthy();
+    expect(primaryPool!.dbConfig.database).toBe("test/db/primary.sqlite3");
+
+    const commonPool = handler.retrieveConnectionPool("common");
+    expect(commonPool).toBeTruthy();
+    expect(commonPool!.dbConfig.database).toBe("test/db/common.sqlite3");
   });
 
   it("validates db configuration and raises on invalid adapter", async () => {
@@ -251,14 +284,11 @@ describe("ConnectionHandlerTest", () => {
     try {
       class Klass2 extends Base {}
 
-      const baseConfig = new HashConfig("development", "primary", {
-        adapter: "sqlite3",
-        database: ":memory:",
-      });
-      const ownConfig = new HashConfig("development", "Klass2", {
-        adapter: "sqlite3",
-        database: ":memory:",
-      });
+      // Rails: klass2.establish_connection(
+      //   ActiveRecord::Base.connection_pool.db_config.configuration_hash)
+      // — the ambient lane config, not a private `:memory:` database.
+      const baseConfig = new HashConfig("development", "primary", ambientPoolConfiguration());
+      const ownConfig = new HashConfig("development", "Klass2", ambientPoolConfiguration());
 
       const basePool = freshHandler.establishConnection(baseConfig, {
         owner: "Base",

--- a/packages/activerecord/src/connection-adapters/connection-handlers-multi-pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-multi-pool-config.test.ts
@@ -4,11 +4,6 @@ import { HashConfig } from "../database-configurations/hash-config.js";
 import { ambientPoolConfiguration } from "../test-adapter.js";
 import { inMemoryDb } from "../support/adapter-helper.js";
 
-// Rails wraps every test in this file in `unless in_memory_db?`
-// (connection_handlers_multi_pool_config_test.rb:21) because they open a real
-// connection against a file-backed database — its hardcoded
-// "test/db/primary.sqlite3" (`:27,:54,:78`) is the file-backed equivalent of
-// our ambient lane config, so the pools here ride that instead of `:memory:`.
 describe.skipIf(inMemoryDb())("ConnectionHandlersMultiPoolConfigTest", () => {
   let handler: ConnectionHandler;
 
@@ -54,7 +49,7 @@ describe.skipIf(inMemoryDb())("ConnectionHandlersMultiPoolConfigTest", () => {
     handler.establishConnection(primaryConfig(), { owner: "primary", shard: "pool_config_two" });
 
     // connect to default
-    await handler.connectionPoolList("writing")[0].leaseConnection();
+    await (await handler.connectionPoolList("writing")[0].checkout()).connectBang();
 
     expect(handler.isConnected("primary")).toBe(true);
     expect(handler.isConnected("primary", { shard: "default" })).toBe(true);

--- a/packages/activerecord/src/connection-adapters/connection-handlers-multi-pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-multi-pool-config.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ConnectionHandler } from "./abstract/connection-handler.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
+import { ambientPoolConfiguration } from "../test-adapter.js";
+import { inMemoryDb } from "../support/adapter-helper.js";
 
-describe("ConnectionHandlersMultiPoolConfigTest", () => {
+// Rails wraps every test in this file in `unless in_memory_db?`
+// (connection_handlers_multi_pool_config_test.rb:21) because they open a real
+// connection against a file-backed database — its hardcoded
+// "test/db/primary.sqlite3" (`:27,:54,:78`) is the file-backed equivalent of
+// our ambient lane config, so the pools here ride that instead of `:memory:`.
+describe.skipIf(inMemoryDb())("ConnectionHandlersMultiPoolConfigTest", () => {
   let handler: ConnectionHandler;
 
-  const primaryConfig = () =>
-    new HashConfig("default_env", "primary", { adapter: "sqlite3", database: ":memory:" });
+  const primaryConfig = () => new HashConfig("default_env", "primary", ambientPoolConfiguration());
 
   beforeEach(() => {
     handler = new ConnectionHandler();

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -913,9 +913,6 @@ describe("SchemaCache DDL invalidation", () => {
   }
 
   beforeEach(async () => {
-    // Rails' schema_cache_test.rb:12 rides a real lane connection
-    // (ARUnit2Model.lease_connection); newRawTestAdapter is the trails
-    // equivalent — a fresh adapter object on the ambient lane database.
     adapter = newRawTestAdapter();
     await adapter.dropTable("things", "stuff", { ifExists: true });
     await adapter.createTable("things", (t) => {

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -6,8 +6,8 @@ import { setSchemaCacheIgnoredTables } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { SchemaStatements } from "./abstract/schema-statements.js";
 import { TableDefinition } from "./abstract/schema-definitions.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import type { AbstractAdapter } from "./abstract-adapter.js";
+import { newRawTestAdapter } from "../test-adapter.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -906,14 +906,18 @@ describe("DDL cache-invalidation safety-net", () => {
 });
 
 describe("SchemaCache DDL invalidation", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: AbstractAdapter;
 
   function warmCache(tableName: string) {
     adapter.schemaCache.setColumns(tableName, [makeColumn("id", "integer")]);
   }
 
   beforeEach(async () => {
-    adapter = new BetterSQLite3Adapter(":memory:");
+    // Rails' schema_cache_test.rb:12 rides a real lane connection
+    // (ARUnit2Model.lease_connection); newRawTestAdapter is the trails
+    // equivalent — a fresh adapter object on the ambient lane database.
+    adapter = newRawTestAdapter();
+    await adapter.dropTable("things", "stuff", { ifExists: true });
     await adapter.createTable("things", (t) => {
       t.string("name");
       t.integer("count");
@@ -923,6 +927,7 @@ describe("SchemaCache DDL invalidation", () => {
   });
 
   afterEach(async () => {
+    await adapter.dropTable("things", "stuff", { ifExists: true });
     await adapter.close();
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3154,6 +3154,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     this.registerClassWithLimit(m, /binary/i, BinaryType);
     m.aliasType(/clob/i, "text");
     m.aliasType(/blob/i, "binary");
+    m.aliasType(/number/i, "decimal");
     this.registerClassWithLimit(m, /real|floa|doub/i, FloatType);
   }
 }

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { StatementPool } from "./statement-pool.js";
+import { isSqliteRun } from "../support/sqlite-template.js";
+import { newRawTestAdapter } from "../test-adapter.js";
 
 describe("StatementPoolTest", () => {
   it("#delete doesn't call dealloc if the statement didn't exist", () => {
@@ -108,13 +110,16 @@ describe("StatementPoolTest", () => {
 });
 
 describe("SQLite3 StatementPool integration", () => {
-  it("caches prepared statements across execute calls", async () => {
-    const { BetterSQLite3Adapter } =
-      await import("../connection-adapters/better-sqlite3-adapter.js");
-    const adapter = new BetterSQLite3Adapter(":memory:");
+  // The Rails-mirrored StatementPoolTest above needs no adapter at all — Rails
+  // builds a bare `TestPool.new` (statement_pool_test.rb:16). This trails-only
+  // test does need one, so it rides the ambient sqlite lane connection rather
+  // than a private `:memory:` handle, and only runs where that lane is sqlite.
+  it.skipIf(!isSqliteRun())("caches prepared statements across execute calls", async () => {
+    const adapter = newRawTestAdapter();
     const prepareSpy = vi.spyOn((adapter as any).driver, "prepare");
 
     try {
+      await adapter.executeMutation('DROP TABLE IF EXISTS "test_pool"');
       await adapter.executeMutation(
         'CREATE TABLE "test_pool" ("id" INTEGER PRIMARY KEY, "name" TEXT)',
       );
@@ -133,9 +138,9 @@ describe("SQLite3 StatementPool integration", () => {
       // db.prepare should have been called once for the SELECT, not twice
       const selectCalls = prepareSpy.mock.calls.filter((c) => c[0] === selectSql);
       expect(selectCalls).toHaveLength(1);
-      await adapter.executeMutation('DROP TABLE IF EXISTS "test_pool"');
     } finally {
       prepareSpy.mockRestore();
+      await adapter.executeMutation('DROP TABLE IF EXISTS "test_pool"');
       adapter.disconnectBang();
     }
   });

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -110,10 +110,6 @@ describe("StatementPoolTest", () => {
 });
 
 describe("SQLite3 StatementPool integration", () => {
-  // The Rails-mirrored StatementPoolTest above needs no adapter at all — Rails
-  // builds a bare `TestPool.new` (statement_pool_test.rb:16). This trails-only
-  // test does need one, so it rides the ambient sqlite lane connection rather
-  // than a private `:memory:` handle, and only runs where that lane is sqlite.
   it.skipIf(!isSqliteRun())("caches prepared statements across execute calls", async () => {
     const adapter = newRawTestAdapter();
     const prepareSpy = vi.spyOn((adapter as any).driver, "prepare");

--- a/packages/activerecord/src/connection-adapters/type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/type-lookup.test.ts
@@ -7,16 +7,12 @@ import { IntegerType } from "@blazetrails/activemodel";
 import { Base } from "../base.js";
 import { adapterType } from "../test-adapter.js";
 
-/** The only surface this suite touches, and not on AbstractAdapter itself. */
 interface TypeLookupConnection {
   lookupCastType(sqlType: string): Type;
 }
 
 let adapter: TypeLookupConnection;
 
-// Rails: `@connection = ActiveRecord::Base.lease_connection`
-// (type_lookup_test.rb:10) — the ambient lane connection, not a private
-// `:memory:` handle. Nothing here writes, so the lease is never closed.
 beforeEach(async () => {
   adapter = (await Base.leaseConnection()) as unknown as TypeLookupConnection;
 });

--- a/packages/activerecord/src/connection-adapters/type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/type-lookup.test.ts
@@ -76,6 +76,9 @@ describe.skipIf(adapterType === "postgres")("TypeLookupTest", () => {
     assertLookupType("decimal", "numeric");
     assertLookupType("decimal", "numeric(2,8)");
     assertLookupType("decimal", "NUMERIC");
+    assertLookupType("decimal", "number");
+    assertLookupType("decimal", "number(2,8)");
+    assertLookupType("decimal", "NUMBER");
   });
 
   it("float types", () => {
@@ -104,7 +107,14 @@ describe.skipIf(adapterType === "postgres")("TypeLookupTest", () => {
   });
 
   it("decimal without scale", () => {
-    for (const sqlType of ["decimal(2)", "decimal(2,0)", "numeric(2)", "numeric(2,0)"]) {
+    for (const sqlType of [
+      "decimal(2)",
+      "decimal(2,0)",
+      "numeric(2)",
+      "numeric(2,0)",
+      "number(2)",
+      "number(2,0)",
+    ]) {
       const castType = adapter.lookupCastType(sqlType);
       expect(castType.type()).toBe("decimal");
       expect(castType.cast(2.1)).toBe(2);

--- a/packages/activerecord/src/connection-adapters/type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/type-lookup.test.ts
@@ -1,20 +1,24 @@
 /**
  * Mirrors Rails activerecord/test/cases/connection_adapters/type_lookup_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Type } from "@blazetrails/activemodel";
 import { IntegerType } from "@blazetrails/activemodel";
+import { Base } from "../base.js";
 import { adapterType } from "../test-adapter.js";
 
-let adapter: AbstractSQLite3Adapter;
+/** The only surface this suite touches, and not on AbstractAdapter itself. */
+interface TypeLookupConnection {
+  lookupCastType(sqlType: string): Type;
+}
 
-beforeEach(() => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-});
+let adapter: TypeLookupConnection;
 
-afterEach(async () => {
-  await adapter.close();
+// Rails: `@connection = ActiveRecord::Base.lease_connection`
+// (type_lookup_test.rb:10) — the ambient lane connection, not a private
+// `:memory:` handle. Nothing here writes, so the lease is never closed.
+beforeEach(async () => {
+  adapter = (await Base.leaseConnection()) as unknown as TypeLookupConnection;
 });
 
 function assertLookupType(expected: string, sqlType: string) {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -261,13 +261,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "initialize_type_map",
-    "call": "alias_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mariadb?",
     "call": "match?",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails abstract_mysql_adapter.rb:92-94 runs `/mariadb/i.match?(full_version)` live; trails isMariadb (abstract-mysql-adapter.ts:422-424) returns the `_mariadb` flag computed once at connect by the same regex (mysql2-adapter.ts:1864)."


### PR DESCRIPTION
Audit finding from `audit-residual-memory-sites` (RFC 0029): connection-handler
and pool tests that Rails runs against the ambient file-backed `arunit` config
were instead building hardcoded `:memory:` HashConfigs / adapters.

## Tests

- `type-lookup.test.ts` — Rails `type_lookup_test.rb:10` leases
  `ActiveRecord::Base.lease_connection`; now does the same, so the suite finally
  exercises the lane's real adapter instead of always a private SQLite one.
- `connection-handler.test.ts` — the custom-pool test establishes from
  `ambientPoolConfiguration()`, mirroring
  `Base.connection_pool.db_config.configuration_hash`
  (`connection_handler_test.rb:287`). The 3-levels test regains the
  `dbConfig.database` file-path assertions Rails makes at `:54,:57`, plus the
  `common` 2-level entry at `:59`.
- `connection-handlers-multi-pool-config.test.ts` — rides the ambient config,
  gains Rails' `unless in_memory_db?` gate (`:21`), and `connected?` now mirrors
  Rails' `checkout.connect!` (`:83`) rather than a bare `leaseConnection()` —
  checkout is lazy on PG/MySQL, so the old form never actually connected.
- `schema-cache.test.ts` — the DDL-invalidation block uses `newRawTestAdapter()`
  (the analogue of `ARUnit2Model.lease_connection` at `schema_cache_test.rb:12`),
  with `things`/`stuff` teardown since the lane DB persists.
- `statement-pool.test.ts` — the Rails-mirrored `StatementPoolTest` already
  builds a bare `TestPool` with no connection, matching
  `statement_pool_test.rb:16`. Only the trails-only integration test needs an
  adapter; it takes the ambient sqlite one, is gated to sqlite runs, and drops
  its table in `finally`.

## Source fixes, required by the above

Pointing `TypeLookupTest` at the real lane connection surfaced that both the
MySQL and SQLite adapters inline a copy of
`AbstractAdapter#initialize_type_map` instead of calling super, and each copy
dropped aliases super provides:

- `AbstractMysqlAdapter.initializeTypeMap` — missing `clob → text` and
  `number → decimal` (`abstract_adapter.rb:898,:901`). Rails' MySQL map is
  `super` plus its own additions (`abstract_mysql_adapter.rb:711-712`).
- `AbstractSQLite3Adapter.initializeTypeMap` — missing `number → decimal`.
  Rails' `sqlite3_adapter.rb:499-502` is `super` plus one `register_class_with_limit`.

Both now use `TypeMap#aliasType`, the direct analogue of Rails' `alias_type`,
rather than open-coding the metadata-relookup.

Review follow-up: `type-lookup.test.ts` was also missing the `number`/`NUMBER`
cases Rails asserts at `type_lookup_test.rb:64-66` and `:90`. Added verbatim —
they are what surfaced the SQLite half of the above.

## Verified

Ran on all three lanes locally (sqlite, PostgreSQL and MySQL via an isolated
compose project), plus `pnpm typecheck` and eslint. Because the type-map change
touches two shared adapters, the sqlite pass was widened to the blast radius —
all of `connection-adapters/` plus `types`, `defaults`, `schema-dumper` and
`migration`: 1780 passed, 0 failed.

The two failures the first CI run reported — `TypeLookupTest > text types` on
MariaDB and `ConnectionHandlersMultiPoolConfigTest > connected?` on PG/MariaDB —
are fixed above.

Out of scope per the story: `pool-config.test.ts` / `pool-manager.test.ts` have
no Rails counterpart and never connect. Test names unchanged.

Filed `0029-sqlite-memory-fidelity/for-current-env-ignores-default-env` for a
divergence found on the way: `DatabaseConfig#forCurrentEnv` does not read
`DatabaseConfigurations.defaultEnv`, so `findDbConfig` misses 3-level entries;
the 3-levels test resolves through `configsFor` until that is fixed.

Closes-story: connection-handler-pool-tests-ambient
