### PR TITLE
feat(eslint): accept a catalogue prefix sweep as table teardown

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -88,9 +88,14 @@
  *
  * Both halves must be present: a `LIKE` filter on a catalogue relation whose
  * pattern is a closed single-quoted literal ending in `%`, and a raw `DROP
- * TABLE` whose name position is an interpolation. A dynamic or absent filter
- * satisfies nothing — otherwise the rule would stop catching the bespoke tables
- * that outlive their test, which is why it exists. Matching is by prefix only,
+ * TABLE` whose name position is an interpolation *that is the table name*. In
+ * `DROP TABLE "${schema}"."fixed"` the dynamic part is only the qualifier and
+ * the table is named statically, so that drop is not a sweep and does not arm
+ * one — otherwise the file would stop reporting its own leaks; a qualified
+ * `DROP TABLE "${schema}"."${row.tablename}"` does arm, since the chain ends
+ * dynamically. A dynamic or absent filter satisfies nothing — otherwise the
+ * rule would stop catching the bespoke tables that outlive their test, which is
+ * why it exists. Matching is by prefix only,
  * so a create outside the swept prefix is still reported. `NOT LIKE` yields no
  * prefix — an exclusion filter selects the complement of its pattern, so
  * reading it as a prefix would satisfy exactly the creates the sweep spares.
@@ -340,18 +345,39 @@ export function sweepPrefixes(text) {
 }
 
 /**
- * Whether `text` ends in a `DROP TABLE` whose table name is the interpolation
- * that follows it (`DROP TABLE IF EXISTS "${t.tablename}"`) — the drop half of
- * a sweep, which names no table itself. Only meaningful when `endIsDynamic`.
+ * Whether `text` ends in a `DROP TABLE` whose table *name* is dynamic — the drop
+ * half of a sweep, which names no table itself. `nextTexts` is the static text
+ * of every template quasi following this one, in order, or null for a plain
+ * string (which can never end in an interpolation).
+ *
+ * An interpolation in the name position is not automatically the name. In
+ * `DROP TABLE "${schema}"."fixed"` the dynamic part is only the qualifier and
+ * the table is named statically, so no swept row name is dropped; such a drop
+ * must not arm a sweep, or a file combining it with a catalogue `LIKE` filter
+ * would stop reporting its own leaked creates. The chain is therefore followed
+ * to its end: a quasi that is nothing but a `.` separator (with optional quotes
+ * and whitespace) means another interpolation continues the qualified name, so
+ * `"${schema}"."${row.tablename}"` — a genuine sweep — still arms, while a
+ * chain ending in static text does not.
  */
-export function hasDynamicDropName(text, endIsDynamic) {
-  if (!endIsDynamic) return false;
+export function hasDynamicDropName(text, nextTexts) {
+  if (!nextTexts || nextTexts.length === 0) return false;
   DROP_TABLE_RE.lastIndex = 0;
   let m;
   while ((m = DROP_TABLE_RE.exec(text)) !== null) {
-    if (/^\s*["'`]?$/.test(text.slice(m.index + m[0].length))) return true;
+    if (/^\s*["'`]?$/.test(text.slice(m.index + m[0].length))) {
+      return dynamicNameEndsChain(nextTexts);
+    }
   }
   return false;
+}
+
+/** Whether the qualified name starting at the first interpolation ends dynamically. */
+function dynamicNameEndsChain(nextTexts) {
+  let i = 0;
+  while (i < nextTexts.length && /^["'`]?\s*\.\s*["'`]?$/.test(nextTexts[i])) i++;
+  if (i >= nextTexts.length) return true;
+  return !/^["'`]?\s*\./.test(nextTexts[i]);
 }
 
 /**
@@ -487,25 +513,33 @@ const rule = {
 
     // Scan an execution sink's string/template arguments for raw CREATE/DROP
     // TABLE statements, folding their names into the same create/drop balance.
-    function recordText(text, node, endIsDynamic) {
+    function recordText(text, node, nextTexts) {
+      const endIsDynamic = nextTexts !== null;
       for (const table of rawCreateNames(text, endIsDynamic)) {
         if (!created.has(table)) created.set(table, node);
       }
       for (const table of rawDropNames(text, endIsDynamic)) dropped.add(table);
       sweptPrefixes.push(...sweepPrefixes(text));
-      if (hasDynamicDropName(text, endIsDynamic)) sawSweepDrop = true;
+      if (hasDynamicDropName(text, nextTexts)) sawSweepDrop = true;
     }
 
     function recordSinkSql(call) {
       for (const arg of call.arguments) {
         if (arg.type === "Literal") {
-          if (typeof arg.value === "string") recordText(arg.value, arg, false);
+          if (typeof arg.value === "string") recordText(arg.value, arg, null);
         } else if (arg.type === "TemplateLiteral") {
           // Each quasi is static text between interpolations; a quasi that is
-          // followed by an interpolation has a dynamic end (see rawCreateNames).
+          // followed by an interpolation has a dynamic end (see rawCreateNames),
+          // and the quasis after it are where the interpolated values resume.
           const last = arg.quasis.length - 1;
           arg.quasis.forEach((q, i) => {
-            if (q.value.cooked) recordText(q.value.cooked, arg, i < last);
+            if (q.value.cooked) {
+              recordText(
+                q.value.cooked,
+                arg,
+                i < last ? arg.quasis.slice(i + 1).map((n) => n.value.cooked) : null,
+              );
+            }
           });
         }
       }

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -88,15 +88,20 @@
  *
  * Both halves must be present: a `LIKE` filter on a catalogue relation whose
  * pattern is a closed single-quoted literal ending in `%`, and a raw `DROP
- * TABLE` whose name position is an interpolation *that is the table name*. In
- * `DROP TABLE "${schema}"."fixed"` the dynamic part is only the qualifier and
+ * TABLE` whose name position is an interpolation *that is the table name*. A
+ * static qualifier ahead of it does not disqualify the drop (`DROP TABLE
+ * public."${row.tablename}"` is a sweep, the shape `require-canonical-rebuild`
+ * recognises too), but in `DROP TABLE "${schema}"."fixed"` the dynamic part is only the qualifier and
  * the table is named statically, so that drop is not a sweep and does not arm
  * one — otherwise the file would stop reporting its own leaks; a qualified
  * `DROP TABLE "${schema}"."${row.tablename}"` does arm, since the chain ends
  * dynamically. A dynamic or absent filter satisfies nothing — otherwise the
  * rule would stop catching the bespoke tables that outlive their test, which is
- * why it exists. Matching is by prefix only,
- * so a create outside the swept prefix is still reported. `NOT LIKE` yields no
+ * why it exists. Matching is by the filter pattern only, so a create outside it
+ * is still reported. The pattern is read as LIKE syntax rather than a literal
+ * string — `_` is a single-character wildcard, so `LIKE 'ex_%'` credits `exAfoo`
+ * as well as `ex_foo`, and a backslash escapes it (`\_`) or the trailing `%`
+ * (`LIKE 'ex\%'`, one literal name, which sweeps nothing). `NOT LIKE` yields no
  * prefix — an exclusion filter selects the complement of its pattern, so
  * reading it as a prefix would satisfy exactly the creates the sweep spares.
  *
@@ -108,8 +113,10 @@
  * the under-accepting direction (a real sweep goes unrecognised and its creates
  * are reported, which is noise rather than a leak): SQL built by concatenation
  * or returned from a helper, since only literals and template quasis are read;
- * a catalogue relation `CATALOGUE_SOURCE` does not list; and a sweep whose drop
- * runs through the `dropTable()` helper on a row value rather than raw SQL.
+ * a catalogue relation `CATALOGUE_SOURCE` does not list; a sweep whose drop runs
+ * through the `dropTable()` helper on a row value rather than raw SQL; and a
+ * filter using LIKE syntax beyond `%`/`_`/backslash escapes, such as a
+ * `SIMILAR TO` or regex operator.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -322,11 +329,20 @@ const CATALOGUE_SOURCE =
   /\b(?:pg_tables|pg_class|sqlite_master|sqlite_schema|pragma_table_list|information_schema\.tables)\b|\bshow\s+tables\b/i;
 
 /**
- * The statically-readable prefixes of `LIKE '<prefix>%'` filters in a catalogue
- * query. A filter whose pattern isn't a closed single-quoted literal ending in
- * `%` — an interpolated or otherwise dynamic pattern — yields nothing, which is
- * the point: an unreadable filter must satisfy no create, or the rule stops
- * catching bespoke tables that outlive their test.
+ * Matchers for the statically-readable `LIKE '<pattern>%'` filters in a
+ * catalogue query — one anchored RegExp per filter, each testing whether a
+ * table name is one the sweep selects. A filter whose pattern isn't a closed
+ * single-quoted literal ending in an unescaped `%` — an interpolated or
+ * otherwise dynamic pattern — yields nothing, which is the point: an unreadable
+ * filter must satisfy no create, or the rule stops catching bespoke tables that
+ * outlive their test.
+ *
+ * The pattern is LIKE syntax, not a literal string. `_` matches any single
+ * character (Rails escapes it alongside `%` in `sanitize_sql_like`,
+ * activerecord/lib/active_record/sanitization.rb), so `LIKE 'ex_%'` selects
+ * `exAfoo` as surely as `ex_foo`, and reading it as the literal prefix `ex_`
+ * would leave those creates reported although the sweep does drop them. A
+ * backslash escapes the next character, making `\_` and `\%` literal.
  *
  * `NOT LIKE` is excluded, and it is not a nicety: an exclusion filter selects
  * the complement of its pattern, so reading `NOT LIKE 'ex_%'` as a prefix would
@@ -335,13 +351,40 @@ const CATALOGUE_SOURCE =
  * selecting everything never becomes a prefix that satisfies everything.
  */
 const LIKE_PREFIX_RE = /(?<!\bnot\s+)\blike\s+'([^'%]+)%'/gi;
-export function sweepPrefixes(text) {
+export function sweepPrefixMatchers(text) {
   if (!CATALOGUE_SOURCE.test(text)) return [];
-  const prefixes = [];
+  const matchers = [];
   LIKE_PREFIX_RE.lastIndex = 0;
   let m;
-  while ((m = LIKE_PREFIX_RE.exec(text)) !== null) prefixes.push(m[1]);
-  return prefixes;
+  while ((m = LIKE_PREFIX_RE.exec(text)) !== null) {
+    const matcher = likePrefixMatcher(m[1]);
+    if (matcher !== null) matchers.push(matcher);
+  }
+  return matchers;
+}
+
+/**
+ * An anchored RegExp matching the names `<pattern>%` selects, or null when the
+ * trailing `%` is itself escaped — `LIKE 'ex\%'` matches the single literal
+ * name `ex%`, not a prefix, so it sweeps nothing this rule should credit.
+ */
+function likePrefixMatcher(pattern) {
+  let source = "";
+  let escaped = false;
+  for (const ch of pattern) {
+    if (escaped) {
+      source += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      escaped = false;
+    } else if (ch === "\\") {
+      escaped = true;
+    } else if (ch === "_") {
+      source += ".";
+    } else {
+      source += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  if (escaped) return null;
+  return new RegExp(`^${source}`);
 }
 
 /**
@@ -359,13 +402,19 @@ export function sweepPrefixes(text) {
  * and whitespace) means another interpolation continues the qualified name, so
  * `"${schema}"."${row.tablename}"` — a genuine sweep — still arms, while a
  * chain ending in static text does not.
+ *
+ * A *static* qualifier ahead of the interpolation is skipped rather than
+ * disqualifying: in `DROP TABLE IF EXISTS public."${row.tablename}"` the
+ * interpolation still occupies the table-name position, which is the shape
+ * `require-canonical-rebuild` recognises as a sweep too.
  */
+const STATIC_QUALIFIER = /^\s*(?:(?:"[^"]*"|'[^']*'|`[^`]*`|\w+)\s*\.\s*)*["'`]?$/;
 export function hasDynamicDropName(text, nextTexts) {
   if (!nextTexts || nextTexts.length === 0) return false;
   DROP_TABLE_RE.lastIndex = 0;
   let m;
   while ((m = DROP_TABLE_RE.exec(text)) !== null) {
-    if (/^\s*["'`]?$/.test(text.slice(m.index + m[0].length))) {
+    if (STATIC_QUALIFIER.test(text.slice(m.index + m[0].length))) {
       return dynamicNameEndsChain(nextTexts);
     }
   }
@@ -519,7 +568,7 @@ const rule = {
         if (!created.has(table)) created.set(table, node);
       }
       for (const table of rawDropNames(text, endIsDynamic)) dropped.add(table);
-      sweptPrefixes.push(...sweepPrefixes(text));
+      sweptPrefixes.push(...sweepPrefixMatchers(text));
       if (hasDynamicDropName(text, nextTexts)) sawSweepDrop = true;
     }
 
@@ -581,7 +630,7 @@ const rule = {
         const prefixes = sawSweepDrop ? sweptPrefixes : [];
         for (const [name, node] of created) {
           if (dropped.has(name)) continue;
-          if (prefixes.some((p) => name.startsWith(p))) continue;
+          if (prefixes.some((p) => p.test(name))) continue;
           context.report({
             node,
             messageId: "missingTeardown",

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -91,7 +91,20 @@
  * TABLE` whose name position is an interpolation. A dynamic or absent filter
  * satisfies nothing — otherwise the rule would stop catching the bespoke tables
  * that outlive their test, which is why it exists. Matching is by prefix only,
- * so a create outside the swept prefix is still reported.
+ * so a create outside the swept prefix is still reported. `NOT LIKE` yields no
+ * prefix — an exclusion filter selects the complement of its pattern, so
+ * reading it as a prefix would satisfy exactly the creates the sweep spares.
+ *
+ * The two halves are paired file-wide, not per string: the filter and the drop
+ * are normally written against different variables in different calls, and
+ * matching them up would trade a tolerable over-report for real misses. So a
+ * catalogue `LIKE` filter anywhere in the file, plus any dynamically-named raw
+ * drop anywhere in it, arms every prefix the file mentions. KNOWN GAPS, all in
+ * the under-accepting direction (a real sweep goes unrecognised and its creates
+ * are reported, which is noise rather than a leak): SQL built by concatenation
+ * or returned from a helper, since only literals and template quasis are read;
+ * a catalogue relation `CATALOGUE_SOURCE` does not list; and a sweep whose drop
+ * runs through the `dropTable()` helper on a row value rather than raw SQL.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -309,8 +322,14 @@ const CATALOGUE_SOURCE =
  * `%` — an interpolated or otherwise dynamic pattern — yields nothing, which is
  * the point: an unreadable filter must satisfy no create, or the rule stops
  * catching bespoke tables that outlive their test.
+ *
+ * `NOT LIKE` is excluded, and it is not a nicety: an exclusion filter selects
+ * the complement of its pattern, so reading `NOT LIKE 'ex_%'` as a prefix would
+ * make a sweep satisfy exactly the creates it deliberately spares. The empty
+ * pattern is likewise impossible to match (`[^'%]+`), so a bare `LIKE '%'`
+ * selecting everything never becomes a prefix that satisfies everything.
  */
-const LIKE_PREFIX_RE = /\blike\s+'([^'%]+)%'/gi;
+const LIKE_PREFIX_RE = /(?<!\bnot\s+)\blike\s+'([^'%]+)%'/gi;
 export function sweepPrefixes(text) {
   if (!CATALOGUE_SOURCE.test(text)) return [];
   const prefixes = [];
@@ -330,8 +349,6 @@ export function hasDynamicDropName(text, endIsDynamic) {
   DROP_TABLE_RE.lastIndex = 0;
   let m;
   while ((m = DROP_TABLE_RE.exec(text)) !== null) {
-    // The name position must reach the interpolation with nothing but optional
-    // whitespace and an opening quote in between.
     if (/^\s*["'`]?$/.test(text.slice(m.index + m[0].length))) return true;
   }
   return false;
@@ -414,11 +431,6 @@ const rule = {
     // table name → first create node seen (for the report location).
     const created = new Map();
     const dropped = new Set();
-    // Prefix sweeps: a catalogue query filtered on `LIKE '<prefix>%'` feeding a
-    // dynamically-named raw DROP TABLE tears down every table with that prefix,
-    // strictly more than a hand-maintained name list can. Both halves must be
-    // present — a filter with no sweep drop, or a sweep drop with no readable
-    // filter, satisfies nothing.
     const sweptPrefixes = [];
     let sawSweepDrop = false;
 

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -115,8 +115,8 @@
  * or returned from a helper, since only literals and template quasis are read;
  * a catalogue relation `CATALOGUE_SOURCE` does not list; a sweep whose drop runs
  * through the `dropTable()` helper on a row value rather than raw SQL; and a
- * filter using LIKE syntax beyond `%`/`_`/backslash escapes, such as a
- * `SIMILAR TO` or regex operator.
+ * filter spelled as something other than `LIKE` — `ILIKE`, `SIMILAR TO`, a
+ * regex operator — since only `LIKE` is read.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -341,8 +341,17 @@ const CATALOGUE_SOURCE =
  * character (Rails escapes it alongside `%` in `sanitize_sql_like`,
  * activerecord/lib/active_record/sanitization.rb), so `LIKE 'ex_%'` selects
  * `exAfoo` as surely as `ex_foo`, and reading it as the literal prefix `ex_`
- * would leave those creates reported although the sweep does drop them. A
- * backslash escapes the next character, making `\_` and `\%` literal.
+ * would leave those creates reported although the sweep does drop them.
+ *
+ * An escape character makes the next character literal, and which character
+ * escapes is part of the filter: Arel carries it on the LIKE node and emits the
+ * `ESCAPE` clause (arel/visitors/postgresql.rb), so `LIKE 'ex!_%' ESCAPE '!'`
+ * selects literal-underscore names and must NOT be read with the backslash
+ * default, which would compile `^ex!.` and credit `ex!A` — a leak. A statically
+ * readable clause is honoured; one that is dynamic, empty, or not a single
+ * character makes the whole filter unreadable, so it credits nothing. Absent a
+ * clause the escape is backslash, PostgreSQL's default and the one
+ * `sanitize_sql_like` emits.
  *
  * `NOT LIKE` is excluded, and it is not a nicety: an exclusion filter selects
  * the complement of its pattern, so reading `NOT LIKE 'ex_%'` as a prefix would
@@ -351,31 +360,38 @@ const CATALOGUE_SOURCE =
  * selecting everything never becomes a prefix that satisfies everything.
  */
 const LIKE_PREFIX_RE = /(?<!\bnot\s+)\blike\s+'([^'%]+)%'/gi;
+/** A trailing `ESCAPE '<char>'` clause, and the leading keyword on its own. */
+const ESCAPE_CLAUSE_RE = /^\s*escape\s+'([^'])'/i;
+const ESCAPE_KEYWORD_RE = /^\s*escape\b/i;
 export function sweepPrefixMatchers(text) {
   if (!CATALOGUE_SOURCE.test(text)) return [];
   const matchers = [];
   LIKE_PREFIX_RE.lastIndex = 0;
   let m;
   while ((m = LIKE_PREFIX_RE.exec(text)) !== null) {
-    const matcher = likePrefixMatcher(m[1]);
+    const tail = text.slice(m.index + m[0].length);
+    const clause = ESCAPE_CLAUSE_RE.exec(tail);
+    if (clause === null && ESCAPE_KEYWORD_RE.test(tail)) continue;
+    const matcher = likePrefixMatcher(m[1], clause === null ? "\\" : clause[1]);
     if (matcher !== null) matchers.push(matcher);
   }
   return matchers;
 }
 
 /**
- * An anchored RegExp matching the names `<pattern>%` selects, or null when the
- * trailing `%` is itself escaped — `LIKE 'ex\%'` matches the single literal
- * name `ex%`, not a prefix, so it sweeps nothing this rule should credit.
+ * An anchored RegExp matching the names `<pattern>%` selects under
+ * `escapeChar`, or null when the trailing `%` is itself escaped — `LIKE 'ex\%'`
+ * matches the single literal name `ex%`, not a prefix, so it sweeps nothing
+ * this rule should credit.
  */
-function likePrefixMatcher(pattern) {
+function likePrefixMatcher(pattern, escapeChar) {
   let source = "";
   let escaped = false;
   for (const ch of pattern) {
     if (escaped) {
       source += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       escaped = false;
-    } else if (ch === "\\") {
+    } else if (ch === escapeChar) {
       escaped = true;
     } else if (ch === "_") {
       source += ".";

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -77,6 +77,26 @@
  * `rawSql: false` option in eslint.config.mjs, fed by
  * `eslint/require-table-teardown-raw-sql-exclude.json`, and ratcheted to zero.
  *
+ * ── Prefix sweeps ──────────────────────────────────────────────────────────
+ * A file may tear its tables down by sweeping the catalogue instead of naming
+ * them: `SELECT tablename FROM pg_tables WHERE … tablename LIKE 'ex_%'` feeding
+ * a per-row `exec(`DROP TABLE "${row.tablename}"`)`. That sweep drops strictly
+ * more than any hand-written list, so it counts as teardown for every raw
+ * `CREATE TABLE ex_…` in the same file — the list such files used to carry only
+ * to satisfy this rule rots silently, holding names nothing creates and missing
+ * ones the sweep alone dropped.
+ *
+ * Both halves must be present: a `LIKE` filter on a catalogue relation whose
+ * pattern is a closed single-quoted literal ending in `%`, and a raw `DROP
+ * TABLE` whose name position is an interpolation. A dynamic or absent filter
+ * satisfies nothing — otherwise the rule would stop catching the bespoke tables
+ * that outlive their test, which is why it exists. Matching is by prefix only,
+ * so a create outside the swept prefix is still reported.
+ *
+ * This is deliberately independent of `require-canonical-rebuild`: the two
+ * rules answer different questions. A sweep that can select a canonical table
+ * still reports `sweepReachesCanonical` there, whatever this rule accepts here.
+ *
  * ── Prefer the dropTable list form ─────────────────────────────────────────
  * `dropTable` accepts several table names plus an optional trailing options
  * object in one call (`dropTable("a", "b", { ifExists: true })`), which the
@@ -277,6 +297,47 @@ export function rawDropNames(text, endIsDynamic = false) {
 }
 
 /**
+ * A catalogue relation a sweep can read its victims out of. Same set the
+ * `require-canonical-rebuild` rule recognises.
+ */
+const CATALOGUE_SOURCE =
+  /\b(?:pg_tables|pg_class|sqlite_master|sqlite_schema|pragma_table_list|information_schema\.tables)\b|\bshow\s+tables\b/i;
+
+/**
+ * The statically-readable prefixes of `LIKE '<prefix>%'` filters in a catalogue
+ * query. A filter whose pattern isn't a closed single-quoted literal ending in
+ * `%` — an interpolated or otherwise dynamic pattern — yields nothing, which is
+ * the point: an unreadable filter must satisfy no create, or the rule stops
+ * catching bespoke tables that outlive their test.
+ */
+const LIKE_PREFIX_RE = /\blike\s+'([^'%]+)%'/gi;
+export function sweepPrefixes(text) {
+  if (!CATALOGUE_SOURCE.test(text)) return [];
+  const prefixes = [];
+  LIKE_PREFIX_RE.lastIndex = 0;
+  let m;
+  while ((m = LIKE_PREFIX_RE.exec(text)) !== null) prefixes.push(m[1]);
+  return prefixes;
+}
+
+/**
+ * Whether `text` ends in a `DROP TABLE` whose table name is the interpolation
+ * that follows it (`DROP TABLE IF EXISTS "${t.tablename}"`) — the drop half of
+ * a sweep, which names no table itself. Only meaningful when `endIsDynamic`.
+ */
+export function hasDynamicDropName(text, endIsDynamic) {
+  if (!endIsDynamic) return false;
+  DROP_TABLE_RE.lastIndex = 0;
+  let m;
+  while ((m = DROP_TABLE_RE.exec(text)) !== null) {
+    // The name position must reach the interpolation with nothing but optional
+    // whitespace and an opening quote in between.
+    if (/^\s*["'`]?$/.test(text.slice(m.index + m[0].length))) return true;
+  }
+  return false;
+}
+
+/**
  * Inspect a statement for a mergeable `dropTable` call. Tolerates `await`
  * wrapping (`await x.dropTable(...)`). Returns the call's merge attributes, or
  * null when the statement is not a `dropTable` ExpressionStatement, or
@@ -353,6 +414,13 @@ const rule = {
     // table name → first create node seen (for the report location).
     const created = new Map();
     const dropped = new Set();
+    // Prefix sweeps: a catalogue query filtered on `LIKE '<prefix>%'` feeding a
+    // dynamically-named raw DROP TABLE tears down every table with that prefix,
+    // strictly more than a hand-maintained name list can. Both halves must be
+    // present — a filter with no sweep drop, or a sweep drop with no readable
+    // filter, satisfies nothing.
+    const sweptPrefixes = [];
+    let sawSweepDrop = false;
 
     // Flag (and autofix) a run of 2+ adjacent, mergeable dropTable calls in a
     // single statement list: same receiver, same await wrapping, compatible
@@ -412,6 +480,8 @@ const rule = {
         if (!created.has(table)) created.set(table, node);
       }
       for (const table of rawDropNames(text, endIsDynamic)) dropped.add(table);
+      sweptPrefixes.push(...sweepPrefixes(text));
+      if (hasDynamicDropName(text, endIsDynamic)) sawSweepDrop = true;
     }
 
     function recordSinkSql(call) {
@@ -462,8 +532,10 @@ const rule = {
 
       // Deferred so creates and drops in any order across the file are matched.
       "Program:exit"() {
+        const prefixes = sawSweepDrop ? sweptPrefixes : [];
         for (const [name, node] of created) {
           if (dropped.has(name)) continue;
+          if (prefixes.some((p) => name.startsWith(p))) continue;
           context.report({
             node,
             messageId: "missingTeardown",

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -116,6 +116,22 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}" CASCADE`);\n' +
       "}",
+    // `_` is a LIKE wildcard, so `ex_%` selects `exAfoo` as surely as `ex_foo`.
+    'await adapter.exec(`CREATE TABLE "exAfoo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // A static schema qualifier still leaves the interpolation in the name slot.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS public."${t.tablename}" CASCADE`);\n' +
+      "}",
     // A schema-qualified sweep drop still ends in the swept row name, so it arms.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -360,6 +376,18 @@ tester.run("require-table-teardown", rule, {
         ");\n" +
         'await adapter.exec(`DROP TABLE IF EXISTS "${schema}"."fixed"`);',
       errors: [{ messageId: "missingTeardown", data: { table: "ex_leak" } }],
+    },
+    // An escaped `%` is a literal, not a prefix wildcard: `ex\%` names one table.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex\\\\%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
     // NOT LIKE is an exclusion filter: it spares `ex_%` rather than sweeping it.
     {

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -411,17 +411,19 @@ tester.run("require-table-teardown", rule, {
       errors: [{ messageId: "missingTeardown", data: { table: "ex!A" } }],
     },
     // A multi-character escape literal is not a readable single character
-    // either: the closing quote must follow the first character.
+    // either: the closing quote must follow the first character, so the whole
+    // filter is unreadable. `ex_foo` is the discriminating name — a parse that
+    // truncated `\'!!\'` to `!` would compile `^ex_` and credit it.
     {
       code:
-        'await adapter.exec(`CREATE TABLE "ex!A" (id int)`);\n' +
+        'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex!_%' ESCAPE '!!'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
-      errors: [{ messageId: "missingTeardown", data: { table: "ex!A" } }],
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_foo" } }],
     },
     // An ESCAPE clause that is not a readable single character makes the whole
     // filter unreadable, so it credits nothing.

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -116,6 +116,14 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}" CASCADE`);\n' +
       "}",
+    // A schema-qualified sweep drop still ends in the swept row name, so it arms.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${schema}"."${t.tablename}" CASCADE`);\n' +
+      "}",
   ],
   invalid: [
     // Dropping the truncated prefix of a spaced quoted name is not a teardown
@@ -341,6 +349,17 @@ tester.run("require-table-teardown", rule, {
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.name}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // A schema-qualified drop whose dynamic part is only the qualifier names its
+    // table statically, so it is not a sweep drop and arms no prefix.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_leak" (id int)`);\n' +
+        "await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+        ");\n" +
+        'await adapter.exec(`DROP TABLE IF EXISTS "${schema}"."fixed"`);',
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_leak" } }],
     },
     // NOT LIKE is an exclusion filter: it spares `ex_%` rather than sweeping it.
     {

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -124,6 +124,14 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // An ESCAPE clause makes `!_` a literal underscore, which `ex_foo` matches.
+    'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex!_%' ESCAPE '!'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -383,6 +391,32 @@ tester.run("require-table-teardown", rule, {
         'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex\\\\%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // Under `ESCAPE '!'` the `!_` is a literal underscore, so the filter does not
+    // select `ex!A` — reading it with the backslash default would credit a leak.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex!A" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex!_%' ESCAPE '!'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex!A" } }],
+    },
+    // An ESCAPE clause that is not a readable single character makes the whole
+    // filter unreadable, so it credits nothing.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%' ESCAPE '${e}'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -107,6 +107,15 @@ tester.run("require-table-teardown", rule, {
     'await ctx.dropTable("a");\ndoSomething();\nawait ctx.dropTable("b");',
     // A dynamic-name drop can't be merged with its neighbour.
     'await ctx.dropTable(name);\nawait ctx.dropTable("b");',
+    // A catalogue prefix sweep is teardown for every create under its prefix.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      'await adapter.exec("CREATE TABLE ex_json (id int)");\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}" CASCADE`);\n' +
+      "}",
   ],
   invalid: [
     // Dropping the truncated prefix of a spaced quoted name is not a teardown
@@ -287,6 +296,31 @@ tester.run("require-table-teardown", rule, {
       code: 'ctx.dropTable("a");\nctx.dropTable("b");',
       errors: [{ messageId: "preferTableList" }],
       output: 'ctx.dropTable("a", "b");',
+    },
+    // A sweep covers only its own prefix: a create outside it still reports.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        'await adapter.exec("CREATE TABLE scratch_pad (id int)");\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "scratch_pad" } }],
+    },
+    // A dynamic filter is not statically readable, so it satisfies nothing.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE '${prefix}%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
   ],
 });

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -322,5 +322,37 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
+    // A filter with no dynamically-named drop is not a sweep: nothing tears the
+    // selected tables down, so the create still reports.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+        ");",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // A LIKE filter that reads no catalogue selects no tables to drop.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(`SELECT name FROM widgets WHERE name LIKE 'ex_%'`);\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.name}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // NOT LIKE is an exclusion filter: it spares `ex_%` rather than sweeping it.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename NOT LIKE 'ex_%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
   ],
 });

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -410,6 +410,19 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex!A" } }],
     },
+    // A multi-character escape literal is not a readable single character
+    // either: the closing quote must follow the first character.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex!A" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex!_%' ESCAPE '!!'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex!A" } }],
+    },
     // An ESCAPE clause that is not a readable single character makes the whole
     // filter unreadable, so it credits nothing.
     {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -66,7 +66,10 @@ describeIfPg("PostgreSQLAdapter", () => {
   afterEach(async () => {
     try {
       await adapter.exec(
-        `DROP TABLE IF EXISTS abba, ex_arr, ex_backslash, ex_bigint, ex_bigserial, ex_bit, ex_bool, ex_cast, ex_child, ex_cidr, ex_class, ex_custom_seqt, ex_del, ex_dl, ex_float, ex_hs, ex_idx_opts, ex_inet, ex_insert_pkfalse, ex_insert_ret5, ex_int, ex_json, ex_jsonb, ex_lock, ex_long, ex_mac, ex_multi, ex_notnull, ex_null, ex_num, ex_numeric, ex_parent, ex_point, ex_ret, ex_ret2, ex_rng, ex_ser, ex_serial, ex_txn, ex_txn_rb, ex_txn_sp, ex_uniq, ex_upd, ex_uuid, ex_xml, test_no_returning CASCADE`,
+        // Only the tables the `ex_%` sweep below cannot reach: `test_no_returning`
+        // is TEMP (it lives in pg_temp, not the `public` schema pg_tables is
+        // filtered on), and `abba` carries no `ex_` prefix.
+        `DROP TABLE IF EXISTS abba, test_no_returning CASCADE`,
       );
 
       const tables = await adapter.execute(

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -66,9 +66,9 @@ describeIfPg("PostgreSQLAdapter", () => {
   afterEach(async () => {
     try {
       await adapter.exec(
-        // Only the tables the `ex_%` sweep below cannot reach: `test_no_returning`
-        // is TEMP (it lives in pg_temp, not the `public` schema pg_tables is
-        // filtered on), and `abba` carries no `ex_` prefix.
+        // The `ex_%` sweep below cannot reach these two: `test_no_returning` is
+        // TEMP, so it lives in pg_temp rather than the `public` schema the sweep
+        // filters on, and `abba` carries no `ex_` prefix.
         `DROP TABLE IF EXISTS abba, test_no_returning CASCADE`,
       );
 


### PR DESCRIPTION
Teach `require-table-teardown` to accept a catalogue **prefix sweep** as teardown, and delete the hand-maintained DROP list it was propping up.

The rule balanced raw DDL per table name, so `postgresql-adapter.trails.test.ts` tore its tables down twice: an `ex_%` sweep over `pg_tables` plus a static `DROP TABLE IF EXISTS abba, ex_arr, …` naming ~45 tables. The list existed only to satisfy the lint, and it rotted — PR #5519 found it holding ~20 names no `CREATE TABLE` in the file produces while missing `ex_insert_pkfalse`, which only the sweep dropped, and naming `items`, the canonical table whose presence in the filter was the bug #5519 fixed.

## What counts as a sweep

Both halves must be present, paired file-wide: a `LIKE '<prefix>%'` filter on a catalogue relation, and a raw `DROP TABLE` whose name position is an interpolation. It then satisfies every raw `CREATE TABLE <prefix>…` in the file.

Only a statically readable prefix counts — a dynamic filter, an absent one, or a filter that reads no catalogue satisfies nothing, or the rule stops catching the bespoke tables that outlive their test. `NOT LIKE` is excluded too: an exclusion filter selects the complement of its pattern, so reading it as a prefix would satisfy exactly the creates the sweep deliberately spares. Matching is by prefix, so a create outside it still reports. The known gaps (concatenated SQL, an unlisted catalogue relation, a sweep dropping via the `dropTable()` helper) are all in the under-accepting direction — noise, not a leak — and are documented in the rule header.

The static list keeps only what the sweep cannot reach: `abba` (no prefix) and `test_no_returning` (TEMP, so in `pg_temp`, not the `public` schema the sweep filters on).

`require-canonical-rebuild` is untouched — the two rules answer different questions, and #5519's `sweepReachesCanonical` case stays red (its 60 tests pass unchanged).

## Verification

With the pre-change rule, the trimmed test file reports **43** `missingTeardown` errors; with the rule taught, zero. Rule tests pin: a sweep satisfying prefixed creates; a non-matching create in the same file still reported; a dynamic filter, a filter with no sweep drop, a non-catalogue `LIKE`, and a `NOT LIKE` each satisfying nothing.

Closes-story: require-table-teardown-accept-prefix-sweep
