### PR TITLE
test(activerecord): port the remaining Migration::RenameTableTest cases

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -763,6 +763,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async renameTable(tableName: string, newName: string): Promise<void> {
+    this.schemaStatements().validateTableLengthBang(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, tableName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, newName);
     await this._execMutation(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4084,6 +4084,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
+    this.schemaStatements().validateTableLengthBang(newName);
     const [oldSchema, unqualifiedOld] = this.extractSchemaQualifiedName(oldName);
     const [, unqualifiedNew] = this.extractSchemaQualifiedName(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, oldName);
@@ -4127,6 +4128,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         }
       }
     }
+    await this.schemaStatements().renameTableIndexes(oldName, newName);
   }
 
   async tables(): Promise<string[]> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1654,11 +1654,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async renameTable(tableName: string, newName: string): Promise<void> {
+    this.schemaStatements().validateTableLengthBang(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, tableName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, newName);
     await this.execute(
       `ALTER TABLE ${quoteTableName(tableName)} RENAME TO ${quoteTableName(newName)}`,
     );
+    await this.schemaStatements().renameTableIndexes(tableName, newName);
   }
 
   async addColumn(

--- a/packages/activerecord/src/migration/rename-table.test.ts
+++ b/packages/activerecord/src/migration/rename-table.test.ts
@@ -39,9 +39,6 @@ describe("Migration", () => {
       await connection.renameTable("octopi", "test_models");
     }
     await connection.dropTable("test_models", { ifExists: true });
-    // No Rails counterpart: `references` is a canonical table on the shared
-    // per-worker database, so if the reserved-words case dies between its two
-    // renames the next file in this worker would find it missing.
     if (await connection.tableExists("old_references")) {
       await connection.dropTable("old_references", { ifExists: true });
       await rebuildCanonicalTables(connection, ["references"]);

--- a/packages/activerecord/src/migration/rename-table.test.ts
+++ b/packages/activerecord/src/migration/rename-table.test.ts
@@ -1,7 +1,6 @@
 /**
- * Port of `test_rename_table` from `ActiveRecord::Migration::RenameTableTest`
- * (vendor/rails/activerecord/test/cases/migration/rename_table_test.rb:43-49).
- * The rest of rename_table_test.rb is unported.
+ * Port of `ActiveRecord::Migration::RenameTableTest`
+ * (vendor/rails/activerecord/test/cases/migration/rename_table_test.rb).
  *
  * Driven by the ambient connection, mirroring Rails'
  * `@connection = ActiveRecord::Base.lease_connection`. `test_models` is not a
@@ -11,6 +10,17 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ambientConnection } from "../support/rocket-tables.js";
+import { ArgumentError } from "@blazetrails/activemodel";
+import { rebuildCanonicalTables } from "../support/canonical-table-rebuild.js";
+
+interface TableNameLimits {
+  tableNameLength(): number;
+}
+
+interface IndexShape {
+  readonly name: string;
+  readonly columns: string[];
+}
 
 describe("Migration", () => {
   beforeEach(async () => {
@@ -29,9 +39,42 @@ describe("Migration", () => {
       await connection.renameTable("octopi", "test_models");
     }
     await connection.dropTable("test_models", { ifExists: true });
+    // No Rails counterpart: `references` is a canonical table on the shared
+    // per-worker database, so if the reserved-words case dies between its two
+    // renames the next file in this worker would find it missing.
+    if (await connection.tableExists("old_references")) {
+      await connection.dropTable("old_references", { ifExists: true });
+      await rebuildCanonicalTables(connection, ["references"]);
+    }
   });
 
   describe("RenameTableTest", () => {
+    it("rename table should work with reserved words", async () => {
+      const connection = await ambientConnection();
+      let renamed = false;
+
+      await connection.renameTable("references", "old_references");
+      await connection.renameTable("test_models", "references");
+
+      renamed = true;
+
+      try {
+        // Using explicit id in insert for compatibility across all databases
+        const tableName = connection.quoteTableName("references");
+        await connection.execute(
+          `INSERT INTO ${tableName} (id, url) VALUES (123, 'http://rubyonrails.com')`,
+        );
+        expect(await connection.selectValue(`SELECT url FROM ${tableName} WHERE id=123`)).toBe(
+          "http://rubyonrails.com",
+        );
+      } finally {
+        if (renamed) {
+          await connection.renameTable("references", "test_models");
+          await connection.renameTable("old_references", "references");
+        }
+      }
+    });
+
     it("rename table", async () => {
       const connection = await ambientConnection();
       await connection.renameTable("test_models", "octopi");
@@ -43,6 +86,70 @@ describe("Migration", () => {
       expect(await connection.selectValue("SELECT url FROM octopi WHERE id=1")).toBe(
         "http://www.foreverflying.com/octopus-black7.jpg",
       );
+    });
+
+    it("rename table raises for long table names", async () => {
+      const connection = await ambientConnection();
+      const nameLimit = (connection as unknown as TableNameLimits).tableNameLength();
+      const longName = "a".repeat(nameLimit + 1);
+      const shortName = "a".repeat(nameLimit);
+
+      try {
+        await expect(connection.renameTable("test_models", longName)).rejects.toThrow(
+          new ArgumentError(
+            `Table name '${longName}' is too long; the limit is ${nameLimit} characters`,
+          ),
+        );
+
+        await connection.renameTable("test_models", shortName);
+        expect(await connection.tableExists(shortName)).toBe(true);
+      } finally {
+        await connection.dropTable(shortName, { ifExists: true });
+      }
+    });
+
+    it("rename table with an index", async () => {
+      const connection = await ambientConnection();
+      await connection.addIndex("test_models", "url");
+
+      await connection.renameTable("test_models", "octopi");
+
+      await connection.execute(
+        `INSERT INTO octopi (${connection.quoteColumnName("id")}, ${connection.quoteColumnName("url")}) VALUES (1, 'http://www.foreverflying.com/octopus-black7.jpg')`,
+      );
+
+      expect(await connection.selectValue("SELECT url FROM octopi WHERE id=1")).toBe(
+        "http://www.foreverflying.com/octopus-black7.jpg",
+      );
+      const index = (await connection.indexes("octopi"))[0] as IndexShape;
+      expect(index.columns).toContain("url");
+      expect(index.name).toBe("index_octopi_on_url");
+    });
+
+    it("rename table with long table name and index", async () => {
+      const connection = await ambientConnection();
+      const longName = "a".repeat((connection as unknown as TableNameLimits).tableNameLength());
+
+      try {
+        await connection.addIndex("test_models", "url");
+        await connection.renameTable("test_models", longName);
+
+        const index = (await connection.indexes(longName))[0] as IndexShape;
+        expect(index.columns).toContain("url");
+      } finally {
+        await connection.renameTable(longName, "test_models");
+      }
+    });
+
+    it("rename table does not rename custom named index", async () => {
+      const connection = await ambientConnection();
+      await connection.addIndex("test_models", "url", { name: "special_url_idx" });
+
+      await connection.renameTable("test_models", "octopi");
+
+      expect((await connection.indexes("octopi")).map((i) => (i as IndexShape).name)).toEqual([
+        "special_url_idx",
+      ]);
     });
   });
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -401,13 +401,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "rename_table",
-    "call": "validate_table_length!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "returning_column_values",
     "call": "first",
     "reason": "Include stand-in: `MySQL::DatabaseStatements#returning_column_values` is ported in the Rails-layout file `connection-adapters/mysql/database-statements.ts` (`returningColumnValues`, which does read `result.rows[0]`); the adapter method is the `include` resolution point and only delegates."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -801,21 +801,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "rename_table",
-    "call": "rename_table_indexes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_table",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_table",
-    "call": "validate_table_length!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -681,20 +681,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "rename_table",
-    "call": "rename_table_indexes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "rename_table",
-    "call": "validate_table_length!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "returning_column_values",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Ports the five unported cases from `vendor/rails/activerecord/test/cases/migration/rename_table_test.rb` into `packages/activerecord/src/migration/rename-table.test.ts`, taking `test:compare` for that file from 5 missing to 0.

Porting them exposed real `rename_table` divergences, fixed here:

- None of the three adapters called `validate_table_length!` on the new name (`sqlite3_adapter.rb:331`, `abstract_mysql_adapter.rb:332`, `postgresql/schema_statements.rb:435`), so `test_rename_table_raises_for_long_table_names` had nothing to raise. `validateTableLengthBang` existed with zero callers.
- The SQLite and PostgreSQL adapters skipped the trailing `rename_table_indexes` call, so an auto-named index kept the old table's name after a rename (`index_test_models_on_url` instead of `index_octopi_on_url`). MySQL already had it.

`test_rename_table_should_work_with_reserved_words` renames the canonical `references` table on the shared per-worker database. The port mirrors Rails' `ensure` restore, and teardown adds a trails-only net (no Rails counterpart, commented at the call site): if the case dies between the two renames, `references` is rebuilt via `rebuildCanonicalTables` so the next file in the worker isn't left without it.

Verified green on all three lanes locally: sqlite3, PostgreSQL (the full `migration/` + `adapters/postgresql/` trees, 1302 passed), and MySQL.

Closes-story: port-migration-rename-table-cases

---

## Review response: `**options` / `_uses_legacy_table_name` pass-through

Not adopting this one — the requested behavior is reachable only from a Rails
subsystem trails deliberately does not have.

`_uses_legacy_table_name` and `_uses_legacy_index_name` have exactly one
producer in the entire Rails tree. Grepping `activerecord/lib` for both keys
returns four *consumers* (`abstract/schema_statements.rb:295,995,1712`, plus the
three adapter `rename_table` bodies) and two *producers*:
`migration/compatibility.rb:117` and `:124-125`. Both producer sites sit inside
`class V7_0` (compatibility.rb:40-163), i.e. `ActiveRecord::Migration[7.0]` and
older.

trails has no versioned-migration compatibility family. That was settled by an
explicit product decision: PR #5070 shipped a complete, CI-green, review-clean
`Migration[6.1]` / `Compatibility::V6_1` implementation and was closed
**unmerged** — "the premise of this pr is not the goal of trails. We have no
backwards compatibility necessary since there never were previous versions of
trails." `packages/activerecord/src/migration/compatibility.ts` registers
version `"1.0"` only, and no `V*` class exists to set either flag.

So the guard would be permanently un-armed: `options[:_uses_legacy_table_name]`
can never be truthy here, making `unless options[...]` equivalent to the
unconditional `validate_table_length!` this PR added, and the forwarded
`**options` always empty. Adding it also means widening
`renameTable(oldName, newName)` — a signature shared by three adapters, the
abstract base, and the `AbstractAdapter` interface — which trips the wide-call
ratchet across the package for a branch that cannot execute.

The pre-existing consumer-side machinery (`schema-statements.ts:1091` reading
`_usesLegacyIndexName`, `:2361` stripping `_usesLegacyTableName`) stays as-is;
the standing guidance is that machinery already shipped remains but is not
extended.

If the legacy-migration family is ever brought into scope, this guard belongs in
that work alongside the `V*` classes that arm it — not ahead of them.
