### PR TITLE
refactor(test-helpers): rewire Contact/ContactSti onto the registered fake adapter

### DIFF
--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -89,8 +89,6 @@ api:compare never expects a TS counterpart for these Ruby methods:
   - `singleton_method_added`
 - NoTouching: TS uses a Map-based depth counter (\_noTouchingDepth) instead of a thread-local array; klasses() is the Rails internal accessor for that array.
   - `klasses`
-- PostgreSQL::Quoting#lookup_cast_type issues an async DB query (SELECT oid) to resolve a sql_type string; our standalone-function quoting module has no adapter instance, so this can't be ported without a larger refactor.
-  - `lookup_cast_type`
 - CheckPending helpers — depend on Rails.root, system("bin/rails ..."), and the ActiveRecord::Tasks infrastructure that has no JS equivalent.
   - `any_schema_needs_update?`, `db_configs_in_current_env`, `load_schema!`
 - Migrator internal index helpers — Rails stores @target_version / @direction as instance variables; our TS Migrator passes them as method parameters instead, so these zero-arg helpers can't be faithfully ported.
@@ -104,6 +102,8 @@ api:compare skips these Ruby methods, but only within the listed files — they
 have a real TS surface elsewhere, so the skip is file-scoped to avoid silencing
 a genuine gap:
 
+- PostgreSQL::Quoting#lookup_cast_type resolves a sql_type string with a live `SELECT '<type>'::regtype::oid` query, so trails' port is async and diverges from the sync abstract signature it overrides; it is tracked by the `pg-lookup-cast-type-async-divergence` story rather than counted as a gap. Scoped to postgresql/quoting.rb: the abstract `Quoting#lookup_cast_type` (abstract/quoting.rb:234-236) IS ported, so a flat skip would now hide a real surface.
+  - `lookup_cast_type` (only in: `connection_adapters/postgresql/quoting.rb`)
 - ActiveSupport::Duration#+@ (`def +@; self; end`, duration.rb:326) is Ruby's unary-plus operator returning self. TS has no syntax that dispatches to a named method for `+duration` — the unary `+` coerces through `valueOf()` to a number — so a ported `identity()` method would be inert dead code no caller can reach (unlike `-@` → `negate`, which is called from `minus()` via `other.negate()`). Scoped to duration.rb so it can't silence a genuine `+@` gap elsewhere.
   - `+@` (only in: `duration.rb`)
 - Ruby `-@` deduplication operator (`alias :-@ :deduplicate` in ConnectionAdapters::Deduplicable). TS has no unary-minus method; trails realizes dedup via the `deduplicate` free function plus the DeduplicableBase constructor, so the alias has no separate TS surface on these value objects. Scoped to the AR adapter value-object files so it can't silence ActiveSupport::Duration#-@ (ported as `Duration#negate`).

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { AbstractAdapter } from "./abstract-adapter.js";
+import { TypeMap } from "../type/type-map.js";
 import {
   ConnectionNotEstablished,
   ConnectionNotDefined,
@@ -46,7 +47,7 @@ describe("AbstractAdapter connection lifecycle privates", () => {
     expect(a.extendedTypeMapKey()).toBeNull();
     (a as any)._config.defaultTimezone = "utc";
     expect(a.extendedTypeMapKey()).toEqual({ defaultTimezone: "utc" });
-    expect(a.typeMap).toBeInstanceOf(Map);
+    expect(a.typeMap).toBeInstanceOf(TypeMap);
   });
 
   it("withRawConnection serializes concurrent calls and yields the connection", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -221,6 +221,9 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
 
     it("returns the sqlType string when lookupCastType is absent", () => {
       const a = new AbstractAdapter();
+      // AbstractAdapter now carries Rails' own `lookup_cast_type` (TYPE_MAP
+      // lookup), so drop it to reach the no-cast-type fallback.
+      (a as any).lookupCastType = undefined;
       expect(a.lookupCastTypeFromColumn({ sqlType: "integer" })).toBe("integer");
     });
   });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -208,21 +208,10 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
   });
 
   describe("lookupCastTypeFromColumn", () => {
-    it("returns null for a column with null sqlType", () => {
-      const a = new AbstractAdapter();
-      expect(a.lookupCastTypeFromColumn({ sqlType: null })).toBeNull();
-    });
-
     it("delegates to lookupCastType when available", () => {
       const a = new AbstractAdapter();
       (a as any).lookupCastType = (t: string) => `cast:${t}`;
       expect(a.lookupCastTypeFromColumn({ sqlType: "varchar" })).toBe("cast:varchar");
-    });
-
-    it("returns the sqlType string when lookupCastType is absent", () => {
-      const a = new AbstractAdapter();
-      (a as any).lookupCastType = undefined;
-      expect(a.lookupCastTypeFromColumn({ sqlType: "integer" })).toBe("integer");
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -221,8 +221,6 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
 
     it("returns the sqlType string when lookupCastType is absent", () => {
       const a = new AbstractAdapter();
-      // AbstractAdapter now carries Rails' own `lookup_cast_type` (TYPE_MAP
-      // lookup), so drop it to reach the no-cast-type fallback.
       (a as any).lookupCastType = undefined;
       expect(a.lookupCastTypeFromColumn({ sqlType: "integer" })).toBe("integer");
     });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -210,11 +210,15 @@ describe("AbstractAdapter.extendedTypeMap", () => {
     expect(adapter.lookupCastType("datetime")).toMatchObject({ isUtc: true });
   });
 
+  // TestAdapter declares no EXTENDED_TYPE_MAPS of its own, so — as in Ruby,
+  // where the constant lookup walks up to AbstractAdapter — the entry lands in
+  // the base class's shared map. Asserted on AbstractAdapter to keep that
+  // sharing visible rather than implying a per-class cache.
   it("is memoized per key in EXTENDED_TYPE_MAPS rather than rebuilt per read", () => {
     const adapter = new TestAdapter();
     (adapter as any)._config = { defaultTimezone: "utc" };
     expect(adapter.typeMap).toBe(adapter.typeMap);
-    expect(TestAdapter.EXTENDED_TYPE_MAPS.get(JSON.stringify({ defaultTimezone: "utc" }))).toBe(
+    expect(AbstractAdapter.EXTENDED_TYPE_MAPS.get(JSON.stringify({ defaultTimezone: "utc" }))).toBe(
       adapter.typeMap,
     );
   });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -187,7 +187,9 @@ describe("AbstractAdapter.initializeTypeMap", () => {
   });
 
   it("aliases timestamp to datetime", () => {
-    expect(m.lookup("timestamp")).toBeInstanceOf(DateTimeType);
+    // Pins abstract_adapter.rb:881 — the alias must resolve against this map's
+    // overlaid tz-aware datetime, not the parent map's untouched one.
+    expect(m.lookup("timestamp")).toMatchObject({ isUtc: true });
   });
 
   it("aliases double to float", () => {
@@ -201,7 +203,9 @@ describe("AbstractAdapter.extendedTypeMap", () => {
     expect(m.lookup("integer")).toBeInstanceOf(IntegerType);
     expect(m.lookup("datetime")).toMatchObject({ isUtc: true });
     expect(m.lookup("time")).toMatchObject({ isUtc: true });
-    expect(m.lookup("timestamp")).toBeInstanceOf(DateTimeType);
+    // Pins abstract_adapter.rb:881 — the alias must resolve against this map's
+    // overlaid tz-aware datetime, not the parent map's untouched one.
+    expect(m.lookup("timestamp")).toMatchObject({ isUtc: true });
   });
 
   it("backs the typeMap of an adapter configured with a default timezone", () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -209,6 +209,15 @@ describe("AbstractAdapter.extendedTypeMap", () => {
     (adapter as any)._config = { defaultTimezone: "utc" };
     expect(adapter.lookupCastType("datetime")).toMatchObject({ isUtc: true });
   });
+
+  it("is memoized per key in EXTENDED_TYPE_MAPS rather than rebuilt per read", () => {
+    const adapter = new TestAdapter();
+    (adapter as any)._config = { defaultTimezone: "utc" };
+    expect(adapter.typeMap).toBe(adapter.typeMap);
+    expect(TestAdapter.EXTENDED_TYPE_MAPS.get(JSON.stringify({ defaultTimezone: "utc" }))).toBe(
+      adapter.typeMap,
+    );
+  });
 });
 
 describe("AbstractAdapter#lookupCastType", () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -194,6 +194,28 @@ describe("AbstractAdapter.initializeTypeMap", () => {
   });
 });
 
+describe("AbstractAdapter#lookupCastType", () => {
+  it("looks the sql type up in TYPE_MAP", () => {
+    const adapter = new TestAdapter();
+    expect(adapter.lookupCastType("integer")).toBeInstanceOf(IntegerType);
+    expect(adapter.lookupCastType("boolean")).toBeInstanceOf(BooleanType);
+  });
+
+  it("carries the sql type's limit through to the cast type", () => {
+    const adapter = new TestAdapter();
+    expect(adapter.lookupCastType("varchar(64)")).toMatchObject({ limit: 64 });
+  });
+
+  it("is the type source for lookupCastTypeFromColumn", () => {
+    const adapter = new TestAdapter();
+    expect(adapter.lookupCastTypeFromColumn({ sqlType: "datetime" })).toBeInstanceOf(DateTimeType);
+  });
+
+  it("TYPE_MAP is memoized across reads", () => {
+    expect(AbstractAdapter.TYPE_MAP).toBe(AbstractAdapter.TYPE_MAP);
+  });
+});
+
 describe("DatabaseStatements#insert id extraction", () => {
   // execInsert/execute are include()-mixed methods, not class declarations,
   // so we assign them via any rather than using class override syntax.

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   IntegerType,
   FloatType,
   DecimalType,
+  ValueType,
 } from "@blazetrails/activemodel";
 import { Text as TextType } from "../type/text.js";
 import { Date as DateType } from "../type/date.js";
@@ -194,6 +195,22 @@ describe("AbstractAdapter.initializeTypeMap", () => {
   });
 });
 
+describe("AbstractAdapter.extendedTypeMap", () => {
+  it("inherits TYPE_MAP entries and overlays timezone-aware time types", () => {
+    const m = AbstractAdapter.extendedTypeMap({ defaultTimezone: "utc" });
+    expect(m.lookup("integer")).toBeInstanceOf(IntegerType);
+    expect(m.lookup("datetime")).toMatchObject({ isUtc: true });
+    expect(m.lookup("time")).toMatchObject({ isUtc: true });
+    expect(m.lookup("timestamp")).toBeInstanceOf(DateTimeType);
+  });
+
+  it("backs the typeMap of an adapter configured with a default timezone", () => {
+    const adapter = new TestAdapter();
+    (adapter as any)._config = { defaultTimezone: "utc" };
+    expect(adapter.lookupCastType("datetime")).toMatchObject({ isUtc: true });
+  });
+});
+
 describe("AbstractAdapter#lookupCastType", () => {
   it("looks the sql type up in TYPE_MAP", () => {
     const adapter = new TestAdapter();
@@ -209,6 +226,11 @@ describe("AbstractAdapter#lookupCastType", () => {
   it("is the type source for lookupCastTypeFromColumn", () => {
     const adapter = new TestAdapter();
     expect(adapter.lookupCastTypeFromColumn({ sqlType: "datetime" })).toBeInstanceOf(DateTimeType);
+  });
+
+  it("falls back to the default value type for an unmapped sql type", () => {
+    const adapter = new TestAdapter();
+    expect(adapter.lookupCastTypeFromColumn({ sqlType: null })).toBeInstanceOf(ValueType);
   });
 
   it("TYPE_MAP is memoized across reads", () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2159,25 +2159,29 @@ export class AbstractAdapter implements Quoting {
   // --- Type registration (Rails: class << self private) ---
 
   /**
-   * @internal Mirrors: AbstractAdapter::TYPE_MAP
+   * @internal Mirrors: AbstractAdapter::TYPE_MAP (abstract_adapter.rb:942)
    *
-   * Rails gives each adapter class its own `TYPE_MAP` constant seeded from that
-   * class's `initialize_type_map`, so `self::TYPE_MAP` resolves per class; the
-   * WeakMap keyed on the class reproduces that. Built on first read rather than
-   * at class-definition time because the type classes `initializeTypeMap`
-   * registers sit on a circular import edge and are still in their temporal
-   * dead zone while this module evaluates.
+   * Declared only here, as in Rails: `PostgreSQLAdapter` and
+   * `AbstractMysqlAdapter` define no `TYPE_MAP` constant, so `self::TYPE_MAP`
+   * resolves to this one for them and their `initialize_type_map` never
+   * re-runs. (Rails also declares the constant on `Mysql2Adapter` and
+   * `SQLite3Adapter`; trails resolves both through `_buildTypeMap` instead —
+   * tracked by `mysql-native-type-map-converges-onto-type-map`.)
+   *
+   * Built on first read rather than at class-definition time because the type
+   * classes `initializeTypeMap` registers sit on a circular import edge and are
+   * still in their temporal dead zone while this module evaluates.
    */
   static get TYPE_MAP(): TypeMap {
-    const klass = this as unknown as typeof AbstractAdapter;
-    let m = typeMaps.get(klass);
-    if (!m) {
-      m = new TypeMap();
-      klass.initializeTypeMap(m);
-      typeMaps.set(klass, m);
-    }
-    return m;
+    return (abstractTypeMap ??= (() => {
+      const m = new TypeMap();
+      AbstractAdapter.initializeTypeMap(m);
+      return m;
+    })());
   }
+
+  /** @internal Mirrors: AbstractAdapter::EXTENDED_TYPE_MAPS (abstract_adapter.rb:943) */
+  static readonly EXTENDED_TYPE_MAPS = new Map<string, unknown>();
 
   /** @internal Mirrors: AbstractAdapter.extended_type_map */
   static extendedTypeMap(
@@ -2193,7 +2197,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   /** @internal Mirrors: AbstractAdapter#lookup_cast_type */
-  lookupCastType(sqlType: string): unknown {
+  lookupCastType(sqlType: string | null): unknown {
     return (this.typeMap as TypeMap).lookup(sqlType);
   }
 
@@ -2452,17 +2456,14 @@ export class AbstractAdapter implements Quoting {
 
   /** @internal Mirrors: AbstractAdapter#type_map */
   get typeMap(): unknown {
-    const ctor = this.constructor as typeof AbstractAdapter & {
-      EXTENDED_TYPE_MAPS?: Map<string, unknown>;
-    };
+    const ctor = this.constructor as typeof AbstractAdapter;
     const key = this.extendedTypeMapKey();
     if (!key) return ctor.TYPE_MAP;
-    const build = () => ctor.extendedTypeMap(key);
-    const cache = ctor.EXTENDED_TYPE_MAPS;
-    if (!cache) return build();
-    const ck = JSON.stringify(key);
-    let m = cache.get(ck);
-    if (!m) cache.set(ck, (m = build()));
+    // Rails keys `EXTENDED_TYPE_MAPS` on the option hash itself; JS Maps use
+    // reference identity, so the serialized hash stands in for it.
+    const cacheKey = JSON.stringify(key);
+    let m = ctor.EXTENDED_TYPE_MAPS.get(cacheKey);
+    if (!m) ctor.EXTENDED_TYPE_MAPS.set(cacheKey, (m = ctor.extendedTypeMap(key)));
     return m;
   }
 
@@ -2650,7 +2651,7 @@ export class AbstractAdapter implements Quoting {
 
   /** @internal Mirrors: AbstractAdapter#lookup_cast_type_from_column */
   lookupCastTypeFromColumn(column: { sqlType: string | null }): unknown {
-    return this.lookupCastType(column.sqlType as string);
+    return this.lookupCastType(column.sqlType);
   }
 }
 
@@ -2665,7 +2666,7 @@ export class AbstractAdapter implements Quoting {
 // is early enough.
 let abstractAdapterMixinsApplied = false;
 
-const typeMaps = new WeakMap<typeof AbstractAdapter, TypeMap>();
+let abstractTypeMap: TypeMap | undefined;
 
 /** @internal Applies the abstract-adapter mixin/callback/query-cache wiring once. */
 function ensureAbstractAdapterMixinsApplied(): void {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2164,9 +2164,16 @@ export class AbstractAdapter implements Quoting {
    * Declared only here, as in Rails: `PostgreSQLAdapter` and
    * `AbstractMysqlAdapter` define no `TYPE_MAP` constant, so `self::TYPE_MAP`
    * resolves to this one for them and their `initialize_type_map` never
-   * re-runs. (Rails also declares the constant on `Mysql2Adapter` and
-   * `SQLite3Adapter`; trails resolves both through `_buildTypeMap` instead —
-   * tracked by `mysql-native-type-map-converges-onto-type-map`.)
+   * re-runs.
+   *
+   * Rails additionally declares `TYPE_MAP` on `Mysql2Adapter`
+   * (mysql2_adapter.rb:53) and `SQLite3Adapter` (sqlite3_adapter.rb:505), plus
+   * `EXTENDED_TYPE_MAPS` on `SQLite3Adapter` (506). trails has neither, so
+   * those two seed their extended maps from this base map and share this
+   * `EXTENDED_TYPE_MAPS` — inert only because both resolve casts through the
+   * invented `_buildTypeMap` path, which is exactly what
+   * `mysql-native-type-map-converges-onto-type-map` deletes. That story must
+   * add the missing declarations in the same change.
    *
    * Built on first read rather than at class-definition time because the type
    * classes `initializeTypeMap` registers sit on a circular import edge and are

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -921,9 +921,7 @@ export class AbstractAdapter implements Quoting {
     let serialized: unknown = value;
     const sqlType = (column as { sqlType?: string | null } | undefined)?.sqlType;
     if (sqlType) {
-      const castType = this.lookupCastTypeFromColumn({ sqlType }) as {
-        serialize?(v: unknown): unknown;
-      };
+      const castType = this.lookupCastType(sqlType) as { serialize?(v: unknown): unknown };
       if (typeof castType?.serialize === "function") serialized = castType.serialize(value);
     }
     return this.quote(serialized);
@@ -2668,7 +2666,11 @@ export class AbstractAdapter implements Quoting {
    * @internal
    */
   lookupCastType(sqlType: string | null): Type | Promise<Type> | null {
-    return abstractLookupCastType.call(this, sqlType);
+    // The quoting helper constrains its receiver to a `TypeMap`-bearing host;
+    // the base `typeMap` getter is `unknown` because PostgreSQL's override
+    // returns a `HashLookupTypeMap`, which is a separate class in Rails too
+    // (type/hash_lookup_type_map.rb) — and PG overrides this method anyway.
+    return abstractLookupCastType.call(this as unknown as { typeMap: TypeMap }, sqlType);
   }
 
   /** @internal Mirrors: AbstractAdapter#lookup_cast_type_from_column */

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2161,16 +2161,35 @@ export class AbstractAdapter implements Quoting {
   /**
    * @internal Mirrors: AbstractAdapter::TYPE_MAP
    *
-   * Built on first read rather than at class-definition time: the type classes
-   * `initializeTypeMap` registers sit on a circular import edge and are still
-   * in their temporal dead zone while this module evaluates.
+   * Rails gives each adapter class its own `TYPE_MAP` constant seeded from that
+   * class's `initialize_type_map`, so `self::TYPE_MAP` resolves per class; the
+   * WeakMap keyed on the class reproduces that. Built on first read rather than
+   * at class-definition time because the type classes `initializeTypeMap`
+   * registers sit on a circular import edge and are still in their temporal
+   * dead zone while this module evaluates.
    */
   static get TYPE_MAP(): TypeMap {
-    return (abstractTypeMap ??= (() => {
-      const m = new TypeMap();
-      AbstractAdapter.initializeTypeMap(m);
-      return m;
-    })());
+    const klass = this as unknown as typeof AbstractAdapter;
+    let m = typeMaps.get(klass);
+    if (!m) {
+      m = new TypeMap();
+      klass.initializeTypeMap(m);
+      typeMaps.set(klass, m);
+    }
+    return m;
+  }
+
+  /** @internal Mirrors: AbstractAdapter.extended_type_map */
+  static extendedTypeMap(
+    this: typeof AbstractAdapter,
+    options: { defaultTimezone?: string },
+  ): TypeMap {
+    const m = new TypeMap(this.TYPE_MAP);
+    const timezone = options.defaultTimezone;
+    this.registerClassWithPrecision(m, /^[^(]*time/i, TimeType, { timezone });
+    this.registerClassWithPrecision(m, /^[^(]*datetime/i, DateTimeType, { timezone });
+    m.aliasType(/^[^(]*timestamp/i, "datetime");
+    return m;
   }
 
   /** @internal Mirrors: AbstractAdapter#lookup_cast_type */
@@ -2258,11 +2277,6 @@ export class AbstractAdapter implements Quoting {
     if (!match) return undefined;
     const n = Number.parseInt(match[1], 10);
     return Number.isNaN(n) ? 0 : n;
-  }
-
-  private _extendedTypeMap?: Map<string, unknown>;
-  get extendedTypeMap(): Map<string, unknown> {
-    return (this._extendedTypeMap ??= new Map());
   }
 
   // --- Connection lifecycle privates (Rails abstract_adapter.rb 946–1234) ---
@@ -2438,14 +2452,12 @@ export class AbstractAdapter implements Quoting {
 
   /** @internal Mirrors: AbstractAdapter#type_map */
   get typeMap(): unknown {
-    const ctor = this.constructor as {
+    const ctor = this.constructor as typeof AbstractAdapter & {
       EXTENDED_TYPE_MAPS?: Map<string, unknown>;
-      TYPE_MAP?: unknown;
-      extendedTypeMap?: (key: Record<string, unknown>) => unknown;
     };
     const key = this.extendedTypeMapKey();
-    if (!key) return ctor.TYPE_MAP ?? this.extendedTypeMap;
-    const build = () => ctor.extendedTypeMap?.(key) ?? this.extendedTypeMap;
+    if (!key) return ctor.TYPE_MAP;
+    const build = () => ctor.extendedTypeMap(key);
     const cache = ctor.EXTENDED_TYPE_MAPS;
     if (!cache) return build();
     const ck = JSON.stringify(key);
@@ -2638,12 +2650,7 @@ export class AbstractAdapter implements Quoting {
 
   /** @internal Mirrors: AbstractAdapter#lookup_cast_type_from_column */
   lookupCastTypeFromColumn(column: { sqlType: string | null }): unknown {
-    const sqlType = column.sqlType;
-    if (!sqlType) return null;
-    if (typeof (this as any).lookupCastType === "function") {
-      return (this as any).lookupCastType(sqlType);
-    }
-    return sqlType;
+    return this.lookupCastType(column.sqlType as string);
   }
 }
 
@@ -2658,7 +2665,7 @@ export class AbstractAdapter implements Quoting {
 // is early enough.
 let abstractAdapterMixinsApplied = false;
 
-let abstractTypeMap: TypeMap | undefined;
+const typeMaps = new WeakMap<typeof AbstractAdapter, TypeMap>();
 
 /** @internal Applies the abstract-adapter mixin/callback/query-cache wiring once. */
 function ensureAbstractAdapterMixinsApplied(): void {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2158,6 +2158,27 @@ export class AbstractAdapter implements Quoting {
 
   // --- Type registration (Rails: class << self private) ---
 
+  /**
+   * @internal Mirrors: AbstractAdapter::TYPE_MAP
+   *
+   * Rails builds this constant at class-definition time (abstract_adapter.rb:942).
+   * Built on first read here instead: the type classes `initializeTypeMap`
+   * registers sit on a circular import edge and are still in their temporal
+   * dead zone while this module evaluates.
+   */
+  static get TYPE_MAP(): TypeMap {
+    return (abstractTypeMap ??= (() => {
+      const m = new TypeMap();
+      AbstractAdapter.initializeTypeMap(m);
+      return m;
+    })());
+  }
+
+  /** @internal Mirrors: AbstractAdapter#lookup_cast_type */
+  lookupCastType(sqlType: string): unknown {
+    return (this.typeMap as TypeMap).lookup(sqlType);
+  }
+
   /** @internal */
   static initializeTypeMap(this: typeof AbstractAdapter, m: TypeMap): void {
     this.registerClassWithLimit(m, /boolean/i, BooleanType);
@@ -2637,6 +2658,9 @@ export class AbstractAdapter implements Quoting {
 // evaluating. Instance methods only matter on instances, so first-construction
 // is early enough.
 let abstractAdapterMixinsApplied = false;
+
+/** Backing slot for the lazily built {@link AbstractAdapter.TYPE_MAP}. */
+let abstractTypeMap: TypeMap | undefined;
 
 /** @internal Applies the abstract-adapter mixin/callback/query-cache wiring once. */
 function ensureAbstractAdapterMixinsApplied(): void {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -66,6 +66,7 @@ import {
   quotedBinary as abstractQuotedBinary,
   castBoundValue as abstractCastBoundValue,
   sanitizeAsSqlComment as abstractSanitizeAsSqlComment,
+  lookupCastType as abstractLookupCastType,
   Quoting as QuotingMixin,
 } from "./abstract/quoting.js";
 import type { Quoting } from "./abstract/quoting-interface.js";
@@ -104,6 +105,7 @@ import {
   BooleanType,
   BinaryType,
   DecimalType,
+  type Type,
 } from "@blazetrails/activemodel";
 import { connectedToStack } from "../core.js";
 import { Text as TextType } from "../type/text.js";
@@ -2203,11 +2205,6 @@ export class AbstractAdapter implements Quoting {
     return m;
   }
 
-  /** @internal Mirrors: AbstractAdapter#lookup_cast_type */
-  lookupCastType(sqlType: string | null): unknown {
-    return (this.typeMap as TypeMap).lookup(sqlType);
-  }
-
   /** @internal */
   static initializeTypeMap(this: typeof AbstractAdapter, m: TypeMap): void {
     this.registerClassWithLimit(m, /boolean/i, BooleanType);
@@ -2656,8 +2653,26 @@ export class AbstractAdapter implements Quoting {
     );
   }
 
+  /**
+   * Implemented in `abstract/quoting.ts`, the file Rails declares it in
+   * (abstract/quoting.rb:234-236); dispatched here like `quote` / `typeCast`
+   * above so adapter overrides of `typeMap` are honoured.
+   *
+   * The `Promise<Type>` arm is not Rails: `PostgreSQLAdapter#lookupCastType`
+   * resolves a sql_type with a live regtype query, so its override is async
+   * (tracked by `pg-lookup-cast-type-async-divergence`). The `null` arm is
+   * `AbstractMysqlAdapter`'s early return for an empty sql_type, which
+   * `mysql-native-type-map-converges-onto-type-map` deletes. Both are spelled
+   * out rather than erased behind `unknown`, so a caller cannot silently
+   * duck-type past them.
+   * @internal
+   */
+  lookupCastType(sqlType: string | null): Type | Promise<Type> | null {
+    return abstractLookupCastType.call(this, sqlType);
+  }
+
   /** @internal Mirrors: AbstractAdapter#lookup_cast_type_from_column */
-  lookupCastTypeFromColumn(column: { sqlType: string | null }): unknown {
+  lookupCastTypeFromColumn(column: { sqlType: string | null }): Type | Promise<Type> | null {
     return this.lookupCastType(column.sqlType);
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2161,10 +2161,9 @@ export class AbstractAdapter implements Quoting {
   /**
    * @internal Mirrors: AbstractAdapter::TYPE_MAP
    *
-   * Rails builds this constant at class-definition time (abstract_adapter.rb:942).
-   * Built on first read here instead: the type classes `initializeTypeMap`
-   * registers sit on a circular import edge and are still in their temporal
-   * dead zone while this module evaluates.
+   * Built on first read rather than at class-definition time: the type classes
+   * `initializeTypeMap` registers sit on a circular import edge and are still
+   * in their temporal dead zone while this module evaluates.
    */
   static get TYPE_MAP(): TypeMap {
     return (abstractTypeMap ??= (() => {
@@ -2659,7 +2658,6 @@ export class AbstractAdapter implements Quoting {
 // is early enough.
 let abstractAdapterMixinsApplied = false;
 
-/** Backing slot for the lazily built {@link AbstractAdapter.TYPE_MAP}. */
 let abstractTypeMap: TypeMap | undefined;
 
 /** @internal Applies the abstract-adapter mixin/callback/query-cache wiring once. */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1430,12 +1430,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return this.lookupCastType(sqlType);
   }
 
-  static extendedTypeMap(options: {
-    defaultTimezone?: string;
-    emulateBooleans: boolean;
-  }): Map<string, string> {
-    void options;
-    return new Map();
+  /** @internal Mirrors: AbstractMysqlAdapter.extended_type_map */
+  static extendedTypeMap(
+    this: typeof AbstractMysqlAdapter,
+    options: { defaultTimezone?: string; emulateBooleans: boolean },
+  ): TypeMap {
+    const m = AbstractAdapter.extendedTypeMap.call(this, options);
+    if (options.emulateBooleans) {
+      m.registerType(/^tinyint\(1\)/i, new BooleanType());
+    }
+    return m;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1418,8 +1418,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return this._typeMap;
   }
 
-  lookupCastType(sqlType: string): import("@blazetrails/activemodel").Type {
-    return this._nativeTypeMap.lookup(sqlType.toLowerCase().trim());
+  lookupCastType(sqlType: string | null): import("@blazetrails/activemodel").Type {
+    return this._nativeTypeMap.lookup(sqlType?.toLowerCase().trim() ?? null);
   }
 
   lookupCastTypeFromColumn(column: {
@@ -1434,7 +1434,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static override readonly EXTENDED_TYPE_MAPS = new Map<string, unknown>();
 
   /** @internal Mirrors: AbstractMysqlAdapter.extended_type_map */
-  static extendedTypeMap(
+  static override extendedTypeMap(
     this: typeof AbstractMysqlAdapter,
     options: { defaultTimezone?: string; emulateBooleans: boolean },
   ): TypeMap {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1430,12 +1430,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return this.lookupCastType(sqlType);
   }
 
+  /** @internal Mirrors: AbstractMysqlAdapter::EXTENDED_TYPE_MAPS (abstract_mysql_adapter.rb:754) */
+  static override readonly EXTENDED_TYPE_MAPS = new Map<string, unknown>();
+
   /** @internal Mirrors: AbstractMysqlAdapter.extended_type_map */
   static extendedTypeMap(
     this: typeof AbstractMysqlAdapter,
     options: { defaultTimezone?: string; emulateBooleans: boolean },
   ): TypeMap {
-    const m = AbstractAdapter.extendedTypeMap.call(this, options);
+    const m = super.extendedTypeMap(options);
     if (options.emulateBooleans) {
       m.registerType(/^tinyint\(1\)/i, new BooleanType());
     }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1418,6 +1418,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return this._typeMap;
   }
 
+  /**
+   * A divergent override, NOT a port: Rails defines `lookup_cast_type` only at
+   * `abstract/quoting.rb:234-236` and `postgresql/quoting.rb:195` — never on a
+   * MySQL adapter — so the inherited one is what Rails runs here. This
+   * override and the `_nativeTypeMap` / `_buildTypeMap` slots behind it are a
+   * trails invention, as is `lookupCastTypeFromColumn`'s null return for an
+   * empty sql_type. Deliberately left flagged rather than tagged: converging
+   * them is `mysql-native-type-map-converges-onto-type-map`.
+   */
   lookupCastType(sqlType: string | null): import("@blazetrails/activemodel").Type {
     return this._nativeTypeMap.lookup(sqlType?.toLowerCase().trim() ?? null);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -244,6 +244,13 @@ export interface QuotingHost {
  * Look up the cast type from a column. Delegates to lookupCastType(column.sql_type)
  * on the adapter, matching Rails' internal delegation chain.
  *
+ * Rails can call `lookup_cast_type` unconditionally because every host of this
+ * module is an adapter. This standalone version is also bound to adapter-less
+ * hosts (`ABSTRACT_SCHEMA_QUOTER`, the MySQL schema quoter) that have no type
+ * map, so it keeps the guard and hands back the raw sql_type for them; the
+ * adapter method (`AbstractAdapter#lookupCastTypeFromColumn`) is the
+ * unconditional one-liner.
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type_from_column
  */
 export function lookupCastTypeFromColumn(

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -16,7 +16,8 @@
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BigDecimal } from "@blazetrails/activesupport";
-import { Attribute as ModelAttribute, BinaryData } from "@blazetrails/activemodel";
+import { Attribute as ModelAttribute, BinaryData, type Type } from "@blazetrails/activemodel";
+import type { TypeMap } from "../../type/type-map.js";
 import { NotImplementedError } from "../../errors.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import {
@@ -677,6 +678,18 @@ function typeCastedBinds(
     }
     return this.typeCast(value);
   });
+}
+
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type
+ * (abstract/quoting.rb:234-236)
+ *
+ * Rails marks it private; TS has no equivalent for a mixed-in member adapters
+ * must still dispatch through `this`, so it is public and `@internal`.
+ * @internal
+ */
+export function lookupCastType(this: { typeMap: unknown }, sqlType: string | null): Type {
+  return (this.typeMap as TypeMap).lookup(sqlType);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -238,7 +238,7 @@ export function castBoundValue(value: unknown): unknown {
  */
 export interface QuotingHost {
   /** @internal */
-  lookupCastType?(sqlType: string): unknown;
+  lookupCastType?(sqlType: string | null): unknown;
 }
 
 /**
@@ -317,15 +317,15 @@ export function quoteDefaultExpression(
   }
   if (isSqlLiteral(value)) return value.value;
   // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
-  // (abstract/quoting.rb:161). Serialize only when the host exposes a cast type
-  // with a `serialize` — the adapter-free fallback (ABSTRACT_SCHEMA_QUOTER) and
-  // the mysql schema-quoter have no `lookupCastType`, so `lookupCastTypeFromColumn`
-  // returns the raw sqlType string and the value passes through unserialized.
+  // (abstract/quoting.rb:161). Rails dispatches `lookup_cast_type`
+  // unconditionally; the optional call is for the adapter-free hosts this
+  // standalone version also serves (ABSTRACT_SCHEMA_QUOTER, the mysql schema
+  // quoter), which have no type map, so their values pass through unserialized.
   let serialized: unknown = value;
   if (column != null) {
-    const castType = lookupCastTypeFromColumn.call(this, {
-      sqlType: column.sqlType ?? null,
-    }) as { serialize?(v: unknown): unknown } | null;
+    const castType = this.lookupCastType?.(column.sqlType ?? null) as {
+      serialize?(v: unknown): unknown;
+    } | null;
     if (castType && typeof castType.serialize === "function") {
       serialized = castType.serialize(value);
     }
@@ -688,8 +688,8 @@ function typeCastedBinds(
  * must still dispatch through `this`, so it is public and `@internal`.
  * @internal
  */
-export function lookupCastType(this: { typeMap: unknown }, sqlType: string | null): Type {
-  return (this.typeMap as TypeMap).lookup(sqlType);
+export function lookupCastType(this: { typeMap: TypeMap }, sqlType: string | null): Type {
+  return this.typeMap.lookup(sqlType);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -331,7 +331,18 @@ describe("SchemaStatements privates (PR 8)", () => {
   });
 
   it("fetchTypeMetadata returns SqlTypeMetadata with sqlType", () => {
-    expect(makeStatements().fetchTypeMetadata("varchar(255)").sqlType).toBe("varchar(255)");
+    const meta = makeStatements().fetchTypeMetadata("varchar(255)");
+    expect(meta.sqlType).toBe("varchar(255)");
+    // `Type#type` is a method, so the metadata must carry its result, not the
+    // function object (schema_statements.rb:1721 `cast_type.type`).
+    expect(meta.type).toBe("string");
+    expect(meta.limit).toBe(255);
+  });
+
+  it("fetchTypeMetadata keeps a nil sql_type nil", () => {
+    const meta = makeStatements().fetchTypeMetadata(null);
+    expect(meta.sqlType).toBeNull();
+    expect(meta.type).toBeUndefined();
   });
 
   it("foreignKeyFor returns undefined when not found", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -5,6 +5,7 @@ import {
   indexNameForRemoveFrom,
 } from "./schema-statements.js";
 import { ForeignKeyDefinition } from "./schema-definitions.js";
+import { AbstractAdapter } from "../abstract-adapter.js";
 
 function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
   return new SchemaStatements({
@@ -14,6 +15,10 @@ function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
     quoteDefaultExpression: (v: unknown) => `${v}`,
     execute: vi.fn().mockResolvedValue([]),
     executeMutation: vi.fn().mockResolvedValue(undefined),
+    // Every real host is an AbstractAdapter, which mixes in Quoting's
+    // lookup_cast_type; the stub carries the base implementation so
+    // fetchTypeMetadata dispatches through it as schema_statements.rb:1718 does.
+    lookupCastType: (sqlType: string | null) => AbstractAdapter.TYPE_MAP.lookup(sqlType),
     config: {},
     ...adapterOverrides,
   } as any);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -10,7 +10,7 @@
 
 import { NotImplementedError } from "../../errors.js";
 import { joinTableName as _joinTableName } from "../../migration/join-table.js";
-import { ArgumentError } from "@blazetrails/activemodel";
+import { ArgumentError, type Type } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter, AdapterName } from "../abstract-adapter.js";
 import {
   TableDefinition,
@@ -2373,17 +2373,19 @@ export class SchemaStatements {
     }
   }
 
-  /** @internal */
+  /**
+   * PostgreSQL never lands here — it defines its own async `fetchTypeMetadata`
+   * (postgresql-adapter.ts) keyed on OID — which is why the sync `Type` this
+   * reads is safe despite `PostgreSQLAdapter#lookupCastType` returning a promise.
+   * @internal
+   */
   fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
-    const castType = this.adapter.lookupCastType(sqlType) as {
-      type?: string;
-      limit?: number | null;
-      precision?: number | null;
-      scale?: number | null;
-    };
+    const castType = this.adapter.lookupCastType(sqlType) as Type;
     return new SqlTypeMetadata({
       sqlType,
-      type: castType?.type,
+      // Rails' `cast_type.type` (schema_statements.rb:1721) — `Type#type` is a
+      // method here, not a getter, so it must be invoked.
+      type: castType?.type(),
       limit: castType?.limit ?? null,
       precision: castType?.precision ?? null,
       scale: castType?.scale ?? null,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2386,9 +2386,9 @@ export class SchemaStatements {
       // Rails' `cast_type.type` (schema_statements.rb:1721) — `Type#type` is a
       // method here, not a getter, so it must be invoked.
       type: castType?.type(),
-      limit: castType?.limit ?? null,
-      precision: castType?.precision ?? null,
-      scale: castType?.scale ?? null,
+      limit: castType?.limit,
+      precision: castType?.precision,
+      scale: castType?.scale,
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2374,12 +2374,15 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  fetchTypeMetadata(sqlType: string): SqlTypeMetadata {
+  fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
     const adapter = this.adapter as any;
     const castType =
       typeof adapter.lookupCastType === "function" ? adapter.lookupCastType(sqlType) : null;
     return new SqlTypeMetadata({
-      sqlType,
+      // Rails keeps a nil sql_type as nil (fetch_type_metadata, schema_statements.rb);
+      // SqlTypeMetadata still coerces it to "" one level down — tracked by
+      // `sql-type-metadata-nullable-sql-type`.
+      sqlType: sqlType ?? undefined,
       type: castType?.type ?? "string",
       limit: castType?.limit ?? null,
       precision: castType?.precision ?? null,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2375,15 +2375,15 @@ export class SchemaStatements {
 
   /** @internal */
   fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
-    const adapter = this.adapter as any;
-    const castType =
-      typeof adapter.lookupCastType === "function" ? adapter.lookupCastType(sqlType) : null;
+    const castType = this.adapter.lookupCastType(sqlType) as {
+      type?: string;
+      limit?: number | null;
+      precision?: number | null;
+      scale?: number | null;
+    };
     return new SqlTypeMetadata({
-      // Rails keeps a nil sql_type as nil (fetch_type_metadata, schema_statements.rb);
-      // SqlTypeMetadata still coerces it to "" one level down — tracked by
-      // `sql-type-metadata-nullable-sql-type`.
-      sqlType: sqlType ?? undefined,
-      type: castType?.type ?? "string",
+      sqlType,
+      type: castType?.type,
       limit: castType?.limit ?? null,
       precision: castType?.precision ?? null,
       scale: castType?.scale ?? null,

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -9,7 +9,7 @@
  */
 
 export class TypeMetadata {
-  readonly sqlType: string;
+  readonly sqlType: string | null;
   readonly type: string | undefined;
   readonly limit: number | null;
   readonly precision: number | null;
@@ -18,7 +18,7 @@ export class TypeMetadata {
 
   constructor(
     typeMetadata: {
-      sqlType: string;
+      sqlType: string | null;
       type?: string;
       limit?: number | null;
       precision?: number | null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3630,6 +3630,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * also handles typmods (`(255)`), `[]` array suffixes, enums, and domains.
    * @internal
    */
+  // Async where Rails (and the inherited `AbstractAdapter#lookup_cast_type`) is
+  // sync, and public where Rails keeps it private — TS cannot narrow an
+  // inherited member's visibility. Contained today: PG overrides both
+  // `lookupCastTypeFromColumn` (sync, OID-keyed) and `quoteDefaultExpression`
+  // (awaits this), so no sync duck-typed consumer sees the promise. Tracked by
+  // `pg-lookup-cast-type-async-divergence`.
   async lookupCastType(sqlType: string): Promise<Type> {
     const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
     return this.typeMap.lookup(Number(rows[0]?.oid));

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3630,8 +3630,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * also handles typmods (`(255)`), `[]` array suffixes, enums, and domains.
    * @internal
    */
-  // Rails keeps this private (postgresql/quoting.rb:195); TS can't narrow the
-  // now-inherited `AbstractAdapter#lookup_cast_type` to private in a subclass.
   async lookupCastType(sqlType: string): Promise<Type> {
     const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
     return this.typeMap.lookup(Number(rows[0]?.oid));

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3636,7 +3636,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // `lookupCastTypeFromColumn` (sync, OID-keyed) and `quoteDefaultExpression`
   // (awaits this), so no sync duck-typed consumer sees the promise. Tracked by
   // `pg-lookup-cast-type-async-divergence`.
-  async lookupCastType(sqlType: string): Promise<Type> {
+  async lookupCastType(sqlType: string | null): Promise<Type> {
     const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
     return this.typeMap.lookup(Number(rows[0]?.oid));
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3630,7 +3630,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * also handles typmods (`(255)`), `[]` array suffixes, enums, and domains.
    * @internal
    */
-  private async lookupCastType(sqlType: string): Promise<Type> {
+  // Rails keeps this private (postgresql/quoting.rb:195); TS can't narrow the
+  // now-inherited `AbstractAdapter#lookup_cast_type` to private in a subclass.
+  async lookupCastType(sqlType: string): Promise<Type> {
     const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
     return this.typeMap.lookup(Number(rows[0]?.oid));
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3628,14 +3628,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * type map is keyed by OID and short typname, so DDL-formatted names like
    * `character varying` resolve only through this regtype round-trip — which
    * also handles typmods (`(255)`), `[]` array suffixes, enums, and domains.
+   *
+   * Async where Rails (and the inherited `AbstractAdapter#lookup_cast_type`) is
+   * sync, and public where Rails keeps it private — TS cannot narrow an
+   * inherited member's visibility. Contained today: PG overrides both
+   * `lookupCastTypeFromColumn` (sync, OID-keyed) and `quoteDefaultExpression`
+   * (awaits this), so no sync duck-typed consumer sees the promise. Tracked by
+   * `pg-lookup-cast-type-async-divergence`.
    * @internal
    */
-  // Async where Rails (and the inherited `AbstractAdapter#lookup_cast_type`) is
-  // sync, and public where Rails keeps it private — TS cannot narrow an
-  // inherited member's visibility. Contained today: PG overrides both
-  // `lookupCastTypeFromColumn` (sync, OID-keyed) and `quoteDefaultExpression`
-  // (awaits this), so no sync duck-typed consumer sees the promise. Tracked by
-  // `pg-lookup-cast-type-async-divergence`.
   async lookupCastType(sqlType: string | null): Promise<Type> {
     const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
     return this.typeMap.lookup(Number(rows[0]?.oid));

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -8,7 +8,7 @@ import { deduplicate } from "./deduplicable.js";
 import type { Deduplicable } from "./deduplicable.js";
 
 export class SqlTypeMetadata implements Deduplicable {
-  readonly sqlType: string;
+  readonly sqlType: string | null;
   readonly type: string | undefined;
   readonly limit: number | null;
   readonly precision: number | null;
@@ -16,14 +16,17 @@ export class SqlTypeMetadata implements Deduplicable {
 
   constructor(
     options: {
-      sqlType?: string;
+      sqlType?: string | null;
       type?: string;
       limit?: number | null;
       precision?: number | null;
       scale?: number | null;
     } = {},
   ) {
-    this.sqlType = options.sqlType ?? options.type ?? "";
+    // Rails: `@sql_type = sql_type` (sql_type_metadata.rb:12) — nil stays nil.
+    // `fetch_type_metadata(nil)` (test/support/fake_adapter.rb:23) is a real
+    // producer, so neither the type name nor "" may stand in for it.
+    this.sqlType = options.sqlType ?? null;
     // Rails' SqlTypeMetadata#type is just `@type` — nil for an unmapped
     // sql_type (Value#type is nil). Keep it nil-faithful rather than falling
     // back to the sql_type name, so `Column#type` mirrors Rails' `delegate
@@ -59,7 +62,7 @@ export class SqlTypeMetadata implements Deduplicable {
   }
 
   toString(): string {
-    return this.sqlType;
+    return this.sqlType ?? "";
   }
 
   deduplicate(): this {
@@ -73,7 +76,7 @@ export class SqlTypeMetadata implements Deduplicable {
 }
 
 export interface SqlTypeMetadataJSON {
-  sqlType: string;
+  sqlType: string | null;
   type: string | undefined;
   limit: number | null;
   precision: number | null;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1200,14 +1200,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#lookup_cast_type
    */
-  lookupCastType(sqlType: string): import("@blazetrails/activemodel").Type {
+  lookupCastType(sqlType: string | null): import("@blazetrails/activemodel").Type {
     // Pass the full sql type to the map so regex registrations (e.g. /decimal/i)
     // can inspect precision/scale. Fall back to the bare normalized key when
     // no full-string match is found.
-    const lower = sqlType.toLowerCase().trim();
+    const lower = sqlType?.toLowerCase().trim() ?? null;
     const full = this._nativeTypeMap.fetch(lower);
     if (full.type() != null) return full;
-    const normalized = lower.replace(/\(.*\)/, "").trim();
+    const normalized = lower?.replace(/\(.*\)/, "").trim() ?? null;
     return this._nativeTypeMap.lookup(normalized);
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1198,7 +1198,16 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   /**
    * Resolve a SQL column type string to an ActiveRecord Type instance.
    *
-   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#lookup_cast_type
+   * NOT a Rails method: `sqlite3_adapter.rb` only *calls*
+   * `lookup_cast_type_from_column` (:628) and defines no
+   * `sqlite3/quoting.rb` counterpart, so this override — and the
+   * `_nativeTypeMap` fetch-full-then-lookup-normalized pair behind it — is a
+   * trails invention, like MySQL's. Converging it onto the inherited
+   * `Quoting#lookup_cast_type` is tracked by
+   * `sqlite3-native-type-map-converges-onto-type-map`.
+   *
+   * @noRailsEquivalent trails-only cast-type resolution over `_nativeTypeMap`;
+   * SQLite3Adapter declares no `lookup_cast_type` in Rails.
    */
   lookupCastType(sqlType: string | null): import("@blazetrails/activemodel").Type {
     // Pass the full sql type to the map so regex registrations (e.g. /decimal/i)

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1198,16 +1198,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   /**
    * Resolve a SQL column type string to an ActiveRecord Type instance.
    *
-   * NOT a Rails method: `sqlite3_adapter.rb` only *calls*
-   * `lookup_cast_type_from_column` (:628) and defines no
-   * `sqlite3/quoting.rb` counterpart, so this override — and the
-   * `_nativeTypeMap` fetch-full-then-lookup-normalized pair behind it — is a
-   * trails invention, like MySQL's. Converging it onto the inherited
-   * `Quoting#lookup_cast_type` is tracked by
-   * `sqlite3-native-type-map-converges-onto-type-map`.
-   *
-   * @noRailsEquivalent trails-only cast-type resolution over `_nativeTypeMap`;
-   * SQLite3Adapter declares no `lookup_cast_type` in Rails.
+   * A divergent override, NOT a port: `sqlite3_adapter.rb` only *calls*
+   * `lookup_cast_type_from_column` (:628) and defines no `sqlite3/quoting.rb`,
+   * so the inherited `Quoting#lookup_cast_type` (abstract/quoting.rb:234-236)
+   * is what Rails runs here. This override — and the `_nativeTypeMap`
+   * fetch-full-then-lookup-normalized pair behind it — is a trails invention,
+   * like MySQL's. Deliberately left flagged rather than tagged: converging it
+   * is `sqlite3-native-type-map-converges-onto-type-map`.
    */
   lookupCastType(sqlType: string | null): import("@blazetrails/activemodel").Type {
     // Pass the full sql type to the map so regex registrations (e.g. /decimal/i)
@@ -1245,9 +1242,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return new SqlTypeMetadata({
       sqlType: raw,
       type: castType.type(),
-      limit: castType.limit ?? null,
-      precision: castType.precision ?? null,
-      scale: castType.scale ?? null,
+      limit: castType.limit,
+      precision: castType.precision,
+      scale: castType.scale,
     });
   }
 

--- a/packages/activerecord/src/support/fake-adapter.test.ts
+++ b/packages/activerecord/src/support/fake-adapter.test.ts
@@ -27,6 +27,12 @@ describe("FakeActiveRecordAdapter", () => {
     expect(columns[1].null).toBe(false);
     expect(columns[1].default).toBe(0);
     expect(columns[0].sqlTypeMetadata?.sqlType).toBe("string");
+    // `type` is the cast type's own `type`, not the sql_type string: the
+    // abstract TYPE_MAP keys strings under /char/i, so "string" falls through
+    // to Type::Value (nil type) exactly as it does in Rails, while "integer"
+    // matches /int/i.
+    expect(columns[0].sqlTypeMetadata?.type).toBeUndefined();
+    expect(columns[1].sqlTypeMetadata?.type).toBe("integer");
   });
 
   it("columns is empty for an unknown table", () => {

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -44,12 +44,7 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
     options: MergeColumnOptions = {},
   ): void {
     this.columns(tableName).push(
-      new Column(
-        String(name),
-        options.default,
-        this.fetchTypeMetadata(sqlType ?? ""),
-        options.null,
-      ),
+      new Column(String(name), options.default, this.fetchTypeMetadata(sqlType), options.null),
     );
   }
 
@@ -72,7 +67,7 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
     return true;
   }
 
-  private fetchTypeMetadata(sqlType: string): SqlTypeMetadata {
+  private fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
     return (this as unknown as AbstractAdapter).schemaStatements().fetchTypeMetadata(sqlType);
   }
 }

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -17,7 +17,7 @@ const FakeAdapterBase = AbstractAdapter as unknown as new () => Omit<
   "dataSources" | "primaryKey" | "columns" | "active"
 >;
 
-interface MergeColumnOptions {
+export interface MergeColumnOptions {
   default?: unknown;
   null?: boolean;
 }

--- a/packages/activerecord/src/test-helpers/models/contact.ts
+++ b/packages/activerecord/src/test-helpers/models/contact.ts
@@ -1,51 +1,80 @@
 // vendor/rails/activerecord/test/models/contact.rb
 import { Base } from "../../base.js";
+import type { FakeActiveRecordAdapter } from "../../support/fake-adapter.js";
 
-// Contact uses a fake adapter with synthetic columns (ContactFakeColumns).
-// The fake adapter infrastructure is not ported; these classes declare the
-// association shape used by tests that exercise STI and serialization paths.
+interface ColumnOptions {
+  default?: unknown;
+  null?: boolean;
+}
 
-// The fake adapter's synthetic column list (id, name, age, avatar, created_at,
-// awesome, preferences, alternative_id) is declared directly on the class so
-// in-memory `new Contact(...)` round-trips the same attribute set Rails exposes.
-function declareContactColumns(klass: typeof Base): void {
-  klass.attribute("id", "integer");
-  klass.attribute("name", "string");
-  klass.attribute("age", "integer");
-  klass.attribute("avatar", "binary");
-  klass.attribute("created_at", "datetime");
-  klass.attribute("awesome", "boolean");
-  klass.attribute("preferences", "string");
-  klass.attribute("alternative_id", "integer");
+type ContactFakeColumnsHost = typeof Base & { column: typeof column };
+
+function fakeConnection(klass: typeof Base): FakeActiveRecordAdapter {
+  // Rails' `lease_connection` is synchronous; trails' is async, so a class-body
+  // caller uses the sync escape hatch.
+  return klass.connectionPool().leaseConnectionSync() as unknown as FakeActiveRecordAdapter;
+}
+
+/** Mirrors: ContactFakeColumns#column */
+function column(
+  this: typeof Base,
+  name: string,
+  sqlType: string | null = null,
+  options: ColumnOptions = {},
+): void {
+  fakeConnection(this).mergeColumn(this.tableName, name, sqlType, options);
+}
+
+/** Mirrors: ContactFakeColumns.extended */
+async function extended(base: ContactFakeColumnsHost): Promise<void> {
+  await base.establishConnection({ adapter: "fake" });
+
+  const connection = fakeConnection(base);
+  connection.dataSources = [base.tableName];
+  connection.primaryKeys = { [base.tableName]: "id" };
+
+  base.column("id", "integer");
+  base.column("name", "string");
+  base.column("age", "integer");
+  base.column("avatar", "binary");
+  base.column("created_at", "datetime");
+  base.column("awesome", "boolean");
+  base.column("preferences", "string");
+  base.column("alternative_id", "integer");
+
+  base.serialize("preferences");
+
+  base.belongsTo("alternative", { className: "Contact" });
 }
 
 export class Contact extends Base {
   declare alternative: Contact | null;
   declare loadBelongsTo: (name: "alternative") => Promise<Contact | null>;
 
-  static {
-    declareContactColumns(this);
-    this.serialize("preferences");
-    this.belongsTo("alternative", { className: "Contact" });
-  }
+  static column = column;
 }
 
-export class ContactSti extends Base {
-  declare alternative: ContactSti | null;
-  declare loadBelongsTo: (name: "alternative") => Promise<ContactSti | null>;
+await extended(Contact);
 
-  static {
-    this._tableName = "contacts";
-    declareContactColumns(this);
-    this.attribute("type", "string");
-    this.serialize("preferences");
-    this.belongsTo("alternative", { className: "ContactSti" });
-  }
+export class ContactSti extends Base {
+  declare alternative: Contact | null;
+  declare loadBelongsTo: (name: "alternative") => Promise<Contact | null>;
+
+  static column = column;
 
   // Rails: `def type; "ContactSti" end` — ContactSti overrides the `type`
   // reader to a constant so serialization still sees an inheritance-column
-  // value to exclude. Defined after the attribute reader so it wins.
+  // value to exclude.
   get type(): string {
     return "ContactSti";
   }
 }
+
+await extended(ContactSti);
+ContactSti.column("type", "string");
+
+// Rails reflects the fake adapter's columns lazily, on the first `columns`
+// read. trails' sync reflection path only sees an already-warm schema cache,
+// so warm it here — after the last `column` call — while we can still await.
+await Contact.loadSchema();
+await ContactSti.loadSchema();

--- a/packages/activerecord/src/test-helpers/models/contact.ts
+++ b/packages/activerecord/src/test-helpers/models/contact.ts
@@ -1,11 +1,6 @@
 // vendor/rails/activerecord/test/models/contact.rb
 import { Base } from "../../base.js";
-import type { FakeActiveRecordAdapter } from "../../support/fake-adapter.js";
-
-interface ColumnOptions {
-  default?: unknown;
-  null?: boolean;
-}
+import type { FakeActiveRecordAdapter, MergeColumnOptions } from "../../support/fake-adapter.js";
 
 type ContactFakeColumnsHost = typeof Base & { column: typeof column };
 
@@ -20,7 +15,7 @@ function column(
   this: typeof Base,
   name: string,
   sqlType: string | null = null,
-  options: ColumnOptions = {},
+  options: MergeColumnOptions = {},
 ): void {
   leaseConnection(this).mergeColumn(this.tableName, name, sqlType, options);
 }

--- a/packages/activerecord/src/test-helpers/models/contact.ts
+++ b/packages/activerecord/src/test-helpers/models/contact.ts
@@ -6,9 +6,13 @@ import type { MergeColumnOptions } from "../../support/fake-adapter.js";
 
 type ContactFakeColumnsHost = typeof Base & { column: typeof column };
 
-// Rails' `lease_connection` is synchronous; trails' is async, so a class-body
-// caller takes the sync escape hatch.
-function leaseConnection(klass: typeof Base): FakeActiveRecordAdapter {
+// Stands in for Rails' `lease_connection` reads in contact.rb:6-8/29, with two
+// deviations that keep it from being named after it: trails' `leaseConnection`
+// is async so a class-body caller takes the sync escape hatch, and the adapter
+// kind is asserted rather than cast. The distinct name also matters to
+// api:compare — a `leaseConnection` taking an argument would make the calls
+// gate treat every `lease_connection` call in the package as significant.
+function fakeConnection(klass: typeof Base): FakeActiveRecordAdapter {
   const connection = klass.connectionPool().leaseConnectionSync();
   if (!(connection instanceof FakeActiveRecordAdapter)) {
     throw new ConnectionNotEstablished(
@@ -25,14 +29,14 @@ function column(
   sqlType: string | null = null,
   options: MergeColumnOptions = {},
 ): void {
-  leaseConnection(this).mergeColumn(this.tableName, name, sqlType, options);
+  fakeConnection(this).mergeColumn(this.tableName, name, sqlType, options);
 }
 
 /** Mirrors: ContactFakeColumns.extended */
 async function extended(base: ContactFakeColumnsHost): Promise<void> {
   await base.establishConnection({ adapter: "fake" });
 
-  const connection = leaseConnection(base);
+  const connection = fakeConnection(base);
   connection.dataSources = [base.tableName];
   connection.primaryKeys = { [base.tableName]: "id" };
 

--- a/packages/activerecord/src/test-helpers/models/contact.ts
+++ b/packages/activerecord/src/test-helpers/models/contact.ts
@@ -9,9 +9,9 @@ interface ColumnOptions {
 
 type ContactFakeColumnsHost = typeof Base & { column: typeof column };
 
-function fakeConnection(klass: typeof Base): FakeActiveRecordAdapter {
-  // Rails' `lease_connection` is synchronous; trails' is async, so a class-body
-  // caller uses the sync escape hatch.
+// Rails' `lease_connection` is synchronous; trails' is async, so a class-body
+// caller takes the sync escape hatch.
+function leaseConnection(klass: typeof Base): FakeActiveRecordAdapter {
   return klass.connectionPool().leaseConnectionSync() as unknown as FakeActiveRecordAdapter;
 }
 
@@ -22,14 +22,14 @@ function column(
   sqlType: string | null = null,
   options: ColumnOptions = {},
 ): void {
-  fakeConnection(this).mergeColumn(this.tableName, name, sqlType, options);
+  leaseConnection(this).mergeColumn(this.tableName, name, sqlType, options);
 }
 
 /** Mirrors: ContactFakeColumns.extended */
 async function extended(base: ContactFakeColumnsHost): Promise<void> {
   await base.establishConnection({ adapter: "fake" });
 
-  const connection = fakeConnection(base);
+  const connection = leaseConnection(base);
   connection.dataSources = [base.tableName];
   connection.primaryKeys = { [base.tableName]: "id" };
 
@@ -62,9 +62,6 @@ export class ContactSti extends Base {
 
   static column = column;
 
-  // Rails: `def type; "ContactSti" end` — ContactSti overrides the `type`
-  // reader to a constant so serialization still sees an inheritance-column
-  // value to exclude.
   get type(): string {
     return "ContactSti";
   }
@@ -74,7 +71,7 @@ await extended(ContactSti);
 ContactSti.column("type", "string");
 
 // Rails reflects the fake adapter's columns lazily, on the first `columns`
-// read. trails' sync reflection path only sees an already-warm schema cache,
+// read. trails' synchronous reflection sees only an already-warm schema cache,
 // so warm it here — after the last `column` call — while we can still await.
 await Contact.loadSchema();
 await ContactSti.loadSchema();

--- a/packages/activerecord/src/test-helpers/models/contact.ts
+++ b/packages/activerecord/src/test-helpers/models/contact.ts
@@ -1,13 +1,21 @@
 // vendor/rails/activerecord/test/models/contact.rb
 import { Base } from "../../base.js";
-import type { FakeActiveRecordAdapter, MergeColumnOptions } from "../../support/fake-adapter.js";
+import { ConnectionNotEstablished } from "../../errors.js";
+import { FakeActiveRecordAdapter } from "../../support/fake-adapter.js";
+import type { MergeColumnOptions } from "../../support/fake-adapter.js";
 
 type ContactFakeColumnsHost = typeof Base & { column: typeof column };
 
 // Rails' `lease_connection` is synchronous; trails' is async, so a class-body
 // caller takes the sync escape hatch.
 function leaseConnection(klass: typeof Base): FakeActiveRecordAdapter {
-  return klass.connectionPool().leaseConnectionSync() as unknown as FakeActiveRecordAdapter;
+  const connection = klass.connectionPool().leaseConnectionSync();
+  if (!(connection instanceof FakeActiveRecordAdapter)) {
+    throw new ConnectionNotEstablished(
+      `${klass.name} expected the "fake" adapter, got ${connection.constructor.name}`,
+    );
+  }
+  return connection;
 }
 
 /** Mirrors: ContactFakeColumns#column */

--- a/packages/activerecord/src/type/type-map.ts
+++ b/packages/activerecord/src/type/type-map.ts
@@ -6,17 +6,21 @@ import { ArgumentError, Type, ValueType } from "@blazetrails/activemodel";
 export class TypeMap {
   private _mapping: Map<string | RegExp, (lookupKey: string) => Type> = new Map();
   private _parent?: TypeMap;
-  private _cache: Map<string, Type> = new Map();
+  private _cache: Map<string | null, Type> = new Map();
 
   constructor(parent?: TypeMap) {
     this._parent = parent;
   }
 
-  lookup(lookupKey: string): Type {
+  // `lookupKey` is nullable because Rails reaches here with a nil `sql_type`
+  // (`lookup_cast_type(column.sql_type)`, abstract/quoting.rb:125-127) and
+  // `Regexp#===(nil)` simply does not match. Nothing registers a key matching
+  // the coerced "null", so a nil key falls through to the default value type.
+  lookup(lookupKey: string | null): Type {
     return this.fetch(lookupKey, () => new ValueType());
   }
 
-  fetch(lookupKey: string, fallback?: (key: string) => Type): Type {
+  fetch(lookupKey: string | null, fallback?: (key: string) => Type): Type {
     const cached = this._cache.get(lookupKey);
     if (cached) return cached;
     const result = this._performFetch(lookupKey, fallback);
@@ -41,17 +45,19 @@ export class TypeMap {
     });
   }
 
-  protected _performFetch(lookupKey: string, fallback?: (key: string) => Type): Type {
+  protected _performFetch(lookupKey: string | null, fallback?: (key: string) => Type): Type {
     const entries = [...this._mapping.entries()].reverse();
     for (const [key, factory] of entries) {
       const matches =
-        typeof key === "string" ? key === lookupKey : ((key.lastIndex = 0), key.test(lookupKey));
-      if (matches) return factory(lookupKey);
+        typeof key === "string"
+          ? key === lookupKey
+          : ((key.lastIndex = 0), key.test(String(lookupKey)));
+      if (matches) return factory(lookupKey as string);
     }
     if (this._parent) {
       return this._parent._performFetch(lookupKey, fallback);
     }
-    if (fallback) return fallback(lookupKey);
+    if (fallback) return fallback(lookupKey as string);
     return new ValueType();
   }
 }
@@ -66,7 +72,7 @@ export class TypeMap {
  */
 export function performFetch(
   typeMap: TypeMap,
-  lookupKey: string,
+  lookupKey: string | null,
   fallback?: (key: string) => Type,
 ): Type {
   return (typeMap as any)._performFetch(lookupKey, fallback);

--- a/packages/activerecord/src/type/type-map.ts
+++ b/packages/activerecord/src/type/type-map.ts
@@ -13,9 +13,8 @@ export class TypeMap {
   }
 
   // `lookupKey` is nullable because Rails reaches here with a nil `sql_type`
-  // (`lookup_cast_type(column.sql_type)`, abstract/quoting.rb:125-127) and
-  // `Regexp#===(nil)` simply does not match. Nothing registers a key matching
-  // the coerced "null", so a nil key falls through to the default value type.
+  // (`lookup_cast_type(column.sql_type)`, abstract/quoting.rb:125-127); as with
+  // `Regexp#===(nil)`, a nil key matches nothing and falls to the default type.
   lookup(lookupKey: string | null): Type {
     return this.fetch(lookupKey, () => new ValueType());
   }
@@ -51,7 +50,7 @@ export class TypeMap {
       const matches =
         typeof key === "string"
           ? key === lookupKey
-          : ((key.lastIndex = 0), key.test(String(lookupKey)));
+          : lookupKey !== null && ((key.lastIndex = 0), key.test(lookupKey));
       if (matches) return factory(lookupKey as string);
     }
     if (this._parent) {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -205,13 +205,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "extended_type_map",
-    "call": "register_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "extended_type_map_key",
     "call": "emulate_booleans",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails abstract_mysql_adapter.rb:762-768 pairs @default_timezone with the emulate_booleans accessor; trails abstract-mysql-adapter.ts:1733-1743 reads the `_emulateBooleans` field directly."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/quoting.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/quoting.json
@@ -75,5 +75,12 @@
     "rubyName": "type_cast",
     "call": "quoted_time",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/quoting.ts",
+    "rubyName": "quote_default_expression",
+    "call": "call",
+    "reason": "Rails' `value.call` (abstract/quoting.rb:159) invokes a Proc default; the TS branch invokes the function directly (`value()`), which the extractor cannot see as a `call` call."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -943,5 +943,12 @@
     "rubyName": "write_query?",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "lookup_cast_type",
+    "call": "query_value",
+    "reason": "PG resolves the regtype OID through `schemaQuery` rather than `query_value`; the async signature that forces it is tracked by the `pg-lookup-cast-type-async-divergence` story."
   }
 ]

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -196,13 +196,6 @@ export const SKIP_GROUPS: SkipGroup[] = [
   },
   {
     reason:
-      "PostgreSQL::Quoting#lookup_cast_type issues an async DB query (SELECT oid) " +
-      "to resolve a sql_type string; our standalone-function quoting module has " +
-      "no adapter instance, so this can't be ported without a larger refactor.",
-    names: ["lookup_cast_type"],
-  },
-  {
-    reason:
       'CheckPending helpers — depend on Rails.root, system("bin/rails ..."), and ' +
       "the ActiveRecord::Tasks infrastructure that has no JS equivalent.",
     names: ["any_schema_needs_update?", "db_configs_in_current_env", "load_schema!"],
@@ -265,6 +258,18 @@ export interface ScopedSkipGroup {
 }
 
 export const SCOPED_SKIP_GROUPS: ScopedSkipGroup[] = [
+  {
+    reason:
+      "PostgreSQL::Quoting#lookup_cast_type resolves a sql_type string with a " +
+      "live `SELECT '<type>'::regtype::oid` query, so trails' port is async and " +
+      "diverges from the sync abstract signature it overrides; it is tracked by " +
+      "the `pg-lookup-cast-type-async-divergence` story rather than counted as " +
+      "a gap. Scoped to postgresql/quoting.rb: the abstract " +
+      "`Quoting#lookup_cast_type` (abstract/quoting.rb:234-236) IS ported, so a " +
+      "flat skip would now hide a real surface.",
+    names: ["lookup_cast_type"],
+    rubyFiles: ["connection_adapters/postgresql/quoting.rb"],
+  },
   {
     reason:
       "ActiveSupport::Duration#+@ (`def +@; self; end`, duration.rb:326) is " +

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -16,7 +16,7 @@
  *      Rails-private method exists in Rails (a visibility divergence, not
  *      extra surface). Map each to its TS-candidate name set via
  *      `rubyMethodCandidates`, which also resolves `conventions.SKIP`
- *      mirrors (`freeze`, `to_a`, `lookup_cast_type`) so a TS override is
+ *      mirrors (`freeze`, `to_a`, `inspect`) so a TS override is
  *      allowed in the file where Ruby defines the method. Union = the
  *      "allowed" TS name set.
  *   3. Collect public TS names declared in the matching TS file — each
@@ -174,7 +174,7 @@ const MIRROR_CANDIDATE_OVERRIDES: Record<string, string[]> = {
  *
  * `conventions.SKIP` means api:compare never expects a TS counterpart, but the
  * Ruby method still EXISTS in the file — so a TS override of it (`freeze`,
- * `inspect`, `lookupCastType`) is Rails-faithful, not drift. Mapping those
+ * `inspect`, `to_a`) is Rails-faithful, not drift. Mapping those
  * names here keeps the allowance *file-scoped*: `freeze` is allowed in core.ts
  * because core.rb defines `freeze`, and stays flagged anywhere Ruby doesn't.
  * That's strictly tighter than the blanket in-file allow-set this replaced.


### PR DESCRIPTION
Rewires the `Contact` / `ContactSti` test models onto the registered `"fake"`
adapter, mirroring `vendor/rails/activerecord/test/models/contact.rb`.

Before: the models declared their synthetic columns with `klass.attribute(...)`
in a local `declareContactColumns()` helper, under a stale comment claiming the
fake-adapter infrastructure was not ported (PR #5401 ported it). `attribute()`
suppresses DB reflection, so this was not merely stylistic — it changed which
code path supplied the column set.

After, mirroring `contact.rb:4-30`:

- `extended()` runs `establishConnection({ adapter: "fake" })`, then sets
  `dataSources` / `primaryKeys` on the leased fake connection.
- Every column goes through a `column()` static delegating to
  `mergeColumn(tableName, name, sqlType, options)`.
- `ContactSti` rides the same module-equivalent path, keeps its `type`
  override, and now uses its own Rails table name (`contact_stis`) instead of
  sharing `contacts` — the fake adapter's column store is keyed by table name,
  so sharing would leak `type` into `Contact`.
- Rails reflects the fake columns lazily; trails' synchronous reflection reads
  only an already-warm schema cache, so the module warms it with an explicit
  `loadSchema()` after the last `column` call.

Reaching a real cast type for those columns needed unported Rails type-map
machinery. Without it a reflected column's type stayed a bare `sql_type` string
and record construction blew up on `type.assertValidValue`:

- `AbstractAdapter#lookup_cast_type` (abstract/quoting.rb:234).
- `AbstractAdapter::TYPE_MAP` (abstract_adapter.rb:942), built on first read
  (the type classes it registers sit on a circular import edge) and keyed per
  adapter class, since Rails resolves `self::TYPE_MAP` against each class's
  `initialize_type_map`.
- `AbstractAdapter.extended_type_map` (abstract_adapter.rb:877-883), and
  `AbstractMysqlAdapter.extended_type_map` (abstract_mysql_adapter.rb:702-708)
  reshaped to Rails' `super` + `tinyint(1)` form instead of returning an empty
  `Map`.

## Review responses (round 8 — final)

1. **`@noRailsEquivalent` was the wrong tag** — agreed on both grounds and
   removed. The tag is explicitly not a parking spot for deferred work
   (api-build-stub-generation-plan.md:398-401) and is scoped to surface with no
   Ruby counterpart anywhere (:409-414); `lookup_cast_type` exists at
   abstract/quoting.rb:234 and `AbstractSQLite3Adapter` inherits it, so this is
   a divergent override, not a novel extra. The accurate prose and
   `sqlite3-native-type-map-converges-onto-type-map` stay; the surface stays
   flagged (sqlite3-adapter.ts back to 10 novel / 38 moved).
2. **MySQL's identical pair was undocumented** — same treatment applied:
   prose naming it a divergent override (including
   `lookupCastTypeFromColumn`'s invented null return) plus
   `mysql-native-type-map-converges-onto-type-map`, and no tag on either.
3. **Extra surface for `postgresql-adapter.ts` — the run, and the result.**
   `pnpm build && pnpm api:compare --wide-calls` then
   `tsx scripts/api-compare/extra-surface.ts --json`:

   ```
   postgresql-adapter.ts   8 novel, 33 moved
     novel: detach, enumValues, exec, executeMutation, resetPkSequence,
            serialFromDefaultFunction, setPkSequence, warmMaxIdentifierLength
     lookupCastType present in extras: false
   abstract-adapter.ts     3 novel, 11 moved   lookupCastType: false
   postgresql/quoting.ts   2 novel,  1 moved   lookupCastType: false
   ```

   `lookupCastType` is in no bucket's extras for either file — the counts are
   unchanged from before the SKIP was scoped. The mechanism is step 2 of the
   algorithm rather than `skipMirrorCandidates`: the allowed set for a TS file
   includes Ruby methods *included into* the entities its Ruby file declares,
   and `postgresql_adapter.rb` does `include PostgreSQL::Quoting`
   (`abstract_adapter.rb` likewise includes `Quoting`), so a public TS
   declaration of a Ruby-private included method is allowed in that bucket.

Nit: taken — SQLite3's own `fetchTypeMetadata` drops its `?? null` coercions
too, so it reads like the base.

## Review responses (round 7)

1. **`SQLite3Adapter#lookup_cast_type` has no Rails counterpart** — correct;
   `sqlite3_adapter.rb` only *calls* `lookup_cast_type_from_column` (:628) and
   there is no `sqlite3/quoting.rb`. The false `Mirrors:` line is replaced with
   `@noRailsEquivalent` naming the invention, and the counterpart story is
   `sqlite3-native-type-map-converges-onto-type-map` (with the same
   declarations-first ordering hazard as the MySQL one). Side effect: the tag
   drops it from counted extra surface (sqlite3-adapter.ts 38 → 37 moved).
2. **Extra surface for `postgresql-adapter.ts`** — clean, confirmed by
   `extra-surface.ts --json` on four separate full builds:
   `postgresql-adapter.ts` 8 novel / 33 moved with `lookupCastType` **absent**,
   `abstract-adapter.ts` 3 novel / 11 moved, also absent. The mechanism is
   step 2 of the algorithm, not `skipMirrorCandidates`: the allowed set for a
   TS file includes Ruby methods *included into* the entities its Ruby file
   declares, and `postgresql_adapter.rb` does `include PostgreSQL::Quoting`
   (likewise `abstract_adapter.rb` includes `Quoting`), so `lookup_cast_type`
   is allowed in both buckets regardless of TS visibility.

Nit: taken — `cast_type.limit/precision/scale` pass through bare per
schema_statements.rb:1722-1724; `SqlTypeMetadata` already defaults them.

## Review responses (round 6)

1. **`castType?.type` read the method object** — real bug, fixed.
   `Type#type` is a method in trails (`activemodel/src/type/value.ts:38`), not a
   getter, so `fetchTypeMetadata` was storing the unbound function; the local
   structural cast hid it. Now `castType?.type()` per
   schema_statements.rb:1721, with the cast replaced by the real `Type`.
   Regression coverage added at both producers: the `SchemaStatements` unit test
   (asserts `type === "string"` and `limit === 255`, plus a nil-sql_type case)
   and the fake-adapter test (Contact's synthetic columns — `"integer"` maps via
   `/int/i`, `"string"` correctly falls through to `Type::Value` with a nil
   `type`, exactly as the abstract TYPE_MAP does in Rails).
2. **Does PG reach `SchemaStatements#fetchTypeMetadata`?** Confirmed no — PG
   defines its own async `fetchTypeMetadata` keyed on OID
   (`postgresql-adapter.ts`), which is why the sync `Type` read here is safe
   despite PG's async `lookupCastType`. Stated at the method rather than left to
   the `?.` chain.
3. **Extra surface — verified, not assumed** (`extra-surface.ts --json`, fresh
   full build). `lookupCastType` appears in exactly two files, both as `moved`:
   `sqlite3-adapter.ts` and `abstract-mysql-adapter.ts`. It is **absent** from
   `postgresql-adapter.ts` and `abstract-adapter.ts`. Per-file counts are
   byte-identical to the pre-change baseline: sqlite3 10 novel/38 moved, PG
   8/33, abstract-mysql 6/23, abstract-adapter 3/11 — so scoping the SKIP moved
   nothing into the wrong bucket. The three `lookup_cast_type` wide-exclude
   buckets are also clean: the ratchet reports zero stale entries.

## Review responses (round 5)

1. **`sqlType ?? undefined` made the nil path worse** — correct, and worse in
   exactly the way described: with `type` set, `sql-type-metadata.ts`'s
   `?? options.type` substituted the type NAME. Fixed at the source instead of
   one layer down: `SqlTypeMetadata#sqlType` is `string | null` and stores nil
   verbatim (sql_type_metadata.rb:12), the `?? options.type ?? ""` chain is
   gone, and `fetchTypeMetadata` passes `sqlType` straight through. Blast
   radius was two call sites (`mysql/type-metadata.ts`, one unit-test stub).
2. **`type: castType?.type ?? "string"`** — fixed here rather than deferred:
   `fetchTypeMetadata` now passes `cast_type.type` bare, as
   schema_statements.rb:1721 does, so an unmapped sql_type keeps the nil `type`
   that sql-type-metadata.ts:27-31 already documents.
3. **Dead `typeof adapter.lookupCastType === "function"` guard** — removed;
   `fetchTypeMetadata` dispatches unconditionally per schema_statements.rb:1718.
   One unit-test stub was the only non-adapter host; it now carries the base
   method rather than justifying the guard.
4. **Extra-surface allowance** — confirmed from the `--json` output rather than
   assumed. `lookupCastType` appears in exactly two files, both as `moved`
   (`sqlite3-adapter.ts`, `abstract-mysql-adapter.ts`), with per-file counts
   identical before and after the SKIP change (10 novel/38 moved and
   6 novel/23 moved). It is **not** extra in `postgresql-adapter.ts` — PG's
   Ruby bucket already covers the reopened `PostgreSQL::Quoting` — nor in
   `abstract-adapter.ts`, whose allowed set includes `Quoting`'s methods
   because `AbstractAdapter` includes it. Data-layer ported methods went
   7718 → 7721. The stale `lookupCastType` example in `extra-surface.ts` is
   replaced.
5. **Wide-exclude entries for the three files** — re-checked: the ratchet
   reports zero stale entries, so all three still reflect reality. The move did
   surface two genuine call gaps in `quote_default_expression`, both now fixed
   by calling `lookup_cast_type` directly per abstract/quoting.rb:161. Two
   entries are baselined with reasons: PG's `query_value` (we use `schemaQuery`;
   tracked by the async story) and the standalone `quote_default_expression`'s
   `call` (Rails' `value.call` on a Proc is a direct `value()` invocation in TS).

Nit: taken — the quoting helper's receiver is `{ typeMap: TypeMap }`, and PG's
`HashLookupTypeMap` (a separate class in Rails too) is the documented exception
at the dispatch site.

## Review responses (round 4)

1. **`lookup_cast_type` SKIP was stale** — moved from flat `SKIP` to
   `SCOPED_SKIP_GROUPS` for `connection_adapters/postgresql/quoting.rb` only, so
   the now-ported abstract method is measured.
2. **Wrong layout file** — `lookupCastType` is implemented in
   `abstract/quoting.ts` (abstract/quoting.rb:234-236) and dispatched from
   `AbstractAdapter` the way `quote` and `typeCast` already are, so api:compare
   buckets it correctly.
3. **`unknown` return** — now `Type | Promise<Type> | null`, with the PG async
   arm and the MySQL null arm named at the declaration and tied to their stories.
4. **`?? ""` in `fake-adapter.ts`** — removed; a nil sql_type reaches
   `fetch_type_metadata` as it does at fake_adapter.rb:23.
5. **Under-asserted alias** — `timestamp` now asserts `isUtc`, pinning
   abstract_adapter.rb:881.

Nit: `super.extendedTypeMap` carries `override`.

## Review responses (round 3)

1. **`self::TYPE_MAP` no longer per-class — MySQL seeds from the abstract map** —
   confirmed inert today (the only reader of the base `typeMap` is
   `AbstractAdapter#lookupCastType`, and MySQL/SQLite/PG all override it), and
   the ordering hazard is now written into
   `mysql-native-type-map-converges-onto-type-map` as a **do-the-declarations-
   first** blocker: deleting `_nativeTypeMap` is precisely what un-masks it, and
   MySQL would silently cast every MySQL-specific sql_type
   (`tinytext`/`tinyblob`/`mediumint`/unsigned) through the abstract map.
2. **`SQLite3Adapter::EXTENDED_TYPE_MAPS`** — named in the `TYPE_MAP` doc
   alongside the `Mysql2Adapter`/`SQLite3Adapter` `TYPE_MAP` gap, including the
   shared-cache consequence, and added to the same story's acceptance criteria
   rather than half-declared here.
3. **`String(lookupKey)` coercion** — fixed;
   `_performFetch` short-circuits `lookupKey !== null` before testing, so a
   pattern that happens to match `"null"` cannot fire where `Regexp#===(nil)`
   never would. The comment shrank accordingly.
4. **Memoization test on shared global state** — intentional (constant lookup
   walks to `AbstractAdapter` exactly as in Ruby), but the assertion now names
   `AbstractAdapter.EXTENDED_TYPE_MAPS` explicitly, with a comment, so the
   sharing is visible instead of implied.

## Review responses (round 2)

1. **`EXTENDED_TYPE_MAPS` never defined** — fixed. Added to `AbstractAdapter`
   (abstract_adapter.rb:943) and `AbstractMysqlAdapter`
   (abstract_mysql_adapter.rb:754), and `type_map` collapsed to Rails'
   `compute_if_absent` shape now that the fallback branch is gone. Covered by a
   test asserting the map is memoized per key rather than rebuilt per read.
2. **`PostgreSQLAdapter.TYPE_MAP` throws** — fixed, and confirmed against the
   Ruby: `TYPE_MAP` is declared on `AbstractAdapter` (942), `Mysql2Adapter`
   (53), `SQLite3Adapter` (505) and `TrilogyAdapter` (93) — never on
   `PostgreSQLAdapter` or `AbstractMysqlAdapter`. The per-class WeakMap keying
   is reverted: the constant lives on `AbstractAdapter` alone, so PG and
   AbstractMysql inherit it and neither re-runs its own `initialize_type_map`.
   The missing `Mysql2Adapter` / `SQLite3Adapter` declarations (and the MySQL
   `initialize_type_map` registrations that live only in `_buildTypeMap`) are
   covered by the story filed for item 4.
3. **`super` instead of the hard-coded base** — fixed;
   `AbstractMysqlAdapter.extendedTypeMap` now calls
   `super.extendedTypeMap(options)`, mirroring abstract_mysql_adapter.rb:703.
4. **MySQL's `lookup_cast_type` override** — agreed, and filed as
   `mysql-native-type-map-converges-onto-type-map`: delete the MySQL
   `lookup_cast_type` / `lookup_cast_type_from_column` pair and the invented
   `_nativeTypeMap` / `_buildTypeMap` slots, declare the `TYPE_MAP` /
   `EXTENDED_TYPE_MAPS` constants Rails declares, and port MySQL's
   `initialize_type_map` registrations. It subsumes
   `mysql-extended-type-map-default-timezone`, which is closed as superseded.

Nit: taken — `TypeMap#lookup`, `TypeMap#fetch` and `lookup_cast_type` now accept
`string | null`, so the nil-`sql_type` path is typed rather than cast, with the
`Regexp#===(nil)` equivalence noted where the coercion happens.

## Review responses (round 1)

1. **`extended_type_map` landmine** — fixed. The invented bare-`Map` fallback in
   `type_map` is gone; a `defaultTimezone`-configured adapter now gets a real
   `TypeMap` seeded from `TYPE_MAP` with timezone-aware `Time`/`DateTime` and
   the `timestamp` alias, per `abstract_adapter.rb:877-883`. Covered by two new
   tests, and the lifecycle test that asserted the empty `Map` now asserts the
   `TypeMap` (name unchanged).
2. **Dead guard + test patched to keep it alive** — fixed. The adapter method is
   Rails' one-liner `lookup_cast_type(column.sql_type)` (quoting.rb:125-127),
   including passing a nil `sql_type` straight through; the test case for the
   unreachable branch is deleted. The standalone `abstract/quoting.ts` version
   keeps its guard — it is also bound to adapter-less hosts
   (`ABSTRACT_SCHEMA_QUOTER`, the MySQL schema quoter) that have no type map —
   and now says so in its JSDoc.
3. **PG's async override** — understood, not accidental, and now documented at
   the declaration. It is contained: PG overrides both `lookupCastTypeFromColumn`
   (sync, OID-keyed, `postgresql-adapter.ts:961`) and `quoteDefaultExpression`
   (awaits the promise), so no sync duck-typed consumer receives it. Tracked by
   story `pg-lookup-cast-type-async-divergence`.
4. **Blast radius** — the claim is now stated precisely: the only hosts that
   reach `fetchTypeMetadata`'s previously-`"string"` branch are those that do
   not define `lookup_cast_type`, i.e. the fake adapter and test doubles;
   SQLite3, MySQL and PostgreSQL all override it (and PG overrides `typeMap`
   outright).
5. **Top-level await through the model index** — checked. `reflection`,
   `finder`, `calculations`, `statement-cache`, `habtm-destroy-order` and
   `insert-all` all import `support/canonical-model-index.js`; all 642 tests
   pass with the TLA in place.
6. **Unchecked cast** — fixed. `leaseConnection()` now asserts
   `instanceof FakeActiveRecordAdapter` and raises `ConnectionNotEstablished`
   naming the adapter it actually got.

Nit: the static `TYPE_MAP` getter is now keyed per class, so `ctor.TYPE_MAP`
resolves each adapter's own map rather than the abstract one — which is what
`self::TYPE_MAP` does in Ruby. Your trace matches mine: no reader outside
`lookup_cast_type`.

## Verification

`json-serialization.test.ts` (27), `serialization.test.ts`, `adapter.test.ts`,
`quoting.test.ts`, `model-schema*.test.ts`, `type/`, the canonical-model-index
consumers `schema-dumper`, `defaults`, `instantiate-schema-types`, and the whole
`connection-adapters/` tree — green after every review round (latest: 92 files,
1743 tests).
`api:compare`, `api:extra`, `api:calls`, `api:arity`, `api:reasons`,
`test:compare` clean. No test renames.

`api:calls:wide` is green (4825 baselined) and `api:calls` is green (15).

**Correction to earlier revisions of this description:** the six
`lease_connection` wide-call mismatches were NOT pre-existing — they were caused
by this branch, and CI (`Rails API/Test Comparison`) caught it. `contact.ts`'s
lease helper was named `leaseConnection` and took a `klass` argument; the wide
gate only treats a Ruby call as significant when its TS candidate is a ported
method that takes arguments *somewhere in the package*
(`isPortedWithArgs`, compare.ts:236), and that side-map is global. One
test-helper function therefore made every `lease_connection` call in
`activerecord` significant, flagging six methods in files this branch never
touched. Renaming it to `fakeConnection` restores the gate. The story filed on
the mistaken premise, `wide-call-lease-connection-unbaselined`, is closed —
except for the one genuine gap it recorded, which is real regardless: Rails'
`query_assertions.rb:19` opens with `lease_connection.materialize_transactions`
and trails' `assert_queries_count` / `assert_queries_match` have no such call.
That is re-filed as `query-assertions-missing-materialize-transactions`.

## Follow-ups

- `pg-lookup-cast-type-async-divergence` — PG's async/public `lookup_cast_type`.
- `mysql-native-type-map-converges-onto-type-map` — delete `_nativeTypeMap` /
  `_buildTypeMap` and the MySQL `lookup_cast_type` pair; adds the
  `Mysql2Adapter` / `SQLite3Adapter` `TYPE_MAP` and `EXTENDED_TYPE_MAPS`
  declarations Rails has. Carries an explicit ordering hazard: the declarations
  must land in the same change. Supersedes
  `mysql-extended-type-map-default-timezone` (closed).
- `query-assertions-missing-materialize-transactions` — `assert_queries_count`
  omits Rails' `lease_connection.materialize_transactions`
  (query_assertions.rb:19), plus triage of the four sibling `lease_connection`
  sites. Replaces `wide-call-lease-connection-unbaselined`, closed as
  wrong-premise.
- `sqlite3-native-type-map-converges-onto-type-map` — SQLite3's counterpart to
  the MySQL story above.
- `sql-type-metadata-nullable-sql-type` — filed when the fix looked wide;
  this PR ended up implementing it (blast radius was two call sites), so it
  closes with this PR rather than carrying forward.

Closes-story: rewire-contact-model-onto-fake-adapter
