### PR TITLE
refactor(migration): make verbose a class attribute like Rails' cattr_accessor

### DIFF
--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -182,4 +182,32 @@ describe("MigrationTest", () => {
     );
     expect(new IllegalMigrationNameError().message).toBe("Illegal name for migration.");
   });
+
+  // Rails' `verbose` is a cattr_accessor (`migration.rb:797`), so the class and
+  // instance readers share one variable and `suppress_messages` toggling it on
+  // an instance is visible class-wide. No Rails test asserts that coupling
+  // directly, so it lives in the trails-only sibling.
+  it("verbose is shared between the class and its instances", async () => {
+    const verboseWas = Migration.verbose;
+    try {
+      class Quiet extends Migration {}
+      const instance = new (class extends Migration {})();
+
+      Migration.verbose = false;
+      expect(instance.verbose).toBe(false);
+      expect(Quiet.verbose).toBe(false);
+
+      instance.verbose = true;
+      expect(Migration.verbose).toBe(true);
+
+      let seen: boolean | undefined;
+      await instance.suppressMessages(async () => {
+        seen = Migration.verbose;
+      });
+      expect(seen).toBe(false);
+      expect(Migration.verbose).toBe(true);
+    } finally {
+      Migration.verbose = verboseWas;
+    }
+  });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -268,11 +268,19 @@ export class EnvironmentStorageError extends MigrationError {
  * its own banners, trails' Migrator drives the execution strategy directly and
  * its migrations may be bare `{ up, down }` proxies with no `announce`.
  */
-function writeMigrationMessage(verbose: boolean, text = ""): void {
-  if (verbose) {
+function writeMigrationMessage(text = ""): void {
+  if (migrationVerbose) {
     stdout.write(`${text}\n`);
   }
 }
+
+/**
+ * @internal Backing store for `Migration.verbose` (`migration.rb:797`,
+ * defaulted at `:811`). Rails' `cattr_accessor` is one variable shared by the
+ * class and every instance, so it lives at module scope rather than as a class
+ * field, which subclasses would shadow.
+ */
+let migrationVerbose = true;
 
 /** @internal The banner `Migration#announce` (`migration.rb:1005`) hands to `write`. */
 function announceMigrationText(header: string, message: string): string {
@@ -302,7 +310,27 @@ export abstract class Migration {
    */
   static delegate: DatabaseAdapter | null = null;
   private _version?: string;
-  verbose = true;
+
+  /**
+   * Mirrors: ActiveRecord::Migration.verbose (`migration.rb:797`) — Rails'
+   * `cattr_accessor`, so the class and instance readers/writers share one
+   * variable.
+   */
+  static get verbose(): boolean {
+    return migrationVerbose;
+  }
+
+  static set verbose(value: boolean) {
+    migrationVerbose = value;
+  }
+
+  get verbose(): boolean {
+    return migrationVerbose;
+  }
+
+  set verbose(value: boolean) {
+    migrationVerbose = value;
+  }
   private static _disableDdlTransaction = false;
 
   /** Return the normalized adapter name from the configured adapter. */
@@ -1276,7 +1304,7 @@ export abstract class Migration {
   // --- Logging (Rails: Migration#write, #announce, #say, #say_with_time, #suppress_messages) ---
 
   write(text = ""): void {
-    writeMigrationMessage(this.verbose, text);
+    writeMigrationMessage(text);
   }
 
   announce(message: string): void {
@@ -1300,12 +1328,12 @@ export abstract class Migration {
   }
 
   async suppressMessages(fn: () => Promise<void>): Promise<void> {
-    const was = this.verbose;
-    this.verbose = false;
+    const was = Migration.verbose;
+    Migration.verbose = false;
     try {
       await fn();
     } finally {
-      this.verbose = was;
+      Migration.verbose = was;
     }
   }
 
@@ -2078,7 +2106,6 @@ export class Migrator {
   private readonly _options: MigratorOptions;
   private readonly _direction: "up" | "down";
   private readonly _targetVersion: number | string | null;
-  verbose = true;
 
   constructor(
     adapter: DatabaseAdapter,
@@ -2224,7 +2251,6 @@ export class Migrator {
       this._migrations,
       this._runOptions("up", targetVersion ?? null),
     );
-    migrator.verbose = this.verbose;
     return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
@@ -2241,7 +2267,6 @@ export class Migrator {
       this._migrations,
       this._runOptions("down", targetVersion ?? null),
     );
-    migrator.verbose = this.verbose;
     return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
   }
 
@@ -2811,7 +2836,6 @@ export class Migrator {
       this._migrations,
       this._runOptions(direction, targetVersion),
     );
-    migrator.verbose = this.verbose;
     return migrator._withAdvisoryLock(() => migrator.runWithoutLock());
   }
 
@@ -2874,7 +2898,7 @@ export class Migrator {
         await this._strategy.exec(direction, migration, this._adapter);
         const elapsed = ((Date.now() - start) / 1000).toFixed(4);
         this._announce(proxy, `${direction === "up" ? "migrated" : "reverted"} (${elapsed}s)`);
-        writeMigrationMessage(this.verbose);
+        writeMigrationMessage();
         if (direction === "up") {
           await this._schemaMigration.recordVersion(proxy.version);
           if (this._internalMetadata.enabled) {
@@ -2896,10 +2920,7 @@ export class Migrator {
 
   /** @internal Rails: `MigrationProxy` delegates `announce`/`write` to the migration. */
   private _announce(proxy: MigrationProxy, message: string): void {
-    writeMigrationMessage(
-      this.verbose,
-      announceMigrationText(`${proxy.version} ${proxy.name}`, message),
-    );
+    writeMigrationMessage(announceMigrationText(`${proxy.version} ${proxy.name}`, message));
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -259,28 +259,28 @@ export class EnvironmentStorageError extends MigrationError {
 }
 
 /**
- * @internal The body of `Migration#write` (`migration.rb:1001`), lifted to a
- * free function so the `verbose` gate exists in exactly one place. Rails puts
- * migration output on `$stdout` via `Kernel#puts`; `stdout` is the
- * activesupport shim standing in for `$stdout` — no logger is involved.
+ * @internal Backing store for `Migration.verbose` (`migration.rb:797`,
+ * defaulted at `:811`). Rails' `cattr_accessor` is one variable shared by the
+ * class and every instance; a static class field would be shadowed by a
+ * subclass assigning to it, so the storage lives at module scope.
+ */
+let migrationVerbose = true;
+
+/**
+ * @internal `Migration#write`'s body (`migration.rb:1001`) for callers that
+ * have no Migration instance. Rails puts migration output on `$stdout` via
+ * `Kernel#puts`; `stdout` is the activesupport shim standing in for `$stdout`
+ * — no logger is involved.
  *
- * The Migrator needs it too: unlike Rails, where `Migration#migrate` announces
- * its own banners, trails' Migrator drives the execution strategy directly and
- * its migrations may be bare `{ up, down }` proxies with no `announce`.
+ * The Migrator needs it: unlike Rails, where `Migration#migrate` announces its
+ * own banners, trails' Migrator drives the execution strategy directly and its
+ * migrations may be bare `{ up, down }` proxies with no `announce`.
  */
 function writeMigrationMessage(text = ""): void {
   if (migrationVerbose) {
     stdout.write(`${text}\n`);
   }
 }
-
-/**
- * @internal Backing store for `Migration.verbose` (`migration.rb:797`,
- * defaulted at `:811`). Rails' `cattr_accessor` is one variable shared by the
- * class and every instance, so it lives at module scope rather than as a class
- * field, which subclasses would shadow.
- */
-let migrationVerbose = true;
 
 /** @internal The banner `Migration#announce` (`migration.rb:1005`) hands to `write`. */
 function announceMigrationText(header: string, message: string): string {
@@ -311,11 +311,7 @@ export abstract class Migration {
   static delegate: DatabaseAdapter | null = null;
   private _version?: string;
 
-  /**
-   * Mirrors: ActiveRecord::Migration.verbose (`migration.rb:797`) — Rails'
-   * `cattr_accessor`, so the class and instance readers/writers share one
-   * variable.
-   */
+  /** Mirrors: ActiveRecord::Migration.verbose (`cattr_accessor`, `migration.rb:797`). */
   static get verbose(): boolean {
     return migrationVerbose;
   }
@@ -1304,7 +1300,9 @@ export abstract class Migration {
   // --- Logging (Rails: Migration#write, #announce, #say, #say_with_time, #suppress_messages) ---
 
   write(text = ""): void {
-    writeMigrationMessage(text);
+    if (Migration.verbose) {
+      stdout.write(`${text}\n`);
+    }
   }
 
   announce(message: string): void {

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { stdout } from "@blazetrails/activesupport";
 import {
+  Migration,
   Migrator,
   DuplicateMigrationVersionError,
   UnknownMigrationVersionError,
@@ -436,19 +437,19 @@ describe("MigratorTest", () => {
     try {
       const { migrations } = sensors(3);
 
+      Migration.verbose = true;
       const upMigrator = new Migrator(adapter, migrations);
-      upMigrator.verbose = true;
       await upMigrator.migrate(1);
       expect(lines.length).not.toBe(0);
 
       lines.length = 0;
 
       const downMigrator = new Migrator(adapter, migrations);
-      downMigrator.verbose = true;
       await downMigrator.migrate(0);
       expect(lines.length).not.toBe(0);
     } finally {
       spy.mockRestore();
+      Migration.verbose = true;
     }
   });
 
@@ -461,17 +462,17 @@ describe("MigratorTest", () => {
     try {
       const { migrations } = sensors(3);
 
+      Migration.verbose = false;
       const upMigrator = new Migrator(adapter, migrations);
-      upMigrator.verbose = false;
       await upMigrator.migrate(1);
       expect(lines.length).toBe(0);
 
       const downMigrator = new Migrator(adapter, migrations);
-      downMigrator.verbose = false;
       await downMigrator.migrate(0);
       expect(lines.length).toBe(0);
     } finally {
       spy.mockRestore();
+      Migration.verbose = true;
     }
   });
 

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -1,5 +1,5 @@
 // Faithful port of vendor/rails/activerecord/test/cases/migrator_test.rb
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { stdout } from "@blazetrails/activesupport";
 import {
   Migration,
@@ -77,15 +77,23 @@ describe("MigratorTest", () => {
     return sm;
   }
 
+  let verboseWas: boolean;
+
   // Rails' setup/teardown do `@schema_migration.create_table` +
   // `delete_all_versions rescue nil` around each test; on the shared
   // `Base.connection` pool the schema_migrations rows persist between tests, so
-  // clear them here to match Rails' fresh-per-test version state.
+  // clear them here to match Rails' fresh-per-test version state. Rails' setup
+  // also stashes `@verbose_was` and its teardown restores it.
   beforeEach(async () => {
     adapter = Base.connection;
     const sm = new SchemaMigration(adapter);
     await sm.createTable();
     await sm.deleteAllVersions();
+    verboseWas = Migration.verbose;
+  });
+
+  afterEach(() => {
+    Migration.verbose = verboseWas;
   });
 
   it("migrator with duplicate names", () => {
@@ -449,7 +457,6 @@ describe("MigratorTest", () => {
       expect(lines.length).not.toBe(0);
     } finally {
       spy.mockRestore();
-      Migration.verbose = true;
     }
   });
 
@@ -472,7 +479,6 @@ describe("MigratorTest", () => {
       expect(lines.length).toBe(0);
     } finally {
       spy.mockRestore();
-      Migration.verbose = true;
     }
   });
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -829,41 +829,53 @@ export class DatabaseTasks {
     // reach check_schema_file. Use == null (nullish) to match that.
     const filename = file ?? this.schemaDumpPath(config, format);
     if (filename == null) return;
-    this.checkSchemaFile(filename);
 
-    if (format === "sql") {
-      await this.structureLoad(config, filename);
-      await this._stampSchemaSha1(config, filename);
-      return;
-    }
+    // Rails: `verbose_was, Migration.verbose = Migration.verbose, verbose? && ENV["VERBOSE"]`
+    // (`database_tasks.rb:380`) — the extra ENV["VERBOSE"] term keeps a schema
+    // load quiet unless VERBOSE was set explicitly; restored at `:394`.
+    const { Migration } = await import("../migration.js");
+    const verboseWas = Migration.verbose;
+    Migration.verbose = isVerbose() && getEnv("VERBOSE") !== undefined;
+    try {
+      this.checkSchemaFile(filename);
 
-    const path = getPath();
-    if (!path.pathToFileURL) {
-      throw new Error(
-        "DatabaseTasks.loadSchema requires PathAdapter.pathToFileURL. " +
-          "The configured PathAdapter does not provide it.",
-      );
+      if (format === "sql") {
+        await this.structureLoad(config, filename);
+        await this._stampSchemaSha1(config, filename);
+        return;
+      }
+
+      const path = getPath();
+      if (!path.pathToFileURL) {
+        throw new Error(
+          "DatabaseTasks.loadSchema requires PathAdapter.pathToFileURL. " +
+            "The configured PathAdapter does not provide it.",
+        );
+      }
+      // Missing isAbsolute means the PathAdapter doesn't model relative vs.
+      // absolute (e.g. a VFS) — treat the incoming filename as already
+      // absolute in that case.
+      const absolute = this._resolveSchemaPath(filename);
+      const href = path.pathToFileURL(absolute).href;
+      const mod = (await import(href)) as {
+        default?: (ctx: unknown) => Promise<void> | void;
+      };
+      const defineSchema =
+        mod.default ?? (mod as unknown as (ctx: unknown) => Promise<void> | void);
+      if (typeof defineSchema !== "function") {
+        throw new Error(`Schema file must export a default function (got ${typeof defineSchema})`);
+      }
+      const adapter = await this._migrationAdapter();
+      const { MigrationContext } = await import("../migration.js");
+      const ctx = new MigrationContext(adapter);
+      await defineSchema(ctx);
+      // Stamp using the resolved absolute path — `filename` may be
+      // relative and `_schemaSha1` reads the file via getFs(), so the
+      // path must match what was actually imported.
+      await this._stampSchemaSha1(config, absolute);
+    } finally {
+      Migration.verbose = verboseWas;
     }
-    // Missing isAbsolute means the PathAdapter doesn't model relative vs.
-    // absolute (e.g. a VFS) — treat the incoming filename as already
-    // absolute in that case.
-    const absolute = this._resolveSchemaPath(filename);
-    const href = path.pathToFileURL(absolute).href;
-    const mod = (await import(href)) as {
-      default?: (ctx: unknown) => Promise<void> | void;
-    };
-    const defineSchema = mod.default ?? (mod as unknown as (ctx: unknown) => Promise<void> | void);
-    if (typeof defineSchema !== "function") {
-      throw new Error(`Schema file must export a default function (got ${typeof defineSchema})`);
-    }
-    const adapter = await this._migrationAdapter();
-    const { MigrationContext } = await import("../migration.js");
-    const ctx = new MigrationContext(adapter);
-    await defineSchema(ctx);
-    // Stamp using the resolved absolute path — `filename` may be
-    // relative and `_schemaSha1` reads the file via getFs(), so the
-    // path must match what was actually imported.
-    await this._stampSchemaSha1(config, absolute);
   }
 
   /**

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -270,15 +270,17 @@ export class DatabaseTasks {
     const effectiveVersion = typeof raw === "string" ? raw.trim() || null : raw;
     this.checkTargetVersion(effectiveVersion ?? undefined);
 
-    const { Migrator } = await import("../migration.js");
+    const { Migration, Migrator } = await import("../migration.js");
     const scope = getEnv("SCOPE");
-    const verbose = isVerbose();
+    // Rails: `verbose_was, Migration.verbose = Migration.verbose, verbose?`
+    // (`database_tasks.rb:264`), restored in the ensure block at `:282`.
+    const verboseWas = Migration.verbose;
+    Migration.verbose = isVerbose();
 
     const runMigration = async (
       adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
     ) => {
       const migrator = new Migrator(adapter, this._migrations);
-      migrator.verbose = verbose;
       // Rails block: `version.blank? ? (scope.blank? || scope == m.scope) : m.version == version`
       // `version` is the *method parameter* (explicit arg), NOT ENV["VERSION"].
       // The rake task always calls migrate() with no arg, so version is nil → scope filter only.
@@ -294,10 +296,10 @@ export class DatabaseTasks {
         filter = (m) => m.scope === scope;
       }
       const ran = await migrator.migrate(effectiveVersion ?? null, filter);
-      if (scope && scope.trim() !== "" && ran.length === 0 && verbose) {
+      if (scope && scope.trim() !== "" && ran.length === 0 && Migration.verbose) {
         // Rails: `Migration.write("No migrations ran. ...")` — write puts to
-        // $stdout (`migration.rb:1001`); `verbose` here is the gate Migration
-        // #write applies. `stdout` is the activesupport $stdout shim.
+        // $stdout (`migration.rb:1001`); `Migration.verbose` is the gate
+        // Migration#write applies. `stdout` is the activesupport $stdout shim.
         stdout.write(`No migrations ran. (using ${scope} scope)\n`);
       }
       // Rails: `migration_connection_pool.schema_cache.clear!` — drop the
@@ -307,9 +309,13 @@ export class DatabaseTasks {
       adapter.schemaCache?.clear();
     };
 
-    const pool = await this.migrationConnectionPool();
-    if (!skipInitialize) await initializeDatabase(pool.dbConfig);
-    await runMigration(await pool.leaseConnection());
+    try {
+      const pool = await this.migrationConnectionPool();
+      if (!skipInitialize) await initializeDatabase(pool.dbConfig);
+      await runMigration(await pool.leaseConnection());
+    } finally {
+      Migration.verbose = verboseWas;
+    }
   }
 
   /** Roll back the last N migrations (default 1). Mirrors `db:rollback`. */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
@@ -481,5 +481,19 @@
     "rubyName": "class_for_adapter",
     "call": "constantize",
     "reason": "Equivalent (different path): classForAdapter resolves the adapter class through trails' adapter registry, not a constant lookup."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "create",
+    "call": "verbose?",
+    "reason": "trails' DatabaseTasks.create/drop emit no banner — the `Created/Dropped database` line is printed by the CLI layer instead (trailties commands/db.ts:530,547), so there is no verbose? gate to call here."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "drop",
+    "call": "verbose?",
+    "reason": "trails' DatabaseTasks.create/drop emit no banner — the `Created/Dropped database` line is printed by the CLI layer instead (trailties commands/db.ts:530,547), so there is no verbose? gate to call here."
   }
 ]


### PR DESCRIPTION
## What

Rails has exactly one verbosity knob for migrations: `cattr_accessor :verbose`
on `ActiveRecord::Migration` (`migration.rb:797`, defaulted to `true` at
`:811`), read by `Migration#write` (`:1002`) and toggled wholesale by
`suppress_messages` (`:1030-1033`).

trails had two unrelated instance fields instead — `Migration#verbose` and
`Migrator#verbose`, the latter a trails invention (Rails' `Migrator` has no
`verbose`).

## Changes

- `Migration.verbose` is now a class-level accessor over a module-scope backing
  variable — module scope, not a static field, so subclasses share the one
  variable the way a Ruby class variable does. The instance accessor stays,
  mirroring `cattr_accessor`'s instance reader/writer over the same storage.
- `Migration#write` carries Rails' body inline (`puts(text) if verbose`);
  `suppressMessages` saves/clears/restores the class attribute.
- `Migrator#verbose` deleted, along with the three
  `migrator.verbose = this.verbose` propagations in `up` / `down` / `run`.
- `DatabaseTasks.migrate` uses Rails' pattern from `database_tasks.rb:264,282`:
  save `Migration.verbose`, set it from `isVerbose()`, restore in a `finally`.
- `DatabaseTasks.loadSchema` does the same for `database_tasks.rb:380,394`,
  including the `&& ENV["VERBOSE"]` term that keeps a schema load quiet unless
  `VERBOSE` was set explicitly.
- `migrator.test.ts`'s `migrator verbosity` / `migrator verbosity off` set
  `Migration.verbose` the way `migrator_test.rb:365-386` does, and the suite
  stashes/restores it in `beforeEach`/`afterEach` like Rails' setup/teardown.
  Test names unchanged.
- `migration.trails.test.ts` gains one trails-only test for the class/instance
  sharing, which no Rails test asserts directly.

`trailties` has no `db`-side verbose knob to converge — its only `verbose` is an
unrelated generator option.

## Wide call ratchet

Making `verbose` a ported method pulled Rails' `verbose?` calls into the wide
call population. Four of the five new entries are now genuinely satisfied
(`write`, `load_schema`). The remaining two — `create` / `drop` — are a
pre-existing displacement: trails emits the `Created/Dropped database` banner
from the CLI layer (`trailties/src/commands/db.ts:530,547`), not from
`DatabaseTasks`, so there is no `verbose?` gate to call. Those two are
baselined with that reason, and converging them is registered as story
`database-tasks-create-drop-emit-banners` under RFC 0051.

## Verification

`pnpm typecheck`; `pnpm api:calls:wide` green; `migrator.test.ts` (35),
`migration.test.ts` (94), `migration.trails.test.ts` (9),
`tasks/*.test.ts` (80+), `trailties/src/commands/db.test.ts` (100) all pass
locally.

Closes-story: migration-verbose-is-instance-not-class-attribute
