### PR TITLE
refactor(connection-handler): resolve bare connection names through findDbConfig

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -355,6 +355,9 @@ export class ConnectionHandler {
     options?: { adapterFactory?: () => DatabaseAdapter },
   ): PoolConfig {
     const dbConfig = baseConfigurations().resolve(config);
+    // Rails calls db_config.validate! here (connection_handler.rb:277). Ours is
+    // async (it awaits adapterClass()) and this path is sync, so the adapter
+    // guard below stands in until establishConnection can await.
     if (!dbConfig.adapter) {
       throw new AdapterNotSpecified("database configuration does not specify adapter");
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -11,7 +11,7 @@ import {
   _setAdapterClassResolver,
 } from "../../database-configurations/database-config.js";
 import {
-  configurationsStore as baseConfigurations,
+  configurationsStore as configurations,
   symbolConnectionName,
 } from "../../database-configurations.js";
 import { PoolConfig } from "../pool-config.js";
@@ -354,7 +354,7 @@ export class ConnectionHandler {
     shard: string,
     options?: { adapterFactory?: () => DatabaseAdapter },
   ): PoolConfig {
-    const dbConfig = baseConfigurations().resolve(config);
+    const dbConfig = configurations().resolve(config);
     // Rails calls db_config.validate! here (connection_handler.rb:277). Ours is
     // async (it awaits adapterClass()) and this path is sync, so the adapter
     // guard below stands in until establishConnection can await.

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -11,7 +11,7 @@ import {
   _setAdapterClassResolver,
 } from "../../database-configurations/database-config.js";
 import { HashConfig } from "../../database-configurations/hash-config.js";
-import { DatabaseConfigurations } from "../../database-configurations.js";
+import { DatabaseConfigurations, symbolConnectionName } from "../../database-configurations.js";
 import { configurations as baseConfigurations } from "../../core.js";
 import { PoolConfig } from "../pool-config.js";
 import { PoolManager } from "../pool-manager.js";
@@ -38,15 +38,6 @@ _setAdapterClassResolver(
 
 export { ConnectionDescriptor };
 export type { ConnectionOwner };
-
-// The stand-in for Ruby's `config.is_a?(Symbol)`: a scheme-less string is a
-// connection name, anything with a scheme is a URL config.
-function symbolConnectionName(
-  config: DatabaseConfig | string | Record<string, unknown> | undefined,
-): string | undefined {
-  if (typeof config !== "string") return undefined;
-  return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config) ? undefined : config;
-}
 
 export class ConnectionHandler {
   private _connectionNameToPoolManager: Map<string, PoolManager>;
@@ -82,10 +73,6 @@ export class ConnectionHandler {
     if (typeof owner === "string") {
       return new ConnectionDescriptor(owner);
     }
-    // Rails' third branch is `elsif config.is_a?(Symbol)` — the bare-name
-    // shorthand `establish_connection :primary`. TS collapses Ruby's Symbol and
-    // String onto `string`, so we key on the same scheme test
-    // DatabaseConfigurations#resolve uses to tell a connection name from a URL.
     const symbolName = symbolConnectionName(config);
     if (symbolName != null) {
       return new ConnectionDescriptor(symbolName);
@@ -366,9 +353,7 @@ export class ConnectionHandler {
       config instanceof DatabaseConfig
         ? config
         : typeof config === "string"
-          ? // Mirrors resolve_pool_config's `Base.configurations.resolve(config)`:
-            // a bare name goes through find_db_config.
-            baseConfigurations().resolve(config)
+          ? baseConfigurations().resolve(config)
           : new HashConfig(DatabaseConfigurations.defaultEnv, connectionName, config as any);
     if (!dbConfig.adapter) {
       throw new AdapterNotSpecified("database configuration does not specify adapter");

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -10,9 +10,10 @@ import {
   DatabaseConfig,
   _setAdapterClassResolver,
 } from "../../database-configurations/database-config.js";
-import { HashConfig } from "../../database-configurations/hash-config.js";
-import { DatabaseConfigurations, symbolConnectionName } from "../../database-configurations.js";
-import { configurations as baseConfigurations } from "../../core.js";
+import {
+  configurationsStore as baseConfigurations,
+  symbolConnectionName,
+} from "../../database-configurations.js";
 import { PoolConfig } from "../pool-config.js";
 import { PoolManager } from "../pool-manager.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
@@ -63,6 +64,11 @@ export class ConnectionHandler {
    * PoolConfig.connectionDescriptor= can call primaryClassQ() on them.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionHandler#determine_owner_name
+   *
+   * Returns undefined where Rails returns `owner_name`'s default, `Base`:
+   * trails has no Base-as-default-owner (Base is a model class here, and
+   * importing it would close a cycle), so establishConnection supplies the
+   * fallback descriptor instead.
    *
    * @internal
    */
@@ -348,13 +354,7 @@ export class ConnectionHandler {
     shard: string,
     options?: { adapterFactory?: () => DatabaseAdapter },
   ): PoolConfig {
-    const connectionName = ownerName.name;
-    const dbConfig =
-      config instanceof DatabaseConfig
-        ? config
-        : typeof config === "string"
-          ? baseConfigurations().resolve(config)
-          : new HashConfig(DatabaseConfigurations.defaultEnv, connectionName, config as any);
+    const dbConfig = baseConfigurations().resolve(config);
     if (!dbConfig.adapter) {
       throw new AdapterNotSpecified("database configuration does not specify adapter");
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -12,6 +12,7 @@ import {
 } from "../../database-configurations/database-config.js";
 import { HashConfig } from "../../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../../database-configurations.js";
+import { configurations as baseConfigurations } from "../../core.js";
 import { PoolConfig } from "../pool-config.js";
 import { PoolManager } from "../pool-manager.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
@@ -37,6 +38,15 @@ _setAdapterClassResolver(
 
 export { ConnectionDescriptor };
 export type { ConnectionOwner };
+
+// The stand-in for Ruby's `config.is_a?(Symbol)`: a scheme-less string is a
+// connection name, anything with a scheme is a URL config.
+function symbolConnectionName(
+  config: DatabaseConfig | string | Record<string, unknown> | undefined,
+): string | undefined {
+  if (typeof config !== "string") return undefined;
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config) ? undefined : config;
+}
 
 export class ConnectionHandler {
   private _connectionNameToPoolManager: Map<string, PoolManager>;
@@ -66,18 +76,19 @@ export class ConnectionHandler {
    * @internal
    */
   determineOwnerName(
-    owner: string | ConnectionOwner,
-    // Rails' third branch is `elsif config.is_a?(Symbol)` — the bare-name
-    // shorthand `establish_connection :primary`. It is deliberately NOT ported:
-    // Ruby distinguishes that Symbol from a String config (a connection URL),
-    // which falls through to `owner_name` unchanged, and TS collapses both onto
-    // `string`. Porting it as `typeof config === "string"` would misread a URL
-    // as a connection name. The parameter stays so the signature matches Rails
-    // and the branch can land once a Symbol-shaped config exists to key on.
-    _config?: DatabaseConfig | Record<string, unknown>,
-  ): ConnectionDescriptor | ConnectionOwner {
+    owner: string | ConnectionOwner | undefined,
+    config?: DatabaseConfig | string | Record<string, unknown>,
+  ): ConnectionDescriptor | ConnectionOwner | undefined {
     if (typeof owner === "string") {
       return new ConnectionDescriptor(owner);
+    }
+    // Rails' third branch is `elsif config.is_a?(Symbol)` — the bare-name
+    // shorthand `establish_connection :primary`. TS collapses Ruby's Symbol and
+    // String onto `string`, so we key on the same scheme test
+    // DatabaseConfigurations#resolve uses to tell a connection name from a URL.
+    const symbolName = symbolConnectionName(config);
+    if (symbolName != null) {
+      return new ConnectionDescriptor(symbolName);
     }
     return owner;
   }
@@ -115,7 +126,7 @@ export class ConnectionHandler {
   }
 
   establishConnection(
-    config: DatabaseConfig | Record<string, unknown>,
+    config: DatabaseConfig | string | Record<string, unknown>,
     options: {
       owner?: string | ConnectionOwner;
       role?: string;
@@ -125,11 +136,10 @@ export class ConnectionHandler {
     } = {},
   ): ConnectionPool {
     const ownerName =
-      options.owner != null
-        ? this.determineOwnerName(options.owner, config)
-        : config instanceof DatabaseConfig
-          ? new ConnectionDescriptor(config.name)
-          : new ConnectionDescriptor(typeof options.owner === "string" ? options.owner : "primary");
+      this.determineOwnerName(options.owner, config) ??
+      (config instanceof DatabaseConfig
+        ? new ConnectionDescriptor(config.name)
+        : new ConnectionDescriptor("primary"));
 
     const role = options.role ?? "writing";
     const shard = options.shard ?? "default";
@@ -345,7 +355,7 @@ export class ConnectionHandler {
 
   /** @internal */
   private resolvePoolConfig(
-    config: DatabaseConfig | Record<string, unknown>,
+    config: DatabaseConfig | string | Record<string, unknown>,
     ownerName: ConnectionDescriptor | ConnectionOwner,
     role: string,
     shard: string,
@@ -355,7 +365,11 @@ export class ConnectionHandler {
     const dbConfig =
       config instanceof DatabaseConfig
         ? config
-        : new HashConfig(DatabaseConfigurations.defaultEnv, connectionName, config as any);
+        : typeof config === "string"
+          ? // Mirrors resolve_pool_config's `Base.configurations.resolve(config)`:
+            // a bare name goes through find_db_config.
+            baseConfigurations().resolve(config)
+          : new HashConfig(DatabaseConfigurations.defaultEnv, connectionName, config as any);
     if (!dbConfig.adapter) {
       throw new AdapterNotSpecified("database configuration does not specify adapter");
     }

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -51,6 +51,7 @@ describe("ConnectionHandlerTest", () => {
       },
       common: { adapter: "sqlite3", database: "test/db/common.sqlite3" },
     };
+    const prevEnv = DatabaseConfigurations.defaultEnv;
     DatabaseConfigurations.defaultEnv = "default_env";
     const prevConfigs = Base.configurations();
     Base.configurations(config);
@@ -73,6 +74,7 @@ describe("ConnectionHandlerTest", () => {
       expect(commonPool!.dbConfig.database).toBe("test/db/common.sqlite3");
     } finally {
       Base.configurations(prevConfigs);
+      DatabaseConfigurations.defaultEnv = prevEnv;
     }
   });
 

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -52,13 +52,16 @@ describe("ConnectionHandlerTest", () => {
       common: { adapter: "sqlite3", database: "test/db/common.sqlite3" },
     });
     DatabaseConfigurations.defaultEnv = "default_env";
+    const prevConfigs = Base.configurations();
+    Base.configurations(configs);
 
-    for (const name of ["primary", "readonly"]) {
-      handler.establishConnection(configs.configsFor({ envName: "default_env", name })[0], {
-        owner: name,
-      });
+    try {
+      handler.establishConnection("common");
+      handler.establishConnection("primary");
+      handler.establishConnection("readonly");
+    } finally {
+      Base.configurations(prevConfigs);
     }
-    handler.establishConnection(configs.configsFor({ envName: "common" })[0], { owner: "common" });
 
     const readonlyPool = handler.retrieveConnectionPool("readonly");
     expect(readonlyPool).toBeTruthy();

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -40,7 +40,7 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("establish connection using 3 levels config", async () => {
-    const configs = new DatabaseConfigurations({
+    const config = {
       default_env: {
         readonly: { adapter: "sqlite3", database: "test/db/readonly.sqlite3" },
         primary: { adapter: "sqlite3", database: "test/db/primary.sqlite3" },
@@ -50,30 +50,30 @@ describe("ConnectionHandlerTest", () => {
         primary: { adapter: "sqlite3", database: "test/db/bad-primary.sqlite3" },
       },
       common: { adapter: "sqlite3", database: "test/db/common.sqlite3" },
-    });
+    };
     DatabaseConfigurations.defaultEnv = "default_env";
     const prevConfigs = Base.configurations();
-    Base.configurations(configs);
+    Base.configurations(config);
 
     try {
       handler.establishConnection("common");
       handler.establishConnection("primary");
       handler.establishConnection("readonly");
+
+      const readonlyPool = handler.retrieveConnectionPool("readonly");
+      expect(readonlyPool).toBeTruthy();
+      expect(readonlyPool!.dbConfig.database).toBe("test/db/readonly.sqlite3");
+
+      const primaryPool = handler.retrieveConnectionPool("primary");
+      expect(primaryPool).toBeTruthy();
+      expect(primaryPool!.dbConfig.database).toBe("test/db/primary.sqlite3");
+
+      const commonPool = handler.retrieveConnectionPool("common");
+      expect(commonPool).toBeTruthy();
+      expect(commonPool!.dbConfig.database).toBe("test/db/common.sqlite3");
     } finally {
       Base.configurations(prevConfigs);
     }
-
-    const readonlyPool = handler.retrieveConnectionPool("readonly");
-    expect(readonlyPool).toBeTruthy();
-    expect(readonlyPool!.dbConfig.database).toBe("test/db/readonly.sqlite3");
-
-    const primaryPool = handler.retrieveConnectionPool("primary");
-    expect(primaryPool).toBeTruthy();
-    expect(primaryPool!.dbConfig.database).toBe("test/db/primary.sqlite3");
-
-    const commonPool = handler.retrieveConnectionPool("common");
-    expect(commonPool).toBeTruthy();
-    expect(commonPool!.dbConfig.database).toBe("test/db/common.sqlite3");
   });
 
   it("validates db configuration and raises on invalid adapter", async () => {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -8,7 +8,12 @@ import { getApplicationRecordClass } from "./inheritance.js";
 import { RecordNotFound, StatementInvalid, StrictLoadingViolationError } from "./errors.js";
 import { actionOnStrictLoadingViolation } from "./ar-config.js";
 import { WRITING_ROLE } from "./roles.js";
-import { DatabaseConfigurations, type RawConfigurations } from "./database-configurations.js";
+import {
+  DatabaseConfigurations,
+  configurationsStore,
+  setConfigurationsStore,
+  type RawConfigurations,
+} from "./database-configurations.js";
 import type { DatabaseConfig } from "./database-configurations/database-config.js";
 import {
   Notifications,
@@ -434,7 +439,9 @@ export function destroyAssociationAsyncJob(this: CoreHost, value?: any): any {
 // (core.rb:71-79), so there is exactly one registry for the whole process:
 // assigning through any model class replaces `ActiveRecord::Base`'s value.
 // A per-class static would instead shadow through the JS prototype chain.
-let _configurations: DatabaseConfigurations | undefined;
+// The store itself lives in database-configurations.ts so that leaf modules
+// (ConnectionHandler) can read it without importing core.ts, which would close
+// an import cycle through base.ts and break its static initializers.
 
 /**
  * Mirrors: ActiveRecord::Base.configurations / .configurations=
@@ -448,14 +455,15 @@ export function configurations(
   config?: RawConfigurations | DatabaseConfigurations | DatabaseConfig[],
 ): DatabaseConfigurations {
   if (config !== undefined) {
-    _configurations =
+    setConfigurationsStore(
       config instanceof DatabaseConfigurations
         ? config
         : Array.isArray(config)
           ? new DatabaseConfigurations(config)
-          : DatabaseConfigurations.fromEnv(config);
+          : DatabaseConfigurations.fromEnv(config),
+    );
   }
-  return _configurations ?? DatabaseConfigurations.fromEnv({});
+  return configurationsStore();
 }
 
 export function isApplicationRecordClass(this: CoreHost): boolean {

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -64,6 +64,10 @@ export function configurationsStore(): DatabaseConfigurations {
 /** @internal */
 export function setConfigurationsStore(configs: DatabaseConfigurations): void {
   _configurations = configs;
+  // Rails has one @@configurations, so `primary?` always answers from whatever
+  // Base.configurations= last stored (core.rb:71-79). Assigning an existing
+  // instance must re-register it, not just the constructor/fromRaw paths.
+  _currentConfigurations = configs;
 }
 
 export class DatabaseConfigurations {

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -36,6 +36,18 @@ type DbConfigHandler = (
   config: DatabaseConfigOptions,
 ) => DatabaseConfig | null | undefined;
 
+/**
+ * The stand-in for Ruby's `config.is_a?(Symbol)`: TS collapses Ruby's Symbol
+ * and String onto `string`, so a scheme-less string is the connection name
+ * Ruby spells as a Symbol and anything with a scheme is a URL config.
+ *
+ * @internal
+ */
+export function symbolConnectionName(config: unknown): string | undefined {
+  if (typeof config !== "string") return undefined;
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config) ? undefined : config;
+}
+
 export class DatabaseConfigurations {
   private static _defaultEnv: string | null = null;
 
@@ -254,8 +266,7 @@ export class DatabaseConfigurations {
       // Mirrors Rails: resolve(symbol) → resolve_symbol_connection → find_db_config
       // Strings with a URI scheme (e.g. "postgres://", "sqlite3:") are treated as URLs.
       // Strings without a scheme are treated as env names (mirrors Ruby symbol lookup).
-      const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config);
-      if (!hasScheme) {
+      if (symbolConnectionName(config) != null) {
         return this.resolveSymbolConnection(config);
       }
       return new UrlConfig(DatabaseConfigurations.defaultEnv, "primary", config);

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -38,14 +38,29 @@ type DbConfigHandler = (
 
 /**
  * The stand-in for Ruby's `config.is_a?(Symbol)`: TS collapses Ruby's Symbol
- * and String onto `string`, so a scheme-less string is the connection name
- * Ruby spells as a Symbol and anything with a scheme is a URL config.
+ * and String onto `string`, so a non-empty scheme-less string is the connection
+ * name Ruby spells as a Symbol; anything with a scheme — and `""`, which Ruby
+ * can only mean as a String — is a URL config.
  *
  * @internal
  */
 export function symbolConnectionName(config: unknown): string | undefined {
-  if (typeof config !== "string") return undefined;
+  if (typeof config !== "string" || config === "") return undefined;
   return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(config) ? undefined : config;
+}
+
+// Backing store for ActiveRecord::Base.configurations (core.ts). It lives here,
+// not in core.ts, so leaf modules can read it without importing core.ts.
+let _configurations: DatabaseConfigurations | undefined;
+
+/** @internal */
+export function configurationsStore(): DatabaseConfigurations {
+  return _configurations ?? DatabaseConfigurations.fromEnv({});
+}
+
+/** @internal */
+export function setConfigurationsStore(configs: DatabaseConfigurations): void {
+  _configurations = configs;
 }
 
 export class DatabaseConfigurations {

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -55,7 +55,10 @@ let _configurations: DatabaseConfigurations | undefined;
 
 /** @internal */
 export function configurationsStore(): DatabaseConfigurations {
-  return _configurations ?? DatabaseConfigurations.fromEnv({});
+  // Memoized on first read so `Base.configurations` holds one object, as Rails'
+  // @@configurations attribute does: save/restore round-trips must be no-ops.
+  _configurations ??= DatabaseConfigurations.fromEnv({});
+  return _configurations;
 }
 
 /** @internal */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -38,13 +38,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "resolve_pool_config",
-    "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "resolve_pool_config",
     "call": "validate!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -45,13 +45,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "resolve_pool_config",
-    "call": "resolve",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "resolve_pool_config",
     "call": "validate!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Removes the `configsFor` workaround PR #5492 left in the 3-levels-config test.

Rails' `ConnectionHandler#establish_connection(:primary)` resolves a bare
connection name through `Base.configurations.resolve(config)` in
`resolve_pool_config` (connection_handler.rb:275-280), which lands in
`DatabaseConfigurations#find_db_config`. That path was unusable in trails
because `DatabaseConfig#forCurrentEnv` was broken; #5496 fixed it, and #5492
has since merged, so the workaround can go.

- `resolvePoolConfig` now resolves *every* config shape through
  `Base.configurations.resolve`, matching connection_handler.rb:276 — `resolve`
  short-circuits `DatabaseConfig` itself (database_configurations.rb:175), and
  the hash path gets Rails' `"primary"` name and `url:`-key handling instead of
  the inline `HashConfig`.
- `determineOwnerName` gains Rails' third branch (`config.is_a?(Symbol)`),
  keyed on `symbolConnectionName` — the scheme test
  `DatabaseConfigurations#resolve` already used to tell a connection name from
  a URL, now shared rather than duplicated. `""` is excluded: Ruby can only
  mean that as a String, so it takes the URL path.
- The `Base.configurations` backing store moves from core.ts into
  database-configurations.ts so ConnectionHandler can read it without an
  import edge into core.ts. Storage location is an implementation detail of
  Rails' `@@configurations` class variable; the `Base.configurations` accessor
  is unchanged.
- The test now mirrors Rails: assign the raw config hash to
  `Base.configurations`, three bare-name `establishConnection` calls, assert,
  restore in `finally` after the assertions.

No test names changed.

## Review responses

**`Base.configurations=` with an instance left `current` stale.** Real bug,
fixed at the root: `setConfigurationsStore` now assigns `_currentConfigurations`
too, so every `Base.configurations=` re-registers — matching Rails, where the
single `@@configurations` (core.rb:71-79) is what `primary?` always answers
from. Previously only the constructor and `fromRaw` registered, so assigning an
existing instance (the restore path this test is the first to exercise) left
`HashConfig.isPrimary` consulting a stale config. Fixing the setter rather than
the test also covers trailties' `runProtectedEnvCheck`, which capture/restores
the same way.

**`db_config.validate!` is tracked.** Story registered and on tasks `main`:
`0029-sqlite-memory-fidelity/stories/resolve-pool-config-validate-bang`
(status `ready`). It carries the `connection_handler.rb:275-280` context, the
async/sync reason `validateBang` can't be called from `resolvePoolConfig`, and
acceptance criteria that include deciding how the sync path is bridged (no
floated promises). The inline comment is the pointer, not the disposition.

**The `current` shim's remaining asymmetry.** Agreed, and already tracked:
`0023-surfaced-deviations/stories/hash-config-primary-resolves-via-global-configurations`
(status `ready`) deletes `_primaryChecker` and `DatabaseConfigurations.current`
outright, on the grounds you give — Rails has one `@@configurations` and no
`current` at all. Not folded in here: it also rips out the
`(DatabaseConfigurations as any).current` save/restore blocks across
connection-handling, sharding, and swapping suites, well past this story's
scope.

I updated that story with what this PR changes for it (tasks `main` 3332d2c33):
the store now lives in `database-configurations.ts` rather than `core.ts`, so
the collapse no longer needs a `core.js` import at all — its acceptance
criteria said to read the accessor from `core.js`, which is now the wrong
instruction — and it names the surviving asymmetry (the `current` setter and
the constructor/`fromRaw` registrations still write only
`_currentConfigurations`) so it gets removed in the same pass.

**Sibling `resolve_pool_config`/`configurations` wide entry.** Done — the
import is now `configurationsStore as configurations`, so the call site reads
`configurations().resolve(config)` against Rails' `Base.configurations.resolve`
(connection_handler.rb:276). Confirmed locally rather than assumed: re-ran
`pnpm api:compare --wide-calls` and the ratchet goes from 4823 to 4822
baselined entries with that exclude entry deleted, so `resolve_pool_config` now
has no baselined call omissions at all.

Closes-story: three-levels-config-through-find-db-config
