### PR TITLE
fix(tasks): keep config identity when normalizing sqlite paths

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -557,7 +557,9 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "127.0.0.1" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain("dev.db");
+    // Resolved: checkProtectedEnvironmentsBang runs the config through
+    // withTemporaryConnection, which resolves relative sqlite paths in place.
+    expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
   });
 
   it("drops configurations with local host", async () => {
@@ -565,7 +567,9 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "localhost" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain("dev.db");
+    // Resolved: checkProtectedEnvironmentsBang runs the config through
+    // withTemporaryConnection, which resolves relative sqlite paths in place.
+    expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
   });
 
   it("drops configurations with blank hosts", async () => {
@@ -573,7 +577,9 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain("dev.db");
+    // Resolved: checkProtectedEnvironmentsBang runs the config through
+    // withTemporaryConnection, which resolves relative sqlite paths in place.
+    expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
   });
 });
 
@@ -601,7 +607,7 @@ describe("DatabaseTasksDropCurrentTest", () => {
   it("drops current environment database", async () => {
     DatabaseTasks.env = "test";
     await DatabaseTasks.dropCurrent("test");
-    expect(dropped).toContain("test:test.db");
+    expect(dropped).toContain(`test:${path.resolve(DatabaseTasks.root, "test.db")}`);
   });
 
   it("drops current environment database with url", async () => {
@@ -1294,5 +1300,42 @@ describe("DatabaseTasksCheckSchemaFileMethods", () => {
     process.env.SCHEMA = "override.rb";
     const config = new HashConfig("test", "animals", { adapter: "sqlite3" });
     expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("override.rb");
+  });
+});
+
+describe("DatabaseTasksWithTemporaryPoolTest", () => {
+  afterEach(() => {
+    try {
+      Base.removeConnection();
+    } catch {
+      /* no pool */
+    }
+  });
+
+  it("reuses the ambient pool for a relative sqlite path", async () => {
+    // Path normalization must not cost config identity: the handler's reuse
+    // check is reference equality on the DatabaseConfig
+    // (connection-handler.ts, existingPoolConfig.dbConfig === poolConfig.dbConfig).
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-temp-pool-"));
+    const previousRoot = DatabaseTasks.root;
+    DatabaseTasks.root = tmp;
+    const config = new HashConfig(DatabaseTasks.env, "primary", {
+      adapter: "sqlite3",
+      database: "relative.sqlite3",
+      pool: 1,
+    });
+    try {
+      await Base.establishConnection(config);
+      const ambientPool = Base.connectionPool();
+      let temporaryPool: unknown = null;
+      await DatabaseTasks.withTemporaryPool(config, async (pool) => {
+        temporaryPool = pool;
+      });
+      expect(temporaryPool).toBe(ambientPool);
+      expect(Base.connectionPool()).toBe(ambientPool);
+      expect(config.database).toBe(path.join(tmp, "relative.sqlite3"));
+    } finally {
+      DatabaseTasks.root = previousRoot;
+    }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -429,7 +429,7 @@ describe("DatabaseTasksCreateCurrentTest", () => {
     expect(establishSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         adapter: "sqlite3",
-        database: path.resolve(DatabaseTasks.root, "dev.db"),
+        database: "dev.db",
       }),
     );
   });
@@ -500,7 +500,7 @@ describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
     expect(establishSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         adapter: "sqlite3",
-        database: path.resolve(DatabaseTasks.root, "dev_primary.db"),
+        database: "dev_primary.db",
       }),
     );
   });
@@ -558,7 +558,7 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "127.0.0.1" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
+    expect(dropped).toContain("dev.db");
   });
 
   it("drops configurations with local host", async () => {
@@ -566,7 +566,7 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "localhost" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
+    expect(dropped).toContain("dev.db");
   });
 
   it("drops configurations with blank hosts", async () => {
@@ -574,7 +574,7 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
+    expect(dropped).toContain("dev.db");
   });
 });
 
@@ -602,7 +602,7 @@ describe("DatabaseTasksDropCurrentTest", () => {
   it("drops current environment database", async () => {
     DatabaseTasks.env = "test";
     await DatabaseTasks.dropCurrent("test");
-    expect(dropped).toContain(`test:${path.resolve(DatabaseTasks.root, "test.db")}`);
+    expect(dropped).toContain("test:test.db");
   });
 
   it("drops current environment database with url", async () => {
@@ -1299,24 +1299,18 @@ describe("DatabaseTasksCheckSchemaFileMethods", () => {
 });
 
 describe("DatabaseTasksWithTemporaryPoolTest", () => {
-  afterEach(() => {
-    try {
-      Base.removeConnection();
-    } catch {
-      /* no pool */
-    }
+  afterEach(async () => {
+    await Base.establishConnection(ambientPoolConfiguration());
   });
 
-  it("reuses the ambient pool for a relative sqlite path", async () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-temp-pool-"));
-    const previousRoot = DatabaseTasks.root;
-    DatabaseTasks.root = tmp;
-    const config = new HashConfig(DatabaseTasks.env, "primary", {
-      adapter: "sqlite3",
-      database: "relative.sqlite3",
-      pool: 1,
-    });
-    try {
+  it.skipIf(adapterType !== "sqlite")(
+    "reuses the ambient pool for a relative sqlite path",
+    async () => {
+      const config = new HashConfig(DatabaseTasks.env, "primary", {
+        adapter: "sqlite3",
+        database: "db/relative.sqlite3",
+        pool: 1,
+      });
       await Base.establishConnection(config);
       const ambientPool = Base.connectionPool();
       let temporaryPool: ConnectionPool | null = null;
@@ -1325,9 +1319,30 @@ describe("DatabaseTasksWithTemporaryPoolTest", () => {
       });
       expect(temporaryPool).toBe(ambientPool);
       expect(Base.connectionPool()).toBe(ambientPool);
-      expect(config.database).toBe(path.join(tmp, "relative.sqlite3"));
+      // The relative path survives: nothing may rewrite the registry config
+      // (Rails' with_temporary_pool does no path work — database_tasks.rb:542).
+      expect(config.database).toBe("db/relative.sqlite3");
+    },
+  );
+
+  it.skipIf(adapterType !== "sqlite")("createAll restores the original pool", async () => {
+    const config = new HashConfig(DatabaseTasks.env, "primary", {
+      adapter: "sqlite3",
+      database: "db/ambient.sqlite3",
+      pool: 1,
+    });
+    await Base.establishConnection(config);
+    const ambientPool = Base.connectionPool();
+    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      [DatabaseTasks.env]: { adapter: "sqlite3", database: "db/other.sqlite3" },
+    });
+    try {
+      await DatabaseTasks.createAll();
+      expect(Base.connectionPool()).toBe(ambientPool);
     } finally {
-      DatabaseTasks.root = previousRoot;
+      DatabaseTasks.clearRegisteredTasks();
+      DatabaseTasks.databaseConfiguration = null;
     }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1333,16 +1333,26 @@ describe("DatabaseTasksWithTemporaryPoolTest", () => {
     });
     await Base.establishConnection(config);
     const ambientPool = Base.connectionPool();
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    // Rails stubs `create` rather than registering a task
+    // (database_tasks_test.rb:587). Registering one here would mean clearing the
+    // registry afterwards, and clearRegisteredTasks() wipes the SQLiteDatabaseTasks
+    // registration the test bootstrap installs (support/connection.ts:396).
+    const createSpy = vi.spyOn(DatabaseTasks, "create").mockResolvedValue(undefined);
+    const previousConfiguration = DatabaseTasks.databaseConfiguration;
+    // The DatabaseConfigurations constructor installs itself as the module-level
+    // current-configurations singleton, so that needs restoring too.
+    const previousCurrent = DatabaseConfigurations.current;
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       [DatabaseTasks.env]: { adapter: "sqlite3", database: "db/other.sqlite3" },
     });
     try {
       await DatabaseTasks.createAll();
+      expect(createSpy).toHaveBeenCalled();
       expect(Base.connectionPool()).toBe(ambientPool);
     } finally {
-      DatabaseTasks.clearRegisteredTasks();
-      DatabaseTasks.databaseConfiguration = null;
+      createSpy.mockRestore();
+      DatabaseTasks.databaseConfiguration = previousConfiguration;
+      DatabaseConfigurations.current = previousCurrent;
     }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -9,6 +9,7 @@ import { DatabaseConfigurations } from "../database-configurations.js";
 import { NoEnvironmentInSchemaError, ProtectedEnvironmentError } from "../migration.js";
 import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
+import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { inMemoryDb } from "../support/adapter-helper.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -557,8 +558,6 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "127.0.0.1" },
     });
     await DatabaseTasks.dropAll();
-    // Resolved: checkProtectedEnvironmentsBang runs the config through
-    // withTemporaryConnection, which resolves relative sqlite paths in place.
     expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
   });
 
@@ -567,8 +566,6 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "localhost" },
     });
     await DatabaseTasks.dropAll();
-    // Resolved: checkProtectedEnvironmentsBang runs the config through
-    // withTemporaryConnection, which resolves relative sqlite paths in place.
     expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
   });
 
@@ -577,8 +574,6 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "" },
     });
     await DatabaseTasks.dropAll();
-    // Resolved: checkProtectedEnvironmentsBang runs the config through
-    // withTemporaryConnection, which resolves relative sqlite paths in place.
     expect(dropped).toContain(path.resolve(DatabaseTasks.root, "dev.db"));
   });
 });
@@ -1313,9 +1308,6 @@ describe("DatabaseTasksWithTemporaryPoolTest", () => {
   });
 
   it("reuses the ambient pool for a relative sqlite path", async () => {
-    // Path normalization must not cost config identity: the handler's reuse
-    // check is reference equality on the DatabaseConfig
-    // (connection-handler.ts, existingPoolConfig.dbConfig === poolConfig.dbConfig).
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-temp-pool-"));
     const previousRoot = DatabaseTasks.root;
     DatabaseTasks.root = tmp;
@@ -1327,7 +1319,7 @@ describe("DatabaseTasksWithTemporaryPoolTest", () => {
     try {
       await Base.establishConnection(config);
       const ambientPool = Base.connectionPool();
-      let temporaryPool: unknown = null;
+      let temporaryPool: ConnectionPool | null = null;
       await DatabaseTasks.withTemporaryPool(config, async (pool) => {
         temporaryPool = pool;
       });

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -218,7 +218,6 @@ export class DatabaseTasks {
     const primaryConfig = this.databaseConfiguration?.findDbConfig(envName);
     if (primaryConfig) {
       const { Base } = await import("../base.js");
-      _normalizeSQLitePath(primaryConfig, this.root);
       await Base.establishConnection(primaryConfig);
     }
   }
@@ -1044,9 +1043,10 @@ export class DatabaseTasks {
   }
 
   /**
-   * Mirrors Rails' `DatabaseTasks.with_temporary_pool`: establishes a fresh
-   * pool for `config` (clobber: true), yields it, then restores the prior
-   * pool (or removes the pool if none existed before).
+   * Mirrors Rails' `DatabaseTasks.with_temporary_pool`: establishes a pool for
+   * `config` (clobber defaults to false, so an existing pool for the same
+   * config object is reused), yields it, then restores the prior pool (or
+   * removes the pool if none existed before).
    *
    * @internal
    */
@@ -1062,7 +1062,6 @@ export class DatabaseTasks {
     } catch (error) {
       if (!(error instanceof ConnectionNotDefined)) throw error;
     }
-    _normalizeSQLitePath(config, this.root);
     // Rails passes the `DatabaseConfig` object itself
     // (tasks/database_tasks.rb:652), which is what lets
     // `ConnectionHandler#establish_connection` recognise an already-established
@@ -1486,33 +1485,6 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
     }
     return !alreadyInitialized;
   });
-}
-
-// Mirrors SQLite3Adapter._isMemoryFilename: `:memory:`, `file::memory:`, and
-// `file:...?mode=memory` are all in-memory and must not be path-resolved.
-function _isSQLiteMemoryDatabase(database: string): boolean {
-  if (database === ":memory:") return true;
-  if (!database.startsWith("file:")) return false;
-  if (database.startsWith("file::memory:")) return true;
-  const q = database.indexOf("?");
-  if (q === -1) return false;
-  return new URLSearchParams(database.slice(q + 1)).get("mode") === "memory";
-}
-
-// Mirrors Rails' SQLiteDatabaseTasks#initialize: resolve relative `database`
-// paths against root so all withTemporaryPool callers behave consistently.
-// Rewrites the config OBJECT in place (Rails' `DatabaseConfig#_database=`):
-// returning a new config would break `ConnectionHandler#establishConnection`'s
-// reference-equality reuse check, so a temporary pool over a relative sqlite
-// path would replace — and disconnect — the ambient pool.
-function _normalizeSQLitePath(config: DatabaseConfig, root: string): void {
-  const adapter = config.adapter;
-  if (typeof adapter !== "string" || !adapter.includes("sqlite")) return;
-  const database = config.database;
-  if (typeof database !== "string" || _isSQLiteMemoryDatabase(database)) return;
-  const p = getPath();
-  if (!p.isAbsolute || p.isAbsolute(database)) return;
-  config._database = p.resolve(root, database);
 }
 
 // Defensive fallback for SQL-level errors that slip through pool proxies or

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -211,9 +211,14 @@ export class DatabaseTasks {
         await this.create(config);
       }
     }
-    // Rails: establish_connection(environment.to_sym) calls configurations.resolve(:env)
-    // → find_db_config(env) which returns forCurrentEnv configs first, then falls back
-    // to the first config for that env_name. findDbConfig mirrors that exact lookup.
+    // Rails is `establish_connection(environment.to_sym)` (database_tasks.rb:653),
+    // which resolves through `Base.configurations`. trails cannot pass the bare env:
+    // `DatabaseTasks.databaseConfiguration` is a SEPARATE registry from
+    // `Base.configurations` (support/connection.ts:390-392 happens to set both, but
+    // callers reassign `databaseConfiguration` alone), so the env string would
+    // resolve against the wrong set of configs. findDbConfig mirrors what
+    // configurations.resolve(:env) does: forCurrentEnv configs first, then the first
+    // config for that env_name.
     const envName = this._normalizeEnv(environment);
     const primaryConfig = this.databaseConfiguration?.findDbConfig(envName);
     if (primaryConfig) {
@@ -1063,7 +1068,7 @@ export class DatabaseTasks {
       if (!(error instanceof ConnectionNotDefined)) throw error;
     }
     // Rails passes the `DatabaseConfig` object itself
-    // (tasks/database_tasks.rb:652), which is what lets
+    // (tasks/database_tasks.rb:542,544), which is what lets
     // `ConnectionHandler#establish_connection` recognise an already-established
     // pool for the same config and reuse it instead of opening a second one
     // (connection_adapters/abstract/connection_handler.rb:139). Handing over a

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -199,7 +199,7 @@ export class DatabaseTasks {
     }
     // Rails: re-establish connection to the original config after all creates.
     if (originalConfig !== null) {
-      await Base.establishConnection(originalConfig.configuration as Record<string, unknown>);
+      await Base.establishConnection(originalConfig);
     }
   }
 
@@ -1501,21 +1501,18 @@ function _isSQLiteMemoryDatabase(database: string): boolean {
 
 // Mirrors Rails' SQLiteDatabaseTasks#initialize: resolve relative `database`
 // paths against root so all withTemporaryPool callers behave consistently.
-// The rewrite is applied to the config OBJECT in place, through Rails'
-// `DatabaseConfig#_database=` (which exists so tasks can swap the database
-// without minting a new config). Returning a new config instead would break
-// `ConnectionHandler#establishConnection`'s reference-equality reuse check,
-// so a temporary pool over a relative sqlite path would replace — and
-// disconnect — the ambient pool.
-function _normalizeSQLitePath(config: DatabaseConfig, root: string): DatabaseConfig {
+// Rewrites the config OBJECT in place (Rails' `DatabaseConfig#_database=`):
+// returning a new config would break `ConnectionHandler#establishConnection`'s
+// reference-equality reuse check, so a temporary pool over a relative sqlite
+// path would replace — and disconnect — the ambient pool.
+function _normalizeSQLitePath(config: DatabaseConfig, root: string): void {
   const adapter = config.adapter;
-  if (typeof adapter !== "string" || !adapter.includes("sqlite")) return config;
+  if (typeof adapter !== "string" || !adapter.includes("sqlite")) return;
   const database = config.database;
-  if (typeof database !== "string" || _isSQLiteMemoryDatabase(database)) return config;
+  if (typeof database !== "string" || _isSQLiteMemoryDatabase(database)) return;
   const p = getPath();
-  if (!p.isAbsolute || p.isAbsolute(database)) return config;
+  if (!p.isAbsolute || p.isAbsolute(database)) return;
   config._database = p.resolve(root, database);
-  return config;
 }
 
 // Defensive fallback for SQL-level errors that slip through pool proxies or

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -218,11 +218,8 @@ export class DatabaseTasks {
     const primaryConfig = this.databaseConfiguration?.findDbConfig(envName);
     if (primaryConfig) {
       const { Base } = await import("../base.js");
-      const configuration = _normalizeSQLitePath(
-        primaryConfig.configuration as Record<string, unknown>,
-        this.root,
-      );
-      await Base.establishConnection(configuration);
+      _normalizeSQLitePath(primaryConfig, this.root);
+      await Base.establishConnection(primaryConfig);
     }
   }
 
@@ -1065,8 +1062,7 @@ export class DatabaseTasks {
     } catch (error) {
       if (!(error instanceof ConnectionNotDefined)) throw error;
     }
-    const rawConfiguration = config.configuration as Record<string, unknown>;
-    const configuration = _normalizeSQLitePath(rawConfiguration, this.root);
+    _normalizeSQLitePath(config, this.root);
     // Rails passes the `DatabaseConfig` object itself
     // (tasks/database_tasks.rb:652), which is what lets
     // `ConnectionHandler#establish_connection` recognise an already-established
@@ -1074,12 +1070,9 @@ export class DatabaseTasks {
     // (connection_adapters/abstract/connection_handler.rb:139). Handing over a
     // plain hash would mint a fresh `HashConfig` that can never match, and a
     // second pool on a `:memory:` database discards the first one's data.
-    // The normalized hash is only used when path resolution actually rewrote
-    // something, since that rewrite has no config-object form.
-    const target = configuration === rawConfiguration ? config : configuration;
     // Mirrors Rails' `ensure` which restores even if establish_connection raises.
     try {
-      await Base.establishConnection(target);
+      await Base.establishConnection(config);
       const pool = Base.connectionPool();
       return await fn(pool);
     } finally {
@@ -1508,17 +1501,21 @@ function _isSQLiteMemoryDatabase(database: string): boolean {
 
 // Mirrors Rails' SQLiteDatabaseTasks#initialize: resolve relative `database`
 // paths against root so all withTemporaryPool callers behave consistently.
-function _normalizeSQLitePath(
-  configuration: Record<string, unknown>,
-  root: string,
-): Record<string, unknown> {
-  const adapter = configuration["adapter"];
-  if (typeof adapter !== "string" || !adapter.includes("sqlite")) return configuration;
-  const database = configuration["database"];
-  if (typeof database !== "string" || _isSQLiteMemoryDatabase(database)) return configuration;
+// The rewrite is applied to the config OBJECT in place, through Rails'
+// `DatabaseConfig#_database=` (which exists so tasks can swap the database
+// without minting a new config). Returning a new config instead would break
+// `ConnectionHandler#establishConnection`'s reference-equality reuse check,
+// so a temporary pool over a relative sqlite path would replace — and
+// disconnect — the ambient pool.
+function _normalizeSQLitePath(config: DatabaseConfig, root: string): DatabaseConfig {
+  const adapter = config.adapter;
+  if (typeof adapter !== "string" || !adapter.includes("sqlite")) return config;
+  const database = config.database;
+  if (typeof database !== "string" || _isSQLiteMemoryDatabase(database)) return config;
   const p = getPath();
-  if (!p.isAbsolute || p.isAbsolute(database)) return configuration;
-  return { ...configuration, database: p.resolve(root, database) };
+  if (!p.isAbsolute || p.isAbsolute(database)) return config;
+  config._database = p.resolve(root, database);
+  return config;
 }
 
 // Defensive fallback for SQL-level errors that slip through pool proxies or


### PR DESCRIPTION
## Problem

`DatabaseTasks.withTemporaryPool` ran `_normalizeSQLitePath` (a trails
invention) over the configuration hash. When the sqlite `database` is
**relative** the helper returned a NEW hash, so the call site fell back to
handing `establishConnection` a plain hash:

```ts
const target = configuration === rawConfiguration ? config : configuration;
```

`resolvePoolConfig` then mints a fresh `HashConfig`, so `ConnectionHandler`'s
reuse check — object identity, `connection-handler.ts:147`, matching
`connection_handler.rb:129` — can never match, and the temporary pool
**replaces** (and disconnects) the ambient pool. Same class of bug #5299 fixed
for the non-normalized path.

## Fix: delete the normalization

The first revision preserved identity by rewriting the `DatabaseConfig` in
place. Review showed that was worse than the disease: the mutation escaped
`withTemporaryPool` into the registry config, and — because reuse is by
identity — rewriting the path and *then* reusing the existing pool hands the
caller a pool on a different file than the config now names.

Rails does no path work here at all:

- `with_temporary_pool` (`database_tasks.rb:542-549`) just calls
  `establish_connection(db_config)`.
- The relative-path expansion lives in the **adapter**:
  `SQLite3Adapter#initialize` does
  `@config[:database] = File.expand_path(@config[:database], Rails.root)`
  (`sqlite3_adapter.rb:114`) — which `sqlite3-adapter.ts:448` already ports,
  against `trailsRoot() ?? cwd`.
- `SQLiteDatabaseTasks#drop` joins root into a **local** (`file`), leaving the
  config alone (`sqlite_database_tasks.rb:23-25`); `sqlite-database-tasks.ts:269`
  already mirrors that.

So the helper was redundant *and* divergent. Removing it fixes the identity bug
with strictly less invention, and nothing mutates a registry config.

Also in scope:

- `createAll` had the same downgrade when restoring the original connection
  (`originalConfig.configuration as Record<string, unknown>`); Rails passes the
  db_config object (`database_tasks.rb:132`), so it does now too.
- Stale docstring: `withTemporaryPool` claimed "establishes a fresh pool
  (clobber: true)". Rails defaults `clobber: false` and trails passes nothing —
  and reuse is the whole point of this fix.
- The `createCurrent` / drop assertions that encoded the normalization are back
  to the unresolved paths Rails asserts (`database_tasks_test.rb:588` asserts
  `establish_connection([:development])`, not a resolved path).

## Tests

Both in `DatabaseTasksWithTemporaryPoolTest`, sqlite-gated via `adapterType`,
both failing on baseline:

- `reuses the ambient pool for a relative sqlite path` — ambient pool over a
  relative sqlite path, `withTemporaryPool` with the same config; asserts the
  yielded pool and the post-restore pool are the identical ambient pool object,
  and that `config.database` is still relative (nothing rewrote the registry).
- `createAll restores the original pool` — covers the `createAll` change.

## Why `createCurrent` looks the config up

Rails is `establish_connection(environment.to_sym)` (`database_tasks.rb:653`),
which resolves through `Base.configurations`. trails can't pass the bare env:
`DatabaseTasks.databaseConfiguration` is a **separate** registry —
`support/connection.ts:390-392` happens to set both, but callers (e.g.
`trailties/src/commands/db.test.ts:1162`) reassign `databaseConfiguration`
alone, so an env string would resolve against the wrong configs. Now noted at
the call site.

## Follow-up registered

`0029-sqlite-memory-fidelity/database-config-database-setter-mutates-shared-hash`
— `DatabaseConfig#_database=` (`database-config.ts:127`) writes through to the
hash the constructor stored by reference, mutating the caller's input; Rails
merges into a new frozen hash (`hash_config.rb:68`). This PR removed the only
in-tree caller, so the divergence is latent rather than live.

Closes-story: temporary-pool-normalized-path-loses-config-identity
