### PR TITLE
refactor(migration): drive migrations through Migration#migrate

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -271,10 +271,6 @@ let migrationVerbose = true;
  * have no Migration instance. Rails puts migration output on `$stdout` via
  * `Kernel#puts`; `stdout` is the activesupport shim standing in for `$stdout`
  * — no logger is involved.
- *
- * The Migrator needs it: unlike Rails, where `Migration#migrate` announces its
- * own banners, trails' Migrator drives the execution strategy directly and its
- * migrations may be bare `{ up, down }` proxies with no `announce`.
  */
 function writeMigrationMessage(text = ""): void {
   if (migrationVerbose) {
@@ -1110,7 +1106,9 @@ export abstract class Migration {
    * Mirrors: ActiveRecord::Migration#name
    */
   get name(): string {
-    return this.constructor.name;
+    // Rails: `attr_reader :name`, defaulting to `self.class.name` when the
+    // migration was built without one (`migration.rb:889`).
+    return this._name ?? this.constructor.name;
   }
 
   /**
@@ -1292,9 +1290,14 @@ export abstract class Migration {
 
   /**
    * Get the migration version from the class name or a static property.
+   *
+   * Rails' `#version` is the `attr_reader` for the `@version` set in
+   * `initialize` (`migration.rb:889`), which `MigrationProxy#load_migration`
+   * supplies; the class-level fallbacks are the trails path for migrations
+   * constructed without one.
    */
   get version(): string {
-    return (this.constructor as any).version ?? this.constructor.name;
+    return this._version ?? (this.constructor as any).version ?? this.constructor.name;
   }
 
   // --- Logging (Rails: Migration#write, #announce, #say, #say_with_time, #suppress_messages) ---
@@ -2071,6 +2074,40 @@ export interface MigrationProxy {
   basename?(): string;
   /** @internal Mirrors: ActiveRecord::MigrationProxy#load_migration */
   loadMigration?(): Promise<MigrationLike>;
+}
+
+/**
+ * Mirrors Rails' `MigrationProxy` delegation (`migration.rb:1187`):
+ * `delegate :migrate, :announce, :write, ... to: :migration`, where `migration`
+ * is a real `Migration` built as `name.constantize.new(name, version)`.
+ *
+ * A trails `MigrationProxy` is a plain record whose `migration()` may yield a
+ * bare `{ up, down }` object with no `migrate`/`announce`, so the Migrator
+ * wraps whatever was loaded in a `Migration` carrying the proxy's
+ * name/version. That wrapper is what supplies `migrate` — and therefore the
+ * announce/benchmark/announce/write banners — for every proxy shape.
+ */
+class MigrationProxyDelegate extends Migration {
+  constructor(
+    proxy: MigrationProxy,
+    private readonly _loaded: MigrationLike,
+    private readonly _execStrategy: ExecutionStrategy,
+  ) {
+    super(proxy.name, proxy.version);
+  }
+
+  override get disableDdlTransaction(): boolean {
+    return this._loaded.disableDdlTransaction ?? false;
+  }
+
+  /**
+   * Rails' `exec_migration` `public_send`s the direction on the migration
+   * itself; trails routes it through the Migrator's execution strategy, which
+   * is where a custom strategy gets to wrap the call.
+   */
+  override async execMigration(conn: DatabaseAdapter, direction: "up" | "down"): Promise<void> {
+    await this._execStrategy.exec(direction, this._loaded, conn);
+  }
 }
 
 /**
@@ -2878,25 +2915,18 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    const migration = await proxy.migration();
+    const migration = new MigrationProxyDelegate(proxy, await proxy.migration(), this._strategy);
+    migration.connection = this._adapter;
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
     // atomically. Without this, a committed migration + failed stamp
     // would leave schema_migrations out of sync.
     try {
       await this._ddlTransaction(migration, async () => {
-        // Rails emits these banners from Migration#migrate (`migration.rb:964`),
-        // which this Migrator bypasses by driving the execution strategy
-        // directly. They belong inside the ddl_transaction because Rails calls
-        // migration.migrate from within it (`migration.rb:1534`).
-        this._announce(proxy, direction === "up" ? "migrating" : "reverting");
-        // Rails benchmarks exec_migration alone (`migration.rb:973`) and emits
-        // the completion banner before record_version_state_after_migrating.
-        const start = Date.now();
-        await this._strategy.exec(direction, migration, this._adapter);
-        const elapsed = ((Date.now() - start) / 1000).toFixed(4);
-        this._announce(proxy, `${direction === "up" ? "migrated" : "reverted"} (${elapsed}s)`);
-        writeMigrationMessage();
+        // Rails: `migration.migrate(@direction)` (`migration.rb:1534`), which
+        // owns the announce/benchmark/announce/write sequence and runs before
+        // record_version_state_after_migrating.
+        await migration.migrate(direction);
         if (direction === "up") {
           await this._schemaMigration.recordVersion(proxy.version);
           if (this._internalMetadata.enabled) {
@@ -2914,11 +2944,6 @@ export class Migrator {
       const msg = `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\n${e instanceof Error ? e.message : e}`;
       throw Object.assign(new Error(msg), { cause: e });
     }
-  }
-
-  /** @internal Rails: `MigrationProxy` delegates `announce`/`write` to the migration. */
-  private _announce(proxy: MigrationProxy, message: string): void {
-    writeMigrationMessage(announceMigrationText(`${proxy.version} ${proxy.name}`, message));
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1287,10 +1287,13 @@ export abstract class Migration {
   }
 
   /**
-   * Get the migration version from the class name or a static property.
+   * Get the migration version. Rails initializes `@version` to nil
+   * (`migration.rb:799`) — only `@name` defaults to the class name — so an
+   * unversioned migration has no version. The static hook is the trails path
+   * for compatibility classes that declare one.
    */
-  get version(): string {
-    return this._version ?? (this.constructor as any).version ?? this.constructor.name;
+  get version(): string | undefined {
+    return this._version ?? (this.constructor as any).version;
   }
 
   // --- Logging (Rails: Migration#write, #announce, #say, #say_with_time, #suppress_messages) ---
@@ -1302,7 +1305,8 @@ export abstract class Migration {
   }
 
   announce(message: string): void {
-    this.write(announceMigrationText(`${this.version} ${this.name}`, message));
+    // Ruby interpolates a nil version as "", not "undefined".
+    this.write(announceMigrationText(`${this.version ?? ""} ${this.name}`, message));
   }
 
   say(message: string, subitem = false): void {
@@ -1515,7 +1519,7 @@ export abstract class Migration {
           migration: async () => {
             const { pathToFileURL } = await import("node:url");
             const mod = (await import(pathToFileURL(newPath).href)) as Record<string, unknown>;
-            return (mod.default ?? mod[proxyName]) as MigrationLike;
+            return loadMigrationFrom(mod, proxyName, newVersion);
           },
         };
         last = copy;
@@ -2067,6 +2071,24 @@ export interface MigrationProxy {
   basename?(): string;
   /** @internal Mirrors: ActiveRecord::MigrationProxy#load_migration */
   loadMigration?(): Promise<MigrationLike>;
+}
+
+/**
+ * Mirrors: ActiveRecord::MigrationProxy#load_migration (`migration.rb:1195`) —
+ * `name.constantize.new(name, version)`. The module's named export is the
+ * migration class; the legacy `default` export is a pre-built instance that
+ * cannot carry the proxy's identity, so it is only the fallback.
+ */
+async function loadMigrationFrom(
+  mod: Record<string, unknown>,
+  name: string,
+  version: string,
+): Promise<MigrationLike> {
+  const exported = mod[name] ?? mod.default;
+  if (typeof exported === "function") {
+    return new (exported as new (name?: string, version?: string) => Migration)(name, version);
+  }
+  return exported as MigrationLike;
 }
 
 /** Mirrors: ActiveRecord::MigrationProxy (`migration.rb:1187`) */
@@ -2674,7 +2696,7 @@ export class Migrator {
         migration: async () => {
           const { pathToFileURL } = await import("node:url");
           const mod = await import(pathToFileURL(file).href);
-          return (mod.default ?? mod[name]) as MigrationLike;
+          return loadMigrationFrom(mod, name, version);
         },
       });
     }
@@ -2709,7 +2731,7 @@ export class Migrator {
         migration: async () => {
           const { pathToFileURL } = await import("node:url");
           const mod = await import(pathToFileURL(file).href);
-          return (mod.default ?? mod[name]) as MigrationLike;
+          return loadMigrationFrom(mod, name, version);
         },
       });
     }
@@ -2893,7 +2915,15 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    const migration = new MigrationProxyDelegate(proxy, await proxy.migration(), this._strategy);
+    const loaded = await proxy.migration();
+    // Rails' MigrationProxy delegates migrate/announce/write to the real
+    // Migration (`migration.rb:1187`), so a subclass override is honoured. The
+    // wrapper is only for the trails-only bare `{ up, down }` proxy shape,
+    // which has no migrate/announce of its own.
+    const migration =
+      loaded instanceof Migration
+        ? loaded
+        : new MigrationProxyDelegate(proxy, loaded, this._strategy);
     migration.connection = this._adapter;
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1106,8 +1106,6 @@ export abstract class Migration {
    * Mirrors: ActiveRecord::Migration#name
    */
   get name(): string {
-    // Rails: `attr_reader :name`, defaulting to `self.class.name` when the
-    // migration was built without one (`migration.rb:889`).
     return this._name ?? this.constructor.name;
   }
 
@@ -1290,11 +1288,6 @@ export abstract class Migration {
 
   /**
    * Get the migration version from the class name or a static property.
-   *
-   * Rails' `#version` is the `attr_reader` for the `@version` set in
-   * `initialize` (`migration.rb:889`), which `MigrationProxy#load_migration`
-   * supplies; the class-level fallbacks are the trails path for migrations
-   * constructed without one.
    */
   get version(): string {
     return this._version ?? (this.constructor as any).version ?? this.constructor.name;
@@ -2076,17 +2069,7 @@ export interface MigrationProxy {
   loadMigration?(): Promise<MigrationLike>;
 }
 
-/**
- * Mirrors Rails' `MigrationProxy` delegation (`migration.rb:1187`):
- * `delegate :migrate, :announce, :write, ... to: :migration`, where `migration`
- * is a real `Migration` built as `name.constantize.new(name, version)`.
- *
- * A trails `MigrationProxy` is a plain record whose `migration()` may yield a
- * bare `{ up, down }` object with no `migrate`/`announce`, so the Migrator
- * wraps whatever was loaded in a `Migration` carrying the proxy's
- * name/version. That wrapper is what supplies `migrate` — and therefore the
- * announce/benchmark/announce/write banners — for every proxy shape.
- */
+/** Mirrors: ActiveRecord::MigrationProxy (`migration.rb:1187`) */
 class MigrationProxyDelegate extends Migration {
   constructor(
     proxy: MigrationProxy,
@@ -2100,11 +2083,6 @@ class MigrationProxyDelegate extends Migration {
     return this._loaded.disableDdlTransaction ?? false;
   }
 
-  /**
-   * Rails' `exec_migration` `public_send`s the direction on the migration
-   * itself; trails routes it through the Migrator's execution strategy, which
-   * is where a custom strategy gets to wrap the call.
-   */
   override async execMigration(conn: DatabaseAdapter, direction: "up" | "down"): Promise<void> {
     await this._execStrategy.exec(direction, this._loaded, conn);
   }
@@ -2923,9 +2901,6 @@ export class Migrator {
     // would leave schema_migrations out of sync.
     try {
       await this._ddlTransaction(migration, async () => {
-        // Rails: `migration.migrate(@direction)` (`migration.rb:1534`), which
-        // owns the announce/benchmark/announce/write sequence and runs before
-        // record_version_state_after_migrating.
         await migration.migrate(direction);
         if (direction === "up") {
           await this._schemaMigration.recordVersion(proxy.version);

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -482,24 +482,52 @@ describe("Migrator drives migrations through Migration#migrate", () => {
     expect(migration.version).toBe("20240101000000");
   });
 
-  it("Migration#name and #version fall back to the class when none were passed", () => {
+  it("Migration#name defaults to the class and #version stays unset", () => {
+    // Rails: `initialize(name = self.class.name, version = nil)`
+    // (migration.rb:799) — only the name falls back to the class.
     class Chunky extends Migration {}
     const migration = new Chunky();
     expect(migration.name).toBe("Chunky");
-    expect(migration.version).toBe("Chunky");
+    expect(migration.version).toBeUndefined();
   });
 
-  it("announces the proxy version and name, not the loaded migration class name", async () => {
+  it("announces the identity the proxy constructed the migration with", async () => {
+    // Rails' load_migration builds `name.constantize.new(name, version)`
+    // (migration.rb:1195), so the banner carries the proxy's identity even
+    // though the class is named something else.
     class SomeOtherClassName extends Migration {
       override async change(): Promise<void> {}
     }
     const migrator = new Migrator(adapter, [
-      { version: "1", name: "CreateWidgets", migration: () => new SomeOtherClassName() },
+      {
+        version: "1",
+        name: "CreateWidgets",
+        migration: () => new SomeOtherClassName("CreateWidgets", "1"),
+      },
     ]);
     await migrator.up();
     const banners = chunks.join("").split("\n").filter(Boolean);
     expect(banners[0]).toMatch(/^== 1 CreateWidgets: migrating =+$/);
     expect(banners[1]).toMatch(/^== 1 CreateWidgets: migrated \(\d+\.\d{4}s\) =+$/);
+  });
+
+  it("honours a Migration subclass override of announce", async () => {
+    // Rails' MigrationProxy delegates announce to the real migration
+    // (migration.rb:1187), so an override wins over the base banner.
+    class Shouty extends Migration {
+      override announce(message: string): void {
+        this.write(`!! ${message} !!`);
+      }
+      override async change(): Promise<void> {}
+    }
+    const migrator = new Migrator(adapter, [
+      { version: "1", name: "Shouty", migration: () => new Shouty("Shouty", "1") },
+    ]);
+    await migrator.up();
+    const output = chunks.join("");
+    expect(output).toContain("!! migrating !!");
+    expect(output).toContain("!! migrated (");
+    expect(output).not.toContain("== 1 Shouty: migrating");
   });
 
   it("announces each banner exactly once", async () => {

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -539,9 +539,16 @@ describe("Migrator drives migrations through Migration#migrate", () => {
   });
 
   it("honours the migration's verbose setting", async () => {
-    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
-    migrator.verbose = false;
-    await migrator.up();
-    expect(chunks.join("")).toBe("");
+    // Rails' verbose is a cattr_accessor (migration.rb:797) — one shared
+    // setting, not per-Migrator state.
+    const was = Migration.verbose;
+    Migration.verbose = false;
+    try {
+      const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+      await migrator.up();
+      expect(chunks.join("")).toBe("");
+    } finally {
+      Migration.verbose = was;
+    }
   });
 });

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -1,7 +1,8 @@
 // trails-only Migrator cases with no counterpart in
 // vendor/rails/activerecord/test/cases/migrator_test.rb. See migrator.test.ts
 // for the faithful Rails mirror.
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { stdout } from "@blazetrails/activesupport";
 import {
   Migrator,
   CheckPending,
@@ -453,5 +454,66 @@ describe("Migrator advisory lock wrapping", () => {
     } as unknown as DatabaseAdapter;
     const migrator = new Migrator(adapter, []);
     expect(migrator.isUseAdvisoryLock()).toBe(false);
+  });
+});
+
+describe("Migrator drives migrations through Migration#migrate", () => {
+  let adapter: DatabaseAdapter;
+  let chunks: string[];
+  let spy: MockInstance;
+
+  beforeEach(() => {
+    adapter = Base.connection;
+    chunks = [];
+    spy = vi.spyOn(stdout, "write").mockImplementation((chunk) => {
+      chunks.push(chunk);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it("Migration#name and #version report the constructor arguments", () => {
+    class Chunky extends Migration {}
+    const migration = new Chunky("Bacon", "20240101000000");
+    expect(migration.name).toBe("Bacon");
+    expect(migration.version).toBe("20240101000000");
+  });
+
+  it("Migration#name and #version fall back to the class when none were passed", () => {
+    class Chunky extends Migration {}
+    const migration = new Chunky();
+    expect(migration.name).toBe("Chunky");
+    expect(migration.version).toBe("Chunky");
+  });
+
+  it("announces the proxy version and name, not the loaded migration class name", async () => {
+    class SomeOtherClassName extends Migration {
+      override async change(): Promise<void> {}
+    }
+    const migrator = new Migrator(adapter, [
+      { version: "1", name: "CreateWidgets", migration: () => new SomeOtherClassName() },
+    ]);
+    await migrator.up();
+    const banners = chunks.join("").split("\n").filter(Boolean);
+    expect(banners[0]).toMatch(/^== 1 CreateWidgets: migrating =+$/);
+    expect(banners[1]).toMatch(/^== 1 CreateWidgets: migrated \(\d+\.\d{4}s\) =+$/);
+  });
+
+  it("announces each banner exactly once", async () => {
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await migrator.up();
+    const output = chunks.join("");
+    expect(output.match(/1 M1: migrating/g)).toHaveLength(1);
+    expect(output.match(/1 M1: migrated/g)).toHaveLength(1);
+  });
+
+  it("honours the migration's verbose setting", async () => {
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    migrator.verbose = false;
+    await migrator.up();
+    expect(chunks.join("")).toBe("");
   });
 });

--- a/packages/activerecord/src/migrator.ts
+++ b/packages/activerecord/src/migrator.ts
@@ -30,7 +30,10 @@ export class MigrationRunner {
   constructor(adapter: DatabaseAdapter, migrations: Migration[]) {
     this.adapter = adapter;
     this.migrations = migrations.map((m) => ({
-      version: m.version,
+      // Rails leaves an unversioned migration's #version nil, but a
+      // schema_migrations row needs a key, so this runner keeps its
+      // long-standing class-name fallback.
+      version: m.version ?? m.constructor.name,
       migration: m,
     }));
   }


### PR DESCRIPTION
Rails' `Migrator#execute_migration_in_transaction`
(`vendor/rails/activerecord/lib/active_record/migration.rb:1534`) runs a
migration with `migration.migrate(@direction)`, so all banner and timing
behaviour lives in exactly one place — `Migration#migrate`
(`migration.rb:964-983`).

trails' `Migrator#_runMigration` never called `Migration#migrate`. It invoked
`this._strategy.exec(...)` directly and re-implemented the
announce/benchmark/announce/write sequence inline, so the same Rails logic was
written twice. #5481 made the duplicate behaviourally faithful but left the
duplication in place.

## What changed

- `Migrator#_runMigration` drives the migration with
  `migration.migrate(direction)` inside the ddl_transaction, exactly as
  `migration.rb:1534` does. The inline banner copy and the `Migrator#_announce`
  helper are deleted — the sequence now exists only in `Migration#migrate`.
- The delegation target is the loaded migration itself whenever it already is a
  `Migration`, matching `delegate :migrate, :announce, :write, ... to:
  :migration` (`migration.rb:1187`), so subclass overrides are honoured.
- New `loadMigrationFrom` mirrors `MigrationProxy#load_migration`
  (`migration.rb:1195`): it prefers the module's named class export and builds
  it as `name.constantize.new(name, version)`, so the migration carries the
  proxy's identity. Previously the disk fixtures' `export default new Foo()`
  instance was preferred, which could not. A pre-built default export remains
  the fallback.
- A file-local `MigrationProxyDelegate extends Migration` is kept only for the
  trails-only bare `{ up, down }` proxy shape, which has no
  `migrate`/`announce` of its own; it routes execution through the Migrator's
  strategy, so a custom `strategy:` still wraps that shape (covered by the
  existing LoggingStrategy test).
- `Migration#name` prefers the `@name` set in `initialize`; `Migration#version`
  prefers `@version` and **no longer falls back to the class name**. Rails
  initializes `@version` to nil and defaults only `@name` to `self.class.name`
  (`migration.rb:799`), so `#version` is now `string | undefined` and
  `announce` renders an unset version as `""` the way Ruby interpolates nil.
  `MigrationRunner` keeps a class-name fallback at its own call site, where a
  schema_migrations row genuinely needs a key.

## Tests

New cases in `migrator.trails.test.ts` (trails-only, no Rails counterpart).
Two are verified to fail on the relevant baseline:

- A `Migration` subclass override of `announce` is honoured — **fails before
  the delegation fix** (`expected '== 1 Shouty: migrating ===…' to contain
  '!! migrating !!'`).
- `Migration#name`/`#version` report their constructor arguments — **fails on
  the pre-change baseline** (`expected 'Chunky' to be 'Bacon'`).
- `#name` defaults to the class while `#version` stays unset (Rails'
  `initialize` defaults).
- The banner carries the identity the proxy constructed the migration with.
- Each banner is emitted exactly once (guards the duplication from returning).
- `verbose = false` stays silent.

## Verification

Banner output for existing migrations is unchanged: same text, same ordering
relative to version stamping, same timer scope, still inside the DDL
transaction. All affected suites pass — `migrator.test.ts`,
`migrator.trails.test.ts`, `migration.test.ts`, `migration.trails.test.ts`,
`multi-db-migrator.test.ts`, `invertible-migration.test.ts`,
`schema-migration.trails.test.ts`, `tasks/database-tasks.test.ts` (274 passed,
30 skipped). `pnpm api:compare` is byte-identical to main. 156 LOC across
3 files.

## Follow-up

The bare `{ up, down }` proxy shape — and therefore `MigrationProxyDelegate`
and the Migrator-level `strategy:` invention — still needs retiring so the
Migrator can delegate unconditionally. Tracked as
`0051-migration-schema-statements-fidelity/retire-bare-up-down-migration-proxy-shape`.

Closes-story: migrator-bypasses-migration-migrate-and-duplicates-banners
