### PR TITLE
fix(eslint): parse quoted table names with embedded spaces in require-table-teardown

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -156,11 +156,16 @@ function droppedTableNames(call) {
  * (`CREATE TABLE "my table"` is the table `my table`, not `my`). Truncating it
  * used to make a create unmatchable by any drop of the real name.
  */
-const NAME_SRC = "(?:`([^`]+)`|\"([^\"]+)\"|'([^']+)'|([\\w.]+))";
-/** The first defined name capture of `m`, whose name groups start at `base`. */
-function capturedName(m, base) {
-  return m[base] ?? m[base + 1] ?? m[base + 2] ?? m[base + 3];
+const NAME_SRC = "(?:([\"'`])((?:(?!\\1)[\\s\\S])+)\\1|([\\w.]+))";
+/** The name `m` captured, quoted or bare. */
+function capturedName(m) {
+  return m[QUOTED_NAME] ?? m[BARE_NAME];
 }
+/**
+ * `NAME_SRC` capture indices. The `\1` backreference pins the fragment to the
+ * first capture group, so it must be the only group in any regex built from it.
+ */
+const [OPEN_QUOTE, QUOTED_NAME, BARE_NAME] = [1, 2, 3];
 const CREATE_TABLE_RE = new RegExp(
   `\\bcreate\\s+(?:(?:global|local)\\s+)?(?:temp(?:orary)?\\s+|unlogged\\s+)?table\\s+(?:if\\s+not\\s+exists\\s+)?${NAME_SRC}`,
   "gi",
@@ -198,7 +203,7 @@ function rawCreateNames(text, endIsDynamic) {
   let m;
   while ((m = CREATE_TABLE_RE.exec(text)) !== null) {
     if (endIsDynamic && m.index + m[0].length === text.length) continue;
-    names.push(capturedName(m, 1));
+    names.push(capturedName(m));
   }
   return names;
 }
@@ -220,8 +225,9 @@ export function rawDropNames(text, endIsDynamic = false) {
     let rest = text.slice(m.index + m[0].length);
     let nm;
     while ((nm = NAME_RE.exec(rest)) !== null) {
-      const name = capturedName(nm, 1);
-      if (nm[4] !== undefined && /^(?:cascade|restrict)$/i.test(name)) break;
+      const name = capturedName(nm);
+      // Only a bare word can be the trailing clause; quoting it makes it a name.
+      if (nm[OPEN_QUOTE] === undefined && /^(?:cascade|restrict)$/i.test(name)) break;
       rest = rest.slice(nm[0].length);
       if (!(endIsDynamic && rest.length === 0)) names.push(name);
       rest = rest.replace(/^\s+/, "");

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -148,16 +148,27 @@ function droppedTableNames(call) {
 /**
  * The leading `CREATE [GLOBAL|LOCAL] [TEMP[ORARY]|UNLOGGED] TABLE [IF NOT
  * EXISTS]` clause, up to and including the table name. The optional opening
- * quote (`` ` ``, `"`, `'`) is matched and stripped via a backreference so a
- * quoted name balances an unquoted helper name (`CREATE TABLE "items"` ↔
- * `dropTable("items")`); `\1?` tolerates an unmatched (no-quote) group.
+ * quote (`` ` ``, `"`, `'`) is matched and stripped so a quoted name balances an
+ * unquoted helper name (`CREATE TABLE "items"` ↔ `dropTable("items")`).
+ *
+ * A quoted name runs to its closing quote rather than to the first
+ * non-identifier character, so an embedded space stays part of the name
+ * (`CREATE TABLE "my table"` is the table `my table`, not `my`). Truncating it
+ * used to make a create unmatchable by any drop of the real name.
  */
-const CREATE_TABLE_RE =
-  /\bcreate\s+(?:(?:global|local)\s+)?(?:temp(?:orary)?\s+|unlogged\s+)?table\s+(?:if\s+not\s+exists\s+)?(`|"|')?([\w.]+)\1?/gi;
+const NAME_SRC = "(?:`([^`]+)`|\"([^\"]+)\"|'([^']+)'|([\\w.]+))";
+/** The first defined name capture of `m`, whose name groups start at `base`. */
+function capturedName(m, base) {
+  return m[base] ?? m[base + 1] ?? m[base + 2] ?? m[base + 3];
+}
+const CREATE_TABLE_RE = new RegExp(
+  `\\bcreate\\s+(?:(?:global|local)\\s+)?(?:temp(?:orary)?\\s+|unlogged\\s+)?table\\s+(?:if\\s+not\\s+exists\\s+)?${NAME_SRC}`,
+  "gi",
+);
 /** The `DROP TABLE [IF EXISTS]` keyword prefix; the name list follows. */
 const DROP_TABLE_RE = /\bdrop\s+table\s+(?:if\s+exists\s+)?/gi;
 /** A single (optionally quoted) table name at the start of `rest`. */
-const NAME_RE = /^\s*(`|"|')?([\w.]+)\1?/;
+const NAME_RE = new RegExp(`^\\s*${NAME_SRC}`);
 
 /**
  * Call names that execute a raw SQL string against the database. A `CREATE
@@ -187,7 +198,7 @@ function rawCreateNames(text, endIsDynamic) {
   let m;
   while ((m = CREATE_TABLE_RE.exec(text)) !== null) {
     if (endIsDynamic && m.index + m[0].length === text.length) continue;
-    names.push(m[2]);
+    names.push(capturedName(m, 1));
   }
   return names;
 }
@@ -209,9 +220,10 @@ export function rawDropNames(text, endIsDynamic = false) {
     let rest = text.slice(m.index + m[0].length);
     let nm;
     while ((nm = NAME_RE.exec(rest)) !== null) {
-      if (/^(?:cascade|restrict)$/i.test(nm[2])) break;
+      const name = capturedName(nm, 1);
+      if (nm[4] !== undefined && /^(?:cascade|restrict)$/i.test(name)) break;
       rest = rest.slice(nm[0].length);
-      if (!(endIsDynamic && rest.length === 0)) names.push(nm[2]);
+      if (!(endIsDynamic && rest.length === 0)) names.push(name);
       rest = rest.replace(/^\s+/, "");
       if (rest[0] !== ",") break;
       rest = rest.slice(1);

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -162,10 +162,14 @@ function droppedTableNames(call) {
  * phantom `my`. `(?!\1)` keeps the `+` bounded — it can never cross an
  * undoubled quote, so a name cannot run past its close or across statements.
  *
- * A name whose opening quote is never closed matches neither branch and is
- * skipped entirely, so the create goes unreported. That is malformed SQL in a
- * plain string literal; in a template it means the closing quote lives past an
- * interpolation, where the name was already unknowable.
+ * A name whose opening quote is never closed is skipped rather than truncated,
+ * so the create goes unreported. Usually it matches neither branch. The
+ * exception is an unclosed name containing a doubled quote
+ * (`CREATE TABLE "my""table${x}`): the `+` can backtrack off the `""` unit and
+ * let its first quote serve as the close, matching the phantom `"my"`. See
+ * `quotedNameTruncated`, which rejects that parse. Either way the input is
+ * malformed SQL in a plain string literal, or — in a template — a name whose
+ * closing quote lives past an interpolation, so it was already unknowable.
  */
 const NAME_SRC = "(?:([\"'`])((?:(?!\\1)[\\s\\S]|\\1\\1)+)\\1|([\\w.]+))";
 /**
@@ -178,6 +182,17 @@ function capturedName(m) {
   const quote = m[OPEN_QUOTE];
   if (quote === undefined) return m[BARE_NAME];
   return m[QUOTED_NAME].replaceAll(quote + quote, quote);
+}
+
+/**
+ * Whether `m` closed a quoted name early by backtracking off a doubled quote,
+ * leaving a phantom short name. `charAfter` is the character following the
+ * match. A real closing quote is never immediately followed by its own quote —
+ * that pair would have been consumed as escaped content — so this signature is
+ * exactly the truncated parse, and the name is dropped rather than recorded.
+ */
+function quotedNameTruncated(m, charAfter) {
+  return m[OPEN_QUOTE] !== undefined && charAfter === m[OPEN_QUOTE];
 }
 
 /**
@@ -220,7 +235,9 @@ function rawCreateNames(text, endIsDynamic) {
   CREATE_TABLE_RE.lastIndex = 0;
   let m;
   while ((m = CREATE_TABLE_RE.exec(text)) !== null) {
-    if (endIsDynamic && m.index + m[0].length === text.length) continue;
+    const end = m.index + m[0].length;
+    if (endIsDynamic && end === text.length) continue;
+    if (quotedNameTruncated(m, text[end])) continue;
     names.push(capturedName(m));
   }
   return names;
@@ -243,6 +260,9 @@ export function rawDropNames(text, endIsDynamic = false) {
     let rest = text.slice(m.index + m[0].length);
     let nm;
     while ((nm = NAME_RE.exec(rest)) !== null) {
+      // A truncated name would credit a teardown that drops nothing, and the
+      // rest of the list can't be trusted either — stop reading.
+      if (quotedNameTruncated(nm, rest[nm[0].length])) break;
       const name = capturedName(nm);
       // Only a bare word can be the trailing clause; quoting it makes it a name.
       if (nm[OPEN_QUOTE] === undefined && /^(?:cascade|restrict)$/i.test(name)) break;

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -146,26 +146,35 @@ function droppedTableNames(call) {
 }
 
 /**
- * The leading `CREATE [GLOBAL|LOCAL] [TEMP[ORARY]|UNLOGGED] TABLE [IF NOT
- * EXISTS]` clause, up to and including the table name. The optional opening
- * quote (`` ` ``, `"`, `'`) is matched and stripped so a quoted name balances an
+ * A table name: either quoted (`` ` ``, `"`, `'`) or a bare identifier. The
+ * quotes are captured separately from the name so a quoted name balances an
  * unquoted helper name (`CREATE TABLE "items"` ↔ `dropTable("items")`).
  *
  * A quoted name runs to its closing quote rather than to the first
  * non-identifier character, so an embedded space stays part of the name
  * (`CREATE TABLE "my table"` is the table `my table`, not `my`). Truncating it
- * used to make a create unmatchable by any drop of the real name.
+ * used to make a create unmatchable by any drop of the real name — and the
+ * phantom short name matchable by a drop that tears down nothing.
+ *
+ * A name whose opening quote is never closed (the closing quote lives in a
+ * later template quasi) matches neither branch and is skipped; such a name is
+ * interpolated, so it was already unknowable.
  */
 const NAME_SRC = "(?:([\"'`])((?:(?!\\1)[\\s\\S])+)\\1|([\\w.]+))";
+/**
+ * `NAME_SRC` capture indices. Its `\1` backreference pins the fragment to the
+ * first capture group, so it must be the only group in any regex built from it.
+ */
+const [OPEN_QUOTE, QUOTED_NAME, BARE_NAME] = [1, 2, 3];
 /** The name `m` captured, quoted or bare. */
 function capturedName(m) {
   return m[QUOTED_NAME] ?? m[BARE_NAME];
 }
+
 /**
- * `NAME_SRC` capture indices. The `\1` backreference pins the fragment to the
- * first capture group, so it must be the only group in any regex built from it.
+ * The leading `CREATE [GLOBAL|LOCAL] [TEMP[ORARY]|UNLOGGED] TABLE [IF NOT
+ * EXISTS]` clause, up to and including the table name.
  */
-const [OPEN_QUOTE, QUOTED_NAME, BARE_NAME] = [1, 2, 3];
 const CREATE_TABLE_RE = new RegExp(
   `\\bcreate\\s+(?:(?:global|local)\\s+)?(?:temp(?:orary)?\\s+|unlogged\\s+)?table\\s+(?:if\\s+not\\s+exists\\s+)?${NAME_SRC}`,
   "gi",

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -156,19 +156,28 @@ function droppedTableNames(call) {
  * used to make a create unmatchable by any drop of the real name — and the
  * phantom short name matchable by a drop that tears down nothing.
  *
- * A name whose opening quote is never closed (the closing quote lives in a
- * later template quasi) matches neither branch and is skipped; such a name is
- * interpolated, so it was already unknowable.
+ * SQLite and PostgreSQL escape a quote inside an identifier by doubling it, so
+ * `\1\1` is consumed as content rather than read as the closing quote:
+ * `"my""table"` is one name, `my"table` (undoubled by `capturedName`), not the
+ * phantom `my`. `(?!\1)` keeps the `+` bounded — it can never cross an
+ * undoubled quote, so a name cannot run past its close or across statements.
+ *
+ * A name whose opening quote is never closed matches neither branch and is
+ * skipped entirely, so the create goes unreported. That is malformed SQL in a
+ * plain string literal; in a template it means the closing quote lives past an
+ * interpolation, where the name was already unknowable.
  */
-const NAME_SRC = "(?:([\"'`])((?:(?!\\1)[\\s\\S])+)\\1|([\\w.]+))";
+const NAME_SRC = "(?:([\"'`])((?:(?!\\1)[\\s\\S]|\\1\\1)+)\\1|([\\w.]+))";
 /**
  * `NAME_SRC` capture indices. Its `\1` backreference pins the fragment to the
  * first capture group, so it must be the only group in any regex built from it.
  */
 const [OPEN_QUOTE, QUOTED_NAME, BARE_NAME] = [1, 2, 3];
-/** The name `m` captured, quoted or bare. */
+/** The name `m` captured, with a quoted name's doubled quotes undoubled. */
 function capturedName(m) {
-  return m[QUOTED_NAME] ?? m[BARE_NAME];
+  const quote = m[OPEN_QUOTE];
+  if (quote === undefined) return m[BARE_NAME];
+  return m[QUOTED_NAME].replaceAll(quote + quote, quote);
 }
 
 /**

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -62,6 +62,10 @@ tester.run("require-table-teardown", rule, {
     // The doubled-quote branch must not overreach: a later `""` elsewhere in
     // the statement is not part of the name, which closes at its own quote.
     'await adapter.exec(`CREATE TABLE "t" (c TEXT DEFAULT "")`);\nawait adapter.exec(`DROP TABLE "t"`);',
+    // An escaped quote as the *last* content character puts a real closing
+    // quote right after a doubled pair — the boundary `quotedNameTruncated`
+    // must not fire on, since `charAfter` is the space, not a quote.
+    'await adapter.exec(`CREATE TABLE "my""" (id int)`);\nawait ctx.dropTable(\'my"\');',
     // An unclosed name containing a doubled quote must not be truncated into a
     // phantom `my` create by backtracking off the `""` — it is unknowable.
     'await adapter.exec(`CREATE TABLE "my""table${x} (id int)`);',

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -52,6 +52,16 @@ tester.run("require-table-teardown", rule, {
     // which would leave the create unmatchable by any drop of the real table.
     'await adapter.exec(`CREATE TABLE "my table" (id int)`);\nawait adapter.exec(`DROP TABLE "my table"`);',
     "await adapter.exec('CREATE TABLE `my table` (id int)');\nawait adapter.exec('DROP TABLE `my table`');",
+    // A quoted raw create balanced by the helper form — the cross-form
+    // equivalence the separate quote capture exists for, in both directions.
+    'await adapter.exec(`CREATE TABLE "my table" (id int)`);\nawait ctx.dropTable("my table");',
+    'await ctx.createTable("my table", () => {});\nawait adapter.exec(`DROP TABLE "my table"`);',
+    // A doubled quote escapes a quote inside the identifier: one name,
+    // `my"table` — not the phantom `my` a truncating parse would record.
+    'await adapter.exec(`CREATE TABLE "my""table" (id int)`);\nawait ctx.dropTable(\'my"table\');',
+    // The doubled-quote branch must not overreach: a later `""` elsewhere in
+    // the statement is not part of the name, which closes at its own quote.
+    'await adapter.exec(`CREATE TABLE "t" (c TEXT DEFAULT "")`);\nawait adapter.exec(`DROP TABLE "t"`);',
     // Quoting turns a would-be trailing clause into a table name, so the drop
     // list keeps reading past it.
     'await adapter.exec(`CREATE TABLE "cascade" (id int)`);\nawait adapter.exec(`CREATE TABLE b (id int)`);\n' +
@@ -99,6 +109,14 @@ tester.run("require-table-teardown", rule, {
         'await adapter.exec(`CREATE TABLE "my table" (id int)`);\n' +
         'await adapter.exec(`DROP TABLE "my"`);',
       errors: [{ messageId: "missingTeardown", data: { table: "my table" } }],
+    },
+    // Dropping the prefix before an escaped (doubled) quote is not a teardown
+    // of the real table either.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "my""table" (id int)`);\n' +
+        'await adapter.exec(`DROP TABLE "my"`);',
+      errors: [{ messageId: "missingTeardown", data: { table: 'my"table' } }],
     },
     // Symmetrically, a DROP name flush against an interpolation is a prefix,
     // not a table: the phantom `tmp_` must not be credited as the teardown of

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -62,6 +62,9 @@ tester.run("require-table-teardown", rule, {
     // The doubled-quote branch must not overreach: a later `""` elsewhere in
     // the statement is not part of the name, which closes at its own quote.
     'await adapter.exec(`CREATE TABLE "t" (c TEXT DEFAULT "")`);\nawait adapter.exec(`DROP TABLE "t"`);',
+    // An unclosed name containing a doubled quote must not be truncated into a
+    // phantom `my` create by backtracking off the `""` — it is unknowable.
+    'await adapter.exec(`CREATE TABLE "my""table${x} (id int)`);',
     // Quoting turns a would-be trailing clause into a table name, so the drop
     // list keeps reading past it.
     'await adapter.exec(`CREATE TABLE "cascade" (id int)`);\nawait adapter.exec(`CREATE TABLE b (id int)`);\n' +
@@ -109,6 +112,14 @@ tester.run("require-table-teardown", rule, {
         'await adapter.exec(`CREATE TABLE "my table" (id int)`);\n' +
         'await adapter.exec(`DROP TABLE "my"`);',
       errors: [{ messageId: "missingTeardown", data: { table: "my table" } }],
+    },
+    // A truncated drop is not credited as the teardown of the phantom name it
+    // would otherwise spell — `my` is still reported.
+    {
+      code:
+        'await adapter.exec("CREATE TABLE my (id int)");\n' +
+        'await adapter.exec(`DROP TABLE "my""table${x}`);',
+      errors: [{ messageId: "missingTeardown", data: { table: "my" } }],
     },
     // Dropping the prefix before an escaped (doubled) quote is not a teardown
     // of the real table either.

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -52,6 +52,10 @@ tester.run("require-table-teardown", rule, {
     // which would leave the create unmatchable by any drop of the real table.
     'await adapter.exec(`CREATE TABLE "my table" (id int)`);\nawait adapter.exec(`DROP TABLE "my table"`);',
     "await adapter.exec('CREATE TABLE `my table` (id int)');\nawait adapter.exec('DROP TABLE `my table`');",
+    // Quoting turns a would-be trailing clause into a table name, so the drop
+    // list keeps reading past it.
+    'await adapter.exec(`CREATE TABLE "cascade" (id int)`);\nawait adapter.exec(`CREATE TABLE b (id int)`);\n' +
+      'await adapter.exec(`DROP TABLE "cascade", b`);',
     // A spaced quoted name in a multi-table drop list.
     'await adapter.exec(`CREATE TABLE "my table" (id int)`);\nawait adapter.exec(`CREATE TABLE b (id int)`);\n' +
       'await adapter.exec(`DROP TABLE "my table", b`);',

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -47,6 +47,14 @@ tester.run("require-table-teardown", rule, {
     'await ctx.createTable("widgets", () => {});\nawait adapter.exec("DROP TABLE widgets");',
     // IF NOT EXISTS / IF EXISTS and trailing clauses don't defeat matching.
     'await c.exec("CREATE TABLE IF NOT EXISTS tmp_x (id int)");\nawait c.exec("DROP TABLE IF EXISTS tmp_x CASCADE");',
+    // A quoted name with an embedded space is one name on both sides — the
+    // identifier pattern must not stop at the space (`"my table"` → `my`),
+    // which would leave the create unmatchable by any drop of the real table.
+    'await adapter.exec(`CREATE TABLE "my table" (id int)`);\nawait adapter.exec(`DROP TABLE "my table"`);',
+    "await adapter.exec('CREATE TABLE `my table` (id int)');\nawait adapter.exec('DROP TABLE `my table`');",
+    // A spaced quoted name in a multi-table drop list.
+    'await adapter.exec(`CREATE TABLE "my table" (id int)`);\nawait adapter.exec(`CREATE TABLE b (id int)`);\n' +
+      'await adapter.exec(`DROP TABLE "my table", b`);',
     // Interpolated raw-SQL table name is unknowable — neither create nor drop.
     "await adapter.exec(`CREATE TABLE ${name} (id int)`);",
     // Static prefix flush against an interpolation is a dynamic-name prefix,
@@ -80,6 +88,14 @@ tester.run("require-table-teardown", rule, {
     'await ctx.dropTable(name);\nawait ctx.dropTable("b");',
   ],
   invalid: [
+    // Dropping the truncated prefix of a spaced quoted name is not a teardown
+    // of the real table — the create is still reported by its full name.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "my table" (id int)`);\n' +
+        'await adapter.exec(`DROP TABLE "my"`);',
+      errors: [{ messageId: "missingTeardown", data: { table: "my table" } }],
+    },
     // Symmetrically, a DROP name flush against an interpolation is a prefix,
     // not a table: the phantom `tmp_` must not be credited as the teardown of
     // the real `tmp_a`.

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
   // require-table-teardown (SQLite has no multi-table DROP).
   await adapter
     .exec(
-      `DROP TABLE IF EXISTS quote_test; DROP TABLE IF EXISTS q; DROP TABLE IF EXISTS my; DROP TABLE IF EXISTS bin_enc; DROP TABLE IF EXISTS bool_test; DROP TABLE IF EXISTS bool_test2; DROP TABLE IF EXISTS bd_test; DROP TABLE IF EXISTS bin_quote; DROP TABLE IF EXISTS time_test; DROP TABLE IF EXISTS time_norm; DROP TABLE IF EXISTS time_utc; DROP TABLE IF EXISTS time_local; DROP TABLE IF EXISTS inf_test; DROP TABLE IF EXISTS nan_test`,
+      `DROP TABLE IF EXISTS quote_test; DROP TABLE IF EXISTS q; DROP TABLE IF EXISTS "my table"; DROP TABLE IF EXISTS bin_enc; DROP TABLE IF EXISTS bool_test; DROP TABLE IF EXISTS bool_test2; DROP TABLE IF EXISTS bd_test; DROP TABLE IF EXISTS bin_quote; DROP TABLE IF EXISTS time_test; DROP TABLE IF EXISTS time_norm; DROP TABLE IF EXISTS time_utc; DROP TABLE IF EXISTS time_local; DROP TABLE IF EXISTS inf_test; DROP TABLE IF EXISTS nan_test`,
     )
     .catch(() => undefined);
   await adapter.close();


### PR DESCRIPTION
`eslint/require-table-teardown.mjs` scanned raw SQL for `CREATE TABLE` /
`DROP TABLE` names with an identifier pattern that stopped at the first
non-identifier character, so a quoted name containing a space was truncated:

```sql
CREATE TABLE "my table" ("id" INTEGER PRIMARY KEY)   →  recorded as `my`
```

No drop of the real table could ever match, and the rule reported the create as
un-torn-down. Worse, the phantom short name was matchable by a drop that tears
down nothing — which is exactly how it silently shaped the code it polices:
`sqlite3/quoting.test.ts` created `"my table"` and dropped `my`, balancing the
rule while leaking the real table. That went unnoticed only because the suite
ran on a throwaway `:memory:` database.

## Changes

- A shared `NAME_SRC` fragment parses a backtick/double/single-quoted identifier
  up to its *closing* quote (spaces included), falling back to the bare `[\w.]+`
  form. Both `rawCreateNames` and `rawDropNames` are built from it.
- SQLite/PG escape a quote inside an identifier by doubling it, so `\1\1` is
  consumed as content: `"my""table"` is the one name `my"table` (undoubled by
  `capturedName`), not the phantom `my`. `(?!\1)` keeps the `+` bounded, so a
  name can never run past its close or across statements.
- `quotedNameTruncated` rejects the one parse that could still spell a phantom:
  an *unclosed* name containing a doubled quote (`CREATE TABLE "my""table${x}`),
  where the `+` backtracks off the `""` and lets its first quote serve as the
  close. A genuine closing quote is never immediately followed by its own quote,
  so that signature is unambiguous; the name is skipped, not truncated.
- The `CASCADE`/`RESTRICT` terminator check applies only to the bare branch —
  quoting turns a would-be trailing clause into a table name, so `DROP TABLE
  "cascade", b` keeps reading the list.
- `sqlite3/quoting.test.ts` teardown drops the real `"my table"` instead of the
  phantom `my`.

## Verification

- Unit coverage on both sides: quoted-with-space create ↔ drop (double-quoted
  and backtick), raw create ↔ `dropTable` helper in both directions, the
  doubled-quote name, a `""` elsewhere in the statement (no greedy overreach),
  the unclosed doubled-quote name on both the create and the drop side, an
  escaped quote as the final content character (a real close adjacent to a
  doubled pair), a
  multi-table drop list, the quoted-`cascade` case, and invalid cases asserting
  that a truncated drop is never credited as teardown.
- Reverting the rule to `origin/main` fails 10 of the new tests, so they
  discriminate rather than pass vacuously.
- Repo-wide `pnpm lint` is clean: no other file was relying on the truncating
  behaviour to balance a create.
- Confirmed end-to-end that the reworked `sqlite3/quoting.test.ts` teardown
  actually drops: the multi-statement `exec` succeeds and `sqlite_master` is
  empty afterward. Its `.catch(() => undefined)` is not masking a parse failure.

### Known limit

A name whose opening quote is never closed is skipped, so the create goes
unreported. That is malformed SQL in a plain string literal; in a template it
means the closing quote lives past an interpolation, where the name was already
unknowable. The rule under-reports there rather than inventing a phantom table.

Closes-story: require-table-teardown-quoted-name
