### PR TITLE
test(schema): port the defaults tables of every *_specific_schema.rb

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -836,7 +836,14 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("DefaultsUsingMultipleSchemasAndDomainTest", () => {
     const DOMAIN_SCHEMA = "schema_1";
+    let oldSearchPath: string;
 
+    // Rails sets the search path to `schema_1, pg_catalog` BEFORE creating
+    // `defaults` and restores it in teardown, so the domain-typed table only
+    // ever lives in `schema_1` and is dropped with the schema (drop_schema is
+    // CASCADE). `public` must stay off the path and the table must never be
+    // dropped by name: `public.defaults` is the boot-laid
+    // postgresql_specific_schema.rb table on the shared per-worker DB.
     beforeEach(async () => {
       await adapter.dropSchema(DOMAIN_SCHEMA, { ifExists: true });
       await adapter.createSchema(DOMAIN_SCHEMA);
@@ -844,7 +851,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`CREATE DOMAIN ${DOMAIN_SCHEMA}.varchar AS varchar`);
       await adapter.exec(`CREATE DOMAIN ${DOMAIN_SCHEMA}.numeric AS numeric`);
       await adapter.exec(`CREATE DOMAIN ${DOMAIN_SCHEMA}.bpchar AS bpchar`);
-      await adapter.exec(`DROP TABLE IF EXISTS defaults`);
+      oldSearchPath = await adapter.schemaSearchPath();
+      await adapter.setSchemaSearchPath(`${DOMAIN_SCHEMA}, pg_catalog`);
+      // Torn down by the afterEach `dropSchema` (DROP SCHEMA … CASCADE), which
+      // is how Rails disposes of it — dropping it by name would hit the
+      // boot-laid `public.defaults` instead.
+      // eslint-disable-next-line blazetrails/require-table-teardown
       await adapter.exec(`
         CREATE TABLE defaults (
           id serial primary key,
@@ -853,10 +865,9 @@ describeIfPg("PostgreSQLAdapter", () => {
           decimal_col ${DOMAIN_SCHEMA}.numeric DEFAULT 3.14159265358979323846
         )
       `);
-      await adapter.setSchemaSearchPath(`${DOMAIN_SCHEMA},public,pg_catalog`);
     });
     afterEach(async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS defaults`);
+      await adapter.setSchemaSearchPath(oldSearchPath);
       await adapter.dropSchema(DOMAIN_SCHEMA, { ifExists: true });
     });
 

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -17,7 +17,6 @@ import {
   isMariaDb,
   Mysql2Adapter,
   MYSQL_TEST_URL,
-  supportsDefaultExpression,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
 import { describeIfPg } from "./adapters/postgresql/test-helper.js";
 import { describeIfSqlite } from "./adapters/sqlite3/test-helper.js";
@@ -78,24 +77,16 @@ describe("DefaultTest", () => {
 describe.skipIf(adapterType === "mysql")("DefaultTest", () => {
   it("multiline default text", async () => {
     const adapter = Base.connection;
-    const ctx = new MigrationContext(adapter);
-    await ctx.createTable("defaults", { force: true }, (t: any) => {
-      t.text("multiline_default", { default: "--- []\n\n" });
-    });
-    try {
-      class Default extends Base {
-        static override tableName = "defaults";
-      }
-      Default.adapter = adapter;
-      await Default.loadSchema();
-      // Rails: assert("--- []\n\n" == record.multiline_default ||
-      //               "--- []\\012\\012" == record.multiline_default)
-      // Older PostgreSQL versions reflect the default with escaped newlines.
-      const multiline = (new Default() as any).multiline_default;
-      expect(["--- []\n\n", "--- []\\012\\012"]).toContain(multiline);
-    } finally {
-      await ctx.dropTable("defaults", { ifExists: true });
+    class Default extends Base {
+      static override tableName = "defaults";
     }
+    Default.adapter = adapter;
+    await Default.loadSchema();
+    // Rails: assert("--- []\n\n" == record.multiline_default ||
+    //               "--- []\\012\\012" == record.multiline_default)
+    // Older PostgreSQL versions reflect the default with escaped newlines.
+    const multiline = (new Default() as any).multiline_default;
+    expect(["--- []\n\n", "--- []\\012\\012"]).toContain(multiline);
   });
 });
 
@@ -263,40 +254,12 @@ describeIfSupports("text_column_with_default", "DefaultTextTest", () => {
 
 // Mirrors `PostgresqlDefaultExpressionTest` (defaults_test.rb), gated to the
 // PostgreSQLAdapter. The `defaults` table comes from postgresql_specific_schema.rb
-// — built here with the migration DSL (expression defaults round-trip through the
-// catalog and reflect via column.defaultFunction) and dumped via dump_table_schema.
+// and is laid at boot by the adapter-specific arm of loadSchema.
 describeIfPg("PostgresqlDefaultExpressionTest", () => {
   let adapter: DatabaseAdapter;
-  let ctx: MigrationContext;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
-    await ctx.createTable("defaults", { force: true }, (t: any) => {
-      t.integer("random_number", { default: () => "random() * 100" });
-      t.string("ruby_on_rails", { default: () => "concat('Ruby ', 'on ', 'Rails')" });
-      t.date("modified_date", { default: () => "CURRENT_DATE" });
-      t.date("modified_date_function", { default: () => "now()" });
-      t.date("fixed_date", { default: "2004-01-01" });
-      t.datetime("modified_time", { default: () => "CURRENT_TIMESTAMP" });
-      t.datetime("modified_time_without_precision", {
-        precision: null,
-        default: () => "CURRENT_TIMESTAMP",
-      });
-      t.datetime("modified_time_with_precision_0", {
-        precision: 0,
-        default: () => "CURRENT_TIMESTAMP",
-      });
-      t.datetime("modified_time_function", { default: () => "now()" });
-      t.datetime("fixed_time", { default: "2004-01-01 00:00:00.000000-00" });
-      t.column("char1", "char(1)", { default: "Y" });
-      t.string("char2", { limit: 50, default: "a varchar field" });
-      t.text("char3", { default: "a text field" });
-    });
-  });
-
-  afterEach(async () => {
-    await ctx.dropTable("defaults", { ifExists: true });
   });
 
   it("schema dump includes default expression", async () => {
@@ -322,46 +285,13 @@ describeIfPg("PostgresqlDefaultExpressionTest", () => {
 });
 
 // Mirrors `MysqlDefaultExpressionTest` (defaults_test.rb), gated to the
-// Mysql2Adapter. The three tables come from mysql2_specific_schema.rb — built
-// here with the migration DSL (the expression defaults round-trip through
-// quoteDefaultExpression) and dumped via SchemaDumpingHelper#dump_table_schema.
+// Mysql2Adapter. The three tables come from mysql2_specific_schema.rb and are
+// laid at boot by the adapter-specific arm of loadSchema.
 describeIfMysql("MysqlDefaultExpressionTest", () => {
   let adapter: DatabaseAdapter;
-  let ctx: MigrationContext;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
-    await ctx.createTable("datetime_defaults", { force: true }, (t: any) => {
-      t.datetime("modified_datetime", { precision: null, default: () => "CURRENT_TIMESTAMP" });
-      t.datetime("precise_datetime", { default: () => "CURRENT_TIMESTAMP(6)" });
-      t.datetime("updated_datetime", {
-        default: () => "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)",
-      });
-    });
-    await ctx.createTable("timestamp_defaults", { force: true }, (t: any) => {
-      t.timestamp("nullable_timestamp");
-      t.timestamp("modified_timestamp", { precision: null, default: () => "CURRENT_TIMESTAMP" });
-      t.timestamp("precise_timestamp", { precision: 6, default: () => "CURRENT_TIMESTAMP(6)" });
-      t.timestamp("updated_timestamp", {
-        precision: 6,
-        default: () => "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)",
-      });
-    });
-    await ctx.createTable("defaults", { force: true }, (t: any) => {
-      t.date("fixed_date", { default: "2004-01-01" });
-      t.datetime("fixed_time", { default: "2004-01-01 00:00:00" });
-      t.column("char1", "char(1)", { default: "Y" });
-      t.string("char2", { limit: 50, default: "a varchar field" });
-      if (supportsDefaultExpression) {
-        t.binary("uuid", { limit: 36, default: () => "(uuid())" });
-        t.string("char2_concatenated", { default: () => "(concat(`char2`, '-'))" });
-      }
-    });
-  });
-
-  afterEach(async () => {
-    await ctx.dropTable("defaults", "timestamp_defaults", "datetime_defaults", { ifExists: true });
   });
 
   // The `uuid()`/`concat()` function defaults reflect on both MySQL 8 (via the
@@ -531,41 +461,14 @@ describeIfMysql("DefaultsTestWithoutTransactionalFixtures", () => {
 });
 
 // Mirrors `Sqlite3DefaultExpressionTest` (defaults_test.rb), gated to the
-// SQLite3Adapter. The `defaults` table comes from sqlite_specific_schema.rb —
-// built here with the migration DSL; expression defaults reflect via
-// column.defaultFunction (newColumnFromField/_extractDefaultFunction).
+// SQLite3Adapter. The `defaults` table comes from sqlite_specific_schema.rb and
+// is laid at boot by the adapter-specific arm of loadSchema; expression defaults
+// reflect via column.defaultFunction (newColumnFromField/_extractDefaultFunction).
 describeIfSqlite("Sqlite3DefaultExpressionTest", () => {
   let adapter: DatabaseAdapter;
-  let ctx: MigrationContext;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
-    await ctx.createTable("defaults", { force: true }, (t: any) => {
-      t.integer("random_number", { default: () => "ABS(RANDOM())" });
-      t.string("ruby_on_rails", { default: () => "('Ruby ' || 'on ' || 'Rails')" });
-      t.date("modified_date", { default: () => "CURRENT_DATE" });
-      t.date("modified_date_function", { default: () => "DATE('now')" });
-      t.date("fixed_date", { default: "2004-01-01" });
-      t.datetime("modified_time", { default: () => "CURRENT_TIMESTAMP" });
-      t.datetime("modified_time_without_precision", {
-        precision: null,
-        default: () => "CURRENT_TIMESTAMP",
-      });
-      t.datetime("modified_time_with_precision_0", {
-        precision: 0,
-        default: () => "CURRENT_TIMESTAMP",
-      });
-      t.datetime("modified_time_function", { default: () => "DATETIME('now')" });
-      t.datetime("fixed_time", { default: "2004-01-01 00:00:00.000000-00" });
-      t.column("char1", "char(1)", { default: "Y" });
-      t.string("char2", { limit: 50, default: "a varchar field" });
-      t.text("char3", { default: "a text field" });
-    });
-  });
-
-  afterEach(async () => {
-    await ctx.dropTable("defaults", { ifExists: true });
   });
 
   it("schema dump includes default expression", async () => {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -614,9 +614,8 @@ describe("SchemaDumperTest", () => {
     // Mirrors Rails: test_schema_dump_includes_bigint_default
     // (activerecord/test/cases/schema_dumper_test.rb:366)
     // assert_match %r{t\.bigint\s+"bigint_default",\s+default: 0}, output
-    await ctx.createTable("defaults", {}, (t) => {
-      t.bigint("bigint_default", { default: 0 });
-    });
+    // `defaults` (with its `0::bigint` default) is laid at boot by the
+    // postgres arm of loadSchema, mirroring postgresql_specific_schema.rb:43.
     const output = await SchemaDumper.dumpTableSchema(Base.connection, "defaults");
     expect(output).toMatch(/t\.bigint\("bigint_default",\s*\{[^}]*default:\s*0[^}]*\}/);
   });
@@ -1043,7 +1042,6 @@ afterAll(async () => {
   await ctx.dropTable("binary_fields", o);
   await ctx.dropTable("booleans", o);
   await ctx.dropTable("companies", o);
-  await ctx.dropTable("defaults", o);
   await ctx.dropTable("dump_defaults", o);
   await ctx.dropTable("indexed", o);
   await ctx.dropTable("infinity_defaults", o);

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -1,5 +1,6 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
+import { adapterSpecificTableNames } from "./load-schema-helper.js";
 
 /**
  * Table names the boot-time canonical schema
@@ -14,6 +15,18 @@ import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
  * state leaks across the reset.
  */
 const CANONICAL_TABLE_NAMES: ReadonlySet<string> = new Set(Object.keys(TEST_SCHEMA));
+
+/**
+ * The boot-laid schema for `adapter`: the canonical `schema.rb` mirror plus the
+ * active adapter's `<adapter>_specific_schema.rb` tables. Both halves come from
+ * one `load_schema` in Rails, so both are truncated between tests rather than
+ * dropped.
+ */
+function bootLaidTableNames(adapter: DatabaseAdapter): ReadonlySet<string> {
+  const specific = adapterSpecificTableNames(adapter.adapterName);
+  if (specific.length === 0) return CANONICAL_TABLE_NAMES;
+  return new Set([...CANONICAL_TABLE_NAMES, ...specific]);
+}
 
 /**
  * Drops every user table/view/matview in the database. Idempotent; per-DROP
@@ -45,15 +58,16 @@ export async function resetTestTables(adapter: DatabaseAdapter): Promise<void> {
 type ResetMode = "drop-all" | "reset";
 
 async function resetTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
+  const bootLaid = bootLaidTableNames(adapter);
   switch (adapter.adapterName) {
     case "postgres":
-      await resetPgTables(adapter, mode);
+      await resetPgTables(adapter, mode, bootLaid);
       break;
     case "mysql":
-      await resetMysqlTables(adapter, mode);
+      await resetMysqlTables(adapter, mode, bootLaid);
       break;
     case "sqlite":
-      await resetSqliteTables(adapter, mode);
+      await resetSqliteTables(adapter, mode, bootLaid);
       break;
   }
 }
@@ -106,23 +120,31 @@ function _isPgConnectionError(e: unknown): boolean {
   );
 }
 
-async function resetPgTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
+async function resetPgTables(
+  adapter: DatabaseAdapter,
+  mode: ResetMode,
+  bootLaid: ReadonlySet<string>,
+): Promise<void> {
   try {
-    await _resetPgTablesOnce(adapter, mode);
+    await _resetPgTablesOnce(adapter, mode, bootLaid);
   } catch (e) {
     // exec() routes through withRawConnection, whose retry loop calls
     // reconnectBang → the PG reconnect() override on a connection error, so
     // _rawConnection is now null and the next _acquireFreshClient() will open a
     // fresh pg.Client. Retry exactly once.
     if (_isPgConnectionError(e)) {
-      await _resetPgTablesOnce(adapter, mode);
+      await _resetPgTablesOnce(adapter, mode, bootLaid);
     } else {
       throw e;
     }
   }
 }
 
-async function _resetPgTablesOnce(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
+async function _resetPgTablesOnce(
+  adapter: DatabaseAdapter,
+  mode: ResetMode,
+  bootLaid: ReadonlySet<string>,
+): Promise<void> {
   const schema = `ANY(current_schemas(false))`;
   // Views/matviews are never canonical — always drop them.
   for (const { schemaname: s, name: n } of (await adapter.execute(
@@ -152,7 +174,7 @@ async function _resetPgTablesOnce(adapter: DatabaseAdapter, mode: ResetMode): Pr
     // A table living outside the default (public) schema — e.g. schema.test.ts's
     // test_schema/test_schema2 — can never be a boot-laid canonical table; drop
     // it regardless of mode so it can't bleed state into the next file.
-    if (mode === "reset" && s === "public" && CANONICAL_TABLE_NAMES.has(t)) {
+    if (mode === "reset" && s === "public" && bootLaid.has(t)) {
       toTruncate.push(t);
       continue;
     }
@@ -165,7 +187,11 @@ async function _resetPgTablesOnce(adapter: DatabaseAdapter, mode: ResetMode): Pr
   await truncateNonEmpty(adapter, toTruncate);
 }
 
-async function resetMysqlTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
+async function resetMysqlTables(
+  adapter: DatabaseAdapter,
+  mode: ResetMode,
+  bootLaid: ReadonlySet<string>,
+): Promise<void> {
   // Works with both the legacy pool model (_driverPool) and the current
   // single-connection model (_client). Falls back to adapter.execute /
   // adapter.executeMutation so both paths share one implementation.
@@ -188,7 +214,7 @@ async function resetMysqlTables(adapter: DatabaseAdapter, mode: ResetMode): Prom
     for (const r of tableRows as Array<{ table_name?: string; TABLE_NAME?: string }>) {
       const name = r.table_name ?? r.TABLE_NAME;
       if (!name) continue;
-      if (mode === "reset" && CANONICAL_TABLE_NAMES.has(name)) {
+      if (mode === "reset" && bootLaid.has(name)) {
         toTruncate.push(name);
         continue;
       }
@@ -204,7 +230,11 @@ async function resetMysqlTables(adapter: DatabaseAdapter, mode: ResetMode): Prom
   }
 }
 
-async function resetSqliteTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
+async function resetSqliteTables(
+  adapter: DatabaseAdapter,
+  mode: ResetMode,
+  bootLaid: ReadonlySet<string>,
+): Promise<void> {
   const toTruncate: string[] = [];
   for (const { name } of (await adapter.execute(
     `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
@@ -216,7 +246,7 @@ async function resetSqliteTables(adapter: DatabaseAdapter, mode: ResetMode): Pro
   for (const { name } of (await adapter.execute(
     `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
   )) as { name: string }[]) {
-    if (mode === "reset" && CANONICAL_TABLE_NAMES.has(name)) {
+    if (mode === "reset" && bootLaid.has(name)) {
       toTruncate.push(name);
       continue;
     }

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -22,10 +22,23 @@ const CANONICAL_TABLE_NAMES: ReadonlySet<string> = new Set(Object.keys(TEST_SCHE
  * one `load_schema` in Rails, so both are truncated between tests rather than
  * dropped.
  */
+const _bootLaidByAdapter = new Map<string, ReadonlySet<string>>();
+
 function bootLaidTableNames(adapter: DatabaseAdapter): ReadonlySet<string> {
-  const specific = adapterSpecificTableNames(adapter.adapterName);
-  if (specific.length === 0) return CANONICAL_TABLE_NAMES;
-  return new Set([...CANONICAL_TABLE_NAMES, ...specific]);
+  const name = adapter.adapterName;
+  // Memoized: this runs in the between-test reset, and both inputs are
+  // module-level constants, so the ~330-name Set is built at most once per
+  // adapter per worker.
+  let cached = _bootLaidByAdapter.get(name);
+  if (!cached) {
+    const specific = adapterSpecificTableNames(name);
+    cached =
+      specific.length === 0
+        ? CANONICAL_TABLE_NAMES
+        : new Set([...CANONICAL_TABLE_NAMES, ...specific]);
+    _bootLaidByAdapter.set(name, cached);
+  }
+  return cached;
 }
 
 /**

--- a/packages/activerecord/src/support/load-schema-helper.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.test.ts
@@ -19,6 +19,9 @@ describe("LoadSchemaHelper", () => {
       expect(tables).toContain("topics");
       expect(tables).toContain("posts");
       expect(tables).not.toContain("chat_messages");
+      // The sqlite arm of ADAPTER_SPECIFIC_SCHEMAS: sqlite_specific_schema.rb's
+      // only table.
+      expect(tables).toContain("defaults");
     } finally {
       await (adapter as unknown as BetterSQLite3Adapter).close();
     }

--- a/packages/activerecord/src/support/load-schema-helper.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.trails.test.ts
@@ -1,0 +1,38 @@
+/**
+ * trails-only guards on `ADAPTER_SPECIFIC_TABLES` — the table-name list
+ * `support/drop-all-tables.ts` reads to decide which tables its between-test
+ * reset must TRUNCATE rather than DROP.
+ *
+ * Rails needs no such list: `load_schema_helper.rb` runs the `.rb` schema file
+ * and nothing between tests drops schema tables. trails' reset does, so a table
+ * added to a loader but missed in the list is silently dropped before the first
+ * test of every file — the exact failure this file exists to catch.
+ */
+import { describe, expect, it } from "vitest";
+import "../sqlite/better-sqlite3.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { Base } from "../base.js";
+import { adapterSpecificTableNames, loadAdapterSpecificSchema } from "./load-schema-helper.js";
+
+describe("ADAPTER_SPECIFIC_TABLES", () => {
+  it("lists exactly the tables the sqlite arm creates", async () => {
+    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    try {
+      await loadAdapterSpecificSchema(adapter);
+      const created = (await adapter.tables()).sort();
+      expect(created).toEqual([...adapterSpecificTableNames("sqlite")].sort());
+    } finally {
+      await (adapter as unknown as BetterSQLite3Adapter).close();
+    }
+  });
+
+  it("lists tables the active lane actually has after boot", async () => {
+    const adapter = Base.connection;
+    const declared = adapterSpecificTableNames(adapter.adapterName);
+    expect(declared.length).toBeGreaterThan(0);
+
+    const present = new Set(await adapter.tables());
+    expect(declared.filter((name) => !present.has(name))).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -18,8 +18,13 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
  * by story `port-postgresql-specific-schema-remainder`.
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
+  // `supportsPgcryptoUuid()` / `supportsVirtualColumns()` read the cached
+  // `databaseVersion`, whose sync getter throws until the version has been
+  // fetched once.
+  await adapter.getDatabaseVersion();
+
   await adapter.enableExtension("uuid-ossp");
-  await adapter.enableExtension("pgcrypto");
+  if (adapter.supportsPgcryptoUuid()) await adapter.enableExtension("pgcrypto");
 
   await adapter.createTable("chat_messages", { id: "uuid", force: true }, (t) => {
     (t as PgTableDefinition).text("content");
@@ -133,27 +138,26 @@ async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<
  */
 async function loadSqliteSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
   await adapter.createTable("defaults", { force: true }, (t) => {
-    const table = t;
-    table.integer("random_number", { default: () => "ABS(RANDOM())" });
-    table.string("ruby_on_rails", { default: () => "('Ruby ' || 'on ' || 'Rails')" });
-    table.date("modified_date", { default: () => "CURRENT_DATE" });
-    table.date("modified_date_function", { default: () => "DATE('now')" });
-    table.date("fixed_date", { default: "2004-01-01" });
-    table.datetime("modified_time", { default: () => "CURRENT_TIMESTAMP" });
-    table.datetime("modified_time_without_precision", {
+    t.integer("random_number", { default: () => "ABS(RANDOM())" });
+    t.string("ruby_on_rails", { default: () => "('Ruby ' || 'on ' || 'Rails')" });
+    t.date("modified_date", { default: () => "CURRENT_DATE" });
+    t.date("modified_date_function", { default: () => "DATE('now')" });
+    t.date("fixed_date", { default: "2004-01-01" });
+    t.datetime("modified_time", { default: () => "CURRENT_TIMESTAMP" });
+    t.datetime("modified_time_without_precision", {
       precision: null,
       default: () => "CURRENT_TIMESTAMP",
     });
-    table.datetime("modified_time_with_precision_0", {
+    t.datetime("modified_time_with_precision_0", {
       precision: 0,
       default: () => "CURRENT_TIMESTAMP",
     });
-    table.datetime("modified_time_function", { default: () => "DATETIME('now')" });
-    table.datetime("fixed_time", { default: "2004-01-01 00:00:00.000000-00" });
-    table.column("char1", "char(1)", { default: "Y" });
-    table.string("char2", { limit: 50, default: "a varchar field" });
-    table.text("char3", { default: "a text field" });
-    table.text("multiline_default", { default: "--- []\n\n" });
+    t.datetime("modified_time_function", { default: () => "DATETIME('now')" });
+    t.datetime("fixed_time", { default: "2004-01-01 00:00:00.000000-00" });
+    t.column("char1", "char(1)", { default: "Y" });
+    t.string("char2", { limit: 50, default: "a varchar field" });
+    t.text("char3", { default: "a text field" });
+    t.text("multiline_default", { default: "--- []\n\n" });
   });
 }
 

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -9,9 +9,7 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
  * The ported slice of
  * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:4-48` —
  * the `uuid-ossp` / `pgcrypto` extension header, the four uuid-primary-key
- * tables and the `defaults` table. `uuid_default` there is `{}` whenever
- * `supports_pgcrypto_uuid?` (PG >= 9.4, always true on our postgres lane), which
- * leaves the uuid PK on the adapter's `gen_random_uuid()` default.
+ * tables and the `defaults` table.
  *
  * The remainder of that file (`postgresql_times`, `postgresql_oids`, the
  * identity, sequence, partition and constraint tables — lines 50-225) is carried
@@ -26,21 +24,31 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
   await adapter.enableExtension("uuid-ossp");
   if (adapter.supportsPgcryptoUuid()) await adapter.enableExtension("pgcrypto");
 
-  await adapter.createTable("chat_messages", { id: "uuid", force: true }, (t) => {
+  // `uuid_default = supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }`
+  // (line 7), splatted into the three `id: :uuid` tables below. With pgcrypto the
+  // adapter's own `gen_random_uuid()` PK default stands; without it that function
+  // does not exist, so the PK falls back to uuid-ossp's `uuid_generate_v4()`.
+  // The bare string (not a thunk) is Rails verbatim: quoteDefaultExpression emits
+  // a `()`-bearing string unquoted on a uuid column.
+  const uuidDefault: { default?: string } = adapter.supportsPgcryptoUuid()
+    ? {}
+    : { default: "uuid_generate_v4()" };
+
+  await adapter.createTable("chat_messages", { id: "uuid", force: true, ...uuidDefault }, (t) => {
     (t as PgTableDefinition).text("content");
   });
 
   await adapter.createTable("chat_messages_custom_pk", { id: false, force: true }, (t) => {
     const pg = t as PgTableDefinition;
-    pg.uuid("message_id", { primaryKey: true, default: () => "uuid_generate_v4()" });
+    pg.uuid("message_id", { primaryKey: true, default: "uuid_generate_v4()" });
     pg.text("content");
   });
 
-  await adapter.createTable("uuid_parents", { id: "uuid", force: true }, (t) => {
+  await adapter.createTable("uuid_parents", { id: "uuid", force: true, ...uuidDefault }, (t) => {
     (t as PgTableDefinition).string("name");
   });
 
-  await adapter.createTable("uuid_children", { id: "uuid", force: true }, (t) => {
+  await adapter.createTable("uuid_children", { id: "uuid", force: true, ...uuidDefault }, (t) => {
     const pg = t as PgTableDefinition;
     pg.string("name");
     pg.uuid("uuid_parent_id");

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -1,22 +1,21 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { TableDefinition as MysqlTableDefinition } from "../connection-adapters/mysql/schema-definitions.js";
 import type { TableDefinition as PgTableDefinition } from "../connection-adapters/postgresql/schema-definitions.js";
+import type { AbstractMysqlAdapter } from "../connection-adapters/abstract-mysql-adapter.js";
 import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
 
 /**
  * The ported slice of
- * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:4-25` —
- * the `uuid-ossp` / `pgcrypto` extension header and the four uuid-primary-key
- * tables. `uuid_default` there is `{}` whenever `supports_pgcrypto_uuid?`
- * (PG >= 9.4, always true on our postgres lane), which leaves the uuid PK on the
- * adapter's `gen_random_uuid()` default.
+ * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:4-48` —
+ * the `uuid-ossp` / `pgcrypto` extension header, the four uuid-primary-key
+ * tables and the `defaults` table. `uuid_default` there is `{}` whenever
+ * `supports_pgcrypto_uuid?` (PG >= 9.4, always true on our postgres lane), which
+ * leaves the uuid PK on the adapter's `gen_random_uuid()` default.
  *
- * The remainder of that file (`defaults`, `postgresql_times`, the identity,
- * sequence, partition and constraint tables — lines 27-225) and the `mysql2_` /
- * `sqlite_` schemas are carried by story `port-adapter-specific-schemas`: the
- * `defaults` table in particular is contended (`adapters/postgresql/schema.test.ts`
- * and `schema-dumper.test.ts` create and DROP their own on the shared per-worker
- * DB), so laying it at boot needs those files repointed in the same change.
+ * The remainder of that file (`postgresql_times`, `postgresql_oids`, the
+ * identity, sequence, partition and constraint tables — lines 50-225) is carried
+ * by story `port-postgresql-specific-schema-remainder`.
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
   await adapter.enableExtension("uuid-ossp");
@@ -41,6 +40,121 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     pg.string("name");
     pg.uuid("uuid_parent_id");
   });
+
+  await adapter.createTable("defaults", { force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    if (adapter.supportsVirtualColumns()) {
+      pg.virtual("virtual_stored_number", {
+        type: "integer",
+        as: "random_number * 10",
+        stored: true,
+      });
+    }
+    pg.integer("random_number", { default: () => "random() * 100" });
+    pg.string("ruby_on_rails", { default: () => "concat('Ruby ', 'on ', 'Rails')" });
+    pg.date("modified_date", { default: () => "CURRENT_DATE" });
+    pg.date("modified_date_function", { default: () => "now()" });
+    pg.date("fixed_date", { default: "2004-01-01" });
+    pg.datetime("modified_time", { default: () => "CURRENT_TIMESTAMP" });
+    pg.datetime("modified_time_without_precision", {
+      precision: null,
+      default: () => "CURRENT_TIMESTAMP",
+    });
+    pg.datetime("modified_time_with_precision_0", {
+      precision: 0,
+      default: () => "CURRENT_TIMESTAMP",
+    });
+    pg.datetime("modified_time_function", { default: () => "now()" });
+    pg.datetime("fixed_time", { default: "2004-01-01 00:00:00.000000-00" });
+    pg.timestamptz("fixed_time_with_time_zone", { default: "2004-01-01 01:00:00+1" });
+    pg.column("char1", "char(1)", { default: "Y" });
+    pg.string("char2", { limit: 50, default: "a varchar field" });
+    pg.text("char3", { default: "a text field" });
+    pg.bigint("bigint_default", { default: () => "0::bigint" });
+    pg.binary("binary_default_function", { default: () => "convert_to('A', 'UTF8')" });
+    pg.text("multiline_default", { default: "--- []\n\n" });
+  });
+}
+
+/**
+ * Port of `vendor/rails/activerecord/test/schema/mysql2_specific_schema.rb:4-26`
+ * — the three default-expression tables. The rest of that file (`binary_fields`,
+ * `key_tests`, `collation_tests`, the stored procedures and the trigger-backed
+ * primary-key table — lines 28-95) is carried by story
+ * `port-mysql2-specific-schema-remainder`.
+ *
+ * `supports_default_expression?` is `adapter_helper.rb:23`, not an adapter
+ * method: on the MySQL family it is MariaDB >= 10.2.1 or MySQL >= 8.0.13. It is
+ * resolved here off the live connection rather than through
+ * `support/supports.ts` because this module is also imported by the vitest
+ * `globalSetup` entry point (template-global-setup.ts), which runs outside the
+ * worker and so cannot pull in `supports.ts`'s `vitest` import.
+ */
+async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<void> {
+  await adapter.getDatabaseVersion();
+  const supportsDefaultExpression = adapter.isMariadb()
+    ? adapter.databaseVersion.gte("10.2.1")
+    : adapter.databaseVersion.gte("8.0.13");
+
+  await adapter.createTable("datetime_defaults", { force: true }, (t) => {
+    t.datetime("modified_datetime", { precision: null, default: () => "CURRENT_TIMESTAMP" });
+    t.datetime("precise_datetime", { default: () => "CURRENT_TIMESTAMP(6)" });
+    t.datetime("updated_datetime", {
+      default: () => "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)",
+    });
+  });
+
+  await adapter.createTable("timestamp_defaults", { force: true }, (t) => {
+    t.timestamp("nullable_timestamp");
+    t.timestamp("modified_timestamp", { precision: null, default: () => "CURRENT_TIMESTAMP" });
+    t.timestamp("precise_timestamp", { precision: 6, default: () => "CURRENT_TIMESTAMP(6)" });
+    t.timestamp("updated_timestamp", {
+      precision: 6,
+      default: () => "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)",
+    });
+  });
+
+  await adapter.createTable("defaults", { force: true }, (t) => {
+    const my = t as MysqlTableDefinition;
+    my.date("fixed_date", { default: "2004-01-01" });
+    my.datetime("fixed_time", { default: "2004-01-01 00:00:00" });
+    my.column("char1", "char(1)", { default: "Y" });
+    my.string("char2", { limit: 50, default: "a varchar field" });
+    if (supportsDefaultExpression) {
+      my.binary("uuid", { limit: 36, default: () => "(uuid())" });
+      my.string("char2_concatenated", { default: () => "(concat(`char2`, '-'))" });
+    }
+  });
+}
+
+/**
+ * Port of `vendor/rails/activerecord/test/schema/sqlite_specific_schema.rb:3-22`
+ * — the SQLite `defaults` table, the file's only content.
+ */
+async function loadSqliteSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
+  await adapter.createTable("defaults", { force: true }, (t) => {
+    const table = t;
+    table.integer("random_number", { default: () => "ABS(RANDOM())" });
+    table.string("ruby_on_rails", { default: () => "('Ruby ' || 'on ' || 'Rails')" });
+    table.date("modified_date", { default: () => "CURRENT_DATE" });
+    table.date("modified_date_function", { default: () => "DATE('now')" });
+    table.date("fixed_date", { default: "2004-01-01" });
+    table.datetime("modified_time", { default: () => "CURRENT_TIMESTAMP" });
+    table.datetime("modified_time_without_precision", {
+      precision: null,
+      default: () => "CURRENT_TIMESTAMP",
+    });
+    table.datetime("modified_time_with_precision_0", {
+      precision: 0,
+      default: () => "CURRENT_TIMESTAMP",
+    });
+    table.datetime("modified_time_function", { default: () => "DATETIME('now')" });
+    table.datetime("fixed_time", { default: "2004-01-01 00:00:00.000000-00" });
+    table.column("char1", "char(1)", { default: "Y" });
+    table.string("char2", { limit: 50, default: "a varchar field" });
+    table.text("char3", { default: "a text field" });
+    table.text("multiline_default", { default: "--- []\n\n" });
+  });
 }
 
 /**
@@ -49,18 +163,45 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
  * `<adapter>_specific_schema` loader when trails has one, and to nothing when it
  * does not.
  *
- * INCOMPLETE, deliberately. Rails has four such files and every one of them has
- * real content; trails has ported part of one. `sqlite_specific_schema.rb:3-21`
- * and `mysql2_specific_schema.rb:3-95` have no entry here at all, so the sqlite
- * and mysql lanes currently boot without the schema Rails gives them. That is a
- * known gap owned by story `port-adapter-specific-schemas` (RFC 0064), not a
- * claim that the gap does not exist. `trilogy_specific_schema.rb` is the one
- * genuine no-op: trails has no Trilogy adapter, so no adapter name ever selects
- * it.
+ * `sqlite_specific_schema.rb` is ported whole. The postgres and mysql arms are
+ * still partial — the remaining tables of
+ * `postgresql_specific_schema.rb:50-225` and `mysql2_specific_schema.rb:28-95`
+ * are owned by stories `port-postgresql-specific-schema-remainder` and
+ * `port-mysql2-specific-schema-remainder`, not a claim that the gap does not
+ * exist. `trilogy_specific_schema.rb` is the one genuine no-op: trails has no
+ * Trilogy adapter, so no adapter name ever selects it.
  */
 const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Promise<void>> = {
   postgres: (adapter) => loadPostgresqlSpecificSchema(adapter as unknown as PostgreSQLAdapter),
+  mysql: (adapter) => loadMysql2SpecificSchema(adapter as unknown as AbstractMysqlAdapter),
+  sqlite: loadSqliteSpecificSchema,
 };
+
+/**
+ * The tables each {@link ADAPTER_SPECIFIC_SCHEMAS} arm lays, by adapter name.
+ * Must be kept in step with the loaders above.
+ *
+ * `support/drop-all-tables.ts` reads this: its between-test `reset` mode drops
+ * every table that is not part of the loaded schema, and these are as much part
+ * of the schema Rails boots with as `schema.rb`'s. Without them here the arm
+ * would be undone before the first test in every file.
+ */
+const ADAPTER_SPECIFIC_TABLES: Record<string, readonly string[]> = {
+  postgres: [
+    "chat_messages",
+    "chat_messages_custom_pk",
+    "uuid_parents",
+    "uuid_children",
+    "defaults",
+  ],
+  mysql: ["datetime_defaults", "timestamp_defaults", "defaults"],
+  sqlite: ["defaults"],
+};
+
+/** The adapter-specific schema tables for `adapterName`; empty when it has no arm. */
+export function adapterSpecificTableNames(adapterName: string): readonly string[] {
+  return ADAPTER_SPECIFIC_TABLES[adapterName] ?? [];
+}
 
 /**
  * Port of `LoadSchemaHelper#load_schema`
@@ -89,7 +230,24 @@ const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Pro
  */
 export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
   await loadCanonicalSchema(adapter);
+  await loadAdapterSpecificSchema(adapter);
+}
 
+/**
+ * The `load adapter_specific_schema_file if File.exist?(...)` arm of
+ * `load_schema_helper.rb:15`, on its own.
+ *
+ * Exported because trails lays the canonical half through two different
+ * mechanisms depending on the lane: {@link loadSchema} (the sqlite/PG template
+ * build) and `DatabaseTasks.reconstructFromSchema`/`loadSchema` on the
+ * generated schema file (`test-setup-dy.ts`, the per-worker DB every AR test
+ * actually rides). The latter knows only about schema.rb's mirror and purges
+ * whatever the template carried, so it has to call this arm itself — otherwise
+ * the `<adapter>_specific_schema.rb` tables exist only in the template.
+ *
+ * @internal Boot/template setup paths only.
+ */
+export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
   if (adapterSpecificSchema) await adapterSpecificSchema(adapter);
 }

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -73,6 +73,13 @@ if (missingTables.length > 0) {
   );
 }
 
+// `load_schema_helper.rb:15` — the adapter-specific arm. DatabaseTasks lays
+// only schema.rb's mirror, so the `<adapter>_specific_schema.rb` tables have to
+// be laid here, on the same per-worker DB (the reconstruct path purges whatever
+// the template carried).
+const { loadAdapterSpecificSchema } = await import("./support/load-schema-helper.js");
+await loadAdapterSpecificSchema(await Base.leaseConnection());
+
 // `schema.rb:1444-1462` — the arunit2 tables Rails creates through
 // `Course.lease_connection`. Imported lazily so the second-database models load
 // after the canonical schema is in place.

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord-test-support/load-schema-helper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord-test-support/load-schema-helper.json
@@ -19,5 +19,12 @@
     "rubyName": "load_schema",
     "call": "new",
     "reason": "`StringIO.new` backs the `$stdout` silencing around Ruby's `load`, which prints a migration line per statement. Laying the schema through the adapter prints nothing, so there is no output to silence."
+  },
+  {
+    "package": "activerecord-test-support",
+    "tsFile": "load-schema-helper.ts",
+    "rubyName": "load_schema",
+    "call": "adapter_name",
+    "reason": "The `adapter_name` read that selects the adapter-specific schema still happens, one frame down: loadSchema delegates that arm to loadAdapterSpecificSchema, which trails must also call on its own from test-setup-dy.ts (the per-worker schema load runs through DatabaseTasks, not through loadSchema). The wide ratchet is lexical per method, so the extraction reads as an omitted call."
   }
 ]


### PR DESCRIPTION
Ports the `defaults` table that **all three** `*_specific_schema.rb` files
define, populating the `mysql` and `sqlite` arms of `ADAPTER_SPECIFIC_SCHEMAS`
and extending the `postgres` arm:

- `sqlite_specific_schema.rb:3-22` — ported whole (`defaults` is its only table).
- `mysql2_specific_schema.rb:4-26` — `datetime_defaults`, `timestamp_defaults`,
  `defaults`.
- `postgresql_specific_schema.rb:27-48` — `defaults`, including
  `virtual_stored_number`, `fixed_time_with_time_zone` (timestamptz),
  `bigint_default`, `binary_default_function` and `multiline_default`.

## Two wiring gaps the story didn't anticipate

The arm existed but never reached the database AR tests actually ride, on any
lane. Both had to be fixed for the ported tables to be observable:

1. `test-setup-dy.ts` lays the per-worker schema through `DatabaseTasks` on the
   *generated canonical schema file*, which knows only `schema.rb`'s mirror —
   and on the reconstruct path it purges whatever the template carried. Only
   `template-global-setup.ts` (the template build) and `setupAdapterSuite`
   called `loadSchema`. `loadAdapterSpecificSchema` is now split out of
   `loadSchema` and called by `test-setup-dy.ts` too.
2. The between-test reset in `support/drop-all-tables.ts` drops every table
   outside `TEST_SCHEMA`, so the arm was undone before the first test in each
   file. It now preserves the active adapter's specific tables — a new
   `ADAPTER_SPECIFIC_TABLES` map alongside the loaders, memoized per adapter so
   the ~330-name set is not rebuilt on every reset.

`ADAPTER_SPECIFIC_TABLES` has to be kept in step with the loaders by hand, so
`load-schema-helper.trails.test.ts` guards it: an exact set match on the sqlite
arm, plus an existence check against whichever lane is running. Both fail if an
entry is removed.

## Repointing

`defaults.test.ts` (`DefaultTest#multiline default text`,
`PostgresqlDefaultExpressionTest`, `MysqlDefaultExpressionTest`,
`Sqlite3DefaultExpressionTest`) and `schema-dumper.test.ts`'s
`schema dump includes bigint default` no longer build these tables inline.

`adapters/postgresql/schema.test.ts`'s `DefaultsUsingMultipleSchemasAndDomainTest`
diverged from `schema_test.rb:708-731`: it set the search path to
`schema_1,public,pg_catalog` *after* creating its domain-typed `defaults` and
dropped that table by name in setup and teardown, which would now take out the
boot-laid `public.defaults` on the shared per-worker DB. It now does what Rails
does — set the path to `schema_1, pg_catalog` first, create the table inside
`schema_1`, restore the saved path in teardown and let `drop_schema`'s CASCADE
dispose of the table.

## Gating

`supports_pgcrypto_uuid?`, `supports_virtual_columns?` and (for MySQL)
`supports_default_expression?` (`adapter_helper.rb:23`) are resolved off the
live connection rather than
through `support/supports.ts`, because this module is imported by the vitest
`globalSetup` entry point, which runs outside the worker and cannot pull in
`supports.ts`'s `vitest` import. This also matches the Ruby: the schema file
calls these inside `Schema.define`, i.e. on `connection`. The PG database
version is fetched once up front — the sync `databaseVersion` getter those
predicates read throws until it has been. `enable_extension!("pgcrypto")` is now
behind `supports_pgcrypto_uuid?` as `postgresql_specific_schema.rb:5` has it.

## Scope

Per the story's "one adapter per PR is the natural cut" — but `defaults` is
defined by all three files, so the coherent cut is the `defaults` family rather
than one adapter. The remaining tables are registered as new stories rather than
fanned out as sibling PRs:

- `port-postgresql-specific-schema-remainder` (postgresql_specific_schema.rb:50-225)
- `port-mysql2-specific-schema-remainder` (mysql2_specific_schema.rb:28-95)

## Testing

Local runs used a private compose stack on unused ports (`AR_DB_FORKS=4`).

- sqlite: `defaults.test.ts`, `schema-dumper.test.ts`, `drop-all-tables.test.ts`,
  `load-schema-helper{,.trails}.test.ts` — all pass.
- postgres: all of `support/` plus `defaults.test.ts`, `schema-dumper.test.ts`,
  `persistence.test.ts`, `adapters/postgresql/schema.test.ts` — 504 passed, 1
  failed: `drop-all-tables > drops all tables` hit the 5 s timeout under 4-fork
  contention on a loaded box, and passes on its own (`9 passed`).
- mysql: `adapters/abstract-mysql-adapter/`, `adapters/mysql2/`,
  `persistence.test.ts` — 390 passed, 1 failed:
  `TableOptionsTest > charset and partitioned table options` times out, and
  fails identically on `origin/main`. `defaults.test.ts`,
  `schema-dumper.test.ts`, `load-schema-helper.test.ts` pass.

The full `api:compare` / `test:compare` gate set was run locally and is green,
including the wide call-mismatch ratchet (the `adapter_name` entry this PR adds
is the one it flagged: the read moved one frame down into
`loadAdapterSpecificSchema`, and the ratchet is lexical per method).

Closes-story: port-adapter-specific-schemas
