### PR TITLE
fix(eslint): read a hoisted sweep's DROP half in require-table-teardown

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -673,7 +673,7 @@ const rule = {
           if (typeof arg.value === "string") recordText(arg.value, arg, null);
         } else if (arg.type === "TemplateLiteral") {
           recordQuasis(
-            arg.quasis.map((q) => q.value.cooked),
+            arg.quasis.map((q) => q.value.cooked ?? ""),
             arg,
           );
         } else if (arg.type === "Identifier") {

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -138,21 +138,23 @@
  * filter spellings read are `LIKE`, `ILIKE`, `SIMILAR TO` and `~` / `~*`; their
  * negations are deliberately read as nothing (see `LIKE_PREFIX_RE`).
  *
- * The identifier in that list is the shared `sqlTexts` (`eslint/sql-texts.mjs`),
+ * The identifier in that list is the shared resolver (`eslint/sql-texts.mjs`),
  * so a filter hoisted to a `const SWEEP_SQL` — or assigned to a `let` after its
  * declaration — arms the same prefixes as the inline spelling, and the two rules
  * cannot disagree about which writes a hoisted query can carry. A string that
  * never reaches a sink still arms nothing, so an expected-SQL assertion over
- * rendered DDL stays quiet. A resolved template is read one quasi at a time
- * (`separateQuasis`), never joined: a joined `LIKE 'ex${suffix}%'` would read as
- * the static prefix `ex `, arming a prefix the query does not select and
- * suppressing the leak of a table like `ex leak`. Reading each quasi alone
- * leaves `LIKE 'ex` unterminated, so an interpolated pattern credits nothing —
- * the same answer the inline-template path gives, and the right one, since `_`
- * and `%` are wildcards whose meaning depends on text the lint pass cannot see.
- * Only the FILTER is read off a resolved variable, never a create or drop name:
- * a name at a quasi boundary needs the dynamic-end signal `recordText` carries,
- * which a resolved text has no node to supply.
+ * rendered DDL stays quiet. A resolved template is read one quasi at a time,
+ * never joined: a joined `LIKE 'ex${suffix}%'` would read as the static prefix
+ * `ex `, arming a prefix the query does not select and suppressing the leak of
+ * a table like `ex leak`. Reading each quasi alone leaves `LIKE 'ex`
+ * unterminated, so an interpolated pattern credits nothing — the same answer
+ * the inline-template path gives, and the right one, since `_` and `%` are
+ * wildcards whose meaning depends on text the lint pass cannot see. The whole
+ * reading is applied to a resolved string, not just the filter: the resolver
+ * hands back each string's quasi array (`createSqlTextGroups`), so every quasi
+ * gets the successor texts `recordText` needs, and a hoisted `DROP TABLE
+ * "${row.tablename}"` arms the sweep while a hoisted `DROP TABLE tmp_${suffix}`
+ * — a name flush against a substitution — still names nothing.
  *
  * This is deliberately independent of `require-canonical-rebuild`: the two
  * rules answer different questions. A sweep that can select a canonical table
@@ -186,7 +188,7 @@
 
 import { calledName, staticString, SQL_SINKS } from "./sql-call-shapes.mjs";
 import { createSweepBinding } from "./sweep-binding.mjs";
-import { createSqlTexts } from "./sql-texts.mjs";
+import { createSqlTextGroups } from "./sql-texts.mjs";
 
 /** The created table name (createTable's first arg), or null if not static. */
 function createdTableName(call) {
@@ -584,7 +586,7 @@ const rule = {
     const { isSweepBound, resolve } = createSweepBinding(context, {
       loopBindingNeedsSinkIterable: true,
     });
-    const sqlTexts = createSqlTexts(resolve, { separateQuasis: true });
+    const sqlTextGroups = createSqlTextGroups(resolve);
 
     // table name → first create node seen (for the report location).
     const created = new Map();
@@ -655,26 +657,31 @@ const rule = {
       if (hasDynamicDropName(text, nextTexts)) sawSweepDrop = true;
     }
 
+    // Each quasi is static text between interpolations; a quasi that is
+    // followed by an interpolation has a dynamic end (see rawCreateNames), and
+    // the quasis after it are where the interpolated values resume.
+    function recordQuasis(quasis, node) {
+      const last = quasis.length - 1;
+      quasis.forEach((text, i) => {
+        if (text) recordText(text, node, i < last ? quasis.slice(i + 1) : null);
+      });
+    }
+
     function recordSinkSql(call) {
       for (const arg of call.arguments) {
         if (arg.type === "Literal") {
           if (typeof arg.value === "string") recordText(arg.value, arg, null);
         } else if (arg.type === "TemplateLiteral") {
-          // Each quasi is static text between interpolations; a quasi that is
-          // followed by an interpolation has a dynamic end (see rawCreateNames),
-          // and the quasis after it are where the interpolated values resume.
-          const last = arg.quasis.length - 1;
-          arg.quasis.forEach((q, i) => {
-            if (q.value.cooked) {
-              recordText(
-                q.value.cooked,
-                arg,
-                i < last ? arg.quasis.slice(i + 1).map((n) => n.value.cooked) : null,
-              );
-            }
-          });
+          recordQuasis(
+            arg.quasis.map((q) => q.value.cooked),
+            arg,
+          );
         } else if (arg.type === "Identifier") {
-          for (const text of sqlTexts(arg)) sweptPrefixes.push(...sweepPrefixMatchers(text));
+          // A resolved string is read exactly like an inline one: its quasi
+          // group carries the same boundary information the AST would, so a
+          // hoisted sweep's DROP half arms and a hoisted raw CREATE/DROP folds
+          // into the same balance.
+          for (const quasis of sqlTextGroups(arg)) recordQuasis(quasis, arg);
         }
       }
     }

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -231,6 +231,23 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // The DROP half hoisted to a variable is the same sweep as the inline
+    // spelling: the resolved template is read one quasi at a time, so the
+    // interpolated name still reads as dynamic.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  const dropSql = `DROP TABLE IF EXISTS "${t.tablename}"`;\n' +
+      "  await adapter.exec(dropSql);\n" +
+      "}",
+    // A raw create and drop hoisted into variables balance each other exactly
+    // as the inline spelling does.
+    'const createSql = `CREATE TABLE "widgets" (id int)`;\n' +
+      "await adapter.exec(createSql);\n" +
+      'const dropSql = "DROP TABLE widgets";\n' +
+      "await adapter.exec(dropSql);",
   ],
   invalid: [
     // Dropping the truncated prefix of a spaced quoted name is not a teardown
@@ -746,6 +763,28 @@ tester.run("require-table-teardown", rule, {
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "EX_FOO" } }],
+    },
+    // A hoisted drop whose name is flush against a substitution names no
+    // knowable table and is not the drop half of a sweep either, so the file's
+    // prefixed create is still reported.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+        ");\n" +
+        "const dropSql = `DROP TABLE tmp_${suffix}`;\n" +
+        "await adapter.exec(dropSql);",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // A hoisted DDL string that never reaches a sink arms nothing: the drop it
+    // spells is never executed, so the create it would balance still reports.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "widgets" (id int)`);\n' +
+        'const dropSql = "DROP TABLE widgets";\n' +
+        "expect(dropSql).toBe(rendered);",
+      errors: [{ messageId: "missingTeardown", data: { table: "widgets" } }],
     },
   ],
 });

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -764,6 +764,12 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "EX_FOO" } }],
     },
+    // A raw create hoisted to a variable and then executed leaks exactly like
+    // the inline spelling, so it is reported when nothing drops it.
+    {
+      code: 'const createSql = `CREATE TABLE "widgets" (id int)`;\nawait adapter.exec(createSql);',
+      errors: [{ messageId: "missingTeardown", data: { table: "widgets" } }],
+    },
     // A hoisted drop whose name is flush against a substitution names no
     // knowable table and is not the drop half of a sweep either, so the file's
     // prefixed create is still reported.

--- a/eslint/sql-texts.mjs
+++ b/eslint/sql-texts.mjs
@@ -18,30 +18,44 @@
  * so hoisting a query to a `const SWEEP_SQL` does not hide it while an
  * expected-SQL assertion never reaches a sink and so arms nothing.
  *
- * A template's quasis are joined with a space by default, which is lossy about
- * where the substitutions sat: it can only ADD strings a reader might match, so
- * it is safe for a rule whose matches produce reports and unsafe for one whose
- * matches suppress them. `separateQuasis` yields each quasi as its own string
- * instead, so nothing spans a substitution — the reading the inline-template
- * path of `require-table-teardown` already uses, where a joined
- * `LIKE 'ex${suffix}%'` would otherwise read as the static prefix `ex `.
+ * A template's quasis are joined with a space, which is lossy about where the
+ * substitutions sat: it can only ADD strings a reader might match, so it is
+ * safe for a rule whose matches produce reports and unsafe for one whose
+ * matches suppress them. A rule that needs to know where the substitutions sat
+ * takes `createSqlTextGroups` below instead of joining.
  */
-export function createSqlTexts(resolve, { separateQuasis = false } = {}) {
-  return function sqlTexts(node, seen = new Set()) {
-    if (node?.type === "Literal") return typeof node.value === "string" ? [node.value] : [];
-    if (node?.type === "TemplateLiteral") {
-      const quasis = node.quasis.map((q) => q.value.cooked ?? "");
-      return separateQuasis ? quasis : [quasis.join(" ")];
-    }
+export function createSqlTexts(resolve) {
+  const sqlTextGroups = createSqlTextGroups(resolve);
+  return function sqlTexts(node) {
+    return sqlTextGroups(node).map((g) => g.join(" "));
+  };
+}
+
+/**
+ * The same resolution, but each resolved string is returned as its *quasi
+ * array* — one entry per static run, in order — rather than as a flat string.
+ *
+ * A caller reading a table NAME off a resolved string needs to know whether the
+ * name it found is complete or runs into a substitution, and the flat form has
+ * thrown that away: `DROP TABLE tmp_${suffix}` and `DROP TABLE tmp_` reduce to
+ * the same text. Keeping the group intact lets the caller pass each quasi its
+ * successors, which is exactly the dynamic-end signal the inline-template path
+ * already derives from the AST. A plain string resolves to a one-element group,
+ * which correctly reads as having no dynamic end anywhere.
+ */
+export function createSqlTextGroups(resolve) {
+  return function sqlTextGroups(node, seen = new Set()) {
+    if (node?.type === "Literal") return typeof node.value === "string" ? [[node.value]] : [];
+    if (node?.type === "TemplateLiteral") return [node.quasis.map((q) => q.value.cooked ?? "")];
     if (node?.type !== "Identifier") return [];
     const variable = resolve(node);
     if (variable === null || seen.has(variable)) return [];
     seen.add(variable);
     const out = [];
     const init = variable.defs?.[0]?.node?.init;
-    if (init) out.push(...sqlTexts(init, seen));
+    if (init) out.push(...sqlTextGroups(init, seen));
     for (const ref of variable.references) {
-      if (ref.writeExpr) out.push(...sqlTexts(ref.writeExpr, seen));
+      if (ref.writeExpr) out.push(...sqlTextGroups(ref.writeExpr, seen));
     }
     return out;
   };


### PR DESCRIPTION
`recordSinkSql`'s `Identifier` branch ran a resolved sink argument through
`sweepPrefixMatchers` only, so a sweep whose `DROP TABLE` template was hoisted
to a variable never set `sawSweepDrop` and the file's prefixed creates all
reported `missingTeardown` — noise in the same under-accepting direction #5572
closed.

The blocker was that `recordText` needs each quasi's successor texts to decide
whether a name at a substitution boundary is complete, and the flat text list
had thrown that away. `createSqlTexts` now delegates to a new
`createSqlTextGroups`, which returns each resolved string as its quasi array;
`createSqlTexts` joins the groups as before, so `require-canonical-rebuild`'s
reading is unchanged. `require-table-teardown` takes the groups and feeds them
through the same `recordQuasis` helper the inline-template path now uses, so a
resolved string is read exactly like an inline one: hoisted sweep drops arm,
hoisted raw `CREATE`/`DROP` fold into the create/drop balance, a name flush
against a substitution (`DROP TABLE tmp_${suffix}`) still names nothing, and an
interpolated `LIKE` pattern still credits no prefix. A hoisted DDL string that
never reaches a sink still arms nothing.

The now-unused `separateQuasis` option is dropped.

Closes-story: require-table-teardown-read-hoisted-sweep-drops
