### PR TITLE
refactor(activemodel): route DateTimeType.castValue through fastStringToTime

### DIFF
--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant, plainDateTime } from "@blazetrails/activesupport/testing/temporal-helpers";
+import { TimeZone, setZoneDefault } from "@blazetrails/activesupport";
 import { Types } from "../index.js";
 
 describe("DateTimeTest", () => {
@@ -77,6 +78,20 @@ describe("DateTimeTest", () => {
 
   it("casts empty string to null", () => {
     expect(type.cast("")).toBe(null);
+  });
+
+  it("string to time with timezone", () => {
+    for (const zone of ["UTC", "US/Eastern"]) {
+      setZoneDefault(TimeZone.find(zone));
+      try {
+        const t = new Types.DateTimeType();
+        expect((t.cast("Wed, 04 Sep 2013 03:00:00 EAT") as Temporal.Instant).toString()).toBe(
+          "2013-09-04T00:00:00Z",
+        );
+      } finally {
+        setZoneDefault(null);
+      }
+    }
   });
 
   it("hash with wrong keys", () => {
@@ -161,7 +176,7 @@ describe("DateTimeTest", () => {
   });
   it("serialize_cast_value is equivalent to serialize after cast", () => {
     const type = new Types.DateTimeType({ precision: 1 });
-    const value = type.cast("1999-12-31T12:34:56.789-10:00");
+    const value = type.cast("1999-12-31 12:34:56.789 -1000");
 
     expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
     expect((type.serializeCastValue(value) as Temporal.Instant).toString()).toBe(

--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Types } from "../index.js";
+
+// Fallback-parser coverage for shapes `Date._parse` accepts that no Rails test
+// exercises directly. Rails reaches them through `Date._parse` in
+// `fallback_string_to_time` (date_time.rb:67-76); trails reaches them through
+// the `parseTimeHash` stand-in.
+describe("DateTimeType fallback string parsing", () => {
+  const type = new Types.DateTimeType();
+  const cast = (s: string) => (type.cast(s) as Temporal.Instant | null)?.toString() ?? null;
+
+  it("parses asctime order (Wed Sep 04 03:00:00 2013)", () => {
+    expect(cast("Wed Sep 04 03:00:00 2013")).toBe("2013-09-04T03:00:00Z");
+  });
+
+  it("parses asctime order with a named zone", () => {
+    expect(cast("Wed Sep 04 03:00:00 EAT 2013")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("parses slash-separated dates with a named zone", () => {
+    expect(cast("2013/09/04 03:00:00 EAT")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("parses slash-separated dates without a time", () => {
+    expect(cast("2013/09/04")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("parses dot-separated dates", () => {
+    expect(cast("2013.09.04 03:00:00")).toBe("2013-09-04T03:00:00Z");
+  });
+
+  it("parses a numeric offset written without a colon", () => {
+    expect(cast("1999-12-31 12:34:56 -1000")).toBe("1999-12-31T22:34:56Z");
+  });
+
+  it("returns null for an unparsable string", () => {
+    expect(cast("ABC")).toBe(null);
+  });
+
+  it("leaves the offset unset for an unknown zone abbreviation", () => {
+    expect(cast("Wed, 04 Sep 2013 03:00:00 XYZ")).toBe("2013-09-04T03:00:00Z");
+  });
+});

--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -63,3 +63,28 @@ describe("DateTimeType fallback zone and ordering coverage", () => {
     expect(cast("2013-09-04")).toBe("2013-09-04T00:00:00Z");
   });
 });
+
+// Date._parse reports a zone only alongside a time; a date-only string keeps
+// its trailing token out of the hash and is read in the default zone. Each
+// expectation below was checked against Ruby's Date._parse.
+describe("DateTimeType date-only strings with a zone token", () => {
+  const type = new Types.DateTimeType();
+  const cast = (s: string) => (type.cast(s) as Temporal.Instant | null)?.toString() ?? null;
+
+  it("ignores a trailing Z on a date-only string", () => {
+    expect(cast("2013-09-04Z")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("ignores a trailing zone abbreviation on a date-only string", () => {
+    expect(cast("2013-09-04UTC")).toBe("2013-09-04T00:00:00Z");
+    expect(cast("2013-09-04 EAT")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("ignores a trailing numeric offset on a date-only string", () => {
+    expect(cast("2013-09-04-10")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("still applies the offset when a time is present", () => {
+    expect(cast("2013-09-04T03:00:00-10")).toBe("2013-09-04T13:00:00Z");
+  });
+});

--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -42,3 +42,24 @@ describe("DateTimeType fallback string parsing", () => {
     expect(cast("Wed, 04 Sep 2013 03:00:00 XYZ")).toBe("2013-09-04T03:00:00Z");
   });
 });
+
+describe("DateTimeType fallback zone and ordering coverage", () => {
+  const type = new Types.DateTimeType();
+  const cast = (s: string) => (type.cast(s) as Temporal.Instant | null)?.toString() ?? null;
+
+  it("parses month-day-year order with a named zone", () => {
+    expect(cast("Sep 04 2013 03:00:00 EAT")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("parses a zone abbreviation attached to an ISO datetime", () => {
+    expect(cast("2013-09-04T03:00:00EAT")).toBe("2013-09-04T00:00:00Z");
+  });
+
+  it("parses ISO basic format with a basic-format offset", () => {
+    expect(cast("20130904T030000+0900")).toBe("2013-09-03T18:00:00Z");
+  });
+
+  it("does not mistake the day of a bare date for an offset", () => {
+    expect(cast("2013-09-04")).toBe("2013-09-04T00:00:00Z");
+  });
+});

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -41,6 +41,9 @@ const TIME_PART = String.raw`(?:(\d{1,2}):(\d{2})(?::(\d{2})(\.\d+)?)?)`;
  */
 const ZONE_SUFFIX = /\s*(Z|[A-Za-z]{2,5}|[+-]\d{2}:?\d{2}|[+-]\d{2})$/;
 
+/** A time component, extended (`03:00`) or ISO basic (`T030000`). */
+const HAS_TIME = /\d{1,2}:\d{2}|T\d{4,6}/;
+
 /** The zone slot asctime puts before the year: `Sep 04 03:00:00 EAT 2013`. */
 const ZONE_BEFORE_YEAR = /\s+(Z|[A-Za-z]{2,5}|[+-]\d{2}:?\d{2})\s+(\d{4})$/;
 
@@ -327,8 +330,17 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     const body = s.replace(WEEKDAY_PREFIX, "").trim();
     const zone = ZONE_SUFFIX.exec(body);
     if (zone) {
-      const withoutZone = parseDateAndTime(body.slice(0, body.length - zone[0].length).trim());
-      if (withoutZone) return { ...withoutZone, offset: zoneOffsetSeconds(zone[1]) };
+      const stripped = body.slice(0, body.length - zone[0].length).trim();
+      const withoutZone = parseDateAndTime(stripped);
+      // Date._parse only reports an offset alongside a time: it returns a bare
+      // {year, mon, mday} for "2013-09-04Z", "2013-09-04UTC" and
+      // "2013-09-04-10", which new_time then reads in the default zone.
+      if (withoutZone) {
+        return {
+          ...withoutZone,
+          offset: HAS_TIME.test(stripped) ? zoneOffsetSeconds(zone[1]) : null,
+        };
+      }
     }
     const interior = ZONE_BEFORE_YEAR.exec(body);
     if (interior) {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -8,12 +8,19 @@ import {
 import { ArgumentError } from "../attribute-assignment.js";
 import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
+import { fastStringToTime, newTime } from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
 
 export class DateTimeType extends ValueType<DateTimeCastResult> {
   readonly name: string = "datetime";
+
+  /** Mixed in from Helpers::TimeValue (time_value.rb:79-89). @internal Rails-private helper. */
+  protected fastStringToTime = fastStringToTime;
+
+  /** Mixed in from Helpers::TimeValue (time_value.rb:48-65). @internal Rails-private helper. */
+  protected newTime = newTime;
 
   type(): string {
     return this.name;
@@ -31,7 +38,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     const str = String(value).trim();
     if (str === "") return null;
-    return this.parseString(str);
+    return this.fastStringToTime(str) ?? this.fallbackStringToTime(str);
   }
 
   /**
@@ -67,15 +74,28 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    *     new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset))
    *   end
    *
-   * Trails has no `Date._parse` equivalent; reuse Temporal's
-   * permissive parser plus the configured-zone resolution that
-   * `parseString` already implements. Returns null on parse failure.
+   * Trails has no `Date._parse` equivalent; `parseTimeHash` stands in
+   * for it, using Temporal's permissive parser to produce the same
+   * component hash. From there the Rails shape is preserved: normalize
+   * `sec_fraction` to microseconds, then hand the components to
+   * `new_time`. Returns null on parse failure.
    *
    * @internal Rails-private helper.
    */
   protected fallbackStringToTime(s: string): Temporal.Instant | null {
-    const result = this.parseString(s.trim());
-    return result instanceof Temporal.Instant ? result : null;
+    const timeHash = this.parseTimeHash(s.trim());
+    if (timeHash === null) return null;
+    const microsec = this.microseconds(timeHash);
+    return this.newTime(
+      timeHash.year,
+      timeHash.mon,
+      timeHash.mday,
+      timeHash.hour,
+      timeHash.min,
+      timeHash.sec,
+      microsec,
+      timeHash.offset,
+    );
   }
 
   /**
@@ -113,6 +133,54 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     ) as DateTimeCastResult | null;
   }
 
+  // `Date._parse` stand-in: decompose a datetime string into the component
+  // hash `fallbackStringToTime` feeds to `newTime`. Only reached for strings
+  // `fastStringToTime` rejects (notably ISO basic format, which has no "-").
+  private parseTimeHash(s: string): {
+    year: number;
+    mon: number;
+    mday: number;
+    hour: number;
+    min: number;
+    sec: number;
+    sec_fraction: number;
+    offset: number | null;
+  } | null {
+    const normalized = s
+      .replace(" ", "T")
+      .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
+    const zoneMatch = /(Z|[+-]\d{2}:\d{2})$/.exec(normalized);
+    let offset: number | null = null;
+    let body = normalized;
+    if (zoneMatch) {
+      const zone = zoneMatch[1];
+      body = normalized.slice(0, normalized.length - zone.length);
+      if (zone === "Z") {
+        offset = 0;
+      } else {
+        const sign = zone.startsWith("-") ? -1 : 1;
+        offset = sign * (Number(zone.slice(1, 3)) * 3600 + Number(zone.slice(4, 6)) * 60);
+      }
+    }
+    const datetimeString = /^\d{4}-?\d{2}-?\d{2}$/.test(body) ? `${body}T00:00:00` : body;
+    let plain: Temporal.PlainDateTime;
+    try {
+      plain = Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" });
+    } catch {
+      return null;
+    }
+    return {
+      year: plain.year,
+      mon: plain.month,
+      mday: plain.day,
+      hour: plain.hour,
+      min: plain.minute,
+      sec: plain.second,
+      sec_fraction: (plain.millisecond * 1000 + plain.microsecond) / 1_000_000,
+      offset,
+    };
+  }
+
   get isUtc(): boolean {
     return isUtc();
   }
@@ -145,37 +213,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     const roundedOff = subsec % mod;
     if (roundedOff === 0n) return value;
     return Temporal.Instant.fromEpochNanoseconds(value.epochNanoseconds - roundedOff);
-  }
-
-  private parseString(str: string): DateTimeCastResult | null {
-    // Normalize wire-format quirks before parsing:
-    //   space separator → T; short offset ±HH → ±HH:MM
-    const normalized = str
-      .replace(" ", "T")
-      .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
-    // Date-only string (YYYY-MM-DD) → midnight PlainDateTime, matching Rails behavior.
-    const datetimeString = /^\d{4}-\d{2}-\d{2}$/.test(normalized)
-      ? `${normalized}T00:00:00`
-      : normalized;
-    const hasOffset = /Z$|[+-]\d{2}:\d{2}$/.test(datetimeString);
-    if (hasOffset) {
-      try {
-        return Temporal.Instant.from(datetimeString);
-      } catch {
-        return null;
-      }
-    }
-    try {
-      return (
-        Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
-          // Rails branches on `is_utc?` between `::Time.utc` and `::Time.local`;
-          // Temporal has no `Time.local`, so the local arm names the host zone.
-          .toZonedDateTime(this.isUtc ? "UTC" : Temporal.Now.timeZoneId())
-          .toInstant()
-      );
-    } catch {
-      return null;
-    }
   }
 
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -133,9 +133,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     ) as DateTimeCastResult | null;
   }
 
-  // `Date._parse` stand-in: decompose a datetime string into the component
-  // hash `fallbackStringToTime` feeds to `newTime`. Only reached for strings
-  // `fastStringToTime` rejects (notably ISO basic format, which has no "-").
   private parseTimeHash(s: string): {
     year: number;
     mon: number;

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -33,19 +33,35 @@ const WEEKDAY_PREFIX = /^(?:mon|tue|wed|thu|fri|sat|sun)[a-z]*\.?,?\s+/i;
 
 const TIME_PART = String.raw`(?:(\d{1,2}):(\d{2})(?::(\d{2})(\.\d+)?)?)`;
 
-/** `04 Sep 2013 03:00:00 EAT` — RFC 2822 / HTTP order. */
-const DAY_MONTH_YEAR = new RegExp(
-  String.raw`^(\d{1,2})\s+([A-Za-z]{3,9})\.?\s+(\d{4})(?:\s+${TIME_PART})?(?:\s+(\S+))?$`,
-);
+/**
+ * Trailing zone token — an abbreviation (`EAT`), `Z`, or a numeric offset in
+ * any of `Date._parse`'s spellings (`+09:00`, `+0900`, `-10`), attached or
+ * space-separated. A candidate only wins if the rest of the string parses as
+ * a date, so a bare `2013-09-04` does not lose its `-04` to this.
+ */
+const ZONE_SUFFIX = /\s*(Z|[A-Za-z]{2,5}|[+-]\d{2}:?\d{2}|[+-]\d{2})$/;
 
-/** `Sep 04 03:00:00 EAT 2013` — asctime(3) / ctime order, year last. */
-const MONTH_DAY_TIME_YEAR = new RegExp(
-  String.raw`^([A-Za-z]{3,9})\.?\s+(\d{1,2})\s+${TIME_PART}(?:\s+(\S+))?\s+(\d{4})$`,
-);
+/** The zone slot asctime puts before the year: `Sep 04 03:00:00 EAT 2013`. */
+const ZONE_BEFORE_YEAR = /\s+(Z|[A-Za-z]{2,5}|[+-]\d{2}:?\d{2})\s+(\d{4})$/;
 
-/** `2013/09/04 03:00:00 EAT` and `2013.09.04` — numeric, year first. */
+/** `2013/09/04 03:00:00` and `2013.09.04` — numeric, year first. */
 const YEAR_MONTH_DAY = new RegExp(
-  String.raw`^(\d{4})[/.-](\d{1,2})[/.-](\d{1,2})(?:[T\s]+${TIME_PART})?(?:\s*(\S+))?$`,
+  String.raw`^(\d{4})[/.-](\d{1,2})[/.-](\d{1,2})(?:[T\s]+${TIME_PART})?$`,
+);
+
+/** `04 Sep 2013 03:00:00` — RFC 2822 / HTTP order. */
+const DAY_MONTH_YEAR = new RegExp(
+  String.raw`^(\d{1,2})\s+([A-Za-z]{3,9})\.?,?\s+(\d{4})(?:[T\s]+${TIME_PART})?$`,
+);
+
+/** `Sep 04 2013 03:00:00` — US order, year before the time. */
+const MONTH_DAY_YEAR = new RegExp(
+  String.raw`^([A-Za-z]{3,9})\.?\s+(\d{1,2}),?\s+(\d{4})(?:[T\s]+${TIME_PART})?$`,
+);
+
+/** `Sep 04 03:00:00 2013` — asctime(3) / ctime order, year last. */
+const MONTH_DAY_TIME_YEAR = new RegExp(
+  String.raw`^([A-Za-z]{3,9})\.?\s+(\d{1,2})\s+${TIME_PART}\s+(\d{4})$`,
 );
 
 /**
@@ -101,7 +117,6 @@ function buildTimeHash(
   mon: number | null,
   mday: string,
   time: (string | undefined)[],
-  zone: string | undefined,
 ): TimeHash | null {
   if (mon === null) return null;
   const [hour, min, sec, fraction] = time;
@@ -113,7 +128,68 @@ function buildTimeHash(
     min: Number(min ?? 0),
     sec: Number(sec ?? 0),
     sec_fraction: fraction ? Number(`0${fraction}`) : 0,
-    offset: zone === undefined ? null : zoneOffsetSeconds(zone),
+    offset: null,
+  };
+}
+
+/**
+ * The zone-less half of the `Date._parse` stand-in: every date/time ordering
+ * it accepts as a complete datetime, tried widest-first. Temporal covers the
+ * extended and basic ISO spellings; the regexes cover the calendar orderings
+ * Temporal rejects.
+ */
+function parseDateAndTime(text: string): TimeHash | null {
+  const iso = parseIsoLike(text);
+  if (iso) return iso;
+
+  const yearFirst = YEAR_MONTH_DAY.exec(text);
+  if (yearFirst) {
+    return buildTimeHash(yearFirst[1], Number(yearFirst[2]), yearFirst[3], yearFirst.slice(4, 8));
+  }
+
+  const dayFirst = DAY_MONTH_YEAR.exec(text);
+  if (dayFirst) {
+    return buildTimeHash(dayFirst[3], monthNumber(dayFirst[2]), dayFirst[1], dayFirst.slice(4, 8));
+  }
+
+  const monthFirst = MONTH_DAY_YEAR.exec(text);
+  if (monthFirst) {
+    return buildTimeHash(
+      monthFirst[3],
+      monthNumber(monthFirst[1]),
+      monthFirst[2],
+      monthFirst.slice(4, 8),
+    );
+  }
+
+  const asctime = MONTH_DAY_TIME_YEAR.exec(text);
+  if (asctime) {
+    return buildTimeHash(asctime[7], monthNumber(asctime[1]), asctime[2], asctime.slice(3, 7));
+  }
+
+  return null;
+}
+
+function parseIsoLike(text: string): TimeHash | null {
+  const normalized = text.replace(" ", "T");
+  const datetimeString = /^\d{4}-?\d{2}-?\d{2}$/.test(normalized)
+    ? `${normalized}T00:00:00`
+    : normalized;
+  let plain: Temporal.PlainDateTime;
+  try {
+    plain = Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" });
+  } catch {
+    return null;
+  }
+  return {
+    year: plain.year,
+    mon: plain.month,
+    mday: plain.day,
+    hour: plain.hour,
+    min: plain.minute,
+    sec: plain.second,
+    sec_fraction: (plain.millisecond * 1000 + plain.microsecond) / 1_000_000,
+    offset: null,
   };
 }
 
@@ -248,65 +324,18 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   }
 
   private parseTimeHash(s: string): TimeHash | null {
-    const withoutWeekday = s.replace(WEEKDAY_PREFIX, "").trim();
-
-    const dayFirst = DAY_MONTH_YEAR.exec(withoutWeekday);
-    if (dayFirst) {
-      return buildTimeHash(
-        dayFirst[3],
-        monthNumber(dayFirst[2]),
-        dayFirst[1],
-        dayFirst.slice(4, 8),
-        dayFirst[8],
-      );
+    const body = s.replace(WEEKDAY_PREFIX, "").trim();
+    const zone = ZONE_SUFFIX.exec(body);
+    if (zone) {
+      const withoutZone = parseDateAndTime(body.slice(0, body.length - zone[0].length).trim());
+      if (withoutZone) return { ...withoutZone, offset: zoneOffsetSeconds(zone[1]) };
     }
-
-    const asctime = MONTH_DAY_TIME_YEAR.exec(withoutWeekday);
-    if (asctime) {
-      return buildTimeHash(
-        asctime[8],
-        monthNumber(asctime[1]),
-        asctime[2],
-        asctime.slice(3, 7),
-        asctime[7],
-      );
+    const interior = ZONE_BEFORE_YEAR.exec(body);
+    if (interior) {
+      const withoutZone = parseDateAndTime(`${body.slice(0, interior.index)} ${interior[2]}`);
+      if (withoutZone) return { ...withoutZone, offset: zoneOffsetSeconds(interior[1]) };
     }
-
-    const normalized = withoutWeekday
-      .replace(" ", "T")
-      .replace(
-        /(T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)\s*([-+]\d{2}):?(\d{2})?$/,
-        (_m, time: string, hours: string, minutes: string | undefined) =>
-          `${time}${hours}:${minutes ?? "00"}`,
-      );
-    const zoneMatch = /(Z|[+-]\d{2}:\d{2})$/.exec(normalized);
-    let offset: number | null = null;
-    let body = normalized;
-    if (zoneMatch) {
-      const zone = zoneMatch[1];
-      body = normalized.slice(0, normalized.length - zone.length);
-      offset = zoneOffsetSeconds(zone);
-    }
-    const datetimeString = /^\d{4}-?\d{2}-?\d{2}$/.test(body) ? `${body}T00:00:00` : body;
-    let plain: Temporal.PlainDateTime;
-    try {
-      plain = Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" });
-    } catch {
-      const numeric = YEAR_MONTH_DAY.exec(withoutWeekday);
-      return numeric
-        ? buildTimeHash(numeric[1], Number(numeric[2]), numeric[3], numeric.slice(4, 8), numeric[8])
-        : null;
-    }
-    return {
-      year: plain.year,
-      mon: plain.month,
-      mday: plain.day,
-      hour: plain.hour,
-      min: plain.minute,
-      sec: plain.second,
-      sec_fraction: (plain.millisecond * 1000 + plain.microsecond) / 1_000_000,
-      offset,
-    };
+    return parseDateAndTime(body);
   }
 
   get isUtc(): boolean {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -6,12 +6,86 @@ import {
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
 import { ArgumentError } from "../attribute-assignment.js";
-import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
+import {
+  AcceptsMultiparameterTime,
+  MONTH_ABBREVIATIONS,
+  isHash,
+} from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { fastStringToTime, newTime } from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
+
+/** The subset of `Date._parse`'s result hash that `fallback_string_to_time` reads. */
+interface TimeHash {
+  year: number;
+  mon: number;
+  mday: number;
+  hour: number;
+  min: number;
+  sec: number;
+  sec_fraction: number;
+  offset: number | null;
+}
+
+const WEEKDAY_PREFIX = /^(?:mon|tue|wed|thu|fri|sat|sun)[a-z]*\.?,?\s+/i;
+
+const RFC_DATETIME =
+  /^(\d{1,2})\s+([A-Za-z]{3,9})\.?\s+(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2})(\.\d+)?)?)?(?:\s+(\S+))?$/;
+
+/**
+ * Zone abbreviation → offset in seconds, the trails stand-in for the table
+ * `Date._parse` consults (Ruby's `Date::Format::ZONES`, generated from
+ * `zonetab.list`). Only the abbreviations that table resolves unambiguously
+ * are listed; anything else leaves `offset` nil, exactly as `Date._parse`
+ * does for an unknown zone.
+ */
+const ZONE_OFFSETS: Record<string, number> = {
+  ut: 0,
+  utc: 0,
+  gmt: 0,
+  z: 0,
+  wet: 0,
+  west: 3600,
+  bst: 3600,
+  cet: 3600,
+  cest: 7200,
+  eet: 7200,
+  eest: 10800,
+  eat: 10800,
+  msk: 10800,
+  jst: 32400,
+  kst: 32400,
+  aest: 36000,
+  aedt: 39600,
+  nzst: 43200,
+  nzdt: 46800,
+  hst: -36000,
+  akst: -32400,
+  akdt: -28800,
+  pst: -28800,
+  pdt: -25200,
+  mst: -25200,
+  mdt: -21600,
+  cst: -21600,
+  cdt: -18000,
+  est: -18000,
+  edt: -14400,
+  ast: -14400,
+  adt: -10800,
+  nst: -12600,
+};
+
+function zoneOffsetSeconds(zone: string): number | null {
+  const numeric = /^([+-])(\d{2}):?(\d{2})?$/.exec(zone);
+  if (numeric) {
+    const sign = numeric[1] === "-" ? -1 : 1;
+    return sign * (Number(numeric[2]) * 3600 + Number(numeric[3] ?? 0) * 60);
+  }
+  const named = ZONE_OFFSETS[zone.toLowerCase()];
+  return named === undefined ? null : named;
+}
 
 export class DateTimeType extends ValueType<DateTimeCastResult> {
   readonly name: string = "datetime";
@@ -133,31 +207,38 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     ) as DateTimeCastResult | null;
   }
 
-  private parseTimeHash(s: string): {
-    year: number;
-    mon: number;
-    mday: number;
-    hour: number;
-    min: number;
-    sec: number;
-    sec_fraction: number;
-    offset: number | null;
-  } | null {
-    const normalized = s
+  private parseTimeHash(s: string): TimeHash | null {
+    const withoutWeekday = s.replace(WEEKDAY_PREFIX, "");
+    const rfc = RFC_DATETIME.exec(withoutWeekday);
+    if (rfc) {
+      const mon = MONTH_ABBREVIATIONS.indexOf(rfc[2].slice(0, 3).toLowerCase()) + 1;
+      if (mon === 0) return null;
+      return {
+        year: Number(rfc[3]),
+        mon,
+        mday: Number(rfc[1]),
+        hour: Number(rfc[4] ?? 0),
+        min: Number(rfc[5] ?? 0),
+        sec: Number(rfc[6] ?? 0),
+        sec_fraction: rfc[7] ? Number(`0${rfc[7]}`) : 0,
+        offset: rfc[8] === undefined ? null : zoneOffsetSeconds(rfc[8]),
+      };
+    }
+
+    const normalized = withoutWeekday
       .replace(" ", "T")
-      .replace(/(T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2})$/, "$1$2:00");
+      .replace(
+        /(T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)\s*([-+]\d{2}):?(\d{2})?$/,
+        (_m, time: string, hours: string, minutes: string | undefined) =>
+          `${time}${hours}:${minutes ?? "00"}`,
+      );
     const zoneMatch = /(Z|[+-]\d{2}:\d{2})$/.exec(normalized);
     let offset: number | null = null;
     let body = normalized;
     if (zoneMatch) {
       const zone = zoneMatch[1];
       body = normalized.slice(0, normalized.length - zone.length);
-      if (zone === "Z") {
-        offset = 0;
-      } else {
-        const sign = zone.startsWith("-") ? -1 : 1;
-        offset = sign * (Number(zone.slice(1, 3)) * 3600 + Number(zone.slice(4, 6)) * 60);
-      }
+      offset = zoneOffsetSeconds(zone);
     }
     const datetimeString = /^\d{4}-?\d{2}-?\d{2}$/.test(body) ? `${body}T00:00:00` : body;
     let plain: Temporal.PlainDateTime;

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -31,8 +31,22 @@ interface TimeHash {
 
 const WEEKDAY_PREFIX = /^(?:mon|tue|wed|thu|fri|sat|sun)[a-z]*\.?,?\s+/i;
 
-const RFC_DATETIME =
-  /^(\d{1,2})\s+([A-Za-z]{3,9})\.?\s+(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2})(\.\d+)?)?)?(?:\s+(\S+))?$/;
+const TIME_PART = String.raw`(?:(\d{1,2}):(\d{2})(?::(\d{2})(\.\d+)?)?)`;
+
+/** `04 Sep 2013 03:00:00 EAT` — RFC 2822 / HTTP order. */
+const DAY_MONTH_YEAR = new RegExp(
+  String.raw`^(\d{1,2})\s+([A-Za-z]{3,9})\.?\s+(\d{4})(?:\s+${TIME_PART})?(?:\s+(\S+))?$`,
+);
+
+/** `Sep 04 03:00:00 EAT 2013` — asctime(3) / ctime order, year last. */
+const MONTH_DAY_TIME_YEAR = new RegExp(
+  String.raw`^([A-Za-z]{3,9})\.?\s+(\d{1,2})\s+${TIME_PART}(?:\s+(\S+))?\s+(\d{4})$`,
+);
+
+/** `2013/09/04 03:00:00 EAT` and `2013.09.04` — numeric, year first. */
+const YEAR_MONTH_DAY = new RegExp(
+  String.raw`^(\d{4})[/.-](\d{1,2})[/.-](\d{1,2})(?:[T\s]+${TIME_PART})?(?:\s*(\S+))?$`,
+);
 
 /**
  * Zone abbreviation → offset in seconds, the trails stand-in for the table
@@ -76,6 +90,32 @@ const ZONE_OFFSETS: Record<string, number> = {
   adt: -10800,
   nst: -12600,
 };
+
+function monthNumber(name: string): number | null {
+  const index = MONTH_ABBREVIATIONS.indexOf(name.slice(0, 3).toLowerCase());
+  return index === -1 ? null : index + 1;
+}
+
+function buildTimeHash(
+  year: string,
+  mon: number | null,
+  mday: string,
+  time: (string | undefined)[],
+  zone: string | undefined,
+): TimeHash | null {
+  if (mon === null) return null;
+  const [hour, min, sec, fraction] = time;
+  return {
+    year: Number(year),
+    mon,
+    mday: Number(mday),
+    hour: Number(hour ?? 0),
+    min: Number(min ?? 0),
+    sec: Number(sec ?? 0),
+    sec_fraction: fraction ? Number(`0${fraction}`) : 0,
+    offset: zone === undefined ? null : zoneOffsetSeconds(zone),
+  };
+}
 
 function zoneOffsetSeconds(zone: string): number | null {
   const numeric = /^([+-])(\d{2}):?(\d{2})?$/.exec(zone);
@@ -208,21 +248,28 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   }
 
   private parseTimeHash(s: string): TimeHash | null {
-    const withoutWeekday = s.replace(WEEKDAY_PREFIX, "");
-    const rfc = RFC_DATETIME.exec(withoutWeekday);
-    if (rfc) {
-      const mon = MONTH_ABBREVIATIONS.indexOf(rfc[2].slice(0, 3).toLowerCase()) + 1;
-      if (mon === 0) return null;
-      return {
-        year: Number(rfc[3]),
-        mon,
-        mday: Number(rfc[1]),
-        hour: Number(rfc[4] ?? 0),
-        min: Number(rfc[5] ?? 0),
-        sec: Number(rfc[6] ?? 0),
-        sec_fraction: rfc[7] ? Number(`0${rfc[7]}`) : 0,
-        offset: rfc[8] === undefined ? null : zoneOffsetSeconds(rfc[8]),
-      };
+    const withoutWeekday = s.replace(WEEKDAY_PREFIX, "").trim();
+
+    const dayFirst = DAY_MONTH_YEAR.exec(withoutWeekday);
+    if (dayFirst) {
+      return buildTimeHash(
+        dayFirst[3],
+        monthNumber(dayFirst[2]),
+        dayFirst[1],
+        dayFirst.slice(4, 8),
+        dayFirst[8],
+      );
+    }
+
+    const asctime = MONTH_DAY_TIME_YEAR.exec(withoutWeekday);
+    if (asctime) {
+      return buildTimeHash(
+        asctime[8],
+        monthNumber(asctime[1]),
+        asctime[2],
+        asctime.slice(3, 7),
+        asctime[7],
+      );
     }
 
     const normalized = withoutWeekday
@@ -245,7 +292,10 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     try {
       plain = Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" });
     } catch {
-      return null;
+      const numeric = YEAR_MONTH_DAY.exec(withoutWeekday);
+      return numeric
+        ? buildTimeHash(numeric[1], Number(numeric[2]), numeric[3], numeric.slice(4, 8), numeric[8])
+        : null;
     }
     return {
       year: plain.year,

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -25,7 +25,7 @@ export function isHash(value: unknown): value is Record<string, unknown> {
 }
 
 // Ruby Time's month-name coercion table (time.c months[]).
-const MONTH_ABBREVIATIONS = [
+export const MONTH_ABBREVIATIONS = [
   "jan",
   "feb",
   "mar",

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1313,7 +1313,7 @@ describe("BasicsTest", () => {
   });
   // `establish_connection(default_timezone:)` is observed through default-string
   // casting: the offset-less `"2004-01-01 00:00:00"` default is parsed lazily at
-  // read time by DateTimeType.cast → parseString, which interprets it in
+  // read time by DateTimeType.cast → fastStringToTime, which interprets it in
   // getDefaultTimezone() (the singleton establishConnection updates). Same cast
   // path as the `default in utc` test above; Rails reaches it via DB column
   // defaults + reset_column_information, we via attribute() defaults.

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/date-time.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/date-time.json
@@ -9,34 +9,6 @@
   {
     "package": "activemodel",
     "tsFile": "type/date-time.ts",
-    "rubyName": "cast_value",
-    "call": "fallback_string_to_time",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/date-time.ts",
-    "rubyName": "cast_value",
-    "call": "fast_string_to_time",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/date-time.ts",
-    "rubyName": "fallback_string_to_time",
-    "call": "microseconds",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/date-time.ts",
-    "rubyName": "fallback_string_to_time",
-    "call": "new_time",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/date-time.ts",
     "rubyName": "fallback_string_to_time",
     "call": "values_at",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
`DateTimeType#parseString` reimplemented string parsing inline (normalize →
offset check → `Instant.from` / `PlainDateTime.from` in the configured zone),
duplicating `fastStringToTime` in `helpers/time-value.ts`. #5402 had to update
both, and `newTime` / `fastStringToTime` were unreachable from `src/` — only
`time-value.test.ts` called them.

In Rails, `Type::DateTime#cast_value` calls `fast_string_to_time` /
`fallback_string_to_time` from the mixed-in `Helpers::TimeValue`
(`date_time.rb:24-39`, `helpers/time_value.rb:91-94`), so there is exactly one
implementation.

- `fastStringToTime` and `newTime` are mixed onto `DateTimeType` as
  `this`-typed members, per the module-mixin convention.
- `castValue` now does `fastStringToTime(str) ?? fallbackStringToTime(str)`;
  the inline duplicate `parseString` is deleted.
- `fallbackStringToTime` follows the Rails shape: a `Date._parse` stand-in
  (`parseTimeHash`, using Temporal's parser) produces the component hash,
  `microseconds` normalizes `sec_fraction`, and `newTime` builds the instant.
  It stays reachable for strings `fastStringToTime` rejects — notably ISO basic
  format, which contains no `-`.

Existing activemodel + activerecord datetime tests pass unchanged; `api:compare`
clean.

Closes-story: route-datetime-cast-through-fast-string-to-time
