### PR TITLE
feat(activerecord): emit create/drop database banners from DatabaseTasks

### DIFF
--- a/packages/activerecord-cli/src/db-tasks.test.ts
+++ b/packages/activerecord-cli/src/db-tasks.test.ts
@@ -54,7 +54,6 @@ describe("DbTasksTest", () => {
     const code = await run(["db:create"], dir);
     expect(code).toBe(0);
     expect(createAll).toHaveBeenCalledOnce();
-    expect(out.join("\n")).toContain("Created database ':memory:'");
   });
 
   it("db:create --all calls DatabaseTasks.create for every config", async () => {
@@ -70,7 +69,6 @@ describe("DbTasksTest", () => {
     const code = await run(["db:drop"], dir);
     expect(code).toBe(0);
     expect(dropAll).toHaveBeenCalledOnce();
-    expect(out.join("\n")).toContain("Dropped database ':memory:'");
   });
 
   it("db:drop --all calls DatabaseTasks.drop for every config", async () => {

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -6,8 +6,6 @@ import { loadDatabaseConfig, loadMigrations, tryLoadModels } from "./db-helpers.
 async function runCreate(
   config: import("@blazetrails/activerecord").DatabaseConfig,
 ): Promise<boolean> {
-  // Banners (success, already-exists, and the failure pair) are emitted by
-  // DatabaseTasks.create itself (database_tasks.rb:118-124).
   try {
     await DatabaseTasks.create(config);
     return true;
@@ -19,7 +17,6 @@ async function runCreate(
 async function runDrop(
   config: import("@blazetrails/activerecord").DatabaseConfig,
 ): Promise<boolean> {
-  // Banners are emitted by DatabaseTasks.drop itself (database_tasks.rb:213-219).
   try {
     await DatabaseTasks.drop(config);
     return true;

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -1,28 +1,17 @@
 import { join, resolve } from "path";
 import { getEnv, getFsAsync, setEnv } from "@blazetrails/activesupport";
-import {
-  DatabaseTasks,
-  DatabaseConfigurations,
-  NoDatabaseError,
-  DatabaseAlreadyExists,
-} from "@blazetrails/activerecord";
+import { DatabaseTasks, DatabaseConfigurations } from "@blazetrails/activerecord";
 import { loadDatabaseConfig, loadMigrations, tryLoadModels } from "./db-helpers.js";
 
 async function runCreate(
   config: import("@blazetrails/activerecord").DatabaseConfig,
 ): Promise<boolean> {
-  const dbName = config.database ?? "(unknown)";
+  // Banners (success, already-exists, and the failure pair) are emitted by
+  // DatabaseTasks.create itself (database_tasks.rb:118-124).
   try {
     await DatabaseTasks.create(config);
-    console.log(`Created database '${dbName}'`);
     return true;
-  } catch (err) {
-    if (err instanceof DatabaseAlreadyExists) {
-      console.error(`Database '${dbName}' already exists`);
-      return true;
-    }
-    console.error(`Couldn't create '${dbName}' database. Please check your configuration.`);
-    console.error(String(err));
+  } catch {
     return false;
   }
 }
@@ -30,18 +19,11 @@ async function runCreate(
 async function runDrop(
   config: import("@blazetrails/activerecord").DatabaseConfig,
 ): Promise<boolean> {
-  const dbName = config.database ?? "(unknown)";
+  // Banners are emitted by DatabaseTasks.drop itself (database_tasks.rb:213-219).
   try {
     await DatabaseTasks.drop(config);
-    console.log(`Dropped database '${dbName}'`);
     return true;
-  } catch (err) {
-    if (err instanceof NoDatabaseError) {
-      console.error(`Database '${dbName}' does not exist`);
-      return true;
-    }
-    console.error(`Couldn't drop database '${dbName}'`);
-    console.error(String(err));
+  } catch {
     return false;
   }
 }

--- a/packages/activerecord/src/tasks/database-tasks-banners.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-banners.trails.test.ts
@@ -1,0 +1,93 @@
+// trails-only: Rails' database_tasks_test.rb has no test for the create/drop
+// banners themselves — they're covered indirectly by railties' rake tests,
+// which trails has no analogue for. These pin the shapes at
+// database_tasks.rb:116-124 and :210-220 directly.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { stdout, stderr } from "@blazetrails/activesupport";
+import { DatabaseTasks } from "./database-tasks.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+import { DatabaseAlreadyExists, NoDatabaseError } from "../errors.js";
+
+function config(): HashConfig {
+  return new HashConfig("development", "primary", { adapter: "sqlite3", database: "my-db" });
+}
+
+describe("DatabaseTasksBannersTest", () => {
+  let out: string[];
+  let err: string[];
+
+  beforeEach(() => {
+    out = [];
+    err = [];
+    vi.spyOn(stdout, "write").mockImplementation((chunk) => {
+      out.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(stderr, "write").mockImplementation((chunk) => {
+      err.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    DatabaseTasks.clearRegisteredTasks();
+    vi.restoreAllMocks();
+  });
+
+  it("create prints the created banner", async () => {
+    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    await DatabaseTasks.create(config());
+    expect(out.join("")).toEqual("Created database 'my-db'\n");
+    expect(err).toEqual([]);
+  });
+
+  it("create prints already exists on DatabaseAlreadyExists", async () => {
+    DatabaseTasks.registerTask("sqlite", {
+      create: async () => {
+        throw new DatabaseAlreadyExists("boom");
+      },
+    });
+    await DatabaseTasks.create(config());
+    expect(out).toEqual([]);
+    expect(err.join("")).toEqual("Database 'my-db' already exists\n");
+  });
+
+  it("create reraises other errors after printing both lines", async () => {
+    DatabaseTasks.registerTask("sqlite", {
+      create: async () => {
+        throw new Error("nope");
+      },
+    });
+    await expect(DatabaseTasks.create(config())).rejects.toThrow("nope");
+    expect(err.join("")).toEqual(
+      "nope\nCouldn't create 'my-db' database. Please check your configuration.\n",
+    );
+  });
+
+  it("drop prints the dropped banner", async () => {
+    DatabaseTasks.registerTask("sqlite", { drop: async () => {} });
+    await DatabaseTasks.drop(config());
+    expect(out.join("")).toEqual("Dropped database 'my-db'\n");
+  });
+
+  it("drop prints does not exist on NoDatabaseError", async () => {
+    DatabaseTasks.registerTask("sqlite", {
+      drop: async () => {
+        throw new NoDatabaseError("boom");
+      },
+    });
+    await DatabaseTasks.drop(config());
+    expect(out).toEqual([]);
+    expect(err.join("")).toEqual("Database 'my-db' does not exist\n");
+  });
+
+  it("drop reraises other errors after printing both lines", async () => {
+    DatabaseTasks.registerTask("sqlite", {
+      drop: async () => {
+        throw new Error("nope");
+      },
+    });
+    await expect(DatabaseTasks.drop(config())).rejects.toThrow("nope");
+    expect(err.join("")).toEqual("nope\nCouldn't drop database 'my-db'\n");
+  });
+});

--- a/packages/activerecord/src/tasks/database-tasks-banners.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-banners.trails.test.ts
@@ -1,7 +1,3 @@
-// trails-only: Rails' database_tasks_test.rb has no test for the create/drop
-// banners themselves — they're covered indirectly by railties' rake tests,
-// which trails has no analogue for. These pin the shapes at
-// database_tasks.rb:116-124 and :210-220 directly.
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { stdout, stderr } from "@blazetrails/activesupport";
 import { DatabaseTasks } from "./database-tasks.js";

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -8,7 +8,15 @@ import { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
-import { getFs, getPath, getCryptoAsync, getOs, getEnv, stdout } from "@blazetrails/activesupport";
+import {
+  getFs,
+  getPath,
+  getCryptoAsync,
+  getOs,
+  getEnv,
+  stdout,
+  stderr,
+} from "@blazetrails/activesupport";
 import { ConnectionNotDefined } from "../errors.js";
 import { Base } from "../base.js";
 
@@ -176,9 +184,23 @@ export class DatabaseTasks {
   }
 
   static async create(config: DatabaseConfig): Promise<void> {
-    const handler = this._resolveTaskOrThrow(this._adapterFor(config));
-    if (handler.create) {
-      await handler.create(config);
+    const { DatabaseAlreadyExists } = await import("../errors.js");
+    try {
+      const handler = this._resolveTaskOrThrow(this._adapterFor(config));
+      if (handler.create) {
+        await handler.create(config);
+      }
+      if (isVerbose()) stdout.write(`Created database '${config.database}'\n`);
+    } catch (error) {
+      if (error instanceof DatabaseAlreadyExists) {
+        if (isVerbose()) stderr.write(`Database '${config.database}' already exists\n`);
+        return;
+      }
+      stderr.write(_errorToS(error) + "\n");
+      stderr.write(
+        `Couldn't create '${config.database}' database. Please check your configuration.\n`,
+      );
+      throw error;
     }
   }
 
@@ -228,9 +250,23 @@ export class DatabaseTasks {
   }
 
   static async drop(config: DatabaseConfig): Promise<void> {
-    const handler = this._resolveTaskOrThrow(this._adapterFor(config));
-    if (handler.drop) {
-      await handler.drop(config);
+    const { NoDatabaseError } = await import("../errors.js");
+    try {
+      const handler = this._resolveTaskOrThrow(this._adapterFor(config));
+      if (handler.drop) {
+        await handler.drop(config);
+      }
+      if (isVerbose()) stdout.write(`Dropped database '${config.database}'\n`);
+    } catch (error) {
+      // Rails' NoDatabaseError arm is deliberately ungated — no `if verbose?`
+      // (database_tasks.rb:214-215), unlike the create/DatabaseAlreadyExists arm.
+      if (error instanceof NoDatabaseError) {
+        stderr.write(`Database '${config.database}' does not exist\n`);
+        return;
+      }
+      stderr.write(_errorToS(error) + "\n");
+      stderr.write(`Couldn't drop database '${config.database}'\n`);
+      throw error;
     }
   }
 
@@ -1365,6 +1401,16 @@ export function resolveConfiguration(configuration: unknown): DatabaseConfig {
   const configs = DatabaseTasks.databaseConfiguration;
   if (!configs) throw new Error("DatabaseTasks.databaseConfiguration is not set");
   return configs.resolve(configuration);
+}
+
+/**
+ * Ruby's `$stderr.puts error` prints `error.to_s`, which for an exception is
+ * its message alone — not the `Error: ` -prefixed form `String(err)` yields.
+ *
+ * @internal
+ */
+function _errorToS(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -258,8 +258,6 @@ export class DatabaseTasks {
       }
       if (isVerbose()) stdout.write(`Dropped database '${config.database}'\n`);
     } catch (error) {
-      // Rails' NoDatabaseError arm is deliberately ungated — no `if verbose?`
-      // (database_tasks.rb:214-215), unlike the create/DatabaseAlreadyExists arm.
       if (error instanceof NoDatabaseError) {
         stderr.write(`Database '${config.database}' does not exist\n`);
         return;
@@ -1403,12 +1401,6 @@ export function resolveConfiguration(configuration: unknown): DatabaseConfig {
   return configs.resolve(configuration);
 }
 
-/**
- * Ruby's `$stderr.puts error` prints `error.to_s`, which for an exception is
- * its message alone — not the `Error: ` -prefixed form `String(err)` yields.
- *
- * @internal
- */
 function _errorToS(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -517,15 +517,12 @@ function displayNameFor(config: HashConfig, raw: RawConfig): string {
 }
 
 async function runCreate(opts: DatabaseOpts = {}): Promise<void> {
-  // The `Created database` / `already exists` banners are emitted by
-  // DatabaseTasks.create itself (database_tasks.rb:118-120).
   await forEachDatabaseConfig(opts, async ({ config }) => {
     await DatabaseTasks.create(config);
   });
 }
 
 async function runDrop(opts: DatabaseOpts = {}): Promise<void> {
-  // Banners come from DatabaseTasks.drop itself (database_tasks.rb:213-215).
   await forEachDatabaseConfig(opts, async ({ config }) => {
     await runProtectedEnvCheck(config, config.envName);
     await DatabaseTasks.drop(config);

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -835,25 +835,33 @@ export function dbCommand(): Command {
       "Create the database if it doesn't exist, run pending migrations, and seed when fresh",
     )
     .action(async () => {
-      // Create the DB first, then connect via withTemporaryPool — establishing
-      // the pool before creation would fail for pg/mysql when the DB doesn't exist.
       const raw = normalizeRawConfig(await loadDatabaseConfig());
       const config = toDbConfig(raw);
-
-      await DatabaseTasks.create(config);
+      const { NoDatabaseError } = await import("@blazetrails/activerecord");
 
       await DatabaseTasks.withTemporaryPool(config, async (pool) => {
-        // Rails measures "fresh" via `!schema_migration.table_exists?`,
-        // matching its `initialize_database` contract. A sqlite DB file
-        // may have been created by either our DatabaseTasks.create call
-        // above or by better-sqlite3 on connect; the meaningful signal
-        // is whether migrations have been applied.
-        const adapter = await pool.leaseConnection();
-        const migrator = createMigrator(adapter, [], raw);
-        const wasFresh = !(await migrator.schemaMigrationTableExists());
+        let adapter: DatabaseAdapter;
+        let databaseAlreadyInitialized: boolean;
+        try {
+          adapter = await pool.leaseConnection();
+          databaseAlreadyInitialized = await createMigrator(
+            adapter,
+            [],
+            raw,
+          ).schemaMigrationTableExists();
+        } catch (error) {
+          if (!(error instanceof NoDatabaseError)) throw error;
+          await DatabaseTasks.create(config);
+          adapter = await pool.leaseConnection();
+          databaseAlreadyInitialized = await createMigrator(
+            adapter,
+            [],
+            raw,
+          ).schemaMigrationTableExists();
+        }
 
         await runMigrate(adapter, raw);
-        if (wasFresh) {
+        if (!databaseAlreadyInitialized) {
           await withSeedAdapter(adapter, runSeed);
         }
       });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -15,13 +15,7 @@ import {
   type DatabaseConfig as RawConfig,
 } from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
-import {
-  DatabaseTasks,
-  HashConfig,
-  Migrator,
-  DatabaseAlreadyExists,
-  NoDatabaseError,
-} from "@blazetrails/activerecord";
+import { DatabaseTasks, HashConfig, Migrator } from "@blazetrails/activerecord";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
@@ -523,35 +517,18 @@ function displayNameFor(config: HashConfig, raw: RawConfig): string {
 }
 
 async function runCreate(opts: DatabaseOpts = {}): Promise<void> {
-  await forEachDatabaseConfig(opts, async ({ raw, config, prefix }) => {
-    const displayName = displayNameFor(config, raw);
-    try {
-      await DatabaseTasks.create(config);
-      console.log(`${prefix}Created database '${displayName}'`);
-    } catch (error) {
-      if (error instanceof DatabaseAlreadyExists) {
-        console.error(`${prefix}Database '${displayName}' already exists`);
-        return;
-      }
-      throw error;
-    }
+  // The `Created database` / `already exists` banners are emitted by
+  // DatabaseTasks.create itself (database_tasks.rb:118-120).
+  await forEachDatabaseConfig(opts, async ({ config }) => {
+    await DatabaseTasks.create(config);
   });
 }
 
 async function runDrop(opts: DatabaseOpts = {}): Promise<void> {
-  await forEachDatabaseConfig(opts, async ({ raw, config, prefix }) => {
-    const displayName = displayNameFor(config, raw);
+  // Banners come from DatabaseTasks.drop itself (database_tasks.rb:213-215).
+  await forEachDatabaseConfig(opts, async ({ config }) => {
     await runProtectedEnvCheck(config, config.envName);
-    try {
-      await DatabaseTasks.drop(config);
-      console.log(`${prefix}Dropped database '${displayName}'`);
-    } catch (error) {
-      if (error instanceof NoDatabaseError) {
-        console.error(`${prefix}Database '${displayName}' does not exist`);
-        return;
-      }
-      throw error;
-    }
+    await DatabaseTasks.drop(config);
   });
 }
 
@@ -865,14 +842,8 @@ export function dbCommand(): Command {
       // the pool before creation would fail for pg/mysql when the DB doesn't exist.
       const raw = normalizeRawConfig(await loadDatabaseConfig());
       const config = toDbConfig(raw);
-      const { DatabaseAlreadyExists } = await import("@blazetrails/activerecord");
 
-      try {
-        await DatabaseTasks.create(config);
-        console.log(`Created database '${displayNameFor(config, raw)}'`);
-      } catch (error) {
-        if (!(error instanceof DatabaseAlreadyExists)) throw error;
-      }
+      await DatabaseTasks.create(config);
 
       await DatabaseTasks.withTemporaryPool(config, async (pool) => {
         // Rails measures "fresh" via `!schema_migration.table_exists?`,

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
@@ -481,19 +481,5 @@
     "rubyName": "class_for_adapter",
     "call": "constantize",
     "reason": "Equivalent (different path): classForAdapter resolves the adapter class through trails' adapter registry, not a constant lookup."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "create",
-    "call": "verbose?",
-    "reason": "trails' DatabaseTasks.create/drop emit no banner — the `Created/Dropped database` line is printed by the CLI layer instead (trailties commands/db.ts:530,547), so there is no verbose? gate to call here."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "drop",
-    "call": "verbose?",
-    "reason": "trails' DatabaseTasks.create/drop emit no banner — the `Created/Dropped database` line is printed by the CLI layer instead (trailties commands/db.ts:530,547), so there is no verbose? gate to call here."
   }
 ]


### PR DESCRIPTION
Rails' `DatabaseTasks.create` / `drop` print their own banners — `Created
database '<name>'` / `Dropped database '<name>'` behind `verbose?`, plus the
`DatabaseAlreadyExists` / `NoDatabaseError` and generic-exception rescue arms
(`database_tasks.rb:116-124`, `:210-220`).

trails delegated bare to the task handler and emitted the banners a layer up,
duplicated across `trailties/src/commands/db.ts` and
`activerecord-cli/src/db-tasks.ts`. This moves them into `DatabaseTasks`
(writing to the activesupport `stdout` / `stderr` shims) and deletes the
CLI-layer copies so nothing prints twice.

Notes:
- Rails' `drop` `NoDatabaseError` arm is deliberately **not** gated on
  `verbose?`, unlike `create`'s already-exists arm — preserved as-is.
- `$stderr.puts error` prints `error.to_s` (the message alone), so the port
  uses a small `_errorToS` helper rather than `String(err)`, which would add an
  `Error: ` prefix Rails never emits.
- The two `verbose?` entries for `create` / `drop` are removed from
  `call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json`;
  `pnpm api:calls:wide` is green (4805 baselined).

Closes-story: database-tasks-create-drop-emit-banners
