### PR TITLE
refactor(activerecord): converge queryTransformers onto the ActiveRecord accessor

### DIFF
--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -6,6 +6,7 @@
  */
 import { ArgumentError } from "@blazetrails/activemodel";
 import { DefaultStrategy } from "./migration/default-strategy.js";
+import type { QueryTransformer } from "./query-transformers.js";
 
 /** Any constructable class — used for module-config flags that hold a class. */
 type AnyClass = abstract new (...args: never[]) => object;
@@ -179,6 +180,7 @@ export function setDatabaseCli(value: Record<string, string | string[]>): void {
 let _asyncQueryExecutor: "global_thread_pool" | "multi_thread_pool" | null = null;
 let _queues: Record<string, unknown> = {};
 let _maintainTestSchema: boolean | null = null;
+let _queryTransformers: QueryTransformer[] = [];
 
 /**
  * The `ActiveRecord` module itself, as far as its singleton configuration
@@ -233,6 +235,22 @@ export const ActiveRecord = {
 
   set maintainTestSchema(value: boolean | null) {
     _maintainTestSchema = value;
+  },
+
+  /**
+   * The mutable, process-global transformer list applied to every SQL
+   * statement before execution. Mutate in place
+   * (`ActiveRecord.queryTransformers.push(...)`) to register or reset, exactly
+   * as Rails appends to and resets `ActiveRecord.query_transformers`; assigning
+   * replaces the list wholesale. Mirrors `ActiveRecord.query_transformers`
+   * (active_record.rb:431, default `[]`).
+   */
+  get queryTransformers(): QueryTransformer[] {
+    return _queryTransformers;
+  },
+
+  set queryTransformers(value: QueryTransformer[]) {
+    _queryTransformers = value;
   },
 };
 

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -237,14 +237,7 @@ export const ActiveRecord = {
     _maintainTestSchema = value;
   },
 
-  /**
-   * The mutable, process-global transformer list applied to every SQL
-   * statement before execution. Mutate in place
-   * (`ActiveRecord.queryTransformers.push(...)`) to register or reset, exactly
-   * as Rails appends to and resets `ActiveRecord.query_transformers`; assigning
-   * replaces the list wholesale. Mirrors `ActiveRecord.query_transformers`
-   * (active_record.rb:431, default `[]`).
-   */
+  /** Mirrors `ActiveRecord.query_transformers` (active_record.rb:431-432, default `[]`). */
   get queryTransformers(): QueryTransformer[] {
     return _queryTransformers;
   },

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -40,7 +40,8 @@ import {
   type DatabaseStatementsHost,
 } from "./database-statements.js";
 import { Result } from "../../result.js";
-import { queryTransformers, type QueryTransformer } from "../../query-transformers.js";
+import { ActiveRecord } from "../../ar-config.js";
+import type { QueryTransformer } from "../../query-transformers.js";
 import type { Quoting } from "./quoting-interface.js";
 import { fixtures } from "../../test-fixtures.js";
 
@@ -500,14 +501,14 @@ describe("preprocessQuery", () => {
 
   describe("queryTransformers loop", () => {
     function withTransformers(transformers: QueryTransformer[], fn: () => void): void {
-      const saved = queryTransformers.slice();
-      queryTransformers.length = 0;
-      queryTransformers.push(...transformers);
+      const saved = ActiveRecord.queryTransformers.slice();
+      ActiveRecord.queryTransformers.length = 0;
+      ActiveRecord.queryTransformers.push(...transformers);
       try {
         fn();
       } finally {
-        queryTransformers.length = 0;
-        queryTransformers.push(...saved);
+        ActiveRecord.queryTransformers.length = 0;
+        ActiveRecord.queryTransformers.push(...saved);
       }
     }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -46,7 +46,7 @@ import { TransactionManager } from "./transaction.js";
 import { exceedsBindParamsLimit } from "./database-limits.js";
 import { Result } from "../../result.js";
 import { isWriteQuerySql } from "../sql-classification.js";
-import { queryTransformers } from "../../query-transformers.js";
+import { ActiveRecord } from "../../ar-config.js";
 
 /**
  * A single entry in `Relation#explain`'s options list. Either a bare
@@ -1934,7 +1934,7 @@ export function preprocessQuery(this: DatabaseStatementsHost, sql: string): stri
   }
   host._inQueryTransformers = true;
   try {
-    for (const t of queryTransformers) {
+    for (const t of ActiveRecord.queryTransformers) {
       sql = t.call(sql, this);
     }
   } finally {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -4,7 +4,8 @@ import { Base } from "../base.js";
 import { fixtures } from "../test-fixtures.js";
 import { describeIfSqlite } from "../support/describe-if-sqlite.js";
 import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
-import { queryTransformers, type QueryTransformer } from "../query-transformers.js";
+import { ActiveRecord } from "../ar-config.js";
+import type { QueryTransformer } from "../query-transformers.js";
 
 fixtures([]);
 
@@ -19,13 +20,13 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
 
   beforeEach(() => {
     adapter = Base.connection as AbstractSQLite3Adapter;
-    savedTransformers = queryTransformers.slice();
-    queryTransformers.length = 0;
+    savedTransformers = ActiveRecord.queryTransformers.slice();
+    ActiveRecord.queryTransformers.length = 0;
   });
 
   afterEach(() => {
-    queryTransformers.length = 0;
-    queryTransformers.push(...savedTransformers);
+    ActiveRecord.queryTransformers.length = 0;
+    ActiveRecord.queryTransformers.push(...savedTransformers);
   });
 
   function captureSql<T>(fn: () => Promise<T>): Promise<{ result: T; sqls: string[] }> {
@@ -39,7 +40,7 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   }
 
   it("appends the comment to read queries and instruments the commented SQL", async () => {
-    queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
+    ActiveRecord.queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
     const { result, sqls } = await captureSql(() => adapter.execute("SELECT 1 AS one"));
     // The query still executes correctly with the comment appended.
     expect(result).toEqual([{ one: 1 }]);
@@ -48,7 +49,7 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   });
 
   it("applies the comment on write queries too", async () => {
-    queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
+    ActiveRecord.queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
     const { sqls } = await captureSql(() =>
       adapter.executeMutation("INSERT INTO customers (name) VALUES ('x')"),
     );
@@ -64,7 +65,7 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
   });
 
   it("leaves executeBatch statements uncommented (matches Rails execute_batch)", async () => {
-    queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
+    ActiveRecord.queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
     const { sqls } = await captureSql(() =>
       adapter.executeBatch([
         "INSERT INTO customers (name) VALUES ('a')",
@@ -79,7 +80,7 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
     // The batch-suppression flag is consumed synchronously inside preprocessQuery
     // (before any await), so a query interleaved with an in-flight batch still
     // gets transformed. If the flag spanned the await, this comment would be lost.
-    queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
+    ActiveRecord.queryTransformers.push({ call: (sql) => `${sql} /*app:test*/` });
     const { sqls } = await captureSql(() =>
       Promise.all([
         adapter.executeBatch([
@@ -96,7 +97,7 @@ describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
 
   it("applies each transformer exactly once per query", async () => {
     let calls = 0;
-    queryTransformers.push({
+    ActiveRecord.queryTransformers.push({
       call: (sql) => {
         calls++;
         return `${sql} /*c1*/`;

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -165,7 +165,6 @@ export { QueryCache } from "./query-cache.js";
 export { Store as QueryCacheStore } from "./connection-adapters/abstract/query-cache.js";
 export { QueryLogs, escapeComment, LegacyFormatter, SQLCommenter } from "./query-logs.js";
 export type { TagValue, TagHandler, TagDefinition, QueryLogsFormatter } from "./query-logs.js";
-export { queryTransformers, setQueryTransformers } from "./query-transformers.js";
 export type { QueryTransformer } from "./query-transformers.js";
 export {
   StatementCache,

--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -5,7 +5,8 @@ import { Base } from "./base.js";
 import { QueryLogs, escapeComment, GetKeyHandler } from "./query-logs.js";
 import { LegacyFormatter, SQLCommenter } from "./query-logs-formatter.js";
 import { queryLogs } from "./query-logs-instance.js";
-import { queryTransformers, type QueryTransformer } from "./query-transformers.js";
+import { ActiveRecord } from "./ar-config.js";
+import type { QueryTransformer } from "./query-transformers.js";
 import { assertQueriesMatch } from "./testing/query-assertions.js";
 import { fixtures } from "./test-fixtures.js";
 import { Dashboard } from "./test-helpers/models/dashboard.js";
@@ -20,7 +21,8 @@ function leaseConnection(): RawAdapter {
 // Mirrors: activerecord/test/cases/query_logs_test.rb
 //
 // These tests drive real queries through the full pipeline — the
-// `queryTransformers` loop wired into `preprocessQuery` (QL PR 3) appends the
+// `ActiveRecord.queryTransformers` loop wired into `preprocessQuery` (QL PR 3) appends
+// the
 // QueryLogs comment, and the `sql.active_record` notification carries the
 // post-transform SQL — and assert the tagged SQL via `assertQueriesMatch`
 // (Rails' `assert_queries_match` / `SQLCounter`), exactly as the Rails
@@ -41,9 +43,9 @@ describe("QueryLogsTest", () => {
   // sharing the process-global registry / singleton.
   beforeEach(() => {
     ExecutionContext.clear();
-    originalTransformers = [...queryTransformers];
-    queryTransformers.length = 0;
-    queryTransformers.push(queryLogs);
+    originalTransformers = [...ActiveRecord.queryTransformers];
+    ActiveRecord.queryTransformers.length = 0;
+    ActiveRecord.queryTransformers.push(queryLogs);
     queryLogs.prependComment = false;
     queryLogs.cacheQueryLogTags = false;
     queryLogs.clearCache();
@@ -54,8 +56,8 @@ describe("QueryLogsTest", () => {
   });
 
   afterEach(() => {
-    queryTransformers.length = 0;
-    queryTransformers.push(...originalTransformers);
+    ActiveRecord.queryTransformers.length = 0;
+    ActiveRecord.queryTransformers.push(...originalTransformers);
     queryLogs.prependComment = false;
     queryLogs.cacheQueryLogTags = false;
     queryLogs.tags = [];

--- a/packages/activerecord/src/query-transformers.test.ts
+++ b/packages/activerecord/src/query-transformers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { queryTransformers } from "./query-transformers.js";
+import { ActiveRecord } from "./ar-config.js";
 import type { QueryTransformer } from "./query-transformers.js";
 import { QueryLogs } from "./query-logs.js";
 
@@ -10,26 +10,26 @@ describe("queryTransformers", () => {
   // it nor leak an emptied registry into sibling suites.
   let saved: QueryTransformer[];
   beforeEach(() => {
-    saved = [...queryTransformers];
+    saved = [...ActiveRecord.queryTransformers];
   });
   afterEach(() => {
-    queryTransformers.splice(0, queryTransformers.length, ...saved);
+    ActiveRecord.queryTransformers.splice(0, ActiveRecord.queryTransformers.length, ...saved);
   });
 
   it("defaults to an empty list", () => {
-    expect(queryTransformers).toEqual([]);
+    expect(ActiveRecord.queryTransformers).toEqual([]);
   });
 
   it("is mutable in place — push registers a transformer", () => {
     const t: QueryTransformer = { call: (sql) => `${sql} /*x*/` };
-    queryTransformers.push(t);
-    expect(queryTransformers).toContain(t);
+    ActiveRecord.queryTransformers.push(t);
+    expect(ActiveRecord.queryTransformers).toContain(t);
   });
 
   it("a registered transformer rewrites SQL via call(sql, connection)", () => {
-    queryTransformers.push({ call: (sql) => `${sql} -- tagged` });
+    ActiveRecord.queryTransformers.push({ call: (sql) => `${sql} -- tagged` });
     let sql = "SELECT 1";
-    for (const t of queryTransformers) sql = t.call(sql, null);
+    for (const t of ActiveRecord.queryTransformers) sql = t.call(sql, null);
     expect(sql).toBe("SELECT 1 -- tagged");
   });
 
@@ -37,7 +37,7 @@ describe("queryTransformers", () => {
     const logs = new QueryLogs();
     logs.tags = [{ app: "MyApp" }];
     const transformer: QueryTransformer = logs;
-    queryTransformers.push(transformer);
+    ActiveRecord.queryTransformers.push(transformer);
     expect(transformer.call("SELECT 1", null)).toContain("MyApp");
   });
 });

--- a/packages/activerecord/src/query-transformers.ts
+++ b/packages/activerecord/src/query-transformers.ts
@@ -7,6 +7,9 @@
  * Rails iterates this list in `preprocess_query`:
  * `ActiveRecord.query_transformers.each { |t| sql = t.call(sql, self) }`.
  *
+ * The list itself lives on the `ActiveRecord` module object in `ar-config.ts`,
+ * alongside the other `singleton_class.attr_accessor` flags.
+ *
  * A transformer is any object responding to `call(sql, connection)` and
  * returning the (possibly rewritten) SQL — `ActiveRecord::QueryLogs` is the
  * canonical one. The `connection` slot is opaque to the registry, hence
@@ -15,23 +18,4 @@
 
 export interface QueryTransformer {
   call(sql: string, connection: unknown): string;
-}
-
-/**
- * The mutable, process-global transformer list. Mutate in place
- * (`queryTransformers.push(...)`, `queryTransformers.length = 0`) to register
- * or reset, exactly as Rails appends to and resets
- * `ActiveRecord.query_transformers`. Consumers import this live binding and
- * iterate it fresh on every query, so {@link setQueryTransformers} (a
- * wholesale reassignment, mirroring Rails' `query_transformers=`) is also
- * observed.
- */
-export let queryTransformers: QueryTransformer[] = [];
-
-/**
- * Replaces the transformer list wholesale. Mirrors
- * `ActiveRecord.query_transformers=` (active_record.rb:431).
- */
-export function setQueryTransformers(value: QueryTransformer[]): void {
-  queryTransformers = value;
 }

--- a/packages/activerecord/src/query-transformers.ts
+++ b/packages/activerecord/src/query-transformers.ts
@@ -7,9 +7,6 @@
  * Rails iterates this list in `preprocess_query`:
  * `ActiveRecord.query_transformers.each { |t| sql = t.call(sql, self) }`.
  *
- * The list itself lives on the `ActiveRecord` module object in `ar-config.ts`,
- * alongside the other `singleton_class.attr_accessor` flags.
- *
  * A transformer is any object responding to `call(sql, connection)` and
  * returning the (possibly rewritten) SQL — `ActiveRecord::QueryLogs` is the
  * canonical one. The `connection` slot is opaque to the registry, hence


### PR DESCRIPTION
Last shape-2 conversion in RFC 0081. `setQueryTransformers` was the one
module-level writer re-spelling outside `ar-config.ts`.

## Host decision

`queryTransformers` joins the existing `ActiveRecord` object literal in
`packages/activerecord/src/ar-config.ts` rather than getting its own object.
Rails spells it `ActiveRecord.query_transformers=` on the same
`module ActiveRecord` singleton that already hosts the other flags, and there
is **no import cycle**: `query-transformers.ts` now holds only the
`QueryTransformer` interface and imports nothing, so `ar-config.ts` takes a
type-only import of it and nothing imports back.

## Changes

- `ar-config.ts`: `get`/`set queryTransformers` over a file-local
  `_queryTransformers` backing binding.
- `query-transformers.ts`: `export let queryTransformers` and
  `setQueryTransformers` deleted; the file keeps the `QueryTransformer`
  interface and its Rails-anchored doc comment.
- `index.ts`: drops the `queryTransformers` / `setQueryTransformers` value
  exports (the flag is reachable as `ActiveRecord.queryTransformers`, already
  exported); the `QueryTransformer` type export stays.
- Call sites updated: `preprocessQuery` in `database-statements.ts` plus four
  test files. In-place mutation (`.push(...)`, `.length = 0`) still works
  through the getter, so the test setup/teardown shape is unchanged. No test
  names were changed.

## Verification

- `pnpm typecheck` clean.
- `pnpm vitest run` on the four touched test files: 133 passed.
- `pnpm api:compare`: `query_transformers` and `query_transformers=` are both
  credited to `queryTransformers` (`actualFile: ar-config.ts`), replacing the
  `setQueryTransformers` fallback match. Data layer 7721/7816, overall
  11739/17536 — no drop.

RFC README note recorded in the tasks repo (`983694c8c`).

Closes-story: convert-query-transformers-accessor
