### PR TITLE
fix(tasks): distinguish next-bundle's two empty-result cases

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -63,6 +63,8 @@ import {
   listFiltered,
   newRfc,
   newStory,
+  emptyBundleReason,
+  formatEmptyBundle,
   nextBundle,
   summarizeBundle,
   numberFlag,
@@ -419,6 +421,59 @@ describe("nextBundle", () => {
     const bundle = nextBundle(idx, { maxLoc: 250 });
     // Both clusters tie at 100; either may win, but never both together.
     expect(bundle.length).toBe(1);
+  });
+
+  it("returns [] when the filters select no ready story", () => {
+    const idx = index([story({ id: "a", cluster: "c1", est_loc: 100, priority: 1 })]);
+    expect(nextBundle(idx, { maxLoc: 250, cluster: "nope" })).toEqual([]);
+  });
+
+  it("returns [] when in-scope stories exist but none fit the budget", () => {
+    // No priorities anywhere, so the knapsack path runs and nothing packs:
+    // one story has no estimate, the other is over budget.
+    const idx = index([
+      story({ id: "a", cluster: "c1", est_loc: null }),
+      story({ id: "b", cluster: "c1", est_loc: 900 }),
+    ]);
+    expect(nextBundle(idx, { maxLoc: 250 })).toEqual([]);
+  });
+
+  it("never returns [] once any in-scope story is prioritized", () => {
+    const idx = index([story({ id: "a", cluster: "c1", est_loc: 900, priority: 1 })]);
+    expect(nextBundle(idx, { maxLoc: 250 }).map((s) => s.id)).toEqual(["a"]);
+  });
+});
+
+describe("emptyBundleReason", () => {
+  it("reports no-matching-stories when the filters select nothing", () => {
+    const idx = index([story({ id: "a", cluster: "c1", est_loc: 100 })]);
+    expect(emptyBundleReason(idx, { cluster: "nope" })).toBe("no-matching-stories");
+  });
+
+  it("reports none-within-budget when the selection is non-empty", () => {
+    const idx = index([story({ id: "a", cluster: "c1", est_loc: 900 })]);
+    expect(emptyBundleReason(idx, {})).toBe("none-within-budget");
+  });
+});
+
+describe("formatEmptyBundle", () => {
+  it("omits the LOC budget when nothing matched the filters", () => {
+    expect(formatEmptyBundle("no-matching-stories", 250, { rfc: "0024-tasks-cli-coverage" })).toBe(
+      "no ready stories matching rfc 0024-tasks-cli-coverage",
+    );
+  });
+
+  it("names both filters when both are set", () => {
+    expect(formatEmptyBundle("no-matching-stories", 250, { rfc: "0024", cluster: "c1" })).toBe(
+      "no ready stories matching rfc 0024 + cluster c1",
+    );
+  });
+
+  it("reports the budget when the selection was non-empty", () => {
+    expect(formatEmptyBundle("none-within-budget", 250)).toBe("no ready stories within 250 LOC");
+    expect(formatEmptyBundle("none-within-budget", 250, { cluster: "c1" })).toBe(
+      "no ready stories matching cluster c1 within 250 LOC",
+    );
   });
 });
 

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -474,21 +474,12 @@ export function bestBundle(items: StoryEntry[], budget: number): StoryEntry[] {
   return chosen.reverse();
 }
 
-// The ready stories a bundle may draw from, in `ready()`'s priority order.
-// Shared with `emptyBundleReason` so the "nothing matched" diagnosis is
-// computed from the same selection the bundle itself packs.
 export function bundleScope(index: Index, opts: { cluster?: string; rfc?: string }): StoryEntry[] {
   return ready(index, { rfc: opts.rfc }).filter((s) =>
     opts.cluster ? s.cluster === opts.cluster : true,
   );
 }
 
-// Why `nextBundle` returned nothing. Only meaningful for an empty result, and
-// an empty result implies no in-scope story carries a priority: the prioritized
-// branch always returns `[lead, ...fill]`. That leaves two distinguishable
-// causes — the filters selected no ready story at all (usually a typo in
-// `--rfc`/`--cluster`), or the selection was non-empty but nothing fit the
-// budget (every candidate missing an `est_loc`, or all of them over it).
 export type EmptyBundleReason = "no-matching-stories" | "none-within-budget";
 
 export function emptyBundleReason(
@@ -561,9 +552,6 @@ export function summarizeBundle(
   return { total, leadExceedsBudget: total > maxLoc };
 }
 
-// The line `next-bundle` prints instead of a bundle banner when it has no
-// rows. Naming the active filters matters most for `no-matching-stories`,
-// where the usual cause is a filter value that matches nothing.
 export function formatEmptyBundle(
   reason: EmptyBundleReason,
   maxLoc: number,
@@ -3169,6 +3157,7 @@ function main(): void {
               bundle_total_loc: total,
               max_loc: maxLoc,
               lead_exceeds_budget: leadExceedsBudget,
+              empty_reason: rows.length === 0 ? emptyBundleReason(idx, filters) : null,
             },
             null,
             2,

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -474,13 +474,35 @@ export function bestBundle(items: StoryEntry[], budget: number): StoryEntry[] {
   return chosen.reverse();
 }
 
+// The ready stories a bundle may draw from, in `ready()`'s priority order.
+// Shared with `emptyBundleReason` so the "nothing matched" diagnosis is
+// computed from the same selection the bundle itself packs.
+export function bundleScope(index: Index, opts: { cluster?: string; rfc?: string }): StoryEntry[] {
+  return ready(index, { rfc: opts.rfc }).filter((s) =>
+    opts.cluster ? s.cluster === opts.cluster : true,
+  );
+}
+
+// Why `nextBundle` returned nothing. Only meaningful for an empty result, and
+// an empty result implies no in-scope story carries a priority: the prioritized
+// branch always returns `[lead, ...fill]`. That leaves two distinguishable
+// causes — the filters selected no ready story at all (usually a typo in
+// `--rfc`/`--cluster`), or the selection was non-empty but nothing fit the
+// budget (every candidate missing an `est_loc`, or all of them over it).
+export type EmptyBundleReason = "no-matching-stories" | "none-within-budget";
+
+export function emptyBundleReason(
+  index: Index,
+  opts: { cluster?: string; rfc?: string },
+): EmptyBundleReason {
+  return bundleScope(index, opts).length === 0 ? "no-matching-stories" : "none-within-budget";
+}
+
 export function nextBundle(
   index: Index,
   opts: { maxLoc: number; cluster?: string; rfc?: string },
 ): StoryEntry[] {
-  const inScope = ready(index, { rfc: opts.rfc }).filter((s) =>
-    opts.cluster ? s.cluster === opts.cluster : true,
-  );
+  const inScope = bundleScope(index, opts);
   // Priority overrides cluster-LOC packing. The legend says "lower N = higher
   // priority"; honor it literally — any prioritized story outranks every
   // unprioritized one, regardless of cluster or how well it fills the budget.
@@ -537,6 +559,24 @@ export function summarizeBundle(
 ): { total: number; leadExceedsBudget: boolean } {
   const total = rows.reduce((a, s) => a + (s.est_loc ?? 0), 0);
   return { total, leadExceedsBudget: total > maxLoc };
+}
+
+// The line `next-bundle` prints instead of a bundle banner when it has no
+// rows. Naming the active filters matters most for `no-matching-stories`,
+// where the usual cause is a filter value that matches nothing.
+export function formatEmptyBundle(
+  reason: EmptyBundleReason,
+  maxLoc: number,
+  filters: { cluster?: string; rfc?: string } = {},
+): string {
+  const named = [
+    filters.rfc ? `rfc ${filters.rfc}` : null,
+    filters.cluster ? `cluster ${filters.cluster}` : null,
+  ].filter((p): p is string => p !== null);
+  const scope = named.length ? ` matching ${named.join(" + ")}` : "";
+  return reason === "no-matching-stories"
+    ? `no ready stories${scope}`
+    : `no ready stories${scope} within ${maxLoc} LOC`;
 }
 
 export function listFiltered(
@@ -3118,11 +3158,8 @@ function main(): void {
       if (!/^\d+$/.test(maxLocRaw) || Number(maxLocRaw) <= 0) usage();
       const maxLoc = Number(maxLocRaw);
       const idx = readIndexSource().index;
-      const rows = nextBundle(idx, {
-        maxLoc,
-        cluster: stringFlag(flags, "cluster"),
-        rfc: stringFlag(flags, "rfc"),
-      });
+      const filters = { cluster: stringFlag(flags, "cluster"), rfc: stringFlag(flags, "rfc") };
+      const rows = nextBundle(idx, { maxLoc, ...filters });
       const { total, leadExceedsBudget } = summarizeBundle(rows, maxLoc);
       if (flags.json) {
         console.log(
@@ -3138,7 +3175,7 @@ function main(): void {
           ),
         );
       } else if (rows.length === 0) {
-        console.log(`no ready stories within ${maxLoc} LOC`);
+        console.log(formatEmptyBundle(emptyBundleReason(idx, filters), maxLoc, filters));
       } else {
         const note = leadExceedsBudget ? " — lead exceeds budget" : "";
         console.log(`bundle (sum ${total} / max ${maxLoc}${note}):`);


### PR DESCRIPTION
`next-bundle` printed `no ready stories within ${maxLoc} LOC` for every empty
bundle, conflating two different situations. This splits them.

## Reachability

The branch is **not** dead, but it is narrower than the message implies. An
empty `nextBundle` result implies no in-scope story carries an effective
priority — the prioritized branch always returns `[lead, ...fill]`. With no
priorities in scope, `[]` comes back in exactly two cases:

- the filters (`--rfc` / `--cluster`, in any combination, including none)
  selected no ready story at all;
- the selection was non-empty but nothing packed — every candidate is missing
  an `est_loc`, or all of them are over budget.

So the message stays; it just needs to say which happened.

## Changes

- `bundleScope` — extracted from `nextBundle`, shared with the new
  `emptyBundleReason` so the diagnosis reads the same selection the bundle packs.
- `emptyBundleReason` → `"no-matching-stories" | "none-within-budget"`.
- `formatEmptyBundle` — names the active filters and drops the LOC budget when
  the filters matched nothing, so `--rfc <typo>` no longer reads as a budget
  problem (and never prints a bundle banner over zero rows).

- `--json` now carries `empty_reason` (`null` when the bundle is non-empty), so
  scripted consumers see the same distinction the human-readable line does.

Tests cover both empty cases, the "prioritized ⇒ never empty" invariant, and
each rendering.

Closes-story: next-bundle-empty-result-message-unreachable
