### PR TITLE
test(activerecord): retire the describeIfMysql server-reachability probe

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/adapter-prevent-writes.test.ts
@@ -2,12 +2,12 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { describeIfMysql, Mysql2Adapter } from "./test-helper.js";
+import { describeIfMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../index.js";
 import { ReadOnlyError, QueryCanceled } from "../../errors.js";
 import { fixtures } from "../../test-fixtures.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   fixtures([]);
 
   // Rails: @conn = ActiveRecord::Base.lease_connection

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { describeIfMysql, isMariaDb, Mysql2Adapter } from "./test-helper.js";
+import { describeIfMysqlAdapter, isMariaDb, Mysql2Adapter } from "./test-helper.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Base } from "../../index.js";
@@ -10,12 +10,12 @@ import { Author } from "../../test-helpers/models/author.js";
 import { Post } from "../../test-helpers/models/post.js";
 import { registerModel } from "../../index.js";
 
-// The outer `describeIfMysql` beforeAll reads `Base.connection` before the
+// The outer `describeIfMysqlAdapter` beforeAll reads `Base.connection` before the
 // nested MySQLExplainTest `fixtures()` establishes it, so the handler wiring has
 // to be laid at file scope here — it is NOT redundant with the nested call.
 fixtures({}, { useTransactionalTests: false });
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   registerModel(Author);
   registerModel(Post);
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/optimizer-hints.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/optimizer-hints.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
  */
 import { it, expect, beforeAll } from "vitest";
-import { describeIfMysql, Mysql2Adapter } from "./test-helper.js";
+import { describeIfMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { describeIfSupports } from "../../support/supports.js";
 import { captureSql } from "../../testing/sql-capture.js";
 import { Base } from "../../index.js";
@@ -12,7 +12,7 @@ import { Post } from "../../test-helpers/models/post.js";
 // Rails wraps the whole OptimizerHintsTest body in `if supports_optimizer_hints?`
 // (MySQL ≥ 5.7.7, never MariaDB), so the examples never run on a server that
 // reports no support. Mirror that with a conditional describe.
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   describeIfSupports("optimizer_hints", "OptimizerHintsTest", () => {
     // mirrors Rails: fixtures :posts
     fixtures(["posts"]);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
@@ -2,12 +2,12 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
  */
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter } from "./test-helper.js";
+import { describeIfMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { Topic } from "../../test-helpers/models/topic.js";
 import { fixtures } from "../../test-fixtures.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   describe("StoredProcedureTest", () => {
     // Rails `fixtures :topics` — load canonical topics via the handler connection.
     const { topics } = fixtures(["topics"]);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -12,13 +12,10 @@ import { Base } from "../../base.js";
 // here so MySQL adapter tests can keep importing it from this module.
 export { withDbWarningsAction } from "../../support/with-db-warnings-action.js";
 
-// A *serialization* of the MySQL sub-settings (MYSQL_HOST/MYSQL_PORT/
-// MYSQL_USER/...), not an env var of its own. Its only callers are the tests
-// that deliberately build a *second*, differently configured adapter (a
-// non-strict sql_mode, ANSI_QUOTES, a statementLimit, a socket the retry loop
-// may tear down) — cases where the config itself is under test and must not
-// leak onto the shared leased connection. Everything else rides the ambient
-// `Base.connection` via leaseMysqlAdapter below.
+// A *serialization* of the MySQL sub-settings, not an env var of its own. Only
+// for tests that build a *second*, differently configured adapter, where the
+// config is itself under test and must not leak onto the shared leased
+// connection. Everything else rides leaseMysqlAdapter below.
 export const MYSQL_TEST_URL = mysqlUrl();
 
 /**
@@ -39,12 +36,11 @@ export const { arunit: ARUNIT_DATABASE, arunit2: ARUNIT2_DATABASE } = arunitData
 let mariaDb = false;
 let mysqlVersionStr = "";
 
-// Probes the server once at module load purely to read VERSION(): the
-// supports* gates below mirror Rails' version-keyed `supports_*?` predicates,
-// which have no static answer (the mysql lane may be MySQL 8 or the MariaDB CI
-// stand-in). An unreachable server yields an empty version, which makes every
-// gate false rather than skipping any suite — suite selection is
-// describeIfMysqlAdapter's job.
+// Reads VERSION() once at load: the supports* gates below mirror Rails'
+// version-keyed `supports_*?` predicates, which have no static answer (the
+// mysql lane may be MySQL 8 or the MariaDB CI stand-in). An unreachable server
+// yields an empty version, so every gate reads false — it never skips a suite,
+// which is describeIfMysqlAdapter's job alone.
 async function checkMysql(): Promise<{ isMariaDb: boolean; version: string }> {
   let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
   try {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -13,12 +13,12 @@ import { Base } from "../../base.js";
 export { withDbWarningsAction } from "../../support/with-db-warnings-action.js";
 
 // A *serialization* of the MySQL sub-settings (MYSQL_HOST/MYSQL_PORT/
-// MYSQL_USER/...), not an env var of its own: the suites still on
-// describeIfMysql probe the server directly regardless of ARCONN, so they need
-// a URL to hand the driver, but they no longer source one from the
-// environment. Being burned down in favour of describeIfMysqlAdapter +
-// leaseMysqlAdapter below; the remaining legitimate callers are the tests that
-// deliberately build a second, differently configured adapter.
+// MYSQL_USER/...), not an env var of its own. Its only callers are the tests
+// that deliberately build a *second*, differently configured adapter (a
+// non-strict sql_mode, ANSI_QUOTES, a statementLimit, a socket the retry loop
+// may tear down) — cases where the config itself is under test and must not
+// leak onto the shared leased connection. Everything else rides the ambient
+// `Base.connection` via leaseMysqlAdapter below.
 export const MYSQL_TEST_URL = mysqlUrl();
 
 /**
@@ -36,33 +36,31 @@ export const { arunit: ARUNIT_DATABASE, arunit2: ARUNIT2_DATABASE } = arunitData
   mysqlSettings().database,
 );
 
-let mysqlAvailable = false;
 let mariaDb = false;
 let mysqlVersionStr = "";
 
-async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean; version: string }> {
+// Probes the server once at module load purely to read VERSION(): the
+// supports* gates below mirror Rails' version-keyed `supports_*?` predicates,
+// which have no static answer (the mysql lane may be MySQL 8 or the MariaDB CI
+// stand-in). An unreachable server yields an empty version, which makes every
+// gate false rather than skipping any suite — suite selection is
+// describeIfMysqlAdapter's job.
+async function checkMysql(): Promise<{ isMariaDb: boolean; version: string }> {
   let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
   try {
     conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
     const [rows] = await conn.query("SELECT VERSION() AS v");
     const ver = (rows as Array<{ v: string }>)[0]?.v ?? "";
-    return { available: true, isMariaDb: /mariadb/i.test(ver), version: ver };
+    return { isMariaDb: /mariadb/i.test(ver), version: ver };
   } catch {
-    return { available: false, isMariaDb: false, version: "" };
+    return { isMariaDb: false, version: "" };
   } finally {
     await conn?.end().catch(() => {});
   }
 }
 
-({ available: mysqlAvailable, isMariaDb: mariaDb, version: mysqlVersionStr } = await checkMysql());
+({ isMariaDb: mariaDb, version: mysqlVersionStr } = await checkMysql());
 
-/**
- * Server-reachability probe, NOT the port of `current_adapter?(:Mysql2Adapter)`
- * — use {@link describeIfMysqlAdapter} for that. A suite gated on this one runs
- * under every `ARCONN` against a self-built adapter, bypassing the leased pool
- * connection.
- */
-export const describeIfMysql = mysqlAvailable ? describe : (describe.skip as typeof describe);
 /** true when the connected server is MariaDB; false on MySQL or when MySQL is unavailable. */
 export const isMariaDb = mariaDb;
 /** Raw VERSION() string from the connected MySQL/MariaDB server (empty when unavailable). */
@@ -81,8 +79,7 @@ const _serverVersion = parseMysqlVersion(mysqlVersionStr);
  * never MariaDB. Lets adapter tests gate on hint support the way the Rails
  * suite wraps `OptimizerHintsTest` in `if supports_optimizer_hints?`.
  */
-export const supportsOptimizerHints =
-  mysqlAvailable && !mariaDb && _serverVersion?.gte("5.7.7") === true;
+export const supportsOptimizerHints = !mariaDb && _serverVersion?.gte("5.7.7") === true;
 
 /**
  * Mirrors `supports_default_expression?` (adapter_helper.rb:23) for MySQL: an
@@ -90,9 +87,9 @@ export const supportsOptimizerHints =
  * Gates the `defaults` table's `uuid` / `char2_concatenated` expression columns
  * exactly as Rails' mysql2_specific_schema.rb does.
  */
-export const supportsDefaultExpression =
-  mysqlAvailable &&
-  (mariaDb ? _serverVersion?.gte("10.2.1") === true : _serverVersion?.gte("8.0.13") === true);
+export const supportsDefaultExpression = mariaDb
+  ? _serverVersion?.gte("10.2.1") === true
+  : _serverVersion?.gte("8.0.13") === true;
 
 /**
  * Mirrors AbstractMysqlAdapter#supports_expression_index?
@@ -101,18 +98,15 @@ export const supportsDefaultExpression =
  * the answer into a static adapterType table — the mysql lane may be MySQL 8
  * (true) or the MariaDB CI stand-in (false).
  */
-export const supportsExpressionIndex =
-  mysqlAvailable && !mariaDb && _serverVersion?.gte("8.0.13") === true;
+export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13") === true;
 
 export { Mysql2Adapter };
 
 /**
  * The port of `current_adapter?(:Mysql2Adapter)` — the gate every
- * `ActiveRecord::AbstractMysqlTestCase` suite runs under. `describeIfMysql`
- * above is a *server-reachability* probe (it runs these suites against a
- * self-built adapter under every `ARCONN`); this is the adapter gate, so the
- * suite rides the ambient `Base.connection` on the mysql2 lane and skips
- * everywhere else, exactly as Rails does.
+ * `ActiveRecord::AbstractMysqlTestCase` suite runs under. The suite rides the
+ * ambient `Base.connection` on the mysql2 lane and skips everywhere else,
+ * exactly as Rails does.
  */
 export const describeIfMysqlAdapter =
   adapterType === "mysql" ? describe : (describe.skip as typeof describe);

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -37,7 +37,7 @@ import { Result } from "../../result.js";
 
 // Fabricated-error translate_exception checks. These don't touch a live
 // MySQL server (they feed Object.assign(new Error(...), { errno/code })
-// straight into translateException), so they live outside describeIfMysql
+// straight into translateException), so they live outside describeIfMysqlAdapter
 // to keep coverage on dev machines without MySQL installed.
 describe("Mysql2Adapter#translateException (fabricated errors)", () => {
   let adapter: Mysql2Adapter;

--- a/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
@@ -15,7 +15,7 @@
  */
 import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
   Mysql2Adapter,
   MYSQL_TEST_URL,
 } from "../abstract-mysql-adapter/test-helper.js";
@@ -28,7 +28,7 @@ interface RetryLoopSeams {
   rawConnectionForBlock(): Promise<unknown>;
 }
 
-describeIfMysql("Mysql2Adapter savepoint statements dirty the parent (trails)", () => {
+describeIfMysqlAdapter("Mysql2Adapter savepoint statements dirty the parent (trails)", () => {
   let adapter: Mysql2Adapter;
 
   beforeEach(() => {

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect, beforeEach } from "vitest";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
-import { describeIfMysql } from "../adapters/abstract-mysql-adapter/test-helper.js";
+import { describeIfMysqlAdapter } from "../adapters/abstract-mysql-adapter/test-helper.js";
 
 // Minimal subclass of the *concrete* Mysql2Adapter — char/varchar/enum/set
 // string registrations live on the concrete adapter (mysql2_adapter.rb:40-49),
@@ -31,7 +31,7 @@ function assertLookupType(expected: string, lookup: string) {
   expect(castType.type()).toBe(expected);
 }
 
-describeIfMysql("MysqlTypeLookupTest", () => {
+describeIfMysqlAdapter("MysqlTypeLookupTest", () => {
   it("boolean types", () => {
     // emulate_booleans = true: tinyint(1) → boolean
     assertLookupType("boolean", "tinyint(1)");

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -13,7 +13,7 @@ import { adapterType } from "./test-adapter.js";
 import { MigrationContext } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
   isMariaDb,
   Mysql2Adapter,
   MYSQL_TEST_URL,
@@ -287,7 +287,7 @@ describeIfPg("PostgresqlDefaultExpressionTest", () => {
 // Mirrors `MysqlDefaultExpressionTest` (defaults_test.rb), gated to the
 // Mysql2Adapter. The three tables come from mysql2_specific_schema.rb and are
 // laid at boot by the adapter-specific arm of loadSchema.
-describeIfMysql("MysqlDefaultExpressionTest", () => {
+describeIfMysqlAdapter("MysqlDefaultExpressionTest", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(() => {
@@ -395,7 +395,7 @@ describeIfMysql("MysqlDefaultExpressionTest", () => {
 // to the Mysql2Adapter. Rails toggles strict mode via
 // `establish_connection(..., strict:)`; our Mysql2Adapter accepts the same
 // `strict` config key, so `using_strict` becomes a fresh adapter per block.
-describeIfMysql("DefaultsTestWithoutTransactionalFixtures", () => {
+describeIfMysqlAdapter("DefaultsTestWithoutTransactionalFixtures", () => {
   // Mirrors `with_mysql_not_null_table`: build the NOT NULL table on a
   // strict/non-strict connection, yield the model, then drop it.
   async function withMysqlNotNullTable(

--- a/packages/activerecord/src/invalid-connection.test.ts
+++ b/packages/activerecord/src/invalid-connection.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, afterEach, it, expect } from "vitest";
 import { Base } from "./base.js";
-import { describeIfMysql } from "./adapters/abstract-mysql-adapter/test-helper.js";
+import { describeIfMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
 
 // Mirrors: activerecord/test/cases/invalid_connection_test.rb
 //
 // Rails gates this on `current_adapter?(:Mysql2Adapter, :TrilogyAdapter)`
 // because sqlite3 would create a database file on the fly, so the connection
-// config would never be "invalid". We mirror that gate with describeIfMysql.
-describeIfMysql("TestAdapterWithInvalidConnection", () => {
+// config would never be "invalid". We mirror that gate with describeIfMysqlAdapter.
+describeIfMysqlAdapter("TestAdapterWithInvalidConnection", () => {
   class Bird extends Base {}
 
   beforeEach(async () => {

--- a/packages/activerecord/src/support/describe-if-sqlite.ts
+++ b/packages/activerecord/src/support/describe-if-sqlite.ts
@@ -9,6 +9,6 @@ import { isSqliteRun } from "./sqlite-template.js";
  * must skip there rather than run against a backend Rails never points them at.
  * Reuses the canonical {@link isSqliteRun} predicate so the "what counts as a
  * SQLite run" rule has one source of truth. Counterpart to `describeIfPg` /
- * `describeIfMysql`.
+ * `describeIfMysqlAdapter`.
  */
 export const describeIfSqlite = isSqliteRun() ? describe : (describe.skip as typeof describe);

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -3,7 +3,7 @@ import { adapterType } from "../test-adapter.js";
 
 /**
  * TS mirror of Rails' connection `supports_<feature>?` predicates — the
- * *feature* counterpart to {@link describeIfPg}/{@link describeIfMysql}/
+ * *feature* counterpart to {@link describeIfPg}/{@link describeIfMysqlAdapter}/
  * {@link describeIfSqlite}'s *adapter* gating. Use these to scope a suite or
  * test to the backends that support a DB capability, exactly as Rails does
  * with `skip unless supports_<feature>?`.

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -17,10 +17,6 @@ describe("gates.ts pure helpers", () => {
       adapters: ["postgresql"],
       source: ["wrapper"],
     });
-    expect(gateFromWrapper("describeIfMysql")).toEqual({
-      adapters: ["mysql"],
-      source: ["wrapper"],
-    });
     expect(gateFromWrapper("describeIfMysqlAdapter")).toEqual({
       adapters: ["mysql"],
       source: ["wrapper"],
@@ -241,10 +237,10 @@ describe("TS extractor gate detection", () => {
   });
 
   it("composes an adapter wrapper's .skipIf form with the inline guard", () => {
-    // describeIfMysql restricts to mysql; skipIf(postgres) → runs on !postgres;
+    // describeIfMysqlAdapter restricts to mysql; skipIf(postgres) → runs on !postgres;
     // intersection = mysql.
     const g = tsGates(`
-      describeIfMysql.skipIf(adapterType === "postgres")("S", () => { it("j", () => {}); });
+      describeIfMysqlAdapter.skipIf(adapterType === "postgres")("S", () => { it("j", () => {}); });
     `);
     // wrapper gate (mysql) ∩ inline guard → source unions both origins.
     expect(g["j"]).toEqual({ adapters: ["mysql"], source: ["test", "wrapper"] });
@@ -253,7 +249,7 @@ describe("TS extractor gate detection", () => {
   it("preserves an empty adapter set for contradictory nested wrappers", () => {
     const g = tsGates(`
       describeIfPg("outer", () => {
-        describeIfMysql("inner", () => { it("never", () => {}); });
+        describeIfMysqlAdapter("inner", () => { it("never", () => {}); });
       });
     `);
     // pg ∩ mysql = [] → "runs nowhere", kept distinct from an absent key.

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -55,7 +55,7 @@ export function mergeGate(base: TestGate | undefined, add: TestGate): TestGate {
  * Normalize a freshly-built gate's array fields (sort + de-dupe). A
  * *present-but-empty* `adapters` array is preserved (not dropped): it means
  * contradictory gates intersected to "runs on no adapter" (e.g. describeIfPg ▸
- * describeIfMysql), which is distinct from an absent key (= "runs on all").
+ * describeIfMysqlAdapter), which is distinct from an absent key (= "runs on all").
  * Mirrors the Ruby extractor's `finalize_gate` (`merged.key?(:adapters)`).
  */
 export function finalizeGate(gate: TestGate): TestGate {
@@ -68,7 +68,6 @@ export function finalizeGate(gate: TestGate): TestGate {
 
 export const ADAPTER_GATE_WRAPPERS = [
   "describeIfPg",
-  "describeIfMysql",
   "describeIfMysqlAdapter",
   "describeIfSqlite",
 ] as const;
@@ -108,10 +107,7 @@ export function gateFromWrapper(name: string, featureArg?: string | null): TestG
   switch (name) {
     case "describeIfPg":
       return { adapters: ["postgresql"], source: ["wrapper"] };
-    case "describeIfMysql":
-    // The port of `current_adapter?(:Mysql2Adapter)` — same gate as
-    // describeIfMysql, but keyed on the active adapter rather than on a
-    // server-reachability probe.
+    // The port of `current_adapter?(:Mysql2Adapter)`.
     case "describeIfMysqlAdapter":
       return { adapters: ["mysql"], source: ["wrapper"] };
     case "describeIfSqlite":

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,7 +50,7 @@ const SHARED_EXCLUDE = [
 // The pure-unit `connection-adapters/<db>/**` subdirs (OID types, quoting
 // helpers, schema-creation stubs) are NOT in this exclude — they run on every
 // CI job regardless of ARCONN. Live-DB cases inside them are wrapped in
-// `describeIfPg` / `describeIfMysql` / `describeIfSqlite`.
+// `describeIfPg` / `describeIfMysqlAdapter` / `describeIfSqlite`.
 //
 // CI sets ARCONN=postgresql on postgres-tests and ARCONN=mysql2 on
 // mysql-tests. sqlite-tests leaves ARCONN unset (defaults to sqlite3).


### PR DESCRIPTION
`describeIfMysql` gated MySQL suites on a module-load `SELECT VERSION()`
*server-reachability* probe rather than on the active adapter, so a suite gated
on it **silently skipped its whole file** when the server was unreachable on the
MySQL lane — where that should be a loud failure. It is not the port of anything
in Rails: Rails gates these suites with `current_adapter?(:Mysql2Adapter)`
(`vendor/rails/activerecord/test/support/adapter_helper.rb:4-9`), which #5306
ported as `describeIfMysqlAdapter`.

The `mysql-tests-self-built-adapter-burndown` batches (#5306, #5327, #5328)
drained 19 call sites down to 8; this moves the last 8 over and deletes the
probe.

## What changed

- Moved the 8 remaining callers to `describeIfMysqlAdapter`: `defaults.test.ts`
  (×2), `invalid-connection.test.ts`, `adapter-prevent-writes.test.ts`,
  `mysql-explain.test.ts`, `sp.test.ts`, `optimizer-hints.test.ts`,
  `savepoint-reconnect.trails.test.ts`, `mysql-type-lookup.test.ts`.
- Deleted `describeIfMysql` and the `available` plumbing from `checkMysql()`.
  The version probe **stays**: `isMariaDb` / `mysqlVersion` /
  `supportsOptimizerHints` / `supportsDefaultExpression` /
  `supportsExpressionIndex` mirror Rails' version-keyed `supports_*?`
  predicates, which have no static answer (the mysql lane may be MySQL 8 or the
  MariaDB CI stand-in). An unreachable server now yields an empty version — so
  every `supports*` gate is false — instead of skipping a suite; the
  `mysqlAvailable &&` guards were already redundant with that, since an empty
  version parses to `null` and every `gte` comparison already returned false.
- `MYSQL_TEST_URL` survives — 13 files still legitimately build a *second*,
  differently configured adapter (non-strict `sql_mode`, `ANSI_QUOTES`, a
  `statementLimit`, a socket the retry loop tears down), cases where the config
  itself is under test and must not leak onto the shared leased connection. Its
  doc comment is narrowed to exactly those callers.
- Dropped `describeIfMysql` from test-compare's `ADAPTER_GATE_WRAPPERS` and
  `gateFromWrapper` (`scripts/test-compare/gates.ts`), plus its now-dead
  extractor test case.

Two of the moved suites (`DefaultsTestWithoutTransactionalFixtures`,
`savepoint-reconnect.trails`) keep building a self-built adapter on purpose —
the burn-down's audit marked both as legitimate second-adapter callers. Only
their *gate* changes, from reachability to adapter.

## Verification

- All 8 moved files pass on the mysql2 lane (local MySQL 8): 54 tests green.
- On the sqlite lane they skip, as before.
- `pnpm test:compare` reports no gate-mismatch.
- `pnpm typecheck` clean.

Closes-story: retire-describe-if-mysql-reachability-probe
