### PR TITLE
feat(eslint): read ILIKE sweep filters in require-table-teardown

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -336,14 +336,14 @@ const CATALOGUE_SOURCE =
  * the `i` flag: `ILIKE 'ex_%'` really does select `EX_FOO`, and compiling it
  * case-sensitively would leave that create reported although the sweep drops it.
  *
- * `NOT LIKE` (and `NOT ILIKE`) is excluded, and it is not a nicety: an exclusion
- * filter selects
- * the complement of its pattern, so reading `NOT LIKE 'ex_%'` as a prefix would
- * make a sweep satisfy exactly the creates it deliberately spares. The empty
+ * `NOT LIKE` and `NOT ILIKE` are excluded, and it is not a nicety: an exclusion
+ * filter selects the complement of its pattern, so reading `NOT LIKE 'ex_%'` as
+ * a prefix would make a sweep satisfy exactly the creates it deliberately
+ * spares. The empty
  * pattern is likewise impossible to match (`[^'%]+`), so a bare `LIKE '%'`
  * selecting everything never becomes a prefix that satisfies everything.
  */
-const LIKE_PREFIX_RE = /(?<!\bnot\s+)\b(i?)like\s+'([^'%]+)%'/gi;
+const LIKE_PREFIX_RE = /(?<!\bnot\s+)\b(?<i>i?)like\s+'(?<pattern>[^'%]+)%'/gi;
 /** A trailing `ESCAPE '<char>'` clause, and the leading keyword on its own. */
 const ESCAPE_CLAUSE_RE = /^\s*escape\s+'([^'])'/i;
 const ESCAPE_KEYWORD_RE = /^\s*escape\b/i;
@@ -356,7 +356,8 @@ export function sweepPrefixMatchers(text) {
     const tail = text.slice(m.index + m[0].length);
     const clause = ESCAPE_CLAUSE_RE.exec(tail);
     if (clause === null && ESCAPE_KEYWORD_RE.test(tail)) continue;
-    const matcher = likePrefixMatcher(m[2], clause === null ? "\\" : clause[1], m[1] !== "");
+    const { i, pattern } = m.groups;
+    const matcher = likePrefixMatcher(pattern, clause === null ? "\\" : clause[1], i !== "");
     if (matcher !== null) matchers.push(matcher);
   }
   return matchers;
@@ -366,9 +367,11 @@ export function sweepPrefixMatchers(text) {
  * An anchored RegExp matching the names `<pattern>%` selects under
  * `escapeChar`, or null when the trailing `%` is itself escaped — `LIKE 'ex\%'`
  * matches the single literal name `ex%`, not a prefix, so it sweeps nothing
- * this rule should credit.
+ * this rule should credit. `caseInsensitive` is set for `ILIKE` filters only —
+ * `LIKE` is case-sensitive in PostgreSQL, so widening it would credit creates
+ * the sweep leaves behind.
  */
-function likePrefixMatcher(pattern, escapeChar, caseInsensitive = false) {
+function likePrefixMatcher(pattern, escapeChar, caseInsensitive) {
   let source = "";
   let escaped = false;
   for (const ch of pattern) {

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -132,8 +132,8 @@
  * are reported, which is noise rather than a leak): SQL built by concatenation
  * or returned from a helper, since only literals and template quasis are read;
  * a catalogue relation `CATALOGUE_SOURCE` does not list; and a
- * filter spelled as something other than `LIKE` — `ILIKE`, `SIMILAR TO`, a
- * regex operator — since only `LIKE` is read.
+ * filter spelled as something other than `LIKE` or `ILIKE` — `SIMILAR TO`, a
+ * regex operator — since only those two are read.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -330,13 +330,20 @@ const CATALOGUE_SOURCE =
  * clause the escape is backslash, PostgreSQL's default and the one
  * `sanitize_sql_like` emits.
  *
- * `NOT LIKE` is excluded, and it is not a nicety: an exclusion filter selects
+ * PostgreSQL's `ILIKE` is the case-insensitive spelling of the same filter —
+ * Arel emits both from `visit_Arel_Nodes_Matches` (arel/visitors/postgresql.rb),
+ * `ESCAPE` clause included — so it is read the same way, but its matcher carries
+ * the `i` flag: `ILIKE 'ex_%'` really does select `EX_FOO`, and compiling it
+ * case-sensitively would leave that create reported although the sweep drops it.
+ *
+ * `NOT LIKE` (and `NOT ILIKE`) is excluded, and it is not a nicety: an exclusion
+ * filter selects
  * the complement of its pattern, so reading `NOT LIKE 'ex_%'` as a prefix would
  * make a sweep satisfy exactly the creates it deliberately spares. The empty
  * pattern is likewise impossible to match (`[^'%]+`), so a bare `LIKE '%'`
  * selecting everything never becomes a prefix that satisfies everything.
  */
-const LIKE_PREFIX_RE = /(?<!\bnot\s+)\blike\s+'([^'%]+)%'/gi;
+const LIKE_PREFIX_RE = /(?<!\bnot\s+)\b(i?)like\s+'([^'%]+)%'/gi;
 /** A trailing `ESCAPE '<char>'` clause, and the leading keyword on its own. */
 const ESCAPE_CLAUSE_RE = /^\s*escape\s+'([^'])'/i;
 const ESCAPE_KEYWORD_RE = /^\s*escape\b/i;
@@ -349,7 +356,7 @@ export function sweepPrefixMatchers(text) {
     const tail = text.slice(m.index + m[0].length);
     const clause = ESCAPE_CLAUSE_RE.exec(tail);
     if (clause === null && ESCAPE_KEYWORD_RE.test(tail)) continue;
-    const matcher = likePrefixMatcher(m[1], clause === null ? "\\" : clause[1]);
+    const matcher = likePrefixMatcher(m[2], clause === null ? "\\" : clause[1], m[1] !== "");
     if (matcher !== null) matchers.push(matcher);
   }
   return matchers;
@@ -361,7 +368,7 @@ export function sweepPrefixMatchers(text) {
  * matches the single literal name `ex%`, not a prefix, so it sweeps nothing
  * this rule should credit.
  */
-function likePrefixMatcher(pattern, escapeChar) {
+function likePrefixMatcher(pattern, escapeChar, caseInsensitive = false) {
   let source = "";
   let escaped = false;
   for (const ch of pattern) {
@@ -377,7 +384,7 @@ function likePrefixMatcher(pattern, escapeChar) {
     }
   }
   if (escaped) return null;
-  return new RegExp(`^${source}`);
+  return new RegExp(`^${source}`, caseInsensitive ? "i" : "");
 }
 
 /**

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -520,6 +520,18 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
+    // LIKE stays case-sensitive: only ILIKE's matcher carries the `i` flag.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "EX_FOO" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex!_%' ESCAPE '!'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "EX_FOO" } }],
+    },
     // NOT ILIKE is an exclusion filter too, and yields no prefix either.
     {
       code:

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -132,6 +132,22 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // ILIKE is case-insensitive, so `ex_%` selects `EX_FOO` too.
+    'await adapter.exec(`CREATE TABLE "EX_FOO" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ILIKE 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // The ESCAPE clause is honoured on ILIKE as well: `!_` is a literal `_`.
+    'await adapter.exec(`CREATE TABLE "EX_FOO" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ILIKE 'ex!_%' ESCAPE '!'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -498,6 +514,18 @@ tester.run("require-table-teardown", rule, {
         'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename NOT LIKE 'ex_%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // NOT ILIKE is an exclusion filter too, and yields no prefix either.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename NOT ILIKE 'ex_%'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +


### PR DESCRIPTION
`sweepPrefixMatchers` read only `LIKE` filters: `\blike` cannot match inside
`ILIKE` (no word boundary between `i` and `l`), so a teardown sweep written as
`WHERE tablename ILIKE 'ex_%'` credited nothing and every raw `CREATE TABLE
ex_…` in that file still reported `missingTeardown`.

PostgreSQL's `ILIKE` is the case-insensitive spelling of the same filter — Arel
emits both from `visit_Arel_Nodes_Matches`
(`arel/visitors/postgresql.rb:7-16`), `ESCAPE` clause included — so it is now
read the same way, with the matcher compiled with the `i` flag: `ILIKE 'ex_%'`
credits `EX_FOO`. `NOT ILIKE` yields no matcher, exactly as `NOT LIKE` does
(the existing negative lookbehind covers it). The header's KNOWN GAPS paragraph
drops `ILIKE` from its list; `SIMILAR TO` and regex operators remain gaps.

Tests pin all three: the case-insensitive credit, `ESCAPE` on an `ILIKE`
filter, and `NOT ILIKE` still reporting. Both new valid cases fail on baseline.

Closes-story: require-table-teardown-read-ilike-sweep-filters
