### PR TITLE
refactor(test-adapter): derive the primary configuration from the ARCONN connection entry

### DIFF
--- a/packages/activerecord/src/connection-adapters/adapter-args.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.test.ts
@@ -29,6 +29,16 @@ describe("buildAdapterArg", () => {
       ]);
     });
 
+    it("preserves the SQLite timeout option", () => {
+      const args = buildAdapterArg("sqlite3", {
+        adapter: "sqlite3",
+        database: "x.db",
+        timeout: 5000,
+        strict: true,
+      });
+      expect(args).toEqual(["x.db", { strict: true, timeout: 5000 }]);
+    });
+
     it("ignores unrelated database.yml keys (pool, host, etc.)", () => {
       const args = buildAdapterArg("sqlite3", {
         adapter: "sqlite3",

--- a/packages/activerecord/src/connection-adapters/adapter-args.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.ts
@@ -156,6 +156,7 @@ export function buildAdapterArg(
       driver,
       pragmas,
       strict,
+      timeout,
       statementLimit,
       preparedStatements,
       driverOptions,
@@ -167,6 +168,10 @@ export function buildAdapterArg(
     if (driver !== undefined) options.driver = driver;
     if (pragmas !== undefined) options.pragmas = pragmas;
     if (strict !== undefined) options.strict = strict;
+    // Rails' SQLite3Adapter reads `@config[:timeout]` and applies it as the
+    // driver's busy timeout (sqlite3_adapter.rb:821-826); `config.example.yml:84`
+    // sets it on both arunit entries.
+    if (timeout !== undefined) options.timeout = timeout;
     if (statementLimit !== undefined) options.statementLimit = statementLimit;
     if (preparedStatements !== undefined) options.preparedStatements = preparedStatements;
     if (driverOptions !== undefined) options.driverOptions = driverOptions;

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -319,6 +319,9 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   // Mirrors: database.yml `strict:` — disables double-quoted string literal fallback
   // (DQS) at the connection level. Defaults to SQLite3Adapter.strictStringsByDefault.
   strict?: boolean;
+  // Mirrors: database.yml `timeout:` — the driver's busy timeout, in ms
+  // (`sqlite3_adapter.rb:821-826` sets `busy_handler_timeout`).
+  timeout?: number;
   // Driver-specific options passed through to SqliteOpenConfig.driverOptions.
   // Used by e.g. libsql-remote to forward `authToken` to the Database constructor.
   driverOptions?: Record<string, unknown>;

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -24,6 +24,7 @@ import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection, BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { newRawTestAdapter, ambientPoolConfiguration, adapterType } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 import type { LeasedTestAdapter } from "./test-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -610,60 +611,68 @@ describe("ConnectionPool schema cache", () => {
     });
   });
 
-  it("eagerly warms the schema cache by introspection on first connection when enabled", async () => {
-    // Production analogue of Rails' schema_cache.addAll(pool) at boot: with
-    // no schema_cache.json on disk, eager warming introspects the live DB so
-    // a synchronous read sees real columns. Await pool._eagerWarmPromise so
-    // we're not timing-dependent. Introspects the ambient lane DB's canonical
-    // `posts` table (Rails' scratch-table name) instead of an invented one.
+  // The pool under test opens its own handle, and on the sqlite3_mem lane that
+  // is its own empty database — there is no canonical `posts` to introspect.
+  it.skipIf(inMemoryDb())(
+    "eagerly warms the schema cache by introspection on first connection when enabled",
+    async () => {
+      // Production analogue of Rails' schema_cache.addAll(pool) at boot: with
+      // no schema_cache.json on disk, eager warming introspects the live DB so
+      // a synchronous read sees real columns. Await pool._eagerWarmPromise so
+      // we're not timing-dependent. Introspects the ambient lane DB's canonical
+      // `posts` table (Rails' scratch-table name) instead of an invented one.
 
-    const prevEager = SchemaReflection.eagerLoadSchemaCache;
-    SchemaReflection.eagerLoadSchemaCache = true;
+      const prevEager = SchemaReflection.eagerLoadSchemaCache;
+      SchemaReflection.eagerLoadSchemaCache = true;
 
-    // No schemaCachePath: there is no dump file, so only DB introspection
-    // can populate the cache.
-    const pool = makeAmbientPool({ schemaCachePath: "" });
-    try {
-      await pool.leaseConnection();
-      pool.releaseConnection();
-      expect(pool._eagerWarmPromise).not.toBeNull();
-      await pool._eagerWarmPromise;
-      expect(pool.schemaCache.isCached("posts")).toBe(true);
-      // Adapter-visible raw cache is propagated so synchronous consumers
-      // (Model.columnNames) see the introspected columns without a DB hit.
-      expect(pool.poolConfig.schemaCache).not.toBeNull();
-      expect(pool.poolConfig.schemaCache!.isColumnsHash(null, "posts")).toBe(true);
-    } finally {
-      SchemaReflection.eagerLoadSchemaCache = prevEager;
-      await closePoolConnections(pool);
-    }
-  });
+      // No schemaCachePath: there is no dump file, so only DB introspection
+      // can populate the cache.
+      const pool = makeAmbientPool({ schemaCachePath: "" });
+      try {
+        await pool.leaseConnection();
+        pool.releaseConnection();
+        expect(pool._eagerWarmPromise).not.toBeNull();
+        await pool._eagerWarmPromise;
+        expect(pool.schemaCache.isCached("posts")).toBe(true);
+        // Adapter-visible raw cache is propagated so synchronous consumers
+        // (Model.columnNames) see the introspected columns without a DB hit.
+        expect(pool.poolConfig.schemaCache).not.toBeNull();
+        expect(pool.poolConfig.schemaCache!.isColumnsHash(null, "posts")).toBe(true);
+      } finally {
+        SchemaReflection.eagerLoadSchemaCache = prevEager;
+        await closePoolConnections(pool);
+      }
+    },
+  );
 
-  it("lets eager warming win when both lazy and eager flags are on", async () => {
-    // Eager subsumes lazy (loadAllBang consults the dump first, then
-    // introspects). With both flags on and NO dump file, the lazy path must
-    // not suppress the eager introspection — otherwise the cache stays empty.
+  it.skipIf(inMemoryDb())(
+    "lets eager warming win when both lazy and eager flags are on",
+    async () => {
+      // Eager subsumes lazy (loadAllBang consults the dump first, then
+      // introspects). With both flags on and NO dump file, the lazy path must
+      // not suppress the eager introspection — otherwise the cache stays empty.
 
-    const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
-    const prevEager = SchemaReflection.eagerLoadSchemaCache;
-    SchemaReflection.lazilyLoadSchemaCache = true;
-    SchemaReflection.eagerLoadSchemaCache = true;
+      const prevLazy = SchemaReflection.lazilyLoadSchemaCache;
+      const prevEager = SchemaReflection.eagerLoadSchemaCache;
+      SchemaReflection.lazilyLoadSchemaCache = true;
+      SchemaReflection.eagerLoadSchemaCache = true;
 
-    const pool = makeAmbientPool({ schemaCachePath: "" });
-    try {
-      await pool.leaseConnection();
-      pool.releaseConnection();
-      // Lazy path suppressed; eager path drove the warm.
-      expect(pool._lazyLoadPromise).toBeNull();
-      expect(pool._eagerWarmPromise).not.toBeNull();
-      await pool._eagerWarmPromise;
-      expect(pool.schemaCache.isCached("posts")).toBe(true);
-    } finally {
-      SchemaReflection.lazilyLoadSchemaCache = prevLazy;
-      SchemaReflection.eagerLoadSchemaCache = prevEager;
-      await closePoolConnections(pool);
-    }
-  });
+      const pool = makeAmbientPool({ schemaCachePath: "" });
+      try {
+        await pool.leaseConnection();
+        pool.releaseConnection();
+        // Lazy path suppressed; eager path drove the warm.
+        expect(pool._lazyLoadPromise).toBeNull();
+        expect(pool._eagerWarmPromise).not.toBeNull();
+        await pool._eagerWarmPromise;
+        expect(pool.schemaCache.isCached("posts")).toBe(true);
+      } finally {
+        SchemaReflection.lazilyLoadSchemaCache = prevLazy;
+        SchemaReflection.eagerLoadSchemaCache = prevEager;
+        await closePoolConnections(pool);
+      }
+    },
+  );
 
   it("does not eagerly warm when the flag is off (default)", async () => {
     // Canonical `posts` exists in the ambient lane DB (via the describe's
@@ -682,26 +691,29 @@ describe("ConnectionPool schema cache", () => {
     }
   });
 
-  it("BoundSchemaReflection.dumpTo(filename) round-trips through the pool", async () => {
-    // End-to-end Rails path: pool.schema_cache.dump_to(filename)
-    // allocates a fresh SchemaCache, addAll(pool) populates it via
-    // the pool's withConnection, dumpTo writes the JSON. Covers the
-    // full chain Rails uses for db:schema:cache:dump. Dumps the ambient lane
-    // DB's canonical `posts` table (provided by the describe's fixtures).
-    await withCacheDir(async (dir) => {
-      const pool = makeAmbientPool();
-      try {
-        const filename = join(dir, "schema_cache.json");
-        await pool.schemaCache.dumpTo(filename);
-        const parsed = JSON.parse(await readFile(filename, "utf8")) as {
-          columns: Record<string, unknown[]>;
-        };
-        expect(Object.keys(parsed.columns)).toContain("posts");
-      } finally {
-        await closePoolConnections(pool);
-      }
-    });
-  });
+  it.skipIf(inMemoryDb())(
+    "BoundSchemaReflection.dumpTo(filename) round-trips through the pool",
+    async () => {
+      // End-to-end Rails path: pool.schema_cache.dump_to(filename)
+      // allocates a fresh SchemaCache, addAll(pool) populates it via
+      // the pool's withConnection, dumpTo writes the JSON. Covers the
+      // full chain Rails uses for db:schema:cache:dump. Dumps the ambient lane
+      // DB's canonical `posts` table (provided by the describe's fixtures).
+      await withCacheDir(async (dir) => {
+        const pool = makeAmbientPool();
+        try {
+          const filename = join(dir, "schema_cache.json");
+          await pool.schemaCache.dumpTo(filename);
+          const parsed = JSON.parse(await readFile(filename, "utf8")) as {
+            columns: Record<string, unknown[]>;
+          };
+          expect(Object.keys(parsed.columns)).toContain("posts");
+        } finally {
+          await closePoolConnections(pool);
+        }
+      });
+    },
+  );
 
   it("PoolConfig treats blank/empty schemaCachePath as presence-based 'no cache'", async () => {
     // User explicitly setting schemaCachePath — even to '' or '   ' —

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -11,8 +11,8 @@
  *
  * `in_memory_db?` reads `Base.connection_pool.db_config.database` once Base is
  * connected, exactly as Rails does. Before that there is no pool to ask, so it
- * falls back to `configuredConnectionHash()` — the same `connections:` entry
- * `ARCONN` selects, so the two cannot drift. `sqlite3_mem` is the only entry
+ * falls back to `ambientPoolConfiguration()` — the very `arunit` entry the pool
+ * is established from, so the two cannot drift. `sqlite3_mem` is the only entry
  * whose database is `":memory:"` (config.example.yml:93); the default `sqlite3`
  * entry is file-backed (config.example.yml:83).
  * `sqlite3AdapterStrictStringsDisabled` reads `strict` off that same hash.
@@ -29,8 +29,7 @@
  * connection); they stay there for the same reason.
  */
 
-import { adapterType } from "../test-adapter.js";
-import { configuredConnectionHash } from "./connection.js";
+import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { Base } from "../base.js";
 
 export type AdapterClassName =
@@ -53,7 +52,7 @@ export function currentAdapter(...types: AdapterClassName[]): boolean {
 function poolConfigurationHash(): Record<string, unknown> {
   return Base.isConnectedQ()
     ? (Base.connectionPool().dbConfig.configurationHash as Record<string, unknown>)
-    : configuredConnectionHash();
+    : ambientPoolConfiguration();
 }
 
 export function inMemoryDb(): boolean {

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -225,28 +225,6 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
 };
 
 /**
- * The connection-hash keys of the `ARCONN`-selected entry that are known
- * without doing async work — the pre-connection stand-in for
- * `ActiveRecord::Base.connection_pool.db_config.configuration_hash`. The
- * sqlite3 entry's `database` is resolved asynchronously
- * ({@link fallbackDatabasePath}) and is therefore absent here.
- */
-export function configuredConnectionHash(): Record<string, unknown> {
-  switch (connectionName()) {
-    case "sqlite3_mem":
-      return { adapter: "sqlite3", database: ":memory:", pool: 1 };
-    case "sqlite3":
-      return { adapter: "sqlite3", timeout: 5000, strict: true };
-    case "postgresql":
-      return serverHash("postgresql", postgresSettings());
-    case "mysql2":
-      return serverHash("mysql2", mysqlSettings());
-    default:
-      return {};
-  }
-}
-
-/**
  * Expand a connection's entries into the three named configs, mirroring
  * `expand_config` (`config.rb:26-37`): iterate `arunit`, `arunit2` and
  * `arunit_without_prepared_statements`, creating any the connection omits, then

--- a/packages/activerecord/src/test-adapter.trails.test.ts
+++ b/packages/activerecord/src/test-adapter.trails.test.ts
@@ -9,29 +9,35 @@
 import { describe, expect, test } from "vitest";
 import { Base } from "./base.js";
 import { ambientPoolConfiguration, newRawTestAdapter } from "./test-adapter.js";
-import { inMemoryDb } from "./support/adapter-helper.js";
+import { currentAdapter, inMemoryDb } from "./support/adapter-helper.js";
 
 describe("ambientPoolConfiguration", () => {
   test("matches the primary pool's configuration hash key-for-key", () => {
     expect(ambientPoolConfiguration()).toEqual(Base.connectionPool().dbConfig.configurationHash);
   });
 
-  // A `:memory:` database belongs to its own connection, so on the sqlite3_mem
-  // lane a second handle is a second, empty database by design.
+  // A `:memory:` database belongs to its own connection: on the sqlite3_mem lane
+  // a second handle is a second, empty database by design.
   test.skipIf(inMemoryDb())("newRawTestAdapter opens the database Base rides", async () => {
     const adapter = newRawTestAdapter();
     try {
-      const ambient = ambientPoolConfiguration();
-      // The canonical schema is laid on the primary database at worker boot, so
-      // seeing it here means this handle opened that same database.
       expect(await adapter.tableExists("posts")).toBe(true);
-      if (ambient.adapter === "sqlite3") {
-        expect((adapter as unknown as { strictStrings: boolean }).strictStrings).toBe(
-          ambient.strict,
-        );
-      }
     } finally {
       await adapter.disconnectBang();
     }
   });
+
+  test.skipIf(!currentAdapter("SQLite3Adapter"))(
+    "newRawTestAdapter opens sqlite with the ambient strict setting",
+    async () => {
+      const adapter = newRawTestAdapter() as unknown as { strictStrings: boolean } & {
+        disconnectBang(): Promise<void>;
+      };
+      try {
+        expect(adapter.strictStrings).toBe(Boolean(ambientPoolConfiguration().strict));
+      } finally {
+        await adapter.disconnectBang();
+      }
+    },
+  );
 });

--- a/packages/activerecord/src/test-adapter.trails.test.ts
+++ b/packages/activerecord/src/test-adapter.trails.test.ts
@@ -1,0 +1,37 @@
+/**
+ * trails-only: `ambientPoolConfiguration()` claims to be Rails'
+ * `ActiveRecord::Base.connection_pool.db_config.configuration_hash`. It used to
+ * rebuild the sqlite entry by hand and disagreed with the pool on `database`,
+ * `timeout` and `strict`; this pins the two to one source — the `connections:`
+ * entry `ARCONN` selects.
+ */
+
+import { describe, expect, test } from "vitest";
+import { Base } from "./base.js";
+import { ambientPoolConfiguration, newRawTestAdapter } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
+
+describe("ambientPoolConfiguration", () => {
+  test("matches the primary pool's configuration hash key-for-key", () => {
+    expect(ambientPoolConfiguration()).toEqual(Base.connectionPool().dbConfig.configurationHash);
+  });
+
+  // A `:memory:` database belongs to its own connection, so on the sqlite3_mem
+  // lane a second handle is a second, empty database by design.
+  test.skipIf(inMemoryDb())("newRawTestAdapter opens the database Base rides", async () => {
+    const adapter = newRawTestAdapter();
+    try {
+      const ambient = ambientPoolConfiguration();
+      // The canonical schema is laid on the primary database at worker boot, so
+      // seeing it here means this handle opened that same database.
+      expect(await adapter.tableExists("posts")).toBe(true);
+      if (ambient.adapter === "sqlite3") {
+        expect((adapter as unknown as { strictStrings: boolean }).strictStrings).toBe(
+          ambient.strict,
+        );
+      }
+    } finally {
+      await adapter.disconnectBang();
+    }
+  });
+});

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -26,7 +26,8 @@
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import type { TransactionManager } from "./connection-adapters/abstract/transaction.js";
-import type { SQLite3Config } from "./connection-adapters/pool-config.js";
+import type { SQLite3AdapterOptions } from "./connection-adapters/pool-config.js";
+import { buildAdapterArg } from "./connection-adapters/adapter-args.js";
 import { resetTestTables } from "./support/drop-all-tables.js";
 import { Base } from "./base.js";
 import { activeLane, testConfigurationHashes } from "./support/connection.js";
@@ -70,6 +71,13 @@ export type LeasedTestAdapter = DatabaseAdapter & {
 // It is the `arunit` entry `connect()` establishes the primary pool from, so
 // the two cannot drift; resolved with top-level await because the sqlite3
 // database is only known asynchronously (`fallbackDatabasePath()`).
+//
+// Order-dependent: this snapshot and `connect()` resolve the entry separately
+// and agree only because `test-setup-worker-db.ts` stamps AR_TEST_WORKER_DB /
+// AR_DB_SLOT before anything imports this module. A module in that setupFile's
+// graph reaching test-adapter.ts (or adapter-helper.ts, which imports it) would
+// snapshot the fallback database while Base rides the worker clone —
+// `test-adapter.trails.test.ts` asserts the two stay equal.
 const _primaryConfiguration: Record<string, unknown> = {
   ...(await testConfigurationHashes()).envConfig.configurationHash,
 };
@@ -98,26 +106,35 @@ export function ambientPoolConfiguration(): Record<string, unknown> {
  */
 export let newRawTestAdapter: () => DatabaseAdapter;
 
+// `buildAdapterArg` is the boundary `ConnectionPool#newConnection` builds its
+// adapters through, so going through it here means a raw adapter is constructed
+// from the ambient hash exactly as the primary pool's are — including the
+// per-adapter key whitelisting that keeps config-only keys out of the drivers.
+const adapterArgs = buildAdapterArg(_primaryConfiguration.adapter as string, _primaryConfiguration);
+
 if (adapterType === "postgres") {
   const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
+  const [config] = adapterArgs as [Record<string, unknown>];
   // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
   // exactly one PG server connection (the outer ConnectionPool multiplexes).
   newRawTestAdapter = () =>
-    new PostgreSQLAdapter({ ..._primaryConfiguration, max: 1 }) as unknown as DatabaseAdapter;
+    new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter;
 } else if (adapterType === "mysql") {
   // Built from the config hash rather than a URL so a socket-configured run
   // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
   const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
+  const [config] = adapterArgs as [Record<string, unknown>];
   newRawTestAdapter = () =>
     new Mysql2Adapter({
-      ..._primaryConfiguration,
+      ...config,
       connectionLimit: 1,
       flags: ["FOUND_ROWS"],
     }) as unknown as DatabaseAdapter;
 } else {
   const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
+  const [filename, options] = adapterArgs as [string, SQLite3AdapterOptions | undefined];
   newRawTestAdapter = () =>
-    new BetterSQLite3Adapter(_primaryConfiguration as SQLite3Config) as unknown as DatabaseAdapter;
+    new BetterSQLite3Adapter(filename, options) as unknown as DatabaseAdapter;
 }
 
 // --- In-test pool for pool-mechanics suites ---------------------------------

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -6,8 +6,8 @@
  * a connection detail (see `support/config.ts`):
  *   - ARCONN=postgresql → PostgreSQLAdapter
  *   - ARCONN=mysql2     → Mysql2Adapter
- *   - (default)         → SQLite3Adapter (the per-worker template clone, or
- *     `:memory:` when no clone was built)
+ *   - (default)         → SQLite3Adapter (the per-worker template clone, or the
+ *     run-scoped fallback file `support/connection.ts` resolves)
  *
  * RFC 0059 retired the standing sidecar `_pool`: Rails has no sidecar test
  * pool (`grep -r sidecar vendor/rails/activerecord/test` = 0 hits) — every
@@ -26,11 +26,10 @@
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import type { TransactionManager } from "./connection-adapters/abstract/transaction.js";
+import type { SQLite3Config } from "./connection-adapters/pool-config.js";
 import { resetTestTables } from "./support/drop-all-tables.js";
 import { Base } from "./base.js";
-import { getEnv } from "@blazetrails/activesupport";
-import { driverConfig, mysqlSettings, postgresSettings } from "./support/config.js";
-import { activeLane } from "./support/connection.js";
+import { activeLane, testConfigurationHashes } from "./support/connection.js";
 
 /**
  * Which adapter backend is active. Read once at module load — the worker's
@@ -67,12 +66,16 @@ export type LeasedTestAdapter = DatabaseAdapter & {
 // `ActiveRecord::Base.connection_pool.db_config.configuration_hash`, letting
 // pool-mechanics tests clone the ambient config (with per-test overrides)
 // instead of hardcoding `adapter: "sqlite3"`.
-const _primaryConfiguration: Record<string, unknown> =
-  adapterType === "postgres"
-    ? { adapter: "postgresql", ...driverConfig(postgresSettings()) }
-    : adapterType === "mysql"
-      ? { adapter: "mysql2", ...driverConfig(mysqlSettings()) }
-      : { adapter: "sqlite3", database: getEnv("AR_TEST_WORKER_DB") ?? ":memory:" };
+//
+// Read from the one source Rails has — the `connections:` entry `ARCONN`
+// selects (`support/connection.ts`, mirroring `config.example.yml`) — via the
+// same `arunit` entry `connect()` establishes the primary pool from, so this
+// hash and `Base.connectionPool().dbConfig.configurationHash` cannot drift.
+// The entry is resolved with top-level await because the sqlite3 database is
+// only known asynchronously (`fallbackDatabasePath()`).
+const _primaryConfiguration: Record<string, unknown> = {
+  ...(await testConfigurationHashes()).envConfig.configurationHash,
+};
 
 /**
  * A copy of the active lane's primary configuration hash. Mirrors Rails'
@@ -99,27 +102,25 @@ export function ambientPoolConfiguration(): Record<string, unknown> {
 export let newRawTestAdapter: () => DatabaseAdapter;
 
 if (adapterType === "postgres") {
-  const config = driverConfig(postgresSettings());
   const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
   // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
   // exactly one PG server connection (the outer ConnectionPool multiplexes).
   newRawTestAdapter = () =>
-    new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter;
+    new PostgreSQLAdapter({ ..._primaryConfiguration, max: 1 }) as unknown as DatabaseAdapter;
 } else if (adapterType === "mysql") {
   // Built from the config hash rather than a URL so a socket-configured run
   // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
-  const config = driverConfig(mysqlSettings());
   const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
   newRawTestAdapter = () =>
     new Mysql2Adapter({
-      ...config,
+      ..._primaryConfiguration,
       connectionLimit: 1,
       flags: ["FOUND_ROWS"],
     }) as unknown as DatabaseAdapter;
 } else {
-  const database = getEnv("AR_TEST_WORKER_DB") ?? ":memory:";
   const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
-  newRawTestAdapter = () => new BetterSQLite3Adapter(database) as unknown as DatabaseAdapter;
+  newRawTestAdapter = () =>
+    new BetterSQLite3Adapter(_primaryConfiguration as SQLite3Config) as unknown as DatabaseAdapter;
 }
 
 // --- In-test pool for pool-mechanics suites ---------------------------------

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -67,12 +67,9 @@ export type LeasedTestAdapter = DatabaseAdapter & {
 // pool-mechanics tests clone the ambient config (with per-test overrides)
 // instead of hardcoding `adapter: "sqlite3"`.
 //
-// Read from the one source Rails has — the `connections:` entry `ARCONN`
-// selects (`support/connection.ts`, mirroring `config.example.yml`) — via the
-// same `arunit` entry `connect()` establishes the primary pool from, so this
-// hash and `Base.connectionPool().dbConfig.configurationHash` cannot drift.
-// The entry is resolved with top-level await because the sqlite3 database is
-// only known asynchronously (`fallbackDatabasePath()`).
+// It is the `arunit` entry `connect()` establishes the primary pool from, so
+// the two cannot drift; resolved with top-level await because the sqlite3
+// database is only known asynchronously (`fallbackDatabasePath()`).
 const _primaryConfiguration: Record<string, unknown> = {
   ...(await testConfigurationHashes()).envConfig.configurationHash,
 };

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -26,7 +26,7 @@
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import type { TransactionManager } from "./connection-adapters/abstract/transaction.js";
-import type { SQLite3AdapterOptions } from "./connection-adapters/pool-config.js";
+import type { SQLite3AdapterOptions, SQLite3Config } from "./connection-adapters/pool-config.js";
 import { buildAdapterArg } from "./connection-adapters/adapter-args.js";
 import { resetTestTables } from "./support/drop-all-tables.js";
 import { Base } from "./base.js";
@@ -132,9 +132,12 @@ if (adapterType === "postgres") {
     }) as unknown as DatabaseAdapter;
 } else {
   const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
+  // Recombined into the Rails-shaped single-hash form the adapter constructor
+  // prefers; `buildAdapterArg` returns the positional pair only because the
+  // pool's resolver predates that overload.
   const [filename, options] = adapterArgs as [string, SQLite3AdapterOptions | undefined];
-  newRawTestAdapter = () =>
-    new BetterSQLite3Adapter(filename, options) as unknown as DatabaseAdapter;
+  const config: SQLite3Config = { ...options, database: filename };
+  newRawTestAdapter = () => new BetterSQLite3Adapter(config) as unknown as DatabaseAdapter;
 }
 
 // --- In-test pool for pool-mechanics suites ---------------------------------


### PR DESCRIPTION
`test-adapter.ts` rebuilt the primary configuration hash by hand — for sqlite
that meant `{ adapter: "sqlite3", database: AR_TEST_WORKER_DB ?? ":memory:" }`,
a second reconstruction of what the `sqlite3` entry in `support/connection.ts`
(`CONNECTIONS.sqlite3` → `sqliteHash()`) builds. Since #5398 the two disagreed on
all three keys: the real entry resolves a file path (`AR_TEST_WORKER_DB ||
fallbackDatabasePath()`, never `":memory:"`) and carries `timeout: 5000` /
`strict: true` per `config.example.yml:83-87`. So `ambientPoolConfiguration()`
and `newRawTestAdapter()` described a `:memory:` handle with DQS still legal
while `Base`'s pool rode a file-backed strict-strings database.

Rails has exactly one source — the `connections:` hash — and
`connection_pool.db_config.configuration_hash` reads from it
(`test/support/connection.rb:10-19,31-35`). `_primaryConfiguration` now *is* the
`arunit` entry `connect()` establishes the primary pool from, resolved with
top-level await because the sqlite database is only known asynchronously.

`newRawTestAdapter()` builds through `buildAdapterArg()` — the same boundary
`ConnectionPool#newConnection` constructs adapters through — so a raw adapter is
now built from the ambient hash exactly as the primary pool's are, per-adapter
key whitelisting included.

With the ambient hash authoritative, `adapter-helper.ts`'s pre-connection
fallback reads it directly and `configuredConnectionHash()` — the hand-kept
partial stand-in — is deleted.

`test-adapter.trails.test.ts` pins the invariant: the ambient hash equals
`Base.connectionPool().dbConfig.configurationHash` key-for-key, and
`newRawTestAdapter()` opens the schema-loaded database with the ambient
`strict`. All three fail on baseline.

## Review responses

1. **`pool: 1` on the `sqlite3_mem` lane** — kept, and it is the faithful
   behavior: `connection_pool_test.rb:16-30` merges only `checkout_timeout` onto
   `configuration_hash`, inheriting the entry's pool size. Only `sqlite3_mem`
   carries a `pool` key, so no other lane changes; on that lane size 1 is also
   protective, since a second member is a second empty `:memory:` database. The
   sweep did miss `connection-pool.trails.test.ts` on that lane and it caught a
   real break — three schema-cache tests introspect a *fresh* handle for
   canonical `posts`, which cannot exist on a per-connection `:memory:` database.
   They now carry `skipIf(inMemoryDb())`, the same guard the `posts` test uses.
   Both pool suites are green on both sqlite lanes.

2. **mysql `preparedStatements: false` in `newRawTestAdapter()`** — intended.
   It is what the `arunit` entry declares (`config.example.yml:3-40`) and what
   `Base`'s own mysql adapters already ride; the raw factory diverging from the
   pool is the bug this PR removes, not a property to preserve.

3. **mysql keys the driver rejects** — resolved by the `buildAdapterArg()`
   routing above rather than needing a wider story. `mysql-adapter-arg-whitelist`
   targets `buildAdapterArg`'s MySQL branch, which every pool-built adapter goes
   through; previously `newRawTestAdapter()` bypassed it by calling
   `new Mysql2Adapter(hash)` directly. It no longer does, so that story's fix now
   covers this surface for free and its scope stands unchanged.

4. **sqlite `strict: true` reaching raw adapters** — confirmed in the lane sweep,
   not just the new file. `migration.trails.test.ts`, `schema-cache.test.ts`,
   `pooled-connections.test.ts`, `statement-pool.test.ts`, both
   `connection-pool*` suites, `uniqueness-validation.trails.test.ts`,
   `transaction-isolation.test.ts`, `shard-selector.test.ts`,
   `database-tasks.test.ts` and both `connection-handler*` suites: 13 files,
   309 passed / 14 skipped on `sqlite3`, and 9 files, 217 passed / 12 skipped on
   `sqlite3_mem`.

5. **Order dependence** — noted in a comment on `_primaryConfiguration` naming
   the `test-setup-worker-db.ts` stamping order and the `adapter-helper.ts`
   import edge, and pointing at the equality test that would catch a break.

## Round 2

6. **sqlite `timeout: 5000` dropped by the whitelist** — fixed here rather than
   deferred. Rails' `SQLite3Adapter` reads `@config[:timeout]` and applies it as
   the driver busy timeout (`sqlite3_adapter.rb:821-826`), and
   `config.example.yml:84,88` sets it on both arunit entries, so omitting it from
   `buildAdapterArg`'s sqlite whitelist was a divergence on the pool path too.
   `timeout` joins the whitelist (`adapter-args.ts`), is declared on
   `SQLite3AdapterOptions` where it was previously read but untyped, and is
   pinned by a new `buildAdapterArg` test. This makes `Base`'s own sqlite
   adapters honour the entry's busy timeout for the first time.

7. **`MYSQL_PREPARED_STATEMENTS` ignored** — a real divergence
   (`config.example.yml:7-11,26-30` toggles the value on that env var; our
   entries hardcode `false`), but pre-existing and outside this PR's scope, so it
   is registered as story `mysql-prepared-statements-env-toggle` on RFC 0064 with
   the `config.test.ts` key-set implication captured.

8. **`@deprecated` positional constructor** — avoided. The sqlite branch now
   recombines `buildAdapterArg`'s tuple into the Rails-shaped
   `{ ...options, database: filename }` hash, so it keeps the pool's whitelisting
   while calling the non-deprecated overload.

## Round 3

9. **Uncast `timeout`** — deliberate at this layer, and the gap it exposes is
   registered as story `sqlite-timeout-config-coercion` on RFC 0064. Rails casts
   in `configure_connection` (`sqlite3_adapter.rb:820-830`), i.e. at the adapter,
   not in the config plumbing — its own hash reaches the adapter untouched, which
   is why every other whitelisted key here is uncast too. Casting inside
   `buildAdapterArg` would put the coercion one layer above where Rails has it.
   The story covers the whole missing block: `typeCastConfigToInteger` (already
   ported at `abstract-adapter.ts:1880` and used for `statementLimit`), the
   `TypeError` for a non-integer, and the absent `retries` key with its
   `timeout`+`retries` `ArgumentError` and deprecation warning. Nothing in the
   suite feeds a string today — the `arunit` entry's `timeout: 5000` is a number.

The pg and mysql lanes are CI-only here; both branches now build through
`buildAdapterArg` from the same hash the pool uses.

Closes-story: converge-test-adapter-primary-configuration
