### PR TITLE
test(activerecord): converge the sqlite3_mem entries on config.example.yml

### DIFF
--- a/packages/activerecord/src/pooled-test-adapter.test.ts
+++ b/packages/activerecord/src/pooled-test-adapter.test.ts
@@ -46,14 +46,13 @@ describe("createPooledTestAdapter (Phase B smoke)", () => {
     }
   });
 
-  // The duplicate pool inherits the primary's size, which `sqlite3_mem` pins to
-  // 1. This test needs two: the setup lease above plus the pinned one. So
-  // `pinConnectionBang` raises ConnectionTimeoutError ("All 1 connections are
-  // in use") before it issues any SQL.
-  //
-  // Checkout starvation, NOT the duplicate pool landing on its own empty
-  // `:memory:` database — the setup CREATE TABLE on the preceding line
-  // succeeds, as does the CREATE-then-read in the schemaCache case above.
+  // This test needs two connections: the setup lease above plus the pinned one.
+  // A SQLite `:memory:` database belongs to the connection that opened it, so
+  // on `sqlite3_mem` the second one is a second, EMPTY database and the pinned
+  // INSERT raises `no such table` — it never sees the setup CREATE TABLE.
+  // Rails guards its own pinned-connection case the same way —
+  // `skip("Can't test with in-memory dbs") if in_memory_db?`
+  // (`connection_pool_test.rb:891`).
   it.skipIf(inMemoryDb())(
     "pinConnectionBang + write + unpinConnectionBang rolls back",
     async () => {

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -149,12 +149,19 @@ describe("connect", () => {
     expect(envConfig.database).toBe("/tmp/ar-test-worker.sqlite3");
   });
 
-  it("pins pool 1 on the sqlite3_mem :memory: connection", async () => {
+  // `config.example.yml:93-99` carries `adapter` and `database` alone, so the
+  // built hash must too — no `pool:`, and therefore Rails' default pool size,
+  // the same one the file-backed lane above inherits.
+  it("builds the sqlite3_mem entries from adapter and database alone", async () => {
     vi.stubEnv("ARCONN", "sqlite3_mem");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const { adapter, envConfig } = await testConfigurationHashes();
+    const { adapter, envConfig, configurationHashes } = await testConfigurationHashes();
     expect(adapter).toBe("sqlite");
-    expect(envConfig.pool).toBe(1);
+    expect(configurationHashes.slice(0, 2).map((c) => c.configurationHash)).toEqual([
+      { adapter: "sqlite3", database: ":memory:" },
+      { adapter: "sqlite3", database: ":memory:" },
+    ]);
+    expect(envConfig.pool).toBe(5);
   });
 
   it("selects the postgresql connection named by ARCONN", async () => {

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -145,7 +145,7 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3: {
     adapter: "sqlite3",
     lane: "sqlite",
-    // `config.example.yml:82-89`: two file databases, both `timeout`/`strict`.
+    // `config.example.yml:83-91`: two file databases, both `timeout`/`strict`.
     // Rails names them under FIXTURES_ROOT; ours are the worker database and
     // its derived sibling, filled in by `expandConfig`.
     build: async () => {
@@ -156,18 +156,14 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3_mem: {
     adapter: "sqlite3",
     lane: "sqlite",
-    // `config.example.yml:91-97` — both entries are their own `:memory:` database.
+    // `config.example.yml:93-99` — both entries are their own `:memory:` database,
+    // carrying `adapter` and `database` and nothing else.
     // Exercised by ci.yml's `sqlite-mem-tests` job — the only lane where
     // `inMemoryDb()` is true, and so the only thing keeping the
     // `skipIf(inMemoryDb())` guards from rotting.
-    //
-    // `pool: 1` has no counterpart in the yml: a `:memory:` database belongs to
-    // its connection, so a second pool member would silently be a second, empty
-    // database. Rails never notices — its suite checks out one connection at a
-    // time; our pool leases concurrently.
     build: async () => ({
-      arunit: { adapter: "sqlite3", database: ":memory:", pool: 1 },
-      arunit2: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+      arunit: { adapter: "sqlite3", database: ":memory:" },
+      arunit2: { adapter: "sqlite3", database: ":memory:" },
     }),
   },
   postgresql: {


### PR DESCRIPTION
`sqlite3_mem` built both `arunit` and `arunit2` with `pool: 1`, a key
`config.example.yml:93-99` does not have. **No deviation granted — this
converges.** The key is gone; the built configuration hash is now exactly
`{ adapter: "sqlite3", database: ":memory:" }` for both entries, byte-matching
the vendored yml, and the lane inherits Rails' default pool size (5) like every
other entry.

The internal reason the pin existed is real — a SQLite `:memory:` database
belongs to the connection that opened it, so a second pool member is a second,
empty database — but that is not a reason to put a `pool:` key in a
connection profile that mirrors Rails'. The constraint is a property of
`:memory:`, not a knob the config should carry.

## What holds it together instead

The one case that actually needed two connections on this lane is
`pooled-test-adapter.test.ts`'s
`pinConnectionBang + write + unpinConnectionBang rolls back`. It was already
`it.skipIf(inMemoryDb())` and stays so — the skip was never contingent on
`pool: 1`, only its failure mode was. **Rails guards its own pinned-connection
case identically:**

```ruby
def test_pin_connection_connected?
  skip("Can't test with in-memory dbs") if in_memory_db?
```

— `vendor/rails/activerecord/test/cases/connection_pool_test.rb:891`

So the skip is now justified by the Rails source rather than by a trails
invention. Its comment was rewritten: the old text described checkout
starvation ("All 1 connections are in use"), which is no longer what happens.

## Verification

- `ARCONN=sqlite3_mem` over `adapters/sqlite3/`, `connection-adapters/`, and
  `support/` — **129 files, 2067 passed, 114 skipped**, exit 0.
- `support/connection.test.ts` — 22 passed. Its assertion was rewritten from
  `expect(envConfig.pool).toBe(1)` to assert the full hash equals
  `{ adapter, database }`, so re-adding any key fails the test.
- Rebased onto current `main`; both re-verified after the rebase.
- Labelled `run-sqlite-mem` so the full `sqlite-mem-tests` job runs on this PR
  rather than being skipped.

## Also fixed

Both sqlite profiles cited wrong yml ranges — `sqlite3_mem` as `91-97` (opening
on the file-backed profile's `strict: true`, closing before `arunit2`'s
`database`) and `sqlite3` as `82-89`. Now `93-99` and `83-91`.

An earlier revision of this PR recorded the deviation in the README instead of
removing it. That is fully reverted — `README.md` and the website deviations
guide are both byte-identical to `main`.

Closes-story: sqlite3-mem-pool-1-is-not-in-rails-yml

