### PR TITLE
fix(activerecord): gate pk_autopopulated_by_a_trigger_records in ADAPTER_SPECIFIC_TABLES

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -24,14 +24,14 @@ const CANONICAL_TABLE_NAMES: ReadonlySet<string> = new Set(Object.keys(TEST_SCHE
  */
 const _bootLaidByAdapter = new Map<string, ReadonlySet<string>>();
 
-function bootLaidTableNames(adapter: DatabaseAdapter): ReadonlySet<string> {
+async function bootLaidTableNames(adapter: DatabaseAdapter): Promise<ReadonlySet<string>> {
   const name = adapter.adapterName;
   // Memoized: this runs in the between-test reset, and both inputs are
   // module-level constants, so the ~330-name Set is built at most once per
   // adapter per worker.
   let cached = _bootLaidByAdapter.get(name);
   if (!cached) {
-    const specific = adapterSpecificTableNames(name);
+    const specific = await adapterSpecificTableNames(adapter);
     cached =
       specific.length === 0
         ? CANONICAL_TABLE_NAMES
@@ -71,7 +71,7 @@ export async function resetTestTables(adapter: DatabaseAdapter): Promise<void> {
 type ResetMode = "drop-all" | "reset";
 
 async function resetTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
-  const bootLaid = bootLaidTableNames(adapter);
+  const bootLaid = await bootLaidTableNames(adapter);
   switch (adapter.adapterName) {
     case "postgres":
       await resetPgTables(adapter, mode, bootLaid);

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -22,21 +22,20 @@ const CANONICAL_TABLE_NAMES: ReadonlySet<string> = new Set(Object.keys(TEST_SCHE
  * one `load_schema` in Rails, so both are truncated between tests rather than
  * dropped.
  */
-const _bootLaidByAdapter = new Map<string, ReadonlySet<string>>();
+const _bootLaidBySpecificTables = new Map<string, ReadonlySet<string>>();
 
 async function bootLaidTableNames(adapter: DatabaseAdapter): Promise<ReadonlySet<string>> {
-  const name = adapter.adapterName;
-  // Memoized: this runs in the between-test reset, and both inputs are
-  // module-level constants, so the ~330-name Set is built at most once per
-  // adapter per worker.
-  let cached = _bootLaidByAdapter.get(name);
+  const specific = await adapterSpecificTableNames(adapter);
+  if (specific.length === 0) return CANONICAL_TABLE_NAMES;
+
+  // Keyed on the resolved list, not on `adapterName`: the mysql arm is gated on
+  // `supportsInsertReturning()`, so a MySQL 8 and a MariaDB >= 10.5 connection
+  // share an adapter name but lay different tables.
+  const key = specific.join(",");
+  let cached = _bootLaidBySpecificTables.get(key);
   if (!cached) {
-    const specific = await adapterSpecificTableNames(adapter);
-    cached =
-      specific.length === 0
-        ? CANONICAL_TABLE_NAMES
-        : new Set([...CANONICAL_TABLE_NAMES, ...specific]);
-    _bootLaidByAdapter.set(name, cached);
+    cached = new Set([...CANONICAL_TABLE_NAMES, ...specific]);
+    _bootLaidBySpecificTables.set(key, cached);
   }
   return cached;
 }

--- a/packages/activerecord/src/support/load-schema-helper.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.trails.test.ts
@@ -21,7 +21,7 @@ describe("ADAPTER_SPECIFIC_TABLES", () => {
     try {
       await loadAdapterSpecificSchema(adapter);
       const created = (await adapter.tables()).sort();
-      expect(created).toEqual([...adapterSpecificTableNames("sqlite")].sort());
+      expect(created).toEqual([...(await adapterSpecificTableNames(adapter))].sort());
     } finally {
       await (adapter as unknown as BetterSQLite3Adapter).close();
     }
@@ -29,7 +29,7 @@ describe("ADAPTER_SPECIFIC_TABLES", () => {
 
   it("lists tables the active lane actually has after boot", async () => {
     const adapter = Base.connection;
-    const declared = adapterSpecificTableNames(adapter.adapterName);
+    const declared = await adapterSpecificTableNames(adapter);
     expect(declared.length).toBeGreaterThan(0);
 
     const present = new Set(await adapter.tables());

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -391,10 +391,6 @@ const ADAPTER_SPECIFIC_TABLES: Record<
     "test_unique_constraints",
   ],
   mysql: async (adapter) => {
-    // Same `supports_insert_returning?` gate the loader applies to
-    // `pk_autopopulated_by_a_trigger_records` (mysql2_specific_schema.rb:84).
-    // The version fetch mirrors the loader's, so a cold pool lease cannot
-    // answer `false` on MariaDB and leave the table unshielded.
     await adapter.getDatabaseVersion();
     return [
       "datetime_defaults",

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -360,15 +360,20 @@ const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Pro
 
 /**
  * The tables each {@link ADAPTER_SPECIFIC_SCHEMAS} arm lays, by adapter name.
- * Must be kept in step with the loaders above.
+ * Must be kept in step with the loaders above — including their support gates,
+ * which is why each arm resolves against the live adapter rather than being a
+ * flat list.
  *
  * `support/drop-all-tables.ts` reads this: its between-test `reset` mode drops
  * every table that is not part of the loaded schema, and these are as much part
  * of the schema Rails boots with as `schema.rb`'s. Without them here the arm
  * would be undone before the first test in every file.
  */
-const ADAPTER_SPECIFIC_TABLES: Record<string, readonly string[]> = {
-  postgres: [
+const ADAPTER_SPECIFIC_TABLES: Record<
+  string,
+  (adapter: DatabaseAdapter) => Promise<readonly string[]>
+> = {
+  postgres: async () => [
     "chat_messages",
     "chat_messages_custom_pk",
     "uuid_parents",
@@ -385,21 +390,30 @@ const ADAPTER_SPECIFIC_TABLES: Record<string, readonly string[]> = {
     "test_exclusion_constraints",
     "test_unique_constraints",
   ],
-  mysql: [
-    "datetime_defaults",
-    "timestamp_defaults",
-    "defaults",
-    "binary_fields",
-    "key_tests",
-    "collation_tests",
-    "pk_autopopulated_by_a_trigger_records",
-  ],
-  sqlite: ["defaults"],
+  mysql: async (adapter) => {
+    // Same `supports_insert_returning?` gate the loader applies to
+    // `pk_autopopulated_by_a_trigger_records` (mysql2_specific_schema.rb:84).
+    // The version fetch mirrors the loader's, so a cold pool lease cannot
+    // answer `false` on MariaDB and leave the table unshielded.
+    await adapter.getDatabaseVersion();
+    return [
+      "datetime_defaults",
+      "timestamp_defaults",
+      "defaults",
+      "binary_fields",
+      "key_tests",
+      "collation_tests",
+      ...(adapter.supportsInsertReturning() ? ["pk_autopopulated_by_a_trigger_records"] : []),
+    ];
+  },
+  sqlite: async () => ["defaults"],
 };
 
-/** The adapter-specific schema tables for `adapterName`; empty when it has no arm. */
-export function adapterSpecificTableNames(adapterName: string): readonly string[] {
-  return ADAPTER_SPECIFIC_TABLES[adapterName] ?? [];
+/** The adapter-specific schema tables for `adapter`; empty when it has no arm. */
+export async function adapterSpecificTableNames(
+  adapter: DatabaseAdapter,
+): Promise<readonly string[]> {
+  return (await ADAPTER_SPECIFIC_TABLES[adapter.adapterName]?.(adapter)) ?? [];
 }
 
 /**


### PR DESCRIPTION
`ADAPTER_SPECIFIC_TABLES.mysql` listed `pk_autopopulated_by_a_trigger_records`
unconditionally, but `loadMysql2SpecificSchema` only creates it inside
`if (adapter.supportsInsertReturning())` — the same `if supports_insert_returning?`
gate Rails uses at `mysql2_specific_schema.rb:84-95`. On MariaDB the gate is true
and the two agree; on MySQL 8 it is false, the table is never laid, and the
bookkeeping stops describing the boot schema.

Each `ADAPTER_SPECIFIC_TABLES` arm is now a function of the live adapter, so the
mysql arm can apply the loader's gate. It warms the version first
(`await adapter.getDatabaseVersion()`), mirroring the loader — `supportsInsertReturning`
reads the lazily-populated `_mariadb`/`_databaseVersion`, so a cold pool lease
would otherwise answer `false` on MariaDB and leave the table unshielded from the
between-test drop.

`adapterSpecificTableNames` therefore takes the adapter and is async; its one
non-test caller, `bootLaidTableNames` in `support/drop-all-tables.ts`, is already
reached from the async `resetTables`.

Verified against MySQL 8 locally on `ARCONN=mysql2`:
`load-schema-helper.trails.test.ts`'s "lists tables the active lane actually has
after boot" fails on the baseline (`expected [ Array(1) ] to deeply equal []`)
and passes with the fix. Typecheck clean.

Closes-story: mysql-specific-table-list-ignores-insert-returning-gate
