### PR TITLE
refactor(activerecord): drive prevent-writes tests through Base.whilePreventingWrites

### DIFF
--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -1,84 +1,65 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapter_prevent_writes_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base } from "./index.js";
+import type { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { ReadOnlyError, StatementInvalid } from "./errors.js";
 import { itIfSupports } from "./support/supports.js";
 import { adapterType } from "./test-adapter.js";
-import { scratchDatabasePath } from "./support/scratch-database.js";
-import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
-import { PG_TEST_URL } from "./support/describe-if-pg.js";
+import { fixtures } from "./test-fixtures.js";
 
-// Rails' `setup` is `@connection = ActiveRecord::Base.lease_connection` — the
-// ambient file-backed `arunit` connection, with `subscribers` coming from
-// schema.rb. trails cannot ride that connection here because write prevention
-// (`while_preventing_writes`) is only implemented on the sqlite3 adapter, so
-// this suite stays sqlite-pinned on every lane. What it does drop is the
-// `:memory:` database: the connection is file-backed like `arunit`, on its own
-// path because the suite creates and drops `subscribers` itself and must not
-// touch the worker's canonical copy.
-let adapter: AbstractSQLite3Adapter;
-
-beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(await scratchDatabasePath("adapter-prevent-writes"));
-  await adapter.exec(`DROP TABLE IF EXISTS "subscribers"`);
-  await adapter.exec(
-    `CREATE TABLE "subscribers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "nick" TEXT)`,
-  );
-});
-
-afterEach(async () => {
-  await adapter.exec(`DROP TABLE IF EXISTS "subscribers"`).catch(() => undefined);
-  await adapter.close();
-});
+let connection: AbstractAdapter;
 
 describe("AdapterPreventWritesTest", () => {
-  it("preventing writes predicate", async () => {
-    expect(adapter.preventingWrites).toBe(false);
+  fixtures([]);
 
-    await adapter.withPreventedWrites(async () => {
-      expect(adapter.preventingWrites).toBe(true);
+  beforeEach(async () => {
+    connection = await Base.leaseConnection();
+  });
+
+  it("preventing writes predicate", async () => {
+    expect(connection.isPreventingWrites()).toBe(false);
+
+    await Base.whilePreventingWrites(async () => {
+      expect(connection.isPreventingWrites()).toBe(true);
     });
 
-    expect(adapter.preventingWrites).toBe(false);
+    expect(connection.isPreventingWrites()).toBe(false);
   });
 
   it("errors when an insert query is called while preventing writes", async () => {
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')"),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   it("errors when an update query is called while preventing writes", async () => {
-    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+    await connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')");
 
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(
-          `UPDATE "subscribers" SET "nick" = 'updated' WHERE "nick" = 'test'`,
-        ),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.update("UPDATE subscribers SET nick = '9989' WHERE nick = '138853948594'"),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   it("errors when a delete query is called while preventing writes", async () => {
-    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+    await connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')");
 
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(`DELETE FROM "subscribers" WHERE "nick" = 'test'`),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.delete("DELETE FROM subscribers WHERE nick = '138853948594'"),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   // Rails defines two variants of this test in the same class: one for PostgreSQL
   // (raises StatementInvalid on encoding errors before the write-prevention check) and
   // one for all other adapters (assert_nothing_raised). This first occurrence is the
-  // PostgreSQL variant; it requires a live PG connection to exercise.
+  // PostgreSQL variant.
   it.skipIf(adapterType !== "postgres")(
     "doesnt error when a select query has encoding errors",
     async () => {
@@ -87,35 +68,30 @@ describe("AdapterPreventWritesTest", () => {
       // a raw 0xC8 byte — node-pg always emits valid UTF-8 — so we provoke the same
       // UTF8 encoding error server-side via a bytea literal. The key assertion holds:
       // the write-prevention check (a read) doesn't pre-empt the encoding failure.
-      const pg = new PostgreSQLAdapter(PG_TEST_URL);
-      (pg as PostgreSQLAdapter & { pool: { preventWrites?: boolean } }).pool = {
-        preventWrites: true,
-      };
-      try {
-        await expect(pg.selectAll(`SELECT convert_from('\\xc8'::bytea, 'UTF8')`)).rejects.toThrow(
-          StatementInvalid,
-        );
-      } finally {
-        await pg.close();
-      }
+      await Base.whilePreventingWrites(async () => {
+        await expect(
+          connection.selectAll(`SELECT convert_from('\\xc8'::bytea, 'UTF8')`),
+        ).rejects.toThrow(StatementInvalid);
+      });
     },
   );
 
   // Non-PostgreSQL variant (Rails' `else` branch): the extractor records it as
   // unconditional, so this stays ungated to pair with that variant.
   it("doesnt error when a select query has encoding errors", async () => {
-    await adapter.withPreventedWrites(async () => {
-      // SQLite returns invalid bytes as-is rather than failing
-      await expect(adapter.execute(`SELECT '\xC8'`)).resolves.toBeDefined();
+    await Base.whilePreventingWrites(async () => {
+      await expect(connection.selectAll(`SELECT '\xC8'`)).resolves.toBeDefined();
     });
   });
 
   it("doesnt error when a select query is called while preventing writes", async () => {
-    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+    await connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')");
 
-    await adapter.withPreventedWrites(async () => {
-      const result = await adapter.execute(`SELECT * FROM "subscribers" WHERE "nick" = 'test'`);
-      expect(result).toHaveLength(1);
+    await Base.whilePreventingWrites(async () => {
+      const result = await connection.selectAll(
+        "SELECT subscribers.* FROM subscribers WHERE nick = '138853948594'",
+      );
+      expect(result.length).toBe(1);
     });
   });
 
@@ -123,84 +99,80 @@ describe("AdapterPreventWritesTest", () => {
     "common_table_expressions",
     "doesnt error when a read query with a cte is called while preventing writes",
     async () => {
-      await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+      await connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')");
 
-      await adapter.withPreventedWrites(async () => {
-        const result = await adapter.execute(`
-        WITH matching AS (SELECT * FROM "subscribers" WHERE "nick" = 'test')
-        SELECT * FROM matching
-      `);
-        expect(result).toHaveLength(1);
+      await Base.whilePreventingWrites(async () => {
+        const result = await connection.selectAll(`
+          WITH matching_subscribers AS (SELECT subscribers.* FROM subscribers WHERE nick = '138853948594')
+          SELECT * FROM matching_subscribers
+        `);
+        expect(result.length).toBe(1);
       });
     },
   );
 
   it("doesnt error when a select query starting with a slash star comment is called while preventing writes", async () => {
-    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+    await connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')");
 
-    await adapter.withPreventedWrites(async () => {
-      const result = await adapter.execute(
-        `/* some comment */ SELECT * FROM "subscribers" WHERE "nick" = 'test'`,
+    await Base.whilePreventingWrites(async () => {
+      const result = await connection.selectAll(
+        "/* some comment */ SELECT subscribers.* FROM subscribers WHERE nick = '138853948594'",
       );
-      expect(result).toHaveLength(1);
+      expect(result.length).toBe(1);
     });
   });
 
   it("errors when an insert query prefixed by a slash star comment is called while preventing writes", async () => {
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(
-          `/* some comment */ INSERT INTO "subscribers" ("nick") VALUES ('test')`,
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.insert(
+          "/* some comment */ INSERT INTO subscribers(nick) VALUES ('138853948594')",
         ),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   it("doesnt error when a select query starting with double dash comments is called while preventing writes", async () => {
-    await adapter.executeMutation(`INSERT INTO "subscribers" ("nick") VALUES ('test')`);
+    await connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')");
 
-    await adapter.withPreventedWrites(async () => {
-      const result = await adapter.execute(
-        `-- some comment\n-- comment about INSERT\nSELECT * FROM "subscribers" WHERE "nick" = 'test'`,
+    await Base.whilePreventingWrites(async () => {
+      const result = await connection.selectAll(
+        "-- some comment\n-- comment about INSERT\nSELECT subscribers.* FROM subscribers WHERE nick = '138853948594'",
       );
-      expect(result).toHaveLength(1);
+      expect(result.length).toBe(1);
     });
   });
 
   it("errors when an insert query prefixed by a double dash comment is called while preventing writes", async () => {
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(
-          `-- some comment\nINSERT INTO "subscribers" ("nick") VALUES ('test')`,
-        ),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.insert("-- some comment\nINSERT INTO subscribers(nick) VALUES ('138853948594')"),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   it("errors when an insert query prefixed by a multiline double dash comment is called while preventing writes", async () => {
     const manyComments = "-- comment\n".repeat(50);
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(
-          `${manyComments}INSERT INTO "subscribers" ("nick") VALUES ('test')`,
-        ),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.insert(`${manyComments}INSERT INTO subscribers(nick) VALUES ('138853948594')`),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   it("errors when an insert query prefixed by a slash star comment containing read command is called while preventing writes", async () => {
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(`/* SELECT */ INSERT INTO "subscribers" ("nick") VALUES ('test')`),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.insert("/* SELECT */ INSERT INTO subscribers(nick) VALUES ('138853948594')"),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   it("errors when an insert query prefixed by a double dash comment containing read command is called while preventing writes", async () => {
-    await expect(
-      adapter.withPreventedWrites(() =>
-        adapter.executeMutation(`-- SELECT\nINSERT INTO "subscribers" ("nick") VALUES ('test')`),
-      ),
-    ).rejects.toThrow(ReadOnlyError);
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.insert("-- SELECT\nINSERT INTO subscribers(nick) VALUES ('138853948594')"),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 });

--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -56,18 +56,9 @@ describe("AdapterPreventWritesTest", () => {
     });
   });
 
-  // Rails defines two variants of this test in the same class: one for PostgreSQL
-  // (raises StatementInvalid on encoding errors before the write-prevention check) and
-  // one for all other adapters (assert_nothing_raised). This first occurrence is the
-  // PostgreSQL variant.
   it.skipIf(adapterType !== "postgres")(
     "doesnt error when a select query has encoding errors",
     async () => {
-      // Rails sends Ruby's `'\xC8'` literal as a raw 0xC8 byte, which PG's client
-      // eagerly rejects as invalid UTF-8 (StatementInvalid). JS strings can't carry
-      // a raw 0xC8 byte — node-pg always emits valid UTF-8 — so we provoke the same
-      // UTF8 encoding error server-side via a bytea literal. The key assertion holds:
-      // the write-prevention check (a read) doesn't pre-empt the encoding failure.
       await Base.whilePreventingWrites(async () => {
         await expect(
           connection.selectAll(`SELECT convert_from('\\xc8'::bytea, 'UTF8')`),
@@ -76,8 +67,6 @@ describe("AdapterPreventWritesTest", () => {
     },
   );
 
-  // Non-PostgreSQL variant (Rails' `else` branch): the extractor records it as
-  // unconditional, so this stays ungated to pair with that variant.
   it("doesnt error when a select query has encoding errors", async () => {
     await Base.whilePreventingWrites(async () => {
       await expect(connection.selectAll(`SELECT '\xC8'`)).resolves.toBeDefined();

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -9,6 +9,7 @@
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
+import { Base } from "../../base.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
@@ -105,12 +106,12 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     // The guard lives in preprocess_query's check_if_write_query, so it covers
     // execute and executeMutation alike.
     await expect(
-      adapter.withPreventedWrites(() => adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`)),
+      Base.whilePreventingWrites(() => adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`)),
     ).rejects.toThrow(ReadOnlyError);
   });
 
   it("does not prevent a read routed through execute while preventing writes", async () => {
-    await adapter.withPreventedWrites(async () => {
+    await Base.whilePreventingWrites(async () => {
       await expect(adapter.execute(`SELECT * FROM "pq"`)).resolves.toEqual([]);
     });
   });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -102,17 +102,26 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     expect([...ids].sort((a, b) => a - b)).toEqual(Array.from({ length: n }, (_, i) => i + 1));
   });
 
+  // Rails' `preventing_writes?` returns false when `connection_descriptor` is nil
+  // (abstract_adapter.rb:229), so a `Base` scope only reaches a pool-backed
+  // connection — these two lease rather than reuse the standalone adapter above.
+  // The guard itself lives in preprocess_query's check_if_write_query, so it
+  // covers execute and executeMutation alike.
   it("errors when a write is routed through execute while preventing writes", async () => {
-    // The guard lives in preprocess_query's check_if_write_query, so it covers
-    // execute and executeMutation alike.
+    const connection = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
     await expect(
-      Base.whilePreventingWrites(() => adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`)),
+      Base.whilePreventingWrites(() =>
+        connection.execute(`INSERT INTO subscribers(nick) VALUES ('pq')`),
+      ),
     ).rejects.toThrow(ReadOnlyError);
   });
 
   it("does not prevent a read routed through execute while preventing writes", async () => {
+    const connection = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
     await Base.whilePreventingWrites(async () => {
-      await expect(adapter.execute(`SELECT * FROM "pq"`)).resolves.toEqual([]);
+      await expect(
+        connection.execute(`SELECT * FROM subscribers WHERE nick = 'pq'`),
+      ).resolves.toEqual([]);
     });
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
@@ -25,7 +25,7 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
 
   it("errors when an insert query is called while preventing writes", async () => {
     await adapter.exec(`CREATE TABLE "pw" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    await adapter.withPreventedWrites(async () => {
+    await Base.whilePreventingWrites(async () => {
       await expect(
         adapter.executeMutation(`INSERT INTO "pw" ("name") VALUES ('x')`),
       ).rejects.toThrow(ReadOnlyError);
@@ -35,7 +35,7 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   it("errors when an update query is called while preventing writes", async () => {
     await adapter.exec(`CREATE TABLE "pw2" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.executeMutation(`INSERT INTO "pw2" ("name") VALUES ('x')`);
-    await adapter.withPreventedWrites(async () => {
+    await Base.whilePreventingWrites(async () => {
       await expect(adapter.executeMutation(`UPDATE "pw2" SET "name" = 'y'`)).rejects.toThrow(
         ReadOnlyError,
       );
@@ -45,14 +45,14 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   it("errors when a delete query is called while preventing writes", async () => {
     await adapter.exec(`CREATE TABLE "pw3" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.executeMutation(`INSERT INTO "pw3" ("name") VALUES ('x')`);
-    await adapter.withPreventedWrites(async () => {
+    await Base.whilePreventingWrites(async () => {
       await expect(adapter.executeMutation(`DELETE FROM "pw3"`)).rejects.toThrow(ReadOnlyError);
     });
   });
 
   it("errors when a replace query is called while preventing writes", async () => {
     await adapter.exec(`CREATE TABLE "pw4" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    await adapter.withPreventedWrites(async () => {
+    await Base.whilePreventingWrites(async () => {
       await expect(
         adapter.executeMutation(`REPLACE INTO "pw4" ("id", "name") VALUES (1, 'x')`),
       ).rejects.toThrow(ReadOnlyError);
@@ -61,14 +61,14 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
 
   it("doesnt error when a select query is called while preventing writes", async () => {
     await adapter.exec(`CREATE TABLE "pw5" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    await adapter.withPreventedWrites(async () => {
+    await Base.whilePreventingWrites(async () => {
       const rows = await adapter.execute(`SELECT * FROM "pw5"`);
       expect(rows).toHaveLength(0);
     });
   });
 
   it("doesnt error when a read query with leading chars is called while preventing writes", async () => {
-    await adapter.withPreventedWrites(async () => {
+    await Base.whilePreventingWrites(async () => {
       const rows = await adapter.execute(`  SELECT 1 AS val`);
       expect(rows[0].val).toBe(1);
     });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -305,7 +305,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   private _sqlite3SchemaCreation?: SQLite3SchemaCreation;
   private _readonly: boolean;
   private _strict: boolean;
-  private _preventWrites = false;
   /** @internal Rails' `@last_affected_rows`; read by the affected_rows port. */
   _lastAffectedRows = 0;
   _lastInsertRowid: number | bigint = 0;
@@ -602,38 +601,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   async pragma(name: string): Promise<unknown> {
     await this.ensureConnected();
     return await this.driver.pragma(name);
-  }
-
-  /**
-   * Prevent or allow write operations. Delegates to the predicate so this and
-   * `isPreventingWrites()` — both Rails `preventing_writes?` — cannot disagree:
-   * the getter would otherwise miss the pool/replica component.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#preventing_writes?
-   */
-  get preventingWrites(): boolean {
-    return this.isPreventingWrites();
-  }
-
-  /**
-   * Folds `withPreventedWrites`' local flag into the inherited pool/replica
-   * check so the guard reaches every statement through preprocess_query's
-   * check_if_write_query, rather than only the executeMutation entry point.
-   */
-  override isPreventingWrites(): boolean {
-    return this._preventWrites || super.isPreventingWrites();
-  }
-
-  /**
-   * Execute a block with writes prevented.
-   */
-  async withPreventedWrites<R>(fn: () => R | Promise<R>): Promise<R> {
-    this._preventWrites = true;
-    try {
-      return await fn();
-    } finally {
-      this._preventWrites = false;
-    }
   }
 
   /**


### PR DESCRIPTION
Ports `while_preventing_writes` coverage off the sqlite3-only adapter flag and
onto the Rails-shaped `Base`/pool path, so adapter write prevention is exercised
on all three lanes.

## What was wrong

Rails puts write prevention on `Base`/the pool — `while_preventing_writes` →
`connected_to(prevent_writes: true)`, with `AbstractAdapter#preventing_writes?`
reading it (`connection_handling.rb:235`, `abstract_adapter.rb:227`). trails
already ports that whole path (`connection-handling.ts` `whilePreventingWrites`,
`abstract-adapter.ts` `isPreventingWrites`), but
`adapter_prevent_writes_test.rb` was pinned to a bespoke sqlite3-only adapter
flag (`AbstractSQLite3Adapter#withPreventedWrites` + a `preventingWrites`
getter). On the PG and MySQL lanes the suite silently constructed a
`BetterSQLite3Adapter` against a scratch file, so the `ReadOnlyError` gating had
no coverage there at all.

## What changed

- `adapter-prevent-writes.test.ts` leases the ambient connection
  (`Base.leaseConnection()`, matching `adapter_prevent_writes_test.rb:13`),
  wraps each case in `Base.whilePreventingWrites`, and drives
  `connection.insert` / `update` / `delete` / `selectAll` like Rails does.
  Probes lose their sqlite-only identifier quoting and run against the
  canonical `subscribers` table.
- The PG-gated `doesnt error when a select query has encoding errors` variant
  keeps its `adapterType` gate and now runs on the real PG lane connection
  instead of standing up its own adapter with a faked `pool` object. The two
  Rails variants stay distinct.
- `AbstractSQLite3Adapter._preventWrites`, its `preventingWrites` getter, the
  `isPreventingWrites` override and `withPreventedWrites` are deleted; the
  remaining sqlite3-lane callers (`sqlite3-adapter-prevent-writes.test.ts`,
  `sqlite3-adapter-perform-query.trails.test.ts`) move to
  `Base.whilePreventingWrites`, which is what their Rails counterpart uses.

No test renamed.

## Verification

Ran locally against an isolated compose stack:

| lane | result |
| --- | --- |
| sqlite3 | 14 passed, 1 skipped (PG-gated variant) |
| postgresql | 15 passed (encoding-error variant now runs) |
| mysql2 | 14 passed, 1 skipped |

`sqlite3-adapter-prevent-writes.test.ts`, `sqlite3-adapter-perform-query.trails.test.ts`
and `base-prevent-writes.test.ts` also pass. `pnpm api:compare` exits 0.

Diff: 99 insertions, 158 deletions.

Closes-story: while-preventing-writes-non-sqlite-adapters

## Review gates

- **Rails fidelity** — write prevention now runs through the Rails path only:
  `Base.whilePreventingWrites` (`connection_handling.rb:235`) →
  `AbstractAdapter#isPreventingWrites` (`abstract_adapter.rb:227`) →
  `checkIfWriteQuery` in `preprocessQuery`. The bespoke sqlite3 flag is gone.
  Setup, block structure, SQL literals and assertions match
  `adapter_prevent_writes_test.rb` line for line.
- **No stubs** — deletions only; nothing added as a placeholder.
- **`api:compare`** exits 0.
- **`test:compare` delta** — matched 14729/22203 on both baseline and branch
  (delta 0, non-negative); assertion-kind mismatches drop 4034 → 4030.
