### PR TITLE
test(sqlite3): converge connection-adapters sqlite3 scratch tables onto canonical ones

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -6,9 +6,6 @@ import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 import { queryTransformers, type QueryTransformer } from "../query-transformers.js";
 
-// Every statement below is a read or a write against the canonical `customers`
-// table, so the fixture transaction rolls the suite's writes back and no
-// scratch DDL is needed.
 fixtures([]);
 
 // Integration proof for QL PR 3: a registered query transformer is applied in
@@ -26,7 +23,7 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
     queryTransformers.length = 0;
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     queryTransformers.length = 0;
     queryTransformers.push(...savedTransformers);
   });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -6,7 +6,10 @@ import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 import { queryTransformers, type QueryTransformer } from "../query-transformers.js";
 
-fixtures([], { useTransactionalTests: false });
+// Every statement below is a read or a write against the canonical `customers`
+// table, so the fixture transaction rolls the suite's writes back and no
+// scratch DDL is needed.
+fixtures([]);
 
 // Integration proof for QL PR 3: a registered query transformer is applied in
 // preprocessQuery and the post-transform (commented) SQL flows all the way into
@@ -16,32 +19,15 @@ fixtures([], { useTransactionalTests: false });
 describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   let adapter: AbstractSQLite3Adapter;
   let savedTransformers: QueryTransformer[];
-  // Teardown-only handle. `adapter` stays non-optional for the test bodies, but
-  // the teardown has to tolerate a beforeEach that failed before the lease, so
-  // it reads a genuinely optional binding rather than casting `adapter`.
-  let leased: AbstractSQLite3Adapter | undefined;
 
-  // The ambient connection is a shared worker DB, so the scratch tables are
-  // cleared on the way in as well as out: a hard-killed run must not wedge the
-  // next one.
-  const dropScratchTables = async (): Promise<void> => {
-    await leased?.exec(
-      "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS t; DROP TABLE IF EXISTS a; DROP TABLE IF EXISTS b",
-    );
-  };
-
-  beforeEach(async () => {
-    adapter = leased = Base.connection as AbstractSQLite3Adapter;
+  beforeEach(() => {
+    adapter = Base.connection as AbstractSQLite3Adapter;
     savedTransformers = queryTransformers.slice();
     queryTransformers.length = 0;
-    await dropScratchTables();
   });
 
   afterEach(async () => {
-    // Drop before restoring: on the shared ambient connection a globally
-    // registered transformer would otherwise rewrite the teardown DDL.
     queryTransformers.length = 0;
-    await dropScratchTables();
     queryTransformers.push(...savedTransformers);
   });
 
@@ -65,12 +51,11 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   });
 
   it("applies the comment on write queries too", async () => {
-    await adapter.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)");
     queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
     const { sqls } = await captureSql(() =>
-      adapter.executeMutation("INSERT INTO widgets (name) VALUES ('x')"),
+      adapter.executeMutation("INSERT INTO customers (name) VALUES ('x')"),
     );
-    expect(sqls.some((s) => s === "INSERT INTO widgets (name) VALUES ('x') /*app:test*/")).toBe(
+    expect(sqls.some((s) => s === "INSERT INTO customers (name) VALUES ('x') /*app:test*/")).toBe(
       true,
     );
   });
@@ -85,8 +70,8 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
     queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
     const { sqls } = await captureSql(() =>
       adapter.executeBatch([
-        "CREATE TABLE a (id INTEGER PRIMARY KEY)",
-        "CREATE TABLE b (id INTEGER PRIMARY KEY)",
+        "INSERT INTO customers (name) VALUES ('a')",
+        "INSERT INTO customers (name) VALUES ('b')",
       ]),
     );
     expect(sqls.length).toBeGreaterThan(0);
@@ -97,16 +82,18 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
     // The batch-suppression flag is consumed synchronously inside preprocessQuery
     // (before any await), so a query interleaved with an in-flight batch still
     // gets transformed. If the flag spanned the await, this comment would be lost.
-    await adapter.executeMutation("CREATE TABLE t (id INTEGER PRIMARY KEY)");
     queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
     const { sqls } = await captureSql(() =>
       Promise.all([
-        adapter.executeBatch(["INSERT INTO t (id) VALUES (1)", "INSERT INTO t (id) VALUES (2)"]),
-        adapter.execute("SELECT id FROM t"),
+        adapter.executeBatch([
+          "INSERT INTO customers (name) VALUES ('c1')",
+          "INSERT INTO customers (name) VALUES ('c2')",
+        ]),
+        adapter.execute("SELECT id FROM customers"),
       ]),
     );
     // The batch statements stay uncommented; the concurrent SELECT keeps its comment.
-    expect(sqls.some((s) => s === "SELECT id FROM t /*app:test*/")).toBe(true);
+    expect(sqls.some((s) => s === "SELECT id FROM customers /*app:test*/")).toBe(true);
     expect(sqls.some((s) => s.startsWith("INSERT") && s.includes("/*app:test*/"))).toBe(false);
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2785,24 +2785,33 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       columns: string[] | string;
       unique: boolean;
       where?: string;
+      orders?: Record<string, string>;
     }>;
     const { bare: bareFrom } = this._splitTableName(from);
     const { bare: bareTo } = this._splitTableName(to);
-    const toCols = (await this.columns(to)).map((c) => c.name);
     for (const idx of idxRows) {
       let name = idx.name;
       if (to === `a${from}`) name = `t${name}`;
       else if (from === `a${to}`) name = name.slice(1);
-      // Rails gates the rename/filter on `columns.is_a?(Array)`: an expression
-      // index carries its parenthesized expression as a bare string, which is
-      // copied across verbatim (no column-name mapping applies).
-      const cols = Array.isArray(idx.columns)
-        ? idx.columns.map((c) => rename[c] ?? c).filter((c) => toCols.includes(c))
-        : idx.columns;
+      // Rails gates the rename/filter on `columns.is_a?(Array)` — and with it
+      // the `columns(to)` reflection: an expression index carries its
+      // parenthesized expression as a bare string, copied across verbatim.
+      let cols: string[] | string;
+      if (Array.isArray(idx.columns)) {
+        const toCols = (await this.columns(to)).map((c) => c.name);
+        cols = idx.columns.map((c) => rename[c] ?? c).filter((c) => toCols.includes(c));
+      } else {
+        cols = idx.columns;
+      }
       if (!cols.length) continue;
       const escapedFrom = bareFrom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${bareTo}_`);
-      const colSql = Array.isArray(cols) ? cols.map((c) => quoteColumnName(c)).join(", ") : cols;
+      // Rails forwards `index.orders` to add_index, which keys the direction off
+      // the column name as it appears in the copied list.
+      const orders = idx.orders ?? {};
+      const colSql = Array.isArray(cols)
+        ? cols.map((c) => `${quoteColumnName(c)}${orders[c] === "desc" ? " DESC" : ""}`).join(", ")
+        : cols;
       let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${quoteColumnName(newName)} ON ${quoteTableName(to)} (${colSql})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;
       await this.driver.exec(sql);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2806,11 +2806,17 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       if (!cols.length) continue;
       const escapedFrom = bareFrom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${bareTo}_`);
-      // Rails forwards `index.orders` to add_index, which keys the direction off
-      // the column name as it appears in the copied list.
+      // Rails forwards `index.orders` to add_index, whose add_index_sort_order
+      // appends any present direction upcased (`column << " #{orders[name].upcase}"`)
+      // keyed off the column name as it appears in the copied list. This
+      // hand-built CREATE INDEX stands in for add_index, so it must stay
+      // value-agnostic: `indexes()` only records "desc" today, but an "asc" or
+      // upper-cased entry must not be silently dropped.
       const orders = idx.orders ?? {};
       const colSql = Array.isArray(cols)
-        ? cols.map((c) => `${quoteColumnName(c)}${orders[c] === "desc" ? " DESC" : ""}`).join(", ")
+        ? cols
+            .map((c) => `${quoteColumnName(c)}${orders[c] ? ` ${orders[c].toUpperCase()}` : ""}`)
+            .join(", ")
         : cols;
       let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${quoteColumnName(newName)} ON ${quoteTableName(to)} (${colSql})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2782,7 +2782,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   ): Promise<void> {
     const idxRows = (await this.indexes(from)) as Array<{
       name: string;
-      columns: string[];
+      columns: string[] | string;
       unique: boolean;
       where?: string;
     }>;
@@ -2793,11 +2793,20 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       let name = idx.name;
       if (to === `a${from}`) name = `t${name}`;
       else if (from === `a${to}`) name = name.slice(1);
-      const cols = idx.columns.map((c) => rename[c] ?? c).filter((c) => toCols.includes(c));
+      // Rails gates the rename/filter on `columns.is_a?(Array)`: an expression
+      // index carries its parenthesized expression as a bare string, which is
+      // copied across verbatim (no column-name mapping applies).
+      const isColumnList = Array.isArray(idx.columns);
+      const cols = isColumnList
+        ? (idx.columns as string[]).map((c) => rename[c] ?? c).filter((c) => toCols.includes(c))
+        : idx.columns;
       if (!cols.length) continue;
       const escapedFrom = bareFrom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${bareTo}_`);
-      let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${quoteColumnName(newName)} ON ${quoteTableName(to)} (${cols.map((c) => quoteColumnName(c)).join(", ")})`;
+      const colSql = isColumnList
+        ? (cols as string[]).map((c) => quoteColumnName(c)).join(", ")
+        : (cols as string);
+      let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${quoteColumnName(newName)} ON ${quoteTableName(to)} (${colSql})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;
       await this.driver.exec(sql);
     }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2796,16 +2796,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       // Rails gates the rename/filter on `columns.is_a?(Array)`: an expression
       // index carries its parenthesized expression as a bare string, which is
       // copied across verbatim (no column-name mapping applies).
-      const isColumnList = Array.isArray(idx.columns);
-      const cols = isColumnList
-        ? (idx.columns as string[]).map((c) => rename[c] ?? c).filter((c) => toCols.includes(c))
+      const cols = Array.isArray(idx.columns)
+        ? idx.columns.map((c) => rename[c] ?? c).filter((c) => toCols.includes(c))
         : idx.columns;
       if (!cols.length) continue;
       const escapedFrom = bareFrom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${bareTo}_`);
-      const colSql = isColumnList
-        ? (cols as string[]).map((c) => quoteColumnName(c)).join(", ")
-        : (cols as string);
+      const colSql = Array.isArray(cols) ? cols.map((c) => quoteColumnName(c)).join(", ") : cols;
       let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${quoteColumnName(newName)} ON ${quoteTableName(to)} (${colSql})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;
       await this.driver.exec(sql);

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -4,7 +4,7 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 
-fixtures([], { useTransactionalTests: false });
+fixtures([]);
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: AbstractSQLite3Adapter;
@@ -12,7 +12,7 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   const dropCopyTargets = async (): Promise<void> => {
     if (db === undefined) return;
     await db.exec(
-      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"`,
+      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"; DROP INDEX IF EXISTS index_customers_on_name`,
     );
   };
 
@@ -78,15 +78,22 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
     expect(await copiedIndexSql("books2", "lower")).toMatch(/lower\(external_id\)/i);
   });
 
+  it("copyTableIndexes carries the index column orders across", async () => {
+    await db.addIndex("customers", ["name"], { order: { name: "desc" } });
+    await (db as any).copyTable("customers", "customers2");
+    expect(await copiedIndexSql("customers2", "name")).toMatch(/"name"\s+DESC/i);
+  });
+
   // --- moveTable ---
 
   it("moveTable copies data to destination and drops source", async () => {
     await (db as any).copyTable("customers", "customers2");
     await db.executeMutation("INSERT INTO customers2 (name) VALUES ('Alice')");
+    const sourceRows = await db.execute("SELECT * FROM customers2");
     await (db as any).moveTable("customers2", "customers3");
     const rows = await db.execute("SELECT * FROM customers3");
-    expect(rows).toHaveLength(1);
-    expect((rows[0] as any).name).toBe("Alice");
+    expect(rows).toHaveLength(sourceRows.length);
+    expect(rows.map((r: any) => r.name)).toContain("Alice");
     const tables = await db.execute("SELECT name FROM sqlite_master WHERE type='table'");
     expect(tables.map((t: any) => t.name)).not.toContain("customers2");
   });

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -4,26 +4,14 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 
-// The rebuild helpers are DDL, so the suite cannot run inside the fixture
-// transaction. Sources are canonical tables read-only; every table this file
-// writes is a `<canonical>2`/`<canonical>3` copy target (the naming Rails'
-// copy_table_test.rb uses) that the drop below reclaims.
 fixtures([], { useTransactionalTests: false });
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: AbstractSQLite3Adapter;
 
-  // The ambient connection is a shared worker DB, so the copy targets are
-  // cleared on the way in as well as out: a hard-killed run must not wedge the
-  // next one. `_alter_tmp_customers2` is alterTable's rebuild scratch table
-  // (sqlite3-adapter.ts `_alter_tmp_${bareTable}`), which it only drops on the
-  // success path — a mid-rebuild failure leaves it behind.
   const dropCopyTargets = async (): Promise<void> => {
-    // Guarded so a beforeEach that fails before the lease surfaces its own
-    // error rather than a TypeError on `undefined.exec` from this teardown.
-    const conn = db as AbstractSQLite3Adapter | undefined;
-    if (!conn) return;
-    await conn.exec(
+    if (db === undefined) return;
+    await db.exec(
       `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"`,
     );
   };
@@ -38,8 +26,6 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   // --- tableStructureSql ---
 
   it("tableStructureSql returns column definition strings from CREATE TABLE SQL", async () => {
-    // The splitter only breaks before the named columns, so `customers`' seven
-    // columns yield two strings: `id`, and `name` plus the trailing remainder.
     const strings = await (db as any).tableStructureSql("customers", ["id", "name"]);
     expect(strings).toHaveLength(2);
     expect(strings[0]).toMatch(/"id"/);
@@ -52,8 +38,6 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   });
 
   it("tableStructureSql includes CONSTRAINT strings", async () => {
-    // `fk_test_has_fk` is the canonical table whose CREATE TABLE carries a named
-    // FOREIGN KEY constraint (schema.rb: fk_name → fk_test_has_pk.pk_id).
     const strings = await (db as any).tableStructureSql("fk_test_has_fk", ["id", "fk_id"]);
     expect(strings.some((s: string) => s.includes("CONSTRAINT"))).toBe(true);
   });
@@ -61,9 +45,6 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   // --- tableStructureWithCollation ---
 
   it("tableStructureWithCollation extracts auto_increment flag", async () => {
-    // Rails' SQLite primary key is `integer PRIMARY KEY AUTOINCREMENT NOT NULL`,
-    // so any canonical table exercises the AUTOINCREMENT branch. (The COLLATE
-    // branch is covered by the Rails port at adapters/sqlite3/collation.test.ts.)
     const basic = await (db as any).tableInfo("customers");
     const enriched = await (db as any).tableStructureWithCollation("customers", basic);
     const idCol = enriched.find((c: any) => c.name === "id");
@@ -78,17 +59,23 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
 
   // --- copyTableIndexes ---
 
+  const copiedIndexSql = async (table: string, matching: string): Promise<string | undefined> => {
+    const rows = (await db.execute(
+      `SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='${table}'`,
+    )) as Array<{ sql: string | null }>;
+    return rows.find((row) => row.sql?.includes(matching))?.sql ?? undefined;
+  };
+
   it("copyTableIndexes preserves partial index WHERE clause", async () => {
-    // `books` carries schema.rb's unique partial index on `isbn`
-    // (`WHERE published_on IS NOT NULL`); its generated name embeds the source
-    // table, so the copy is renamed to index_books2_on_isbn — no collision.
     await (db as any).copyTable("books", "books2");
-    const idxSql = (
-      await db.execute("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='books2'")
-    ).find((row: any) => typeof row["sql"] === "string" && row["sql"].includes("isbn")) as
-      | { sql: string }
-      | undefined;
-    expect(idxSql?.sql).toMatch(/WHERE\s+published_on\s+IS\s+NOT\s+NULL/i);
+    expect(await copiedIndexSql("books2", "isbn")).toMatch(
+      /WHERE\s+published_on\s+IS\s+NOT\s+NULL/i,
+    );
+  });
+
+  it("copyTableIndexes copies an expression index verbatim", async () => {
+    await (db as any).copyTable("books", "books2");
+    expect(await copiedIndexSql("books2", "lower")).toMatch(/lower\(external_id\)/i);
   });
 
   // --- moveTable ---
@@ -110,11 +97,9 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
     // PRAGMA table_info normalizes a declared `integer` to `INTEGER` but leaves
     // `bigint` verbatim, so hand-written DDL is the one way the rebuild sees an
     // AR-spelled integer-like type — the shape that makes newColumnDefinition
-    // flip the column to :primary_key, where the constraint rides entirely on
-    // type_to_sql(:primary_key). No canonical table declares a `bigint` primary
-    // key, so this one table is laid down by hand; it reuses the `customers2`
-    // copy-target name rather than inventing a table.
-
+    // flip the column to :primary_key. No canonical table declares a `bigint`
+    // primary key, so this table alone is laid down by hand, under the
+    // `customers2` copy-target name the teardown above already reclaims.
     await db.exec('CREATE TABLE "customers2" ("id" bigint PRIMARY KEY, "name" TEXT)');
     await db.removeColumn("customers2", "name");
     const pk = (await (db as any).tableInfo("customers2")).filter((c: any) => Number(c.pk) > 0);

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -12,7 +12,7 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   const dropCopyTargets = async (): Promise<void> => {
     if (db === undefined) return;
     await db.exec(
-      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"; DROP INDEX IF EXISTS index_customers_on_name`,
+      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"`,
     );
   };
 
@@ -79,6 +79,7 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   });
 
   it("copyTableIndexes carries the index column orders across", async () => {
+    // Rolled back with the fixture transaction; no teardown needed.
     await db.addIndex("customers", ["name"], { order: { name: "desc" } });
     await (db as any).copyTable("customers", "customers2");
     expect(await copiedIndexSql("customers2", "name")).toMatch(/"name"\s+DESC/i);

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -8,16 +8,19 @@ fixtures([]);
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: AbstractSQLite3Adapter;
+  // Teardown-only handle. `db` stays non-optional for the test bodies, but the
+  // teardown has to tolerate a beforeEach that failed before the lease, so it
+  // reads a genuinely optional binding rather than casting `db`.
+  let leased: AbstractSQLite3Adapter | undefined;
 
   const dropCopyTargets = async (): Promise<void> => {
-    if (db === undefined) return;
-    await db.exec(
+    await leased?.exec(
       `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"`,
     );
   };
 
   beforeEach(async () => {
-    db = Base.connection as AbstractSQLite3Adapter;
+    db = leased = Base.connection as AbstractSQLite3Adapter;
     await dropCopyTargets();
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -4,38 +4,43 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 
+// The rebuild helpers are DDL, so the suite cannot run inside the fixture
+// transaction. Sources are canonical tables read-only; every table this file
+// writes is a `<canonical>2`/`<canonical>3` copy target (the naming Rails'
+// copy_table_test.rb uses) that the drop below reclaims.
 fixtures([], { useTransactionalTests: false });
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: AbstractSQLite3Adapter;
-  // Teardown-only handle. `db` stays non-optional for the test bodies, but the
-  // teardown has to tolerate a beforeEach that failed before the lease, so it
-  // reads a genuinely optional binding rather than casting `db`.
-  let leased: AbstractSQLite3Adapter | undefined;
 
-  // The ambient connection is a shared worker DB, so the scratch tables are
+  // The ambient connection is a shared worker DB, so the copy targets are
   // cleared on the way in as well as out: a hard-killed run must not wedge the
-  // next one. `_alter_tmp_rebuild_users` is alterTable's rebuild scratch table
+  // next one. `_alter_tmp_customers2` is alterTable's rebuild scratch table
   // (sqlite3-adapter.ts `_alter_tmp_${bareTable}`), which it only drops on the
   // success path — a mid-rebuild failure leaves it behind.
-  const dropScratchTables = async (): Promise<void> => {
-    await leased?.exec(
-      `DROP TABLE IF EXISTS rebuild_users; DROP TABLE IF EXISTS rebuild_orders; DROP TABLE IF EXISTS src; DROP TABLE IF EXISTS dst; DROP TABLE IF EXISTS "_alter_tmp_rebuild_users"`,
+  const dropCopyTargets = async (): Promise<void> => {
+    // Guarded so a beforeEach that fails before the lease surfaces its own
+    // error rather than a TypeError on `undefined.exec` from this teardown.
+    const conn = db as AbstractSQLite3Adapter | undefined;
+    if (!conn) return;
+    await conn.exec(
+      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"`,
     );
   };
 
   beforeEach(async () => {
-    db = leased = Base.connection as AbstractSQLite3Adapter;
-    await dropScratchTables();
+    db = Base.connection as AbstractSQLite3Adapter;
+    await dropCopyTargets();
   });
 
-  afterEach(dropScratchTables);
+  afterEach(dropCopyTargets);
 
   // --- tableStructureSql ---
 
   it("tableStructureSql returns column definition strings from CREATE TABLE SQL", async () => {
-    await db.exec('CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY, "name" TEXT NOT NULL)');
-    const strings = await (db as any).tableStructureSql("rebuild_users", ["id", "name"]);
+    // The splitter only breaks before the named columns, so `customers`' seven
+    // columns yield two strings: `id`, and `name` plus the trailing remainder.
+    const strings = await (db as any).tableStructureSql("customers", ["id", "name"]);
     expect(strings).toHaveLength(2);
     expect(strings[0]).toMatch(/"id"/);
     expect(strings[1]).toMatch(/"name"/);
@@ -47,152 +52,56 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   });
 
   it("tableStructureSql includes CONSTRAINT strings", async () => {
-    await db.exec(
-      'CREATE TABLE "rebuild_orders" ("id" INTEGER PRIMARY KEY, "user_id" INTEGER, CONSTRAINT "fk_user" FOREIGN KEY("user_id") REFERENCES "rebuild_users"("id"))',
-    );
-    const strings = await (db as any).tableStructureSql("rebuild_orders", ["id", "user_id"]);
+    // `fk_test_has_fk` is the canonical table whose CREATE TABLE carries a named
+    // FOREIGN KEY constraint (schema.rb: fk_name → fk_test_has_pk.pk_id).
+    const strings = await (db as any).tableStructureSql("fk_test_has_fk", ["id", "fk_id"]);
     expect(strings.some((s: string) => s.includes("CONSTRAINT"))).toBe(true);
   });
 
   // --- tableStructureWithCollation ---
 
-  it("tableStructureWithCollation extracts collation from CREATE TABLE SQL", async () => {
-    await db.exec(
-      'CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY, "name" TEXT COLLATE "NOCASE")',
-    );
-    const basic = [
-      { name: "id", type: "INTEGER", notnull: 0, dflt_value: null, pk: 1 },
-      { name: "name", type: "TEXT", notnull: 0, dflt_value: null, pk: 0 },
-    ];
-    const enriched = await (db as any).tableStructureWithCollation("rebuild_users", basic);
-    const nameCol = enriched.find((c: any) => c.name === "name");
-    expect(nameCol.collation).toBe("NOCASE");
-  });
-
   it("tableStructureWithCollation extracts auto_increment flag", async () => {
-    await db.exec(
-      'CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)',
-    );
-    const basic = [
-      { name: "id", type: "INTEGER", notnull: 0, dflt_value: null, pk: 1 },
-      { name: "name", type: "TEXT", notnull: 0, dflt_value: null, pk: 0 },
-    ];
-    const enriched = await (db as any).tableStructureWithCollation("rebuild_users", basic);
+    // Rails' SQLite primary key is `integer PRIMARY KEY AUTOINCREMENT NOT NULL`,
+    // so any canonical table exercises the AUTOINCREMENT branch. (The COLLATE
+    // branch is covered by the Rails port at adapters/sqlite3/collation.test.ts.)
+    const basic = await (db as any).tableInfo("customers");
+    const enriched = await (db as any).tableStructureWithCollation("customers", basic);
     const idCol = enriched.find((c: any) => c.name === "id");
     expect(idCol.auto_increment).toBe(true);
   });
 
-  // --- tableInfo ---
-
-  it("tableInfo returns PRAGMA table_info rows", async () => {
-    await db.exec("CREATE TABLE rebuild_users (id INTEGER PRIMARY KEY, name TEXT)");
-    const info = await (db as any).tableInfo("rebuild_users");
-    expect(info).toHaveLength(2);
-    expect(info[0].name).toBe("id");
-  });
-
   // --- tableStructure ---
-
-  it("tableStructure returns enriched column info", async () => {
-    await db.exec(
-      'CREATE TABLE "rebuild_users" ("id" INTEGER PRIMARY KEY, "name" TEXT COLLATE "NOCASE")',
-    );
-    const structure = await (db as any).tableStructure("rebuild_users");
-    expect(structure).toHaveLength(2);
-    const nameCol = structure.find((c: any) => c.name === "name");
-    expect(nameCol.collation).toBe("NOCASE");
-  });
 
   it("tableStructure throws StatementInvalid for non-existent table", async () => {
     await expect((db as any).tableStructure("no_such")).rejects.toThrow(/Could not find table/);
   });
 
-  // --- copyTableContents ---
-
-  it("copyTableContents copies rows from source to destination", async () => {
-    await db.exec("CREATE TABLE src (id INTEGER, name TEXT)");
-    await db.exec("CREATE TABLE dst (id INTEGER, name TEXT)");
-    await db.exec("INSERT INTO src VALUES (1, 'Alice'), (2, 'Bob')");
-    await (db as any).copyTableContents("src", "dst", ["id", "name"]);
-    const rows = (db.raw as import("better-sqlite3").Database)
-      .prepare("SELECT * FROM dst ORDER BY id")
-      .all();
-    expect(rows).toHaveLength(2);
-    expect((rows[0] as any).name).toBe("Alice");
-  });
-
-  it("copyTableContents respects column rename mapping", async () => {
-    await db.exec("CREATE TABLE src (id INTEGER, old_name TEXT)");
-    await db.exec("CREATE TABLE dst (id INTEGER, new_name TEXT)");
-    await db.exec("INSERT INTO src VALUES (1, 'Alice')");
-    // rename: {srcCol: destCol} = {old_name: new_name}
-    await (db as any).copyTableContents("src", "dst", ["id", "new_name"], {
-      old_name: "new_name",
-    });
-    const rows = (db.raw as import("better-sqlite3").Database).prepare("SELECT * FROM dst").all();
-    expect((rows[0] as any).new_name).toBe("Alice");
-  });
-
   // --- copyTableIndexes ---
 
-  it("copyTableIndexes recreates indexes on destination table", async () => {
-    await db.exec("CREATE TABLE src (id INTEGER, email TEXT)");
-    await db.exec("CREATE UNIQUE INDEX index_src_on_email ON src (email)");
-    await db.exec("CREATE TABLE dst (id INTEGER, email TEXT)");
-    await (db as any).copyTableIndexes("src", "dst");
-    const idxList = (db.raw as import("better-sqlite3").Database)
-      .prepare("PRAGMA index_list(dst)")
-      .all() as any[];
-    expect(idxList.length).toBeGreaterThan(0);
-    expect(idxList[0].unique).toBe(1);
-  });
-
   it("copyTableIndexes preserves partial index WHERE clause", async () => {
-    await db.exec("CREATE TABLE src (id INTEGER, active INTEGER, email TEXT)");
-    await db.exec("CREATE UNIQUE INDEX index_src_on_email_active ON src (email) WHERE active = 1");
-    await db.exec("CREATE TABLE dst (id INTEGER, active INTEGER, email TEXT)");
-    await (db as any).copyTableIndexes("src", "dst");
-    const idxSql = (db.raw as import("better-sqlite3").Database)
-      .prepare("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='dst'")
-      .get() as { sql: string } | undefined;
-    expect(idxSql?.sql).toMatch(/WHERE\s+active\s*=\s*1/i);
-  });
-
-  // --- copyTable ---
-
-  it("copyTable creates destination with same schema and data", async () => {
-    await db.exec("CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
-    await db.exec("INSERT INTO src VALUES (1, 'Alice')");
-    await (db as any).copyTable("src", "dst");
-    const rows = (db.raw as import("better-sqlite3").Database).prepare("SELECT * FROM dst").all();
-    expect(rows).toHaveLength(1);
-    expect((rows[0] as any).name).toBe("Alice");
-  });
-
-  it("copyTable renames columns when options.rename is provided", async () => {
-    await db.exec("CREATE TABLE src (id INTEGER, old_col TEXT)");
-    await db.exec("INSERT INTO src VALUES (1, 'hello')");
-    await (db as any).copyTable("src", "dst", { rename: { old_col: "new_col" } });
-    const cols = (db.raw as import("better-sqlite3").Database)
-      .prepare("PRAGMA table_info(dst)")
-      .all() as any[];
-    expect(cols.map((c: any) => c.name)).toContain("new_col");
-    const rows = (db.raw as import("better-sqlite3").Database).prepare("SELECT * FROM dst").all();
-    expect((rows[0] as any).new_col).toBe("hello");
+    // `books` carries schema.rb's unique partial index on `isbn`
+    // (`WHERE published_on IS NOT NULL`); its generated name embeds the source
+    // table, so the copy is renamed to index_books2_on_isbn — no collision.
+    await (db as any).copyTable("books", "books2");
+    const idxSql = (
+      await db.execute("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='books2'")
+    ).find((row: any) => typeof row["sql"] === "string" && row["sql"].includes("isbn")) as
+      | { sql: string }
+      | undefined;
+    expect(idxSql?.sql).toMatch(/WHERE\s+published_on\s+IS\s+NOT\s+NULL/i);
   });
 
   // --- moveTable ---
 
   it("moveTable copies data to destination and drops source", async () => {
-    await db.exec("CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT)");
-    await db.exec("INSERT INTO src VALUES (1, 'Alice')");
-    await (db as any).moveTable("src", "dst");
-    const rows = (db.raw as import("better-sqlite3").Database).prepare("SELECT * FROM dst").all();
+    await (db as any).copyTable("customers", "customers2");
+    await db.executeMutation("INSERT INTO customers2 (name) VALUES ('Alice')");
+    await (db as any).moveTable("customers2", "customers3");
+    const rows = await db.execute("SELECT * FROM customers3");
     expect(rows).toHaveLength(1);
-    const tables = (db.raw as import("better-sqlite3").Database)
-      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-      .all() as any[];
-    expect(tables.map((t: any) => t.name)).not.toContain("src");
+    expect((rows[0] as any).name).toBe("Alice");
+    const tables = await db.execute("SELECT name FROM sqlite_master WHERE type='table'");
+    expect(tables.map((t: any) => t.name)).not.toContain("customers2");
   });
 
   // --- alterTable ---
@@ -202,10 +111,13 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
     // `bigint` verbatim, so hand-written DDL is the one way the rebuild sees an
     // AR-spelled integer-like type — the shape that makes newColumnDefinition
     // flip the column to :primary_key, where the constraint rides entirely on
-    // type_to_sql(:primary_key).
-    await db.exec('CREATE TABLE "rebuild_users" ("id" bigint PRIMARY KEY, "name" TEXT)');
-    await db.removeColumn("rebuild_users", "name");
-    const pk = (await (db as any).tableInfo("rebuild_users")).filter((c: any) => Number(c.pk) > 0);
+    // type_to_sql(:primary_key). No canonical table declares a `bigint` primary
+    // key, so this one table is laid down by hand; it reuses the `customers2`
+    // copy-target name rather than inventing a table.
+
+    await db.exec('CREATE TABLE "customers2" ("id" bigint PRIMARY KEY, "name" TEXT)');
+    await db.removeColumn("customers2", "name");
+    const pk = (await (db as any).tableInfo("customers2")).filter((c: any) => Number(c.pk) > 0);
     expect(pk.map((c: any) => c.name)).toEqual(["id"]);
   });
 });


### PR DESCRIPTION
Converges the two trails-only `connection-adapters/sqlite3*` test files off
bespoke tables (`rebuild_users`, `rebuild_orders`, `src`, `dst`, `widgets`,
`t`, `a`, `b`) and onto the canonical schema, per CLAUDE.md's
"canonical tables only" rule.

## Decisions recorded by this PR

**`sqlite3-copy-table.test.ts` — outcome (a) + (b).** Eight of its fifteen tests
are redundant with faithful Rails ports and are deleted:

| deleted test | already covered by |
| --- | --- |
| `copyTableContents copies rows from source to destination` | `adapters/sqlite3/copy-table.test.ts` → `copy table` |
| `copyTableContents respects column rename mapping` | `copy table renaming column` |
| `copyTableIndexes recreates indexes on destination table` | `copy table with index` |
| `copyTable creates destination with same schema and data` | `copy table` |
| `copyTable renames columns when options.rename is provided` | `copy table renaming column` |
| `tableInfo returns PRAGMA table_info rows` | exercised by every `tableStructure` path |
| `tableStructureWithCollation extracts collation from CREATE TABLE SQL` | `adapters/sqlite3/collation.test.ts` (Rails `collation_test.rb`) |
| `tableStructure returns enriched column info` | same |

The remainder is private-helper coverage the Rails ports genuinely cannot
reach (`tableStructureSql`'s empty/CONSTRAINT branches, the AUTOINCREMENT
branch, `tableStructure`'s `StatementInvalid`, `moveTable`'s drop-source,
and the `alterTable` bigint-PK regression). Those keep their test names and
move to canonical sources — `customers`, `books`, `fk_test_has_fk` — writing
only `<canonical>2` / `<canonical>3` copy targets, which is the naming
`copy_table_test.rb` itself uses (`customers2`).

**`sqlite3-adapter.query-transformers.test.ts` — outcome (b).** Every
statement now runs against canonical `customers`, so the suite needs no
scratch DDL at all and runs under ordinary transactional fixtures.

The one hand-written table that remains is the `bigint PRIMARY KEY` shape in
the `alterTable` regression: PRAGMA `table_info` leaves `bigint` verbatim, so
no canonical table can produce it. Justified at the call site.

## Drive-by fidelity fix

Pointing the partial-index test at canonical `books` surfaced a real gap:
`books` also carries an expression index, whose `columns` is a bare string.
Rails' `copy_table_indexes` gates the rename/filter on `columns.is_a?(Array)`
and copies the expression verbatim; ours called `.map` on the string and threw
`TypeError`. Ported the guard, with a direct regression test
(`copyTableIndexes copies an expression index verbatim`) that fails on
baseline.

Note: this touches two of the three files in #5500 and adopts that PR's
ambient-connection move for them, so #5500 should drop those two files.

## Review round 1

1. **`moveTable` exact row count on a shared `customers`** — fixed twice over.
   Dropped `useTransactionalTests: false` (see 2), and the assertion no longer
   hard-codes 1: it compares `customers3` against the `customers2` row count
   captured before the move and checks Alice is among the copied names.
2. **Why `useTransactionalTests: false`?** No concrete failure drove it — it was
   inherited from #5500's shape, which needed it for scratch DDL this PR no
   longer creates. Removed; the suite runs under default transactional fixtures
   like the sibling port `adapters/sqlite3/copy-table.test.ts`. Suite passes.
3. **`options[:order] = index.orders` was dropped** — real bug, ported. The
   copied `add_index` now emits `"col" DESC` for columns `index.orders` marks
   descending, keyed off the column name as it appears in the copied list
   (Rails' `add_index` does the same, including its quirk of keying on the
   *renamed* name). Regression test
   `copyTableIndexes carries the index column orders across`; verified it fails
   on baseline.
4. **`toCols` computed unconditionally** — fixed. `columns(to)` now only runs
   inside the `Array.isArray` branch, so an expression-only index issues no
   extra reflection, matching `copy_table_indexes`.
5. **Is the COLLATE enrichment still covered?** Yes.
   `adapters/sqlite3/collation.test.ts` asserts the value, not just the column
   list: `string column with collation` asserts
   `stringNocase.collation === "NOCASE"` and
   `stringAfterDecimal.collation === "NOCASE"`; `text column with collation`
   asserts `textRtrim.collation === "RTRIM"`. Those go through `columns()` →
   `tableStructure` → `tableStructureWithCollation`, so `COLLATE_REGEX`
   (sqlite3-adapter.ts:2677) has to fire for them to pass — including the
   after-a-DECIMAL case the deleted test did not cover.

## Review round 2

1. **Hardcoded `=== "desc"` in place of `add_index`** — fixed properly rather
   than commented. `add_index_sort_order` (schema_statements.rb:1622) appends
   *any* present direction, upcased: `column << " #{orders[name].upcase}" if
   orders[name].present?`. Ours now does the same —
   `orders[c] ? \` ${orders[c].toUpperCase()}\` : ""\` — so `asc` or an
   upper-cased entry survives a later `indexes()` change instead of being
   dropped. The comment records why this hand-built CREATE INDEX has to stay
   value-agnostic.
2. **`DROP INDEX IF EXISTS index_customers_on_name` in the shared teardown** —
   removed, exactly as you read it: the `addIndex` is rolled back with the
   fixture transaction, and the unguarded drop would have taken out a canonical
   index of that name for every test in the file. Verified by running the file
   twice back to back — the second run's `addIndex` would fail on a leaked
   index, and both runs are green.

Closes-story: converge-connection-adapters-sqlite3-bespoke-tables
