### PR TITLE
test(migration): port ForeignKeyTest supports_validate_constraints cases

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3940,7 +3940,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async validateForeignKey(
     fromTable: string,
     toTable?: string,
-    options?: { name?: string },
+    options?: Omit<ForeignKeyLookupOptions, "toTable">,
   ): Promise<void> {
     await this.pgSchemaStatements().validateForeignKey(fromTable, toTable, options);
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -18,6 +18,7 @@ import {
   type ColumnType,
   type ColumnOptions,
   type AddForeignKeyOptions,
+  type ForeignKeyLookupOptions,
   type AddIndexOptions,
   type IdHashOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
@@ -775,8 +776,8 @@ export abstract class Migration {
 
   async validateForeignKey(
     fromTable: string,
-    toTableOrOptions?: string | { name?: string },
-    options?: { name?: string },
+    toTableOrOptions?: string | Omit<ForeignKeyLookupOptions, "toTable">,
+    options?: Omit<ForeignKeyLookupOptions, "toTable">,
   ): Promise<void> {
     const toTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
     const opts = typeof toTableOrOptions === "object" ? toTableOrOptions : (options ?? undefined);

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -21,8 +21,9 @@ import {
   withRocketTables,
 } from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
-import { describeIfSupports, itIfSupports } from "../support/supports.js";
+import { adapterSupports, describeIfSupports, itIfSupports } from "../support/supports.js";
 import { assertQueriesMatch } from "../testing/query-assertions.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { dumpTableSchema } from "../support/schema-dumping-helper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { Base } from "../base.js";
@@ -33,6 +34,33 @@ import { SchemaDumper } from "../schema-dumper.js";
 // assertions: PRAGMA foreign_key_list exposes no constraint name, so SQLite
 // has no name to compare.
 const unlessSqlite3Adapter = adapterType !== "sqlite";
+
+// Rails' `else` arm of `if supports_validate_constraints?`. Held in a const so
+// the `it.skipIf(...)` call site carries no feature literal: the gate extractor
+// drops the negation, and an inline `adapterSupports("validate_constraints")`
+// would tag the else-arm case with the very feature it excludes — colliding
+// with the `if` arm, which shares the test name.
+const supportsValidateConstraints = adapterSupports("validate_constraints");
+
+/**
+ * `validate_foreign_key` / `validate_constraint` live on
+ * PostgreSQL::SchemaStatements only, so they are absent from the
+ * `AbstractAdapter` type the shared rocket-tables helper hands back. The cases
+ * that call them are gated on `validate_constraints` (PostgreSQL-only), so the
+ * narrowing is sound wherever it is used.
+ */
+interface ValidatingAdapter {
+  validateForeignKey(
+    fromTable: string,
+    toTable?: string,
+    options?: { column?: string; name?: string },
+  ): Promise<void>;
+  validateConstraint(tableName: string, constraintName: string): Promise<void>;
+}
+
+function validating(conn: AbstractAdapter): ValidatingAdapter {
+  return conn as unknown as ValidatingAdapter;
+}
 
 /** Rails' `silence_stream($stdout) { migration.migrate(...) }`. */
 class SilentMigration extends Migration {
@@ -355,6 +383,159 @@ describeIfSupports("foreign_keys", "Migration", () => {
         expect((await conn.foreignKeys("astronauts")).length).toBe(1);
         await conn.removeForeignKey("astronauts", "rockets", { onDelete: "restrict" });
         expect(await conn.foreignKeys("astronauts")).toEqual([]);
+      });
+    });
+
+    itIfSupports("validate_constraints", "add invalid foreign key", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          validate: false,
+        });
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(fk.isValidated).toBe(false);
+      });
+    });
+
+    itIfSupports("validate_constraints", "validate foreign key infers column", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { validate: false });
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(false);
+
+        await validating(conn).validateForeignKey("astronauts", "rockets");
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(true);
+      });
+    });
+
+    itIfSupports("validate_constraints", "validate foreign key by column", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          validate: false,
+        });
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(false);
+
+        await validating(conn).validateForeignKey("astronauts", undefined, {
+          column: "rocket_id",
+        });
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(true);
+      });
+    });
+
+    // Ruby's `column: :rocket_id` symbol has no TS analogue; the string form of
+    // the previous case is the only spelling available here.
+    itIfSupports("validate_constraints", "validate foreign key by symbol column", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          validate: false,
+        });
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(false);
+
+        await validating(conn).validateForeignKey("astronauts", undefined, {
+          column: "rocket_id",
+        });
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(true);
+      });
+    });
+
+    itIfSupports("validate_constraints", "validate foreign key by name", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          name: "fancy_named_fk",
+          validate: false,
+        });
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(false);
+
+        await validating(conn).validateForeignKey("astronauts", undefined, {
+          name: "fancy_named_fk",
+        });
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(true);
+      });
+    });
+
+    itIfSupports(
+      "validate_constraints",
+      "validate foreign non existing foreign key raises",
+      async () => {
+        const conn = await ambientConnection();
+        await withRocketTables(conn, async () => {
+          await expect(
+            validating(conn).validateForeignKey("astronauts", "rockets"),
+          ).rejects.toThrow(ArgumentError);
+        });
+      },
+    );
+
+    itIfSupports("validate_constraints", "validate constraint by name", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          name: "fancy_named_fk",
+          validate: false,
+        });
+
+        await validating(conn).validateConstraint("astronauts", "fancy_named_fk");
+        expect((await conn.foreignKeys("astronauts"))[0].isValidated).toBe(true);
+      });
+    });
+
+    itIfSupports("validate_constraints", "schema dumping with validate false", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          validate: false,
+        });
+
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+
+        expect(output).toMatch(
+          /\s+await ctx\.addForeignKey\("astronauts", "rockets", \{ validate: false \}\);$/m,
+        );
+      });
+    });
+
+    itIfSupports("validate_constraints", "schema dumping with validate true", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          validate: true,
+        });
+
+        const output = await dumpTableSchema(conn as unknown as SchemaSource, "astronauts");
+
+        expect(output).toMatch(/\s+await ctx\.addForeignKey\("astronauts", "rockets"\);$/m);
+      });
+    });
+
+    // Rails' `else` arm: without `supports_validate_constraints?` the foreign
+    // key is still created, but is never reported as invalid.
+    it.skipIf(supportsValidateConstraints)("add invalid foreign key", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          validate: false,
+        });
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(fk.isValidated).toBe(true);
       });
     });
 

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -2,7 +2,7 @@
  * Port of the `add_foreign_key`, `remove_foreign_key` and `SchemaDumpingHelper`
  * halves of `ActiveRecord::Migration::ForeignKeyTest`
  * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330,
- * :393-451, :536-619, :643-747 and :749-773) plus all of its sibling
+ * :393-451, :453-535, :536-619, :643-747 and :749-773) plus all of its sibling
  * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912).
  *
  * Driven by the ambient connection, mirroring Rails'

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -24,6 +24,7 @@ import { adapterType } from "../test-adapter.js";
 import { adapterSupports, describeIfSupports, itIfSupports } from "../support/supports.js";
 import { assertQueriesMatch } from "../testing/query-assertions.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { dumpTableSchema } from "../support/schema-dumping-helper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { Base } from "../base.js";
@@ -45,21 +46,12 @@ const supportsValidateConstraints = adapterSupports("validate_constraints");
 /**
  * `validate_foreign_key` / `validate_constraint` live on
  * PostgreSQL::SchemaStatements only, so they are absent from the
- * `AbstractAdapter` type the shared rocket-tables helper hands back. The cases
- * that call them are gated on `validate_constraints` (PostgreSQL-only), so the
- * narrowing is sound wherever it is used.
+ * `AbstractAdapter` type the shared rocket-tables helper hands back. Every
+ * caller below is gated on `validate_constraints` (PostgreSQL-only), so the
+ * downcast holds wherever it is used.
  */
-interface ValidatingAdapter {
-  validateForeignKey(
-    fromTable: string,
-    toTable?: string,
-    options?: { column?: string; name?: string },
-  ): Promise<void>;
-  validateConstraint(tableName: string, constraintName: string): Promise<void>;
-}
-
-function validating(conn: AbstractAdapter): ValidatingAdapter {
-  return conn as unknown as ValidatingAdapter;
+function validating(conn: AbstractAdapter): PostgreSQLAdapter {
+  return conn as PostgreSQLAdapter;
 }
 
 /** Rails' `silence_stream($stdout) { migration.migrate(...) }`. */

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -72,6 +72,9 @@ const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // PostgreSQL only (postgresql_adapter.rb:224/228; abstract default false).
   exclusion_constraints: ["postgres"],
   unique_constraints: ["postgres"],
+  // `supports_validate_constraints?`: PostgreSQL only (postgresql_adapter.rb:232;
+  // abstract default false).
+  validate_constraints: ["postgres"],
   // `supports_deferrable_constraints?`: PostgreSQL + SQLite true, abstract
   // default false. (postgresql_adapter.rb:236, sqlite3_adapter.rb:249)
   deferrable_constraints: ["postgres", "sqlite"],


### PR DESCRIPTION
Ports the `if ActiveRecord::Base.lease_connection.supports_validate_constraints?`
block of `ActiveRecord::Migration::ForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:453-535`),
**both arms** — the nine `if`-arm cases plus the `else` arm's
`test_add_invalid_foreign_key`.

- Adds `validate_constraints: ["postgres"]` to `support/supports.ts` — Rails'
  `supports_validate_constraints?` is PostgreSQL-only
  (`postgresql_adapter.rb:232`; abstract default false).
- `if` arm → `itIfSupports("validate_constraints", …)`; `else` arm → plain
  `it.skipIf(supportsValidateConstraints)`.

Both arms had to land together: #5486 backed out the `else` arm alone because
the Ruby gate extractor drops the negation, so with only one TS test present
the matcher paired it with the `validate_constraints` Rails entry and
`test:compare --gates --check` reported `[wrong-gate] "add invalid foreign key"`.
The `skipIf` condition is hoisted into a module const for the same reason — an
inline `adapterSupports("validate_constraints")` at the call site tags the
else-arm case with the very feature it excludes, re-creating the collision.

Rails' `validated?` is trails' `ForeignKeyDefinition#isValidated`.

### Drive-by fix

Porting `test_validate_foreign_key_by_column` surfaced a real typing defect:
`PostgreSQLAdapter#validateForeignKey` declared `options?: { name?: string }`
while forwarding straight to `PostgreSQL::SchemaStatements#validateForeignKey`,
which takes a full `ForeignKeyLookupOptions`. Rails'
`validate_foreign_key :astronauts, column: "rocket_id"` was therefore a type
error even though it works at runtime. Widened to
`Omit<ForeignKeyLookupOptions, "toTable">` on both the adapter and the
`Migration#validateForeignKey` wrapper, which had the identical narrowing.

Verified:
- `pnpm test:compare --gates --check` → exit 0, no gate mismatches.
- `foreign_key_test.rb` row: 36 → 45 matched tests.
- foreign-key.test.ts green on sqlite, postgres and mysql;
  migration.test.ts and invertible-migration.test.ts green (drive-by callers).

Closes-story: port-migration-foreign-key-validate-constraints-cases

### Review response: stale sibling declaration at `postgresql/schema-statements.ts:102`

Confirmed dead, so not updated here — and deliberately not widened in place.

`export interface SchemaStatements` (`postgresql/schema-statements.ts:47-373`)
has **zero importers**. The only two consumers of that module take
`CreateDatabaseOptions` and `PgIndexDefinition` only
(`postgresql-adapter.ts:106`, `postgresql/schema-statements-class.ts:22`). The
live contract is the class — `PostgreSQLSchemaStatements extends
SchemaStatements` (`schema-statements-class.ts:97`), where that
`SchemaStatements` is the **abstract class** from
`connection-adapters/abstract/schema-statements.js`, a different symbol that
merely shares the name. Rails agrees there is no interface to mirror:
`PostgreSQL::SchemaStatements` (`postgresql/schema_statements.rb`) is a module
mixed into the adapter, which trails already models as that class.

Widening the two drifting declarations in place was rejected: it would dress a
dead, unenforced interface up as a maintained contract, which is the same
failure mode as the bespoke `ValidatingAdapter` this PR already removed — that
one masked the very `validateForeignKey` narrowing the drive-by fixes.

Deleting it (plus its now-unused type imports) is ~330 deletions, which would
push this PR past the 500-LOC ceiling, so it is registered as its own story:
`0005-activerecord-gaps/remove-dead-pg-schema-statements-interface`. That story
covers `validateCheckConstraint` (`:101`) with the same drift, and calls for
auditing the rest of the interface rather than assuming those two are the only
stale declarations.
