### PR TITLE
test(activerecord): lay the create_table half of postgresql_specific_schema.rb at boot

### DIFF
--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -595,47 +595,25 @@ describe("SchemaDumperTest", () => {
   });
 
   it.skipIf(adapterType !== "postgres")("schema dump includes limit on array type", async () => {
-    const adapter = Base.connection;
-    const testCtx = new MigrationContext(adapter);
-    await testCtx.createTable("bigint_array", { force: true }, (t) => {
-      (t as any).integer("big_int_data_points", { limit: 8, array: true });
-    });
-    const output = await SchemaDumper.dumpTableSchema(adapter, "bigint_array");
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "bigint_array");
     expect(output).toMatch(/t\.bigint\("big_int_data_points", \{ array: true \}\)/);
   });
   it.skipIf(adapterType !== "postgres")(
     "schema dump allows array of decimal defaults",
     async () => {
-      const testAdapter = Base.connection;
-      const testCtx = new MigrationContext(testAdapter);
-      await testCtx.createTable("bigint_array", { force: true }, (t) => {
-        t.integer("big_int_data_points", { limit: 8, array: true });
-        t.decimal("decimal_array_default", { array: true, default: [1.23, 3.45] });
-      });
-      const output = await SchemaDumper.dumpTableSchema(testAdapter, "bigint_array");
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "bigint_array");
       expect(output).toMatch(
         /t\.decimal\("decimal_array_default",\s*\{[^}]*default:\s*\["1\.23", "3\.45"\][^}]*array:\s*true/,
       );
     },
   );
   it.skipIf(adapterType !== "postgres")("schema dump interval type", async () => {
-    const adapter = Base.connection;
-    const testCtx = new MigrationContext(adapter);
-    await testCtx.createTable("postgresql_times", {}, (t) => {
-      (t as any).interval("time_interval");
-      (t as any).interval("scaled_time_interval", { precision: 6 });
-    });
-    const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_times");
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "postgresql_times");
     expect(output).toMatch(/t\.interval\("time_interval"\)/);
     expect(output).toMatch(/t\.interval\("scaled_time_interval", \{ precision: 6 \}\)/);
   });
   it.skipIf(adapterType !== "postgres")("schema dump oid type", async () => {
-    const adapter = Base.connection;
-    const testCtx = new MigrationContext(adapter);
-    await testCtx.createTable("postgresql_oids", {}, (t) => {
-      (t as any).oid("obj_id");
-    });
-    const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_oids");
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "postgresql_oids");
     expect(output).toMatch(/t\.oid\("obj_id"\)/);
   });
   it.skipIf(adapterType !== "postgres")("schema dump includes extensions", async () => {
@@ -1012,7 +990,6 @@ describe("SchemaDumperDefaultsTest", () => {
 afterAll(async () => {
   const ctx = new MigrationContext(Base.connection);
   const o = { ifExists: true } as const;
-  await ctx.dropTable("bigint_array", o);
   await ctx.dropTable("booleans", o);
   await ctx.dropTable("companies", o);
   await ctx.dropTable("dump_defaults", o);
@@ -1023,8 +1000,6 @@ afterAll(async () => {
   await ctx.dropTable("myapp_users", o);
   await ctx.dropTable("myapp_users_v1", o);
   await ctx.dropTable("numeric_data", o);
-  await ctx.dropTable("postgresql_oids", o);
-  await ctx.dropTable("postgresql_times", o);
   await ctx.dropTable("posts", o);
   await ctx.dropTable("schema_dump_probe", o);
   await ctx.dropTable("products", o);

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -102,8 +102,6 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     (t as PgTableDefinition).oid("obj_id");
   });
 
-  // "This table is to verify if the :limit option is being ignored for text and
-  // binary columns" (postgresql_specific_schema.rb:130).
   await adapter.createTable("limitless_fields", { force: true }, (t) => {
     const pg = t as PgTableDefinition;
     pg.binary("binary", { limit: 100_000 });

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -7,13 +7,17 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
 
 /**
  * The ported slice of
- * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:4-48` —
- * the `uuid-ossp` / `pgcrypto` extension header, the four uuid-primary-key
- * tables and the `defaults` table.
+ * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb` — the
+ * `uuid-ossp` / `pgcrypto` extension header, the four uuid-primary-key tables,
+ * `defaults` (lines 4-48), and the plain `create_table` remainder:
+ * `postgresql_times`, `postgresql_oids`, `limitless_fields`, `bigint_array`,
+ * the four `uuid_*` tables and the exclusion/unique constraint tables.
  *
- * The remainder of that file (`postgresql_times`, `postgresql_oids`, the
- * identity, sequence, partition and constraint tables — lines 50-225) is carried
- * by story `port-postgresql-specific-schema-remainder`.
+ * Still unported: the `supports_identity_columns?` tables (50-66), the
+ * `companies_nonstd_seq`/`setval` sequence pass and the partition +
+ * `timestamp_with_zones` raw-DDL block (77-128), the `measurements*`
+ * partitioned tables and `company_include_index` (187-201), and the
+ * `supports_insert_returning?` trigger table (203-225).
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
   // `supportsPgcryptoUuid()` / `supportsVirtualColumns()` read the cached
@@ -86,6 +90,107 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     pg.bigint("bigint_default", { default: () => "0::bigint" });
     pg.binary("binary_default_function", { default: () => "convert_to('A', 'UTF8')" });
     pg.text("multiline_default", { default: "--- []\n\n" });
+  });
+
+  await adapter.createTable("postgresql_times", { force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.interval("time_interval");
+    pg.interval("scaled_time_interval", { precision: 6 });
+  });
+
+  await adapter.createTable("postgresql_oids", { force: true }, (t) => {
+    (t as PgTableDefinition).oid("obj_id");
+  });
+
+  // "This table is to verify if the :limit option is being ignored for text and
+  // binary columns" (postgresql_specific_schema.rb:130).
+  await adapter.createTable("limitless_fields", { force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.binary("binary", { limit: 100_000 });
+    pg.text("text", { limit: 100_000 });
+  });
+
+  await adapter.createTable("bigint_array", { force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.integer("big_int_data_points", { limit: 8, array: true });
+    pg.decimal("decimal_array_default", { array: true, default: [1.23, 3.45] });
+  });
+
+  await adapter.createTable("uuid_comments", { force: true, id: false }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.uuid("uuid", { primaryKey: true, ...uuidDefault });
+    pg.string("content");
+  });
+
+  await adapter.createTable("uuid_entries", { force: true, id: false }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.uuid("uuid", { primaryKey: true, ...uuidDefault });
+    pg.string("entryable_type", { null: false });
+    pg.uuid("entryable_uuid", { null: false });
+  });
+
+  await adapter.createTable("uuid_items", { force: true, id: false }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.uuid("uuid", { primaryKey: true, ...uuidDefault });
+    pg.string("title");
+  });
+
+  await adapter.createTable("uuid_messages", { force: true, id: false }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.uuid("uuid", { primaryKey: true, ...uuidDefault });
+    pg.string("subject");
+  });
+
+  await adapter.createTable("test_exclusion_constraints", { force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.date("start_date");
+    pg.date("end_date");
+    pg.date("valid_from");
+    pg.date("valid_to");
+    pg.date("transaction_from");
+    pg.date("transaction_to");
+
+    pg.exclusionConstraint("daterange(start_date, end_date) WITH &&", {
+      using: "gist",
+      where: "start_date IS NOT NULL AND end_date IS NOT NULL",
+      name: "test_exclusion_constraints_date_overlap",
+    });
+    pg.exclusionConstraint("daterange(valid_from, valid_to) WITH &&", {
+      using: "gist",
+      where: "valid_from IS NOT NULL AND valid_to IS NOT NULL",
+      name: "test_exclusion_constraints_valid_overlap",
+      deferrable: "immediate",
+    });
+    pg.exclusionConstraint("daterange(transaction_from, transaction_to) WITH &&", {
+      using: "gist",
+      where: "transaction_from IS NOT NULL AND transaction_to IS NOT NULL",
+      name: "test_exclusion_constraints_transaction_overlap",
+      deferrable: "deferred",
+    });
+  });
+
+  await adapter.createTable("test_unique_constraints", { force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.integer("position_1");
+    pg.integer("position_2");
+    pg.integer("position_3");
+    pg.integer("position_4");
+
+    pg.uniqueConstraint("position_1", {
+      name: "test_unique_constraints_position_deferrable_false",
+    });
+    pg.uniqueConstraint("position_2", {
+      name: "test_unique_constraints_position_deferrable_immediate",
+      deferrable: "immediate",
+    });
+    pg.uniqueConstraint("position_3", {
+      name: "test_unique_constraints_position_deferrable_deferred",
+      deferrable: "deferred",
+    });
+    pg.uniqueConstraint("position_4", {
+      name: "test_unique_constraints_position_nulls_not_distinct",
+      nullsNotDistinct: true,
+    });
   });
 }
 
@@ -271,6 +376,16 @@ const ADAPTER_SPECIFIC_TABLES: Record<string, readonly string[]> = {
     "uuid_parents",
     "uuid_children",
     "defaults",
+    "postgresql_times",
+    "postgresql_oids",
+    "limitless_fields",
+    "bigint_array",
+    "uuid_comments",
+    "uuid_entries",
+    "uuid_items",
+    "uuid_messages",
+    "test_exclusion_constraints",
+    "test_unique_constraints",
   ],
   mysql: [
     "datetime_defaults",


### PR DESCRIPTION
Ports the plain `create_table` half of
`vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:50-225`
into `loadPostgresqlSpecificSchema`, so the postgres lane boots with the tables
Rails boots with:

- `postgresql_times` (`interval`, `scaled_time_interval` precision 6) — 68-71
- `postgresql_oids` (`t.oid :obj_id`) — 73-75
- `limitless_fields`, `bigint_array` — 130-140
- `uuid_comments`, `uuid_entries`, `uuid_items`, `uuid_messages` — 142-160
- `test_exclusion_constraints`, `test_unique_constraints` (with the three
  gist/`deferrable` exclusion constraints and the four unique constraints
  including `nulls_not_distinct`) — 162-185

All ten are added to `ADAPTER_SPECIFIC_TABLES`, without which
`support/drop-all-tables.ts`'s between-test reset drops them before the first
test in every file.

`schema-dumper.test.ts`'s inline `bigint_array` / `postgresql_times` /
`postgresql_oids` layers are repointed at the boot-laid tables, and their
entries removed from that file's `afterAll` drop list.

The raw-DDL remainder of the file is out of scope here to stay under the LOC
ceiling and is registered as three follow-up stories under RFC 0064:

- `port-postgresql-specific-schema-identity-and-trigger-tables` (50-66, 203-225)
- `port-postgresql-specific-schema-sequences-and-partitions` (77-128)
- `port-postgresql-specific-schema-measurements-and-include-index` (187-201)

Verified on an isolated PG stack: `schema-dumper.test.ts`,
`migration/{unique,exclusion}-constraint.test.ts`,
`adapters/postgresql/{uuid,datatype,array}.test.ts`,
`connection-adapters/postgresql/schema-statements.test.ts` and all of
`support/` pass.

Closes-story: port-postgresql-specific-schema-remainder
