### PR TITLE
feat(eslint): read SIMILAR TO and regex sweep filters in require-table-teardown

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -132,8 +132,11 @@
  * are reported, which is noise rather than a leak): SQL built by concatenation
  * or returned from a helper, since only a literal, a template, or an identifier
  * holding one is read; a catalogue relation `CATALOGUE_SOURCE` does not list;
- * and a filter spelled as something other than `LIKE` or `ILIKE` — `SIMILAR TO`,
- * a regex operator — since only those two are read.
+ * a `SIMILAR TO` pattern using regex syntax the LIKE compiler does not translate
+ * (`| * + ? ( ) [ ] { }` unescaped); and a regex (`~` / `~*`) filter that is
+ * either unanchored or whose pattern past the `^` is not a plain literal. The
+ * filter spellings read are `LIKE`, `ILIKE`, `SIMILAR TO` and `~` / `~*`; their
+ * negations are deliberately read as nothing (see `LIKE_PREFIX_RE`).
  *
  * The identifier in that list is the shared `sqlTexts` (`eslint/sql-texts.mjs`),
  * so a filter hoisted to a `const SWEEP_SQL` — or assigned to a `let` after its
@@ -361,21 +364,69 @@ const CATALOGUE_SOURCE =
  * selecting everything never becomes a prefix that satisfies everything.
  */
 const LIKE_PREFIX_RE = /(?<!\bnot\s+)\b(?<i>i?)like\s+'(?<pattern>[^'%]+)%'/gi;
+/**
+ * `SIMILAR TO` is the same catalogue filter in SQL-standard regex spelling: `%`
+ * and `_` stay LIKE wildcards and the `ESCAPE` clause still applies, so it is
+ * read through the same compiler — but it ALSO gives regex meaning to
+ * `| * + ? ( ) [ ] { }`, which LIKE does not. Those are refused rather than
+ * translated (`similarMetacharUnreadable`): reading `SIMILAR TO '(ex|tmp)_%'`
+ * as the literal prefix `(ex|tmp)` would credit nothing anyway, and reading
+ * `'ex*_%'` as a literal asterisk would credit `ex*A` — a name that sweep does
+ * not select, which is a leak. Escaping one (`ex\*_%` under the default escape)
+ * makes it the literal it says it is, and that IS read. `NOT SIMILAR TO` is an
+ * exclusion filter and yields no prefix, exactly as `NOT LIKE` does.
+ */
+const SIMILAR_PREFIX_RE = /(?<!\bnot\s+)\bsimilar\s+to\s+'(?<pattern>[^'%]+)%'/gi;
+/**
+ * PostgreSQL's regex match operators, which Arel emits from
+ * `visit_Arel_Nodes_Regexp` (arel/visitors/postgresql.rb). `~*` is the
+ * case-insensitive spelling, so its matcher carries the `i` flag as `ILIKE`
+ * does; the negated `!~` / `!~*` are excluded by the lookbehind, since an
+ * exclusion filter would otherwise satisfy exactly the creates it spares.
+ *
+ * A regex filter is a prefix filter ONLY when the pattern is anchored: `~ 'ex_'`
+ * matches mid-name (`fooex1bar`) and selects far more than the prefix, but
+ * crediting it as a prefix would be under-crediting, not a leak — the risk runs
+ * the other way, so the `^` is required and an unanchored pattern yields no
+ * matcher. Past the anchor only a metachar-free literal is read: the remaining
+ * POSIX regex syntax is not JS regex syntax (bracket expressions, back
+ * references, `{n,m}` bounds), so translating it would be guesswork, and reading
+ * it literally would credit names the sweep does not select.
+ */
+const REGEXP_PREFIX_RE = /(?<![!~])(?<op>~\*?)\s*'(?<pattern>[^']*)'/g;
+const REGEXP_LITERAL_RE = /^\^(?<literal>[^.*+?^${}()|[\]\\]*)$/;
 /** A trailing `ESCAPE '<char>'` clause, and the leading keyword on its own. */
 const ESCAPE_CLAUSE_RE = /^\s*escape\s+'([^'])'/i;
 const ESCAPE_KEYWORD_RE = /^\s*escape\b/i;
 export function sweepPrefixMatchers(text) {
   if (!CATALOGUE_SOURCE.test(text)) return [];
   const matchers = [];
-  LIKE_PREFIX_RE.lastIndex = 0;
+  for (const [re, similar] of [
+    [LIKE_PREFIX_RE, false],
+    [SIMILAR_PREFIX_RE, true],
+  ]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      const tail = text.slice(m.index + m[0].length);
+      const clause = ESCAPE_CLAUSE_RE.exec(tail);
+      if (clause === null && ESCAPE_KEYWORD_RE.test(tail)) continue;
+      const { i, pattern } = m.groups;
+      const matcher = likePrefixMatcher(
+        pattern,
+        clause === null ? "\\" : clause[1],
+        i !== undefined && i !== "",
+        similar,
+      );
+      if (matcher !== null) matchers.push(matcher);
+    }
+  }
+  REGEXP_PREFIX_RE.lastIndex = 0;
   let m;
-  while ((m = LIKE_PREFIX_RE.exec(text)) !== null) {
-    const tail = text.slice(m.index + m[0].length);
-    const clause = ESCAPE_CLAUSE_RE.exec(tail);
-    if (clause === null && ESCAPE_KEYWORD_RE.test(tail)) continue;
-    const { i, pattern } = m.groups;
-    const matcher = likePrefixMatcher(pattern, clause === null ? "\\" : clause[1], i !== "");
-    if (matcher !== null) matchers.push(matcher);
+  while ((m = REGEXP_PREFIX_RE.exec(text)) !== null) {
+    const literal = REGEXP_LITERAL_RE.exec(m.groups.pattern);
+    if (literal === null || literal.groups.literal === "") continue;
+    matchers.push(new RegExp(`^${literal.groups.literal}`, m.groups.op === "~*" ? "i" : ""));
   }
   return matchers;
 }
@@ -386,9 +437,11 @@ export function sweepPrefixMatchers(text) {
  * matches the single literal name `ex%`, not a prefix, so it sweeps nothing
  * this rule should credit. `caseInsensitive` is set for `ILIKE` filters only —
  * `LIKE` is case-sensitive in PostgreSQL, so widening it would credit creates
- * the sweep leaves behind.
+ * the sweep leaves behind. `similarMetacharUnreadable` is set for `SIMILAR TO`,
+ * where an unescaped regex metacharacter carries meaning this compiler does not
+ * translate and so makes the whole filter unreadable.
  */
-function likePrefixMatcher(pattern, escapeChar, caseInsensitive) {
+function likePrefixMatcher(pattern, escapeChar, caseInsensitive, similarMetacharUnreadable) {
   let source = "";
   let escaped = false;
   for (const ch of pattern) {
@@ -399,6 +452,8 @@ function likePrefixMatcher(pattern, escapeChar, caseInsensitive) {
       escaped = true;
     } else if (ch === "_") {
       source += ".";
+    } else if (similarMetacharUnreadable && "|*+?()[]{}".includes(ch)) {
+      return null;
     } else {
       source += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     }

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -388,13 +388,15 @@ const SIMILAR_PREFIX_RE = /(?<!\bnot\s+)\bsimilar\s+to\s+'(?<pattern>[^'%]+)%'/g
  * matches mid-name (`fooex1bar`) and selects far more than the prefix, but
  * crediting it as a prefix would be under-crediting, not a leak — the risk runs
  * the other way, so the `^` is required and an unanchored pattern yields no
- * matcher. Past the anchor only a metachar-free literal is read: the remaining
- * POSIX regex syntax is not JS regex syntax (bracket expressions, back
- * references, `{n,m}` bounds), so translating it would be guesswork, and reading
- * it literally would credit names the sweep does not select.
+ * matcher. Past the anchor only a metachar-free literal is read, optionally
+ * followed by a trailing `.*` (which constrains nothing, so `^ex_.*` is the same
+ * prefix as `^ex_`): the remaining POSIX regex syntax is not JS regex syntax
+ * (bracket expressions, back references, `{n,m}` bounds), so translating it
+ * would be guesswork, and reading it literally would credit names the sweep does
+ * not select.
  */
 const REGEXP_PREFIX_RE = /(?<![!~])(?<op>~\*?)\s*'(?<pattern>[^']*)'/g;
-const REGEXP_LITERAL_RE = /^\^(?<literal>[^.*+?^${}()|[\]\\]*)$/;
+const REGEXP_LITERAL_RE = /^\^(?<literal>[^.*+?^${}()|[\]\\]+)(?:\.\*)?$/;
 /** A trailing `ESCAPE '<char>'` clause, and the leading keyword on its own. */
 const ESCAPE_CLAUSE_RE = /^\s*escape\s+'([^'])'/i;
 const ESCAPE_KEYWORD_RE = /^\s*escape\b/i;
@@ -415,7 +417,7 @@ export function sweepPrefixMatchers(text) {
       const matcher = likePrefixMatcher(
         pattern,
         clause === null ? "\\" : clause[1],
-        i !== undefined && i !== "",
+        Boolean(i),
         similar,
       );
       if (matcher !== null) matchers.push(matcher);
@@ -425,7 +427,7 @@ export function sweepPrefixMatchers(text) {
   let m;
   while ((m = REGEXP_PREFIX_RE.exec(text)) !== null) {
     const literal = REGEXP_LITERAL_RE.exec(m.groups.pattern);
-    if (literal === null || literal.groups.literal === "") continue;
+    if (literal === null) continue;
     matchers.push(new RegExp(`^${literal.groups.literal}`, m.groups.op === "~*" ? "i" : ""));
   }
   return matchers;

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -148,6 +148,38 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // SIMILAR TO keeps `%` and `_` as LIKE wildcards, so `ex_%` sweeps `exAfoo`.
+    'await adapter.exec(`CREATE TABLE "exAfoo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // An escaped SIMILAR TO metacharacter is the literal it says it is.
+    'await adapter.exec(`CREATE TABLE "ex*foo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex!*%' ESCAPE '!'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // An anchored `~` pattern is a prefix filter.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // `~*` is the case-insensitive spelling, so `^ex_` selects `EX_FOO` too.
+    'await adapter.exec(`CREATE TABLE "EX_FOO" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~* '^ex_'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -586,6 +618,102 @@ tester.run("require-table-teardown", rule, {
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // NOT SIMILAR TO is an exclusion filter and yields no prefix either.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename NOT SIMILAR TO 'ex_%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // An alternation is regex syntax under SIMILAR TO, not a literal prefix.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO '(ex|tmp)_%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // `*` is a repeat under SIMILAR TO, so it is not read as a literal asterisk.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex*foo" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex*%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex*foo" } }],
+    },
+    // An unanchored `~` pattern matches mid-name, so it is not a prefix filter.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ 'ex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // Regex syntax past the anchor is not translated, so it credits nothing.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^(ex|tmp)_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // `!~` is the negated operator: an exclusion filter yields no prefix.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename !~ '^ex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // `!~*` is negated too, case-insensitivity notwithstanding.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "EX_FOO" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename !~* '^ex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "EX_FOO" } }],
+    },
+    // `~` stays case-sensitive: only `~*` carries the `i` flag.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "EX_FOO" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "EX_FOO" } }],
     },
   ],
 });

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -180,6 +180,14 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // A trailing `.*` constrains nothing, so `^ex_.*` is the same prefix.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_.*'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -702,6 +710,30 @@ tester.run("require-table-teardown", rule, {
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "EX_FOO" } }],
+    },
+    // A bare anchor selects every name and is no prefix, so it credits nothing.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // `~~` is the LIKE operator, not the regex one, and is not read as a regex.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~~ '^ex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
     // `~` stays case-sensitive: only `~*` carries the `i` flag.
     {


### PR DESCRIPTION
Reads two further spellings of the catalogue sweep filter in `sweepPrefixMatchers`, both previously listed as KNOWN GAPS (under-accepting: a real sweep went unrecognised and its creates reported `missingTeardown`).

- `SIMILAR TO` / `NOT SIMILAR TO` — routed through the LIKE compiler (`%`/`_` wildcards, `ESCAPE` clause honoured), but an unescaped `| * + ? ( ) [ ] { }` carries regex meaning the compiler does not translate, so it makes the filter unreadable rather than being mis-read as a literal. Escaped, it is the literal it says it is.
- `~` / `~*` / `!~` / `!~*` — a prefix only when anchored with `^`; unanchored yields no matcher. Past the anchor only a metachar-free literal is read. `~*` compiles with the `i` flag; the negated forms yield nothing, as `NOT LIKE` already does.

Rule tests pin each accepted and each rejected spelling; the header KNOWN GAPS paragraph now states what is actually read.

Closes-story: require-table-teardown-read-similar-to-and-regex-sweep-filters
