### PR TITLE
test(activerecord): port the primary-key-prefix and timestamptz ChangeSchemaTest cases

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -16,19 +16,7 @@ export const pgSupportsOptimizerHints = pgAvailable && pgHasHintPlan;
 /** Mirrors PostgreSQLAdapter#supportsNativePartitioning — PG 10+ (100000). */
 export const pgSupportsNativePartitioning = pgServerVersion >= 100000;
 
-/** Mirrors Rails' with_postgresql_datetime_type — temporarily changes the adapter's datetimeType. */
-export async function withPostgresqlDatetimeType<T>(
-  type: string,
-  fn: () => T | Promise<T>,
-): Promise<T> {
-  const original = PostgreSQLAdapter.datetimeType;
-  PostgreSQLAdapter.datetimeType = type;
-  try {
-    return await fn();
-  } finally {
-    PostgreSQLAdapter.datetimeType = original;
-  }
-}
+export { withPostgresqlDatetimeType } from "../../support/with-postgresql-datetime-type.js";
 
 /** Temporarily registers extra entries in nativeDatabaseTypes, then restores the originals. */
 export async function withNativeDatabaseTypeOverrides<T>(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -197,6 +197,7 @@ import {
   toKey as _toKey,
   PrimaryKey as _PrimaryKey,
   getPrimaryKeyAttr as _getPrimaryKeyAttr,
+  getPrimaryKey as _getPrimaryKey,
   setPrimaryKeyAttr as _setPrimaryKeyAttr,
   isCompositePrimaryKey as _isCompositePrimaryKey,
 } from "./attribute-methods/primary-key.js";
@@ -4388,6 +4389,8 @@ export class Base extends Model {
   // Mirrors: ActiveRecord::ModelSchema.primary_key_prefix_type (model_schema.rb:163).
   static primaryKeyPrefixType: string | null = null;
 
+  static getPrimaryKey = _getPrimaryKey;
+
   // Column used to order records when no explicit order is given (e.g. for
   // `first`/`last`). nil by default. Read by relation/finder-methods.ts.
   // Mirrors: ActiveRecord::ModelSchema.implicit_order_column (model_schema.rb:169).
@@ -5193,6 +5196,9 @@ registerTableNameOptions({
   },
   get pluralizeTableNames() {
     return Base.pluralizeTableNames;
+  },
+  getPrimaryKey(baseName: string) {
+    return Base.getPrimaryKey(baseName);
   },
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -333,8 +333,6 @@ export interface AbstractAdapter {
     options: { name?: string; column?: string | string[] },
   ): Promise<string>;
   tableExists(tableName: string): Promise<boolean>;
-  // Mixed in from SchemaStatements; declared here because Rails' migration
-  // tests call `connection.type_to_sql(...)` through the adapter.
   typeToSql(type: ColumnType, options?: ColumnOptions): string;
   // Options SchemaMigration / InternalMetadata pass to `t.string` for their
   // primary key. Mixed in from SchemaStatements; declared here so those

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -333,6 +333,9 @@ export interface AbstractAdapter {
     options: { name?: string; column?: string | string[] },
   ): Promise<string>;
   tableExists(tableName: string): Promise<boolean>;
+  // Mixed in from SchemaStatements; declared here because Rails' migration
+  // tests call `connection.type_to_sql(...)` through the adapter.
+  typeToSql(type: ColumnType, options?: ColumnOptions): string;
   // Options SchemaMigration / InternalMetadata pass to `t.string` for their
   // primary key. Mixed in from SchemaStatements; declared here so those
   // callers can reach it through the AbstractAdapter type.

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -8,6 +8,7 @@ import {
   globalPluralizeTableNames,
   globalTableNamePrefix,
   globalTableNameSuffix,
+  globalGetPrimaryKey,
 } from "./table-name-options.js";
 
 /**
@@ -1002,7 +1003,11 @@ export class TableDefinition {
         if (tdOptions.default !== undefined) pkOpts.default = tdOptions.default;
         if (tdOptions.autoIncrement !== undefined) pkOpts.autoIncrement = tdOptions.autoIncrement;
       }
-      this.columns.push(this.newColumnDefinition(pkNameOverride ?? "id", pkType, pkOpts));
+      // Rails' set_primary_key: `pk = primary_key || Base.get_primary_key(table_name.to_s.singularize)`
+      // (schema_definitions.rb:397) — the implicit PK column honours
+      // `Base.primary_key_prefix_type`, so `testings` becomes `testing_id`/`testingid`.
+      const pkName = pkNameOverride ?? globalGetPrimaryKey(singularize(tableName));
+      this.columns.push(this.newColumnDefinition(pkName, pkType, pkOpts));
     }
   }
 
@@ -1012,7 +1017,7 @@ export class TableDefinition {
    *   caller uses it directly with a hash-form id it must pre-process the hash.
    */
   setPrimaryKey(
-    _tableName: string,
+    tableName: string,
     id: ColumnType | false,
     primaryKey?: string,
     _options: Record<string, unknown> = {},
@@ -1026,7 +1031,7 @@ export class TableDefinition {
     // their columns defined by the SELECT, so never add a PK column.
     if (id === false || this.as) return;
 
-    const pkName = primaryKey ?? "id";
+    const pkName = primaryKey ?? globalGetPrimaryKey(singularize(tableName));
     const pkType = typeof id === "string" ? id : "primary_key";
     this.columns.unshift(this.newColumnDefinition(pkName, pkType, { primaryKey: true }));
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1003,9 +1003,6 @@ export class TableDefinition {
         if (tdOptions.default !== undefined) pkOpts.default = tdOptions.default;
         if (tdOptions.autoIncrement !== undefined) pkOpts.autoIncrement = tdOptions.autoIncrement;
       }
-      // Rails' set_primary_key: `pk = primary_key || Base.get_primary_key(table_name.to_s.singularize)`
-      // (schema_definitions.rb:397) — the implicit PK column honours
-      // `Base.primary_key_prefix_type`, so `testings` becomes `testing_id`/`testingid`.
       const pkName = pkNameOverride ?? globalGetPrimaryKey(singularize(tableName));
       this.columns.push(this.newColumnDefinition(pkName, pkType, pkOpts));
     }

--- a/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
@@ -13,6 +13,8 @@ export interface TableNameOptionsSource {
   readonly tableNamePrefix: string;
   readonly tableNameSuffix: string;
   readonly pluralizeTableNames: boolean;
+  /** `Base.get_primary_key(base_name)` — read by `TableDefinition#set_primary_key`. */
+  getPrimaryKey(baseName: string): string;
 }
 
 let _source: TableNameOptionsSource | null = null;
@@ -35,4 +37,14 @@ export function globalTableNameSuffix(): string {
 /** @internal */
 export function globalPluralizeTableNames(): boolean {
   return _source?.pluralizeTableNames ?? true;
+}
+
+/**
+ * @internal Rails' `TableDefinition#set_primary_key` names the implicit PK
+ * column with `Base.get_primary_key(table_name.to_s.singularize)`, which
+ * honours `Base.primary_key_prefix_type`. Before `Base` has loaded (adapter
+ * used standalone) there is no prefix type to apply, so "id" is the answer.
+ */
+export function globalGetPrimaryKey(baseName: string): string {
+  return _source?.getPrimaryKey(baseName) ?? "id";
 }

--- a/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/table-name-options.ts
@@ -13,7 +13,6 @@ export interface TableNameOptionsSource {
   readonly tableNamePrefix: string;
   readonly tableNameSuffix: string;
   readonly pluralizeTableNames: boolean;
-  /** `Base.get_primary_key(base_name)` — read by `TableDefinition#set_primary_key`. */
   getPrimaryKey(baseName: string): string;
 }
 
@@ -39,12 +38,7 @@ export function globalPluralizeTableNames(): boolean {
   return _source?.pluralizeTableNames ?? true;
 }
 
-/**
- * @internal Rails' `TableDefinition#set_primary_key` names the implicit PK
- * column with `Base.get_primary_key(table_name.to_s.singularize)`, which
- * honours `Base.primary_key_prefix_type`. Before `Base` has loaded (adapter
- * used standalone) there is no prefix type to apply, so "id" is the answer.
- */
+/** @internal */
 export function globalGetPrimaryKey(baseName: string): string {
   return _source?.getPrimaryKey(baseName) ?? "id";
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1950,25 +1950,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // (SQLite3::TableDefinition resolves :virtual that way; no type when the
   // option is absent).
   private _baseColumnType(type: string, options?: Record<string, unknown>): string {
-    if (type !== "virtual") return this.typeToSql(type, options);
-    return options?.type ? this.typeToSql(String(options.type), options) : "";
-  }
-
-  private typeToSql(type: string, options?: Record<string, unknown>): string {
-    const raw = this.nativeDatabaseTypes()[type]?.name ?? type.toUpperCase();
-    // Validate: only allow safe SQL type identifiers (letters, digits, underscores, spaces)
-    if (!/^[A-Za-z_][A-Za-z0-9_ ]*$/.test(raw)) {
-      throw new Error(`Invalid SQL type: ${raw}`);
-    }
-    const base = raw;
-    const precision =
-      typeof options?.precision === "number" ? Math.floor(options.precision) : undefined;
-    const scale = typeof options?.scale === "number" ? Math.floor(options.scale) : undefined;
-    const limit = typeof options?.limit === "number" ? Math.floor(options.limit) : undefined;
-    if (precision !== undefined && scale !== undefined) return `${base}(${precision},${scale})`;
-    if (precision !== undefined) return `${base}(${precision})`;
-    if (limit !== undefined) return `${base}(${limit})`;
-    return base;
+    const opts = (options ?? {}) as ColumnOptions;
+    if (type !== "virtual") return this.typeToSql(type as ColumnType, opts);
+    return options?.type ? this.typeToSql(String(options.type) as ColumnType, opts) : "";
   }
 
   private async _getCreateTableSql(tableName: string): Promise<string | null> {

--- a/packages/activerecord/src/migration/change-schema.test.ts
+++ b/packages/activerecord/src/migration/change-schema.test.ts
@@ -7,10 +7,10 @@
  * `@connection = ActiveRecord::Base.lease_connection`. `testings` is created
  * and dropped by the test in Rails too, so it is not a canonical-schema table.
  *
- * Seven cases are still unported — the bigint/timestamp/datetime `sql_type`
- * assertions and the two `primary_key_prefix_type` ones. Each fails on a
- * production divergence, not a porting gap; tracked by the
- * `port-migration-change-schema-type-reflection-cases` story.
+ * Four cases are still unported — the bigint/timestamp/datetime `sql_type`
+ * assertions. Each needs `type_to_sql` to source its base names from
+ * `native_database_types` rather than a hardcoded uppercase switch; tracked by
+ * the `converge-type-to-sql-base-names-on-native-database-types` story.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
@@ -18,6 +18,7 @@ import { Migration } from "../migration.js";
 import { NotNullViolation, StatementInvalid } from "../errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { ambientConnection } from "../support/rocket-tables.js";
+import { withPostgresqlDatetimeType } from "../support/with-postgresql-datetime-type.js";
 import { currentAdapter } from "../support/adapter-helper.js";
 import { adapterType } from "../test-adapter.js";
 import { describeIfSupports } from "../support/supports.js";
@@ -181,6 +182,32 @@ describe("Migration", () => {
       }
     });
 
+    it("create table with primary key prefix as table name with underscore", async () => {
+      Base.primaryKeyPrefixType = "table_name_with_underscore";
+      const connection = await ambientConnection();
+      await connection.createTable("testings", (t) => {
+        t.column("foo", "string");
+      });
+
+      expect((await connection.columns("testings")).map((c) => c.name)).toEqual([
+        "testing_id",
+        "foo",
+      ]);
+    });
+
+    it("create table with primary key prefix as table name", async () => {
+      Base.primaryKeyPrefixType = "table_name";
+      const connection = await ambientConnection();
+      await connection.createTable("testings", (t) => {
+        t.column("foo", "string");
+      });
+
+      expect((await connection.columns("testings")).map((c) => c.name)).toEqual([
+        "testingid",
+        "foo",
+      ]);
+    });
+
     it("create table raises when redefining primary key column", async () => {
       const connection = await ambientConnection();
       await expect(
@@ -283,6 +310,22 @@ describe("Migration", () => {
         ),
       ).rejects.toThrow(NotNullViolation);
     });
+
+    it.skipIf(adapterType !== "postgres")(
+      "add column with datetime in timestamptz mode",
+      async () => {
+        await withPostgresqlDatetimeType("timestamptz", async () => {
+          const connection = await ambientConnection();
+          await connection.createTable("testings", (t) => {
+            t.column("foo", "datetime");
+          });
+
+          const column = detect(await connection.columns("testings"), "foo");
+          expect(column.type).toBe("datetime");
+          expect(column.sqlType).toBe("timestamp(6) with time zone");
+        });
+      },
+    );
 
     it("change column quotes column names", async () => {
       const connection = await ambientConnection();

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -13,24 +13,12 @@ import {
   dumpTableSchema,
   FULL_DUMP_TIMEOUT_MS,
 } from "./support/schema-dumping-helper.js";
+import { withPostgresqlDatetimeType } from "./support/with-postgresql-datetime-type.js";
 
 // The first describe uses `fixtures({})` (canonical schema + reset shield);
 // the later bespoke-table describes deliberately keep the global per-test reset,
 // so they only need `Base.connection` *established* — which the worker setup
 // file already did, as Rails' `cases/helper.rb` does for the whole process.
-
-// Mirrors: ActiveRecord::TestCase#with_postgresql_datetime_type. Temporarily
-// flips PostgreSQLAdapter.datetimeType so :datetime resolves to :timestamptz.
-async function withPostgresqlDatetimeType(type: string, fn: () => Promise<void>): Promise<void> {
-  const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
-  const was = PostgreSQLAdapter.datetimeType;
-  PostgreSQLAdapter.datetimeType = type;
-  try {
-    await fn();
-  } finally {
-    PostgreSQLAdapter.datetimeType = was;
-  }
-}
 
 // Faithful port of the Rails cases that dump the *standard loaded schema*
 // (`standard_dump` / `dump_table_schema "companies"`). Rails loads `schema.rb`;

--- a/packages/activerecord/src/support/with-postgresql-datetime-type.ts
+++ b/packages/activerecord/src/support/with-postgresql-datetime-type.ts
@@ -1,0 +1,25 @@
+/**
+ * Mirrors `ActiveRecord::TestCase#with_postgresql_datetime_type`
+ * (vendor/rails/activerecord/test/support/connection_helper.rb) — temporarily
+ * flips `PostgreSQLAdapter.datetime_type` so `:datetime` resolves to
+ * `:timestamptz`.
+ *
+ * Lives here rather than in `adapters/postgresql/test-helper.ts` because that
+ * module re-exports `support/describe-if-pg.js`, whose top-level `await` probes
+ * a PostgreSQL server on *every* lane. Suites that are not PG-only (e.g.
+ * `migration/change-schema.test.ts`) need the helper without paying that probe,
+ * so the adapter import is deferred to call time.
+ */
+export async function withPostgresqlDatetimeType<T>(
+  type: string,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const { PostgreSQLAdapter } = await import("../connection-adapters/postgresql-adapter.js");
+  const original = PostgreSQLAdapter.datetimeType;
+  PostgreSQLAdapter.datetimeType = type;
+  try {
+    return await fn();
+  } finally {
+    PostgreSQLAdapter.datetimeType = original;
+  }
+}

--- a/packages/activerecord/src/support/with-postgresql-datetime-type.ts
+++ b/packages/activerecord/src/support/with-postgresql-datetime-type.ts
@@ -1,14 +1,10 @@
 /**
  * Mirrors `ActiveRecord::TestCase#with_postgresql_datetime_type`
- * (vendor/rails/activerecord/test/support/connection_helper.rb) — temporarily
- * flips `PostgreSQLAdapter.datetime_type` so `:datetime` resolves to
- * `:timestamptz`.
+ * (vendor/rails/activerecord/test/cases/test_case.rb:193).
  *
- * Lives here rather than in `adapters/postgresql/test-helper.ts` because that
- * module re-exports `support/describe-if-pg.js`, whose top-level `await` probes
- * a PostgreSQL server on *every* lane. Suites that are not PG-only (e.g.
- * `migration/change-schema.test.ts`) need the helper without paying that probe,
- * so the adapter import is deferred to call time.
+ * The adapter import is deferred to call time so non-PG lanes can import this
+ * module without loading `adapters/postgresql/test-helper.ts`, whose
+ * `describe-if-pg` re-export probes a PostgreSQL server at module scope.
  */
 export async function withPostgresqlDatetimeType<T>(
   type: string,

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -194,12 +194,5 @@
     "rubyName": "set_primary_key",
     "call": "primary_keys",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "set_primary_key",
-    "call": "singularize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]


### PR DESCRIPTION
Ports three of the seven remaining cases in
`vendor/rails/activerecord/test/cases/migration/change_schema_test.rb`, fixing
the production divergence each one sits on rather than weakening the assertion.

### `test_create_table_with_primary_key_prefix_as_table_name{,_with_underscore}` (:152-170)

`TableDefinition` named the implicit PK column `"id"` unconditionally (both the
constructor path `createTable` uses and `setPrimaryKey`), so
`Base.primaryKeyPrefixType` had no effect on the emitted DDL. It now resolves
the name through `Base.getPrimaryKey(singularize(tableName))`, mirroring Rails'
`TableDefinition#set_primary_key` (`schema_definitions.rb:397`).

`Base` reaches the adapter layer through the existing `table-name-options`
registry — the established indirection for exactly this cycle
(`base.ts` → `connection-handler.ts` → adapters). `getPrimaryKey` itself was
already ported in `attribute-methods/primary-key.ts` but never wired to `Base`;
it is now a `Base` class method, which is where
`AttributeMethods::PrimaryKey::ClassMethods` puts it.

Known remaining gap in that helper (pre-existing, out of scope here): Rails'
`get_primary_key` has a third branch that reflects the PK off an existing table
(`ActiveRecord::Base != self && table_exists?`). It is unreachable from this
call site — the receiver *is* `Base`, and `set_primary_key` runs while the table
is being created — but a subclass receiver would still diverge. Porting it needs
an async `table_exists?` inside a sync method, so it is left alone.

### `test_add_column_with_datetime_in_timestamptz_mode` (:303-316)

PG-only, needs `with_postgresql_datetime_type`
(`test/cases/test_case.rb:193`). trails' port lived in
`adapters/postgresql/test-helper.ts`, which re-exports `support/describe-if-pg`
— whose top-level `await` probes a PG server on *every* lane, so a non-PG-only
suite could not import it. Moved to `support/with-postgresql-datetime-type.ts`
with the adapter import deferred to call time; `test-helper.ts` re-exports it,
and the duplicate local copy in `schema-dumper.test.ts` is folded into it.

### Drive-by production fix

The SQLite adapter carried a **private** `typeToSql` that shadowed the public
`SchemaStatements#typeToSql` at runtime, uppercasing its result and then
rejecting it (`Invalid SQL type: DATETIME(6)`) — so `connection.typeToSql(...)`
threw on any type string the switch didn't know, where Rails returns it verbatim
(`schema_statements.rb:1414-1415`). Removed; `_baseColumnType` routes through
the public method, which is now declared on the `AbstractAdapter` interface so
callers (and Rails' tests) can reach it.

### Parity

- **api:compare: 0 delta.** Measured against `origin/main` with a matching
  `pnpm build` on both sides — `activerecord 6082/6148`, Data layer
  `7721/7816`, Overall `11739/17536` on both.
- **test:compare: +3.** `migration/change_schema_test.rb` goes 1 OK → 4 OK,
  with 0 wrong-describe, 0 gate-mismatch and 0 misplaced.
- **Wide call-mismatches ratchet: one baseline entry removed.**
  `set_primary_key → singularize` converged (trails now makes the call Rails
  makes), so the stale entry is deleted from
  `call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json`.
  Removed by hand, not reseeded with `--write`.

### Verification

Green on all three lanes (sqlite3, postgresql, mysql2) for `migration/`,
`migration.test.ts`, `schema-dumper.test.ts` and `active-record-schema.test.ts`.
Both new PK cases were confirmed to **fail** with the production files reverted
to `origin/main` and the tests kept, so they are genuine regression tests.

### Deferred

The four remaining cases (`test_create_table_with_bigint`,
`test_add_column_with_timestamp_type`,
`test_add_column_with_postgresql_datetime_type`,
`test_change_column_with_timestamp_type`) are all blocked on the same change:
`SchemaCreation#typeToSql` must source its base names from the adapter's
`nativeDatabaseTypes()` (lowercase everywhere, and **no `:bigint` entry on
SQLite**) instead of a hardcoded uppercase switch. That has a wide blast radius
on schema-dumper snapshots and every `sqlType` assertion on the SQLite lane, so
it is registered separately as
`0005-activerecord-gaps/converge-type-to-sql-base-names-on-native-database-types`
— which builds on the `typeToSql` shadow removal here.

Closes-story: port-migration-change-schema-type-reflection-cases
