### PR TITLE
fix(activerecord): guarantee a cold statement pool in the mysql statement-pool suite

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -21,13 +21,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     adapter = await leaseMysqlAdapter();
     originalPreparedStatements = adapter.preparedStatements;
     originalStatementLimit = adapter.statementLimit;
-    // Cold-pool guarantee. The afterEach below only covers statements this
-    // file's own tests cached; under `MYSQL_PREPARED_STATEMENTS` the adapter is
-    // prepared-by-default for the whole run, so the leased connection arrives
-    // already carrying worker-startup reflection — `test-setup-dy`'s
-    // `tableExists` assertion leaves the `information_schema.tables` probe in
-    // the pool, which made the very first test start at length 1. Drop the pool
-    // before the settings are flipped so both lanes assert on an empty one.
     adapter.disconnectBang();
     adapter.preparedStatements = true;
   });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -21,6 +21,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     adapter = await leaseMysqlAdapter();
     originalPreparedStatements = adapter.preparedStatements;
     originalStatementLimit = adapter.statementLimit;
+    // Cold-pool guarantee. The afterEach below only covers statements this
+    // file's own tests cached; under `MYSQL_PREPARED_STATEMENTS` the adapter is
+    // prepared-by-default for the whole run, so the leased connection arrives
+    // already carrying worker-startup reflection — `test-setup-dy`'s
+    // `tableExists` assertion leaves the `information_schema.tables` probe in
+    // the pool, which made the very first test start at length 1. Drop the pool
+    // before the settings are flipped so both lanes assert on an empty one.
+    adapter.disconnectBang();
     adapter.preparedStatements = true;
   });
   afterEach(() => {


### PR DESCRIPTION
## Problem

The advisory prepared-statements lane (`maria-prepared-tests`, `ARCONN=mysql2` +
`MYSQL_PREPARED_STATEMENTS=1`, added by #5533) failed the first test in
`statement-pool.trails.test.ts` — `statement pool tracks distinct prepared
queries` — with `expected 2 to be 1`.

## Root cause

Instrumenting the pool at the top of `beforeEach` shows exactly one leftover key
on the first test and none thereafter:

```
SELECT 1 AS one FROM information_schema.tables
  WHERE table_schema = COALESCE(?, database())
  AND table_name = ? AND table_type = ? LIMIT 1
```

That is `Mysql2Adapter#informationSchemaExists`, issued by the worker-startup
`tableExists` assertion in `test-setup-dy.ts` (accounts / topics / posts). Under
the prepared default the adapter prepares that bind query for real, so the pool
on the leased connection is already at length 1 when the suite's first test runs.
The existing `afterEach` `disconnectBang()` only covers statements this file's
own tests cached, so every test *except* the first one was already cold — which
is why exactly one test failed. On the default lane `preparedStatements` is off
during worker startup, so nothing is cached and the first test starts cold by
accident.

## Fix

Extend the same teardown to setup: `beforeEach` drops the inherited pool via
`disconnectBang()` (reconnectable — the next query re-establishes) before
flipping `preparedStatements`, so the cold-pool invariant the suite asserts holds
on both lanes rather than being an artifact of the default lane's configuration.
No assertion, test name, or skip was touched.

## Verification

Local, own compose stack, `statement-pool.trails.test.ts`:

- `ARCONN=mysql2 MYSQL_PREPARED_STATEMENTS=1` — 11 passed (was 1 failed / 10 passed)
- `ARCONN=mysql2` — 11 passed

Closes-story: statement-pool-cold-start-under-prepared-default
