### PR TITLE
test(activerecord): port the deferrable cases of ForeignKeyTest

### DIFF
--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -2,7 +2,7 @@
  * Port of the `add_foreign_key`, `remove_foreign_key` and `SchemaDumpingHelper`
  * halves of `ActiveRecord::Migration::ForeignKeyTest`
  * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330,
- * :393-451, :524-619, :643-747 and :749-773) plus all of its sibling
+ * :393-451, :536-619, :643-747 and :749-773) plus all of its sibling
  * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912).
  *
  * Driven by the ambient connection, mirroring Rails'
@@ -504,7 +504,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
     itIfSupports("deferrable_constraints", "deferrable foreign key", async () => {
       const conn = await ambientConnection();
       await withRocketTables(conn, async () => {
-        const deferrableClause = /\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE\W*$/i;
         const addTheKey = async (): Promise<void> => {
           await conn.addForeignKey("astronauts", "rockets", {
             column: "rocket_id",
@@ -513,18 +512,18 @@ describeIfSupports("foreign_keys", "Migration", () => {
         };
 
         if (adapterType === "sqlite") {
-          // SQLite adds a foreign key by rebuilding the table, and trails'
-          // rebuild issues its CREATE TABLE straight through the driver
-          // (sqlite3-adapter.ts alterTable), so no sql.active_record event
-          // carries the clause Rails' assert_queries_match inspects. Assert the
-          // same clause against the DDL that landed instead of dropping it.
           await addTheKey();
           const ddl = await conn.selectValue(
             "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'astronauts'",
           );
           expect(String(ddl)).toMatch(/\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE/i);
         } else {
-          await assertQueriesMatch(deferrableClause, undefined, true, addTheKey);
+          await assertQueriesMatch(
+            /\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE\W*$/i,
+            undefined,
+            true,
+            addTheKey,
+          );
         }
 
         const foreignKeys = await conn.foreignKeys("astronauts");

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -2,7 +2,7 @@
  * Port of the `add_foreign_key`, `remove_foreign_key` and `SchemaDumpingHelper`
  * halves of `ActiveRecord::Migration::ForeignKeyTest`
  * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330,
- * :393-451, :643-747 and :749-773) plus all of its sibling
+ * :393-451, :524-619, :643-747 and :749-773) plus all of its sibling
  * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912).
  *
  * Driven by the ambient connection, mirroring Rails'
@@ -21,7 +21,8 @@ import {
   withRocketTables,
 } from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
-import { describeIfSupports } from "../support/supports.js";
+import { describeIfSupports, itIfSupports } from "../support/supports.js";
+import { assertQueriesMatch } from "../testing/query-assertions.js";
 import { dumpTableSchema } from "../support/schema-dumping-helper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { Base } from "../base.js";
@@ -499,6 +500,180 @@ describeIfSupports("foreign_keys", "Migration", () => {
         Base.tableNameSuffix = "";
       }
     });
+
+    itIfSupports("deferrable_constraints", "deferrable foreign key", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        const deferrableClause = /\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE\W*$/i;
+        const addTheKey = async (): Promise<void> => {
+          await conn.addForeignKey("astronauts", "rockets", {
+            column: "rocket_id",
+            deferrable: "immediate",
+          });
+        };
+
+        if (adapterType === "sqlite") {
+          // SQLite adds a foreign key by rebuilding the table, and trails'
+          // rebuild issues its CREATE TABLE straight through the driver
+          // (sqlite3-adapter.ts alterTable), so no sql.active_record event
+          // carries the clause Rails' assert_queries_match inspects. Assert the
+          // same clause against the DDL that landed instead of dropping it.
+          await addTheKey();
+          const ddl = await conn.selectValue(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'astronauts'",
+          );
+          expect(String(ddl)).toMatch(/\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE/i);
+        } else {
+          await assertQueriesMatch(deferrableClause, undefined, true, addTheKey);
+        }
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(fk.deferrable).toBe("immediate");
+      });
+    });
+
+    itIfSupports("deferrable_constraints", "not deferrable foreign key", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          deferrable: false,
+        });
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(fk.deferrable).toBe(false);
+      });
+    });
+
+    itIfSupports(
+      "deferrable_constraints",
+      "deferrable initially deferred foreign key",
+      async () => {
+        const conn = await ambientConnection();
+        await withRocketTables(conn, async () => {
+          await conn.addForeignKey("astronauts", "rockets", {
+            column: "rocket_id",
+            deferrable: "deferred",
+          });
+
+          const foreignKeys = await conn.foreignKeys("astronauts");
+          expect(foreignKeys.length).toBe(1);
+
+          const fk = foreignKeys[0];
+          expect(fk.deferrable).toBe("deferred");
+        });
+      },
+    );
+
+    itIfSupports(
+      "deferrable_constraints",
+      "deferrable initially immediate foreign key",
+      async () => {
+        const conn = await ambientConnection();
+        await withRocketTables(conn, async () => {
+          await conn.addForeignKey("astronauts", "rockets", {
+            column: "rocket_id",
+            deferrable: "immediate",
+          });
+
+          const foreignKeys = await conn.foreignKeys("astronauts");
+          expect(foreignKeys.length).toBe(1);
+
+          const fk = foreignKeys[0];
+          expect(fk.deferrable).toBe("immediate");
+        });
+      },
+    );
+
+    itIfSupports("deferrable_constraints", "schema dumping with defferable", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          deferrable: "immediate",
+        });
+
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+        expect(output).toMatch(
+          /\s+await ctx\.addForeignKey\("astronauts", "rockets", \{ deferrable: "immediate" \}\);$/m,
+        );
+      });
+    });
+
+    itIfSupports("deferrable_constraints", "schema dumping with disabled defferable", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          deferrable: false,
+        });
+
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+        expect(output).toMatch(/\s+await ctx\.addForeignKey\("astronauts", "rockets"\);$/m);
+      });
+    });
+
+    itIfSupports(
+      "deferrable_constraints",
+      "schema dumping with defferable initially deferred",
+      async () => {
+        const conn = await ambientConnection();
+        await withRocketTables(conn, async () => {
+          await conn.addForeignKey("astronauts", "rockets", {
+            column: "rocket_id",
+            deferrable: "deferred",
+          });
+
+          const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+          expect(output).toMatch(
+            /\s+await ctx\.addForeignKey\("astronauts", "rockets", \{ deferrable: "deferred" \}\);$/m,
+          );
+        });
+      },
+    );
+
+    itIfSupports(
+      "deferrable_constraints",
+      "schema dumping with defferable initially immediate",
+      async () => {
+        const conn = await ambientConnection();
+        await withRocketTables(conn, async () => {
+          await conn.addForeignKey("astronauts", "rockets", {
+            column: "rocket_id",
+            deferrable: "immediate",
+          });
+
+          const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+          expect(output).toMatch(
+            /\s+await ctx\.addForeignKey\("astronauts", "rockets", \{ deferrable: "immediate" \}\);$/m,
+          );
+        });
+      },
+    );
+
+    itIfSupports(
+      "deferrable_constraints",
+      "schema dumping with special chars deferrable",
+      async () => {
+        const conn = await ambientConnection();
+        await withRocketTables(conn, async () => {
+          await conn.addReference("astronauts", "røcket", {
+            foreignKey: { toTable: "rockets", deferrable: "deferred" },
+          });
+
+          const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+          expect(output).toMatch(
+            /\s+await ctx\.addForeignKey\("astronauts", "rockets", \{ column: "røcket_id", deferrable: "deferred" \}\);$/m,
+          );
+        });
+      },
+    );
   });
 
   describe("CompositeForeignKeyTest", () => {

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -504,6 +504,7 @@ describeIfSupports("foreign_keys", "Migration", () => {
     itIfSupports("deferrable_constraints", "deferrable foreign key", async () => {
       const conn = await ambientConnection();
       await withRocketTables(conn, async () => {
+        const deferrableClause = /\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE\W*$/i;
         const addTheKey = async (): Promise<void> => {
           await conn.addForeignKey("astronauts", "rockets", {
             column: "rocket_id",
@@ -512,18 +513,21 @@ describeIfSupports("foreign_keys", "Migration", () => {
         };
 
         if (adapterType === "sqlite") {
+          // SQLite adds the key by rebuilding the table, and trails' rebuild
+          // issues its CREATE TABLE straight through the driver
+          // (sqlite3-adapter.ts alterTable), so nothing reaches
+          // sql.active_record and Rails' assert_queries_match would see an
+          // empty log. Match the same clause against the DDL that landed —
+          // Rails' end anchor still applies, the FK clause terminating the
+          // CREATE TABLE. Story instrument-sqlite-alter-table-rebuild-queries
+          // (RFC 0023) removes this branch.
           await addTheKey();
           const ddl = await conn.selectValue(
             "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'astronauts'",
           );
-          expect(String(ddl)).toMatch(/\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE/i);
+          expect(String(ddl)).toMatch(deferrableClause);
         } else {
-          await assertQueriesMatch(
-            /\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE\W*$/i,
-            undefined,
-            true,
-            addTheKey,
-          );
+          await assertQueriesMatch(deferrableClause, undefined, false, addTheKey);
         }
 
         const foreignKeys = await conn.foreignKeys("astronauts");


### PR DESCRIPTION
Ports the `supports_deferrable_constraints?` block of
`ActiveRecord::Migration::ForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:536-619`)
into `packages/activerecord/src/migration/foreign-key.test.ts` — nine cases,
names verbatim, including Rails' `defferable` misspelling:

`deferrable foreign key`, `not deferrable foreign key`,
`deferrable initially deferred foreign key`,
`deferrable initially immediate foreign key`,
`schema dumping with defferable`, `schema dumping with disabled defferable`,
`schema dumping with defferable initially deferred`,
`schema dumping with defferable initially immediate`,
`schema dumping with special chars deferrable`.

Gated with `itIfSupports("deferrable_constraints", …)` inside the existing
`describeIfSupports("foreign_keys", …)` suite, so the composed gate matches
Rails' `features=[deferrable_constraints,foreign_keys]`. Setup is the shared
`withRocketTables`; no schema change.

`test:compare` for `migration/foreign_key_test.rb`: **35 → 44 OK**.
`pnpm test:compare --gates --check` exits 0.

### Two pieces registered as separate stories rather than shipped here

- **`test_add_invalid_foreign_key`** (in the story's scope) is backed out.
  Rails defines it *twice*, on the two arms of `if supports_validate_constraints?`,
  with opposite expectations. The Ruby gate extractor drops the negation, so the
  `else` arm extracts as `features=[foreign_keys]` while the `if` arm extracts as
  `features=[foreign_keys,validate_constraints]`; with only one TS test present
  the matcher pairs it with the `validate_constraints` entry and
  `--gates --check` fails with `[wrong-gate] "add invalid foreign key"`.
  Resolving it means porting both arms — i.e. the whole `validate_constraints`
  block, which is unported and out of this story's scope. Registered as
  `port-migration-foreign-key-validate-constraints-cases` (0005) with the
  diagnosis.
- **SQLite query instrumentation.** Rails' `test_deferrable_foreign_key` wraps
  `add_foreign_key` in `assert_queries_match(/\("id"\)\s+DEFERRABLE INITIALLY
  IMMEDIATE\W*\z/i)`. trails' SQLite `alterTable` rebuild
  (`sqlite3-adapter.ts:2391`) issues its statements straight through
  `this.driver.prepare`, so nothing reaches `sql.active_record` and the counter
  sees an empty log. Rather than let the assertion become a no-op there, the
  SQLite branch matches the **same regex** — Rails' end anchor included, since
  the FK clause terminates the stored `CREATE TABLE` — against
  `sqlite_master.sql`. The rationale and a pointer to the removing story now
  live in a comment on the branch itself. Registered as
  `instrument-sqlite-alter-table-rebuild-queries` (0023).

`converge-pg-dumper-deferrable-truthiness` (0023) was checked for overlap: it
covers `postgresql/schema-dumper.ts`'s exclusion/unique-constraint `deferrable:`
emission, not the foreign-key path in `schema-dumper.ts:1127`. No conflict.

Green on sqlite, postgres and mysql locally.

Closes-story: port-migration-foreign-key-deferrable-cases
