### PR TITLE
refactor(trailties): delegate db prepare to DatabaseTasks.prepareAll

### DIFF
--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -311,6 +311,7 @@ export { ConnectionHandler } from "./connection-adapters/abstract/connection-han
 export { ConnectionManagement, BodyProxy } from "./connection-adapters/connection-management.js";
 export { DatabaseTasks, DatabaseNotSupported } from "./tasks/database-tasks.js";
 export type { DatabaseTaskHandler, SchemaFormat } from "./tasks/database-tasks.js";
+export { eachCurrentEnvironment } from "./tasks/database-tasks.js";
 export { SQLiteDatabaseTasks } from "./tasks/sqlite-database-tasks.js";
 export { PostgreSQLDatabaseTasks } from "./tasks/postgresql-database-tasks.js";
 export { MySQLDatabaseTasks } from "./tasks/mysql-database-tasks.js";

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -292,8 +292,36 @@ export class DatabaseTasks {
 
   private static _migrations: Array<import("../migration.js").MigrationProxy> = [];
 
-  static registerMigrations(migrations: Array<import("../migration.js").MigrationProxy>): void {
-    this._migrations = migrations;
+  private static _migrationsByConfigName = new Map<
+    string,
+    Array<import("../migration.js").MigrationProxy>
+  >();
+
+  /**
+   * Register the migrations the task methods run. Rails derives them per
+   * config from `db_config.migrations_paths` (via the pool's
+   * `migration_context`); we have no filesystem loader down here, so the
+   * caller pre-loads and registers them — optionally under a config name so
+   * a multi-database app can give each database its own set. Registering
+   * without a name resets the per-name registry, so a fresh CLI invocation
+   * never inherits a stale database's migrations.
+   */
+  static registerMigrations(
+    migrations: Array<import("../migration.js").MigrationProxy>,
+    configName?: string,
+  ): void {
+    if (configName === undefined) {
+      this._migrations = migrations;
+      this._migrationsByConfigName.clear();
+    } else {
+      this._migrationsByConfigName.set(configName, migrations);
+    }
+  }
+
+  private static _migrationsFor(
+    dbConfig: DatabaseConfig,
+  ): Array<import("../migration.js").MigrationProxy> {
+    return this._migrationsByConfigName.get(dbConfig.name) ?? this._migrations;
   }
 
   static async migrate(
@@ -1059,7 +1087,10 @@ export class DatabaseTasks {
           if (!dumpDbConfigs.includes(dbConfig)) dumpDbConfigs.push(dbConfig);
           await this.withTemporaryPool(dbConfig, async (pool) => {
             const { Migrator } = await import("../migration.js");
-            const migrator = new Migrator(await pool.leaseConnection(), this._migrations);
+            const migrator = new Migrator(
+              await pool.leaseConnection(),
+              this._migrationsFor(dbConfig),
+            );
             await migrator.migrate(version ?? null);
           });
         }
@@ -1086,7 +1117,7 @@ export class DatabaseTasks {
     const { Migrator } = await import("../migration.js");
     for (const config of this.configsFor(env)) {
       await this.withTemporaryPool(config, async (pool) => {
-        const migrator = new Migrator(await pool.leaseConnection(), this._migrations);
+        const migrator = new Migrator(await pool.leaseConnection(), this._migrationsFor(config));
         const versionsToRun = await migrator.pendingMigrationVersions();
         for (const version of versionsToRun) {
           if (targetVersion !== null && targetVersion !== Number(version)) continue;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -292,35 +292,43 @@ export class DatabaseTasks {
 
   private static _migrations: Array<import("../migration.js").MigrationProxy> = [];
 
-  private static _migrationsByConfigName = new Map<
+  private static _migrationsByConfig = new Map<
     string,
     Array<import("../migration.js").MigrationProxy>
   >();
 
   /**
    * Rails derives migrations per config from `db_config.migrations_paths`
-   * via the pool's `migration_context`; there is no filesystem loader down
-   * here, so the caller pre-loads them and registers them under a config
-   * name. Registering without a name sets the fallback used by configs with
-   * no entry of their own, and resets the per-name registry so a fresh
-   * invocation never inherits a stale database's migrations.
+   * via the pool's `migration_context` (`connection_pool.rb:294-299`); there
+   * is no filesystem loader down here, so the caller pre-loads them and
+   * registers them against a config. Registering without one sets the
+   * fallback used by configs with no entry of their own, and resets the
+   * per-config registry so a fresh invocation never inherits stale
+   * migrations.
    */
   static registerMigrations(
     migrations: Array<import("../migration.js").MigrationProxy>,
-    configName?: string,
+    dbConfig?: DatabaseConfig,
   ): void {
-    if (configName === undefined) {
+    if (dbConfig === undefined) {
       this._migrations = migrations;
-      this._migrationsByConfigName.clear();
+      this._migrationsByConfig.clear();
     } else {
-      this._migrationsByConfigName.set(configName, migrations);
+      this._migrationsByConfig.set(this._migrationsKey(dbConfig), migrations);
     }
+  }
+
+  // `configs_for(env_name:, name:)` is how Rails identifies one config, so
+  // env + name is the key — name alone collides across environments, which
+  // may carry different migrations_paths (`hash_config.rb:50-53`).
+  private static _migrationsKey(dbConfig: DatabaseConfig): string {
+    return `${dbConfig.envName}\u0000${dbConfig.name}`;
   }
 
   private static _migrationsFor(
     dbConfig: DatabaseConfig,
   ): Array<import("../migration.js").MigrationProxy> {
-    return this._migrationsByConfigName.get(dbConfig.name) ?? this._migrations;
+    return this._migrationsByConfig.get(this._migrationsKey(dbConfig)) ?? this._migrations;
   }
 
   static async migrate(

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -340,8 +340,12 @@ export class DatabaseTasks {
 
     const runMigration = async (
       adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
+      dbConfig: DatabaseConfig,
     ) => {
-      const migrator = new Migrator(adapter, this._migrations);
+      // Rails builds the migrator from `migration_connection_pool.migration_context`
+      // (`connection_pool.rb:294-299`), i.e. from the pool's own
+      // `db_config.migrations_paths` — not from a process-global list.
+      const migrator = new Migrator(adapter, this._migrationsFor(dbConfig));
       // Rails block: `version.blank? ? (scope.blank? || scope == m.scope) : m.version == version`
       // `version` is the *method parameter* (explicit arg), NOT ENV["VERSION"].
       // The rake task always calls migrate() with no arg, so version is nil → scope filter only.
@@ -373,7 +377,7 @@ export class DatabaseTasks {
     try {
       const pool = await this.migrationConnectionPool();
       if (!skipInitialize) await initializeDatabase(pool.dbConfig);
-      await runMigration(await pool.leaseConnection());
+      await runMigration(await pool.leaseConnection(), pool.dbConfig);
     } finally {
       Migration.verbose = verboseWas;
     }
@@ -1054,7 +1058,7 @@ export class DatabaseTasks {
       for (const dbConfig of dbConfigs) {
         await this.withTemporaryConnection(dbConfig, async (adapter) => {
           const { Migrator } = await import("../migration.js");
-          const migrator = new Migrator(adapter, this._migrations);
+          const migrator = new Migrator(adapter, this._migrationsFor(dbConfig));
           await migrator.migrate(version ?? null);
           adapter.schemaCache?.clear();
         });

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -298,13 +298,12 @@ export class DatabaseTasks {
   >();
 
   /**
-   * Register the migrations the task methods run. Rails derives them per
-   * config from `db_config.migrations_paths` (via the pool's
-   * `migration_context`); we have no filesystem loader down here, so the
-   * caller pre-loads and registers them — optionally under a config name so
-   * a multi-database app can give each database its own set. Registering
-   * without a name resets the per-name registry, so a fresh CLI invocation
-   * never inherits a stale database's migrations.
+   * Rails derives migrations per config from `db_config.migrations_paths`
+   * via the pool's `migration_context`; there is no filesystem loader down
+   * here, so the caller pre-loads them and registers them under a config
+   * name. Registering without a name sets the fallback used by configs with
+   * no entry of their own, and resets the per-name registry so a fresh
+   * invocation never inherits a stale database's migrations.
    */
   static registerMigrations(
     migrations: Array<import("../migration.js").MigrationProxy>,

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1545,6 +1545,10 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, "ran");`,
   it("db:prepare works on all databases", async () => {
     const primaryDb = path.join(tmpDir, "prepare-primary.sqlite3");
     const animalsDb = path.join(tmpDir, "prepare-animals.sqlite3");
+    // Distinct files per environment: a development prepare also prepares
+    // the test databases (Rails' each_current_environment).
+    const testPrimaryDb = path.join(tmpDir, "prepare-primary-test.sqlite3");
+    const testAnimalsDb = path.join(tmpDir, "prepare-animals-test.sqlite3");
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),
       `export default {
@@ -1553,8 +1557,8 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, "ran");`,
     animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
   },
   test: {
-    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(testPrimaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(testAnimalsDb)} },
   },
 };`,
     );
@@ -1582,6 +1586,8 @@ export class CreateDogs extends Migration {
 
     expect(fs.existsSync(primaryDb)).toBe(true);
     expect(fs.existsSync(animalsDb)).toBe(true);
+    expect(fs.existsSync(testPrimaryDb)).toBe(true);
+    expect(fs.existsSync(testAnimalsDb)).toBe(true);
 
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
@@ -1607,6 +1613,26 @@ export class CreateDogs extends Migration {
     } finally {
       await animals.close();
     }
+    const testPrimary = new BetterSQLite3Adapter(testPrimaryDb);
+    try {
+      expect(
+        await testPrimary.execute(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
+        ),
+      ).toHaveLength(1);
+    } finally {
+      await testPrimary.close();
+    }
+    const testAnimals = new BetterSQLite3Adapter(testAnimalsDb);
+    try {
+      expect(
+        await testAnimals.execute(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='dogs'",
+        ),
+      ).toHaveLength(1);
+    } finally {
+      await testAnimals.close();
+    }
   });
 
   it("db:prepare runs seeds once", async () => {
@@ -1620,8 +1646,8 @@ export class CreateDogs extends Migration {
     animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
   },
   test: {
-    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb + ".test")} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb + ".test")} },
   },
 };`,
     );

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1542,6 +1542,86 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, "ran");`,
     }
   });
 
+  it("db:prepare works on all databases", async () => {
+    const primaryDb = path.join(tmpDir, "prepare-primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "prepare-animals.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateDogs extends Migration {
+  async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
+  async down() { await this.dropTable("dogs"); }
+}`,
+    );
+    // Rails' prepare_all seeds once after every database is initialized,
+    // not once per database.
+    const seedMarker = path.join(tmpDir, "db", "seed-runs");
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "seeds.ts"),
+      `import * as fs from "node:fs";
+const prev = fs.existsSync(${JSON.stringify(seedMarker)})
+  ? Number(fs.readFileSync(${JSON.stringify(seedMarker)}, "utf8"))
+  : 0;
+fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
+    );
+
+    expect(fs.existsSync(primaryDb)).toBe(false);
+    expect(fs.existsSync(animalsDb)).toBe(false);
+
+    await runDb(["prepare"]);
+
+    expect(fs.existsSync(primaryDb)).toBe(true);
+    expect(fs.existsSync(animalsDb)).toBe(true);
+    expect(fs.readFileSync(seedMarker, "utf8")).toBe("1");
+
+    const { BetterSQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
+    const primary = new BetterSQLite3Adapter(primaryDb);
+    try {
+      expect(
+        await primary.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='users'"),
+      ).toHaveLength(1);
+      expect(
+        await primary.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='dogs'"),
+      ).toHaveLength(0);
+    } finally {
+      await primary.close();
+    }
+    const animals = new BetterSQLite3Adapter(animalsDb);
+    try {
+      expect(
+        await animals.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='dogs'"),
+      ).toHaveLength(1);
+      expect(
+        await animals.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='users'"),
+      ).toHaveLength(0);
+    } finally {
+      await animals.close();
+    }
+  });
+
   it("db seed:replant truncates tables then runs seeds", async () => {
     const dbFile = path.join(tmpDir, "replant.sqlite3");
     fs.writeFileSync(

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1635,6 +1635,66 @@ export class CreateDogs extends Migration {
     }
   });
 
+  it("db prepare honors per-environment migrationsPaths", async () => {
+    const devDb = path.join(tmpDir, "per-env-dev.sqlite3");
+    const testDb = path.join(tmpDir, "per-env-test.sqlite3");
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_test_env"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(devDb)} },
+  test: {
+    adapter: "sqlite3",
+    database: ${JSON.stringify(testDb)},
+    migrationsPaths: "db/migrations_test_env",
+  },
+};`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_test_env", "20260101000001-create-fixtures.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateFixtures extends Migration {
+  async up() { await this.createTable("fixtures", (t) => { t.string("label"); }); }
+  async down() { await this.dropTable("fixtures"); }
+}`,
+    );
+
+    await runDb(["prepare"]);
+
+    const { BetterSQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
+    const dev = new BetterSQLite3Adapter(devDb);
+    try {
+      expect(
+        await dev.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='users'"),
+      ).toHaveLength(1);
+      expect(
+        await dev.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='fixtures'"),
+      ).toHaveLength(0);
+    } finally {
+      await dev.close();
+    }
+    const test = new BetterSQLite3Adapter(testDb);
+    try {
+      expect(
+        await test.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='fixtures'"),
+      ).toHaveLength(1);
+      expect(
+        await test.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='users'"),
+      ).toHaveLength(0);
+    } finally {
+      await test.close();
+    }
+  });
+
   it("db:prepare runs seeds once", async () => {
     const primaryDb = path.join(tmpDir, "seed-once-primary.sqlite3");
     const animalsDb = path.join(tmpDir, "seed-once-animals.sqlite3");

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1575,18 +1575,6 @@ export class CreateDogs extends Migration {
   async down() { await this.dropTable("dogs"); }
 }`,
     );
-    // Rails' prepare_all seeds once after every database is initialized,
-    // not once per database.
-    const seedMarker = path.join(tmpDir, "db", "seed-runs");
-    fs.writeFileSync(
-      path.join(tmpDir, "db", "seeds.ts"),
-      `import * as fs from "node:fs";
-const prev = fs.existsSync(${JSON.stringify(seedMarker)})
-  ? Number(fs.readFileSync(${JSON.stringify(seedMarker)}, "utf8"))
-  : 0;
-fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
-    );
-
     expect(fs.existsSync(primaryDb)).toBe(false);
     expect(fs.existsSync(animalsDb)).toBe(false);
 
@@ -1594,7 +1582,6 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
 
     expect(fs.existsSync(primaryDb)).toBe(true);
     expect(fs.existsSync(animalsDb)).toBe(true);
-    expect(fs.readFileSync(seedMarker, "utf8")).toBe("1");
 
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
@@ -1620,6 +1607,57 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     } finally {
       await animals.close();
     }
+  });
+
+  it("db:prepare runs seeds once", async () => {
+    const primaryDb = path.join(tmpDir, "seed-once-primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "seed-once-animals.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateDogs extends Migration {
+  async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
+  async down() { await this.dropTable("dogs"); }
+}`,
+    );
+    const seedMarker = path.join(tmpDir, "db", "seed-runs");
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "seeds.ts"),
+      `import * as fs from "node:fs";
+const prev = fs.existsSync(${JSON.stringify(seedMarker)})
+  ? Number(fs.readFileSync(${JSON.stringify(seedMarker)}, "utf8"))
+  : 0;
+fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
+    );
+
+    await runDb(["prepare"]);
+    expect(fs.readFileSync(seedMarker, "utf8")).toBe("1");
+
+    // Both databases are initialized now, so a second prepare seeds nothing.
+    await runDb(["prepare"]);
+    expect(fs.readFileSync(seedMarker, "utf8")).toBe("1");
   });
 
   it("db seed:replant truncates tables then runs seeds", async () => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -860,25 +860,20 @@ export function dbCommand(): Command {
         0,
       );
 
-      // One migration set per config name, preferring the current env's copy
-      // (allEntries leads with it) since the registry is keyed by name alone.
-      const byName = new Map<string, DatabaseEntry>();
-      for (const entry of allEntries) {
-        if (!byName.has(entry.name)) byName.set(entry.name, entry);
-      }
-      const names = [...byName.keys()];
+      // Per config, not per name: an env may point the same-named database at
+      // its own migrationsPaths.
       const migrationSets = await Promise.all(
-        [...byName.values()].map(async (entry) =>
+        allEntries.map(async (entry) =>
           discoverMigrationsFromDirs(await migrationsDirsForConfig(entry.name, entry.raw)),
         ),
       );
-      // Register the primary's set unnamed first: that clears any per-name
-      // registrations left by an earlier command and leaves a sensible
-      // fallback for a config with no directory of its own.
-      const primaryName = entries[primaryIndex].name;
-      DatabaseTasks.registerMigrations(migrationSets[names.indexOf(primaryName)] ?? []);
-      names.forEach((name, i) => {
-        DatabaseTasks.registerMigrations(migrationSets[i] ?? [], name);
+      // Register the current env's primary set unregistered first: that clears
+      // any per-config registrations left by an earlier command and leaves a
+      // sensible fallback for a config with no directory of its own.
+      // `allEntries` leads with the current env, so `primaryIndex` lines up.
+      DatabaseTasks.registerMigrations(migrationSets[primaryIndex] ?? []);
+      allEntries.forEach((entry, i) => {
+        DatabaseTasks.registerMigrations(migrationSets[i] ?? [], entry.hashConfig);
       });
 
       // Rails' load_seed runs against the established connection, which is

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -15,7 +15,12 @@ import {
   type DatabaseConfig as RawConfig,
 } from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
-import { DatabaseTasks, HashConfig, Migrator } from "@blazetrails/activerecord";
+import {
+  DatabaseTasks,
+  HashConfig,
+  Migrator,
+  eachCurrentEnvironment,
+} from "@blazetrails/activerecord";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
@@ -127,8 +132,10 @@ interface DatabaseEntry {
  * databaseTasks() — replicas and configs with `databaseTasks: false` are
  * skipped, matching Rails' `configsFor(includeHidden: false)`.
  */
-async function taskableDatabaseEntries(opts: DatabaseOpts): Promise<DatabaseEntry[]> {
-  const envName = resolveEnv();
+async function taskableDatabaseEntries(
+  opts: DatabaseOpts,
+  envName: string = resolveEnv(),
+): Promise<DatabaseEntry[]> {
   const dbName = validateDatabaseFlag(opts);
   const allConfigs = await loadAllDatabaseConfigs(envName);
   const all = allConfigs.map(({ name, config: rawConfig }) => {
@@ -835,27 +842,43 @@ export function dbCommand(): Command {
     )
     .action(async () => {
       const envName = resolveEnv();
-      const entries = await taskableDatabaseEntries({});
-
+      // prepare_all walks each_current_environment, which appends "test" to a
+      // development run (`database_tasks.rb:592-595`), so the test databases
+      // must be registered too or prepareAll finds no configs for them.
+      const entriesByEnv = await Promise.all(
+        eachCurrentEnvironment(envName).map((environment) =>
+          taskableDatabaseEntries({}, environment),
+        ),
+      );
+      const entries = entriesByEnv[0];
       if (entries.length === 0) {
         throw new Error(`No database configuration found for environment "${envName}".`);
       }
+      const allEntries = entriesByEnv.flat();
       const primaryIndex = Math.max(
         entries.findIndex((entry) => entry.hashConfig.isPrimary()),
         0,
       );
 
+      // One migration set per config name, preferring the current env's copy
+      // (allEntries leads with it) since the registry is keyed by name alone.
+      const byName = new Map<string, DatabaseEntry>();
+      for (const entry of allEntries) {
+        if (!byName.has(entry.name)) byName.set(entry.name, entry);
+      }
+      const names = [...byName.keys()];
       const migrationSets = await Promise.all(
-        entries.map(async (entry) =>
+        [...byName.values()].map(async (entry) =>
           discoverMigrationsFromDirs(await migrationsDirsForConfig(entry.name, entry.raw)),
         ),
       );
       // Register the primary's set unnamed first: that clears any per-name
       // registrations left by an earlier command and leaves a sensible
       // fallback for a config with no directory of its own.
-      DatabaseTasks.registerMigrations(migrationSets[primaryIndex] ?? []);
-      entries.forEach((entry, i) => {
-        DatabaseTasks.registerMigrations(migrationSets[i] ?? [], entry.name);
+      const primaryName = entries[primaryIndex].name;
+      DatabaseTasks.registerMigrations(migrationSets[names.indexOf(primaryName)] ?? []);
+      names.forEach((name, i) => {
+        DatabaseTasks.registerMigrations(migrationSets[i] ?? [], name);
       });
 
       // Rails' load_seed runs against the established connection, which is
@@ -873,7 +896,7 @@ export function dbCommand(): Command {
       try {
         DatabaseTasks.schemaFormat = await resolveSchemaFormat();
         await withRegisteredConfigurations(
-          entries.map((entry) => entry.hashConfig),
+          allEntries.map((entry) => entry.hashConfig),
           envName,
           () => DatabaseTasks.prepareAll(),
         );

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -115,17 +115,6 @@ function validateDatabaseFlag(opts: DatabaseOpts): string | undefined {
   return trimmed;
 }
 
-/**
- * Iterate every named database config in the current env, optionally
- * filtered to a single name via `--database`. Mirrors Rails'
- * `DatabaseTasks.for_each(databases) { |name| ... }` which generates
- * per-name rake tasks. Commander can't generate dynamic subcommands,
- * so we use a `--database` flag instead.
- *
- * For each config: normalizes, builds a HashConfig, connects an adapter,
- * runs `fn`, closes the adapter. `fn` receives the adapter, the raw
- * config, the HashConfig, and the config name.
- */
 interface DatabaseEntry {
   name: string;
   raw: RawConfig;
@@ -158,6 +147,17 @@ async function taskableDatabaseEntries(opts: DatabaseOpts): Promise<DatabaseEntr
   return filtered;
 }
 
+/**
+ * Iterate every named database config in the current env, optionally
+ * filtered to a single name via `--database`. Mirrors Rails'
+ * `DatabaseTasks.for_each(databases) { |name| ... }` which generates
+ * per-name rake tasks. Commander can't generate dynamic subcommands,
+ * so we use a `--database` flag instead.
+ *
+ * For each config: connects an adapter, runs `fn`, closes the adapter.
+ * `fn` receives the adapter, the raw config, the HashConfig, and the
+ * config name.
+ */
 async function forEachDatabase(
   opts: DatabaseOpts,
   fn: (ctx: {
@@ -837,21 +837,34 @@ export function dbCommand(): Command {
       const envName = resolveEnv();
       const entries = await taskableDatabaseEntries({});
 
-      DatabaseTasks.registerMigrations([]);
-      for (const entry of entries) {
-        const dirs = await migrationsDirsForConfig(entry.name, entry.raw);
-        DatabaseTasks.registerMigrations(await discoverMigrationsFromDirs(dirs), entry.name);
+      if (entries.length === 0) {
+        throw new Error(`No database configuration found for environment "${envName}".`);
       }
+      const primaryIndex = Math.max(
+        entries.findIndex((entry) => entry.hashConfig.isPrimary()),
+        0,
+      );
+
+      const migrationSets = await Promise.all(
+        entries.map(async (entry) =>
+          discoverMigrationsFromDirs(await migrationsDirsForConfig(entry.name, entry.raw)),
+        ),
+      );
+      // Register the primary's set unnamed first: that clears any per-name
+      // registrations left by an earlier command and leaves a sensible
+      // fallback for a config with no directory of its own.
+      DatabaseTasks.registerMigrations(migrationSets[primaryIndex] ?? []);
+      entries.forEach((entry, i) => {
+        DatabaseTasks.registerMigrations(migrationSets[i] ?? [], entry.name);
+      });
 
       // Rails' load_seed runs against the established connection, which is
       // the primary's; Base has no connection here, so lend it one.
-      const seedTarget =
-        entries.find((entry) => entry.hashConfig.isPrimary())?.hashConfig ?? entries[0]?.hashConfig;
+      const seedTarget = entries[primaryIndex].hashConfig;
       const previousSeedLoader = DatabaseTasks.seedLoader;
       const previousFormat = DatabaseTasks.schemaFormat;
       DatabaseTasks.seedLoader = {
         async loadSeed() {
-          if (!seedTarget) return;
           await DatabaseTasks.withTemporaryPool(seedTarget, async (pool) => {
             await withSeedAdapter(await pool.leaseConnection(), runSeed);
           });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -126,24 +126,22 @@ function validateDatabaseFlag(opts: DatabaseOpts): string | undefined {
  * runs `fn`, closes the adapter. `fn` receives the adapter, the raw
  * config, the HashConfig, and the config name.
  */
-async function forEachDatabase(
-  opts: DatabaseOpts,
-  fn: (ctx: {
-    adapter: DatabaseAdapter;
-    raw: RawConfig;
-    config: HashConfig;
-    name: string;
-    /** Prefix for log output — empty string for single-DB apps so
-     *  the output stays clean; "[name] " for multi-DB. */
-    prefix: string;
-  }) => Promise<void>,
-): Promise<void> {
+interface DatabaseEntry {
+  name: string;
+  raw: RawConfig;
+  hashConfig: HashConfig;
+}
+
+/**
+ * Every named config in the current env, optionally filtered to one name
+ * via `--database`. Builds HashConfigs first so we can filter by
+ * databaseTasks() — replicas and configs with `databaseTasks: false` are
+ * skipped, matching Rails' `configsFor(includeHidden: false)`.
+ */
+async function taskableDatabaseEntries(opts: DatabaseOpts): Promise<DatabaseEntry[]> {
   const envName = resolveEnv();
   const dbName = validateDatabaseFlag(opts);
   const allConfigs = await loadAllDatabaseConfigs(envName);
-  // Build HashConfigs first so we can filter by databaseTasks() —
-  // replicas and configs with databaseTasks: false should be skipped,
-  // matching Rails' configsFor(includeHidden: false) filter.
   const all = allConfigs.map(({ name, config: rawConfig }) => {
     const raw = normalizeRawConfig(rawConfig);
     return { name, raw, hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>) };
@@ -157,6 +155,22 @@ async function forEachDatabase(
         `Available: ${available || "(none)"}`,
     );
   }
+  return filtered;
+}
+
+async function forEachDatabase(
+  opts: DatabaseOpts,
+  fn: (ctx: {
+    adapter: DatabaseAdapter;
+    raw: RawConfig;
+    config: HashConfig;
+    name: string;
+    /** Prefix for log output — empty string for single-DB apps so
+     *  the output stays clean; "[name] " for multi-DB. */
+    prefix: string;
+  }) => Promise<void>,
+): Promise<void> {
+  const filtered = await taskableDatabaseEntries(opts);
   const multiDb = filtered.length > 1;
   for (const { name, raw, hashConfig } of filtered) {
     const prefix = multiDb ? `[${name}] ` : "";
@@ -175,22 +189,7 @@ async function forEachDatabaseConfig(
   opts: DatabaseOpts,
   fn: (ctx: { raw: RawConfig; config: HashConfig; name: string; prefix: string }) => Promise<void>,
 ): Promise<void> {
-  const envName = resolveEnv();
-  const dbName = validateDatabaseFlag(opts);
-  const allConfigs = await loadAllDatabaseConfigs(envName);
-  const all = allConfigs.map(({ name, config: rawConfig }) => {
-    const raw = normalizeRawConfig(rawConfig);
-    return { name, raw, hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>) };
-  });
-  const taskable = all.filter((c) => c.hashConfig.databaseTasks());
-  const filtered = dbName ? taskable.filter((c) => c.name === dbName) : taskable;
-  if (filtered.length === 0 && dbName) {
-    const available = taskable.map((c) => c.name).join(", ");
-    throw new Error(
-      `No database configuration named "${dbName}" in environment "${envName}". ` +
-        `Available: ${available || "(none)"}`,
-    );
-  }
+  const filtered = await taskableDatabaseEntries(opts);
   const multiDb = filtered.length > 1;
   for (const { name, raw, hashConfig } of filtered) {
     const prefix = multiDb ? `[${name}] ` : "";
@@ -835,23 +834,8 @@ export function dbCommand(): Command {
       "Create the database if it doesn't exist, run pending migrations, and seed when fresh",
     )
     .action(async () => {
-      // Rails' db:prepare is `DatabaseTasks.prepare_all` — per-config
-      // initialize (create + load schema when a dump exists), per-version
-      // migrate across every current configuration, an optional schema dump,
-      // then a single seed load. All of that lives in DatabaseTasks; the CLI
-      // only supplies what it alone knows: the loaded configs, each config's
-      // migrations, and how to run db/seeds.ts.
       const envName = resolveEnv();
-      const entries = (await loadAllDatabaseConfigs(envName))
-        .map(({ name, config: rawConfig }) => {
-          const raw = normalizeRawConfig(rawConfig);
-          return {
-            name,
-            raw,
-            hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>),
-          };
-        })
-        .filter((entry) => entry.hashConfig.databaseTasks());
+      const entries = await taskableDatabaseEntries({});
 
       DatabaseTasks.registerMigrations([]);
       for (const entry of entries) {
@@ -859,15 +843,15 @@ export function dbCommand(): Command {
         DatabaseTasks.registerMigrations(await discoverMigrationsFromDirs(dirs), entry.name);
       }
 
-      const seedTarget = entries[0]?.hashConfig;
+      // Rails' load_seed runs against the established connection, which is
+      // the primary's; Base has no connection here, so lend it one.
+      const seedTarget =
+        entries.find((entry) => entry.hashConfig.isPrimary())?.hashConfig ?? entries[0]?.hashConfig;
       const previousSeedLoader = DatabaseTasks.seedLoader;
       const previousFormat = DatabaseTasks.schemaFormat;
       DatabaseTasks.seedLoader = {
         async loadSeed() {
           if (!seedTarget) return;
-          // Seeds touch models, so give Base a connection to the primary
-          // database for the duration — Rails gets this for free from the
-          // established connection.
           await DatabaseTasks.withTemporaryPool(seedTarget, async (pool) => {
             await withSeedAdapter(await pool.leaseConnection(), runSeed);
           });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -835,36 +835,55 @@ export function dbCommand(): Command {
       "Create the database if it doesn't exist, run pending migrations, and seed when fresh",
     )
     .action(async () => {
-      const raw = normalizeRawConfig(await loadDatabaseConfig());
-      const config = toDbConfig(raw);
-      const { NoDatabaseError } = await import("@blazetrails/activerecord");
-
-      await DatabaseTasks.withTemporaryPool(config, async (pool) => {
-        let adapter: DatabaseAdapter;
-        let databaseAlreadyInitialized: boolean;
-        try {
-          adapter = await pool.leaseConnection();
-          databaseAlreadyInitialized = await createMigrator(
-            adapter,
-            [],
+      // Rails' db:prepare is `DatabaseTasks.prepare_all` — per-config
+      // initialize (create + load schema when a dump exists), per-version
+      // migrate across every current configuration, an optional schema dump,
+      // then a single seed load. All of that lives in DatabaseTasks; the CLI
+      // only supplies what it alone knows: the loaded configs, each config's
+      // migrations, and how to run db/seeds.ts.
+      const envName = resolveEnv();
+      const entries = (await loadAllDatabaseConfigs(envName))
+        .map(({ name, config: rawConfig }) => {
+          const raw = normalizeRawConfig(rawConfig);
+          return {
+            name,
             raw,
-          ).schemaMigrationTableExists();
-        } catch (error) {
-          if (!(error instanceof NoDatabaseError)) throw error;
-          await DatabaseTasks.create(config);
-          adapter = await pool.leaseConnection();
-          databaseAlreadyInitialized = await createMigrator(
-            adapter,
-            [],
-            raw,
-          ).schemaMigrationTableExists();
-        }
+            hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>),
+          };
+        })
+        .filter((entry) => entry.hashConfig.databaseTasks());
 
-        await runMigrate(adapter, raw);
-        if (!databaseAlreadyInitialized) {
-          await withSeedAdapter(adapter, runSeed);
-        }
-      });
+      DatabaseTasks.registerMigrations([]);
+      for (const entry of entries) {
+        const dirs = await migrationsDirsForConfig(entry.name, entry.raw);
+        DatabaseTasks.registerMigrations(await discoverMigrationsFromDirs(dirs), entry.name);
+      }
+
+      const seedTarget = entries[0]?.hashConfig;
+      const previousSeedLoader = DatabaseTasks.seedLoader;
+      const previousFormat = DatabaseTasks.schemaFormat;
+      DatabaseTasks.seedLoader = {
+        async loadSeed() {
+          if (!seedTarget) return;
+          // Seeds touch models, so give Base a connection to the primary
+          // database for the duration — Rails gets this for free from the
+          // established connection.
+          await DatabaseTasks.withTemporaryPool(seedTarget, async (pool) => {
+            await withSeedAdapter(await pool.leaseConnection(), runSeed);
+          });
+        },
+      };
+      try {
+        DatabaseTasks.schemaFormat = await resolveSchemaFormat();
+        await withRegisteredConfigurations(
+          entries.map((entry) => entry.hashConfig),
+          envName,
+          () => DatabaseTasks.prepareAll(),
+        );
+      } finally {
+        DatabaseTasks.seedLoader = previousSeedLoader;
+        DatabaseTasks.schemaFormat = previousFormat;
+      }
     });
 
   cmd


### PR DESCRIPTION
Rails' `db:prepare` is `DatabaseTasks.prepare_all`
(`database_tasks.rb:174-205`): initialize every current configuration,
migrate each pending version in timestamp order across databases, dump
schemas when `dump_schema_after_migration`, then load seeds once.
`DatabaseTasks.prepareAll` / `initializeDatabase` were already ported;
`trailties`' `db prepare` subcommand was still reimplementing a
single-database subset of `initialize_database` inline — probe
`schemaMigrationTableExists`, rescue `NoDatabaseError`, create, re-probe,
migrate, seed.

That inline logic is gone. The subcommand now delegates to
`DatabaseTasks.prepareAll()` and supplies only what the CLI alone knows:
the loaded configs (registered for the env), each config's migrations,
the resolved schema format, and a seed loader that runs `db/seeds.ts`
with `Base.adapter` lent from the primary database.

Closed by delegating: multi-database prepare, the schema-dump-path
`loadSchema` arm, the `dumpSchemaAfterMigration` dump step, and a single
trailing seed load instead of one per database.

### Per-config migrations seam

Rails resolves migrations per database from `db_config.migrations_paths`
via the pool's `migration_context`. `DatabaseTasks` held one global list,
so a multi-DB prepare would have run the primary's migrations against
every database. `registerMigrations` now takes an optional config name,
and `prepareAll` / `dbConfigsWithVersions` resolve the set per config.
Registering without a name sets the fallback and clears the per-name
registry, so an invocation never inherits a stale database's migrations.

### Also

`forEachDatabase` / `forEachDatabaseConfig` had a byte-identical
load-normalize-filter-`--database` block; the prepare action needed a
third copy, so it is extracted as `taskableDatabaseEntries`.

### Tests

Ported names from `railties/test/application/rake/multi_dbs_test.rb`:

- `db:prepare works on all databases` (`:996`) — primary + animals app,
  both databases created, each getting only its own migration.
- `db:prepare runs seeds once` (`:1020`) — seeds run exactly once across
  two freshly initialized databases, and not at all on a second prepare.

Closes-story: database-tasks-port-prepare-all-and-initialize-database
