### PR TITLE
refactor(activemodel): spell the ProtectedParams stub method permitBang

### DIFF
--- a/packages/activemodel/src/forbidden-attributes-protection.test.ts
+++ b/packages/activemodel/src/forbidden-attributes-protection.test.ts
@@ -8,9 +8,6 @@ class Account extends Model {
   }
 }
 
-// Mirrors Rails' ProtectedParams stub (forbidden_attributes_protection_test.rb):
-// a params-like wrapper exposing `permitted?` and `to_h`. Trails dispatches on
-// the camelCase `permitted` / `toH` members.
 class ProtectedParams {
   private parameters: Record<string, unknown>;
   private _permitted = false;

--- a/packages/activemodel/src/forbidden-attributes-protection.test.ts
+++ b/packages/activemodel/src/forbidden-attributes-protection.test.ts
@@ -23,7 +23,7 @@ class ProtectedParams {
     return this._permitted;
   }
 
-  permit(): this {
+  permitBang(): this {
     this._permitted = true;
     return this;
   }
@@ -42,7 +42,7 @@ describe("ActiveModelMassUpdateProtectionTest", () => {
   });
 
   it("permitted attributes can be used for mass updating", () => {
-    const params = new ProtectedParams({ a: "b" }).permit();
+    const params = new ProtectedParams({ a: "b" }).permitBang();
     expect(
       new Account().sanitizeForbiddenAttributes(params as unknown as Record<string, unknown>),
     ).toEqual({ a: "b" });


### PR DESCRIPTION
Rails spells the stub method `permit!` in both ActiveModel stubs (`vendor/rails/activemodel/test/cases/forbidden_attributes_protection_test.rb:18,37`), which the repo's bang convention maps to `permitBang`. The AR stub (`packages/activerecord/src/support/stubs/strong-parameters.ts`, renamed in #5517) and `attribute-assignment.test.ts` already use `permitBang`; this file was the last one spelling it `permit()`.

The class is file-local, so the rename cannot affect other packages. Test names unchanged.

Closes-story: converge-protectedparams-permit-bang-spelling