### PR TITLE
test(activerecord): give the dropAllTables self-test its own database

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -2,11 +2,15 @@ import { afterAll, afterEach, describe, it, expect, beforeAll, vi } from "vitest
 import { Base } from "../base.js";
 import { setupHandlerSuite } from "./setup-handler-suite.js";
 import { dropAllTables, resetTestTables } from "./drop-all-tables.js";
-import { rebuildCanonicalTables } from "./canonical-table-rebuild.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
+import { openIsolatedDatabase, type IsolatedDatabase } from "./isolated-database.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 let adapter: DatabaseAdapter;
+// The `dropAllTables` suite asserts a zero-table database, so it cannot ride
+// the per-worker adapter every other AR file shares: `test-setup-dy.ts` loads
+// the canonical schema once per worker, not once per file, and nothing would
+// lay it back down for the next file. It gets its own database instead.
+let isolated: IsolatedDatabase | undefined;
 
 async function listTables(a: DatabaseAdapter): Promise<string[]> {
   if (a.adapterName === "sqlite") {
@@ -38,17 +42,6 @@ setupHandlerSuite();
 
 beforeAll(() => {
   adapter = Base.adapter;
-});
-
-// The `dropAllTables` suite below asserts a zero-table database, so it wipes the
-// canonical schema out of the per-worker DB this file shares with every other
-// AR test file. Nothing lays it back down on its own — `test-setup-dy.ts` loads
-// the schema once per worker, not once per file — so restore it here or the next
-// file in this worker opens on an empty database. `schema_migrations` and
-// `ar_internal_metadata` are bookkeeping, not canonical, and are deliberately
-// left dropped (the Migrator tests want a clean `schema_migrations`).
-afterAll(async () => {
-  await rebuildCanonicalTables(adapter, Object.keys(TEST_SCHEMA));
 });
 
 describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
@@ -163,30 +156,54 @@ describe("resetTestTables", () => {
 });
 
 describe("dropAllTables", () => {
+  let dropAdapter: DatabaseAdapter;
+
+  beforeAll(async () => {
+    isolated = await openIsolatedDatabase("drop-all-tables");
+    dropAdapter = isolated.adapter;
+  });
+
+  afterAll(async () => {
+    await isolated?.close();
+    isolated = undefined;
+  });
+
   it("drops all tables", async () => {
-    await adapter.executeMutation(`CREATE TABLE drop_t1 (id INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE drop_t2 (id INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE drop_t3 (id INTEGER PRIMARY KEY)`);
-    await dropAllTables(adapter);
-    expect(await tableCount(adapter)).toBe(0);
+    await dropAdapter.executeMutation(`CREATE TABLE drop_t1 (id INTEGER PRIMARY KEY)`);
+    await dropAdapter.executeMutation(`CREATE TABLE drop_t2 (id INTEGER PRIMARY KEY)`);
+    await dropAdapter.executeMutation(`CREATE TABLE drop_t3 (id INTEGER PRIMARY KEY)`);
+    await dropAllTables(dropAdapter);
+    expect(await tableCount(dropAdapter)).toBe(0);
   });
 
   it("is idempotent — second call is a no-op", async () => {
-    await dropAllTables(adapter);
-    await dropAllTables(adapter);
-    expect(await tableCount(adapter)).toBe(0);
+    await dropAllTables(dropAdapter);
+    await dropAllTables(dropAdapter);
+    expect(await tableCount(dropAdapter)).toBe(0);
   });
 
   it("drops 3-table FK chain without error", async () => {
-    const int = adapter.adapterName === "mysql" ? "INT" : "INTEGER";
-    await adapter.executeMutation(`CREATE TABLE fk_parent (id ${int} PRIMARY KEY)`);
-    await adapter.executeMutation(
+    const int = dropAdapter.adapterName === "mysql" ? "INT" : "INTEGER";
+    await dropAdapter.executeMutation(`CREATE TABLE fk_parent (id ${int} PRIMARY KEY)`);
+    await dropAdapter.executeMutation(
       `CREATE TABLE fk_child (id ${int} PRIMARY KEY, parent_id ${int})`,
     );
-    await adapter.executeMutation(
+    await dropAdapter.executeMutation(
       `CREATE TABLE fk_grandchild (id ${int} PRIMARY KEY, child_id ${int})`,
     );
-    await dropAllTables(adapter);
-    expect(await tableCount(adapter)).toBe(0);
+    await dropAllTables(dropAdapter);
+    expect(await tableCount(dropAdapter)).toBe(0);
+  });
+});
+
+// Guards the isolation above: the per-worker database this file shares with
+// every other AR test file must still carry the canonical schema after the
+// zero-table suite has run. Before the isolation it was empty here.
+describe("dropAllTables (shared worker database)", () => {
+  it("leaves the shared canonical schema intact", async () => {
+    const tables = await listTables(adapter);
+    expect(tables.length).toBeGreaterThan(0);
+    expect(tables).toContain("items");
+    expect(tables).toContain("posts");
   });
 });

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -6,10 +6,6 @@ import { openIsolatedDatabase, type IsolatedDatabase } from "./isolated-database
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 let adapter: DatabaseAdapter;
-// The `dropAllTables` suite asserts a zero-table database, so it cannot ride
-// the per-worker adapter every other AR file shares: `test-setup-dy.ts` loads
-// the canonical schema once per worker, not once per file, and nothing would
-// lay it back down for the next file. It gets its own database instead.
 let isolated: IsolatedDatabase | undefined;
 
 async function listTables(a: DatabaseAdapter): Promise<string[]> {
@@ -196,9 +192,6 @@ describe("dropAllTables", () => {
   });
 });
 
-// Guards the isolation above: the per-worker database this file shares with
-// every other AR test file must still carry the canonical schema after the
-// zero-table suite has run. Before the isolation it was empty here.
 describe("dropAllTables (shared worker database)", () => {
   it("leaves the shared canonical schema intact", async () => {
     const tables = await listTables(adapter);

--- a/packages/activerecord/src/support/isolated-database.ts
+++ b/packages/activerecord/src/support/isolated-database.ts
@@ -1,0 +1,120 @@
+/**
+ * A private, throwaway database for a single test file.
+ *
+ * Rails' suite never needs this: a test that wipes a database wholesale
+ * (`drop_all_tables`-style teardown) runs in its own process against its own
+ * `arunit` database. trails shares one database per *vitest worker* across
+ * every file the worker runs, so a suite that asserts a zero-table end state
+ * would take the canonical schema down with it and leave the next file in the
+ * worker opening on an empty database.
+ *
+ * The database is per lane and per worker slot: on sqlite it is a scratch file
+ * (see `scratch-database.ts` for why `:memory:` is the wrong stand-in), on
+ * PostgreSQL/MySQL a real database derived from the primary one's configured
+ * name — config-derived rather than invented, the same rule `arunit2-config.ts`
+ * follows — recreated on open so a run killed before teardown cannot hand the
+ * caller a stale schema.
+ *
+ * @internal
+ */
+
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";
+import { mysqlSettings, postgresSettings, settingsUrl } from "./config.js";
+import { activeLane } from "./connection.js";
+import { scratchDatabasePath } from "./scratch-database.js";
+
+/** An open isolated database and the teardown that disposes of it. */
+export interface IsolatedDatabase {
+  adapter: DatabaseAdapter;
+  /** Closes the connection and, on PG/MySQL, drops the database. */
+  close(): Promise<void>;
+}
+
+/**
+ * `label` names the owning test file, so two files can never share a database
+ * — the same rule {@link scratchDatabasePath} states for its own labels. Only
+ * word characters survive into a SQL identifier.
+ */
+function databaseNameFor(primary: string, label: string): string {
+  return `${primary}_${label.replace(/\W+/g, "_")}`;
+}
+
+/**
+ * Opens an isolated database for `label` on whichever lane is active. Every
+ * caller must `close()` the handle in `afterAll`, or a PG/MySQL database is
+ * left behind for the rest of the run.
+ */
+export async function openIsolatedDatabase(label: string): Promise<IsolatedDatabase> {
+  switch (activeLane()) {
+    case "postgres":
+      return openPostgresDatabase(label);
+    case "mysql":
+      return openMysqlDatabase(label);
+    default:
+      return openSqliteDatabase(label);
+  }
+}
+
+async function openSqliteDatabase(label: string): Promise<IsolatedDatabase> {
+  const adapter = new BetterSQLite3Adapter(await scratchDatabasePath(label));
+  return {
+    adapter,
+    close: async () => {
+      await adapter.close();
+    },
+  };
+}
+
+async function openPostgresDatabase(label: string): Promise<IsolatedDatabase> {
+  const settings = postgresSettings();
+  const database = databaseNameFor(settings.database, label);
+  const root = new PostgreSQLAdapter(settingsUrl("postgres", settings));
+  try {
+    await root.recreateDatabase(database);
+  } finally {
+    await root.close();
+  }
+  const adapter = new PostgreSQLAdapter(settingsUrl("postgres", { ...settings, database }));
+  return {
+    adapter,
+    close: async () => {
+      await adapter.close();
+      const cleanup = new PostgreSQLAdapter(settingsUrl("postgres", settings));
+      try {
+        await cleanup.dropDatabase(database);
+      } finally {
+        await cleanup.close();
+      }
+    },
+  };
+}
+
+async function openMysqlDatabase(label: string): Promise<IsolatedDatabase> {
+  const settings = mysqlSettings();
+  const database = databaseNameFor(settings.database, label);
+  const root = new Mysql2Adapter(settingsUrl("mysql", settings));
+  try {
+    // Spelled with an explicit charset because MySQL's `createDatabase` only
+    // infers one from a database version it has already probed, and this root
+    // adapter is cold.
+    await root.recreateDatabase(database, { charset: "utf8mb4" });
+  } finally {
+    await root.close();
+  }
+  const adapter = new Mysql2Adapter(settingsUrl("mysql", { ...settings, database }));
+  return {
+    adapter,
+    close: async () => {
+      await adapter.close();
+      const cleanup = new Mysql2Adapter(settingsUrl("mysql", settings));
+      try {
+        await cleanup.dropDatabase(database);
+      } finally {
+        await cleanup.close();
+      }
+    },
+  };
+}

--- a/packages/activerecord/src/support/isolated-database.ts
+++ b/packages/activerecord/src/support/isolated-database.ts
@@ -97,9 +97,6 @@ async function openMysqlDatabase(label: string): Promise<IsolatedDatabase> {
   const database = databaseNameFor(settings.database, label);
   const root = new Mysql2Adapter(settingsUrl("mysql", settings));
   try {
-    // Spelled with an explicit charset because MySQL's `createDatabase` only
-    // infers one from a database version it has already probed, and this root
-    // adapter is cold.
     await root.recreateDatabase(database, { charset: "utf8mb4" });
   } finally {
     await root.close();


### PR DESCRIPTION
`describe("dropAllTables")` in `packages/activerecord/src/support/drop-all-tables.test.ts` asserts a zero-table end state, so running it against the shared per-worker adapter wiped the canonical schema for every later file in the worker. PR #5269 shielded that with an `afterAll` full ~322-table `rebuildCanonicalTables`, which is correct but pays a DROP+CREATE of the entire canonical schema on every run — and DROP TABLE dominates AR test wall-time.

This removes the shield by removing the need for it: the block now opens its own database.

- New `support/isolated-database.ts` — `openIsolatedDatabase(label)` returns an adapter on a private database per lane and worker slot: a scratch sqlite file (via the existing `scratchDatabasePath`), or a config-derived `<primary>_<label>` database recreated on open for PG/MySQL. `close()` drops it.
- `describe("dropAllTables")` runs against that adapter; the `toBe(0)` assertions are unchanged (genuine zero-table, not a scoped subset).
- The `afterAll` canonical rebuild from #5269 is gone.
- `resetTestTables` keeps riding the shared database — it truncates rather than drops.
- New guard test asserts the shared worker database still has a non-zero table count and carries `items`/`posts` after the file runs.

Verified locally on all three lanes (sqlite, postgresql, mysql2): 10/10 passing.

Closes-story: isolate-drop-all-tables-suite-from-shared-worker-db