### PR TITLE
ci: skip guides-typecheck for test-only changes in guides-dep packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,10 @@ jobs:
           # scripts/guides-typecheck/ is the job's own implementation and is
           # carved out of the infra sweep (INFRA_CARVEOUT_RE), so it must be
           # named here or a checker-only change would stop running the checker.
+          # GUIDES_EXCL_RE drops test-only paths before the match: guides
+          # compile against exported types, which no suite or fixture reaches.
           GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|did-you-mean|trails-tsc)/|packages/website/docs/guides/|scripts/guides-typecheck/)'
+          GUIDES_EXCL_RE='(/src/test-helpers/|/test-fixtures?/|/__fixtures__/|/__snapshots__/|\.test\.ts$)'
           # website_affected gates the Website build (SvelteKit + typedoc +
           # VitePress). Scoped narrowly to packages/website/ — package-source
           # changes alone don't trigger it. To run the site build on a PR
@@ -234,8 +237,8 @@ jobs:
           # change can't move any comparison output, so it skips.
           # packages/website/ is EXCLUDED: it's the SvelteKit docs site, never
           # one of apiComparePackages() (vendor/sources.ts), so the comparison
-          # never scans it — it is filtered out of comparison_files below
-          # before the COMPARISON_RE `^packages/` clause is applied.
+          # never scans it — set_gate's exclusion argument drops it before
+          # the COMPARISON_RE `^packages/` clause is applied.
           # NOTE: scripts/api-compare/conventions.ts regenerates
           # docs/ruby-ts-conventions.md (checked by api:conventions --check in
           # the job); the scripts/api-compare/ clause keeps that drift check
@@ -363,9 +366,12 @@ jobs:
                   # each carved subtree still flips its own consuming job's gate
                   # via that gate's regex.
                   infra_files=$(echo "$files" | grep -vE "$INFRA_CARVEOUT_RE" || true)
+                  # $3 is an optional exclusion applied to $files before the
+                  # gate regex: paths that cannot reach what the job checks.
                   set_gate() {
-                    local name="$1" re="$2"
-                    if echo "$infra_files" | grep -qE "$INFRA_RE" || echo "$files" | grep -qE "$re"; then
+                    local name="$1" re="$2" gate_files="$files"
+                    if [ -n "$3" ]; then gate_files=$(echo "$files" | grep -vE "$3" || true); fi
+                    if echo "$infra_files" | grep -qE "$INFRA_RE" || echo "$gate_files" | grep -qE "$re"; then
                       echo "${name}=true"  >> "$GITHUB_OUTPUT"
                     else
                       echo "${name}=false" >> "$GITHUB_OUTPUT"
@@ -379,18 +385,9 @@ jobs:
                   set_gate trails_tsc_affected   "$TRAILS_TSC_PKGS_RE"
                   set_gate tse_compiler_affected "$TSE_COMPILER_PKGS_RE"
                   set_gate unit_tests_affected   "$UNIT_TESTS_PKGS_RE"
-                  set_gate guides_affected       "$GUIDES_PKGS_RE"
+                  set_gate guides_affected       "$GUIDES_PKGS_RE" "$GUIDES_EXCL_RE"
                   set_gate website_affected      "$WEBSITE_PKGS_RE"
-                  # comparison_affected can't reuse set_gate: it must first
-                  # drop packages/website/ (which the comparison never scans)
-                  # so a website-only PR skips the job. INFRA_RE still applies
-                  # via infra_files (website doesn't match INFRA_RE anyway).
-                  comparison_files=$(echo "$files" | grep -vE '^packages/website/' || true)
-                  if echo "$infra_files" | grep -qE "$INFRA_RE" || echo "$comparison_files" | grep -qE "$COMPARISON_RE"; then
-                    echo "comparison_affected=true"  >> "$GITHUB_OUTPUT"
-                  else
-                    echo "comparison_affected=false" >> "$GITHUB_OUTPUT"
-                  fi
+                  set_gate comparison_affected   "$COMPARISON_RE" '^packages/website/'
                 fi
                 ;;
             esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,6 @@ jobs:
           # scripts/guides-typecheck/ is the job's own implementation and is
           # carved out of the infra sweep (INFRA_CARVEOUT_RE), so it must be
           # named here or a checker-only change would stop running the checker.
-          # GUIDES_EXCL_RE drops test-only paths before the match: guides
-          # compile against exported types, which no suite or fixture reaches.
           GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|did-you-mean|trails-tsc)/|packages/website/docs/guides/|scripts/guides-typecheck/)'
           GUIDES_EXCL_RE='(/src/test-helpers/|/test-fixtures?/|/__fixtures__/|/__snapshots__/|\.test\.ts$)'
           # website_affected gates the Website build (SvelteKit + typedoc +
@@ -366,11 +364,9 @@ jobs:
                   # each carved subtree still flips its own consuming job's gate
                   # via that gate's regex.
                   infra_files=$(echo "$files" | grep -vE "$INFRA_CARVEOUT_RE" || true)
-                  # $3 is an optional exclusion applied to $files before the
-                  # gate regex: paths that cannot reach what the job checks.
                   set_gate() {
-                    local name="$1" re="$2" gate_files="$files"
-                    if [ -n "$3" ]; then gate_files=$(echo "$files" | grep -vE "$3" || true); fi
+                    local name="$1" re="$2" excl="${3:-}" gate_files="$files"
+                    if [ -n "$excl" ]; then gate_files=$(echo "$files" | grep -vE "$excl" || true); fi
                     if echo "$infra_files" | grep -qE "$INFRA_RE" || echo "$gate_files" | grep -qE "$re"; then
                       echo "${name}=true"  >> "$GITHUB_OUTPUT"
                     else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           # carved out of the infra sweep (INFRA_CARVEOUT_RE), so it must be
           # named here or a checker-only change would stop running the checker.
           GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|did-you-mean|trails-tsc)/|packages/website/docs/guides/|scripts/guides-typecheck/)'
-          GUIDES_EXCL_RE='(/src/test-helpers/|/test-fixtures?/|/__fixtures__/|/__snapshots__/|\.test\.ts$)'
+          GUIDES_EXCL_RE='(/src/test-helpers(/|\.ts$)|/test-fixtures?(/|\.ts$)|/__fixtures__/|/__snapshots__/|\.test\.ts$)'
           # website_affected gates the Website build (SvelteKit + typedoc +
           # VitePress). Scoped narrowly to packages/website/ — package-source
           # changes alone don't trigger it. To run the site build on a PR

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -174,6 +174,37 @@ describe("CI runs every tooling test suite", () => {
     expect(unmatched).toEqual([]);
   });
 
+  // guides-typecheck runs a full `pnpm build` plus `pnpm guides:typecheck`,
+  // so it is one of the most expensive gated jobs. The guides only ever
+  // compile against the PUBLIC type surface of the packages they import, so
+  // the changes job strips test-only paths (GUIDES_EXCL_RE) out of the
+  // changed-file list before matching GUIDES_PKGS_RE. Trace both directions:
+  // a source change must still run it, a test-only change must not.
+  it("fires guides_affected only for paths that can reach the public type surface", async () => {
+    const yml = await readFile(CI_YML, "utf8");
+    const gate = gateRegex(yml, "GUIDES_PKGS_RE");
+    const excl = gateRegex(yml, "GUIDES_EXCL_RE");
+    const fires = (file: string): boolean => !excl.test(file) && gate.test(file);
+
+    const runs = [
+      "packages/activerecord/src/relation.ts",
+      "packages/activemodel/src/validations.ts",
+      "packages/website/docs/guides/active-record-basics.md",
+      "scripts/guides-typecheck/check.ts",
+    ];
+    const skips = [
+      "packages/activerecord/src/relation.test.ts",
+      "packages/activerecord/src/test-helpers/models/topic.ts",
+      "packages/activerecord/src/test-helpers/fixtures/topics.yml",
+      "packages/arel/src/__snapshots__/visitors.test.ts.snap",
+    ];
+    expect(runs.filter((f) => !fires(f))).toEqual([]);
+    expect(skips.filter(fires)).toEqual([]);
+    // The exclusion, not the package regex, is what drops them: every skipped
+    // path still lives under a guides-dep package.
+    expect(skips.filter((f) => !gate.test(f))).toEqual([]);
+  });
+
   it("keeps KNOWN_UNRUN free of entries CI already runs", async () => {
     const yml = await readFile(CI_YML, "utf8");
     const filters = ciVitestFilters(yml);

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -226,6 +226,8 @@ describe("CI runs every tooling test suite", () => {
       "packages/activerecord/src/test-helpers/models/topic.ts",
       "packages/activerecord/src/test-helpers/fixtures/topics.yml",
       "packages/arel/src/__snapshots__/visitors.test.ts.snap",
+      "packages/activerecord/src/test-fixtures.ts",
+      "packages/activerecord/src/test-fixtures/fixture-connection.ts",
     ];
     const fired = await Promise.all([...runs, ...skips].map(runGate));
     const outcome = Object.fromEntries(

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from "vitest";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 // Guard for the defect this file was added with: vitest.config.ts has always
 // collected the tooling test suites under scripts/ into the "other" project,
@@ -125,6 +129,38 @@ function gateRegex(yml: string, name: string): RegExp {
   return new RegExp(source);
 }
 
+/**
+ * Runs the `changes` job's own gate block — the `*_RE` definitions plus the
+ * `infra_files`/`set_gate` region lifted verbatim out of ci.yml — over a
+ * changed-file list, under the same `set -euo pipefail` the job uses. Modelling
+ * the regexes in JS instead would miss shell-level faults (an unbound `$3`
+ * under `set -u` took the whole job down once).
+ */
+async function gateRunner(yml: string): Promise<(file: string) => Promise<Record<string, string>>> {
+  const lines = yml.split("\n").map((l) => l.trim());
+  const defs = lines.filter((l) => /^[A-Z_]+_RE='/.test(l));
+  const start = lines.findIndex((l) => l.startsWith("infra_files=$("));
+  const end = lines.findIndex((l) => l.startsWith("set_gate comparison_affected"));
+  if (start === -1 || end === -1) throw new Error("no gate block in ci.yml");
+  const script = [
+    "set -euo pipefail",
+    ...defs,
+    'GITHUB_OUTPUT=$(mktemp)\nfiles="$1"',
+    ...lines.slice(start, end + 1),
+    'cat "$GITHUB_OUTPUT"; rm -f "$GITHUB_OUTPUT"',
+  ].join("\n");
+
+  return async (file) => {
+    const { stdout } = await execFileAsync("bash", ["-c", script, "gate", file]);
+    return Object.fromEntries(
+      stdout
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => l.split("=") as [string, string]),
+    );
+  };
+}
+
 describe("CI runs every tooling test suite", () => {
   it("covers each scripts/eslint/vendor test file with a ci.yml vitest filter", async () => {
     const yml = await readFile(CI_YML, "utf8");
@@ -174,17 +210,10 @@ describe("CI runs every tooling test suite", () => {
     expect(unmatched).toEqual([]);
   });
 
-  // guides-typecheck runs a full `pnpm build` plus `pnpm guides:typecheck`,
-  // so it is one of the most expensive gated jobs. The guides only ever
-  // compile against the PUBLIC type surface of the packages they import, so
-  // the changes job strips test-only paths (GUIDES_EXCL_RE) out of the
-  // changed-file list before matching GUIDES_PKGS_RE. Trace both directions:
-  // a source change must still run it, a test-only change must not.
   it("fires guides_affected only for paths that can reach the public type surface", async () => {
     const yml = await readFile(CI_YML, "utf8");
     const gate = gateRegex(yml, "GUIDES_PKGS_RE");
-    const excl = gateRegex(yml, "GUIDES_EXCL_RE");
-    const fires = (file: string): boolean => !excl.test(file) && gate.test(file);
+    const runGate = await gateRunner(yml);
 
     const runs = [
       "packages/activerecord/src/relation.ts",
@@ -198,11 +227,21 @@ describe("CI runs every tooling test suite", () => {
       "packages/activerecord/src/test-helpers/fixtures/topics.yml",
       "packages/arel/src/__snapshots__/visitors.test.ts.snap",
     ];
-    expect(runs.filter((f) => !fires(f))).toEqual([]);
-    expect(skips.filter(fires)).toEqual([]);
-    // The exclusion, not the package regex, is what drops them: every skipped
-    // path still lives under a guides-dep package.
+    const fired = await Promise.all([...runs, ...skips].map(runGate));
+    const outcome = Object.fromEntries(
+      [...runs, ...skips].map((f, i) => [f, fired[i].guides_affected]),
+    );
+    expect(runs.filter((f) => outcome[f] !== "true")).toEqual([]);
+    expect(skips.filter((f) => outcome[f] !== "false")).toEqual([]);
     expect(skips.filter((f) => !gate.test(f))).toEqual([]);
+  });
+
+  it("keeps comparison_affected off for website-only changes", async () => {
+    const runGate = await gateRunner(await readFile(CI_YML, "utf8"));
+    expect((await runGate("packages/website/src/app.ts")).comparison_affected).toBe("false");
+    expect((await runGate("packages/activerecord/src/relation.ts")).comparison_affected).toBe(
+      "true",
+    );
   });
 
   it("keeps KNOWN_UNRUN free of entries CI already runs", async () => {


### PR DESCRIPTION
`guides_affected` fired the expensive `guides-typecheck` job (full `pnpm build`
+ `pnpm guides:typecheck`) for **any** change under the guides-dep packages —
including `*.test.ts`, `src/test-helpers/`, fixtures and snapshots. Guides only
compile against the packages' public type surface, so those paths cannot break
them.

- `GUIDES_EXCL_RE` is stripped from the changed-file list before matching
  `GUIDES_PKGS_RE`. `set_gate` grew an optional third argument (exclusion
  regex), which also absorbs the hand-rolled `comparison_files` block that did
  the same thing for `packages/website/`.
- The gate output and both consumers (`guides-typecheck`'s `if:` and the `ci`
  aggregate allowlist) still key on the same `guides_affected` output.
- `scripts/ci-suite-coverage.test.ts` now lifts the gate block out of ci.yml
  (the `*_RE` definitions plus the `infra_files`/`set_gate` region) and
  **executes it in bash under the same `set -euo pipefail`**, tracing: AR src →
  runs, guides doc → runs, checker → runs; AR `*.test.ts` / test-helpers /
  fixtures / snapshots → skipped, and website-only → `comparison_affected=false`
  (unchanged behaviour). Modelling the regexes in JS would not have caught the
  `set -u` fault that took the `changes` job down on the first push.

The `changes` job's inline `run:` script sits a few hundred bytes under a hard
Actions size limit, so this change is net-smaller: 20,695 B → 20,396 B.

Closes-story: tighten-guides-typecheck-gate
