### PR TITLE
test(sqlite): derive long-tail :memory: sites from the ambient config

### DIFF
--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -7,12 +7,22 @@ import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapt
 import { ReadOnlyError, StatementInvalid } from "./errors.js";
 import { itIfSupports } from "./support/supports.js";
 import { adapterType } from "./test-adapter.js";
+import { scratchDatabasePath } from "./support/scratch-database.js";
 import { PostgreSQLAdapter, PG_TEST_URL } from "./adapters/postgresql/test-helper.js";
 
+// Rails' `setup` is `@connection = ActiveRecord::Base.lease_connection` — the
+// ambient file-backed `arunit` connection, with `subscribers` coming from
+// schema.rb. trails cannot ride that connection here because write prevention
+// (`while_preventing_writes`) is only implemented on the sqlite3 adapter, so
+// this suite stays sqlite-pinned on every lane. What it does drop is the
+// `:memory:` database: the connection is file-backed like `arunit`, on its own
+// path because the suite creates and drops `subscribers` itself and must not
+// touch the worker's canonical copy.
 let adapter: AbstractSQLite3Adapter;
 
 beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(":memory:");
+  adapter = new BetterSQLite3Adapter(await scratchDatabasePath("prevent-writes"));
+  await adapter.exec(`DROP TABLE IF EXISTS "subscribers"`);
   await adapter.exec(
     `CREATE TABLE "subscribers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "nick" TEXT)`,
   );

--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -21,7 +21,7 @@ import { PostgreSQLAdapter, PG_TEST_URL } from "./adapters/postgresql/test-helpe
 let adapter: AbstractSQLite3Adapter;
 
 beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(await scratchDatabasePath("prevent-writes"));
+  adapter = new BetterSQLite3Adapter(await scratchDatabasePath("adapter-prevent-writes"));
   await adapter.exec(`DROP TABLE IF EXISTS "subscribers"`);
   await adapter.exec(
     `CREATE TABLE "subscribers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "nick" TEXT)`,

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1030,7 +1030,7 @@ describe("PreloaderTest", () => {
       database: {
         writing: {
           adapter: "sqlite3",
-          database: await scratchDatabasePath("animals"),
+          database: await scratchDatabasePath("associations-animals"),
           pool: 1,
         },
       },

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -44,6 +44,7 @@ import { markForDestruction, isMarkedForDestruction } from "./autosave-associati
 import { Preloader } from "./associations/preloader.js";
 import { Batch } from "./associations/preloader/batch.js";
 import { LoaderQuery } from "./associations/preloader/association.js";
+import { scratchDatabasePath } from "./support/scratch-database.js";
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -1022,8 +1023,17 @@ describe("PreloaderTest", () => {
     }
     registerModel("OtherDog", OtherDog);
 
+    // Rails' arunit2 is a file, not `:memory:` — the loaders must be
+    // distinguished by connection identity, and a real second database on disk
+    // is what makes that distinction observable.
     const [secondaryPool] = AnimalsBase.connectsTo({
-      database: { writing: { adapter: "sqlite3", database: ":memory:", pool: 1 } },
+      database: {
+        writing: {
+          adapter: "sqlite3",
+          database: await scratchDatabasePath("animals"),
+          pool: 1,
+        },
+      },
     });
     try {
       await secondaryPool.adapterReady;

--- a/packages/activerecord/src/database-statements.test.ts
+++ b/packages/activerecord/src/database-statements.test.ts
@@ -1,26 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
+import { Base } from "./base.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
-// Mirrors Rails' DatabaseStatementsTest. Each test leases a fresh in-memory
-// connection against the accounts table the corresponding Rails fixtures
-// materialize, created inline here so the suite stays self-contained.
+// Mirrors Rails' DatabaseStatementsTest, whose `setup` is
+// `@connection = ActiveRecord::Base.lease_connection` — the ambient
+// file-backed connection, with `accounts` coming from the canonical schema.
 async function returnTheInsertedId(method: "insert" | "create"): Promise<unknown> {
-  const conn = new BetterSQLite3Adapter(":memory:");
-  try {
-    await conn.executeMutation(
-      "CREATE TABLE accounts (id integer PRIMARY KEY, firm_id integer, credit_limit integer)",
-    );
-    const result = await conn[method](
-      "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)",
-    );
-    await conn.executeMutation("DROP TABLE IF EXISTS accounts");
-    return result;
-  } finally {
-    await conn.close();
-  }
+  const connection = await Base.leaseConnection();
+  return connection[method]("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)");
 }
 
 describe("DatabaseStatementsTest", () => {
+  fixtures({});
+
   it("insert should return the inserted id", async () => {
     expect(await returnTheInsertedId("insert")).not.toBeNull();
   });

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -2,15 +2,21 @@
  * Multi-DB migrator tests: two separate database connections run migrations independently.
  * Mirrors: activerecord/test/cases/multi_db_migrator_test.rb
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { scratchDatabasePath } from "./support/scratch-database.js";
 
-async function makeSqliteAdapter(): Promise<DatabaseAdapter> {
+// Rails takes `ActiveRecord::Base.connection_pool` and
+// `ARUnit2Model.connection_pool` — two *different* databases, both file-backed
+// (`arunit` / `arunit2`). The point of the test is that the two schema_migration
+// tables are independent, so each adapter gets its own on-disk database rather
+// than a private `:memory:` one.
+async function makeSqliteAdapter(label: string): Promise<DatabaseAdapter> {
   const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
-  return new BetterSQLite3Adapter(":memory:");
+  return new BetterSQLite3Adapter(await scratchDatabasePath(label));
 }
 
 function sensor(
@@ -43,8 +49,8 @@ describe("MultiDbMigratorTest", () => {
   let migrationsB: MigrationProxy[];
 
   beforeEach(async () => {
-    adapterA = await makeSqliteAdapter();
-    adapterB = await makeSqliteAdapter();
+    adapterA = await makeSqliteAdapter("multi-db-migrator-a");
+    adapterB = await makeSqliteAdapter("multi-db-migrator-b");
     smA = new SchemaMigration(adapterA);
     smB = new SchemaMigration(adapterB);
     await smA.createTable();
@@ -81,6 +87,13 @@ describe("MultiDbMigratorTest", () => {
         migration: () => ({ up: async () => {}, down: async () => {} }),
       },
     ];
+  });
+
+  // The databases are files now, so the handles have to be released — a leaked
+  // one keeps the WAL sidecars alive past the run.
+  afterEach(async () => {
+    await adapterA.close();
+    await adapterB.close();
   });
 
   it("schema migration is different for different connections", async () => {

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -139,11 +139,11 @@ describe("MultipleDbTest", () => {
   // Rails guards these two with `unless in_memory_db?` (multiple_db_test.rb): its
   // in-memory harness can't give arunit2 a genuinely separate pool, so College
   // would resolve to Base's connection. trails' arunit2 is always a genuinely
-  // separate pool — a provisioned database on PG/MySQL, its own `:memory:` DB on
-  // sqlite — so the assertions hold and we run them. This differs from the
-  // primary-class pair, which stay skipped because `connects_to(arunit/arunit)`
-  // is *expected* to share Base's connection — which independent in-memory DBs
-  // can't do.
+  // separate pool — a provisioned database on PG/MySQL, the `_arunit2` sibling
+  // file on sqlite (`support/arunit2-config.ts`) — so the assertions hold and we
+  // run them. This differs from the primary-class pair, which stay skipped
+  // because `connects_to(arunit/arunit)` is *expected* to share Base's
+  // connection — which independent in-memory DBs can't do.
   it("count on custom connection", async () => {
     expect(await ARUnit2Model.leaseConnection()).toBe(await College.leaseConnection());
     expect(await Base.leaseConnection()).not.toBe(await College.leaseConnection());

--- a/packages/activerecord/src/shard-selector.test.ts
+++ b/packages/activerecord/src/shard-selector.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "./base.js";
 import { ShardSelector } from "./middleware/shard-selector.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
+import { ambientPoolConfiguration } from "./test-adapter.js";
 
 describe("ShardSelectorTest", () => {
   afterEach(async () => {
@@ -9,7 +10,10 @@ describe("ShardSelectorTest", () => {
   });
 
   function setupShards() {
-    const dbConfig = new HashConfig("test", "Base", { adapter: "sqlite3", database: ":memory:" });
+    // Rails' ShardSelectorTest resolves shards from the ambient `arunit`
+    // configuration; the shard pool clones that config rather than naming a
+    // database of its own.
+    const dbConfig = new HashConfig("test", "Base", ambientPoolConfiguration());
     Base.connectionHandler.establishConnection(dbConfig, {
       owner: "Base",
       role: "writing",

--- a/packages/activerecord/src/support/scratch-database.test.ts
+++ b/packages/activerecord/src/support/scratch-database.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Covers the invariants callers of `scratchDatabasePath` depend on: a path that
+ * is stable per label (so an adapter can be closed and reopened against the
+ * same database), distinct across labels (so `MultiDbMigratorTest`'s two pools
+ * really are two databases), never `:memory:`, and empty on first use.
+ *
+ * The listeners `registerDbFileCleanupOnExit` attaches are taken back off in
+ * `afterAll` so they don't accumulate across test files.
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
+import { getOsAsync } from "@blazetrails/activesupport";
+import { unlinkDbFiles } from "./sqlite-template.js";
+import { scratchDatabasePath } from "./scratch-database.js";
+
+describe("scratchDatabasePath", () => {
+  const before = new Set(process.listeners("exit"));
+
+  afterAll(async () => {
+    const fs = await getFsAsync();
+    for (const path of [
+      await scratchDatabasePath("scratch-database-spec"),
+      await scratchDatabasePath("scratch-database-spec-other"),
+    ]) {
+      unlinkDbFiles(fs, path);
+    }
+    for (const fn of process.listeners("exit")) {
+      if (!before.has(fn)) process.off("exit", fn);
+    }
+  });
+
+  it("returns the same path for the same label", async () => {
+    expect(await scratchDatabasePath("scratch-database-spec")).toBe(
+      await scratchDatabasePath("scratch-database-spec"),
+    );
+  });
+
+  it("returns distinct paths for distinct labels", async () => {
+    expect(await scratchDatabasePath("scratch-database-spec")).not.toBe(
+      await scratchDatabasePath("scratch-database-spec-other"),
+    );
+  });
+
+  it("returns an on-disk path under the temp root, never :memory:", async () => {
+    const os = await getOsAsync();
+    const path = await scratchDatabasePath("scratch-database-spec");
+
+    expect(path).not.toBe(":memory:");
+    expect(path.startsWith(os.tmpdir())).toBe(true);
+    expect(path).toContain("scratch-database-spec");
+  });
+
+  it("wipes a database left behind by an earlier run", async () => {
+    const fs = await getFsAsync();
+    // The label has not been resolved yet, so this run's `writeFileSync` stands
+    // in for a file a killed run left at the same deterministic path.
+    const stale = (await scratchDatabasePath("scratch-database-spec")).replace(
+      "scratch-database-spec",
+      "scratch-database-stale",
+    );
+    fs.writeFileSync(stale, "not a database");
+    expect(fs.existsSync(stale)).toBe(true);
+
+    expect(await scratchDatabasePath("scratch-database-stale")).toBe(stale);
+    expect(fs.existsSync(stale)).toBe(false);
+  });
+});

--- a/packages/activerecord/src/support/scratch-database.ts
+++ b/packages/activerecord/src/support/scratch-database.ts
@@ -38,7 +38,8 @@ const paths = new Map<string, Promise<string>>();
  * The name carries the run token and the worker's isolation slot (the same two
  * discriminators `sqlite-template.ts` uses for the worker clone) so parallel
  * vitest workers — and parallel worktrees sharing one tmpdir — cannot land on
- * the same file.
+ * the same file. `label` discriminates *within* a worker, so name it after the
+ * test file that owns it: two files sharing a label would share a database.
  */
 export function scratchDatabasePath(label: string): Promise<string> {
   let resolved = paths.get(label);

--- a/packages/activerecord/src/support/scratch-database.ts
+++ b/packages/activerecord/src/support/scratch-database.ts
@@ -1,0 +1,63 @@
+/**
+ * On-disk scratch sqlite databases for tests whose Rails counterpart runs
+ * against a *distinct* database rather than `ActiveRecord::Base`'s own.
+ *
+ * Rails never opens a `:memory:` database in these spots — `arunit` and
+ * `arunit2` are both files in `config.example.yml`, so a test that needs a
+ * second, independent database (`MultiDbMigratorTest`'s two pools, the
+ * `AnimalsBase` pool behind `OtherDog`) gets a file, and a test that mutates a
+ * schema `ActiveRecord::Base` shares (`AdapterPreventWritesTest`'s
+ * create/drop of `subscribers`) gets one too rather than scribbling on the
+ * worker's canonical database.
+ *
+ * `:memory:` is the wrong stand-in for either: it silently makes every
+ * connection its own private database, which is exactly the divergence RFC
+ * 0029 exists to remove. A file path keeps the "two adapters, one database"
+ * and "two databases, one process" distinctions real.
+ *
+ * @internal
+ */
+
+import { getEnv, getOsAsync } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport/fs-adapter";
+import { registerDbFileCleanupOnExit, unlinkDbFiles } from "./sqlite-template.js";
+
+/**
+ * Resolved paths, keyed by label. One label is one database for the life of the
+ * worker, exactly as `arunit`/`arunit2` are one database for the life of a Rails
+ * run — reopening the same label hands back the same file. It also keeps the
+ * exit-cleanup listeners bounded: `registerDbFileCleanupOnExit` attaches one per
+ * distinct path, and a per-call unique name would exhaust the emitter's limit.
+ */
+const paths = new Map<string, Promise<string>>();
+
+/**
+ * An absolute path to an on-disk sqlite database for `label`, wiped on first
+ * use and registered for best-effort cleanup when the worker exits.
+ *
+ * The name carries the run token and the worker's isolation slot (the same two
+ * discriminators `sqlite-template.ts` uses for the worker clone) so parallel
+ * vitest workers — and parallel worktrees sharing one tmpdir — cannot land on
+ * the same file.
+ */
+export function scratchDatabasePath(label: string): Promise<string> {
+  let resolved = paths.get(label);
+  if (!resolved) {
+    resolved = buildScratchDatabasePath(label);
+    paths.set(label, resolved);
+  }
+  return resolved;
+}
+
+async function buildScratchDatabasePath(label: string): Promise<string> {
+  const path = await getPathAsync();
+  const os = await getOsAsync();
+  const runToken = getEnv("AR_TEST_RUN_TOKEN") || "x";
+  const slot = getEnv("VITEST_POOL_ID") || getEnv("VITEST_WORKER_ID") || "1";
+  const dbPath = path.join(os.tmpdir(), `ar-test-${label}-${runToken}-${slot}.sqlite`);
+  // A run killed before its exit handlers fire leaves the file behind, and a
+  // stale database would hand the caller someone else's schema.
+  unlinkDbFiles(await getFsAsync(), dbPath);
+  await registerDbFileCleanupOnExit(dbPath);
+  return dbPath;
+}

--- a/packages/activerecord/src/unconnected.test.ts
+++ b/packages/activerecord/src/unconnected.test.ts
@@ -17,6 +17,9 @@ describe("TestUnconnectedAdapter", () => {
     connectionName = Base.removeConnection();
   });
 
+  // Rails pairs the re-establish with `load_schema if in_memory_db?` — removing
+  // the connection destroys an in-memory database along with it. The ambient
+  // connection is a file, so the schema survives and there is nothing to reload.
   afterEach(async () => {
     await Base.establishConnection(connectionName);
   });

--- a/packages/activerecord/src/unconnected.test.ts
+++ b/packages/activerecord/src/unconnected.test.ts
@@ -1,20 +1,24 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "./base.js";
-import { HashConfig } from "./database-configurations/hash-config.js";
+import type { DatabaseConfig } from "./database-configurations/database-config.js";
 import { ConnectionNotDefined } from "./errors.js";
 
 class TestRecord extends Base {}
 
 describe("TestUnconnectedAdapter", () => {
   let underlying: { active: boolean };
+  // Rails' `remove_connection` hands back the db_config the pool was opened
+  // from, and teardown re-establishes it — the ambient `arunit` connection is
+  // never named or rebuilt by hand here.
+  let connectionName: DatabaseConfig | undefined;
 
   beforeEach(async () => {
-    Base.connectionHandler.establishConnection(
-      new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:", pool: 1 }),
-      { owner: "Base" },
-    );
     underlying = (await Base.leaseConnection()) as unknown as { active: boolean };
-    Base.removeConnection();
+    connectionName = Base.removeConnection();
+  });
+
+  afterEach(async () => {
+    await Base.establishConnection(connectionName);
   });
 
   it("connection no longer established", async () => {


### PR DESCRIPTION
RFC 0029. Six long-tail test sites hardcoded `":memory:"` where Rails'
counterpart rides the ambient file-backed `arunit` connection, or a second
file-backed database.

## Ambient connection / config

- **`database-statements.test.ts`** — Rails' `setup` is
  `@connection = ActiveRecord::Base.lease_connection`
  (`database_statements_test.rb:7`) and `accounts` comes from `schema.rb`. Now
  `fixtures({})` + `Base.leaseConnection()`; the inline `CREATE TABLE accounts`
  / `DROP TABLE` scaffolding is gone.
- **`unconnected.test.ts`** — Rails leases the ambient connection, captures what
  `remove_connection` hands back, and re-establishes it in teardown
  (`unconnected_test.rb:12,21`); it never names a database. Ported literally,
  including the previously-missing restore.
- **`shard-selector.test.ts`** — the shard pool clones `ambientPoolConfiguration()`
  instead of naming `":memory:"`.

## Explicit on-disk databases

New `support/scratch-database.ts` hands out a per-label on-disk sqlite path in
tmpdir (run token + worker slot in the name, wiped on first use, registered for
exit cleanup), covered by `support/scratch-database.test.ts`. Labels are named
after the owning test file, since a label is what discriminates *within* a
worker. Used where *distinct databases* are the point and `":memory:"` silently
gives every connection a private one:

- **`multi-db-migrator.test.ts`** — Rails takes `ActiveRecord::Base.connection_pool`
  and `ARUnit2Model.connection_pool` (`multi_db_migrator_test.rb:24-25`), two
  file-backed databases. Adapters are now closed in `afterEach` since the
  handles are real files.
- **`associations.test.ts`** — the `AnimalsBase.connectsTo` pool behind
  `OtherDog`; Rails' animals/`arunit2` connection is file-backed.
- **`adapter-prevent-writes.test.ts`** — Rails uses `Base.lease_connection`, but
  trails implements `withPreventedWrites` only on the sqlite3 adapter, so this
  suite stays sqlite-pinned on every lane (as it already was). Only the database
  changes: file-backed, on its own path because the suite creates and drops
  `subscribers` itself and must not touch the worker's canonical copy. Porting
  it onto the ambient connection needs `while_preventing_writes` on the
  PG/MySQL adapters — out of scope here.

## Comment-only sites

Left as-is per the story (they document Rails' `in_memory_db?` gates
correctly), except `multiple-db.test.ts:140-146`, which claimed arunit2 is "its
own `:memory:` DB on sqlite". That is stale — `support/arunit2-config.ts`
derives a `_arunit2` sibling *file* from the primary database name. Corrected.

## Testing

All six files plus `multiple-db.test.ts`, `associations.test.ts` and the new
helper spec pass locally on the sqlite lane — 194 passed, 1 skipped (the PG-only
encoding-error variant). `unconnected.test.ts` was also run `--no-file-parallelism`
alongside three connection-sensitive suites to confirm that tearing down and
re-establishing `Base`'s real pool leaves the worker intact. `pnpm typecheck` and
eslint clean.

## Review note: the `AnimalsBase` pool's adapter

Raised as non-blocking — `associations.test.ts`'s `finally` calls only
`removeConnectionPool("AnimalsBase")` and appears to leave the adapter open. It
does not: `removeConnectionPool` →
`disconnectPoolFromPoolManager` (`connection-adapters/abstract/connection-handler.ts:329-344`)
calls `void poolConfig.disconnect()`, which closes the driver connections. The
`void` is deliberate and documented there — Rails'
`remove_connection_pool` is synchronous while trails' `disconnect` is async
(`driver.close()`), so the drain settles in the background rather than forcing
the sync API async. The handle is closed, just not awaited, so no follow-up is
needed and no leaked handles should surface in CI.

Closes-story: long-tail-memory-sites-ambient

