### PR TITLE
feat(eslint): translate SIMILAR TO and POSIX regex sweep filters in require-table-teardown

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -132,9 +132,14 @@
  * are reported, which is noise rather than a leak): SQL built by concatenation
  * or returned from a helper, since only a literal, a template, or an identifier
  * holding one is read; a catalogue relation `CATALOGUE_SOURCE` does not list;
- * a `SIMILAR TO` pattern using regex syntax the LIKE compiler does not translate
- * (`| * + ? ( ) [ ] { }` unescaped); and a regex (`~` / `~*`) filter that is
- * either unanchored or whose pattern past the `^` is not a plain literal. The
+ * an unanchored regex (`~` / `~*`) filter, which matches mid-name and is no
+ * prefix at all; and, in either regex spelling, a construct whose JS meaning
+ * differs from its POSIX one and so is refused rather than mistranslated — a
+ * POSIX class or collating element (`[[:alpha:]]`), a back reference or class
+ * shorthand (`\1`, `\d`), an `^` or `$` past the leading anchor, and a pattern
+ * that does not compile at all. Everything else in the two regex grammars —
+ * alternation, grouping, `* + ?`, `{n,m}` bounds, bracket expressions, `.` — is
+ * translated (`posixRegexpSource`, `similarPrefixMatcher`). The
  * filter spellings read are `LIKE`, `ILIKE`, `SIMILAR TO` and `~` / `~*`; their
  * negations are deliberately read as nothing (see `LIKE_PREFIX_RE`).
  *
@@ -366,15 +371,12 @@ const CATALOGUE_SOURCE =
 const LIKE_PREFIX_RE = /(?<!\bnot\s+)\b(?<i>i?)like\s+'(?<pattern>[^'%]+)%'/gi;
 /**
  * `SIMILAR TO` is the same catalogue filter in SQL-standard regex spelling: `%`
- * and `_` stay LIKE wildcards and the `ESCAPE` clause still applies, so it is
- * read through the same compiler — but it ALSO gives regex meaning to
- * `| * + ? ( ) [ ] { }`, which LIKE does not. Those are refused rather than
- * translated (`similarMetacharUnreadable`): reading `SIMILAR TO '(ex|tmp)_%'`
- * as the literal prefix `(ex|tmp)` would credit nothing anyway, and reading
- * `'ex*_%'` as a literal asterisk would credit `ex*A` — a name that sweep does
- * not select, which is a leak. Escaping one (`ex\*_%` under the default escape)
- * makes it the literal it says it is, and that IS read. `NOT SIMILAR TO` is an
- * exclusion filter and yields no prefix, exactly as `NOT LIKE` does.
+ * and `_` stay LIKE wildcards and the `ESCAPE` clause still applies — but it
+ * ALSO gives regex meaning to `| * + ? ( ) [ ] { }`, which LIKE does not, so it
+ * gets its own compiler (`similarPrefixMatcher`) rather than the LIKE one.
+ * Escaping a metacharacter (`ex\*_%` under the default escape) makes it the
+ * literal it says it is. `NOT SIMILAR TO` is an exclusion filter and yields no
+ * prefix, exactly as `NOT LIKE` does.
  */
 const SIMILAR_PREFIX_RE = /(?<!\bnot\s+)\bsimilar\s+to\s+'(?<pattern>[^'%]+)%'/gi;
 /**
@@ -388,24 +390,20 @@ const SIMILAR_PREFIX_RE = /(?<!\bnot\s+)\bsimilar\s+to\s+'(?<pattern>[^'%]+)%'/g
  * matches mid-name (`fooex1bar`) and selects far more than the prefix, but
  * crediting it as a prefix would be under-crediting, not a leak — the risk runs
  * the other way, so the `^` is required and an unanchored pattern yields no
- * matcher. Past the anchor only a metachar-free literal is read, optionally
- * followed by a trailing `.*` (which constrains nothing, so `^ex_.*` is the same
- * prefix as `^ex_`): the remaining POSIX regex syntax is not JS regex syntax
- * (bracket expressions, back references, `{n,m}` bounds), so translating it
- * would be guesswork, and reading it literally would credit names the sweep does
- * not select.
+ * matcher. Past the anchor the pattern is translated by `posixRegexpSource`,
+ * never handed to `new RegExp` as-is: POSIX ERE is not JS regex syntax, so every
+ * construct is either translated explicitly or refuses the whole filter.
  */
 const REGEXP_PREFIX_RE = /(?<![!~])(?<op>~\*?)\s*'(?<pattern>[^']*)'/g;
-const REGEXP_LITERAL_RE = /^\^(?<literal>[^.*+?^${}()|[\]\\]+)(?:\.\*)?$/;
 /** A trailing `ESCAPE '<char>'` clause, and the leading keyword on its own. */
 const ESCAPE_CLAUSE_RE = /^\s*escape\s+'([^'])'/i;
 const ESCAPE_KEYWORD_RE = /^\s*escape\b/i;
 export function sweepPrefixMatchers(text) {
   if (!CATALOGUE_SOURCE.test(text)) return [];
   const matchers = [];
-  for (const [re, similar] of [
-    [LIKE_PREFIX_RE, false],
-    [SIMILAR_PREFIX_RE, true],
+  for (const [re, compile] of [
+    [LIKE_PREFIX_RE, likePrefixMatcher],
+    [SIMILAR_PREFIX_RE, similarPrefixMatcher],
   ]) {
     re.lastIndex = 0;
     let m;
@@ -414,23 +412,170 @@ export function sweepPrefixMatchers(text) {
       const clause = ESCAPE_CLAUSE_RE.exec(tail);
       if (clause === null && ESCAPE_KEYWORD_RE.test(tail)) continue;
       const { i, pattern } = m.groups;
-      const matcher = likePrefixMatcher(
-        pattern,
-        clause === null ? "\\" : clause[1],
-        Boolean(i),
-        similar,
-      );
+      const matcher = compile(pattern, clause === null ? "\\" : clause[1], Boolean(i));
       if (matcher !== null) matchers.push(matcher);
     }
   }
   REGEXP_PREFIX_RE.lastIndex = 0;
   let m;
   while ((m = REGEXP_PREFIX_RE.exec(text)) !== null) {
-    const literal = REGEXP_LITERAL_RE.exec(m.groups.pattern);
-    if (literal === null) continue;
-    matchers.push(new RegExp(`^${literal.groups.literal}`, m.groups.op === "~*" ? "i" : ""));
+    const matcher = regexpPrefixMatcher(m.groups.pattern, m.groups.op === "~*");
+    if (matcher !== null) matchers.push(matcher);
   }
   return matchers;
+}
+
+/** The characters that must be backslash-escaped to stay literal in a JS regex. */
+const JS_METACHAR_RE = /[.*+?^${}()|[\]\\]/g;
+/** A bounded repeat, `{n}` / `{n,}` / `{n,m}` — the one spelling JS reads alike. */
+const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
+
+/**
+ * A JS character class equivalent to the POSIX bracket expression starting at
+ * `pattern[start]`, plus the index just past its `]`, or null when the
+ * expression is unterminated or uses syntax whose JS meaning differs.
+ *
+ * The two halves overlap almost exactly — a leading `^` negates, `a-z` is a
+ * range, a `]` in first position is a literal — but two do not, and both are
+ * refused rather than guessed: a POSIX class/collating/equivalence element
+ * (`[[:alpha:]]`, `[[.x.]]`, `[[=a=]]`) has no JS spelling, and a backslash is
+ * an ordinary literal character inside POSIX brackets while JS reads it as an
+ * escape, so it is emitted doubled rather than passed through.
+ */
+function bracketSource(pattern, start) {
+  let source = "[";
+  let i = start + 1;
+  if (pattern[i] === "^") {
+    source += "^";
+    i++;
+  }
+  if (pattern[i] === "]") {
+    source += "\\]";
+    i++;
+  }
+  for (; i < pattern.length && pattern[i] !== "]"; i++) {
+    const ch = pattern[i];
+    if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
+    source += ch === "\\" ? "\\\\" : ch === "[" ? "\\[" : ch === "^" ? "\\^" : ch;
+  }
+  if (i >= pattern.length) return null;
+  return { source: `${source}]`, next: i + 1 };
+}
+
+/**
+ * The JS regex source equivalent to the POSIX ERE `pattern`, or null when it
+ * uses a construct this compiler will not translate. Refusing is always safe
+ * (the sweep goes unrecognised and its creates are reported as noise); guessing
+ * is not, since a widened matcher credits a name the filter does not select.
+ *
+ * Alternation, grouping and the quantifiers `* + ?` are spelled identically in
+ * both, as are `{n,m}` bounds and `.`; bracket expressions go through
+ * `bracketSource`. Refused: a backslash escape of a word character, since
+ * POSIX-ERE back references (`\1`) and PostgreSQL's ARE class shorthands (`\d`)
+ * do not mean in JS what they mean here; a `{` that does not open a bound; and
+ * an `^` or `$` past the leading anchor, which would constrain a position this
+ * prefix reading does not model.
+ */
+function posixRegexpSource(pattern) {
+  let source = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "[") {
+      const bracket = bracketSource(pattern, i);
+      if (bracket === null) return null;
+      source += bracket.source;
+      i = bracket.next;
+    } else if (ch === "\\") {
+      const next = pattern[i + 1];
+      if (next === undefined || /\w/.test(next)) return null;
+      source += `\\${next}`;
+      i += 2;
+    } else if (ch === "{") {
+      const bound = BOUND_RE.exec(pattern.slice(i));
+      if (bound === null) return null;
+      source += bound[0];
+      i += bound[0].length;
+    } else if (ch === "^" || ch === "$") {
+      return null;
+    } else {
+      source += "()|*+?.".includes(ch) ? ch : ch.replace(JS_METACHAR_RE, "\\$&");
+      i++;
+    }
+  }
+  return source;
+}
+
+/**
+ * An anchored RegExp matching the names the regex filter `pattern` selects, or
+ * null when it is unanchored or untranslatable. A bare `^` selects every name
+ * and is no prefix, so it too yields nothing.
+ *
+ * The translated source is wrapped in a group before the anchor is reapplied:
+ * `^(?:a|b)` is what `^a|b` means here, whereas the unwrapped `^a|b` would read
+ * the anchor as binding to the first branch alone. That the POSIX match is a
+ * *search* past the anchor needs no `.*` — a name our matcher accepts matched
+ * the whole translated pattern at position 0, so the filter matches it too.
+ */
+function regexpPrefixMatcher(pattern, caseInsensitive) {
+  if (!pattern.startsWith("^")) return null;
+  const source = posixRegexpSource(pattern.slice(1));
+  if (source === null || source === "") return null;
+  return compileMatcher(`^(?:${source})`, caseInsensitive);
+}
+
+/**
+ * An anchored RegExp matching the names `<pattern>%` selects under
+ * `escapeChar`, or null when the pattern is untranslatable. `SIMILAR TO` reads
+ * `_` and `%` as LIKE wildcards and everything in `| * + ? ( ) [ ] { }` as
+ * regex, which is why it cannot share the LIKE compiler.
+ *
+ * The trailing `%` is translated with the rest (`.*`) and the whole thing
+ * full-matched rather than treated as an implicit prefix, because `SIMILAR TO`
+ * matches the entire name: in `'ex|tmp%'` the `%` belongs to the second branch
+ * only, so a prefix reading of the alternation would credit `exFOO`, which the
+ * filter does not select.
+ */
+function similarPrefixMatcher(pattern, escapeChar, caseInsensitive) {
+  let source = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === escapeChar) {
+      const next = pattern[i + 1];
+      if (next === undefined) return null;
+      source += next.replace(JS_METACHAR_RE, "\\$&");
+      i += 2;
+    } else if (ch === "[") {
+      const bracket = bracketSource(pattern, i);
+      if (bracket === null) return null;
+      source += bracket.source;
+      i = bracket.next;
+    } else if (ch === "{") {
+      const bound = BOUND_RE.exec(pattern.slice(i));
+      if (bound === null) return null;
+      source += bound[0];
+      i += bound[0].length;
+    } else {
+      source += ch === "_" ? "." : "()|*+?".includes(ch) ? ch : ch.replace(JS_METACHAR_RE, "\\$&");
+      i++;
+    }
+  }
+  return compileMatcher(`^(?:${source}.*)$`, caseInsensitive);
+}
+
+/**
+ * `new RegExp(source)`, or null when the source does not compile — a pattern
+ * whose grouping or quantifier placement is unbalanced (`'(ex_%'`, `'*ex_%'`)
+ * is malformed rather than translatable, and must credit nothing rather than
+ * throw out of the lint pass.
+ */
+function compileMatcher(source, caseInsensitive) {
+  try {
+    return new RegExp(source, caseInsensitive ? "i" : "");
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -439,25 +584,22 @@ export function sweepPrefixMatchers(text) {
  * matches the single literal name `ex%`, not a prefix, so it sweeps nothing
  * this rule should credit. `caseInsensitive` is set for `ILIKE` filters only —
  * `LIKE` is case-sensitive in PostgreSQL, so widening it would credit creates
- * the sweep leaves behind. `similarMetacharUnreadable` is set for `SIMILAR TO`,
- * where an unescaped regex metacharacter carries meaning this compiler does not
- * translate and so makes the whole filter unreadable.
+ * the sweep leaves behind. `SIMILAR TO` gives regex meaning to characters LIKE
+ * reads literally and goes through `similarPrefixMatcher` instead.
  */
-function likePrefixMatcher(pattern, escapeChar, caseInsensitive, similarMetacharUnreadable) {
+function likePrefixMatcher(pattern, escapeChar, caseInsensitive) {
   let source = "";
   let escaped = false;
   for (const ch of pattern) {
     if (escaped) {
-      source += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      source += ch.replace(JS_METACHAR_RE, "\\$&");
       escaped = false;
     } else if (ch === escapeChar) {
       escaped = true;
     } else if (ch === "_") {
       source += ".";
-    } else if (similarMetacharUnreadable && "|*+?()[]{}".includes(ch)) {
-      return null;
     } else {
-      source += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      source += ch.replace(JS_METACHAR_RE, "\\$&");
     }
   }
   if (escaped) return null;

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -181,6 +181,15 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // The ESCAPE clause still applies inside a translated pattern: `!(` is a
+    // literal paren, so only the second `(` opens a group.
+    'await adapter.exec(`CREATE TABLE "ex(tmp" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex!((ex|tmp)%' ESCAPE '!'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A bracket expression and a bounded repeat are spelled alike in JS.
     'await adapter.exec(`CREATE TABLE "ex12_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -711,6 +720,18 @@ tester.run("require-table-teardown", rule, {
         'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename ~ 'ex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // An unterminated bracket expression is malformed, so it credits nothing.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[0-9'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -164,6 +164,31 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // An alternation is translated: both branches are prefixes the sweep drops.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      'await adapter.exec(`CREATE TABLE "tmp_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO '(ex|tmp)_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // `ex*` is `e` followed by any run of `x`, so `ex*foo` is a name it selects.
+    'await adapter.exec(`CREATE TABLE "ex*foo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex*%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // A bracket expression and a bounded repeat are spelled alike in JS.
+    'await adapter.exec(`CREATE TABLE "ex12_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex[0-9]{2}_%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // An anchored `~` pattern is a prefix filter.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -184,6 +209,22 @@ tester.run("require-table-teardown", rule, {
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
       "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_.*'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // POSIX alternation past the anchor is translated, not refused.
+    'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^(ex|tmp)_'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // A bracket expression and a `+` quantifier past the anchor are translated.
+    'await adapter.exec(`CREATE TABLE "ex_12" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[0-9]+'`,\n" +
       ");\n" +
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
@@ -639,29 +680,30 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
-    // An alternation is regex syntax under SIMILAR TO, not a literal prefix.
+    // SIMILAR TO matches the whole name, so the `%` belongs to the last branch
+    // alone: `ex|tmp%` selects exactly `ex`, never the prefix `ex`.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "exfoo" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex|tmp%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "exfoo" } }],
+    },
+    // A quantifier with nothing to quantify is malformed, not translatable.
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
-        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO '(ex|tmp)_%'`,\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO '*ex_%'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
-    },
-    // `*` is a repeat under SIMILAR TO, so it is not read as a literal asterisk.
-    {
-      code:
-        'await adapter.exec(`CREATE TABLE "ex*foo" (id int)`);\n' +
-        "const rows = await adapter.execute(\n" +
-        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex*%'`,\n" +
-        ");\n" +
-        "for (const t of rows) {\n" +
-        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
-        "}",
-      errors: [{ messageId: "missingTeardown", data: { table: "ex*foo" } }],
     },
     // An unanchored `~` pattern matches mid-name, so it is not a prefix filter.
     {
@@ -675,12 +717,37 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
-    // Regex syntax past the anchor is not translated, so it credits nothing.
+    // A POSIX class element has no JS spelling, so it is refused, not guessed.
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
-        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^(ex|tmp)_'`,\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:alpha:]]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // A backslash escape of a word character means something else in JS.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\d'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // An `$` past the leading anchor constrains a position this reading models
+    // as open-ended, so the filter is refused rather than read as a prefix.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_$'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +


### PR DESCRIPTION
`sweepPrefixMatchers` read `SIMILAR TO` and the regex operators `~` / `~*` only
in their degenerate, LIKE-shaped spellings: a `SIMILAR TO` pattern containing an
unescaped `| * + ? ( ) [ ] { }` was refused outright, and a regex pattern was read
only when everything past the `^` was a metachar-free literal (plus an optional
trailing `.*`). Both gaps were deliberate and under-accepting — a real prefix
sweep went unrecognised and its creates reported `missingTeardown`.

Both grammars are now translated explicitly rather than refused or passed through
to `new RegExp`:

- `similarPrefixMatcher` compiles the SQL-standard subset — alternation,
  grouping, `* + ?`, `{n,m}` bounds, bracket expressions — alongside the LIKE
  wildcards `_`/`%` and the `ESCAPE` clause. Because `SIMILAR TO` matches the
  whole name, the trailing `%` is translated with the rest and the result
  full-matched (`^(?:....*)$`), so `'ex|tmp%'` binds the `%` to its last branch
  only and does not widen into the prefix `ex`.
- `posixRegexpSource` translates an anchored POSIX ERE past the `^`. Constructs
  whose JS meaning differs from their POSIX one are refused, not guessed: POSIX
  class/collating elements (`[[:alpha:]]`), backslash escapes of word characters
  (`\1`, `\d`), an `^`/`$` past the leading anchor, a backslash inside a bracket
  expression (literal in POSIX, an escape in JS — emitted doubled), and any
  source that does not compile.

The anchor requirement is unchanged: an unanchored `~ 'ex_'` still yields no
matcher, as does every negated spelling. No matcher was widened to credit a name
its filter does not select. Rule tests pin each newly accepted and each still
refused pattern, and the header's KNOWN GAPS paragraph now describes what is
actually read.

Still pre-emptive: no file in the tree writes such a sweep today.

Closes-story: require-table-teardown-translate-sweep-filter-regex-syntax
