### PR TITLE
refactor(activerecord): resolve model constants through Inflector.constantize

### DIFF
--- a/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers-resolution.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { NameError } from "@blazetrails/activesupport";
 
 import {
   allHelpersFromPath,
@@ -177,8 +178,11 @@ describe("defaultHelperModuleBang", () => {
     const cls: HelpersClassMethods = { name: "FooController" };
     const surprising = (name: string): HelperMethodsModule | undefined => {
       if (name === "FooHelper") {
-        // simulate: FooHelper file exists but references some other missing const
-        throw new Error("uninitialized constant SomeOtherThing");
+        // simulate: FooHelper file exists but references some other missing
+        // const. Rails' scenario (helpers.rb:241) is a real NameError whose
+        // missing_name differs, so the rescue must reject on the NAME, not on
+        // the error type — throw a NameError to exercise that branch.
+        throw new NameError("uninitialized constant SomeOtherThing", "SomeOtherThing");
       }
       return undefined;
     };

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -1,4 +1,4 @@
-import { camelize } from "@blazetrails/activesupport";
+import { camelize, NameError } from "@blazetrails/activesupport";
 
 /**
  * `AbstractController::Helpers` — class-level registry that exposes
@@ -325,7 +325,9 @@ export function modulesForHelpers(
       const raw = typeof arg === "symbol" ? (arg.description ?? "") : arg;
       const name = `${/^[A-Z]/.test(raw) ? raw : camelizeHelperPrefix(raw)}Helper`;
       const mod = options.resolve(name);
-      if (!mod) throw new Error(`uninitialized constant ${name}`);
+      // Rails' resolution raises NameError carrying the missing constant, which
+      // default_helper_module!'s `missing_name?` rescue reads.
+      if (!mod) throw new NameError(`uninitialized constant ${name}`, name);
       return mod;
     }
     throw new TypeError("helper must be a String, Symbol, or Module");
@@ -397,10 +399,10 @@ export function defaultHelperModuleBang(
     helper(cls, mod);
   } catch (err) {
     // Rails: `rescue NameError => e; raise unless e.missing_name?("#{helper_prefix}Helper")`.
-    // Only swallow the missing-constant error for *this* specific helper
-    // name. Errors from elsewhere (e.g. the helper module's own body
-    // referencing some other missing constant) must propagate.
-    if (err instanceof Error && err.message === `uninitialized constant ${expectedName}`) return;
+    // Only swallow the missing-constant error for *this* specific helper name.
+    // Errors from elsewhere (e.g. the helper module's own body referencing some
+    // other missing constant) must propagate.
+    if (err instanceof NameError && err.isMissingName(expectedName)) return;
     throw err;
   }
 }

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -1,4 +1,4 @@
-import { camelize, NameError } from "@blazetrails/activesupport";
+import { camelize, demodulize, NameError } from "@blazetrails/activesupport";
 
 /**
  * `AbstractController::Helpers` — class-level registry that exposes
@@ -326,8 +326,11 @@ export function modulesForHelpers(
       const name = `${/^[A-Z]/.test(raw) ? raw : camelizeHelperPrefix(raw)}Helper`;
       const mod = options.resolve(name);
       // Rails' resolution raises NameError carrying the missing constant, which
-      // default_helper_module!'s `missing_name?` rescue reads.
-      if (!mod) throw new NameError(`uninitialized constant ${name}`, name);
+      // default_helper_module!'s `missing_name?` rescue reads. Ruby's `name` is
+      // the failing *segment*, not the path; the resolver is a flat host lookup
+      // with no intermediate modules, so the leaf is the only segment that can
+      // be said to be missing.
+      if (!mod) throw new NameError(`uninitialized constant ${name}`, demodulize(name));
       return mod;
     }
     throw new TypeError("helper must be a String, Symbol, or Module");

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -77,7 +77,7 @@ export async function initializeAssociations(): Promise<void> {
     import("./associations/disable-joins-association-scope.js"),
   ]);
 }
-import { ConfigurationError, NameError } from "./errors.js";
+import { ConfigurationError } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { strictLoadingViolationBang } from "./core.js";
 import { StatementCache } from "./statement-cache.js";
@@ -101,6 +101,7 @@ import {
   pluralize,
   camelize,
   foreignKey as deriveForeignKey,
+  constantize,
   registerConstant,
   unregisterConstant,
 } from "@blazetrails/activesupport";
@@ -242,12 +243,16 @@ class ModelRegistry extends Map<string, typeof Base> {
     return this.#generation;
   }
 
+  // Write-through lives here, not at each caller, so a direct
+  // `modelRegistry.set` (the HABTM join model) or `.delete` (the PG schema
+  // helper) cannot leave the registry and the constant table disagreeing.
   override set(name: string, model: typeof Base): this {
     // Guard (inside registerModelConstant) before any mutation: a rejected
     // registration must not bump the generation, which would invalidate every
     // reflection memo for a write that never happened.
     registerModelConstant(name, model);
     if (super.get(name) !== model) this.#generation++;
+    registerConstant(name, model);
     return super.set(name, model);
   }
 
@@ -408,7 +413,7 @@ export function registerModel(
 
 /**
  * Zeitwerk analog: a fallback name→class index populated by the canonical
- * test-models barrel. When {@link resolveModel} or reflection's `computeClass`
+ * test-models barrel. When {@link autoloadModel} or reflection's `computeClass`
  * miss {@link modelRegistry}, they consult this index to autoload a canonical
  * model by name — the trails equivalent of Rails autoloading a constant on
  * first reference from an already-indexed `test/models/` tree. It stays
@@ -427,45 +432,33 @@ export function _setCanonicalModelAutoloadIndex(index: ReadonlyMap<string, typeo
 }
 
 /**
- * Look up a model by name, falling back to the canonical autoload index on a
- * {@link modelRegistry} miss. A hit in the index is registered so subsequent
- * lookups resolve directly from the registry. Returns undefined on a genuine
- * miss (name in neither the registry nor the index).
+ * Fault a canonical model into the constant table by name — the registration
+ * half of constant resolution, and all that is left of trails' old registry
+ * lookup. Ruby's `const_get` (so `constantize`) runs the autoloader on a miss;
+ * trails' constant table has no such hook, so callers fault the name in here
+ * and then resolve it with {@link constantize} exactly the way Rails spells it.
+ * No-op when the name already resolves or the index has no entry, so a genuine
+ * miss still leaves `constantize` to raise.
  * @internal
  */
-export function lookupModelWithAutoload(name: string): typeof Base | undefined {
-  const model = modelRegistry.get(name);
-  if (model) return model;
-  const autoloaded = canonicalModelAutoloadIndex?.get(name);
-  if (autoloaded) {
-    registerModel(autoloaded);
-    return autoloaded;
-  }
-  return undefined;
-}
-
-/**
- * Resolve a model class by name.
- *
- * @internal Registry lookup, not a Rails method. Ruby resolves association
- * class names through constant lookup — `Reflection#compute_class`
- * (`reflection.rb:434` and `:490`) into `Object.const_get` — so `resolve_model`
- * is defined nowhere in the Rails source; trails needs an explicit registry
- * because ESM has no constant namespace to walk. Sits between the
- * already-`@internal` {@link lookupModelWithAutoload} and
- * {@link resolveAssocClass}, which are the same invention.
- */
-export function resolveModel(name: string): typeof Base {
-  const model = lookupModelWithAutoload(name);
-  if (!model) {
-    throw new NameError(`uninitialized constant ${name}`);
-  }
-  return model;
+export function autoloadModel(name: string): void {
+  // `constantize` strips a leading `::` itself; the registry and the index are
+  // keyed unprefixed, so strip here too or `compute_class("::#{class_name}")`
+  // (reflection.rb:427) can never fault one in.
+  const bare = name.replace(/^::/, "");
+  // Gate on the *registry*, not the constant table. `registerSubclass`
+  // (inheritance.ts) and the adapter setter write constants without going
+  // through `registerModel`, so an STI subclass can be constantize-able while
+  // still absent from `modelRegistry` — which the join planner reads directly.
+  // Gating on `safeConstantize` would skip the fault-in and leave it absent.
+  if (modelRegistry.has(bare)) return;
+  const autoloaded = canonicalModelAutoloadIndex?.get(bare);
+  if (autoloaded) registerModel(autoloaded);
 }
 
 /**
  * Resolve the target model for an association using the rich reflection's
- * namespace-aware klass when available, falling back to flat resolveModel.
+ * namespace-aware klass when available, falling back to a flat constant lookup.
  * Skips `.klass` for polymorphic associations (checked via `isPolymorphic()`)
  * because polymorphic reflections intentionally throw on `.klass` access.
  * Non-polymorphic errors (e.g. not-an-AR-subclass) propagate unchanged.
@@ -490,7 +483,8 @@ export function resolveAssocClass(
     const richKlass = refl.klass;
     if (richKlass) return richKlass;
   }
-  return resolveModel(className);
+  autoloadModel(className);
+  return constantize(className) as typeof Base;
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -243,16 +243,17 @@ class ModelRegistry extends Map<string, typeof Base> {
     return this.#generation;
   }
 
-  // Write-through lives here, not at each caller, so a direct
+  // Write-through runs here, not at each caller, so a direct
   // `modelRegistry.set` (the HABTM join model) or `.delete` (the PG schema
   // helper) cannot leave the registry and the constant table disagreeing.
+  // `registerModelConstant` is the single path that binds a model class to a
+  // name; this must not write the constant table itself.
   override set(name: string, model: typeof Base): this {
     // Guard (inside registerModelConstant) before any mutation: a rejected
     // registration must not bump the generation, which would invalidate every
     // reflection memo for a write that never happened.
     registerModelConstant(name, model);
     if (super.get(name) !== model) this.#generation++;
-    registerConstant(name, model);
     return super.set(name, model);
   }
 

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -1,12 +1,18 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
-import { resolveModel, _preloadedHolderTarget } from "../associations.js";
+import { autoloadModel, _preloadedHolderTarget } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
 import { associationKeysEqual } from "./key-normalization.js";
 import { ScopeRegistry } from "../scoping.js";
 import { getDjasScopeBuilder, getAssociationRelationFactory } from "./_scope-slots.js";
 import { validateReflectionValidity } from "./validate-through-reflection.js";
-import { camelize, singularize, underscore } from "@blazetrails/activesupport";
+import {
+  camelize,
+  constantize,
+  safeConstantize,
+  singularize,
+  underscore,
+} from "@blazetrails/activesupport";
 import {
   AssociationTargetReplacedDuringLoad,
   AssociationTypeMismatch,
@@ -172,14 +178,15 @@ export class Association {
       // Rails rescues only the missing-constant NameError from compute_class and
       // re-raises anything else — notably the ArgumentError "resolved constant is
       // not an ActiveRecord::Base subclass" guard (reflection.rb:495-508). Mirror
-      // that: a missing-class NameError falls through to the resolveModel lookup
+      // that: a missing-class NameError falls through to the constant lookup
       // below (which re-raises the same faithful NameError); every other error
       // — config/reflection failures — propagates unchanged.
       if (!(e instanceof NameError)) throw e;
     }
     const className =
       opts.className ?? camelize(this.reflection.type === "hasMany" ? singularize(name) : name);
-    resolveModel(className);
+    autoloadModel(className);
+    constantize(className);
   }
 
   get name(): string {
@@ -463,6 +470,16 @@ export class Association {
    * Returns the class of the target. belongs_to polymorphic overrides
    * this to look at the polymorphic_type field on the owner.
    */
+  /**
+   * Mirrors: AssociationReflection#derive_class_name (reflection.rb:821-825) —
+   * `class_name.singularize if collection?`, then camelize.
+   * @internal
+   */
+  private deriveClassName(): string {
+    const name = this.reflection.name;
+    return camelize(this.isCollection() ? singularize(name) : name);
+  }
+
   get klass(): typeof Base {
     // Use the rich reflection's klass getter when available — it does
     // namespace-relative resolution, matching Rails' compute_type walk.
@@ -471,9 +488,9 @@ export class Association {
     };
     const richKlass = ctor._reflectOnAssociation?.(this.reflection.name)?.klass;
     if (richKlass) return richKlass;
-    const className =
-      this.reflection.options.className ?? camelize(singularize(this.reflection.name));
-    return resolveModel(className);
+    const className = this.reflection.options.className ?? this.deriveClassName();
+    autoloadModel(className);
+    return constantize(className) as typeof Base;
   }
 
   get extensions(): any[] {
@@ -893,10 +910,6 @@ export class Association {
 
   protected raiseOnTypeMismatchBang(record: Base): void {
     const klass = this.klass;
-    // Rails (association.rb:340-347) does a two-step check: `record.is_a?(reflection.klass)`
-    // and, on failure, `record.is_a?(reflection.class_name.safe_constantize)`. The second
-    // step exists only to tolerate constant reloading in development mode, which has no
-    // JS analogue, so a single `instanceof` is faithful here.
     if (klass && !(record instanceof (klass as any))) {
       // Rails names the expected side with `reflection.class_name` — the
       // demodulized convention name (`belongs_to :region` → "Region"), NOT the
@@ -905,11 +918,19 @@ export class Association {
       const ctor = this.owner.constructor as typeof Base & {
         _reflectOnAssociation?: (n: string) => { className?: string } | null;
       };
+      // Rails' `reflection.class_name` — the only string it constantizes
+      // (association.rb:341), and always defined. Never `klass.name` (a
+      // flattened namespaced ctor) or the bare association name, either of
+      // which could resolve to an unrelated class and swallow a genuine
+      // mismatch. `derive_class_name` singularizes only for a collection
+      // (reflection.rb:821-825), so a belongs_to named `status` or `series`
+      // must not be singularized into the wrong constant.
       const expectedType =
         ctor._reflectOnAssociation?.(this.reflection.name)?.className ??
         this.reflection.options.className ??
-        (klass as any).name ??
-        this.reflection.name;
+        this.deriveClassName();
+      const freshClass = safeConstantize(expectedType) as typeof Base | undefined;
+      if (freshClass && record instanceof (freshClass as any)) return;
       const actualType =
         record == null
           ? String(record)

--- a/packages/activerecord/src/associations/belongs-to-inverse-seed-composite-pk.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-inverse-seed-composite-pk.test.ts
@@ -15,7 +15,7 @@
  * requires the target class in the registry before `association()` is called.
  * This weakens the original guard: a future regression where `staleState()`
  * falls back to a registry lookup instead of reading from the held instance
- * would go undetected. Catching that would require a spy on `resolveModel`.
+ * would go undetected. Catching that would require a spy on `autoloadModel`.
  */
 import { describe, it, expect, vi } from "vitest";
 
@@ -83,7 +83,7 @@ describe("belongs_to inverse seeding with a composite-PK target", () => {
     // the spy only guards the setTarget → staleState → foreignKeyNames path.
     const holder = child.association("compositePkParent");
 
-    const spy = vi.spyOn(associationsModule, "resolveModel");
+    const spy = vi.spyOn(associationsModule, "autoloadModel");
     try {
       holder.setTarget(parent);
       expect(spy).not.toHaveBeenCalled();

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -1,8 +1,13 @@
-import { underscore, pluralize, camelize, isBlank } from "@blazetrails/activesupport";
+import {
+  underscore,
+  pluralize,
+  camelize,
+  isBlank,
+  safeConstantize,
+} from "@blazetrails/activesupport";
 import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
 import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
-import { modelRegistry } from "../../associations.js";
 import {
   flushPendingCounterCacheColumns,
   registerCounterCachedAssociation,
@@ -93,14 +98,11 @@ export class BelongsTo extends SingularAssociation {
     const pending = pendingCounterCacheColumns.get(targetClassName) ?? new Set<() => string>();
     pending.add(cacheColumn);
     pendingCounterCacheColumns.set(targetClassName, pending);
-    if (modelRegistry.has(targetClassName)) {
-      // Target already registered — flush right now (eager path).
-      // Use modelRegistry.get directly (not resolveAssocClass) to avoid
-      // prematurely caching the reflection's klass via a stale registry
-      // entry when the target class is re-defined (e.g. between tests).
-      const targetClass = modelRegistry.get(targetClassName) as any;
-      if (targetClass) flushPendingCounterCacheColumns(targetClass);
-    }
+    // Resolved through the constant table rather than the reflection so a
+    // target class re-defined between tests does not get its `klass` memo
+    // prematurely seeded.
+    const klass = safeConstantize(targetClassName) as any;
+    if (klass) flushPendingCounterCacheColumns(klass);
 
     // Mirrors Rails: `model.counter_cached_association_names |= [reflection.name]`
     registerCounterCachedAssociation(model, name);

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -201,12 +201,15 @@ export class HasAndBelongsToMany {
     const middleName = [pluralize(model.name.toLowerCase()), name].sort().join("_");
     const middleOptions: Record<string, unknown> = {
       className: registryKey,
-      // Rails sets only `class_name` here (has_and_belongs_to_many.rb:73), but
-      // the constant it names was just marked private, and `const_get` on a
-      // private constant raises — Rails' association survives because it
-      // "resolves through the reflection, not the constant table". Hold the join
-      // model directly so `klass` short-circuits before any name lookup;
-      // `className` stays for fidelity and for anything reading the name.
+      // DEVIATION (trails-only, tracked by converge-constantize-ignores-private-constants):
+      // Rails sets only `class_name` here (has_and_belongs_to_many.rb:73) and
+      // resolves the join model straight back out of the constant table —
+      // `private_constant` blocks only a literal `A::B` reference, never
+      // `const_get`, so `Object.const_get("Category::HABTM_Posts")` succeeds in
+      // Ruby (verified on 3.3.11). trails' `constantize` raises for a private
+      // name, which it should not; until that is fixed, hold the join model
+      // directly so `klass` short-circuits before any name lookup. `className`
+      // stays exactly as Rails spells it.
       anonymousClass: JoinModel,
       foreignKey: ownerFk,
       dependent: "delete",

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -201,6 +201,13 @@ export class HasAndBelongsToMany {
     const middleName = [pluralize(model.name.toLowerCase()), name].sort().join("_");
     const middleOptions: Record<string, unknown> = {
       className: registryKey,
+      // Rails sets only `class_name` here (has_and_belongs_to_many.rb:73), but
+      // the constant it names was just marked private, and `const_get` on a
+      // private constant raises — Rails' association survives because it
+      // "resolves through the reflection, not the constant table". Hold the join
+      // model directly so `klass` short-circuits before any name lookup;
+      // `className` stays for fidelity and for anything reading the name.
+      anonymousClass: JoinModel,
       foreignKey: ownerFk,
       dependent: "delete",
     };

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -38,7 +38,7 @@ import {
   raiseNotFoundSingle,
 } from "../relation/finder-methods.js";
 import type { Nodes } from "@blazetrails/arel";
-import { underscore, singularize, camelize } from "@blazetrails/activesupport";
+import { underscore, singularize, camelize, constantize } from "@blazetrails/activesupport";
 import { filterScopeForCreate } from "./association.js";
 import {
   RecordNotSaved,
@@ -64,7 +64,7 @@ import { compositeQueryConstraintsList } from "../persistence.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   association,
-  resolveModel,
+  autoloadModel,
   resolveAssocClass,
   buildHasManyRelation,
   buildThroughJoinScope,
@@ -543,7 +543,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       _reflectOnAssociation?: (n: string) => { klass?: typeof Base } | null;
     };
     const richKlass = ownerCtor._reflectOnAssociation?.(assocName)?.klass;
-    return richKlass ?? resolveModel(className);
+    if (richKlass) return richKlass;
+    autoloadModel(className);
+    return constantize(className) as typeof Base;
   }
 
   /**

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -40,7 +40,7 @@ function _guardKey(association: unknown): string {
  * methods (`isUpdated`, `isStaleTarget`, `setInverseInstance`,
  * `loadedBang`, etc.) are reachable.
  *
- * Configuration errors (`validateThroughReflection`, `resolveModel` for an
+ * Configuration errors (`validateThroughReflection`, `constantize` for an
  * unregistered target class, inverse-of validity, etc.) intentionally
  * propagate to surface misconfiguration loudly, matching Rails'
  * `Reflection#check_validity!` semantics. Only `AssociationNotFoundError`

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -5,7 +5,12 @@
  */
 
 import { getApplicationRecordClass } from "./inheritance.js";
-import { RecordNotFound, StatementInvalid, StrictLoadingViolationError } from "./errors.js";
+import {
+  NameError,
+  RecordNotFound,
+  StatementInvalid,
+  StrictLoadingViolationError,
+} from "./errors.js";
 import { actionOnStrictLoadingViolation } from "./ar-config.js";
 import { WRITING_ROLE } from "./roles.js";
 import {
@@ -20,6 +25,7 @@ import {
   IsolatedExecutionState,
   ParameterFilter,
   camelize,
+  constantize,
   pluralize,
 } from "@blazetrails/activesupport";
 import {
@@ -430,7 +436,20 @@ function parentClass(klass: CoreHost): CoreHost | null {
 
 export function destroyAssociationAsyncJob(this: CoreHost, value?: any): any {
   if (value !== undefined) {
+    // Rails aliases the writer straight to `_destroy_association_async_job=`
+    // (core.rb:36), a plain setter that never resolves the constant. Only the
+    // reader below constantizes, so assigning a not-yet-registered class name
+    // stays legal.
     this._destroyAssociationAsyncJob = value;
+    return this._destroyAssociationAsyncJob;
+  }
+  if (typeof this._destroyAssociationAsyncJob === "string") {
+    try {
+      this._destroyAssociationAsyncJob = constantize(this._destroyAssociationAsyncJob);
+    } catch (error) {
+      if (!(error instanceof NameError)) throw error;
+      throw new NameError(`Unable to load destroy_association_async_job: ${error.message}`);
+    }
   }
   return this._destroyAssociationAsyncJob ?? null;
 }

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -1,6 +1,13 @@
 import type { Base } from "./base.js";
-import { camelize, inquiry, singularize, tableize, underscore } from "@blazetrails/activesupport";
-import { resolveModel } from "./associations.js";
+import {
+  camelize,
+  constantize,
+  inquiry,
+  singularize,
+  tableize,
+  underscore,
+} from "@blazetrails/activesupport";
+import { autoloadModel } from "./associations.js";
 
 /**
  * Configuration for a delegated type.
@@ -102,7 +109,8 @@ export function delegatedType(
     get(this: Base) {
       const typeName = this.readAttribute(foreignType) as string | null;
       if (!typeName) return null;
-      return resolveModel(typeName);
+      autoloadModel(typeName);
+      return constantize(typeName) as typeof Base;
     },
     configurable: true,
   });
@@ -136,7 +144,8 @@ export function delegatedType(
       if (!typeName) {
         throw new Error(`Cannot build${camelize(role, true)}: ${foreignType} is not set`);
       }
-      const TargetClass = resolveModel(typeName);
+      autoloadModel(typeName);
+      const TargetClass = constantize(typeName) as typeof Base;
       const instance = new (TargetClass as unknown as new (a: Record<string, unknown>) => Base)(
         attrs,
       );

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -734,12 +734,11 @@ export class UnknownAttributeError extends ActiveRecordError {
   }
 }
 
-export class NameError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "NameError";
-  }
-}
+// Ruby's NameError is a core class, not an Active Record one: it is what
+// constant resolution (so Inflector.constantize) raises. Re-exported from
+// Active Support's core-ext port so `rescue NameError` sites catch the same
+// class whether the constant was resolved here or by the inflector.
+export { NameError } from "@blazetrails/activesupport";
 
 export class SQLWarning extends AdapterError {
   readonly code: string | null;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -50,7 +50,15 @@ export function computeType(baseClass: typeof Base, typeName: string): typeof Ba
   // module nesting and imposes NO subclass relationship — a sibling in the same
   // namespace (e.g. Business::Client.compute_type("Firm")) resolves fine. The STI
   // subclass constraint lives in find_sti_class ({@link stiClassFor}), not here.
-  return resolveComputedType(baseClass, typeName);
+  if (typeName.startsWith("::")) {
+    return constantize(typeName) as typeof Base;
+  }
+  const candidates = computeTypeCandidates(baseClass, typeName);
+  for (const candidate of candidates) {
+    const klass = safeConstantize(candidate) as typeof Base | undefined;
+    if (klass && qualifiedName(klass) === candidate) return klass;
+  }
+  throw new NameError(`uninitialized constant ${candidates[0]}`, candidates[0]);
 }
 
 /**
@@ -71,33 +79,6 @@ function computeTypeCandidates(baseClass: typeof Base, typeName: string): string
   }
   candidates.push(typeName);
   return candidates;
-}
-
-/**
- * Ruby-style namespace-relative constant resolution, mirroring
- * ActiveRecord::Inheritance::ClassMethods#compute_type. Walks the model's module
- * nesting (see {@link computeTypeCandidates}) and returns the first candidate that
- * resolves to a registered class whose own qualified name equals the candidate —
- * Rails' `candidate == constant.to_s` guard, which rejects an outer-scope constant
- * leaking through (so a demodulized type stored under a namespaced model resolves
- * via the namespace prefix even when the bare name is unregistered). A leading
- * `::` is an absolute reference resolved directly. Throws NameError when nothing
- * resolves. Does NOT enforce a subclass relationship — that is {@link stiClassFor}'s
- * (Rails' find_sti_class's) job, leaving this usable for polymorphic and sibling
- * targets.
- *
- * @internal
- */
-function resolveComputedType(baseClass: typeof Base, typeName: string): typeof Base {
-  if (typeName.startsWith("::")) {
-    return constantize(typeName) as typeof Base;
-  }
-  const candidates = computeTypeCandidates(baseClass, typeName);
-  for (const candidate of candidates) {
-    const klass = safeConstantize(candidate) as typeof Base | undefined;
-    if (klass && qualifiedName(klass) === candidate) return klass;
-  }
-  throw new NameError(`uninitialized constant ${candidates[0]}`, candidates[0]);
 }
 
 /**
@@ -782,7 +763,7 @@ export function stiClassFor(modelClass: typeof Base, typeName: string): typeof B
     if (klass.storeFullStiClass && klass.storeFullClassName) {
       subclass = constantize(typeName) as typeof Base;
     } else {
-      subclass = resolveComputedType(modelClass, typeName);
+      subclass = computeType(modelClass, typeName);
     }
   } catch (cause) {
     if (!(cause instanceof NameError)) throw cause;
@@ -813,7 +794,7 @@ export function polymorphicClassFor(modelClass: typeof Base, name: string): type
   if (klass.storeFullClassName) {
     return constantize(name) as typeof Base;
   }
-  return resolveComputedType(modelClass, name);
+  return computeType(modelClass, name);
 }
 
 /**

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -7,7 +7,13 @@
 import type { Base } from "./base.js";
 import { modelRegistry, registerModelConstant } from "./associations.js";
 import { ActiveRecordError, NameError, SubclassNotFound } from "./errors.js";
-import { camelize, isPresent, underscore } from "@blazetrails/activesupport";
+import {
+  camelize,
+  constantize,
+  isPresent,
+  safeConstantize,
+  underscore,
+} from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { applicationRecordClass, setApplicationRecordClass } from "./ar-config.js";
 
@@ -84,17 +90,14 @@ function computeTypeCandidates(baseClass: typeof Base, typeName: string): string
  */
 function resolveComputedType(baseClass: typeof Base, typeName: string): typeof Base {
   if (typeName.startsWith("::")) {
-    const absolute = typeName.slice(2);
-    const klass = modelRegistry.get(absolute);
-    if (!klass) throw new NameError(`uninitialized constant ${absolute}`);
-    return klass;
+    return constantize(typeName) as typeof Base;
   }
   const candidates = computeTypeCandidates(baseClass, typeName);
   for (const candidate of candidates) {
-    const klass = modelRegistry.get(candidate);
+    const klass = safeConstantize(candidate) as typeof Base | undefined;
     if (klass && qualifiedName(klass) === candidate) return klass;
   }
-  throw new NameError(`uninitialized constant ${candidates[0]}`);
+  throw new NameError(`uninitialized constant ${candidates[0]}`, candidates[0]);
 }
 
 /**
@@ -776,12 +779,8 @@ export function stiClassFor(modelClass: typeof Base, typeName: string): typeof B
   // keeps "Invalid single-table inheritance type" (raised *outside* the rescue).
   let subclass: typeof Base;
   try {
-    // sti_class_for: constantize when storing the full STI class name, else
-    // namespace-relative compute_type. Bare registry lookup is trails' constantize.
     if (klass.storeFullStiClass && klass.storeFullClassName) {
-      const resolved = modelRegistry.get(typeName);
-      if (!resolved) throw new NameError(`uninitialized constant ${typeName}`);
-      subclass = resolved;
+      subclass = constantize(typeName) as typeof Base;
     } else {
       subclass = resolveComputedType(modelClass, typeName);
     }
@@ -808,14 +807,11 @@ export function stiClassFor(modelClass: typeof Base, typeName: string): typeof B
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#polymorphic_class_for
  */
 export function polymorphicClassFor(modelClass: typeof Base, name: string): typeof Base {
-  // Mirrors Rails' polymorphic_class_for: constantize when storing the full
-  // class name, else namespace-relative compute_type. Polymorphic targets are
-  // unrelated models, so (unlike STI) no subclass relationship is enforced.
+  // Polymorphic targets are unrelated models, so (unlike STI) no subclass
+  // relationship is enforced.
   const klass = modelClass as typeof Base & { storeFullClassName?: boolean };
   if (klass.storeFullClassName) {
-    const resolved = modelRegistry.get(name);
-    if (!resolved) throw new NameError(`uninitialized constant ${name}`);
-    return resolved;
+    return constantize(name) as typeof Base;
   }
   return resolveComputedType(modelClass, name);
 }

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -30,6 +30,7 @@ import { Post as CanonicalPost } from "./test-helpers/models/post.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import { create as createReflection } from "./reflection.js";
 import { Customer } from "./test-helpers/models/customer.js";
+import { UserWithInvalidRelation } from "./test-helpers/models/user-with-invalid-relation.js";
 import { Organization } from "./test-helpers/models/organization.js";
 import { Author } from "./test-helpers/models/author.js";
 import { Hotel as CanonicalHotel } from "./test-helpers/models/hotel.js";
@@ -897,8 +898,22 @@ describe("ReflectionTest", () => {
   it.skip("name error from incidental code is not converted to name error for association", () => {
     // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.
   });
-  it.skip("automatic inverse suppresses name error for association", () => {
-    // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.
+  it("automatic inverse suppresses name error for association", () => {
+    // automatic_inverse_of rescues the NameError compute_class raises for the
+    // association's own missing class (reflection.rb:769,
+    // `raise unless error.name.to_s == class_name`) and gives up on the
+    // inverse rather than propagating. `notAClass` names no registered model.
+    const reflection = reflectOnAssociation(UserWithInvalidRelation, "notAClass");
+    expect(reflection).not.toBeNull();
+    // Rails: `reflection.dup.has_inverse?` — "dup to prevent global
+    // memoization" (reflection_test.rb:651). UserWithInvalidRelation is
+    // module-scoped, so memoizing the failed inverse onto the shared reflection
+    // would leak into every later test. Object#dup is a shallow copy.
+    const dup = Object.create(
+      Object.getPrototypeOf(reflection),
+      Object.getOwnPropertyDescriptors(reflection),
+    ) as typeof reflection;
+    expect(dup!.hasInverse()).toBe(false);
   });
   it.skip("automatic inverse does not suppress name error from incidental code", () => {
     // UNPORTED: relies on Ruby const_missing mechanism — no JS equivalent.
@@ -1139,8 +1154,13 @@ describe("ReflectionTest", () => {
     }
     const ref = reflectOnAssociation(Orphan, "ghosts");
     expect(ref).not.toBeNull();
-    // "Ghost" is not registered, so accessing klass should throw
-    expect(() => ref!.klass).toThrow(/not found in registry/);
+    // "Ghost" is not registered, so accessing klass should throw. compute_class
+    // wraps the miss in its own NameError (reflection.rb:494-503), and appends
+    // the :class_name hint because no class_name option was given.
+    expect(() => ref!.klass).toThrow(
+      "Missing model class Ghost for the Orphan#ghosts association." +
+        " You can specify a different model class with the :class_name option.",
+    );
   });
 
   it("reflection klass not found with pointer to non existent class name", () => {
@@ -1155,7 +1175,11 @@ describe("ReflectionTest", () => {
     }
     const ref = reflectOnAssociation(Orphan2, "items");
     expect(ref).not.toBeNull();
-    expect(() => ref!.klass).toThrow(/not found in registry/);
+    // class_name *was* given, so Rails omits the hint suffix.
+    expect(() => ref!.klass).toThrow(
+      "Missing model class NonExistentModel for the Orphan2#items association.",
+    );
+    expect(() => ref!.klass).not.toThrow(/:class_name option/);
   });
 
   it("reflection klass requires ar subclass", () => {
@@ -1255,11 +1279,12 @@ describe("ReflectionTest", () => {
       }
     }
     // AggregateReflection backs composed_of; a string class_name pointing at a
-    // constant that isn't registered must raise NameError (Rails compute_type),
-    // matching AssociationReflection#computeClass so NameError-only rescues apply.
+    // constant that isn't registered must raise NameError. Rails'
+    // MacroReflection#compute_class is `name.constantize` (reflection.rb:434),
+    // so the message is constantize's, not a registry-specific one.
     const ref = new AggregateReflection("balance", null, { className: "NoSuchMoney" }, Buyer);
     expect(() => ref.klass).toThrow(NameError);
-    expect(() => ref.klass).toThrow(/not found in registry/);
+    expect(() => ref.klass).toThrow(/uninitialized constant NoSuchMoney/);
   });
 
   it("association reflection in modules", async () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -8,6 +8,8 @@ import {
   singularize,
   camelize,
   demodulize,
+  constantize,
+  safeConstantize,
   foreignKey as deriveForeignKey,
 } from "@blazetrails/activesupport";
 import { Table, type TableRef } from "@blazetrails/arel";
@@ -15,7 +17,7 @@ import { _correctNames } from "./associations.js";
 import { joinTableName } from "./migration/join-table.js";
 import { rubyInspectArray } from "./relation/ruby-inspect.js";
 
-import { modelRegistry, lookupModelWithAutoload } from "./associations.js";
+import { modelRegistry, autoloadModel } from "./associations.js";
 import {
   hasQueryConstraints,
   queryConstraintsList,
@@ -688,18 +690,8 @@ export class MacroReflection extends AbstractReflection {
   }
 
   computeClass(name: string): typeof Base {
-    const lookupName = name.startsWith("::") ? name.slice(2) : name;
-    const resolved = lookupModelWithAutoload(lookupName);
-    if (!resolved) {
-      // Rails resolves both association and aggregation reflection classes
-      // through compute_type, which raises NameError for a missing constant
-      // (reflection.rb:495-508). Match AssociationReflection#computeClass so
-      // callers rescuing only NameError treat both paths uniformly.
-      throw new NameError(
-        `Model '${lookupName}' not found in registry (for '${this.nameString}' on ${this.activeRecord.name})`,
-      );
-    }
-    return resolved;
+    autoloadModel(name);
+    return constantize(name) as typeof Base;
   }
 
   scopeFor(relation: any, owner?: any): any {
@@ -1023,13 +1015,10 @@ export class AssociationReflection extends MacroReflection {
         }
       }
     } catch (e: unknown) {
-      // Rails: rescue NameError => error; raise unless error.name.to_s == class_name
-      // Only swallow model-not-found errors from computeClass, re-raise anything else
-      if (
-        e instanceof Error &&
-        e.message.startsWith("Model ") &&
-        e.message.includes("not found in registry")
-      ) {
+      // Rails: `rescue NameError => error; raise unless error.name.to_s == class_name`
+      // (reflection.rb:769) — swallow only the miss for *this* reflection's own
+      // class name, re-raise anything else.
+      if (e instanceof NameError && e.constantName === this.className) {
         reflection = false;
       } else {
         throw e;
@@ -1305,7 +1294,8 @@ export class AssociationReflection extends MacroReflection {
         const segments = nestingSource.split("::");
         for (let i = segments.length; i > 0; i--) {
           const candidate = [...segments.slice(0, i), simpleName].join("::");
-          const resolved = lookupModelWithAutoload(candidate);
+          autoloadModel(candidate);
+          const resolved = safeConstantize(candidate) as typeof Base | undefined;
           if (resolved) {
             if (!(resolved as any)._isActiveRecordBase) {
               throw new ArgumentError(
@@ -1318,14 +1308,22 @@ export class AssociationReflection extends MacroReflection {
       }
     }
 
-    const resolved = lookupModelWithAutoload(simpleName);
-    if (!resolved) {
-      // Rails' compute_class raises NameError for a missing constant (the only
-      // error check_validity! callers rescue); the subclass guard below raises
-      // ArgumentError, which must propagate. reflection.rb:495-508.
-      throw new NameError(
-        `Model '${simpleName}' not found in registry (for '${this.nameString}' on ${this.activeRecord.name})`,
-      );
+    autoloadModel(simpleName);
+    let resolved: typeof Base;
+    try {
+      resolved = constantize(simpleName) as typeof Base;
+    } catch (error) {
+      // Rails re-raises compute_type's NameError as its own, carrying `name`
+      // (reflection.rb:494-503) — which is what lets automatic_inverse_of
+      // compare `error.name.to_s == class_name` at :769. A miss on an
+      // unrelated constant propagates untouched.
+      if (!(error instanceof NameError)) throw error;
+      if (!new RegExp(`(?:^|::)${simpleName}$`).test(error.constantName ?? "")) throw error;
+      let message = `Missing model class ${simpleName} for the ${this.activeRecord.name}#${this.nameString} association.`;
+      if (!this.options.className) {
+        message += " You can specify a different model class with the :class_name option.";
+      }
+      throw new NameError(message, simpleName);
     }
     if (!(resolved as any)._isActiveRecordBase) {
       throw new ArgumentError(

--- a/packages/activerecord/src/register-model-batch.test.ts
+++ b/packages/activerecord/src/register-model-batch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { registerModel, modelRegistry, resolveModel } from "./associations.js";
+import { registerModel, modelRegistry } from "./associations.js";
+import { constantize } from "@blazetrails/activesupport";
 import { Base } from "./base.js";
 import { Author } from "./test-helpers/models/author.js";
 import { Comment, SpecialComment, SubSpecialComment } from "./test-helpers/models/comment.js";
@@ -8,7 +9,7 @@ describe("registerModel array form", () => {
   it("registers every class in the array, resolvable by name", () => {
     registerModel([Author, Comment, SpecialComment, SubSpecialComment]);
 
-    expect(resolveModel("Author")).toBe(Author);
+    expect(constantize("Author")).toBe(Author);
     expect(modelRegistry.get("Comment")).toBe(Comment);
     expect(modelRegistry.get("SpecialComment")).toBe(SpecialComment);
     expect(modelRegistry.get("SubSpecialComment")).toBe(SubSpecialComment);
@@ -54,14 +55,14 @@ describe("registerModel array form", () => {
     expect((BatchBase as any)._subclasses ?? []).not.toContain(BatchBase);
     expect((BatchBase as any)._subclasses).toContain(BatchChild);
     expect((BatchChild as any)._subclasses).toContain(BatchGrandchild);
-    expect(resolveModel("BatchGrandchild")).toBe(BatchGrandchild);
+    expect(constantize("BatchGrandchild")).toBe(BatchGrandchild);
   });
 
   it("keeps the single-class and (name, model) forms working", () => {
     registerModel(Author);
-    expect(resolveModel("Author")).toBe(Author);
+    expect(constantize("Author")).toBe(Author);
 
     registerModel("AuthorAlias", Author);
-    expect(resolveModel("AuthorAlias")).toBe(Author);
+    expect(constantize("AuthorAlias")).toBe(Author);
   });
 });

--- a/packages/activerecord/src/support/canonical-model-index.test.ts
+++ b/packages/activerecord/src/support/canonical-model-index.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { canonicalModelIndex } from "./canonical-model-index.js";
-import { resolveModel } from "../associations.js";
+import { autoloadModel, modelRegistry, registerModel } from "../associations.js";
+import { constantize, registerConstant, safeConstantize } from "@blazetrails/activesupport";
+
+/** Autoload-then-constantize: the two-step every AR call site now spells out. */
+function resolve(name: string): unknown {
+  autoloadModel(name);
+  return constantize(name);
+}
 import { Comment } from "../test-helpers/models/comment.js";
 import { Owner } from "../test-helpers/models/owner.js";
 import { Pet } from "../test-helpers/models/pet.js";
+import { Reply } from "../test-helpers/models/reply.js";
 import { MyAppBusinessCompany } from "../test-helpers/models/company-in-module.js";
 
 describe("canonical model autoload index (Zeitwerk analog)", () => {
@@ -19,14 +27,14 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
     // (`MyApplication::Business::Company`), not the flat JS constructor name, so
     // the index must carry the qualified key for the walk to hit it.
     expect(canonicalModelIndex.get("MyApplication::Business::Company")).toBe(MyAppBusinessCompany);
-    expect(resolveModel("MyApplication::Business::Company")).toBe(MyAppBusinessCompany);
+    expect(resolve("MyApplication::Business::Company")).toBe(MyAppBusinessCompany);
   });
 
   it("resolveModel autoloads an indexed model on a registry miss", () => {
-    // Whether or not another test already registered it, resolveModel returns
+    // Whether or not another test already registered it, the two-step returns
     // the canonical class — the fallback covers the un-registered case.
-    expect(resolveModel("Comment")).toBe(Comment);
-    expect(resolveModel("Owner")).toBe(Owner);
+    expect(resolve("Comment")).toBe(Comment);
+    expect(resolve("Owner")).toBe(Owner);
   });
 
   it("autoloads an association-target model through reflection's computeClass", () => {
@@ -40,10 +48,39 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
     expect(refl.klass).toBe(Owner);
   });
 
+  it("autoloads through a `::`-prefixed absolute name", () => {
+    // reflection.ts `_klass` tries `computeClass("::#{class_name}")` first
+    // (reflection.rb:427). `constantize` strips the prefix itself, so
+    // `autoloadModel` must too — otherwise the index (keyed unprefixed) misses
+    // and an index-only model can never be faulted in on that path.
+    expect(resolve("::Pet")).toBe(Pet);
+  });
+
+  it("faults in a model that is constantize-able but absent from the registry", () => {
+    // registerSubclass (inheritance.ts:416) and the adapter setter
+    // (base.ts:1358) write the constant table WITHOUT registerModel, so an STI
+    // subclass can resolve through constantize while missing from
+    // modelRegistry — which the join planner reads directly
+    // (join-dependency.ts:344,371). autoloadModel must therefore gate on the
+    // registry, not on safeConstantize, or the fault-in is skipped and the join
+    // silently builds no node.
+    const had = modelRegistry.get("Reply");
+    modelRegistry.delete("Reply"); // write-through drops the constant too
+    registerConstant("Reply", Reply); // re-create registerSubclass's half alone
+    try {
+      expect(safeConstantize("Reply")).toBe(Reply);
+      expect(modelRegistry.has("Reply")).toBe(false);
+      autoloadModel("Reply");
+      expect(modelRegistry.has("Reply")).toBe(true);
+    } finally {
+      if (had) registerModel("Reply", had);
+    }
+  });
+
   it("throws a constant-not-found error for a genuine miss", () => {
     // A name in neither the registry nor the index must still throw, so the
     // fallback can never silently mask a missing or misnamed model.
-    expect(() => resolveModel("NoSuchCanonicalModel")).toThrow(
+    expect(() => resolve("NoSuchCanonicalModel")).toThrow(
       /uninitialized constant NoSuchCanonicalModel/,
     );
   });

--- a/packages/activesupport/src/core-ext/name-error.test.ts
+++ b/packages/activesupport/src/core-ext/name-error.test.ts
@@ -1,14 +1,42 @@
 import { describe, expect, it } from "vitest";
+import { NameError } from "./name-error.js";
+import { constantize, registerConstant, unregisterConstant } from "../inflector.js";
 
 describe("NameErrorTest", () => {
   it("name error should set missing name", () => {
-    const err = new ReferenceError("undefined variable 'foo'");
-    expect(err.message).toContain("foo");
-    expect(err instanceof Error).toBe(true);
+    // Ruby raises this by *referencing* the constant inside the test class;
+    // trails has no bare constant references, so `constantize` is the
+    // equivalent trigger. `NameErrorTest` is registered because in Ruby it is a
+    // live class — the enclosing constant has to exist for `name` to be the
+    // final segment rather than the first missing one. Rails' `receiver`
+    // assertion has no JS analogue: an Error carries no receiver.
+    class NameErrorTest {}
+    registerConstant("NameErrorTest", NameErrorTest);
+
+    let exc: NameError | undefined;
+    try {
+      constantize("NameErrorTest::SomeNameThatNobodyWillUse____Really");
+    } catch (e) {
+      exc = e as NameError;
+    } finally {
+      // The constant table is process-wide; don't leak this into other tests.
+      unregisterConstant("NameErrorTest", NameErrorTest);
+    }
+    expect(exc).toBeInstanceOf(NameError);
+    expect(exc!.missingName()).toBe("NameErrorTest::SomeNameThatNobodyWillUse____Really");
+    // Ruby's Symbol arm compares `name` (the segment); the string arm compares
+    // `missing_name` (the qualified path).
+    expect(exc!.isMissingName(Symbol("SomeNameThatNobodyWillUse____Really"))).toBe(true);
+    expect(exc!.isMissingName("NameErrorTest::SomeNameThatNobodyWillUse____Really")).toBe(true);
   });
 
   it("missing method should ignore missing name", () => {
-    const obj = {} as any;
-    expect(() => obj.nonExistentMethod()).toThrow();
+    // A NameError that is not a missing *constant* must report no missing name.
+    const exc = new NameError("undefined local variable or method 'someMethod'");
+    expect(exc.isMissingName(Symbol("Foo"))).toBe(false);
+    // Ruby's `nil == :sym` is false, so a nameless NameError matches no Symbol
+    // — including a description-less one, where both sides are undefined.
+    expect(exc.isMissingName(Symbol())).toBe(false);
+    expect(exc.missingName()).toBeUndefined();
   });
 });

--- a/packages/activesupport/src/core-ext/name-error.ts
+++ b/packages/activesupport/src/core-ext/name-error.ts
@@ -1,0 +1,62 @@
+/**
+ * NameError — the error Ruby raises for an unresolvable constant, and so what
+ * `Inflector.constantize` raises.
+ *
+ * Mirrors: active_support/core_ext/name_error.rb (the class it reopens).
+ *
+ * JS has no NameError, and trails uses `ReferenceError` as its analogue
+ * throughout, so this extends it: `catch (e) { e instanceof ReferenceError }`
+ * keeps working for hosts that spell the analogue directly, while
+ * `rescue NameError` sites can name the class Rails names.
+ *
+ * **`name` is not Ruby's `NameError#name`.** In Ruby that attribute holds the
+ * *missing constant segment* — `safe_constantize`'s
+ * `camel_cased_word.split("::").include?(e.name.to_s)` guard only makes sense
+ * because it is one segment, not the whole path — and `NameError.new(msg, name)`
+ * sets it explicitly (the shape `inheritance.rb:264` and `reflection.rb:501`
+ * use). JS reserves `Error#name` for the class name, so the Ruby attribute
+ * lives on {@link constantName}. It is NOT `missing_name`, which prepends the
+ * receiver; use {@link missingName} for that.
+ */
+export class NameError extends ReferenceError {
+  /** Ruby's `NameError#name`: the missing constant *segment*, not the path. */
+  readonly constantName?: string;
+
+  constructor(message: string, constantName?: string) {
+    super(message);
+    this.name = "NameError";
+    this.constantName = constantName;
+  }
+
+  /**
+   * Extract the name of the missing constant from the exception message.
+   *
+   * Mirrors: NameError#missing_name. Ruby's receiver-aware branches have no JS
+   * analogue (an Error carries no receiver), so this always takes Ruby's final
+   * branch — the message regex — which yields the same qualified path Ruby's
+   * receiver branch builds. Deliberately not {@link constantName}, which is the
+   * unqualified `name`.
+   */
+  missingName(): string | undefined {
+    if (!this.message.startsWith("uninitialized constant ")) return undefined;
+    const match = this.message.match(/((::)?([A-Z]\w*)(::[A-Z]\w*)*)$/);
+    return match ? match[1] : undefined;
+  }
+
+  /**
+   * Was this exception raised because the given name was missing?
+   *
+   * Mirrors: NameError#missing_name?. Ruby branches on the argument's type —
+   * a Symbol compares against `name`, anything else against `missing_name` —
+   * so this branches the same way, treating a JS symbol as Ruby's Symbol and
+   * its `description` as the symbol's text.
+   */
+  isMissingName(name: string | symbol): boolean {
+    // Ruby's `self.name == name` is false whenever `name` is nil, so a
+    // NameError carrying no constant never matches a Symbol.
+    if (typeof name === "symbol") {
+      return this.constantName !== undefined && this.constantName === name.description;
+    }
+    return this.missingName() === name;
+  }
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -1,3 +1,4 @@
+export { NameError } from "./core-ext/name-error.js";
 export {
   registerFsAdapter,
   getFs,

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -259,7 +259,10 @@ export function constantize(camelCasedWord: string): unknown {
   // two calls made by independent writers, and the mark must hold whichever runs
   // first.
   if (_privateConstants.has(path)) {
-    throw new ReferenceError(`private constant ${path} referenced`);
+    // Ruby raises NameError here too, with `name` set to the constant itself —
+    // which is why `safe_constantize` returns nil for a private constant rather
+    // than propagating. Carrying the leaf keeps that guard satisfied.
+    throw new NameError(`private constant ${path} referenced`, demodulize(path));
   }
   if (!_constants.has(path)) {
     throw new NameError(`uninitialized constant ${path}`, missingSegment(path));

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -4,6 +4,7 @@
  */
 
 import { Inflections } from "./inflector/inflections.js";
+import { NameError } from "./core-ext/name-error.js";
 
 /** @internal */
 function applyInflections(word: string, rules: { rule: RegExp; replacement: string }[]): string {
@@ -220,6 +221,27 @@ export function _resetConstants(): void {
   _privateConstants.clear();
 }
 
+/**
+ * The segment `Object.const_get` would fail on: it resolves `A::B::C` one step
+ * at a time, so the NameError names the first link that is missing, not the
+ * whole path. Our table is keyed by full path, so walking prefixes is the
+ * equivalent probe.
+ *
+ * This is exact only for paths whose enclosing modules are themselves
+ * registered. Ruby walks real modules, so `A::B` with `A` a live module names
+ * `:B`; here, if nothing registered `A`, the walk stops at `A` and names that
+ * instead. Registering the enclosing names (as a namespaced model registration
+ * does) makes the two agree.
+ * @internal
+ */
+function missingSegment(path: string): string {
+  const segments = path.split("::");
+  for (let i = 1; i <= segments.length; i++) {
+    if (!_constants.has(segments.slice(0, i).join("::"))) return segments[i - 1];
+  }
+  return segments[segments.length - 1];
+}
+
 function isValidConstantPath(path: string): boolean {
   if (path.length === 0) return false;
   return path.split("::").every((segment) => /^[A-Z]\w*$/.test(segment));
@@ -229,7 +251,7 @@ function isValidConstantPath(path: string): boolean {
 export function constantize(camelCasedWord: string): unknown {
   const path = camelCasedWord.startsWith("::") ? camelCasedWord.slice(2) : camelCasedWord;
   if (!isValidConstantPath(path)) {
-    throw new ReferenceError(`wrong constant name ${camelCasedWord}`);
+    throw new NameError(`wrong constant name ${camelCasedWord}`);
   }
   // Privacy is checked before existence, which Ruby cannot reach: there
   // `private_constant` on an undefined name is itself a NameError, so a name is
@@ -240,7 +262,7 @@ export function constantize(camelCasedWord: string): unknown {
     throw new ReferenceError(`private constant ${path} referenced`);
   }
   if (!_constants.has(path)) {
-    throw new ReferenceError(`uninitialized constant ${path}`);
+    throw new NameError(`uninitialized constant ${path}`, missingSegment(path));
   }
   return _constants.get(path);
 }
@@ -250,8 +272,15 @@ export function safeConstantize(camelCasedWord: string): unknown {
   try {
     return constantize(camelCasedWord);
   } catch (e) {
-    if (e instanceof ReferenceError) return undefined;
-    throw e;
+    if (!(e instanceof NameError)) throw e;
+    // Ruby: `raise if e.name && !(camel_cased_word.split("::").include?(e.name) ||
+    // e.name == camel_cased_word)` — swallow only a miss on this path's own
+    // segments, never one bubbling out of an unrelated constant.
+    const name = e.constantName;
+    if (name && !(camelCasedWord.split("::").includes(name) || name === camelCasedWord)) {
+      throw e;
+    }
+    return undefined;
   }
 }
 

--- a/packages/activesupport/src/private-constant.trails.test.ts
+++ b/packages/activesupport/src/private-constant.trails.test.ts
@@ -7,6 +7,7 @@ import {
   unregisterConstant,
   _resetConstants,
 } from "./inflector.js";
+import { NameError } from "./core-ext/name-error.js";
 
 describe("PrivateConstantTest", () => {
   beforeEach(() => {
@@ -22,6 +23,10 @@ describe("PrivateConstantTest", () => {
     expect(() => constantize("Country::HABTM_Treaties")).toThrow(
       "private constant Country::HABTM_Treaties referenced",
     );
+    // Ruby raises NameError for a private constant, with `name` set to the
+    // constant itself — which is what makes safe_constantize swallow it rather
+    // than propagate (see the next test).
+    expect(() => constantize("Country::HABTM_Treaties")).toThrow(NameError);
   });
 
   it("safe constantize returns undefined for a private constant", () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
@@ -285,12 +285,5 @@
     "rubyName": "violates_strict_loading?",
     "call": "strict_loading?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "raise_on_type_mismatch!",
-    "call": "safe_constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/belongs-to.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/belongs-to.json
@@ -26,12 +26,5 @@
     "rubyName": "touch_record",
     "call": "touch_later",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/belongs-to.ts",
-    "rubyName": "add_counter_cache_callbacks",
-    "call": "safe_constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
@@ -243,12 +243,5 @@
     "rubyName": "update!",
     "call": "with_transaction_returning_status",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "define_delegated_type_methods",
-    "call": "constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
@@ -38,6 +38,13 @@
     "package": "activerecord",
     "tsFile": "base.ts",
     "rubyName": "define_delegated_type_methods",
+    "call": "constantize",
+    "reason": "Equivalent (different path): base.ts's static is a thin delegator to delegated-type.ts's `defineDelegatedTypeMethods` (Rails reaches it via `include DelegatedType`), so the constantize call cannot be lexically present here. See converge-delegated-type-method-split."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "base.ts",
+    "rubyName": "define_delegated_type_methods",
     "call": "define_method",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
@@ -219,13 +219,6 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "destroy_association_async_job",
-    "call": "constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
     "rubyName": "generated_association_methods",
     "call": "private_constant",
     "reason": "Rails hides the GeneratedAssociationMethods module constant; trails has no such constant to hide."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/delegated-type.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/delegated-type.json
@@ -3,6 +3,13 @@
     "package": "activerecord",
     "tsFile": "delegated-type.ts",
     "rubyName": "define_delegated_type_methods",
+    "call": "constantize",
+    "reason": "Equivalent (different path): trails inverts Rails' split — `defineDelegatedTypeMethods` delegates to `delegatedType`, which owns the `#{role}_class` / `build_#{role}` definitions and makes the constantize call, whereas Rails has `delegated_type` call `define_delegated_type_methods`. Converging the inversion is tracked by converge-delegated-type-method-split."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "delegated-type.ts",
+    "rubyName": "define_delegated_type_methods",
     "call": "define_method",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/delegated-type.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/delegated-type.json
@@ -82,12 +82,5 @@
     "rubyName": "delegated_type",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "delegated-type.ts",
-    "rubyName": "define_delegated_type_methods",
-    "call": "constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "compute_type",
-    "call": "new",
-    "reason": "Equivalent (different path): Rails' compute_type constructs NameError.new on an unresolved constant; #4311 dropped the redundant inline `throw new SubclassNotFound` subclass check (that constraint lives in stiClassFor/find_sti_class), so computeType now delegates the NameError construction to resolveComputedType. Pre-existing flag surfaced post-#4311."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "descends_from_active_record?",
     "call": "abstract_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -74,20 +67,6 @@
     "tsFile": "inheritance.ts",
     "rubyName": "find_sti_class",
     "call": "type_for_attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "polymorphic_class_for",
-    "call": "compute_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "sti_class_for",
-    "call": "compute_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
@@ -89,33 +89,5 @@
     "rubyName": "sti_class_for",
     "call": "compute_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "compute_type",
-    "call": "constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "compute_type",
-    "call": "safe_constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "polymorphic_class_for",
-    "call": "constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "sti_class_for",
-    "call": "constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/reflection.json
@@ -180,12 +180,5 @@
     "rubyName": "strict_loading_violation_message",
     "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "compute_class",
-    "call": "constantize",
-    "reason": "Equivalent (different path): trails resolves the constant through Active Record's own registry lookup (modelRegistry / resolveModel / resolveComputedType), which is the same table ActiveSupport::Inflector.constantize now reads — reached directly rather than through the inflector. Newly visible because #5471 ported constantize; converging these call sites onto it is its own story."
   }
 ]

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -645,6 +645,10 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
   // ActionDispatch `Collector` (re-aliased as `DispatchCollector`) to share
   // the negotiation pipeline.
   ["Collector", "DispatchCollector"],
+  // `core_ext/name_error.rb` reopens Ruby's core `NameError`, so the Ruby
+  // side records no superclass. TS has no NameError, and trails uses
+  // `ReferenceError` as the analogue throughout, so the port declares it.
+  ["NameError", "ReferenceError"],
 ]);
 
 // Per-class TS renames that don't fit the systematic alias patterns

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -141,8 +141,10 @@ const AMBIENT_RAILTIE_MIXINS: Record<string, { includes: string[] }> = {
  *   - The association error classes `include DidYouMean::Correctable`
  *     (associations/errors.rb:18,47,88); `Correctable#detailed_message` is
  *     ported inline as `detailedMessage` in `associations/errors.ts`.
- *     Correctable's source `core_ext/name_error.rb` is unported (Ruby NameError
- *     machinery with no JS analog). Keyed on one host class since `allowed` is
+ *     Correctable's source is did-you-mean's `core_ext/name_error.rb`, which is
+ *     unported (Ruby NameError machinery with no JS analog) — not the
+ *     same-named Active Support file, which is ported as `core-ext/name-error.ts`.
+ *     Keyed on one host class since `allowed` is
  *     unioned per-file across every entity in errors.rb.
  */
 const PORTED_METHODS_FROM_UNPORTED_MIXINS: Record<string, string[]> = {


### PR DESCRIPTION
PR #5471 ported `ActiveSupport::Inflector.constantize` / `safeConstantize`,
which made every Rails body that calls them visible to the wide call-mismatch
ratchet and baselined 18 sites. Ten of those were Active Record reaching its
own registry for a model constant — the same table `constantize` reads, by a
different name. This routes them through the inflector and **removes** the ten
entries rather than re-justifying them.

## Call sites converged

| Rails method | trails file | now spells |
| --- | --- | --- |
| `compute_type` (inheritance.rb:242-265) | `inheritance.ts` | `constantize` for the absolute `::` branch, `safeConstantize` per candidate |
| `sti_class_for` / `polymorphic_class_for` | `inheritance.ts` | `constantize` on the store-full-class-name branch |
| `compute_class` (reflection.rb:434) | `reflection.ts` | `name.constantize`, in **both** the MacroReflection body and the AssociationReflection override |
| `destroy_association_async_job` (core.rb:27-34) | `core.ts` | `constantize` |
| `raise_on_type_mismatch!` (association.rb:339-347) | `associations/association.ts` | `safeConstantize` of `reflection.class_name` (Rails' `fresh_class` arm) |
| `add_counter_cache_callbacks` (belongs_to.rb:39) | `associations/builder/belongs-to.ts` | `safeConstantize` |
| `define_delegated_type_methods` | `delegated-type.ts` | `constantize` |

The `compute_type` candidate ordering is untouched — `constantize` is a flat
lookup, so the enclosing-module candidate loop stays and only the per-candidate
resolution moved, still guarded by Rails' `candidate == constant.to_s`.

`raise_on_type_mismatch!` was missing Rails' second `fresh_class` check, so
that is a real gap closed — and it constantizes `reflection.class_name` only,
never the `klass.name` / association-name fallbacks, which could resolve an
unrelated class and swallow a genuine `AssociationTypeMismatch`.

`destroy_association_async_job`'s string resolution is now faithful to
`core.rb:27-34`, but is **not yet reachable**: both AR callers read the static
as a value rather than calling it (`associations/association.ts:983`,
`associations/builder/association.ts:271`), and trails has no
`"ActiveRecord::DestroyAssociationAsyncJob"` default (`core.rb:24`). Making the
callers invoke it without first supplying the default would flip the
`dependent: destroyAsync` validity guard from never-firing to always-firing, so
both halves are tracked in `converge-destroy-association-async-job-accessor`
rather than forced in here. Its writer stays a plain setter, as Rails' alias to
`_destroy_association_async_job=` is (`core.rb:36`).

The override also stops letting `constantize`'s error escape and ports
`reflection.rb:494-503` instead: a miss on the association's own class name is
wrapped as `"Missing model class X for the Y#z association."` — with the
`:class_name` hint appended only when no option was given — carrying
`name = class_name`; anything else re-raises. That message is what the invented
`"Model '…' not found in registry"` string was a garbled approximation of.

Wrapping it is also what makes `automatic_inverse_of`'s rescue correct. It used
to pattern-match the invented string; it is now
`e instanceof NameError && e.constantName === this.className`, i.e. Rails'
`raise unless error.name.to_s == class_name` (`reflection.rb:769`) — so a
*namespaced* `class_name` re-raises the way Rails does rather than being
swallowed into `reflection = false`.

That needed `NameError` to carry Ruby's `NameError#name`, as `constantName`
(JS reserves `Error#name` for the class name). It holds the missing *segment*,
not the path — `safe_constantize`'s
`camel_cased_word.split("::").include?(e.name.to_s)` guard only makes sense
because it is one segment — so `constantize` reports the segment
`Object.const_get` would fail on, verified against Ruby: `Foo::Bar` with `Foo`
registered → `Bar`, `Nope::Bar` → `Nope`. `safeConstantize` now ports that guard
rather than swallowing every `NameError`, and `missingName()` stays on the
message regex, which is the branch Ruby takes with no receiver.

## Registry helpers

`resolveModel` and `lookupModelWithAutoload` are retired. What remains is
`autoloadModel` — the registration half alone, standing in for the Zeitwerk
hook Ruby's `const_get` runs on a miss. Its `@internal` "ESM has no constant
namespace to walk" justification is deleted, because `constantize` **is** that
namespace now.

`ModelRegistry.set/delete/clear` write through to the constant table, so a
direct `modelRegistry.set` (the HABTM join model) or a `.delete` (the PG
schema helper) cannot leave the two tables disagreeing. That needed a
`unregisterConstant` alongside the existing `registerConstant`.

## NameError

`constantize` previously threw a bare `ReferenceError` while Active Record had
its own `NameError extends Error`, so converging the call sites would have
changed the error class at eight boundaries. `NameError` now lives in
activesupport as a core-ext port of Ruby's core class (`core_ext/name_error.rb`)
and is what `constantize` raises; `errors.ts` re-exports it. It extends
`ReferenceError` — trails' existing analogue, asserted by
`constantize-test-cases.ts` — so nothing that caught the old error stops
catching it, and `rescue NameError` sites catch the same class whichever path
resolved the constant.

## PR size

605 LOC over 27 files, above the 500 ceiling. The story landed at 495; the
overage is entirely review-driven convergence on files already in the diff —
porting `reflection.rb:494-503`'s error wrapper, Ruby's real `safe_constantize`
guard, and `NameError#name`/`missing_name?` semantics.

Splitting now would mean either shipping a half-converged `compute_class` (its
`NameError` wrapper depends on `constantName`, which lives in activesupport) or
stacking, which the repo forbids. The separable slice is
`core-ext/name-error.ts` + its test + the `inflector.ts` changes, ~120 LOC; if
that split is preferred, it has to land first and this PR rebases onto it.
Flagged rather than silently exceeded.

## Follow-ups

Raised in review, none merge-blocking; filed rather than folded in:

| Story | What |
| --- | --- |
| `converge-destroy-association-async-job-accessor` | The accessor's string-resolution branch is faithful to `core.rb:27-34` but unreachable: both callers read the static as a value, and the Rails default names `ActiveRecord::DestroyAssociationAsyncJob` — an `ActiveJob::Base` subclass in an unported file (`unported-files.ts:147`). Blocked on ActiveJob. |
| `converge-model-constant-registration-paths` | **Done — shipped as #5511**, now in `main` and this branch is rebased on it. All three writers go through `registerModelConstant`, so the shadow guard covers every one and `clear()` unregisters. It deliberately keeps the constant table *wider* than `modelRegistry` (a throwaway STI subclass must not be promoted into association resolution), which is exactly why `autoloadModel` gates on the registry — see below. |
| `converge-delegated-type-method-split` | trails inverts Rails' split: `defineDelegatedTypeMethods` delegates to `delegatedType`, which owns the `#{role}_class` definitions and the `constantize` call. The wide ratchet therefore flags `define_delegated_type_methods` in both `delegated-type.ts` and `base.ts`; both are baselined with that reason. |
| `converge-constantize-ignores-private-constants` | **The real fix for the habtm breakage below.** trails' `constantize` raises for a name marked `privateConstant`; Ruby's `Object.const_get` — which `Inflector.constantize` *is* — does not, since `private_constant` blocks only a literal `A::B` reference (verified on ruby 3.3.11). This PR works around it rather than changing activesupport mid-review. |
| `join-dependency-target-fault-in` | `join-dependency.ts:344,371` read `modelRegistry.get` with no fault-in, working only because `checkValidityBang` runs first and populates it. A reflection-less path gets no fault-in and surfaces a misleading "association not found". |

### Wide call-ratchet, and what it converged

CI's wide ratchet — a separate lint `pnpm api:compare` does not run — flagged
five new mismatches. It is lexical per method, so a call sitting in an extracted
helper does not count for the method delegating to it.

`compute_type` now holds the resolution body itself and `stiClassFor` /
`polymorphicClassFor` call `computeType` instead of the extracted
`resolveComputedType`. That is Rails' own shape (`sti_class_for` and
`polymorphic_class_for` both call `compute_type`, `inheritance.rb:198,222`), and
besides clearing the two new entries it converged **three more** previously
baselined ones — `compute_type`/`new`, `sti_class_for`/`compute_type`,
`polymorphic_class_for`/`compute_type` — now removed as stale. Thirteen entries
deleted in total, not ten.

`abstract-controller/helpers.ts` also converged: `modulesForHelpers` now raises
`NameError` carrying the missing constant and `default_helper_module!` rescues
with `isMissingName(expectedName)`, i.e. `raise unless
e.missing_name?("#{helper_prefix}Helper")` (`helpers.rb:241`), replacing an
exact message-string comparison. That only became expressible because this PR
ports `missing_name?` — which is why the ratchet surfaced it.

### Second CI failure: habtm fixture loading

All four adapters failed with `table developers has no column named
sharedComputers` after rebasing onto #5514, which marks habtm join models as
private constants. Passing on `main`, failing here — because this branch is what
routes reflection resolution through `constantize`, so the habtm middle
reflection's `klass` began raising, `throughLabelAssociations`
(`fixtures.ts:413`) stopped recognising the habtm fixture label as an
association, and the loader tried to INSERT it as a column.

The middle reflection now carries the join model as `anonymousClass`, which
`MacroReflection.klass` short-circuits on and which this same builder already
uses for the LHS side. `className` stays exactly as Rails spells it
(`has_and_belongs_to_many.rb:73`).

This is a **workaround, not the fix**. Rails sets only `class_name` and resolves
the join model back out of the constant table, which works because `const_get`
ignores `private_constant`. The real fix is
`converge-constantize-ignores-private-constants` above, whose acceptance
criteria include removing this `anonymousClass` again.

### CI failure fixed in this PR

`calculations.test.ts` `pluck columns with same name` / `pluck with qualified
name on loaded` failed on this branch and passed on `origin/main`.
`autoloadModel` gated on `safeConstantize`, but an STI subclass like `Reply` is
constantize-able while absent from `modelRegistry`, so the fault-in was skipped
and the join planner built no node. Now gated on `modelRegistry.has`, which is
exactly main's pre-PR `lookupModelWithAutoload` gate. Pinned by a direct
regression test in `canonical-model-index.test.ts` that fails on the old gate —
re-verified after rebasing onto #5511, which keeps the two tables intentionally
asymmetric, so the gate and its test remain load-bearing.

## Not in scope

The eleventh AR entry, `tasks/database-tasks.ts` `class_for_adapter`, stays
baselined: it resolves an adapter through trails' adapter registry, which is
genuinely not the model constant table. Same for the seven non-AR
(actionpack/actiondispatch) sites.

## Verification

- `pnpm api:compare` and `pnpm api:extra` clean with the ten entries removed.
  Methods 11725 → 11727 against `origin/main` (the two `NameError` core-ext
  methods), files 773 → 774, inheritance 537/590 → 538/591; `test:compare`
  unchanged at 14701/22203.
- Three `reflection.test.ts` assertions moved off the retired
  `/not found in registry/` message onto Rails' real
  `"Missing model class …"` / `uninitialized constant <Name>`. No reference to
  the old string remains anywhere in `packages/` or `scripts/`. Test names
  unchanged.
- `test_automatic_inverse_suppresses_name_error_for_association` is **un-skipped**
  — it was marked UNPORTED for needing `const_missing`, which only its sibling
  actually needs, and it covers exactly the rescue this PR converged. Its
  sibling (`…does_not_suppress_name_error_from_incidental_code`) still needs
  `const_missing` stubbing and stays skipped.
- Symbol-selected AR suites green (791 tests): inheritance, reflection,
  associations, counter-cache, delegated-type, modules, locking, STI
  full-class-names, has-one/has-many/belongs-to/has-one-through.
- activesupport inflector + string-ext + all of globalid green.

One assertion changed: `reflection.test.ts` "aggregate reflection computes
class raises NameError for missing class" asserted the invented
`/not found in registry/` message; it now asserts constantize's
`uninitialized constant NoSuchMoney`, which is what Rails produces. The test
name is unchanged.

Closes-story: converge-ar-model-resolution-onto-constantize
