### PR TITLE
test(activerecord): move describeIfSqlite to support so both test trees share it

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { BigIntegerType, IntegerType, BooleanType } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";

--- a/packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
  */
 import { describe, it, expect } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { fixtures } from "../../test-fixtures.js";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { Post } from "../../test-helpers/models/post.js";

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 

--- a/packages/activerecord/src/adapters/sqlite3/dbconsole.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/dbconsole.test.ts
@@ -1,5 +1,5 @@
 import { it } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 
 describeIfSqlite("SQLite3DbConsoleTest", () => {
   it.skip("sqlite3", () => {

--- a/packages/activerecord/src/adapters/sqlite3/explain.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/explain.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Author } from "../../test-helpers/models/author.js";
 // Opt into the canonical-model autoload index so `Author.has_many :posts`

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -4,7 +4,7 @@
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";

--- a/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
@@ -1,5 +1,5 @@
 import { it } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 
 describeIfSqlite("SqliteDBCreateTest", () => {
   it.skip("db checks database exists", () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -8,7 +8,7 @@
  * where a statement both returns rows and writes (`INSERT ... RETURNING`).
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { ReadOnlyError } from "../../errors.js";

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { itIfSupports } from "../../support/supports.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-create-folder.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-create-folder.test.ts
@@ -5,7 +5,7 @@ import { it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 
 // -- Rails test class: sqlite3_create_folder_test.rb --

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-trails-root.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-trails-root.test.ts
@@ -9,7 +9,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { setTrailsRoot } from "@blazetrails/activesupport";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 
 describeIfSqlite("SQLite3 Trails.root path resolution", () => {

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.test.ts
@@ -1,5 +1,5 @@
 import { it } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 
 describeIfSqlite("SQLite3StatementPoolTest", () => {
   // Rails' only test here is guarded by `Process.respond_to?(:fork)` and forks a

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
@@ -1,5 +1,5 @@
 import { it, expect, afterEach } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 

--- a/packages/activerecord/src/adapters/sqlite3/test-helper.ts
+++ b/packages/activerecord/src/adapters/sqlite3/test-helper.ts
@@ -2,22 +2,9 @@
  * Shared helpers for `adapters/sqlite3/*.test.ts`. Keep this file tiny —
  * anything beyond cross-test glue belongs in the source tree, not here.
  */
-import { describe, expect } from "vitest";
+import { expect } from "vitest";
 import { Notifications, squish } from "@blazetrails/activesupport";
 import type { NotificationEvent } from "@blazetrails/activesupport";
-import { isSqliteRun } from "../../support/sqlite-template.js";
-
-/**
- * Scope a suite to the SQLite backend, mirroring Rails'
- * `ActiveRecord::SQLite3TestCase`. The handler connection is swapped to
- * PG/MySQL in the cross-backend CI matrix, so suites whose assertions are
- * SQLite-specific — `EXPLAIN QUERY PLAN` plan shape, `"`-quoted identifiers —
- * must skip there rather than run against a backend Rails never points them at.
- * Reuses the canonical {@link isSqliteRun} predicate so the "what counts as a
- * SQLite run" rule has one source of truth. Counterpart to `describeIfPg` /
- * `describeIfMysql`.
- */
-export const describeIfSqlite = isSqliteRun() ? describe : (describe.skip as typeof describe);
 
 /**
  * Subscribe to `sql.active_record` for the duration of `fn`, then assert the

--- a/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
@@ -8,7 +8,7 @@
  */
 import { it, expect, afterEach } from "vitest";
 import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { TransactionIsolationError } from "../../errors.js";

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
  */
 import { expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../index.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { FixtureSet } from "../../fixtures.js";

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
 import "../../index.js";
-import { describeIfSqlite } from "./test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -2,7 +2,7 @@ import { it, expect, beforeEach, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base } from "../base.js";
 import { fixtures } from "../test-fixtures.js";
-import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
+import { describeIfSqlite } from "../support/describe-if-sqlite.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 import { queryTransformers, type QueryTransformer } from "../query-transformers.js";
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts
@@ -1,7 +1,7 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
 import { fixtures } from "../test-fixtures.js";
-import { describeIfSqlite } from "../adapters/sqlite3/test-helper.js";
+import { describeIfSqlite } from "../support/describe-if-sqlite.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 
 fixtures([]);

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -3,7 +3,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BinaryData } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import { describeIfSqlite } from "../../adapters/sqlite3/test-helper.js";
+import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { type AbstractSQLite3Adapter, SQLiteDateTimeType } from "../sqlite3-adapter.js";
 import { Date as DateType } from "../../type/date.js";
 import { Time as TimeType } from "../../type/time.js";

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -19,7 +19,7 @@ import {
   MYSQL_TEST_URL,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
 import { describeIfPg } from "./adapters/postgresql/test-helper.js";
-import { describeIfSqlite } from "./adapters/sqlite3/test-helper.js";
+import { describeIfSqlite } from "./support/describe-if-sqlite.js";
 import { describeIfSupports, itIfSupports } from "./support/supports.js";
 import { fixtures } from "./test-fixtures.js";
 import { Entrant } from "./test-helpers/models/entrant.js";

--- a/packages/activerecord/src/support/describe-if-sqlite.ts
+++ b/packages/activerecord/src/support/describe-if-sqlite.ts
@@ -10,9 +10,5 @@ import { isSqliteRun } from "./sqlite-template.js";
  * Reuses the canonical {@link isSqliteRun} predicate so the "what counts as a
  * SQLite run" rule has one source of truth. Counterpart to `describeIfPg` /
  * `describeIfMysql`.
- *
- * Lives here rather than in `adapters/sqlite3/test-helper.ts` because both the
- * `adapters/sqlite3/` and the pre-RFC-0026 `connection-adapters/` test trees
- * need the same gate, and neither tree should import test glue from the other.
  */
 export const describeIfSqlite = isSqliteRun() ? describe : (describe.skip as typeof describe);

--- a/packages/activerecord/src/support/describe-if-sqlite.ts
+++ b/packages/activerecord/src/support/describe-if-sqlite.ts
@@ -1,0 +1,18 @@
+import { describe } from "vitest";
+import { isSqliteRun } from "./sqlite-template.js";
+
+/**
+ * Scope a suite to the SQLite backend, mirroring Rails'
+ * `ActiveRecord::SQLite3TestCase`. The handler connection is swapped to
+ * PG/MySQL in the cross-backend CI matrix, so suites whose assertions are
+ * SQLite-specific — `EXPLAIN QUERY PLAN` plan shape, `"`-quoted identifiers —
+ * must skip there rather than run against a backend Rails never points them at.
+ * Reuses the canonical {@link isSqliteRun} predicate so the "what counts as a
+ * SQLite run" rule has one source of truth. Counterpart to `describeIfPg` /
+ * `describeIfMysql`.
+ *
+ * Lives here rather than in `adapters/sqlite3/test-helper.ts` because both the
+ * `adapters/sqlite3/` and the pre-RFC-0026 `connection-adapters/` test trees
+ * need the same gate, and neither tree should import test glue from the other.
+ */
+export const describeIfSqlite = isSqliteRun() ? describe : (describe.skip as typeof describe);


### PR DESCRIPTION
Moves `describeIfSqlite` out of `adapters/sqlite3/test-helper.ts` into a tree-neutral `support/describe-if-sqlite.ts`, next to the `isSqliteRun` predicate it is built from.

PR #5500 needed the same SQLite-lane gate for three pre-RFC-0026 `connection-adapters/` files and imported it across trees, which made the helper docstring ("Shared helpers for `adapters/sqlite3/*.test.ts`") false and coupled two test trees RFC 0026 is separating. The predicate still has exactly one definition — only its home changed; every importer in both trees now points at `support/`.

No test names changed; no behavior change.

Closes-story: relocate-describe-if-sqlite-out-of-adapters-tree
