### PR TITLE
test(mysql): drop false Rails anchors from mysql adapter suites

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -1,5 +1,8 @@
 /**
- * Mirrors Rails activerecord/test/cases/adapters/mysql2/statement_pool_test.rb
+ * Trails-only: Rails has no mysql2/abstract_mysql_adapter statement pool suite
+ * (only postgresql/ and sqlite3/ ship a statement_pool_test.rb), so these test
+ * names are trails prose covering Mysql2StatementPool
+ * (activerecord/lib/active_record/connection_adapters/mysql2/…).
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -1,8 +1,9 @@
 /**
- * Trails-only: Rails has no mysql2/abstract_mysql_adapter statement pool suite
- * (only postgresql/ and sqlite3/ ship a statement_pool_test.rb), so these test
- * names are trails prose covering Mysql2StatementPool
- * (activerecord/lib/active_record/connection_adapters/mysql2/…).
+ * Trails-only. Rails ships a statement_pool_test.rb for postgresql/ and
+ * sqlite3/ but none for mysql, so every test name below is trails prose, not a
+ * Rails name. Subject under test is `Mysql2StatementPool`, our subclass of the
+ * port of `AbstractMysqlAdapter::StatementPool`
+ * (activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb).
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -178,9 +178,9 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
     });
   });
 
-  // Rails has no mysql translate_exception test file; these cover
-  // AbstractMysqlAdapter#translate_exception
-  // (activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:815).
+  // Rails has no mysql translate_exception test file, so these names are trails
+  // prose covering `AbstractMysqlAdapter#translate_exception`
+  // (activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb).
   // Matches the PG adapter's equivalent suite.
   describe("translate_exception", () => {
     beforeEach(async () => {

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -178,8 +178,10 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
     });
   });
 
-  // Rails: activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_adapter_test.rb
-  // translate_exception tests. Matches the PG adapter's equivalent suite.
+  // Rails has no mysql translate_exception test file; these cover
+  // AbstractMysqlAdapter#translate_exception
+  // (activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:815).
+  // Matches the PG adapter's equivalent suite.
   describe("translate_exception", () => {
     beforeEach(async () => {
       await adapter.executeMutation(`DROP TABLE IF EXISTS ex_child`);


### PR DESCRIPTION
`packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts`
claimed to mirror `activerecord/test/cases/adapters/mysql2/statement_pool_test.rb`.
That file does not exist in Rails — only `postgresql/statement_pool_test.rb` and
`sqlite3/statement_pool_test.rb` are vendored. The header was a false anchor: it
pointed `pnpm rails:find` / `test:compare` at an unresolvable path and implied the
suite's `it(...)` names were Rails-verbatim when every one of them is trails prose.

Took option 1 from the story: rename to `statement-pool.trails.test.ts`, matching
the sibling trails-only adapter suites (`nested-deadlock.trails.test.ts`,
`savepoint-reconnect.trails.test.ts`), and replace the header with one that says
plainly that Rails has no counterpart and points at the class actually under
test (`Mysql2StatementPool`, our subclass of the port of
`AbstractMysqlAdapter::StatementPool` in
`activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb`).

Sibling sweep (acceptance criterion 4): every `activerecord/test/cases/adapters/…`
path referenced under `adapters/mysql2/` and `adapters/abstract-mysql-adapter/`
was checked against `vendor/rails/`. Exactly two did not resolve — the one above,
and an inline anchor in `mysql2-adapter.trails.test.ts` pointing at
`abstract_mysql_adapter/mysql_adapter_test.rb` for the `translate_exception`
describe. Rails ships no mysql `translate_exception` test file either, so that
comment is re-anchored at `AbstractMysqlAdapter#translate_exception` in
`activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb`.
All 24 other anchors resolve.

The rename is safe for tooling: nothing references the old path, and the vitest
mysql project selects these suites by directory glob
(`packages/activerecord/src/adapters/abstract-mysql-adapter/**`), not by filename.

## test:compare

Unchanged, exactly as expected — a Ruby file that doesn't exist can't have been
contributing to the tally, so the file was already counted as TS-only extra under
both names.

```text
before: Overall: 14701/22203 tests (66.2%) … 4012 extra (TS only)  |  759/1044 files  |  202 misplaced
after:  Overall: 14701/22203 tests (66.2%) … 4012 extra (TS only)  |  759/1044 files  |  202 misplaced
```

Test names are unchanged; only the file name and two comments moved.

Closes-story: statement-pool-test-false-rails-anchor
