### PR TITLE
test(activerecord): ride boot-laid stored procedures in sp.test.ts

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
  */
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import { describeIfMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { Topic } from "../../test-helpers/models/topic.js";
@@ -11,23 +11,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
   describe("StoredProcedureTest", () => {
     // Rails `fixtures :topics` — load canonical topics via the handler connection.
     const { topics } = fixtures(["topics"]);
-
-    beforeAll(async () => {
-      await Base.connection.executeMutation("DROP PROCEDURE IF EXISTS ten");
-      await Base.connection.executeMutation(
-        `CREATE PROCEDURE ten() SQL SECURITY INVOKER BEGIN SELECT 10; END`,
-      );
-      await Base.connection.executeMutation("DROP PROCEDURE IF EXISTS topics");
-      await Base.connection.executeMutation(
-        `CREATE PROCEDURE topics(IN num INT) SQL SECURITY INVOKER` +
-          ` BEGIN SELECT * FROM topics LIMIT num; END`,
-      );
-    });
-
-    afterAll(async () => {
-      await Base.connection.executeMutation("DROP PROCEDURE IF EXISTS ten");
-      await Base.connection.executeMutation("DROP PROCEDURE IF EXISTS topics");
-    });
 
     it("multi results", async () => {
       const rows = await Base.connection.selectRows("CALL ten();");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
@@ -9,7 +9,6 @@ import { fixtures } from "../../test-fixtures.js";
 
 describeIfMysqlAdapter("Mysql2Adapter", () => {
   describe("StoredProcedureTest", () => {
-    // Rails `fixtures :topics` — load canonical topics via the handler connection.
     const { topics } = fixtures(["topics"]);
 
     it("multi results", async () => {


### PR DESCRIPTION
`sp.test.ts` created `ten()` and `topics(IN num INT)` in `beforeAll` and dropped
them in `afterAll`. Since #5534 ported `mysql2_specific_schema.rb:66-82`, the
mysql lane lays both procedures at boot in `loadMysql2SpecificSchema`, so the
inline setup is redundant — and worse, the teardown drops boot schema that
nothing recreates for a later file in the same worker (`drop-all-tables.ts`
shields tables only, it has no notion of procedures).

Rails' `sp_test.rb` has no such setup: its `setup` only leases the connection
and version-skips; the procedures come from the schema file. This drops the
`beforeAll`/`afterAll` so the test rides the boot-laid pair.

Test names unchanged.

Verified on `ARCONN=mysql2`: `sp.test.ts` alone, and with
`--no-file-parallelism` after `active-schema.test.ts` + `schema.test.ts` in the
same worker (26 tests, all pass).

Closes-story: repoint-sp-test-at-boot-laid-procedures
