### PR TITLE
test(sqlite3): run adapter sibling suites on the ambient connection

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -1,17 +1,23 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
+import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { BigIntegerType, IntegerType, BooleanType } from "@blazetrails/activemodel";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 
 let adapter: AbstractSQLite3Adapter;
 const bigType = new BigIntegerType();
 const intType = new IntegerType();
 const boolType = new BooleanType();
 
-beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-  await adapter.exec(`
+describeIfSqlite("SQLite3 bigint round-trip", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  beforeEach(async () => {
+    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    await adapter.exec(`DROP TABLE IF EXISTS "big_items"`);
+    await adapter.exec(`
     CREATE TABLE "big_items" (
       "id"     INTEGER PRIMARY KEY AUTOINCREMENT,
       "score"  BIGINT NOT NULL,
@@ -19,14 +25,13 @@ beforeEach(async () => {
       "active" INTEGER NOT NULL DEFAULT 1
     )
   `);
-});
+  });
 
-afterEach(async () => {
-  await adapter.exec(`DROP TABLE IF EXISTS "big_items"`).catch(() => undefined);
-  await adapter.close();
-});
+  // The ambient database outlives the test, so the ad-hoc table must be dropped.
+  afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS "big_items"`).catch(() => undefined);
+  });
 
-describeIfSqlite("SQLite3 bigint round-trip", () => {
   const BIG = 2n ** 62n; // 4611686018427387904 — well above Number.MAX_SAFE_INTEGER
 
   it("returns bigint for BIGINT column", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -17,17 +17,17 @@ describeIfSqlite("SQLite3 bigint round-trip", () => {
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
     await adapter.exec(`
-    CREATE TABLE "big_items" (
-      "id"     INTEGER PRIMARY KEY AUTOINCREMENT,
-      "score"  BIGINT NOT NULL,
-      "count"  INTEGER NOT NULL DEFAULT 0,
-      "active" INTEGER NOT NULL DEFAULT 1
-    )
-  `);
+      CREATE TABLE "big_items" (
+        "id"     INTEGER PRIMARY KEY AUTOINCREMENT,
+        "score"  BIGINT NOT NULL,
+        "count"  INTEGER NOT NULL DEFAULT 0,
+        "active" INTEGER NOT NULL DEFAULT 1
+      )
+    `);
   });
 
   afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS "big_items"`).catch(() => undefined);
+    await adapter.dropTable("big_items", { ifExists: true });
   });
 
   const BIG = 2n ** 62n; // 4611686018427387904 — well above Number.MAX_SAFE_INTEGER

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -4,7 +4,7 @@ import { describeIfSqlite } from "./test-helper.js";
 import { BigIntegerType, IntegerType, BooleanType } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 let adapter: AbstractSQLite3Adapter;
 const bigType = new BigIntegerType();
@@ -12,11 +12,10 @@ const intType = new IntegerType();
 const boolType = new BooleanType();
 
 describeIfSqlite("SQLite3 bigint round-trip", () => {
-  fixtures([], { useTransactionalTests: false });
+  fixtures([]);
 
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
-    await adapter.exec(`DROP TABLE IF EXISTS "big_items"`);
     await adapter.exec(`
     CREATE TABLE "big_items" (
       "id"     INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -27,7 +26,6 @@ describeIfSqlite("SQLite3 bigint round-trip", () => {
   `);
   });
 
-  // The ambient database outlives the test, so the ad-hoc table must be dropped.
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS "big_items"`).catch(() => undefined);
   });

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -6,16 +6,14 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
 let adapter: AbstractSQLite3Adapter;
 
 describeIfSqlite("SQLite3CollationTest", () => {
-  fixtures([], { useTransactionalTests: false });
+  fixtures([]);
 
-  // Rails `setup`: `@connection = ActiveRecord::Base.lease_connection`, then
-  // `create_table :collation_table_sqlite3, force: true`.
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
     await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`);
@@ -28,8 +26,6 @@ describeIfSqlite("SQLite3CollationTest", () => {
   )`);
   });
 
-  // Rails `teardown`: drop_table :collation_table_sqlite3, if_exists: true.
-  // Required now that the ambient database outlives the test.
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`).catch(() => undefined);
   });

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -2,30 +2,38 @@
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/collation_test.rb
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
+import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
 let adapter: AbstractSQLite3Adapter;
 
-beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-  await adapter.exec(`CREATE TABLE "collation_table_sqlite3" (
+describeIfSqlite("SQLite3CollationTest", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  // Rails `setup`: `@connection = ActiveRecord::Base.lease_connection`, then
+  // `create_table :collation_table_sqlite3, force: true`.
+  beforeEach(async () => {
+    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`);
+    await adapter.exec(`CREATE TABLE "collation_table_sqlite3" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "string_nocase" VARCHAR(255) COLLATE "NOCASE",
     "text_rtrim" TEXT COLLATE "RTRIM",
     "decimal_col" DECIMAL(6, 2),
     "string_after_decimal_nocase" VARCHAR(255) COLLATE "NOCASE"
   )`);
-});
+  });
 
-afterEach(async () => {
-  await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`).catch(() => undefined);
-  await adapter.close();
-});
+  // Rails `teardown`: drop_table :collation_table_sqlite3, if_exists: true.
+  // Required now that the ambient database outlives the test.
+  afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`).catch(() => undefined);
+  });
 
-describeIfSqlite("SQLite3CollationTest", () => {
   it("string column with collation", async () => {
     const columns = await adapter.columns("collation_table_sqlite3");
 

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -16,18 +16,18 @@ describeIfSqlite("SQLite3CollationTest", () => {
 
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
-    await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`);
+    await adapter.dropTable("collation_table_sqlite3", { ifExists: true });
     await adapter.exec(`CREATE TABLE "collation_table_sqlite3" (
-    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "string_nocase" VARCHAR(255) COLLATE "NOCASE",
-    "text_rtrim" TEXT COLLATE "RTRIM",
-    "decimal_col" DECIMAL(6, 2),
-    "string_after_decimal_nocase" VARCHAR(255) COLLATE "NOCASE"
-  )`);
+      "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+      "string_nocase" VARCHAR(255) COLLATE "NOCASE",
+      "text_rtrim" TEXT COLLATE "RTRIM",
+      "decimal_col" DECIMAL(6, 2),
+      "string_after_decimal_nocase" VARCHAR(255) COLLATE "NOCASE"
+    )`);
   });
 
   afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`).catch(() => undefined);
+    await adapter.dropTable("collation_table_sqlite3", { ifExists: true });
   });
 
   it("string column with collation", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -3,10 +3,11 @@
  * (plus the JSONSharedTestCases it includes).
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
+import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
-import { Base } from "../../index.js";
 
 let adapter: AbstractSQLite3Adapter;
 
@@ -16,25 +17,28 @@ class JsonDataType extends Base {
   }
 }
 
-beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-  JsonDataType.adapter = adapter;
-  // Mirrors Rails JSONSharedTestCases#setup creating the table ad-hoc:
-  //   t.json "payload", default: {}
-  //   t.json "settings"
-  await adapter.createTable("json_data_type", {}, (t: any) => {
-    t.json("payload", { default: "{}" });
-    t.json("settings");
-  });
-});
-
-afterEach(async () => {
-  // Mirrors Rails JSONSharedTestCases#teardown: drop_table :json_data_type.
-  await adapter.dropTable("json_data_type", { ifExists: true });
-  await adapter.close();
-});
-
 describeIfSqlite("SQLite3JSONTest", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  beforeEach(async () => {
+    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    await adapter.dropTable("json_data_type", { ifExists: true });
+    // Mirrors Rails JSONSharedTestCases#setup creating the table ad-hoc:
+    //   t.json "payload", default: {}
+    //   t.json "settings"
+    await adapter.createTable("json_data_type", {}, (t: any) => {
+      t.json("payload", { default: "{}" });
+      t.json("settings");
+    });
+    JsonDataType.resetColumnInformation();
+  });
+
+  afterEach(async () => {
+    // Mirrors Rails JSONSharedTestCases#teardown: drop_table :json_data_type.
+    await adapter.dropTable("json_data_type", { ifExists: true });
+    JsonDataType.resetColumnInformation();
+  });
+
   it("test_assigning_string_literal", async () => {
     await JsonDataType.loadSchema();
     const json = await JsonDataType.create({ payload: "foo" });

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -7,7 +7,7 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 let adapter: AbstractSQLite3Adapter;
 
@@ -18,11 +18,10 @@ class JsonDataType extends Base {
 }
 
 describeIfSqlite("SQLite3JSONTest", () => {
-  fixtures([], { useTransactionalTests: false });
+  fixtures([]);
 
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
-    await adapter.dropTable("json_data_type", { ifExists: true });
     // Mirrors Rails JSONSharedTestCases#setup creating the table ad-hoc:
     //   t.json "payload", default: {}
     //   t.json "settings"

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -29,7 +29,6 @@ describeIfSqlite("SQLite3JSONTest", () => {
       t.json("payload", { default: "{}" });
       t.json("settings");
     });
-    JsonDataType.resetColumnInformation();
   });
 
   afterEach(async () => {

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -55,11 +55,6 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quote table name", async () => {
-    // The rule's raw-SQL name scanner stops at the space inside the quoted
-    // identifier and records this table as `my`, which no drop can match. The
-    // afterEach drops the real name; story `require-table-teardown-quoted-name`
-    // fixes the scanner.
-    // eslint-disable-next-line blazetrails/require-table-teardown
     await adapter.exec(`CREATE TABLE "my table" ("id" INTEGER PRIMARY KEY)`);
     const rows = await adapter.execute(`SELECT * FROM "my table"`);
     expect(rows).toHaveLength(0);

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -6,21 +6,18 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 let adapter: AbstractSQLite3Adapter;
 
 // -- Rails test class: quoting_test.rb --
 describeIfSqlite("SQLite3QuotingTest", () => {
-  fixtures([], { useTransactionalTests: false });
+  fixtures([]);
 
-  // Rails `setup`: `@conn = ActiveRecord::Base.lease_connection`.
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
   });
 
-  // The ambient database outlives the test, so every ad-hoc table each case
-  // creates has to be dropped by name (SQLite has no multi-table DROP).
   afterEach(async () => {
     await adapter
       .exec(

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -19,11 +19,23 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   afterEach(async () => {
-    await adapter
-      .exec(
-        `DROP TABLE IF EXISTS quote_test; DROP TABLE IF EXISTS q; DROP TABLE IF EXISTS "my table"; DROP TABLE IF EXISTS bin_enc; DROP TABLE IF EXISTS bool_test; DROP TABLE IF EXISTS bool_test2; DROP TABLE IF EXISTS bd_test; DROP TABLE IF EXISTS bin_quote; DROP TABLE IF EXISTS time_test; DROP TABLE IF EXISTS time_norm; DROP TABLE IF EXISTS time_utc; DROP TABLE IF EXISTS time_local; DROP TABLE IF EXISTS inf_test; DROP TABLE IF EXISTS nan_test`,
-      )
-      .catch(() => undefined);
+    await adapter.dropTable(
+      "quote_test",
+      "q",
+      "my table",
+      "bin_enc",
+      "bool_test",
+      "bool_test2",
+      "bd_test",
+      "bin_quote",
+      "time_test",
+      "time_norm",
+      "time_utc",
+      "time_local",
+      "inf_test",
+      "nan_test",
+      { ifExists: true },
+    );
   });
 
   it("quote string", async () => {
@@ -43,6 +55,11 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quote table name", async () => {
+    // The rule's raw-SQL name scanner stops at the space inside the quoted
+    // identifier and records this table as `my`, which no drop can match. The
+    // afterEach drops the real name; story `require-table-teardown-quoted-name`
+    // fixes the scanner.
+    // eslint-disable-next-line blazetrails/require-table-teardown
     await adapter.exec(`CREATE TABLE "my table" ("id" INTEGER PRIMARY KEY)`);
     const rows = await adapter.execute(`SELECT * FROM "my table"`);
     expect(rows).toHaveLength(0);

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -2,29 +2,33 @@
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/quoting_test.rb
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
+import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 
 let adapter: AbstractSQLite3Adapter;
 
-beforeEach(() => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-});
-
-afterEach(async () => {
-  // Throwaway :memory: tables; per-name IF EXISTS drops balance
-  // require-table-teardown (SQLite has no multi-table DROP).
-  await adapter
-    .exec(
-      `DROP TABLE IF EXISTS quote_test; DROP TABLE IF EXISTS q; DROP TABLE IF EXISTS "my table"; DROP TABLE IF EXISTS bin_enc; DROP TABLE IF EXISTS bool_test; DROP TABLE IF EXISTS bool_test2; DROP TABLE IF EXISTS bd_test; DROP TABLE IF EXISTS bin_quote; DROP TABLE IF EXISTS time_test; DROP TABLE IF EXISTS time_norm; DROP TABLE IF EXISTS time_utc; DROP TABLE IF EXISTS time_local; DROP TABLE IF EXISTS inf_test; DROP TABLE IF EXISTS nan_test`,
-    )
-    .catch(() => undefined);
-  await adapter.close();
-});
-
 // -- Rails test class: quoting_test.rb --
 describeIfSqlite("SQLite3QuotingTest", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  // Rails `setup`: `@conn = ActiveRecord::Base.lease_connection`.
+  beforeEach(async () => {
+    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+  });
+
+  // The ambient database outlives the test, so every ad-hoc table each case
+  // creates has to be dropped by name (SQLite has no multi-table DROP).
+  afterEach(async () => {
+    await adapter
+      .exec(
+        `DROP TABLE IF EXISTS quote_test; DROP TABLE IF EXISTS q; DROP TABLE IF EXISTS "my table"; DROP TABLE IF EXISTS bin_enc; DROP TABLE IF EXISTS bool_test; DROP TABLE IF EXISTS bool_test2; DROP TABLE IF EXISTS bd_test; DROP TABLE IF EXISTS bin_quote; DROP TABLE IF EXISTS time_test; DROP TABLE IF EXISTS time_norm; DROP TABLE IF EXISTS time_utc; DROP TABLE IF EXISTS time_local; DROP TABLE IF EXISTS inf_test; DROP TABLE IF EXISTS nan_test`,
+      )
+      .catch(() => undefined);
+  });
+
   it("quote string", async () => {
     // Rails asserts quote_string("'") == "''" (escaped content, no wrapping
     // quotes). Trails' quoteString wraps — round-trip the same "'" datum.

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
@@ -6,23 +6,19 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
 
 let adapter: AbstractSQLite3Adapter;
 
 // -- Rails test class: sqlite3_adapter_prevent_writes_test.rb --
 describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
-  // Rails: `self.use_transactional_tests = false`.
   fixtures([], { useTransactionalTests: false });
 
-  // Rails `setup`: `@conn = ActiveRecord::Base.lease_connection`.
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
   });
 
-  // The ambient database outlives the test, so every ad-hoc table each case
-  // creates has to be dropped by name (SQLite has no multi-table DROP).
   afterEach(async () => {
     await adapter
       .exec(

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
@@ -2,30 +2,35 @@
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_prevent_writes_test.rb
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
+import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
 
 let adapter: AbstractSQLite3Adapter;
 
-beforeEach(() => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-});
-
-afterEach(async () => {
-  // Throwaway :memory: tables; per-name IF EXISTS drops balance
-  // require-table-teardown (SQLite has no multi-table DROP).
-  await adapter
-    .exec(
-      `DROP TABLE IF EXISTS pw; DROP TABLE IF EXISTS pw2; DROP TABLE IF EXISTS pw3; DROP TABLE IF EXISTS pw4; DROP TABLE IF EXISTS pw5`,
-    )
-    .catch(() => undefined);
-  await adapter.close();
-});
-
 // -- Rails test class: sqlite3_adapter_prevent_writes_test.rb --
 describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
+  // Rails: `self.use_transactional_tests = false`.
+  fixtures([], { useTransactionalTests: false });
+
+  // Rails `setup`: `@conn = ActiveRecord::Base.lease_connection`.
+  beforeEach(async () => {
+    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+  });
+
+  // The ambient database outlives the test, so every ad-hoc table each case
+  // creates has to be dropped by name (SQLite has no multi-table DROP).
+  afterEach(async () => {
+    await adapter
+      .exec(
+        `DROP TABLE IF EXISTS pw; DROP TABLE IF EXISTS pw2; DROP TABLE IF EXISTS pw3; DROP TABLE IF EXISTS pw4; DROP TABLE IF EXISTS pw5`,
+      )
+      .catch(() => undefined);
+  });
+
   it("errors when an insert query is called while preventing writes", async () => {
     await adapter.exec(`CREATE TABLE "pw" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.withPreventedWrites(async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
@@ -20,11 +20,7 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   });
 
   afterEach(async () => {
-    await adapter
-      .exec(
-        `DROP TABLE IF EXISTS pw; DROP TABLE IF EXISTS pw2; DROP TABLE IF EXISTS pw3; DROP TABLE IF EXISTS pw4; DROP TABLE IF EXISTS pw5`,
-      )
-      .catch(() => undefined);
+    await adapter.dropTable("pw", "pw2", "pw3", "pw4", "pw5", { ifExists: true });
   });
 
   it("errors when an insert query is called while preventing writes", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
@@ -3,7 +3,7 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import type { Column } from "../../connection-adapters/sqlite3/column.js";
 
 let adapter: AbstractSQLite3Adapter;
@@ -13,7 +13,7 @@ let adapter: AbstractSQLite3Adapter;
 // but PRAGMA table_info hides them — a table_info-sourced rebuild silently
 // drops every pre-existing generated column.
 describeIfSqlite("SQLite3VirtualColumnTest trails extras", () => {
-  fixtures([], { useTransactionalTests: false });
+  fixtures([]);
 
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
@@ -26,7 +26,6 @@ describeIfSqlite("SQLite3VirtualColumnTest trails extras", () => {
     );
   });
 
-  // The ambient database outlives the test, so the ad-hoc table must be dropped.
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
   });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
@@ -17,7 +17,7 @@ describeIfSqlite("SQLite3VirtualColumnTest trails extras", () => {
 
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
-    await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`);
+    await adapter.dropTable("virtual_columns", { ifExists: true });
     await adapter.exec(
       `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "column1" integer)`,
     );
@@ -27,7 +27,7 @@ describeIfSqlite("SQLite3VirtualColumnTest trails extras", () => {
   });
 
   afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
+    await adapter.dropTable("virtual_columns", { ifExists: true });
   });
 
   it("alter-table rebuild preserves pre-existing generated columns", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
@@ -1,31 +1,36 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
+import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import type { Column } from "../../connection-adapters/sqlite3/column.js";
 
 let adapter: AbstractSQLite3Adapter;
-
-beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-  await adapter.exec(
-    `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "column1" integer)`,
-  );
-  await adapter.executeMutation(
-    `INSERT INTO "virtual_columns" ("name", "column1") VALUES ('Rails', 10)`,
-  );
-});
-
-afterEach(async () => {
-  await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
-  await adapter.close();
-});
 
 // TS-only regression coverage: Rails' alter_table rebuilds from columns(from)
 // and re-adds generated columns with as:/stored: (sqlite3_adapter.rb:623),
 // but PRAGMA table_info hides them — a table_info-sourced rebuild silently
 // drops every pre-existing generated column.
 describeIfSqlite("SQLite3VirtualColumnTest trails extras", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  beforeEach(async () => {
+    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`);
+    await adapter.exec(
+      `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "column1" integer)`,
+    );
+    await adapter.executeMutation(
+      `INSERT INTO "virtual_columns" ("name", "column1") VALUES ('Rails', 10)`,
+    );
+  });
+
+  // The ambient database outlives the test, so the ad-hoc table must be dropped.
+  afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
+  });
+
   it("alter-table rebuild preserves pre-existing generated columns", async () => {
     await adapter.changeTable("virtual_columns", async (t) => {
       await t.virtual("decr_column1", { type: "integer", as: "column1 - 1", stored: true });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -6,19 +6,16 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
 let adapter: AbstractSQLite3Adapter;
 
 describeIfSqlite("SQLite3VirtualTableTest", () => {
-  fixtures([], { useTransactionalTests: false });
+  fixtures([]);
 
-  // Rails `setup`: `@connection = ActiveRecord::Base.lease_connection`, then
-  // `create_virtual_table :searchables, :fts5, [...]`.
   beforeEach(async () => {
     adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
-    await adapter.dropTable("searchables", { ifExists: true });
     await adapter.createVirtualTable("searchables", "fts5", [
       "content",
       "meta UNINDEXED",
@@ -26,10 +23,11 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
     ]);
   });
 
-  // Rails `teardown`: drop_table :searchables, if_exists: true. Required now
-  // that the ambient database outlives the test.
   afterEach(async () => {
     await adapter.dropTable("searchables", { ifExists: true }).catch(() => undefined);
+    // Deviation: Rails' teardown drops only :searchables, leaking the :emails
+    // table "schema load" creates. Harmless there, not here — the ambient
+    // database is reused by every later suite on this worker.
     await adapter.dropTable("emails", { ifExists: true }).catch(() => undefined);
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -2,27 +2,37 @@
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
+import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
 let adapter: AbstractSQLite3Adapter;
 
-beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-  await adapter.createVirtualTable("searchables", "fts5", [
-    "content",
-    "meta UNINDEXED",
-    "tokenize='porter ascii'",
-  ]);
-});
-
-afterEach(async () => {
-  await adapter.close();
-});
-
 describeIfSqlite("SQLite3VirtualTableTest", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  // Rails `setup`: `@connection = ActiveRecord::Base.lease_connection`, then
+  // `create_virtual_table :searchables, :fts5, [...]`.
+  beforeEach(async () => {
+    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    await adapter.dropTable("searchables", { ifExists: true });
+    await adapter.createVirtualTable("searchables", "fts5", [
+      "content",
+      "meta UNINDEXED",
+      "tokenize='porter ascii'",
+    ]);
+  });
+
+  // Rails `teardown`: drop_table :searchables, if_exists: true. Required now
+  // that the ambient database outlives the test.
+  afterEach(async () => {
+    await adapter.dropTable("searchables", { ifExists: true }).catch(() => undefined);
+    await adapter.dropTable("emails", { ifExists: true }).catch(() => undefined);
+  });
+
   it("schema dump", async () => {
     const output = await SchemaDumper.dump(adapter);
 
@@ -40,9 +50,7 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
     expect(await adapter.virtualTableExists("searchables")).toBe(true);
 
     // Re-create via createVirtualTable (mirrors Schema.define creating the table)
-    const adapter2 = new BetterSQLite3Adapter(":memory:");
-    await adapter2.createVirtualTable("emails", "fts5", ["content", "meta UNINDEXED"]);
-    expect(await adapter2.virtualTableExists("emails")).toBe(true);
-    await adapter2.close();
+    await adapter.createVirtualTable("emails", "fts5", ["content", "meta UNINDEXED"]);
+    expect(await adapter.virtualTableExists("emails")).toBe(true);
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -24,6 +24,9 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
   });
 
   afterEach(async () => {
+    // Deviation: Rails drops only :searchables (virtual_table_test.rb:15-17),
+    // leaking the :emails table "schema load" creates. Harmless there, not
+    // here — the ambient database is reused by every later test in this file.
     await adapter.dropTable("searchables", "emails", { ifExists: true });
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -24,10 +24,7 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
   });
 
   afterEach(async () => {
-    // Deviation: Rails drops only :searchables (virtual_table_test.rb:15-17),
-    // leaking the :emails table "schema load" creates. Harmless there, not
-    // here — the ambient database is reused by every later test in this file.
-    await adapter.dropTable("searchables", "emails", { ifExists: true });
+    await adapter.dropTable("searchables", { ifExists: true });
   });
 
   it("schema dump", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -24,11 +24,7 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
   });
 
   afterEach(async () => {
-    await adapter.dropTable("searchables", { ifExists: true }).catch(() => undefined);
-    // Deviation: Rails' teardown drops only :searchables, leaking the :emails
-    // table "schema load" creates. Harmless there, not here — the ambient
-    // database is reused by every later suite on this worker.
-    await adapter.dropTable("emails", { ifExists: true }).catch(() => undefined);
+    await adapter.dropTable("searchables", "emails", { ifExists: true });
   });
 
   it("schema dump", async () => {


### PR DESCRIPTION
## What

RFC 0029 (sqlite-memory-fidelity). Rails' `test/cases/adapters/sqlite3/` names
`:memory:` in exactly two files — `sqlite3_adapter_test.rb` (18) and
`transaction_test.rb` (1). Every sibling leases the ambient connection in
`setup` (`@conn = ActiveRecord::Base.lease_connection`) and runs against the
configured test database.

trails built a throwaway `new BetterSQLite3Adapter(":memory:")` in `beforeEach`
in eight of them. This swaps each for `Base.leaseConnection()`.

## Changes

- All eight suites lease the ambient connection; `BetterSQLite3Adapter` is no
  longer imported by any of them.
- Setup/teardown hooks moved **inside** `describeIfSqlite`. They previously sat
  at module scope, which was harmless while they built their own SQLite adapter
  but would run SQLite-only DDL against PG/MySQL once the connection is ambient.
- The database now outlives each test, so every suite drops its ad-hoc tables in
  teardown. Rails' `use_transactional_tests = false` is reproduced on the
  prevent-writes suite only — the other seven ride the transactional default,
  matching their Rails counterparts. Where Rails passes `create_table
  force: true` (collation, virtual-column) the setup pre-drops; elsewhere
  teardown is the sole cleanup, as in Rails.
- `json.test.ts` drops the direct `JsonDataType.adapter =` assignment and rides
  the handler connection; it resets column information around each test, which
  the per-test throwaway adapter used to do implicitly.
- `virtual-table.test.ts`'s "schema load" case built a *second* `:memory:`
  adapter for the `emails` table; it now creates it on the ambient connection.
  Teardown matches Rails exactly — `drop_table :searchables, if_exists: true`.

Test names are unchanged. `sqlite3-adapter.test.ts` and `transaction.test.ts`
are untouched (fidelity-correct per the story).

## Review round 2

- Restored the call-site justification for dropping `emails`; a lint-staged
  autofix had collapsed the two `dropTable` calls and taken the comment with it.
- Dropped the setup-side `resetColumnInformation()` in `json.test.ts` — Rails'
  `JSONSharedTestCases#setup` only leases; the reset belongs in teardown.
- Every raw `exec("DROP TABLE IF EXISTS ...")` teardown is now
  `dropTable(..., { ifExists: true })`. This answers the schema-cache question
  structurally rather than by argument: `dropTable` clears the per-name cache
  entry (`schema-statements.ts:407`); raw `exec` does not. (Staleness across a
  suite boundary was already impossible — `pool: "forks"` with vitest's default
  `isolate: true` gives each file a fresh process, so the pool and its schema
  cache are per-file, and none of these table names appear in more than one
  file. This makes it structural instead of incidental.) The varargs form is
  Rails' `drop_table(*names, **options)`, and the `.catch(() => undefined)`
  swallows are retired.
- Re-indented the `collation` / `bigint-roundtrip` SQL template literals.

## Review round 3

The `emails` drop is gone; teardown now matches `virtual_table_test.rb:15-17`
exactly, with no deviation left to justify.

The reviewer was right that the call-site justification was wrong: this suite
rides the transactional default, so the `emails` table `test_schema_load`
creates is rolled back with the rest of the test — "the ambient database is
reused by every later test" simply wasn't the operative reason. Rather than
reword the note, I checked whether the drop does anything at all. A throwaway
probe suite that creates `emails` in one test and drops only `searchables` in
teardown reports `virtualTableExists("emails") === false` in the very next
test. The drop is a verified no-op, so the right move is to delete the
deviation rather than document it.

## Rebased again (conflict with main)

Main landed **#5504**, which taught `require-table-teardown`'s raw-SQL scanner
to parse a quoted identifier with an embedded space — the exact fix story
`require-table-teardown-quoted-name` asked for, closed by that PR. Its one-line
change to `quoting.test.ts` (dropping `my` → `"my table"`) conflicted with this
branch, which removes that whole teardown block in favour of
`dropTable("my table", ...)`. Resolved in favour of this branch: the fix is
subsumed, since we already drop the real name.

With the scanner fixed, the scoped `eslint-disable-next-line` and its
explanation are obsolete and have been removed — the rule now matches the
`dropTable` against the create on its own. That closes the last outstanding
annotation: **no `eslint-disable` and no deviation comment remain in this diff.**

### On the `"my table"` history

An early revision of this description called the original `my` / `"my table"`
mismatch a latent bug. It was really the scanner truncating the quoted name, so
the old code balanced the rule while leaking the real table — which is why the
fix belonged in the lint rule, where #5504 put it, not here.

## Verification

All 8 suites pass locally — 42 tests, on the ambient file-backed connection.
`pnpm typecheck` and `eslint` clean.

Closes-story: sqlite3-adapter-siblings-ambient-connection
