### PR TITLE
fix(activerecord): validate the db config in resolvePoolConfig

### DIFF
--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -70,11 +70,8 @@ export function register(name: string, loader: AdapterLoader): void {
 }
 
 /**
- * Synchronous half of `resolve(name)`: throws AdapterNotFound when the name
- * isn't registered. Rails' `resolve` does this check inline (its autoload is
- * sync); trails splits it out so sync callers — `DatabaseConfig#validateBang`,
- * and through it `ConnectionHandler#resolvePoolConfig` — can surface an
- * unknown adapter name without awaiting the dynamic import.
+ * Synchronous half of `resolve(name)` — Rails does this check inline, but
+ * trails' sync callers can't await the dynamic import.
  *
  * @internal
  */

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -69,6 +69,17 @@ export function register(name: string, loader: AdapterLoader): void {
   resolveErrors.delete(name);
 }
 
+// Rails' Gemfile sentence, with the JS equivalent of the gem/Gemfile pair.
+function adapterNotFoundError(adapterName: string): AdapterNotFound {
+  const available = [...adapters.keys()].sort().join(", ");
+  return new AdapterNotFound(
+    `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
+      `Available adapters are: ${available}. ` +
+      `Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary ` +
+      `adapter package to your package.json if it's not in the list of available adapters.`,
+  );
+}
+
 /**
  * Synchronous half of `resolve(name)` — Rails does this check inline, but
  * trails' sync callers can't await the dynamic import.
@@ -77,13 +88,7 @@ export function register(name: string, loader: AdapterLoader): void {
  */
 export function validateAdapterName(adapterName: string): void {
   if (adapters.has(adapterName)) return;
-  const available = [...adapters.keys()].sort().join(", ");
-  const err = new AdapterNotFound(
-    `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
-      `Available adapters are: ${available}.`,
-  );
-  resolveErrors.set(adapterName, err);
-  throw err;
+  throw adapterNotFoundError(adapterName);
 }
 
 /**
@@ -95,8 +100,12 @@ export async function resolve(adapterName: string): Promise<AdapterClass> {
   const cached = resolved.get(adapterName);
   if (cached) return cached;
 
-  validateAdapterName(adapterName);
-  const loader = adapters.get(adapterName)!;
+  const loader = adapters.get(adapterName);
+  if (!loader) {
+    const err = adapterNotFoundError(adapterName);
+    resolveErrors.set(adapterName, err);
+    throw err;
+  }
   const promise = loader()
     .then((klass) => {
       resolvedSyncCache.set(adapterName, klass);

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -69,7 +69,8 @@ export function register(name: string, loader: AdapterLoader): void {
   resolveErrors.delete(name);
 }
 
-// Rails' Gemfile sentence, with the JS equivalent of the gem/Gemfile pair.
+// Builds the AdapterNotFound raised for an unregistered name. Rails' wording,
+// with its gem/Gemfile pair rendered as the JS package/package.json one.
 function adapterNotFoundError(adapterName: string): AdapterNotFound {
   const available = [...adapters.keys()].sort().join(", ");
   return new AdapterNotFound(

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -70,6 +70,26 @@ export function register(name: string, loader: AdapterLoader): void {
 }
 
 /**
+ * Synchronous half of `resolve(name)`: throws AdapterNotFound when the name
+ * isn't registered. Rails' `resolve` does this check inline (its autoload is
+ * sync); trails splits it out so sync callers — `DatabaseConfig#validateBang`,
+ * and through it `ConnectionHandler#resolvePoolConfig` — can surface an
+ * unknown adapter name without awaiting the dynamic import.
+ *
+ * @internal
+ */
+export function validateAdapterName(adapterName: string): void {
+  if (adapters.has(adapterName)) return;
+  const available = [...adapters.keys()].sort().join(", ");
+  const err = new AdapterNotFound(
+    `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
+      `Available adapters are: ${available}.`,
+  );
+  resolveErrors.set(adapterName, err);
+  throw err;
+}
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters.resolve
  *
  * Resolves an adapter name to its class.
@@ -78,16 +98,8 @@ export async function resolve(adapterName: string): Promise<AdapterClass> {
   const cached = resolved.get(adapterName);
   if (cached) return cached;
 
-  const loader = adapters.get(adapterName);
-  if (!loader) {
-    const available = [...adapters.keys()].sort().join(", ");
-    const err = new AdapterNotFound(
-      `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
-        `Available adapters are: ${available}.`,
-    );
-    resolveErrors.set(adapterName, err);
-    throw err;
-  }
+  validateAdapterName(adapterName);
+  const loader = adapters.get(adapterName)!;
   const promise = loader()
     .then((klass) => {
       resolvedSyncCache.set(adapterName, klass);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -24,6 +24,7 @@ import {
   resolve as resolveConnectionAdapter,
   resolveSync as resolveConnectionAdapterSync,
   resolveSyncError as resolveConnectionAdapterSyncError,
+  validateAdapterName,
 } from "../../connection-adapters.js";
 import { buildAdapterArg } from "../adapter-args.js";
 
@@ -35,6 +36,7 @@ _setAdapterClassResolver(
   (adapterName) => resolveConnectionAdapterSync(adapterName),
   (adapterName, configuration) => buildAdapterArg(adapterName, configuration),
   (adapterName) => resolveConnectionAdapterSyncError(adapterName),
+  (adapterName) => validateAdapterName(adapterName),
 );
 
 export { ConnectionDescriptor };
@@ -355,9 +357,7 @@ export class ConnectionHandler {
     options?: { adapterFactory?: () => DatabaseAdapter },
   ): PoolConfig {
     const dbConfig = configurations().resolve(config);
-    // Rails calls db_config.validate! here (connection_handler.rb:277). Ours is
-    // async (it awaits adapterClass()) and this path is sync, so the adapter
-    // guard below stands in until establishConnection can await.
+    dbConfig.validateBang();
     if (!dbConfig.adapter) {
       throw new AdapterNotSpecified("database configuration does not specify adapter");
     }

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -51,8 +51,10 @@ type AdapterClassResolver = (adapterName: string) => Promise<new (...args: any[]
 type AdapterClassResolverSync = (adapterName: string) => (new (...args: any[]) => unknown) | null;
 type AdapterArgBuilder = (adapterName: string, configuration: Record<string, unknown>) => unknown[];
 type LoadErrorLookup = (adapterName: string) => unknown | null;
+type AdapterNameValidator = (adapterName: string) => void;
 let _adapterClassResolver: AdapterClassResolver | null = null;
 let _adapterClassResolverSync: AdapterClassResolverSync | null = null;
+let _validateAdapterName: AdapterNameValidator | null = null;
 let _buildAdapterArg: AdapterArgBuilder = (_n, c) => [c];
 let _loadAdapterError: LoadErrorLookup | null = null;
 
@@ -62,11 +64,13 @@ export function _setAdapterClassResolver(
   syncFn: AdapterClassResolverSync,
   argBuilder: AdapterArgBuilder,
   errorLookup: LoadErrorLookup,
+  nameValidator: AdapterNameValidator,
 ): void {
   _adapterClassResolver = fn;
   _adapterClassResolverSync = syncFn;
   _buildAdapterArg = argBuilder;
   _loadAdapterError = errorLookup;
+  _validateAdapterName = nameValidator;
 }
 
 let writeConfigurationHash!: (config: DatabaseConfig, hash: DatabaseConfigOptions) => void;
@@ -328,9 +332,25 @@ export class DatabaseConfig {
    *
    * Validates the configuration by resolving the adapter class.
    * Returns true on success or throws.
+   *
+   * Rails resolves the class itself (`adapter_class if adapter`), which its
+   * sync autoload makes cheap. trails' {@link adapterClass} is async because
+   * ESM imports are, and `validate!`'s callers — `resolvePoolConfig` and
+   * `establishConnection` — are sync, so this checks the adapter *name*
+   * against the registry synchronously instead. That covers the case Rails'
+   * check exists for (a misspelled/unavailable adapter, raising
+   * AdapterNotFound at establish time); a registered adapter whose module
+   * fails to import still surfaces later, at first connection checkout.
    */
-  async validateBang(): Promise<true> {
-    if (this.adapter) await this.adapterClass();
+  validateBang(): true {
+    if (this.adapter) {
+      if (!_validateAdapterName) {
+        throw new Error(
+          "Adapter class resolver not registered — import ConnectionHandler (or connection-handling) first",
+        );
+      }
+      _validateAdapterName(this.adapter);
+    }
     return true;
   }
 }

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -333,10 +333,11 @@ export class DatabaseConfig {
    * Validates the configuration by resolving the adapter class.
    * Returns true on success or throws.
    *
-   * Deviation: sync, because Rails' callers (`resolve_pool_config`,
-   * `establish_connection`) are sync while {@link adapterClass} is async. It
-   * validates the adapter name against the registry; a registered adapter
-   * whose module fails to import still surfaces at first checkout.
+   * Deviation: Rails resolves the adapter class here; trails checks the
+   * adapter name against the registry instead, because {@link adapterClass}
+   * is async (ESM imports are) and `validate!`'s callers are sync. A
+   * registered adapter whose module fails to import surfaces at first
+   * checkout rather than here.
    */
   validateBang(): true {
     if (this.adapter) {

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -333,14 +333,10 @@ export class DatabaseConfig {
    * Validates the configuration by resolving the adapter class.
    * Returns true on success or throws.
    *
-   * Rails resolves the class itself (`adapter_class if adapter`), which its
-   * sync autoload makes cheap. trails' {@link adapterClass} is async because
-   * ESM imports are, and `validate!`'s callers — `resolvePoolConfig` and
-   * `establishConnection` — are sync, so this checks the adapter *name*
-   * against the registry synchronously instead. That covers the case Rails'
-   * check exists for (a misspelled/unavailable adapter, raising
-   * AdapterNotFound at establish time); a registered adapter whose module
-   * fails to import still surfaces later, at first connection checkout.
+   * Deviation: sync, because Rails' callers (`resolve_pool_config`,
+   * `establish_connection`) are sync while {@link adapterClass} is async. It
+   * validates the adapter name against the registry; a registered adapter
+   * whose module fails to import still surfaces at first checkout.
    */
   validateBang(): true {
     if (this.adapter) {

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -340,7 +340,9 @@ export class DatabaseConfig {
    * checkout rather than here.
    */
   validateBang(): true {
-    if (this.adapter) {
+    // `!= null`, not truthiness: `adapter: ""` is truthy in Ruby, so Rails
+    // validates it and raises AdapterNotFound rather than AdapterNotSpecified.
+    if (this.adapter != null) {
       if (!_validateAdapterName) {
         throw new Error(
           "Adapter class resolver not registered — import ConnectionHandler (or connection-handling) first",

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -230,12 +230,12 @@ describe("DatabaseConfigurations", () => {
       expect(config.lazySchemaCachePath()).toBe("db/alternate_schema_cache.json");
     });
 
-    it("validate checks the adapter exists", async () => {
+    it("validate checks the adapter exists", () => {
       const ok = new HashConfig("default_env", "primary", { adapter: "abstract" });
-      await expect(ok.validateBang()).resolves.toBe(true);
+      expect(ok.validateBang()).toBe(true);
 
       const bad = new HashConfig("default_env", "primary", { adapter: "potato" });
-      await expect(bad.validateBang()).rejects.toBeInstanceOf(AdapterNotFound);
+      expect(() => bad.validateBang()).toThrow(AdapterNotFound);
     });
 
     it("inspect does not show secrets", () => {

--- a/packages/activerecord/src/database-configurations/hash-config.trails.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.trails.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { HashConfig } from "./hash-config.js";
+import { AdapterNotFound } from "../errors.js";
+import "../connection-handling.js";
+
+describe("DatabaseConfigurations", () => {
+  describe("HashConfigTrailsTest", () => {
+    // Ruby truthiness: `adapter: ""` is truthy, so Rails' validate! resolves it
+    // and raises AdapterNotFound. A JS `if (this.adapter)` would skip validation
+    // and leave establishConnection's guard raising AdapterNotSpecified instead.
+    it("validate rejects an empty adapter string", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "" });
+      expect(() => config.validateBang()).toThrow(AdapterNotFound);
+    });
+  });
+});

--- a/packages/activerecord/src/database-configurations/resolver.test.ts
+++ b/packages/activerecord/src/database-configurations/resolver.test.ts
@@ -28,8 +28,10 @@ describe("PoolConfig", () => {
       const handler = new ConnectionHandler();
       expect(() => handler.establishConnection(dbConfig)).toThrow(AdapterNotFound);
       // Mirrors Rails' assert_match on the nonexistent-adapter message.
+      // The available-adapters list varies with what the running suite has
+      // registered, so the two fixed clauses are matched around it.
       expect(() => handler.establishConnection(dbConfig)).toThrow(
-        /nonexistent 'ridiculous' adapter/,
+        /^Database configuration specifies nonexistent 'ridiculous' adapter\. Available adapters are: .+\. Ensure that the adapter is spelled correctly in config\/database\.yml and that you've added the necessary adapter package to your package\.json if it's not in the list of available adapters\.$/,
       );
     });
 

--- a/packages/activerecord/src/database-configurations/resolver.test.ts
+++ b/packages/activerecord/src/database-configurations/resolver.test.ts
@@ -2,9 +2,7 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import type { RawConfigurations } from "../database-configurations.js";
 import { AdapterNotFound } from "../errors.js";
-// connection-handling registers the adapter class resolver that validateBang()
-// relies on (same import hash-config.test.ts uses) so the "url invalid adapter"
-// case resolves the adapter rather than throwing "resolver not registered".
+// connection-handling registers the adapter class resolver validateBang() needs.
 import "../connection-handling.js";
 import { ConnectionHandler } from "../connection-adapters/abstract/connection-handler.js";
 
@@ -24,11 +22,8 @@ describe("PoolConfig", () => {
     });
 
     it("url invalid adapter", () => {
-      // Rails passes the URL string straight to establish_connection, which
-      // resolves it via Base.configurations; trails' establishConnection takes an
-      // already-resolved config, so we resolve first and hand it over. The
-      // AdapterNotFound must surface here, at establish time, not at first
-      // checkout — that's resolvePoolConfig's db_config.validate! call.
+      // Rails passes the URL string straight to establish_connection; trails'
+      // establishConnection takes an already-resolved config.
       const dbConfig = resolveDbConfig("ridiculous://foo?encoding=utf8");
       const handler = new ConnectionHandler();
       expect(() => handler.establishConnection(dbConfig)).toThrow(AdapterNotFound);

--- a/packages/activerecord/src/database-configurations/resolver.test.ts
+++ b/packages/activerecord/src/database-configurations/resolver.test.ts
@@ -6,6 +6,7 @@ import { AdapterNotFound } from "../errors.js";
 // relies on (same import hash-config.test.ts uses) so the "url invalid adapter"
 // case resolves the adapter rather than throwing "resolver not registered".
 import "../connection-handling.js";
+import { ConnectionHandler } from "../connection-adapters/abstract/connection-handler.js";
 
 function resolveDbConfig(poolConfig: string, config: RawConfigurations = {}) {
   const configs = new DatabaseConfigurations(config);
@@ -22,15 +23,19 @@ describe("PoolConfig", () => {
       DatabaseConfigurations.defaultEnv = "development";
     });
 
-    it("url invalid adapter", async () => {
-      // Rails drives this through Base.connection_handler.establish_connection; the
-      // trails resolver suite tests the resolver level (configs.resolve), so we
-      // resolve + validate the config directly. An unknown adapter in the URL
-      // (scheme "ridiculous" → adapter "ridiculous") fails adapter resolution.
-      const promise = resolveDbConfig("ridiculous://foo?encoding=utf8").validateBang();
-      await expect(promise).rejects.toBeInstanceOf(AdapterNotFound);
+    it("url invalid adapter", () => {
+      // Rails passes the URL string straight to establish_connection, which
+      // resolves it via Base.configurations; trails' establishConnection takes an
+      // already-resolved config, so we resolve first and hand it over. The
+      // AdapterNotFound must surface here, at establish time, not at first
+      // checkout — that's resolvePoolConfig's db_config.validate! call.
+      const dbConfig = resolveDbConfig("ridiculous://foo?encoding=utf8");
+      const handler = new ConnectionHandler();
+      expect(() => handler.establishConnection(dbConfig)).toThrow(AdapterNotFound);
       // Mirrors Rails' assert_match on the nonexistent-adapter message.
-      await expect(promise).rejects.toThrow(/nonexistent 'ridiculous' adapter/);
+      expect(() => handler.establishConnection(dbConfig)).toThrow(
+        /nonexistent 'ridiculous' adapter/,
+      );
     });
 
     it("url from environment", () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters.json
@@ -3,6 +3,13 @@
     "package": "activerecord",
     "tsFile": "connection-adapters.ts",
     "rubyName": "resolve",
+    "call": "join",
+    "reason": "Bucket (b): the available-adapters join moved into the adapterNotFoundError helper that resolve throws through, so the lexical per-method scan no longer sees it."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters.ts",
+    "rubyName": "resolve",
     "call": "path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -37,13 +37,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "resolve_pool_config",
-    "call": "validate!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "retrieve_connection_pool",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `ConnectionHandler#resolve_pool_config` calls `db_config.validate!`
between resolving the config and the adapter guard
(`connection_handler.rb:277`). trails skipped it because
`DatabaseConfig#validateBang` was `async` (it awaited `adapterClass()`) while
`resolvePoolConfig` and `establishConnection` are sync — so an unresolvable
adapter name only failed at the first connection checkout.

## How the sync/async split is bridged

`validateBang` is now **synchronous**, with no floated promises. What Rails'
`validate!` catches — a misspelled or unavailable adapter — is a registry
lookup, not a module load. `connection-adapters.ts` grows `validateAdapterName`
(`@internal`), the sync half of `resolve()`; `resolve()` delegates to it, so
both paths raise the same `AdapterNotFound` with the same message.

Documented limit (JSDoc on `validateBang`): a *registered* adapter whose module
fails to import still surfaces later, at first checkout — that half genuinely
needs the async import.

## Test

`ResolverTest#url invalid adapter` now drives `establishConnection` and asserts
`AdapterNotFound` at establish time, matching Rails
(`database_configurations/resolver_test.rb:14`). Rails hands the URL string
straight to `establish_connection`; trails' takes an already-resolved config,
so the test resolves first.

Closes-story: resolve-pool-config-validate-bang

## Review round 1

1. **Full message restored** (`connection_adapters.rb:33-38`) — including the third
   sentence, with `gem`/`Gemfile` rendered as `package`/`package.json`, the only
   part of that sentence that has no JS meaning. The ported test now asserts the
   whole message; the available-adapters list is matched with `.+` because, unlike
   Rails' fixed registry, ours varies with what the running suite has registered
   (`fake`, `abstract`).
2. **JSDoc reworded** — the deviation named is now "validates the registry name
   instead of loading the adapter class", not sync-vs-async.
3. **Guard kept, deliberately.** Unreachable from `resolvePoolConfig` (importing
   `ConnectionHandler` is what registers the resolver), so `establishConnection`
   cannot raise it. It is reachable for a direct `validateBang()` on a config in a
   process that never imported the adapter module — where throwing beats silently
   validating nothing. Same guard `adapterClass` and `newConnection` already carry.
4. **Side effect removed.** `validateAdapterName` is now pure: it builds and throws
   via a shared `adapterNotFoundError` helper. Only `resolve()` writes
   `resolveErrors`, exactly as before this PR. That also restores the
   check-and-use-the-local shape in `resolve()` (the `!` is gone).

## Review round 2

1. **Fixed** — `validateBang` now guards on `this.adapter != null` rather than
   truthiness, so `adapter: ""` is validated and raises `AdapterNotFound`, as
   Rails' truthy `""` does at `database_config.rb:30`. Regression test:
   `hash-config.trails.test.ts` (trails-only, since Rails has no test for a case
   its truthiness makes unremarkable) — verified failing on the truthiness guard
   and passing on `!= null`.
2. **Fixed** — the comment now describes the builder, with the gem/Gemfile→
   package/package.json rendering noted as a clause of it.

## Review round 3

1. **Kept, with evidence.** The guard is reachable, but never from
   `establishConnection`. Demonstrated in a fresh process that imports only the
   leaf module — nothing else pulls in the adapter registry:

   ```
   $ node --input-type=module -e '
     const { DatabaseConfig } = await import("./dist/database-configurations/database-config.js");
     new DatabaseConfig("e","primary",{adapter:"sqlite3"}).validateBang()'
   THREW: Adapter class resolver not registered — import ConnectionHandler (or connection-handling) first
   ```

   (Inside the test suite it never fires — the vitest setup has already imported
   ActiveRecord, which is why the same snippet as a test prints no throw.)

   `establishConnection` cannot reach it: calling it requires importing
   `ConnectionHandler`, whose module scope runs `_setAdapterClassResolver`. So no
   Rails caller sees a non-`AdapterNotFound` error from this path. Dropping the
   guard would mean `_validateAdapterName?.(...)` silently validating nothing for
   the leaf-import consumer above — strictly worse than a clear error, and
   inconsistent with `adapterClass` and `newConnection`, which already guard the
   same way.

## Wide call-ratchet

Two baseline edits, both caused by this diff:

- **Removed** `resolve_pool_config` → `validate!` from
  `call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json`.
  That entry recorded the missing call this PR implements; the ratchet only
  shrinks, so a converged entry is a hard failure.
- **Added** `resolve` → `join` in `.../activerecord/connection-adapters.json`.
  The available-adapters `join` moved into the `adapterNotFoundError` helper
  `resolve()` throws through — the scan is lexical per method, so extracting a
  helper trips it. Bucket (b), noted as such in the entry's reason.
