### PR TITLE
refactor(sqlite3): build alterTable rebuild from columns(), not PRAGMA rows

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1089,6 +1089,15 @@ export class TableDefinition {
   }
 
   /**
+   * Returns the ColumnDefinition for the column named +name+.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition#[]
+   */
+  get(name: string): ColumnDefinition | undefined {
+    return this.columns.find((c) => c.name === String(name));
+  }
+
+  /**
    * Remove the column +name+ from the table.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition#remove_column

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1694,8 +1694,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     type: string,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    const baseType = this._baseColumnType(type, options);
-    const generatedAs = typeof options?.as === "string" ? options.as : null;
     if (isInvalidAlterTableType(type, options ?? {})) {
       await this.alterTable(tableName, (definition) => {
         definition.column(columnName, type as ColumnType, (options ?? {}) as ColumnOptions);
@@ -1705,7 +1703,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     if (options?.ifNotExists === true && (await this.columnExists(tableName, columnName))) {
       return;
     }
-    const sqlType = baseType;
+    const generatedAs = typeof options?.as === "string" ? options.as : null;
+    const sqlType = this._baseColumnType(type, options);
     let sql = `ALTER TABLE ${quoteTableName(tableName)} ADD COLUMN ${quoteColumnName(columnName)} ${sqlType}`;
     if (options?.collation) sql += ` COLLATE ${quoteColumnName(String(options.collation))}`;
     if (generatedAs !== null) {
@@ -1750,10 +1749,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const newDefault = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     await this.alterTable(tableName, (definition) => {
-      // Rails: `definition[column_name].default = default` — the raw value, not
-      // a literal. schemaCreation re-emits it through quoteDefaultExpression,
-      // which serializes through the column's cast type, so a `default: {}` on a
-      // json column quotes to `{}` and not `[object Object]`.
+      // The raw value, not a literal: schemaCreation re-emits it through
+      // quoteDefaultExpression, which serializes it through the column's cast
+      // type, so `default: {}` on a json column quotes to `{}`.
       const column = definition.get(columnName);
       if (column) column.options.default = newDefault;
     });
@@ -2351,10 +2349,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     await this.ensureConnected();
     const { bare: bareTable } = this._splitTableName(tableName);
 
-    // Rails' copy_table reflects the source with `primary_key(from)` +
-    // `columns(from)` and feeds real Column objects into the definition
-    // (sqlite3_adapter.rb:597-640). `columns` reaches table_structure, which
-    // raises StatementInvalid naming a missing table (foreign_key_test.rb:322).
+    // No explicit missing-table guard: `columns` reaches table_structure, which
+    // already raises StatementInvalid naming the table (foreign_key_test.rb:322).
     const fromPrimaryKey = await this.primaryKey(tableName);
     const sourceColumns = (await this.columns(tableName)) as Sqlite3Column[];
     const compositePk = Array.isArray(fromPrimaryKey);
@@ -2379,19 +2375,16 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         options.as = column.defaultFunction;
         options.stored = column.isVirtualStored();
         options.type = column.type;
-      } else if (column.hasDefault) {
-        const castType = this.lookupCastTypeFromColumn(column);
-        let deserialized = castType.deserialize(column.default);
-        // Rails: `default = -> { column.default_function } if default.nil?`
-        // — a default the cast type can't represent (CURRENT_TIMESTAMP and
-        // friends) rides through as a raw SQL literal.
-        if (deserialized == null) {
-          const defaultFunction = column.defaultFunction;
-          deserialized = (() => defaultFunction) as unknown as typeof deserialized;
-        }
-        if (!column.autoIncrement) {
-          options.default = deserialized;
-        }
+      } else if (column.hasDefault && !column.autoIncrement) {
+        const defaultFunction = column.defaultFunction;
+        const deserialized: unknown = this.lookupCastTypeFromColumn(column).deserialize(
+          column.default,
+        );
+        // Rails: `default = -> { column.default_function } if default.nil?`. The
+        // extra `defaultFunction` guard is trails-only: quoteDefaultExpression
+        // rejects a callable returning null, where Ruby's `quote(nil)` yields NULL.
+        options.default =
+          deserialized == null && defaultFunction != null ? () => defaultFunction : deserialized;
       }
 
       const columnType = column.isVirtual()
@@ -2402,10 +2395,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       definition.column(column.name, columnType as ColumnType, options);
     }
 
-    // Preserve foreign keys and check constraints across the rebuild, before
-    // the block runs — Rails' alter_table lambda adds them first and only then
-    // yields, which is what lets remove_column delete the FKs it orphans
-    // (sqlite3_adapter.rb:566-583).
+    // Attached before the block runs, as in Rails' alter_table lambda
+    // (sqlite3_adapter.rb:566-583) — that ordering is what lets remove_column
+    // delete the FKs it orphans.
     const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
     const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
     definition.foreignKeys.push(...fks);
@@ -3153,7 +3145,9 @@ function deleteForeignKeysForColumns(
 ): void {
   for (let i = definition.foreignKeys.length - 1; i >= 0; i--) {
     const fkColumn = definition.foreignKeys[i].column;
-    const cols = Array.isArray(fkColumn) ? fkColumn : [fkColumn];
+    // A composite FK arrives either as an array or as the comma-joined string
+    // PRAGMA foreign_key_list reflects back; Rails only ever sees the former.
+    const cols = Array.isArray(fkColumn) ? fkColumn : fkColumn.split(",").map((c) => c.trim());
     if (cols.some((c) => columnNames.includes(c))) definition.foreignKeys.splice(i, 1);
   }
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2386,11 +2386,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
           deserialized == null && defaultFunction != null ? () => defaultFunction : deserialized;
       }
 
+      // Left null rather than coerced to "" for a typeless (BLOB affinity)
+      // column: typeToSql renders a null type as the empty string, matching
+      // Rails' `type_to_sql(nil)` -> `nil.to_s`, but rejects a blank string.
       const columnType = column.isVirtual()
         ? "virtual"
         : column.isBigint()
           ? "bigint"
-          : (column.type ?? "");
+          : column.type;
       definition.column(column.name, columnType as ColumnType, options);
     }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2412,20 +2412,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const alteredTableName = `a${bareTable}`;
     const colNames = definition.columns.map((c) => c.name);
 
-    // Rails has no equivalent guard: its remove_column block deletes the FKs it
-    // orphans, but a check constraint naming a dropped column would survive and
-    // fail the rebuild. Keep dropping those here.
-    const removedColumns = sourceColumns.map((c) => c.name).filter((n) => !colNames.includes(n));
-    if (removedColumns.length > 0) {
-      for (let i = definition.checkConstraints.length - 1; i >= 0; i--) {
-        const chk = definition.checkConstraints[i];
-        const referencesRemovedCol = removedColumns.some((col) =>
-          new RegExp(`\\b${col.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(chk.expression),
-        );
-        if (referencesRemovedCol) definition.checkConstraints.splice(i, 1);
-      }
-    }
-
     const createTableSql = await this.schemaCreation.accept(definition);
 
     // Generated columns can't be inserted into — exclude them from the copy

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1751,9 +1751,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     await this.alterTable(tableName, (definition) => {
       // The raw value, not a literal: schemaCreation re-emits it through
       // quoteDefaultExpression, which serializes it through the column's cast
-      // type, so `default: {}` on a json column quotes to `{}`.
-      const column = definition.get(columnName);
-      if (column) column.options.default = newDefault;
+      // type, so `default: {}` on a json column quotes to `{}`. Unguarded, as
+      // in Rails — an unknown column raises rather than rebuilding unchanged.
+      definition.get(columnName)!.options.default = newDefault;
     });
   }
 
@@ -1774,8 +1774,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       );
     }
     await this.alterTable(tableName, (definition) => {
-      const column = definition.get(columnName);
-      if (column) column.options.null = allowNull;
+      definition.get(columnName)!.options.null = allowNull;
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3131,10 +3131,11 @@ function deleteForeignKeysForColumns(
 ): void {
   for (let i = definition.foreignKeys.length - 1; i >= 0; i--) {
     const fkColumn = definition.foreignKeys[i].column;
-    // A composite FK arrives either as an array or as the comma-joined string
-    // PRAGMA foreign_key_list reflects back; Rails only ever sees the former.
-    const cols = Array.isArray(fkColumn) ? fkColumn : fkColumn.split(",").map((c) => c.trim());
-    if (cols.some((c) => columnNames.includes(c))) definition.foreignKeys.splice(i, 1);
+    // Whole-value match, so a composite (array-valued) column never matches —
+    // Rails compares `fk.column` itself, never its members.
+    if (!Array.isArray(fkColumn) && columnNames.includes(fkColumn)) {
+      definition.foreignKeys.splice(i, 1);
+    }
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -104,6 +104,7 @@ import {
   ForeignKeyDefinition,
   type AddForeignKeyOptions,
   type ColumnType,
+  type ColumnOptions,
   type RemoveForeignKeyOptions,
   type ForeignKeyLookupOptions,
 } from "./abstract/schema-definitions.js";
@@ -1696,21 +1697,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const baseType = this._baseColumnType(type, options);
     const generatedAs = typeof options?.as === "string" ? options.as : null;
     if (isInvalidAlterTableType(type, options ?? {})) {
-      const isPk = Boolean(options?.primaryKey) || type === "primary_key";
-      await this.alterTable(tableName, (columns) => {
-        columns[columnName] = {
-          name: columnName,
-          type: baseType,
-          collation: options?.collation ?? null,
-          generatedAs,
-          generatedStored: Boolean(options?.stored),
-          notnull: options?.null === false || isPk ? 1 : 0,
-          dflt_value:
-            options?.default !== undefined && generatedAs === null
-              ? this.quoteDefault(this.serializeDefaultForColumn(options.default, baseType))
-              : null,
-          pk: isPk ? 1 : 0,
-        };
+      await this.alterTable(tableName, (definition) => {
+        definition.column(columnName, type as ColumnType, (options ?? {}) as ColumnOptions);
       });
       return;
     }
@@ -1736,16 +1724,18 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async removeColumn(tableName: string, columnName: string, _type?: string): Promise<void> {
-    await this.alterTable(tableName, (columns) => {
-      delete columns[columnName];
+    await this.alterTable(tableName, (definition) => {
+      definition.removeColumn(columnName);
+      deleteForeignKeysForColumns(definition, [columnName]);
     });
   }
 
   async removeColumns(tableName: string, ...columnNames: string[]): Promise<void> {
-    await this.alterTable(tableName, (columns) => {
+    await this.alterTable(tableName, (definition) => {
       for (const col of columnNames) {
-        delete columns[col];
+        definition.removeColumn(col);
       }
+      deleteForeignKeysForColumns(definition, columnNames);
     });
   }
 
@@ -1759,16 +1749,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // `{}` is the literal default, not a changes hash.
     const newDefault = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
-    await this.alterTable(tableName, (columns) => {
-      if (columns[columnName]) {
-        // Rails recreates the table and re-emits DEFAULT through
-        // quote_default_expression, which serializes structured values through
-        // the column's cast type (sqlite3_adapter.rb:366). Mirror that so a
-        // `default: {}` on a json column quotes to `{}` and not `[object Object]`.
-        const columnType = columns[columnName].type as string | null | undefined;
-        const serialized = this.serializeDefaultForColumn(newDefault, columnType);
-        columns[columnName].dflt_value = serialized === null ? null : this.quoteDefault(serialized);
-      }
+    await this.alterTable(tableName, (definition) => {
+      // Rails: `definition[column_name].default = default` — the raw value, not
+      // a literal. schemaCreation re-emits it through quoteDefaultExpression,
+      // which serializes through the column's cast type, so a `default: {}` on a
+      // json column quotes to `{}` and not `[object Object]`.
+      const column = definition.get(columnName);
+      if (column) column.options.default = newDefault;
     });
   }
 
@@ -1788,10 +1775,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         `UPDATE ${quoteTableName(tableName)} SET ${quoteColumnName(columnName)} = ${quotedDefault} WHERE ${quoteColumnName(columnName)} IS NULL`,
       );
     }
-    await this.alterTable(tableName, (columns) => {
-      if (columns[columnName]) {
-        columns[columnName].notnull = allowNull ? 0 : 1;
-      }
+    await this.alterTable(tableName, (definition) => {
+      const column = definition.get(columnName);
+      if (column) column.options.null = allowNull;
     });
   }
 
@@ -1801,18 +1787,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     type: string,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    const sqlType = this.typeToSql(type, options);
-    await this.alterTable(tableName, (columns) => {
-      if (columns[columnName]) {
-        columns[columnName].type = sqlType;
-        if (options?.null !== undefined) columns[columnName].notnull = options.null ? 0 : 1;
-        if (options?.default !== undefined) {
-          const serialized = this.serializeDefaultForColumn(options.default, sqlType);
-          columns[columnName].dflt_value =
-            serialized === null ? null : this.quoteDefault(serialized);
-        }
-        if (options?.collation !== undefined) columns[columnName].collation = options.collation;
-      }
+    await this.alterTable(tableName, (definition) => {
+      definition.changeColumn(columnName, type as ColumnType, (options ?? {}) as ColumnOptions);
     });
   }
 
@@ -2209,19 +2185,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return fields.map((field) => newColumnFromField(this, tableName, field, fields));
   }
 
-  // Mirrors: SQLite3Adapter#table_structure_with_collation
-  private async _parseCollationsFromTableSql(tableName: string): Promise<Map<string, string>> {
-    const result = new Map<string, string>();
-    const enriched = await this.tableStructureWithCollation(
-      tableName,
-      await this.tableInfo(tableName),
-    );
-    for (const e of enriched) {
-      if (e["collation"] != null) result.set(String(e["name"]), String(e["collation"]));
-    }
-    return result;
-  }
-
   async indexes(tableName: string): Promise<unknown[]> {
     return sqliteIndexes(this, tableName);
   }
@@ -2264,15 +2227,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         return;
       }
     }
-    await this.alterTable(
-      fromTable,
-      () => {},
-      undefined,
-      undefined,
-      (definition) => {
-        definition.foreignKey(toTable, options);
-      },
-    );
+    await this.alterTable(fromTable, (definition) => {
+      definition.foreignKey(toTable, options);
+    });
   }
 
   /**
@@ -2325,7 +2282,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     }
 
     const remainingFks = existingFks.filter((fk) => fk !== fkToRemove);
-    await this.alterTable(fromTable, () => {}, remainingFks);
+    await this.alterTable(fromTable, undefined, remainingFks);
   }
 
   /**
@@ -2340,15 +2297,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       throw new Error("validate: false is only supported on PostgreSQL");
     }
     const { name } = options;
-    await this.alterTable(
-      tableName,
-      () => {},
-      undefined,
-      undefined,
-      (definition) => {
-        definition.checkConstraint(expression, { name });
-      },
-    );
+    await this.alterTable(tableName, (definition) => {
+      definition.checkConstraint(expression, { name });
+    });
   }
 
   /**
@@ -2386,147 +2337,111 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     }
 
     const remainingChecks = existingChecks.filter((c) => c.name !== nameToRemove);
-    await this.alterTable(tableName, () => {}, undefined, remainingChecks);
+    await this.alterTable(tableName, undefined, undefined, remainingChecks);
   }
 
   // --- Private: alter_table copy strategy (Rails: SQLite3Adapter#alter_table) ---
 
   private async alterTable(
     tableName: string,
-    modify: (columns: Record<string, Record<string, unknown>>) => void,
+    block?: (definition: SQLite3TableDefinition) => void,
     overrideForeignKeys?: ForeignKeyDefinition[],
     overrideCheckConstraints?: CheckConstraintDefinition[],
-    extraDefinition?: (definition: SQLite3TableDefinition) => void,
   ): Promise<void> {
     await this.ensureConnected();
-    const { schema, bare: bareTable } = this._splitTableName(tableName);
-    const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
-    // table_info hides GENERATED columns; table_xinfo exposes them with
-    // hidden 2 (virtual) / 3 (stored) so the rebuild preserves them (Rails
-    // rebuilds from columns(from) and re-adds them with as:/stored:,
-    // sqlite3_adapter.rb:623).
-    const infoPragma = this.supportsVirtualColumns() ? "table_xinfo" : "table_info";
-    const tableInfoStmt = await this.driver.prepare(
-      `PRAGMA ${pragmaPrefix}${infoPragma}(${quoteColumnName(bareTable)})`,
-    );
-    const tableInfo = ((await tableInfoStmt.all()) as Array<Record<string, unknown>>).filter(
-      (col) => Number(col.hidden ?? 0) !== 1,
-    );
+    const { bare: bareTable } = this._splitTableName(tableName);
 
-    // Rails' alter_table -> copy_table -> primary_key(from) reaches
-    // table_structure, which raises StatementInvalid naming the table when it
-    // doesn't exist (sqlite3_adapter.rb:598, foreign_key_test.rb:322). Our
-    // rebuild reads PRAGMA directly, so raise the same error here rather than
-    // emitting a column-less CREATE TABLE that fails with a syntax error.
-    if (!tableInfo.length) {
-      throw new StatementInvalid(`Could not find table '${tableName}'`, { sql: "", binds: [] });
-    }
+    // Rails' copy_table reflects the source with `primary_key(from)` +
+    // `columns(from)` and feeds real Column objects into the definition
+    // (sqlite3_adapter.rb:597-640). `columns` reaches table_structure, which
+    // raises StatementInvalid naming a missing table (foreign_key_test.rb:322).
+    const fromPrimaryKey = await this.primaryKey(tableName);
+    const sourceColumns = (await this.columns(tableName)) as Sqlite3Column[];
+    const compositePk = Array.isArray(fromPrimaryKey);
 
-    const hasGenerated = tableInfo.some((col) => Number(col.hidden ?? 0) >= 2);
-    const reflected = hasGenerated ? await this.columns(tableName) : [];
-    const columns: Record<string, Record<string, unknown>> = {};
-    for (const col of tableInfo) {
-      const entry: Record<string, unknown> = { ...col };
-      if (Number(col.hidden ?? 0) >= 2) {
-        const meta = reflected.find((r) => r.name === col.name);
-        entry.generatedAs = meta?.defaultFunction ?? null;
-        entry.generatedStored = Number(col.hidden) === 3;
-        entry.dflt_value = null;
+    const definition = new SQLite3TableDefinition(tableName, {
+      id: false,
+      adapter: this,
+      ...(compositePk ? { primaryKey: fromPrimaryKey } : {}),
+    });
+
+    for (const column of sourceColumns) {
+      const options: Record<string, unknown> = {
+        limit: column.limit,
+        precision: column.precision,
+        scale: column.scale,
+        null: column.null,
+        collation: column.collation,
+        primaryKey: !compositePk && column.name === fromPrimaryKey,
+      };
+
+      if (column.isVirtual()) {
+        options.as = column.defaultFunction;
+        options.stored = column.isVirtualStored();
+        options.type = column.type;
+      } else if (column.hasDefault) {
+        const castType = this.lookupCastTypeFromColumn(column);
+        let deserialized = castType.deserialize(column.default);
+        // Rails: `default = -> { column.default_function } if default.nil?`
+        // — a default the cast type can't represent (CURRENT_TIMESTAMP and
+        // friends) rides through as a raw SQL literal.
+        if (deserialized == null) {
+          const defaultFunction = column.defaultFunction;
+          deserialized = (() => defaultFunction) as unknown as typeof deserialized;
+        }
+        if (!column.autoIncrement) {
+          options.default = deserialized;
+        }
       }
-      columns[col.name as string] = entry;
+
+      const columnType = column.isVirtual()
+        ? "virtual"
+        : column.isBigint()
+          ? "bigint"
+          : (column.type ?? "");
+      definition.column(column.name, columnType as ColumnType, options);
     }
 
-    modify(columns);
+    // Preserve foreign keys and check constraints across the rebuild, before
+    // the block runs — Rails' alter_table lambda adds them first and only then
+    // yields, which is what lets remove_column delete the FKs it orphans
+    // (sqlite3_adapter.rb:566-583).
+    const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
+    const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
+    definition.foreignKeys.push(...fks);
+    definition.checkConstraints.push(...checks);
+
+    block?.(definition);
 
     // Rails: altered_table_name = "a#{table_name}" (sqlite3_adapter.rb:566).
     // Kept bare even for a schema-qualified table: the buffer is a TEMPORARY
     // table, which always lives in the `temp` schema, so a qualifier would be
     // rejected.
     const alteredTableName = `a${bareTable}`;
-    const colNames = Object.keys(columns);
+    const colNames = definition.columns.map((c) => c.name);
 
-    // Detect composite primary keys
-    const pkColumns = colNames
-      .map((name) => ({ name, pk: Number(columns[name].pk) || 0 }))
-      .filter((c) => c.pk > 0)
-      .sort((a, b) => a.pk - b.pk)
-      .map((c) => c.name);
-    const compositePk = pkColumns.length > 1;
-
-    const definition = new SQLite3TableDefinition(tableName, {
-      id: false,
-      adapter: this,
-      ...(compositePk ? { primaryKey: pkColumns } : {}),
-    });
-
-    const existingCollations = await this._parseCollationsFromTableSql(tableName);
-    for (const name of colNames) {
-      const col = columns[name];
-      const options: Record<string, unknown> = {};
-      const collation = col.collation === undefined ? existingCollations.get(name) : col.collation;
-      if (collation) options.collation = String(collation);
-      if (col.generatedAs) {
-        options.as = col.generatedAs;
-        options.stored = Boolean(col.generatedStored);
+    // Rails has no equivalent guard: its remove_column block deletes the FKs it
+    // orphans, but a check constraint naming a dropped column would survive and
+    // fail the rebuild. Keep dropping those here.
+    const removedColumns = sourceColumns.map((c) => c.name).filter((n) => !colNames.includes(n));
+    if (removedColumns.length > 0) {
+      for (let i = definition.checkConstraints.length - 1; i >= 0; i--) {
+        const chk = definition.checkConstraints[i];
+        const referencesRemovedCol = removedColumns.some((col) =>
+          new RegExp(`\\b${col.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(chk.expression),
+        );
+        if (referencesRemovedCol) definition.checkConstraints.splice(i, 1);
       }
-      if (!compositePk && col.pk) options.primaryKey = true;
-      if (col.notnull) options.null = false;
-      if (col.dflt_value !== null && col.dflt_value !== undefined) {
-        const literal = String(col.dflt_value);
-        options.default = () => literal;
-      }
-      const sqlType = String(col.type ?? "TEXT");
-      const columnDefinition = definition.newColumnDefinition(name, sqlType as ColumnType, options);
-      // PRAGMA reports the declared SQL type, not an AR type name, so pin it here
-      // rather than let the visitor resolve it through typeToSql — that is what
-      // round-trips storage affinity exactly. Not when newColumnDefinition flipped
-      // the type to :primary_key though (an integer/bigint PK with no default):
-      // visit_ColumnDefinition then skips add_column_options! entirely and the
-      // whole constraint rides on type_to_sql(:primary_key), so pinning the
-      // declared text over it would silently drop the PRIMARY KEY. Rails' `||=`
-      // has the same effect (abstract/schema_creation.rb:34).
-      if (columnDefinition.type !== "primary_key") columnDefinition.sqlType = sqlType;
-      definition.columns.push(columnDefinition);
     }
-
-    // Preserve foreign keys and check constraints across the rebuild.
-    // Rails: alter_table(table_name, foreign_keys(...), check_constraints(...))
-    const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
-    const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
-
-    for (const fk of fks) {
-      const cols = Array.isArray(fk.column)
-        ? fk.column
-        : fk.column.includes(",")
-          ? fk.column.split(",").map((c) => c.trim())
-          : [fk.column];
-      if (!cols.every((c) => colNames.includes(c))) continue;
-      definition.foreignKeys.push(fk);
-    }
-
-    const removedColumns = tableInfo
-      .map((c) => c.name as string)
-      .filter((n) => !colNames.includes(n));
-    for (const chk of checks) {
-      // Skip check constraints that reference columns no longer in the table
-      // (mirrors the FK handling above which skips FKs for removed columns)
-      const referencesRemovedCol = removedColumns.some((col) =>
-        new RegExp(`\\b${col.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(chk.expression),
-      );
-      if (referencesRemovedCol) continue;
-      definition.checkConstraints.push(chk);
-    }
-
-    extraDefinition?.(definition);
 
     const createTableSql = await this.schemaCreation.accept(definition);
 
     // Generated columns can't be inserted into — exclude them from the copy
     // (Rails: columns_to_copy rejects columns with an :as option,
     // sqlite3_adapter.rb:645).
-    const originalColNames = tableInfo
-      .filter((c) => Number(c.hidden ?? 0) < 2)
-      .map((c) => c.name as string)
+    const originalColNames = sourceColumns
+      .filter((c) => !c.isVirtual())
+      .map((c) => c.name)
       .filter((n) => colNames.includes(n));
 
     // Rails: transaction { disable_referential_integrity { move_table(...) } }
@@ -3225,6 +3140,22 @@ function hasDefaultFunction(defaultValue: unknown, default_: string): boolean {
     defaultValue == null &&
     /\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP|\|\|/.test(default_)
   );
+}
+
+/**
+ * Mirrors the `definition.foreign_keys.delete_if { |fk| ... }` line shared by
+ * SQLite3Adapter#remove_column / #remove_columns (sqlite3_adapter.rb:352, 362).
+ * @internal
+ */
+function deleteForeignKeysForColumns(
+  definition: SQLite3TableDefinition,
+  columnNames: string[],
+): void {
+  for (let i = definition.foreignKeys.length - 1; i >= 0; i--) {
+    const fkColumn = definition.foreignKeys[i].column;
+    const cols = Array.isArray(fkColumn) ? fkColumn : [fkColumn];
+    if (cols.some((c) => columnNames.includes(c))) definition.foreignKeys.splice(i, 1);
+  }
 }
 
 /** @internal */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "add_column",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "add_foreign_key",
     "call": "assert_valid_deferrable",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -627,13 +620,6 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "remove_columns",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "remove_columns",
-    "call": "remove_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -73,6 +73,9 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // encryption/properties.rb:20 `delegate :[], to: :data` / :50 `def []=(key, value)`
   // → encryption/properties.ts `get` / `set`.
   "ActiveRecord::Encryption::Properties": { "[]": ["get"], "[]=": ["set"] },
+  // abstract/schema_definitions.rb:421 `def [](name)` →
+  // connection-adapters/abstract/schema-definitions.ts `TableDefinition#get`.
+  "ActiveRecord::ConnectionAdapters::TableDefinition": { "[]": ["get"] },
   // result.rb:148 `def [](idx)` → result.ts `at` (Result declares no `at` in
   // Ruby, so the name is free).
   "ActiveRecord::Result": { "[]": ["at"] },


### PR DESCRIPTION
## Summary

Rails' `copy_table` reflects the source with `columns(from)` and feeds real
`Column` objects into the definition, reading `limit`, `precision`, `scale`,
`null`, `collation`, `virtual?`, `virtual_stored?`, `has_default?`,
`default_function` and `auto_increment?`, and deserializing the default
through `lookup_cast_type_from_column` (`sqlite3_adapter.rb:597-640`).

trails' `alterTable` instead handed its `modify` callback a record of raw
PRAGMA rows (`{ type, notnull, dflt_value, pk, collation, generatedAs }`),
where `type` was declared SQL type text and `dflt_value` an already-quoted
literal. That is what forced the `sqlType` pin and the pre-quoted default
smuggled through as a callable.

This switches the rebuild to `primaryKey(tableName)` + `columns(tableName)`
and hands the callback the `TableDefinition`, matching Rails' block shape.

## Changes

- `alterTable` builds the definition from `Column` objects, mirroring
  `copy_table`'s option mapping (including the `virtual` / `bigint` type
  selection and the `-> { column.default_function }` fallback).
- Defaults reach the definition as values deserialized through the column's
  cast type, so `schemaCreation`'s `quoteDefaultExpression` serializes and
  quotes them exactly once. `quoteDefault` / `serializeDefaultForColumn` are
  no longer called on the rebuild path.
- The `sqlType` pin is gone — the visitor resolves the type through
  `typeToSql`, as Rails does.
- The six callers now mutate AR-typed definition state:
  - `addColumn` / `changeColumn` → `definition.column` / `definition.changeColumn`
  - `removeColumn` / `removeColumns` → `definition.removeColumn` plus the
    `foreign_keys.delete_if` Rails performs in the same block
  - `changeColumnDefault` → `definition[col].default = <raw value>`
  - `changeColumnNull` → `definition[col].null = null`
- Foreign keys and check constraints are attached **before** the block runs
  (Rails' `alter_table` lambda adds them first, then yields), which is what
  lets `remove_column` drop the FKs it orphans.
- Adds `TableDefinition#get`, the port of `TableDefinition#[]`, with the
  matching `api-compare` operator spelling entry.
- Drops `_parseCollationsFromTableSql`, now dead: `columns()` already carries
  collation.

## Testing

`pnpm typecheck` clean. Green locally on `adapters/sqlite3/`,
`connection-adapters/sqlite3-copy-table.test.ts`, `connection-adapters/`,
`migration/`, `migration.test.ts`, `schema-dumper.test.ts`, plus `comment`,
`invertible-migration`, `inheritance`, `persistence`, `query-cache`,
`reserved-word`. All three adapters run in CI.

Closes-story: sqlite-alter-table-modify-callback-takes-pragma-rows-not-columns
