### PR TITLE
test(activerecord): lay measurements partitions and company_include_index at boot

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -991,36 +991,18 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("SchemaIndexIncludeColumnsTest", () => {
     it("schema dumps index included columns", async () => {
-      try {
-        await adapter.exec(
-          `CREATE TABLE trains (id serial primary key, firm_id integer, type varchar(50), name varchar(50), account_id integer)`,
-        );
-        await adapter.getDatabaseVersion();
-        if (adapter.supportsIndexInclude()) {
-          await adapter.exec(
-            `CREATE INDEX company_include_index ON trains USING btree(firm_id, type) INCLUDE (name, account_id)`,
-          );
-        } else {
-          await adapter.exec(
-            `CREATE INDEX company_include_index ON trains USING btree(firm_id, type)`,
-          );
-        }
-        const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
-        const indexLine = lines.find((l) => l.includes("company_include_index"))?.trim();
-        expect(indexLine).toBeDefined();
-        if (adapter.supportsIndexInclude()) {
-          expect(indexLine).toContain(`include: ["name","account_id"]`);
-          // INCLUDE columns must not appear in the key columns list (PG11+ stores them in indkey).
-          // Assert the exact key columns argument follows the table name.
-          expect(indexLine).toContain(`"trains", ["firm_id", "type"]`);
-          expect(indexLine).not.toContain(`["firm_id", "type", "name"`);
-        } else {
-          expect(indexLine).not.toContain("include:");
-        }
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS trains`);
-      }
+      await adapter.getDatabaseVersion();
+      const lines: string[] = [];
+      await adapter.createSchemaDumper(adapter).dumpTable(lines, "companies");
+      const indexLine = lines.find((l) => l.includes("company_include_index"))?.trim();
+      expect(indexLine).toBeDefined();
+      // INCLUDE columns must not appear in the key columns list (PG11+ stores
+      // them in indkey), so the key columns argument is the same either way.
+      expect(indexLine).toContain(`"companies", ["firm_id", "type"]`);
+      expect(indexLine).not.toContain(`["firm_id", "type", "name"`);
+      expect(indexLine?.includes(`include: ["name","account_id"]`)).toBe(
+        adapter.supportsIndexInclude(),
+      );
     });
   });
 

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -996,8 +996,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.createSchemaDumper(adapter).dumpTable(lines, "companies");
       const indexLine = lines.find((l) => l.includes("company_include_index"))?.trim();
       expect(indexLine).toBeDefined();
-      // INCLUDE columns must not appear in the key columns list (PG11+ stores
-      // them in indkey), so the key columns argument is the same either way.
       expect(indexLine).toContain(`"companies", ["firm_id", "type"]`);
       expect(indexLine).not.toContain(`["firm_id", "type", "name"`);
       expect(indexLine?.includes(`include: ["name","account_id"]`)).toBe(

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -35,6 +35,7 @@ import { Book } from "./test-helpers/models/book.js";
 import { Cart } from "./test-helpers/models/cart.js";
 import { Category, SpecialCategory } from "./test-helpers/models/category.js";
 import { Developer } from "./test-helpers/models/developer.js";
+import { Measurement } from "./test-helpers/models/measurement.js";
 import { Ship } from "./test-helpers/models/ship.js";
 import { Speedometer } from "./test-helpers/models/speedometer.js";
 
@@ -1003,54 +1004,13 @@ describe("InsertAllTest", () => {
 
   // Rails gates test_upsert_all_works_with_partitioned_indexes on
   // supports_insert_on_duplicate_update? && supports_insert_conflict_target? &&
-  // supports_partitioned_indexes? → PostgreSQL >= 11 only. The canonical
-  // `measurements` partitioned table (postgresql_specific_schema.rb:186-198) has
-  // no partition DSL in our defineSchema, so it is built via raw PG DDL below.
+  // supports_partitioned_indexes? → PostgreSQL >= 11 only. The `measurements`
+  // partitioned table (postgresql_specific_schema.rb:186-198) is laid at boot by
+  // loadPostgresqlSpecificSchema under the same supports_partitioned_indexes? gate.
   itIfSupports(
     "insert_conflict_target,insert_on_duplicate_update,partitioned_indexes",
     "upsert all works with partitioned indexes",
     async () => {
-      // supports_partitioned_indexes? is PostgreSQL >= 11; every PG lane we run
-      // (CI uses postgres:17) clears that, and the conjunction's other two features
-      // (insert_conflict_target, insert_on_duplicate_update) keep the runtime to PG.
-      const conn = Base.connection as any;
-
-      await conn.executeMutation('DROP TABLE IF EXISTS "measurements" CASCADE');
-      await conn.executeMutation(
-        'CREATE TABLE "measurements" (' +
-          '"city_id" character varying NOT NULL, ' +
-          '"logdate" date NOT NULL, ' +
-          '"peaktemp" integer, ' +
-          '"unitsales" integer' +
-          ") PARTITION BY LIST (city_id)",
-      );
-      await conn.executeMutation(
-        'CREATE UNIQUE INDEX "index_measurements_on_logdate_and_city_id" ' +
-          'ON "measurements" ("logdate", "city_id")',
-      );
-      await conn.executeMutation(
-        'CREATE TABLE "measurements_toronto" PARTITION OF "measurements" FOR VALUES IN (1)',
-      );
-      await conn.executeMutation(
-        'CREATE TABLE "measurements_concepcion" PARTITION OF "measurements" FOR VALUES IN (2)',
-      );
-      conn.schemaCache?.clear();
-
-      // Rails uses the empty `models/measurement.rb` and introspects the
-      // partitioned table's columns + (absent) primary key. Our PK introspection
-      // still defaults a no-PK table to "id", so the columns and `primaryKey = ""`
-      // (no PK, mirroring the partitioned table) are declared here instead — the
-      // alternative the story sanctions over DB introspection.
-      class Measurement extends Base {
-        static {
-          this.primaryKey = "";
-          this.attribute("city_id", "string");
-          this.attribute("logdate", "date");
-          this.attribute("peaktemp", "integer");
-          this.attribute("unitsales", "integer");
-        }
-      }
-
       const today = Temporal.Now.plainDateISO();
       const oneDayAgo = today.subtract({ days: 1 });
       const twoDaysAgo = today.subtract({ days: 2 });
@@ -1077,13 +1037,6 @@ describe("InsertAllTest", () => {
         [twoDaysAgo.toString(), 2, 2],
         [threeDaysAgo.toString(), 0, 0],
       ]);
-
-      // The partitions are dropped by the CASCADE below; name them explicitly so
-      // require-table-teardown balances the raw-created partition tables.
-      await conn.executeMutation(
-        'DROP TABLE IF EXISTS "measurements_toronto", "measurements_concepcion" CASCADE',
-      );
-      await conn.executeMutation('DROP TABLE IF EXISTS "measurements" CASCADE');
     },
   );
 

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -1002,11 +1002,6 @@ describe("InsertAllTest", () => {
     );
   });
 
-  // Rails gates test_upsert_all_works_with_partitioned_indexes on
-  // supports_insert_on_duplicate_update? && supports_insert_conflict_target? &&
-  // supports_partitioned_indexes? → PostgreSQL >= 11 only. The `measurements`
-  // partitioned table (postgresql_specific_schema.rb:186-198) is laid at boot by
-  // loadPostgresqlSpecificSchema under the same supports_partitioned_indexes? gate.
   itIfSupports(
     "insert_conflict_target,insert_on_duplicate_update,partitioned_indexes",
     "upsert all works with partitioned indexes",

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -40,6 +40,15 @@ beforeAll(() => {
   adapter = Base.adapter;
 });
 
+// `adapterSpecificTableNames`'s postgres arm resolves its boot list against the
+// live adapter's support gates, so a fake standing in for a PG adapter has to
+// answer them. PG >= 11 is what every lane we run reports.
+const pgBootListStubs = {
+  getDatabaseVersion: async () => "17.0",
+  supportsIdentityColumns: () => true,
+  supportsPartitionedIndexes: () => true,
+};
+
 describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
   afterEach(() => vi.restoreAllMocks());
 
@@ -51,6 +60,7 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
     let executeCallCount = 0;
     const fakeAdapter = {
       adapterName: "postgres" as const,
+      ...pgBootListStubs,
       execute: vi.fn(async () => {
         executeCallCount++;
         if (executeCallCount === 1) throw connErr;
@@ -70,6 +80,7 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
     const appErr = new Error("syntax error");
     const fakeAdapter = {
       adapterName: "postgres" as const,
+      ...pgBootListStubs,
       execute: vi.fn(async () => {
         throw appErr;
       }),
@@ -88,6 +99,7 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
     let mutationCallCount = 0;
     const fakeAdapter = {
       adapterName: "postgres" as const,
+      ...pgBootListStubs,
       execute: vi.fn(async (sql: string) => {
         // Return one matview on first pass; empty on retry.
         if (sql.includes("matviewname")) {

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -14,10 +14,8 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
  * the four `uuid_*` tables and the exclusion/unique constraint tables, the
  * `supports_identity_columns?` tables (50-66), the `companies_nonstd_seq`/`setval`
  * sequence pass and the partition + `timestamp_with_zones` raw-DDL block (77-128),
- * and the `supports_insert_returning?` trigger table (203-225).
- *
- * Still unported: the `measurements*` partitioned tables and
- * `company_include_index` (187-201).
+ * the `measurements*` partitioned tables and `company_include_index` (187-201),
+ * and the `supports_insert_returning?` trigger table (203-225) — the file whole.
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
   // `supportsPgcryptoUuid()` / `supportsVirtualColumns()` read the cached
@@ -270,6 +268,39 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     });
   });
 
+  if (adapter.supportsPartitionedIndexes()) {
+    await adapter.createTable(
+      "measurements",
+      { id: false, force: true, options: "PARTITION BY LIST (city_id)" },
+      (t) => {
+        const pg = t as PgTableDefinition;
+        pg.string("city_id", { null: false });
+        pg.date("logdate", { null: false });
+        pg.integer("peaktemp");
+        pg.integer("unitsales");
+        pg.index(["logdate", "city_id"], { unique: true });
+      },
+    );
+    await adapter.createTable("measurements_toronto", {
+      id: false,
+      force: true,
+      options: "PARTITION OF measurements FOR VALUES IN (1)",
+    });
+    await adapter.createTable("measurements_concepcion", {
+      id: false,
+      force: true,
+      options: "PARTITION OF measurements FOR VALUES IN (2)",
+    });
+  }
+
+  // Deviation from Rails' bare `add_index` (line 201): trails re-runs this loader
+  // on every worker boot against a database that may already carry the index.
+  await adapter.addIndex("companies", ["firm_id", "type"], {
+    name: "company_include_index",
+    include: ["name", "account_id"],
+    ifNotExists: true,
+  });
+
   if (adapter.supportsInsertReturning()) {
     await adapter.createTable(
       "pk_autopopulated_by_a_trigger_records",
@@ -452,11 +483,9 @@ async function loadSqliteSpecificSchema(adapter: DatabaseAdapter): Promise<void>
  * `<adapter>_specific_schema` loader when trails has one, and to nothing when it
  * does not.
  *
- * `sqlite_specific_schema.rb` and `mysql2_specific_schema.rb` are ported whole.
- * The postgres arm is still partial — the remaining tables of
- * `postgresql_specific_schema.rb:50-225` are owned by story
- * `port-postgresql-specific-schema-remainder`, not a claim that the gap does not
- * exist. `trilogy_specific_schema.rb` is the one genuine no-op: trails has no
+ * `sqlite_specific_schema.rb`, `mysql2_specific_schema.rb` and
+ * `postgresql_specific_schema.rb` are ported whole.
+ * `trilogy_specific_schema.rb` is the one genuine no-op: trails has no
  * Trilogy adapter, so no adapter name ever selects it.
  */
 const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Promise<void>> = {
@@ -480,29 +509,35 @@ const ADAPTER_SPECIFIC_TABLES: Record<
   string,
   (adapter: DatabaseAdapter) => Promise<readonly string[]>
 > = {
-  postgres: async () => [
-    "chat_messages",
-    "chat_messages_custom_pk",
-    "uuid_parents",
-    "uuid_children",
-    "defaults",
-    "postgresql_times",
-    "postgresql_oids",
-    "postgresql_timestamp_with_zones",
-    "postgresql_partitioned_table_parent",
-    "postgresql_partitioned_table",
-    "limitless_fields",
-    "bigint_array",
-    "uuid_comments",
-    "uuid_entries",
-    "uuid_items",
-    "uuid_messages",
-    "test_exclusion_constraints",
-    "test_unique_constraints",
-    "postgresql_identity_table",
-    "cpk_postgresql_identity_table",
-    "pk_autopopulated_by_a_trigger_records",
-  ],
+  postgres: async (adapter) => {
+    await adapter.getDatabaseVersion();
+    return [
+      "chat_messages",
+      "chat_messages_custom_pk",
+      "uuid_parents",
+      "uuid_children",
+      "defaults",
+      "postgresql_times",
+      "postgresql_oids",
+      "postgresql_timestamp_with_zones",
+      "postgresql_partitioned_table_parent",
+      "postgresql_partitioned_table",
+      "limitless_fields",
+      "bigint_array",
+      "uuid_comments",
+      "uuid_entries",
+      "uuid_items",
+      "uuid_messages",
+      "test_exclusion_constraints",
+      "test_unique_constraints",
+      "postgresql_identity_table",
+      "cpk_postgresql_identity_table",
+      ...(adapter.supportsPartitionedIndexes()
+        ? ["measurements", "measurements_toronto", "measurements_concepcion"]
+        : []),
+      "pk_autopopulated_by_a_trigger_records",
+    ];
+  },
   mysql: async (adapter) => {
     await adapter.getDatabaseVersion();
     return [

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -510,7 +510,8 @@ const ADAPTER_SPECIFIC_TABLES: Record<
   (adapter: DatabaseAdapter) => Promise<readonly string[]>
 > = {
   postgres: async (adapter) => {
-    await adapter.getDatabaseVersion();
+    const pg = adapter as unknown as PostgreSQLAdapter;
+    await pg.getDatabaseVersion();
     return [
       "chat_messages",
       "chat_messages_custom_pk",
@@ -530,9 +531,10 @@ const ADAPTER_SPECIFIC_TABLES: Record<
       "uuid_messages",
       "test_exclusion_constraints",
       "test_unique_constraints",
-      "postgresql_identity_table",
-      "cpk_postgresql_identity_table",
-      ...(adapter.supportsPartitionedIndexes()
+      ...(pg.supportsIdentityColumns()
+        ? ["postgresql_identity_table", "cpk_postgresql_identity_table"]
+        : []),
+      ...(pg.supportsPartitionedIndexes()
         ? ["measurements", "measurements_toronto", "measurements_concepcion"]
         : []),
       "pk_autopopulated_by_a_trigger_records",


### PR DESCRIPTION
Ports `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:187-201`
into `loadPostgresqlSpecificSchema`:

- the `measurements` / `measurements_toronto` / `measurements_concepcion`
  partitioned tables under a `supportsPartitionedIndexes()` gate, verbatim
  (`PARTITION BY LIST (city_id)`, `PARTITION OF … FOR VALUES IN (n)`, the
  unique `[logdate, city_id]` index), listed in `ADAPTER_SPECIFIC_TABLES`;
- `company_include_index` on `companies` with `include: [name, account_id]`.

`insert-all.test.ts`'s `upsert all works with partitioned indexes` is repointed
at the boot-laid tables and the canonical `Measurement` model — its raw
`executeMutation` DDL, the inline model with declared attributes, and its
teardown drops are gone.

The one deviation from Rails is `ifNotExists: true` on the `add_index` call,
justified at the call site: Rails loads the schema once per suite, trails re-runs
this loader on every worker boot and workers can share a database. `force: true`
covers the `create_table` calls; `add_index` has no such flag.

The boot-laid index also made `SchemaIndexIncludeColumnsTest` convergeable — it
was dumping a bespoke `trains` table, whose `company_include_index` now collides
schema-wide, so it dumps `companies` like Rails does.

Verified on PG 17 and SQLite: `insert-all.test.ts`,
`support/load-schema-helper.trails.test.ts`, `schema-dumper.test.ts`,
`schema-dumper.trails.test.ts`, `adapters/postgresql/schema.test.ts`.

Closes-story: port-postgresql-specific-schema-measurements-and-include-index
