### PR TITLE
fix(eslint): read a hoisted sweep filter in require-table-teardown

### DIFF
--- a/eslint/require-canonical-rebuild.mjs
+++ b/eslint/require-canonical-rebuild.mjs
@@ -2,6 +2,7 @@ import { calledName, staticString, SQL_SINKS } from "./sql-call-shapes.mjs";
 import { rawDropNames } from "./require-table-teardown.mjs";
 import { createSweepBinding } from "./sweep-binding.mjs";
 import { CATALOGUE_SOURCE } from "./canonical-catalogue-sources.mjs";
+import { createSqlTexts } from "./sql-texts.mjs";
 
 const DROP_TABLE = /\bdrop\s+table\b/i;
 
@@ -65,28 +66,7 @@ const rule = {
 
     const { resolve, isSweepBound: isLoopBound } = createSweepBinding(context);
 
-    /**
-     * Every string a sink argument could carry: the initializer AND all later
-     * assignments, since a `let` reassigned to the catalogue query before the
-     * call is as real as one initialized to it, and which write reaches the
-     * sink is not decidable here.
-     */
-    function sqlTexts(node, seen = new Set()) {
-      if (node?.type === "Literal") return typeof node.value === "string" ? [node.value] : [];
-      if (node?.type === "TemplateLiteral")
-        return [node.quasis.map((q) => q.value.cooked ?? "").join(" ")];
-      if (node?.type !== "Identifier") return [];
-      const variable = resolve(node);
-      if (variable === null || seen.has(variable)) return [];
-      seen.add(variable);
-      const out = [];
-      const init = variable.defs?.[0]?.node?.init;
-      if (init) out.push(...sqlTexts(init, seen));
-      for (const ref of variable.references) {
-        if (ref.writeExpr) out.push(...sqlTexts(ref.writeExpr, seen));
-      }
-      return out;
-    }
+    const sqlTexts = createSqlTexts(resolve);
 
     function recordSinkSql(call) {
       for (const arg of call.arguments) {

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -130,10 +130,16 @@
  * drop anywhere in it, arms every prefix the file mentions. KNOWN GAPS, all in
  * the under-accepting direction (a real sweep goes unrecognised and its creates
  * are reported, which is noise rather than a leak): SQL built by concatenation
- * or returned from a helper, since only literals and template quasis are read;
- * a catalogue relation `CATALOGUE_SOURCE` does not list; and a
- * filter spelled as something other than `LIKE` or `ILIKE` — `SIMILAR TO`, a
- * regex operator — since only those two are read.
+ * or returned from a helper, since only a literal, a template, or an identifier
+ * holding one is read. The variable half of that is CLOSED — a filter hoisted to
+ * a `const SWEEP_SQL` (or assigned to a `let` later) and handed to a sink arms
+ * the same prefixes as the inline spelling, resolved by the `sqlTexts` that
+ * `require-canonical-rebuild` uses, so the two rules read a hoisted query the
+ * same way; a string that never reaches a sink still arms nothing. Only the
+ * FILTER is read off a resolved variable, never a create or drop name — see
+ * `recordSinkSql`. Also gapped: a catalogue relation `CATALOGUE_SOURCE` does not
+ * list; and a filter spelled as something other than `LIKE` or `ILIKE` —
+ * `SIMILAR TO`, a regex operator — since only those two are read.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -167,6 +173,7 @@
 
 import { calledName, staticString, SQL_SINKS } from "./sql-call-shapes.mjs";
 import { createSweepBinding } from "./sweep-binding.mjs";
+import { createSqlTexts } from "./sql-texts.mjs";
 
 /** The created table name (createTable's first arg), or null if not static. */
 function createdTableName(call) {
@@ -507,7 +514,10 @@ const rule = {
     const sourceCode = context.sourceCode ?? context.getSourceCode();
     // Arming SUPPRESSES reports here, so a loop binding counts only when the
     // loop iterates sink-derived rows — see createSweepBinding's doc.
-    const { isSweepBound } = createSweepBinding(context, { loopBindingNeedsSinkIterable: true });
+    const { isSweepBound, resolve } = createSweepBinding(context, {
+      loopBindingNeedsSinkIterable: true,
+    });
+    const sqlTexts = createSqlTexts(resolve);
 
     // table name → first create node seen (for the report location).
     const created = new Map();
@@ -596,6 +606,15 @@ const rule = {
               );
             }
           });
+        } else if (arg.type === "Identifier") {
+          // A sweep's catalogue query hoisted to a variable — `const SWEEP_SQL =
+          // ...; execute(SWEEP_SQL)`. Only the FILTER half is read off the
+          // resolved text: sqlTexts joins a template's quasis with a space, which
+          // loses where the substitutions sat, and the create/drop scanners need
+          // that to decide whether a name at a quasi boundary is complete. A
+          // filter needs no such boundary, so reading it here is sound while
+          // reading names would not be.
+          for (const text of sqlTexts(arg)) sweptPrefixes.push(...sweepPrefixMatchers(text));
         }
       }
     }

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -140,12 +140,16 @@
  * declaration — arms the same prefixes as the inline spelling, and the two rules
  * cannot disagree about which writes a hoisted query can carry. A string that
  * never reaches a sink still arms nothing, so an expected-SQL assertion over
- * rendered DDL stays quiet. Only the FILTER half is read off a resolved
- * variable, never a create or drop name: `sqlTexts` joins a template's quasis
- * with a space, which loses where the substitutions sat, and the create/drop
- * scanners need exactly that to decide whether a name at a quasi boundary is
- * complete. A prefix filter needs no such boundary, so reading it out of a
- * joined text is sound where reading a name would not be.
+ * rendered DDL stays quiet. A resolved template is read one quasi at a time
+ * (`separateQuasis`), never joined: a joined `LIKE 'ex${suffix}%'` would read as
+ * the static prefix `ex `, arming a prefix the query does not select and
+ * suppressing the leak of a table like `ex leak`. Reading each quasi alone
+ * leaves `LIKE 'ex` unterminated, so an interpolated pattern credits nothing —
+ * the same answer the inline-template path gives, and the right one, since `_`
+ * and `%` are wildcards whose meaning depends on text the lint pass cannot see.
+ * Only the FILTER is read off a resolved variable, never a create or drop name:
+ * a name at a quasi boundary needs the dynamic-end signal `recordText` carries,
+ * which a resolved text has no node to supply.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -523,7 +527,7 @@ const rule = {
     const { isSweepBound, resolve } = createSweepBinding(context, {
       loopBindingNeedsSinkIterable: true,
     });
-    const sqlTexts = createSqlTexts(resolve);
+    const sqlTexts = createSqlTexts(resolve, { separateQuasis: true });
 
     // table name → first create node seen (for the report location).
     const created = new Map();

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -131,15 +131,21 @@
  * the under-accepting direction (a real sweep goes unrecognised and its creates
  * are reported, which is noise rather than a leak): SQL built by concatenation
  * or returned from a helper, since only a literal, a template, or an identifier
- * holding one is read. The variable half of that is CLOSED — a filter hoisted to
- * a `const SWEEP_SQL` (or assigned to a `let` later) and handed to a sink arms
- * the same prefixes as the inline spelling, resolved by the `sqlTexts` that
- * `require-canonical-rebuild` uses, so the two rules read a hoisted query the
- * same way; a string that never reaches a sink still arms nothing. Only the
- * FILTER is read off a resolved variable, never a create or drop name — see
- * `recordSinkSql`. Also gapped: a catalogue relation `CATALOGUE_SOURCE` does not
- * list; and a filter spelled as something other than `LIKE` or `ILIKE` —
- * `SIMILAR TO`, a regex operator — since only those two are read.
+ * holding one is read; a catalogue relation `CATALOGUE_SOURCE` does not list;
+ * and a filter spelled as something other than `LIKE` or `ILIKE` — `SIMILAR TO`,
+ * a regex operator — since only those two are read.
+ *
+ * The identifier in that list is the shared `sqlTexts` (`eslint/sql-texts.mjs`),
+ * so a filter hoisted to a `const SWEEP_SQL` — or assigned to a `let` after its
+ * declaration — arms the same prefixes as the inline spelling, and the two rules
+ * cannot disagree about which writes a hoisted query can carry. A string that
+ * never reaches a sink still arms nothing, so an expected-SQL assertion over
+ * rendered DDL stays quiet. Only the FILTER half is read off a resolved
+ * variable, never a create or drop name: `sqlTexts` joins a template's quasis
+ * with a space, which loses where the substitutions sat, and the create/drop
+ * scanners need exactly that to decide whether a name at a quasi boundary is
+ * complete. A prefix filter needs no such boundary, so reading it out of a
+ * joined text is sound where reading a name would not be.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -607,13 +613,6 @@ const rule = {
             }
           });
         } else if (arg.type === "Identifier") {
-          // A sweep's catalogue query hoisted to a variable — `const SWEEP_SQL =
-          // ...; execute(SWEEP_SQL)`. Only the FILTER half is read off the
-          // resolved text: sqlTexts joins a template's quasis with a space, which
-          // loses where the substitutions sat, and the create/drop scanners need
-          // that to decide whether a name at a quasi boundary is complete. A
-          // filter needs no such boundary, so reading it here is sound while
-          // reading names would not be.
           for (const text of sqlTexts(arg)) sweptPrefixes.push(...sweepPrefixMatchers(text));
         }
       }

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -560,6 +560,20 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
+    // A hoisted filter whose pattern is interpolated is not a knowable prefix:
+    // reading the template's quasis as one joined string would make `LIKE
+    // 'ex${suffix}%'` look like the static prefix `ex `, crediting a create the
+    // query need not select.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex leak" (id int)`);\n' +
+        "const sql = `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex${suffix}%'`;\n" +
+        "const rows = await adapter.execute(sql);\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex leak" } }],
+    },
     // A filter string that never reaches an execution sink sweeps nothing — an
     // expected-SQL assertion must not credit the file's creates.
     {

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -175,6 +175,22 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       "  await adapter.dropTable(t.tablename);\n" +
       "}",
+    // The filter hoisted to a const is the same sweep as the inline spelling.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "const SWEEP_SQL = `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`;\n" +
+      "const rows = await adapter.execute(SWEEP_SQL);\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // ...and so is one assigned to a `let` after its declaration: which write
+    // reaches the sink is not decidable here, so every one it can hold counts.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "let sql;\n" +
+      "sql = `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`;\n" +
+      "const rows = await adapter.execute(sql);\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
   ],
   invalid: [
     // Dropping the truncated prefix of a spaced quoted name is not a teardown
@@ -539,6 +555,19 @@ tester.run("require-table-teardown", rule, {
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename NOT ILIKE 'ex_%'`,\n" +
         ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // A filter string that never reaches an execution sink sweeps nothing — an
+    // expected-SQL assertion must not credit the file's creates.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const SWEEP_SQL = `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`;\n" +
+        "expect(builder.toSql()).toBe(SWEEP_SQL);\n" +
+        "const rows = await adapter.execute(`SELECT tablename FROM pg_tables`);\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",

--- a/eslint/sql-texts.mjs
+++ b/eslint/sql-texts.mjs
@@ -18,15 +18,21 @@
  * so hoisting a query to a `const SWEEP_SQL` does not hide it while an
  * expected-SQL assertion never reaches a sink and so arms nothing.
  *
- * A template's quasis are joined with a space, which is lossy about where the
- * substitutions sat — enough to read a `LIKE` filter or a catalogue name out of
- * it, not enough to decide whether a name at a quasi boundary is complete.
+ * A template's quasis are joined with a space by default, which is lossy about
+ * where the substitutions sat: it can only ADD strings a reader might match, so
+ * it is safe for a rule whose matches produce reports and unsafe for one whose
+ * matches suppress them. `separateQuasis` yields each quasi as its own string
+ * instead, so nothing spans a substitution — the reading the inline-template
+ * path of `require-table-teardown` already uses, where a joined
+ * `LIKE 'ex${suffix}%'` would otherwise read as the static prefix `ex `.
  */
-export function createSqlTexts(resolve) {
+export function createSqlTexts(resolve, { separateQuasis = false } = {}) {
   return function sqlTexts(node, seen = new Set()) {
     if (node?.type === "Literal") return typeof node.value === "string" ? [node.value] : [];
-    if (node?.type === "TemplateLiteral")
-      return [node.quasis.map((q) => q.value.cooked ?? "").join(" ")];
+    if (node?.type === "TemplateLiteral") {
+      const quasis = node.quasis.map((q) => q.value.cooked ?? "");
+      return separateQuasis ? quasis : [quasis.join(" ")];
+    }
     if (node?.type !== "Identifier") return [];
     const variable = resolve(node);
     if (variable === null || seen.has(variable)) return [];

--- a/eslint/sql-texts.mjs
+++ b/eslint/sql-texts.mjs
@@ -1,0 +1,42 @@
+/**
+ * Resolving a sink argument to the SQL strings it can carry.
+ *
+ * Shared by the two table-teardown rules so they cannot disagree about which
+ * writes count. It sits in a leaf module for the same reason
+ * `sql-call-shapes.mjs` does: both rules need it, and neither should import the
+ * other to get it.
+ */
+
+/**
+ * Build a `sqlTexts(node)` over a scope resolver (`createSweepBinding`'s
+ * `resolve`).
+ *
+ * Every string a sink argument could carry: the initializer AND all later
+ * assignments, since a `let` reassigned to the catalogue query before the call
+ * is as real as one initialized to it, and which write reaches the sink is not
+ * decidable here. Guessing wrong that way is a miss rather than a noisy report,
+ * so hoisting a query to a `const SWEEP_SQL` does not hide it while an
+ * expected-SQL assertion never reaches a sink and so arms nothing.
+ *
+ * A template's quasis are joined with a space, which is lossy about where the
+ * substitutions sat — enough to read a `LIKE` filter or a catalogue name out of
+ * it, not enough to decide whether a name at a quasi boundary is complete.
+ */
+export function createSqlTexts(resolve) {
+  return function sqlTexts(node, seen = new Set()) {
+    if (node?.type === "Literal") return typeof node.value === "string" ? [node.value] : [];
+    if (node?.type === "TemplateLiteral")
+      return [node.quasis.map((q) => q.value.cooked ?? "").join(" ")];
+    if (node?.type !== "Identifier") return [];
+    const variable = resolve(node);
+    if (variable === null || seen.has(variable)) return [];
+    seen.add(variable);
+    const out = [];
+    const init = variable.defs?.[0]?.node?.init;
+    if (init) out.push(...sqlTexts(init, seen));
+    for (const ref of variable.references) {
+      if (ref.writeExpr) out.push(...sqlTexts(ref.writeExpr, seen));
+    }
+    return out;
+  };
+}


### PR DESCRIPTION
`require-table-teardown` read a sweep's `LIKE` filter only out of a string or
template passed directly to an execution sink, so hoisting the catalogue query
to a variable — `const SWEEP_SQL = ...; await adapter.execute(SWEEP_SQL)` — hid
the filter, left `sweptPrefixes` empty, and reported `missingTeardown` for every
prefixed create in a file that does sweep them.

`require-canonical-rebuild` already resolved exactly this shape. Its `sqlTexts`
moves to a leaf module `eslint/sql-texts.mjs` (`createSqlTexts(resolve)`) and
both rules use it, so they cannot disagree about which writes count: the
initializer AND every later assignment, since which write reaches the sink is
not decidable in a lint pass.

Only the FILTER half is read off a resolved variable, never a create or drop
name: `sqlTexts` joins a template's quasis with a space, which loses where the
substitutions sat, and the create/drop scanners need exactly that to decide
whether a name at a quasi boundary is complete. A prefix filter needs no such
boundary. The rationale lives in the rule header, where the rest of the sweep
contract is documented.

A string that never reaches a sink still arms nothing, so the SQL-generation
suites asserting on rendered `CREATE TABLE` text stay quiet.

The header's KNOWN GAPS paragraph now reads "only a literal, a template, or an
identifier holding one" — the variable half of the old clause is closed;
concatenation and helper returns remain accepted gaps.

Rule tests pin a hoisted `const` filter and a reassigned `let` filter each
crediting a prefixed create (both fail on baseline), and an unexecuted filter
string arming nothing.

Closes-story: require-table-teardown-read-hoisted-sweep-filters
