### PR TITLE
refactor(activerecord): converge 12 internal ar-config flags onto ActiveRecord accessors

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -4,10 +4,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
-import {
-  IntegerOutOf64BitRange,
-  quotingConfig,
-} from "../../connection-adapters/postgresql/quoting.js";
+import { IntegerOutOf64BitRange } from "../../connection-adapters/postgresql/quoting.js";
+import { ActiveRecord } from "../../ar-config.js";
 import { Range as OidRange, RangeType } from "../../connection-adapters/postgresql/oid/range.js";
 import { Bit } from "../../connection-adapters/postgresql/oid/bit.js";
 import { IntegerType } from "@blazetrails/activemodel";
@@ -162,12 +160,12 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("do not raise when raise int wider than 64bit is false", () => {
-      const saved = quotingConfig.raiseIntWiderThan64Bit;
-      quotingConfig.raiseIntWiderThan64Bit = false;
+      const saved = ActiveRecord.raiseIntWiderThan64bit;
+      ActiveRecord.raiseIntWiderThan64bit = false;
       try {
         expect(adapter.quote(BigInt("9223372036854775808"))).toBe("9223372036854775808");
       } finally {
-        quotingConfig.raiseIntWiderThan64Bit = saved;
+        ActiveRecord.raiseIntWiderThan64bit = saved;
       }
     });
   });

--- a/packages/activerecord/src/ar-config.test.ts
+++ b/packages/activerecord/src/ar-config.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, afterEach } from "vitest";
-import * as arConfig from "./ar-config.js";
 import { ActiveRecord } from "./ar-config.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
 
 describe("ar-config module-level flags", () => {
   it("mirror the ActiveRecord module defaults from active_record.rb", () => {
-    expect(arConfig.databaseCli).toEqual({
+    expect(ActiveRecord.databaseCli).toEqual({
       postgresql: "psql",
       mysql: ["mysql", "mysql5"],
       sqlite: "sqlite3",
@@ -16,46 +15,17 @@ describe("ar-config module-level flags", () => {
     // `belongsToRequiredValidatesForeignKey` is deliberately absent: the AR test
     // harness flips it to false suite-wide (helper.rb:43), so the live binding
     // never reads back the framework default here. `trailtie.test.ts` covers the
-    // `true` default via the untouched versioned-defaults hash; the setter
-    // round-trip below covers the live binding.
-    expect(arConfig.applicationRecordClass).toBeNull();
-    expect(arConfig.errorOnIgnoredOrder).toBe(false);
-    expect(arConfig.timestampedMigrations).toBe(true);
-    expect(arConfig.migrationStrategy).toBe(DefaultStrategy);
-    expect(arConfig.verifyForeignKeysForFixtures).toBe(false);
-    expect(arConfig.useYamlUnsafeLoad).toBe(false);
-    expect(arConfig.raiseIntWiderThan64bit).toBe(true);
-    expect(arConfig.yamlColumnPermittedClasses).toEqual([Symbol]);
-    expect(arConfig.generateSecureTokenOn).toBe("create");
-  });
-
-  describe("setters update the live binding", () => {
-    afterEach(() => {
-      arConfig.setErrorOnIgnoredOrder(false);
-      arConfig.setTimestampedMigrations(true);
-      arConfig.setGenerateSecureTokenOn("create");
-      arConfig.setRaiseIntWiderThan64bit(true);
-      // Back to the value the AR harness installs (helper.rb:43), not the
-      // framework default.
-      arConfig.setBelongsToRequiredValidatesForeignKey(false);
-    });
-
-    it("round-trip a written value", () => {
-      arConfig.setErrorOnIgnoredOrder(true);
-      expect(arConfig.errorOnIgnoredOrder).toBe(true);
-
-      arConfig.setTimestampedMigrations(false);
-      expect(arConfig.timestampedMigrations).toBe(false);
-
-      arConfig.setGenerateSecureTokenOn("initialize");
-      expect(arConfig.generateSecureTokenOn).toBe("initialize");
-
-      arConfig.setRaiseIntWiderThan64bit(false);
-      expect(arConfig.raiseIntWiderThan64bit).toBe(false);
-
-      arConfig.setBelongsToRequiredValidatesForeignKey(true);
-      expect(arConfig.belongsToRequiredValidatesForeignKey).toBe(true);
-    });
+    // `true` default via the untouched versioned-defaults hash; the round-trip
+    // below covers the live binding.
+    expect(ActiveRecord.applicationRecordClass).toBeNull();
+    expect(ActiveRecord.errorOnIgnoredOrder).toBe(false);
+    expect(ActiveRecord.timestampedMigrations).toBe(true);
+    expect(ActiveRecord.migrationStrategy).toBe(DefaultStrategy);
+    expect(ActiveRecord.verifyForeignKeysForFixtures).toBe(false);
+    expect(ActiveRecord.useYamlUnsafeLoad).toBe(false);
+    expect(ActiveRecord.raiseIntWiderThan64bit).toBe(true);
+    expect(ActiveRecord.yamlColumnPermittedClasses).toEqual([Symbol]);
+    expect(ActiveRecord.generateSecureTokenOn).toBe("create");
   });
 
   describe("the ActiveRecord module object assigns through to the live value", () => {
@@ -63,6 +33,13 @@ describe("ar-config module-level flags", () => {
       ActiveRecord.asyncQueryExecutor = null;
       ActiveRecord.queues = {};
       ActiveRecord.maintainTestSchema = null;
+      ActiveRecord.errorOnIgnoredOrder = false;
+      ActiveRecord.timestampedMigrations = true;
+      ActiveRecord.generateSecureTokenOn = "create";
+      ActiveRecord.raiseIntWiderThan64bit = true;
+      // Back to the value the AR harness installs (helper.rb:43), not the
+      // framework default.
+      ActiveRecord.belongsToRequiredValidatesForeignKey = false;
     });
 
     it("round-trip a written value", () => {
@@ -74,6 +51,21 @@ describe("ar-config module-level flags", () => {
 
       ActiveRecord.maintainTestSchema = true;
       expect(ActiveRecord.maintainTestSchema).toBe(true);
+
+      ActiveRecord.errorOnIgnoredOrder = true;
+      expect(ActiveRecord.errorOnIgnoredOrder).toBe(true);
+
+      ActiveRecord.timestampedMigrations = false;
+      expect(ActiveRecord.timestampedMigrations).toBe(false);
+
+      ActiveRecord.generateSecureTokenOn = "initialize";
+      expect(ActiveRecord.generateSecureTokenOn).toBe("initialize");
+
+      ActiveRecord.raiseIntWiderThan64bit = false;
+      expect(ActiveRecord.raiseIntWiderThan64bit).toBe(false);
+
+      ActiveRecord.belongsToRequiredValidatesForeignKey = true;
+      expect(ActiveRecord.belongsToRequiredValidatesForeignKey).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -32,21 +32,6 @@ export function isSchemaCacheIgnoredTable(tableName: string): boolean {
   return false;
 }
 
-/**
- * Maps each DBMS to the command-line client invoked by `dbconsole`. Mirrors
- * `ActiveRecord.database_cli` (active_record.rb:211-212, default
- * `{ postgresql: "psql", mysql: %w[mysql mysql5], sqlite: "sqlite3" }`).
- */
-export let databaseCli: Record<string, string | string[]> = {
-  postgresql: "psql",
-  mysql: ["mysql", "mysql5"],
-  sqlite: "sqlite3",
-};
-
-export function setDatabaseCli(value: Record<string, string | string[]>): void {
-  databaseCli = value;
-}
-
 let _protocolAdapters: Record<string, string> = {
   postgres: "postgresql",
   postgresql: "postgresql",
@@ -66,6 +51,22 @@ let _asyncQueryExecutor: "global_thread_pool" | "multi_thread_pool" | null = nul
 let _queues: Record<string, unknown> = {};
 let _maintainTestSchema: boolean | null = null;
 let _queryTransformers: QueryTransformer[] = [];
+let _databaseCli: Record<string, string | string[]> = {
+  postgresql: "psql",
+  mysql: ["mysql", "mysql5"],
+  sqlite: "sqlite3",
+};
+let _belongsToRequiredValidatesForeignKey = true;
+let _applicationRecordClass: AnyClass | null = null;
+let _errorOnIgnoredOrder = false;
+let _timestampedMigrations = true;
+let _migrationStrategy: AnyClass = DefaultStrategy;
+let _verifyForeignKeysForFixtures = false;
+let _useYamlUnsafeLoad = false;
+let _raiseIntWiderThan64bit = true;
+let _yamlColumnPermittedClasses: unknown[] = [Symbol];
+let _generateSecureTokenOn: "create" | "initialize" = "create";
+let _raiseOnAssignToAttrReadonly = false;
 
 /**
  * The `ActiveRecord` module itself, as far as its singleton configuration
@@ -75,8 +76,8 @@ let _queryTransformers: QueryTransformer[] = [];
  * attributes: `ActiveRecord.maintain_test_schema = true`.
  *
  * ESM live bindings are read-only for importers, so a bare `export let` cannot
- * carry the writer half — hence the `get`/`set` accessors. Flags still declared
- * as `export let` below have not been migrated yet.
+ * carry the writer half — hence the `get`/`set` accessors. Every module-config
+ * flag now lives here; there is no `export let` left in this file.
  */
 export const ActiveRecord = {
   /**
@@ -263,137 +264,165 @@ export const ActiveRecord = {
   set queryTransformers(value: QueryTransformer[]) {
     _queryTransformers = value;
   },
+
+  /**
+   * Maps each DBMS to the command-line client invoked by `dbconsole`. Mirrors
+   * `ActiveRecord.database_cli` (active_record.rb:211-212, default
+   * `{ postgresql: "psql", mysql: %w[mysql mysql5], sqlite: "sqlite3" }`).
+   */
+  get databaseCli(): Record<string, string | string[]> {
+    return _databaseCli;
+  },
+
+  set databaseCli(value: Record<string, string | string[]>) {
+    _databaseCli = value;
+  },
+
+  /**
+   * When true (the default), a required `belongs_to` also validates that the
+   * association's foreign key is present, not just the association object.
+   * Mirrors `ActiveRecord.belongs_to_required_validates_foreign_key`
+   * (active_record.rb:345-346, default true).
+   */
+  get belongsToRequiredValidatesForeignKey(): boolean {
+    return _belongsToRequiredValidatesForeignKey;
+  },
+
+  set belongsToRequiredValidatesForeignKey(value: boolean) {
+    _belongsToRequiredValidatesForeignKey = value;
+  },
+
+  /**
+   * The application's primary abstract record class (`ApplicationRecord`).
+   * `null` until `primary_abstract_class` is declared. Mirrors
+   * `ActiveRecord.application_record_class` (active_record.rb:329-330, default nil).
+   */
+  get applicationRecordClass(): AnyClass | null {
+    return _applicationRecordClass;
+  },
+
+  set applicationRecordClass(value: AnyClass | null) {
+    _applicationRecordClass = value;
+  },
+
+  /**
+   * When true, a batch enumerator (`find_each`/`in_batches`) raises if the
+   * relation carries an explicit order it must ignore; when false (the default)
+   * it silently overrides the order. Mirrors
+   * `ActiveRecord.error_on_ignored_order` (active_record.rb:376-381, default false).
+   */
+  get errorOnIgnoredOrder(): boolean {
+    return _errorOnIgnoredOrder;
+  },
+
+  set errorOnIgnoredOrder(value: boolean) {
+    _errorOnIgnoredOrder = value;
+  },
+
+  /**
+   * When true (the default), generated migration filenames are prefixed with a
+   * UTC timestamp rather than a sequential number. Mirrors
+   * `ActiveRecord.timestamped_migrations` (active_record.rb:384-387, default true).
+   */
+  get timestampedMigrations(): boolean {
+    return _timestampedMigrations;
+  },
+
+  set timestampedMigrations(value: boolean) {
+    _timestampedMigrations = value;
+  },
+
+  /**
+   * The execution strategy migrations run through. Defaults to
+   * {@link DefaultStrategy}, which runs the migration's `up`/`down` directly.
+   * Mirrors `ActiveRecord.migration_strategy` (active_record.rb:398-401, default
+   * `Migration::DefaultStrategy`).
+   */
+  get migrationStrategy(): AnyClass {
+    return _migrationStrategy;
+  },
+
+  set migrationStrategy(value: AnyClass) {
+    _migrationStrategy = value;
+  },
+
+  /**
+   * When true, fixtures are loaded with foreign-key checks verified afterwards.
+   * Mirrors `ActiveRecord.verify_foreign_keys_for_fixtures`
+   * (active_record.rb:423-429, default false).
+   */
+  get verifyForeignKeysForFixtures(): boolean {
+    return _verifyForeignKeysForFixtures;
+  },
+
+  set verifyForeignKeysForFixtures(value: boolean) {
+    _verifyForeignKeysForFixtures = value;
+  },
+
+  /**
+   * When true, the YAML column coder loads with Psych's unsafe loader instead
+   * of `safe_load`. Mirrors `ActiveRecord.use_yaml_unsafe_load`
+   * (active_record.rb:435-439, default false).
+   */
+  get useYamlUnsafeLoad(): boolean {
+    return _useYamlUnsafeLoad;
+  },
+
+  set useYamlUnsafeLoad(value: boolean) {
+    _useYamlUnsafeLoad = value;
+  },
+
+  /**
+   * When true (the default), the PostgreSQL adapter raises if handed an integer
+   * wider than signed 64-bit. Mirrors `ActiveRecord.raise_int_wider_than_64bit`
+   * (active_record.rb:451-456, default true).
+   */
+  get raiseIntWiderThan64bit(): boolean {
+    return _raiseIntWiderThan64bit;
+  },
+
+  set raiseIntWiderThan64bit(value: boolean) {
+    _raiseIntWiderThan64bit = value;
+  },
+
+  /**
+   * Additional classes the YAML column coder permits during `safe_load`.
+   * Mirrors `ActiveRecord.yaml_column_permitted_classes`
+   * (active_record.rb:458-462, default `[Symbol]`).
+   */
+  get yamlColumnPermittedClasses(): unknown[] {
+    return _yamlColumnPermittedClasses;
+  },
+
+  set yamlColumnPermittedClasses(value: unknown[]) {
+    _yamlColumnPermittedClasses = value;
+  },
+
+  /**
+   * Controls when `has_secure_token` generates its value: `"create"` (the
+   * default) or `"initialize"`. Mirrors `ActiveRecord.generate_secure_token_on`
+   * (active_record.rb:464-468, default `:create`).
+   */
+  get generateSecureTokenOn(): "create" | "initialize" {
+    return _generateSecureTokenOn;
+  },
+
+  set generateSecureTokenOn(value: "create" | "initialize") {
+    _generateSecureTokenOn = value;
+  },
+
+  /**
+   * When true, assigning to a readonly attribute on a persisted record raises
+   * `ReadonlyAttributeError`; when false (the default) the write is silently
+   * skipped. Mirrors `ActiveRecord.raise_on_assign_to_attr_readonly`
+   * (active_record.rb:342-343, default false). The Rails 7.1 framework default
+   * and the AR test suite (`test/cases/helper.rb:42`) flip it to true.
+   */
+  get raiseOnAssignToAttrReadonly(): boolean {
+    return _raiseOnAssignToAttrReadonly;
+  },
+
+  set raiseOnAssignToAttrReadonly(value: boolean) {
+    _raiseOnAssignToAttrReadonly = value;
+  },
 };
-
-/**
- * When true (the default), a required `belongs_to` also validates that the
- * association's foreign key is present, not just the association object.
- * Mirrors `ActiveRecord.belongs_to_required_validates_foreign_key`
- * (active_record.rb:345-346, default true).
- */
-export let belongsToRequiredValidatesForeignKey = true;
-
-export function setBelongsToRequiredValidatesForeignKey(value: boolean): void {
-  belongsToRequiredValidatesForeignKey = value;
-}
-
-/**
- * The application's primary abstract record class (`ApplicationRecord`). `null`
- * until `primary_abstract_class` is declared. Mirrors
- * `ActiveRecord.application_record_class` (active_record.rb:329-330, default nil).
- */
-export let applicationRecordClass: AnyClass | null = null;
-
-export function setApplicationRecordClass(value: AnyClass | null): void {
-  applicationRecordClass = value;
-}
-
-/**
- * When true, a batch enumerator (`find_each`/`in_batches`) raises if the
- * relation carries an explicit order it must ignore; when false (the default)
- * it silently overrides the order. Mirrors `ActiveRecord.error_on_ignored_order`
- * (active_record.rb:376-381, default false).
- */
-export let errorOnIgnoredOrder = false;
-
-export function setErrorOnIgnoredOrder(value: boolean): void {
-  errorOnIgnoredOrder = value;
-}
-
-/**
- * When true (the default), generated migration filenames are prefixed with a
- * UTC timestamp rather than a sequential number. Mirrors
- * `ActiveRecord.timestamped_migrations` (active_record.rb:384-387, default true).
- */
-export let timestampedMigrations = true;
-
-export function setTimestampedMigrations(value: boolean): void {
-  timestampedMigrations = value;
-}
-
-/**
- * The execution strategy migrations run through. Defaults to
- * {@link DefaultStrategy}, which runs the migration's `up`/`down` directly.
- * Mirrors `ActiveRecord.migration_strategy` (active_record.rb:398-401, default
- * `Migration::DefaultStrategy`).
- */
-export let migrationStrategy: AnyClass = DefaultStrategy;
-
-export function setMigrationStrategy(value: AnyClass): void {
-  migrationStrategy = value;
-}
-
-/**
- * When true, fixtures are loaded with foreign-key checks verified afterwards.
- * Mirrors `ActiveRecord.verify_foreign_keys_for_fixtures`
- * (active_record.rb:423-429, default false).
- */
-export let verifyForeignKeysForFixtures = false;
-
-export function setVerifyForeignKeysForFixtures(value: boolean): void {
-  verifyForeignKeysForFixtures = value;
-}
-
-/**
- * When true, the YAML column coder loads with Psych's unsafe loader instead of
- * `safe_load`. Mirrors `ActiveRecord.use_yaml_unsafe_load`
- * (active_record.rb:435-439, default false).
- */
-export let useYamlUnsafeLoad = false;
-
-export function setUseYamlUnsafeLoad(value: boolean): void {
-  useYamlUnsafeLoad = value;
-}
-
-/**
- * When true (the default), the PostgreSQL adapter raises if handed an integer
- * wider than signed 64-bit. Mirrors `ActiveRecord.raise_int_wider_than_64bit`
- * (active_record.rb:451-456, default true).
- */
-export let raiseIntWiderThan64bit = true;
-
-/**
- * Writer for the `ActiveRecord.raise_int_wider_than_64bit=` module attribute
- * (`singleton_class.attr_accessor`, active_record.rb:446). Needed only because
- * ESM live bindings are read-only for importers; converging it onto an
- * `ActiveRecord` accessor is RFC 0081's `convert-ar-config-accessors-internal-flags`
- * story.
- */
-export function setRaiseIntWiderThan64bit(value: boolean): void {
-  raiseIntWiderThan64bit = value;
-}
-
-/**
- * Additional classes the YAML column coder permits during `safe_load`. Mirrors
- * `ActiveRecord.yaml_column_permitted_classes` (active_record.rb:458-462,
- * default `[Symbol]`).
- */
-export let yamlColumnPermittedClasses: unknown[] = [Symbol];
-
-export function setYamlColumnPermittedClasses(value: unknown[]): void {
-  yamlColumnPermittedClasses = value;
-}
-
-/**
- * Controls when `has_secure_token` generates its value: `"create"` (the
- * default) or `"initialize"`. Mirrors `ActiveRecord.generate_secure_token_on`
- * (active_record.rb:464-468, default `:create`).
- */
-export let generateSecureTokenOn: "create" | "initialize" = "create";
-
-export function setGenerateSecureTokenOn(value: "create" | "initialize"): void {
-  generateSecureTokenOn = value;
-}
-
-/**
- * When true, assigning to a readonly attribute on a persisted record raises
- * `ReadonlyAttributeError`; when false (the default) the write is silently
- * skipped. Mirrors `ActiveRecord.raise_on_assign_to_attr_readonly`
- * (active_record.rb:342-343, default false). The Rails 7.1 framework default
- * and the AR test suite (`test/cases/helper.rb:42`) flip it to true.
- */
-export let raiseOnAssignToAttrReadonly = false;
-
-export function setRaiseOnAssignToAttrReadonly(value: boolean): void {
-  raiseOnAssignToAttrReadonly = value;
-}

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -67,10 +67,7 @@ import {
   CpkPost,
 } from "../test-helpers/models/cpk.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
-import {
-  setBelongsToRequiredValidatesForeignKey,
-  belongsToRequiredValidatesForeignKey,
-} from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { travelTo, travelBack } from "@blazetrails/activesupport";
 
@@ -2118,8 +2115,8 @@ describe("BelongsToAssociationsTest", () => {
   });
 
   it("runs parent presence check if parent has not changed and belongs_to_required_validates_foreign_key is set", async () => {
-    const original = belongsToRequiredValidatesForeignKey;
-    setBelongsToRequiredValidatesForeignKey(true);
+    const original = ActiveRecord.belongsToRequiredValidatesForeignKey;
+    ActiveRecord.belongsToRequiredValidatesForeignKey = true;
 
     try {
       class TempShip extends Base {
@@ -2142,7 +2139,7 @@ describe("BelongsToAssociationsTest", () => {
       });
       expect(ship.name).toBe("Leviathan");
     } finally {
-      setBelongsToRequiredValidatesForeignKey(original);
+      ActiveRecord.belongsToRequiredValidatesForeignKey = original;
     }
   });
 

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -14,7 +14,7 @@ import {
 } from "../../counter-cache.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
-import { belongsToRequiredValidatesForeignKey } from "../../ar-config.js";
+import { ActiveRecord } from "../../ar-config.js";
 
 /**
  * Mirrors: ActiveRecord::Associations::Builder::BelongsTo
@@ -387,7 +387,7 @@ export class BelongsTo extends SingularAssociation {
             record._readAttribute(attr) == null ||
             (typeof record.attributeChanged === "function" && record.attributeChanged(attr)),
         );
-      const railsRuns = belongsToRequiredValidatesForeignKey
+      const railsRuns = ActiveRecord.belongsToRequiredValidatesForeignKey
         ? () => true
         : (record: any) =>
             needsValidation(record, foreignKeys) ||

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -4,11 +4,11 @@
  */
 import { describe, it, expect, afterAll, afterEach, vi } from "vitest";
 import {
+  ActiveRecord,
   Base,
   NotImplementedError,
   ReadonlyAttributeError,
   getRaiseOnAssignToAttrReadonly,
-  setRaiseOnAssignToAttrReadonly,
 } from "./index.js";
 import { TableNotSpecified, ActiveRecordError } from "./errors.js";
 
@@ -1084,7 +1084,7 @@ describe("BasicsTest", () => {
   });
   it("readonly attributes when configured to not raise", async () => {
     const prev = getRaiseOnAssignToAttrReadonly();
-    setRaiseOnAssignToAttrReadonly(false);
+    ActiveRecord.raiseOnAssignToAttrReadonly = false;
     try {
       class NonRaisingPost extends Base {
         static {
@@ -1125,7 +1125,7 @@ describe("BasicsTest", () => {
       expect(post.readAttribute("title")).toBe("cannot change this");
       expect(post.readAttribute("body")).toBe("changed via update");
     } finally {
-      setRaiseOnAssignToAttrReadonly(prev);
+      ActiveRecord.raiseOnAssignToAttrReadonly = prev;
     }
   });
   it("readonly attributes on belongs to association", async () => {

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Relation } from "./index.js";
-import { errorOnIgnoredOrder, setErrorOnIgnoredOrder } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 import { fixtures } from "./test-fixtures.js";
 import { assertQueriesCount, assertQueriesMatch } from "./testing/query-assertions.js";
 import { quoteTableName, escapeRegExp } from "./support/quote-regex.js";
@@ -264,8 +264,8 @@ describe("EachTest", () => {
   });
 
   it("find in batches should not error if config overridden", async () => {
-    const prev = errorOnIgnoredOrder;
-    setErrorOnIgnoredOrder(true);
+    const prev = ActiveRecord.errorOnIgnoredOrder;
+    ActiveRecord.errorOnIgnoredOrder = true;
     let threw = false;
     try {
       for await (const _b of PostWithDefaultScope.findInBatches({ errorOnIgnore: false })) {
@@ -273,21 +273,21 @@ describe("EachTest", () => {
     } catch {
       threw = true;
     } finally {
-      setErrorOnIgnoredOrder(prev);
+      ActiveRecord.errorOnIgnoredOrder = prev;
     }
     expect(threw).toBe(false);
   });
 
   it("find in batches should error on config specified to error", async () => {
-    const prev = errorOnIgnoredOrder;
-    setErrorOnIgnoredOrder(true);
+    const prev = ActiveRecord.errorOnIgnoredOrder;
+    ActiveRecord.errorOnIgnoredOrder = true;
     try {
       await expect(async () => {
         for await (const _b of PostWithDefaultScope.findInBatches({})) {
         }
       }).rejects.toThrow();
     } finally {
-      setErrorOnIgnoredOrder(prev);
+      ActiveRecord.errorOnIgnoredOrder = prev;
     }
   });
 

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -14,10 +14,7 @@ import { beforeEach } from "vitest";
 import { Base } from "../base.js";
 import { getZone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
 import { DelegateCache } from "../relation/delegation.js";
-import {
-  setBelongsToRequiredValidatesForeignKey,
-  setRaiseOnAssignToAttrReadonly,
-} from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 import { resetTestAdapterState } from "../test-adapter.js";
 import { shouldSkipGlobalReset } from "../support/skip-global-reset.js";
 import { registerFakeAdapter } from "../support/fake-adapter.js";
@@ -47,14 +44,14 @@ Base.automaticallyInvertPluralAssociations = true;
 // Mirror Rails activerecord/test/cases/helper.rb:42 — the AR test suite enables
 // raise-on-assign-to-readonly globally; the framework default (active_record.rb:343)
 // is false, flipped to true by load_defaults 7.1 (configuration.rb:286).
-setRaiseOnAssignToAttrReadonly(true);
+ActiveRecord.raiseOnAssignToAttrReadonly = true;
 
 // Mirror Rails activerecord/test/cases/helper.rb:43 — the AR test suite turns
 // off the required-`belongs_to` foreign-key presence check globally, so the
 // presence validation only runs when the FK (or polymorphic type) is nil or
 // changed. Production keeps the Rails default of `true` (active_record.rb:345-346);
 // only the test harness flips it.
-setBelongsToRequiredValidatesForeignKey(false);
+ActiveRecord.belongsToRequiredValidatesForeignKey = false;
 
 // Mirror Rails activerecord/test/cases/helper.rb:98-102 — configure encryption
 // once, suite-wide, BEFORE any model class loads, so a model's `encrypts`

--- a/packages/activerecord/src/coders/yaml-column.test.ts
+++ b/packages/activerecord/src/coders/yaml-column.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { YAMLColumn, DisallowedClass } from "./yaml-column.js";
-import { setUseYamlUnsafeLoad } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 // Trails-only round-trip coverage plus the ported safe-dump restriction. The
@@ -32,7 +32,7 @@ describe("YAMLColumn round-trip", () => {
   // top-level or nested — while `ActiveRecord.use_yaml_unsafe_load = true`
   // switches to the unrestricted `::YAML.dump` branch (yaml_column.rb:15-24).
   describe("safe dump", () => {
-    afterEach(() => setUseYamlUnsafeLoad(false));
+    afterEach(() => (ActiveRecord.useYamlUnsafeLoad = false));
 
     class Unpermitted {
       secret = "s3cret";
@@ -48,7 +48,7 @@ describe("YAMLColumn round-trip", () => {
     });
 
     it("dumps unpermitted class instances when use_yaml_unsafe_load is set", () => {
-      setUseYamlUnsafeLoad(true);
+      ActiveRecord.useYamlUnsafeLoad = true;
       const coder = new YAMLColumn("params");
       expect(coder.dump(new Unpermitted())).toContain("s3cret");
     });

--- a/packages/activerecord/src/coders/yaml-column.ts
+++ b/packages/activerecord/src/coders/yaml-column.ts
@@ -1,5 +1,5 @@
 import { parse as yamlParse, stringify as yamlStringify } from "@blazetrails/activesupport/yaml";
-import { useYamlUnsafeLoad, yamlColumnPermittedClasses } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 import { ColumnSerializer } from "./column-serializer.js";
 
 type ClassLike = new (...args: unknown[]) => unknown;
@@ -40,7 +40,7 @@ class SafeCoder {
   ) {}
 
   dump(object: unknown): string {
-    if (!(this.unsafeLoad ?? useYamlUnsafeLoad)) this.assertDumpable(object);
+    if (!(this.unsafeLoad ?? ActiveRecord.useYamlUnsafeLoad)) this.assertDumpable(object);
     return yamlStringify(object, { directives: true });
   }
 
@@ -77,7 +77,10 @@ class SafeCoder {
       for (const element of Object.values(value)) this.assertDumpable(element, seen);
       return;
     }
-    for (const permitted of [...this.permittedClasses, ...yamlColumnPermittedClasses]) {
+    for (const permitted of [
+      ...this.permittedClasses,
+      ...ActiveRecord.yamlColumnPermittedClasses,
+    ]) {
       if (typeof permitted === "function" && value instanceof permitted) return;
     }
     throw new DisallowedClass("dump", value.constructor?.name ?? "Object");

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -9,6 +9,7 @@
  */
 
 import { BinaryData } from "@blazetrails/activemodel";
+import { ActiveRecord } from "../../ar-config.js";
 import {
   quote as abstractQuote,
   quotedDate as abstractQuotedDate,
@@ -44,11 +45,6 @@ export class IntegerOutOf64BitRange extends Error {
 
 const PG_INT64_MIN = BigInt("-9223372036854775808");
 const PG_INT64_MAX = BigInt("9223372036854775807");
-
-// Mirrors: ActiveRecord.raise_int_wider_than_64bit (active_record.rb:446).
-export const quotingConfig = {
-  raiseIntWiderThan64Bit: true,
-};
 
 export interface BinaryBind {
   value: string;
@@ -158,7 +154,7 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // integer number values — JS integers beyond MAX_SAFE_INTEGER lose
   // precision silently, so they must be rejected the same way bigints are.
   if (typeof value === "bigint" || (typeof value === "number" && Number.isInteger(value))) {
-    if (quotingConfig.raiseIntWiderThan64Bit) checkIntegerRange(value);
+    if (ActiveRecord.raiseIntWiderThan64bit) checkIntegerRange(value);
     return String(value);
   }
   if (typeof value === "string") return quoteString(value);
@@ -263,7 +259,7 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
     return encodeRange.call(this, value);
   }
   if (typeof value === "bigint" || (typeof value === "number" && Number.isInteger(value))) {
-    if (quotingConfig.raiseIntWiderThan64Bit) checkIntegerRange(value);
+    if (ActiveRecord.raiseIntWiderThan64bit) checkIntegerRange(value);
   }
   return abstractTypeCast.call(this, value);
 }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -15,7 +15,7 @@ import {
   underscore,
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { applicationRecordClass, setApplicationRecordClass } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 
 /**
  * Helper: cast inheritance column value through its attribute type.
@@ -699,12 +699,12 @@ export function isFinderNeedsTypeCondition(modelClass: typeof Base): boolean {
 
 /** Test-only: reset the primary abstract class singleton. */
 export function __resetPrimaryAbstractClass(): void {
-  setApplicationRecordClass(null);
+  ActiveRecord.applicationRecordClass = null;
 }
 
 /** @internal */
 export function getApplicationRecordClass(): typeof Base | null {
-  return applicationRecordClass as typeof Base | null;
+  return ActiveRecord.applicationRecordClass as typeof Base | null;
 }
 
 /**
@@ -717,8 +717,8 @@ export function getApplicationRecordClass(): typeof Base | null {
  * Mirrors: ActiveRecord::Core::ClassMethods#application_record_class?
  */
 export function applicationRecordClassQ(modelClass: typeof Base): boolean {
-  if (applicationRecordClass) {
-    return modelClass === applicationRecordClass;
+  if (ActiveRecord.applicationRecordClass) {
+    return modelClass === ActiveRecord.applicationRecordClass;
   }
   return modelClass === (globalThis as Record<string, unknown>)["ApplicationRecord"];
 }
@@ -731,14 +731,14 @@ export function applicationRecordClassQ(modelClass: typeof Base): boolean {
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#primary_abstract_class
  */
 export function primaryAbstractClass(modelClass: typeof Base): void {
-  if (applicationRecordClass && applicationRecordClass !== modelClass) {
+  if (ActiveRecord.applicationRecordClass && ActiveRecord.applicationRecordClass !== modelClass) {
     throw new ArgumentError(
-      `The \`primary_abstract_class\` is already set to ${applicationRecordClass.name}. ` +
+      `The \`primary_abstract_class\` is already set to ${ActiveRecord.applicationRecordClass.name}. ` +
         "There can only be one `primary_abstract_class` in an application.",
     );
   }
   (modelClass as any).abstractClass = true;
-  setApplicationRecordClass(modelClass);
+  ActiveRecord.applicationRecordClass = modelClass;
 }
 
 /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1404,16 +1404,21 @@ export abstract class Migration {
     // across iterations within the same second. Accepts bigint/string so
     // versions beyond Number.MAX_SAFE_INTEGER (e.g. future renumbering above
     // 9.0e15) survive without precision loss.
+    const raw =
+      number == null
+        ? 0n
+        : typeof number === "bigint"
+          ? number
+          : BigInt(typeof number === "number" ? Math.max(0, Math.trunc(number)) : number);
+    const n = raw < 0n ? 0n : raw;
+    // Rails' `else "%.3d" % number.to_i` branch: sequential numbering, no
+    // timestamp consulted at all (migration.rb:1128-1134).
+    if (!ActiveRecord.timestampedMigrations) return n.toString().padStart(3, "0");
     const stamp = Temporal.Now.instant()
       .toString()
       .replace(/[-T:Z.]/g, "")
       .slice(0, 14);
     if (number == null) return stamp;
-    const raw =
-      typeof number === "bigint"
-        ? number
-        : BigInt(typeof number === "number" ? Math.max(0, Math.trunc(number)) : number);
-    const n = raw < 0n ? 0n : raw;
     // Numeric (BigInt) comparison — string compare goes lexicographic once
     // either side exceeds 14 digits and would mis-order (e.g. a 15-digit
     // "100…" would sort below a 14-digit "2026…" string).
@@ -3204,7 +3209,7 @@ export class Migrator {
   // Rails: MigrationContext#validate_timestamp?
   /** @internal */
   isValidateTimestamp(): boolean {
-    return Migrator.validateMigrationTimestamps;
+    return ActiveRecord.timestampedMigrations && Migrator.validateMigrationTimestamps;
   }
 
   // Rails: MigrationContext#valid_migration_timestamp?

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -1,7 +1,7 @@
 import type { Base } from "./base.js";
 import { Model, MissingAttributeError, resolveAliasNameIn } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "./errors.js";
-import { raiseOnAssignToAttrReadonly, setRaiseOnAssignToAttrReadonly } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 
 /**
  * Raised when a persisted record attempts to write to a column declared
@@ -17,17 +17,20 @@ import { raiseOnAssignToAttrReadonly, setRaiseOnAssignToAttrReadonly } from "./a
  */
 /**
  * Reads `ActiveRecord.raise_on_assign_to_attr_readonly` — the canonical module
- * flag lives in `ar-config.ts` (default false, active_record.rb:343). Re-exported
- * here so the historic `getRaiseOnAssignToAttrReadonly`/`setRaiseOnAssignToAttrReadonly`
- * public surface stays put while the home is the single ar-config binding.
+ * flag lives in `ar-config.ts` (default false, active_record.rb:343). These two
+ * wrappers keep the historic `getRaiseOnAssignToAttrReadonly`/
+ * `setRaiseOnAssignToAttrReadonly` public surface in place while the home is the
+ * single `ActiveRecord.raiseOnAssignToAttrReadonly` accessor.
  *
  * Mirrors: ActiveRecord.raise_on_assign_to_attr_readonly
  */
 export function getRaiseOnAssignToAttrReadonly(): boolean {
-  return raiseOnAssignToAttrReadonly;
+  return ActiveRecord.raiseOnAssignToAttrReadonly;
 }
 
-export { setRaiseOnAssignToAttrReadonly };
+export function setRaiseOnAssignToAttrReadonly(value: boolean): void {
+  ActiveRecord.raiseOnAssignToAttrReadonly = value;
+}
 
 export class ReadonlyAttributeError extends ActiveRecordError {
   readonly attribute: string;
@@ -67,7 +70,7 @@ export function attrReadonly(this: typeof Base, ...attributes: string[]): void {
   // flip of the live flag does not retroactively arm (or disarm) the guards on
   // an already-declared model. `include` is idempotent and one-way, so we never
   // clear the flag once set.
-  if (raiseOnAssignToAttrReadonly) {
+  if (ActiveRecord.raiseOnAssignToAttrReadonly) {
     this._readonlyAttributesRaise = true;
   }
 }

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveRecord::Batches
  */
-import { errorOnIgnoredOrder } from "../ar-config.js";
+import { ActiveRecord } from "../ar-config.js";
 
 export class Batches {
   static readonly ORDER_IGNORE_MESSAGE =
@@ -120,7 +120,7 @@ export function buildBatchOrders(
 
 /** @internal */
 export function actOnIgnoredOrder(errorOnIgnore: boolean | undefined): void {
-  const raise = errorOnIgnore !== undefined ? errorOnIgnore : errorOnIgnoredOrder;
+  const raise = errorOnIgnore !== undefined ? errorOnIgnore : ActiveRecord.errorOnIgnoredOrder;
   if (raise) {
     throw new Error(Batches.ORDER_IGNORE_MESSAGE);
   }

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -4,7 +4,7 @@
  * Mirrors: activerecord/test/cases/serialized_attribute_test.rb
  */
 import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
-import { setUseYamlUnsafeLoad } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 import { ValueType, MissingAttributeError } from "@blazetrails/activemodel";
 import { Base, serialize, SerializationTypeMismatch } from "./index.js";
 import { HashObject } from "./serialize.js";
@@ -42,8 +42,8 @@ describe("SerializedAttributeTest", () => {
   // Rails: `setup { ActiveRecord.use_yaml_unsafe_load = true }`
   // (serialized_attribute_test.rb:10) — the default YAML coder safe-dumps, and
   // these tests serialize non-permitted classes like MyObject.
-  beforeEach(() => setUseYamlUnsafeLoad(true));
-  afterAll(() => setUseYamlUnsafeLoad(false));
+  beforeEach(() => (ActiveRecord.useYamlUnsafeLoad = true));
+  afterAll(() => (ActiveRecord.useYamlUnsafeLoad = false));
 
   it("serialize does not eagerly load columns", () => {
     // Rails: assert_no_queries { Topic.serialize(:content) }

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -10,7 +10,7 @@ import { ExtendedDeterministicUniquenessValidator } from "./encryption/extended-
 import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 import { UniquenessValidator } from "./validations.js";
 import { deprecator } from "./deprecator.js";
-import { raiseOnAssignToAttrReadonly, setRaiseOnAssignToAttrReadonly } from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 
 const { deprecators } = BaseRailtie;
 
@@ -39,7 +39,7 @@ describe("RailtieTest", () => {
     savedDecodeDates = PostgreSQLAdapter.decodeDates;
     savedEncryptionSupportUnencryptedData = EncryptionConfigurable.config.supportUnencryptedData;
     savedPartialInserts = Base.partialInserts;
-    savedRaiseOnAssignToAttrReadonly = raiseOnAssignToAttrReadonly;
+    savedRaiseOnAssignToAttrReadonly = ActiveRecord.raiseOnAssignToAttrReadonly;
     savedExtendQueries = EncryptionConfigurable.config.extendQueries;
 
     // Simulate a fresh app boot for each test: clear the load-hook registry
@@ -63,7 +63,7 @@ describe("RailtieTest", () => {
     PostgreSQLAdapter.decodeDates = savedDecodeDates;
     EncryptionConfigurable.config.supportUnencryptedData = savedEncryptionSupportUnencryptedData;
     Base.partialInserts = savedPartialInserts;
-    setRaiseOnAssignToAttrReadonly(savedRaiseOnAssignToAttrReadonly);
+    ActiveRecord.raiseOnAssignToAttrReadonly = savedRaiseOnAssignToAttrReadonly;
     // The suite boots with extended query support installed
     // (cases/helper.ts, mirroring helper.rb:104-107); tests here uninstall it
     // to observe the initializer doing the install, so put it back.
@@ -187,9 +187,9 @@ describe("RailtieTest", () => {
   });
 
   it("load_defaults 7.1 sets raise_on_assign_to_attr_readonly to true", () => {
-    setRaiseOnAssignToAttrReadonly(false); // framework default before load_defaults
+    ActiveRecord.raiseOnAssignToAttrReadonly = false; // framework default before load_defaults
     loadDefaults("7.1");
-    expect(raiseOnAssignToAttrReadonly).toBe(true);
+    expect(ActiveRecord.raiseOnAssignToAttrReadonly).toBe(true);
   });
 
   it("load_defaults raises for an unknown version string", () => {

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -38,12 +38,7 @@ import {
   appendInfoToPayload,
 } from "./trailties/controller-runtime.js";
 import { instrument } from "./trailties/job-runtime.js";
-import {
-  ActiveRecord,
-  setBelongsToRequiredValidatesForeignKey,
-  setGenerateSecureTokenOn,
-  setRaiseOnAssignToAttrReadonly,
-} from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 
 export const ControllerRuntime = { processAction, cleanupViewRuntime, appendInfoToPayload };
 export const JobRuntime = { instrument };
@@ -86,7 +81,7 @@ export function loadDefaults(version: string): void {
     if (compareVersions(v, version) <= 0) {
       if (defaults.partialInserts !== undefined) Base.partialInserts = defaults.partialInserts;
       if (defaults.raiseOnAssignToAttrReadonly !== undefined) {
-        setRaiseOnAssignToAttrReadonly(defaults.raiseOnAssignToAttrReadonly);
+        ActiveRecord.raiseOnAssignToAttrReadonly = defaults.raiseOnAssignToAttrReadonly;
       }
     }
   }
@@ -235,9 +230,9 @@ export class Trailtie extends BaseRailtie {
       // source of truth at runtime.
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
       ActiveRecord.maintainTestSchema = cfg.maintainTestSchema;
-      setRaiseOnAssignToAttrReadonly(cfg.raiseOnAssignToAttrReadonly);
-      setBelongsToRequiredValidatesForeignKey(cfg.belongsToRequiredValidatesForeignKey);
-      setGenerateSecureTokenOn(cfg.generateSecureTokenOn);
+      ActiveRecord.raiseOnAssignToAttrReadonly = cfg.raiseOnAssignToAttrReadonly;
+      ActiveRecord.belongsToRequiredValidatesForeignKey = cfg.belongsToRequiredValidatesForeignKey;
+      ActiveRecord.generateSecureTokenOn = cfg.generateSecureTokenOn;
       ActiveRecord.queues = cfg.queues;
     });
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -509,5 +509,12 @@
     "rubyName": "write_query?",
     "call": "match?",
     "reason": "Include stand-in: `MySQL::DatabaseStatements#write_query?` is ported in the Rails-layout file `connection-adapters/mysql/database-statements.ts` (`isWriteQuery`, which does run `READ_QUERY.test(sql)`); the adapter method is the `include` resolution point and only delegates."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "dbconsole",
+    "call": "database_cli",
+    "reason": "Rails reads the cli name only to pass it to `find_cmd_and_exec` (abstract_mysql_adapter.rb); that PTY exec is Ruby-only and unported, so our `dbconsole` returns the arg list and never needs the lookup."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -950,5 +950,12 @@
     "rubyName": "lookup_cast_type",
     "call": "query_value",
     "reason": "PG resolves the regtype OID through `schemaQuery` rather than `query_value`; the async signature that forces it is tracked by the `pg-lookup-cast-type-async-divergence` story."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "dbconsole",
+    "call": "database_cli",
+    "reason": "Rails reads the cli name only to pass it to `find_cmd_and_exec` (postgresql_adapter.rb); that PTY exec is Ruby-only and unported, so our `dbconsole` returns the arg list and never needs the lookup."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -817,5 +817,12 @@
     "rubyName": "virtual_tables",
     "call": "match",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "dbconsole",
+    "call": "database_cli",
+    "reason": "Rails reads the cli name only to pass it to `find_cmd_and_exec` (sqlite3_adapter.rb:51); that PTY exec is Ruby-only and unported, so our `dbconsole` returns the arg list and never needs the lookup."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
@@ -222,5 +222,12 @@
     "rubyName": "generated_association_methods",
     "call": "private_constant",
     "reason": "Rails hides the GeneratedAssociationMethods module constant; trails has no such constant to hide."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
+    "rubyName": "application_record_class?",
+    "call": "application_record_class",
+    "reason": "`applicationRecordClassQ` is ported in inheritance.ts, not core.ts, and does read `ActiveRecord.applicationRecordClass` there; the omission is the file placement, not a missing call."
   }
 ]


### PR DESCRIPTION
Follow-up to the RFC 0081 pilot (`module-level-config-accessor-shape`), which
settled the shape-2 decision and converted 3 of 23 flags.

Converts the 12 module-config flags that are **not** re-exported from
`index.ts` (so the change is package-internal) from `export let` + `setX` onto
`get`/`set` accessor pairs on the `ActiveRecord` module object in
`packages/activerecord/src/ar-config.ts`:

`databaseCli`, `belongsToRequiredValidatesForeignKey`, `applicationRecordClass`,
`errorOnIgnoredOrder`, `timestampedMigrations`, `migrationStrategy`,
`verifyForeignKeysForFixtures`, `useYamlUnsafeLoad`, `raiseIntWiderThan64bit`,
`yamlColumnPermittedClasses`, `generateSecureTokenOn`,
`raiseOnAssignToAttrReadonly`.

The old `export let` readers and their `setX` companions are deleted, not
deprecated, per the RFC. All internal call sites now read and write
`ActiveRecord.x` — the spelling Rails uses for these
`singleton_class.attr_accessor` attributes. `trailtie.ts`'s
`active_record.set_configs` initializer follows the pattern the pilot
established for `maintainTestSchema` / `queues`.

`ar-config.test.ts`'s default assertions and setter round-trips move onto
`ActiveRecord.x`; the round-trip cases fold into the existing
"the ActiveRecord module object assigns through to the live value" block.

**Deliberately left in place:** the `getRaiseOnAssignToAttrReadonly` /
`setRaiseOnAssignToAttrReadonly` wrappers in `readonly-attributes.ts`. Those
are index-exported public surface, not the `ar-config.ts` bindings this story
covers; they now delegate to the accessor rather than to a deleted setter.

**Rebase note (this sentence used to say the opposite).** When this PR opened,
`ar-config.ts` still had `export let` for the 8 index-exported flags and for
`queryTransformers`. Those landed on `main` meanwhile as #5563 and #5565, so
this PR — the last of the three — is what empties the file: after it there is
no `export let` left in `ar-config.ts`, which is this story's stated acceptance
criterion. The `ActiveRecord` object's doc comment was updated to match.

To be explicit about attribution, since the end state now shows every flag
converted: **this PR's diff removes only its own 12 flags.**
`disablePreparedStatements`, `setPermanentConnectionCheckout` and
`setSchemaCacheIgnoredTables` were removed by #5563/#5565 and are already
absent from `main` — `git diff origin/main...HEAD -- packages/activerecord/src/ar-config.ts`
contains no deletion of any of them.

On the deep-import break for the 12 flags this PR *does* remove
(`@blazetrails/activerecord/ar-config.js` resolves through the `./*` subpath):
that is RFC 0081's settled decision, not an oversight. The RFC rejects keeping
the old `export let` as a compatibility reader because it **forks the storage** —
the accessor writes the file-local backing binding while an importer holding the
live binding reads a value that no longer updates, and a silently-stale reader is
strictly worse than a compile error. The breakage is compile-time and total, so
no caller can be missed; `pnpm typecheck` is clean and no in-repo caller of any
removed binding remains. Rails has no deprecated alias for these
(`active_record.rb:342-468` declares them as bare `singleton_class.attr_accessor`),
so adding one would be trails-only surface.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm api:compare`: all 12 flags still credited under their Rails names
  (they resolve via the `moves` path against `base.rb`, same as before);
  data layer 7721/7816, overall 11739/17536.
- Touched suites pass: `ar-config`, `trailtie`, `batches`, `coders/yaml-column`,
  `serialized-attribute`, `base`, `inheritance`,
  `associations/belongs-to-associations`.

Closes-story: convert-ar-config-accessors-internal-flags


---

## Follow-up: wide calls ratchet (CI failure, fixed in 2d065a0a0)

Converting these flags to accessors turns them into *ported methods*, so the
wide calls ratchet started checking the Rails bodies that read them. Eight new
mismatches — four real omissions, four artifacts:

**Implemented** (trails was genuinely not reading the flag Rails reads):

- `migration.ts` `nextMigrationNumber` — added Rails' `else "%.3d" % number.to_i`
  sequential branch (migration.rb:1128-1134). Previously the UTC timestamp was
  used unconditionally and `timestamped_migrations` was never consulted at all.
- `migration.ts` `isValidateTimestamp` — added the missing
  `timestamped_migrations &&` conjunct (migration.rb:1377-1379).
- `connection-adapters/postgresql/quoting.ts` — deleted the trails-only
  `quotingConfig.raiseIntWiderThan64Bit` fork and pointed `quote()` / `typeCast()`
  at `ActiveRecord.raiseIntWiderThan64bit` (quoting.rb:97-100). This was exactly
  the forked-storage failure mode RFC 0081 warns about: a parallel copy that no
  longer tracked the canonical flag.

**Baselined** in `call-mismatches-wide-exclude/`, with per-entry reasons:

- `dbconsole` / `database_cli` ×3 (sqlite3, postgresql, abstract-mysql) — Rails
  reads the cli name only to pass it to `find_cmd_and_exec`; that PTY exec is
  Ruby-only and unported, so our `dbconsole` returns the arg list.
- `core.ts` `application_record_class?` — ported in `inheritance.ts`, where it
  does read `ActiveRecord.applicationRecordClass`; the omission is file
  placement, not a missing call.

`pnpm exec tsx scripts/api-compare/lint-call-mismatches-wide.ts` now reports
`OK (4809 baselined)`. api:compare totals unchanged (11739/17536; arity 7576
pairs, 7493 matching). Migration suites (`migration`, `migrator`,
`multi-db-migrator`, `invertible-migration`, `migration/*`) pass — 371 tests.

**LOC note:** this pushes the PR to 550 LOC, 50 over the ceiling. The overage is
entirely the CI gate that this PR's own conversion tripped; deferring it to a
sibling PR would leave `main` red, and splitting would mean a stacked PR. Flagging
rather than silently splitting.

