### PR TITLE
test(sqlite3): run connection-adapters sqlite3 tests on the ambient connection

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -20,10 +20,15 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   // The ambient connection is a shared worker DB, so the scratch tables are
   // cleared on the way in as well as out: a hard-killed run must not wedge the
   // next one.
-  const dropScratchTables = (): Promise<void> =>
-    adapter.exec(
+  const dropScratchTables = async (): Promise<void> => {
+    // Guarded so a beforeEach that fails before the lease surfaces its own
+    // error rather than a TypeError on `undefined.exec` from this teardown.
+    const conn = adapter as AbstractSQLite3Adapter | undefined;
+    if (!conn) return;
+    await conn.exec(
       "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t; DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b",
     );
+  };
 
   beforeEach(async () => {
     adapter = Base.connection as AbstractSQLite3Adapter;
@@ -33,9 +38,11 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   });
 
   afterEach(async () => {
+    // Drop before restoring: on the shared ambient connection a globally
+    // registered transformer would otherwise rewrite the teardown DDL.
     queryTransformers.length = 0;
-    queryTransformers.push(...savedTransformers);
     await dropScratchTables();
+    queryTransformers.push(...savedTransformers);
   });
 
   function captureSql<T>(fn: () => Promise<T>): Promise<{ result: T; sqls: string[] }> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -16,22 +16,22 @@ fixtures([], { useTransactionalTests: false });
 describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   let adapter: AbstractSQLite3Adapter;
   let savedTransformers: QueryTransformer[];
+  // Teardown-only handle. `adapter` stays non-optional for the test bodies, but
+  // the teardown has to tolerate a beforeEach that failed before the lease, so
+  // it reads a genuinely optional binding rather than casting `adapter`.
+  let leased: AbstractSQLite3Adapter | undefined;
 
   // The ambient connection is a shared worker DB, so the scratch tables are
   // cleared on the way in as well as out: a hard-killed run must not wedge the
   // next one.
   const dropScratchTables = async (): Promise<void> => {
-    // Guarded so a beforeEach that fails before the lease surfaces its own
-    // error rather than a TypeError on `undefined.exec` from this teardown.
-    const conn = adapter as AbstractSQLite3Adapter | undefined;
-    if (!conn) return;
-    await conn.exec(
+    await leased?.exec(
       "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t; DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b",
     );
   };
 
   beforeEach(async () => {
-    adapter = Base.connection as AbstractSQLite3Adapter;
+    adapter = leased = Base.connection as AbstractSQLite3Adapter;
     savedTransformers = queryTransformers.slice();
     queryTransformers.length = 0;
     await dropScratchTables();

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -1,20 +1,24 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { it, expect, beforeEach, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { Base } from "../base.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
+import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 import { queryTransformers, type QueryTransformer } from "../query-transformers.js";
+
+fixtures([], { useTransactionalTests: false });
 
 // Integration proof for QL PR 3: a registered query transformer is applied in
 // preprocessQuery and the post-transform (commented) SQL flows all the way into
 // both the executed statement and the `sql.active_record` instrumentation
 // payload — the Rails-faithful ordering where preprocess_query runs before
 // raw_execute's log block.
-describe("SQLite3Adapter queryTransformers wiring", () => {
+describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   let adapter: AbstractSQLite3Adapter;
   let savedTransformers: QueryTransformer[];
 
   beforeEach(() => {
-    adapter = new BetterSQLite3Adapter(":memory:");
+    adapter = Base.connection as AbstractSQLite3Adapter;
     savedTransformers = queryTransformers.slice();
     queryTransformers.length = 0;
   });
@@ -22,12 +26,12 @@ describe("SQLite3Adapter queryTransformers wiring", () => {
   afterEach(async () => {
     queryTransformers.length = 0;
     queryTransformers.push(...savedTransformers);
-    // Throwaway :memory: tables; per-name IF EXISTS drops balance
-    // require-table-teardown (SQLite has no multi-table DROP).
-    await adapter
-      .exec("DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t")
-      .catch(() => undefined);
-    await adapter.close().catch(() => undefined);
+    // Scratch tables on the ambient test connection: drop them by name so the
+    // shared worker DB is left exactly as it was found (SQLite has no
+    // multi-table DROP, hence one IF EXISTS per name).
+    await adapter.exec(
+      "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t; DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b",
+    );
   });
 
   function captureSql<T>(fn: () => Promise<T>): Promise<{ result: T; sqls: string[] }> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -26,9 +26,6 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   afterEach(async () => {
     queryTransformers.length = 0;
     queryTransformers.push(...savedTransformers);
-    // Scratch tables on the ambient test connection: drop them by name so the
-    // shared worker DB is left exactly as it was found (SQLite has no
-    // multi-table DROP, hence one IF EXISTS per name).
     await adapter.exec(
       "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t; DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b",
     );

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -17,18 +17,25 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   let adapter: AbstractSQLite3Adapter;
   let savedTransformers: QueryTransformer[];
 
-  beforeEach(() => {
+  // The ambient connection is a shared worker DB, so the scratch tables are
+  // cleared on the way in as well as out: a hard-killed run must not wedge the
+  // next one.
+  const dropScratchTables = (): Promise<void> =>
+    adapter.exec(
+      "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t; DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b",
+    );
+
+  beforeEach(async () => {
     adapter = Base.connection as AbstractSQLite3Adapter;
     savedTransformers = queryTransformers.slice();
     queryTransformers.length = 0;
+    await dropScratchTables();
   });
 
   afterEach(async () => {
     queryTransformers.length = 0;
     queryTransformers.push(...savedTransformers);
-    await adapter.exec(
-      "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t; DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b",
-    );
+    await dropScratchTables();
   });
 
   function captureSql<T>(fn: () => Promise<T>): Promise<{ result: T; sqls: string[] }> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -8,6 +8,10 @@ fixtures([], { useTransactionalTests: false });
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: AbstractSQLite3Adapter;
+  // Teardown-only handle. `db` stays non-optional for the test bodies, but the
+  // teardown has to tolerate a beforeEach that failed before the lease, so it
+  // reads a genuinely optional binding rather than casting `db`.
+  let leased: AbstractSQLite3Adapter | undefined;
 
   // The ambient connection is a shared worker DB, so the scratch tables are
   // cleared on the way in as well as out: a hard-killed run must not wedge the
@@ -15,17 +19,13 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   // (sqlite3-adapter.ts `_alter_tmp_${bareTable}`), which it only drops on the
   // success path — a mid-rebuild failure leaves it behind.
   const dropScratchTables = async (): Promise<void> => {
-    // Guarded so a beforeEach that fails before the lease surfaces its own
-    // error rather than a TypeError on `undefined.exec` from this teardown.
-    const conn = db as AbstractSQLite3Adapter | undefined;
-    if (!conn) return;
-    await conn.exec(
+    await leased?.exec(
       `DROP TABLE IF EXISTS rebuild_users; DROP TABLE IF EXISTS rebuild_orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst; DROP TABLE IF EXISTS "_alter_tmp_rebuild_users"`,
     );
   };
 
   beforeEach(async () => {
-    db = Base.connection as AbstractSQLite3Adapter;
+    db = leased = Base.connection as AbstractSQLite3Adapter;
     await dropScratchTables();
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -1,28 +1,32 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { it, expect, beforeEach, afterEach } from "vitest";
+import { Base } from "../base.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
+import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 
-describe("SQLite3Adapter table-rebuild cluster", () => {
+fixtures([], { useTransactionalTests: false });
+
+describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: AbstractSQLite3Adapter;
 
   beforeEach(() => {
-    db = new BetterSQLite3Adapter(":memory:");
+    db = Base.connection as AbstractSQLite3Adapter;
   });
 
   afterEach(async () => {
-    // Throwaway :memory: tables; per-name IF EXISTS drops balance
-    // require-table-teardown (SQLite has no multi-table DROP).
+    // Scratch tables on the ambient test connection: drop them by name so the
+    // shared worker DB is left exactly as it was found (SQLite has no
+    // multi-table DROP, hence one IF EXISTS per name).
     await db.exec(
-      `DROP TABLE IF EXISTS users; DROP TABLE IF EXISTS orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst`,
+      `DROP TABLE IF EXISTS rebuild_users; DROP TABLE IF EXISTS rebuild_orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst`,
     );
-    await db.close();
   });
 
   // --- tableStructureSql ---
 
   it("tableStructureSql returns column definition strings from CREATE TABLE SQL", async () => {
-    await db.exec('CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "name" TEXT NOT NULL)');
-    const strings = await (db as any).tableStructureSql("users", ["id", "name"]);
+    await db.exec('CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY, "name" TEXT NOT NULL)');
+    const strings = await (db as any).tableStructureSql("rebuild_users", ["id", "name"]);
     expect(strings).toHaveLength(2);
     expect(strings[0]).toMatch(/"id"/);
     expect(strings[1]).toMatch(/"name"/);
@@ -35,32 +39,36 @@ describe("SQLite3Adapter table-rebuild cluster", () => {
 
   it("tableStructureSql includes CONSTRAINT strings", async () => {
     await db.exec(
-      'CREATE TABLE "orders" ("id" INTEGER PRIMARY KEY, "user_id" INTEGER, CONSTRAINT "fk_user" FOREIGN KEY("user_id") REFERENCES "users"("id"))',
+      'CREATE TABLE "rebuild_orders" ("id" INTEGER PRIMARY KEY, "user_id" INTEGER, CONSTRAINT "fk_user" FOREIGN KEY("user_id") REFERENCES "rebuild_users"("id"))',
     );
-    const strings = await (db as any).tableStructureSql("orders", ["id", "user_id"]);
+    const strings = await (db as any).tableStructureSql("rebuild_orders", ["id", "user_id"]);
     expect(strings.some((s: string) => s.includes("CONSTRAINT"))).toBe(true);
   });
 
   // --- tableStructureWithCollation ---
 
   it("tableStructureWithCollation extracts collation from CREATE TABLE SQL", async () => {
-    await db.exec('CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "name" TEXT COLLATE "NOCASE")');
+    await db.exec(
+      'CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY, "name" TEXT COLLATE "NOCASE")',
+    );
     const basic = [
       { name: "id", type: "INTEGER", notnull: 0, dflt_value: null, pk: 1 },
       { name: "name", type: "TEXT", notnull: 0, dflt_value: null, pk: 0 },
     ];
-    const enriched = await (db as any).tableStructureWithCollation("users", basic);
+    const enriched = await (db as any).tableStructureWithCollation("rebuild_users", basic);
     const nameCol = enriched.find((c: any) => c.name === "name");
     expect(nameCol.collation).toBe("NOCASE");
   });
 
   it("tableStructureWithCollation extracts auto_increment flag", async () => {
-    await db.exec('CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)');
+    await db.exec(
+      'CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)',
+    );
     const basic = [
       { name: "id", type: "INTEGER", notnull: 0, dflt_value: null, pk: 1 },
       { name: "name", type: "TEXT", notnull: 0, dflt_value: null, pk: 0 },
     ];
-    const enriched = await (db as any).tableStructureWithCollation("users", basic);
+    const enriched = await (db as any).tableStructureWithCollation("rebuild_users", basic);
     const idCol = enriched.find((c: any) => c.name === "id");
     expect(idCol.auto_increment).toBe(true);
   });
@@ -68,8 +76,8 @@ describe("SQLite3Adapter table-rebuild cluster", () => {
   // --- tableInfo ---
 
   it("tableInfo returns PRAGMA table_info rows", async () => {
-    await db.exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");
-    const info = await (db as any).tableInfo("users");
+    await db.exec("CREATE TABLE rebuild_users (id INTEGER PRIMARY KEY, name TEXT)");
+    const info = await (db as any).tableInfo("rebuild_users");
     expect(info).toHaveLength(2);
     expect(info[0].name).toBe("id");
   });
@@ -77,8 +85,10 @@ describe("SQLite3Adapter table-rebuild cluster", () => {
   // --- tableStructure ---
 
   it("tableStructure returns enriched column info", async () => {
-    await db.exec('CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "name" TEXT COLLATE "NOCASE")');
-    const structure = await (db as any).tableStructure("users");
+    await db.exec(
+      'CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY, "name" TEXT COLLATE "NOCASE")',
+    );
+    const structure = await (db as any).tableStructure("rebuild_users");
     expect(structure).toHaveLength(2);
     const nameCol = structure.find((c: any) => c.name === "name");
     expect(nameCol.collation).toBe("NOCASE");
@@ -184,9 +194,9 @@ describe("SQLite3Adapter table-rebuild cluster", () => {
     // AR-spelled integer-like type — the shape that makes newColumnDefinition
     // flip the column to :primary_key, where the constraint rides entirely on
     // type_to_sql(:primary_key).
-    await db.exec('CREATE TABLE "users" ("id" bigint PRIMARY KEY, "name" TEXT)');
-    await db.removeColumn("users", "name");
-    const pk = (await (db as any).tableInfo("users")).filter((c: any) => Number(c.pk) > 0);
+    await db.exec('CREATE TABLE "rebuild_users" ("id" bigint PRIMARY KEY, "name" TEXT)');
+    await db.removeColumn("rebuild_users", "name");
+    const pk = (await (db as any).tableInfo("rebuild_users")).filter((c: any) => Number(c.pk) > 0);
     expect(pk.map((c: any) => c.name)).toEqual(["id"]);
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -11,11 +11,18 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
 
   // The ambient connection is a shared worker DB, so the scratch tables are
   // cleared on the way in as well as out: a hard-killed run must not wedge the
-  // next one.
-  const dropScratchTables = (): Promise<void> =>
-    db.exec(
-      `DROP TABLE IF EXISTS rebuild_users; DROP TABLE IF EXISTS rebuild_orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst`,
+  // next one. `_alter_tmp_rebuild_users` is alterTable's rebuild scratch table
+  // (sqlite3-adapter.ts `_alter_tmp_${bareTable}`), which it only drops on the
+  // success path — a mid-rebuild failure leaves it behind.
+  const dropScratchTables = async (): Promise<void> => {
+    // Guarded so a beforeEach that fails before the lease surfaces its own
+    // error rather than a TypeError on `undefined.exec` from this teardown.
+    const conn = db as AbstractSQLite3Adapter | undefined;
+    if (!conn) return;
+    await conn.exec(
+      `DROP TABLE IF EXISTS rebuild_users; DROP TABLE IF EXISTS rebuild_orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst; DROP TABLE IF EXISTS "_alter_tmp_rebuild_users"`,
     );
+  };
 
   beforeEach(async () => {
     db = Base.connection as AbstractSQLite3Adapter;

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -14,9 +14,6 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   });
 
   afterEach(async () => {
-    // Scratch tables on the ambient test connection: drop them by name so the
-    // shared worker DB is left exactly as it was found (SQLite has no
-    // multi-table DROP, hence one IF EXISTS per name).
     await db.exec(
       `DROP TABLE IF EXISTS rebuild_users; DROP TABLE IF EXISTS rebuild_orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst`,
     );

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -9,15 +9,20 @@ fixtures([], { useTransactionalTests: false });
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: AbstractSQLite3Adapter;
 
-  beforeEach(() => {
-    db = Base.connection as AbstractSQLite3Adapter;
-  });
-
-  afterEach(async () => {
-    await db.exec(
+  // The ambient connection is a shared worker DB, so the scratch tables are
+  // cleared on the way in as well as out: a hard-killed run must not wedge the
+  // next one.
+  const dropScratchTables = (): Promise<void> =>
+    db.exec(
       `DROP TABLE IF EXISTS rebuild_users; DROP TABLE IF EXISTS rebuild_orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst`,
     );
+
+  beforeEach(async () => {
+    db = Base.connection as AbstractSQLite3Adapter;
+    await dropScratchTables();
   });
+
+  afterEach(dropScratchTables);
 
   // --- tableStructureSql ---
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BinaryData } from "@blazetrails/activemodel";
-import { AbstractSQLite3Adapter, SQLiteDateTimeType } from "../sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../better-sqlite3-adapter.js";
+import { Base } from "../../base.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
+import { describeIfSqlite } from "../../adapters/sqlite3/test-helper.js";
+import { type AbstractSQLite3Adapter, SQLiteDateTimeType } from "../sqlite3-adapter.js";
 import { Date as DateType } from "../../type/date.js";
 import { Time as TimeType } from "../../type/time.js";
 import {
@@ -37,6 +39,8 @@ const HOST = {
 };
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
+
+fixtures([], { useTransactionalTests: false });
 
 describe("SQLite3::Quoting", () => {
   describe("columnNameMatcher", () => {
@@ -341,12 +345,13 @@ describe("SQLite3::Quoting", () => {
     });
   });
 
-  describe("SQLite microsecond round-trip — integration", () => {
+  describeIfSqlite("SQLite microsecond round-trip — integration", () => {
     let adapter: AbstractSQLite3Adapter;
 
     beforeEach(async () => {
-      adapter = new BetterSQLite3Adapter(":memory:");
-      await adapter.exec(`CREATE TABLE "events" (
+      adapter = Base.connection as AbstractSQLite3Adapter;
+      await adapter.exec(`DROP TABLE IF EXISTS "quoting_events"`);
+      await adapter.exec(`CREATE TABLE "quoting_events" (
         "id" INTEGER PRIMARY KEY AUTOINCREMENT,
         "ts"  DATETIME,
         "dt"  DATETIME,
@@ -356,14 +361,15 @@ describe("SQLite3::Quoting", () => {
     });
 
     afterEach(async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS "events"`).catch(() => undefined);
-      await adapter.close();
+      await adapter.exec(`DROP TABLE IF EXISTS "quoting_events"`);
     });
 
     it("Temporal.Instant with microsecond precision survives INSERT → SELECT as Instant", async () => {
       const instant = Temporal.Instant.from("2026-04-18T12:34:56.123456Z");
-      await adapter.executeMutation(`INSERT INTO "events" ("ts") VALUES (${quote(instant)})`);
-      const rows = await adapter.execute(`SELECT "ts" FROM "events" LIMIT 1`);
+      await adapter.executeMutation(
+        `INSERT INTO "quoting_events" ("ts") VALUES (${quote(instant)})`,
+      );
+      const rows = await adapter.execute(`SELECT "ts" FROM "quoting_events" LIMIT 1`);
       const raw = rows[0].ts as string;
       // SQLiteDateTimeType converts the offset-less UTC string → Temporal.Instant.
       const cast = new SQLiteDateTimeType().cast(raw);
@@ -374,8 +380,8 @@ describe("SQLite3::Quoting", () => {
 
     it("Temporal.PlainDateTime with microseconds survives INSERT → SELECT as Instant", async () => {
       const dt = Temporal.PlainDateTime.from("2026-04-18T12:34:56.654321");
-      await adapter.executeMutation(`INSERT INTO "events" ("dt") VALUES (${quote(dt)})`);
-      const rows = await adapter.execute(`SELECT "dt" FROM "events" LIMIT 1`);
+      await adapter.executeMutation(`INSERT INTO "quoting_events" ("dt") VALUES (${quote(dt)})`);
+      const rows = await adapter.execute(`SELECT "dt" FROM "quoting_events" LIMIT 1`);
       const raw = rows[0].dt as string;
       const cast = new SQLiteDateTimeType().cast(raw) as Temporal.Instant;
       expect(cast).toBeInstanceOf(Temporal.Instant);
@@ -386,8 +392,8 @@ describe("SQLite3::Quoting", () => {
 
     it("Temporal.PlainDate survives INSERT → SELECT", async () => {
       const date = Temporal.PlainDate.from("2026-04-18");
-      await adapter.executeMutation(`INSERT INTO "events" ("d") VALUES (${quote(date)})`);
-      const rows = await adapter.execute(`SELECT "d" FROM "events" LIMIT 1`);
+      await adapter.executeMutation(`INSERT INTO "quoting_events" ("d") VALUES (${quote(date)})`);
+      const rows = await adapter.execute(`SELECT "d" FROM "quoting_events" LIMIT 1`);
       const raw = rows[0].d as string;
       const cast = new DateType().cast(raw);
       expect(cast).toBeInstanceOf(Temporal.PlainDate);
@@ -402,8 +408,8 @@ describe("SQLite3::Quoting", () => {
       // TimeType#cast handles the full '2000-01-01 HH:MM:SS.ffffff' string via
       // extractTimePortion(), so no manual stripping is needed.
       const time = Temporal.PlainTime.from("14:23:55.654321");
-      await adapter.executeMutation(`INSERT INTO "events" ("t") VALUES (${quote(time)})`);
-      const rows = await adapter.execute(`SELECT "t" FROM "events" LIMIT 1`);
+      await adapter.executeMutation(`INSERT INTO "quoting_events" ("t") VALUES (${quote(time)})`);
+      const rows = await adapter.execute(`SELECT "t" FROM "quoting_events" LIMIT 1`);
       const raw = rows[0].t as string;
       const cast = new TimeType().cast(raw) as Temporal.PlainTime;
       expect(cast).toBeInstanceOf(Temporal.PlainTime);


### PR DESCRIPTION
RFC 0029 (sqlite-memory-fidelity) — the `connection-adapters/sqlite3*` cluster
built private `new BetterSQLite3Adapter(":memory:")` adapters where the matching
Rails file runs on the ambient `@connection`. Three files now derive their
adapter from the ambient file-backed test connection:

- `connection-adapters/sqlite3/quoting.test.ts` — the "SQLite microsecond
  round-trip" block (Rails `adapters/sqlite3/quoting_test.rb`, ambient).
- `connection-adapters/sqlite3-copy-table.test.ts` (Rails
  `adapters/sqlite3/copy_table_test.rb`, ambient `@connection`).
- `connection-adapters/sqlite3-adapter.query-transformers.test.ts` (Rails
  `adapters/sqlite3/sqlite3_adapter_test.rb`).

Each gets the handler via `fixtures([], { useTransactionalTests: false })` (the
suites issue DDL) and reads `Base.connection`, mirroring Rails'
`@connection = ActiveRecord::Base.lease_connection` (`copy_table_test.rb:9`).
Because the ambient connection is swapped to PG/MySQL in the cross-backend
matrix while these assertions are SQLite-specific (`PRAGMA` shapes, `db.raw`,
`"`-quoting), the suites are gated with `describeIfSqlite` — matching Rails,
where all three are `ActiveRecord::SQLite3TestCase`.

## Disposition: bespoke tables in the canonical worker DB

**Follow-up story, not fixed here:**
`0029-sqlite-memory-fidelity/converge-connection-adapters-sqlite3-bespoke-tables`

`src`, `dst`, `rebuild_users`, `rebuild_orders`, `widgets`, `t`, `a`, `b` are
trails inventions, and moving these suites onto the ambient connection means
they are now created in the shared canonical DB rather than a private
`:memory:` one — so CLAUDE.md's "canonical tables only" rule bites harder than
it did before. That is a real consequence of this PR and it is deliberately
recorded rather than silently absorbed.

It is **not** fixed here because the fix is not mechanical:
`connection-adapters/sqlite3-copy-table.test.ts` is not a duplicate of the
canonical `adapters/sqlite3/copy-table.test.ts` port. It is a trails-invented
unit suite over the *private* rebuild helpers (`tableStructureSql`,
`tableStructureWithCollation`, `tableInfo`, `tableStructure`,
`copyTableContents`, `copyTableIndexes`, `moveTable`, `alterTable`), finer
grained than Rails' `copy_table_test.rb` — several cases (the `bigint`-declared
PK rebuild, partial-index `WHERE` preservation) are not reachable through the
canonical port's public surface. So "delete as duplicate" and "converge onto
canonical tables" both depend on a coverage question this story cannot answer,
and per CLAUDE.md the answer belongs in its own scheduled story rather than a
self-opened sibling PR. The new story carries both options and the `file:line`
evidence.

## Deterministic cleanup

- the stale "throwaway `:memory:`" comments are gone and `adapter.close()` on
  the ambient connection is dropped;
- the per-name `DROP TABLE IF EXISTS` lists are complete — `a` / `b`, created by
  the `executeBatch` case, were previously never dropped;
- the drops run on setup as well as teardown, so a hard-killed run cannot wedge
  the next one on a shared worker DB;
- the `.catch(() => undefined)` swallows are removed, so a failing teardown is
  now visible.

Three scratch tables collided with canonical tables of the same name and were
renamed so the worker DB is left exactly as found: `users` -> `rebuild_users`,
`orders` -> `rebuild_orders`, `events` -> `quoting_events`. The non-colliding
scratch names are left alone — renaming `src`/`dst` breaks `copyTableIndexes`'
index-name rewriting, which keys off the source table name.

`sqlite3-adapter.hash-constructor.test.ts` is untouched — its `:memory:` is the
subject under test. Test names are unchanged. 79 tests pass on the sqlite lane.

## Review round 1

1. **`_alter_tmp_rebuild_users` missing from the drop list** — fixed. Confirmed
   at `sqlite3-adapter.ts:2459`, dropped only on the rebuild success path.
2. **Teardown DDL ran through restored transformers** — fixed. `afterEach` now
   clears, drops, *then* restores `savedTransformers`.
3. **`dropScratchTables` closing over an unassigned `let`** — fixed.
4. **Bespoke tables** — see the Disposition section above.

## Review round 2

1. **Bespoke-table disposition** — already recorded; the round-1 body edit and
   the review raced, so it was read stale. Promoted to its own top-level
   section above so it is not missed again. No code change.
2. **The `undefined` guard was a cast, not a check** — fixed, and agreed the
   cast laundered the type. Neither suggested form was quite right: declaring
   `db` optional costs ~37 `db!` sites in `sqlite3-copy-table.test.ts` alone,
   pure churn in the test bodies. Instead each suite keeps its non-optional
   `db` / `adapter` for the tests and adds a genuinely optional teardown handle
   (`let leased: AbstractSQLite3Adapter | undefined`), assigned alongside it in
   `beforeEach` and read with a real `leased?.exec(...)`. No cast, no `!`, and
   the type now states the fact the guard relies on.

Closes-story: sqlite3-connection-adapter-tests-ambient
