### PR TITLE
fix(activerecord): sweep temp sqlite DBs on every adapter lane

### DIFF
--- a/packages/activerecord/src/support/template-global-setup.test.ts
+++ b/packages/activerecord/src/support/template-global-setup.test.ts
@@ -1,13 +1,3 @@
-/**
- * Lane-independent probe: globalSetup must stamp the run token on *every*
- * adapter lane, not just sqlite.
- *
- * The teardown sweep (`sweepRunDbFiles`) matches temp DB files by run token,
- * and `scratchDatabasePath` / `fallbackDatabasePath` mint on-disk sqlite files
- * whatever the active lane is — `multi-db-migrator.test.ts` opens one on a PG
- * run too. If the token were sqlite-only those files would carry the `"x"` (or
- * a random per-process) fallback stamp and survive the run.
- */
 import { describe, it, expect } from "vitest";
 import { RUN_TOKEN_ENV } from "./sqlite-template.js";
 import { scratchDatabasePath } from "./scratch-database.js";

--- a/packages/activerecord/src/support/template-global-setup.test.ts
+++ b/packages/activerecord/src/support/template-global-setup.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Lane-independent probe: globalSetup must stamp the run token on *every*
+ * adapter lane, not just sqlite.
+ *
+ * The teardown sweep (`sweepRunDbFiles`) matches temp DB files by run token,
+ * and `scratchDatabasePath` / `fallbackDatabasePath` mint on-disk sqlite files
+ * whatever the active lane is — `multi-db-migrator.test.ts` opens one on a PG
+ * run too. If the token were sqlite-only those files would carry the `"x"` (or
+ * a random per-process) fallback stamp and survive the run.
+ */
+import { describe, it, expect } from "vitest";
+import { RUN_TOKEN_ENV } from "./sqlite-template.js";
+import { scratchDatabasePath } from "./scratch-database.js";
+
+const runToken = process.env[RUN_TOKEN_ENV];
+
+describe("temp sqlite DB sweep arming", () => {
+  it("stamps the run token regardless of the active lane", () => {
+    expect(runToken).toBeTruthy();
+  });
+
+  it("stamps scratch database paths with the swept run token", async () => {
+    expect(await scratchDatabasePath("global-setup-probe")).toContain(`-${runToken}-`);
+  });
+});

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -274,7 +274,10 @@ export default async function setup(): Promise<(() => Promise<void>) | undefined
   }
 
   return async () => {
-    await Promise.all(teardowns.map((t) => t()));
-    await sweepRunDbFiles(runToken);
+    try {
+      await Promise.all(teardowns.map((t) => t()));
+    } finally {
+      await sweepRunDbFiles(runToken);
+    }
   };
 }

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -54,6 +54,20 @@ function slotCount(): number {
   return workerForkCount() <= 1 ? 1 : slotPoolSize();
 }
 
+/**
+ * Mint this invocation's run token and publish it to the workers.
+ *
+ * Every lane needs it, not just sqlite: `scratchDatabasePath` and
+ * `fallbackDatabasePath` build on-disk sqlite files whatever the active
+ * adapter is (`multi-db-migrator.test.ts` opens one on a PG run too), and the
+ * teardown sweep only matches files stamped with the token. Without this the
+ * token-less fallbacks (`"x"`, or a random per-process token) are reachable
+ * only by the 6h stale sweep, which itself runs on sqlite runs alone.
+ */
+function currentRunToken(): string {
+  return (process.env[RUN_TOKEN_ENV] ??= `${Date.now()}-${Math.floor(Math.random() * 1e9)}`);
+}
+
 async function buildTemplateSchema(
   adapter: DatabaseAdapter,
   close: () => Promise<void>,
@@ -100,20 +114,14 @@ const sqliteAdapter: DbTemplateAdapter = {
       );
     }
 
-    await sweepStaleDbFiles();
-
-    const runToken = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-    const templatePath = await templatePathFor(runToken);
+    const templatePath = await templatePathFor(currentRunToken());
 
     const adapter = new BetterSQLite3Adapter(templatePath);
     await buildTemplateSchema(adapter as unknown as DatabaseAdapter, () => adapter.close());
 
     process.env[TEMPLATE_PATH_ENV] = templatePath;
-    process.env[RUN_TOKEN_ENV] = runToken;
 
-    return async () => {
-      await sweepRunDbFiles(runToken);
-    };
+    return undefined;
   },
 };
 
@@ -265,6 +273,11 @@ const mysqlAdapter: DbTemplateAdapter = {
 const ADAPTERS: DbTemplateAdapter[] = [sqliteAdapter, pgAdapter, mysqlAdapter];
 
 export default async function setup(): Promise<(() => Promise<void>) | undefined> {
+  // Lane-independent: temp sqlite DBs are created on PG and MySQL runs too, so
+  // the stale sweep and the run-token sweep are armed before any adapter
+  // dispatch and torn down after all of them.
+  await sweepStaleDbFiles();
+  const runToken = currentRunToken();
   const teardowns: (() => Promise<void>)[] = [];
 
   for (const adapter of ADAPTERS) {
@@ -273,8 +286,9 @@ export default async function setup(): Promise<(() => Promise<void>) | undefined
     if (teardown) teardowns.push(teardown);
   }
 
-  if (teardowns.length === 0) return undefined;
   return async () => {
     await Promise.all(teardowns.map((t) => t()));
+    // Last, so files an adapter teardown itself leaves behind are still caught.
+    await sweepRunDbFiles(runToken);
   };
 }

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -54,16 +54,6 @@ function slotCount(): number {
   return workerForkCount() <= 1 ? 1 : slotPoolSize();
 }
 
-/**
- * Mint this invocation's run token and publish it to the workers.
- *
- * Every lane needs it, not just sqlite: `scratchDatabasePath` and
- * `fallbackDatabasePath` build on-disk sqlite files whatever the active
- * adapter is (`multi-db-migrator.test.ts` opens one on a PG run too), and the
- * teardown sweep only matches files stamped with the token. Without this the
- * token-less fallbacks (`"x"`, or a random per-process token) are reachable
- * only by the 6h stale sweep, which itself runs on sqlite runs alone.
- */
 function currentRunToken(): string {
   return (process.env[RUN_TOKEN_ENV] ??= `${Date.now()}-${Math.floor(Math.random() * 1e9)}`);
 }
@@ -273,9 +263,6 @@ const mysqlAdapter: DbTemplateAdapter = {
 const ADAPTERS: DbTemplateAdapter[] = [sqliteAdapter, pgAdapter, mysqlAdapter];
 
 export default async function setup(): Promise<(() => Promise<void>) | undefined> {
-  // Lane-independent: temp sqlite DBs are created on PG and MySQL runs too, so
-  // the stale sweep and the run-token sweep are armed before any adapter
-  // dispatch and torn down after all of them.
   await sweepStaleDbFiles();
   const runToken = currentRunToken();
   const teardowns: (() => Promise<void>)[] = [];
@@ -288,7 +275,6 @@ export default async function setup(): Promise<(() => Promise<void>) | undefined
 
   return async () => {
     await Promise.all(teardowns.map((t) => t()));
-    // Last, so files an adapter teardown itself leaves behind are still caught.
     await sweepRunDbFiles(runToken);
   };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -358,7 +358,9 @@ export default defineConfig({
           exclude: [...SHARED_EXCLUDE, ...ADAPTER_SPECIFIC_EXCLUDE, ...SQLITE_DRIVER_TESTS],
           // Phase 0 sqlite template-clone (perf): build the canonical schema
           // into a template file once for the whole run; workers clone it
-          // instead of re-issuing the DDL per file. No-op on PG/MySQL runs.
+          // instead of re-issuing the DDL per file. The template build is a
+          // no-op on PG/MySQL runs; the temp-DB sweep it arms is not — scratch
+          // and fallback sqlite files are minted on every lane.
           globalSetup: ["./packages/activerecord/src/support/template-global-setup.ts"],
           setupFiles: [
             "./packages/activerecord/src/test-setup-worker-db.ts",


### PR DESCRIPTION
## Problem

PR #5580's run-token sweep (`sweepRunDbFiles`) was wired into
`sqliteAdapter.provision()` in `support/template-global-setup.ts`, so it only
armed on sqlite runs. But temp sqlite files are minted on **every** lane:
`scratchDatabasePath` (`support/scratch-database.ts`) and
`fallbackDatabasePath` (`support/connection.ts`) are lane-agnostic —
`multi-db-migrator.test.ts` opens two of them on a PG run. Those files also
carried the token-less `-x-` stamp, so nothing but the 6h stale sweep (itself
sqlite-only) ever collected them.

## Change

- Hoist `sweepStaleDbFiles()`, the run-token mint, and the teardown
  `sweepRunDbFiles(runToken)` out of `sqliteAdapter` into the shared `setup()`
  dispatch. The sweep runs last, after every adapter teardown.
- Stamping `AR_TEST_RUN_TOKEN` lane-independently is what covers the
  token-less paths: both fallbacks read that env var, so they now land with
  the token the sweep matches instead of `x` / a random per-process value.

## Verification

Local PG run of `multi-db-migrator.test.ts` (isolated compose project),
before/after `ls /tmp/ar-test-*`:

- baseline: leaks `ar-test-multi-db-migrator-{a,b}-x-1.sqlite`
- with this change: no new files

`support/template-global-setup.test.ts` is the regression probe — it asserts
the run token is stamped on whatever lane is active and that scratch paths
carry it. It fails on baseline for the PG/MySQL lanes.

Closes-story: sweep-temp-sqlite-dbs-on-non-sqlite-lanes
