### PR TITLE
test(connection-handling): build isPreventingWrites pools from their db_config

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -613,11 +613,6 @@ describe("withRoleAndShard loads Relation return values within scope (Story K ga
   });
 });
 
-// The pools below inject their adapter via `adapterFactory`, so the pool never
-// opens the declared `database` — `new BetterSQLite3Adapter()` defaults to
-// `:memory:` (sqlite3-adapter.ts:357). The config therefore states what is
-// actually opened; naming a file here would claim a file-backed pool that does
-// not exist.
 describe("AbstractAdapter#isPreventingWrites stack matching", () => {
   afterEach(async () => {
     connectedToStack().length = 0;
@@ -633,11 +628,7 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
     }
     Base.connectionHandler.establishConnection(
       new HashConfig("test", "UnrelatedAbstract", { adapter: "sqlite3", database: ":memory:" }),
-      {
-        owner: "UnrelatedAbstract",
-        role: "writing",
-        adapterFactory: () => new BetterSQLite3Adapter(),
-      },
+      { owner: "UnrelatedAbstract", role: "writing" },
     );
     const conn = await UnrelatedAbstract.leaseConnection();
     expect(conn.isPreventingWrites()).toBe(false);
@@ -662,11 +653,11 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
     }
     Base.connectionHandler.establishConnection(
       new HashConfig("test", "AnimalsRecord", { adapter: "sqlite3", database: ":memory:" }),
-      { owner: "AnimalsRecord", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
+      { owner: "AnimalsRecord", role: "writing" },
     );
     Base.connectionHandler.establishConnection(
       new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: ":memory:" }),
-      { owner: "MealsRecord", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
+      { owner: "MealsRecord", role: "writing" },
     );
     const animals = await AnimalsRecord.leaseConnection();
     const meals = await MealsRecord.leaseConnection();
@@ -699,15 +690,11 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
     }
     Base.connectionHandler.establishConnection(
       new HashConfig("test", "ApplicationRecord", { adapter: "sqlite3", database: ":memory:" }),
-      {
-        owner: ApplicationRecord,
-        role: "writing",
-        adapterFactory: () => new BetterSQLite3Adapter(),
-      },
+      { owner: ApplicationRecord, role: "writing" },
     );
     Base.connectionHandler.establishConnection(
       new HashConfig("test", "OtherAbstract", { adapter: "sqlite3", database: ":memory:" }),
-      { owner: "OtherAbstract", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
+      { owner: "OtherAbstract", role: "writing" },
     );
     const appConn = await ApplicationRecord.leaseConnection();
     const otherConn = await OtherAbstract.leaseConnection();

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -626,10 +626,11 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
         this.connectionClass = true;
       }
     }
-    Base.connectionHandler.establishConnection(
+    const pool = Base.connectionHandler.establishConnection(
       new HashConfig("test", "UnrelatedAbstract", { adapter: "sqlite3", database: ":memory:" }),
       { owner: "UnrelatedAbstract", role: "writing" },
     );
+    await pool.adapterReady;
     const conn = await UnrelatedAbstract.leaseConnection();
     expect(conn.isPreventingWrites()).toBe(false);
     Base.connectedTo({ role: "writing", preventWrites: true }, () => {
@@ -651,14 +652,15 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
         this.connectionClass = true;
       }
     }
-    Base.connectionHandler.establishConnection(
+    const animalsPool = Base.connectionHandler.establishConnection(
       new HashConfig("test", "AnimalsRecord", { adapter: "sqlite3", database: ":memory:" }),
       { owner: "AnimalsRecord", role: "writing" },
     );
-    Base.connectionHandler.establishConnection(
+    const mealsPool = Base.connectionHandler.establishConnection(
       new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: ":memory:" }),
       { owner: "MealsRecord", role: "writing" },
     );
+    await Promise.all([animalsPool.adapterReady, mealsPool.adapterReady]);
     const animals = await AnimalsRecord.leaseConnection();
     const meals = await MealsRecord.leaseConnection();
     AnimalsRecord.connectedTo({ role: "writing", preventWrites: true }, () => {
@@ -688,14 +690,15 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
         this.connectionClass = true;
       }
     }
-    Base.connectionHandler.establishConnection(
+    const appPool = Base.connectionHandler.establishConnection(
       new HashConfig("test", "ApplicationRecord", { adapter: "sqlite3", database: ":memory:" }),
       { owner: ApplicationRecord, role: "writing" },
     );
-    Base.connectionHandler.establishConnection(
+    const otherPool = Base.connectionHandler.establishConnection(
       new HashConfig("test", "OtherAbstract", { adapter: "sqlite3", database: ":memory:" }),
       { owner: "OtherAbstract", role: "writing" },
     );
+    await Promise.all([appPool.adapterReady, otherPool.adapterReady]);
     const appConn = await ApplicationRecord.leaseConnection();
     const otherConn = await OtherAbstract.leaseConnection();
     ApplicationRecord.connectedTo({ role: "writing", preventWrites: true }, () => {


### PR DESCRIPTION
Drops the zero-arg `adapterFactory: () => new BetterSQLite3Adapter()` override from the five pools in the `AbstractAdapter#isPreventingWrites stack matching` describe.

`new BetterSQLite3Adapter()` defaults `filenameOrConfig` to `:memory:` and never reads the pool `HashConfig`, so the declared `database` was inert — the pool opened `:memory:` regardless. Rails builds the pool adapter from `db_config`; a pool whose adapter ignores its own `db_config` has no Rails counterpart.

Without the override, `establishConnection` warms the adapter cache from `dbConfig.adapter` and `newConnection` goes through `dbConfig.newConnection()`, so config and reality now agree. Still in-memory (the config says `:memory:`), so nothing new is written to disk. Test names unchanged.

Closes-story: prevent-writes-pools-adapter-ignores-db-config
