### PR TITLE
feat(eslint): translate ARE class shorthands in require-table-teardown regex sweeps

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -136,7 +136,7 @@
  * prefix at all; and, in either regex spelling, a construct whose JS meaning
  * differs from its POSIX one and so is refused rather than mistranslated — a
  * POSIX class or collating element (`[[:alpha:]]`), a back reference (`\1`), an
- * ARE-only escape (`\A`, `\Z`, `\y`, `\m`, `\M`, and `\b`, which PostgreSQL
+ * ARE-only escape (`\A`, `\Z`, `\y`, `\Y`, `\m`, `\M`, and `\b`, which PostgreSQL
  * also spells backspace with inside brackets), a shorthand JS reads more widely
  * than ARE does (`\D`, `\W`, `\s`), a backslash inside a bracket
  * expression, whose meaning depends on which regex engine reads it, an `^` or
@@ -492,7 +492,8 @@ function bracketSource(pattern, start) {
  *
  * Refused alongside them: back references, `\b` (a word boundary in both, but
  * ALSO PostgreSQL's spelling of backspace inside a bracket expression), and the
- * ARE-only `\A` / `\Z` / `\y` / `\m` / `\M`, which JS cannot spell at all.
+ * ARE-only `\A` / `\Z` / `\y` / `\Y` / `\m` / `\M`, which JS cannot spell at all
+ * (`\Y` is ARE's *not* a word boundary, documented alongside the others).
  */
 const ARE_SHORTHANDS = new Set(["d", "w", "S"]);
 
@@ -508,7 +509,7 @@ const ARE_SHORTHANDS = new Set(["d", "w", "S"]);
  * for the ARE class shorthands whose JS meaning is identical (`ARE_SHORTHANDS`);
  * every other one is refused, since a back reference (`\1`) means something
  * else once the `^(?:…)` wrapper adds a group, and the ARE-only escapes (`\A`,
- * `\Z`, `\y`, `\m`, `\M`) have no JS spelling at all. Also refused: a `{` that
+ * `\Z`, `\y`, `\Y`, `\m`, `\M`) have no JS spelling at all. Also refused: a `{` that
  * does not open a bound, and an `^` or `$` past the leading anchor, which would
  * constrain a position this prefix reading does not model.
  */

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -137,10 +137,14 @@
  * differs from its POSIX one and so is refused rather than mistranslated — a
  * POSIX class or collating element (`[[:alpha:]]`), a back reference (`\1`), an
  * ARE-only escape (`\A`, `\Z`, `\y`, `\m`, `\M`, and `\b`, which PostgreSQL
- * also spells backspace with inside brackets), an `^` or `$` past the leading
+ * also spells backspace with inside brackets), a shorthand JS reads more widely
+ * than ARE does (`\D`, `\W`, `\s`), a backslash inside a bracket
+ * expression, whose meaning depends on which regex engine reads it, an `^` or
+ * `$` past the leading
  * anchor, and a pattern that does not compile at all. Everything else in the
  * two regex grammars — alternation, grouping, `* + ?`, `{n,m}` bounds, bracket
- * expressions, `.`, the ARE class shorthands `\d \D \s \S \w \W` — is
+ * expressions, `.`, and the ARE class shorthands whose JS set is no wider
+ * (`\d`, `\w`, `\S` — see `ARE_SHORTHANDS`) — is
  * translated (`posixRegexpSource`, `similarPrefixMatcher`). The
  * filter spellings read are `LIKE`, `ILIKE`, `SIMILAR TO` and `~` / `~*`; their
  * negations are deliberately read as nothing (see `LIKE_PREFIX_RE`).
@@ -442,9 +446,13 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * The two halves overlap almost exactly — a leading `^` negates, `a-z` is a
  * range, a `]` in first position is a literal — but two do not, and both are
  * refused rather than guessed: a POSIX class/collating/equivalence element
- * (`[[:alpha:]]`, `[[.x.]]`, `[[=a=]]`) has no JS spelling, and a backslash is
- * an ordinary literal character inside POSIX brackets while JS reads it as an
- * escape, so it is emitted doubled rather than passed through.
+ * (`[[:alpha:]]`, `[[.x.]]`, `[[=a=]]`) has no JS spelling, and a backslash
+ * means different things in the two grammars. Bare POSIX brackets read it as an
+ * ordinary literal, but PostgreSQL's engine is ARE, which reads it as an escape
+ * inside brackets too (`[\d]` is the digits, not a backslash and a `d`), so
+ * emitting it doubled would credit `exd` for `~ '^ex[\d]'` — a name the filter
+ * does not select. Which reading is right depends on the engine, so a backslash
+ * in a bracket expression refuses the whole filter instead.
  */
 function bracketSource(pattern, start) {
   let source = "[";
@@ -460,7 +468,8 @@ function bracketSource(pattern, start) {
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
     if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
-    source += ch === "\\" ? "\\\\" : ch === "[" ? "\\[" : ch === "^" ? "\\^" : ch;
+    if (ch === "\\") return null;
+    source += ch === "[" ? "\\[" : ch === "^" ? "\\^" : ch;
   }
   if (i >= pattern.length) return null;
   return { source: `${source}]`, next: i + 1 };
@@ -468,14 +477,24 @@ function bracketSource(pattern, start) {
 
 /**
  * The class shorthands PostgreSQL's regex engine (ARE, not bare POSIX ERE)
- * reads and JS reads identically, so `~ '^ex_\d+'` can be translated rather
- * than refused. Deliberately just the six classes: `\b` is a word boundary in
- * both but ALSO PostgreSQL's spelling of backspace inside a bracket
- * expression, and `\A` / `\Z` / `\y` / `\m` / `\M` are ARE-only constraints
- * with no JS equivalent, so all of those stay refused alongside back
- * references.
+ * reads and JS reads alike, so `~ '^ex_\d+'` can be translated rather than
+ * refused.
+ *
+ * Only the three whose JS character set cannot be the *wider* of the two are
+ * here, because a wider matcher credits a name the filter does not select.
+ * ARE's classes are the POSIX ones (`\d` is `[[:digit:]]`, `\w` is
+ * `[[:alnum:]_]`, `\s` is `[[:space:]]`), which a non-C database locale can
+ * extend beyond ASCII; JS's `\d` and `\w` stay ASCII, so both are subsets and
+ * under-accept at worst, and `\S` is the complement of the JS `\s` superset, so
+ * it is a subset too. The complements `\D` and `\W` — and `\s` itself, which JS
+ * extends to Unicode separators PostgreSQL's `[[:space:]]` need not include —
+ * run the other way and stay refused.
+ *
+ * Refused alongside them: back references, `\b` (a word boundary in both, but
+ * ALSO PostgreSQL's spelling of backspace inside a bracket expression), and the
+ * ARE-only `\A` / `\Z` / `\y` / `\m` / `\M`, which JS cannot spell at all.
  */
-const ARE_SHORTHANDS = new Set(["d", "D", "s", "S", "w", "W"]);
+const ARE_SHORTHANDS = new Set(["d", "w", "S"]);
 
 /**
  * The JS regex source equivalent to the POSIX ERE `pattern`, or null when it

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -135,10 +135,12 @@
  * an unanchored regex (`~` / `~*`) filter, which matches mid-name and is no
  * prefix at all; and, in either regex spelling, a construct whose JS meaning
  * differs from its POSIX one and so is refused rather than mistranslated — a
- * POSIX class or collating element (`[[:alpha:]]`), a back reference or class
- * shorthand (`\1`, `\d`), an `^` or `$` past the leading anchor, and a pattern
- * that does not compile at all. Everything else in the two regex grammars —
- * alternation, grouping, `* + ?`, `{n,m}` bounds, bracket expressions, `.` — is
+ * POSIX class or collating element (`[[:alpha:]]`), a back reference (`\1`), an
+ * ARE-only escape (`\A`, `\Z`, `\y`, `\m`, `\M`, and `\b`, which PostgreSQL
+ * also spells backspace with inside brackets), an `^` or `$` past the leading
+ * anchor, and a pattern that does not compile at all. Everything else in the
+ * two regex grammars — alternation, grouping, `* + ?`, `{n,m}` bounds, bracket
+ * expressions, `.`, the ARE class shorthands `\d \D \s \S \w \W` — is
  * translated (`posixRegexpSource`, `similarPrefixMatcher`). The
  * filter spellings read are `LIKE`, `ILIKE`, `SIMILAR TO` and `~` / `~*`; their
  * negations are deliberately read as nothing (see `LIKE_PREFIX_RE`).
@@ -465,6 +467,17 @@ function bracketSource(pattern, start) {
 }
 
 /**
+ * The class shorthands PostgreSQL's regex engine (ARE, not bare POSIX ERE)
+ * reads and JS reads identically, so `~ '^ex_\d+'` can be translated rather
+ * than refused. Deliberately just the six classes: `\b` is a word boundary in
+ * both but ALSO PostgreSQL's spelling of backspace inside a bracket
+ * expression, and `\A` / `\Z` / `\y` / `\m` / `\M` are ARE-only constraints
+ * with no JS equivalent, so all of those stay refused alongside back
+ * references.
+ */
+const ARE_SHORTHANDS = new Set(["d", "D", "s", "S", "w", "W"]);
+
+/**
  * The JS regex source equivalent to the POSIX ERE `pattern`, or null when it
  * uses a construct this compiler will not translate. Refusing is always safe
  * (the sweep goes unrecognised and its creates are reported as noise); guessing
@@ -472,11 +485,13 @@ function bracketSource(pattern, start) {
  *
  * Alternation, grouping and the quantifiers `* + ?` are spelled identically in
  * both, as are `{n,m}` bounds and `.`; bracket expressions go through
- * `bracketSource`. Refused: a backslash escape of a word character, since
- * POSIX-ERE back references (`\1`) and PostgreSQL's ARE class shorthands (`\d`)
- * do not mean in JS what they mean here; a `{` that does not open a bound; and
- * an `^` or `$` past the leading anchor, which would constrain a position this
- * prefix reading does not model.
+ * `bracketSource`. A backslash escape of a word character is translated only
+ * for the ARE class shorthands whose JS meaning is identical (`ARE_SHORTHANDS`);
+ * every other one is refused, since a back reference (`\1`) means something
+ * else once the `^(?:…)` wrapper adds a group, and the ARE-only escapes (`\A`,
+ * `\Z`, `\y`, `\m`, `\M`) have no JS spelling at all. Also refused: a `{` that
+ * does not open a bound, and an `^` or `$` past the leading anchor, which would
+ * constrain a position this prefix reading does not model.
  */
 function posixRegexpSource(pattern) {
   let source = "";
@@ -490,7 +505,8 @@ function posixRegexpSource(pattern) {
       i = bracket.next;
     } else if (ch === "\\") {
       const next = pattern[i + 1];
-      if (next === undefined || /\w/.test(next)) return null;
+      if (next === undefined) return null;
+      if (/\w/.test(next) && !ARE_SHORTHANDS.has(next)) return null;
       source += `\\${next}`;
       i += 2;
     } else if (ch === "{") {

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -238,6 +238,50 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // PostgreSQL's regex engine is ARE, so the class shorthands mean exactly
+    // what they mean in JS and are translated rather than refused.
+    'await adapter.exec(`CREATE TABLE "ex_12" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\d+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\w+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\D'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\S'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_ 1" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\s'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_-1" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\W'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -767,17 +811,114 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
-    // A backslash escape of a word character means something else in JS.
+    // A back reference means something else once the `^(?:…)` wrapper adds a
+    // group, so it stays refused although JS spells it identically.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_ex_1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^(ex)_\\\\1'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_ex_1" } }],
+    },
+    // `\A` is an ARE-only constraint with no JS equivalent.
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
-        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\d'`,\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^\\\\Aex_'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // `\Z` likewise.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\Z'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // `\y`, `\m` and `\M` are ARE word-boundary constraints JS cannot spell.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^\\\\yex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^\\\\mex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\M'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // `\b` is a word boundary in JS but PostgreSQL also spells backspace with
+    // it, so it stays refused rather than translated on a resemblance.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^\\\\bex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    // A translated shorthand credits only the names its filter selects:
+    // `^ex_\d+` does not select `ex_foo`.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\d+'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_foo" } }],
+    },
+    // `\D` is likewise read for what it means: it does not select `ex_1`.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\D'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
     },
     // An `$` past the leading anchor constrains a position this reading models
     // as open-ended, so the filter is refused rather than read as a prefix.

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -842,12 +842,24 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
-    // `\y`, `\m` and `\M` are ARE word-boundary constraints JS cannot spell.
+    // `\y`, `\Y`, `\m` and `\M` are ARE word-boundary constraints JS cannot
+    // spell — `\Y` is the negated one, "not beginning or end of a word".
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^\\\\yex_'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+    },
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\Y'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -256,28 +256,7 @@ tester.run("require-table-teardown", rule, {
       "}",
     'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
-      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\D'`,\n" +
-      ");\n" +
-      "for (const t of rows) {\n" +
-      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
-      "}",
-    'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
-      "const rows = await adapter.execute(\n" +
       "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\S'`,\n" +
-      ");\n" +
-      "for (const t of rows) {\n" +
-      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
-      "}",
-    'await adapter.exec(`CREATE TABLE "ex_ 1" (id int)`);\n' +
-      "const rows = await adapter.execute(\n" +
-      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\s'`,\n" +
-      ");\n" +
-      "for (const t of rows) {\n" +
-      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
-      "}",
-    'await adapter.exec(`CREATE TABLE "ex_-1" (id int)`);\n' +
-      "const rows = await adapter.execute(\n" +
-      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\W'`,\n" +
       ");\n" +
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
@@ -811,6 +790,21 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
+    // A backslash inside a bracket expression is an escape to PostgreSQL's ARE
+    // engine and a literal to bare POSIX, so the filter is refused: reading
+    // `[\d]` as a literal backslash-or-`d` would credit `exd`, which
+    // `~ '^ex[\d]'` does not select.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "exd" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex[\\\\d]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "exd" } }],
+    },
     // A back reference means something else once the `^(?:…)` wrapper adds a
     // group, so it stays refused although JS spells it identically.
     {
@@ -908,17 +902,41 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_foo" } }],
     },
-    // `\D` is likewise read for what it means: it does not select `ex_1`.
+    // `\D`, `\W` and `\s` are wider in JS than ARE's locale-dependent POSIX
+    // classes, so translating them could credit a name the filter does not
+    // select; they are refused rather than accepted on the resemblance.
     {
       code:
-        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\D'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
-      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_foo" } }],
+    },
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_-1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\W'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_-1" } }],
+    },
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_ 1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_\\\\s'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_ 1" } }],
     },
     // An `$` past the leading anchor constrains a position this reading models
     // as open-ended, so the filter is refused rather than read as a prefix.


### PR DESCRIPTION
`posixRegexpSource` refused every backslash escape of a word character, which
lumped together two unlike populations: back references (`\1`), whose meaning
changes once the `^(?:…)` wrapper adds a group, and PostgreSQL's ARE class
shorthands, which JS spells the same way for the `~` / `~*` patterns Arel emits
from `visit_Arel_Nodes_Regexp`. The shorthands are now translated, so
`~ '^ex_\d+'` credits its creates instead of reporting `missingTeardown` as
noise.

Accepted is the subset whose JS character set cannot be the *wider* of the two,
since a wider matcher credits a name the filter does not select: `\d`, `\w` and
`\S`. ARE's classes are the POSIX ones (`\d` = `[[:digit:]]`, `\w` =
`[[:alnum:]_]`), which a non-C database locale can extend past ASCII, while JS's
stay ASCII — subsets, so they under-accept at worst. Their complements `\D` and
`\W`, and `\s` (JS extends it to Unicode separators `[[:space:]]` need not
include), run the other way and stay refused, as do back references, `\b` (a
word boundary in both, but also PostgreSQL's backspace inside brackets) and the
ARE-only `\A` / `\Z` / `\y` / `\m` / `\M`.

Same reasoning closes a leak in the adjacent bracket path: `bracketSource`
emitted a backslash doubled, reading it as bare POSIX's literal. PostgreSQL's
engine is ARE, which escapes inside brackets too, so `~ '^ex[\d]'` was crediting
`exd` — a name it does not select. Which reading is right depends on the engine,
so a backslash in a bracket expression now refuses the filter.

Rule tests pin each accepted shorthand, each refused one, the bracket case, and
that `^ex_\d+` does not satisfy `ex_foo`. The KNOWN GAPS paragraph matches what
is actually read.

Closes-story: require-table-teardown-translate-are-class-shorthands
