### PR TITLE
refactor(mysql): mix foreignKeys onto AbstractMysqlAdapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -819,3 +819,54 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
     expect(() => adapter.checkVersion()).not.toThrow();
   });
 });
+
+describe("AbstractMysqlAdapter#foreignKeys", () => {
+  async function makeAdapter(rows: Record<string, unknown>[]) {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as InstanceType<
+      typeof AbstractMysqlAdapter
+    >;
+    Object.assign(adapter, {
+      schemaQuery: async () => rows,
+      quote: mysqlQuote,
+    });
+    return adapter;
+  }
+
+  it("reads foreign keys through the mixed-in MySQL::SchemaStatements method", async () => {
+    const adapter = await makeAdapter([
+      {
+        to_table: "rockets",
+        primary_key: "id",
+        column: "rocket_id",
+        name: "fk_rails_78e6cee8fd",
+        position: 1,
+        on_update: "CASCADE",
+        on_delete: "SET NULL",
+      },
+    ]);
+    const [fk] = await adapter.foreignKeys("astronauts");
+    expect(fk.fromTable).toBe("astronauts");
+    expect(fk.toTable).toBe("rockets");
+    expect(fk.column).toBe("rocket_id");
+    expect(fk.onUpdate).toBe("cascade");
+    expect(fk.onDelete).toBe("nullify");
+  });
+
+  it("reflects RESTRICT as nil", async () => {
+    const adapter = await makeAdapter([
+      {
+        to_table: "rockets",
+        primary_key: "id",
+        column: "rocket_id",
+        name: "fk_rails_78e6cee8fd",
+        position: 1,
+        on_update: "RESTRICT",
+        on_delete: "RESTRICT",
+      },
+    ]);
+    const [fk] = await adapter.foreignKeys("astronauts");
+    expect(fk.onUpdate).toBeUndefined();
+    expect(fk.onDelete).toBeUndefined();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1093,13 +1093,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return mysqlQuoteTableName(name);
   }
 
-  // Rails: `include MySQL::SchemaStatements` makes `foreign_keys` and its
-  // protected helper `extract_foreign_key_action` real instance methods on
-  // every MySQL adapter (mysql/schema_statements.rb:225).
-  foreignKeys = mysqlForeignKeys;
+  declare foreignKeys: typeof mysqlForeignKeys;
 
-  /** @internal */
-  extractForeignKeyAction = mysqlExtractForeignKeyAction;
+  declare extractForeignKeyAction: typeof mysqlExtractForeignKeyAction;
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
     // supportsCheckConstraints() reads the cached databaseVersion, which throws
@@ -2235,3 +2231,5 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
 
 // Rails: `include MySQL::SchemaStatements` (abstract_mysql_adapter.rb:19).
 include(AbstractMysqlAdapter, MysqlSchemaStatements);
+AbstractMysqlAdapter.prototype.foreignKeys = mysqlForeignKeys;
+AbstractMysqlAdapter.prototype.extractForeignKeyAction = mysqlExtractForeignKeyAction;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -69,7 +69,6 @@ import {
   CheckConstraintDefinition,
   ColumnDefinition,
   CreateIndexDefinition,
-  ForeignKeyDefinition,
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
 import type {
@@ -83,6 +82,8 @@ import {
 } from "./mysql/schema-definitions.js";
 import {
   dataSourceSql as mysqlDataSourceSql,
+  extractForeignKeyAction as mysqlExtractForeignKeyAction,
+  foreignKeys as mysqlForeignKeys,
   isRowFormatDynamicByDefault,
   newColumnFromField,
   quotedScope,
@@ -1092,10 +1093,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return mysqlQuoteTableName(name);
   }
 
-  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    void tableName;
-    return [];
-  }
+  // Rails: `include MySQL::SchemaStatements` makes `foreign_keys` and its
+  // protected helper `extract_foreign_key_action` real instance methods on
+  // every MySQL adapter (mysql/schema_statements.rb:225).
+  foreignKeys = mysqlForeignKeys;
+
+  /** @internal */
+  extractForeignKeyAction = mysqlExtractForeignKeyAction;
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
     // supportsCheckConstraints() reads the cached databaseVersion, which throws

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1095,6 +1095,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   declare foreignKeys: typeof mysqlForeignKeys;
 
+  /** @internal */
   declare extractForeignKeyAction: typeof mysqlExtractForeignKeyAction;
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -34,7 +34,6 @@ import {
   SQLWarning,
 } from "../errors.js";
 import { Result } from "../result.js";
-import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import {
   affectedRows as mysql2AffectedRows,
@@ -55,8 +54,6 @@ import type { SchemaSource } from "../schema-dumper.js";
 import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
 import { abandonRawSocket } from "./abandon-raw-socket.js";
 import {
-  foreignKeys as mysqlForeignKeys,
-  extractForeignKeyAction as mysqlExtractForeignKeyAction,
   indexes as mysqlIndexes,
   parseMysqlName as mysqlParseName,
   MysqlSchemaStatements,
@@ -1833,18 +1830,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       );
     }
     return this._client;
-  }
-
-  /** Delegates to {@link mysqlForeignKeys} in `mysql/schema-statements.ts`. */
-  override async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    return mysqlForeignKeys.call(
-      {
-        schemaQuery: this.schemaQuery.bind(this),
-        quote: this.quote.bind(this),
-        extractForeignKeyAction: mysqlExtractForeignKeyAction,
-      },
-      tableName,
-    );
   }
 
   /** @internal */


### PR DESCRIPTION
Mixes MySQL's `foreignKeys` (and its protected helper `extractForeignKeyAction`)
onto `AbstractMysqlAdapter`, mirroring Rails' `include MySQL::SchemaStatements`
(`abstract_mysql_adapter.rb:22`, `mysql/schema_statements.rb:225`).

- `AbstractMysqlAdapter#foreignKeys` was a stub returning `[]`. Both standalones
  are now installed on `AbstractMysqlAdapter.prototype` next to the existing
  `include(...)` call, with `declare` members carrying the types.
  Prototype install (rather than class fields) keeps them visible to
  `Object.create(AbstractMysqlAdapter.prototype)` hosts and guarantees they win
  over anything `include()` copies from `BaseSchemaStatements`.
- `Mysql2Adapter#foreignKeys` and its hand-assembled `ForeignKeysHost` literal
  are gone; `ForeignKeysHost` is now the `this` type the adapter itself satisfies.
- New coverage in `abstract-mysql-adapter.test.ts` exercises the abstract path
  directly (including RESTRICT reflecting as nil); both cases fail on `main`.

Verified against MySQL 8: `migration/foreign-key.test.ts` (36 passed),
`mysql/schema-statements.test.ts` (49), `abstract-mysql-adapter.test.ts` (68).
`pnpm typecheck`, targeted `eslint`, and `pnpm api:compare` are clean.

Closes-story: mix-mysql-foreign-keys-onto-abstract-adapter
