### PR TITLE
test(support): resolve mysql2 preparedStatements from MYSQL_PREPARED_STATEMENTS

### DIFF
--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -86,7 +86,7 @@ describe("config", () => {
   it("interpolates exactly the sub-setting key set config.example.yml interpolates", () => {
     // Rails interpolates only MYSQL_HOST/MYSQL_PORT/MYSQL_SOCK
     // (config.example.yml:12-20) plus MYSQL_PREPARED_STATEMENTS
-    // (config.example.yml:7-11,26-30) and hard-codes the credential and database;
+    // (config.example.yml:7-11,27-31) and hard-codes the credential and database;
     // its postgresql: entries carry no fields so libpq reads PG* itself
     // (config.example.yml:74-81). AR_DB_SLOT is the one trails addition — the
     // per-worker database copy Rails has no analogue for. Re-widening this set
@@ -117,7 +117,7 @@ describe("config", () => {
   });
 
   it("turns prepared statements on when MYSQL_PREPARED_STATEMENTS is present", () => {
-    // config.example.yml:7-11,26-30 tests the var with a bare `if`, so any
+    // config.example.yml:7-11,27-31 tests the var with a bare `if`, so any
     // value at all — including "" and "0" — turns prepared statements on.
     expect(mysqlPreparedStatements(reader({}))).toBe(false);
     expect(mysqlPreparedStatements(reader({ MYSQL_PREPARED_STATEMENTS: "1" }))).toBe(true);

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   driverConfig,
   settingsUrl,
+  mysqlPreparedStatements,
   mysqlSettings,
   mysqlUrl,
   postgresSettings,
@@ -84,7 +85,8 @@ describe("config", () => {
 
   it("interpolates exactly the sub-setting key set config.example.yml interpolates", () => {
     // Rails interpolates only MYSQL_HOST/MYSQL_PORT/MYSQL_SOCK
-    // (config.example.yml:12-20) and hard-codes the credential and database;
+    // (config.example.yml:12-20) plus MYSQL_PREPARED_STATEMENTS
+    // (config.example.yml:7-11,26-30) and hard-codes the credential and database;
     // its postgresql: entries carry no fields so libpq reads PG* itself
     // (config.example.yml:74-81). AR_DB_SLOT is the one trails addition — the
     // per-worker database copy Rails has no analogue for. Re-widening this set
@@ -96,8 +98,15 @@ describe("config", () => {
     };
 
     mysqlSettings(recording({}));
+    mysqlPreparedStatements(recording({}));
     expect(new Set(seen)).toEqual(
-      new Set(["MYSQL_HOST", "MYSQL_PORT", "MYSQL_SOCK", "AR_DB_SLOT"]),
+      new Set([
+        "MYSQL_HOST",
+        "MYSQL_PORT",
+        "MYSQL_SOCK",
+        "MYSQL_PREPARED_STATEMENTS",
+        "AR_DB_SLOT",
+      ]),
     );
 
     seen.length = 0;
@@ -105,6 +114,15 @@ describe("config", () => {
     expect(new Set(seen)).toEqual(
       new Set(["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "AR_DB_SLOT"]),
     );
+  });
+
+  it("turns prepared statements on when MYSQL_PREPARED_STATEMENTS is present", () => {
+    // config.example.yml:7-11,26-30 tests the var with a bare `if`, so any
+    // value at all — including "" and "0" — turns prepared statements on.
+    expect(mysqlPreparedStatements(reader({}))).toBe(false);
+    expect(mysqlPreparedStatements(reader({ MYSQL_PREPARED_STATEMENTS: "1" }))).toBe(true);
+    expect(mysqlPreparedStatements(reader({ MYSQL_PREPARED_STATEMENTS: "0" }))).toBe(true);
+    expect(mysqlPreparedStatements(reader({ MYSQL_PREPARED_STATEMENTS: "" }))).toBe(true);
   });
 
   it("suffixes the database with the worker isolation slot above slot 1", () => {

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -21,8 +21,11 @@
  *     `connections:` hash (`test/support/connection.rb:10,14-19`). Nothing
  *     else selects a backend — there is no "is this env var set?" sniffing.
  *   - **How to reach it** comes from the connection entry itself, over which
- *     Rails interpolates exactly three env vars: `MYSQL_HOST` / `MYSQL_PORT` /
- *     `MYSQL_SOCK` (`config.example.yml:12-20`). The postgresql entries carry
+ *     Rails interpolates exactly four env vars: `MYSQL_HOST` / `MYSQL_PORT` /
+ *     `MYSQL_SOCK` (`config.example.yml:12-20`) and
+ *     `MYSQL_PREPARED_STATEMENTS` (`config.example.yml:7-11,26-30`), the last
+ *     of which selects a value rather than supplying one — see
+ *     {@link mysqlPreparedStatements}. The postgresql entries carry
  *     no connection fields at all (`config.example.yml:74-81`), leaving libpq
  *     to resolve `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD` itself.
  *
@@ -192,8 +195,8 @@ export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
 /**
  * MySQL/MariaDB connection details.
  *
- * Exactly the three keys Rails interpolates — `MYSQL_HOST` / `MYSQL_PORT` /
- * `MYSQL_SOCK` (`config.example.yml:12-20`) — over the hard-coded
+ * Exactly the three connection keys Rails interpolates — `MYSQL_HOST` /
+ * `MYSQL_PORT` / `MYSQL_SOCK` (`config.example.yml:12-20`) — over the hard-coded
  * `username: rails` (`config.example.yml:4,24`) and the `expand_config`
  * database. The credential is not env-driven because Rails' is not.
  */
@@ -205,6 +208,22 @@ export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
     database: applySlot(ARUNIT_DATABASE, read),
     socket: present(read, "MYSQL_SOCK"),
   };
+}
+
+/**
+ * The mysql2 `prepared_statements` value for the `arunit` / `arunit2` entries:
+ * `true` when `MYSQL_PREPARED_STATEMENTS` is set, `false` otherwise
+ * (`config.example.yml:7-11,26-30`).
+ *
+ * Presence, not truthiness, and deliberately not routed through the
+ * empty-string rejection the other sub-settings use: Rails tests the variable
+ * with a bare `if`, under which `""` and `"0"` are both truthy, so
+ * `MYSQL_PREPARED_STATEMENTS=` turns prepared statements ON there and must here
+ * too. `arunit_without_prepared_statements` is unaffected — that entry exists
+ * to be the one with them off (`config.rb:27-28`).
+ */
+export function mysqlPreparedStatements(read: EnvReader = getEnv): boolean {
+  return read("MYSQL_PREPARED_STATEMENTS") !== undefined;
 }
 
 /**

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -23,7 +23,7 @@
  *   - **How to reach it** comes from the connection entry itself, over which
  *     Rails interpolates exactly four env vars: `MYSQL_HOST` / `MYSQL_PORT` /
  *     `MYSQL_SOCK` (`config.example.yml:12-20`) and
- *     `MYSQL_PREPARED_STATEMENTS` (`config.example.yml:7-11,26-30`), the last
+ *     `MYSQL_PREPARED_STATEMENTS` (`config.example.yml:7-11,27-31`), the last
  *     of which selects a value rather than supplying one — see
  *     {@link mysqlPreparedStatements}. The postgresql entries carry
  *     no connection fields at all (`config.example.yml:74-81`), leaving libpq
@@ -213,7 +213,7 @@ export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
 /**
  * The mysql2 `prepared_statements` value for the `arunit` / `arunit2` entries:
  * `true` when `MYSQL_PREPARED_STATEMENTS` is set, `false` otherwise
- * (`config.example.yml:7-11,26-30`).
+ * (`config.example.yml:7-11,27-31`).
  *
  * Presence, not truthiness, and deliberately not routed through the
  * empty-string rejection the other sub-settings use: Rails tests the variable

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -219,8 +219,11 @@ export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
  * empty-string rejection the other sub-settings use: Rails tests the variable
  * with a bare `if`, under which `""` and `"0"` are both truthy, so
  * `MYSQL_PREPARED_STATEMENTS=` turns prepared statements ON there and must here
- * too. `arunit_without_prepared_statements` is unaffected — that entry exists
- * to be the one with them off (`config.rb:27-28`).
+ * too. `arunit_without_prepared_statements` is unaffected: the yml carries no
+ * `prepared_statements` key on the mysql2 entry (it does not spell that entry
+ * out at all), so Rails falls back to
+ * `Mysql2Adapter#default_prepared_statements` (`mysql2_adapter.rb:186-188`),
+ * which is `false` whatever the env var says.
  */
 export function mysqlPreparedStatements(read: EnvReader = getEnv): boolean {
   return read("MYSQL_PREPARED_STATEMENTS") !== undefined;

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -67,7 +67,9 @@ describe("connect", () => {
 
   it("turns prepared statements on for mysql2 when MYSQL_PREPARED_STATEMENTS is set", async () => {
     // config.example.yml:7-11,26-30 — the var flips arunit and arunit2 only;
-    // the third entry exists to be the one with them off (config.rb:27-28).
+    // the third entry carries no prepared_statements key on mysql2, so it
+    // falls back to Mysql2Adapter#default_prepared_statements
+    // (mysql2_adapter.rb:186-188), which is false.
     vi.stubEnv("ARCONN", "mysql2");
     vi.stubEnv("MYSQL_PREPARED_STATEMENTS", undefined);
     const off = (await testConfigurationHashes()).configurationHashes;

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -65,6 +65,19 @@ describe("connect", () => {
     expect(withoutPrepared.adapter).toBe("mysql2");
   });
 
+  it("turns prepared statements on for mysql2 when MYSQL_PREPARED_STATEMENTS is set", async () => {
+    // config.example.yml:7-11,26-30 — the var flips arunit and arunit2 only;
+    // the third entry exists to be the one with them off (config.rb:27-28).
+    vi.stubEnv("ARCONN", "mysql2");
+    vi.stubEnv("MYSQL_PREPARED_STATEMENTS", undefined);
+    const off = (await testConfigurationHashes()).configurationHashes;
+    expect(off.map((c) => c.configurationHash.preparedStatements)).toEqual([false, false, false]);
+
+    vi.stubEnv("MYSQL_PREPARED_STATEMENTS", "1");
+    const on = (await testConfigurationHashes()).configurationHashes;
+    expect(on.map((c) => c.configurationHash.preparedStatements)).toEqual([true, true, false]);
+  });
+
   it("carries min_messages on every postgresql entry", async () => {
     vi.stubEnv("ARCONN", "postgresql");
     const { configurationHashes } = await testConfigurationHashes();

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -66,7 +66,7 @@ describe("connect", () => {
   });
 
   it("turns prepared statements on for mysql2 when MYSQL_PREPARED_STATEMENTS is set", async () => {
-    // config.example.yml:7-11,26-30 — the var flips arunit and arunit2 only;
+    // config.example.yml:7-11,27-31 — the var flips arunit and arunit2 only;
     // the third entry carries no prepared_statements key on mysql2, so it
     // falls back to Mysql2Adapter#default_prepared_statements
     // (mysql2_adapter.rb:186-188), which is false.

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -194,9 +194,13 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
     // `config.example.yml:3-40`: `arunit` and `arunit2` differ — unicode vs
     // general collation, and only `arunit` carries the `time_zone` variable.
     // Rails leaves `arunit_without_prepared_statements` out for mysql2, so
-    // `expandConfig` synthesizes it from the defaults alone — and pins its
-    // `preparedStatements: false` regardless of `MYSQL_PREPARED_STATEMENTS`,
-    // which is the whole point of that entry (`config.rb:27-28`).
+    // `expandConfig` synthesizes it from the defaults alone. Its
+    // `preparedStatements: false` therefore does NOT come from the yml or from
+    // `expand_config` (which fills in `database` / `adapter` only,
+    // `config.rb:26-37`): with no key on the entry, Rails falls back to
+    // `Mysql2Adapter#default_prepared_statements` (`mysql2_adapter.rb:186-188`),
+    // which is `false`. So the entry stays off whatever
+    // `MYSQL_PREPARED_STATEMENTS` says, matching Rails.
     //
     // `buildAdapterArg` forwards the whole hash to mysql2, which logs
     // "Ignoring invalid configuration option" for the keys it does not know
@@ -287,8 +291,11 @@ function expandConfig(
     const entry = { ...(entries[name] ?? {}) };
     entry.database ??= defaultDatabase[name];
     entry.adapter ??= connection.adapter;
-    // Rails' third entry exists to turn prepared statements off, so a
-    // connection that does not spell the entry out still gets the flag.
+    // Rails' third entry exists to turn prepared statements off. Spelling the
+    // flag out here is what the postgresql yml does
+    // (`config.example.yml:77-79`); on mysql2, where no entry is spelled out at
+    // all, it stands in for `Mysql2Adapter#default_prepared_statements`
+    // (`mysql2_adapter.rb:186-188`) — same `false`, reached a different way.
     if (name === "arunit_without_prepared_statements") entry.preparedStatements ??= false;
     return new HashConfig(name, "primary", entry);
   });

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -36,6 +36,7 @@ import {
   CONNECTION_LANES,
   DEFAULT_CONNECTION,
   driverConfig,
+  mysqlPreparedStatements,
   mysqlSettings,
   postgresSettings,
   type ConnectionName,
@@ -193,7 +194,9 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
     // `config.example.yml:3-40`: `arunit` and `arunit2` differ — unicode vs
     // general collation, and only `arunit` carries the `time_zone` variable.
     // Rails leaves `arunit_without_prepared_statements` out for mysql2, so
-    // `expandConfig` synthesizes it from the defaults alone.
+    // `expandConfig` synthesizes it from the defaults alone — and pins its
+    // `preparedStatements: false` regardless of `MYSQL_PREPARED_STATEMENTS`,
+    // which is the whole point of that entry (`config.rb:27-28`).
     //
     // `buildAdapterArg` forwards the whole hash to mysql2, which logs
     // "Ignoring invalid configuration option" for the keys it does not know
@@ -204,12 +207,13 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
     // `mysql-adapter-arg-whitelist`.
     build: async () => {
       const shared = serverHash("mysql2", mysqlSettings());
+      const preparedStatements = mysqlPreparedStatements();
       return {
         arunit: {
           ...shared,
           encoding: "utf8mb4",
           collation: "utf8mb4_unicode_ci",
-          preparedStatements: false,
+          preparedStatements,
           variables: { time_zone: "+00:00" },
         },
         arunit2: {
@@ -217,7 +221,7 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
           database: undefined,
           encoding: "utf8mb4",
           collation: "utf8mb4_general_ci",
-          preparedStatements: false,
+          preparedStatements,
         },
       };
     },

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -197,7 +197,7 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
     // `expandConfig` synthesizes it from the defaults alone. Its
     // `preparedStatements: false` therefore does NOT come from the yml or from
     // `expand_config` (which fills in `database` / `adapter` only,
-    // `config.rb:26-37`): with no key on the entry, Rails falls back to
+    // `support/config.rb:26-41`): with no key on the entry, Rails falls back to
     // `Mysql2Adapter#default_prepared_statements` (`mysql2_adapter.rb:186-188`),
     // which is `false`. So the entry stays off whatever
     // `MYSQL_PREPARED_STATEMENTS` says, matching Rails.
@@ -256,7 +256,7 @@ export function configuredConnectionHash(): Record<string, unknown> {
 
 /**
  * Expand a connection's entries into the three named configs, mirroring
- * `expand_config` (`config.rb:26-37`): iterate `arunit`, `arunit2` and
+ * `expand_config` (`support/config.rb:26-41`): iterate `arunit`, `arunit2` and
  * `arunit_without_prepared_statements`, creating any the connection omits, then
  * fill in only a missing `database` or `adapter`. Options a connection does
  * declare are preserved per entry — mysql2's two collations, postgresql's


### PR DESCRIPTION
`config.example.yml:7-11,27-31` makes the mysql2 `prepared_statements` value an
env toggle — `true` when `ENV['MYSQL_PREPARED_STATEMENTS']` is present, `false`
otherwise — on both `arunit` and `arunit2`. `support/connection.ts` hardcoded
`preparedStatements: false` on both, so the var was inert: there was no way to
run the mysql lane with prepared statements on, and
`arunit_without_prepared_statements` — whose whole purpose is to be the one
entry with them off (its `false` comes from `Mysql2Adapter#default_prepared_statements`, `mysql2_adapter.rb:186-188`) — was indistinguishable from `arunit`.
Surfaced during review of #5516, which made that entry the source for
`newRawTestAdapter()` as well as the pool.

- New `mysqlPreparedStatements()` reader in `support/config.ts`; the mysql2
  `arunit` / `arunit2` builders use it.
- **Presence, not truthiness**: Rails tests the var with a bare `if`, under
  which `""` and `"0"` are both truthy, so the reader deliberately does *not*
  route through `present()`'s empty-string rejection. Pinned by a test.
- `arunit_without_prepared_statements` keeps `preparedStatements: false`
  regardless — `expandConfig` synthesizes it from `{}` for mysql2.
- `config.test.ts`'s "interpolates exactly the sub-setting key set
  config.example.yml interpolates" assertion now covers
  `MYSQL_PREPARED_STATEMENTS`.

Closes-story: mysql-prepared-statements-env-toggle
