### PR TITLE
ci(activerecord): add a label-gated MariaDB prepared-statements lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
     #                         main / the weekly sweep / workflow_dispatch).
     #                         Opting in also gates the merge on it: the job is
     #                         in the `ci` aggregator's `needs:`.
+    #   run-mysql-prepared  — the MYSQL_PREPARED_STATEMENTS AR suite (otherwise
+    #                         only main / the weekly sweep / workflow_dispatch).
+    #                         Opting in also gates the merge on it: the job is
+    #                         in the `ci` aggregator's `needs:`.
     #   run-db-adapters     — force the PostgreSQL + MariaDB AR suites on a
     #                         draft PR that doesn't touch adapter paths; they
     #                         run unconditionally once it is ready for review.
@@ -1309,16 +1313,19 @@ jobs:
         env:
           MYSQL_TEST_URL: mysql://rails@localhost:3306/activerecord_unittest
 
-  # ADVISORY: deliberately absent from the `ci` aggregator's `needs` list, so a
-  # red leg reports without blocking merge. Runner budget is why it is also
-  # unsharded (hence the wider timeout) — the required maria-tests lane already
-  # burns two runners per PR.
+  # A second full pass over the AR suite, so not on every PR: it runs on `main`,
+  # on the Monday sweep, on `workflow_dispatch`, and on a PR labelled
+  # `run-mysql-prepared`. It is in the `ci` aggregator's `needs:`, so whenever it
+  # does run a failure blocks the merge. Unsharded (hence the wider timeout):
+  # off the per-PR critical path, one runner is the cheaper trade.
   maria-prepared-tests:
     name: Active Record MariaDB Tests (prepared statements)
     needs: changes
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.activerecord_affected == 'true'
+      needs.changes.outputs.activerecord_affected == 'true' &&
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'run-mysql-prepared'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     services:
@@ -1761,6 +1768,7 @@ jobs:
       - trailties-tests
       - sqlite-tests
       - sqlite-mem-tests
+      - maria-prepared-tests
       - postgres-tests
       - mysql-tests
       - maria-tests
@@ -1797,6 +1805,7 @@ jobs:
           PARITY_POSTGRES: ${{ needs.changes.outputs.parity_postgres }}
           PARITY_MYSQL: ${{ needs.changes.outputs.parity_mysql }}
           SQLITE_MEM_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-sqlite-mem') }}
+          MYSQL_PREPARED_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-mysql-prepared') }}
           DB_ADAPTERS_DRAFT_DEFERRED: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && needs.changes.outputs.db_adapter_affected != 'true' && !contains(github.event.pull_request.labels.*.name, 'run-db-adapters') }}
         run: |
           set -euo pipefail
@@ -1856,6 +1865,12 @@ jobs:
                 sqlite-mem-tests)
                   if [ "$AR_AFFECTED" = "false" ] || \
                      [ "$SQLITE_MEM_UNLABELLED" = "true" ]; then
+                    continue
+                  fi
+                  ;;
+                maria-prepared-tests)
+                  if [ "$AR_AFFECTED" = "false" ] || \
+                     [ "$MYSQL_PREPARED_UNLABELLED" = "true" ]; then
                     continue
                   fi
                   ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1309,21 +1309,10 @@ jobs:
         env:
           MYSQL_TEST_URL: mysql://rails@localhost:3306/activerecord_unittest
 
-  # Prepared-statement lane. Rails runs a `mysql2_prepared` CI leg so the
-  # `prepared_statements: true` branch of the mysql2 adapter is exercised by a
-  # real suite run, not just unit tests; ours are `mysql2-adapter.ts` (the
-  # execute/exec_query split) and `abstract-adapter.ts` (the statement cache).
-  # `MYSQL_PREPARED_STATEMENTS` flips the arunit/arunit2 entries
-  # (support/config.ts `mysqlPreparedStatements`), matching
-  # vendor/rails/activerecord/test/config.example.yml:7-11,27-31.
-  #
-  # ADVISORY, not required-to-merge: it is deliberately absent from the `ci`
-  # aggregator's `needs` list, so a red leg reports on the PR without blocking.
-  # Runner budget is the reason — the required MariaDB lane already burns two
-  # runners per PR, and mirroring its 2-way shard here would double that. This
-  # lane therefore runs unsharded (hence the wider timeout) on one runner, and
-  # skips the CLI E2E step, which does not touch the prepared path. Promote it
-  # to required once the prepared path is green and the budget allows.
+  # ADVISORY: deliberately absent from the `ci` aggregator's `needs` list, so a
+  # red leg reports without blocking merge. Runner budget is why it is also
+  # unsharded (hence the wider timeout) — the required maria-tests lane already
+  # burns two runners per PR.
   maria-prepared-tests:
     name: Active Record MariaDB Tests (prepared statements)
     needs: changes
@@ -1365,8 +1354,6 @@ jobs:
           ARCONN: mysql2
           MYSQL_HOST: localhost
           MYSQL_PORT: "3306"
-          # Presence is what counts, not the value (config.example.yml uses
-          # `<%= ENV["MYSQL_PREPARED_STATEMENTS"] ? true : false %>`).
           MYSQL_PREPARED_STATEMENTS: "1"
 
   website:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1309,6 +1309,66 @@ jobs:
         env:
           MYSQL_TEST_URL: mysql://rails@localhost:3306/activerecord_unittest
 
+  # Prepared-statement lane. Rails runs a `mysql2_prepared` CI leg so the
+  # `prepared_statements: true` branch of the mysql2 adapter is exercised by a
+  # real suite run, not just unit tests; ours are `mysql2-adapter.ts` (the
+  # execute/exec_query split) and `abstract-adapter.ts` (the statement cache).
+  # `MYSQL_PREPARED_STATEMENTS` flips the arunit/arunit2 entries
+  # (support/config.ts `mysqlPreparedStatements`), matching
+  # vendor/rails/activerecord/test/config.example.yml:7-11,27-31.
+  #
+  # ADVISORY, not required-to-merge: it is deliberately absent from the `ci`
+  # aggregator's `needs` list, so a red leg reports on the PR without blocking.
+  # Runner budget is the reason — the required MariaDB lane already burns two
+  # runners per PR, and mirroring its 2-way shard here would double that. This
+  # lane therefore runs unsharded (hence the wider timeout) on one runner, and
+  # skips the CLI E2E step, which does not touch the prepared path. Promote it
+  # to required once the prepared path is green and the budget allows.
+  maria-prepared-tests:
+    name: Active Record MariaDB Tests (prepared statements)
+    needs: changes
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.activerecord_affected == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_DATABASE: activerecord_unittest
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
+        ports:
+          - 3306:3306
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/mysql
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile --prefer-offline
+      - uses: ./.github/actions/cache-build
+      - run: pnpm build
+      - name: Provision Rails' test user
+        run: |
+          mysql -h 127.0.0.1 -uroot -e "
+            CREATE USER IF NOT EXISTS 'rails'@'%';
+            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%';
+            CREATE USER IF NOT EXISTS 'rails'@'localhost';
+            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'localhost';
+            FLUSH PRIVILEGES;"
+      - run: pnpm vitest run packages/activerecord/
+        env:
+          ARCONN: mysql2
+          MYSQL_HOST: localhost
+          MYSQL_PORT: "3306"
+          # Presence is what counts, not the value (config.example.yml uses
+          # `<%= ENV["MYSQL_PREPARED_STATEMENTS"] ? true : false %>`).
+          MYSQL_PREPARED_STATEMENTS: "1"
+
   website:
     name: Website
     needs: changes


### PR DESCRIPTION
Adds a label-gated CI lane that runs the activerecord suite against MariaDB with `MYSQL_PREPARED_STATEMENTS` set, so the prepared-statement branches of `mysql2-adapter.ts` and `abstract-adapter.ts` are exercised by a real suite run rather than only by unit tests. The var is the one Rails' own `activerecord/test/config.example.yml:7-11,27-31` branches on; Rails runs its equivalent prepared leg in buildkite, which is not part of the vendored tree.

## When it runs, and whether it gates

Follows the `sqlite-mem-tests` model rather than running on every PR. The lane runs on `main`, on the Monday sweep, on `workflow_dispatch`, and on any PR carrying the **`run-mysql-prepared`** label. In exchange it is in the `ci` aggregator's `needs:`, so whenever it does run a failure blocks the merge — required-when-it-runs rather than advisory-always.

That is the right trade for a second full pass over the AR suite: 15m51s on one unsharded runner is too much to put on every AR PR's critical path, but a lane that never blocks is a lane whose red gets ignored. Off the critical path, unsharded on a single runner is the cheaper trade, hence the wider timeout.

This PR carries the label, so the lane runs here and the gate is exercised end to end.

## What the lane found (all fixed)

The lane found real prepared-path divergences on every run — which is the point of the story. Nothing is skipped or relaxed to make it pass; each root cause is registered as its own story under RFC 0064.

**First run — 10 failures.** Both causes are now fixed and merged:

- 9x `bind-parameter.test.ts` `TypeError: ... reading 'keys'` — the helper read `conn._statementPool`, which mysql2 named `_stmtPool`. Rails uses one `@statements` ivar for every adapter (`bind_parameter_test.rb:260-274`). Fixed by #5577.
- 1x `statement-pool.trails.test.ts` pool not cold under the prepared default. Fixed by #5586.

**Current run — 3 failures**, all new, all in `bind-parameter.test.ts`, all passing on the plain MariaDB / PostgreSQL / SQLite lanes on this same commit and failing only with `MYSQL_PREPARED_STATEMENTS` set:

- 2x `bind params to sql with {prepared,unprepared} statements` — `toSql` renders an array bind as `IN ('1', '2', '3')` instead of Rails' `IN (1, 2, 3)`. Story: `array-bind-elements-quoted-under-prepared-default`.
- 1x `binds are logged` — the `sql.active_record` payload no longer carries the caller's own `QueryAttribute` objects. Story: `binds-missing-from-notification-under-prepared-default`.

All four are merged, and the lane now passes.

Closes-story: mysql-prepared-statements-ci-lane
