### PR TITLE
fix(sqlite3): re-point foreign keys across a renamed column in alterTable

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1070,8 +1070,16 @@ export class SchemaStatements {
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
+    this.validateIndexLengthBang(tableName, newName);
+
+    const oldIndexDef = (await this.indexes(tableName)).find((i) => i.name === oldName);
+    if (!oldIndexDef) return;
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(`ALTER INDEX ${this._qi(oldName)} RENAME TO ${this._qi(newName)}`);
+    await this.addIndex(tableName, oldIndexDef.columns, {
+      name: newName,
+      unique: oldIndexDef.unique,
+    });
+    await this.removeIndex(tableName, { name: oldName });
   }
 
   indexName(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -978,6 +978,16 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     await this.renameColumnIndexes(tableName, columnName, newColumnName);
   }
 
+  override async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
+    this.validateIndexLengthBang(tableName, newName);
+
+    const [schema] = this.pg.extractSchemaQualifiedName(tableName);
+    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    await this.adapter.execute(
+      `ALTER INDEX ${schema ? `${this._qt(schema)}.` : ""}${this._qi(oldName)} RENAME TO ${this._qt(newName)}`,
+    );
+  }
+
   override async changeColumnDefault(
     tableName: string,
     columnName: string,

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -898,10 +898,14 @@ describe("DDL cache-invalidation safety-net", () => {
     });
 
     const ss = new SchemaStatements(adapter as any);
+    vi.spyOn(ss, "indexes").mockResolvedValue([
+      { table: "posts", name: "index_posts_on_title", columns: ["title"], unique: false } as any,
+    ]);
     await ss.renameIndex("posts", "index_posts_on_title", "index_posts_on_headline");
 
     expect(cache.isCached("posts")).toBe(false);
-    expect(order).toEqual(["clear:posts", "sql"]);
+    expect(order[0]).toBe("clear:posts");
+    expect(order).toContain("sql");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1790,10 +1790,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
+    const column = await this.columnFor(tableName, columnName);
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
-    await this.execute(
-      `ALTER TABLE ${quoteTableName(tableName)} RENAME COLUMN ${quoteColumnName(columnName)} TO ${quoteColumnName(newColumnName)}`,
-    );
+    await this.alterTable(tableName, undefined, undefined, undefined, {
+      rename: { [column.name]: newColumnName },
+    });
+    await this.schemaStatements().renameColumnIndexes(tableName, column.name, newColumnName);
   }
 
   async addTimestamps(tableName: string, options?: Record<string, unknown>): Promise<void> {
@@ -2344,8 +2346,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     block?: (definition: SQLite3TableDefinition) => void,
     overrideForeignKeys?: ForeignKeyDefinition[],
     overrideCheckConstraints?: CheckConstraintDefinition[],
+    options: { rename?: Record<string, string> } = {},
   ): Promise<void> {
     await this.ensureConnected();
+    const rename = options.rename ?? {};
+    const renamed = (name: string): string => rename[name] ?? name;
     const { bare: bareTable } = this._splitTableName(tableName);
 
     // No explicit missing-table guard: `columns` reaches table_structure, which
@@ -2357,11 +2362,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const definition = new SQLite3TableDefinition(tableName, {
       id: false,
       adapter: this,
-      ...(compositePk ? { primaryKey: fromPrimaryKey } : {}),
+      ...(compositePk ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
     });
 
     for (const column of sourceColumns) {
-      const options: Record<string, unknown> = {
+      const columnOptions: Record<string, unknown> = {
         limit: column.limit,
         precision: column.precision,
         scale: column.scale,
@@ -2371,9 +2376,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       };
 
       if (column.isVirtual()) {
-        options.as = column.defaultFunction;
-        options.stored = column.isVirtualStored();
-        options.type = column.type;
+        columnOptions.as = column.defaultFunction;
+        columnOptions.stored = column.isVirtualStored();
+        columnOptions.type = column.type;
       } else if (column.hasDefault && !column.autoIncrement) {
         const defaultFunction = column.defaultFunction;
         const deserialized: unknown = this.lookupCastTypeFromColumn(column).deserialize(
@@ -2382,7 +2387,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         // Rails: `default = -> { column.default_function } if default.nil?`. The
         // extra `defaultFunction` guard is trails-only: quoteDefaultExpression
         // rejects a callable returning null, where Ruby's `quote(nil)` yields NULL.
-        options.default =
+        columnOptions.default =
           deserialized == null && defaultFunction != null ? () => defaultFunction : deserialized;
       }
 
@@ -2394,7 +2399,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         : column.isBigint()
           ? "bigint"
           : column.type;
-      definition.column(column.name, columnType as ColumnType, options);
+      definition.column(renamed(column.name), columnType as ColumnType, columnOptions);
     }
 
     // Attached before the block runs, as in Rails' alter_table lambda
@@ -2402,7 +2407,25 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // delete the FKs it orphans.
     const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
     const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
-    definition.foreignKeys.push(...fks);
+    definition.foreignKeys.push(
+      ...fks.map((fk) => {
+        const column = typeof fk.column === "string" ? (rename[fk.column] ?? fk.column) : fk.column;
+        return column === fk.column
+          ? fk
+          : new ForeignKeyDefinition(
+              fk.fromTable,
+              fk.toTable,
+              column,
+              fk.primaryKey,
+              fk.name,
+              fk.onDelete,
+              fk.onUpdate,
+              fk.deferrable,
+              fk.storesValidate ? fk.validate : undefined,
+              fk.storedOptionKeys,
+            );
+      }),
+    );
     definition.checkConstraints.push(...checks);
 
     block?.(definition);
@@ -2422,7 +2445,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const originalColNames = sourceColumns
       .filter((c) => !c.isVirtual())
       .map((c) => c.name)
-      .filter((n) => colNames.includes(n));
+      .filter((n) => colNames.includes(renamed(n)));
 
     // Rails: transaction { disable_referential_integrity { move_table(...) } }
     // Use savepoint if already inside a transaction (e.g. migration),
@@ -2441,14 +2464,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         // throwaway "a"-prefixed buffer is built by copy_table off the source
         // table's own reflection, so it carries the full column definitions
         // rather than a hand-concatenated CREATE TABLE.
-        await this.moveTable(tableName, alteredTableName, { temporary: true });
+        await this.moveTable(tableName, alteredTableName, { temporary: true, rename });
         // The second move is copy_table + drop_table with the definition supplied
         // by the caller above (fks/checks/`modify`) instead of re-derived from the
         // buffer — that is where alter_table's whole point lives, and the buffer's
         // reflection would have lost the pending changes.
         await this.execCopyTable(createTableSql);
         await this.copyTableIndexes(alteredTableName, tableName);
-        await this.copyTableContents(alteredTableName, tableName, originalColNames);
+        await this.copyTableContents(alteredTableName, tableName, originalColNames.map(renamed));
         await this.execCopyTable(`DROP TABLE ${quoteTableName(alteredTableName)}`);
       });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -114,6 +114,32 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
 
   // --- alterTable ---
 
+  it("alterTable re-points a foreign key across a column rename", async () => {
+    await (db as any).alterTable("fk_test_has_fk", undefined, undefined, undefined, {
+      rename: { fk_id: "renamed_fk_id" },
+    });
+    const fks = await db.foreignKeys("fk_test_has_fk");
+    expect(fks).toHaveLength(1);
+    expect(fks[0].column).toBe("renamed_fk_id");
+    expect(fks[0].toTable).toBe("fk_test_has_pk");
+  });
+
+  it("removeColumn keeps a multi-column index on the surviving columns", async () => {
+    await db.addIndex("customers", ["name", "gps_location"], { unique: true });
+    await db.removeColumn("customers", "gps_location");
+    const indexes = (await db.indexes("customers")) as Array<{ name: string; columns: string[] }>;
+    expect(indexes.map((i) => i.name)).toEqual(["index_customers_on_name_and_gps_location"]);
+    expect(indexes[0].columns).toEqual(["name"]);
+  });
+
+  it("renameColumn renames the index whose name embeds the column", async () => {
+    await db.addIndex("customers", ["name"]);
+    await db.renameColumn("customers", "name", "nickname");
+    const names = ((await db.indexes("customers")) as Array<{ name: string }>).map((i) => i.name);
+    expect(names).toContain("index_customers_on_nickname");
+    expect(names).not.toContain("index_customers_on_name");
+  });
+
   it("alterTable keeps the primary key of a lowercase integer-like declared type", async () => {
     // PRAGMA table_info normalizes a declared `integer` to `INTEGER` but leaves
     // `bigint` verbatim, so hand-written DDL is the one way the rebuild sees an

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -852,6 +852,83 @@ describeIfSupports("foreign_keys", "Migration", () => {
     );
   });
 
+  describe("ForeignKeyChangeColumnTest", () => {
+    fixtures([], { useTransactionalTests: false });
+
+    const withChangeColumnTables = async (
+      body: (conn: AbstractAdapter) => Promise<void>,
+    ): Promise<void> => {
+      const conn = await ambientConnection();
+      await conn.dropTable("astronauts", "rockets", { ifExists: true });
+      await conn.createTable("rockets", {}, (t) => {
+        t.string("name");
+      });
+      await conn.createTable("astronauts", {}, (t) => {
+        t.string("name");
+        t.references("rocket", { foreignKey: true });
+      });
+      try {
+        await body(conn);
+      } finally {
+        await conn.dropTable("astronauts", "rockets", { ifExists: true });
+      }
+    };
+
+    const createRocketWithAstronaut = async (conn: AbstractAdapter): Promise<void> => {
+      await conn.executeMutation(
+        `INSERT INTO ${conn.quoteTableName("rockets")} (name) VALUES ('myrocket')`,
+      );
+      const rows = (await conn.execute(
+        `SELECT id FROM ${conn.quoteTableName("rockets")}`,
+      )) as Array<{
+        id: number;
+      }>;
+      await conn.executeMutation(
+        `INSERT INTO ${conn.quoteTableName("astronauts")} (rocket_id) VALUES (${rows[0].id})`,
+      );
+    };
+
+    const rocketName = async (conn: AbstractAdapter): Promise<string> => {
+      const rows = (await conn.execute(
+        `SELECT name FROM ${conn.quoteTableName("rockets")} ORDER BY id`,
+      )) as Array<{ name: string }>;
+      return rows[0].name;
+    };
+
+    it("rename column of child table", async () => {
+      await withChangeColumnTables(async (conn) => {
+        await createRocketWithAstronaut(conn);
+
+        await conn.renameColumn("astronauts", "name", "astronaut_name");
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(await rocketName(conn)).toBe("myrocket");
+        expect(fk.fromTable).toBe("astronauts");
+        expect(fk.toTable).toBe("rockets");
+      });
+    });
+
+    it.skipIf(adapterType === "mysql")("rename reference column of child table", async () => {
+      await withChangeColumnTables(async (conn) => {
+        await createRocketWithAstronaut(conn);
+
+        await conn.renameColumn("astronauts", "rocket_id", "new_rocket_id");
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(await rocketName(conn)).toBe("myrocket");
+        expect(fk.fromTable).toBe("astronauts");
+        expect(fk.toTable).toBe("rockets");
+        expect(fk.column).toBe("new_rocket_id");
+      });
+    });
+  });
+
   describe("CompositeForeignKeyTest", () => {
     fixtures([], { useTransactionalTests: false });
 

--- a/packages/activerecord/src/migration/foreign-key.trails.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.trails.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-fixtures.js";
 import { ambientConnection, withRocketTables } from "../support/rocket-tables.js";
+import { Base } from "../base.js";
 
 describe("removeForeignKey option narrowing", () => {
   fixtures([], { useTransactionalTests: false });
@@ -46,5 +47,29 @@ describe("removeForeignKey option narrowing", () => {
       expect(remaining.map((fk) => fk.column)).toEqual(["favorite_rocket_id"]);
       expect(remaining[0].onDelete).toBe("nullify");
     });
+  });
+});
+
+describe("renameColumn under a table_name_prefix", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  it("keeps the foreign key pointing at the prefixed table", async () => {
+    const conn = await ambientConnection();
+    Base.tableNamePrefix = "p_";
+    await conn.createTable("p_rockets", { force: true }, () => {});
+    await conn.createTable("p_astronauts", { force: true }, (t) => {
+      t.references("rocket", { foreignKey: true });
+    });
+    try {
+      await conn.renameColumn("p_astronauts", "rocket_id", "new_rocket_id");
+
+      const foreignKeys = await conn.foreignKeys("p_astronauts");
+      expect(foreignKeys.length).toBe(1);
+      expect(foreignKeys[0].toTable).toBe("p_rockets");
+      expect(foreignKeys[0].column).toBe("new_rocket_id");
+    } finally {
+      await conn.dropTable("p_astronauts", "p_rockets", { ifExists: true });
+      Base.tableNamePrefix = "";
+    }
   });
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -625,48 +625,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_index",
-    "call": "add_index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_index",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_index",
-    "call": "detect",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_index",
-    "call": "indexes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_index",
-    "call": "remove_index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_index",
-    "call": "validate_index_length!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "table_exists?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -674,27 +674,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "rename_column",
-    "call": "alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "rename_column",
-    "call": "column_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "rename_column",
-    "call": "rename_column_indexes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "rename_table",
     "call": "exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

Rails' `alter_table` takes a `rename:` map and threads it through `copy_table`
(column names), `copy_table_indexes`, `copy_table_contents` and the `caller`
lambda that re-adds foreign keys, re-pointing an FK at the renamed column
instead of dropping it (`sqlite3_adapter.rb:561-592`).

trails' `alterTable` had no rename map, and `renameColumn` sidestepped the
rebuild entirely with SQLite's native `ALTER TABLE ... RENAME COLUMN`, so
`rename_column_indexes` never ran and index names kept the old column.

- `alterTable` accepts `options.rename` and passes it to the **first**
  `moveTable`, exactly as Rails does (`options.merge(temporary: true)`), so the
  `a`-prefixed buffer already carries the new names and the second copy needs
  none. The map is also applied to the rebuilt column list, the composite
  primary key, and the foreign keys — via a whole-option
  `rename[fk.options[:column]]` lookup, so a composite (Array) `:column` is
  left untouched just as it is in Ruby (`sqlite3_adapter.rb:571-574`).
- `renameColumn` converges on Rails: `columnFor` → `alterTable(rename:)` →
  `renameColumnIndexes` (`sqlite3_adapter.rb:391-395`).
- The PostgreSQL-only `ALTER INDEX ... RENAME TO` form of `renameIndex` was
  sitting in the abstract `SchemaStatements`, where it is invalid SQL on
  SQLite. Moved to the PostgreSQL override
  (`postgresql/schema_statements.rb:565`); the abstract is restored to Rails'
  naive add-then-remove (`abstract/schema_statements.rb:980`). MySQL already
  had its own override.

Rails also strips the table-name prefix/suffix off `fk.to_table` before
re-adding, because `definition.foreign_key` re-applies it. trails pushes the
already-prefixed reflected definition, so that round trip is a no-op we skip —
pinned by a test rather than a comment.

## Tests

- `migration/foreign-key.test.ts`: ports `ForeignKeyChangeColumnTest`'s
  `rename column of child table` and `rename reference column of child table`
  (`foreign_key_test.rb:80-112`), including Rails' MySQL `supports_rename_index?`
  skip.
- `migration/foreign-key.trails.test.ts`: renaming an FK column under a
  configured `table_name_prefix` keeps the key pointed at the prefixed table.
- `sqlite3-copy-table.test.ts`: `alterTable` re-pointing an FK across a rename,
  `renameColumn` renaming the index whose name embeds the column (both fail on
  baseline), and `removeColumn` keeping a multi-column index on its survivors.

Verified on SQLite, PostgreSQL and MySQL.

## Follow-ups

- `sqlite-alter-table-block-argument-goes-last` (RFC 0051) — `alterTable`'s
  callback sits second, ahead of the foreign-key/check-constraint overrides;
  Rails' `alter_table` takes the block last. That order arrived with #5528 and
  is untouched here; reordering it churns every call site, so it is scheduled
  separately.

Closes-story: sqlite-alter-table-drops-fks-instead-of-remapping-renamed-columns
