### PR TITLE
test(activerecord): port columns_test.rb's seven blocked cases

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -183,3 +183,29 @@ describe("ReferenceDefinition#foreign_table_name", () => {
     expect(td.foreignKeys[0].toTable).toBe("accounts");
   });
 });
+
+describe("TableDefinition column methods", () => {
+  it("defines one column per name, mirroring `names.each` in define_column_methods", () => {
+    const td = new TableDefinition("posts", { id: false });
+    td.string("goat", "sheep", { limit: 40 });
+
+    expect(td.columns.map((c) => c.name)).toEqual(["goat", "sheep"]);
+    expect(td.columns.map((c) => c.options.limit)).toEqual([40, 40]);
+  });
+
+  it("defines a single column when no options are passed", () => {
+    const td = new TableDefinition("posts", { id: false });
+    td.integer("votes");
+
+    expect(td.columns.map((c) => c.name)).toEqual(["votes"]);
+  });
+
+  it("raises when called with no column name", () => {
+    const td = new TableDefinition("posts", { id: false });
+
+    expect(() => (td.timestamp as () => unknown)()).toThrow("Missing column name(s) for timestamp");
+    expect(() => (td.string as (o: object) => unknown)({ limit: 40 })).toThrow(
+      "Missing column name(s) for string",
+    );
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -650,23 +650,40 @@ export class IndexDefinition {
  * Interface for column type methods shared between TableDefinition and Table.
  */
 export interface ColumnMethods {
-  string(name: string, options?: ColumnOptions): unknown;
-  text(name: string, options?: ColumnOptions): unknown;
-  integer(name: string, options?: ColumnOptions): unknown;
-  bigint(name: string, options?: ColumnOptions): unknown;
-  float(name: string, options?: ColumnOptions): unknown;
-  decimal(name: string, options?: ColumnOptions): unknown;
-  boolean(name: string, options?: ColumnOptions): unknown;
-  date(name: string, options?: ColumnOptions): unknown;
-  datetime(name: string, options?: ColumnOptions): unknown;
-  timestamp(name: string, options?: ColumnOptions): unknown;
-  binary(name: string, options?: ColumnOptions): unknown;
-  blob(name: string, options?: ColumnOptions): unknown;
-  numeric(name: string, options?: ColumnOptions): unknown;
-  json(name: string, options?: ColumnOptions): unknown;
+  string(...names: string[]): unknown;
+  string(...args: [...names: string[], options: ColumnOptions]): unknown;
+  text(...names: string[]): unknown;
+  text(...args: [...names: string[], options: ColumnOptions]): unknown;
+  integer(...names: string[]): unknown;
+  integer(...args: [...names: string[], options: ColumnOptions]): unknown;
+  bigint(...names: string[]): unknown;
+  bigint(...args: [...names: string[], options: ColumnOptions]): unknown;
+  float(...names: string[]): unknown;
+  float(...args: [...names: string[], options: ColumnOptions]): unknown;
+  decimal(...names: string[]): unknown;
+  decimal(...args: [...names: string[], options: ColumnOptions]): unknown;
+  boolean(...names: string[]): unknown;
+  boolean(...args: [...names: string[], options: ColumnOptions]): unknown;
+  date(...names: string[]): unknown;
+  date(...args: [...names: string[], options: ColumnOptions]): unknown;
+  datetime(...names: string[]): unknown;
+  datetime(...args: [...names: string[], options: ColumnOptions]): unknown;
+  timestamp(...names: string[]): unknown;
+  timestamp(...args: [...names: string[], options: ColumnOptions]): unknown;
+  binary(...names: string[]): unknown;
+  binary(...args: [...names: string[], options: ColumnOptions]): unknown;
+  blob(...names: string[]): unknown;
+  blob(...args: [...names: string[], options: ColumnOptions]): unknown;
+  numeric(...names: string[]): unknown;
+  numeric(...args: [...names: string[], options: ColumnOptions]): unknown;
+  json(...names: string[]): unknown;
+  json(...args: [...names: string[], options: ColumnOptions]): unknown;
+  virtual(...names: string[]): unknown;
   virtual(
-    name: string,
-    options?: ColumnOptions & { type?: ColumnType; as?: string; stored?: boolean },
+    ...args: [
+      ...names: string[],
+      options: ColumnOptions & { type?: ColumnType; as?: string; stored?: boolean },
+    ]
   ): unknown;
 }
 
@@ -1277,86 +1294,134 @@ export class TableDefinition {
       if (!(type in TableDefinition.prototype)) {
         (TableDefinition.prototype as any)[type] = function (
           this: TableDefinition,
-          name: string,
-          options: ColumnOptions = {},
+          ...args: unknown[]
         ) {
-          return this.column(name, type as ColumnType, options);
+          return this.definedColumn(type as ColumnType, args);
         };
       }
     }
   }
 
-  string(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "string", options);
+  /** @internal */
+  protected definedColumn(type: ColumnType, args: unknown[]): this {
+    const rest = [...args];
+    const last = rest[rest.length - 1];
+    const options = (typeof last === "object" && last !== null ? rest.pop() : {}) as ColumnOptions;
+    const names = rest as string[];
+    if (names.length === 0) {
+      throw new ArgumentError(`Missing column name(s) for ${type}`);
+    }
+    for (const name of names) {
+      this.column(name, type, options);
+    }
+    return this;
   }
 
-  text(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "text", options);
+  string(...names: string[]): this;
+  string(...args: [...names: string[], options: ColumnOptions]): this;
+  string(...args: unknown[]): this {
+    return this.definedColumn("string", args);
   }
 
-  integer(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "integer", options);
+  text(...names: string[]): this;
+  text(...args: [...names: string[], options: ColumnOptions]): this;
+  text(...args: unknown[]): this {
+    return this.definedColumn("text", args);
   }
 
-  bigint(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "bigint", options);
+  integer(...names: string[]): this;
+  integer(...args: [...names: string[], options: ColumnOptions]): this;
+  integer(...args: unknown[]): this {
+    return this.definedColumn("integer", args);
   }
 
-  float(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "float", options);
+  bigint(...names: string[]): this;
+  bigint(...args: [...names: string[], options: ColumnOptions]): this;
+  bigint(...args: unknown[]): this {
+    return this.definedColumn("bigint", args);
   }
 
-  decimal(name: string, options: ColumnOptions = {}): this {
+  float(...names: string[]): this;
+  float(...args: [...names: string[], options: ColumnOptions]): this;
+  float(...args: unknown[]): this {
+    return this.definedColumn("float", args);
+  }
+
+  decimal(...names: string[]): this;
+  decimal(...args: [...names: string[], options: ColumnOptions]): this;
+  decimal(...args: unknown[]): this {
     // Rails' TableDefinition#decimal performs no validation; a scale without a
     // precision is rejected later in type_to_sql (schema_statements.rb:1400),
     // so the same ArgumentError covers every column-creation path.
-    return this.column(name, "decimal", options);
+    return this.definedColumn("decimal", args);
   }
 
-  boolean(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "boolean", options);
+  boolean(...names: string[]): this;
+  boolean(...args: [...names: string[], options: ColumnOptions]): this;
+  boolean(...args: unknown[]): this {
+    return this.definedColumn("boolean", args);
   }
 
-  date(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "date", options);
+  date(...names: string[]): this;
+  date(...args: [...names: string[], options: ColumnOptions]): this;
+  date(...args: unknown[]): this {
+    return this.definedColumn("date", args);
   }
 
-  time(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "time", options);
+  time(...names: string[]): this;
+  time(...args: [...names: string[], options: ColumnOptions]): this;
+  time(...args: unknown[]): this {
+    return this.definedColumn("time", args);
   }
 
-  datetime(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "datetime", options);
+  datetime(...names: string[]): this;
+  datetime(...args: [...names: string[], options: ColumnOptions]): this;
+  datetime(...args: unknown[]): this {
+    return this.definedColumn("datetime", args);
   }
 
-  timestamp(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "timestamp", options);
+  timestamp(...names: string[]): this;
+  timestamp(...args: [...names: string[], options: ColumnOptions]): this;
+  timestamp(...args: unknown[]): this {
+    return this.definedColumn("timestamp", args);
   }
 
-  binary(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "binary", options);
+  binary(...names: string[]): this;
+  binary(...args: [...names: string[], options: ColumnOptions]): this;
+  binary(...args: unknown[]): this {
+    return this.definedColumn("binary", args);
   }
 
   // Mirrors Rails' `alias :blob :binary` / `alias :numeric :decimal` in
   // abstract/schema_definitions.rb — `t.blob`/`t.numeric` create binary/decimal
   // columns that introspect (and dump) back as `t.binary`/`t.decimal`.
-  blob(name: string, options: ColumnOptions = {}): this {
-    return this.binary(name, options);
+  blob(...names: string[]): this;
+  blob(...args: [...names: string[], options: ColumnOptions]): this;
+  blob(...args: unknown[]): this {
+    return this.definedColumn("binary", args);
   }
 
-  numeric(name: string, options: ColumnOptions = {}): this {
-    return this.decimal(name, options);
+  numeric(...names: string[]): this;
+  numeric(...args: [...names: string[], options: ColumnOptions]): this;
+  numeric(...args: unknown[]): this {
+    return this.definedColumn("decimal", args);
   }
 
-  json(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "json", options);
+  json(...names: string[]): this;
+  json(...args: [...names: string[], options: ColumnOptions]): this;
+  json(...args: unknown[]): this {
+    return this.definedColumn("json", args);
   }
 
+  virtual(...names: string[]): this;
   virtual(
-    name: string,
-    options: ColumnOptions & { type?: ColumnType; as?: string; stored?: boolean } = {},
-  ): this {
-    return this.column(name, "virtual" as ColumnType, options);
+    ...args: [
+      ...names: string[],
+      options: ColumnOptions & { type?: ColumnType; as?: string; stored?: boolean },
+    ]
+  ): this;
+  virtual(...args: unknown[]): this {
+    return this.definedColumn("virtual" as ColumnType, args);
   }
 
   jsonb(name: string, options: ColumnOptions = {}): this {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -43,6 +43,7 @@ import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
 import { singularize, pluralize, getCrypto, isPresent } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
+import { rubyInspect } from "../../relation/ruby-inspect.js";
 import { Utils as PgUtils } from "../postgresql/utils.js";
 import { indexes as sqliteIndexes } from "../sqlite3/schema-statements.js";
 import {
@@ -431,6 +432,9 @@ export class SchemaStatements {
     _type?: string,
     options: { ifExists?: boolean } = {},
   ): Promise<void> {
+    if (columnName === undefined) {
+      throw new ArgumentError("wrong number of arguments (given 1, expected 2..3)");
+    }
     if (options.ifExists && !(await this.columnExists(tableName, columnName))) {
       return;
     }
@@ -700,6 +704,7 @@ export class SchemaStatements {
     allowNull: boolean,
     defaultValue?: unknown,
   ): Promise<void> {
+    this.validateChangeColumnNullArgumentBang(allowNull);
     if (!allowNull && defaultValue !== undefined) {
       const quoted = await this.adapter.quoteDefaultExpression(defaultValue);
       await this.adapter.execute(
@@ -959,30 +964,19 @@ export class SchemaStatements {
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
-    // Rails (abstract/schema_statements.rb:1459) issues a single combined ALTER TABLE for every
-    // adapter and relies on SQLite's adapter-level override to swap in the alter_table rebuild
-    // path. trails uses a wrapper SchemaAdapter that cannot dispatch back to inner-adapter
-    // overrides, so we branch on supportsBulkAlter() here: bulk-alter adapters (MySQL, PG) get
-    // the combined ALTER TABLE; non-bulk adapters fall back to two sequential addColumn calls.
-    // trails' SQLite3Adapter still defines its own addTimestamps override for direct callers.
-    if ((this.adapter as any).supportsBulkAlter?.() === true) {
-      const fragments = await this.addTimestampsForAlter(tableName, options);
-      await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
-      return;
+    const adapter = this.adapter as any;
+    if (
+      adapter !== (this as unknown) &&
+      typeof adapter.addTimestamps === "function" &&
+      adapter.addTimestamps !== SchemaStatements.prototype.addTimestamps
+    ) {
+      return adapter.addTimestamps(tableName, options);
     }
-
-    const opts: ColumnOptions = { ...options, null: options.null ?? false };
-    if (!("precision" in opts) && (this.adapter as any).supportsDatetimeWithPrecision?.()) {
-      opts.precision = 6;
-    }
-    await this.addColumn(tableName, "created_at", "datetime", opts);
-    await this.addColumn(tableName, "updated_at", "datetime", opts);
+    const fragments = await this.addTimestampsForAlter(tableName, options);
+    await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
   }
 
   async removeTimestamps(tableName: string): Promise<void> {
-    // Mirrors Rails (abstract/schema_statements.rb:1468): route through removeColumns so
-    // adapter overrides apply. The default removeColumns loops sequentially (matching Rails);
-    // SQLite overrides to use a single alter_table rebuild.
     await this.removeColumns(tableName, "updated_at", "created_at");
   }
 
@@ -1116,9 +1110,22 @@ export class SchemaStatements {
       ifExists?: boolean;
     };
     const columns = columnsOrOptions as string[];
-    for (const col of columns) {
-      await this.removeColumn(tableName, col, opts.type, { ifExists: opts.ifExists });
+    if (columns.length === 0) {
+      throw new ArgumentError(
+        "You must specify at least one column name. Example: remove_columns(:people, :first_name)",
+      );
     }
+    const adapter = this.adapter as any;
+    if (
+      adapter !== (this as unknown) &&
+      typeof adapter.removeColumns === "function" &&
+      adapter.removeColumns !== SchemaStatements.prototype.removeColumns
+    ) {
+      return adapter.removeColumns(tableName, ...columns);
+    }
+    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    const fragments = this.removeColumnsForAlter(tableName, columns, opts);
+    await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
   }
 
   async addColumns(
@@ -2180,7 +2187,7 @@ export class SchemaStatements {
   validateChangeColumnNullArgumentBang(value: unknown): void {
     if (value !== true && value !== false) {
       throw new ArgumentError(
-        `change_column_null expects a boolean value (true for NULL, false for NOT NULL). Got: ${String(value)}`,
+        `change_column_null expects a boolean value (true for NULL, false for NOT NULL). Got: ${rubyInspect(value)}`,
       );
     }
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -285,3 +285,37 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
     expect(await toSql(td, host)).not.toContain("CHECK");
   });
 });
+
+describe("MySQL::TableDefinition column methods", () => {
+  it("defines one column per name, mirroring `names.each` in define_column_methods", () => {
+    const td = new MyTd("t", { id: false });
+    td.longtext("body", "summary");
+    td.unsignedInteger("hits", "misses");
+
+    expect(td.columns.map((c) => c.name)).toEqual(["body", "summary", "hits", "misses"]);
+    expect(td.columns.map((c) => c.sqlType)).toEqual([
+      "LONGTEXT",
+      "LONGTEXT",
+      "INT UNSIGNED",
+      "INT UNSIGNED",
+    ]);
+  });
+
+  it("applies the shared options and per-name sizing to every blob name", () => {
+    const td = new MyTd("t", { id: false });
+    td.blob("thumb", "preview", { limit: 300 });
+
+    expect(td.columns.map((c) => c.name)).toEqual(["thumb", "preview"]);
+    expect(td.columns.map((c) => c.sqlType)).toEqual(["BLOB", "BLOB"]);
+  });
+
+  it("raises when called with no column name", () => {
+    const td = new MyTd("t", { id: false });
+
+    expect(() => (td.blob as () => unknown)()).toThrow("Missing column name(s) for blob");
+    expect(() => (td.tinytext as () => unknown)()).toThrow("Missing column name(s) for tinytext");
+    expect(() => (td.unsignedBigint as () => unknown)()).toThrow(
+      "Missing column name(s) for unsigned_bigint",
+    );
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -39,19 +39,32 @@ const UNSIGNED_DECIMAL_DEPRECATION =
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::ColumnMethods
  */
 export interface ColumnMethods {
-  blob(name: string, options?: ColumnOptions & { limit?: number }): unknown;
-  tinyblob(name: string, options?: ColumnOptions): unknown;
-  mediumblob(name: string, options?: ColumnOptions): unknown;
-  longblob(name: string, options?: ColumnOptions): unknown;
-  tinytext(name: string, options?: ColumnOptions): unknown;
-  mediumtext(name: string, options?: ColumnOptions): unknown;
-  longtext(name: string, options?: ColumnOptions): unknown;
-  unsignedInteger(name: string, options?: ColumnOptions): unknown;
-  unsignedBigint(name: string, options?: ColumnOptions): unknown;
+  blob(...names: string[]): unknown;
+  blob(...args: [...names: string[], options: ColumnOptions & { limit?: number }]): unknown;
+  tinyblob(...names: string[]): unknown;
+  tinyblob(...args: [...names: string[], options: ColumnOptions]): unknown;
+  mediumblob(...names: string[]): unknown;
+  mediumblob(...args: [...names: string[], options: ColumnOptions]): unknown;
+  longblob(...names: string[]): unknown;
+  longblob(...args: [...names: string[], options: ColumnOptions]): unknown;
+  tinytext(...names: string[]): unknown;
+  tinytext(...args: [...names: string[], options: ColumnOptions]): unknown;
+  mediumtext(...names: string[]): unknown;
+  mediumtext(...args: [...names: string[], options: ColumnOptions]): unknown;
+  longtext(...names: string[]): unknown;
+  longtext(...args: [...names: string[], options: ColumnOptions]): unknown;
+  unsignedInteger(...names: string[]): unknown;
+  unsignedInteger(...args: [...names: string[], options: ColumnOptions]): unknown;
+  unsignedBigint(...names: string[]): unknown;
+  unsignedBigint(...args: [...names: string[], options: ColumnOptions]): unknown;
   /** @deprecated */
-  unsignedFloat(name: string, options?: ColumnOptions): unknown;
+  unsignedFloat(...names: string[]): unknown;
   /** @deprecated */
-  unsignedDecimal(name: string, options?: ColumnOptions): unknown;
+  unsignedFloat(...args: [...names: string[], options: ColumnOptions]): unknown;
+  /** @deprecated */
+  unsignedDecimal(...names: string[]): unknown;
+  /** @deprecated */
+  unsignedDecimal(...args: [...names: string[], options: ColumnOptions]): unknown;
 }
 
 export class TableDefinition extends AbstractTableDefinition {
@@ -84,73 +97,134 @@ export class TableDefinition extends AbstractTableDefinition {
     this.collation = collation ?? undefined;
   }
 
-  blob(name: string, options: ColumnOptions & { limit?: number } = {}): this {
-    let sqlType: string;
-    const limit = options.limit;
-    if (limit != null) {
-      if (limit <= 255) sqlType = "TINYBLOB";
-      else if (limit <= 65535) sqlType = "BLOB";
-      else if (limit <= 16777215) sqlType = "MEDIUMBLOB";
-      else sqlType = "LONGBLOB";
-    } else {
-      sqlType = "BLOB";
+  /** @internal */
+  protected definedMysqlColumn(
+    columnType: string,
+    type: ColumnType,
+    sqlType: string | ((options: ColumnOptions) => string),
+    args: unknown[],
+  ): this {
+    const rest = [...args];
+    const last = rest[rest.length - 1];
+    const options = (typeof last === "object" && last !== null ? rest.pop() : {}) as ColumnOptions;
+    const names = rest as string[];
+    if (names.length === 0) {
+      throw new ArgumentError(`Missing column name(s) for ${columnType}`);
     }
-    return this.mysqlColumn(name, "binary" as ColumnType, sqlType, options);
+    const resolved = typeof sqlType === "function" ? sqlType(options) : sqlType;
+    for (const name of names) {
+      this.mysqlColumn(name, type, resolved, options);
+    }
+    return this;
   }
 
-  tinyblob(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "binary" as ColumnType, "TINYBLOB", options);
+  blob(...names: string[]): this;
+  blob(...args: [...names: string[], options: ColumnOptions & { limit?: number }]): this;
+  blob(...args: unknown[]): this {
+    return this.definedMysqlColumn(
+      "blob",
+      "binary" as ColumnType,
+      (options) => {
+        const limit = (options as ColumnOptions & { limit?: number }).limit;
+        if (limit == null) return "BLOB";
+        if (limit <= 255) return "TINYBLOB";
+        if (limit <= 65535) return "BLOB";
+        if (limit <= 16777215) return "MEDIUMBLOB";
+        return "LONGBLOB";
+      },
+      args,
+    );
   }
 
-  mediumblob(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "binary" as ColumnType, "MEDIUMBLOB", options);
+  tinyblob(...names: string[]): this;
+  tinyblob(...args: [...names: string[], options: ColumnOptions]): this;
+  tinyblob(...args: unknown[]): this {
+    return this.definedMysqlColumn("tinyblob", "binary" as ColumnType, "TINYBLOB", args);
   }
 
-  longblob(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "binary" as ColumnType, "LONGBLOB", options);
+  mediumblob(...names: string[]): this;
+  mediumblob(...args: [...names: string[], options: ColumnOptions]): this;
+  mediumblob(...args: unknown[]): this {
+    return this.definedMysqlColumn("mediumblob", "binary" as ColumnType, "MEDIUMBLOB", args);
   }
 
-  tinytext(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "text" as ColumnType, "TINYTEXT", options);
+  longblob(...names: string[]): this;
+  longblob(...args: [...names: string[], options: ColumnOptions]): this;
+  longblob(...args: unknown[]): this {
+    return this.definedMysqlColumn("longblob", "binary" as ColumnType, "LONGBLOB", args);
   }
 
-  mediumtext(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "text" as ColumnType, "MEDIUMTEXT", options);
+  tinytext(...names: string[]): this;
+  tinytext(...args: [...names: string[], options: ColumnOptions]): this;
+  tinytext(...args: unknown[]): this {
+    return this.definedMysqlColumn("tinytext", "text" as ColumnType, "TINYTEXT", args);
   }
 
-  longtext(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "text" as ColumnType, "LONGTEXT", options);
+  mediumtext(...names: string[]): this;
+  mediumtext(...args: [...names: string[], options: ColumnOptions]): this;
+  mediumtext(...args: unknown[]): this {
+    return this.definedMysqlColumn("mediumtext", "text" as ColumnType, "MEDIUMTEXT", args);
   }
 
-  unsignedInteger(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "integer" as ColumnType, "INT UNSIGNED", options);
+  longtext(...names: string[]): this;
+  longtext(...args: [...names: string[], options: ColumnOptions]): this;
+  longtext(...args: unknown[]): this {
+    return this.definedMysqlColumn("longtext", "text" as ColumnType, "LONGTEXT", args);
   }
 
-  unsignedBigint(name: string, options: ColumnOptions = {}): this {
-    return this.mysqlColumn(name, "bigint" as ColumnType, "BIGINT UNSIGNED", options);
+  unsignedInteger(...names: string[]): this;
+  unsignedInteger(...args: [...names: string[], options: ColumnOptions]): this;
+  unsignedInteger(...args: unknown[]): this {
+    return this.definedMysqlColumn(
+      "unsigned_integer",
+      "integer" as ColumnType,
+      "INT UNSIGNED",
+      args,
+    );
+  }
+
+  unsignedBigint(...names: string[]): this;
+  unsignedBigint(...args: [...names: string[], options: ColumnOptions]): this;
+  unsignedBigint(...args: unknown[]): this {
+    return this.definedMysqlColumn(
+      "unsigned_bigint",
+      "bigint" as ColumnType,
+      "BIGINT UNSIGNED",
+      args,
+    );
   }
 
   /** @deprecated */
-  unsignedFloat(name: string, options: ColumnOptions = {}): this {
+  unsignedFloat(...names: string[]): this;
+  /** @deprecated */
+  unsignedFloat(...args: [...names: string[], options: ColumnOptions]): this;
+  /** @deprecated */
+  unsignedFloat(...args: unknown[]): this {
     deprecator().warn(UNSIGNED_FLOAT_DEPRECATION);
-    return this.mysqlColumn(name, "float" as ColumnType, "FLOAT UNSIGNED", options);
+    return this.definedMysqlColumn("unsigned_float", "float" as ColumnType, "FLOAT UNSIGNED", args);
   }
 
   /** @deprecated */
-  unsignedDecimal(name: string, options: ColumnOptions = {}): this {
+  unsignedDecimal(...names: string[]): this;
+  /** @deprecated */
+  unsignedDecimal(...args: [...names: string[], options: ColumnOptions]): this;
+  /** @deprecated */
+  unsignedDecimal(...args: unknown[]): this {
     deprecator().warn(UNSIGNED_DECIMAL_DEPRECATION);
-    if (options.scale != null && options.precision == null) {
-      throw new ArgumentError(
-        "Error adding decimal column: precision cannot be empty if scale is specified",
-      );
-    }
-    const precision = options.precision ?? 10;
-    const scale = options.scale ?? 0;
-    return this.mysqlColumn(
-      name,
+    return this.definedMysqlColumn(
+      "unsigned_decimal",
       "decimal" as ColumnType,
-      `DECIMAL(${precision}, ${scale}) UNSIGNED`,
-      options,
+      (options) => {
+        if (options.scale != null && options.precision == null) {
+          throw new ArgumentError(
+            "Error adding decimal column: precision cannot be empty if scale is specified",
+          );
+        }
+        const precision = options.precision ?? 10;
+        const scale = options.scale ?? 0;
+        return `DECIMAL(${precision}, ${scale}) UNSIGNED`;
+      },
+      args,
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1696,6 +1696,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async removeColumn(tableName: string, columnName: string, _type?: string): Promise<void> {
+    if ((columnName as string | undefined) === undefined) {
+      throw new ArgumentError("wrong number of arguments (given 1, expected 2..3)");
+    }
     await this.alterTable(tableName, (definition) => {
       definition.removeColumn(columnName);
       deleteForeignKeysForColumns(definition, [columnName]);
@@ -1736,6 +1739,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     allowNull: boolean,
     defaultValue?: unknown,
   ): Promise<void> {
+    this.schemaStatements().validateChangeColumnNullArgumentBang(allowNull);
     if (!allowNull && defaultValue !== undefined) {
       // Rails backfills NULLs via quote_default_expression, which serializes the
       // value through the column's cast type (abstract/schema_statements.rb).
@@ -1772,12 +1776,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async addTimestamps(tableName: string, options?: Record<string, unknown>): Promise<void> {
-    const opts = {
-      null: false,
-      ...options,
-    };
-    await this.addColumn(tableName, "created_at", "datetime", opts);
-    await this.addColumn(tableName, "updated_at", "datetime", opts);
+    const opts: Record<string, unknown> = { ...options };
+    if (opts.null == null) opts.null = false;
+    if (!("precision" in opts)) opts.precision = 6;
+
+    await this.alterTable(tableName, (definition) => {
+      definition.column("created_at", "datetime", opts);
+      definition.column("updated_at", "datetime", opts);
+    });
   }
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
@@ -1919,16 +1925,17 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   override async disableReferentialIntegrity(fn: () => Promise<void>): Promise<void> {
     await this.ensureConnected();
-    const oldForeignKeys = ((await this.driver.pragma("foreign_keys")) as any[])[0]?.foreign_keys;
-    const oldDefer = ((await this.driver.pragma("defer_foreign_keys")) as any[])[0]
-      ?.defer_foreign_keys;
+    const pragmaValue = async (sql: string): Promise<unknown> =>
+      Object.values((await this.execute(sql))[0] ?? {})[0];
+    const oldForeignKeys = await pragmaValue("PRAGMA foreign_keys");
+    const oldDeferForeignKeys = await pragmaValue("PRAGMA defer_foreign_keys");
     try {
-      await this.driver.pragma("defer_foreign_keys = ON");
-      await this.driver.pragma("foreign_keys = OFF");
+      await this.execute("PRAGMA defer_foreign_keys = ON");
+      await this.execute("PRAGMA foreign_keys = OFF");
       await fn();
     } finally {
-      await this.driver.pragma(`defer_foreign_keys = ${oldDefer ?? 0}`);
-      await this.driver.pragma(`foreign_keys = ${oldForeignKeys ?? 1}`);
+      await this.execute(`PRAGMA defer_foreign_keys = ${String(oldDeferForeignKeys)}`);
+      await this.execute(`PRAGMA foreign_keys = ${String(oldForeignKeys)}`);
     }
   }
 
@@ -2548,11 +2555,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * @internal
    */
   private async execCopyTable(sql: string): Promise<void> {
-    try {
-      await this.driver.exec(sql);
-    } catch (e) {
-      throw this._translateException(e, sql, []);
-    }
+    const payload = this._notificationPayload(sql, [], "SQL");
+    await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      try {
+        await this.driver.exec(sql);
+      } catch (e) {
+        throw this._translateException(e, sql, []);
+      }
+    });
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
 import type { Column } from "../connection-adapters/column.js";
-import { ActiveRecordError, StatementInvalid } from "../errors.js";
+import { ActiveRecordError, StatementInvalid, NotNullViolation } from "../errors.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { ambientConnection } from "../support/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
@@ -10,6 +10,8 @@ import {
   serverVersion,
   supportsDefaultExpression,
 } from "../support/mysql-server-version.js";
+import { ArgumentError } from "@blazetrails/activemodel";
+import { assertQueriesCount } from "../testing/query-assertions.js";
 import { adapterSupports } from "../support/supports.js";
 
 const mariaDbRejectsUniqueColumnDrop =
@@ -17,6 +19,8 @@ const mariaDbRejectsUniqueColumnDrop =
 
 const indexesSurvivingColumnDrop =
   adapterType === "postgres" ? [] : ["index_test_models_on_hat_style_and_hat_size"];
+
+const expectedAlterQueryCount = adapterType === "sqlite" ? 14 : 1;
 
 async function indexNames(conn: AbstractAdapter, table: string): Promise<string[]> {
   const indexes = (await conn.indexes(table)) as Array<{ name: string }>;
@@ -492,6 +496,94 @@ describe("Migration", () => {
       TestModel.resetColumnInformation();
       await TestModel.loadSchema();
       expect(TestModel.columnsHash()["created_at"].defaultFunction).toBe(fn);
+    });
+
+    it("change column null false", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+      await connection.changeColumnNull("test_models", "first_name", false);
+      TestModel.resetColumnInformation();
+
+      await expect(TestModel.create({ first_name: null })).rejects.toThrow(NotNullViolation);
+    });
+
+    it("change column null true", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+      await connection.changeColumnNull("test_models", "first_name", true);
+      TestModel.resetColumnInformation();
+
+      const before = (await TestModel.count()) as number;
+      await TestModel.create({ first_name: null });
+      expect(await TestModel.count()).toBe(before + 1);
+    });
+
+    it("change column null with non boolean arguments raises", async () => {
+      const connection = await ambientConnection();
+      await connection.addColumn("test_models", "first_name", "string");
+      await expect(
+        connection.changeColumnNull("test_models", "first_name", {
+          from: true,
+          to: false,
+        } as unknown as boolean),
+      ).rejects.toThrow(
+        "change_column_null expects a boolean value (true for NULL, false for NOT NULL). Got: {from: true, to: false}",
+      );
+    });
+
+    it("remove column no second parameter raises exception", async () => {
+      const connection = await ambientConnection();
+      await expect(
+        (connection.removeColumn as (t: string) => Promise<void>)("funny"),
+      ).rejects.toThrow(ArgumentError);
+    });
+
+    it("add column without column name", async () => {
+      const connection = await ambientConnection();
+      try {
+        await expect(
+          connection.createTable("my_table", { force: true }, (t) => {
+            (t.timestamp as () => unknown)();
+          }),
+        ).rejects.toThrow("Missing column name(s) for timestamp");
+      } finally {
+        await connection.dropTable("my_table", { ifExists: true });
+      }
+    });
+
+    it("remove columns single statement", async () => {
+      const connection = await ambientConnection();
+      try {
+        await connection.createTable("my_table", {}, (t) => {
+          t.integer("col_one");
+          t.integer("col_two");
+        });
+
+        await assertQueriesCount(expectedAlterQueryCount, false, async () => {
+          await connection.removeColumns("my_table", "col_one", "col_two");
+        });
+
+        const columns = (await connection.columns("my_table")).map((c) => c.name);
+        expect(columns).toEqual(["id"]);
+      } finally {
+        await connection.dropTable("my_table", { ifExists: true });
+      }
+    });
+
+    it("add timestamps single statement", async () => {
+      const connection = await ambientConnection();
+      try {
+        await connection.createTable("my_table");
+
+        await assertQueriesCount(expectedAlterQueryCount, false, async () => {
+          await connection.addTimestamps("my_table");
+        });
+
+        const columns = (await connection.columns("my_table")).map((c) => c.name);
+        expect(columns).toEqual(["id", "created_at", "updated_at"]);
+      } finally {
+        await connection.dropTable("my_table", { ifExists: true });
+      }
     });
   });
 });

--- a/packages/activerecord/src/relation/ruby-inspect.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.ts
@@ -47,9 +47,21 @@ export function rubyInspect(value: unknown): string {
     /* eslint-enable no-control-regex */
   }
   if (Array.isArray(value)) return rubyInspectArray(value);
+  if (isPlainObject(value)) return rubyInspectHash(value);
   // Fallback — Ruby's `Object#inspect` gives `#<Class …>`; here we
   // just call `String(value)` for anything unhandled.
   return String(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value) as unknown;
+  return proto === Object.prototype || proto === null;
+}
+
+export function rubyInspectHash(value: Record<string, unknown>): string {
+  const pairs = Object.entries(value).map(([key, val]) => `${key}: ${rubyInspect(val)}`);
+  return `{${pairs.join(", ")}}`;
 }
 
 export function rubyInspectArray(values: unknown[]): string {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -535,35 +535,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_columns",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_columns",
-    "call": "join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_columns",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_columns",
     "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_columns",
-    "call": "remove_columns_for_alter",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -23,20 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "add_timestamps",
-    "call": "alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "add_timestamps",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "alter_table",
     "call": "check_constraint",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -109,13 +95,6 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "change_column_null",
     "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "change_column_null",
-    "call": "validate_change_column_null_argument!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -312,13 +291,6 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "dbconsole",
     "call": "root",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "disable_referential_integrity",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Ports the seven unconditional cases still missing from
`vendor/rails/activerecord/test/cases/migration/columns_test.rb`, each of which
was blocked on machinery #5560 did not grow into. `test:compare` for this file
goes 8 → 15 ported (0 misplaced, 0 gate-mismatch); the remaining 21 are the
adapter-gated cases tracked separately.

## Implementation work each case needed

**`change_column_null`'s boolean guard** (`test_change_column_null_false`,
`_true`, `_with_non_boolean_arguments_raises`) — Rails calls
`validate_change_column_null_argument!` from *every* adapter's
`change_column_null` (sqlite3_adapter.rb:375, postgresql/schema_statements.rb:498,
abstract_mysql_adapter.rb:382, plus the abstract one). trails only called it from
PG and MySQL, so the abstract and SQLite paths are wired up here. The message
also interpolated `String(value)`, which renders a Hash as `[object Object]`
where Ruby's `#{value.inspect}` gives `{from: true, to: false}` — `rubyInspect`
grows Hash support to match.

**`TableDefinition`'s missing-name guard** (`test_add_column_without_column_name`)
— Rails' `define_column_methods` generates `t.<type>(*names, **options)` with
`raise ArgumentError, "Missing column name(s) for #{column_type}" if names.empty?`
(schema_definitions.rb:335-336). trails' statically-declared column methods had
no equivalent, so every `define_column_methods` type now routes through a
`definedColumn` helper carrying that raise.

**`remove_column`'s arity** (`test_remove_column_no_second_parameter_raises_exception`)
— Ruby's required second parameter makes `remove_column("funny")` an
`ArgumentError` before any DDL runs. TypeScript enforces no arity, so both the
abstract and SQLite implementations mirror the raise (and Ruby's message)
explicitly.

**One statement, not one per column** (`test_remove_columns_single_statement`,
`test_add_timestamps_single_statement`) — these assert
`assert_queries_count(current_adapter?(:SQLite3Adapter) ? 14 : 1)`, so they are
only meaningful against a real query count. Three gaps stood between us and it:

- `SchemaStatements#removeColumns` looped `removeColumn` per column instead of
  issuing Rails' single combined `ALTER TABLE` (schema_statements.rb:675-682),
  and had no delegation gate to reach SQLite's single-rebuild override. Both
  fixed; `addTimestamps` gets the same gate.
- SQLite's `addTimestamps` added the two columns with two `addColumn` calls,
  rebuilding the table twice; Rails adds both inside one `alter_table`
  (sqlite3_adapter.rb:397-408).
- The SQLite rebuild's DDL (`execCopyTable`) and
  `disableReferentialIntegrity`'s pragmas ran off the instrumented path, so none
  of the rebuild's statements reached the `sql.active_record` log — the block
  counted 2 queries where Rails counts 14. Rails issues both through
  `execute`/`query_value`, so they are instrumented here too.

## Verification

All three lanes green on `migration/columns.test.ts` (14/14), and on
`migration.test.ts` + `migration/` + `schema-dumper.test.ts` + `schema.test.ts`;
sqlite additionally green on `connection-adapters/`, `batches`, `query-cache`,
`relation` and `transactions` (the query-count-sensitive suites).
`api:compare` shows no new extra surface and regenerates no manifests.

Closes-story: port-migration-columns-blocked-cases
