### PR TITLE
feat(eslint): translate ARE class shorthands inside bracket expressions in require-table-teardown

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -492,13 +492,16 @@ function bracketSource(pattern, start, areEscapes = false) {
     source += "\\]";
     i++;
   }
+  // Where the members start, so a `-` in first position is read as the literal
+  // it is in both grammars rather than as the open end of a range.
+  const bodyStart = source.length;
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
     if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
     if (ch === "\\") {
       const next = pattern[i + 1];
       if (!areEscapes || next === undefined || !ARE_SHORTHANDS.has(next)) return null;
-      if (source.endsWith("-") && !source.endsWith("[-")) return null;
+      if (source.endsWith("-") && source.length - 1 > bodyStart) return null;
       if (pattern[i + 2] === "-" && (pattern[i + 3] ?? "]") !== "]") return null;
       source += `\\${next}`;
       i++;

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -143,10 +143,16 @@
  * POSIX class or collating element (`[[:alpha:]]`), a back reference (`\1`), an
  * ARE-only escape (`\A`, `\Z`, `\y`, `\Y`, `\m`, `\M`, and `\b`, which PostgreSQL
  * also spells backspace with inside brackets), a shorthand JS reads more widely
- * than ARE does (`\D`, `\W`, `\s`), a backslash inside a bracket
- * expression, whose meaning depends on which regex engine reads it, an `^` or
+ * than ARE does (`\D`, `\W`, `\s`), an `^` or
  * `$` past the leading
- * anchor, and a pattern that does not compile at all. Everything else in the
+ * anchor, and a pattern that does not compile at all. A backslash inside a
+ * bracket expression is read only in the `~` / `~*` spelling, where the engine
+ * is known to be ARE and a bracketed `ARE_SHORTHANDS` member (`[\d]`) means what
+ * the same shorthand means in a JS character class; anything else bracketed
+ * (`[\W]`, `[\b]`, `[\1]`, `[\\]`, a shorthand as a range endpoint) and every
+ * backslash inside a `SIMILAR TO` bracket expression — whose interaction with
+ * that grammar's `ESCAPE` character is unsettled — still refuses. Everything
+ * else in the
  * two regex grammars — alternation, grouping, `* + ?`, `{n,m}` bounds, bracket
  * expressions, `.`, and the ARE class shorthands whose JS set is no wider
  * (`\d`, `\w`, `\S` — see `ARE_SHORTHANDS`) — is
@@ -460,10 +466,22 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * ordinary literal, but PostgreSQL's engine is ARE, which reads it as an escape
  * inside brackets too (`[\d]` is the digits, not a backslash and a `d`), so
  * emitting it doubled would credit `exd` for `~ '^ex[\d]'` — a name the filter
- * does not select. Which reading is right depends on the engine, so a backslash
- * in a bracket expression refuses the whole filter instead.
+ * does not select.
+ *
+ * `areEscapes` says which reading applies, so the caller that knows the engine
+ * decides. The `~` / `~*` path sets it: those patterns are read by ARE, where a
+ * bracketed `ARE_SHORTHANDS` member means exactly what the same shorthand means
+ * in a JS character class, so `[\d]` translates. Every other backslash inside
+ * brackets still refuses — the complements (`[\W]`), `\b` (backspace here, not
+ * a word boundary), a back reference (`[\1]`), and a bare `[\\]`, whose ARE
+ * meaning is a literal backslash but whose bare-POSIX one is two of them. A
+ * shorthand used as a range endpoint (`[a-\d]`, `[\d-z]`) is refused too: ARE
+ * rejects it outright, while JS's Annex B grammar quietly reads the `-` as a
+ * literal and would credit a name containing one. Unset (the `SIMILAR TO`
+ * path), any backslash refuses: that grammar carries its own `ESCAPE`
+ * character, and how it composes with a bracketed backslash is unsettled.
  */
-function bracketSource(pattern, start) {
+function bracketSource(pattern, start, areEscapes = false) {
   let source = "[";
   let i = start + 1;
   if (pattern[i] === "^") {
@@ -477,7 +495,15 @@ function bracketSource(pattern, start) {
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
     if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
-    if (ch === "\\") return null;
+    if (ch === "\\") {
+      const next = pattern[i + 1];
+      if (!areEscapes || next === undefined || !ARE_SHORTHANDS.has(next)) return null;
+      if (source.endsWith("-") && !source.endsWith("[-")) return null;
+      if (pattern[i + 2] === "-" && (pattern[i + 3] ?? "]") !== "]") return null;
+      source += `\\${next}`;
+      i++;
+      continue;
+    }
     source += ch === "[" ? "\\[" : ch === "^" ? "\\^" : ch;
   }
   if (i >= pattern.length) return null;
@@ -514,7 +540,9 @@ const ARE_SHORTHANDS = new Set(["d", "w", "S"]);
  *
  * Alternation, grouping and the quantifiers `* + ?` are spelled identically in
  * both, as are `{n,m}` bounds and `.`; bracket expressions go through
- * `bracketSource`. A backslash escape of a word character is translated only
+ * `bracketSource` in its ARE reading, so a bracketed `ARE_SHORTHANDS` member
+ * (`[\d]`) translates like the bare one. A backslash escape of a word character
+ * is translated only
  * for the ARE class shorthands whose JS meaning is identical (`ARE_SHORTHANDS`);
  * every other one is refused, since a back reference (`\1`) means something
  * else once the `^(?:…)` wrapper adds a group, and the ARE-only escapes (`\A`,
@@ -528,7 +556,7 @@ function posixRegexpSource(pattern) {
   while (i < pattern.length) {
     const ch = pattern[i];
     if (ch === "[") {
-      const bracket = bracketSource(pattern, i);
+      const bracket = bracketSource(pattern, i, true);
       if (bracket === null) return null;
       source += bracket.source;
       i = bracket.next;

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -261,6 +261,37 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // Inside a bracket expression the same ARE shorthands mean what they mean in
+    // a JS character class, so `[\d]` translates rather than refusing the filter.
+    'await adapter.exec(`CREATE TABLE "ex_12" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[\\\\d]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_foo" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[\\\\w]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // A shorthand alongside ordinary bracket members, and under negation.
+    'await adapter.exec(`CREATE TABLE "ex_-1" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[-\\\\S]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_ab" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^\\\\d]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -826,9 +857,8 @@ tester.run("require-table-teardown", rule, {
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
     // A backslash inside a bracket expression is an escape to PostgreSQL's ARE
-    // engine and a literal to bare POSIX, so the filter is refused: reading
-    // `[\d]` as a literal backslash-or-`d` would credit `exd`, which
-    // `~ '^ex[\d]'` does not select.
+    // engine and a literal to bare POSIX. `[\d]` is read as the digits, so it
+    // still credits nothing for `exd` — the literal reading would.
     {
       code:
         'await adapter.exec(`CREATE TABLE "exd" (id int)`);\n' +
@@ -839,6 +869,94 @@ tester.run("require-table-teardown", rule, {
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "exd" } }],
+    },
+    // `\W` is wider in JS than ARE's `[^[:alnum:]_]` need be, so it stays
+    // refused inside brackets exactly as it is outside them.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_-" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[\\\\W]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_-" } }],
+    },
+    // `\b` inside a bracket expression is PostgreSQL's backspace, not JS's word
+    // boundary, so it is refused rather than translated.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_b" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[\\\\b]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_b" } }],
+    },
+    // A back reference inside brackets is not a shorthand, so it refuses too.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^(ex)_[\\\\1]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
+    },
+    // A bare `[\\]` is one literal backslash to ARE and two characters to bare
+    // POSIX, so which set it denotes still depends on the engine.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_x" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[\\\\\\\\]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_x" } }],
+    },
+    // A shorthand as a range endpoint is an error to ARE, but JS's Annex B
+    // grammar reads the `-` as a literal — which would credit `ex_-`.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_-" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[a-\\\\d]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_-" } }],
+    },
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_-" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[\\\\d-z]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_-" } }],
+    },
+    // `SIMILAR TO` carries its own ESCAPE character, and how that composes with
+    // a backslash inside brackets is unsettled, so that path still refuses.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\d]%'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
     },
     // A back reference means something else once the `^(?:…)` wrapper adds a
     // group, so it stays refused although JS spells it identically.

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -292,6 +292,15 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // A `-` in first position is a literal in both grammars, even under
+    // negation, so the shorthand after it is not a range endpoint.
+    'await adapter.exec(`CREATE TABLE "ex_ab" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^-\\\\d]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +


### PR DESCRIPTION
`bracketSource` refused any backslash inside a bracket expression (#5582),
because bare POSIX reads it as a literal and PostgreSQL's ARE reads it as an
escape. That is correct but under-accepting: `~ '^ex_[\d]+'` is an ordinary
sweep filter that credited nothing, so its creates reported `missingTeardown`
as noise.

`bracketSource` now takes an `areEscapes` flag. The `~` / `~*` path sets it —
those patterns are read by ARE, where a bracketed `ARE_SHORTHANDS` member
(`\d` / `\w` / `\S`) means exactly what the same shorthand means in a JS
character class. Everything else bracketed still refuses: the complements
(`[\W]`), `\b` (backspace inside brackets, not a word boundary), a back
reference (`[\1]`), a bare `[\\]`, and a shorthand used as a range endpoint
(`[a-\d]`, `[\d-z]`) — ARE errors on that, while JS's Annex B grammar quietly
reads the `-` as a literal and would credit a name containing one.

The `SIMILAR TO` path is deliberately left refusing: that grammar carries its
own `ESCAPE` character and its interaction with a bracketed backslash is
unsettled, so it does not get widened by accident through the shared helper.

Rule tests pin each newly accepted and each still-refused bracket escape
(including the `SIMILAR TO` refusal); the KNOWN GAPS paragraph is updated to
match what is actually read. All four new valid cases fail on baseline.

Closes-story: require-table-teardown-translate-bracket-shorthands
