### PR TITLE
refactor(activerecord): relocate default_timezone writer to ar-config

### DIFF
--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -47,6 +47,7 @@ let _actionOnStrictLoadingViolation: "raise" | "log" = "raise";
 let _indexNestedAttributeErrors = false;
 let _schemaCacheIgnoredTables: ReadonlyArray<string | RegExp> = [];
 let _permanentConnectionCheckout: true | "deprecated" | "disallowed" = true;
+let _defaultTimezone: "utc" | "local" = "utc";
 let _asyncQueryExecutor: "global_thread_pool" | "multi_thread_pool" | null = null;
 let _queues: Record<string, unknown> = {};
 let _maintainTestSchema: boolean | null = null;
@@ -186,6 +187,22 @@ export const ActiveRecord = {
   /** @internal */
   set schemaCacheIgnoredTables(value: ReadonlyArray<string | RegExp>) {
     _schemaCacheIgnoredTables = value;
+  },
+
+  /**
+   * Determines whether to use UTC (`"utc"`) or the local zone (`"local"`) when
+   * pulling dates and times from the database. Mirrors
+   * `ActiveRecord.default_timezone` (active_record.rb:214-226, default :utc).
+   */
+  get defaultTimezone(): "utc" | "local" {
+    return _defaultTimezone;
+  },
+
+  set defaultTimezone(value: "utc" | "local") {
+    if (value !== "utc" && value !== "local") {
+      throw new ArgumentError("default_timezone must be either :utc (default) or :local.");
+    }
+    _defaultTimezone = value;
   },
 
   /**

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { TimeZoneConverter } from "./time-zone-conversion.js";
 import { DateTime } from "../type/date-time.js";
-import { getDefaultTimezone, setDefaultTimezone } from "../type/internal/timezone.js";
+import { ActiveRecord } from "../ar-config.js";
 import { ValueType } from "@blazetrails/activemodel";
 import { TimeWithZone, TimeZone, setZone, resetZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -150,10 +150,10 @@ describe("TimeZoneConverterTest", () => {
   });
 
   it("falls back to ActiveRecord.default_timezone when the subtype has no is_utc?", () => {
-    const previous = getDefaultTimezone();
+    const previous = ActiveRecord.defaultTimezone;
     vi.spyOn(Temporal.Now, "timeZoneId").mockReturnValue("America/New_York");
     setZone("UTC");
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     try {
       class ZonelessDateTime extends ValueType<unknown> {
         override type(): string {
@@ -168,7 +168,7 @@ describe("TimeZoneConverterTest", () => {
       expect(result).toBeInstanceOf(TimeWithZone);
       expect((result as TimeWithZone).utc().toString()).toBe("2024-06-15T10:00:00Z");
     } finally {
-      setDefaultTimezone(previous);
+      ActiveRecord.defaultTimezone = previous;
     }
   });
 });

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1314,7 +1314,7 @@ describe("BasicsTest", () => {
   // `establish_connection(default_timezone:)` is observed through default-string
   // casting: the offset-less `"2004-01-01 00:00:00"` default is parsed lazily at
   // read time by DateTimeType.cast → fastStringToTime, which interprets it in
-  // getDefaultTimezone() (the singleton establishConnection updates). Same cast
+  // ActiveRecord.defaultTimezone (the singleton establishConnection updates). Same cast
   // path as the `default in utc` test above; Rails reaches it via DB column
   // defaults + reset_column_information, we via attribute() defaults.
   it("connection in local time", async () => {

--- a/packages/activerecord/src/cache-key.test.ts
+++ b/packages/activerecord/src/cache-key.test.ts
@@ -6,7 +6,7 @@ import { Base } from "./index.js";
 import { adapterType } from "./test-adapter.js";
 import { MigrationContext } from "./migration.js";
 import { fixtures } from "./test-fixtures.js";
-import { setDefaultTimezone } from "./type/internal/timezone.js";
+import { ActiveRecord } from "./ar-config.js";
 
 // Mirrors Time#to_fs(:usec) → "YYYYMMDDHHMMSSuuuuuu" (20 chars).
 function usec(ts: unknown): string {
@@ -173,12 +173,12 @@ describe("CacheKeyTest", () => {
       const record = await CacheMeWithVersion.create({});
       const recordFromDb = await CacheMeWithVersion.find(record.id);
       const spy = vi.spyOn(recordFromDb, "readAttribute");
-      setDefaultTimezone("local");
+      ActiveRecord.defaultTimezone = "local";
       try {
         recordFromDb.cacheVersion();
         expect(spy).toHaveBeenCalledWith("updated_at");
       } finally {
-        setDefaultTimezone("utc");
+        ActiveRecord.defaultTimezone = "utc";
       }
     },
   );

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -50,7 +50,7 @@ describe("formatInstantForSql", () => {
   });
 
   it("converts a non-UTC instant to UTC when default_timezone is utc (the default)", () => {
-    // getDefaultTimezone() returns "utc" in tests; local-tz path is
+    // defaultTimezone is "utc" in tests; local-tz path is
     // integration-tested in PR 7 (timestamp.test.ts with time-travel).
     const v = Temporal.Instant.from("2026-04-26T16:23:55+02:00");
     expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55");

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -13,7 +13,7 @@
  */
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { getDefaultTimezone } from "../../type/internal/timezone.js";
+import { ActiveRecord } from "../../ar-config.js";
 
 /**
  * Return the IANA timezone string for SQL datetime serialization/deserialization,
@@ -21,7 +21,7 @@ import { getDefaultTimezone } from "../../type/internal/timezone.js";
  * by `SQLiteDateTimeType#cast` so both directions always agree on the timezone.
  */
 export function defaultSqlTimezone(): string {
-  return getDefaultTimezone() === "utc" ? "UTC" : Temporal.Now.timeZoneId();
+  return ActiveRecord.defaultTimezone === "utc" ? "UTC" : Temporal.Now.timeZoneId();
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -14,7 +14,7 @@ import {
   DateNegativeInfinity,
 } from "./temporal-wire.js";
 import { formatInstantForSql } from "./sql-datetime.js";
-import { getDefaultTimezone, setDefaultTimezone } from "../../type/internal/timezone.js";
+import { ActiveRecord } from "../../ar-config.js";
 
 describe("parsePostgresInstant", () => {
   it("parses a timestamptz with space separator and two-digit offset", () => {
@@ -258,26 +258,26 @@ describe("naive parsers honor ActiveRecord.default_timezone", () => {
   let saved: "utc" | "local";
 
   beforeEach(() => {
-    saved = getDefaultTimezone();
+    saved = ActiveRecord.defaultTimezone;
   });
   afterEach(() => {
-    setDefaultTimezone(saved);
+    ActiveRecord.defaultTimezone = saved;
   });
 
   it("Postgres timestamp parses as UTC when default_timezone=utc", () => {
-    setDefaultTimezone("utc");
+    ActiveRecord.defaultTimezone = "utc";
     const result = parsePostgresTimestampAsInstant("2026-04-26 14:23:55") as Temporal.Instant;
     expect(result.toString()).toBe("2026-04-26T14:23:55Z");
   });
 
   it("MySQL DATETIME parses as UTC when default_timezone=utc", () => {
-    setDefaultTimezone("utc");
+    ActiveRecord.defaultTimezone = "utc";
     const result = parseMysqlDatetimeAsInstant("2026-04-26 14:23:55") as Temporal.Instant;
     expect(result.toString()).toBe("2026-04-26T14:23:55Z");
   });
 
   it("naive parsers + formatInstantForSql round-trip symmetrically under default_timezone=local", () => {
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     // Pick a wall-clock that is unambiguous in any timezone.
     const wireString = "2026-06-15 12:00:00";
     const parsed = parsePostgresTimestampAsInstant(wireString) as Temporal.Instant;
@@ -288,7 +288,7 @@ describe("naive parsers honor ActiveRecord.default_timezone", () => {
   });
 
   it("MySQL DATETIME round-trips symmetrically with formatInstantForSql under local", () => {
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     const wireString = "2026-06-15 12:00:00";
     const parsed = parseMysqlDatetimeAsInstant(wireString) as Temporal.Instant;
     expect(formatInstantForSql(parsed)).toBe(wireString);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -48,7 +48,7 @@ import {
   temporalToBindString,
   transactionIsolationLevels,
 } from "./abstract/database-statements.js";
-import { getDefaultTimezone } from "../type/internal/timezone.js";
+import { ActiveRecord } from "../ar-config.js";
 import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
@@ -299,7 +299,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * line in `Mysql2Adapter#perform_query`.
    */
   private _syncDatabaseTimezone(): void {
-    this.databaseTimezone = getDefaultTimezone();
+    this.databaseTimezone = ActiveRecord.defaultTimezone;
   }
 
   protected override _onStatementLimitChanged(value: number): void {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -12,7 +12,7 @@ import { isRubyTruthy } from "../ruby-truthy.js";
 import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { TypeMap } from "../type/type-map.js";
-import { getDefaultTimezone } from "../type/internal/timezone.js";
+import { ActiveRecord } from "../ar-config.js";
 import { Name, Utils } from "./postgresql/utils.js";
 import {
   checkAllForeignKeysValidBang,
@@ -911,9 +911,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // Rails threads @default_timezone into the instance initializer so
       // time / timestamp registrations use the connection's timezone
       // preference. We read the repo-wide default here so that
-      // setDefaultTimezone() is honored consistently with the quoting
+      // (ActiveRecord.defaultTimezone = ) is honored consistently with the quoting
       // path.
-      initializeInstanceTypeMap(this._typeMap, getDefaultTimezone());
+      initializeInstanceTypeMap(this._typeMap, ActiveRecord.defaultTimezone);
     }
     return this._typeMap;
   }
@@ -5172,7 +5172,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // (postgresql_adapter.rb:1005): configure_connection already applied it and
     // it must never be overridden by the default_timezone SET below.
     if (this._sessionVariables["timezone"]) return;
-    const tz = getDefaultTimezone();
+    const tz = ActiveRecord.defaultTimezone;
     // Off the withRawConnection loop. This runs as the first step of
     // performQuery (database-statements.ts), which is itself the block
     // executing inside withRawConnection on the same async chain. Re-entering
@@ -5254,7 +5254,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // the hot path. node-pg uses custom type parsers registered at pool
     // construction time via getTypeParser (see constructor); a timezone change
     // only requires a session-level SET so subsequent result sets decode right.
-    const tz = getDefaultTimezone();
+    const tz = ActiveRecord.defaultTimezone;
     if (this._mappedDefaultTimezone === tz) return;
     this._mappedDefaultTimezone = tz;
     await this.reconfigureConnectionTimezone();

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -28,7 +28,6 @@ import {
   ActiveRecordError,
 } from "./errors.js";
 import { ActiveRecord } from "./ar-config.js";
-import { setDefaultTimezone } from "./type/internal/timezone.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import {
   connectedToStack,
@@ -801,7 +800,7 @@ export async function establishConnection(
  * Rails stores the connection's `default_timezone` as per-adapter instance
  * state (`AbstractAdapter#default_timezone`, abstract_adapter.rb:167/219-220),
  * so two simultaneous connections can cast in different zones. Our date/time
- * casting resolves the zone from the process-wide `setDefaultTimezone`, so the
+ * casting resolves the zone from the process-wide `ActiveRecord.defaultTimezone`, so the
  * caller applies the validated value to that singleton on success — giving the
  * same observable result for the single-connection case the tests exercise.
  * The multi-connection divergence (last establish_connection wins for all
@@ -861,7 +860,7 @@ async function establishWithDbConfig(
   }
 
   await establishWithConfig(modelClass, adapterName, connectUrl, configForConnect, dbConfig);
-  if (tz) setDefaultTimezone(tz);
+  if (tz) ActiveRecord.defaultTimezone = tz;
 }
 
 /**

--- a/packages/activerecord/src/date-time.test.ts
+++ b/packages/activerecord/src/date-time.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "./index.js";
-import { setDefaultTimezone } from "./type/internal/timezone.js";
+import { ActiveRecord } from "./ar-config.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 
 afterEach(() => {
-  setDefaultTimezone("utc");
+  ActiveRecord.defaultTimezone = "utc";
 });
 
 describe("DateTimeTest", () => {
   it("default timezone validation", () => {
-    expect(() => setDefaultTimezone("UTC" as "utc")).toThrow(ArgumentError);
-    expect(() => setDefaultTimezone("local")).not.toThrow();
-    expect(() => setDefaultTimezone("utc")).not.toThrow();
+    expect(() => (ActiveRecord.defaultTimezone = "UTC" as "utc")).toThrow(ArgumentError);
+    expect(() => (ActiveRecord.defaultTimezone = "local")).not.toThrow();
+    expect(() => (ActiveRecord.defaultTimezone = "utc")).not.toThrow();
   });
 
   it("high precision current timestamp", () => {

--- a/packages/activerecord/src/integration.ts
+++ b/packages/activerecord/src/integration.ts
@@ -7,7 +7,7 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 import { squish, parameterize, truncate } from "@blazetrails/activesupport";
-import { getDefaultTimezone } from "./type/internal/timezone.js";
+import { ActiveRecord } from "./ar-config.js";
 
 interface Identifiable {
   id: unknown;
@@ -255,7 +255,7 @@ const TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{1,6})?$/;
  * usec format, default_timezone == utc, not user-assigned, and expected DB
  * timestamp shape. Rails reads the timezone via
  * `with_connection(&:default_timezone) == :utc`; trails reads it synchronously
- * from the process-wide `getDefaultTimezone()` (kept in lockstep with the
+ * from the process-wide `defaultTimezone` (kept in lockstep with the
  * connection's configured `default_timezone` by `establishConnection`), which
  * realizes Rails' own FIXME to cache this rather than checking out a connection.
  * When default_timezone is not UTC, the raw DB string can't be reused verbatim,
@@ -273,7 +273,7 @@ export function canUseFastCacheVersion(record: Identifiable, timestamp: unknown)
   if (typeof timestamp !== "string") return false;
   const klass = record.constructor as any;
   if ((klass.cacheTimestampFormat ?? "usec") !== "usec") return false;
-  if (getDefaultTimezone() !== "utc") return false;
+  if (ActiveRecord.defaultTimezone !== "utc") return false;
   if (record.cameFromUser("updated_at")) return false;
   return TIMESTAMP_RE.test(timestamp);
 }

--- a/packages/activerecord/src/quoting.test.ts
+++ b/packages/activerecord/src/quoting.test.ts
@@ -35,11 +35,11 @@ import {
   formatInstantForSql,
   formatPlainTimeForSql,
 } from "./connection-adapters/abstract/sql-datetime.js";
-import { setDefaultTimezone } from "./type/internal/timezone.js";
+import { ActiveRecord } from "./ar-config.js";
 import { NotImplementedError } from "./errors.js";
 
 afterEach(() => {
-  setDefaultTimezone("utc");
+  ActiveRecord.defaultTimezone = "utc";
 });
 
 describe("QuotingTest", () => {
@@ -159,7 +159,7 @@ describe("QuotingTest", () => {
     expect(() => quoteTableName("foo")).toThrow(NotImplementedError);
   });
   it("quoted timestamp local", () => {
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     const zone = Temporal.Now.timeZoneId();
     const zdt = Temporal.ZonedDateTime.from(`2026-04-07T15:30:00[${zone}]`);
     expect(quotedDate(zdt.toInstant())).toBe("2026-04-07 15:30:00");
@@ -168,7 +168,7 @@ describe("QuotingTest", () => {
     // Mirrors Rails' with_timezone_config(:local); quotedTime takes only naive
     // types (PlainTime/PlainDateTime), so the local setting is intentionally a
     // no-op here — kept to parallel the Rails test's structure.
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     const t = Temporal.PlainTime.from("15:30:45");
     expect(quotedTime(t)).toBe("15:30:45");
   });
@@ -178,7 +178,7 @@ describe("QuotingTest", () => {
   });
   it("quoted datetime local", () => {
     // DateTime has no getlocal, so the local setting is a no-op for naive values.
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     const t = Temporal.PlainDateTime.from("2026-04-07T15:30:00");
     expect(quotedDate(t)).toBe("2026-04-07 15:30:00");
   });

--- a/packages/activerecord/src/test-helper.test.ts
+++ b/packages/activerecord/src/test-helper.test.ts
@@ -16,7 +16,7 @@ describe("withTimezoneConfig", () => {
     setZoneDefault(null);
   });
 
-  it("temporarily changes ActiveRecord.defaultTimezone and restores it", async () => {
+  it("temporarily changes defaultTimezone and restores it", async () => {
     const before = ActiveRecord.defaultTimezone;
     const captured: Array<"utc" | "local"> = [];
     await withTimezoneConfig({ default: "local" }, () => {
@@ -56,7 +56,7 @@ describe("withTimezoneConfig", () => {
     expect(getZone()).toBe(paris);
   });
 
-  it("restores ActiveRecord.defaultTimezone even if fn throws", async () => {
+  it("restores defaultTimezone even if fn throws", async () => {
     const before = ActiveRecord.defaultTimezone;
     await expect(
       withTimezoneConfig({ default: "local" }, () => {

--- a/packages/activerecord/src/test-helper.test.ts
+++ b/packages/activerecord/src/test-helper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { withTimezoneConfig } from "./test-helper.js";
-import { getDefaultTimezone } from "./type/internal/timezone.js";
+import { ActiveRecord } from "./ar-config.js";
 import {
   getZone,
   setZone,
@@ -16,14 +16,14 @@ describe("withTimezoneConfig", () => {
     setZoneDefault(null);
   });
 
-  it("temporarily changes defaultTimezone and restores it", async () => {
-    const before = getDefaultTimezone();
+  it("temporarily changes ActiveRecord.defaultTimezone and restores it", async () => {
+    const before = ActiveRecord.defaultTimezone;
     const captured: Array<"utc" | "local"> = [];
     await withTimezoneConfig({ default: "local" }, () => {
-      captured.push(getDefaultTimezone());
+      captured.push(ActiveRecord.defaultTimezone);
     });
     expect(captured[0]).toBe("local");
-    expect(getDefaultTimezone()).toBe(before);
+    expect(ActiveRecord.defaultTimezone).toBe(before);
   });
 
   it("restores zone to unset state when zone was not explicitly set before", async () => {
@@ -56,13 +56,13 @@ describe("withTimezoneConfig", () => {
     expect(getZone()).toBe(paris);
   });
 
-  it("restores defaultTimezone even if fn throws", async () => {
-    const before = getDefaultTimezone();
+  it("restores ActiveRecord.defaultTimezone even if fn throws", async () => {
+    const before = ActiveRecord.defaultTimezone;
     await expect(
       withTimezoneConfig({ default: "local" }, () => {
         throw new Error("boom");
       }),
     ).rejects.toThrow("boom");
-    expect(getDefaultTimezone()).toBe(before);
+    expect(ActiveRecord.defaultTimezone).toBe(before);
   });
 });

--- a/packages/activerecord/src/test-helper.ts
+++ b/packages/activerecord/src/test-helper.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: activerecord/test/cases/test_case.rb
  */
-import { getDefaultTimezone, setDefaultTimezone } from "./type/internal/timezone.js";
+import { ActiveRecord } from "./ar-config.js";
 import { Base } from "./base.js";
 import { getZone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
 
@@ -27,7 +27,7 @@ export async function withTimezoneConfig(
   cfg: TimezoneConfig,
   fn: () => Promise<void> | void,
 ): Promise<void> {
-  const oldDefault = getDefaultTimezone();
+  const oldDefault = ActiveRecord.defaultTimezone;
   const base = Base as any;
 
   // Snapshot existence + value so restore is symmetric: if the property wasn't
@@ -40,7 +40,7 @@ export async function withTimezoneConfig(
   const oldZone = getZone();
 
   try {
-    if (cfg.default !== undefined) setDefaultTimezone(cfg.default);
+    if (cfg.default !== undefined) ActiveRecord.defaultTimezone = cfg.default;
     // Apply unconditionally — mirrors Rails' Base.time_zone_aware_attributes = cfg[:aware_attributes].
     // If Base doesn't define the property yet the assignment still takes effect (JS class property),
     // making the helper forward-compatible when the wiring lands.
@@ -49,7 +49,7 @@ export async function withTimezoneConfig(
     if (cfg.zone !== undefined) setZone(cfg.zone);
     await fn();
   } finally {
-    setDefaultTimezone(oldDefault);
+    ActiveRecord.defaultTimezone = oldDefault;
     if (hadAwareAttributes) {
       base.timeZoneAwareAttributes = oldAwareAttributes;
     } else {

--- a/packages/activerecord/src/type/date-time.trails.test.ts
+++ b/packages/activerecord/src/type/date-time.trails.test.ts
@@ -4,25 +4,25 @@ import { TimeZone, TimeWithZone, setZone, resetZone } from "@blazetrails/actives
 import { TimeZoneConverter } from "../attribute-methods/time-zone-conversion.js";
 import { Range, RangeType } from "../connection-adapters/postgresql/oid/range.js";
 import { DateTime } from "./date-time.js";
-import { setDefaultTimezone } from "./internal/timezone.js";
+import { ActiveRecord } from "../ar-config.js";
 
 afterEach(() => {
-  setDefaultTimezone("utc");
+  ActiveRecord.defaultTimezone = "utc";
   resetZone();
 });
 
 describe("ActiveRecord::Type::DateTime timezone dispatch", () => {
   it("is_utc? follows ActiveRecord.default_timezone", () => {
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     expect(new DateTime().isUtc).toBe(false);
-    setDefaultTimezone("utc");
+    ActiveRecord.defaultTimezone = "utc";
     expect(new DateTime().isUtc).toBe(true);
   });
 
   it("is_utc? follows the per-type timezone override", () => {
-    setDefaultTimezone("utc");
+    ActiveRecord.defaultTimezone = "utc";
     expect(new DateTime({ timezone: "local" }).isUtc).toBe(false);
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     expect(new DateTime({ timezone: "utc" }).isUtc).toBe(true);
   });
 
@@ -33,12 +33,12 @@ describe("ActiveRecord::Type::DateTime timezone dispatch", () => {
       .toZonedDateTime(Temporal.Now.timeZoneId())
       .toInstant();
 
-    setDefaultTimezone("utc");
+    ActiveRecord.defaultTimezone = "utc";
     expect((new DateTime().cast(bare) as Temporal.Instant).epochNanoseconds).toBe(
       utc.epochNanoseconds,
     );
 
-    setDefaultTimezone("local");
+    ActiveRecord.defaultTimezone = "local";
     expect((new DateTime().cast(bare) as Temporal.Instant).epochNanoseconds).toBe(
       local.epochNanoseconds,
     );

--- a/packages/activerecord/src/type/internal/timezone.ts
+++ b/packages/activerecord/src/type/internal/timezone.ts
@@ -11,32 +11,10 @@ export interface TimezoneOptions {
   limit?: number;
 }
 
-import { ArgumentError } from "@blazetrails/activemodel";
-
-let defaultTimezone: "utc" | "local" = "utc";
-
-export function getDefaultTimezone(): "utc" | "local" {
-  return defaultTimezone;
-}
-
-/**
- * This is the port of `ActiveRecord.default_timezone=` (active_record.rb:218) —
- * not of anything in `type/internal/timezone.rb`, which carries readers only.
- * It lives here because the module-level state it writes is read by `isUtc` /
- * `Timezone#defaultTimezone` below. Converging it onto `ar-config.ts` (where
- * the rest of the `active_record.rb` module attributes live) is tracked by RFC
- * 0081's `relocate-ar-default-timezone-to-ar-config` story.
- */
-export function setDefaultTimezone(tz: "utc" | "local"): void {
-  if (tz !== "utc" && tz !== "local")
-    throw new ArgumentError(
-      `"${tz}" is not a valid value for default_timezone. Valid values are :utc and :local`,
-    );
-  defaultTimezone = tz;
-}
+import { ActiveRecord } from "../../ar-config.js";
 
 export function isUtc(timezone?: "utc" | "local"): boolean {
-  return (timezone ?? defaultTimezone) === "utc";
+  return (timezone ?? ActiveRecord.defaultTimezone) === "utc";
 }
 
 /**
@@ -57,6 +35,6 @@ export class Timezone {
   }
 
   get defaultTimezone(): "utc" | "local" {
-    return this._timezone ?? getDefaultTimezone();
+    return this._timezone ?? ActiveRecord.defaultTimezone;
   }
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -516,5 +516,12 @@
     "rubyName": "dbconsole",
     "call": "database_cli",
     "reason": "Rails reads the cli name only to pass it to `find_cmd_and_exec` (abstract_mysql_adapter.rb); that PTY exec is Ruby-only and unported, so our `dbconsole` returns the arg list and never needs the lookup."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "type_cast",
+    "call": "default_timezone",
+    "reason": "Rails' MySQL type_cast branches on default_timezone inline (mysql/quoting.rb:100,106); trails' override delegates to mysql/quoting.ts typeCast, which reaches ActiveRecord.defaultTimezone via dispatchQuotedDate to quotedDate to defaultSqlTimezone()."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/quoting.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/quoting.json
@@ -82,5 +82,12 @@
     "rubyName": "quote_default_expression",
     "call": "call",
     "reason": "Rails' `value.call` (abstract/quoting.rb:159) invokes a Proc default; the TS branch invokes the function directly (`value()`), which the extractor cannot see as a `call` call."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/quoting.ts",
+    "rubyName": "quoted_date",
+    "call": "default_timezone",
+    "reason": "Rails' quoted_date branches on default_timezone inline (abstract/quoting.rb:186); trails' quotedDate formats through formatInstantForSql / formatPlainDateTimeForSql in abstract/sql-datetime.ts, whose defaultSqlTimezone() reads ActiveRecord.defaultTimezone."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/quoting.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/quoting.json
@@ -12,5 +12,12 @@
     "rubyName": "type_cast",
     "call": "utc?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql/quoting.ts",
+    "rubyName": "type_cast",
+    "call": "default_timezone",
+    "reason": "Rails' MySQL type_cast branches on default_timezone for TimeWithZone/Time (mysql/quoting.rb:100,106); trails' typeCast routes both through dispatchQuotedDate to quotedDate to defaultSqlTimezone(), which reads ActiveRecord.defaultTimezone."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2-adapter.json
@@ -75,5 +75,12 @@
     "rubyName": "reconnect",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "configure_connection",
+    "call": "default_timezone",
+    "reason": "Rails sets query_options[:database_timezone] = default_timezone inline (mysql2_adapter.rb:160); trails keeps databaseTimezone current via _syncDatabaseTimezone(), which assigns ActiveRecord.defaultTimezone on every perform-query entry point instead."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2/database-statements.json
@@ -40,5 +40,12 @@
     "rubyName": "select_all",
     "call": "unprepared_statement",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2/database-statements.ts",
+    "rubyName": "perform_query",
+    "call": "default_timezone",
+    "reason": "Rails re-reads default_timezone into query_options inside perform_query (mysql2/database_statements.rb:49); trails' callers (execute, executeMutation, internalExecute, internalExecQuery, explain) call _syncDatabaseTimezone() one frame up, so performQuery itself never reads it."
   }
 ]


### PR DESCRIPTION
`setDefaultTimezone` was a port of `ActiveRecord.default_timezone=`
(`vendor/rails/activerecord/lib/active_record.rb:218`) living in
`packages/activerecord/src/type/internal/timezone.ts`, whose Rails counterpart
(`type/internal/timezone.rb`) carries readers only — so `api:compare` had no
Ruby method to match it against under either spelling.

- `default_timezone` now lives in `ar-config.ts` as a `get`/`set` accessor on
  the `ActiveRecord` module object, alongside the other `active_record.rb`
  module attributes (`ActiveRecord.defaultTimezone = "local"`). That is the
  shape RFC 0081's `module-level-config-accessor-shape` established on main,
  and it mirrors Rails' `singleton_class.attr_reader :default_timezone`
  (`:214`) + `def self.default_timezone=` (`:218`) directly, so the separate
  `setDefaultTimezone` writer function disappears entirely.
- The setter's validation is Rails' own, including the verbatim message
  `"default_timezone must be either :utc (default) or :local."`
  (`active_record.rb:220`) — the previous trails-invented text is gone.
- `type/internal/timezone.ts` keeps only the Rails-shaped readers (`isUtc`,
  `Timezone#defaultTimezone`), reading `ActiveRecord.defaultTimezone`.
- All call sites updated (`connection-handling.ts`, `test-helper.ts`, adapters,
  tests). Test names unchanged.

Rebased onto current `main`.

`pnpm typecheck` clean; `api:compare` Data layer 7723/7816 (98.8%), files
409/409, and the timezone/quoting/cache-key/temporal-wire/tz-converter/
test-helper suites pass.

Closes-story: relocate-ar-default-timezone-to-ar-config
