### PR TITLE
feat(activerecord): source typeToSql base names from nativeDatabaseTypes

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -838,7 +838,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const types = PostgreSQLAdapter.nativeDatabaseTypes();
       expect(types.string).toEqual({ name: "character varying" });
       expect(types.binary).toEqual({ name: "bytea" });
-      expect(types.primaryKey).toBe("bigserial primary key");
+      expect(types.primary_key).toEqual({ name: "bigserial primary key" });
       expect(types.datetime).toBeDefined();
     });
 

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -838,7 +838,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const types = PostgreSQLAdapter.nativeDatabaseTypes();
       expect(types.string).toEqual({ name: "character varying" });
       expect(types.binary).toEqual({ name: "bytea" });
-      expect(types.primary_key).toEqual({ name: "bigserial primary key" });
+      expect(types.primary_key).toBe("bigserial primary key");
       expect(types.datetime).toBeDefined();
     });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -423,6 +423,7 @@ export interface AbstractAdapter {
   // resolves it through here rather than a duplicate on SchemaStatements.
   tableAliasLength(): number;
   nativeDatabaseTypes(): Record<string, unknown>;
+  typeToSql(type: ColumnType, options?: ColumnOptions): string;
   dataSources(): Promise<string[]>;
   isDataSourceExists(name: string): Promise<boolean>;
   // --- DatabaseStatements ---

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -138,24 +138,10 @@ class MysqlBigInteger extends BigIntegerType {
 }
 import { UnsignedInteger } from "../type/unsigned-integer.js";
 import { Text as TextType } from "../type/text.js";
-
-const NATIVE_DATABASE_TYPES: Record<string, { name: string; limit?: number }> = {
-  primary_key: { name: "bigint auto_increment PRIMARY KEY" },
-  string: { name: "varchar", limit: 255 },
-  text: { name: "text" },
-  integer: { name: "int" },
-  bigint: { name: "bigint" },
-  float: { name: "float", limit: 24 },
-  decimal: { name: "decimal" },
-  datetime: { name: "datetime" },
-  timestamp: { name: "timestamp" },
-  time: { name: "time" },
-  date: { name: "date" },
-  binary: { name: "blob" },
-  blob: { name: "blob" },
-  boolean: { name: "tinyint", limit: 1 },
-  json: { name: "json" },
-};
+import {
+  MYSQL_NATIVE_DATABASE_TYPES,
+  type NativeDatabaseType,
+} from "./abstract/native-database-types.js";
 
 const ER_DUP_ENTRY = 1062;
 const ER_CANNOT_ADD_FOREIGN = 1215;
@@ -594,8 +580,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return false;
   }
 
-  nativeDatabaseTypes(): Record<string, { name: string; limit?: number }> {
-    return NATIVE_DATABASE_TYPES;
+  nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+    return MYSQL_NATIVE_DATABASE_TYPES;
   }
 
   // Mirrors MySQL's explicit `ColumnMethods` list (`mysql/schema_definitions.rb:46`

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -140,7 +140,7 @@ import { UnsignedInteger } from "../type/unsigned-integer.js";
 import { Text as TextType } from "../type/text.js";
 import {
   MYSQL_NATIVE_DATABASE_TYPES,
-  type NativeDatabaseType,
+  type NativeDatabaseTypes,
 } from "./abstract/native-database-types.js";
 
 const ER_DUP_ENTRY = 1062;
@@ -580,7 +580,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return false;
   }
 
-  nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+  nativeDatabaseTypes(): NativeDatabaseTypes {
     return MYSQL_NATIVE_DATABASE_TYPES;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
@@ -6,8 +6,15 @@ export interface NativeDatabaseType {
   scale?: number;
 }
 
-export const SQLITE3_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
-  primary_key: { name: "integer PRIMARY KEY AUTOINCREMENT NOT NULL" },
+/**
+ * A whole hash. Rails stores `:primary_key` as a bare String and every other
+ * entry as a Hash; `type_to_sql` branches on `native.is_a?(Hash)`
+ * (abstract/schema_statements.rb:1387-1388), so both shapes are load-bearing.
+ */
+export type NativeDatabaseTypes = Record<string, string | NativeDatabaseType>;
+
+export const SQLITE3_NATIVE_DATABASE_TYPES: NativeDatabaseTypes = {
+  primary_key: "integer PRIMARY KEY AUTOINCREMENT NOT NULL",
   string: { name: "varchar" },
   text: { name: "text" },
   integer: { name: "integer" },
@@ -21,8 +28,8 @@ export const SQLITE3_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> =
   json: { name: "json" },
 };
 
-export const MYSQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
-  primary_key: { name: "bigint auto_increment PRIMARY KEY" },
+export const MYSQL_NATIVE_DATABASE_TYPES: NativeDatabaseTypes = {
+  primary_key: "bigint auto_increment PRIMARY KEY",
   string: { name: "varchar", limit: 255 },
   text: { name: "text" },
   integer: { name: "int", limit: 4 },
@@ -39,8 +46,8 @@ export const MYSQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
   json: { name: "json" },
 };
 
-export const POSTGRESQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
-  primary_key: { name: "bigserial primary key" },
+export const POSTGRESQL_NATIVE_DATABASE_TYPES: NativeDatabaseTypes = {
+  primary_key: "bigserial primary key",
   string: { name: "character varying" },
   text: { name: "text" },
   integer: { name: "integer", limit: 4 },
@@ -94,19 +101,18 @@ export const POSTGRESQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType
  */
 export function postgresqlNativeDatabaseTypes(
   datetimeType: string,
-  overrides: Record<string, string | NativeDatabaseType> = {},
-): Record<string, NativeDatabaseType> {
-  const types: Record<string, NativeDatabaseType> = { ...POSTGRESQL_NATIVE_DATABASE_TYPES };
-  for (const [key, value] of Object.entries(overrides)) {
-    types[key] = typeof value === "string" ? { name: value } : value;
-  }
-  types["datetime"] = types[datetimeType] ?? { name: "timestamp" };
+  overrides: NativeDatabaseTypes = {},
+): NativeDatabaseTypes {
+  const types: NativeDatabaseTypes = { ...POSTGRESQL_NATIVE_DATABASE_TYPES, ...overrides };
+  // Rails assigns with no default, so a `datetime_type` naming no entry leaves
+  // `:datetime` nil and `type_to_sql(:datetime)` falls through to "datetime".
+  types["datetime"] = types[datetimeType];
   return types;
 }
 
 export const NATIVE_DATABASE_TYPES_BY_ADAPTER: Record<
   "sqlite" | "postgres" | "mysql",
-  Record<string, NativeDatabaseType>
+  NativeDatabaseTypes
 > = {
   sqlite: SQLITE3_NATIVE_DATABASE_TYPES,
   postgres: POSTGRESQL_NATIVE_DATABASE_TYPES,

--- a/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
@@ -1,20 +1,4 @@
-/**
- * The per-adapter `NATIVE_DATABASE_TYPES` hashes, transcribed from Rails.
- *
- * Rails declares each hash as a constant inside its adapter class. trails keeps
- * one copy per adapter here, in a leaf module with no imports, because the
- * shared `SchemaCreation` visitor also needs them: `type_to_sql` builds every
- * base type name from `native_database_types[type][:name]`
- * (abstract/schema_statements.rb:1385-1415), and the visitor is constructed
- * without an adapter on the host-less unit-test path. Each adapter's
- * `nativeDatabaseTypes()` returns the hash from here, so there is still exactly
- * one source per adapter.
- *
- * The names are lowercase in Rails and stay lowercase here — the declared type
- * text is what SQLite reflects back verbatim, so uppercasing it would diverge.
- */
-
-/** One entry of a `NATIVE_DATABASE_TYPES` hash — Rails' `{ name:, limit: }` shape. */
+/** Per-adapter `NATIVE_DATABASE_TYPES`, transcribed from Rails. */
 export interface NativeDatabaseType {
   name?: string;
   limit?: number;
@@ -22,7 +6,6 @@ export interface NativeDatabaseType {
   scale?: number;
 }
 
-/** Mirrors: `SQLite3Adapter::NATIVE_DATABASE_TYPES` (sqlite3_adapter.rb:69). */
 export const SQLITE3_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
   primary_key: { name: "integer PRIMARY KEY AUTOINCREMENT NOT NULL" },
   string: { name: "varchar" },
@@ -38,7 +21,6 @@ export const SQLITE3_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> =
   json: { name: "json" },
 };
 
-/** Mirrors: `AbstractMysqlAdapter::NATIVE_DATABASE_TYPES` (abstract_mysql_adapter.rb:31). */
 export const MYSQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
   primary_key: { name: "bigint auto_increment PRIMARY KEY" },
   string: { name: "varchar", limit: 255 },
@@ -57,11 +39,6 @@ export const MYSQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
   json: { name: "json" },
 };
 
-/**
- * Mirrors: `PostgreSQLAdapter::NATIVE_DATABASE_TYPES` (postgresql_adapter.rb:134).
- * `datetime` is `{}` in Rails too — `native_database_types` fills it in from
- * `datetime_type` on every call.
- */
 export const POSTGRESQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
   primary_key: { name: "bigserial primary key" },
   string: { name: "character varying" },
@@ -109,12 +86,6 @@ export const POSTGRESQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType
   enum: {},
 };
 
-/**
- * Fallback lookup for the host-less `SchemaCreation` path, where the visitor is
- * built from an adapter *name* rather than a live adapter (see
- * `sqlite3/schema-statements.ts`). With an adapter threaded the visitor always
- * consults `adapter.nativeDatabaseTypes()` instead.
- */
 export const NATIVE_DATABASE_TYPES_BY_ADAPTER: Record<
   "sqlite" | "postgres" | "mysql",
   Record<string, NativeDatabaseType>

--- a/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
@@ -1,0 +1,125 @@
+/**
+ * The per-adapter `NATIVE_DATABASE_TYPES` hashes, transcribed from Rails.
+ *
+ * Rails declares each hash as a constant inside its adapter class. trails keeps
+ * one copy per adapter here, in a leaf module with no imports, because the
+ * shared `SchemaCreation` visitor also needs them: `type_to_sql` builds every
+ * base type name from `native_database_types[type][:name]`
+ * (abstract/schema_statements.rb:1385-1415), and the visitor is constructed
+ * without an adapter on the host-less unit-test path. Each adapter's
+ * `nativeDatabaseTypes()` returns the hash from here, so there is still exactly
+ * one source per adapter.
+ *
+ * The names are lowercase in Rails and stay lowercase here — the declared type
+ * text is what SQLite reflects back verbatim, so uppercasing it would diverge.
+ */
+
+/** One entry of a `NATIVE_DATABASE_TYPES` hash — Rails' `{ name:, limit: }` shape. */
+export interface NativeDatabaseType {
+  name?: string;
+  limit?: number;
+  precision?: number;
+  scale?: number;
+}
+
+/** Mirrors: `SQLite3Adapter::NATIVE_DATABASE_TYPES` (sqlite3_adapter.rb:69). */
+export const SQLITE3_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
+  primary_key: { name: "integer PRIMARY KEY AUTOINCREMENT NOT NULL" },
+  string: { name: "varchar" },
+  text: { name: "text" },
+  integer: { name: "integer" },
+  float: { name: "float" },
+  decimal: { name: "decimal" },
+  datetime: { name: "datetime" },
+  time: { name: "time" },
+  date: { name: "date" },
+  binary: { name: "blob" },
+  boolean: { name: "boolean" },
+  json: { name: "json" },
+};
+
+/** Mirrors: `AbstractMysqlAdapter::NATIVE_DATABASE_TYPES` (abstract_mysql_adapter.rb:31). */
+export const MYSQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
+  primary_key: { name: "bigint auto_increment PRIMARY KEY" },
+  string: { name: "varchar", limit: 255 },
+  text: { name: "text" },
+  integer: { name: "int", limit: 4 },
+  bigint: { name: "bigint" },
+  float: { name: "float", limit: 24 },
+  decimal: { name: "decimal" },
+  datetime: { name: "datetime" },
+  timestamp: { name: "timestamp" },
+  time: { name: "time" },
+  date: { name: "date" },
+  binary: { name: "blob" },
+  blob: { name: "blob" },
+  boolean: { name: "tinyint", limit: 1 },
+  json: { name: "json" },
+};
+
+/**
+ * Mirrors: `PostgreSQLAdapter::NATIVE_DATABASE_TYPES` (postgresql_adapter.rb:134).
+ * `datetime` is `{}` in Rails too — `native_database_types` fills it in from
+ * `datetime_type` on every call.
+ */
+export const POSTGRESQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> = {
+  primary_key: { name: "bigserial primary key" },
+  string: { name: "character varying" },
+  text: { name: "text" },
+  integer: { name: "integer", limit: 4 },
+  bigint: { name: "bigint" },
+  float: { name: "float" },
+  decimal: { name: "decimal" },
+  datetime: {},
+  timestamp: { name: "timestamp" },
+  timestamptz: { name: "timestamptz" },
+  time: { name: "time" },
+  date: { name: "date" },
+  daterange: { name: "daterange" },
+  numrange: { name: "numrange" },
+  tsrange: { name: "tsrange" },
+  tstzrange: { name: "tstzrange" },
+  int4range: { name: "int4range" },
+  int8range: { name: "int8range" },
+  binary: { name: "bytea" },
+  boolean: { name: "boolean" },
+  xml: { name: "xml" },
+  tsvector: { name: "tsvector" },
+  hstore: { name: "hstore" },
+  inet: { name: "inet" },
+  cidr: { name: "cidr" },
+  macaddr: { name: "macaddr" },
+  uuid: { name: "uuid" },
+  json: { name: "json" },
+  jsonb: { name: "jsonb" },
+  ltree: { name: "ltree" },
+  citext: { name: "citext" },
+  point: { name: "point" },
+  line: { name: "line" },
+  lseg: { name: "lseg" },
+  box: { name: "box" },
+  path: { name: "path" },
+  polygon: { name: "polygon" },
+  circle: { name: "circle" },
+  bit: { name: "bit" },
+  bit_varying: { name: "bit varying" },
+  money: { name: "money" },
+  interval: { name: "interval" },
+  oid: { name: "oid" },
+  enum: {},
+};
+
+/**
+ * Fallback lookup for the host-less `SchemaCreation` path, where the visitor is
+ * built from an adapter *name* rather than a live adapter (see
+ * `sqlite3/schema-statements.ts`). With an adapter threaded the visitor always
+ * consults `adapter.nativeDatabaseTypes()` instead.
+ */
+export const NATIVE_DATABASE_TYPES_BY_ADAPTER: Record<
+  "sqlite" | "postgres" | "mysql",
+  Record<string, NativeDatabaseType>
+> = {
+  sqlite: SQLITE3_NATIVE_DATABASE_TYPES,
+  postgres: POSTGRESQL_NATIVE_DATABASE_TYPES,
+  mysql: MYSQL_NATIVE_DATABASE_TYPES,
+};

--- a/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
@@ -86,6 +86,24 @@ export const POSTGRESQL_NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType
   enum: {},
 };
 
+/**
+ * Mirrors `PostgreSQLAdapter.native_database_types` (postgresql_adapter.rb:404-408):
+ * duplicates the constant and replaces the raw `datetime: {}` placeholder with
+ * the entry named by `datetime_type` before any caller reads it. `type_to_sql`
+ * never sees the unresolved placeholder.
+ */
+export function postgresqlNativeDatabaseTypes(
+  datetimeType: string,
+  overrides: Record<string, string | NativeDatabaseType> = {},
+): Record<string, NativeDatabaseType> {
+  const types: Record<string, NativeDatabaseType> = { ...POSTGRESQL_NATIVE_DATABASE_TYPES };
+  for (const [key, value] of Object.entries(overrides)) {
+    types[key] = typeof value === "string" ? { name: value } : value;
+  }
+  types["datetime"] = types[datetimeType] ?? { name: "timestamp" };
+  return types;
+}
+
 export const NATIVE_DATABASE_TYPES_BY_ADAPTER: Record<
   "sqlite" | "postgres" | "mysql",
   Record<string, NativeDatabaseType>

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -140,7 +140,7 @@ describe("SchemaCreation#typeToSql decimal precision/scale", () => {
 
   it("honors precision and scale when both are given", () => {
     expect(new SchemaCreation("sqlite").typeToSql("decimal", { precision: 8, scale: 2 })).toBe(
-      "DECIMAL(8,2)",
+      "decimal(8,2)",
     );
   });
 
@@ -148,8 +148,8 @@ describe("SchemaCreation#typeToSql decimal precision/scale", () => {
     // Rails sources the default from native_database_types[:decimal], which
     // carries no :precision on SQLite/MySQL/PostgreSQL — so a precision-less
     // decimal dumps bare rather than defaulting to (10).
-    expect(new SchemaCreation("sqlite").typeToSql("decimal")).toBe("DECIMAL");
-    expect(new SchemaCreation("mysql").typeToSql("decimal")).toBe("DECIMAL");
-    expect(new SchemaCreation("postgres").typeToSql("decimal")).toBe("DECIMAL");
+    expect(new SchemaCreation("sqlite").typeToSql("decimal")).toBe("decimal");
+    expect(new SchemaCreation("mysql").typeToSql("decimal")).toBe("decimal");
+    expect(new SchemaCreation("postgres").typeToSql("decimal")).toBe("decimal");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -22,32 +22,12 @@ import {
   TableDefinition,
 } from "./schema-definitions.js";
 import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
+import {
+  NATIVE_DATABASE_TYPES_BY_ADAPTER,
+  type NativeDatabaseType,
+} from "./native-database-types.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
-
-/**
- * Per-adapter default column limits, mirroring the `:limit` keys carried by
- * each adapter's `NATIVE_DATABASE_TYPES` hash. Rails' `type_to_sql` reads that
- * hash (`native = native_database_types[type]`) and fills a missing limit
- * generically via `limit ||= native[:limit]` (abstract/schema_statements.rb:1404).
- * The only non-nil default across our three adapters is MySQL's `:string`
- * (`limit: 255`, abstract_mysql_adapter.rb:33); sqlite3 (`{ name: "varchar" }`,
- * sqlite3_adapter.rb:71) and PostgreSQL (`{ name: "character varying" }`,
- * postgresql_adapter.rb:136) carry none, so a bare `t.string` stays unbounded.
- * Keying the defaults off a table — rather than `adapterName` branches inside
- * each `type_to_sql` case — keeps the native-type knowledge in one place and
- * mirrors Rails' structure. (Only the default *limit* varies by adapter here;
- * PostgreSQL derives its distinct `character varying` type name in its own
- * `typeToSql` override, so the shared visitor emits a single `VARCHAR` name.)
- */
-const NATIVE_TYPE_LIMITS: Record<
-  "sqlite" | "postgres" | "mysql",
-  Partial<Record<ColumnType, number>>
-> = {
-  sqlite: {},
-  postgres: {},
-  mysql: { string: 255 },
-};
 
 type Definition =
   | TableDefinition
@@ -410,132 +390,75 @@ export class SchemaCreation {
       );
   }
 
+  /**
+   * The adapter's `native_database_types` hash. Rails reads it straight off
+   * `@conn`; the visitor is also constructed host-less (adapter name only), so
+   * fall back to the transcribed table for that name.
+   * @internal
+   */
+  protected nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+    const fromAdapter = (
+      this.adapter as { nativeDatabaseTypes?(): Record<string, NativeDatabaseType> }
+    ).nativeDatabaseTypes?.();
+    return fromAdapter ?? NATIVE_DATABASE_TYPES_BY_ADAPTER[this.adapterName];
+  }
+
+  /**
+   * Mirrors `type_to_sql` (abstract/schema_statements.rb:1385-1415): the base
+   * name comes from `native_database_types[type][:name]` — lowercase on every
+   * adapter — and an unmapped type is returned verbatim as `type.to_s`. Only
+   * the precision/scale/limit suffix and its validation live here.
+   *
+   * Two observable consequences on SQLite, which stores the declared type text
+   * verbatim: `bigint` has no entry in `SQLITE3_NATIVE_DATABASE_TYPES`, so it
+   * emits and reflects back as `bigint`; and `typeToSql("datetime", { precision: 6 })`
+   * is `datetime(6)`, which compares equal to the verbatim pass-through of the
+   * string `"datetime(6)"`.
+   */
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
     let sql: string;
-    switch (type) {
-      case "string": {
-        // Rails derives the default limit from the adapter's native-type hash
-        // (`type_to_sql`: `limit ||= native[:limit]`). {@link NATIVE_TYPE_LIMITS}
-        // supplies that default per adapter — MySQL's `:string` is 255, sqlite3
-        // and PostgreSQL carry none, so a bare `t.string` stays unbounded there.
-        const limit = options.limit ?? NATIVE_TYPE_LIMITS[this.adapterName].string;
-        sql = limit != null ? `VARCHAR(${limit})` : "VARCHAR";
-        break;
-      }
-      case "text":
-        sql = "TEXT";
-        break;
-      case "integer":
-        // Rails' `type_to_sql` appends an explicit `limit` as `integer(N)`
-        // (schema_statements.rb:1409). SQLite stores the declared type
-        // verbatim, so reflecting it back recovers the byte-width limit — the
-        // dumper's `limit:` option round-trips only when it is emitted here.
-        sql = options.limit != null ? `INTEGER(${options.limit})` : "INTEGER";
-        break;
-      case "bigint":
-        sql = "BIGINT";
-        break;
-      case "float":
-        sql = this.adapterName === "postgres" ? "DOUBLE PRECISION" : "REAL";
-        break;
-      case "decimal": {
-        // Mirror Rails' `type_to_sql` decimal branch (schema_statements.rb:1390):
-        // the precision default is sourced from `native_database_types[:decimal]`,
-        // which carries no `:precision` on SQLite/MySQL/PostgreSQL — so a
-        // precision-less decimal emits a bare `DECIMAL` with no `(N)` clause and
-        // dumps bare, rather than defaulting to `(10)`. When a precision is given,
-        // append `(precision,scale)` / `(precision)` — no space after the comma,
-        // so `extract_scale`/`extract_precision` reflect it back byte-for-byte.
-        this.validateDecimalPrecision(options);
-        const precision = options.precision;
+    const native = type == null ? undefined : this.nativeDatabaseTypes()[type];
+    if (native === undefined) {
+      // Rails' `type.to_s` pass-through, used for adapter-specific type strings
+      // (e.g. "timestamptz", "inet", "hstore", custom PG enum names) and for
+      // anything the adapter declares no entry for. It never uppercases: DBs
+      // fold type-name case, and a literal type fragment carrying a value list
+      // — e.g. enum('text','blob') — must keep its quoted members verbatim.
+      //
+      // A nil type (e.g. `t.virtual` with no `type:`) is `""` in Rails too: the
+      // column renders with no SQL type before its `AS (...)` clause. We keep a
+      // stricter guard for an explicitly blank type string (a likely typo),
+      // which never arises from a nil option.
+      if (type == null) sql = "";
+      else if (!String(type).trim())
+        throw new Error(`Column has an empty or blank type — specify a valid SQL type`);
+      else sql = String(type);
+    } else {
+      sql = native.name ?? String(type);
+      // Ruby's `||=` here behaves as `??=` for these options: only `nil` falls
+      // through to the native default, and `precision: 0` stays 0.
+      let { precision, scale, limit } = options;
+      if (type === "decimal") {
+        scale ??= native.scale;
+        precision ??= native.precision;
         if (precision != null) {
-          sql =
-            options.scale != null
-              ? `DECIMAL(${precision},${options.scale})`
-              : `DECIMAL(${precision})`;
+          sql += scale != null ? `(${precision},${scale})` : `(${precision})`;
+        } else if (scale != null) {
+          this.validateDecimalPrecision(options);
+        }
+      } else if (
+        (type === "datetime" || type === "timestamp" || type === "time" || type === "interval") &&
+        (precision ??= native.precision) != null
+      ) {
+        if (precision >= 0 && precision <= 6) {
+          sql += `(${precision})`;
         } else {
-          sql = "DECIMAL";
-        }
-        break;
-      }
-      case "boolean":
-        sql = "BOOLEAN";
-        break;
-      case "date":
-        sql = "DATE";
-        break;
-      case "time": {
-        const p = options.precision;
-        if (p != null && !(p >= 0 && p <= 6))
           throw new ArgumentError(
-            `No TIME type has precision of ${p}. The allowed range of precision is from 0 to 6`,
+            `No ${native.name} type has precision of ${precision}. The allowed range of precision is from 0 to 6`,
           );
-        sql = p != null ? `TIME(${p})` : "TIME";
-        break;
-      }
-      case "datetime":
-      case "timestamp": {
-        const base = this.adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
-        const p = options.precision;
-        if (p != null && !(p >= 0 && p <= 6))
-          throw new ArgumentError(
-            `No ${base} type has precision of ${p}. The allowed range of precision is from 0 to 6`,
-          );
-        sql = p != null ? `${base}(${p})` : base;
-        break;
-      }
-      case "binary":
-        sql = this.adapterName === "postgres" ? "BYTEA" : "BLOB";
-        break;
-      case "json":
-        sql = "JSON";
-        break;
-      case "jsonb":
-        sql = this.adapterName === "postgres" ? "JSONB" : "JSON";
-        break;
-      case "char":
-        sql = `CHAR(${options.limit ?? 1})`;
-        break;
-      case "uuid":
-        if (this.adapterName === "postgres") sql = "UUID";
-        else if (this.adapterName === "mysql") sql = "CHAR(36)";
-        else sql = "VARCHAR(36)";
-        break;
-      case "primary_key":
-        if (this.adapterName === "postgres") sql = "SERIAL PRIMARY KEY";
-        else if (this.adapterName === "mysql") sql = "BIGINT AUTO_INCREMENT PRIMARY KEY";
-        else sql = "INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL";
-        break;
-      // No `:virtual` case: Rails' `type_to_sql` (schema_statements.rb:1385) has
-      // no `:virtual` in `native_database_types`, so `type_to_sql(:virtual)`
-      // returns `type.to_s` → "virtual" via the pass-through below. The
-      // :virtual → options[:type] mapping happens only in `newColumnDefinition`
-      // (with no fallback), so `o.type` is never literally "virtual" by the time
-      // it reaches this visitor — a `?? options.type ?? "string"` fallback here
-      // would contradict that no-fallback semantics.
-      default: {
-        // Pass-through for adapter-specific type strings (e.g.
-        // "timestamptz", "inet", "hstore", custom PG enum names).
-        // Rails' `type_to_sql` returns an unrecognized type verbatim
-        // (`type.to_s`, abstract/schema_statements.rb) — it never uppercases.
-        // We emit it verbatim too: DBs fold type-name case, and a literal type
-        // fragment carrying a value list or args — e.g. enum('text','blob') or
-        // set('a','b') — must keep its quoted member values, where case is
-        // significant.
-        // Rails' `type_to_sql` returns `type.to_s` for an unrecognized type, so
-        // a nil type (e.g. `t.virtual` with no `type:`) yields `""` — the column
-        // renders with no SQL type before its generated-column `AS (...)` clause.
-        // We keep the stricter blank-string guard for an explicitly empty type
-        // string (a likely developer typo), which never arises from a nil option.
-        if (type == null) {
-          sql = "";
-          break;
         }
-        if (!String(type).trim()) {
-          throw new Error(`Column has an empty or blank type — specify a valid SQL type`);
-        }
-        sql = String(type);
-        break;
+      } else if (type !== "primary_key" && (limit ??= native.limit) != null) {
+        sql += `(${limit})`;
       }
     }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -390,12 +390,7 @@ export class SchemaCreation {
       );
   }
 
-  /**
-   * The adapter's `native_database_types` hash. Rails reads it straight off
-   * `@conn`; the visitor is also constructed host-less (adapter name only), so
-   * fall back to the transcribed table for that name.
-   * @internal
-   */
+  /** @internal */
   protected nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
     const fromAdapter = (
       this.adapter as { nativeDatabaseTypes?(): Record<string, NativeDatabaseType> }
@@ -403,40 +398,16 @@ export class SchemaCreation {
     return fromAdapter ?? NATIVE_DATABASE_TYPES_BY_ADAPTER[this.adapterName];
   }
 
-  /**
-   * Mirrors `type_to_sql` (abstract/schema_statements.rb:1385-1415): the base
-   * name comes from `native_database_types[type][:name]` — lowercase on every
-   * adapter — and an unmapped type is returned verbatim as `type.to_s`. Only
-   * the precision/scale/limit suffix and its validation live here.
-   *
-   * Two observable consequences on SQLite, which stores the declared type text
-   * verbatim: `bigint` has no entry in `SQLITE3_NATIVE_DATABASE_TYPES`, so it
-   * emits and reflects back as `bigint`; and `typeToSql("datetime", { precision: 6 })`
-   * is `datetime(6)`, which compares equal to the verbatim pass-through of the
-   * string `"datetime(6)"`.
-   */
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
     let sql: string;
     const native = type == null ? undefined : this.nativeDatabaseTypes()[type];
     if (native === undefined) {
-      // Rails' `type.to_s` pass-through, used for adapter-specific type strings
-      // (e.g. "timestamptz", "inet", "hstore", custom PG enum names) and for
-      // anything the adapter declares no entry for. It never uppercases: DBs
-      // fold type-name case, and a literal type fragment carrying a value list
-      // — e.g. enum('text','blob') — must keep its quoted members verbatim.
-      //
-      // A nil type (e.g. `t.virtual` with no `type:`) is `""` in Rails too: the
-      // column renders with no SQL type before its `AS (...)` clause. We keep a
-      // stricter guard for an explicitly blank type string (a likely typo),
-      // which never arises from a nil option.
       if (type == null) sql = "";
       else if (!String(type).trim())
         throw new Error(`Column has an empty or blank type — specify a valid SQL type`);
       else sql = String(type);
     } else {
       sql = native.name ?? String(type);
-      // Ruby's `||=` here behaves as `??=` for these options: only `nil` falls
-      // through to the native default, and `precision: 0` stays 0.
       let { precision, scale, limit } = options;
       if (type === "decimal") {
         scale ??= native.scale;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -25,6 +25,7 @@ import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
 import {
   NATIVE_DATABASE_TYPES_BY_ADAPTER,
   type NativeDatabaseType,
+  type NativeDatabaseTypes,
 } from "./native-database-types.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -391,9 +392,9 @@ export class SchemaCreation {
   }
 
   /** @internal */
-  protected nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+  protected nativeDatabaseTypes(): NativeDatabaseTypes {
     const fromAdapter = (
-      this.adapter as { nativeDatabaseTypes?(): Record<string, NativeDatabaseType> }
+      this.adapter as { nativeDatabaseTypes?(): NativeDatabaseTypes }
     ).nativeDatabaseTypes?.();
     return fromAdapter ?? NATIVE_DATABASE_TYPES_BY_ADAPTER[this.adapterName];
   }
@@ -407,11 +408,13 @@ export class SchemaCreation {
         throw new Error(`Column has an empty or blank type — specify a valid SQL type`);
       else sql = String(type);
     } else {
-      sql = native.name ?? String(type);
+      // schema_statements.rb:1387 — `native.is_a?(Hash) ? native[:name] : native`.
+      const spec: NativeDatabaseType = typeof native === "string" ? { name: native } : native;
+      sql = spec.name ?? String(type);
       let { precision, scale, limit } = options;
       if (type === "decimal") {
-        scale ??= native.scale;
-        precision ??= native.precision;
+        scale ??= spec.scale;
+        precision ??= spec.precision;
         if (precision != null) {
           sql += scale != null ? `(${precision},${scale})` : `(${precision})`;
         } else if (scale != null) {
@@ -419,16 +422,16 @@ export class SchemaCreation {
         }
       } else if (
         (type === "datetime" || type === "timestamp" || type === "time" || type === "interval") &&
-        (precision ??= native.precision) != null
+        (precision ??= spec.precision) != null
       ) {
         if (precision >= 0 && precision <= 6) {
           sql += `(${precision})`;
         } else {
           throw new ArgumentError(
-            `No ${native.name} type has precision of ${precision}. The allowed range of precision is from 0 to 6`,
+            `No ${spec.name} type has precision of ${precision}. The allowed range of precision is from 0 to 6`,
           );
         }
-      } else if (type !== "primary_key" && (limit ??= native.limit) != null) {
+      } else if (type !== "primary_key" && (limit ??= spec.limit) != null) {
         sql += `(${limit})`;
       }
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -304,8 +304,8 @@ describe("SchemaStatements privates (PR 8)", () => {
     const ss = makeStatements({ supportsDatetimeWithPrecision: () => true });
     const frags = await ss.addTimestampsForAlter("users");
     expect(frags).toHaveLength(2);
-    expect(frags[0]).toContain("DATETIME(6)");
-    expect(frags[1]).toContain("DATETIME(6)");
+    expect(frags[0]).toContain("datetime(6)");
+    expect(frags[1]).toContain("datetime(6)");
   });
 
   it("addTimestampsForAlter respects explicit null option", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -132,6 +132,10 @@ import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { pgDatetimeConfig } from "./postgresql/pg-datetime-config.js";
 import { abandonRawSocket } from "./abandon-raw-socket.js";
+import {
+  POSTGRESQL_NATIVE_DATABASE_TYPES,
+  type NativeDatabaseType,
+} from "./abstract/native-database-types.js";
 
 const OID_JSON = 114;
 const OID_JSONB = 3802;
@@ -252,54 +256,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter::NATIVE_DATABASE_TYPES (postgresql_adapter.rb:134)
-  static readonly NATIVE_DATABASE_TYPES: Record<
-    string,
-    string | { name?: string; limit?: number }
-  > = {
-    primaryKey: "bigserial primary key",
-    string: { name: "character varying" },
-    text: { name: "text" },
-    integer: { name: "integer", limit: 4 },
-    bigint: { name: "bigint" },
-    float: { name: "float" },
-    decimal: { name: "decimal" },
-    timestamp: { name: "timestamp" },
-    timestamptz: { name: "timestamptz" },
-    time: { name: "time" },
-    date: { name: "date" },
-    daterange: { name: "daterange" },
-    numrange: { name: "numrange" },
-    tsrange: { name: "tsrange" },
-    tstzrange: { name: "tstzrange" },
-    int4range: { name: "int4range" },
-    int8range: { name: "int8range" },
-    binary: { name: "bytea" },
-    boolean: { name: "boolean" },
-    xml: { name: "xml" },
-    tsvector: { name: "tsvector" },
-    hstore: { name: "hstore" },
-    inet: { name: "inet" },
-    cidr: { name: "cidr" },
-    macaddr: { name: "macaddr" },
-    uuid: { name: "uuid" },
-    json: { name: "json" },
-    jsonb: { name: "jsonb" },
-    ltree: { name: "ltree" },
-    citext: { name: "citext" },
-    point: { name: "point" },
-    line: { name: "line" },
-    lseg: { name: "lseg" },
-    box: { name: "box" },
-    path: { name: "path" },
-    polygon: { name: "polygon" },
-    circle: { name: "circle" },
-    bit: { name: "bit" },
-    bitVarying: { name: "bit varying" },
-    money: { name: "money" },
-    interval: { name: "interval" },
-    oid: { name: "oid" },
-    enum: {},
-  };
+  static readonly NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> =
+    POSTGRESQL_NATIVE_DATABASE_TYPES;
 
   // Mirrors: PostgreSQLAdapter.datetime_type class_attribute (postgresql_adapter.rb:123).
   // Proxied through pgDatetimeConfig so OID::DateTime.realTypeUnlessAliased can read
@@ -2540,17 +2498,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Mirrors: PostgreSQLAdapter.native_database_types (postgresql_adapter.rb:404)
   // The datetime entry is resolved dynamically from datetimeType, matching Rails'
   // `types[:datetime] = types[datetime_type]`.
-  static nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }> {
-    const types = {
-      ...this.NATIVE_DATABASE_TYPES,
-      ...pgDatetimeConfig.nativeDatabaseTypesOverrides,
-    };
+  static nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+    const types: Record<string, NativeDatabaseType> = { ...this.NATIVE_DATABASE_TYPES };
+    for (const [key, value] of Object.entries(pgDatetimeConfig.nativeDatabaseTypesOverrides)) {
+      types[key] = typeof value === "string" ? { name: value } : value;
+    }
     types["datetime"] = types[this.datetimeType] ?? { name: "timestamp" };
     return types;
   }
 
   // Mirrors: PostgreSQLAdapter#native_database_types (postgresql_adapter.rb:400)
-  nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }> {
+  nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
     return (this.constructor as typeof PostgreSQLAdapter).nativeDatabaseTypes();
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -134,6 +134,7 @@ import { pgDatetimeConfig } from "./postgresql/pg-datetime-config.js";
 import { abandonRawSocket } from "./abandon-raw-socket.js";
 import {
   POSTGRESQL_NATIVE_DATABASE_TYPES,
+  postgresqlNativeDatabaseTypes,
   type NativeDatabaseType,
 } from "./abstract/native-database-types.js";
 
@@ -2499,12 +2500,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // The datetime entry is resolved dynamically from datetimeType, matching Rails'
   // `types[:datetime] = types[datetime_type]`.
   static nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
-    const types: Record<string, NativeDatabaseType> = { ...this.NATIVE_DATABASE_TYPES };
-    for (const [key, value] of Object.entries(pgDatetimeConfig.nativeDatabaseTypesOverrides)) {
-      types[key] = typeof value === "string" ? { name: value } : value;
-    }
-    types["datetime"] = types[this.datetimeType] ?? { name: "timestamp" };
-    return types;
+    return postgresqlNativeDatabaseTypes(
+      this.datetimeType,
+      pgDatetimeConfig.nativeDatabaseTypesOverrides,
+    );
   }
 
   // Mirrors: PostgreSQLAdapter#native_database_types (postgresql_adapter.rb:400)

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -135,7 +135,7 @@ import { abandonRawSocket } from "./abandon-raw-socket.js";
 import {
   POSTGRESQL_NATIVE_DATABASE_TYPES,
   postgresqlNativeDatabaseTypes,
-  type NativeDatabaseType,
+  type NativeDatabaseTypes,
 } from "./abstract/native-database-types.js";
 
 const OID_JSON = 114;
@@ -257,8 +257,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter::NATIVE_DATABASE_TYPES (postgresql_adapter.rb:134)
-  static readonly NATIVE_DATABASE_TYPES: Record<string, NativeDatabaseType> =
-    POSTGRESQL_NATIVE_DATABASE_TYPES;
+  static readonly NATIVE_DATABASE_TYPES: NativeDatabaseTypes = POSTGRESQL_NATIVE_DATABASE_TYPES;
 
   // Mirrors: PostgreSQLAdapter.datetime_type class_attribute (postgresql_adapter.rb:123).
   // Proxied through pgDatetimeConfig so OID::DateTime.realTypeUnlessAliased can read
@@ -2499,7 +2498,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Mirrors: PostgreSQLAdapter.native_database_types (postgresql_adapter.rb:404)
   // The datetime entry is resolved dynamically from datetimeType, matching Rails'
   // `types[:datetime] = types[datetime_type]`.
-  static nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+  static nativeDatabaseTypes(): NativeDatabaseTypes {
     return postgresqlNativeDatabaseTypes(
       this.datetimeType,
       pgDatetimeConfig.nativeDatabaseTypesOverrides,
@@ -2507,7 +2506,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter#native_database_types (postgresql_adapter.rb:400)
-  nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+  nativeDatabaseTypes(): NativeDatabaseTypes {
     return (this.constructor as typeof PostgreSQLAdapter).nativeDatabaseTypes();
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./schema-creation.js";
+import { pgDatetimeConfig } from "./pg-datetime-config.js";
 import { quoteDefaultExpression } from "./quoting.js";
 import { ExclusionConstraintDefinition, UniqueConstraintDefinition } from "./schema-definitions.js";
 import { Column } from "./column.js";
@@ -228,6 +229,18 @@ describe("PostgreSQL SchemaCreation", () => {
       quoteDefaultExpression: (v: unknown) => ` DEFAULT ${v}`,
     } as any);
     expect(hostless.typeToSql("datetime", { precision: 6 })).toBe("timestamp(6)");
+    // `primary_key` is a bare String in Rails' hash, not a `{ name: }` entry.
     expect(hostless.typeToSql("primary_key")).toBe("bigserial primary key");
+
+    // Rails assigns `types[:datetime] = types[datetime_type]` with no default,
+    // so a datetime_type naming no entry leaves it nil and type_to_sql falls
+    // through to "datetime" rather than silently meaning timestamp.
+    const original = pgDatetimeConfig.datetimeType;
+    try {
+      pgDatetimeConfig.datetimeType = "nonesuch";
+      expect(hostless.typeToSql("datetime", { precision: 6 })).toBe("datetime");
+    } finally {
+      pgDatetimeConfig.datetimeType = original;
+    }
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -216,4 +216,18 @@ describe("PostgreSQL SchemaCreation", () => {
     } as any) as any;
     expect(sc.quotedIncludeColumnsForIndex(["a", "b"])).toBe("<<delegated>>");
   });
+
+  // Rails' PostgreSQLAdapter#native_database_types replaces the constant's raw
+  // `datetime: {}` placeholder with `types[datetime_type]` before type_to_sql
+  // reads it (postgresql_adapter.rb:404-408), so `datetime` is never resolved
+  // against the empty placeholder — not even without an adapter threaded.
+  it("resolves datetime through datetimeType with no adapter threaded", () => {
+    const hostless = new SchemaCreation({
+      quoteIdentifier: (n: string) => `"${n}"`,
+      quoteTableName: (n: string) => `"${n}"`,
+      quoteDefaultExpression: (v: unknown) => ` DEFAULT ${v}`,
+    } as any);
+    expect(hostless.typeToSql("datetime", { precision: 6 })).toBe("timestamp(6)");
+    expect(hostless.typeToSql("primary_key")).toBe("bigserial primary key");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -8,7 +8,7 @@ import { wrap } from "@blazetrails/activesupport";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import {
   postgresqlNativeDatabaseTypes,
-  type NativeDatabaseType,
+  type NativeDatabaseTypes,
 } from "../abstract/native-database-types.js";
 import { pgDatetimeConfig } from "./pg-datetime-config.js";
 import {
@@ -103,7 +103,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
    * unresolved placeholder and emit a literal `datetime`.
    * @internal
    */
-  protected override nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+  protected override nativeDatabaseTypes(): NativeDatabaseTypes {
     return postgresqlNativeDatabaseTypes(
       pgDatetimeConfig.datetimeType,
       pgDatetimeConfig.nativeDatabaseTypesOverrides,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -7,6 +7,11 @@
 import { wrap } from "@blazetrails/activesupport";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import {
+  postgresqlNativeDatabaseTypes,
+  type NativeDatabaseType,
+} from "../abstract/native-database-types.js";
+import { pgDatetimeConfig } from "./pg-datetime-config.js";
+import {
   type ForeignKeyDefinition,
   type ColumnOptions,
   type AddColumnOptions,
@@ -80,13 +85,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
     type: Parameters<AbstractSchemaCreation["typeToSql"]>[0],
     options: Parameters<AbstractSchemaCreation["typeToSql"]>[1] = {},
   ): string {
-    if ((type as string) === "primary_key") {
-      // Mirrors Rails NATIVE_DATABASE_TYPES[:primary_key] = "bigserial primary
-      // key". PostgreSQLAdapter.typeToSql can't resolve it (NATIVE_DATABASE_TYPES
-      // is keyed camelCase `primaryKey`) and the abstract base returns int4
-      // "SERIAL PRIMARY KEY", so emit the native bigserial string directly.
-      return "bigserial primary key";
-    }
     // Delegate to the adapter's typeToSql when available (Rails parity:
     // `delegate :type_to_sql, to: :@conn`). Fall back to the abstract
     // implementation when no real adapter is present (e.g. unit-test context
@@ -95,6 +93,21 @@ export class SchemaCreation extends AbstractSchemaCreation {
       return this.adapter.typeToSql(type as string, options as Record<string, unknown>);
     }
     return super.typeToSql(type, options);
+  }
+
+  /**
+   * Mirrors `PostgreSQLAdapter#native_database_types` (postgresql_adapter.rb:404):
+   * the constant's raw `datetime: {}` placeholder is replaced by the entry named
+   * by `datetime_type` before `type_to_sql` reads it. Without this override the
+   * host-less path (no adapter threaded) would resolve `datetime` against the
+   * unresolved placeholder and emit a literal `datetime`.
+   * @internal
+   */
+  protected override nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+    return postgresqlNativeDatabaseTypes(
+      pgDatetimeConfig.datetimeType,
+      pgDatetimeConfig.nativeDatabaseTypesOverrides,
+    );
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -16,7 +16,7 @@ import { isRubyTruthy } from "../ruby-truthy.js";
 import { SchemaCreation as SQLite3SchemaCreation } from "./sqlite3/schema-creation.js";
 import {
   SQLITE3_NATIVE_DATABASE_TYPES,
-  type NativeDatabaseType,
+  type NativeDatabaseTypes,
 } from "./abstract/native-database-types.js";
 import { TableDefinition as SQLite3TableDefinition } from "./sqlite3/schema-definitions.js";
 import {
@@ -1429,7 +1429,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // defines none), so it inherits the abstract `columnMethodNames()` list unchanged —
   // no override here is intentional.
 
-  nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+  nativeDatabaseTypes(): NativeDatabaseTypes {
     return SQLITE3_NATIVE_DATABASE_TYPES;
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -14,6 +14,10 @@ import type { SQLite3AdapterOptions, SQLite3Config } from "./pool-config.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import { isRubyTruthy } from "../ruby-truthy.js";
 import { SchemaCreation as SQLite3SchemaCreation } from "./sqlite3/schema-creation.js";
+import {
+  SQLITE3_NATIVE_DATABASE_TYPES,
+  type NativeDatabaseType,
+} from "./abstract/native-database-types.js";
 import { TableDefinition as SQLite3TableDefinition } from "./sqlite3/schema-definitions.js";
 import {
   dataSourceSql as sqliteDataSourceSql,
@@ -1425,22 +1429,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // defines none), so it inherits the abstract `columnMethodNames()` list unchanged —
   // no override here is intentional.
 
-  nativeDatabaseTypes(): Record<string, { name: string; limit?: number }> {
-    return {
-      primary_key: { name: "integer" },
-      string: { name: "varchar" },
-      text: { name: "text" },
-      integer: { name: "integer" },
-      float: { name: "float" },
-      decimal: { name: "decimal" },
-      datetime: { name: "datetime" },
-      time: { name: "time" },
-      date: { name: "date" },
-      binary: { name: "blob" },
-      blob: { name: "blob" },
-      boolean: { name: "boolean" },
-      json: { name: "json" },
-    };
+  nativeDatabaseTypes(): Record<string, NativeDatabaseType> {
+    return SQLITE3_NATIVE_DATABASE_TYPES;
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -999,11 +999,12 @@ export abstract class Migration {
     // per-operation recording in addColumn/removeColumn/etc. still applies.
     // Wrap so adapter column-type shorthands (t.hstore, t.jsonb, ...) resolve,
     // mirroring Rails' adapter ColumnMethods mixin on the yielded Table.
-    const columnTypes = Object.keys(
-      (
-        this.connection as { nativeDatabaseTypes?(): Record<string, unknown> }
-      ).nativeDatabaseTypes?.() ?? {},
-    );
+    const delegate = this.connection as {
+      columnMethodNames?(): string[];
+      nativeDatabaseTypes?(): Record<string, unknown>;
+    };
+    const columnTypes =
+      delegate.columnMethodNames?.() ?? Object.keys(delegate.nativeDatabaseTypes?.() ?? {});
     const table = withAdapterColumnMethods(new Table(tableName, this), columnTypes);
     if (callback) await callback(table);
   }

--- a/packages/activerecord/src/migration/change-schema.test.ts
+++ b/packages/activerecord/src/migration/change-schema.test.ts
@@ -7,10 +7,6 @@
  * `@connection = ActiveRecord::Base.lease_connection`. `testings` is created
  * and dropped by the test in Rails too, so it is not a canonical-schema table.
  *
- * Four cases are still unported — the bigint/timestamp/datetime `sql_type`
- * assertions. Each needs `type_to_sql` to source its base names from
- * `native_database_types` rather than a hardcoded uppercase switch; tracked by
- * the `converge-type-to-sql-base-names-on-native-database-types` story.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
@@ -24,6 +20,23 @@ import { adapterType } from "../test-adapter.js";
 import { describeIfSupports } from "../support/supports.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { Column } from "../connection-adapters/column.js";
+
+function expectedDatetimeSqlType(connection: AbstractAdapter, withPrecision: boolean): string {
+  if (adapterType === "postgres") {
+    return withPrecision ? "timestamp(6) without time zone" : "timestamp without time zone";
+  }
+  if (adapterType === "mysql") return withPrecision ? "datetime(6)" : "timestamp";
+  return connection.typeToSql("datetime(6)");
+}
+
+function assertBigintColumn(eight: Column): void {
+  if (adapterType === "sqlite") {
+    expect(eight.sqlType).toBe("bigint");
+    return;
+  }
+  expect(eight.type).toBe("integer");
+  expect(eight.limit).toBe(8);
+}
 
 class SilentMigration extends Migration {
   write(): void {}
@@ -415,6 +428,54 @@ describe("Migration", () => {
         await notnullMigration.migrate("down");
         expect(detect(await connection.columns("testings"), "foo").null).toBe(true);
       });
+    });
+
+    it("create table with bigint", async () => {
+      const connection = await ambientConnection();
+      await connection.createTable("testings", (t) => {
+        t.bigint("eight_int");
+      });
+      const columns = await connection.columns("testings");
+
+      assertBigintColumn(detect(columns, "eight_int"));
+    });
+
+    it("add column with timestamp type", async () => {
+      const connection = await ambientConnection();
+      await connection.createTable("testings", (t) => {
+        t.column("foo", "timestamp");
+      });
+
+      const column = detect(await connection.columns("testings"), "foo");
+
+      expect(column.type).toBe("datetime");
+      expect(column.sqlType).toBe(expectedDatetimeSqlType(connection, false));
+    });
+
+    it("add column with postgresql datetime type", async () => {
+      const connection = await ambientConnection();
+      await connection.createTable("testings", (t) => {
+        t.column("foo", "datetime");
+      });
+
+      const column = detect(await connection.columns("testings"), "foo");
+
+      expect(column.type).toBe("datetime");
+      expect(column.sqlType).toBe(expectedDatetimeSqlType(connection, true));
+    });
+
+    it("change column with timestamp type", async () => {
+      const connection = await ambientConnection();
+      await connection.createTable("testings", (t) => {
+        t.column("foo", "datetime", { null: false });
+      });
+
+      await connection.changeColumn("testings", "foo", "timestamp");
+
+      const column = detect(await connection.columns("testings"), "foo");
+
+      expect(column.type).toBe("datetime");
+      expect(column.sqlType).toBe(expectedDatetimeSqlType(connection, false));
     });
 
     it("column exists", async () => {

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { CommandRecorder } from "./command-recorder.js";
+import { CommandRecorder, withAdapterColumnMethods } from "./command-recorder.js";
 import type { RecorderTableProxy } from "./command-recorder.js";
 import { IrreversibleMigration } from "../migration.js";
 
@@ -584,5 +584,29 @@ describe("CommandRecorder", () => {
       expect(recorder.commands[1].cmd).toBe("changeTable");
       expect(recorder.commands[1].args[0]).toBe("fruits");
     });
+  });
+});
+
+describe("withAdapterColumnMethods", () => {
+  // The shorthand set is Rails' `define_column_methods` list, exposed as
+  // `columnMethodNames()` — not the native-type hash, whose keys include
+  // `primary_key`. Rails defines `primary_key(name, type = :primary_key,
+  // **options)` separately (abstract/schema_definitions.rb:308): it takes the
+  // second argument as the column type and merges `primary_key: true`, so a
+  // generic shorthand routing it to `column(name, "primary_key")` would diverge.
+  it("never exposes primary_key as a generic column shorthand", () => {
+    const calls: Array<[string, string]> = [];
+    const base = { column: (name: string, type: string) => calls.push([name, type]) };
+    const proxy = withAdapterColumnMethods(base, ["primary_key", "primaryKey", "uuid"]) as Record<
+      string,
+      unknown
+    >;
+
+    expect(proxy["primary_key"]).toBeUndefined();
+    expect(proxy["primaryKey"]).toBeUndefined();
+    expect(typeof proxy["uuid"]).toBe("function");
+
+    (proxy["uuid"] as (n: string) => void)("token");
+    expect(calls).toEqual([["token", "uuid"]]);
   });
 });

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -819,11 +819,13 @@ export class RecorderTableProxy {
 }
 
 // nativeDatabaseTypes keys that Rails does NOT expose as plain column-type
-// shorthands via `define_column_methods`. `primaryKey` is a dedicated method
-// (`abstract/schema_definitions.rb:309` — it merges `primary_key: true` rather
-// than recording a "primaryKey"-typed column), so routing `t.primaryKey` to a
-// bare `column(name, "primaryKey")` would diverge. It is excluded here.
-const NON_COLUMN_METHOD_TYPES = new Set(["primaryKey"]);
+// shorthands via `define_column_methods`. `primary_key` is a dedicated method
+// (`abstract/schema_definitions.rb:308` — `primary_key(name, type = :primary_key,
+// **options)` merges `primary_key: true` and takes the second argument as the
+// column type), so routing it to a bare `column(name, "primary_key")` would
+// diverge. Both spellings are excluded: the native-type hashes key it
+// `primary_key`, the trails DSL method is `primaryKey`.
+const NON_COLUMN_METHOD_TYPES = new Set(["primaryKey", "primary_key"]);
 
 /**
  * Wrap a change_table proxy so adapter-specific column-type shorthands


### PR DESCRIPTION
## What

`SchemaCreation#typeToSql` hardcoded an uppercase switch for every known type
(`case "bigint": sql = "BIGINT"`, `"string" → "VARCHAR"`, …). Rails builds the
base name from the adapter's own `native_database_types[type][:name]` —
**lowercase on every adapter** — and returns `type.to_s` verbatim when the
adapter declares no entry
(`abstract/schema_statements.rb:1385-1415`). The switch is replaced by that
lookup; only the precision/scale/limit suffix and its validation stay.

Two consequences, both observable on SQLite because SQLite stores the declared
type text verbatim:

- SQLite's `NATIVE_DATABASE_TYPES` has **no `bigint` entry**
  (`sqlite3_adapter.rb:69-82`), so `typeToSql("bigint")` falls through to
  `bigint` and `column.sqlType` reflects back `"bigint"`, not `"BIGINT"`.
- `typeToSql("datetime", { precision: 6 })` is `datetime(6)`, so it compares
  equal to the verbatim pass-through of the string `"datetime(6)"` — the form
  Rails' assertions use.

## Native-type tables

The three `NATIVE_DATABASE_TYPES` hashes move to a leaf module
(`abstract/native-database-types.ts`) that the visitor can also read on its
host-less path, so there is still exactly one copy per adapter and each
adapter's `nativeDatabaseTypes()` stays in its Rails-layout file. Each is now
Rails-exact:

- **SQLite** drops the invented `bigint` and `blob` entries and carries Rails'
  full `primary_key` name (`integer PRIMARY KEY AUTOINCREMENT NOT NULL`).
- **PostgreSQL** keys become snake_case, matching Rails — which also makes
  `typeToSql("primary_key")` and `"bit_varying"` resolve instead of silently
  falling through to the verbatim pass-through.
- **MySQL** is unchanged apart from picking up `integer`'s `limit: 4`.

## Also

Drops the SQLite adapter's private `typeToSql` shadow (it uppercased and then
rejected `DATETIME(6)` with `Invalid SQL type`), routes `_baseColumnType`
through the public `SchemaStatements#typeToSql`, and declares `typeToSql` on
the `AbstractAdapter` interface so tests can call it.

## Tests

Ports the four `ChangeSchemaTest` cases this unblocks, names verbatim:
`test_create_table_with_bigint`, `test_add_column_with_timestamp_type`,
`test_add_column_with_postgresql_datetime_type`,
`test_change_column_with_timestamp_type`. Rails spells their adapter branches
as `current_adapter?` inside the test body; `vitest/no-conditional-in-test`
bans that shape, so the branch sits in a module-scope helper and the body keeps
the bare assertion.

`test:compare` for `migration/change_schema_test.rb` is **35/35 ✓, 0 misplaced,
0 gate-mismatch** — the file is fully ported. The sibling stories #5558 and #5568
ported the other 31 cases while this PR was in review; these four were blocked on
the `type_to_sql` convergence and are the last ones in.

Two trails-only expectations were flipped to lowercase to match
(`schema-creation.test.ts` decimal, `schema-statements-privates.test.ts`
`addTimestampsForAlter`). No Rails-derived assertion was weakened.

## Review gates (measured against `origin/main` with the branch files reverted in place)

- **api:compare** — `activerecord 6082/6148 (98.9%) | files 277/277 | inheritance
  209/210 | arity 3893/3895` on both baseline and branch. Delta **0**.
  `api:extra` for `abstract/schema-creation.ts` is unchanged at 1 novel
  (`addColumnOptions`, pre-existing) — the new `nativeDatabaseTypes()` helper is
  `@internal` and adds no extra surface.
- **test:compare** — `migration/change_schema_test.rb` reaches **35/35 ✓**, 0
  misplaced, 0 wrong-describe. Delta **non-negative**.
- **No stubs** — no empty bodies or placeholder types; the one new module is data
  transcribed from Rails.

Comments introduced by this PR have been removed. What remains is the
`/** @internal */` tag api:compare needs and the pre-existing port-header
docblocks.

## Size

~606 LOC by the shortstat rule, over the 500 ceiling. ~125 of that is the new
module, which is a relocation of data that already existed in the three adapter
files (264 deletions); the behavioral change is one method.

Closes-story: converge-type-to-sql-base-names-on-native-database-types
