### PR TITLE
refactor(sqlite3): build alter_table's buffer with copy_table, not a hand-rolled CREATE

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -13,6 +13,28 @@ describe("SqliteAdapter", () => {
     await adapter.close();
   });
 
+  // TS-only coverage for the alter_table rebuild: a typeless column has BLOB
+  // affinity, and both the throwaway "a"-prefixed buffer and the rebuilt table
+  // have to keep the declared type empty or the affinity silently becomes TEXT.
+  describe("alterTable", () => {
+    it("round-trips a typeless (BLOB affinity) column", async () => {
+      await adapter.exec(
+        `CREATE TABLE "affinities" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "untyped", "doomed" varchar)`,
+      );
+      await adapter.executeMutation(`INSERT INTO "affinities" ("untyped") VALUES (42)`);
+
+      await adapter.removeColumn("affinities", "doomed");
+
+      const columns = await adapter.columns("affinities");
+      expect(columns.map((c) => c.name)).toEqual(["id", "untyped"]);
+      expect(columns.find((c) => c.name === "untyped")?.sqlType).toBe("");
+      const rows = await adapter.selectAll(`SELECT typeof("untyped") AS t FROM "affinities"`);
+      expect(rows.rows[0]?.[0]).toBe("integer");
+
+      await adapter.dropTable("affinities");
+    });
+  });
+
   describe("lookupCastType", () => {
     it("resolves base SQL types", () => {
       expect(adapter.lookupCastType("string").name).toBe("string");
@@ -49,91 +71,91 @@ describe("SqliteAdapter", () => {
       expect(adapter.lookupCastType("tinyint").name).toBe("integer");
     });
   });
-});
 
-describe("SQLite3Adapter._isMemoryFilename", () => {
-  const isMemoryFilename = (
-    AbstractSQLite3Adapter as unknown as {
-      _isMemoryFilename(filename: string): boolean;
-    }
-  )._isMemoryFilename.bind(AbstractSQLite3Adapter);
+  describe("SQLite3Adapter._isMemoryFilename", () => {
+    const isMemoryFilename = (
+      AbstractSQLite3Adapter as unknown as {
+        _isMemoryFilename(filename: string): boolean;
+      }
+    )._isMemoryFilename.bind(AbstractSQLite3Adapter);
 
-  it("treats :memory: as in-memory", () => {
-    expect(isMemoryFilename(":memory:")).toBe(true);
-  });
-
-  it("treats file::memory: URI as in-memory", () => {
-    expect(isMemoryFilename("file::memory:?cache=shared")).toBe(true);
-  });
-
-  it("treats file:?mode=memory URI as in-memory", () => {
-    expect(isMemoryFilename("file:memdb1?mode=memory&cache=shared")).toBe(true);
-  });
-
-  it("does NOT treat a path containing mode=memory text as in-memory", () => {
-    expect(isMemoryFilename("file:/tmp/mode=memory.db")).toBe(false);
-  });
-
-  it("treats a regular file path as on-disk", () => {
-    expect(isMemoryFilename("/tmp/test.db")).toBe(false);
-  });
-});
-
-describe("SQLite3Adapter pragmas option", () => {
-  let adapter: AbstractSQLite3Adapter | undefined;
-
-  afterEach(async () => {
-    await adapter?.close();
-    vi.restoreAllMocks();
-  });
-
-  it("applies a valid numeric pragma on construction", () => {
-    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { cache_size: 500 } });
-    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-      "cache_size",
-    ) as Array<{ cache_size: number }>;
-    expect(result[0]?.cache_size).toBe(500);
-  });
-
-  it("applies a valid string enum pragma", () => {
-    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { synchronous: "FULL" } });
-    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-      "synchronous",
-    ) as Array<{ synchronous: number }>;
-    expect(result[0]?.synchronous).toBe(2);
-  });
-
-  it("converts boolean true to 1 for pragma", () => {
-    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: true } });
-    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-      "foreign_keys",
-    ) as Array<{ foreign_keys: number }>;
-    expect(result[0]?.foreign_keys).toBe(1);
-  });
-
-  it("converts boolean false to 0 for pragma", () => {
-    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: false } });
-    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-      "foreign_keys",
-    ) as Array<{ foreign_keys: number }>;
-    expect(result[0]?.foreign_keys).toBe(0);
-  });
-
-  it("warns and skips an invalid pragma name", () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    adapter = new BetterSQLite3Adapter(":memory:", {
-      pragmas: { "bad-name!": 1 } as Record<string, number>,
+    it("treats :memory: as in-memory", () => {
+      expect(isMemoryFilename(":memory:")).toBe(true);
     });
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining("invalid SQLite pragma name"),
-    );
+
+    it("treats file::memory: URI as in-memory", () => {
+      expect(isMemoryFilename("file::memory:?cache=shared")).toBe(true);
+    });
+
+    it("treats file:?mode=memory URI as in-memory", () => {
+      expect(isMemoryFilename("file:memdb1?mode=memory&cache=shared")).toBe(true);
+    });
+
+    it("does NOT treat a path containing mode=memory text as in-memory", () => {
+      expect(isMemoryFilename("file:/tmp/mode=memory.db")).toBe(false);
+    });
+
+    it("treats a regular file path as on-disk", () => {
+      expect(isMemoryFilename("/tmp/test.db")).toBe(false);
+    });
   });
 
-  it("warns and skips a string value with unsafe characters", () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    adapter = new BetterSQLite3Adapter(":memory:", {
-      pragmas: { synchronous: "FULL; DROP TABLE users" },
+  describe("SQLite3Adapter pragmas option", () => {
+    let adapter: AbstractSQLite3Adapter | undefined;
+
+    afterEach(async () => {
+      await adapter?.close();
+      vi.restoreAllMocks();
     });
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
+
+    it("applies a valid numeric pragma on construction", () => {
+      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { cache_size: 500 } });
+      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+        "cache_size",
+      ) as Array<{ cache_size: number }>;
+      expect(result[0]?.cache_size).toBe(500);
+    });
+
+    it("applies a valid string enum pragma", () => {
+      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { synchronous: "FULL" } });
+      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+        "synchronous",
+      ) as Array<{ synchronous: number }>;
+      expect(result[0]?.synchronous).toBe(2);
+    });
+
+    it("converts boolean true to 1 for pragma", () => {
+      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: true } });
+      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+        "foreign_keys",
+      ) as Array<{ foreign_keys: number }>;
+      expect(result[0]?.foreign_keys).toBe(1);
+    });
+
+    it("converts boolean false to 0 for pragma", () => {
+      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: false } });
+      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+        "foreign_keys",
+      ) as Array<{ foreign_keys: number }>;
+      expect(result[0]?.foreign_keys).toBe(0);
+    });
+
+    it("warns and skips an invalid pragma name", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      adapter = new BetterSQLite3Adapter(":memory:", {
+        pragmas: { "bad-name!": 1 } as Record<string, number>,
+      });
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("invalid SQLite pragma name"),
+      );
+    });
+
+    it("warns and skips a string value with unsafe characters", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      adapter = new BetterSQLite3Adapter(":memory:", {
+        pragmas: { synchronous: "FULL; DROP TABLE users" },
+      });
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
+    });
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -71,91 +71,91 @@ describe("SqliteAdapter", () => {
       expect(adapter.lookupCastType("tinyint").name).toBe("integer");
     });
   });
+});
 
-  describe("SQLite3Adapter._isMemoryFilename", () => {
-    const isMemoryFilename = (
-      AbstractSQLite3Adapter as unknown as {
-        _isMemoryFilename(filename: string): boolean;
-      }
-    )._isMemoryFilename.bind(AbstractSQLite3Adapter);
+describe("SQLite3Adapter._isMemoryFilename", () => {
+  const isMemoryFilename = (
+    AbstractSQLite3Adapter as unknown as {
+      _isMemoryFilename(filename: string): boolean;
+    }
+  )._isMemoryFilename.bind(AbstractSQLite3Adapter);
 
-    it("treats :memory: as in-memory", () => {
-      expect(isMemoryFilename(":memory:")).toBe(true);
-    });
-
-    it("treats file::memory: URI as in-memory", () => {
-      expect(isMemoryFilename("file::memory:?cache=shared")).toBe(true);
-    });
-
-    it("treats file:?mode=memory URI as in-memory", () => {
-      expect(isMemoryFilename("file:memdb1?mode=memory&cache=shared")).toBe(true);
-    });
-
-    it("does NOT treat a path containing mode=memory text as in-memory", () => {
-      expect(isMemoryFilename("file:/tmp/mode=memory.db")).toBe(false);
-    });
-
-    it("treats a regular file path as on-disk", () => {
-      expect(isMemoryFilename("/tmp/test.db")).toBe(false);
-    });
+  it("treats :memory: as in-memory", () => {
+    expect(isMemoryFilename(":memory:")).toBe(true);
   });
 
-  describe("SQLite3Adapter pragmas option", () => {
-    let adapter: AbstractSQLite3Adapter | undefined;
+  it("treats file::memory: URI as in-memory", () => {
+    expect(isMemoryFilename("file::memory:?cache=shared")).toBe(true);
+  });
 
-    afterEach(async () => {
-      await adapter?.close();
-      vi.restoreAllMocks();
-    });
+  it("treats file:?mode=memory URI as in-memory", () => {
+    expect(isMemoryFilename("file:memdb1?mode=memory&cache=shared")).toBe(true);
+  });
 
-    it("applies a valid numeric pragma on construction", () => {
-      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { cache_size: 500 } });
-      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-        "cache_size",
-      ) as Array<{ cache_size: number }>;
-      expect(result[0]?.cache_size).toBe(500);
-    });
+  it("does NOT treat a path containing mode=memory text as in-memory", () => {
+    expect(isMemoryFilename("file:/tmp/mode=memory.db")).toBe(false);
+  });
 
-    it("applies a valid string enum pragma", () => {
-      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { synchronous: "FULL" } });
-      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-        "synchronous",
-      ) as Array<{ synchronous: number }>;
-      expect(result[0]?.synchronous).toBe(2);
-    });
+  it("treats a regular file path as on-disk", () => {
+    expect(isMemoryFilename("/tmp/test.db")).toBe(false);
+  });
+});
 
-    it("converts boolean true to 1 for pragma", () => {
-      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: true } });
-      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-        "foreign_keys",
-      ) as Array<{ foreign_keys: number }>;
-      expect(result[0]?.foreign_keys).toBe(1);
-    });
+describe("SQLite3Adapter pragmas option", () => {
+  let adapter: AbstractSQLite3Adapter | undefined;
 
-    it("converts boolean false to 0 for pragma", () => {
-      adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: false } });
-      const result = (adapter.raw as import("better-sqlite3").Database).pragma(
-        "foreign_keys",
-      ) as Array<{ foreign_keys: number }>;
-      expect(result[0]?.foreign_keys).toBe(0);
-    });
+  afterEach(async () => {
+    await adapter?.close();
+    vi.restoreAllMocks();
+  });
 
-    it("warns and skips an invalid pragma name", () => {
-      vi.spyOn(console, "warn").mockImplementation(() => {});
-      adapter = new BetterSQLite3Adapter(":memory:", {
-        pragmas: { "bad-name!": 1 } as Record<string, number>,
-      });
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining("invalid SQLite pragma name"),
-      );
-    });
+  it("applies a valid numeric pragma on construction", () => {
+    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { cache_size: 500 } });
+    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+      "cache_size",
+    ) as Array<{ cache_size: number }>;
+    expect(result[0]?.cache_size).toBe(500);
+  });
 
-    it("warns and skips a string value with unsafe characters", () => {
-      vi.spyOn(console, "warn").mockImplementation(() => {});
-      adapter = new BetterSQLite3Adapter(":memory:", {
-        pragmas: { synchronous: "FULL; DROP TABLE users" },
-      });
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
+  it("applies a valid string enum pragma", () => {
+    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { synchronous: "FULL" } });
+    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+      "synchronous",
+    ) as Array<{ synchronous: number }>;
+    expect(result[0]?.synchronous).toBe(2);
+  });
+
+  it("converts boolean true to 1 for pragma", () => {
+    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: true } });
+    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+      "foreign_keys",
+    ) as Array<{ foreign_keys: number }>;
+    expect(result[0]?.foreign_keys).toBe(1);
+  });
+
+  it("converts boolean false to 0 for pragma", () => {
+    adapter = new BetterSQLite3Adapter(":memory:", { pragmas: { foreign_keys: false } });
+    const result = (adapter.raw as import("better-sqlite3").Database).pragma(
+      "foreign_keys",
+    ) as Array<{ foreign_keys: number }>;
+    expect(result[0]?.foreign_keys).toBe(0);
+  });
+
+  it("warns and skips an invalid pragma name", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    adapter = new BetterSQLite3Adapter(":memory:", {
+      pragmas: { "bad-name!": 1 } as Record<string, number>,
     });
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid SQLite pragma name"),
+    );
+  });
+
+  it("warns and skips a string value with unsafe characters", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    adapter = new BetterSQLite3Adapter(":memory:", {
+      pragmas: { synchronous: "FULL; DROP TABLE users" },
+    });
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2438,25 +2438,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
     modify(columns);
 
-    // Collect existing indexes to recreate after table rebuild
-    const indexListStmt = await this.driver.prepare(
-      `PRAGMA ${pragmaPrefix}index_list(${quoteColumnName(bareTable)})`,
-    );
-    const indexList = (await indexListStmt.all()) as Array<Record<string, unknown>>;
-    const indexDefs: string[] = [];
-    for (const idx of indexList) {
-      const idxName = idx.name as string;
-      // Skip auto-created indexes (sqlite_autoindex_*)
-      if (idxName.startsWith("sqlite_autoindex_")) continue;
-      const idxSqlStmt = await this.driver.prepare(
-        `SELECT sql FROM ${pragmaPrefix}sqlite_master WHERE type='index' AND name=${sqliteQuoteStringLiteral(idxName)}`,
-      );
-      const createSql = (await idxSqlStmt.get()) as { sql: string } | undefined;
-      if (createSql?.sql) {
-        indexDefs.push(createSql.sql);
-      }
-    }
-
     // Rails: altered_table_name = "a#{table_name}" (sqlite3_adapter.rb:566).
     // Kept bare even for a schema-qualified table: the buffer is a TEMPORARY
     // table, which always lives in the `temp` schema, so a qualifier would be
@@ -2578,22 +2559,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         // buffer — that is where alter_table's whole point lives, and the buffer's
         // reflection would have lost the pending changes.
         await execTranslated(createTableSql);
+        await this.copyTableIndexes(alteredTableName, tableName);
         await this.copyTableContents(alteredTableName, tableName, originalColNames);
         await execTranslated(`DROP TABLE ${quoteTableName(alteredTableName)}`);
       });
-
-      // Recreate indexes inside the transaction so failures roll back
-      // the entire rebuild rather than leaving a partially-migrated table.
-      for (const sql of indexDefs) {
-        try {
-          await this.driver.exec(sql);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : "";
-          if (!msg.includes("no such column") && !msg.includes("already exists")) {
-            throw err;
-          }
-        }
-      }
 
       if (alreadyInTransaction) {
         await this.releaseSavepoint(savepointName);
@@ -2794,8 +2763,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const { bare: bareTo } = this._splitTableName(to);
     for (const idx of idxRows) {
       let name = idx.name;
-      if (to === `a${from}`) name = `t${name}`;
-      else if (from === `a${to}`) name = name.slice(1);
+      // Compared on the bare names: alter_table's buffer is a TEMPORARY table,
+      // so it is unqualified even when the source is `aux.posts`, and comparing
+      // the qualified names would miss the "a"-prefix relationship — leaving an
+      // index whose name doesn't embed the table name (a custom `name:`) unrenamed
+      // and colliding with the still-live original.
+      if (bareTo === `a${bareFrom}`) name = `t${name}`;
+      else if (bareFrom === `a${bareTo}`) name = name.slice(1);
       // Rails gates the rename/filter on `columns.is_a?(Array)` — and with it
       // the `columns(to)` reflection: an expression index carries its
       // parenthesized expression as a bare string, copied across verbatim.
@@ -2821,7 +2795,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
             .map((c) => `${quoteColumnName(c)}${orders[c] ? ` ${orders[c].toUpperCase()}` : ""}`)
             .join(", ")
         : cols;
-      let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${quoteColumnName(newName)} ON ${quoteTableName(to)} (${colSql})`;
+      // SQLite puts the schema on the INDEX name, not on the table it indexes
+      // (`CREATE INDEX aux.by_name ON widgets (...)`); qualifying the table
+      // instead is a syntax error. Rails has no ATTACHed-schema notion here.
+      const { schema: toSchema } = this._splitTableName(to);
+      const target = toSchema
+        ? `${quoteColumnName(toSchema)}.${quoteColumnName(newName)} ON ${quoteColumnName(bareTo)}`
+        : `${quoteColumnName(newName)} ON ${quoteTableName(to)}`;
+      let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${target} (${colSql})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;
       await this.execCopyTable(sql);
     }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2401,7 +2401,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     await this.ensureConnected();
     const { schema, bare: bareTable } = this._splitTableName(tableName);
     const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
-    const qTable = quoteTableName(tableName);
     // table_info hides GENERATED columns; table_xinfo exposes them with
     // hidden 2 (virtual) / 3 (stored) so the rebuild preserves them (Rails
     // rebuilds from columns(from) and re-adds them with as:/stored:,
@@ -2458,9 +2457,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       }
     }
 
-    const prefix = schema ? `${schema}.` : "";
-    const tmpTable = `${prefix}_alter_tmp_${bareTable}`;
-    const qTmp = quoteTableName(tmpTable);
+    // Rails: altered_table_name = "a#{table_name}" (sqlite3_adapter.rb:566).
+    // Kept bare even for a schema-qualified table: the buffer is a TEMPORARY
+    // table, which always lives in the `temp` schema, so a qualifier would be
+    // rejected.
+    const alteredTableName = `a${bareTable}`;
     const colNames = Object.keys(columns);
 
     // Detect composite primary keys
@@ -2566,35 +2567,19 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     };
     try {
       await this.disableReferentialIntegrity(async () => {
-        const selectCols = originalColNames.map((n) => quoteColumnName(n)).join(", ");
-        // Rails' copy_table builds even the throwaway "a"-prefixed table through
-        // the full create_table machinery. This buffer carries the declared type
-        // verbatim (so storage affinity round-trips exactly, including the
-        // typeless/BLOB-affinity case) but drops NOT NULL/DEFAULT/CHECK/PK: rows
-        // come straight from a table that already satisfied those, so omitting
-        // them can only ever be more permissive, and no INSERT here relies on a
-        // default — both name every column explicitly.
-        const originalTypes = new Map(
-          tableInfo.map((c) => [c.name as string, (c.type as string | null) ?? ""]),
-        );
-        const tmpColDefs = originalColNames.map((n) => {
-          const declaredType = originalTypes.get(n) ?? "";
-          return declaredType === "" ? quoteColumnName(n) : `${quoteColumnName(n)} ${declaredType}`;
-        });
-        if (tmpColDefs.length > 0) {
-          await execTranslated(`CREATE TABLE ${qTmp} (${tmpColDefs.join(", ")})`);
-          await execTranslated(
-            `INSERT INTO ${qTmp} (${selectCols}) SELECT ${selectCols} FROM ${qTable}`,
-          );
-        }
-        await execTranslated(`DROP TABLE ${qTable}`);
+        // Rails' alter_table is two move_table calls, each copy_table + drop_table
+        // (sqlite3_adapter.rb:585-596). The first move is Rails' verbatim: the
+        // throwaway "a"-prefixed buffer is built by copy_table off the source
+        // table's own reflection, so it carries the full column definitions
+        // rather than a hand-concatenated CREATE TABLE.
+        await this.moveTable(tableName, alteredTableName, { temporary: true });
+        // The second move is copy_table + drop_table with the definition supplied
+        // by the caller above (fks/checks/`modify`) instead of re-derived from the
+        // buffer — that is where alter_table's whole point lives, and the buffer's
+        // reflection would have lost the pending changes.
         await execTranslated(createTableSql);
-        if (tmpColDefs.length > 0) {
-          await execTranslated(
-            `INSERT INTO ${qTable} (${selectCols}) SELECT ${selectCols} FROM ${qTmp}`,
-          );
-          await execTranslated(`DROP TABLE ${qTmp}`);
-        }
+        await this.copyTableContents(alteredTableName, tableName, originalColNames);
+        await execTranslated(`DROP TABLE ${quoteTableName(alteredTableName)}`);
       });
 
       // Recreate indexes inside the transaction so failures roll back
@@ -2718,6 +2703,21 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return this.tableStructure(tableName);
   }
 
+  /**
+   * Rails runs the copy-table family's DDL through `execute` and its INSERT
+   * through `internal_exec_query`, both of which translate driver errors
+   * (sqlite3_adapter.rb:593-648). These helpers go straight to the driver to
+   * stay inert w.r.t. savepoint nesting, so translate here instead.
+   * @internal
+   */
+  private async execCopyTable(sql: string): Promise<void> {
+    try {
+      await this.driver.exec(sql);
+    } catch (e) {
+      throw this._translateException(e, sql, []);
+    }
+  }
+
   /** @internal */
   private async moveTable(
     from: string,
@@ -2726,7 +2726,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     block?: (colDefs: string[]) => void,
   ): Promise<void> {
     await this.copyTable(from, to, options, block);
-    await this.driver.exec(`DROP TABLE ${quoteTableName(from)}`);
+    await this.execCopyTable(`DROP TABLE ${quoteTableName(from)}`);
   }
 
   /** @internal */
@@ -2772,7 +2772,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     }
     if (block) block(colDefs);
     const prefix = options.temporary ? "CREATE TEMPORARY TABLE" : "CREATE TABLE";
-    await this.driver.exec(`${prefix} ${quoteTableName(to)} (${colDefs.join(", ")})`);
+    await this.execCopyTable(`${prefix} ${quoteTableName(to)} (${colDefs.join(", ")})`);
     await this.copyTableIndexes(from, to, rename);
     await this.copyTableContents(from, to, contentCols, rename);
   }
@@ -2823,7 +2823,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         : cols;
       let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${quoteColumnName(newName)} ON ${quoteTableName(to)} (${colSql})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;
-      await this.driver.exec(sql);
+      await this.execCopyTable(sql);
     }
   }
 
@@ -2843,7 +2843,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const fromColsToCopy = validCols.map((col) => destToSrc[col]);
     const quotedDest = validCols.map((c) => quoteColumnName(c)).join(", ");
     const quotedSrc = fromColsToCopy.map((c) => quoteColumnName(c)).join(", ");
-    await this.driver.exec(
+    await this.execCopyTable(
       `INSERT INTO ${quoteTableName(to)} (${quotedDest}) SELECT ${quotedSrc} FROM ${quoteTableName(from)}`,
     );
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2539,13 +2539,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     } else {
       await this.beginTransaction();
     }
-    const execTranslated = async (sql: string): Promise<void> => {
-      try {
-        await this.driver.exec(sql);
-      } catch (e) {
-        throw this._translateException(e, sql, []);
-      }
-    };
     try {
       await this.disableReferentialIntegrity(async () => {
         // Rails' alter_table is two move_table calls, each copy_table + drop_table
@@ -2558,10 +2551,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         // by the caller above (fks/checks/`modify`) instead of re-derived from the
         // buffer — that is where alter_table's whole point lives, and the buffer's
         // reflection would have lost the pending changes.
-        await execTranslated(createTableSql);
+        await this.execCopyTable(createTableSql);
         await this.copyTableIndexes(alteredTableName, tableName);
         await this.copyTableContents(alteredTableName, tableName, originalColNames);
-        await execTranslated(`DROP TABLE ${quoteTableName(alteredTableName)}`);
+        await this.execCopyTable(`DROP TABLE ${quoteTableName(alteredTableName)}`);
       });
 
       if (alreadyInTransaction) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2719,8 +2719,16 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       } else {
         if (!compositePk && pkCols.includes(col.name)) def += " PRIMARY KEY";
         if (!col.null) def += " NOT NULL";
-        if (!sqlite3Col.autoIncrement && col.default !== null && col.default !== undefined) {
-          def += ` DEFAULT ${this.quoteDefault(col.default)}`;
+        if (!sqlite3Col.autoIncrement) {
+          if (col.default !== null && col.default !== undefined) {
+            def += ` DEFAULT ${this.quoteDefault(col.default)}`;
+          } else if (col.defaultFunction) {
+            // Rails swaps in `-> { column.default_function }` when the
+            // deserialized default is nil (sqlite3_adapter.rb:630), and a proc
+            // default is emitted raw by quote_default_expression. Without this
+            // a `DEFAULT CURRENT_TIMESTAMP` column loses its default in the copy.
+            def += ` DEFAULT ${col.defaultFunction}`;
+          }
         }
         // Generated columns are computed, never copied as content (Rails rejects
         // columns whose options carry `:as`).

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -15,7 +15,7 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
 
   const dropCopyTargets = async (): Promise<void> => {
     await leased?.exec(
-      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "acustomers2"`,
+      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS auto_id_tests2; DROP TABLE IF EXISTS "acustomers2"`,
     );
   };
 
@@ -86,6 +86,16 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
     await db.addIndex("customers", ["name"], { order: { name: "desc" } });
     await (db as any).copyTable("customers", "customers2");
     expect(await copiedIndexSql("customers2", "name")).toMatch(/"name"\s+DESC/i);
+  });
+
+  it("copyTable keeps a column's SQL function default", async () => {
+    // Rails deserializes column.default and, when that is nil, substitutes
+    // `-> { column.default_function }` before handing it to create_table
+    // (sqlite3_adapter.rb:627-634). `auto_id_tests.published_at` is the
+    // canonical `default: -> { "CURRENT_TIMESTAMP" }` column.
+    await (db as any).copyTable("auto_id_tests", "auto_id_tests2");
+    const copied = (await db.columns("auto_id_tests2")).find((c) => c.name === "published_at");
+    expect(copied?.defaultFunction).toBe("CURRENT_TIMESTAMP");
   });
 
   // --- moveTable ---

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -15,7 +15,7 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
 
   const dropCopyTargets = async (): Promise<void> => {
     await leased?.exec(
-      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "_alter_tmp_customers2"`,
+      `DROP TABLE IF EXISTS customers2; DROP TABLE IF EXISTS customers3; DROP TABLE IF EXISTS books2; DROP TABLE IF EXISTS "acustomers2"`,
     );
   };
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -182,6 +182,29 @@ describe("SQLite3Adapter schema introspection", () => {
     ]);
   });
 
+  it("alterTable rebuilds a schema-qualified table whose index has a custom name", async () => {
+    // The alter_table buffer is a TEMPORARY table, so it is unqualified even
+    // when the source is `aux.widgets`. copy_table_indexes has to spot the
+    // "a"-prefix relationship on the bare names to reach its `t`-prefix rename;
+    // otherwise an index name that doesn't embed the table name is copied onto
+    // the buffer under its original name and collides with the live original.
+    const auxPath = path.join(tmpDir, "aux-alter.sqlite3");
+    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
+    await adapter.executeMutation(
+      "CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY, name TEXT, doomed TEXT)",
+    );
+    await adapter.executeMutation("CREATE INDEX aux.by_name ON widgets (name)");
+    await adapter.executeMutation("INSERT INTO aux.widgets (name) VALUES ('gizmo')");
+
+    await adapter.removeColumn("aux.widgets", "doomed");
+
+    expect((await adapter.columns("aux.widgets")).map((c) => c.name)).toEqual(["id", "name"]);
+    const indexes = (await adapter.indexes("aux.widgets")) as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toEqual(["by_name"]);
+    const rows = await adapter.selectAll("SELECT name FROM aux.widgets");
+    expect(rows.rows).toEqual([["gizmo"]]);
+  });
+
   it("dataSourceExists matches both tables and views, hides sqlite_* internals", async () => {
     await adapter.executeMutation(
       "CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)",

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -182,6 +182,37 @@ describe("SQLite3Adapter schema introspection", () => {
     ]);
   });
 
+  it("alterTable preserves expression, partial and unique indexes across the rebuild", async () => {
+    // The rebuild used to replay each index's sqlite_master CREATE SQL
+    // verbatim; it now round-trips them through copy_table_indexes, which
+    // reconstructs from reflection. Pin the option-carrying shapes.
+    await adapter.executeMutation(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT, code TEXT, doomed TEXT)",
+    );
+    await adapter.executeMutation("CREATE INDEX widgets_on_lower_name ON widgets (lower(name))");
+    await adapter.executeMutation(
+      "CREATE UNIQUE INDEX widgets_on_code ON widgets (code) WHERE code IS NOT NULL",
+    );
+    await adapter.executeMutation(`CREATE INDEX widgets_on_name_desc ON widgets ("name" DESC)`);
+
+    const before = await adapter.indexes("widgets");
+    await adapter.removeColumn("widgets", "doomed");
+
+    const indexes = (await adapter.indexes("widgets")) as Array<{
+      name: string;
+      columns: string[] | string;
+      unique: boolean;
+      where?: string;
+      orders?: Record<string, string>;
+    }>;
+    expect(indexes).toEqual(before);
+    const byName = Object.fromEntries(indexes.map((i) => [i.name, i]));
+    expect(byName["widgets_on_lower_name"]?.columns).toBe("lower(name)");
+    expect(byName["widgets_on_code"]?.unique).toBe(true);
+    expect(byName["widgets_on_code"]?.where).toBe("code IS NOT NULL");
+    expect(byName["widgets_on_name_desc"]?.orders).toEqual({ name: "desc" });
+  });
+
   it("alterTable rebuilds a schema-qualified table whose index has a custom name", async () => {
     // The alter_table buffer is a TEMPORARY table, so it is unqualified even
     // when the source is `aux.widgets`. copy_table_indexes has to spot the

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -195,7 +195,9 @@ describe("SQLite3Adapter schema introspection", () => {
     );
     await adapter.executeMutation(`CREATE INDEX widgets_on_name_desc ON widgets ("name" DESC)`);
 
-    const before = await adapter.indexes("widgets");
+    const byNameSorted = (list: readonly unknown[]): Array<{ name: string }> =>
+      [...(list as Array<{ name: string }>)].sort((a, b) => a.name.localeCompare(b.name));
+    const before = byNameSorted(await adapter.indexes("widgets"));
     await adapter.removeColumn("widgets", "doomed");
 
     const indexes = (await adapter.indexes("widgets")) as Array<{
@@ -205,7 +207,8 @@ describe("SQLite3Adapter schema introspection", () => {
       where?: string;
       orders?: Record<string, string>;
     }>;
-    expect(indexes).toEqual(before);
+    // Sorted by name: index creation order is not part of the contract.
+    expect(byNameSorted(indexes)).toEqual(before);
     const byName = Object.fromEntries(indexes.map((i) => [i.name, i]));
     expect(byName["widgets_on_lower_name"]?.columns).toBe("lower(name)");
     expect(byName["widgets_on_code"]?.unique).toBe(true);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -66,13 +66,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "alter_table",
-    "call": "move_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "alter_table",
     "call": "strip_table_name_prefix_and_suffix",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Rails' `alter_table` is two `move_table` calls, each `copy_table` +
`drop_table` (`sqlite3_adapter.rb:585-596`), so even the throwaway
`a`-prefixed table gets the full `TableDefinition` treatment.

trails instead built a bespoke `_alter_tmp_<table>` buffer whose CREATE
TABLE was hand-concatenated (and deliberately dropped NOT NULL / DEFAULT /
CHECK / PK), then restored indexes by replaying each one's `sqlite_master`
CREATE SQL verbatim. Both were the last hand-rolled DDL in a method whose
whole point after #5487 is that it has none.

## What changed

- **First move is Rails' verbatim**:
  `moveTable(tableName, "a<table>", { temporary: true })`, reusing the
  already-ported `copyTable`, which builds the buffer's column definitions
  from the source table's own reflection.
- **Second move** keeps the caller-supplied definition — the pending
  fks/checks/`modify` changes, which re-deriving from the buffer would lose
  — then `copyTableIndexes` + `copyTableContents` + `DROP TABLE`, which is
  `move_table`'s body.
- **The bespoke index replay is gone.** It tolerated `already exists` /
  `no such column` to paper over indexes the rebuild invalidated;
  `copy_table_indexes` already filters columns the rebuilt table lost.
- **`copyTable` no longer drops SQL function defaults.** It only re-emitted
  a literal default, so a `DEFAULT CURRENT_TIMESTAMP` column lost it in the
  copy. Rails swaps in `-> { column.default_function }` when the deserialized
  default is nil (`sqlite3_adapter.rb:627-634`) and emits a proc default raw.
  Regression-tested against canonical `auto_id_tests.published_at`; fails on
  `main` with `null`.
- The copy-table family now routes its DDL/INSERT through a translating
  exec. Rails gets this free (`create_table` -> `execute`,
  `copy_table_contents` -> `internal_exec_query`); ours went straight to the
  driver, which regressed
  `CompositeForeignKeyTest > add composite foreign key raises without options`
  to a raw `SqliteError`.

## Two SQLite-only details `copyTableIndexes` needed

The buffer is a TEMPORARY table, so it is unqualified even when the source
is `aux.widgets`:

- The `"a"`-prefix relationship is compared on the **bare** names.
  Comparing qualified names missed it, leaving an index whose name doesn't
  embed the table name (a custom `name:`) unrenamed and colliding with the
  still-live original.
- `CREATE INDEX` takes the schema on the **index** name, not on the table
  (`CREATE INDEX aux.by_name ON widgets (...)`); qualifying the table is a
  syntax error. This is why the old verbatim replay broke outright on a
  schema-qualified table — it replayed unqualified SQL against `main`.

Rails has no ATTACHed-schema notion here, so both are noted at the call
site.

## Typeless columns

A typeless column (BLOB affinity) has an empty declared type. `copyTable`
uses `sqlTypeMetadata.sqlType ?? "TEXT"`, and `""` is not nullish, so the
buffer keeps it empty and the affinity round-trips. Pinned in
`sqlite3-adapter.trails.test.ts` (`typeof()` still `integer`, `sqlType`
still `""`).

## Testing

New coverage in `sqlite3-introspection.test.ts`: one test pins that
expression, partial, unique and `DESC` index options survive the rebuild
(`indexes()` before == after, compared by name), guarding the switch from
verbatim replay to reconstruction; the other pins that a schema-qualified
table with a custom-named index rebuilds at all — that one fails on
`main` (`no such table: main.widgets`).

Green locally on sqlite: `adapters/sqlite3/`, `sqlite3-copy-table`,
`sqlite3-introspection`, `schema-dumper`, `migration/`, `migration.test`,
`invertible-migration`, `hot-compatibility`, `reserved-word`,
`query-cache*`, `locking`, `persistence`, `inheritance`, `schema-cache`,
`schema-statements-on-adapter`, `schema-definitions`. PG/MySQL are
untouched (SQLite-only file); CI covers all three.

Closes-story: sqlite-alter-table-buffer-table-is-not-rails-two-move-copy
