### PR TITLE
fix(database-configurations): replace the config hash in _database= instead of mutating it

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -546,6 +546,27 @@ describe("ConnectionHandlingTest", () => {
       (DatabaseConfigurations as any).current = priorCurrent;
     }
   });
+
+  // The adapter backfill in establishWithDbConfig is only reached by an
+  // adapter-less config carrying a derivable URL — a UrlConfig pre-infers the
+  // adapter in buildUrlHash, so only a HashConfig gets here. Configuration
+  // hashes are frozen, so the backfill has to replace the hash rather than
+  // write into it.
+  it("establishConnection backfills the adapter on an adapter-less HashConfig", async () => {
+    const { DatabaseConfigurations } = await import("./database-configurations.js");
+    const { HashConfig } = await import("./database-configurations/hash-config.js");
+    const env = DatabaseConfigurations.currentEnv();
+
+    const dbConfig = new HashConfig(env, "primary", { url: "sqlite3:db/foo.sqlite3" });
+    expect(dbConfig.adapter).toBeUndefined();
+
+    class BackfillModel extends Base {}
+    await BackfillModel.establishConnection(dbConfig as any);
+
+    expect(dbConfig.adapter).toBe("sqlite");
+    expect(Object.isFrozen(dbConfig.configurationHash)).toBe(true);
+    expect(BackfillModel.connectionPool().dbConfig).toBe(dbConfig);
+  });
 });
 
 describe("withRoleAndShard loads Relation return values within scope (Story K gap 5)", () => {

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -561,11 +561,18 @@ describe("ConnectionHandlingTest", () => {
     expect(dbConfig.adapter).toBeUndefined();
 
     class BackfillModel extends Base {}
-    await BackfillModel.establishConnection(dbConfig as any);
+    try {
+      await BackfillModel.establishConnection(dbConfig as any);
 
-    expect(dbConfig.adapter).toBe("sqlite");
-    expect(Object.isFrozen(dbConfig.configurationHash)).toBe(true);
-    expect(BackfillModel.connectionPool().dbConfig).toBe(dbConfig);
+      expect(dbConfig.adapter).toBe("sqlite");
+      expect(Object.isFrozen(dbConfig.configurationHash)).toBe(true);
+      const pool = BackfillModel.connectionPool();
+      expect(pool.dbConfig).toBe(dbConfig);
+      // Never checked out — db/foo.sqlite3 must not be created by this test.
+      expect(pool.activeConnection).toBeNull();
+    } finally {
+      BackfillModel.removeConnection();
+    }
   });
 });
 

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -845,11 +845,17 @@ async function establishWithDbConfig(
   // config already names its adapter — matching Rails, whose URL configs always
   // parse a scheme. Defensively backfill should a non-UrlConfig path ever hand
   // us an adapter-less hash with a derivable URL.
+  // Replaces the hash rather than writing into it: configuration hashes are
+  // frozen (Rails freezes them in HashConfig#initialize), and the object
+  // identity the handler's pool-reuse check keys on is the DatabaseConfig, not
+  // its hash.
+  let configForConnect = config;
   if (!dbConfig.adapter) {
-    (config as { adapter?: string }).adapter = adapterName;
+    dbConfig.configuration = Object.freeze({ ...config, adapter: adapterName });
+    configForConnect = dbConfig.configuration as Record<string, unknown>;
   }
 
-  await establishWithConfig(modelClass, adapterName, connectUrl, config, dbConfig);
+  await establishWithConfig(modelClass, adapterName, connectUrl, configForConnect, dbConfig);
   if (tz) setDefaultTimezone(tz);
 }
 

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -6,7 +6,10 @@ import { getFsAsync, getPathAsync, trailsRoot } from "@blazetrails/activesupport
 import { DatabaseConfigurations, type RawConfigurations } from "./database-configurations.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { UrlConfig } from "./database-configurations/url-config.js";
-import { DatabaseConfig } from "./database-configurations/database-config.js";
+import {
+  DatabaseConfig,
+  _setConfigurationHash,
+} from "./database-configurations/database-config.js";
 import {
   resolve as resolveConnectionAdapter,
   resolveSync as resolveConnectionAdapterSync,
@@ -851,8 +854,10 @@ async function establishWithDbConfig(
   // its hash.
   let configForConnect = config;
   if (!dbConfig.adapter) {
-    dbConfig.configuration = Object.freeze({ ...config, adapter: adapterName });
-    configForConnect = dbConfig.configuration as Record<string, unknown>;
+    configForConnect = _setConfigurationHash(dbConfig, {
+      ...config,
+      adapter: adapterName,
+    }) as Record<string, unknown>;
   }
 
   await establishWithConfig(modelClass, adapterName, connectUrl, configForConnect, dbConfig);

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -69,13 +69,40 @@ export function _setAdapterClassResolver(
   _loadAdapterError = errorLookup;
 }
 
+let writeConfigurationHash!: (config: DatabaseConfig, hash: DatabaseConfigOptions) => void;
+
+/**
+ * Replace a config's hash with a frozen copy of `hash`, preserving the
+ * `DatabaseConfig` object's identity (the pool-reuse check keys on it).
+ *
+ * @internal
+ */
+export function _setConfigurationHash(
+  config: DatabaseConfig,
+  hash: DatabaseConfigOptions,
+): DatabaseConfigOptions {
+  const frozen = Object.freeze({ ...hash });
+  writeConfigurationHash(config, frozen);
+  return frozen;
+}
+
 /**
  * Mirrors: ActiveRecord::DatabaseConfigurations::DatabaseConfig
  */
 export class DatabaseConfig {
   readonly envName: string;
   readonly name: string;
-  configuration: DatabaseConfigOptions;
+  #configuration: DatabaseConfigOptions;
+
+  // Rails is `attr_reader :configuration_hash` — no writer. The one trails-only
+  // path that must replace the hash (connection-handling's adapter backfill)
+  // goes through _setConfigurationHash, which reaches the private field via
+  // this static-block closure rather than a Rails-visible public writer.
+  static {
+    writeConfigurationHash = (config, hash) => {
+      config.#configuration = hash;
+    };
+  }
 
   constructor(envName: string, name: string, configuration: DatabaseConfigOptions = {}) {
     this.envName = envName;
@@ -83,7 +110,11 @@ export class DatabaseConfig {
     // Rails: `@configuration_hash = configuration_hash.symbolize_keys.freeze`
     // (hash_config.rb:40) — a new frozen hash, so the caller's literal is
     // never aliased and no later write can reach it.
-    this.configuration = Object.freeze({ ...configuration });
+    this.#configuration = Object.freeze({ ...configuration });
+  }
+
+  get configuration(): DatabaseConfigOptions {
+    return this.#configuration;
   }
 
   /**
@@ -128,7 +159,7 @@ export class DatabaseConfig {
    * db:create can swap the database without creating a new config.
    */
   set _database(database: string) {
-    this.configuration = Object.freeze({ ...this.configuration, database });
+    this.#configuration = Object.freeze({ ...this.#configuration, database });
   }
 
   /**

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -80,7 +80,10 @@ export class DatabaseConfig {
   constructor(envName: string, name: string, configuration: DatabaseConfigOptions = {}) {
     this.envName = envName;
     this.name = name;
-    this.configuration = configuration;
+    // Rails: `@configuration_hash = configuration_hash.symbolize_keys.freeze`
+    // (hash_config.rb:40) — a new frozen hash, so the caller's literal is
+    // never aliased and no later write can reach it.
+    this.configuration = Object.freeze({ ...configuration });
   }
 
   /**

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -75,8 +75,6 @@ export function _setAdapterClassResolver(
 export class DatabaseConfig {
   readonly envName: string;
   readonly name: string;
-  // Not readonly: `_database=` replaces the hash wholesale (Rails reassigns
-  // @configuration_hash) rather than writing through to the caller's literal.
   configuration: DatabaseConfigOptions;
 
   constructor(envName: string, name: string, configuration: DatabaseConfigOptions = {}) {
@@ -125,10 +123,6 @@ export class DatabaseConfig {
    *
    * Internal setter for the database name. Rails exposes this so things like
    * db:create can swap the database without creating a new config.
-   *
-   * Rails: `@configuration_hash = configuration_hash.merge(database:).freeze`
-   * — the hash the caller passed in is never mutated, and the config object's
-   * own identity is preserved (ConnectionHandler's reuse check depends on it).
    */
   set _database(database: string) {
     this.configuration = Object.freeze({ ...this.configuration, database });

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -75,7 +75,9 @@ export function _setAdapterClassResolver(
 export class DatabaseConfig {
   readonly envName: string;
   readonly name: string;
-  readonly configuration: DatabaseConfigOptions;
+  // Not readonly: `_database=` replaces the hash wholesale (Rails reassigns
+  // @configuration_hash) rather than writing through to the caller's literal.
+  configuration: DatabaseConfigOptions;
 
   constructor(envName: string, name: string, configuration: DatabaseConfigOptions = {}) {
     this.envName = envName;
@@ -123,9 +125,13 @@ export class DatabaseConfig {
    *
    * Internal setter for the database name. Rails exposes this so things like
    * db:create can swap the database without creating a new config.
+   *
+   * Rails: `@configuration_hash = configuration_hash.merge(database:).freeze`
+   * — the hash the caller passed in is never mutated, and the config object's
+   * own identity is preserved (ConnectionHandler's reuse check depends on it).
    */
   set _database(database: string) {
-    (this.configuration as Record<string, unknown>).database = database;
+    this.configuration = Object.freeze({ ...this.configuration, database });
   }
 
   /**

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -272,17 +272,20 @@ describe("DatabaseConfigurations", () => {
       expect(config.seeds).toBe(true);
     });
 
-    // trails-only: Rails' _database= replaces @configuration_hash with a frozen
-    // merge, so the hash the caller passed in can never be written through.
     it("_database= does not mutate the hash passed to the constructor", () => {
       const original = { adapter: "abstract", database: "original_db" };
       const config = new HashConfig("default_env", "primary", original);
 
+      const hashBefore = config.configurationHash;
       config._database = "swapped_db";
 
       expect(original.database).toBe("original_db");
       expect(config.database).toBe("swapped_db");
       expect(config.configurationHash.adapter).toBe("abstract");
+      expect(config.configurationHash).not.toBe(hashBefore);
+
+      config._database = "swapped_again";
+      expect(config.database).toBe("swapped_again");
     });
   });
 });

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -283,9 +283,21 @@ describe("DatabaseConfigurations", () => {
       expect(config.database).toBe("swapped_db");
       expect(config.configurationHash.adapter).toBe("abstract");
       expect(config.configurationHash).not.toBe(hashBefore);
+      expect(Object.isFrozen(config.configurationHash)).toBe(true);
 
       config._database = "swapped_again";
       expect(config.database).toBe("swapped_again");
+    });
+
+    it("the configuration hash is a frozen copy of the hash passed to the constructor", () => {
+      const original: Record<string, unknown> = { adapter: "abstract", database: "original_db" };
+      const config = new HashConfig("default_env", "primary", original);
+
+      expect(config.configurationHash).not.toBe(original);
+      expect(Object.isFrozen(config.configurationHash)).toBe(true);
+
+      original.database = "mutated_after_construction";
+      expect(config.database).toBe("original_db");
     });
   });
 });

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -271,5 +271,18 @@ describe("DatabaseConfigurations", () => {
       vi.spyOn(config, "isPrimary").mockReturnValue(false);
       expect(config.seeds).toBe(true);
     });
+
+    // trails-only: Rails' _database= replaces @configuration_hash with a frozen
+    // merge, so the hash the caller passed in can never be written through.
+    it("_database= does not mutate the hash passed to the constructor", () => {
+      const original = { adapter: "abstract", database: "original_db" };
+      const config = new HashConfig("default_env", "primary", original);
+
+      config._database = "swapped_db";
+
+      expect(original.database).toBe("original_db");
+      expect(config.database).toBe("swapped_db");
+      expect(config.configurationHash.adapter).toBe("abstract");
+    });
   });
 });


### PR DESCRIPTION
`DatabaseConfig#_database=` wrote through to `this.configuration`, which the
constructor stored by reference — so setting it mutated the caller's original
database config literal.

Rails replaces the hash instead (`hash_config.rb:67-69`), and freezes it at
construction (`hash_config.rb:38-41`):

```ruby
def initialize(env_name, name, configuration_hash)
  super(env_name, name)
  @configuration_hash = configuration_hash.symbolize_keys.freeze
end

def _database=(database)
  @configuration_hash = configuration_hash.merge(database: database).freeze
end
```

## What changed

- **Constructor** stores a frozen copy — the caller's literal is never aliased,
  so a later `h.database = ...` can't reach the config.
- **`_database=`** assigns a new frozen hash. The `DatabaseConfig` object's own
  identity is unchanged, so `ConnectionHandler`'s reuse check
  (`connection-handler.ts:147`, `connection_handler.rb:139`) still matches.
- **The hash is private.** `#configuration` behind a `get configuration()`
  reader, mirroring `attr_reader :configuration_hash` — there is no public
  writer. `_database=` is the only Rails-sanctioned mutation path.
- **`_setConfigurationHash(config, hash)`** (`@internal`, so it stays off the
  api:compare extra-surface ledger) is the sole other write path: it freezes a
  copy and reaches the private field through a static-initializer closure
  declared on the base class, preserving object identity. Its one caller is the
  adapter backfill in `establishWithDbConfig`, which previously wrote into the
  hash in place — now a `TypeError` against a frozen hash.

## Adapter backfill: why it persists

`establishWithDbConfig` backfills `adapter` when an adapter-less config carries
a derivable URL, and that replacement outlives the `establishConnection` call.
Intentional, and unchanged in scope from before this PR:

- The backfilled object is the one the pool stores (`establishWithConfig`'s
  `dbConfigOverride`), and the handler re-reads `dbConfig.adapter` →
  `configuration.adapter` afterwards (`resolvePoolConfig`, the `adapterReady`
  warm-up at `connection-handler.ts:177`). A call-scoped copy would leave the
  stored config disagreeing with its own pool.
- Rails needs no equivalent — its URL configs always parse a scheme, so
  `configuration_hash[:adapter]` is never absent
  (`connection_handling.rb:66-79` indeed never touches the hash). The backfill
  is trails-only compensation for scheme-less shorthand, not a port.
- Holders of the *old* hash object: the `!connection.active_record` payload
  reads `poolConfig.dbConfig.configuration` at instrument time
  (`connection-handler.ts:170`), which is after the backfill, so it observes
  the backfilled hash exactly as it did with the in-place write. No subscriber
  retains a hash object across establishes, so nothing depends on the
  adapter-less version.

## Coverage

Three tests, all failing on baseline:

- `HashConfig` construction doesn't alias the caller's hash (and the hash is
  frozen).
- `_database=` leaves the constructor's hash untouched, replaces rather than
  mutates, preserves other keys, stays reusable, and yields a frozen hash.
- `establishConnection` backfills the adapter on an adapter-less `HashConfig`
  (`{ url: "sqlite3:db/foo.sqlite3" }` — the only shape that enters the branch,
  since `UrlConfig` pre-infers the adapter in `buildUrlHash`). Pre-fix, with
  the constructor freeze in place, this fails with `TypeError: Cannot add
  property adapter, object is not extensible`. It asserts the pool stays lazy
  (so no `db/foo.sqlite3` is ever created) and tears its pool down in a
  `finally`.

Swept for other in-place writes into a config hash before landing the freeze:
`buildAdapterArg` spreads, the mysql/pg database-tasks snapshot with
`{ ...dbConfig.configuration }`, `database-tasks.ts:1068` only compares
identity, and `toBooleanBang` runs pre-`super()` (and has no callers). ~2,000
connection/pool/adapter/tasks/config tests re-run green.

Closes-story: database-config-database-setter-mutates-shared-hash
