### PR TITLE
fix(tasks): flag next-bundle totals that bust --max-loc

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -381,9 +381,6 @@ describe("nextBundle", () => {
   });
 
   it("leads with a prioritized story whose est_loc exceeds the budget, flagged as over-budget", () => {
-    // Priority outranks the budget, so the oversized lead still leads — but
-    // the summary must say the total busted `maxLoc` rather than report it as
-    // a conforming bundle. The fill stays empty (negative leftover budget).
     const idx = index([
       story({ id: "big", cluster: "c1", est_loc: 450, priority: 2 }),
       story({ id: "f", cluster: "c1", est_loc: 80 }),
@@ -399,7 +396,6 @@ describe("nextBundle", () => {
       story({ id: "f", cluster: "c1", est_loc: 80 }),
     ]);
     const bundle = nextBundle(idx, { maxLoc: 250 });
-    // The null-est_loc lead counts as 0, so this stays within budget.
     expect(summarizeBundle(bundle, 250)).toEqual({ total: 80, leadExceedsBudget: false });
   });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -64,6 +64,7 @@ import {
   newRfc,
   newStory,
   nextBundle,
+  summarizeBundle,
   numberFlag,
   parseFlags,
   ready,
@@ -377,6 +378,29 @@ describe("nextBundle", () => {
     const bundle = nextBundle(idx, { maxLoc: 250 });
     expect(bundle[0].id).toBe("p");
     expect(bundle.map((s) => s.id)).toEqual(["p", "f"]);
+  });
+
+  it("leads with a prioritized story whose est_loc exceeds the budget, flagged as over-budget", () => {
+    // Priority outranks the budget, so the oversized lead still leads — but
+    // the summary must say the total busted `maxLoc` rather than report it as
+    // a conforming bundle. The fill stays empty (negative leftover budget).
+    const idx = index([
+      story({ id: "big", cluster: "c1", est_loc: 450, priority: 2 }),
+      story({ id: "f", cluster: "c1", est_loc: 80 }),
+    ]);
+    const bundle = nextBundle(idx, { maxLoc: 250 });
+    expect(bundle.map((s) => s.id)).toEqual(["big"]);
+    expect(summarizeBundle(bundle, 250)).toEqual({ total: 450, leadExceedsBudget: true });
+  });
+
+  it("does not flag a bundle whose total fits the budget", () => {
+    const idx = index([
+      story({ id: "p", cluster: "c1", est_loc: null, priority: 1 }),
+      story({ id: "f", cluster: "c1", est_loc: 80 }),
+    ]);
+    const bundle = nextBundle(idx, { maxLoc: 250 });
+    // The null-est_loc lead counts as 0, so this stays within budget.
+    expect(summarizeBundle(bundle, 250)).toEqual({ total: 80, leadExceedsBudget: false });
   });
 
   it("orders multiple prioritized stories by ascending priority (lower N first)", () => {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -531,11 +531,6 @@ export function nextBundle(
   return best;
 }
 
-// A prioritized lead outranks the budget by design (see `nextBundle`), so a
-// bundle's total can legitimately exceed `maxLoc` — but only ever because of
-// the lead, never the packing (`bestBundle` gets the leftover budget and
-// returns [] when it's negative). Callers report `leadExceedsBudget` instead
-// of printing a total above `max` as if the budget had held.
 export function summarizeBundle(
   rows: StoryEntry[],
   maxLoc: number,
@@ -3128,7 +3123,7 @@ function main(): void {
         cluster: stringFlag(flags, "cluster"),
         rfc: stringFlag(flags, "rfc"),
       });
-      const { total, leadExceedsBudget: overBudget } = summarizeBundle(rows, maxLoc);
+      const { total, leadExceedsBudget } = summarizeBundle(rows, maxLoc);
       if (flags.json) {
         console.log(
           JSON.stringify(
@@ -3136,7 +3131,7 @@ function main(): void {
               stories: rows,
               bundle_total_loc: total,
               max_loc: maxLoc,
-              lead_exceeds_budget: overBudget,
+              lead_exceeds_budget: leadExceedsBudget,
             },
             null,
             2,
@@ -3145,7 +3140,7 @@ function main(): void {
       } else if (rows.length === 0) {
         console.log(`no ready stories within ${maxLoc} LOC`);
       } else {
-        const note = overBudget ? " — lead exceeds budget" : "";
+        const note = leadExceedsBudget ? " — lead exceeds budget" : "";
         console.log(`bundle (sum ${total} / max ${maxLoc}${note}):`);
         fmt(rows, undefined, rfcPriorityMap(idx));
       }
@@ -3362,6 +3357,8 @@ function usage(): never {
 
   ready [--json] [--rfc <slug>]
   next-bundle [--max-loc N] [--cluster <name>] [--rfc <slug>] [--json]
+                                               (a prioritized lead outranks --max-loc; the
+                                                banner and --json flag the overrun)
   list [--rfc <slug>] [--status <v>] [--cluster <n>] [--json]
   show <id>
   status

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -531,6 +531,19 @@ export function nextBundle(
   return best;
 }
 
+// A prioritized lead outranks the budget by design (see `nextBundle`), so a
+// bundle's total can legitimately exceed `maxLoc` — but only ever because of
+// the lead, never the packing (`bestBundle` gets the leftover budget and
+// returns [] when it's negative). Callers report `leadExceedsBudget` instead
+// of printing a total above `max` as if the budget had held.
+export function summarizeBundle(
+  rows: StoryEntry[],
+  maxLoc: number,
+): { total: number; leadExceedsBudget: boolean } {
+  const total = rows.reduce((a, s) => a + (s.est_loc ?? 0), 0);
+  return { total, leadExceedsBudget: total > maxLoc };
+}
+
 export function listFiltered(
   index: Index,
   opts: { rfc?: string; status?: string; cluster?: string } = {},
@@ -3115,15 +3128,25 @@ function main(): void {
         cluster: stringFlag(flags, "cluster"),
         rfc: stringFlag(flags, "rfc"),
       });
-      const total = rows.reduce((a, s) => a + (s.est_loc ?? 0), 0);
+      const { total, leadExceedsBudget: overBudget } = summarizeBundle(rows, maxLoc);
       if (flags.json) {
         console.log(
-          JSON.stringify({ stories: rows, bundle_total_loc: total, max_loc: maxLoc }, null, 2),
+          JSON.stringify(
+            {
+              stories: rows,
+              bundle_total_loc: total,
+              max_loc: maxLoc,
+              lead_exceeds_budget: overBudget,
+            },
+            null,
+            2,
+          ),
         );
       } else if (rows.length === 0) {
         console.log(`no ready stories within ${maxLoc} LOC`);
       } else {
-        console.log(`bundle (sum ${total} / max ${maxLoc}):`);
+        const note = overBudget ? " — lead exceeds budget" : "";
+        console.log(`bundle (sum ${total} / max ${maxLoc}${note}):`);
         fmt(rows, undefined, rfcPriorityMap(idx));
       }
       break;


### PR DESCRIPTION
`pnpm tasks next-bundle` could report a total above its own `--max-loc` with no
warning: `nextBundle`'s prioritized path leads with `prioritized[0]` without
checking its `est_loc` against the budget, so a 450-LOC prioritized story
printed as `bundle (sum 450 / max 250)` as if the budget had held. The fill is
already correct (`bestBundle` gets a negative budget and returns `[]`), so only
the lead can bust it.

Keeps the priority-outranks-budget contract — a prioritized story is an
explicit "do this", including when it has no `est_loc` (still treated as 0) —
but makes the overrun visible:

- New `summarizeBundle(rows, maxLoc)` returns `{ total, leadExceedsBudget }`.
- Banner gains a suffix: `bundle (sum 450 / max 250 — lead exceeds budget):`.
- `--json` gains `lead_exceeds_budget`, so consumers don't re-derive the sum.

Tests cover a prioritized lead above the budget and a prioritized lead with a
null `est_loc` (unflagged, still leads).

Closes-story: next-bundle-prioritized-lead-busts-max-loc
