### PR TITLE
fix(activerecord): gate pk_autopopulated_by_a_trigger_records in the postgres arm

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -47,6 +47,7 @@ const pgBootListStubs = {
   getDatabaseVersion: async () => "17.0",
   supportsIdentityColumns: () => true,
   supportsPartitionedIndexes: () => true,
+  supportsInsertReturning: () => true,
 };
 
 describe("dropAllTables (PG connection-error retry, fake adapter)", () => {

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -537,7 +537,7 @@ const ADAPTER_SPECIFIC_TABLES: Record<
       ...(pg.supportsPartitionedIndexes()
         ? ["measurements", "measurements_toronto", "measurements_concepcion"]
         : []),
-      "pk_autopopulated_by_a_trigger_records",
+      ...(pg.supportsInsertReturning() ? ["pk_autopopulated_by_a_trigger_records"] : []),
     ];
   },
   mysql: async (adapter) => {


### PR DESCRIPTION
`ADAPTER_SPECIFIC_TABLES.postgres` listed `pk_autopopulated_by_a_trigger_records` unconditionally, but `loadPostgresqlSpecificSchema` only lays it inside `if (adapter.supportsInsertReturning())`, mirroring Rails' `if supports_insert_returning?` block at `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:203-225`. The entry now splices in behind that gate, matching the `supportsIdentityColumns()` and `supportsPartitionedIndexes()` entries beside it.

Same defect class as #5546 (mysql arm) and #5550 (identity tables). Impact is latent, not live: `supports_insert_returning?` is true on every PostgreSQL version trails supports (>= 8.2), so no lane currently mis-resets — this is a correctness-of-the-list fix, keeping the boot list in step with the loader's support gates. No behavior change on any lane, hence no new test; the existing "lists tables the active lane actually has after boot" guard in `load-schema-helper.trails.test.ts` still covers the live case.

Audited the other postgres entries: the loader has exactly three gated blocks (`supportsIdentityColumns`, `supportsPartitionedIndexes`, `supportsInsertReturning`) and all three are now reflected in the arm; every other table is created unconditionally.

Closes-story: pg-boot-list-ignores-insert-returning-gate
