### PR TITLE
refactor(activerecord): relocate describeIfMysqlAdapter out of the adapters tree

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -35,9 +35,9 @@ import { Movie } from "./test-helpers/models/movie.js";
 import { Subscriber } from "./test-helpers/models/subscriber.js";
 import { Event } from "./test-helpers/models/event.js";
 import { QueryAttribute } from "./relation/query-attribute.js";
+import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import {
   leaseMysqlAdapter,
-  Mysql2Adapter,
   ARUNIT_DATABASE,
   ARUNIT2_DATABASE,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -1,10 +1,6 @@
-import { describe } from "vitest";
-import mysql from "mysql2/promise";
 import { Mysql2Adapter } from "../../connection-adapters/mysql2-adapter.js";
-import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { arunitDatabaseNames } from "../../support/arunit2-config.js";
-import { mysqlSettings, mysqlUrl } from "../../support/config.js";
-import { adapterType } from "../../test-adapter.js";
+import { mysqlSettings } from "../../support/config.js";
 import { Base } from "../../base.js";
 
 // `dbWarningsAction` is a single global setting on the base adapter, so the
@@ -12,11 +8,20 @@ import { Base } from "../../base.js";
 // here so MySQL adapter tests can keep importing it from this module.
 export { withDbWarningsAction } from "../../support/with-db-warnings-action.js";
 
-// A *serialization* of the MySQL sub-settings, not an env var of its own. Only
-// for tests that build a *second*, differently configured adapter, where the
-// config is itself under test and must not leak onto the shared leased
-// connection. Everything else rides leaseMysqlAdapter below.
-export const MYSQL_TEST_URL = mysqlUrl();
+// The adapter gate and the live-server version probe live under `support/`
+// alongside `describe-if-pg` / `describe-if-sqlite`, so suites outside this
+// tree never import gate glue from an adapter's test-helper. Re-exported for
+// the MySQL suites that already sit here.
+export { describeIfMysqlAdapter } from "../../support/describe-if-mysql-adapter.js";
+export {
+  MYSQL_TEST_URL,
+  isMariaDb,
+  mysqlVersion,
+  supportsDefaultExpression,
+  supportsExpressionIndex,
+  supportsOptimizerHints,
+  supportsRenameIndex,
+} from "../../support/mysql-server-version.js";
 
 /**
  * ARTest models the AR suite as two databases — `arunit` (primary) and
@@ -33,90 +38,7 @@ export const { arunit: ARUNIT_DATABASE, arunit2: ARUNIT2_DATABASE } = arunitData
   mysqlSettings().database,
 );
 
-let mariaDb = false;
-let mysqlVersionStr = "";
-
-// Reads VERSION() once at load: the supports* gates below mirror Rails'
-// version-keyed `supports_*?` predicates, which have no static answer (the
-// mysql lane may be MySQL 8 or the MariaDB CI stand-in). An unreachable server
-// yields an empty version, so every gate reads false — it never skips a suite,
-// which is describeIfMysqlAdapter's job alone.
-async function checkMysql(): Promise<{ isMariaDb: boolean; version: string }> {
-  let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
-  try {
-    conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
-    const [rows] = await conn.query("SELECT VERSION() AS v");
-    const ver = (rows as Array<{ v: string }>)[0]?.v ?? "";
-    return { isMariaDb: /mariadb/i.test(ver), version: ver };
-  } catch {
-    return { isMariaDb: false, version: "" };
-  } finally {
-    await conn?.end().catch(() => {});
-  }
-}
-
-({ isMariaDb: mariaDb, version: mysqlVersionStr } = await checkMysql());
-
-/** true when the connected server is MariaDB; false on MySQL or when MySQL is unavailable. */
-export const isMariaDb = mariaDb;
-/** Raw VERSION() string from the connected MySQL/MariaDB server (empty when unavailable). */
-export const mysqlVersion = mysqlVersionStr;
-
-// Parse the dotted version out of the raw VERSION() string the same way
-// AbstractMysqlAdapter#version_string does (strips the MariaDB 5.5.5- prefix).
-function parseMysqlVersion(full: string): Version | null {
-  const m = full.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/);
-  return m ? new Version(m[1]) : null;
-}
-const _serverVersion = parseMysqlVersion(mysqlVersionStr);
-
-/**
- * Mirrors AbstractMysqlAdapter#supports_optimizer_hints?: MySQL ≥ 5.7.7 only;
- * never MariaDB. Lets adapter tests gate on hint support the way the Rails
- * suite wraps `OptimizerHintsTest` in `if supports_optimizer_hints?`.
- */
-export const supportsOptimizerHints = !mariaDb && _serverVersion?.gte("5.7.7") === true;
-
-/**
- * Mirrors `supports_default_expression?` (adapter_helper.rb:23) for MySQL: an
- * expression/function column default needs MariaDB ≥ 10.2.1 or MySQL ≥ 8.0.13.
- * Gates the `defaults` table's `uuid` / `char2_concatenated` expression columns
- * exactly as Rails' mysql2_specific_schema.rb does.
- */
-export const supportsDefaultExpression = mariaDb
-  ? _serverVersion?.gte("10.2.1") === true
-  : _serverVersion?.gte("8.0.13") === true;
-
-/**
- * Mirrors AbstractMysqlAdapter#supports_expression_index?
- * (abstract_mysql_adapter.rb:104): MySQL ≥ 8.0.13 only; never MariaDB. Feeds
- * the `expression_index` entry in support/supports.ts, which cannot bake
- * the answer into a static adapterType table — the mysql lane may be MySQL 8
- * (true) or the MariaDB CI stand-in (false).
- */
-export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13") === true;
-
-/**
- * Mirrors AbstractMysqlAdapter#supports_rename_index?
- * (abstract_mysql_adapter.rb:896-901): MariaDB ≥ 10.5.2, MySQL ≥ 5.7.6. Lets a
- * test reproduce Rails' `skip "Cannot drop index, needed in a foreign key
- * constraint" if current_adapter?(:Mysql2Adapter) && !supports_rename_index?`
- * without hiding the supported MySQL path behind a blanket adapter skip.
- */
-export const supportsRenameIndex = mariaDb
-  ? _serverVersion?.gte("10.5.2") === true
-  : _serverVersion?.gte("5.7.6") === true;
-
 export { Mysql2Adapter };
-
-/**
- * The port of `current_adapter?(:Mysql2Adapter)` — the gate every
- * `ActiveRecord::AbstractMysqlTestCase` suite runs under. The suite rides the
- * ambient `Base.connection` on the mysql2 lane and skips everywhere else,
- * exactly as Rails does.
- */
-export const describeIfMysqlAdapter =
-  adapterType === "mysql" ? describe : (describe.skip as typeof describe);
 
 /**
  * Port of these suites' `setup` line

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -3,7 +3,7 @@
  */
 import { it, expect, beforeEach } from "vitest";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
-import { describeIfMysqlAdapter } from "../adapters/abstract-mysql-adapter/test-helper.js";
+import { describeIfMysqlAdapter } from "../support/describe-if-mysql-adapter.js";
 
 // Minimal subclass of the *concrete* Mysql2Adapter — char/varchar/enum/set
 // string registrations live on the concrete adapter (mysql2_adapter.rb:40-49),

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -12,12 +12,9 @@ import { NotNullViolation } from "./errors.js";
 import { adapterType } from "./test-adapter.js";
 import { MigrationContext } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import {
-  describeIfMysqlAdapter,
-  isMariaDb,
-  Mysql2Adapter,
-  MYSQL_TEST_URL,
-} from "./adapters/abstract-mysql-adapter/test-helper.js";
+import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
+import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
+import { isMariaDb, MYSQL_TEST_URL } from "./support/mysql-server-version.js";
 import { describeIfPg } from "./support/describe-if-pg.js";
 import { describeIfSqlite } from "./support/describe-if-sqlite.js";
 import { describeIfSupports, itIfSupports } from "./support/supports.js";

--- a/packages/activerecord/src/invalid-connection.test.ts
+++ b/packages/activerecord/src/invalid-connection.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, afterEach, it, expect } from "vitest";
 import { Base } from "./base.js";
-import { describeIfMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
+import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
 
 // Mirrors: activerecord/test/cases/invalid_connection_test.rb
 //

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -38,11 +38,9 @@ import { Person } from "./test-helpers/models/person.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
 import { itIfSupports, describeIfSupports } from "./support/supports.js";
 import { describeIfPg } from "./support/describe-if-pg.js";
-import {
-  describeIfMysqlAdapter,
-  leaseMysqlAdapter,
-  Mysql2Adapter,
-} from "./adapters/abstract-mysql-adapter/test-helper.js";
+import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
+import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
+import { leaseMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
 
 async function freshContext(): Promise<{ adapter: DatabaseAdapter; ctx: MigrationContext }> {
   const adapter = Base.connection;

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -29,7 +29,7 @@ import { adapterSupports, describeIfSupports, itIfSupports } from "../support/su
 import { assertQueriesMatch } from "../testing/query-assertions.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { supportsRenameIndex } from "../adapters/abstract-mysql-adapter/test-helper.js";
+import { supportsRenameIndex } from "../support/mysql-server-version.js";
 import { dumpTableSchema } from "../support/schema-dumping-helper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { Base } from "../base.js";

--- a/packages/activerecord/src/support/describe-if-mysql-adapter.ts
+++ b/packages/activerecord/src/support/describe-if-mysql-adapter.ts
@@ -1,0 +1,17 @@
+import { describe } from "vitest";
+import { adapterType } from "../test-adapter.js";
+
+/**
+ * The port of `current_adapter?(:Mysql2Adapter)` — the gate every
+ * `ActiveRecord::AbstractMysqlTestCase` suite runs under. The suite rides the
+ * ambient `Base.connection` on the mysql2 lane and skips everywhere else,
+ * exactly as Rails does. Lives in `support/` rather than the
+ * `adapters/abstract-mysql-adapter/` test-helper because suites outside that
+ * tree gate on it too — a test file should never have to import glue from
+ * another adapter's tree. Counterpart to `describeIfPg` / `describeIfSqlite`.
+ *
+ * Unlike those two this is a static `adapterType` check with no server probe
+ * behind it, so importing it never opens a connection.
+ */
+export const describeIfMysqlAdapter =
+  adapterType === "mysql" ? describe : (describe.skip as typeof describe);

--- a/packages/activerecord/src/support/mysql-server-version.ts
+++ b/packages/activerecord/src/support/mysql-server-version.ts
@@ -1,0 +1,83 @@
+import mysql from "mysql2/promise";
+import { Version } from "../connection-adapters/abstract-adapter.js";
+import { mysqlUrl } from "./config.js";
+
+// A *serialization* of the MySQL sub-settings, not an env var of its own. Only
+// for tests that build a *second*, differently configured adapter, where the
+// config is itself under test and must not leak onto the shared leased
+// connection. Everything else rides leaseMysqlAdapter (MySQL test-helper).
+export const MYSQL_TEST_URL = mysqlUrl();
+
+let mariaDb = false;
+let mysqlVersionStr = "";
+
+// Reads VERSION() once at load: the supports* gates below mirror Rails'
+// version-keyed `supports_*?` predicates, which have no static answer (the
+// mysql lane may be MySQL 8 or the MariaDB CI stand-in). An unreachable server
+// yields an empty version, so every gate reads false — it never skips a suite,
+// which is describeIfMysqlAdapter's job alone.
+async function checkMysql(): Promise<{ isMariaDb: boolean; version: string }> {
+  let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
+  try {
+    conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
+    const [rows] = await conn.query("SELECT VERSION() AS v");
+    const ver = (rows as Array<{ v: string }>)[0]?.v ?? "";
+    return { isMariaDb: /mariadb/i.test(ver), version: ver };
+  } catch {
+    return { isMariaDb: false, version: "" };
+  } finally {
+    await conn?.end().catch(() => {});
+  }
+}
+
+({ isMariaDb: mariaDb, version: mysqlVersionStr } = await checkMysql());
+
+/** true when the connected server is MariaDB; false on MySQL or when MySQL is unavailable. */
+export const isMariaDb = mariaDb;
+/** Raw VERSION() string from the connected MySQL/MariaDB server (empty when unavailable). */
+export const mysqlVersion = mysqlVersionStr;
+
+// Parse the dotted version out of the raw VERSION() string the same way
+// AbstractMysqlAdapter#version_string does (strips the MariaDB 5.5.5- prefix).
+function parseMysqlVersion(full: string): Version | null {
+  const m = full.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/);
+  return m ? new Version(m[1]) : null;
+}
+const _serverVersion = parseMysqlVersion(mysqlVersionStr);
+
+/**
+ * Mirrors AbstractMysqlAdapter#supports_optimizer_hints?: MySQL ≥ 5.7.7 only;
+ * never MariaDB. Lets adapter tests gate on hint support the way the Rails
+ * suite wraps `OptimizerHintsTest` in `if supports_optimizer_hints?`.
+ */
+export const supportsOptimizerHints = !mariaDb && _serverVersion?.gte("5.7.7") === true;
+
+/**
+ * Mirrors `supports_default_expression?` (adapter_helper.rb:23) for MySQL: an
+ * expression/function column default needs MariaDB ≥ 10.2.1 or MySQL ≥ 8.0.13.
+ * Gates the `defaults` table's `uuid` / `char2_concatenated` expression columns
+ * exactly as Rails' mysql2_specific_schema.rb does.
+ */
+export const supportsDefaultExpression = mariaDb
+  ? _serverVersion?.gte("10.2.1") === true
+  : _serverVersion?.gte("8.0.13") === true;
+
+/**
+ * Mirrors AbstractMysqlAdapter#supports_expression_index?
+ * (abstract_mysql_adapter.rb:104): MySQL ≥ 8.0.13 only; never MariaDB. Feeds
+ * the `expression_index` entry in support/supports.ts, which cannot bake
+ * the answer into a static adapterType table — the mysql lane may be MySQL 8
+ * (true) or the MariaDB CI stand-in (false).
+ */
+export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13") === true;
+
+/**
+ * Mirrors AbstractMysqlAdapter#supports_rename_index?
+ * (abstract_mysql_adapter.rb:896-901): MariaDB ≥ 10.5.2, MySQL ≥ 5.7.6. Lets a
+ * test reproduce Rails' `skip "Cannot drop index, needed in a foreign key
+ * constraint" if current_adapter?(:Mysql2Adapter) && !supports_rename_index?`
+ * without hiding the supported MySQL path behind a blanket adapter skip.
+ */
+export const supportsRenameIndex = mariaDb
+  ? _serverVersion?.gte("10.5.2") === true
+  : _serverVersion?.gte("5.7.6") === true;

--- a/packages/activerecord/src/support/supports.test.ts
+++ b/packages/activerecord/src/support/supports.test.ts
@@ -6,7 +6,7 @@ import { adapterSupports, describeIfSupports, itIfSupports } from "./supports.js
 // attempt on the pg/sqlite lanes.
 const mysqlSupportsExpressionIndex =
   adapterType === "mysql"
-    ? (await import("../adapters/abstract-mysql-adapter/test-helper.js")).supportsExpressionIndex
+    ? (await import("./mysql-server-version.js")).supportsExpressionIndex
     : false;
 
 // Assertions are computed from `adapterType` so they hold on every CI lane

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -47,7 +47,7 @@ type Backend = (typeof ALL)[number];
 // connection attempt off the pg/sqlite lanes.
 const mysqlExpressionIndex =
   adapterType === "mysql"
-    ? (await import("../adapters/abstract-mysql-adapter/test-helper.js")).supportsExpressionIndex
+    ? (await import("./mysql-server-version.js")).supportsExpressionIndex
     : false;
 
 const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {


### PR DESCRIPTION
Completes the set started by #5536 (`describeIfSqlite`) and #5540 (`describeIfPg`):
the MySQL adapter-current gate no longer lives in an adapter test-helper tree.

- `support/describe-if-mysql-adapter.ts` — the one-line `adapterType === "mysql"`
  gate, with no probe behind it, so importing it never opens a connection.
- `support/mysql-server-version.ts` — the live `VERSION()` probe and the
  version-keyed `supports*` predicates it feeds. Moved too because `supports.ts`
  (and `migration/foreign-key.test.ts`, via `supportsRenameIndex`) needed
  `supportsExpressionIndex` from outside the MySQL tree; `supports.ts` now
  dynamic-imports a `support/` module rather than an adapter test-helper, and
  the mysql-lane-only gating around that import is unchanged.
- `adapters/abstract-mysql-adapter/test-helper.ts` keeps only what is genuinely
  MySQL-tree — `ARUNIT_DATABASE`/`ARUNIT2_DATABASE`, `leaseMysqlAdapter`,
  `Mysql2Adapter` — and re-exports the relocated symbols so the in-tree mysql2
  suites keep their existing imports. One definition per predicate; no duplication.
- Cross-tree importers repointed: `defaults.test.ts`, `migration.test.ts`,
  `invalid-connection.test.ts`, `connection-adapters/mysql-type-lookup.test.ts`,
  `migration/foreign-key.test.ts`, `support/supports{,.test}.ts`. `Mysql2Adapter`
  now comes straight from `connection-adapters/mysql2-adapter.js` (as #5540 did
  for `PostgreSQLAdapter`). `adapter.test.ts` still imports `leaseMysqlAdapter`
  and the `ARUNIT*` names from the MySQL tree — those are not gates.

`scripts/test-compare/gates.ts` matches these wrappers by name, not import path,
so the gate delta is unmoved (as verified in #5536 and #5540). No test names changed.

Closes-story: relocate-describe-if-mysql-adapter-out-of-adapters-tree
