### PR TITLE
fix(activerecord): coerce and validate the sqlite timeout config option

### DIFF
--- a/packages/activerecord/src/connection-adapters/adapter-args.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.test.ts
@@ -39,6 +39,15 @@ describe("buildAdapterArg", () => {
       expect(args).toEqual(["x.db", { strict: true, timeout: 5000 }]);
     });
 
+    it("preserves the SQLite retries option", () => {
+      const args = buildAdapterArg("sqlite3", {
+        adapter: "sqlite3",
+        database: "x.db",
+        retries: 3,
+      });
+      expect(args).toEqual(["x.db", { retries: 3 }]);
+    });
+
     it("ignores unrelated database.yml keys (pool, host, etc.)", () => {
       const args = buildAdapterArg("sqlite3", {
         adapter: "sqlite3",

--- a/packages/activerecord/src/connection-adapters/adapter-args.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.ts
@@ -157,6 +157,7 @@ export function buildAdapterArg(
       pragmas,
       strict,
       timeout,
+      retries,
       statementLimit,
       preparedStatements,
       driverOptions,
@@ -172,6 +173,7 @@ export function buildAdapterArg(
     // driver's busy timeout (sqlite3_adapter.rb:821-826); `config.example.yml:84`
     // sets it on both arunit entries.
     if (timeout !== undefined) options.timeout = timeout;
+    if (retries !== undefined) options.retries = retries;
     if (statementLimit !== undefined) options.statementLimit = statementLimit;
     if (preparedStatements !== undefined) options.preparedStatements = preparedStatements;
     if (driverOptions !== undefined) options.driverOptions = driverOptions;

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -321,11 +321,7 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   strict?: boolean;
   // Mirrors: database.yml `timeout:` — the driver's busy timeout, in ms
   // (`sqlite3_adapter.rb:821-826` sets `busy_handler_timeout`).
-  // YAML-parsed configs commonly yield a string here, so the adapter coerces
-  // with `typeCastConfigToInteger` at Rails' `configure_connection` site.
   timeout?: number | string;
-  // Mirrors: database.yml `retries:` — deprecated in Rails 8.0 in favour of
-  // `timeout` (`sqlite3_adapter.rb:827-832`).
   retries?: number | string;
   // Driver-specific options passed through to SqliteOpenConfig.driverOptions.
   // Used by e.g. libsql-remote to forward `authToken` to the Database constructor.

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -321,8 +321,8 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   strict?: boolean;
   // Mirrors: database.yml `timeout:` — the driver's busy timeout, in ms
   // (`sqlite3_adapter.rb:821-826` sets `busy_handler_timeout`).
-  timeout?: number | string;
-  retries?: number | string;
+  timeout?: number | string | false;
+  retries?: number | string | false;
   // Driver-specific options passed through to SqliteOpenConfig.driverOptions.
   // Used by e.g. libsql-remote to forward `authToken` to the Database constructor.
   driverOptions?: Record<string, unknown>;

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -321,7 +321,12 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   strict?: boolean;
   // Mirrors: database.yml `timeout:` — the driver's busy timeout, in ms
   // (`sqlite3_adapter.rb:821-826` sets `busy_handler_timeout`).
-  timeout?: number;
+  // YAML-parsed configs commonly yield a string here, so the adapter coerces
+  // with `typeCastConfigToInteger` at Rails' `configure_connection` site.
+  timeout?: number | string;
+  // Mirrors: database.yml `retries:` — deprecated in Rails 8.0 in favour of
+  // `timeout` (`sqlite3_adapter.rb:827-832`).
+  retries?: number | string;
   // Driver-specific options passed through to SqliteOpenConfig.driverOptions.
   // Used by e.g. libsql-remote to forward `authToken` to the Database constructor.
   driverOptions?: Record<string, unknown>;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
@@ -31,6 +31,19 @@ describe("SQLite3Adapter timeout config coercion", () => {
     ).toThrow(new ArgumentError("Cannot specify both timeout and retries arguments"));
   });
 
+  it("treats a false timeout and a false retries as unset", async () => {
+    const warn = vi.spyOn(deprecator(), "warn").mockImplementation(() => {});
+    adapter = new BetterSQLite3Adapter({ database: ":memory:", timeout: false, retries: false });
+    await adapter.execute("SELECT 1");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("treats a zero timeout as set", async () => {
+    adapter = new BetterSQLite3Adapter({ database: ":memory:", timeout: 0 });
+    const rows = await adapter.execute("PRAGMA busy_timeout");
+    expect(Number(rows[0].timeout)).toBe(0);
+  });
+
   it("deprecates the retries option", async () => {
     const warn = vi.spyOn(deprecator(), "warn").mockImplementation(() => {});
     adapter = new BetterSQLite3Adapter({ database: ":memory:", retries: 3 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { ArgumentError } from "@blazetrails/activemodel";
+import { deprecator } from "../deprecator.js";
+
+// Rails applies the sqlite `timeout`/`retries` options inside
+// `configure_connection` (sqlite3_adapter.rb:820-833): `timeout` is coerced with
+// `type_cast_config_to_integer`, a non-integer raises TypeError, and the two
+// options are mutually exclusive. Rails has no test coverage for that block, so
+// these are trails-only regression tests.
+describe("SQLite3Adapter timeout config coercion", () => {
+  let adapter: AbstractSQLite3Adapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("casts a string timeout to an integer", async () => {
+    adapter = new BetterSQLite3Adapter({ database: ":memory:", timeout: "5000" });
+    const rows = await adapter.execute("PRAGMA busy_timeout");
+    expect(Number(rows[0].timeout)).toBe(5000);
+  });
+
+  it("raises TypeError when the timeout does not cast to an integer", () => {
+    expect(() => new BetterSQLite3Adapter({ database: ":memory:", timeout: "5s" })).toThrow(
+      new TypeError("timeout must be integer, not 5s"),
+    );
+  });
+
+  it("raises ArgumentError when both timeout and retries are given", () => {
+    expect(
+      () => new BetterSQLite3Adapter({ database: ":memory:", timeout: 5000, retries: 3 }),
+    ).toThrow(new ArgumentError("Cannot specify both timeout and retries arguments"));
+  });
+
+  it("deprecates the retries option", async () => {
+    const warn = vi.spyOn(deprecator(), "warn").mockImplementation(() => {});
+    adapter = new BetterSQLite3Adapter({ database: ":memory:", retries: 3 });
+    await adapter.execute("SELECT 1");
+    expect(warn).toHaveBeenCalledWith(
+      "The retries option is deprecated and will be removed in Rails 8.1. Use timeout instead.\n",
+    );
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
@@ -4,11 +4,6 @@ import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { deprecator } from "../deprecator.js";
 
-// Rails applies the sqlite `timeout`/`retries` options inside
-// `configure_connection` (sqlite3_adapter.rb:820-833): `timeout` is coerced with
-// `type_cast_config_to_integer`, a non-integer raises TypeError, and the two
-// options are mutually exclusive. Rails has no test coverage for that block, so
-// these are trails-only regression tests.
 describe("SQLite3Adapter timeout config coercion", () => {
   let adapter: AbstractSQLite3Adapter | undefined;
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -46,6 +46,7 @@ import {
   TransactionIsolationError,
 } from "../errors.js";
 import { ArgumentError, BinaryData } from "@blazetrails/activemodel";
+import { deprecator } from "../deprecator.js";
 import { TypeMap } from "../type/type-map.js";
 import { Date as DateType } from "../type/date.js";
 import { DateTime as ARDateTimeType } from "../type/date-time.js";
@@ -2759,6 +2760,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   /** @internal */
   private connect(): void {
+    // Built outside the try so a bad `timeout`/`retries` config surfaces as the
+    // ArgumentError/TypeError Rails raises, not a DatabaseConnectionError.
+    const openConfig = this.openConfig();
     try {
       const factory = this.resolveDriverFactory();
       if (!factory.openSync) {
@@ -2766,7 +2770,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         this._asyncConnectPending = true;
         return;
       }
-      const syncConn = factory.openSync(this.openConfig());
+      const syncConn = factory.openSync(openConfig);
       // Pre-warm version cache while the connection is a known-sync handle so
       // getDatabaseVersion() never needs to touch this.driver directly. (#1269)
       const vRow = syncConn.prepare("SELECT sqlite_version() AS v").get() as any;
@@ -2795,7 +2799,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       database: this._filename,
       readOnly: this._readonly,
       strict: this._strict,
-      timeout: cfg.timeout,
+      timeout: this.castTimeout(),
       noMutex: cfg.noMutex,
       driverOptions: cfg.driverOptions,
     };
@@ -2803,9 +2807,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   /** Async counterpart to `connect()` for async-only drivers. @internal */
   private async connectAsync(): Promise<void> {
+    const openConfig = this.openConfig();
     try {
       const factory = this.resolveDriverFactory();
-      const conn = await factory.open(this.openConfig());
+      const conn = await factory.open(openConfig);
       const vStmt = await conn.prepare("SELECT sqlite_version() AS v");
       const vRow = (await vStmt.get()) as any;
       this._databaseVersion = new Version(vRow?.v ?? "0.0.0");
@@ -2946,6 +2951,26 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   /**
+   * The `timeout`/`retries` half of Rails' `configure_connection`
+   * (`sqlite3_adapter.rb:821-826`): coerce `timeout` and reject a non-integer.
+   * Our drivers take the busy timeout as an open option instead of exposing a
+   * `busy_handler_timeout=` setter, so `openConfig()` reads the coerced value
+   * from here rather than the raw config. @internal
+   */
+  private castTimeout(): number | undefined {
+    const cfg = this._config as SQLite3AdapterOptions;
+    if (cfg.timeout != null && cfg.retries != null) {
+      throw new ArgumentError("Cannot specify both timeout and retries arguments");
+    }
+    if (cfg.timeout == null) return undefined;
+    const timeout = AbstractSQLite3Adapter.typeCastConfigToInteger(cfg.timeout);
+    if (typeof timeout !== "number" || !Number.isInteger(timeout)) {
+      throw new TypeError(`timeout must be integer, not ${String(timeout)}`);
+    }
+    return timeout;
+  }
+
+  /**
    * Mirrors Rails: AbstractAdapter#configure_connection → check_version. Sync
    * for in-process drivers; for async-only drivers (no `openSync()`) returns a
    * Promise that awaits each PRAGMA — the base `attemptConfigureConnection()`
@@ -2953,6 +2978,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * @internal
    */
   override configureConnection(): void | Promise<void> {
+    this.castTimeout();
+    const retries = (this._config as SQLite3AdapterOptions).retries;
+    if (retries != null && (this._config as SQLite3AdapterOptions).timeout == null) {
+      deprecator().warn(
+        "The retries option is deprecated and will be removed in Rails 8.1. Use timeout instead.\n",
+      );
+    }
     // Base only runs the sync version check; SQLite's PRAGMAs are the async
     // work, awaited by the driver-async branch below. Void the base call.
     void super.configureConnection();

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2760,8 +2760,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   /** @internal */
   private connect(): void {
-    // Built outside the try so a bad `timeout`/`retries` config surfaces as the
-    // ArgumentError/TypeError Rails raises, not a DatabaseConnectionError.
     const openConfig = this.openConfig();
     try {
       const factory = this.resolveDriverFactory();
@@ -2950,13 +2948,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return stmts;
   }
 
-  /**
-   * The `timeout`/`retries` half of Rails' `configure_connection`
-   * (`sqlite3_adapter.rb:821-826`): coerce `timeout` and reject a non-integer.
-   * Our drivers take the busy timeout as an open option instead of exposing a
-   * `busy_handler_timeout=` setter, so `openConfig()` reads the coerced value
-   * from here rather than the raw config. @internal
-   */
+  /** @internal */
   private castTimeout(): number | undefined {
     const cfg = this._config as SQLite3AdapterOptions;
     if (cfg.timeout != null && cfg.retries != null) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2951,10 +2951,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   /** @internal */
   private castTimeout(): number | undefined {
     const cfg = this._config as SQLite3AdapterOptions;
-    if (cfg.timeout != null && cfg.retries != null) {
+    if (isRubyTruthy(cfg.timeout) && isRubyTruthy(cfg.retries)) {
       throw new ArgumentError("Cannot specify both timeout and retries arguments");
     }
-    if (cfg.timeout == null) return undefined;
+    if (!isRubyTruthy(cfg.timeout)) return undefined;
     const timeout = AbstractSQLite3Adapter.typeCastConfigToInteger(cfg.timeout);
     if (typeof timeout !== "number" || !Number.isInteger(timeout)) {
       throw new TypeError(`timeout must be integer, not ${String(timeout)}`);
@@ -2971,8 +2971,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    */
   override configureConnection(): void | Promise<void> {
     this.castTimeout();
-    const retries = (this._config as SQLite3AdapterOptions).retries;
-    if (retries != null && (this._config as SQLite3AdapterOptions).timeout == null) {
+    const cfg = this._config as SQLite3AdapterOptions;
+    if (isRubyTruthy(cfg.retries) && !isRubyTruthy(cfg.timeout)) {
       // Deviation: Rails' retries branch also installs
       // `raw_connection.busy_handler { |count| count <= retries }`
       // (sqlite3_adapter.rb:827-832), which is the sqlite3 gem's binding for

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2973,6 +2973,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     this.castTimeout();
     const retries = (this._config as SQLite3AdapterOptions).retries;
     if (retries != null && (this._config as SQLite3AdapterOptions).timeout == null) {
+      // Deviation: Rails' retries branch also installs
+      // `raw_connection.busy_handler { |count| count <= retries }`
+      // (sqlite3_adapter.rb:827-832), which is the sqlite3 gem's binding for
+      // `sqlite3_busy_handler`. None of our drivers (better-sqlite3, node:sqlite,
+      // libsql) expose that callback — they only accept a busy *timeout* at open
+      // — so there is nothing to install and adding a driver hook would be a
+      // stub no driver can implement. Rails itself deprecates the option for
+      // removal in 8.1, so we warn and let `timeout` be the supported path.
       deprecator().warn(
         "The retries option is deprecated and will be removed in Rails 8.1. Use timeout instead.\n",
       );


### PR DESCRIPTION
Ports the `timeout`/`retries` half of Rails'
`SQLite3Adapter#configure_connection`
(`sqlite3_adapter.rb:820-833`), which trails was missing entirely.

- `timeout` is cast with `typeCastConfigToInteger` (a YAML-parsed
  `database.yml` commonly yields a string), and a result that isn't an integer
  raises `TypeError: timeout must be integer, not <value>`.
- `timeout` together with `retries` raises
  `ArgumentError: Cannot specify both timeout and retries arguments`.
- `retries` alone emits Rails' deprecation warning instead of being silently
  dropped; the key is now part of `SQLite3AdapterOptions`.

The coercion lives on the adapter, at Rails' `configure_connection` site — not
in `buildAdapterArg`, whose other whitelisted keys stay uncast for the same
reason. Our drivers take the busy timeout as an open option rather than
exposing a `busy_handler_timeout=` setter, so `openConfig()` reads the coerced
value from the same helper; `openConfig()` is now built outside `connect()`'s
try block so a bad config surfaces as the Rails error rather than a
`DatabaseConnectionError`.

Rails has no test coverage for this block, so the tests are trails-only
(`*.trails.test.ts`).

Closes-story: sqlite-timeout-config-coercion
