### PR TITLE
test(activerecord): relocate the 6 misplaced migration cases to their Rails files

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
@@ -22,14 +22,6 @@ describeIfPg("Migration", () => {
   });
 
   describe("PgChangeSchemaTest", () => {
-    it("change column", async () => {
-      await adapter.exec("ALTER TABLE strings ADD COLUMN age integer");
-      await adapter.changeColumn("strings", "age", "string");
-      const cols = await adapter.columns("strings");
-      const col = cols.find((c) => c.name === "age");
-      expect(col!.sqlType).toBe("character varying");
-    });
-
     it("change column with null", async () => {
       await adapter.exec("ALTER TABLE strings ADD COLUMN score integer");
       await adapter.changeColumn("strings", "score", "integer", { null: false });
@@ -53,14 +45,6 @@ describeIfPg("Migration", () => {
       const col = cols.find((c) => c.name === "score");
       expect(col!.default).toBeNull();
       expect(col!.null).toBe(false);
-    });
-
-    it("change column null", async () => {
-      await adapter.exec("ALTER TABLE strings ADD COLUMN score integer NOT NULL DEFAULT 0");
-      await adapter.changeColumn("strings", "score", "integer", { null: true });
-      const cols = await adapter.columns("strings");
-      const col = cols.find((c) => c.name === "score");
-      expect(col!.null).toBe(true);
     });
 
     it("change column scale", async () => {

--- a/packages/activerecord/src/adapters/postgresql/rename-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/rename-table.test.ts
@@ -26,13 +26,6 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlRenameTableTest", () => {
-    it("rename table", async () => {
-      await adapter.exec("CREATE TABLE before_rename (id serial primary key, name text)");
-      await adapter.renameTable("before_rename", "after_rename");
-      expect(await adapter.dataSourceExists("after_rename")).toBe(true);
-      expect(await adapter.dataSourceExists("before_rename")).toBe(false);
-    });
-
     it("rename table with index", async () => {
       await adapter.exec("CREATE TABLE before_rename (id serial primary key, name text)");
       await adapter.exec("CREATE INDEX idx_before_name ON before_rename (name)");

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -336,19 +336,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`ALTER TABLE ${SCHEMA_NAME}.${TABLE_NAME} DROP COLUMN IF EXISTS bio`);
     });
 
-    it("rename column", async () => {
-      await adapter.addColumn(`${SCHEMA_NAME}.${TABLE_NAME}`, "old_col", "integer");
-      await adapter.renameColumn(`${SCHEMA_NAME}.${TABLE_NAME}`, "old_col", "new_col");
-      const cols = await adapter.schemaQuery(
-        `SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`,
-        [SCHEMA_NAME, TABLE_NAME],
-      );
-      const names = cols.map((r) => r.column_name);
-      expect(names).toContain("new_col");
-      expect(names).not.toContain("old_col");
-      await adapter.exec(`ALTER TABLE ${SCHEMA_NAME}.${TABLE_NAME} DROP COLUMN IF EXISTS new_col`);
-    });
-
     it("change column default", async () => {
       await adapter.addColumn(`${SCHEMA_NAME}.${TABLE_NAME}`, "rating", "integer");
       await adapter.changeColumnDefault(`${SCHEMA_NAME}.${TABLE_NAME}`, "rating", 5);
@@ -453,119 +440,6 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("typeToSql binary limit too large throws", () => {
       expect(() => adapter.typeToSql("binary", { limit: 0x40000000 })).toThrow();
-    });
-  });
-
-  describe("UniqueConstraintTest", () => {
-    beforeEach(async () => {
-      await adapter.exec(
-        `CREATE TABLE ${SCHEMA_NAME}.test_unique_constraints (
-           id serial PRIMARY KEY,
-           position_1 integer,
-           position_2 integer,
-           position_3 integer,
-           position_4 integer,
-           CONSTRAINT test_unique_constraints_position_deferrable_false UNIQUE (position_1),
-           CONSTRAINT test_unique_constraints_position_deferrable_immediate UNIQUE (position_2)
-             DEFERRABLE INITIALLY IMMEDIATE,
-           CONSTRAINT test_unique_constraints_position_deferrable_deferred UNIQUE (position_3)
-             DEFERRABLE INITIALLY DEFERRED,
-           CONSTRAINT test_unique_constraints_position_nulls_not_distinct
-             UNIQUE NULLS NOT DISTINCT (position_4)
-         )`,
-      );
-    });
-
-    it("unique constraints", async () => {
-      const uniqueConstraints = await adapter.uniqueConstraints(
-        `${SCHEMA_NAME}.test_unique_constraints`,
-      );
-      const expectedConstraints = [
-        {
-          name: "test_unique_constraints_position_deferrable_false",
-          deferrable: false,
-          column: ["position_1"],
-        },
-        {
-          name: "test_unique_constraints_position_deferrable_immediate",
-          deferrable: "immediate",
-          column: ["position_2"],
-        },
-        {
-          name: "test_unique_constraints_position_deferrable_deferred",
-          deferrable: "deferred",
-          column: ["position_3"],
-        },
-      ];
-      expect(uniqueConstraints.length).toBe(expectedConstraints.length + 1);
-
-      for (const expected of expectedConstraints) {
-        const constraint = uniqueConstraints.find((c) => c.name === expected.name)!;
-        expect(constraint.tableName).toBe(`${SCHEMA_NAME}.test_unique_constraints`);
-        expect(constraint.name).toBe(expected.name);
-        expect(constraint.column).toEqual(expected.column);
-        expect(constraint.deferrable).toBe(expected.deferrable);
-      }
-
-      const nullsNotDistinct = uniqueConstraints.find(
-        (c) => c.name === "test_unique_constraints_position_nulls_not_distinct",
-      )!;
-      expect(nullsNotDistinct.column).toEqual(["position_4"]);
-      expect(nullsNotDistinct.nullsNotDistinct).toBe(true);
-    });
-  });
-
-  describe("ExclusionConstraintTest", () => {
-    beforeEach(async () => {
-      await adapter.exec(
-        `CREATE TABLE ${SCHEMA_NAME}.test_exclusion_constraints (
-           id serial PRIMARY KEY,
-           start_date date,
-           end_date date,
-           valid_from date,
-           valid_to date,
-           CONSTRAINT test_exclusion_constraints_date_overlap
-             EXCLUDE USING gist (daterange(start_date, end_date) WITH &&)
-             WHERE (start_date IS NOT NULL AND end_date IS NOT NULL),
-           CONSTRAINT test_exclusion_constraints_valid_overlap
-             EXCLUDE USING gist (daterange(valid_from, valid_to) WITH &&)
-             WHERE (valid_from IS NOT NULL AND valid_to IS NOT NULL)
-             DEFERRABLE INITIALLY IMMEDIATE
-         )`,
-      );
-    });
-
-    it("exclusion constraints", async () => {
-      const exclusionConstraints = await adapter.exclusionConstraints(
-        `${SCHEMA_NAME}.test_exclusion_constraints`,
-      );
-      const expectedConstraints = [
-        {
-          name: "test_exclusion_constraints_date_overlap",
-          expression: "daterange(start_date, end_date) WITH &&",
-          where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)",
-          using: "gist",
-          deferrable: false,
-        },
-        {
-          name: "test_exclusion_constraints_valid_overlap",
-          expression: "daterange(valid_from, valid_to) WITH &&",
-          where: "(valid_from IS NOT NULL) AND (valid_to IS NOT NULL)",
-          using: "gist",
-          deferrable: "immediate",
-        },
-      ];
-      expect(exclusionConstraints.length).toBe(expectedConstraints.length);
-
-      for (const expected of expectedConstraints) {
-        const constraint = exclusionConstraints.find((c) => c.name === expected.name)!;
-        expect(constraint.tableName).toBe(`${SCHEMA_NAME}.test_exclusion_constraints`);
-        expect(constraint.name).toBe(expected.name);
-        expect(constraint.expression).toBe(expected.expression);
-        expect(constraint.using).toBe(expected.using);
-        expect(constraint.where).toBe(expected.where);
-        expect(constraint.deferrable).toBe(expected.deferrable);
-      }
     });
   });
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -659,10 +659,6 @@ export abstract class Migration {
       return;
     }
     tableName = this._pt(tableName);
-    // Rails' `method_missing` forwards to the connection, so the adapter's own
-    // override runs. Going through `this.schema` instead reached the abstract
-    // `ALTER COLUMN ... SET NOT NULL`, which SQLite has no syntax for — its
-    // table-rebuild override on the adapter was unreachable from a migration.
     const conn = this.connection;
     assertSchemaAdapter(conn);
     await conn.changeColumnNull(tableName, columnName, allowNull, defaultValue);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -659,7 +659,13 @@ export abstract class Migration {
       return;
     }
     tableName = this._pt(tableName);
-    await this.schema.changeColumnNull(tableName, columnName, allowNull, defaultValue);
+    // Rails' `method_missing` forwards to the connection, so the adapter's own
+    // override runs. Going through `this.schema` instead reached the abstract
+    // `ALTER COLUMN ... SET NOT NULL`, which SQLite has no syntax for — its
+    // table-rebuild override on the adapter was unreachable from a migration.
+    const conn = this.connection;
+    assertSchemaAdapter(conn);
+    await conn.changeColumnNull(tableName, columnName, allowNull, defaultValue);
   }
 
   async addReference(

--- a/packages/activerecord/src/migration/change-schema.test.ts
+++ b/packages/activerecord/src/migration/change-schema.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Port of `test_change_column_null` from `ActiveRecord::Migration::
+ * ChangeSchemaTest` (vendor/rails/activerecord/test/cases/migration/
+ * change_schema_test.rb:397-411). The rest of change_schema_test.rb is
+ * unported.
+ *
+ * Driven by the ambient connection, mirroring Rails'
+ * `@connection = ActiveRecord::Base.lease_connection`. `testings` is created
+ * and dropped by the test in Rails too, so it is not a canonical-schema table.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { Migration } from "../migration.js";
+import { ambientConnection } from "../support/rocket-tables.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+
+/** Rails' `suppress_messages { migration.migrate(...) }`. */
+class SilentMigration extends Migration {
+  write(): void {}
+}
+
+class NotnullMigration extends SilentMigration {
+  async change(): Promise<void> {
+    await this.changeColumnNull("testings", "foo", false);
+  }
+}
+
+/** change_schema_test.rb:489-495. */
+async function testingTableWithOnlyFooAttribute(
+  connection: AbstractAdapter,
+  body: () => Promise<void>,
+): Promise<void> {
+  await connection.createTable("testings", { id: false }, (t) => {
+    t.column("foo", "string");
+  });
+
+  await body();
+}
+
+describe("Migration", () => {
+  afterEach(async () => {
+    const connection = await ambientConnection();
+    await connection.dropTable("testings", { ifExists: true });
+  });
+
+  describe("ChangeSchemaTest", () => {
+    it("change column null", async () => {
+      const connection = await ambientConnection();
+      await testingTableWithOnlyFooAttribute(connection, async () => {
+        const notnullMigration = new NotnullMigration();
+        await notnullMigration.migrate("up");
+        expect((await connection.columns("testings")).find((c) => c.name === "foo")!.null).toBe(
+          false,
+        );
+        await notnullMigration.migrate("down");
+        expect((await connection.columns("testings")).find((c) => c.name === "foo")!.null).toBe(
+          true,
+        );
+      });
+    });
+  });
+});

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -46,8 +46,6 @@ describe("Migration", () => {
 
       await connection.renameColumn("test_models", "first_name", "nick_name");
       TestModel.resetColumnInformation();
-      // `reset_column_information` is lazy in Rails; trails' schema load is
-      // async, so the reflection is pulled explicitly before reading it.
       await TestModel.loadSchema();
       expect(TestModel.columnNames()).toContain("nick_name");
       expect((await TestModel.all()).map((m) => m.nick_name)).toEqual(["foo"]);
@@ -69,8 +67,6 @@ describe("Migration", () => {
       expect(newColumns.find((c) => c.name === "age" && c.type === "integer")).toBeFalsy();
       expect(newColumns.find((c) => c.name === "age" && c.type === "string")).toBeTruthy();
 
-      // Rails deserializes `c.default` inline in each block; `lookupCastTypeFromColumn`
-      // is async here, so the boolean `approved` default is resolved up front.
       const approvedDefault = async (columns: readonly Column[]): Promise<unknown> => {
         const column = columns.find((c) => c.name === "approved" && c.type === "boolean");
         if (!column) return undefined;

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Port of `test_rename_column` and `test_change_column` from
+ * `ActiveRecord::Migration::ColumnsTest`
+ * (vendor/rails/activerecord/test/cases/migration/columns_test.rb:43-51,
+ * :181-204). The rest of columns_test.rb is unported.
+ *
+ * Driven by the ambient connection, mirroring Rails'
+ * `@connection = ActiveRecord::Base.lease_connection`. `test_models` is not a
+ * canonical-schema table in Rails either — `Migration::TestHelper`'s setup
+ * creates and drops it (migration/helper.rb:20-34) — so this mirrors that
+ * rather than reaching for the canonical schema.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Base } from "../base.js";
+import type { Column } from "../connection-adapters/column.js";
+import { ambientConnection } from "../support/rocket-tables.js";
+
+/** `ActiveRecord::Migration::TestHelper::TestModel`, migration/helper.rb:16-18. */
+class TestModel extends Base {
+  static {
+    this._tableName = "test_models";
+  }
+}
+
+describe("Migration", () => {
+  beforeEach(async () => {
+    const connection = await ambientConnection();
+    await connection.createTable("test_models", { force: true }, (t) => {
+      t.timestamps({ null: true });
+    });
+    TestModel.resetColumnInformation();
+  });
+
+  afterEach(async () => {
+    const connection = await ambientConnection();
+    await connection.dropTable("test_models", { ifExists: true });
+    TestModel.resetColumnInformation();
+  });
+
+  describe("ColumnsTest", () => {
+    it("rename column", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+
+      await TestModel.create({ first_name: "foo" });
+
+      await connection.renameColumn("test_models", "first_name", "nick_name");
+      TestModel.resetColumnInformation();
+      // `reset_column_information` is lazy in Rails; trails' schema load is
+      // async, so the reflection is pulled explicitly before reading it.
+      await TestModel.loadSchema();
+      expect(TestModel.columnNames()).toContain("nick_name");
+      expect((await TestModel.all()).map((m) => m.nick_name)).toEqual(["foo"]);
+    });
+
+    it("change column", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "age", "integer");
+      await connection.addColumn("test_models", "approved", "boolean", { default: true });
+
+      let oldColumns = await connection.columns(TestModel.tableName);
+
+      expect(oldColumns.find((c) => c.name === "age" && c.type === "integer")).toBeTruthy();
+
+      await connection.changeColumn("test_models", "age", "string");
+
+      let newColumns = await connection.columns(TestModel.tableName);
+
+      expect(newColumns.find((c) => c.name === "age" && c.type === "integer")).toBeFalsy();
+      expect(newColumns.find((c) => c.name === "age" && c.type === "string")).toBeTruthy();
+
+      // Rails deserializes `c.default` inline in each block; `lookupCastTypeFromColumn`
+      // is async here, so the boolean `approved` default is resolved up front.
+      const approvedDefault = async (columns: readonly Column[]): Promise<unknown> => {
+        const column = columns.find((c) => c.name === "approved" && c.type === "boolean");
+        if (!column) return undefined;
+        const castType = await connection.lookupCastTypeFromColumn(column);
+        return castType?.deserialize(column.default);
+      };
+
+      oldColumns = await connection.columns(TestModel.tableName);
+      expect(await approvedDefault(oldColumns)).toBe(true);
+
+      await connection.changeColumn("test_models", "approved", "boolean", { default: false });
+      newColumns = await connection.columns(TestModel.tableName);
+
+      expect(await approvedDefault(newColumns)).not.toBe(true);
+      expect(await approvedDefault(newColumns)).toBe(false);
+    });
+  });
+});

--- a/packages/activerecord/src/migration/exclusion-constraint.test.ts
+++ b/packages/activerecord/src/migration/exclusion-constraint.test.ts
@@ -3,9 +3,8 @@
  * (PostgreSQL-only — `supports_exclusion_constraints?`).
  *
  * The model-backed arms (test_added_exclusion_constraint_ensures_valid_values,
- * test_added_deferrable_initially_immediate_exclusion_constraint) and the
- * introspection arms that need Rails' `test_exclusion_constraints` fixture
- * table are not ported here; this file covers the add/remove paths that
+ * test_added_deferrable_initially_immediate_exclusion_constraint) are not
+ * ported here; this file covers the add/remove paths that
  * PostgreSQL::SchemaStatements#add_exclusion_constraint and
  * #remove_exclusion_constraint route through create_alter_table +
  * schema_creation.accept.
@@ -39,6 +38,50 @@ describeIfSupports("exclusion_constraints", "Migration", () => {
   });
 
   describe("ExclusionConstraintTest", () => {
+    it("exclusion constraints", async () => {
+      const expectedExclusionConstraints = [
+        {
+          tableName: "test_exclusion_constraints",
+          name: "test_exclusion_constraints_date_overlap",
+          expression: "daterange(start_date, end_date) WITH &&",
+          where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)",
+          using: "gist",
+          deferrable: false,
+        },
+        {
+          tableName: "test_exclusion_constraints",
+          name: "test_exclusion_constraints_valid_overlap",
+          expression: "daterange(valid_from, valid_to) WITH &&",
+          where: "(valid_from IS NOT NULL) AND (valid_to IS NOT NULL)",
+          using: "gist",
+          deferrable: "immediate",
+        },
+        {
+          tableName: "test_exclusion_constraints",
+          name: "test_exclusion_constraints_transaction_overlap",
+          expression: "daterange(transaction_from, transaction_to) WITH &&",
+          where: "(transaction_from IS NOT NULL) AND (transaction_to IS NOT NULL)",
+          using: "gist",
+          deferrable: "deferred",
+        },
+      ];
+
+      const exclusionConstraints = await connection.exclusionConstraints(
+        "test_exclusion_constraints",
+      );
+      expect(exclusionConstraints.length).toBe(expectedExclusionConstraints.length);
+
+      for (const expected of expectedExclusionConstraints) {
+        const constraint = exclusionConstraints.find((c) => c.name === expected.name)!;
+        expect(constraint.tableName).toBe(expected.tableName);
+        expect(constraint.name).toBe(expected.name);
+        expect(constraint.expression).toBe(expected.expression);
+        expect(constraint.using).toBe(expected.using);
+        expect(constraint.where).toBe(expected.where);
+        expect(constraint.deferrable).toBe(expected.deferrable);
+      }
+    });
+
     it("add exclusion constraint", async () => {
       await connection.addExclusionConstraint("invoices", EXPRESSION, { using: "gist" });
 

--- a/packages/activerecord/src/migration/exclusion-constraint.test.ts
+++ b/packages/activerecord/src/migration/exclusion-constraint.test.ts
@@ -30,9 +30,6 @@ describeIfSupports("exclusion_constraints", "Migration", () => {
 
   afterEach(async () => {
     await connection.dropTable("invoices", { ifExists: true });
-    // Rails' setup replaces `invoices` with a start_date/end_date table and its
-    // teardown drops it; restore the canonical shape so the shared per-worker
-    // database does not drift for the files that run next.
     await rebuildCanonicalTables(connection, ["invoices"]);
     await connection.close();
   });

--- a/packages/activerecord/src/migration/rename-table.test.ts
+++ b/packages/activerecord/src/migration/rename-table.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Port of `test_rename_table` from `ActiveRecord::Migration::RenameTableTest`
+ * (vendor/rails/activerecord/test/cases/migration/rename_table_test.rb:43-49).
+ * The rest of rename_table_test.rb is unported.
+ *
+ * Driven by the ambient connection, mirroring Rails'
+ * `@connection = ActiveRecord::Base.lease_connection`. `test_models` is not a
+ * canonical-schema table in Rails either — `Migration::TestHelper`'s setup
+ * creates and drops it (migration/helper.rb:20-34) — so this mirrors that
+ * rather than reaching for the canonical schema.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ambientConnection } from "../support/rocket-tables.js";
+
+describe("Migration", () => {
+  beforeEach(async () => {
+    const connection = await ambientConnection();
+    await connection.createTable("test_models", { force: true }, (t) => {
+      t.timestamps({ null: true });
+    });
+    await connection.addColumn("test_models", "url", "string");
+    await connection.removeColumn("test_models", "created_at");
+    await connection.removeColumn("test_models", "updated_at");
+  });
+
+  afterEach(async () => {
+    const connection = await ambientConnection();
+    if (await connection.tableExists("octopi")) {
+      await connection.renameTable("octopi", "test_models");
+    }
+    await connection.dropTable("test_models", { ifExists: true });
+  });
+
+  describe("RenameTableTest", () => {
+    it("rename table", async () => {
+      const connection = await ambientConnection();
+      await connection.renameTable("test_models", "octopi");
+
+      await connection.execute(
+        `INSERT INTO octopi (${connection.quoteColumnName("id")}, ${connection.quoteColumnName("url")}) VALUES (1, 'http://www.foreverflying.com/octopus-black7.jpg')`,
+      );
+
+      expect(await connection.selectValue("SELECT url FROM octopi WHERE id=1")).toBe(
+        "http://www.foreverflying.com/octopus-black7.jpg",
+      );
+    });
+  });
+});

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -65,13 +65,15 @@ describeIfSupports("unique_constraints", "Migration", () => {
         expect(constraint.deferrable).toBe(expected.deferrable);
       }
 
-      const nullsNotDistinct = uniqueConstraints.find(
-        (c) => c.name === expectedNullsNotDistinct.name,
-      )!;
-      expect(nullsNotDistinct.tableName).toBe("test_unique_constraints");
-      expect(nullsNotDistinct.name).toBe(expectedNullsNotDistinct.name);
-      expect(nullsNotDistinct.column).toEqual(expectedNullsNotDistinct.column);
-      expect(nullsNotDistinct.nullsNotDistinct).toBe(expectedNullsNotDistinct.nullsNotDistinct);
+      await connection.getDatabaseVersion();
+      // eslint-disable-next-line vitest/no-conditional-in-test -- mirrors Rails' inline `if supports_nulls_not_distinct?` guard (PG 15+)
+      if (connection.supportsNullsNotDistinct()) {
+        const constraint = uniqueConstraints.find((c) => c.name === expectedNullsNotDistinct.name)!;
+        expect(constraint.tableName).toBe("test_unique_constraints");
+        expect(constraint.name).toBe(expectedNullsNotDistinct.name);
+        expect(constraint.column).toEqual(expectedNullsNotDistinct.column);
+        expect(constraint.nullsNotDistinct).toBe(expectedNullsNotDistinct.nullsNotDistinct);
+      }
     });
 
     it("add unique constraint without deferrable", async () => {

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -2,8 +2,7 @@
  * Mirrors Rails activerecord/test/cases/migration/unique_constraint_test.rb
  * (PostgreSQL-only — `supports_unique_constraints?`).
  *
- * The model-backed and schema-scoped arms, and the arms that need Rails'
- * `test_unique_constraints` fixture table, are not ported here.
+ * The model-backed and schema-scoped arms are not ported here.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -31,6 +30,53 @@ describeIfSupports("unique_constraints", "Migration", () => {
   });
 
   describe("UniqueConstraintTest", () => {
+    it("unique constraints", async () => {
+      const uniqueConstraints = await connection.uniqueConstraints("test_unique_constraints");
+
+      const expectedConstraints = [
+        {
+          name: "test_unique_constraints_position_deferrable_false",
+          deferrable: false,
+          column: ["position_1"],
+        },
+        {
+          name: "test_unique_constraints_position_deferrable_immediate",
+          deferrable: "immediate",
+          column: ["position_2"],
+        },
+        {
+          name: "test_unique_constraints_position_deferrable_deferred",
+          deferrable: "deferred",
+          column: ["position_3"],
+        },
+        {
+          name: "test_unique_constraints_position_nulls_not_distinct",
+          nullsNotDistinct: true,
+          column: ["position_4"],
+        },
+      ];
+
+      expect(uniqueConstraints.length).toBe(expectedConstraints.length);
+
+      const expectedNullsNotDistinct = expectedConstraints.pop()!;
+
+      for (const expected of expectedConstraints) {
+        const constraint = uniqueConstraints.find((c) => c.name === expected.name)!;
+        expect(constraint.tableName).toBe("test_unique_constraints");
+        expect(constraint.name).toBe(expected.name);
+        expect(constraint.column).toEqual(expected.column);
+        expect(constraint.deferrable).toBe(expected.deferrable);
+      }
+
+      const nullsNotDistinct = uniqueConstraints.find(
+        (c) => c.name === expectedNullsNotDistinct.name,
+      )!;
+      expect(nullsNotDistinct.tableName).toBe("test_unique_constraints");
+      expect(nullsNotDistinct.name).toBe(expectedNullsNotDistinct.name);
+      expect(nullsNotDistinct.column).toEqual(expectedNullsNotDistinct.column);
+      expect(nullsNotDistinct.nullsNotDistinct).toBe(expectedNullsNotDistinct.nullsNotDistinct);
+    });
+
     it("add unique constraint without deferrable", async () => {
       await connection.addUniqueConstraint("sections", ["position"]);
 

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -22,9 +22,6 @@ describeIfSupports("unique_constraints", "Migration", () => {
 
   afterEach(async () => {
     await connection.dropTable("sections", { ifExists: true });
-    // Rails' setup replaces `sections` with a single-column table and its
-    // teardown drops it; restore the canonical shape so the shared per-worker
-    // database does not drift for the files that run next.
     await rebuildCanonicalTables(connection, ["sections"]);
     await connection.close();
   });


### PR DESCRIPTION
Unskipping `vendor/rails/activerecord/test/cases/migration/` in `test:compare`
(#5451) exposed six ported cases living in a TS file whose Rails counterpart is
a different file. Each now sits under `Migration > <ClassName>` in the file
mirroring its Rails home, with the test name unchanged:

| test | new home |
| --- | --- |
| `rename column`, `change column` | `migration/columns.test.ts` |
| `change column null` | `migration/change-schema.test.ts` |
| `rename table` | `migration/rename-table.test.ts` |
| `unique constraints` | `migration/unique-constraint.test.ts` |
| `exclusion constraints` | `migration/exclusion-constraint.test.ts` |

`pnpm test:compare --package activerecord`: **6 misplaced → 0**, gate-mismatch
stays 0.

### Why the three new files are ports, not verbatim moves

The old bodies were PostgreSQL-adapter-specific (`describeIfPg`, hand-rolled
`strings` / schema-scoped tables), but their Rails cases are unconditional, so
a straight move traded 6 misplaced for **4 gate-mismatch** — a hard zero in
`--gates --check`. The four now ride the ambient connection and Rails' own
`test_models` / `testings` scaffolding, which `Migration::TestHelper` creates
and drops itself (`migration/helper.rb:20-34`), so they are not bespoke
canonical-schema tables.

The two constraint cases converge onto the canonical `test_unique_constraints`
/ `test_exclusion_constraints` tables that 7d18e9ab5 laid at boot, replacing the
schema-scoped tables their old home built inline — that also picks up the
`nulls_not_distinct` and `transaction_overlap` arms Rails asserts.

### One production change

`Migration#changeColumnNull` now forwards to the connection, as Rails'
`method_missing` does. Routing through `this.schema` reached the abstract
`ALTER COLUMN ... SET NOT NULL`, which SQLite has no syntax for — its
table-rebuild override on the adapter was unreachable from a migration, so
`change column null` failed on the sqlite lane.

### Verification

`packages/activerecord/src/migration/` green on all three lanes (sqlite
149 passed, postgres 388 passed across the migration + migrator + pg
schema-statements files, mysql 136 passed). Lint and typecheck clean.

Closes-story: relocate-misplaced-migration-cases
