### PR TITLE
test(activerecord): move describeIfPg/describeIfMysql to support so all trees share them

### DIFF
--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -8,7 +8,8 @@ import { ReadOnlyError, StatementInvalid } from "./errors.js";
 import { itIfSupports } from "./support/supports.js";
 import { adapterType } from "./test-adapter.js";
 import { scratchDatabasePath } from "./support/scratch-database.js";
-import { PostgreSQLAdapter, PG_TEST_URL } from "./adapters/postgresql/test-helper.js";
+import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
+import { PG_TEST_URL } from "./support/describe-if-pg.js";
 
 // Rails' `setup` is `@connection = ActiveRecord::Base.lease_connection` — the
 // ambient file-backed `arunit` connection, with `subscribers` coming from

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -4,9 +4,6 @@ import { Notifications, squish } from "@blazetrails/activesupport";
 import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/activesupport";
 import { pgAvailable, pgHasHintPlan, pgServerVersion } from "../../support/describe-if-pg.js";
 
-// The PG server-reachability gate and the probe behind it are tree-neutral —
-// suites outside this tree gate on them — so they live in support/. Re-exported
-// so this tree's tests keep a single import.
 export { describeIfPg, pgServerVersion, PG_TEST_URL } from "../../support/describe-if-pg.js";
 
 /**

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -1,56 +1,14 @@
-import { describe } from "vitest";
-import pg from "pg";
 import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
 import { Notifications, squish } from "@blazetrails/activesupport";
 import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/activesupport";
-import { postgresUrl } from "../../support/config.js";
+import { pgAvailable, pgHasHintPlan, pgServerVersion } from "../../support/describe-if-pg.js";
 
-// A *serialization* of the PG sub-settings (PGHOST/PGPORT/PGUSER/PGPASSWORD/
-// PGDATABASE), not an env var of its own: these adapter suites probe the server
-// directly via describeIfPg regardless of ARCONN, so they need a URL to hand
-// the driver, but they no longer source one from the environment.
-export const PG_TEST_URL = postgresUrl();
+// The PG server-reachability gate and the probe behind it are tree-neutral —
+// suites outside this tree gate on them — so they live in support/. Re-exported
+// so this tree's tests keep a single import.
+export { describeIfPg, pgServerVersion, PG_TEST_URL } from "../../support/describe-if-pg.js";
 
-let pgAvailable = false;
-let pgServerVersionNum = 0;
-let pgHasHintPlan = false;
-
-async function checkPg(): Promise<{
-  available: boolean;
-  serverVersionNum: number;
-  hasHintPlan: boolean;
-}> {
-  const client = new pg.Client({ connectionString: PG_TEST_URL });
-  try {
-    await client.connect();
-    const res = await client.query<{ v: string }>(
-      "SELECT current_setting('server_version_num') AS v",
-    );
-    const ext = await client.query<{ count: string }>(
-      "SELECT COUNT(*) AS count FROM pg_available_extensions WHERE name = 'pg_hint_plan'",
-    );
-    return {
-      available: true,
-      serverVersionNum: Number(res.rows[0]?.v ?? 0),
-      hasHintPlan: Number(ext.rows[0]?.count ?? 0) > 0,
-    };
-  } catch {
-    return { available: false, serverVersionNum: 0, hasHintPlan: false };
-  } finally {
-    await client.end().catch(() => {});
-  }
-}
-
-({
-  available: pgAvailable,
-  serverVersionNum: pgServerVersionNum,
-  hasHintPlan: pgHasHintPlan,
-} = await checkPg());
-
-export const describeIfPg = pgAvailable ? describe : (describe.skip as typeof describe);
-/** PG server_version_num at module load (0 when unavailable). */
-export const pgServerVersion = pgServerVersionNum;
 /**
  * Mirrors PostgreSQLAdapter#supports_optimizer_hints? — true when the
  * `pg_hint_plan` extension is installed and available. Rails wraps the whole
@@ -59,7 +17,7 @@ export const pgServerVersion = pgServerVersionNum;
  */
 export const pgSupportsOptimizerHints = pgAvailable && pgHasHintPlan;
 /** Mirrors PostgreSQLAdapter#supportsNativePartitioning — PG 10+ (100000). */
-export const pgSupportsNativePartitioning = pgServerVersionNum >= 100000;
+export const pgSupportsNativePartitioning = pgServerVersion >= 100000;
 
 /** Mirrors Rails' with_postgresql_datetime_type — temporarily changes the adapter's datetimeType. */
 export async function withPostgresqlDatetimeType<T>(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -13,11 +13,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import {
-  describeIfPg,
-  PostgreSQLAdapter,
-  PG_TEST_URL,
-} from "../../adapters/postgresql/test-helper.js";
+import { PostgreSQLAdapter } from "../postgresql-adapter.js";
+import { describeIfPg, PG_TEST_URL } from "../../support/describe-if-pg.js";
 
 const SCHEMA_NAME = "test_schema_stmts";
 const TABLE_NAME = "things";

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -18,7 +18,7 @@ import {
   Mysql2Adapter,
   MYSQL_TEST_URL,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
-import { describeIfPg } from "./adapters/postgresql/test-helper.js";
+import { describeIfPg } from "./support/describe-if-pg.js";
 import { describeIfSqlite } from "./support/describe-if-sqlite.js";
 import { describeIfSupports, itIfSupports } from "./support/supports.js";
 import { fixtures } from "./test-fixtures.js";

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -37,7 +37,7 @@ function emitTableSql(td: TableDefinition): Promise<string> {
 import { Person } from "./test-helpers/models/person.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
 import { itIfSupports, describeIfSupports } from "./support/supports.js";
-import { describeIfPg } from "./adapters/postgresql/test-helper.js";
+import { describeIfPg } from "./support/describe-if-pg.js";
 import {
   describeIfMysqlAdapter,
   leaseMysqlAdapter,

--- a/packages/activerecord/src/migration/exclusion-constraint.test.ts
+++ b/packages/activerecord/src/migration/exclusion-constraint.test.ts
@@ -12,7 +12,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { PostgreSQLAdapter, PG_TEST_URL } from "../adapters/postgresql/test-helper.js";
+import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { PG_TEST_URL } from "../support/describe-if-pg.js";
 import { describeIfSupports } from "../support/supports.js";
 import { rebuildCanonicalTables } from "../support/canonical-table-rebuild.js";
 

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -7,7 +7,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { PostgreSQLAdapter, PG_TEST_URL } from "../adapters/postgresql/test-helper.js";
+import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { PG_TEST_URL } from "../support/describe-if-pg.js";
 import { describeIfSupports } from "../support/supports.js";
 import { rebuildCanonicalTables } from "../support/canonical-table-rebuild.js";
 

--- a/packages/activerecord/src/support/describe-if-pg.ts
+++ b/packages/activerecord/src/support/describe-if-pg.ts
@@ -47,6 +47,6 @@ export const pgHasHintPlan = probe.hasHintPlan;
  * Scope a suite to a reachable PostgreSQL server. Lives in `support/` rather
  * than the `adapters/postgresql/` test-helper because suites outside that tree
  * gate on it too — a test file should never have to import glue from another
- * adapter's tree. Counterpart to `describeIfSqlite` / `describeIfMysql`.
+ * adapter's tree. Counterpart to `describeIfSqlite` / `describeIfMysqlAdapter`.
  */
 export const describeIfPg = pgAvailable ? describe : (describe.skip as typeof describe);

--- a/packages/activerecord/src/support/describe-if-pg.ts
+++ b/packages/activerecord/src/support/describe-if-pg.ts
@@ -1,0 +1,52 @@
+import { describe } from "vitest";
+import pg from "pg";
+import { postgresUrl } from "./config.js";
+
+// A *serialization* of the PG sub-settings (PGHOST/PGPORT/PGUSER/PGPASSWORD/
+// PGDATABASE), not an env var of its own: these suites probe the server
+// directly via describeIfPg regardless of ARCONN, so they need a URL to hand
+// the driver, but they no longer source one from the environment.
+export const PG_TEST_URL = postgresUrl();
+
+async function checkPg(): Promise<{
+  available: boolean;
+  serverVersionNum: number;
+  hasHintPlan: boolean;
+}> {
+  const client = new pg.Client({ connectionString: PG_TEST_URL });
+  try {
+    await client.connect();
+    const res = await client.query<{ v: string }>(
+      "SELECT current_setting('server_version_num') AS v",
+    );
+    const ext = await client.query<{ count: string }>(
+      "SELECT COUNT(*) AS count FROM pg_available_extensions WHERE name = 'pg_hint_plan'",
+    );
+    return {
+      available: true,
+      serverVersionNum: Number(res.rows[0]?.v ?? 0),
+      hasHintPlan: Number(ext.rows[0]?.count ?? 0) > 0,
+    };
+  } catch {
+    return { available: false, serverVersionNum: 0, hasHintPlan: false };
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+const probe = await checkPg();
+
+/** true when a PostgreSQL server answered the probe at module load. */
+export const pgAvailable = probe.available;
+/** PG server_version_num at module load (0 when unavailable). */
+export const pgServerVersion = probe.serverVersionNum;
+/** true when the `pg_hint_plan` extension is available on the probed server. */
+export const pgHasHintPlan = probe.hasHintPlan;
+
+/**
+ * Scope a suite to a reachable PostgreSQL server. Lives in `support/` rather
+ * than the `adapters/postgresql/` test-helper because suites outside that tree
+ * gate on it too — a test file should never have to import glue from another
+ * adapter's tree. Counterpart to `describeIfSqlite` / `describeIfMysql`.
+ */
+export const describeIfPg = pgAvailable ? describe : (describe.skip as typeof describe);


### PR DESCRIPTION
Follows #5536 (`describeIfSqlite`): `describeIfPg` now lives in a tree-neutral
`support/describe-if-pg.ts` next to `describe-if-sqlite.ts`, so test files outside
`adapters/postgresql/` stop importing gate glue from that tree.

- New `support/describe-if-pg.ts` holds the server probe and the gate, plus the
  probe-derived facts (`pgServerVersion`, `pgHasHintPlan`, `PG_TEST_URL`).
- `adapters/postgresql/test-helper.ts` re-exports the gate (one definition, no
  duplicate) and keeps only the adapter-specific derivations
  (`pgSupportsOptimizerHints`, `pgSupportsNativePartitioning`,
  `withPostgresqlDatetimeType`, `suiteTable`, `SQLSubscriber`).
- Cross-tree importers repointed: `defaults.test.ts`, `migration.test.ts`,
  `adapter-prevent-writes.test.ts`,
  `connection-adapters/postgresql/schema-statements.test.ts`,
  `migration/unique-constraint.test.ts`, `migration/exclusion-constraint.test.ts`.
  `PostgreSQLAdapter` now comes from `connection-adapters/postgresql-adapter.js` at
  those call sites rather than through the test helper.

**MySQL half dropped after rebase.** #5537 retired the `describeIfMysql`
server-reachability probe outright in favour of `describeIfMysqlAdapter`, so there is
no longer a MySQL gate to relocate — the story's second predicate resolved itself.
`describeIfMysqlAdapter` stays in the MySQL test helper (it is the adapter-current
gate, not a reachability probe) and is out of scope here.

No test names changed. `scripts/test-compare/gates.ts` recognizes these wrappers by
name, not import path, so the gate delta does not move.

Closes-story: relocate-describe-if-pg-and-mysql-out-of-adapters-trees
