### PR TITLE
test(activerecord): lay the sequence/partition half of postgresql_specific_schema.rb at boot

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -131,10 +131,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("timestamp with zone values with rails time zone support and no time zone set", async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
-      await adapter.exec(
-        `CREATE TABLE postgresql_timestamp_with_zones (id SERIAL PRIMARY KEY, "time" TIMESTAMP WITH TIME ZONE)`,
-      );
       await adapter.execute(
         `INSERT INTO postgresql_timestamp_with_zones (id, "time") VALUES (1, '2010-01-01 10:00:00-1')`,
       );
@@ -157,15 +153,11 @@ describeIfPg("PostgreSQLAdapter", () => {
         });
       } finally {
         await adapter.reconnect();
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
+        await adapter.execute(`DELETE FROM postgresql_timestamp_with_zones`);
       }
     });
 
     it("timestamp with zone values without rails time zone support", async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
-      await adapter.exec(
-        `CREATE TABLE postgresql_timestamp_with_zones (id SERIAL PRIMARY KEY, "time" TIMESTAMP WITH TIME ZONE)`,
-      );
       await adapter.execute(
         `INSERT INTO postgresql_timestamp_with_zones (id, "time") VALUES (1, '2010-01-01 10:00:00-1')`,
       );
@@ -188,17 +180,13 @@ describeIfPg("PostgreSQLAdapter", () => {
         });
       } finally {
         await adapter.reconnect();
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
+        await adapter.execute(`DELETE FROM postgresql_timestamp_with_zones`);
       }
     });
   });
 
   describe("PostgreSQLTimestampWithAwareTypesTest", () => {
     it("timestamp with zone values with rails time zone support and time zone set", async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
-      await adapter.exec(
-        `CREATE TABLE postgresql_timestamp_with_zones (id SERIAL PRIMARY KEY, "time" TIMESTAMP WITH TIME ZONE)`,
-      );
       await adapter.execute(
         `INSERT INTO postgresql_timestamp_with_zones (id, "time") VALUES (1, '2010-01-01 10:00:00-1')`,
       );
@@ -229,17 +217,13 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
       } finally {
         await adapter.reconnect();
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
+        await adapter.execute(`DELETE FROM postgresql_timestamp_with_zones`);
       }
     });
   });
 
   describe("PostgreSQLTimestampWithTimeZoneTest", () => {
     it("timestamp with zone values with rails time zone support and timestamptz and no time zone set", async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
-      await adapter.exec(
-        `CREATE TABLE postgresql_timestamp_with_zones (id SERIAL PRIMARY KEY, "time" TIMESTAMP WITH TIME ZONE)`,
-      );
       await adapter.execute(
         `INSERT INTO postgresql_timestamp_with_zones (id, "time") VALUES (1, '2010-01-01 10:00:00-1')`,
       );
@@ -271,14 +255,10 @@ describeIfPg("PostgreSQLAdapter", () => {
         });
       } finally {
         await adapter.reconnect();
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
+        await adapter.execute(`DELETE FROM postgresql_timestamp_with_zones`);
       }
     });
     it("timestamp with zone values with rails time zone support and timestamptz and time zone set", async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
-      await adapter.exec(
-        `CREATE TABLE postgresql_timestamp_with_zones (id SERIAL PRIMARY KEY, "time" TIMESTAMP WITH TIME ZONE)`,
-      );
       await adapter.execute(
         `INSERT INTO postgresql_timestamp_with_zones (id, "time") VALUES (1, '2010-01-01 10:00:00-1')`,
       );
@@ -309,7 +289,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         });
       } finally {
         await adapter.reconnect();
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
+        await adapter.execute(`DELETE FROM postgresql_timestamp_with_zones`);
       }
     });
   });
@@ -426,9 +406,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgreSQLTimestampMigrationTest", () => {
     it("adds column as timestamp", async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
       try {
-        await adapter.exec(`CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`);
         await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
         const rows = await adapter.execute(
           `SELECT data_type FROM information_schema.columns
@@ -436,17 +414,16 @@ describeIfPg("PostgreSQLAdapter", () => {
         );
         expect(rows[0]?.data_type).toBe("timestamp without time zone");
       } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        // Rails leans on transactional tests to roll the added column back;
+        // this file is non-transactional (the three classes above set
+        // use_transactional_tests = false), so it is removed by hand.
+        await adapter.removeColumn("postgresql_timestamp_with_zones", "times");
       }
     });
 
     it("adds column as timestamptz if datetime type changed", async () => {
       await withPostgresqlDatetimeType("timestamptz", async () => {
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
         try {
-          await adapter.exec(
-            `CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`,
-          );
           await adapter.addColumn("postgresql_timestamp_with_zones", "times", "datetime");
           const rows = await adapter.execute(
             `SELECT data_type FROM information_schema.columns
@@ -454,17 +431,15 @@ describeIfPg("PostgreSQLAdapter", () => {
           );
           expect(rows[0]?.data_type).toBe("timestamp with time zone");
         } finally {
-          await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+          await adapter.removeColumn("postgresql_timestamp_with_zones", "times");
         }
       });
     });
 
     it("adds column as custom type", async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
       await adapter.exec(`DROP TYPE IF EXISTS custom_time_format`);
       try {
         await adapter.exec(`CREATE TYPE custom_time_format AS ENUM ('past', 'present', 'future')`);
-        await adapter.exec(`CREATE TABLE postgresql_timestamp_with_zones (id serial primary key)`);
         await withNativeDatabaseTypeOverrides(
           { datetimes_as_enum: { name: "custom_time_format" } },
           () =>
@@ -481,7 +456,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect(rows[0]?.data_type).toBe("USER-DEFINED");
         expect(rows[0]?.udt_name).toBe("custom_time_format");
       } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones CASCADE`);
+        await adapter.removeColumn("postgresql_timestamp_with_zones", "times");
         await adapter.exec(`DROP TYPE IF EXISTS custom_time_format`);
       }
     });

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -12,12 +12,12 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
  * `defaults` (lines 4-48), and the plain `create_table` remainder:
  * `postgresql_times`, `postgresql_oids`, `limitless_fields`, `bigint_array`,
  * the four `uuid_*` tables and the exclusion/unique constraint tables, the
- * `supports_identity_columns?` tables (50-66) and the
- * `supports_insert_returning?` trigger table (203-225).
+ * `supports_identity_columns?` tables (50-66), the `companies_nonstd_seq`/`setval`
+ * sequence pass and the partition + `timestamp_with_zones` raw-DDL block (77-128),
+ * and the `supports_insert_returning?` trigger table (203-225).
  *
- * Still unported: the `companies_nonstd_seq`/`setval` sequence pass and the
- * partition + `timestamp_with_zones` raw-DDL block (77-128), and the
- * `measurements*` partitioned tables and `company_include_index` (187-201).
+ * Still unported: the `measurements*` partitioned tables and
+ * `company_include_index` (187-201).
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
   // `supportsPgcryptoUuid()` / `supportsVirtualColumns()` read the cached
@@ -119,6 +119,67 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
   await adapter.createTable("postgresql_oids", { force: true }, (t) => {
     (t as PgTableDefinition).oid("obj_id");
   });
+
+  await adapter.dropTable("postgresql_timestamp_with_zones", { ifExists: true });
+  await adapter.dropTable("postgresql_partitioned_table", { ifExists: true });
+  await adapter.dropTable("postgresql_partitioned_table_parent", { ifExists: true });
+
+  await adapter.execute("DROP SEQUENCE IF EXISTS companies_nonstd_seq CASCADE");
+  await adapter.execute("CREATE SEQUENCE companies_nonstd_seq START 101 OWNED BY companies.id");
+  await adapter.execute(
+    "ALTER TABLE companies ALTER COLUMN id SET DEFAULT nextval('companies_nonstd_seq')",
+  );
+  await adapter.execute("DROP SEQUENCE IF EXISTS companies_id_seq");
+
+  await adapter.execute("DROP FUNCTION IF EXISTS partitioned_insert_trigger()");
+
+  for (const seqName of [
+    "accounts_id_seq",
+    "developers_id_seq",
+    "projects_id_seq",
+    "topics_id_seq",
+    "customers_id_seq",
+    "orders_id_seq",
+  ]) {
+    await adapter.execute(`SELECT setval('${seqName}', 100)`);
+  }
+
+  await adapter.execute(
+    "CREATE TABLE postgresql_timestamp_with_zones (\n" +
+      "  id SERIAL PRIMARY KEY,\n" +
+      "  time TIMESTAMP WITH TIME ZONE\n" +
+      ")",
+  );
+
+  // Rails wraps the block below in a `rescue StatementInvalid` that runs
+  // `CREATE LANGUAGE 'plpgsql'` and retries (lines 122-128). plpgsql has been
+  // installed by default since PostgreSQL 9.0, below trails' supported floor,
+  // so the rescue arm has no reachable counterpart here.
+  await adapter.execute(
+    "CREATE TABLE postgresql_partitioned_table_parent (\n" +
+      "  id SERIAL PRIMARY KEY,\n" +
+      "  number integer\n" +
+      ")",
+  );
+  await adapter.execute(
+    "CREATE TABLE postgresql_partitioned_table ( )\n" +
+      "  INHERITS (postgresql_partitioned_table_parent)",
+  );
+  await adapter.execute(
+    "CREATE OR REPLACE FUNCTION partitioned_insert_trigger()\n" +
+      "RETURNS TRIGGER AS $$\n" +
+      "BEGIN\n" +
+      "  INSERT INTO postgresql_partitioned_table VALUES (NEW.*);\n" +
+      "  RETURN NULL;\n" +
+      "END;\n" +
+      "$$\n" +
+      "LANGUAGE plpgsql",
+  );
+  await adapter.execute(
+    "CREATE TRIGGER insert_partitioning_trigger\n" +
+      "  BEFORE INSERT ON postgresql_partitioned_table_parent\n" +
+      "  FOR EACH ROW EXECUTE PROCEDURE partitioned_insert_trigger()",
+  );
 
   await adapter.createTable("limitless_fields", { force: true }, (t) => {
     const pg = t as PgTableDefinition;
@@ -427,6 +488,9 @@ const ADAPTER_SPECIFIC_TABLES: Record<
     "defaults",
     "postgresql_times",
     "postgresql_oids",
+    "postgresql_timestamp_with_zones",
+    "postgresql_partitioned_table_parent",
+    "postgresql_partitioned_table",
     "limitless_fields",
     "bigint_array",
     "uuid_comments",


### PR DESCRIPTION
Ports the raw-DDL block of
`vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:77-128`
into `loadPostgresqlSpecificSchema`, statement by statement:

- the three `drop_table ... if_exists: true` calls,
- the `companies_nonstd_seq` swap (`CREATE SEQUENCE ... OWNED BY companies.id`,
  the `ALTER TABLE companies ALTER COLUMN id SET DEFAULT nextval(...)`, and the
  `DROP SEQUENCE companies_id_seq`) — `Company.sequenceName` already pointed at
  a sequence that did not exist,
- `DROP FUNCTION IF EXISTS partitioned_insert_trigger()` and the
  `setval('<table>_id_seq', 100)` pass,
- `postgresql_timestamp_with_zones`,
- `postgresql_partitioned_table_parent` / `postgresql_partitioned_table` plus
  the `partitioned_insert_trigger()` plpgsql function and
  `insert_partitioning_trigger`.

Rails' `rescue StatementInvalid` → `CREATE LANGUAGE 'plpgsql'` → `retry` arm
(lines 122-128) has no counterpart: plpgsql has shipped installed by default
since PostgreSQL 9.0, below trails' floor. Noted at the call site.

The three new tables join `ADAPTER_SPECIFIC_TABLES` so the between-test reset
truncates rather than drops them.

`adapters/postgresql/timestamp.test.ts` is repointed at the boot-laid
`postgresql_timestamp_with_zones`: the five inline `DROP TABLE` /
`CREATE TABLE` setups become the bare `INSERT` of Rails' `setup` block with a
`DELETE FROM` standing in for its `delete_all` teardown, and the three
`PostgreSQLTimestampMigrationTest` cases now `add_column` against the boot-laid
table. Rails leans on transactional tests to roll that column back; this file
is non-transactional, so it is removed by hand in `finally`.

Verified on the PG lane: `adapters/postgresql/` (942 passed),
`connection-adapters/postgresql/`, `base.test.ts`,
`support/load-schema-helper.trails.test.ts`.

Closes-story: port-postgresql-specific-schema-sequences-and-partitions
