### PR TITLE
test(activerecord): port columns_test.rb rename/remove-column index cases

### DIFF
--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -1,8 +1,8 @@
 /**
- * Port of `test_rename_column` and `test_change_column` from
- * `ActiveRecord::Migration::ColumnsTest`
+ * Port of `test_rename_column`, the rename/remove-column index cluster and
+ * `test_change_column` from `ActiveRecord::Migration::ColumnsTest`
  * (vendor/rails/activerecord/test/cases/migration/columns_test.rb:43-51,
- * :181-204). The rest of columns_test.rb is unported.
+ * :96-155, :181-204). The rest of columns_test.rb is unported.
  *
  * Driven by the ambient connection, mirroring Rails'
  * `@connection = ActiveRecord::Base.lease_connection`. `test_models` is not a
@@ -13,7 +13,21 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
 import type { Column } from "../connection-adapters/column.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { ambientConnection } from "../support/rocket-tables.js";
+import { adapterType } from "../test-adapter.js";
+import { isMariaDb, serverVersion } from "../support/mysql-server-version.js";
+
+const mariaDbRejectsUniqueColumnDrop =
+  adapterType === "mysql" && isMariaDb && serverVersion?.gte("10.2.8") === true;
+
+const indexesSurvivingColumnDrop =
+  adapterType === "postgres" ? [] : ["index_test_models_on_hat_style_and_hat_size"];
+
+async function indexNames(conn: AbstractAdapter, table: string): Promise<string[]> {
+  const indexes = (await conn.indexes(table)) as Array<{ name: string }>;
+  return indexes.map((i) => i.name);
+}
 
 /** `ActiveRecord::Migration::TestHelper::TestModel`, migration/helper.rb:16-18. */
 class TestModel extends Base {
@@ -49,6 +63,66 @@ describe("Migration", () => {
       await TestModel.loadSchema();
       expect(TestModel.columnNames()).toContain("nick_name");
       expect((await TestModel.all()).map((m) => m.nick_name)).toEqual(["foo"]);
+    });
+
+    it("rename column with an index", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "hat_name", "string");
+      await connection.addIndex("test_models", "hat_name");
+
+      expect((await connection.indexes("test_models")).length).toBe(1);
+      await connection.renameColumn("test_models", "hat_name", "name");
+
+      expect(await indexNames(connection, "test_models")).toEqual(["index_test_models_on_name"]);
+    });
+
+    it("rename column with multi column index", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "hat_size", "integer");
+      await connection.addColumn("test_models", "hat_style", "string", { limit: 100 });
+      await connection.addIndex("test_models", ["hat_style", "hat_size"], { unique: true });
+
+      await connection.renameColumn("test_models", "hat_size", "size");
+      expect(await indexNames(connection, "test_models")).toEqual([
+        "index_test_models_on_hat_style_and_size",
+      ]);
+
+      await connection.renameColumn("test_models", "hat_style", "style");
+      expect(await indexNames(connection, "test_models")).toEqual([
+        "index_test_models_on_style_and_size",
+      ]);
+    });
+
+    it("rename column does not rename custom named index", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "hat_name", "string");
+      await connection.addIndex("test_models", "hat_name", { name: "idx_hat_name" });
+
+      expect((await connection.indexes("test_models")).length).toBe(1);
+      await connection.renameColumn("test_models", "hat_name", "name");
+      expect(await indexNames(connection, "test_models")).toEqual(["idx_hat_name"]);
+    });
+
+    it("remove column with index", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "hat_name", "string");
+      await connection.addIndex("test_models", "hat_name");
+
+      expect((await connection.indexes("test_models")).length).toBe(1);
+      await connection.removeColumn("test_models", "hat_name");
+      expect((await connection.indexes("test_models")).length).toBe(0);
+    });
+
+    it.skipIf(mariaDbRejectsUniqueColumnDrop)("remove column with multi column index", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "hat_size", "integer");
+      await connection.addColumn("test_models", "hat_style", "string", { limit: 100 });
+      await connection.addIndex("test_models", ["hat_style", "hat_size"], { unique: true });
+
+      expect((await connection.indexes("test_models")).length).toBe(1);
+      await connection.removeColumn("test_models", "hat_size");
+
+      expect(await indexNames(connection, "test_models")).toEqual(indexesSurvivingColumnDrop);
     });
 
     it("change column", async () => {

--- a/packages/activerecord/src/support/mysql-server-version.ts
+++ b/packages/activerecord/src/support/mysql-server-version.ts
@@ -45,6 +45,9 @@ function parseMysqlVersion(full: string): Version | null {
 }
 const _serverVersion = parseMysqlVersion(mysqlVersionStr);
 
+/** The port of `connection.database_version`; null when MySQL is unavailable. */
+export const serverVersion = _serverVersion;
+
 /**
  * Mirrors AbstractMysqlAdapter#supports_optimizer_hints?: MySQL ≥ 5.7.7 only;
  * never MariaDB. Lets adapter tests gate on hint support the way the Rails


### PR DESCRIPTION
Ports the rename/remove-column index cluster of
`ActiveRecord::Migration::ColumnsTest`
(`vendor/rails/activerecord/test/cases/migration/columns_test.rb:96-155`) into a
new `packages/activerecord/src/migration/columns.test.ts`:

- `test_rename_column_with_an_index`
- `test_rename_column_with_multi_column_index`
- `test_rename_column_does_not_rename_custom_named_index`
- `test_remove_column_with_index`
- `test_remove_column_with_multi_column_index` (MariaDB ≥ 10.2.8 skip, and the
  PostgreSQL-vs-others branch on the surviving-index assertion, hoisted to a
  module const so `vitest/no-conditional-in-test` stays happy)

Setup/teardown mirror `ActiveRecord::Migration::TestHelper`
(`test/cases/migration/helper.rb:22-33`) — `test_models` is created and dropped
by the test in Rails too, so it is built inline rather than taken from the
canonical schema (same rule as `withRocketTables`).

The overlapping trails-only regressions this was meant to replace already went
away: `connection-adapters/sqlite3-copy-table.test.ts` was retired in #5538, so
nothing is left to delete.

`test:compare` now matches all five cases; the file's missing count drops from
33 to 28.

Verified green on sqlite, postgres and mysql locally.

Closes-story: port-columns-test-rename-and-remove-column-index-cases
