### PR TITLE
test(sqlite): make ARCONN=sqlite3_mem a supported, CI-exercised lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,21 +874,20 @@ jobs:
       - run: pnpm vitest run packages/activerecord/
       - run: pnpm vitest run packages/activerecord-cli
 
-  # `ARCONN=sqlite3_mem` — Rails' `config.example.yml` `sqlite3_mem` connection
-  # (`:memory:`, one connection). It is the ONLY lane that makes `in_memory_db?`
-  # true, so without it every `skipIf(inMemoryDb())` guard is dead code that can
-  # rot unnoticed (story sqlite3-mem-lane-status, RFC 0029).
+  # `ARCONN=sqlite3_mem` is the only lane where `in_memory_db?` is true, so
+  # without it every `skipIf(inMemoryDb())` guard is dead code (RFC 0029).
   #
-  # Deliberately NOT in the `ci` aggregator's `needs:` and NOT run on every PR:
-  # it is a second full pass over the AR suite, and runner minutes are scarce.
-  # It runs where regressions still surface within a week — on `main` after a
-  # merge, on the Monday sweep, on demand, and on any PR labelled
-  # `run-sqlite-mem`. It is not `continue-on-error`: a failure is a red job.
+  # A second full pass over the AR suite, so deliberately not in the `ci`
+  # aggregator's `needs:` and not on every PR: it runs on `main`, on the Monday
+  # sweep (where `changes` forces every gate true), on `workflow_dispatch`, and
+  # on a PR labelled `run-sqlite-mem`. Not `continue-on-error` — a failure is a
+  # red job.
   sqlite-mem-tests:
     name: "Active Record SQLite :memory: Tests"
     needs: changes
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.activerecord_affected == 'true' &&
       (github.event_name != 'pull_request' ||
        contains(github.event.pull_request.labels.*.name, 'run-sqlite-mem'))
     runs-on: ubuntu-latest
@@ -899,9 +898,9 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
-      # Trailing slash as in `sqlite-tests` above. The CLI package is not run
-      # here: it shells out to its own subprocesses, which do not inherit this
-      # lane's meaning.
+      # Trailing slash for the reason given on `sqlite-tests`. The CLI package
+      # is excluded: it owns no `inMemoryDb()` guards, so it has nothing this
+      # lane can check.
       - run: pnpm vitest run packages/activerecord/
         env:
           ARCONN: sqlite3_mem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ on:
     #   run-parity-postgres — Postgres-specific parity (future)
     #   run-parity-mysql    — MySQL/MariaDB-specific parity (future)
     #   run-sqlite-mem      — the ARCONN=sqlite3_mem AR suite (otherwise only
-    #                         main / the weekly sweep / workflow_dispatch)
+    #                         main / the weekly sweep / workflow_dispatch).
+    #                         Runs the lane for a look; does NOT gate the merge
+    #                         — `sqlite-mem-tests` is deliberately absent from
+    #                         the `ci` aggregator's `needs:`, so a failure here
+    #                         is red on its own job and nothing else.
     #   website             — force the Website build on a PR that doesn't
     #                         touch packages/website/
     #   release             — implies `website` (release PRs need the site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     #   run-parity-sqlite   — schema + query parity (SQLite fixtures)
     #   run-parity-postgres — Postgres-specific parity (future)
     #   run-parity-mysql    — MySQL/MariaDB-specific parity (future)
+    #   run-sqlite-mem      — the ARCONN=sqlite3_mem AR suite (otherwise only
+    #                         main / the weekly sweep / workflow_dispatch)
     #   website             — force the Website build on a PR that doesn't
     #                         touch packages/website/
     #   release             — implies `website` (release PRs need the site
@@ -871,6 +873,38 @@ jobs:
       # / perturb fork scheduling — see trails-models-dump tests).
       - run: pnpm vitest run packages/activerecord/
       - run: pnpm vitest run packages/activerecord-cli
+
+  # `ARCONN=sqlite3_mem` — Rails' `config.example.yml` `sqlite3_mem` connection
+  # (`:memory:`, one connection). It is the ONLY lane that makes `in_memory_db?`
+  # true, so without it every `skipIf(inMemoryDb())` guard is dead code that can
+  # rot unnoticed (story sqlite3-mem-lane-status, RFC 0029).
+  #
+  # Deliberately NOT in the `ci` aggregator's `needs:` and NOT run on every PR:
+  # it is a second full pass over the AR suite, and runner minutes are scarce.
+  # It runs where regressions still surface within a week — on `main` after a
+  # merge, on the Monday sweep, on demand, and on any PR labelled
+  # `run-sqlite-mem`. It is not `continue-on-error`: a failure is a red job.
+  sqlite-mem-tests:
+    name: "Active Record SQLite :memory: Tests"
+    needs: changes
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'run-sqlite-mem'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile --prefer-offline
+      - uses: ./.github/actions/cache-build
+      - run: pnpm build
+      # Trailing slash as in `sqlite-tests` above. The CLI package is not run
+      # here: it shells out to its own subprocesses, which do not inherit this
+      # lane's meaning.
+      - run: pnpm vitest run packages/activerecord/
+        env:
+          ARCONN: sqlite3_mem
 
   # Reporting-only AR coverage (story ar-sqlite-lane-coverage-reporting, RFC
   # 0028). Runs the sqlite AR suite (the cheapest backend) with v8 coverage and

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -42,6 +42,12 @@ describe("ConnectionHandlingTest", () => {
     await setupConnection();
   });
 
+  // Under ARCONN=sqlite3_mem this teardown discards the database along with the
+  // connections and re-establishes an EMPTY one, so no case in this describe
+  // may depend on the canonical schema — including the ones left unguarded
+  // below. Today none does. A ported case that touches a table has to either
+  // take `it.skipIf(inMemoryDb())` like its neighbours or live in the
+  // fixture-bearing describe at the bottom of this file.
   afterEach(async () => {
     connectedToStack().length = 0;
     await Base.connectionHandler.clearAllConnectionsBang();

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -52,10 +52,9 @@ describe("ConnectionHandlingTest", () => {
   // Rails puts every one of its `ConnectionHandlingTest` cases inside
   // `unless in_memory_db?` (connection_handling_test.rb:18-185): they release
   // and re-lease `Base`'s connection, and on `:memory:` the released connection
-  // takes the database with it. The guard is per-`it` rather than a wrapping
-  // `describe` because this file also holds cases with no Rails counterpart,
-  // and because the test:compare gate extractor only resolves inline
-  // `it.skipIf(...)`.
+  // takes the database with it. Per-`it` rather than a wrapping `describe`
+  // because this file also holds cases with no Rails counterpart, and the
+  // test:compare gate extractor only resolves inline `it.skipIf(...)`.
   it.skipIf(inMemoryDb())(
     "#with_connection lease the connection for the duration of the block",
     async () => {

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -18,6 +18,7 @@ import {
 import { setTrailsRoot } from "@blazetrails/activesupport";
 import type { DatabaseConfig } from "./database-configurations/database-config.js";
 import { adapterType } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 import * as nodeFs from "node:fs";
 import * as nodeOs from "node:os";
 import * as nodePath from "node:path";
@@ -48,46 +49,65 @@ describe("ConnectionHandlingTest", () => {
     await setupConnection();
   });
 
-  it("#with_connection lease the connection for the duration of the block", async () => {
-    Base.releaseConnection();
-    const pool = Base.connectionPool();
-    expect(pool.activeConnection).toBeNull();
-    await Base.withConnection((conn) => {
-      expect(conn).toBeTruthy();
-      expect(pool.activeConnection).toBeTruthy();
-    });
-  });
+  // Rails puts every one of its `ConnectionHandlingTest` cases inside
+  // `unless in_memory_db?` (connection_handling_test.rb:18-185): they release
+  // and re-lease `Base`'s connection, and on `:memory:` the released connection
+  // takes the database with it. The guard is per-`it` rather than a wrapping
+  // `describe` because this file also holds cases with no Rails counterpart,
+  // and because the test:compare gate extractor only resolves inline
+  // `it.skipIf(...)`.
+  it.skipIf(inMemoryDb())(
+    "#with_connection lease the connection for the duration of the block",
+    async () => {
+      Base.releaseConnection();
+      const pool = Base.connectionPool();
+      expect(pool.activeConnection).toBeNull();
+      await Base.withConnection((conn) => {
+        expect(conn).toBeTruthy();
+        expect(pool.activeConnection).toBeTruthy();
+      });
+    },
+  );
 
-  it("#lease_connection makes the lease permanent even inside #with_connection", async () => {
-    await Base.withConnection(async () => {
+  it.skipIf(inMemoryDb())(
+    "#lease_connection makes the lease permanent even inside #with_connection",
+    async () => {
+      await Base.withConnection(async () => {
+        const leased = await Base.leaseConnection();
+        expect(leased).toBeTruthy();
+      });
+      // leaseConnection makes sticky=true, so connection persists
+      expect(Base.connectionPool().activeConnection).toBeTruthy();
+      Base.releaseConnection();
+    },
+  );
+
+  it.skipIf(inMemoryDb())(
+    "#lease_connection makes the lease permanent even inside #with_connection(prevent_permanent_checkout: true)",
+    async () => {
+      Base.releaseConnection();
+      await Base.withConnection(
+        async (connection) => {
+          expect(await Base.leaseConnection()).toBe(connection);
+        },
+        { preventPermanentCheckout: true },
+      );
+      expect(Base.connectionPool().activeConnection).toBeNull();
+    },
+  );
+
+  it.skipIf(inMemoryDb())(
+    "#with_connection use the already leased connection if available",
+    async () => {
       const leased = await Base.leaseConnection();
-      expect(leased).toBeTruthy();
-    });
-    // leaseConnection makes sticky=true, so connection persists
-    expect(Base.connectionPool().activeConnection).toBeTruthy();
-    Base.releaseConnection();
-  });
+      await Base.withConnection((conn) => {
+        expect(conn).toBe(leased);
+      });
+      Base.releaseConnection();
+    },
+  );
 
-  it("#lease_connection makes the lease permanent even inside #with_connection(prevent_permanent_checkout: true)", async () => {
-    Base.releaseConnection();
-    await Base.withConnection(
-      async (connection) => {
-        expect(await Base.leaseConnection()).toBe(connection);
-      },
-      { preventPermanentCheckout: true },
-    );
-    expect(Base.connectionPool().activeConnection).toBeNull();
-  });
-
-  it("#with_connection use the already leased connection if available", async () => {
-    const leased = await Base.leaseConnection();
-    await Base.withConnection((conn) => {
-      expect(conn).toBe(leased);
-    });
-    Base.releaseConnection();
-  });
-
-  it("#with_connection is reentrant", async () => {
+  it.skipIf(inMemoryDb())("#with_connection is reentrant", async () => {
     await Base.withConnection(async (outer) => {
       await Base.withConnection((inner) => {
         expect(inner).toBe(outer);
@@ -95,81 +115,93 @@ describe("ConnectionHandlingTest", () => {
     });
   });
 
-  it("#connection is a soft-deprecated alias to #lease_connection", async () => {
-    setPermanentConnectionCheckout(true);
-    Base.releaseConnection();
-    expect(Base.connectionPool().activeConnection).toBeNull();
+  it.skipIf(inMemoryDb())(
+    "#connection is a soft-deprecated alias to #lease_connection",
+    async () => {
+      setPermanentConnectionCheckout(true);
+      Base.releaseConnection();
+      expect(Base.connectionPool().activeConnection).toBeNull();
 
-    let conn: unknown;
-    await Base.withConnection(async (connection) => {
-      conn = connection;
+      let conn: unknown;
+      await Base.withConnection(async (connection) => {
+        conn = connection;
+        expect(Base.connectionPool().activeConnection).toBeTruthy();
+        expect(Base.connection).toBe(connection);
+        expect(Base.connection).toBe(connection);
+      });
+
       expect(Base.connectionPool().activeConnection).toBeTruthy();
-      expect(Base.connection).toBe(connection);
-      expect(Base.connection).toBe(connection);
-    });
-
-    expect(Base.connectionPool().activeConnection).toBeTruthy();
-    expect(Base.connection).toBe(conn);
-    Base.releaseConnection();
-  });
-
-  it("#connection emits a deprecation warning if ActiveRecord.permanent_connection_checkout == :deprecated", async () => {
-    setPermanentConnectionCheckout("deprecated");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    try {
+      expect(Base.connection).toBe(conn);
       Base.releaseConnection();
+    },
+  );
 
-      void Base.connection;
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      warnSpy.mockClear();
+  it.skipIf(inMemoryDb())(
+    "#connection emits a deprecation warning if ActiveRecord.permanent_connection_checkout == :deprecated",
+    async () => {
+      setPermanentConnectionCheckout("deprecated");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        Base.releaseConnection();
 
-      void Base.connection;
-      expect(warnSpy).not.toHaveBeenCalled();
-
-      Base.releaseConnection();
-
-      void Base.connection;
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      warnSpy.mockClear();
-      Base.releaseConnection();
-
-      await Base.withConnection(async () => {
         void Base.connection;
         expect(warnSpy).toHaveBeenCalledTimes(1);
-      });
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
+        warnSpy.mockClear();
 
-  it("#connection raises an error if ActiveRecord.permanent_connection_checkout == :disallowed", async () => {
-    setPermanentConnectionCheckout("disallowed");
-    Base.releaseConnection();
+        void Base.connection;
+        expect(warnSpy).not.toHaveBeenCalled();
 
-    expect(() => Base.connection).toThrow(ActiveRecordError);
+        Base.releaseConnection();
 
-    await Base.withConnection(async () => {
+        void Base.connection;
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        warnSpy.mockClear();
+        Base.releaseConnection();
+
+        await Base.withConnection(async () => {
+          void Base.connection;
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+      } finally {
+        warnSpy.mockRestore();
+      }
+    },
+  );
+
+  it.skipIf(inMemoryDb())(
+    "#connection raises an error if ActiveRecord.permanent_connection_checkout == :disallowed",
+    async () => {
+      setPermanentConnectionCheckout("disallowed");
+      Base.releaseConnection();
+
       expect(() => Base.connection).toThrow(ActiveRecordError);
-    });
 
-    await Base.leaseConnection();
-    expect(() => Base.connection).not.toThrow();
-    Base.releaseConnection();
-  });
+      await Base.withConnection(async () => {
+        expect(() => Base.connection).toThrow(ActiveRecordError);
+      });
 
-  it("#connection doesn't make the lease permanent if inside #with_connection(prevent_permanent_checkout: true)", async () => {
-    setPermanentConnectionCheckout("disallowed");
-    Base.releaseConnection();
+      await Base.leaseConnection();
+      expect(() => Base.connection).not.toThrow();
+      Base.releaseConnection();
+    },
+  );
 
-    await Base.withConnection(
-      async (connection) => {
-        expect(Base.connection).toBe(connection);
-      },
-      { preventPermanentCheckout: true },
-    );
+  it.skipIf(inMemoryDb())(
+    "#connection doesn't make the lease permanent if inside #with_connection(prevent_permanent_checkout: true)",
+    async () => {
+      setPermanentConnectionCheckout("disallowed");
+      Base.releaseConnection();
 
-    expect(Base.connectionPool().activeConnection).toBeNull();
-  });
+      await Base.withConnection(
+        async (connection) => {
+          expect(Base.connection).toBe(connection);
+        },
+        { preventPermanentCheckout: true },
+      );
+
+      expect(Base.connectionPool().activeConnection).toBeNull();
+    },
+  );
 
   it("connected_to switches role for block", async () => {
     expect(currentRole.call(Base)).toBe("writing");
@@ -808,20 +840,23 @@ describe("ConnectionHandlingTest", () => {
     await Post.where({ title: "foo" }).deleteAll();
   });
 
-  it("common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed", async () => {
-    setPermanentConnectionCheckout("deprecated");
-    Base.releaseConnection();
-    expect(Base.connectionPool().activeConnection).toBeNull();
+  it.skipIf(inMemoryDb())(
+    "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed",
+    async () => {
+      setPermanentConnectionCheckout("deprecated");
+      Base.releaseConnection();
+      expect(Base.connectionPool().activeConnection).toBeNull();
 
-    await Post.createBang({ title: "foo", body: "bar" });
-    expect(Post.connectionPool().activeConnection).toBeNull();
+      await Post.createBang({ title: "foo", body: "bar" });
+      expect(Post.connectionPool().activeConnection).toBeNull();
 
-    await Post.first();
-    expect(Post.connectionPool().activeConnection).toBeNull();
+      await Post.first();
+      expect(Post.connectionPool().activeConnection).toBeNull();
 
-    await Post.count();
-    expect(Post.connectionPool().activeConnection).toBeNull();
-  });
+      await Post.count();
+      expect(Post.connectionPool().activeConnection).toBeNull();
+    },
+  );
 });
 
 // trails-internal mechanism (no Rails counterpart): the connection threaded by

--- a/packages/activerecord/src/pooled-test-adapter.test.ts
+++ b/packages/activerecord/src/pooled-test-adapter.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, afterAll } from "vitest";
 
 import { createPooledTestAdapter, _resetPooledTestAdapterForTests } from "./test-adapter.js";
 import { withExecutionContext } from "./connection-adapters/abstract/connection-pool/execution-context.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 
 type Execable = { exec(sql: string): Promise<void> };
 const asExec = (a: unknown) => a as Execable;
@@ -45,34 +46,41 @@ describe("createPooledTestAdapter (Phase B smoke)", () => {
     }
   });
 
-  it("pinConnectionBang + write + unpinConnectionBang rolls back", async () => {
-    const { adapter: setupAdapter, pool } = await createPooledTestAdapter();
-    const tableName = "pooled_smoke_pin_rollback";
-    await asExec(setupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
-    await asExec(setupAdapter).exec(`CREATE TABLE ${tableName} (id INTEGER PRIMARY KEY)`);
-    try {
-      await withExecutionContext(async () => {
-        // Pin first, THEN check out so the pinned connection is the one we
-        // write through. Leases are keyed by executionContextId, so a lease
-        // taken outside this context would resolve to a different connection.
-        await pool.pinConnectionBang(false);
-        try {
-          const pinned = await pool.checkout();
-          await asExec(pinned).exec(`INSERT INTO ${tableName} (id) VALUES (1)`);
-          const inside = await pinned.execute(`SELECT count(*) AS c FROM ${tableName}`);
-          expect(Number((inside[0] as { c: number }).c)).toBe(1);
-        } finally {
-          const clean = await pool.unpinConnectionBang();
-          expect(clean).toBe(true);
-        }
-      });
-
-      const after = await setupAdapter.execute(`SELECT count(*) AS c FROM ${tableName}`);
-      expect(Number((after[0] as { c: number }).c)).toBe(0);
-    } finally {
+  // The duplicate pool inherits the primary's size, and the `sqlite3_mem`
+  // connection pins that to 1 (`:memory:` is only shared within one connection).
+  // This test needs a second connection — the setup lease plus the pinned one —
+  // so on that lane it can only ever time out.
+  it.skipIf(inMemoryDb())(
+    "pinConnectionBang + write + unpinConnectionBang rolls back",
+    async () => {
+      const { adapter: setupAdapter, pool } = await createPooledTestAdapter();
+      const tableName = "pooled_smoke_pin_rollback";
       await asExec(setupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
-    }
-  });
+      await asExec(setupAdapter).exec(`CREATE TABLE ${tableName} (id INTEGER PRIMARY KEY)`);
+      try {
+        await withExecutionContext(async () => {
+          // Pin first, THEN check out so the pinned connection is the one we
+          // write through. Leases are keyed by executionContextId, so a lease
+          // taken outside this context would resolve to a different connection.
+          await pool.pinConnectionBang(false);
+          try {
+            const pinned = await pool.checkout();
+            await asExec(pinned).exec(`INSERT INTO ${tableName} (id) VALUES (1)`);
+            const inside = await pinned.execute(`SELECT count(*) AS c FROM ${tableName}`);
+            expect(Number((inside[0] as { c: number }).c)).toBe(1);
+          } finally {
+            const clean = await pool.unpinConnectionBang();
+            expect(clean).toBe(true);
+          }
+        });
+
+        const after = await setupAdapter.execute(`SELECT count(*) AS c FROM ${tableName}`);
+        expect(Number((after[0] as { c: number }).c)).toBe(0);
+      } finally {
+        await asExec(setupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
+      }
+    },
+  );
 
   it("two pooled-adapter handles share the same pool", async () => {
     const a = await createPooledTestAdapter();

--- a/packages/activerecord/src/pooled-test-adapter.test.ts
+++ b/packages/activerecord/src/pooled-test-adapter.test.ts
@@ -46,9 +46,8 @@ describe("createPooledTestAdapter (Phase B smoke)", () => {
     }
   });
 
-  // The duplicate pool inherits the primary's size, and the `sqlite3_mem`
-  // connection pins that to 1 (`:memory:` is only shared within one connection).
-  // This test needs a second connection — the setup lease plus the pinned one —
+  // The duplicate pool inherits the primary's size, which `sqlite3_mem` pins to
+  // 1. This test needs two connections — the setup lease plus the pinned one —
   // so on that lane it can only ever time out.
   it.skipIf(inMemoryDb())(
     "pinConnectionBang + write + unpinConnectionBang rolls back",

--- a/packages/activerecord/src/pooled-test-adapter.test.ts
+++ b/packages/activerecord/src/pooled-test-adapter.test.ts
@@ -47,8 +47,13 @@ describe("createPooledTestAdapter (Phase B smoke)", () => {
   });
 
   // The duplicate pool inherits the primary's size, which `sqlite3_mem` pins to
-  // 1. This test needs two connections — the setup lease plus the pinned one —
-  // so on that lane it can only ever time out.
+  // 1. This test needs two: the setup lease above plus the pinned one. So
+  // `pinConnectionBang` raises ConnectionTimeoutError ("All 1 connections are
+  // in use") before it issues any SQL.
+  //
+  // Checkout starvation, NOT the duplicate pool landing on its own empty
+  // `:memory:` database — the setup CREATE TABLE on the preceding line
+  // succeeds, as does the CREATE-then-read in the schemaCache case above.
   it.skipIf(inMemoryDb())(
     "pinConnectionBang + write + unpinConnectionBang rolls back",
     async () => {

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -156,17 +156,14 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
     adapter: "sqlite3",
     lane: "sqlite",
     // `config.example.yml:91-97` — both entries are their own `:memory:` database.
+    // Exercised by ci.yml's `sqlite-mem-tests` job — the only lane where
+    // `inMemoryDb()` is true, and so the only thing keeping the
+    // `skipIf(inMemoryDb())` guards from rotting.
     //
-    // A supported, CI-exercised lane: the `sqlite-mem-tests` job in ci.yml runs
-    // the AR suite under `ARCONN=sqlite3_mem` on main, on the weekly sweep, and
-    // on any PR labelled `run-sqlite-mem`. It is the only lane where
-    // `inMemoryDb()` is true, so it is what keeps the `skipIf(inMemoryDb())`
-    // guards honest.
-    //
-    // `pool: 1` has no counterpart in the yml. A `:memory:` database belongs to
+    // `pool: 1` has no counterpart in the yml: a `:memory:` database belongs to
     // its connection, so a second pool member would silently be a second, empty
-    // database; Rails never notices because its suite checks out one connection
-    // at a time, but our pool leases concurrently.
+    // database. Rails never notices — its suite checks out one connection at a
+    // time; our pool leases concurrently.
     build: async () => ({
       arunit: { adapter: "sqlite3", database: ":memory:", pool: 1 },
       arunit2: { adapter: "sqlite3", database: ":memory:", pool: 1 },

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -156,6 +156,17 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
     adapter: "sqlite3",
     lane: "sqlite",
     // `config.example.yml:91-97` — both entries are their own `:memory:` database.
+    //
+    // A supported, CI-exercised lane: the `sqlite-mem-tests` job in ci.yml runs
+    // the AR suite under `ARCONN=sqlite3_mem` on main, on the weekly sweep, and
+    // on any PR labelled `run-sqlite-mem`. It is the only lane where
+    // `inMemoryDb()` is true, so it is what keeps the `skipIf(inMemoryDb())`
+    // guards honest.
+    //
+    // `pool: 1` has no counterpart in the yml. A `:memory:` database belongs to
+    // its connection, so a second pool member would silently be a second, empty
+    // database; Rails never notices because its suite checks out one connection
+    // at a time, but our pool leases concurrently.
     build: async () => ({
       arunit: { adapter: "sqlite3", database: ":memory:", pool: 1 },
       arunit2: { adapter: "sqlite3", database: ":memory:", pool: 1 },

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -24,6 +24,7 @@ import {
 
 import { adapterType } from "./test-adapter.js";
 import { itIfSupports } from "./support/supports.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import { Reply, SillyReply, UniqueReply, SillyUniqueReply } from "./test-helpers/models/reply.js";
@@ -1310,8 +1311,13 @@ describe("TransactionTest", () => {
 // still-incomplete transaction. These run OUTSIDE the shared fixture
 // transaction (`usesTransaction`) because evicting the connection mid-test would
 // poison transactional-fixtures teardown.
+//
+// Rails wraps this whole group in `if !in_memory_db?`
+// (transactions_test.rb:232-368): evicting the sole connection of a `:memory:`
+// database throws the database away with it, leaving every later test with an
+// empty schema.
 // ==========================================================================
-describe("TransactionTest", () => {
+describe.skipIf(inMemoryDb())("TransactionTest", () => {
   const { topics } = fixtures(["topics"], {
     usesTransaction: [
       "rollback dirty changes even with raise during rollback removes from pool",


### PR DESCRIPTION
## Verdict: supported, not vestigial

`sqlite3_mem` is Rails' own `config.example.yml` connection
(`config.example.yml:93-97`) and the **only** lane where `in_memory_db?` is
true. Without it every `skipIf(inMemoryDb())` guard in the suite is dead code.
So the entry stays — and now something runs it.

## Scope check

The story measured `adapter.test.ts` at 47 failed. That is stale: it passes
today (35 passed | 38 skipped), fixed by the intervening test-pool work
(#5414 / #5415).

A full AR-suite run under `ARCONN=sqlite3_mem` on `main`:

```console
Test Files  3 failed | 542 passed | 24 skipped (569)
     Tests  26 failed | 11199 passed | 509 skipped | 1 todo (11735)
```

Not lane breakage — three places where our port dropped a guard Rails has:

| file | cause |
| --- | --- |
| `transactions.test.ts` (24) | Rails wraps the connection-eviction group in `if !in_memory_db?` (`transactions_test.rb:232-368`). Evicting the sole connection of a `:memory:` database throws the database away with it, so every later test in the file found an empty schema — one missing guard, 24 failures. |
| `connection-handling.test.ts` (1) | Rails puts all ten `ConnectionHandlingTest` cases inside `unless in_memory_db?` (`connection_handling_test.rb:18-185`). All ten are guarded here, not just the one that failed. |
| `pooled-test-adapter.test.ts` (1) | trails-only smoke test. Its pin+checkout case needs a second connection; the lane pins the pool to 1. |

## Keeping it from rotting

A `sqlite-mem-tests` job runs the AR suite under the lane on `main`, on the
Monday sweep, on `workflow_dispatch`, and on any PR labelled `run-sqlite-mem`
— gated on `activerecord_affected`, which the `changes` job forces true on the
non-PR events.

It is deliberately **not** in the `ci` aggregator's `needs:` and **not** on
every PR: it is a second full pass over the AR suite and runner minutes are
scarce. It is not `continue-on-error` either, so a regression surfaces as a red
job within a week rather than silently. The lane's status and the non-Rails
`pool: 1` are documented on the `CONNECTIONS` entry itself.

## Verification

`ARCONN=sqlite3_mem pnpm vitest run --project activerecord`, with this branch —
the whole lane, green:

```console
Test Files  545 passed | 24 skipped (569)
     Tests  11210 passed | 524 skipped | 1 todo (11735)
```

Default `sqlite3` lane unchanged on all four touched files (154 passed | 7
skipped, same skip counts as `main`).

Most of the diff is reindentation: wrapping ten `it(...)` calls in
`it.skipIf(inMemoryDb())(...)` pushes each body one level right under Prettier.

Closes-story: sqlite3-mem-lane-status

## Review round 1

1. **`run-sqlite-mem` is non-gating — intentional, now stated.** Documented at
   the label list (ci.yml:12-17): the label runs the lane for a look, it does
   not gate the merge, because `sqlite-mem-tests` is deliberately absent from
   the `ci` aggregator's `needs:`.
2. **`afterEach` `:memory:` constraint — comment added**
   (`connection-handling.test.ts:45-50`). Records that the teardown
   re-establishes an empty database on this lane, so no case in the describe
   may depend on the canonical schema, and names the two ways out for the next
   ported case.
3. **Confirmed checkout starvation, not a different empty database.** Re-ran
   the case with the guard removed under `ARCONN=sqlite3_mem`:

   ```console
   ConnectionTimeoutError: Could not obtain a connection from the pool. All 1 connections are in use.
    ❯ ConnectionPool._acquireConnection connection-pool.ts:877:11
    ❯ ConnectionPool.pinConnectionBang  connection-pool.ts:725:68
    ❯ pooled-test-adapter.test.ts:64:22
   ```

   It raises inside `pinConnectionBang` before issuing any SQL. Two facts rule
   out the wrong-database hypothesis: the setup `CREATE TABLE` on the preceding
   line succeeds, and the `lazy-loads schemaCache.columns after CREATE TABLE`
   case — a CREATE-then-read roundtrip on that same duplicate pool — passes on
   this lane. The duplicate pool's `:memory:` database is self-consistent; it
   is just one connection wide. Comment updated to name the error class and
   the ruled-out alternative.
