### PR TITLE
test(activerecord): port ForeignKeyInCreateTest and ForeignKeyChangeColumnTest cases

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -103,9 +103,9 @@ export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13")
  * constraint" if current_adapter?(:Mysql2Adapter) && !supports_rename_index?`
  * without hiding the supported MySQL path behind a blanket adapter skip.
  */
-export const supportsRenameIndex =
-  mysqlAvailable &&
-  (mariaDb ? _serverVersion?.gte("10.5.2") === true : _serverVersion?.gte("5.7.6") === true);
+export const supportsRenameIndex = mariaDb
+  ? _serverVersion?.gte("10.5.2") === true
+  : _serverVersion?.gte("5.7.6") === true;
 
 export { Mysql2Adapter };
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -96,6 +96,17 @@ export const supportsDefaultExpression = mariaDb
  */
 export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13") === true;
 
+/**
+ * Mirrors AbstractMysqlAdapter#supports_rename_index?
+ * (abstract_mysql_adapter.rb:896-901): MariaDB ≥ 10.5.2, MySQL ≥ 5.7.6. Lets a
+ * test reproduce Rails' `skip "Cannot drop index, needed in a foreign key
+ * constraint" if current_adapter?(:Mysql2Adapter) && !supports_rename_index?`
+ * without hiding the supported MySQL path behind a blanket adapter skip.
+ */
+export const supportsRenameIndex =
+  mysqlAvailable &&
+  (mariaDb ? _serverVersion?.gte("10.5.2") === true : _serverVersion?.gte("5.7.6") === true);
+
 export { Mysql2Adapter };
 
 /**

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -4,14 +4,16 @@
  * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330,
  * :336-391, :393-451, :453-535, :536-619, :621-747, :749-773 and :775-823) plus
  * all of its sibling
- * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912).
+ * `ActiveRecord::Migration::CompositeForeignKeyTest` (:824-912), plus
+ * `ForeignKeyInCreateTest` (:9-21) and `ForeignKeyChangeColumnTest` (:23-143)
+ * with its `WithPrefix`/`WithSuffix` subclasses (:145-163).
  *
  * Driven by the ambient connection, mirroring Rails'
  * `@connection = ActiveRecord::Base.lease_connection`. The rockets/astronauts
  * setup/teardown is shared with schema-statements-on-adapter.test.ts via
  * `withRocketTables`.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { StatementInvalid } from "../errors.js";
 import type { ReferentialAction } from "../connection-adapters/abstract/schema-definitions.js";
@@ -92,6 +94,24 @@ class CreateSchoolsAndClassesMigration extends SilentMigration {
 }
 
 describeIfSupports("foreign_keys", "Migration", () => {
+  describe("ForeignKeyInCreateTest", () => {
+    fixtures([]);
+
+    it("foreign keys", async () => {
+      const conn = await ambientConnection();
+      const foreignKeys = await conn.foreignKeys("fk_test_has_fk");
+      expect(foreignKeys.length).toBe(1);
+
+      const fk = foreignKeys[0];
+      expect(fk.fromTable).toBe("fk_test_has_fk");
+      expect(fk.toTable).toBe("fk_test_has_pk");
+      expect(fk.column).toBe("fk_id");
+      expect(fk.primaryKey).toBe("pk_id");
+      // eslint-disable-next-line vitest/no-conditional-in-test -- mirrors Rails' inline `unless current_adapter?(:SQLite3Adapter)` guard on the name assertion
+      if (unlessSqlite3Adapter) expect(fk.name).toBe("fk_name");
+    });
+  });
+
   describe("ForeignKeyTest", () => {
     // DDL can't run inside the transactional-fixtures wrapper (PG aborts the
     // outer transaction on a failed statement), matching the schema-statements
@@ -1013,82 +1033,163 @@ describeIfSupports("foreign_keys", "Migration", () => {
     );
   });
 
-  describe("ForeignKeyChangeColumnTest", () => {
-    fixtures([], { useTransactionalTests: false });
+  /**
+   * Rails' `ForeignKeyChangeColumnTest` plus its two subclasses,
+   * `ForeignKeyChangeColumnWithPrefixTest` and
+   * `ForeignKeyChangeColumnWithSuffixTest`, which re-run the whole body under
+   * `ActiveRecord::Base.table_name_prefix = "p_"` / `table_name_suffix = "_s"`.
+   * TS has no test-class inheritance, so the body is a function called three
+   * times rather than copied.
+   *
+   * Rails' `CreateRocketsMigration` runs through `Migration#method_missing`,
+   * which routes the table name through `proper_table_name` — hence the
+   * prefixed/suffixed literals here. The `t.references(..., foreign_key: true)`
+   * target is prefixed by `TableDefinition#new_foreign_key_definition` itself,
+   * so `rocket` still resolves to the decorated rockets table.
+   */
+  function foreignKeyChangeColumnTest(name: string, prefix: string, suffix: string): void {
+    describe(name, () => {
+      fixtures([], { useTransactionalTests: false });
 
-    const withChangeColumnTables = async (
-      body: (conn: AbstractAdapter) => Promise<void>,
-    ): Promise<void> => {
-      const conn = await ambientConnection();
-      await conn.dropTable("astronauts", "rockets", { ifExists: true });
-      await conn.createTable("rockets", {}, (t) => {
-        t.string("name");
+      const rockets = `${prefix}rockets${suffix}`;
+      const astronauts = `${prefix}astronauts${suffix}`;
+
+      beforeEach(() => {
+        Base.tableNamePrefix = prefix;
+        Base.tableNameSuffix = suffix;
       });
-      await conn.createTable("astronauts", {}, (t) => {
-        t.string("name");
-        t.references("rocket", { foreignKey: true });
+
+      afterEach(() => {
+        Base.tableNamePrefix = "";
+        Base.tableNameSuffix = "";
       });
-      try {
-        await body(conn);
-      } finally {
-        await conn.dropTable("astronauts", "rockets", { ifExists: true });
-      }
-    };
 
-    const createRocketWithAstronaut = async (conn: AbstractAdapter): Promise<void> => {
-      await conn.executeMutation(
-        `INSERT INTO ${conn.quoteTableName("rockets")} (name) VALUES ('myrocket')`,
-      );
-      const rows = (await conn.execute(
-        `SELECT id FROM ${conn.quoteTableName("rockets")}`,
-      )) as Array<{
-        id: number;
-      }>;
-      await conn.executeMutation(
-        `INSERT INTO ${conn.quoteTableName("astronauts")} (rocket_id) VALUES (${rows[0].id})`,
-      );
-    };
+      const withChangeColumnTables = async (
+        body: (conn: AbstractAdapter) => Promise<void>,
+      ): Promise<void> => {
+        const conn = await ambientConnection();
+        await conn.dropTable(astronauts, rockets, { ifExists: true });
+        await conn.createTable(rockets, {}, (t) => {
+          t.string("name");
+        });
+        await conn.createTable(astronauts, {}, (t) => {
+          t.string("name");
+          t.references("rocket", { foreignKey: true });
+        });
+        try {
+          await body(conn);
+        } finally {
+          await conn.dropTable(astronauts, rockets, { ifExists: true });
+        }
+      };
 
-    const rocketName = async (conn: AbstractAdapter): Promise<string> => {
-      const rows = (await conn.execute(
-        `SELECT name FROM ${conn.quoteTableName("rockets")} ORDER BY id`,
-      )) as Array<{ name: string }>;
-      return rows[0].name;
-    };
+      const createRocketWithAstronaut = async (conn: AbstractAdapter): Promise<void> => {
+        await conn.executeMutation(
+          `INSERT INTO ${conn.quoteTableName(rockets)} (name) VALUES ('myrocket')`,
+        );
+        const rows = (await conn.execute(
+          `SELECT id FROM ${conn.quoteTableName(rockets)}`,
+        )) as Array<{
+          id: number;
+        }>;
+        await conn.executeMutation(
+          `INSERT INTO ${conn.quoteTableName(astronauts)} (rocket_id) VALUES (${rows[0].id})`,
+        );
+      };
 
-    it("rename column of child table", async () => {
-      await withChangeColumnTables(async (conn) => {
-        await createRocketWithAstronaut(conn);
+      const rocketName = async (conn: AbstractAdapter): Promise<string> => {
+        const rows = (await conn.execute(
+          `SELECT name FROM ${conn.quoteTableName(rockets)} ORDER BY id`,
+        )) as Array<{ name: string }>;
+        return rows[0].name;
+      };
 
-        await conn.renameColumn("astronauts", "name", "astronaut_name");
+      it("change column of parent table", async () => {
+        await withChangeColumnTables(async (conn) => {
+          await createRocketWithAstronaut(conn);
 
-        const foreignKeys = await conn.foreignKeys("astronauts");
-        expect(foreignKeys.length).toBe(1);
+          await conn.changeColumnNull(rockets, "name", false);
 
-        const fk = foreignKeys[0];
-        expect(await rocketName(conn)).toBe("myrocket");
-        expect(fk.fromTable).toBe("astronauts");
-        expect(fk.toTable).toBe("rockets");
+          const foreignKeys = await conn.foreignKeys(astronauts);
+          expect(foreignKeys.length).toBe(1);
+
+          const fk = foreignKeys[0];
+          expect(await rocketName(conn)).toBe("myrocket");
+          expect(fk.fromTable).toBe(astronauts);
+          expect(fk.toTable).toBe(rockets);
+        });
+      });
+
+      it("rename column of child table", async () => {
+        await withChangeColumnTables(async (conn) => {
+          await createRocketWithAstronaut(conn);
+
+          await conn.renameColumn(astronauts, "name", "astronaut_name");
+
+          const foreignKeys = await conn.foreignKeys(astronauts);
+          expect(foreignKeys.length).toBe(1);
+
+          const fk = foreignKeys[0];
+          expect(await rocketName(conn)).toBe("myrocket");
+          expect(fk.fromTable).toBe(astronauts);
+          expect(fk.toTable).toBe(rockets);
+        });
+      });
+
+      it.skipIf(adapterType === "mysql")("rename reference column of child table", async () => {
+        await withChangeColumnTables(async (conn) => {
+          await createRocketWithAstronaut(conn);
+
+          await conn.renameColumn(astronauts, "rocket_id", "new_rocket_id");
+
+          const foreignKeys = await conn.foreignKeys(astronauts);
+          expect(foreignKeys.length).toBe(1);
+
+          const fk = foreignKeys[0];
+          expect(await rocketName(conn)).toBe("myrocket");
+          expect(fk.fromTable).toBe(astronauts);
+          expect(fk.toTable).toBe(rockets);
+          expect(fk.column).toBe("new_rocket_id");
+        });
+      });
+
+      it("remove reference column of child table", async () => {
+        await withChangeColumnTables(async (conn) => {
+          await createRocketWithAstronaut(conn);
+
+          await conn.removeColumn(astronauts, "rocket_id");
+
+          expect(await conn.foreignKeys(astronauts)).toEqual([]);
+        });
+      });
+
+      it("remove foreign key by column", async () => {
+        await withChangeColumnTables(async (conn) => {
+          await createRocketWithAstronaut(conn);
+
+          await conn.removeForeignKey(astronauts, { column: "rocket_id" });
+
+          expect(await conn.foreignKeys(astronauts)).toEqual([]);
+        });
+      });
+
+      it("remove foreign key by column in change table", async () => {
+        await withChangeColumnTables(async (conn) => {
+          await createRocketWithAstronaut(conn);
+
+          await conn.changeTable(astronauts, async (t) => {
+            await t.removeForeignKey({ column: "rocket_id" });
+          });
+
+          expect(await conn.foreignKeys(astronauts)).toEqual([]);
+        });
       });
     });
+  }
 
-    it.skipIf(adapterType === "mysql")("rename reference column of child table", async () => {
-      await withChangeColumnTables(async (conn) => {
-        await createRocketWithAstronaut(conn);
-
-        await conn.renameColumn("astronauts", "rocket_id", "new_rocket_id");
-
-        const foreignKeys = await conn.foreignKeys("astronauts");
-        expect(foreignKeys.length).toBe(1);
-
-        const fk = foreignKeys[0];
-        expect(await rocketName(conn)).toBe("myrocket");
-        expect(fk.fromTable).toBe("astronauts");
-        expect(fk.toTable).toBe("rockets");
-        expect(fk.column).toBe("new_rocket_id");
-      });
-    });
-  });
+  foreignKeyChangeColumnTest("ForeignKeyChangeColumnTest", "", "");
+  foreignKeyChangeColumnTest("ForeignKeyChangeColumnWithPrefixTest", "p_", "");
+  foreignKeyChangeColumnTest("ForeignKeyChangeColumnWithSuffixTest", "", "_s");
 
   describe("CompositeForeignKeyTest", () => {
     fixtures([], { useTransactionalTests: false });

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -29,6 +29,7 @@ import { adapterSupports, describeIfSupports, itIfSupports } from "../support/su
 import { assertQueriesMatch } from "../testing/query-assertions.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { supportsRenameIndex } from "../adapters/abstract-mysql-adapter/test-helper.js";
 import { dumpTableSchema } from "../support/schema-dumping-helper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { Base } from "../base.js";
@@ -1122,22 +1123,25 @@ describeIfSupports("foreign_keys", "Migration", () => {
         });
       });
 
-      it.skipIf(adapterType === "mysql")("rename reference column of child table", async () => {
-        await withChangeColumnTables(async (conn) => {
-          await createRocketWithAstronaut(conn);
+      it.skipIf(adapterType === "mysql" && !supportsRenameIndex)(
+        "rename reference column of child table",
+        async () => {
+          await withChangeColumnTables(async (conn) => {
+            await createRocketWithAstronaut(conn);
 
-          await conn.renameColumn(astronauts, "rocket_id", "new_rocket_id");
+            await conn.renameColumn(astronauts, "rocket_id", "new_rocket_id");
 
-          const foreignKeys = await conn.foreignKeys(astronauts);
-          expect(foreignKeys.length).toBe(1);
+            const foreignKeys = await conn.foreignKeys(astronauts);
+            expect(foreignKeys.length).toBe(1);
 
-          const fk = foreignKeys[0];
-          expect(await rocketName(conn)).toBe("myrocket");
-          expect(fk.fromTable).toBe(astronauts);
-          expect(fk.toTable).toBe(rockets);
-          expect(fk.column).toBe("new_rocket_id");
-        });
-      });
+            const fk = foreignKeys[0];
+            expect(await rocketName(conn)).toBe("myrocket");
+            expect(fk.fromTable).toBe(astronauts);
+            expect(fk.toTable).toBe(rockets);
+            expect(fk.column).toBe("new_rocket_id");
+          });
+        },
+      );
 
       it("remove reference column of child table", async () => {
         await withChangeColumnTables(async (conn) => {

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -107,7 +107,7 @@ describeIfSupports("foreign_keys", "Migration", () => {
       expect(fk.toTable).toBe("fk_test_has_pk");
       expect(fk.column).toBe("fk_id");
       expect(fk.primaryKey).toBe("pk_id");
-      // eslint-disable-next-line vitest/no-conditional-in-test -- mirrors Rails' inline `unless current_adapter?(:SQLite3Adapter)` guard on the name assertion
+      // eslint-disable-next-line vitest/no-conditional-in-test
       if (unlessSqlite3Adapter) expect(fk.name).toBe("fk_name");
     });
   });
@@ -1033,20 +1033,6 @@ describeIfSupports("foreign_keys", "Migration", () => {
     );
   });
 
-  /**
-   * Rails' `ForeignKeyChangeColumnTest` plus its two subclasses,
-   * `ForeignKeyChangeColumnWithPrefixTest` and
-   * `ForeignKeyChangeColumnWithSuffixTest`, which re-run the whole body under
-   * `ActiveRecord::Base.table_name_prefix = "p_"` / `table_name_suffix = "_s"`.
-   * TS has no test-class inheritance, so the body is a function called three
-   * times rather than copied.
-   *
-   * Rails' `CreateRocketsMigration` runs through `Migration#method_missing`,
-   * which routes the table name through `proper_table_name` — hence the
-   * prefixed/suffixed literals here. The `t.references(..., foreign_key: true)`
-   * target is prefixed by `TableDefinition#new_foreign_key_definition` itself,
-   * so `rocket` still resolves to the decorated rockets table.
-   */
   function foreignKeyChangeColumnTest(name: string, prefix: string, suffix: string): void {
     describe(name, () => {
       fixtures([], { useTransactionalTests: false });

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -669,9 +669,13 @@ describeIfSupports("foreign_keys", "Migration", () => {
       const connection = new BetterSQLite3Adapter(":memory:", { foreignKeys: false });
 
       try {
+        // These live in this test's own `:memory:` connection, disconnected in
+        // the finally below — nothing to collide with a sibling fork.
+        // eslint-disable-next-line blazetrails/require-table-teardown
         await connection.createTable("rockets", { force: true }, (t) => {
           t.string("name");
         });
+        // eslint-disable-next-line blazetrails/require-table-teardown
         await connection.createTable("astronauts", { force: true }, (t) => {
           t.string("name");
           t.references("rocket");


### PR DESCRIPTION
Ports the two classes at the top of
`vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb` that were
still unported, into `packages/activerecord/src/migration/foreign-key.test.ts`.

- `ForeignKeyInCreateTest#test_foreign_keys` (:9-21) — reads the canonical
  `fk_test_has_fk` foreign key, keeping Rails' `unless
  current_adapter?(:SQLite3Adapter)` guard on the `fk_name` assertion.
- The four `ForeignKeyChangeColumnTest` cases still missing (:63-142):
  `change_column_of_parent_table`, `remove_reference_column_of_child_table`,
  `remove_foreign_key_by_column`,
  `remove_foreign_key_by_column_in_change_table`. The two that landed earlier
  (`rename_column_of_child_table`, `rename_reference_column_of_child_table`)
  keep their existing bodies.
- Review follow-up: `rename reference column of child table` was skipped for
  every MySQL run. Rails skips it only when
  `current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && !supports_rename_index?`
  (:95-98), so modern servers do execute it. Added a `supportsRenameIndex`
  probe to `adapters/abstract-mysql-adapter/test-helper.ts` mirroring
  `AbstractMysqlAdapter#supports_rename_index?`
  (abstract_mysql_adapter.rb:896-901 — MariaDB >= 10.5.2, MySQL >= 5.7.6),
  alongside the existing `supportsExpressionIndex` / `supportsOptimizerHints`
  probes, and gated on it. The three cases now run and pass on MySQL 8.
- `ForeignKeyChangeColumnWithPrefixTest` (:145-153) and
  `ForeignKeyChangeColumnWithSuffixTest` (:155-163). TS has no test-class
  inheritance, so the shared body is a function called three times — `""/""`,
  `"p_"/""`, `""/"_s"` — rather than copied. Each variant sets
  `Base.tableNamePrefix` / `tableNameSuffix` in `beforeEach` and clears it in
  `afterEach`, mirroring the subclasses' `setup`/`teardown` blocks.

Notes on fidelity:

- Rails' `CreateRocketsMigration` reaches the adapter through
  `Migration#method_missing` → `proper_table_name`, which is where the
  prefix/suffix lands on the table name; the port passes the decorated name
  directly. The `t.references(..., foreign_key: true)` target is still
  decorated by `TableDefinition#new_foreign_key_definition` itself, so this
  exercises the prefix/suffix machinery #5453 wired to the adapter layer.
- The rows are set up with raw `INSERT`s rather than Rails'
  `Rocket.create!` / `rocket.astronauts << Astronaut.create!`. That is the
  existing convention for this describe (it arrived with the two cases already
  on main); declaring bespoke `Rocket`/`Astronaut` models here would
  `registerModel` over the canonical models file-wide and affect the other 60
  cases in the file.

Verification:

- `test:compare` for `foreign_key_test.rb`: 56 → 61 ported. The 6 still
  missing are unrelated cases (`foreign key exists` ×4, `remove constraint`,
  `does not create foreign keys when bypassed by config`) plus `ForeignKeyTest`'s
  own `test_foreign_keys` at :197.
- `test:compare --gates --check`: 0 gate mismatches. The case factory lives
  inside the `describeIfSupports("foreign_keys", ...)` callback so the
  extractor still sees the enclosing feature gate.
- `api:compare`: unchanged (test-only diff, no source files touched) —
  activerecord 6082/6148 (98.9%).
- Green on sqlite3, postgresql and mysql2 locally.

Closes-story: port-migration-foreign-key-in-create-and-change-column-cases
