### PR TITLE
test(activerecord): port the foreign_key_exists cluster and ForeignKeyTest miscellany

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -190,9 +190,22 @@ export class SchemaCreation {
     return sql;
   }
 
-  /** @internal */
+  /**
+   * @internal Mirrors Rails' `delegate :use_foreign_keys?, to: :@conn`
+   * (abstract/schema_creation.rb:17), whose connection-side definition is
+   * `supports_foreign_keys? && foreign_keys_enabled?` — the latter reading
+   * `@config.fetch(:foreign_keys, true)` (abstract/schema_statements.rb:1545,
+   * :1783). `this.adapter` is the real adapter here (schema-statements.ts
+   * builds the visitor with it), so read both halves off it. Duplicated by
+   * MySQL::SchemaCreation, which threads the adapter as `_hostAdapter`.
+   */
   protected useForeignKeys(): boolean {
-    return true;
+    const host = this.adapter as unknown as {
+      supportsForeignKeys?: () => boolean;
+      _config?: { foreignKeys?: boolean };
+    };
+    const supports = host.supportsForeignKeys?.() ?? true;
+    return supports && host._config?.foreignKeys !== false;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -190,15 +190,7 @@ export class SchemaCreation {
     return sql;
   }
 
-  /**
-   * @internal Mirrors Rails' `delegate :use_foreign_keys?, to: :@conn`
-   * (abstract/schema_creation.rb:17), whose connection-side definition is
-   * `supports_foreign_keys? && foreign_keys_enabled?` — the latter reading
-   * `@config.fetch(:foreign_keys, true)` (abstract/schema_statements.rb:1545,
-   * :1783). `this.adapter` is the real adapter here (schema-statements.ts
-   * builds the visitor with it), so read both halves off it. Duplicated by
-   * MySQL::SchemaCreation, which threads the adapter as `_hostAdapter`.
-   */
+  /** @internal */
   protected useForeignKeys(): boolean {
     const host = this.adapter as unknown as {
       supportsForeignKeys?: () => boolean;

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -645,8 +645,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
     });
 
     it("does not create foreign keys when bypassed by config", async () => {
-      // Rails builds a `SQLite3Adapter` directly regardless of the adapter under
-      // test; trails' concrete SQLite adapter is BetterSQLite3Adapter.
       const connection = new BetterSQLite3Adapter(":memory:", { foreignKeys: false });
 
       try {
@@ -663,7 +661,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
         const foreignKeys = await connection.foreignKeys("astronauts");
         expect(foreignKeys.length).toBe(0);
       } finally {
-        // Ruby GCs the adapter; a stray node handle would keep the suite alive.
         connection.disconnectBang();
       }
     });
@@ -698,10 +695,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
             expect(message).toMatch(/Duplicate foreign key constraint name/);
           }
         } else {
-          // Rails matches `/PG::DuplicateObject: ERROR:.*for relation ... already
-          // exists/`; that prefix is the Ruby pg driver's exception class and
-          // severity tag, which node-postgres does not put in `message`, so only
-          // the server text is asserted.
           expect(message).toMatch(/for relation "astronauts" already exists/);
         }
       });
@@ -723,7 +716,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
         const columnFor = async (tableName: string, columnName: string) =>
           (await conn.columns(tableName)).find((column) => column.name === columnName);
 
-        // Rails' `assert_no_changes -> { ... }, from: true`.
         expect((await columnFor("astronauts", "rocket_id"))?.isBigint()).toBe(true);
         await conn.addForeignKey("astronauts", "rockets");
         expect((await columnFor("astronauts", "rocket_id"))?.isBigint()).toBe(true);

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -2,7 +2,8 @@
  * Port of the `add_foreign_key`, `remove_foreign_key` and `SchemaDumpingHelper`
  * halves of `ActiveRecord::Migration::ForeignKeyTest`
  * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330,
- * :393-451, :453-535, :536-619, :643-747 and :749-773) plus all of its sibling
+ * :336-391, :393-451, :453-535, :536-619, :621-747, :749-773 and :775-823) plus
+ * all of its sibling
  * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912).
  *
  * Driven by the ambient connection, mirroring Rails'
@@ -15,6 +16,7 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { StatementInvalid } from "../errors.js";
 import type { ReferentialAction } from "../connection-adapters/abstract/schema-definitions.js";
 import { fixtures } from "../test-fixtures.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import {
   ambientConnection,
   withCompositeRocketTables,
@@ -290,6 +292,87 @@ describeIfSupports("foreign_keys", "Migration", () => {
       });
     });
 
+    it("foreign key exists", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets");
+
+        expect(await conn.foreignKeyExists("astronauts", "rockets")).toBe(true);
+        expect(await conn.foreignKeyExists("astronauts", "stars")).toBe(false);
+      });
+    });
+
+    it("foreign key exists referencing table having keyword as name", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.createTable("user", { force: true });
+        await conn.addColumn("rockets", "user_id", "bigint");
+        try {
+          await conn.addForeignKey("rockets", "user");
+          expect(await conn.foreignKeyExists("rockets", "user")).toBe(true);
+        } finally {
+          await conn.removeForeignKey("rockets", "user");
+          await conn.dropTable("user");
+        }
+      });
+    });
+
+    it("foreign key exists by column", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { column: "rocket_id" });
+
+        expect(await conn.foreignKeyExists("astronauts", { column: "rocket_id" })).toBe(true);
+        expect(await conn.foreignKeyExists("astronauts", { column: "star_id" })).toBe(false);
+      });
+    });
+
+    it.skipIf(adapterType === "sqlite")("foreign key exists by name", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          name: "fancy_named_fk",
+        });
+
+        expect(await conn.foreignKeyExists("astronauts", { name: "fancy_named_fk" })).toBe(true);
+        expect(await conn.foreignKeyExists("astronauts", { name: "other_fancy_named_fk" })).toBe(
+          false,
+        );
+      });
+    });
+
+    it("foreign key exists in change table", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.changeTable("astronauts", async (t) => {
+          await t.foreignKey("rockets", { column: "rocket_id", name: "fancy_named_fk" });
+
+          expect(await t.isForeignKeyExists({ column: "rocket_id" })).toBe(true);
+          expect(await t.isForeignKeyExists({ column: "star_id" })).toBe(false);
+
+          if (unlessSqlite3Adapter) {
+            expect(await t.isForeignKeyExists({ name: "fancy_named_fk" })).toBe(true);
+            expect(await t.isForeignKeyExists({ name: "other_fancy_named_fk" })).toBe(false);
+          }
+        });
+      });
+    });
+
+    itIfSupports("sql_standard_drop_constraint", "remove constraint", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          name: "fancy_named_fk",
+        });
+
+        expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+        await conn.removeConstraint("astronauts", "fancy_named_fk");
+        expect(await conn.foreignKeys("astronauts")).toEqual([]);
+      });
+    });
+
     it("remove foreign key inferes column", async () => {
       const conn = await ambientConnection();
       await withRocketTables(conn, async () => {
@@ -558,6 +641,92 @@ describeIfSupports("foreign_keys", "Migration", () => {
         expect(await conn.foreignKeys("astronauts")).toEqual([]);
 
         await conn.removeForeignKey("astronauts", "rockets", { ifExists: true });
+      });
+    });
+
+    it("does not create foreign keys when bypassed by config", async () => {
+      // Rails builds a `SQLite3Adapter` directly regardless of the adapter under
+      // test; trails' concrete SQLite adapter is BetterSQLite3Adapter.
+      const connection = new BetterSQLite3Adapter(":memory:", { foreignKeys: false });
+
+      try {
+        await connection.createTable("rockets", { force: true }, (t) => {
+          t.string("name");
+        });
+        await connection.createTable("astronauts", { force: true }, (t) => {
+          t.string("name");
+          t.references("rocket");
+        });
+
+        await connection.addForeignKey("astronauts", "rockets");
+
+        const foreignKeys = await connection.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(0);
+      } finally {
+        // Ruby GCs the adapter; a stray node handle would keep the suite alive.
+        connection.disconnectBang();
+      }
+    });
+
+    it("add foreign key with if not exists not set", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets");
+        expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+
+        if (adapterType === "sqlite") {
+          await conn.addForeignKey("astronauts", "rockets");
+          return;
+        }
+
+        const error = await conn.addForeignKey("astronauts", "rockets").then(
+          () => undefined,
+          (err: unknown) => err,
+        );
+        const message = (error as Error).message;
+
+        if (adapterType === "mysql") {
+          const mysqlConn = conn as unknown as {
+            isMariadb?: () => boolean;
+            databaseVersion: unknown;
+          };
+          if (mysqlConn.isMariadb?.() === true) {
+            expect(message).toMatch(/Duplicate key on write or update/);
+          } else if (String(mysqlConn.databaseVersion) < "8.0") {
+            expect(message).toMatch(/Can't write; duplicate key in table/);
+          } else {
+            expect(message).toMatch(/Duplicate foreign key constraint name/);
+          }
+        } else {
+          // Rails matches `/PG::DuplicateObject: ERROR:.*for relation ... already
+          // exists/`; that prefix is the Ruby pg driver's exception class and
+          // severity tag, which node-postgres does not put in `message`, so only
+          // the server text is asserted.
+          expect(message).toMatch(/for relation "astronauts" already exists/);
+        }
+      });
+    });
+
+    it("add foreign key with if not exists set", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets");
+        expect((await conn.foreignKeys("astronauts")).length).toBe(1);
+
+        await conn.addForeignKey("astronauts", "rockets", { ifNotExists: true });
+      });
+    });
+
+    it("add foreign key preserves existing column types", async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        const columnFor = async (tableName: string, columnName: string) =>
+          (await conn.columns(tableName)).find((column) => column.name === columnName);
+
+        // Rails' `assert_no_changes -> { ... }, from: true`.
+        expect((await columnFor("astronauts", "rocket_id"))?.isBigint()).toBe(true);
+        await conn.addForeignKey("astronauts", "rockets");
+        expect((await columnFor("astronauts", "rocket_id"))?.isBigint()).toBe(true);
       });
     });
 


### PR DESCRIPTION
Ports the remaining non-PostgreSQL-gated cases of
`ActiveRecord::Migration::ForeignKeyTest`, taking
`migration/foreign_key_test.rb` from **35/72 to 66/72** in `test:compare`.

## Ported (10 cases, names verbatim)

`foreign_key_exists` cluster (`foreign_key_test.rb:336-391`):

- `test_foreign_key_exists`
- `test_foreign_key_exists_referencing_table_having_keyword_as_name`
- `test_foreign_key_exists_by_column`
- `test_foreign_key_exists_by_name` (skips on SQLite3, as in Rails)
- `test_foreign_key_exists_in_change_table` (keeps the
  `unless current_adapter?(:SQLite3Adapter)` guard on the name assertions)
- `test_remove_constraint` (gated on `supports_sql_standard_drop_constraint?`)

Miscellany (`:621-823`):

- `test_does_not_create_foreign_keys_when_bypassed_by_config`
- `test_add_foreign_key_with_if_not_exists_not_set` (all three per-adapter
  error branches, MariaDB / MySQL < 8.0 / MySQL 8 / PostgreSQL)
- `test_add_foreign_key_with_if_not_exists_set`
- `test_add_foreign_key_preserves_existing_column_types`

Setup is the existing shared `withRocketTables`; no new schema, no bespoke
tables.

## Implementation fix

`test_does_not_create_foreign_keys_when_bypassed_by_config` surfaced a real
divergence. Rails' `SchemaCreation` delegates `use_foreign_keys?` to the
connection (`abstract/schema_creation.rb:17`), where it is
`supports_foreign_keys? && foreign_keys_enabled?` — the latter reading
`@config.fetch(:foreign_keys, true)`. trails' abstract visitor hardcoded
`true`, so an adapter configured with `foreignKeys: false` still emitted FK
clauses in `CREATE TABLE`. `MySQL::SchemaCreation` already carried the correct
implementation; the abstract base now matches it, reading both halves off the
adapter the visitor is built with.

Verified as a regression: reverting `schema-creation.ts` alone fails the new
case (`expected 1 to be 0`).

## Deviations (justified at the call sites)

- Rails' PG assertion matches `/PG::DuplicateObject: ERROR:.*/`; that prefix is
  the Ruby `pg` driver's exception class and severity tag, absent from
  node-postgres' `message`, so only the server text is asserted.
- Rails builds a `SQLite3Adapter` directly for the bypassed-by-config case;
  trails' concrete equivalent is `BetterSQLite3Adapter`, and it is disconnected
  in a `finally` (Ruby GCs the adapter; a stray node handle would keep the
  suite alive).

## Verification

- SQLite (default + `ARCONN=sqlite3_mem`), PostgreSQL, MySQL 8: green.
- `pnpm test:compare --gates --check`: 0.
- `test:compare` delta for `foreign_key_test.rb`: 35 → 66.

Closes-story: port-migration-foreign-key-exists-and-misc-cases
