### PR TITLE
test(activerecord): port the rename/remove/change column ColumnsTest cases

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1993,9 +1993,7 @@ export class SchemaStatements {
     const indexName =
       options.name?.toString() ?? this.indexName(tableName, this.indexNameOptions(columnNames));
 
-    if (!options.internal) {
-      this._validateIndexLength(tableName, indexName);
-    }
+    this.validateIndexLengthBang(tableName, indexName, options.internal);
 
     const idx = new IndexDefinition(tableName, indexName, !!options.unique, columnNames, {
       where: options.where,
@@ -2165,15 +2163,6 @@ export class SchemaStatements {
 
   maxIndexNameSize(): number {
     return 62;
-  }
-
-  private _validateIndexLength(tableName: string, indexName: string): void {
-    const limit = this.maxIndexNameSize();
-    if (indexName.length > limit) {
-      throw new Error(
-        `Index name '${indexName}' on table '${tableName}' is too long; the limit is ${limit} characters`,
-      );
-    }
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -12,6 +12,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js"
 import type { CheckConstraintDefinition } from "../abstract/schema-definitions.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { SchemaCreation } from "./schema-creation.js";
+import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 import { SchemaDumper } from "./schema-dumper.js";
 import { Column } from "./column.js";
@@ -214,9 +215,19 @@ function validTableDefinitionOptions(): string[] {
 }
 
 /** @internal */
-function validateIndexLengthBang(_tableName: string, _newName: string, internal = false): void {
-  // SQLite skips index name length validation for internal indexes
+function validateIndexLengthBang(
+  this: { adapter: DatabaseAdapter },
+  tableName: string,
+  newName: string,
+  internal = false,
+): void {
   if (internal) return;
+  AbstractSchemaStatements.prototype.validateIndexLengthBang.call(
+    this,
+    tableName,
+    newName,
+    internal,
+  );
 }
 
 /** @internal */

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -1,8 +1,8 @@
 /**
- * Port of `test_rename_column`, the rename/remove-column index cluster and
- * `test_change_column` from `ActiveRecord::Migration::ColumnsTest`
- * (vendor/rails/activerecord/test/cases/migration/columns_test.rb:43-51,
- * :96-155, :181-204). The rest of columns_test.rb is unported.
+ * Port of the `rename_column`, `remove_column` and `change_column` families of
+ * `ActiveRecord::Migration::ColumnsTest`
+ * (vendor/rails/activerecord/test/cases/migration/columns_test.rb). The
+ * adapter-gated cases and the `assert_queries_count` pair are still unported.
  *
  * Driven by the ambient connection, mirroring Rails'
  * `@connection = ActiveRecord::Base.lease_connection`. `test_models` is not a
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
 import type { Column } from "../connection-adapters/column.js";
+import { ActiveRecordError, StatementInvalid } from "../errors.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { ambientConnection } from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
@@ -27,6 +28,10 @@ const indexesSurvivingColumnDrop =
 async function indexNames(conn: AbstractAdapter, table: string): Promise<string[]> {
   const indexes = (await conn.indexes(table)) as Array<{ name: string }>;
   return indexes.map((i) => i.name);
+}
+
+function indexNameLength(conn: AbstractAdapter): number {
+  return (conn as unknown as { indexNameLength(): number }).indexNameLength();
 }
 
 /** `ActiveRecord::Migration::TestHelper::TestModel`, migration/helper.rb:16-18. */
@@ -52,6 +57,35 @@ describe("Migration", () => {
   });
 
   describe("ColumnsTest", () => {
+    it("add rename", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "girlfriend", "string");
+      TestModel.resetColumnInformation();
+
+      await TestModel.create({ girlfriend: "bobette" });
+
+      await connection.renameColumn("test_models", "girlfriend", "exgirlfriend");
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      const bob = await TestModel.first();
+
+      expect(bob?.exgirlfriend).toBe("bobette");
+    });
+
+    it("rename column using symbol arguments", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+
+      await TestModel.create({ first_name: "foo" });
+
+      await connection.renameColumn("test_models", "first_name", "nick_name");
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.columnNames()).toContain("nick_name");
+      expect((await TestModel.all()).map((m) => m.nick_name)).toEqual(["foo"]);
+    });
+
     it("rename column", async () => {
       const connection = await ambientConnection();
       await connection.addColumn("test_models", "first_name", "string");
@@ -63,6 +97,45 @@ describe("Migration", () => {
       await TestModel.loadSchema();
       expect(TestModel.columnNames()).toContain("nick_name");
       expect((await TestModel.all()).map((m) => m.nick_name)).toEqual(["foo"]);
+    });
+
+    it("rename column preserves default value not null", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "salary", "integer", { default: 70000 });
+
+      const defaultBefore = (await connection.columns("test_models")).find(
+        (c) => c.name === "salary",
+      )?.default;
+      expect(defaultBefore).toBe("70000");
+
+      await connection.renameColumn("test_models", "salary", "annual_salary");
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.columnNames()).toContain("annual_salary");
+      const defaultAfter = (await connection.columns("test_models")).find(
+        (c) => c.name === "annual_salary",
+      )?.default;
+      expect(defaultAfter).toBe("70000");
+    });
+
+    it("rename nonexistent column", async () => {
+      const connection = await ambientConnection();
+      const exception = adapterType === "postgres" ? StatementInvalid : ActiveRecordError;
+
+      await expect(
+        connection.renameColumn("test_models", "nonexistent", "should_fail"),
+      ).rejects.toThrow(exception);
+    });
+
+    it("rename column with sql reserved word", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+      await connection.renameColumn("test_models", "first_name", "group");
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.columnNames()).toContain("group");
     });
 
     it("rename column with an index", async () => {
@@ -125,6 +198,79 @@ describe("Migration", () => {
       expect(await indexNames(connection, "test_models")).toEqual(indexesSurvivingColumnDrop);
     });
 
+    it("removing and renaming column preserves custom primary key", async () => {
+      const connection = await ambientConnection();
+      try {
+        await connection.createTable(
+          "my_table",
+          { primaryKey: "my_table_id", force: true },
+          (t) => {
+            t.integer("col_one");
+            t.string("col_two", { limit: 128, null: false });
+          },
+        );
+
+        await connection.removeColumn("my_table", "col_two");
+        await connection.renameColumn("my_table", "col_one", "col_three");
+
+        expect(await connection.primaryKey("my_table")).toBe("my_table_id");
+      } finally {
+        await connection.dropTable("my_table", { ifExists: true });
+      }
+    });
+
+    it("column with index", async () => {
+      const connection = await ambientConnection();
+      try {
+        await connection.createTable("my_table", { force: true }, (t) => {
+          t.string("item_number", { index: true });
+        });
+
+        expect(
+          await connection.indexExists("my_table", "item_number", {
+            name: "index_my_table_on_item_number",
+          }),
+        ).toBe(true);
+      } finally {
+        await connection.dropTable("my_table", { ifExists: true });
+      }
+    });
+
+    it("change type of not null column", async () => {
+      const connection = await ambientConnection();
+      try {
+        await connection.changeColumn("test_models", "updated_at", "datetime", { null: false });
+        await connection.changeColumn("test_models", "updated_at", "datetime", { null: false });
+
+        TestModel.resetColumnInformation();
+        await TestModel.loadSchema();
+        expect(TestModel.columnsHash()["updated_at"]?.null).toBe(false);
+      } finally {
+        await connection.changeColumn("test_models", "updated_at", "datetime", { null: true });
+      }
+    });
+
+    it("change column nullability", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "funny", "boolean");
+      await TestModel.loadSchema();
+      expect(TestModel.columnsHash()["funny"]?.null).toBe(true);
+
+      await connection.changeColumn("test_models", "funny", "boolean", {
+        null: false,
+        default: true,
+      });
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.columnsHash()["funny"]?.null).toBe(false);
+
+      await connection.changeColumn("test_models", "funny", "boolean", { null: true });
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.columnsHash()["funny"]?.null).toBe(true);
+    });
+
     it("change column", async () => {
       const connection = await ambientConnection();
       await connection.addColumn("test_models", "age", "integer");
@@ -156,6 +302,131 @@ describe("Migration", () => {
 
       expect(await approvedDefault(newColumns)).not.toBe(true);
       expect(await approvedDefault(newColumns)).toBe(false);
+    });
+
+    it("change column with nil default", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "contributor", "boolean", { default: true });
+      await TestModel.loadSchema();
+      expect(TestModel.new().queryAttribute("contributor")).toBe(true);
+
+      await connection.changeColumn("test_models", "contributor", "boolean", { default: null });
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().queryAttribute("contributor")).toBe(false);
+      expect(TestModel.new().contributor).toBeNull();
+    });
+
+    it("change column to drop default with null false", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "contributor", "boolean", {
+        default: true,
+        null: false,
+      });
+      await TestModel.loadSchema();
+      expect(TestModel.new().queryAttribute("contributor")).toBe(true);
+
+      await connection.changeColumn("test_models", "contributor", "boolean", {
+        default: null,
+        null: false,
+      });
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().queryAttribute("contributor")).toBe(false);
+      expect(TestModel.new().contributor).toBeNull();
+    });
+
+    it("change column with new default", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "administrator", "boolean", { default: true });
+      await TestModel.loadSchema();
+      expect(TestModel.new().queryAttribute("administrator")).toBe(true);
+
+      await connection.changeColumn("test_models", "administrator", "boolean", { default: false });
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().queryAttribute("administrator")).toBe(false);
+    });
+
+    it("change column with custom index name", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "category", "string");
+      await connection.addIndex("test_models", "category", { name: "test_models_categories_idx" });
+
+      expect(await indexNames(connection, "test_models")).toEqual(["test_models_categories_idx"]);
+      await connection.changeColumn("test_models", "category", "string", {
+        null: false,
+        default: "article",
+      });
+
+      expect(await indexNames(connection, "test_models")).toEqual(["test_models_categories_idx"]);
+    });
+
+    it("change column with long index name", async () => {
+      const connection = await ambientConnection();
+      const tableNamePrefix = "test_models_";
+      const longIndexName =
+        tableNamePrefix + "x".repeat(indexNameLength(connection) - tableNamePrefix.length);
+      await connection.addColumn("test_models", "category", "string");
+      await connection.addIndex("test_models", "category", { name: longIndexName });
+
+      await connection.changeColumn("test_models", "category", "string", {
+        null: false,
+        default: "article",
+      });
+
+      expect(await indexNames(connection, "test_models")).toEqual([longIndexName]);
+    });
+
+    it("change column default", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+      await connection.changeColumnDefault("test_models", "first_name", "Tester");
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().first_name).toBe("Tester");
+    });
+
+    it("change column default to null", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+      await connection.changeColumnDefault("test_models", "first_name", null);
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().first_name).toBeNull();
+    });
+
+    it("change column default to null with not null", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string", { null: false });
+      await connection.addColumn("test_models", "age", "integer", { null: false });
+
+      await connection.changeColumnDefault("test_models", "first_name", null);
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().first_name).toBeNull();
+
+      await connection.changeColumnDefault("test_models", "age", null);
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().age).toBeNull();
+    });
+
+    it("change column default with from and to", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+      await connection.changeColumnDefault("test_models", "first_name", {
+        from: null,
+        to: "Tester",
+      });
+
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.new().first_name).toBe("Tester");
     });
   });
 });

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -1,15 +1,3 @@
-/**
- * Port of the `rename_column`, `remove_column` and `change_column` families of
- * `ActiveRecord::Migration::ColumnsTest`
- * (vendor/rails/activerecord/test/cases/migration/columns_test.rb). The
- * adapter-gated cases and the `assert_queries_count` pair are still unported.
- *
- * Driven by the ambient connection, mirroring Rails'
- * `@connection = ActiveRecord::Base.lease_connection`. `test_models` is not a
- * canonical-schema table in Rails either — `Migration::TestHelper`'s setup
- * creates and drops it (migration/helper.rb:20-34) — so this mirrors that
- * rather than reaching for the canonical schema.
- */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
 import type { Column } from "../connection-adapters/column.js";
@@ -34,7 +22,6 @@ function indexNameLength(conn: AbstractAdapter): number {
   return (conn as unknown as { indexNameLength(): number }).indexNameLength();
 }
 
-/** `ActiveRecord::Migration::TestHelper::TestModel`, migration/helper.rb:16-18. */
 class TestModel extends Base {
   static {
     this._tableName = "test_models";

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_index_options",
-    "call": "validate_index_length!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_timestamps",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Ports 18 more cases of `ActiveRecord::Migration::ColumnsTest`
(`vendor/rails/activerecord/test/cases/migration/columns_test.rb`) into
`packages/activerecord/src/migration/columns.test.ts`.

`test:compare` for `migration/columns_test.rb`: **7 ported / 29 missing → 25
ported / 11 missing**, 0 gate-mismatch, 0 misplaced.

Rebased onto #5548, which landed the rename/remove-column index cluster while
this was open; this branch keeps that PR's `indexNames(conn, table)` helper and
its `it.skipIf(mariaDbRejectsUniqueColumnDrop)` / `indexesSurvivingColumnDrop`
gating style rather than reintroducing its own.

## What's in

- rename family: `test_add_rename`, `..._using_symbol_arguments`,
  `..._preserves_default_value_not_null`, `test_rename_nonexistent_column`,
  `..._with_sql_reserved_word`
- `test_removing_and_renaming_column_preserves_custom_primary_key`,
  `test_column_with_index`
- change family: `test_change_type_of_not_null_column`,
  `test_change_column_nullability`, `..._with_nil_default`,
  `..._to_drop_default_with_null_false`, `..._with_new_default`,
  `..._with_custom_index_name`, `..._with_long_index_name`,
  `test_change_column_default`, `..._to_null`, `..._to_null_with_not_null`,
  `..._with_from_and_to`

Every case ported here is unconditional in Rails and runs unconditionally on
all three lanes. `test_rename_nonexistent_column` mirrors Rails' own
`current_adapter?(:PostgreSQLAdapter)` choice of expected exception class
(`StatementInvalid` vs `ActiveRecordError`) as a value, not as a gate.
Verified green on sqlite3, postgresql and mysql2 locally.

## Source change

`test_change_column_with_long_index_name` builds an index name of exactly
`index_name_length` characters. It raised, because the trails-only private
`_validateIndexLength` compared against `max_index_name_size` (62) where Rails'
`validate_index_length!` compares against `index_name_length`
(`max_identifier_length` — 64 on sqlite/mysql, 63 on pg;
`abstract/database_limits.rb:20-23`, `abstract/schema_statements.rb:1808-1812`).

The private duplicate is deleted; `add_index_options` now calls the
already-faithful `validateIndexLengthBang` unconditionally with `internal`,
exactly as `schema_statements.rb:1484` does. Rails' `validate_index_length!`
ignores `internal`, so the previous `if (!options.internal)` gate was
trails-only too. `max_index_name_size` stays where Rails uses it, in
`generateIndexName`. No stubs, no placeholders; `api:compare` runs clean and the
change only removes trails-invented surface.

## What's still missing (11)

Registered as sibling stories rather than fanned out from here:

- `port-migration-columns-adapter-gated-cases` — the four adapter-gated cases
  (`test_mysql_rename_column_preserves_auto_increment`, the two SQLite
  `default_function` cases, `test_change_column_null_does_not_change_default_functions`).
- `port-migration-columns-blocked-cases` — the `change_column_null` trio (needs
  `assert_difference`), the two `assert_queries_count` cases, and the two
  `ArgumentError` cases whose messages trails does not emit yet.

Closes-story: port-migration-columns-cases
