### PR TITLE
fix(activerecord): sweep temp sqlite DBs from globalSetup teardown

### DIFF
--- a/packages/activerecord/src/support/sqlite-template.test.ts
+++ b/packages/activerecord/src/support/sqlite-template.test.ts
@@ -15,6 +15,8 @@ import {
   WORKER_DB_ENV,
   isSqliteRun,
   registerDbFileCleanupOnExit,
+  sweepRunDbFiles,
+  sweepStaleDbFiles,
   unlinkDbFiles,
 } from "./sqlite-template.js";
 
@@ -62,6 +64,61 @@ describe("registerDbFileCleanupOnExit", () => {
     const fs = await getFsAsync();
     const base = await tmpPath();
     expect(() => unlinkDbFiles(fs, base)).not.toThrow();
+  });
+});
+
+describe("sweepRunDbFiles", () => {
+  const token = () => `sweep${Math.random().toString(36).slice(2)}`;
+
+  async function seed(name: string): Promise<string> {
+    const [fs, os] = [await getFsAsync(), await getOsAsync()];
+    const target = `${os.tmpdir()}/${name}`;
+    fs.writeFileSync(target, "");
+    return target;
+  }
+
+  it("unlinks every temp DB stamped with the run token, sidecars included", async () => {
+    const fs = await getFsAsync();
+    const run = token();
+    const seeded = await Promise.all([
+      seed(`ar-test-template-${run}.sqlite`),
+      seed(`ar-test-worker-${run}-1.sqlite`),
+      seed(`ar-test-worker-${run}-1.sqlite-wal`),
+      seed(`ar-test-worker-${run}-1.sqlite-shm`),
+      seed(`ar-test-worker-${run}-1.sqlite_arunit2`),
+      seed(`ar-test-animals-${run}-2.sqlite`),
+    ]);
+
+    await sweepRunDbFiles(run);
+
+    for (const target of seeded) expect(await fs.exists(target), target).toBe(false);
+  });
+
+  it("leaves a concurrent run's files alone", async () => {
+    const fs = await getFsAsync();
+    const other = await seed(`ar-test-worker-${token()}-1.sqlite`);
+    try {
+      await sweepRunDbFiles(token());
+      expect(await fs.exists(other)).toBe(true);
+    } finally {
+      unlinkDbFiles(fs, other);
+    }
+  });
+});
+
+describe("sweepStaleDbFiles", () => {
+  it("keeps a temp DB that a running suite could still be using", async () => {
+    const fs = await getFsAsync();
+    const fresh = `${(await getOsAsync()).tmpdir()}/ar-test-worker-stale${Math.random()
+      .toString(36)
+      .slice(2)}-1.sqlite`;
+    fs.writeFileSync(fresh, "");
+    try {
+      await sweepStaleDbFiles();
+      expect(await fs.exists(fresh)).toBe(true);
+    } finally {
+      unlinkDbFiles(fs, fresh);
+    }
   });
 });
 

--- a/packages/activerecord/src/support/sqlite-template.ts
+++ b/packages/activerecord/src/support/sqlite-template.ts
@@ -118,7 +118,6 @@ async function tempDbEntries(fs: FsAdapter): Promise<string[]> {
   try {
     return (await fs.readdir(await tmpRoot())).filter((name) => name.startsWith(TEMP_DB_PREFIX));
   } catch {
-    // tmpdir unreadable — cleanup is best-effort, never a run failure.
     return [];
   }
 }
@@ -127,7 +126,7 @@ async function unlinkQuietly(fs: FsAdapter, target: string): Promise<void> {
   try {
     await fs.unlink?.(target);
   } catch {
-    // already gone / raced with another sweep — nothing to do.
+    // best-effort
   }
 }
 

--- a/packages/activerecord/src/support/sqlite-template.ts
+++ b/packages/activerecord/src/support/sqlite-template.ts
@@ -65,6 +65,11 @@ const cleanupG = globalThis as typeof globalThis & { __arDbCleanupPaths?: Set<st
  * Register a best-effort `process.on("exit")` unlink of a sqlite file DB and
  * its WAL sidecars, at most once per path per process.
  *
+ * Best-effort really means it: vitest's fork pool signals its workers dead, and
+ * a signalled process never runs `"exit"` listeners. {@link sweepRunDbFiles} in
+ * globalSetup's teardown is what guarantees the files go away; this listener
+ * only makes them go away *sooner* when a worker does exit cleanly.
+ *
  * Callers that must stay `process`-free (`support/connection.ts`, whose
  * fallback DB otherwise lingers in tmpdir after every setup-free run) route
  * their cleanup through here — this module already carries the `process`
@@ -89,6 +94,88 @@ export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
     registered.delete(base);
     throw error;
   }
+}
+
+/**
+ * Shared filename prefix of every temp sqlite DB the AR test harness creates:
+ * the template, the per-worker clones, the scratch databases
+ * (`support/scratch-database.ts`), the setup-free fallback DB
+ * (`support/connection.ts`) and their `_arunit2` siblings.
+ */
+export const TEMP_DB_PREFIX = "ar-test-";
+
+/**
+ * Age past which an `ar-test-*` file in tmpdir is assumed to be orphaned by an
+ * earlier run and swept. No AR test run comes near this, so the cutoff cannot
+ * pull a file out from under a *concurrent* run — which a blanket
+ * prefix-unlink would, since parallel worktrees share one tmpdir.
+ */
+const STALE_DB_AGE_MS = 6 * 60 * 60 * 1000;
+
+/** Temp-dir entries the harness owns, or `[]` when the fs adapter can't list. */
+async function tempDbEntries(fs: FsAdapter): Promise<string[]> {
+  if (!fs.readdir) return [];
+  try {
+    return (await fs.readdir(await tmpRoot())).filter((name) => name.startsWith(TEMP_DB_PREFIX));
+  } catch {
+    // tmpdir unreadable — cleanup is best-effort, never a run failure.
+    return [];
+  }
+}
+
+async function unlinkQuietly(fs: FsAdapter, target: string): Promise<void> {
+  try {
+    await fs.unlink?.(target);
+  } catch {
+    // already gone / raced with another sweep — nothing to do.
+  }
+}
+
+/**
+ * Unlink every temp DB file stamped with `runToken`, whatever created it.
+ *
+ * This is the cleanup that actually survives the run: the
+ * `registerDbFileCleanupOnExit` listeners live in vitest's forked workers, and
+ * tinypool tears those down with a signal rather than a clean shutdown, so
+ * `"exit"` handlers never run and each run leaks its worker clones, scratch
+ * DBs and WAL sidecars. Sweeping from globalSetup's teardown — the one place
+ * that outlives every worker — collects them regardless of how the worker died.
+ *
+ * Matching is by run token, not by prefix alone, so a concurrent run's live
+ * databases are never touched.
+ */
+export async function sweepRunDbFiles(runToken: string): Promise<void> {
+  const [fs, path] = [await getFsAsync(), await getPathAsync()];
+  const root = await tmpRoot();
+  const stamp = `-${runToken}`;
+  await Promise.all(
+    (await tempDbEntries(fs))
+      .filter((name) => name.includes(stamp))
+      .map((name) => unlinkQuietly(fs, path.join(root, name))),
+  );
+}
+
+/**
+ * Unlink temp DB files left behind by runs that predate the token sweep (or
+ * that were killed before their teardown ran, e.g. a `^C`-ed vitest). Runs at
+ * globalSetup time, when nothing of this run exists yet.
+ */
+export async function sweepStaleDbFiles(): Promise<void> {
+  const [fs, path] = [await getFsAsync(), await getPathAsync()];
+  if (!fs.stat) return;
+  const root = await tmpRoot();
+  const cutoff = Date.now() - STALE_DB_AGE_MS;
+  await Promise.all(
+    (await tempDbEntries(fs)).map(async (name) => {
+      const target = path.join(root, name);
+      try {
+        if ((await fs.stat!(target)).mtime.getTime() >= cutoff) return;
+      } catch {
+        return;
+      }
+      await unlinkQuietly(fs, target);
+    }),
+  );
 }
 
 /** Env var: absolute path of the canonical template DB built by globalSetup. */

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -111,10 +111,6 @@ const sqliteAdapter: DbTemplateAdapter = {
     process.env[TEMPLATE_PATH_ENV] = templatePath;
     process.env[RUN_TOKEN_ENV] = runToken;
 
-    // Sweeps the whole run by token — the template, every worker clone and
-    // every scratch DB — because the workers' own `process.on("exit")` unlinks
-    // never fire under the fork pool (see `registerDbFileCleanupOnExit`), and
-    // this teardown is the only hook that outlives them all.
     return async () => {
       await sweepRunDbFiles(runToken);
     };

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -16,7 +16,6 @@
 import pg from "pg";
 import mysql from "mysql2/promise";
 import "../sqlite/better-sqlite3.js";
-import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
@@ -29,8 +28,9 @@ import {
   RUN_TOKEN_ENV,
   TEMPLATE_PATH_ENV,
   isSqliteRun,
+  sweepRunDbFiles,
+  sweepStaleDbFiles,
   templatePathFor,
-  unlinkDbFiles,
 } from "./sqlite-template.js";
 import { slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 import {
@@ -100,6 +100,8 @@ const sqliteAdapter: DbTemplateAdapter = {
       );
     }
 
+    await sweepStaleDbFiles();
+
     const runToken = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
     const templatePath = await templatePathFor(runToken);
 
@@ -109,8 +111,12 @@ const sqliteAdapter: DbTemplateAdapter = {
     process.env[TEMPLATE_PATH_ENV] = templatePath;
     process.env[RUN_TOKEN_ENV] = runToken;
 
+    // Sweeps the whole run by token — the template, every worker clone and
+    // every scratch DB — because the workers' own `process.on("exit")` unlinks
+    // never fire under the fork pool (see `registerDbFileCleanupOnExit`), and
+    // this teardown is the only hook that outlives them all.
     return async () => {
-      unlinkDbFiles(await getFsAsync(), templatePath);
+      await sweepRunDbFiles(runToken);
     };
   },
 };


### PR DESCRIPTION
## Why the exit handler never fires

`registerDbFileCleanupOnExit` attaches `process.on("exit")` in the *worker*
process. vitest's fork pool (tinypool) tears its workers down with a signal, and
a signalled process never runs `"exit"` listeners — so the worker clone, the
scratch DBs (`support/scratch-database.ts`), the setup-free fallback DB, the
`_arunit2` siblings and all their `-wal`/`-shm` sidecars stayed in tmpdir. This
machine had accumulated 10,779 `ar-test-*` files, dated days apart.

## Fix

`sweepRunDbFiles(runToken)` unlinks every `ar-test-*` tmpdir entry stamped with
the run's token, called from the sqlite globalSetup teardown — the one hook that
outlives every worker, and which already owned the template DB's lifecycle. It
replaces the teardown's single-path `unlinkDbFiles(templatePath)`.

Matching is by run token rather than by prefix alone: parallel worktrees share
one tmpdir, so a blanket `ar-test-*` unlink would delete a concurrent run's live
databases.

`sweepStaleDbFiles()` runs at globalSetup time and collects files orphaned by
earlier runs (or by a `^C`-ed run whose teardown never ran), gated on an mtime
older than 6h so it likewise cannot touch a concurrent run.

The `process.on("exit")` listeners stay as a supplement — they still fire on a
clean exit and free the files sooner — with the caveat now documented.

## Verification

`ls /tmp | grep -c ar-test` before/after a two-file sqlite run: identical file
lists, no new leftovers. The pre-existing 10,779-file backlog was collected by
the stale sweep on first run.

Closes-story: sqlite-temp-db-exit-cleanup-unreliable
