### PR TITLE
feat(eslint): arm a table-teardown sweep on the dropTable() helper form

### DIFF
--- a/eslint/require-canonical-rebuild.mjs
+++ b/eslint/require-canonical-rebuild.mjs
@@ -1,4 +1,5 @@
-import { calledName, staticString, rawDropNames, SQL_SINKS } from "./require-table-teardown.mjs";
+import { calledName, staticString, SQL_SINKS } from "./sql-call-shapes.mjs";
+import { rawDropNames } from "./require-table-teardown.mjs";
 import { createSweepBinding } from "./sweep-binding.mjs";
 import { CATALOGUE_SOURCE } from "./canonical-catalogue-sources.mjs";
 

--- a/eslint/require-canonical-rebuild.mjs
+++ b/eslint/require-canonical-rebuild.mjs
@@ -1,4 +1,5 @@
 import { calledName, staticString, rawDropNames, SQL_SINKS } from "./require-table-teardown.mjs";
+import { createSweepBinding } from "./sweep-binding.mjs";
 import { CATALOGUE_SOURCE } from "./canonical-catalogue-sources.mjs";
 
 const DROP_TABLE = /\bdrop\s+table\b/i;
@@ -61,15 +62,7 @@ const rule = {
       if (canonical.has(table) && !dropped.has(table)) dropped.set(table, node);
     }
 
-    function resolve(node) {
-      if (node?.type !== "Identifier") return null;
-      const scope = context.sourceCode.getScope(node);
-      for (let s = scope; s; s = s.upper) {
-        const found = s.variables.find((v) => v.name === node.name);
-        if (found) return found;
-      }
-      return null;
-    }
+    const { resolve, isSweepBound: isLoopBound } = createSweepBinding(context);
 
     /**
      * Every string a sink argument could carry: the initializer AND all later
@@ -119,126 +112,6 @@ const rule = {
       for (const [, name] of text.matchAll(/'([A-Za-z_][A-Za-z0-9_]*)'/g)) {
         if (canonical.has(name)) namesInScope.add(name);
       }
-    }
-
-    /**
-     * One unwrapping step shared by both walkers, so they cannot drift apart:
-     * they differ only in that isSinkDerived also descends a CallExpression.
-     * Returns undefined when the node is not a wrapper, null at a dead end.
-     */
-    function unwrapStep(node) {
-      switch (node?.type) {
-        case "AwaitExpression":
-          return node.argument;
-        case "ChainExpression":
-        case "TSNonNullExpression":
-          return node.expression;
-        case "ConditionalExpression":
-          return node.consequent;
-        case "LogicalExpression":
-          return node.left;
-        case "MemberExpression":
-          return node.object;
-        case "TemplateLiteral":
-          return node.expressions.length === 1 ? node.expressions[0] : null;
-        default:
-          return undefined;
-      }
-    }
-
-    function rootIdentifier(expr) {
-      let cur = expr;
-      for (;;) {
-        if (!cur) return null;
-        if (cur.type === "CallExpression" && cur.arguments.length === 1) {
-          cur = cur.arguments[0];
-          continue;
-        }
-        const next = unwrapStep(cur);
-        if (next === undefined) return cur.type === "Identifier" ? cur : null;
-        cur = next;
-      }
-    }
-
-    /**
-     * A value read out of a query's result rows — the row source of a sweep.
-     * The sink call can sit at ANY level of the chain, not just the top:
-     * `(await execute(sql)).rows` and `(await execute(sql)).rows.forEach` both
-     * bottom out in a call rather than an identifier, so stopping at the first
-     * non-call would miss the collapsed one-liner form while reporting the
-     * two-step `const res = …; const rows = res.rows;` spelling.
-     */
-    function isSinkDerived(node, seen) {
-      let cur = node;
-      for (;;) {
-        if (!cur) return false;
-        if (cur.type === "CallExpression") {
-          if (SQL_SINKS.has(calledName(cur.callee))) return true;
-          // Toward the function, never the arguments: this exists only to reach
-          // a member chain's object (`res.rows.filter(cb)`). Landing on a plain
-          // function binding is an accepted dead end, not an error.
-          cur = cur.callee;
-          continue;
-        }
-        const next = unwrapStep(cur);
-        if (next === undefined) break;
-        cur = next;
-      }
-      return cur?.type === "Identifier" ? varIsSweepBound(resolve(cur), seen) : false;
-    }
-
-    /**
-     * The variable must BE the sweep binding, never merely be enclosed by one:
-     * walking up to an enclosing construct arms every fixed name declared
-     * inside a describe/it callback or a loop body.
-     */
-    function varIsSweepBound(variable, seen = new Set()) {
-      if (variable === null || seen.has(variable)) return false;
-      seen.add(variable);
-      const boundByDef = variable.defs.some((def) => {
-        if (def.type === "Parameter") return isRowCallbackParam(def.node, seen);
-        const declarator = def.node;
-        if (declarator?.type !== "VariableDeclarator") return false;
-        const declaration = declarator.parent;
-        const loop = declaration?.parent;
-        if (
-          (loop?.type === "ForOfStatement" || loop?.type === "ForInStatement") &&
-          loop.left === declaration
-        ) {
-          return true;
-        }
-        return declarator.init ? isSinkDerived(declarator.init, seen) : false;
-      });
-      if (boundByDef) return true;
-      // `let name; name = row.tablename;` binds by assignment, not initializer —
-      // the same spelling sqlTexts already follows on the SQL side.
-      return variable.references.some((ref) => ref.writeExpr && isSinkDerived(ref.writeExpr, seen));
-    }
-
-    /**
-     * A parameter of a callback whose call also carries the row set — as the
-     * callee's object (`tables.map(cb)`) or as a sibling argument
-     * (`eachRow(rows, cb)`, `pMap(rows, cb)`). Shape, not method name: a name
-     * list misses every non-member spelling, and `withConnection((conn) => …)`
-     * stays quiet here because it carries no sink-derived value at all.
-     *
-     * Arming is per-CALL, not per-parameter: every parameter of every callback
-     * in a qualifying call counts, whatever its role. A `reduce` accumulator
-     * arms, and so does the resource parameter of
-     * `withRows(rows, (conn) => …)`. Over-report direction, accepted.
-     */
-    function isRowCallbackParam(fn, seen) {
-      if (fn?.type !== "ArrowFunctionExpression" && fn?.type !== "FunctionExpression") return false;
-      const call = fn.parent;
-      if (call?.type !== "CallExpression" || !call.arguments.includes(fn)) return false;
-      const callee = call.callee;
-      if (callee?.type === "MemberExpression" && isSinkDerived(callee.object, seen)) return true;
-      return call.arguments.some((arg) => arg !== fn && isSinkDerived(arg, seen));
-    }
-
-    function isLoopBound(expr) {
-      const root = rootIdentifier(expr);
-      return root === null ? false : varIsSweepBound(resolve(root));
     }
 
     return {

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -100,10 +100,13 @@
  * `eslint/sweep-binding.mjs` — so the two rules cannot disagree about what a
  * swept name is. `dropTable("ex_foo")` is a fixed name and arms nothing, for
  * the same reason a statically-named raw drop does not, and neither does a
- * fixed name held in a variable. A name bound by a for-of over a hand-written
- * array does arm, an over-accept inherited from the shared resolver and left
- * as-is: such a loop is still a drop of every name it iterates, so crediting
- * it costs only the creates that loop already tears down. A
+ * fixed name held in a variable. Nor does a name bound by a for-of over a
+ * hand-written array (`for (const t of ["ex_int"]) dropTable(t)`): the resolver
+ * is asked here for its strict mode, in which a loop binding counts only when
+ * the loop iterates sink-derived rows. `require-canonical-rebuild` accepts any
+ * loop binding, and the difference is not an inconsistency but the two rules'
+ * opposite polarity — arming ADDS reports there and SUPPRESSES them here, so
+ * the loose reading is a tolerable over-report there and a leaked table here. A
  * static qualifier ahead of it does not disqualify the drop (`DROP TABLE
  * public."${row.tablename}"` is a sweep, the shape `require-canonical-rebuild`
  * recognises too), but in `DROP TABLE "${schema}"."fixed"` the dynamic part is only the qualifier and
@@ -492,7 +495,9 @@ const rule = {
     const checkRawSql = context.options[0]?.rawSql !== false;
 
     const sourceCode = context.sourceCode ?? context.getSourceCode();
-    const { isSweepBound } = createSweepBinding(context);
+    // Arming SUPPRESSES reports here, so a loop binding counts only when the
+    // loop iterates sink-derived rows — see createSweepBinding's doc.
+    const { isSweepBound } = createSweepBinding(context, { loopBindingNeedsSinkIterable: true });
 
     // table name → first create node seen (for the report location).
     const created = new Map();

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -57,7 +57,8 @@
  * helper-created ones, and they are the bulk of the ~2,600 distinct tables the
  * `dropAllTables` fan-out re-drops every run (RFC 0028 Path D). When the
  * `rawSql` option is on (the default), the rule scans the **string/template
- * arguments of execution-sink calls** (see `SQL_SINKS`) for `CREATE TABLE` /
+ * arguments of execution-sink calls** (see `SQL_SINKS` in
+ * `eslint/sql-call-shapes.mjs`) for `CREATE TABLE` /
  * `DROP TABLE` statements and folds their table names into the same per-name
  * create/drop balance — a raw create may be torn down by a raw drop or by the
  * `dropTable` helper, and vice versa.
@@ -98,7 +99,11 @@
  * resolver is shared with `require-canonical-rebuild` — see
  * `eslint/sweep-binding.mjs` — so the two rules cannot disagree about what a
  * swept name is. `dropTable("ex_foo")` is a fixed name and arms nothing, for
- * the same reason a statically-named raw drop does not. A
+ * the same reason a statically-named raw drop does not, and neither does a
+ * fixed name held in a variable. A name bound by a for-of over a hand-written
+ * array does arm, an over-accept inherited from the shared resolver and left
+ * as-is: such a loop is still a drop of every name it iterates, so crediting
+ * it costs only the creates that loop already tears down. A
  * static qualifier ahead of it does not disqualify the drop (`DROP TABLE
  * public."${row.tablename}"` is a sweep, the shape `require-canonical-rebuild`
  * recognises too), but in `DROP TABLE "${schema}"."fixed"` the dynamic part is only the qualifier and
@@ -157,38 +162,8 @@
  * side are still flagged independently).
  */
 
-// Cyclic with this module by design: sweep-binding.mjs reads `calledName` and
-// `SQL_SINKS` from here, and touches both only at lint time, so neither module
-// observes the other half-initialized.
+import { calledName, staticString, SQL_SINKS } from "./sql-call-shapes.mjs";
 import { createSweepBinding } from "./sweep-binding.mjs";
-
-/**
- * The called function's name, whether it's a bare call (`createTable(...)`) or
- * a method call (`recv.createTable(...)`). Receiver-agnostic by design — the
- * rule cares about the operation, not what it's invoked on. Returns null for
- * dynamic/computed callees (`recv[fn](...)`).
- */
-export function calledName(callee) {
-  if (callee.type === "Identifier") return callee.name;
-  if (callee.type !== "MemberExpression") return null;
-  if (callee.computed || callee.property.type !== "Identifier") return null;
-  return callee.property.name;
-}
-
-/**
- * The static string value of a node, or null when it isn't statically known.
- * Plain string literals (`"foo"`) and template literals with no substitutions
- * (`` `foo` ``) both qualify; a template with an interpolation (`` `${s}.foo` ``)
- * does not — its table name can't be matched statically, so it's skipped.
- */
-export function staticString(node) {
-  if (!node) return null;
-  if (node.type === "Literal" && typeof node.value === "string") return node.value;
-  if (node.type === "TemplateLiteral" && node.expressions.length === 0) {
-    return node.quasis[0].value.cooked;
-  }
-  return null;
-}
 
 /** The created table name (createTable's first arg), or null if not static. */
 function createdTableName(call) {
@@ -266,21 +241,6 @@ const CREATE_TABLE_RE = new RegExp(
 const DROP_TABLE_RE = /\bdrop\s+table\s+(?:if\s+exists\s+)?/gi;
 /** A single (optionally quoted) table name at the start of `rest`. */
 const NAME_RE = new RegExp(`^\\s*${NAME_SRC}`);
-
-/**
- * Call names that execute a raw SQL string against the database. A `CREATE
- * TABLE` handed to one of these leaks a real table; the same string passed to
- * `expect(...).toContain` does not. Receiver-agnostic, like every other name
- * the rule matches. Extend this set if a new execution sink appears.
- */
-export const SQL_SINKS = new Set([
-  "exec",
-  "execute",
-  "executeMutation",
-  "internalExecute",
-  "execQuery",
-  "query",
-]);
 
 /**
  * Statically-knowable `CREATE TABLE` names in `text`. When `endIsDynamic` (this

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -87,8 +87,18 @@
  * ones the sweep alone dropped.
  *
  * Both halves must be present: a `LIKE` filter on a catalogue relation whose
- * pattern is a closed single-quoted literal ending in `%`, and a raw `DROP
- * TABLE` whose name position is an interpolation *that is the table name*. A
+ * pattern is a closed single-quoted literal ending in `%`, and a drop that
+ * names no table itself. The drop is recognised in either spelling, on the same
+ * footing: a raw `DROP TABLE` whose name position is an interpolation *that is
+ * the table name*, or a `dropTable()` helper call whose argument traces back to
+ * a sink-derived row binding (`for (const t of rows) await
+ * adapter.dropTable(t.tablename)`). The helper form is the one CLAUDE.md steers
+ * tests toward, so recognising only the raw one left a file written the
+ * recommended way reporting every create it does tear down. The binding
+ * resolver is shared with `require-canonical-rebuild` — see
+ * `eslint/sweep-binding.mjs` — so the two rules cannot disagree about what a
+ * swept name is. `dropTable("ex_foo")` is a fixed name and arms nothing, for
+ * the same reason a statically-named raw drop does not. A
  * static qualifier ahead of it does not disqualify the drop (`DROP TABLE
  * public."${row.tablename}"` is a sweep, the shape `require-canonical-rebuild`
  * recognises too), but in `DROP TABLE "${schema}"."fixed"` the dynamic part is only the qualifier and
@@ -113,8 +123,7 @@
  * the under-accepting direction (a real sweep goes unrecognised and its creates
  * are reported, which is noise rather than a leak): SQL built by concatenation
  * or returned from a helper, since only literals and template quasis are read;
- * a catalogue relation `CATALOGUE_SOURCE` does not list; a sweep whose drop runs
- * through the `dropTable()` helper on a row value rather than raw SQL; and a
+ * a catalogue relation `CATALOGUE_SOURCE` does not list; and a
  * filter spelled as something other than `LIKE` — `ILIKE`, `SIMILAR TO`, a
  * regex operator — since only `LIKE` is read.
  *
@@ -147,6 +156,11 @@
  * dynamic/computed table name breaks the run (any contiguous sub-runs on either
  * side are still flagged independently).
  */
+
+// Cyclic with this module by design: sweep-binding.mjs reads `calledName` and
+// `SQL_SINKS` from here, and touches both only at lint time, so neither module
+// observes the other half-initialized.
+import { createSweepBinding } from "./sweep-binding.mjs";
 
 /**
  * The called function's name, whether it's a bare call (`createTable(...)`) or
@@ -518,6 +532,7 @@ const rule = {
     const checkRawSql = context.options[0]?.rawSql !== false;
 
     const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const { isSweepBound } = createSweepBinding(context);
 
     // table name → first create node seen (for the report location).
     const created = new Map();
@@ -623,6 +638,12 @@ const rule = {
           if (table !== null && !created.has(table)) created.set(table, node);
         } else if (name === "dropTable") {
           for (const table of droppedTableNames(node)) dropped.add(table);
+          // The helper spelling of a sweep's drop half: `dropTable(row.name)`
+          // names no table itself, so it arms only when its argument traces
+          // back to a sink-derived row binding. A fixed name arms nothing.
+          for (const arg of node.arguments) {
+            if (staticString(arg) === null && isSweepBound(arg)) sawSweepDrop = true;
+          }
         } else if (checkRawSql && name !== null && SQL_SINKS.has(name)) {
           recordSinkSql(node);
         }

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -409,6 +409,18 @@ tester.run("require-table-teardown", rule, {
         'await adapter.dropTable("ex_int");',
       errors: [{ messageId: "missingTeardown", data: { table: "ex_leak" } }],
     },
+    // A fixed name held in a variable is not sweep-bound either: the dropTable()
+    // argument has to trace back to a row set, not merely be non-literal.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+        ");\n" +
+        'const name = "ex_int";\n' +
+        "await adapter.dropTable(name);",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
     // An escaped `%` is a literal, not a prefix wildcard: `ex\%` names one table.
     {
       code:

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -421,6 +421,24 @@ tester.run("require-table-teardown", rule, {
         "await adapter.dropTable(name);",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
+    // A for-of over a hand-written array is not a sweep: it drops exactly the
+    // names it lists, so crediting it with the filter's whole prefix would
+    // suppress the leak of every other table under that prefix.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        'await adapter.exec(`CREATE TABLE "ex_leak" (id int)`);\n' +
+        "await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+        ");\n" +
+        'for (const t of ["ex_int"]) {\n' +
+        "  await adapter.dropTable(t);\n" +
+        "}",
+      errors: [
+        { messageId: "missingTeardown", data: { table: "ex_int" } },
+        { messageId: "missingTeardown", data: { table: "ex_leak" } },
+      ],
+    },
     // An escaped `%` is a literal, not a prefix wildcard: `ex\%` names one table.
     {
       code:

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -148,6 +148,17 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${schema}"."${t.tablename}" CASCADE`);\n' +
       "}",
+    // The helper spelling of the drop half: dropTable() on a swept row name is
+    // a sweep on the same footing as the raw one, so it satisfies the creates
+    // under the filter's prefix.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      'await adapter.exec("CREATE TABLE ex_json (id int)");\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      "  await adapter.dropTable(t.tablename);\n" +
+      "}",
   ],
   invalid: [
     // Dropping the truncated prefix of a spaced quoted name is not a teardown
@@ -383,6 +394,19 @@ tester.run("require-table-teardown", rule, {
         "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
         ");\n" +
         'await adapter.exec(`DROP TABLE IF EXISTS "${schema}"."fixed"`);',
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_leak" } }],
+    },
+    // A fixed-name dropTable() arms no sweep, however many catalogue filters the
+    // file carries — otherwise the rule stops catching the bespoke tables that
+    // outlive their test. The named table is torn down; the other is reported.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        'await adapter.exec(`CREATE TABLE "ex_leak" (id int)`);\n' +
+        "await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+        ");\n" +
+        'await adapter.dropTable("ex_int");',
       errors: [{ messageId: "missingTeardown", data: { table: "ex_leak" } }],
     },
     // An escaped `%` is a literal, not a prefix wildcard: `ex\%` names one table.

--- a/eslint/sql-call-shapes.mjs
+++ b/eslint/sql-call-shapes.mjs
@@ -1,0 +1,52 @@
+/**
+ * Call-shape helpers shared by the table-teardown rules.
+ *
+ * These sit in a leaf module rather than in `require-table-teardown.mjs`, where
+ * they used to live, so that `sweep-binding.mjs` can read them without the two
+ * importing each other: the sweep resolver needs to recognise an execution
+ * sink, and the teardown rule needs the resolver. Nothing here knows about a
+ * rule; it is all shape questions about an AST node.
+ */
+
+/**
+ * The called function's name, whether it's a bare call (`createTable(...)`) or
+ * a method call (`recv.createTable(...)`). Receiver-agnostic by design — the
+ * rule cares about the operation, not what it's invoked on. Returns null for
+ * dynamic/computed callees (`recv[fn](...)`).
+ */
+export function calledName(callee) {
+  if (callee.type === "Identifier") return callee.name;
+  if (callee.type !== "MemberExpression") return null;
+  if (callee.computed || callee.property.type !== "Identifier") return null;
+  return callee.property.name;
+}
+
+/**
+ * The static string value of a node, or null when it isn't statically known.
+ * Plain string literals (`"foo"`) and template literals with no substitutions
+ * (`` `foo` ``) both qualify; a template with an interpolation (`` `${s}.foo` ``)
+ * does not — its table name can't be matched statically, so it's skipped.
+ */
+export function staticString(node) {
+  if (!node) return null;
+  if (node.type === "Literal" && typeof node.value === "string") return node.value;
+  if (node.type === "TemplateLiteral" && node.expressions.length === 0) {
+    return node.quasis[0].value.cooked;
+  }
+  return null;
+}
+
+/**
+ * Call names that execute a raw SQL string against the database. A `CREATE
+ * TABLE` handed to one of these leaks a real table; the same string passed to
+ * `expect(...).toContain` does not. Receiver-agnostic, like every other name
+ * the rule matches. Extend this set if a new execution sink appears.
+ */
+export const SQL_SINKS = new Set([
+  "exec",
+  "execute",
+  "executeMutation",
+  "internalExecute",
+  "execQuery",
+  "query",
+]);

--- a/eslint/sweep-binding.mjs
+++ b/eslint/sweep-binding.mjs
@@ -26,8 +26,21 @@ import { calledName, SQL_SINKS } from "./sql-call-shapes.mjs";
  * `{ resolve, isSweepBound }`: `resolve` maps an Identifier node to its scope
  * variable, and `isSweepBound` answers whether an expression's value traces
  * back to a sink-derived row binding.
+ *
+ * `loopBindingNeedsSinkIterable` picks which side to err on when a for-of/for-in
+ * binding's iterable is NOT sink-derived (`for (const t of ["ex_int"])`), and
+ * the two rules need opposite answers because arming means opposite things to
+ * them. In `require-canonical-rebuild` an armed sweep ADDS reports, so accepting
+ * every loop binding is a tolerable over-report — and a deliberate one: it is
+ * what covers the index and while loops whose variable has no binding form to
+ * detect. In `require-table-teardown` an armed sweep SUPPRESSES reports, since
+ * a sweep counts as teardown for every create under its prefix, so the same
+ * acceptance is a false negative: a file with a catalogue `LIKE` filter and
+ * `for (const t of ["ex_int"]) dropTable(t)` would stop reporting a leaked
+ * `ex_leak`, which is the exact leak the rule exists to catch. Set there, the
+ * flag requires the iterable itself to be sink-derived.
  */
-export function createSweepBinding(context) {
+export function createSweepBinding(context, { loopBindingNeedsSinkIterable = false } = {}) {
   function resolve(node) {
     if (node?.type !== "Identifier") return null;
     const scope = context.sourceCode.getScope(node);
@@ -122,7 +135,7 @@ export function createSweepBinding(context) {
         (loop?.type === "ForOfStatement" || loop?.type === "ForInStatement") &&
         loop.left === declaration
       ) {
-        return true;
+        return loopBindingNeedsSinkIterable ? isSinkDerived(loop.right, seen) : true;
       }
       return declarator.init ? isSinkDerived(declarator.init, seen) : false;
     });

--- a/eslint/sweep-binding.mjs
+++ b/eslint/sweep-binding.mjs
@@ -1,0 +1,162 @@
+/**
+ * Shared sweep-binding resolver for `require-canonical-rebuild` and
+ * `require-table-teardown`.
+ *
+ * A catalogue sweep names no table in its DROP: the victims come out of a
+ * catalogue query, and the drop runs per row — either as raw SQL
+ * (`` exec(`DROP TABLE "${row.tablename}"`) ``) or through the schema-statement
+ * helper (`await adapter.dropTable(row.tablename)`). Both spellings are only a
+ * sweep when the dropped name traces back to a row set, so both rules need the
+ * same question answered: does this expression bottom out in a value that came
+ * from an execution sink?
+ *
+ * The answer lives here rather than in either rule so the two cannot drift:
+ * `require-table-teardown` used to recognise only the raw-SQL spelling, which
+ * left the helper form — the form CLAUDE.md steers tests toward — reporting
+ * every prefixed create in a file that does tear down correctly.
+ *
+ * See the `require-canonical-rebuild` rule doc for the full statement of what
+ * arms, what does not, and the accepted over- and under-approximations; this
+ * module is that description's implementation.
+ */
+import { calledName, SQL_SINKS } from "./require-table-teardown.mjs";
+
+/**
+ * A sweep-binding resolver bound to one lint `context`. Returns
+ * `{ resolve, isSweepBound }`: `resolve` maps an Identifier node to its scope
+ * variable, and `isSweepBound` answers whether an expression's value traces
+ * back to a sink-derived row binding.
+ */
+export function createSweepBinding(context) {
+  function resolve(node) {
+    if (node?.type !== "Identifier") return null;
+    const scope = context.sourceCode.getScope(node);
+    for (let s = scope; s; s = s.upper) {
+      const found = s.variables.find((v) => v.name === node.name);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  /**
+   * One unwrapping step shared by both walkers, so they cannot drift apart:
+   * they differ only in that isSinkDerived also descends a CallExpression.
+   * Returns undefined when the node is not a wrapper, null at a dead end.
+   */
+  function unwrapStep(node) {
+    switch (node?.type) {
+      case "AwaitExpression":
+        return node.argument;
+      case "ChainExpression":
+      case "TSNonNullExpression":
+        return node.expression;
+      case "ConditionalExpression":
+        return node.consequent;
+      case "LogicalExpression":
+        return node.left;
+      case "MemberExpression":
+        return node.object;
+      case "TemplateLiteral":
+        return node.expressions.length === 1 ? node.expressions[0] : null;
+      default:
+        return undefined;
+    }
+  }
+
+  function rootIdentifier(expr) {
+    let cur = expr;
+    for (;;) {
+      if (!cur) return null;
+      if (cur.type === "CallExpression" && cur.arguments.length === 1) {
+        cur = cur.arguments[0];
+        continue;
+      }
+      const next = unwrapStep(cur);
+      if (next === undefined) return cur.type === "Identifier" ? cur : null;
+      cur = next;
+    }
+  }
+
+  /**
+   * A value read out of a query's result rows — the row source of a sweep.
+   * The sink call can sit at ANY level of the chain, not just the top:
+   * `(await execute(sql)).rows` and `(await execute(sql)).rows.forEach` both
+   * bottom out in a call rather than an identifier, so stopping at the first
+   * non-call would miss the collapsed one-liner form while reporting the
+   * two-step `const res = …; const rows = res.rows;` spelling.
+   */
+  function isSinkDerived(node, seen) {
+    let cur = node;
+    for (;;) {
+      if (!cur) return false;
+      if (cur.type === "CallExpression") {
+        if (SQL_SINKS.has(calledName(cur.callee))) return true;
+        // Toward the function, never the arguments: this exists only to reach
+        // a member chain's object (`res.rows.filter(cb)`). Landing on a plain
+        // function binding is an accepted dead end, not an error.
+        cur = cur.callee;
+        continue;
+      }
+      const next = unwrapStep(cur);
+      if (next === undefined) break;
+      cur = next;
+    }
+    return cur?.type === "Identifier" ? varIsSweepBound(resolve(cur), seen) : false;
+  }
+
+  /**
+   * The variable must BE the sweep binding, never merely be enclosed by one:
+   * walking up to an enclosing construct arms every fixed name declared
+   * inside a describe/it callback or a loop body.
+   */
+  function varIsSweepBound(variable, seen = new Set()) {
+    if (variable === null || seen.has(variable)) return false;
+    seen.add(variable);
+    const boundByDef = variable.defs.some((def) => {
+      if (def.type === "Parameter") return isRowCallbackParam(def.node, seen);
+      const declarator = def.node;
+      if (declarator?.type !== "VariableDeclarator") return false;
+      const declaration = declarator.parent;
+      const loop = declaration?.parent;
+      if (
+        (loop?.type === "ForOfStatement" || loop?.type === "ForInStatement") &&
+        loop.left === declaration
+      ) {
+        return true;
+      }
+      return declarator.init ? isSinkDerived(declarator.init, seen) : false;
+    });
+    if (boundByDef) return true;
+    // `let name; name = row.tablename;` binds by assignment, not initializer —
+    // the same spelling sqlTexts already follows on the SQL side.
+    return variable.references.some((ref) => ref.writeExpr && isSinkDerived(ref.writeExpr, seen));
+  }
+
+  /**
+   * A parameter of a callback whose call also carries the row set — as the
+   * callee's object (`tables.map(cb)`) or as a sibling argument
+   * (`eachRow(rows, cb)`, `pMap(rows, cb)`). Shape, not method name: a name
+   * list misses every non-member spelling, and `withConnection((conn) => …)`
+   * stays quiet here because it carries no sink-derived value at all.
+   *
+   * Arming is per-CALL, not per-parameter: every parameter of every callback
+   * in a qualifying call counts, whatever its role. A `reduce` accumulator
+   * arms, and so does the resource parameter of
+   * `withRows(rows, (conn) => …)`. Over-report direction, accepted.
+   */
+  function isRowCallbackParam(fn, seen) {
+    if (fn?.type !== "ArrowFunctionExpression" && fn?.type !== "FunctionExpression") return false;
+    const call = fn.parent;
+    if (call?.type !== "CallExpression" || !call.arguments.includes(fn)) return false;
+    const callee = call.callee;
+    if (callee?.type === "MemberExpression" && isSinkDerived(callee.object, seen)) return true;
+    return call.arguments.some((arg) => arg !== fn && isSinkDerived(arg, seen));
+  }
+
+  function isSweepBound(expr) {
+    const root = rootIdentifier(expr);
+    return root === null ? false : varIsSweepBound(resolve(root));
+  }
+
+  return { resolve, isSweepBound };
+}

--- a/eslint/sweep-binding.mjs
+++ b/eslint/sweep-binding.mjs
@@ -19,7 +19,7 @@
  * arms, what does not, and the accepted over- and under-approximations; this
  * module is that description's implementation.
  */
-import { calledName, SQL_SINKS } from "./require-table-teardown.mjs";
+import { calledName, SQL_SINKS } from "./sql-call-shapes.mjs";
 
 /**
  * A sweep-binding resolver bound to one lint `context`. Returns
@@ -127,8 +127,8 @@ export function createSweepBinding(context) {
       return declarator.init ? isSinkDerived(declarator.init, seen) : false;
     });
     if (boundByDef) return true;
-    // `let name; name = row.tablename;` binds by assignment, not initializer —
-    // the same spelling sqlTexts already follows on the SQL side.
+    // `let name; name = row.tablename;` binds by assignment, not initializer,
+    // and is as much a sweep binding as the `const` form.
     return variable.references.some((ref) => ref.writeExpr && isSinkDerived(ref.writeExpr, seen));
   }
 


### PR DESCRIPTION
`require-table-teardown` recognised the drop half of a catalogue sweep only in
raw SQL: `hasDynamicDropName` scanned template quasis of `SQL_SINKS` calls for
`DROP TABLE` followed by an interpolation in the name position. A sweep that
drops through the schema-statement helper instead —
`for (const t of rows) await adapter.dropTable(t.tablename)` — armed nothing, so
every raw `CREATE TABLE <prefix>…` in that file still reported
`missingTeardown`. Under-accepting (noise, not a leak), but the helper form is
the form CLAUDE.md steers tests toward, so a file written the recommended way
got the worse lint outcome.

## What changed

`require-canonical-rebuild` already resolved both spellings. Rather than write a
second implementation, its sweep-binding resolver moves verbatim to
`eslint/sweep-binding.mjs` as `createSweepBinding(context)` — `resolve` plus
`isSweepBound` — and both rules use it, so they cannot drift apart about what a
swept name is. `require-canonical-rebuild` loses ~110 lines and keeps its
behaviour: its 77 rule tests pass untouched.

That resolver has to recognise an execution sink, and the teardown rule has to
call the resolver, which would have made the two modules import each other.
Instead `calledName`, `staticString` and `SQL_SINKS` move to a leaf module,
`eslint/sql-call-shapes.mjs` — pure shape questions about an AST node, no rule
knowledge — and nothing in the set imports in a cycle.

A `dropTable()` argument that is not a static string and traces back to a
sink-derived row binding now sets `sawSweepDrop`. A fixed name does not, whether
written inline (`dropTable("ex_foo")`), held in a variable, or bound by a for-of
over a hand-written array — otherwise the rule stops catching the bespoke tables
that outlive their test.

That last case is where the two rules must diverge, and the resolver takes a
`loopBindingNeedsSinkIterable` mode for it. Arming has opposite polarity in
them: it ADDS reports in `require-canonical-rebuild`, where accepting any loop
binding is a tolerable over-report and is what covers its index and while loops,
and it SUPPRESSES reports here, where a sweep is teardown for every create under
its prefix. Loose there, strict here — a `for (const t of ["ex_int"])` loop
drops exactly what it lists, so crediting it with the filter's whole prefix
would have hidden a leaked `ex_leak`.

## Verification

Four rule tests pin the behaviour: a helper-form sweep satisfying two prefixed
creates, a file whose only drop is `dropTable("ex_int")` still reporting
`ex_leak` despite carrying a catalogue `LIKE` filter, the same for a fixed name
behind a variable, and the array-literal loop reporting both its creates. Each
was confirmed to fail on the code without its fix — the first by stubbing the
new arming out, the last by flipping the resolver back to loose mode.

Both rules were also run over all of `packages/` before and after: zero
`require-table-teardown` / `require-canonical-rebuild` reports either way, so no
file changes status — the widening only makes room for the sweep spelling tests
are steered toward, and the refactor is behaviour-preserving.

The header's KNOWN GAPS paragraph drops the helper-form clause, and the
prefix-sweep section now states both drop spellings and why the loop-binding
reading differs between the two rules.

Closes-story: require-table-teardown-arm-sweep-on-droptable-helper
