### PR TITLE
refactor(activerecord): call super from mysql/sqlite initializeTypeMap

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2215,16 +2215,12 @@ export class AbstractAdapter implements Quoting {
     this.registerClassWithLimit(m, /float/i, FloatType);
     this.registerClassWithLimit(m, /int/i, IntegerType);
 
-    const aliasTo = (targetKey: string) => (sqlType: string) => {
-      const meta = /\(.*\)/.exec(sqlType)?.[0] ?? "";
-      return m.lookup(`${targetKey}${meta}`);
-    };
-    m.registerType(/blob/i, undefined, aliasTo("binary"));
-    m.registerType(/clob/i, undefined, aliasTo("text"));
-    m.registerType(/timestamp/i, undefined, aliasTo("datetime"));
-    m.registerType(/numeric/i, undefined, aliasTo("decimal"));
-    m.registerType(/number/i, undefined, aliasTo("decimal"));
-    m.registerType(/double/i, undefined, aliasTo("float"));
+    m.aliasType(/blob/i, "binary");
+    m.aliasType(/clob/i, "text");
+    m.aliasType(/timestamp/i, "datetime");
+    m.aliasType(/numeric/i, "decimal");
+    m.aliasType(/number/i, "decimal");
+    m.aliasType(/double/i, "float");
 
     m.registerType(/^json/i, new JsonType());
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -101,7 +101,6 @@ import {
   BooleanType,
   BinaryType,
   BinaryData,
-  DecimalType,
 } from "@blazetrails/activemodel";
 
 /**
@@ -138,12 +137,7 @@ class MysqlBigInteger extends BigIntegerType {
   }
 }
 import { UnsignedInteger } from "../type/unsigned-integer.js";
-import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
-import { Date as DateType } from "../type/date.js";
-import { DateTime as DateTimeType } from "../type/date-time.js";
-import { Time as TimeType } from "../type/time.js";
 import { Text as TextType } from "../type/text.js";
-import { Json as JsonType } from "../type/json.js";
 
 const NATIVE_DATABASE_TYPES: Record<string, { name: string; limit?: number }> = {
   primary_key: { name: "bigint auto_increment PRIMARY KEY" },
@@ -1877,64 +1871,19 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /** @internal */
   static override initializeTypeMap(this: typeof AbstractMysqlAdapter, m: TypeMap): void {
-    /**
-     * Mirrors: abstract_mysql_adapter.rb#extract_precision — for the
-     * `(date)?time(stamp)?` family, a missing `(N)` modifier resolves to 0
-     * (TIME ≡ TIME(0) on MySQL/MariaDB), not nil.
-     */
-    function extractMysqlTimePrecision(sqlType: string): number {
-      const m = sqlType.match(/\((\d+)\)/);
-      return m ? Number(m[1]) : 0;
-    }
-
-    // Base types (mirrors AbstractAdapter#initialize_type_map via super)
-    m.registerType(/^boolean/i, undefined, () => new BooleanType());
+    // Rails' `initialize_type_map` opens with `super`
+    // (abstract_mysql_adapter.rb:711-712), so every base registration and alias
+    // — char/binary/text/date/time/datetime/float/int, blob, clob, timestamp,
+    // numeric, number, double, json, decimal — is inherited rather than
+    // re-listed. The temporal registrations pick up the MySQL `(date)?time
+    // (stamp)?` precision rule through the `extractPrecision` override below.
     // NOTE: char/varchar/enum/set string registrations do NOT belong here —
     // they bind mysql2/trilogy-specific `"1"`/`"0"` boolean-string behavior to
     // a concrete client, so Rails registers them in the concrete
     // `Mysql2Adapter#initialize_type_map` (mysql2_adapter.rb:40-49), not in
-    // `AbstractMysqlAdapter#initialize_type_map` (abstract_mysql_adapter.rb:711,
-    // which has no such registration). See Mysql2Adapter.initializeTypeMap.
-    // Rails relies on super's `register_class_with_limit(m, /binary/i, Binary)`
-    // (abstract_mysql_adapter.rb has no binary override), so binary/varbinary
-    // carry the declared length as their limit — e.g. varbinary(255) → 255.
-    m.registerType(
-      /^binary/i,
-      undefined,
-      (sqlType) => new BinaryType({ limit: this.extractLimit(sqlType) }),
-    );
-    m.registerType(
-      /^varbinary/i,
-      undefined,
-      (sqlType) => new BinaryType({ limit: this.extractLimit(sqlType) }),
-    );
-    m.registerType(/^date$/i, new DateType());
-    m.registerType(
-      /^time\b/i,
-      undefined,
-      (sqlType) => new TimeType({ precision: extractMysqlTimePrecision(sqlType) }),
-    );
-    m.registerType(
-      /^datetime/i,
-      undefined,
-      (sqlType) => new DateTimeType({ precision: extractMysqlTimePrecision(sqlType) }),
-    );
-    // Mirrors AbstractAdapter#initialize_type_map's decimal registration
-    // (abstract_adapter.rb:906) — MySQL inherits it in Rails, so extract
-    // precision/scale from the sql_type rather than dropping them. Without
-    // this, `decimal(10,2)` columns build a scale-less DecimalType and values
-    // aren't truncated to the column's scale on cast.
-    const registerDecimal = (sqlType: string) => {
-      const scale = this.extractScale(sqlType);
-      const precision = this.extractPrecision(sqlType);
-      if (scale === 0) return new DecimalWithoutScale({ precision });
-      return new DecimalType({ precision, scale });
-    };
-    m.registerType(/decimal/i, undefined, registerDecimal);
-    m.registerType(/numeric/i, undefined, registerDecimal);
-    m.aliasType(/clob/i, "text");
-    m.aliasType(/number/i, "decimal");
-    m.registerType("json", new JsonType());
+    // `AbstractMysqlAdapter#initialize_type_map`. See
+    // Mysql2Adapter.initializeTypeMap.
+    super.initializeTypeMap(m);
 
     // MySQL-specific overrides (mirrors MySQL's initialize_type_map additions).
     // Rails registers each lob variant with a fixed byte-size limit (2**8-1 …
@@ -1955,13 +1904,21 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     this.registerIntegerType(m, /^mediumint/i, { limit: 3 });
     this.registerIntegerType(m, /^smallint/i, { limit: 2 });
     this.registerIntegerType(m, /^tinyint/i, { limit: 1 });
-    m.registerType(/^year/i, undefined, () => new IntegerType());
-    m.registerType(/^bit/i, undefined, () => new BinaryType());
-    m.registerType(
-      /^timestamp/i,
-      undefined,
-      (sqlType) => new DateTimeType({ precision: extractMysqlTimePrecision(sqlType) }),
-    );
+    m.aliasType(/year/i, "integer");
+    m.aliasType(/bit/i, "binary");
+  }
+
+  /**
+   * @internal Mirrors: AbstractMysqlAdapter.extract_precision
+   * (abstract_mysql_adapter.rb:751-757) — for the `(date)?time(stamp)?` family
+   * a missing `(N)` modifier resolves to 0 (TIME ≡ TIME(0) on MySQL/MariaDB),
+   * not nil. The base type map's temporal registrations read precision through
+   * this hook, which is how Rails' `super` gets MySQL semantics.
+   */
+  static override extractPrecision(sqlType: string): number | undefined {
+    const precision = AbstractAdapter.extractPrecision(sqlType);
+    if (/^(?:date)?time(?:stamp)?\b/i.test(sqlType)) return precision ?? 0;
+    return precision;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1871,24 +1871,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /** @internal */
   static override initializeTypeMap(this: typeof AbstractMysqlAdapter, m: TypeMap): void {
-    // Rails' `initialize_type_map` opens with `super`
-    // (abstract_mysql_adapter.rb:711-712), so every base registration and alias
-    // — char/binary/text/date/time/datetime/float/int, blob, clob, timestamp,
-    // numeric, number, double, json, decimal — is inherited rather than
-    // re-listed. The temporal registrations pick up the MySQL `(date)?time
-    // (stamp)?` precision rule through the `extractPrecision` override below.
-    // NOTE: char/varchar/enum/set string registrations do NOT belong here —
-    // they bind mysql2/trilogy-specific `"1"`/`"0"` boolean-string behavior to
-    // a concrete client, so Rails registers them in the concrete
-    // `Mysql2Adapter#initialize_type_map` (mysql2_adapter.rb:40-49), not in
-    // `AbstractMysqlAdapter#initialize_type_map`. See
-    // Mysql2Adapter.initializeTypeMap.
     super.initializeTypeMap(m);
 
-    // MySQL-specific overrides (mirrors MySQL's initialize_type_map additions).
-    // Rails registers each lob variant with a fixed byte-size limit (2**8-1 …
-    // 2**32-1) rather than extracting it from the sql_type, so column
-    // introspection and the schema dumper's :size mapping see the right limit.
     m.registerType(/tinytext/i, undefined, () => new TextType({ limit: 2 ** 8 - 1 }));
     m.registerType(/tinyblob/i, undefined, () => new BinaryType({ limit: 2 ** 8 - 1 }));
     m.registerType(/text/i, undefined, () => new TextType({ limit: 2 ** 16 - 1 }));
@@ -1908,19 +1892,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     m.aliasType(/bit/i, "binary");
   }
 
-  /**
-   * @internal Mirrors: AbstractMysqlAdapter.extract_precision
-   * (abstract_mysql_adapter.rb:751-757) — for the `(date)?time(stamp)?` family
-   * a missing `(N)` modifier resolves to 0 (TIME ≡ TIME(0) on MySQL/MariaDB),
-   * not nil. The base type map's temporal registrations read precision through
-   * this hook, which is how Rails' `super` gets MySQL semantics.
-   */
-  static override extractPrecision(sqlType: string): number | undefined {
-    const precision = AbstractAdapter.extractPrecision(sqlType);
-    if (/^(?:date)?time(?:stamp)?\b/i.test(sqlType)) return precision ?? 0;
-    return precision;
-  }
-
   /** @internal */
   protected static registerIntegerType(
     mapping: TypeMap,
@@ -1932,6 +1903,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       if (options.limit === 8) return new MysqlBigInteger(options);
       return new IntegerType(options);
     });
+  }
+
+  /** @internal */
+  static override extractPrecision(sqlType: string): number | undefined {
+    const precision = super.extractPrecision(sqlType);
+    if (/^(?:date)?time(?:stamp)?\b/i.test(sqlType)) return precision ?? 0;
+    return precision;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3038,6 +3038,17 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   /** @internal */
   static override initializeTypeMap(m: TypeMap): void {
+    // Rails' `initialize_type_map` opens with `super` (sqlite3_adapter.rb:499-502)
+    // and adds only the `%r(int)i → SQLite3Integer` override, so every base
+    // registration and alias — char/binary/text/date/time/datetime/float/int,
+    // blob, clob, timestamp, numeric, number, double, json, decimal — is
+    // inherited. The registrations below re-declare a subset with SQLite
+    // affinity semantics; because lookup scans in reverse-registration order
+    // they shadow the inherited entries they replace, and everything they do
+    // not replace now resolves from the base map instead of falling through to
+    // the default Value type.
+    super.initializeTypeMap(m);
+
     const sqlite3Int = (limit?: number) => new SQLite3IntegerType({ limit });
     m.registerType("string", new StringType());
     m.registerType("text", new TextType());
@@ -3089,9 +3100,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     this.registerClassWithLimit(m, /char/i, StringType);
     this.registerClassWithLimit(m, /text/i, TextType);
     this.registerClassWithLimit(m, /binary/i, BinaryType);
-    m.aliasType(/clob/i, "text");
-    m.aliasType(/blob/i, "binary");
-    m.aliasType(/number/i, "decimal");
     this.registerClassWithLimit(m, /real|floa|doub/i, FloatType);
   }
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3038,15 +3038,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   /** @internal */
   static override initializeTypeMap(m: TypeMap): void {
-    // Rails' `initialize_type_map` opens with `super` (sqlite3_adapter.rb:499-502)
-    // and adds only the `%r(int)i → SQLite3Integer` override, so every base
-    // registration and alias — char/binary/text/date/time/datetime/float/int,
-    // blob, clob, timestamp, numeric, number, double, json, decimal — is
-    // inherited. The registrations below re-declare a subset with SQLite
-    // affinity semantics; because lookup scans in reverse-registration order
-    // they shadow the inherited entries they replace, and everything they do
-    // not replace now resolves from the base map instead of falling through to
-    // the default Value type.
     super.initializeTypeMap(m);
 
     const sqlite3Int = (limit?: number) => new SQLite3IntegerType({ limit });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -135,13 +135,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "initialize_type_map",
-    "call": "alias_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "lease",
     "call": "context",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `AbstractMysqlAdapter#initialize_type_map` (`abstract_mysql_adapter.rb:711-712`)
and `SQLite3Adapter#initialize_type_map` (`sqlite3_adapter.rb:499-502`) both open with
`super`, inheriting every registration and alias the base map declares at
`abstract_adapter.rb:885-902`. trails inlined a hand-maintained copy of the base map in
each, and entries had silently gone missing.

## Audit (base map vs. each inlined copy)

MySQL omitted `char` outright — nothing replaced it, so `varchar`/`varchar(255)`/
`character varying` resolved to the default Value type on the abstract map. Everything
else it listed was either an exact copy of a base entry (`boolean`, `binary`/`varbinary`,
`date`, `decimal`, `numeric`, `clob`, `number`, `json`) or a genuine override that
survives (lob limits, `^float`/`^double`, integer widths).

SQLite's copy re-declared a subset of the base map with SQLite affinity semantics but
inherited nothing else — `BOOLEAN`, `/^json/i`, and the `numeric`/`number`/`double`
aliases only worked to the extent the copy happened to reproduce them.

## Changes

- Both adapters now call `super.initializeTypeMap(m)` first and keep only their real
  overrides. Reverse-registration lookup means the overrides still shadow the inherited
  entries they replace, so registration-order semantics are unchanged.
- MySQL's `(date)?time(stamp)?` precision rule (missing `(N)` → 0) moves from three
  open-coded registrations to a static `extractPrecision` override, mirroring
  `abstract_mysql_adapter.rb:751-757` — that override is exactly how Rails gets MySQL
  semantics out of the inherited temporal registrations.
- `year`/`bit` become `aliasType` calls as in Rails; `year` consequently resolves through
  `/^int/i` to `limit: 4` instead of an unlimited Integer.
- Base-map aliases use `TypeMap#aliasType` instead of the open-coded
  metadata-extract-and-relookup, which converges the wide call-set baseline entry for
  `alias_type` (removed from `call-mismatches-wide-exclude/`).

## Tests

`connection-adapters/type-lookup.test.ts` already ports `type_lookup_test.rb` in full
(including the `number`/`NUMBER` assertions) and covers the restored lookups; no test
changes were needed. Verified locally on sqlite3 and sqlite3_mem, and the MySQL map was
exercised directly against Rails' assertion list.

Closes-story: adapter-type-maps-inline-base-map-drop-aliases
