### PR TITLE
fix(database-configurations): let an explicitly set defaultEnv outrank the process env

### DIFF
--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -198,6 +198,23 @@ describe("DatabaseConfigurationsTest", () => {
       expect(configs.findDbConfig("common")!.database).toBe("common.sqlite3");
     });
 
+    it("currentEnv prefers TRAILS_ENV over an explicitly set defaultEnv", () => {
+      // Deliberate deviation from Rails, where Rails.env (our defaultEnv)
+      // outranks ENV["RAILS_ENV"] (our TRAILS_ENV, per BC-2). TRAILS_ENV is how
+      // a deploy declares the process env, so no bootstrap may override it.
+      vi.stubEnv("TRAILS_ENV", "production");
+      vi.stubEnv("NODE_ENV", "test");
+      DatabaseConfigurations.defaultEnv = "default_env";
+
+      expect(DatabaseConfigurations.currentEnv()).toBe("production");
+
+      const configs = DatabaseConfigurations.fromRaw({
+        production: { primary: { adapter: "sqlite3", database: "prod.db" } },
+        default_env: { primary: { adapter: "sqlite3", database: "bad.db" } },
+      });
+      expect(configs.findDbConfig("primary")!.database).toBe("prod.db");
+    });
+
     it("fromEnv builds the synthesized DATABASE_URL config under currentEnv", () => {
       // The build env must equal currentEnv() so the runtime selectors in
       // connection-handling find the synthesized config under the same env.

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -5,7 +5,7 @@ import { Base } from "./base.js";
 
 describe("DatabaseConfigurationsTest", () => {
   beforeEach(() => {
-    DatabaseConfigurations.defaultEnv = "development";
+    DatabaseConfigurations.defaultEnv = null;
   });
 
   // Rails' second assertion (`blank?`) is Object#blank?, an ActiveSupport
@@ -151,22 +151,50 @@ describe("DatabaseConfigurationsTest", () => {
   describe("currentEnv resolution", () => {
     afterEach(() => {
       vi.unstubAllEnvs();
+      DatabaseConfigurations.defaultEnv = null;
     });
 
     it("currentEnv prefers TRAILS_ENV over NODE_ENV", () => {
-      DatabaseConfigurations.defaultEnv = "development";
+      DatabaseConfigurations.defaultEnv = null;
       vi.stubEnv("TRAILS_ENV", "production");
       vi.stubEnv("NODE_ENV", "test");
       expect(DatabaseConfigurations.currentEnv()).toBe("production");
     });
 
     it("currentEnv falls back to NODE_ENV, then defaultEnv", () => {
-      DatabaseConfigurations.defaultEnv = "development";
+      DatabaseConfigurations.defaultEnv = null;
       vi.stubEnv("NODE_ENV", "staging");
       expect(DatabaseConfigurations.currentEnv()).toBe("staging");
 
       vi.stubEnv("NODE_ENV", undefined as unknown as string);
       expect(DatabaseConfigurations.currentEnv()).toBe("development");
+    });
+
+    it("forCurrentEnv follows an explicitly set defaultEnv over the process env", () => {
+      // Rails: DEFAULT_ENV.call is Rails.env → RAILS_ENV → RACK_ENV, so an
+      // app-supplied env outranks the process env. defaultEnv is our Rails.env
+      // analogue; before this it was the terminal fallback only, so setting it
+      // left forCurrentEnv reading NODE_ENV and findDbConfig's first pass —
+      // which is gated on forCurrentEnv — never matched a 3-level entry.
+      vi.stubEnv("NODE_ENV", "test");
+      DatabaseConfigurations.defaultEnv = "default_env";
+
+      const configs = DatabaseConfigurations.fromRaw({
+        default_env: {
+          readonly: { adapter: "sqlite3", database: "readonly.sqlite3" },
+          primary: { adapter: "sqlite3", database: "primary.sqlite3" },
+        },
+        another_env: {
+          readonly: { adapter: "sqlite3", database: "bad-readonly.sqlite3" },
+          primary: { adapter: "sqlite3", database: "bad-primary.sqlite3" },
+        },
+        common: { adapter: "sqlite3", database: "common.sqlite3" },
+      });
+
+      expect(DatabaseConfigurations.currentEnv()).toBe("default_env");
+      expect(configs.findDbConfig("primary")!.database).toBe("primary.sqlite3");
+      expect(configs.findDbConfig("readonly")!.database).toBe("readonly.sqlite3");
+      expect(configs.findDbConfig("common")!.database).toBe("common.sqlite3");
     });
 
     it("fromEnv builds the synthesized DATABASE_URL config under currentEnv", () => {
@@ -184,7 +212,7 @@ describe("DatabaseConfigurationsTest", () => {
     it("forCurrentEnv and fromEnv resolve the same env when TRAILS_ENV differs from defaultEnv", () => {
       // Regression: forCurrentEnv previously used defaultEnv while fromEnv() used
       // currentEnv(), so findDbConfig by DB name failed when TRAILS_ENV != defaultEnv.
-      DatabaseConfigurations.defaultEnv = "development";
+      DatabaseConfigurations.defaultEnv = null;
       vi.stubEnv("TRAILS_ENV", "production");
 
       const configs = DatabaseConfigurations.fromEnv({

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -171,11 +171,6 @@ describe("DatabaseConfigurationsTest", () => {
     });
 
     it("forCurrentEnv follows an explicitly set defaultEnv over the process env", () => {
-      // Rails: DEFAULT_ENV.call is Rails.env → RAILS_ENV → RACK_ENV, so an
-      // app-supplied env outranks the process env. defaultEnv is our Rails.env
-      // analogue; before this it was the terminal fallback only, so setting it
-      // left forCurrentEnv reading NODE_ENV and findDbConfig's first pass —
-      // which is gated on forCurrentEnv — never matched a 3-level entry.
       vi.stubEnv("NODE_ENV", "test");
       DatabaseConfigurations.defaultEnv = "default_env";
 
@@ -192,6 +187,12 @@ describe("DatabaseConfigurationsTest", () => {
       });
 
       expect(DatabaseConfigurations.currentEnv()).toBe("default_env");
+      expect(configs.configsFor({ envName: "default_env" }).every((c) => c.forCurrentEnv)).toBe(
+        true,
+      );
+      expect(configs.configsFor({ envName: "another_env" }).some((c) => c.forCurrentEnv)).toBe(
+        false,
+      );
       expect(configs.findDbConfig("primary")!.database).toBe("primary.sqlite3");
       expect(configs.findDbConfig("readonly")!.database).toBe("readonly.sqlite3");
       expect(configs.findDbConfig("common")!.database).toBe("common.sqlite3");

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -155,7 +155,7 @@ describe("DatabaseConfigurationsTest", () => {
     });
 
     it("currentEnv prefers TRAILS_ENV over NODE_ENV", () => {
-      DatabaseConfigurations.defaultEnv = null;
+      DatabaseConfigurations.defaultEnv = "development";
       vi.stubEnv("TRAILS_ENV", "production");
       vi.stubEnv("NODE_ENV", "test");
       expect(DatabaseConfigurations.currentEnv()).toBe("production");
@@ -213,7 +213,7 @@ describe("DatabaseConfigurationsTest", () => {
     it("forCurrentEnv and fromEnv resolve the same env when TRAILS_ENV differs from defaultEnv", () => {
       // Regression: forCurrentEnv previously used defaultEnv while fromEnv() used
       // currentEnv(), so findDbConfig by DB name failed when TRAILS_ENV != defaultEnv.
-      DatabaseConfigurations.defaultEnv = null;
+      DatabaseConfigurations.defaultEnv = "development";
       vi.stubEnv("TRAILS_ENV", "production");
 
       const configs = DatabaseConfigurations.fromEnv({

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -37,11 +37,7 @@ type DbConfigHandler = (
 ) => DatabaseConfig | null | undefined;
 
 export class DatabaseConfigurations {
-  private static _defaultEnv: string = "development";
-  // Analogue of `defined?(Rails.env)` in `ConnectionHandling::RAILS_ENV`: the
-  // initial "development" above is the built-in fallback, not an app-supplied
-  // env, so only an explicit assignment may outrank TRAILS_ENV / NODE_ENV.
-  private static _defaultEnvSet = false;
+  private static _defaultEnv: string | null = null;
 
   /**
    * Mirrors: DatabaseConfigurations.db_config_handlers
@@ -64,18 +60,13 @@ export class DatabaseConfigurations {
 
   /** @internal */
   static get defaultEnv(): string {
+    if (this._defaultEnv === null) return "development";
     return this._defaultEnv || "default";
   }
 
-  /** @internal */
+  /** @internal Assign null to clear the override and fall back to the process env. */
   static set defaultEnv(value: string | null) {
-    if (value === null) {
-      this._defaultEnv = "development";
-      this._defaultEnvSet = false;
-      return;
-    }
     this._defaultEnv = value;
-    this._defaultEnvSet = true;
   }
 
   /**
@@ -95,7 +86,7 @@ export class DatabaseConfigurations {
    */
   static currentEnv(): string {
     return (
-      (this._defaultEnvSet ? this._defaultEnv : "") ||
+      this._defaultEnv ||
       getEnv("TRAILS_ENV") ||
       getEnv("NODE_ENV") ||
       DatabaseConfigurations.defaultEnv
@@ -129,7 +120,7 @@ export class DatabaseConfigurations {
       // merges DATABASE_URL via environment_url_config + merge_db_environment_variables.
       // Uses DatabaseConfigurations.defaultEnv (set by app bootstrap from RAILS_ENV/RACK_ENV),
       // not NODE_ENV — matching Rails' env resolution semantics.
-      this._configurations = this._buildConfigs(configurations, DatabaseConfigurations._defaultEnv);
+      this._configurations = this._buildConfigs(configurations, DatabaseConfigurations.defaultEnv);
     }
     // Register this instance as the current one for HashConfig.isPrimary lookup
     _currentConfigurations = this;

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -72,10 +72,16 @@ export class DatabaseConfigurations {
   /**
    * The active environment resolved from the process, mirroring Rails'
    * `ConnectionHandling::DEFAULT_ENV` / `RAILS_ENV` lambdas:
-   * `Rails.env` → `RAILS_ENV` → `RACK_ENV` → the literal default. Here
+   * `Rails.env` → `RAILS_ENV` → `RACK_ENV` → the literal default.
+   *
+   * `TRAILS_ENV` is the canonical runtime env (BC-2) and outranks everything,
+   * including an explicit `defaultEnv` — deploys set it to say which
+   * environment this process IS, so no bootstrap may override it. Below it,
    * `defaultEnv` (the app-bootstrap / test override) is the `Rails.env`
-   * analogue and so wins when set, `TRAILS_ENV` is the canonical runtime env
-   * (BC-2), and `NODE_ENV` is the one-release fallback.
+   * analogue and wins when set. `NODE_ENV` is last, ahead of only the literal
+   * default: it is a one-release bridge with no Rails counterpart, and test
+   * runners set it unconditionally, so it must not mask a deliberate
+   * `defaultEnv`.
    *
    * Single source of truth for "what env are we building/connecting for" —
    * `fromEnv` (which builds the configs) and the runtime config selectors in
@@ -86,8 +92,8 @@ export class DatabaseConfigurations {
    */
   static currentEnv(): string {
     return (
-      this._defaultEnv ||
       getEnv("TRAILS_ENV") ||
+      this._defaultEnv ||
       getEnv("NODE_ENV") ||
       DatabaseConfigurations.defaultEnv
     );

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -70,18 +70,25 @@ export class DatabaseConfigurations {
   }
 
   /**
-   * The active environment resolved from the process, mirroring Rails'
-   * `ConnectionHandling::DEFAULT_ENV` / `RAILS_ENV` lambdas:
+   * The active environment. Rails' counterpart is
+   * `ConnectionHandling::DEFAULT_ENV` / `RAILS_ENV`, which resolves
    * `Rails.env` → `RAILS_ENV` → `RACK_ENV` → the literal default.
+   * Ours resolves `TRAILS_ENV` → `defaultEnv` → `NODE_ENV` → the literal
+   * default.
    *
-   * `TRAILS_ENV` is the canonical runtime env (BC-2) and outranks everything,
-   * including an explicit `defaultEnv` — deploys set it to say which
-   * environment this process IS, so no bootstrap may override it. Below it,
-   * `defaultEnv` (the app-bootstrap / test override) is the `Rails.env`
-   * analogue and wins when set. `NODE_ENV` is last, ahead of only the literal
-   * default: it is a one-release bridge with no Rails counterpart, and test
-   * runners set it unconditionally, so it must not mask a deliberate
-   * `defaultEnv`.
+   * DELIBERATE DEVIATION — `TRAILS_ENV` outranks `defaultEnv`, Rails is the
+   * other way round. Per BC-2 (`docs/infrastructure/browser-compat-plan.md:88`)
+   * `TRAILS_ENV` is the rename of the old `process.env.NODE_ENV` reads, so it
+   * maps to Rails' `ENV["RAILS_ENV"]` / `ENV["RACK_ENV"]`, and `defaultEnv` is
+   * the `Rails.env` analogue — by `connection_handling.rb:6` `defaultEnv` would
+   * therefore win. trails inverts that on purpose: `TRAILS_ENV` is how a deploy
+   * declares which environment the process is, and no in-process bootstrap may
+   * override it. Consequence to know: with `TRAILS_ENV` set, assigning
+   * `defaultEnv` has no effect on the resolved env.
+   *
+   * `NODE_ENV` sits last, ahead of only the literal default: it is a
+   * one-release bridge with no Rails counterpart, and test runners set it
+   * unconditionally, so it must not mask a deliberate `defaultEnv`.
    *
    * Single source of truth for "what env are we building/connecting for" —
    * `fromEnv` (which builds the configs) and the runtime config selectors in

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -38,6 +38,10 @@ type DbConfigHandler = (
 
 export class DatabaseConfigurations {
   private static _defaultEnv: string = "development";
+  // Analogue of `defined?(Rails.env)` in `ConnectionHandling::RAILS_ENV`: the
+  // initial "development" above is the built-in fallback, not an app-supplied
+  // env, so only an explicit assignment may outrank TRAILS_ENV / NODE_ENV.
+  private static _defaultEnvSet = false;
 
   /**
    * Mirrors: DatabaseConfigurations.db_config_handlers
@@ -64,16 +68,23 @@ export class DatabaseConfigurations {
   }
 
   /** @internal */
-  static set defaultEnv(value: string) {
+  static set defaultEnv(value: string | null) {
+    if (value === null) {
+      this._defaultEnv = "development";
+      this._defaultEnvSet = false;
+      return;
+    }
     this._defaultEnv = value;
+    this._defaultEnvSet = true;
   }
 
   /**
    * The active environment resolved from the process, mirroring Rails'
    * `ConnectionHandling::DEFAULT_ENV` / `RAILS_ENV` lambdas:
-   * `RAILS_ENV` → `RACK_ENV` → the configured default. Here `TRAILS_ENV` is
-   * the canonical runtime env (BC-2), `NODE_ENV` is the one-release fallback,
-   * and `defaultEnv` (the app-bootstrap / test override) is the terminal value.
+   * `Rails.env` → `RAILS_ENV` → `RACK_ENV` → the literal default. Here
+   * `defaultEnv` (the app-bootstrap / test override) is the `Rails.env`
+   * analogue and so wins when set, `TRAILS_ENV` is the canonical runtime env
+   * (BC-2), and `NODE_ENV` is the one-release fallback.
    *
    * Single source of truth for "what env are we building/connecting for" —
    * `fromEnv` (which builds the configs) and the runtime config selectors in
@@ -83,7 +94,12 @@ export class DatabaseConfigurations {
    * @internal
    */
   static currentEnv(): string {
-    return getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
+    return (
+      (this._defaultEnvSet ? this._defaultEnv : "") ||
+      getEnv("TRAILS_ENV") ||
+      getEnv("NODE_ENV") ||
+      DatabaseConfigurations.defaultEnv
+    );
   }
 
   /**
@@ -488,7 +504,8 @@ DatabaseConfigurations.registerDbConfigHandler((envName, name, url, config) => {
 // forCurrentEnv must use the same resolver as fromEnv() so that findDbConfig by
 // DB name locates the config built for the active env. Mirrors Rails:
 // DatabaseConfig#for_current_env? and DatabaseConfigurations#build_configs both
-// call ConnectionHandling::DEFAULT_ENV.call (RAILS_ENV → RACK_ENV → "development").
+// call ConnectionHandling::DEFAULT_ENV.call
+// (Rails.env → RAILS_ENV → RACK_ENV → the literal default).
 _setDefaultEnvGetter(() => DatabaseConfigurations.currentEnv());
 
 // Register the primary checker so HashConfig.isPrimary can consult the


### PR DESCRIPTION
`DatabaseConfigurations.defaultEnv` was the *terminal* fallback in
`currentEnv()`, behind both `TRAILS_ENV` and `NODE_ENV`. Under vitest
`NODE_ENV=test` is always set, so assigning `defaultEnv = "default_env"` did
nothing: `DatabaseConfig#forCurrentEnv` compared against `"test"` and stayed
`false`, and `findDbConfig`'s first pass — which is gated on `forCurrentEnv` —
never matched a 3-level entry by name. `findDbConfig("primary")` on a
`{ default_env: { primary: … } }` config returned `undefined`.

The resolution order is now:

`TRAILS_ENV` → `defaultEnv` (when explicitly set) → `NODE_ENV` → literal default

`TRAILS_ENV` stays on top and is unchanged by this PR. **This is a deliberate
deviation from Rails, not a mirror of it**, and is labelled as such at the call
site. Rails' `connection_handling.rb:6` puts `Rails.env` ahead of
`ENV["RAILS_ENV"]` / `ENV["RACK_ENV"]`; per BC-2
(`docs/infrastructure/browser-compat-plan.md:88`) `TRAILS_ENV` is the rename of
the old `process.env.NODE_ENV` reads, so it maps to those process env vars and
`defaultEnv` is the `Rails.env` analogue — by Rails' precedence `defaultEnv`
would win. trails inverts it because `TRAILS_ENV` is how a deploy declares which
environment the process is, and no in-process bootstrap may override that.
Known consequence: with `TRAILS_ENV` set, assigning `defaultEnv` does not change
the resolved env.

Only `NODE_ENV` moves below an explicit `defaultEnv` — it is a one-release
bridge with no Rails counterpart, and test runners set it unconditionally, so it
was masking deliberate `defaultEnv` assignments. That single move is what fixes
the bug.

`_defaultEnv` now starts as `null` (unset) rather than a literal
`"development"`, so "explicitly assigned" is distinguishable from "never
touched"; assigning `null` clears an override. With `defaultEnv` untouched the
resolved value is unchanged. `findDbConfig` itself — already a line-for-line
port of Rails' — is untouched, as is the `defaultEnv` getter's observable
behaviour (`""` still reads back as `"default"`, per
`test_default_env_fall_back_to_default_env_when_rails_env_or_rack_env_is_empty_string`).

Switching `??` to `||` in the chain also matches `RAILS_ENV`'s `.presence`
(blank string → nil) semantics.

Regression test `forCurrentEnv follows an explicitly set defaultEnv over the
process env` builds the config hash from
`connection_handler_test.rb:test_establish_connection_using_3_levels_config`
and asserts `forCurrentEnv` splits the two envs and all three `findDbConfig`
lookups resolve. On baseline it fails (`currentEnv()` is `"test"`, and
`primary` / `readonly` come back `undefined`).

`currentEnv prefers TRAILS_ENV over an explicitly set defaultEnv` pins the
deviation itself — it fails if the order is flipped back.
`currentEnv prefers TRAILS_ENV over NODE_ENV` and `forCurrentEnv and fromEnv
resolve the same env when TRAILS_ENV differs from defaultEnv` keep setting
`defaultEnv = "development"`, so they now additionally pin that `TRAILS_ENV`
beats an explicit `defaultEnv`. No test names change.

Verified green: `database-configurations*`, `shard-keys`, `connection-handler`,
`connection-handlers-multi-db`, `connection-handlers-sharding-db`,
`merge-and-resolve-default-url-config`, `connection-swapping-nested`,
`connection-handling`, and all of `activerecord-cli` (every suite that assigns
`defaultEnv`).

### Deferred

The story's third acceptance criterion — drop the `configsFor` workaround in
`connection-handler.test.ts`'s "establish connection using 3 levels config" —
depends on #5492, which is still open. Rather than stack, it is registered as
`0029-sqlite-memory-fidelity/three-levels-config-through-find-db-config`.

Closes-story: for-current-env-ignores-default-env
