### PR TITLE
refactor(activerecord): converge 8 exported ar-config flags onto ActiveRecord accessors

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -7,9 +7,8 @@ import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { SchemaCreation } from "./connection-adapters/abstract/schema-creation.js";
 import { AdapterError, ConnectionFailed } from "./errors.js";
 import {
+  ActiveRecord,
   Base,
-  disablePreparedStatements,
-  setDisablePreparedStatements,
   NotNullViolation,
   RecordNotUnique,
   StatementInvalid,
@@ -390,18 +389,18 @@ describe("AdapterTest", () => {
   // Rails gates this `unless in_memory_db?` (adapter_test.rb:176): a
   // re-established `:memory:` connection is a fresh, empty database.
   it.skipIf(inMemoryDb())("disable prepared statements", async () => {
-    const original = disablePreparedStatements;
+    const original = ActiveRecord.disablePreparedStatements;
     try {
       await runWithoutConnection(async (origConnection) => {
         await Base.establishConnection({ ...origConnection, preparedStatements: true });
         expect((await Base.leaseConnection()).preparedStatements).toBe(true);
 
-        setDisablePreparedStatements(true);
+        ActiveRecord.disablePreparedStatements = true;
         await Base.establishConnection({ ...origConnection, preparedStatements: true });
         expect((await Base.leaseConnection()).preparedStatements).toBe(false);
       });
     } finally {
-      setDisablePreparedStatements(original);
+      ActiveRecord.disablePreparedStatements = original;
     }
   });
 

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -11,136 +11,6 @@ import { DefaultStrategy } from "./migration/default-strategy.js";
 type AnyClass = abstract new (...args: never[]) => object;
 
 /**
- * Provides a mapping between database protocols/DBMSs and the underlying
- * database adapter to be used. This is used only by the `DATABASE_URL`
- * environment variable (and `url:` config keys). The protocol names are
- * arbitrary, so external database adapters can register custom protocols by
- * mutating this object or replacing it via {@link setProtocolAdapters}.
- *
- * Mirrors `ActiveRecord.protocol_adapters` (active_record.rb:490).
- */
-export let protocolAdapters: Record<string, string> = {
-  postgres: "postgresql",
-  postgresql: "postgresql",
-  mysql: "mysql2",
-  mysql2: "mysql2",
-  sqlite: "sqlite3",
-  sqlite3: "sqlite3",
-};
-
-export function setProtocolAdapters(value: Record<string, string>): void {
-  protocolAdapters = value;
-}
-
-/**
- * When true, prepared statements are disabled globally regardless of a
- * connection config's `preparedStatements: true`. Adapters consult this on
- * (re-)establishConnection — it is applied in the `preparedStatements` setter,
- * the single chokepoint every adapter constructor flows through. Mirrors
- * `ActiveRecord.disable_prepared_statements` (active_record.rb:182).
- */
-export let disablePreparedStatements = false;
-
-export function setDisablePreparedStatements(value: boolean): void {
-  disablePreparedStatements = value;
-}
-
-/**
- * When true, `before_committed!` runs on every distinct in-memory copy of a
- * record enrolled in a transaction; when false (the raw framework default) it
- * runs only on the first copy of each logical record (deduped by record
- * equality). Affects deferred-touch propagation through associations that hold
- * a second copy of a parent. Mirrors `ActiveRecord.before_committed_on_all_records`
- * (active_record.rb:348-349).
- */
-export let beforeCommittedOnAllRecords = false;
-
-export function setBeforeCommittedOnAllRecords(value: boolean): void {
-  beforeCommittedOnAllRecords = value;
-}
-
-/**
- * When true, `after_commit`/`after_rollback` callbacks run in the order they
- * were defined; when false (the raw framework default) they run in reverse
- * definition order. Only transactional (commit/rollback) callbacks are
- * affected — ordinary `after_*` callbacks always run in definition order.
- * Read at registration time and threaded into the callback chain as the
- * `prepend` flag, mirroring Rails' `prepend_option` (transactions.rb:320-327).
- * Mirrors `ActiveRecord.run_after_transaction_callbacks_in_order_defined`
- * (active_record.rb:351-352, default false).
- */
-export let runAfterTransactionCallbacksInOrderDefined = false;
-
-export function setRunAfterTransactionCallbacksInOrderDefined(value: boolean): void {
-  runAfterTransactionCallbacksInOrderDefined = value;
-}
-
-/**
- * Controls what happens when a strict-loading violation is detected: either
- * `"raise"` (the default — throw `StrictLoadingViolationError`) or `"log"`
- * (instrument `strict_loading_violation.active_record` and continue loading).
- *
- * Mirrors `ActiveRecord.action_on_strict_loading_violation` (active_record.rb:362).
- */
-export let actionOnStrictLoadingViolation: "raise" | "log" = "raise";
-
-export function setActionOnStrictLoadingViolation(value: "raise" | "log"): void {
-  actionOnStrictLoadingViolation = value;
-}
-
-/** @internal */
-export let indexNestedAttributeErrors = false;
-
-/** @internal */
-export function setIndexNestedAttributeErrors(value: boolean): void {
-  indexNestedAttributeErrors = value;
-}
-
-/**
- * A list of table names or regular expressions to match tables to ignore
- * when dumping the schema cache. Mirrors
- * `ActiveRecord.schema_cache_ignored_tables` (active_record.rb:197).
- *
- * @internal
- */
-export let schemaCacheIgnoredTables: ReadonlyArray<string | RegExp> = [];
-
-/** @internal */
-export function setSchemaCacheIgnoredTables(value: ReadonlyArray<string | RegExp>): void {
-  schemaCacheIgnoredTables = value;
-}
-
-/**
- * Controls what happens when `connection` (the soft-deprecated checkout alias)
- * is called on a model that has not yet made the lease permanent.
- *
- * - `true` (default): `connection` behaves exactly like `leaseConnection`.
- * - `'deprecated'`: emits a deprecation warning on the first checkout, then
- *   behaves like `leaseConnection`.
- * - `'disallowed'`: raises `ActiveRecordError` if the lease is not yet
- *   permanent (i.e. the caller should use `withConnection` or
- *   `leaseConnection` explicitly).
- *
- * Mirrors `ActiveRecord.permanent_connection_checkout` (active_record.rb:310).
- */
-export let permanentConnectionCheckout: true | "deprecated" | "disallowed" = true;
-
-/**
- * Writer for the `ActiveRecord.permanent_connection_checkout=` module attribute
- * (active_record.rb:314) — needed only because ESM live bindings are read-only
- * for importers. Converging it onto a module-object accessor is RFC 0081's
- * `module-level-config-accessor-shape` story, not a trails-only seam.
- */
-export function setPermanentConnectionCheckout(value: true | "deprecated" | "disallowed"): void {
-  if (value !== true && value !== "deprecated" && value !== "disallowed") {
-    throw new ArgumentError(
-      "permanentConnectionCheckout must be one of: `true`, `'deprecated'` or `'disallowed'`",
-    );
-  }
-  permanentConnectionCheckout = value;
-}
-
-/**
  * Returns true when `tableName` matches an entry in
  * `schemaCacheIgnoredTables`. Mirrors
  * `ActiveRecord.schema_cache_ignored_table?` (active_record.rb:205).
@@ -148,7 +18,7 @@ export function setPermanentConnectionCheckout(value: true | "deprecated" | "dis
  * @internal
  */
 export function isSchemaCacheIgnoredTable(tableName: string): boolean {
-  for (const entry of schemaCacheIgnoredTables) {
+  for (const entry of _schemaCacheIgnoredTables) {
     if (entry instanceof RegExp) {
       // Reset lastIndex so /g and /y patterns don't alternate between
       // matches across calls (same precaution SchemaDumper#isIgnored takes).
@@ -176,6 +46,21 @@ export function setDatabaseCli(value: Record<string, string | string[]>): void {
   databaseCli = value;
 }
 
+let _protocolAdapters: Record<string, string> = {
+  postgres: "postgresql",
+  postgresql: "postgresql",
+  mysql: "mysql2",
+  mysql2: "mysql2",
+  sqlite: "sqlite3",
+  sqlite3: "sqlite3",
+};
+let _disablePreparedStatements = false;
+let _beforeCommittedOnAllRecords = false;
+let _runAfterTransactionCallbacksInOrderDefined = false;
+let _actionOnStrictLoadingViolation: "raise" | "log" = "raise";
+let _indexNestedAttributeErrors = false;
+let _schemaCacheIgnoredTables: ReadonlyArray<string | RegExp> = [];
+let _permanentConnectionCheckout: true | "deprecated" | "disallowed" = true;
 let _asyncQueryExecutor: "global_thread_pool" | "multi_thread_pool" | null = null;
 let _queues: Record<string, unknown> = {};
 let _maintainTestSchema: boolean | null = null;
@@ -192,6 +77,139 @@ let _maintainTestSchema: boolean | null = null;
  * as `export let` below have not been migrated yet.
  */
 export const ActiveRecord = {
+  /**
+   * Provides a mapping between database protocols/DBMSs and the underlying
+   * database adapter to be used. This is used only by the `DATABASE_URL`
+   * environment variable (and `url:` config keys). The protocol names are
+   * arbitrary, so external database adapters can register custom protocols by
+   * mutating this object or replacing it.
+   *
+   * Mirrors `ActiveRecord.protocol_adapters` (active_record.rb:490).
+   */
+  get protocolAdapters(): Record<string, string> {
+    return _protocolAdapters;
+  },
+
+  set protocolAdapters(value: Record<string, string>) {
+    _protocolAdapters = value;
+  },
+
+  /**
+   * When true, prepared statements are disabled globally regardless of a
+   * connection config's `preparedStatements: true`. Adapters consult this on
+   * (re-)establishConnection — it is applied in the `preparedStatements` setter,
+   * the single chokepoint every adapter constructor flows through. Mirrors
+   * `ActiveRecord.disable_prepared_statements` (active_record.rb:182).
+   */
+  get disablePreparedStatements(): boolean {
+    return _disablePreparedStatements;
+  },
+
+  set disablePreparedStatements(value: boolean) {
+    _disablePreparedStatements = value;
+  },
+
+  /**
+   * When true, `before_committed!` runs on every distinct in-memory copy of a
+   * record enrolled in a transaction; when false (the raw framework default) it
+   * runs only on the first copy of each logical record (deduped by record
+   * equality). Affects deferred-touch propagation through associations that hold
+   * a second copy of a parent. Mirrors
+   * `ActiveRecord.before_committed_on_all_records` (active_record.rb:348-349).
+   */
+  get beforeCommittedOnAllRecords(): boolean {
+    return _beforeCommittedOnAllRecords;
+  },
+
+  set beforeCommittedOnAllRecords(value: boolean) {
+    _beforeCommittedOnAllRecords = value;
+  },
+
+  /**
+   * When true, `after_commit`/`after_rollback` callbacks run in the order they
+   * were defined; when false (the raw framework default) they run in reverse
+   * definition order. Only transactional (commit/rollback) callbacks are
+   * affected — ordinary `after_*` callbacks always run in definition order.
+   * Read at registration time and threaded into the callback chain as the
+   * `prepend` flag, mirroring Rails' `prepend_option` (transactions.rb:320-327).
+   * Mirrors `ActiveRecord.run_after_transaction_callbacks_in_order_defined`
+   * (active_record.rb:351-352, default false).
+   */
+  get runAfterTransactionCallbacksInOrderDefined(): boolean {
+    return _runAfterTransactionCallbacksInOrderDefined;
+  },
+
+  set runAfterTransactionCallbacksInOrderDefined(value: boolean) {
+    _runAfterTransactionCallbacksInOrderDefined = value;
+  },
+
+  /**
+   * Controls what happens when a strict-loading violation is detected: either
+   * `"raise"` (the default — throw `StrictLoadingViolationError`) or `"log"`
+   * (instrument `strict_loading_violation.active_record` and continue loading).
+   *
+   * Mirrors `ActiveRecord.action_on_strict_loading_violation`
+   * (active_record.rb:362).
+   */
+  get actionOnStrictLoadingViolation(): "raise" | "log" {
+    return _actionOnStrictLoadingViolation;
+  },
+
+  set actionOnStrictLoadingViolation(value: "raise" | "log") {
+    _actionOnStrictLoadingViolation = value;
+  },
+
+  /** @internal */
+  get indexNestedAttributeErrors(): boolean {
+    return _indexNestedAttributeErrors;
+  },
+
+  /** @internal */
+  set indexNestedAttributeErrors(value: boolean) {
+    _indexNestedAttributeErrors = value;
+  },
+
+  /**
+   * A list of table names or regular expressions to match tables to ignore
+   * when dumping the schema cache. Mirrors
+   * `ActiveRecord.schema_cache_ignored_tables` (active_record.rb:197).
+   *
+   * @internal
+   */
+  get schemaCacheIgnoredTables(): ReadonlyArray<string | RegExp> {
+    return _schemaCacheIgnoredTables;
+  },
+
+  /** @internal */
+  set schemaCacheIgnoredTables(value: ReadonlyArray<string | RegExp>) {
+    _schemaCacheIgnoredTables = value;
+  },
+
+  /**
+   * Controls what happens when `connection` (the soft-deprecated checkout alias)
+   * is called on a model that has not yet made the lease permanent.
+   *
+   * - `true` (default): `connection` behaves exactly like `leaseConnection`.
+   * - `'deprecated'`: emits a deprecation warning on the first checkout, then
+   *   behaves like `leaseConnection`.
+   * - `'disallowed'`: raises `ActiveRecordError` if the lease is not yet
+   *   permanent (i.e. the caller should use `withConnection` or
+   *   `leaseConnection` explicitly).
+   *
+   * Mirrors `ActiveRecord.permanent_connection_checkout` (active_record.rb:310).
+   */
+  get permanentConnectionCheckout(): true | "deprecated" | "disallowed" {
+    return _permanentConnectionCheckout;
+  },
+
+  set permanentConnectionCheckout(value: true | "deprecated" | "disallowed") {
+    if (value !== true && value !== "deprecated" && value !== "disallowed") {
+      throw new ArgumentError(
+        "permanentConnectionCheckout must be one of: `true`, `'deprecated'` or `'disallowed'`",
+      );
+    }
+    _permanentConnectionCheckout = value;
+  },
   /**
    * Selects the async query executor backing `load_async`. `null` (the
    * default) does not initialize an executor and runs async calls in the
@@ -325,9 +343,10 @@ export let raiseIntWiderThan64bit = true;
 
 /**
  * Writer for the `ActiveRecord.raise_int_wider_than_64bit=` module attribute
- * (`singleton_class.attr_accessor`, active_record.rb:446). Same ESM live-binding
- * constraint as `setPermanentConnectionCheckout`; covered by RFC 0081's
- * `module-level-config-accessor-shape` story.
+ * (`singleton_class.attr_accessor`, active_record.rb:446). Needed only because
+ * ESM live bindings are read-only for importers; converging it onto an
+ * `ActiveRecord` accessor is RFC 0081's `convert-ar-config-accessors-internal-flags`
+ * story.
  */
 export function setRaiseIntWiderThan64bit(value: boolean): void {
   raiseIntWiderThan64bit = value;

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -18,7 +18,7 @@ type AnyClass = abstract new (...args: never[]) => object;
  * @internal
  */
 export function isSchemaCacheIgnoredTable(tableName: string): boolean {
-  for (const entry of _schemaCacheIgnoredTables) {
+  for (const entry of ActiveRecord.schemaCacheIgnoredTables) {
     if (entry instanceof RegExp) {
       // Reset lastIndex so /g and /y patterns don't alternate between
       // matches across calls (same precaution SchemaDumper#isIgnored takes).

--- a/packages/activerecord/src/associations/nested-error.test.ts
+++ b/packages/activerecord/src/associations/nested-error.test.ts
@@ -8,12 +8,7 @@
  * the faked `name`.
  */
 import { describe, it, expect } from "vitest";
-import {
-  Base,
-  registerModel,
-  indexNestedAttributeErrors,
-  setIndexNestedAttributeErrors,
-} from "../index.js";
+import { ActiveRecord, Base, registerModel } from "../index.js";
 import { NestedError } from "./nested-error.js";
 import { fixtures } from "../test-fixtures.js";
 import type { AssociationProxy } from "./collection-proxy.js";
@@ -129,8 +124,8 @@ describe("AssociationsNestedErrorInNestedAttributesOrderTest", () => {
     registerModel("NestedErrorPetOwner", PetOwner);
 
     it("no index when singular association", async () => {
-      const oldAttributeConfig = indexNestedAttributeErrors;
-      setIndexNestedAttributeErrors(true);
+      const oldAttributeConfig = ActiveRecord.indexNestedAttributeErrors;
+      ActiveRecord.indexNestedAttributeErrors = true;
       try {
         const owner = new PetOwner({ petAttributes: { name: null } });
         await owner.isValid();
@@ -148,7 +143,7 @@ describe("AssociationsNestedErrorInNestedAttributesOrderTest", () => {
         expect(error.message).toBe("can't be blank");
         expect(error.base).toBe(owner);
       } finally {
-        setIndexNestedAttributeErrors(oldAttributeConfig);
+        ActiveRecord.indexNestedAttributeErrors = oldAttributeConfig;
       }
     });
   });

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -1,5 +1,5 @@
 import { NestedError as ActiveModelNestedError } from "@blazetrails/activemodel";
-import { indexNestedAttributeErrors } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 
 interface AssociationLike {
   owner: object | null;
@@ -89,7 +89,7 @@ function indexErrorsSetting(this: NestedError): boolean | "nestedAttributesOrder
   if (opts && "indexErrors" in opts) {
     return opts["indexErrors"] as boolean | "nestedAttributesOrder";
   }
-  return indexNestedAttributeErrors;
+  return ActiveRecord.indexNestedAttributeErrors;
 }
 
 /**

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -7,13 +7,12 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
 import { I18n, Error as ModelError } from "@blazetrails/activemodel";
 import {
+  ActiveRecord,
   Base,
   registerModel,
   acceptsNestedAttributesFor,
   assignNestedAttributes,
   RecordInvalid,
-  indexNestedAttributeErrors,
-  setIndexNestedAttributeErrors,
 } from "./index.js";
 import { Associations, association } from "./associations.js";
 
@@ -2262,8 +2261,8 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     return { Parent, Child };
   }
   it("errors should be indexed when global flag is set", async () => {
-    const old = indexNestedAttributeErrors;
-    setIndexNestedAttributeErrors(true);
+    const old = ActiveRecord.indexNestedAttributeErrors;
+    ActiveRecord.indexNestedAttributeErrors = true;
     try {
       const { Parent, Child } = makeIndexedHasMany();
       const parent = new Parent({ name: "p" });
@@ -2272,7 +2271,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       expect(parent.errors.where("children[1].name")).toHaveLength(1);
       expect(parent.errors.where("children.name")).toHaveLength(0);
     } finally {
-      setIndexNestedAttributeErrors(old);
+      ActiveRecord.indexNestedAttributeErrors = old;
     }
   });
   it("errors details should be indexed when passed as array", async () => {
@@ -2439,8 +2438,8 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     }
   });
   it("errors details should be indexed when global flag is set", async () => {
-    const old = indexNestedAttributeErrors;
-    setIndexNestedAttributeErrors(true);
+    const old = ActiveRecord.indexNestedAttributeErrors;
+    ActiveRecord.indexNestedAttributeErrors = true;
     try {
       const { Parent, Child } = makeIndexedHasMany();
       const parent = new Parent({ name: "p" });
@@ -2449,7 +2448,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       expect(parent.errors.details.get("children[1].name")?.length ?? 0).toBeGreaterThan(0);
       expect(parent.errors.details.get("children.name") ?? []).toHaveLength(0);
     } finally {
-      setIndexNestedAttributeErrors(old);
+      ActiveRecord.indexNestedAttributeErrors = old;
     }
   });
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -280,7 +280,7 @@ import {
   afterUpdateCommitMethod as _afterUpdateCommitMethod,
   afterDestroyCommitMethod as _afterDestroyCommitMethod,
 } from "./transactions.js";
-import { runAfterTransactionCallbacksInOrderDefined } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 
 /**
  * Threads ActiveRecord.run_after_transaction_callbacks_in_order_defined into a
@@ -294,7 +294,7 @@ import { runAfterTransactionCallbacksInOrderDefined } from "./ar-config.js";
 function _withTransactionCallbackOrder(
   conditions: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
-  return { ...conditions, prepend: runAfterTransactionCallbacksInOrderDefined };
+  return { ...conditions, prepend: ActiveRecord.runAfterTransactionCallbacksInOrderDefined };
 }
 
 import {
@@ -5253,7 +5253,7 @@ runLoadHooks("active_record", Base);
 // async, and `to_sql` is synchronous in Rails and at every call site here, so
 // the engine must expose a *synchronous* connection. Assigning bare `Base` would
 // route through `Base.connection`, which is deprecated: under
-// `permanentConnectionCheckout = "disallowed"` it raises
+// `ActiveRecord.permanentConnectionCheckout = "disallowed"` it raises
 // (connection-handling.ts:461-463), so every `toSql()` in the app would throw —
 // something Rails' `with_connection`-based `to_sql` never does. This delegates
 // to the pool's non-deprecated sync surface instead: the already-checked-out

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -23,7 +23,7 @@ import {
 } from "../errors.js";
 import { IsolatedExecutionState, Notifications } from "@blazetrails/activesupport";
 import type { EventPayload } from "@blazetrails/activesupport";
-import { disablePreparedStatements } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 import { Result, type ColumnTypes } from "../result.js";
 import { SchemaCache, SchemaReflection, BoundSchemaReflection } from "./schema-cache.js";
 import { NullPool, poolAbsent } from "./abstract/connection-pool.js";
@@ -1055,7 +1055,7 @@ export class AbstractAdapter implements Quoting {
     // (abstract_adapter.rb:159). Every concrete adapter assigns
     // `this.preparedStatements` from its config in the constructor, so honoring
     // the global toggle here covers (re-)establishConnection uniformly.
-    this._preparedStatements = value && !disablePreparedStatements;
+    this._preparedStatements = value && !ActiveRecord.disablePreparedStatements;
   }
 
   get active(): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -13,7 +13,7 @@ import {
   type AsyncContext,
   type NotificationHandle,
 } from "@blazetrails/activesupport";
-import { beforeCommittedOnAllRecords } from "../../ar-config.js";
+import { ActiveRecord } from "../../ar-config.js";
 
 /**
  * Equality-keyed lookup of the candidate instance whose transactional
@@ -495,7 +495,7 @@ export class Transaction {
         // (dedup by object identity); when false (the default), only the first
         // copy of each logical record runs (dedup by record equality), so a
         // deferred touch held on a second copy of a parent never flushes.
-        const ite = beforeCommittedOnAllRecords
+        const ite = ActiveRecord.beforeCommittedOnAllRecords
           ? this.uniqueRecords()
           : this.uniqueRecordsByEquality(recs);
         for (const record of ite) {

--- a/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
@@ -7,7 +7,7 @@ import {
   InvalidConfigurationError,
   type RawConfigurations,
 } from "../database-configurations.js";
-import { protocolAdapters, setProtocolAdapters } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 
 const DEFAULT_ENV = "default_env";
 
@@ -33,7 +33,7 @@ beforeEach(() => {
     delete process.env[key];
   }
   savedDefaultEnv = DatabaseConfigurations.defaultEnv;
-  savedProtocolMapping = { ...protocolAdapters };
+  savedProtocolMapping = { ...ActiveRecord.protocolAdapters };
   DatabaseConfigurations.defaultEnv = DEFAULT_ENV;
 });
 
@@ -43,7 +43,7 @@ afterEach(() => {
     else delete process.env[key];
   }
   DatabaseConfigurations.defaultEnv = savedDefaultEnv;
-  setProtocolAdapters(savedProtocolMapping);
+  ActiveRecord.protocolAdapters = savedProtocolMapping;
 });
 
 function resolveConfig(
@@ -434,7 +434,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   });
 
   it("protocol adapter mapping is used and can be updated", () => {
-    protocolAdapters.potato = "postgresql";
+    ActiveRecord.protocolAdapters.potato = "postgresql";
     process.env["DATABASE_URL"] = "potato://localhost/exampledb";
     DatabaseConfigurations.defaultEnv = "production";
     const actual = resolveDbConfig("production", {});
@@ -446,7 +446,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   });
 
   it("protocol adapter mapping translates underscores to dashes", () => {
-    protocolAdapters.custom_protocol = "postgresql";
+    ActiveRecord.protocolAdapters.custom_protocol = "postgresql";
     process.env["DATABASE_URL"] = "custom-protocol://localhost/exampledb";
     DatabaseConfigurations.defaultEnv = "production";
     const actual = resolveDbConfig("production", {});
@@ -458,7 +458,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   });
 
   it("protocol adapter mapping handles sqlite3 file urls", () => {
-    protocolAdapters.custom_protocol = "sqlite3";
+    ActiveRecord.protocolAdapters.custom_protocol = "sqlite3";
     process.env["DATABASE_URL"] = "custom-protocol:/path/to/db.sqlite3";
     DatabaseConfigurations.defaultEnv = "production";
     const actual = resolveDbConfig("production", {});

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SchemaCache, SchemaReflection, FakePool } from "./schema-cache.js";
 import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
-import { setSchemaCacheIgnoredTables } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { SchemaStatements } from "./abstract/schema-statements.js";
 import { TableDefinition } from "./abstract/schema-definitions.js";
@@ -350,7 +350,7 @@ describe("SchemaCacheTest", () => {
   });
 
   it("marshal dump and load with ignored tables", async () => {
-    setSchemaCacheIgnoredTables(["professors"]);
+    ActiveRecord.schemaCacheIgnoredTables = ["professors"];
     try {
       const fakeConn = {
         primaryKey: async (t: string) => (t === "courses" ? "id" : null),
@@ -390,7 +390,7 @@ describe("SchemaCacheTest", () => {
       expect(await cache.primaryKeys(pool, "professors")).toBeNull();
       expect(await cache.indexes(pool, "professors")).toEqual([]);
     } finally {
-      setSchemaCacheIgnoredTables([]);
+      ActiveRecord.schemaCacheIgnoredTables = [];
     }
   });
   it("marshal dump and load with gzip", () => {

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 import { Base } from "./base.js";
 import { withQueryConnection, threadedConnectionFor } from "./connection-handling.js";
-import { setPermanentConnectionCheckout } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 import { ActiveRecordError } from "./errors.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
@@ -51,7 +51,7 @@ describe("ConnectionHandlingTest", () => {
   afterEach(async () => {
     connectedToStack().length = 0;
     await Base.connectionHandler.clearAllConnectionsBang();
-    setPermanentConnectionCheckout(true);
+    ActiveRecord.permanentConnectionCheckout = true;
     await setupConnection();
   });
 
@@ -123,7 +123,7 @@ describe("ConnectionHandlingTest", () => {
   it.skipIf(inMemoryDb())(
     "#connection is a soft-deprecated alias to #lease_connection",
     async () => {
-      setPermanentConnectionCheckout(true);
+      ActiveRecord.permanentConnectionCheckout = true;
       Base.releaseConnection();
       expect(Base.connectionPool().activeConnection).toBeNull();
 
@@ -144,7 +144,7 @@ describe("ConnectionHandlingTest", () => {
   it.skipIf(inMemoryDb())(
     "#connection emits a deprecation warning if ActiveRecord.permanent_connection_checkout == :deprecated",
     async () => {
-      setPermanentConnectionCheckout("deprecated");
+      ActiveRecord.permanentConnectionCheckout = "deprecated";
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         Base.releaseConnection();
@@ -176,7 +176,7 @@ describe("ConnectionHandlingTest", () => {
   it.skipIf(inMemoryDb())(
     "#connection raises an error if ActiveRecord.permanent_connection_checkout == :disallowed",
     async () => {
-      setPermanentConnectionCheckout("disallowed");
+      ActiveRecord.permanentConnectionCheckout = "disallowed";
       Base.releaseConnection();
 
       expect(() => Base.connection).toThrow(ActiveRecordError);
@@ -194,7 +194,7 @@ describe("ConnectionHandlingTest", () => {
   it.skipIf(inMemoryDb())(
     "#connection doesn't make the lease permanent if inside #with_connection(prevent_permanent_checkout: true)",
     async () => {
-      setPermanentConnectionCheckout("disallowed");
+      ActiveRecord.permanentConnectionCheckout = "disallowed";
       Base.releaseConnection();
 
       await Base.withConnection(
@@ -866,7 +866,7 @@ describe("ConnectionHandlingTest", () => {
   });
 
   afterEach(async () => {
-    setPermanentConnectionCheckout(true);
+    ActiveRecord.permanentConnectionCheckout = true;
     // The test runs outside transactional fixtures (it asserts the pool
     // releases its connection), so the inserted row is committed — clean it up
     // to avoid perturbing the shared worker DB for sibling test files.
@@ -876,7 +876,7 @@ describe("ConnectionHandlingTest", () => {
   it.skipIf(inMemoryDb())(
     "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed",
     async () => {
-      setPermanentConnectionCheckout("deprecated");
+      ActiveRecord.permanentConnectionCheckout = "deprecated";
       Base.releaseConnection();
       expect(Base.connectionPool().activeConnection).toBeNull();
 

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -27,7 +27,7 @@ import {
   NotImplementedError,
   ActiveRecordError,
 } from "./errors.js";
-import { permanentConnectionCheckout } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 import { setDefaultTimezone } from "./type/internal/timezone.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import {
@@ -491,7 +491,7 @@ export function connection(this: typeof Base): DatabaseAdapter {
   if ((this as any)._adapter) return (this as any)._adapter;
   const pool = connectionPool.call(this);
   if (pool.isPermanentLease()) {
-    const setting = permanentConnectionCheckout;
+    const setting = ActiveRecord.permanentConnectionCheckout;
     if (setting === "deprecated") {
       console.warn("DEPRECATION WARNING: " + CONNECTION_DEPRECATION_MSG);
     } else if (setting === "disallowed") {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -11,7 +11,7 @@ import {
   StatementInvalid,
   StrictLoadingViolationError,
 } from "./errors.js";
-import { actionOnStrictLoadingViolation } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 import { WRITING_ROLE } from "./roles.js";
 import {
   DatabaseConfigurations,
@@ -656,7 +656,7 @@ export function strictLoadingViolationBang(
   // Rails passes `owner.class` (Notifications payload + message subject); the
   // message builder stringifies it to the class name, matching Ruby's `#{owner}`.
   const ownerClass = typeof owner === "function" ? owner : owner?.constructor;
-  if (actionOnStrictLoadingViolation === "log") {
+  if (ActiveRecord.actionOnStrictLoadingViolation === "log") {
     Notifications.instrument("strict_loading_violation.active_record", {
       owner: ownerClass,
       reflection: reflectionLike,

--- a/packages/activerecord/src/database-configurations/connection-url-resolver.test.ts
+++ b/packages/activerecord/src/database-configurations/connection-url-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { ConnectionUrlResolver } from "./connection-url-resolver.js";
-import { protocolAdapters, setProtocolAdapters } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 
 describe("ConnectionUrlResolver", () => {
   it("parses a standard postgresql URL", () => {
@@ -94,13 +94,15 @@ describe("ConnectionUrlResolver", () => {
   });
 
   describe("protocol adapter mapping", () => {
-    const saved = { ...protocolAdapters };
-    afterEach(() => setProtocolAdapters(saved));
+    const saved = { ...ActiveRecord.protocolAdapters };
+    afterEach(() => {
+      ActiveRecord.protocolAdapters = saved;
+    });
 
     it("resolves through a mapping replaced via setProtocolAdapters", () => {
       // Mirrors Rails' `ActiveRecord.protocol_adapters = { ... }` (full assignment
       // via the module writer) — the resolver must read the replaced mapping.
-      setProtocolAdapters({ custom: "postgresql" });
+      ActiveRecord.protocolAdapters = { custom: "postgresql" };
       const hash = new ConnectionUrlResolver("custom://localhost/db").toHash();
       expect(hash.adapter).toBe("postgresql");
     });

--- a/packages/activerecord/src/database-configurations/connection-url-resolver.ts
+++ b/packages/activerecord/src/database-configurations/connection-url-resolver.ts
@@ -10,7 +10,7 @@
  *   //      database: "foo_test", username: "foo", password: "bar", pool: "5" }
  */
 import type { DatabaseConfigOptions } from "./database-config.js";
-import { protocolAdapters } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 
 export class ConnectionUrlResolver {
   private readonly _adapter: string | null;
@@ -39,7 +39,7 @@ export class ConnectionUrlResolver {
     const hasAuthority = !!schemeMatch[2];
     const rest = schemeMatch[3];
 
-    this._adapter = protocolAdapters[scheme] ?? scheme;
+    this._adapter = ActiveRecord.protocolAdapters[scheme] ?? scheme;
 
     if (hasAuthority) {
       // Standard URL: scheme://user:pass@host:port/path?query

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -111,26 +111,7 @@ export {
 } from "./transactions.js";
 export { resetCallbacks } from "./callbacks.js";
 export { delegate } from "./delegate.js";
-export {
-  ActiveRecord,
-  indexNestedAttributeErrors,
-  setIndexNestedAttributeErrors,
-  schemaCacheIgnoredTables,
-  setSchemaCacheIgnoredTables,
-  isSchemaCacheIgnoredTable,
-  protocolAdapters,
-  setProtocolAdapters,
-  disablePreparedStatements,
-  setDisablePreparedStatements,
-  actionOnStrictLoadingViolation,
-  setActionOnStrictLoadingViolation,
-  permanentConnectionCheckout,
-  setPermanentConnectionCheckout,
-  beforeCommittedOnAllRecords,
-  setBeforeCommittedOnAllRecords,
-  runAfterTransactionCallbacksInOrderDefined,
-  setRunAfterTransactionCallbacksInOrderDefined,
-} from "./ar-config.js";
+export { ActiveRecord, isSchemaCacheIgnoredTable } from "./ar-config.js";
 export { defineEnum, readEnumValue, castEnumValue } from "./enum.js";
 export type { EnumMacroOptions } from "./enum.js";
 export { registerSubclass, findStiClass } from "./inheritance.js";

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -6,13 +6,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { findTarget } from "./associations/singular-association.js";
 import { Notifications } from "@blazetrails/activesupport";
-import {
-  Base,
-  StrictLoadingViolationError,
-  registerModel,
-  actionOnStrictLoadingViolation,
-  setActionOnStrictLoadingViolation,
-} from "./index.js";
+import { ActiveRecord, Base, StrictLoadingViolationError, registerModel } from "./index.js";
 import { association } from "./associations.js";
 import { fixtures } from "./test-fixtures.js";
 import { Developer, AuditLog, AuditLogRequired } from "./test-helpers/models/developer.js";
@@ -816,7 +810,7 @@ describe("StrictLoadingTest", () => {
 
   // Rails: test_strict_loading_violation_raises_by_default
   it("strict loading violation raises by default", async () => {
-    expect(actionOnStrictLoadingViolation).toBe("raise");
+    expect(ActiveRecord.actionOnStrictLoadingViolation).toBe("raise");
 
     const developer = await Developer.first();
     expect(developer!.isStrictLoading()).toBe(false);
@@ -834,8 +828,8 @@ describe("StrictLoadingTest", () => {
     const developer = await Developer.first();
     developer!.strictLoadingBang();
 
-    setActionOnStrictLoadingViolation("log");
-    expect(actionOnStrictLoadingViolation).toBe("log");
+    ActiveRecord.actionOnStrictLoadingViolation = "log";
+    expect(ActiveRecord.actionOnStrictLoadingViolation).toBe("log");
     let logged = false;
     const sub = Notifications.subscribe("strict_loading_violation.active_record", () => {
       logged = true;
@@ -845,7 +839,7 @@ describe("StrictLoadingTest", () => {
       expect(logged).toBe(true);
     } finally {
       Notifications.unsubscribe(sub);
-      setActionOnStrictLoadingViolation("raise");
+      ActiveRecord.actionOnStrictLoadingViolation = "raise";
     }
   });
 
@@ -875,7 +869,7 @@ describe("StrictLoadingTest", () => {
     treasure.strictLoadingBang();
     expect(treasure.isStrictLoading()).toBe(true);
 
-    setActionOnStrictLoadingViolation("log");
+    ActiveRecord.actionOnStrictLoadingViolation = "log";
     let logged: string | null = null;
     const sub = Notifications.subscribe("strict_loading_violation.active_record", (event: any) => {
       logged = event.payload.reflection.strictLoadingViolationMessage(event.payload.owner);
@@ -888,7 +882,7 @@ describe("StrictLoadingTest", () => {
       );
     } finally {
       Notifications.unsubscribe(sub);
-      setActionOnStrictLoadingViolation("raise");
+      ActiveRecord.actionOnStrictLoadingViolation = "raise";
     }
   });
 });

--- a/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
@@ -21,7 +21,7 @@ describe("fixture connection source", () => {
     ActiveRecord.permanentConnectionCheckout = true;
   });
 
-  it("leases without tripping ActiveRecord.permanentConnectionCheckout = disallowed", () => {
+  it("leases without tripping permanentConnectionCheckout = disallowed", () => {
     ActiveRecord.permanentConnectionCheckout = "disallowed";
 
     expect(() => leaseFixtureConnection()).not.toThrow();

--- a/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
@@ -13,16 +13,16 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "../base.js";
-import { setPermanentConnectionCheckout } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 import { leaseFixtureConnection } from "./fixture-connection.js";
 
 describe("fixture connection source", () => {
   afterEach(() => {
-    setPermanentConnectionCheckout(true);
+    ActiveRecord.permanentConnectionCheckout = true;
   });
 
-  it("leases without tripping permanentConnectionCheckout = disallowed", () => {
-    setPermanentConnectionCheckout("disallowed");
+  it("leases without tripping ActiveRecord.permanentConnectionCheckout = disallowed", () => {
+    ActiveRecord.permanentConnectionCheckout = "disallowed";
 
     expect(() => leaseFixtureConnection()).not.toThrow();
   });
@@ -38,7 +38,7 @@ describe("fixture connection source", () => {
     const previous = Base._adapter;
     Base._adapter = sentinel;
     try {
-      setPermanentConnectionCheckout("disallowed");
+      ActiveRecord.permanentConnectionCheckout = "disallowed";
 
       expect(leaseFixtureConnection()).toBe(sentinel);
     } finally {

--- a/packages/activerecord/src/touch-later.test.ts
+++ b/packages/activerecord/src/touch-later.test.ts
@@ -11,7 +11,7 @@ import { fixtures } from "./test-fixtures.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.
 import "./support/canonical-model-index.js";
-import { setBeforeCommittedOnAllRecords } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 import { Invoice } from "./test-helpers/models/invoice.js";
 import { LineItem } from "./test-helpers/models/line-item.js";
@@ -165,7 +165,7 @@ describe("TouchLaterTest", () => {
   });
 
   it("touching through nested attributes without before committed on all records", async () => {
-    setBeforeCommittedOnAllRecords(false);
+    ActiveRecord.beforeCommittedOnAllRecords = false;
     try {
       const time = twentyFiveDaysAgo();
       const owner = owners("blackbeard") as any;
@@ -179,12 +179,12 @@ describe("TouchLaterTest", () => {
       // The second copy of the parent is not touched, so updated_at is unchanged.
       expect(toI((await owner.reload()).updated_at)).toBe(toI(time));
     } finally {
-      setBeforeCommittedOnAllRecords(false);
+      ActiveRecord.beforeCommittedOnAllRecords = false;
     }
   });
 
   it("touching through nested attributes with before committed on all records", async () => {
-    setBeforeCommittedOnAllRecords(true);
+    ActiveRecord.beforeCommittedOnAllRecords = true;
     try {
       const time = twentyFiveDaysAgo();
       const owner = owners("blackbeard") as any;
@@ -197,7 +197,7 @@ describe("TouchLaterTest", () => {
 
       expect(toI((await owner.reload()).updated_at)).not.toBe(toI(time));
     } finally {
-      setBeforeCommittedOnAllRecords(false);
+      ActiveRecord.beforeCommittedOnAllRecords = false;
     }
   });
 });

--- a/packages/activerecord/src/transaction-callbacks.test.ts
+++ b/packages/activerecord/src/transaction-callbacks.test.ts
@@ -6,6 +6,7 @@ import type { AssociationProxy } from "./associations/collection-proxy.js";
 import type { Temporal } from "@blazetrails/activesupport/temporal";
 import { describe, it, expect, vi } from "vitest";
 import {
+  ActiveRecord,
   Base,
   transaction,
   beforeCommit,
@@ -15,7 +16,6 @@ import {
   afterUpdateCommit,
   afterDestroyCommit,
   afterRollback,
-  setRunAfterTransactionCallbacksInOrderDefined,
   currentTransaction,
   Rollback,
   registerModel,
@@ -1001,7 +1001,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("CallbackOrderTest", () => {
     it("callbacks run in order defined in model if not using run after transaction callbacks in order defined", async () => {
-      setRunAfterTransactionCallbacksInOrderDefined(false);
+      ActiveRecord.runAfterTransactionCallbacksInOrderDefined = false;
       const Topic = defineBehaviourTopic();
 
       const topic = new Topic() as any;
@@ -1169,11 +1169,11 @@ describe("TransactionCallbacksTest", () => {
   describe("CallbackOrderTest", () => {
     it("callbacks run in order defined in model if using run after transaction callbacks in order defined", async () => {
       let Topic: ReturnType<typeof defineBehaviourTopic>;
-      setRunAfterTransactionCallbacksInOrderDefined(true);
+      ActiveRecord.runAfterTransactionCallbacksInOrderDefined = true;
       try {
         Topic = defineBehaviourTopic();
       } finally {
-        setRunAfterTransactionCallbacksInOrderDefined(false);
+        ActiveRecord.runAfterTransactionCallbacksInOrderDefined = false;
       }
 
       const topic = new Topic() as any;

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -94,6 +94,13 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "initialize",
+    "call": "disable_prepared_statements",
+    "reason": "Bucket (b): Rails reads `ActiveRecord.disable_prepared_statements` inline in `initialize` (abstract_adapter.rb:159); the port applies it in the `preparedStatements` setter (abstract-adapter.ts:1058), the chokepoint the constructor and every (re-)establishConnection flow through."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "initialize",
     "call": "build_statement_pool",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## What

RFC 0081, shape 2: converges the 8 `ar-config.ts` flags that are re-exported
from the package index onto `ActiveRecord` object accessors, per the RFC's
prescriptive "Decision — shape 2".

`protocolAdapters`, `disablePreparedStatements`, `beforeCommittedOnAllRecords`,
`runAfterTransactionCallbacksInOrderDefined`, `actionOnStrictLoadingViolation`,
`indexNestedAttributeErrors`, `schemaCacheIgnoredTables`,
`permanentConnectionCheckout`.

Each becomes a `get`/`set` pair over a file-local `let` backing binding; the old
`export let` reader and its `setX` companion are deleted (not deprecated), and
both names come off `index.ts` — `ActiveRecord` is already exported there. Call
sites read and assign as Rails spells it: `ActiveRecord.protocolAdapters = {...}`.

- `setPermanentConnectionCheckout`'s `ArgumentError` validation moves into the
  setter accessor unchanged.
- `isSchemaCacheIgnoredTable` is repointed at the `_schemaCacheIgnoredTables`
  backing binding.

## Verification

- `pnpm api:compare` credits all 8 under their Rails names — `"tsName":
  "protocolAdapters"` against both `protocol_adapters` and `protocol_adapters=`;
  no `setX` entries remain. Data layer 7721/7816, overall 11739/17536.
- Typecheck clean repo-wide; the 12 touched test files pass (554 tests).

## Note

`connection-url-resolver.test.ts` keeps its test name "resolves through a
mapping replaced via setProtocolAdapters" — test names are never reworded in
this repo, even when the API they name has moved.

Closes-story: convert-ar-config-accessors-exported-flags
