### PR TITLE
fix(activerecord): resolve TimeZoneConverter is_utc? fallback via ActiveRecord.default_timezone

### DIFF
--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -2,9 +2,10 @@
  * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion
  */
 import type { Type } from "@blazetrails/activemodel";
-import { ValueType, isUtcTimezone } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 import { TimeWithZone, TimeZone, getZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { isUtc } from "../type/internal/timezone.js";
 type ValueTypeInstance = InstanceType<typeof ValueType>;
 
 export interface TimeZoneConversion {
@@ -206,9 +207,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 }
 
-/** @internal */
+/**
+ * The types TimeZoneConverter wraps are AR types, whose `is_utc?` comes from
+ * ActiveRecord::Type::Internal::Timezone (reading `ActiveRecord.default_timezone`)
+ * — not from ActiveModel's `Time.zone_default`-derived helper. When the wrapped
+ * subtype exposes no `is_utc?`, fall back to the same AR reader Rails would have
+ * resolved for it.
+ *
+ * @internal
+ */
 function zoneForIsUtc(subtypeIsUtc?: boolean): string {
-  return (subtypeIsUtc ?? isUtcTimezone()) ? "UTC" : Temporal.Now.timeZoneId();
+  return (subtypeIsUtc ?? isUtc()) ? "UTC" : Temporal.Now.timeZoneId();
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -207,15 +207,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 }
 
-/**
- * The types TimeZoneConverter wraps are AR types, whose `is_utc?` comes from
- * ActiveRecord::Type::Internal::Timezone (reading `ActiveRecord.default_timezone`)
- * — not from ActiveModel's `Time.zone_default`-derived helper. When the wrapped
- * subtype exposes no `is_utc?`, fall back to the same AR reader Rails would have
- * resolved for it.
- *
- * @internal
- */
+/** @internal */
 function zoneForIsUtc(subtypeIsUtc?: boolean): string {
   return (subtypeIsUtc ?? isUtc()) ? "UTC" : Temporal.Now.timeZoneId();
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -150,18 +150,11 @@ describe("TimeZoneConverterTest", () => {
   });
 
   it("falls back to ActiveRecord.default_timezone when the subtype has no is_utc?", () => {
-    // Rails resolves is_utc? for the wrapped type through
-    // ActiveRecord::Type::Internal::Timezone (ActiveRecord.default_timezone), not
-    // through ActiveModel's Time.zone_default-derived helper. The two diverge only
-    // when default_timezone is :local while Time.zone_default stays UTC.
     const previous = getDefaultTimezone();
-    // The is_utc? = false branch resolves to the host zone; pin it so the
-    // assertion doesn't depend on the machine running the suite.
     vi.spyOn(Temporal.Now, "timeZoneId").mockReturnValue("America/New_York");
-    setZone("UTC"); // Time.zone (and Time.zone_default) stay UTC
+    setZone("UTC");
     setDefaultTimezone("local");
     try {
-      // A subtype exposing no is_utc? — the only case where the fallback fires.
       class ZonelessDateTime extends ValueType<unknown> {
         override type(): string {
           return "datetime";
@@ -173,9 +166,6 @@ describe("TimeZoneConverterTest", () => {
       const converter = new TimeZoneConverter(new ZonelessDateTime());
       const result = converter.cast({ 1: 2024, 2: 6, 3: 15, 4: 10, 5: 0 });
       expect(result).toBeInstanceOf(TimeWithZone);
-      // 14:00Z read as wall-clock in the host zone is 10:00, re-interpreted in
-      // Time.zone (UTC) as 10:00Z. Under the ActiveModel fallback the components
-      // would be read as 14:00 UTC and the instant would come back unchanged.
       expect((result as TimeWithZone).utc().toString()).toBe("2024-06-15T10:00:00Z");
     } finally {
       setDefaultTimezone(previous);

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -1,12 +1,15 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { TimeZoneConverter } from "./time-zone-conversion.js";
 import { DateTime } from "../type/date-time.js";
+import { getDefaultTimezone, setDefaultTimezone } from "../type/internal/timezone.js";
+import { ValueType } from "@blazetrails/activemodel";
 import { TimeWithZone, TimeZone, setZone, resetZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 describe("TimeZoneConverterTest", () => {
   afterEach(() => {
     resetZone();
+    vi.restoreAllMocks();
   });
 
   it("comparison with date time type", () => {
@@ -144,5 +147,38 @@ describe("TimeZoneConverterTest", () => {
     // value_for_database is the cast UTC Temporal.Instant, not a SQL string.
     expect(serialized).toBeInstanceOf(Temporal.Instant);
     expect((serialized as Temporal.Instant).toString()).toBe("2024-06-15T14:00:00Z");
+  });
+
+  it("falls back to ActiveRecord.default_timezone when the subtype has no is_utc?", () => {
+    // Rails resolves is_utc? for the wrapped type through
+    // ActiveRecord::Type::Internal::Timezone (ActiveRecord.default_timezone), not
+    // through ActiveModel's Time.zone_default-derived helper. The two diverge only
+    // when default_timezone is :local while Time.zone_default stays UTC.
+    const previous = getDefaultTimezone();
+    // The is_utc? = false branch resolves to the host zone; pin it so the
+    // assertion doesn't depend on the machine running the suite.
+    vi.spyOn(Temporal.Now, "timeZoneId").mockReturnValue("America/New_York");
+    setZone("UTC"); // Time.zone (and Time.zone_default) stay UTC
+    setDefaultTimezone("local");
+    try {
+      // A subtype exposing no is_utc? — the only case where the fallback fires.
+      class ZonelessDateTime extends ValueType<unknown> {
+        override type(): string {
+          return "datetime";
+        }
+        override cast(): unknown {
+          return Temporal.Instant.from("2024-06-15T14:00:00Z");
+        }
+      }
+      const converter = new TimeZoneConverter(new ZonelessDateTime());
+      const result = converter.cast({ 1: 2024, 2: 6, 3: 15, 4: 10, 5: 0 });
+      expect(result).toBeInstanceOf(TimeWithZone);
+      // 14:00Z read as wall-clock in the host zone is 10:00, re-interpreted in
+      // Time.zone (UTC) as 10:00Z. Under the ActiveModel fallback the components
+      // would be read as 14:00 UTC and the instant would come back unchanged.
+      expect((result as TimeWithZone).utc().toString()).toBe("2024-06-15T10:00:00Z");
+    } finally {
+      setDefaultTimezone(previous);
+    }
   });
 });


### PR DESCRIPTION
Rails resolves `is_utc?` for the type wrapped by `TimeZoneConverter` through
`ActiveRecord::Type::Internal::Timezone` (timezone.rb:9-15), which reads
`ActiveRecord.default_timezone`. trails' `zoneForIsUtc` fell back to
ActiveModel's `isUtc`, which since #5402 derives from `Time.zone_default` —
a different source. Point the fallback at AR's reader instead.

The two agree in the default test setup, so the regression test pins the host
zone and sets `default_timezone = local` with `Time.zone_default` left at UTC;
it fails on the pre-fix baseline.

Closes-story: converge-tz-converter-fallback-onto-ar-default-timezone
