### PR TITLE
refactor(activerecord): converge model constant registration onto one guarded path

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -102,6 +102,7 @@ import {
   camelize,
   foreignKey as deriveForeignKey,
   registerConstant,
+  unregisterConstant,
 } from "@blazetrails/activesupport";
 import { registerSubclass, polymorphicName } from "./inheritance.js";
 import { flushPendingCounterCacheColumns } from "./counter-cache.js";
@@ -243,17 +244,22 @@ class ModelRegistry extends Map<string, typeof Base> {
 
   override set(name: string, model: typeof Base): this {
     if (super.get(name) !== model) this.#generation++;
+    registerConstant(name, model);
     return super.set(name, model);
   }
 
   override delete(name: string): boolean {
     const deleted = super.delete(name);
-    if (deleted) this.#generation++;
+    if (deleted) {
+      this.#generation++;
+      unregisterConstant(name);
+    }
     return deleted;
   }
 
   override clear(): void {
     if (this.size > 0) this.#generation++;
+    for (const name of this.keys()) unregisterConstant(name);
     super.clear();
   }
 }
@@ -299,6 +305,21 @@ function guardCanonicalNameShadow(name: string, model: typeof Base): void {
         `association target. Use the canonical model, or a distinct non-canonical name.`,
     );
   }
+}
+
+/**
+ * The single path that binds a model class to a name in Active Support's
+ * constant table. Every writer — {@link registerModel}, `registerSubclass`, and
+ * `Base.adapter=` — goes through here, so the registry and the constant table
+ * can never disagree in either direction: {@link modelRegistry} owns the
+ * constant write (and the matching unregister on delete/clear), and the shadow
+ * guard covers every path rather than just `registerModel`.
+ * @internal
+ */
+export function registerModelConstant(name: string, model: typeof Base): void {
+  guardCanonicalNameShadow(name, model);
+  modelRegistry.set(name, model);
+  model._modelsByName.set(name, model);
 }
 
 /**
@@ -350,20 +371,14 @@ export function registerModel(
   }
   if (typeof nameOrModel === "string") {
     if (!model) throw new Error("registerModel(name, model) requires a model class");
-    guardCanonicalNameShadow(nameOrModel, model);
-    modelRegistry.set(nameOrModel, model);
-    model._modelsByName.set(nameOrModel, model);
-    registerConstant(nameOrModel, model);
+    registerModelConstant(nameOrModel, model);
     // Attach registry key so counter-cache pending-map lookup can match it.
     const keys: string[] = model._registryKeys ?? [];
     if (!keys.includes(nameOrModel)) keys.push(nameOrModel);
     model._registryKeys = keys;
     flushPendingCounterCacheColumns(model);
   } else {
-    guardCanonicalNameShadow(nameOrModel.name, nameOrModel);
-    modelRegistry.set(nameOrModel.name, nameOrModel);
-    nameOrModel._modelsByName.set(nameOrModel.name, nameOrModel);
-    registerConstant(nameOrModel.name, nameOrModel);
+    registerModelConstant(nameOrModel.name, nameOrModel);
     // A namespaced model carries its Ruby module path via `static moduleName`;
     // derive the `::`-qualified registry key from it (e.g.
     // "MyApplication::Billing::Firm") so cross-namespace `className` resolution

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -244,7 +244,7 @@ class ModelRegistry extends Map<string, typeof Base> {
 
   override set(name: string, model: typeof Base): this {
     if (super.get(name) !== model) this.#generation++;
-    registerConstant(name, model);
+    registerModelConstant(name, model);
     return super.set(name, model);
   }
 
@@ -300,7 +300,7 @@ function guardCanonicalNameShadow(name: string, model: typeof Base): void {
   const canonical = canonicalModelAutoloadIndex?.get(name);
   if (canonical && canonical !== model) {
     throw new Error(
-      `registerModel(${JSON.stringify(name)}, …) would shadow the canonical model of the ` +
+      `Registering a class under ${JSON.stringify(name)} would shadow the canonical model of the ` +
         `same name in the global registry, poisoning every later test that resolves it as an ` +
         `association target. Use the canonical model, or a distinct non-canonical name.`,
     );
@@ -309,17 +309,21 @@ function guardCanonicalNameShadow(name: string, model: typeof Base): void {
 
 /**
  * The single path that binds a model class to a name in Active Support's
- * constant table. Every writer — {@link registerModel}, `registerSubclass`, and
- * `Base.adapter=` — goes through here, so the registry and the constant table
- * can never disagree in either direction: {@link modelRegistry} owns the
- * constant write (and the matching unregister on delete/clear), and the shadow
- * guard covers every path rather than just `registerModel`.
+ * constant table. Every constant write for a model class goes through here —
+ * {@link registerModel} and every other `modelRegistry.set` caller reach it via
+ * `ModelRegistry.set`, `registerSubclass` and `Base.adapter=` call it directly —
+ * so the shadow guard covers every writer, and a name in the registry is always
+ * a registered constant (`delete`/`clear` unregister the matching constant).
+ *
+ * Deliberately narrow: it does NOT write `modelRegistry` (the constant table is
+ * the wider, fallback-only namespace — `registerSubclass` and `Base.adapter=`
+ * must not promote a throwaway subclass into association resolution) and it does
+ * NOT write `_modelsByName`, which its own callers still own.
  * @internal
  */
 export function registerModelConstant(name: string, model: typeof Base): void {
   guardCanonicalNameShadow(name, model);
-  modelRegistry.set(name, model);
-  model._modelsByName.set(name, model);
+  registerConstant(name, model);
 }
 
 /**
@@ -371,14 +375,16 @@ export function registerModel(
   }
   if (typeof nameOrModel === "string") {
     if (!model) throw new Error("registerModel(name, model) requires a model class");
-    registerModelConstant(nameOrModel, model);
+    modelRegistry.set(nameOrModel, model);
+    model._modelsByName.set(nameOrModel, model);
     // Attach registry key so counter-cache pending-map lookup can match it.
     const keys: string[] = model._registryKeys ?? [];
     if (!keys.includes(nameOrModel)) keys.push(nameOrModel);
     model._registryKeys = keys;
     flushPendingCounterCacheColumns(model);
   } else {
-    registerModelConstant(nameOrModel.name, nameOrModel);
+    modelRegistry.set(nameOrModel.name, nameOrModel);
+    nameOrModel._modelsByName.set(nameOrModel.name, nameOrModel);
     // A namespaced model carries its Ruby module path via `static moduleName`;
     // derive the `::`-qualified registry key from it (e.g.
     // "MyApplication::Billing::Firm") so cross-namespace `className` resolution

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -243,23 +243,30 @@ class ModelRegistry extends Map<string, typeof Base> {
   }
 
   override set(name: string, model: typeof Base): this {
-    if (super.get(name) !== model) this.#generation++;
+    // Guard (inside registerModelConstant) before any mutation: a rejected
+    // registration must not bump the generation, which would invalidate every
+    // reflection memo for a write that never happened.
     registerModelConstant(name, model);
+    if (super.get(name) !== model) this.#generation++;
     return super.set(name, model);
   }
 
   override delete(name: string): boolean {
+    // The constant table is wider than the registry, so the name may since have
+    // been rebound (e.g. by registerSubclass) to a class this registry entry
+    // knows nothing about — only drop the constant when it is still ours.
+    const model = super.get(name);
     const deleted = super.delete(name);
     if (deleted) {
       this.#generation++;
-      unregisterConstant(name);
+      unregisterConstant(name, model);
     }
     return deleted;
   }
 
   override clear(): void {
     if (this.size > 0) this.#generation++;
-    for (const name of this.keys()) unregisterConstant(name);
+    for (const [name, model] of this) unregisterConstant(name, model);
     super.clear();
   }
 }

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -194,8 +194,14 @@ export class HasAndBelongsToMany {
       sourceName,
     );
 
-    // Registering the key also binds it in the constant table, matching Rails'
-    // `const_set join_model.name, join_model` on the owner (associations.rb:1877).
+    // Registering the key also binds it in the constant table. Rails does
+    // `const_set join_model.name, join_model` here — but then
+    // `private_constant join_model.name` (associations.rb:1877-1878), so Ruby
+    // raises NameError on `const_get("Country::HABTM_Treaties")`. trails' flat
+    // constant table has no private-constant concept, so the binding is wider
+    // than Rails': the join model is constantize-able. Accepted because the
+    // registry⇒constant invariant is what makes teardown symmetric, and the key
+    // is synthetic — nothing but the habtm reflection names it.
     deps.modelRegistry.set(registryKey, JoinModel);
 
     const middleName = [pluralize(model.name.toLowerCase()), name].sort().join("_");

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -194,6 +194,8 @@ export class HasAndBelongsToMany {
       sourceName,
     );
 
+    // Registering the key also binds it in the constant table, matching Rails'
+    // `const_set join_model.name, join_model` on the owner (associations.rb:1877).
     deps.modelRegistry.set(registryKey, JoinModel);
 
     const middleName = [pluralize(model.name.toLowerCase()), name].sort().join("_");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -154,7 +154,6 @@ import {
   type Included,
   type ParameterFilter,
   type BenchmarkLogger,
-  registerConstant,
 } from "@blazetrails/activesupport";
 import {
   hasAttribute as _hasAttribute,
@@ -310,6 +309,7 @@ import {
   isAssociationCached as _isAssociationCached,
   associationInstanceGet as _associationInstanceGet,
   associationInstanceSet as _associationInstanceSet,
+  registerModelConstant,
   type AssociationDefinition,
 } from "./associations.js";
 import * as _AttributeAssignment from "./attribute-assignment.js";
@@ -1354,8 +1354,7 @@ export class Base extends Model {
     }
     this._adapter = adapter;
     if (this !== Base && this.name) {
-      Base._modelsByName.set(this.name, this);
-      registerConstant(this.name, this);
+      registerModelConstant(this.name, this);
     }
 
     // Full schema reset on adapter swap: drops schema-sourced defs and

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1352,10 +1352,14 @@ export class Base extends Model {
     if (this._adapter === adapter) {
       return;
     }
-    this._adapter = adapter;
+    // Registers (and shadow-guards) the name before any mutation: the guard
+    // throws, and a half-applied swap would leave `_adapter` pointing at the new
+    // adapter with the schema reset below never run.
     if (this !== Base && this.name) {
       registerModelConstant(this.name, this);
+      Base._modelsByName.set(this.name, this);
     }
+    this._adapter = adapter;
 
     // Full schema reset on adapter swap: drops schema-sourced defs and
     // their prototype accessors (preserves user-declared defs), and

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -399,6 +399,9 @@ export function demodulize(name: string): string {
 export function registerSubclass(klass: typeof Base): void {
   const parent = Object.getPrototypeOf(klass) as typeof Base;
   if (!parent || parent === Function.prototype) return;
+  // Guard before any mutation: a rejected registration must not leave the
+  // shadowing subclass permanently listed in subclasses()/descendants().
+  if (klass.name) registerModelConstant(klass.name, klass);
   if (!Object.prototype.hasOwnProperty.call(parent, "_subclasses")) {
     (parent as any)._subclasses = [];
   }
@@ -409,7 +412,6 @@ export function registerSubclass(klass: typeof Base): void {
   if (!(parent as any)._subclasses.includes(klass)) {
     (parent as any)._subclasses.push(klass);
   }
-  if (klass.name) registerModelConstant(klass.name, klass);
 }
 
 /**

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -5,9 +5,9 @@
  */
 
 import type { Base } from "./base.js";
-import { modelRegistry } from "./associations.js";
+import { modelRegistry, registerModelConstant } from "./associations.js";
 import { ActiveRecordError, NameError, SubclassNotFound } from "./errors.js";
-import { camelize, isPresent, registerConstant, underscore } from "@blazetrails/activesupport";
+import { camelize, isPresent, underscore } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { applicationRecordClass, setApplicationRecordClass } from "./ar-config.js";
 
@@ -409,7 +409,7 @@ export function registerSubclass(klass: typeof Base): void {
   if (!(parent as any)._subclasses.includes(klass)) {
     (parent as any)._subclasses.push(klass);
   }
-  if (klass.name) registerConstant(klass.name, klass);
+  if (klass.name) registerModelConstant(klass.name, klass);
 }
 
 /**

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -16,7 +16,6 @@ import { modelRegistry } from "./associations.js";
 import { safeConstantize } from "@blazetrails/activesupport";
 import { Author } from "./test-helpers/models/author.js";
 
-/** A subclass whose `.name` is `name`, without shadowing an imported binding. */
 function subclassNamed(parent: typeof Base, name: string): typeof Base {
   const klass = class extends parent {};
   Object.defineProperty(klass, "name", { value: name });

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -12,6 +12,7 @@
 import "./support/canonical-model-index.js";
 import { describe, it, expect } from "vitest";
 import { Base, registerModel, registerSubclass } from "./index.js";
+import { subclasses } from "./inheritance.js";
 import { modelRegistry } from "./associations.js";
 import { safeConstantize } from "@blazetrails/activesupport";
 import { Author } from "./test-helpers/models/author.js";
@@ -43,12 +44,25 @@ describe("registerModel canonical-name shadow guard", () => {
     const shadow = subclassNamed(RfStiParentXyz, "Author");
     expect(() => registerSubclass(shadow)).toThrow(/shadow the canonical model/);
     expect(safeConstantize("Author")).toBe(Author);
+    expect(subclasses(RfStiParentXyz)).not.toContain(shadow);
   });
 
   it("throws when a bespoke class reaches the registry through a bare set", () => {
     class RfBareSetXyz extends Base {}
+    const before = modelRegistry.generation;
     expect(() => modelRegistry.set("Author", RfBareSetXyz)).toThrow(/shadow the canonical model/);
     expect(modelRegistry.get("Author")).toBe(Author);
+    expect(modelRegistry.generation).toBe(before);
+  });
+
+  it("keeps a constant rebound by another writer when the registry entry is dropped", () => {
+    class RfRebindHostXyz extends Base {}
+    registerModel(RfRebindHostXyz);
+    const sub = subclassNamed(RfRebindHostXyz, "RfRebindHostXyz");
+    registerSubclass(sub);
+    expect(safeConstantize("RfRebindHostXyz")).toBe(sub);
+    modelRegistry.delete("RfRebindHostXyz");
+    expect(safeConstantize("RfRebindHostXyz")).toBe(sub);
   });
 
   it("registers an STI subclass as a constant without widening the registry", () => {
@@ -73,7 +87,13 @@ describe("registerModel canonical-name shadow guard", () => {
       modelRegistry.clear();
       for (const [name] of saved) expect(safeConstantize(name)).toBeUndefined();
     } finally {
-      for (const [name, model] of saved) registerModel(name, model);
+      // Replay each key the way it was installed: a bare `set` key (e.g. the
+      // habtm join key) must not come back with the `_registryKeys` entry and
+      // counter-cache flush that only `registerModel` performs.
+      for (const [name, model] of saved) {
+        if (model._registryKeys?.includes(name)) registerModel(name, model);
+        else modelRegistry.set(name, model);
+      }
     }
   });
 });

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -74,8 +74,11 @@ describe("registerModel canonical-name shadow guard", () => {
     expect(modelRegistry.has("RfStiSubXyz")).toBe(false);
   });
 
-  it("binds the habtm join model as a constant, as Rails' const_set does", () => {
-    // Rails: `const_set join_model.name, join_model` (associations.rb:1877).
+  it("binds the habtm join model as a constant, wider than Rails' private_constant", () => {
+    // Rails const_sets the join model then marks it `private_constant`
+    // (associations.rb:1877-1878), so Ruby's const_get raises NameError here.
+    // trails has no private-constant concept — see the deviation note at
+    // associations/builder/has-and-belongs-to-many.ts.
     expect(safeConstantize("Country::HABTM_Treaties")).toBe(
       modelRegistry.get("Country::HABTM_Treaties"),
     );

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -97,7 +97,11 @@ describe("registerModel canonical-name shadow guard", () => {
     const saved = [...modelRegistry.entries()];
     try {
       modelRegistry.clear();
-      for (const [name] of saved) expect(safeConstantize(name)).toBeUndefined();
+      // The invariant is that clear() drops every constant the registry owns,
+      // not that the name becomes unresolvable: a name rebound elsewhere (see
+      // the rebind case above) keeps the other writer's binding, since
+      // unregisterConstant only removes a constant that is still the registry's.
+      for (const [name, model] of saved) expect(safeConstantize(name)).not.toBe(model);
     } finally {
       // Replay each key the way it was installed: a bare `set` key (e.g. the
       // habtm join key) must not come back with the `_registryKeys` entry and

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -11,8 +11,17 @@
  */
 import "./support/canonical-model-index.js";
 import { describe, it, expect } from "vitest";
-import { Base, registerModel } from "./index.js";
+import { Base, registerModel, registerSubclass } from "./index.js";
+import { modelRegistry } from "./associations.js";
+import { safeConstantize } from "@blazetrails/activesupport";
 import { Author } from "./test-helpers/models/author.js";
+
+/** A subclass whose `.name` is `name`, without shadowing an imported binding. */
+function subclassNamed(parent: typeof Base, name: string): typeof Base {
+  const klass = class extends parent {};
+  Object.defineProperty(klass, "name", { value: name });
+  return klass;
+}
 
 describe("registerModel canonical-name shadow guard", () => {
   it("throws when a bespoke class is registered under a canonical name", () => {
@@ -28,5 +37,30 @@ describe("registerModel canonical-name shadow guard", () => {
   it("allows a bespoke class under a non-canonical name", () => {
     class RfWidgetXyz extends Base {}
     expect(() => registerModel("RfWidgetXyz", RfWidgetXyz)).not.toThrow();
+  });
+
+  it("throws when an STI subclass takes a canonical name", () => {
+    class RfStiParentXyz extends Base {}
+    const shadow = subclassNamed(RfStiParentXyz, "Author");
+    expect(() => registerSubclass(shadow)).toThrow(/shadow the canonical model/);
+    expect(safeConstantize("Author")).toBe(Author);
+  });
+
+  it("unregisters the constant when the registry entry is dropped", () => {
+    class RfDroppedXyz extends Base {}
+    registerModel(RfDroppedXyz);
+    expect(safeConstantize("RfDroppedXyz")).toBe(RfDroppedXyz);
+    modelRegistry.delete("RfDroppedXyz");
+    expect(safeConstantize("RfDroppedXyz")).toBeUndefined();
+  });
+
+  it("leaves no model constants behind when the registry is cleared", () => {
+    const saved = [...modelRegistry.entries()];
+    try {
+      modelRegistry.clear();
+      for (const [name] of saved) expect(safeConstantize(name)).toBeUndefined();
+    } finally {
+      for (const [name, model] of saved) modelRegistry.set(name, model);
+    }
   });
 });

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -45,6 +45,20 @@ describe("registerModel canonical-name shadow guard", () => {
     expect(safeConstantize("Author")).toBe(Author);
   });
 
+  it("throws when a bespoke class reaches the registry through a bare set", () => {
+    class RfBareSetXyz extends Base {}
+    expect(() => modelRegistry.set("Author", RfBareSetXyz)).toThrow(/shadow the canonical model/);
+    expect(modelRegistry.get("Author")).toBe(Author);
+  });
+
+  it("registers an STI subclass as a constant without widening the registry", () => {
+    class RfStiHostXyz extends Base {}
+    const sub = subclassNamed(RfStiHostXyz, "RfStiSubXyz");
+    registerSubclass(sub);
+    expect(safeConstantize("RfStiSubXyz")).toBe(sub);
+    expect(modelRegistry.has("RfStiSubXyz")).toBe(false);
+  });
+
   it("unregisters the constant when the registry entry is dropped", () => {
     class RfDroppedXyz extends Base {}
     registerModel(RfDroppedXyz);
@@ -59,7 +73,7 @@ describe("registerModel canonical-name shadow guard", () => {
       modelRegistry.clear();
       for (const [name] of saved) expect(safeConstantize(name)).toBeUndefined();
     } finally {
-      for (const [name, model] of saved) modelRegistry.set(name, model);
+      for (const [name, model] of saved) registerModel(name, model);
     }
   });
 });

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -16,6 +16,7 @@ import { subclasses } from "./inheritance.js";
 import { modelRegistry } from "./associations.js";
 import { safeConstantize } from "@blazetrails/activesupport";
 import { Author } from "./test-helpers/models/author.js";
+import "./test-helpers/models/country.js";
 
 function subclassNamed(parent: typeof Base, name: string): typeof Base {
   const klass = class extends parent {};
@@ -71,6 +72,14 @@ describe("registerModel canonical-name shadow guard", () => {
     registerSubclass(sub);
     expect(safeConstantize("RfStiSubXyz")).toBe(sub);
     expect(modelRegistry.has("RfStiSubXyz")).toBe(false);
+  });
+
+  it("binds the habtm join model as a constant, as Rails' const_set does", () => {
+    // Rails: `const_set join_model.name, join_model` (associations.rb:1877).
+    expect(safeConstantize("Country::HABTM_Treaties")).toBe(
+      modelRegistry.get("Country::HABTM_Treaties"),
+    );
+    expect(modelRegistry.get("Country::HABTM_Treaties")).toBeDefined();
   });
 
   it("unregisters the constant when the registry entry is dropped", () => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -159,6 +159,7 @@ export {
   constantize,
   safeConstantize,
   registerConstant,
+  unregisterConstant,
   _resetConstants,
   foreignKey,
   humanize,

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -183,12 +183,12 @@ export function registerConstant(name: string, value: unknown): void {
  * {@link registerConstant}). Ruby constants are removed with
  * `Object.send(:remove_const, …)`, which has no ESM analogue; trails needs it so
  * a registry teardown cannot leave a name resolvable through
- * {@link constantize}. Pass `expected` to make the removal conditional: the name
- * is dropped only when it currently resolves to that value, so a caller tearing
+ * {@link constantize}. The removal is conditional on `expected`: the name is
+ * dropped only when it currently resolves to that value, so a caller tearing
  * down its own binding cannot clobber a later rebinding by someone else.
  */
-export function unregisterConstant(name: string, expected?: unknown): void {
-  if (arguments.length > 1 && _constants.get(name) !== expected) return;
+export function unregisterConstant(name: string, expected: unknown): void {
+  if (_constants.get(name) !== expected) return;
   _constants.delete(name);
 }
 

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -183,9 +183,12 @@ export function registerConstant(name: string, value: unknown): void {
  * {@link registerConstant}). Ruby constants are removed with
  * `Object.send(:remove_const, …)`, which has no ESM analogue; trails needs it so
  * a registry teardown cannot leave a name resolvable through
- * {@link constantize}.
+ * {@link constantize}. Pass `expected` to make the removal conditional: the name
+ * is dropped only when it currently resolves to that value, so a caller tearing
+ * down its own binding cannot clobber a later rebinding by someone else.
  */
-export function unregisterConstant(name: string): void {
+export function unregisterConstant(name: string, expected?: unknown): void {
+  if (arguments.length > 1 && _constants.get(name) !== expected) return;
   _constants.delete(name);
 }
 

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -178,6 +178,17 @@ export function registerConstant(name: string, value: unknown): void {
   _constants.set(name, value);
 }
 
+/**
+ * @noRailsEquivalent The removal half of the invented constant table (see
+ * {@link registerConstant}). Ruby constants are removed with
+ * `Object.send(:remove_const, …)`, which has no ESM analogue; trails needs it so
+ * a registry teardown cannot leave a name resolvable through
+ * {@link constantize}.
+ */
+export function unregisterConstant(name: string): void {
+  _constants.delete(name);
+}
+
 /** @internal — test use only: clear the registered constant table. */
 export function _resetConstants(): void {
   _constants.clear();


### PR DESCRIPTION
Three code paths wrote Active Support's constant table for model classes and
disagreed on what else they updated: `registerModel` ran the canonical-name
shadow guard, while `registerSubclass` and the `Base.adapter=` setter (both
added by #5471 for globalid's locator) wrote the constant table alone — so those
two could shadow a canonical model with no error, and their constants survived a
`modelRegistry` clear.

Convergence:

- `registerModelConstant(name, model)` is the single guarded constant writer.
  It is deliberately narrow: guard + `registerConstant`, nothing else.
- `ModelRegistry.set` routes through it, so *every* registry write — including
  bare `modelRegistry.set` callers such as the HABTM join-model builder — is
  shadow-guarded and leaves a matching constant; `delete`/`clear` unregister it.
- `registerSubclass` and `Base.adapter=` call it directly and keep their
  pre-existing scope. They do **not** gain a registry entry: the constant table
  is the wider fallback namespace, and promoting a throwaway STI subclass into
  association resolution would let it win over a canonical model. The setter now
  registers before mutating `_adapter`, so a guard throw cannot leave a
  half-applied adapter swap with the schema reset skipped.
- Every writer guards before it mutates: `ModelRegistry.set` registers before
  bumping `#generation`, `registerSubclass` before pushing onto `_subclasses`,
  `Base.adapter=` before swapping `_adapter`. A rejected registration leaves no
  trace.
- Binding every registry key as a constant now also covers the habtm join key.
  Rails `const_set`s the join model **and then marks it `private_constant`**
  (`activerecord/lib/active_record/associations.rb:1877-1878`), so Ruby's
  `const_get("Country::HABTM_Treaties")` raises NameError. trails' flat constant
  table has no private-constant concept, so this binding is deliberately wider
  than Rails'. Accepted here because the registry⇒constant invariant is what
  makes teardown symmetric and the key is synthetic; the deviation is recorded
  at the call site and convergence is registered as story
  `model-private-constants` (RFC 0080).
- `delete`/`clear` unregister conditionally (`unregisterConstant(name, model)`,
  whose expected value is required):
  the constant table is wider than the registry and may have been rebound, so a
  registry teardown only drops a constant that still points at its own entry.
- `unregisterConstant` added to activesupport as the removal half of the
  invented constant table (`@noRailsEquivalent`).

Scope note: `_modelsByName` is still owned by its own callers (`registerModel`,
the adapter setter) and is not folded into `delete`/`clear` — that map is a
separate pre-existing drift, untouched here.

Existing `modelRegistry.delete("Author"|…)` test cleanups now also drop the
constant. That is safe: AR resolves models through the registry plus the
canonical autoload index (`lookupModelWithAutoload`), not through `constantize`
— no runtime `constantize` call exists in activerecord — so a later lookup
faults the canonical model back in and re-registers the constant. globalid,
the only `constantize` consumer, resolves its own models. The cited suites
(`relation/predicate-builder`, `counter-cache.trails`, `reflection`,
`global-locator`) are green.

Tests: STI-subclass collision (fails on baseline; also asserts the rejected
subclass never lands in `subclasses()`), bare-`set` collision (asserts
`generation` is unchanged), STI subclass registers a constant without entering
the registry, a rebound constant survives a registry delete, constant removal on
delete, and no model constants left behind after `clear` (the restore replays
each key the way it was installed, so bare-`set` keys such as the habtm join key
do not gain `_registryKeys`/counter-cache side effects).

Closes-story: converge-model-constant-registration-paths
