### PR TITLE
test(activerecord): port migration columns adapter-gated cases

### DIFF
--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -6,6 +6,7 @@ import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js
 import { ambientConnection } from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
 import { isMariaDb, serverVersion } from "../support/mysql-server-version.js";
+import { adapterSupports } from "../support/supports.js";
 
 const mariaDbRejectsUniqueColumnDrop =
   adapterType === "mysql" && isMariaDb && serverVersion?.gte("10.2.8") === true;
@@ -415,5 +416,77 @@ describe("Migration", () => {
       await TestModel.loadSchema();
       expect(TestModel.new().first_name).toBe("Tester");
     });
+
+    it.skipIf(adapterType !== "mysql")("mysql rename column preserves auto increment", async () => {
+      const connection = await ambientConnection();
+      try {
+        await connection.renameColumn("test_models", "id", "id_test");
+        const renamed = (await connection.columns("test_models")).find(
+          (c) => c.name === "id_test",
+        ) as (Column & { autoIncrement?: boolean }) | undefined;
+        expect(renamed?.autoIncrement).toBe(true);
+        TestModel.resetColumnInformation();
+      } finally {
+        await connection.renameColumn("test_models", "id_test", "id");
+      }
+    });
+
+    it.skipIf(adapterType !== "sqlite")(
+      "change column default preserves existing column default function",
+      async () => {
+        const connection = await ambientConnection();
+        await connection.changeColumnDefault(
+          "test_models",
+          "created_at",
+          () => "CURRENT_TIMESTAMP",
+        );
+        TestModel.resetColumnInformation();
+        await TestModel.loadSchema();
+        expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe("CURRENT_TIMESTAMP");
+
+        await connection.addColumn("test_models", "edited_at", "datetime");
+        await connection.changeColumnDefault("test_models", "edited_at", () => "CURRENT_TIMESTAMP");
+        TestModel.resetColumnInformation();
+        await TestModel.loadSchema();
+        expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe("CURRENT_TIMESTAMP");
+        expect(TestModel.columnsHash()["edited_at"].defaultFunction).toBe("CURRENT_TIMESTAMP");
+      },
+    );
+
+    it.skipIf(adapterType !== "sqlite")(
+      "change column default supports default function with concatenation operator",
+      async () => {
+        const connection = await ambientConnection();
+        await connection.addColumn("test_models", "ruby_on_rails", "string");
+        await connection.changeColumnDefault(
+          "test_models",
+          "ruby_on_rails",
+          () => "('Ruby ' || 'on ' || 'Rails')",
+        );
+        TestModel.resetColumnInformation();
+        await TestModel.loadSchema();
+        expect(TestModel.columnsHash()["ruby_on_rails"].defaultFunction).toBe(
+          "'Ruby ' || 'on ' || 'Rails'",
+        );
+      },
+    );
+
+    it.skipIf(adapterType !== "mysql" || !adapterSupports("default_expression"))(
+      "change column null does not change default functions",
+      async () => {
+        const connection = await ambientConnection();
+        const fn = isMariaDb ? "current_timestamp(6)" : "(now())";
+
+        await connection.changeColumnDefault("test_models", "created_at", () => fn);
+        TestModel.resetColumnInformation();
+        await TestModel.loadSchema();
+        expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe(fn);
+
+        await connection.changeColumnNull("test_models", "created_at", true);
+        TestModel.resetColumnInformation();
+        await TestModel.loadSchema();
+        expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe(fn);
+      },
+    );
   });
 });

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -5,7 +5,11 @@ import { ActiveRecordError, StatementInvalid } from "../errors.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { ambientConnection } from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
-import { isMariaDb, serverVersion } from "../support/mysql-server-version.js";
+import {
+  isMariaDb,
+  serverVersion,
+  supportsDefaultExpression,
+} from "../support/mysql-server-version.js";
 import { adapterSupports } from "../support/supports.js";
 
 const mariaDbRejectsUniqueColumnDrop =
@@ -471,22 +475,23 @@ describe("Migration", () => {
       },
     );
 
-    it.skipIf(adapterType !== "mysql" || !adapterSupports("default_expression"))(
-      "change column null does not change default functions",
-      async () => {
-        const connection = await ambientConnection();
-        const fn = isMariaDb ? "current_timestamp(6)" : "(now())";
+    it.skipIf(
+      adapterType !== "mysql" ||
+        !adapterSupports("default_expression") ||
+        !supportsDefaultExpression,
+    )("change column null does not change default functions", async () => {
+      const connection = await ambientConnection();
+      const fn = isMariaDb ? "current_timestamp(6)" : "(now())";
 
-        await connection.changeColumnDefault("test_models", "created_at", () => fn);
-        TestModel.resetColumnInformation();
-        await TestModel.loadSchema();
-        expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe(fn);
+      await connection.changeColumnDefault("test_models", "created_at", () => fn);
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe(fn);
 
-        await connection.changeColumnNull("test_models", "created_at", true);
-        TestModel.resetColumnInformation();
-        await TestModel.loadSchema();
-        expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe(fn);
-      },
-    );
+      await connection.changeColumnNull("test_models", "created_at", true);
+      TestModel.resetColumnInformation();
+      await TestModel.loadSchema();
+      expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe(fn);
+    });
   });
 });


### PR DESCRIPTION
Ports the four adapter-gated cases `test:compare` still reported missing for
`vendor/rails/activerecord/test/cases/migration/columns_test.rb`, which PR #5560
left out because everything it ported was unconditional in Rails.

- `test_mysql_rename_column_preserves_auto_increment` (columns_test.rb:69-76) —
  MySQL-only; asserts `autoIncrement` on the reflected column after renaming
  `id` to `id_test`, with the rename-back in a `finally` mirroring Rails' `ensure`.
- `test_change_column_default_preserves_existing_column_default_function`
  (:299-311) — SQLite-only; `changeColumnDefault` with a `() => "CURRENT_TIMESTAMP"`
  function default, read back via `columnsHash()[...].defaultFunction`.
- `test_change_column_default_supports_default_function_with_concatenation_operator`
  (:313-322) — SQLite-only concatenation-operator default.
- `test_change_column_null_does_not_change_default_functions` (:349-361) —
  MySQL + `supports_default_expression?`, branching on `isMariaDb` for the
  expected function text.

No implementation changes were needed: `quoteDefaultExpression` already accepts
function defaults on both the SQLite table-rebuild path and MySQL's
`ChangeColumnDefaultDefinition` path.

Gates mirror Rails exactly — `test:compare` reports 0 gate-mismatch and 0
misplaced for the file, with missing dropping by 4 (28 → 24, matched 8 → 12).

Verified locally on all three lanes (sqlite, postgresql, mysql8).

Closes-story: port-migration-columns-adapter-gated-cases
