### PR TITLE
test(activerecord): port the rest of mysql2_specific_schema.rb

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
@@ -13,12 +13,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
   });
 
   describe("CaseSensitivityTest", () => {
-    // `collation_tests` is laid at boot by the mysql arm of `loadSchema`,
-    // mirroring mysql2_specific_schema.rb:60-64. No explicit schema-cache
-    // priming needed: `columnForAttribute` falls back to `this.columns()` when
-    // pool is null and the cache is cold (the cache is cleared by
-    // `resetColumnInformation` when each `it` block defines a new
-    // `CollationTest` subclass).
     afterEach(async () => {
       await adapter.execute("DELETE FROM collation_tests");
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
@@ -13,20 +13,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
   });
 
   describe("CaseSensitivityTest", () => {
-    // Mirrors test/schema/mysql2_specific_schema.rb's collation_tests table.
-    beforeEach(async () => {
-      await adapter.createTable("collation_tests", { id: false, force: true }, (t: any) => {
-        t.string("string_cs_column", { limit: 1, collation: "utf8mb4_bin" });
-        t.string("string_ci_column", { limit: 1, collation: "utf8mb4_general_ci" });
-        t.binary("binary_column", { limit: 1 });
-      });
-      // No explicit schema-cache priming needed: `columnForAttribute` falls back
-      // to `this.columns()` when pool is null and the cache is cold (the cache
-      // is cleared by `resetColumnInformation` when each `it` block defines a
-      // new `CollationTest` subclass).
-    });
+    // `collation_tests` is laid at boot by the mysql arm of `loadSchema`,
+    // mirroring mysql2_specific_schema.rb:60-64. No explicit schema-cache
+    // priming needed: `columnForAttribute` falls back to `this.columns()` when
+    // pool is null and the cache is cold (the cache is cleared by
+    // `resetColumnInformation` when each `it` block defines a new
+    // `CollationTest` subclass).
     afterEach(async () => {
-      await adapter.dropTable("collation_tests", { ifExists: true });
+      await adapter.execute("DELETE FROM collation_tests");
     });
 
     function collationTestModel(): typeof Base {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -144,33 +144,17 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("dump indexes", async () => {
-      await adapter.dropTable("key_tests", { ifExists: true });
-      try {
-        await adapter.createTable("key_tests", { force: true }, (t: any) => {
-          t.string("awesome");
-          t.string("pizza");
-          t.string("snacks");
-        });
-        await adapter.addIndex("key_tests", ["snacks"], { name: "index_key_tests_on_snack" });
-        await adapter.addIndex("key_tests", ["pizza"], { name: "index_key_tests_on_pizza" });
-        await adapter.addIndex("key_tests", ["awesome"], {
-          name: "index_key_tests_on_awesome",
-          type: "fulltext",
-        });
-        const indexes = (await adapter.indexes("key_tests")).sort((a, b) =>
-          a.name.localeCompare(b.name),
-        );
-        expect(indexes).toHaveLength(3);
-        const byName = (n: string) => indexes.find((i) => i.name === n)!;
-        expect(byName("index_key_tests_on_snack").using).toBe("btree");
-        expect(byName("index_key_tests_on_snack").type).toBeUndefined();
-        expect(byName("index_key_tests_on_pizza").using).toBe("btree");
-        expect(byName("index_key_tests_on_pizza").type).toBeUndefined();
-        expect(byName("index_key_tests_on_awesome").using).toBeUndefined();
-        expect(byName("index_key_tests_on_awesome").type).toBe("fulltext");
-      } finally {
-        await adapter.dropTable("key_tests", { ifExists: true });
-      }
+      const indexes = (await adapter.indexes("key_tests")).sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
+      expect(indexes).toHaveLength(3);
+      const byName = (n: string) => indexes.find((i) => i.name === n)!;
+      expect(byName("index_key_tests_on_snack").using).toBe("btree");
+      expect(byName("index_key_tests_on_snack").type).toBeUndefined();
+      expect(byName("index_key_tests_on_pizza").using).toBe("btree");
+      expect(byName("index_key_tests_on_pizza").type).toBeUndefined();
+      expect(byName("index_key_tests_on_awesome").using).toBeUndefined();
+      expect(byName("index_key_tests_on_awesome").type).toBe("fulltext");
     });
 
     it("drop temporary table", async () => {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -537,13 +537,9 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "mysql")(
     "schema dump includes length for mysql binary fields",
     async () => {
-      const adapter = Base.connection;
-      const testCtx = new MigrationContext(adapter);
-      await testCtx.createTable("binary_fields", { force: true }, (t) => {
-        t.binary("var_binary", { limit: 255 });
-        t.binary("var_binary_large", { limit: 4095 });
-      });
-      const output = await SchemaDumper.dumpTableSchema(adapter, "binary_fields");
+      // `binary_fields` is laid at boot by the mysql arm of `loadSchema`,
+      // mirroring mysql2_specific_schema.rb:28-49.
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "binary_fields");
       expect(output).toMatch(/t\.binary\("var_binary", \{ limit: 255 \}\)/);
       expect(output).toMatch(/t\.binary\("var_binary_large", \{ limit: 4095 \}\)/);
     },
@@ -551,19 +547,7 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "mysql")(
     "schema dump includes length for mysql blob and text fields",
     async () => {
-      const bfAdapter = Base.connection;
-      const bfCtx = new MigrationContext(bfAdapter);
-      await bfCtx.createTable("binary_fields", { force: true }, (t) => {
-        t.binary("tiny_blob", { size: "tiny" });
-        t.binary("normal_blob");
-        t.binary("medium_blob", { size: "medium" });
-        t.binary("long_blob", { size: "long" });
-        t.text("tiny_text", { size: "tiny" });
-        t.text("normal_text");
-        t.text("medium_text", { size: "medium" });
-        t.text("long_text", { size: "long" });
-      });
-      const output = await SchemaDumper.dumpTableSchema(bfAdapter, "binary_fields");
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "binary_fields");
       expect(output).toMatch(/t\.binary\("tiny_blob", \{ size: "tiny" \}\)/);
       expect(output).toMatch(/t\.binary\("normal_blob"\)/);
       expect(output).toMatch(/t\.binary\("medium_blob", \{ size: "medium" \}\)/);
@@ -572,6 +556,12 @@ describe("SchemaDumperTest", () => {
       expect(output).toMatch(/t\.text\("normal_text"\)/);
       expect(output).toMatch(/t\.text\("medium_text", \{ size: "medium" \}\)/);
       expect(output).toMatch(/t\.text\("long_text", \{ size: "long" \}\)/);
+      expect(output).toMatch(/t\.binary\("tiny_blob_2", \{ size: "tiny" \}\)/);
+      expect(output).toMatch(/t\.binary\("medium_blob_2", \{ size: "medium" \}\)/);
+      expect(output).toMatch(/t\.binary\("long_blob_2", \{ size: "long" \}\)/);
+      expect(output).toMatch(/t\.text\("tiny_text_2", \{ size: "tiny" \}\)/);
+      expect(output).toMatch(/t\.text\("medium_text_2", \{ size: "medium" \}\)/);
+      expect(output).toMatch(/t\.text\("long_text_2", \{ size: "long" \}\)/);
     },
   );
   it.skipIf(adapterType !== "mysql")(
@@ -587,21 +577,9 @@ describe("SchemaDumperTest", () => {
     },
   );
   it.skipIf(adapterType !== "mysql")("schema dumps index type", async () => {
-    const ktAdapter = Base.connection;
-    const ktCtx = new MigrationContext(ktAdapter);
-    await ktCtx.createTable("key_tests", {}, (t) => {
-      t.string("awesome");
-      t.string("pizza");
-    });
-    await ktCtx.addIndex("key_tests", "awesome", {
-      type: "fulltext",
-      name: "index_key_tests_on_awesome",
-    });
-    await ktCtx.addIndex("key_tests", "pizza", {
-      using: "btree",
-      name: "index_key_tests_on_pizza",
-    });
-    const output = await SchemaDumper.dumpTableSchema(ktAdapter, "key_tests");
+    // `key_tests` is laid at boot by the mysql arm of `loadSchema`, mirroring
+    // mysql2_specific_schema.rb:51-58.
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "key_tests");
     expect(output).toContain(
       'addIndex("key_tests", "awesome", { name: "index_key_tests_on_awesome", type: "fulltext" })',
     );
@@ -1039,13 +1017,11 @@ afterAll(async () => {
   const ctx = new MigrationContext(Base.connection);
   const o = { ifExists: true } as const;
   await ctx.dropTable("bigint_array", o);
-  await ctx.dropTable("binary_fields", o);
   await ctx.dropTable("booleans", o);
   await ctx.dropTable("companies", o);
   await ctx.dropTable("dump_defaults", o);
   await ctx.dropTable("indexed", o);
   await ctx.dropTable("infinity_defaults", o);
-  await ctx.dropTable("key_tests", o);
   await ctx.dropTable("limits", o);
   await ctx.dropTable("myapp_posts", o);
   await ctx.dropTable("myapp_users", o);

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -537,8 +537,6 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "mysql")(
     "schema dump includes length for mysql binary fields",
     async () => {
-      // `binary_fields` is laid at boot by the mysql arm of `loadSchema`,
-      // mirroring mysql2_specific_schema.rb:28-49.
       const output = await SchemaDumper.dumpTableSchema(Base.connection, "binary_fields");
       expect(output).toMatch(/t\.binary\("var_binary", \{ limit: 255 \}\)/);
       expect(output).toMatch(/t\.binary\("var_binary_large", \{ limit: 4095 \}\)/);
@@ -577,8 +575,6 @@ describe("SchemaDumperTest", () => {
     },
   );
   it.skipIf(adapterType !== "mysql")("schema dumps index type", async () => {
-    // `key_tests` is laid at boot by the mysql arm of `loadSchema`, mirroring
-    // mysql2_specific_schema.rb:51-58.
     const output = await SchemaDumper.dumpTableSchema(Base.connection, "key_tests");
     expect(output).toContain(
       'addIndex("key_tests", "awesome", { name: "index_key_tests_on_awesome", type: "fulltext" })',

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -279,8 +279,6 @@ const ADAPTER_SPECIFIC_TABLES: Record<string, readonly string[]> = {
     "binary_fields",
     "key_tests",
     "collation_tests",
-    // Laid only behind `supportsInsertReturning()` (MariaDB), but listed
-    // unconditionally: this list only shields tables from the between-test drop.
     "pk_autopopulated_by_a_trigger_records",
   ],
   sqlite: ["defaults"],

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -90,11 +90,8 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
 }
 
 /**
- * Port of `vendor/rails/activerecord/test/schema/mysql2_specific_schema.rb:4-26`
- * — the three default-expression tables. The rest of that file (`binary_fields`,
- * `key_tests`, `collation_tests`, the stored procedures and the trigger-backed
- * primary-key table — lines 28-95) is carried by story
- * `port-mysql2-specific-schema-remainder`.
+ * Port of `vendor/rails/activerecord/test/schema/mysql2_specific_schema.rb`,
+ * whole.
  *
  * `supports_default_expression?` is `adapter_helper.rb:23`, not an adapter
  * method: on the MySQL family it is MariaDB >= 10.2.1 or MySQL >= 8.0.13. It is
@@ -138,6 +135,76 @@ async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<
       my.string("char2_concatenated", { default: () => "(concat(`char2`, '-'))" });
     }
   });
+
+  await adapter.createTable("binary_fields", { force: true }, (t) => {
+    const my = t as MysqlTableDefinition;
+    my.binary("var_binary", { limit: 255 });
+    my.binary("var_binary_large", { limit: 4095 });
+
+    my.tinyblob("tiny_blob");
+    my.blob("normal_blob");
+    my.mediumblob("medium_blob");
+    my.longblob("long_blob");
+    my.tinytext("tiny_text");
+    my.text("normal_text");
+    my.mediumtext("medium_text");
+    my.longtext("long_text");
+
+    my.binary("tiny_blob_2", { size: "tiny" });
+    my.binary("medium_blob_2", { size: "medium" });
+    my.binary("long_blob_2", { size: "long" });
+    my.text("tiny_text_2", { size: "tiny" });
+    my.text("medium_text_2", { size: "medium" });
+    my.text("long_text_2", { size: "long" });
+
+    my.index(["var_binary"]);
+  });
+
+  await adapter.createTable(
+    "key_tests",
+    { force: true, options: "CHARSET=utf8 ENGINE=MyISAM" },
+    (t) => {
+      const my = t as MysqlTableDefinition;
+      my.string("awesome");
+      my.string("pizza");
+      my.string("snacks");
+      my.index(["awesome"], { type: "fulltext", name: "index_key_tests_on_awesome" });
+      my.index(["pizza"], { using: "btree", name: "index_key_tests_on_pizza" });
+      my.index(["snacks"], { name: "index_key_tests_on_snack" });
+    },
+  );
+
+  await adapter.createTable("collation_tests", { id: false, force: true }, (t) => {
+    const my = t as MysqlTableDefinition;
+    my.string("string_cs_column", { limit: 1, collation: "utf8mb4_bin" });
+    my.string("string_ci_column", { limit: 1, collation: "utf8mb4_general_ci" });
+    my.binary("binary_column", { limit: 1 });
+  });
+
+  await adapter.execute("DROP PROCEDURE IF EXISTS ten");
+  await adapter.execute("CREATE PROCEDURE ten() SQL SECURITY INVOKER\nBEGIN\n  SELECT 10;\nEND\n");
+
+  await adapter.execute("DROP PROCEDURE IF EXISTS topics");
+  await adapter.execute(
+    "CREATE PROCEDURE topics(IN num INT) SQL SECURITY INVOKER\nBEGIN\n  SELECT * FROM topics LIMIT num;\nEND\n",
+  );
+
+  if (adapter.supportsInsertReturning()) {
+    await adapter.createTable(
+      "pk_autopopulated_by_a_trigger_records",
+      { force: true, id: false },
+      (t) => {
+        (t as MysqlTableDefinition).integer("id", { null: false });
+      },
+    );
+
+    await adapter.execute(
+      "CREATE TRIGGER before_insert_trigger\n" +
+        "BEFORE INSERT ON pk_autopopulated_by_a_trigger_records\n" +
+        "FOR EACH ROW\n" +
+        "SET NEW.id = (SELECT COALESCE(MAX(id), 0) + 1 FROM pk_autopopulated_by_a_trigger_records);\n",
+    );
+  }
 }
 
 /**
@@ -175,11 +242,10 @@ async function loadSqliteSpecificSchema(adapter: DatabaseAdapter): Promise<void>
  * `<adapter>_specific_schema` loader when trails has one, and to nothing when it
  * does not.
  *
- * `sqlite_specific_schema.rb` is ported whole. The postgres and mysql arms are
- * still partial — the remaining tables of
- * `postgresql_specific_schema.rb:50-225` and `mysql2_specific_schema.rb:28-95`
- * are owned by stories `port-postgresql-specific-schema-remainder` and
- * `port-mysql2-specific-schema-remainder`, not a claim that the gap does not
+ * `sqlite_specific_schema.rb` and `mysql2_specific_schema.rb` are ported whole.
+ * The postgres arm is still partial — the remaining tables of
+ * `postgresql_specific_schema.rb:50-225` are owned by story
+ * `port-postgresql-specific-schema-remainder`, not a claim that the gap does not
  * exist. `trilogy_specific_schema.rb` is the one genuine no-op: trails has no
  * Trilogy adapter, so no adapter name ever selects it.
  */
@@ -206,7 +272,17 @@ const ADAPTER_SPECIFIC_TABLES: Record<string, readonly string[]> = {
     "uuid_children",
     "defaults",
   ],
-  mysql: ["datetime_defaults", "timestamp_defaults", "defaults"],
+  mysql: [
+    "datetime_defaults",
+    "timestamp_defaults",
+    "defaults",
+    "binary_fields",
+    "key_tests",
+    "collation_tests",
+    // Laid only behind `supportsInsertReturning()` (MariaDB), but listed
+    // unconditionally: this list only shields tables from the between-test drop.
+    "pk_autopopulated_by_a_trigger_records",
+  ],
   sqlite: ["defaults"],
 };
 


### PR DESCRIPTION
Ports the rest of `vendor/rails/activerecord/test/schema/mysql2_specific_schema.rb`
(lines 28-95) into the mysql arm of `loadSchema`:

- `binary_fields` — `var_binary`/`var_binary_large`, the
  tinyblob/blob/mediumblob/longblob and tinytext/text/mediumtext/longtext
  columns, the `size: tiny|medium|long` binary/text variants, and the
  `var_binary` index.
- `key_tests` — `CHARSET=utf8 ENGINE=MyISAM`, a fulltext index, a btree index
  and a plain one.
- `collation_tests` — the `utf8mb4_bin` / `utf8mb4_general_ci` columns.
- the `ten()` and `topics(IN num INT)` stored procedures.
- `pk_autopopulated_by_a_trigger_records` + `before_insert_trigger`, behind the
  same `supports_insert_returning?` gate Rails uses.

All new tables are listed in `ADAPTER_SPECIFIC_TABLES` so the between-test reset
does not drop them.

Siblings that laid these tables inline are repointed at the boot-laid ones:
`schema-dumper.test.ts` (the two `binary_fields` dumps and the `key_tests`
index-type dump — the blob/text case also picks up the `_2` assertions Rails
makes, which were missing because the inline table had no `_2` columns) and
`adapters/abstract-mysql-adapter/{schema,case-sensitivity}.test.ts`.

Verified locally against MySQL 8 (`ARCONN=mysql2`): `schema-dumper.test.ts`
(44 passed), `abstract-mysql-adapter/schema.test.ts` and
`abstract-mysql-adapter/case-sensitivity.test.ts` (16 passed).

Closes-story: port-mysql2-specific-schema-remainder
