### PR TITLE
test(activerecord): capture stdout/stderr in DatabaseTasks create/drop describes

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } fr
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { stdout } from "@blazetrails/activesupport";
+import { stdout, stderr } from "@blazetrails/activesupport";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
@@ -289,7 +289,28 @@ describe("DatabaseTasksDumpSchemaTest", () => {
   });
 });
 
+/**
+ * Rails: `DatabaseTasksHelper#setup` / `#teardown` swap `$stdout` / `$stderr`
+ * for `StringIO`s for the duration of each test and restore them afterwards
+ * (vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb:26-32),
+ * keeping the `create` / `drop` banners out of the test output.
+ */
+function captureStdoutAndStderr(): void {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(stdout, "write").mockImplementation(() => true);
+    stderrSpy = vi.spyOn(stderr, "write").mockImplementation(() => true);
+  });
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+}
+
 describe("DatabaseTasksCreateAllTest", () => {
+  captureStdoutAndStderr();
+
   let created: string[];
   beforeEach(() => {
     created = [];
@@ -362,6 +383,8 @@ describe("DatabaseTasksCreateAllTest", () => {
 });
 
 describe("DatabaseTasksCreateCurrentTest", () => {
+  captureStdoutAndStderr();
+
   let created: string[];
 
   let establishSpy: MockInstance<any>;
@@ -436,6 +459,8 @@ describe("DatabaseTasksCreateCurrentTest", () => {
 });
 
 describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
+  captureStdoutAndStderr();
+
   let created: string[];
 
   let establishSpy: MockInstance<any>;
@@ -507,6 +532,8 @@ describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
 });
 
 describe("DatabaseTasksDropAllTest", () => {
+  captureStdoutAndStderr();
+
   let dropped: string[];
   beforeEach(() => {
     dropped = [];
@@ -579,6 +606,8 @@ describe("DatabaseTasksDropAllTest", () => {
 });
 
 describe("DatabaseTasksDropCurrentTest", () => {
+  captureStdoutAndStderr();
+
   let dropped: string[];
   beforeEach(() => {
     dropped = [];
@@ -633,6 +662,8 @@ describe("DatabaseTasksDropCurrentTest", () => {
 });
 
 describe("DatabaseTasksDropCurrentThreeTierTest", () => {
+  captureStdoutAndStderr();
+
   let dropped: string[];
   beforeEach(() => {
     dropped = [];

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -289,12 +289,6 @@ describe("DatabaseTasksDumpSchemaTest", () => {
   });
 });
 
-/**
- * Rails: `DatabaseTasksHelper#setup` / `#teardown` swap `$stdout` / `$stderr`
- * for `StringIO`s for the duration of each test and restore them afterwards
- * (vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb:26-32),
- * keeping the `create` / `drop` banners out of the test output.
- */
 function captureStdoutAndStderr(): void {
   let stdoutSpy: MockInstance;
   let stderrSpy: MockInstance;


### PR DESCRIPTION
Ports the `$stdout` / `$stderr` redirection from Rails'
`DatabaseTasksHelper#setup` / `#teardown`
(`vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb:26-32`)
into the six trails describes ported from test cases that include it:
`DatabaseTasksCreateAllTest`, `DatabaseTasksCreateCurrentTest`,
`DatabaseTasksCreateCurrentThreeTierTest`, `DatabaseTasksDropAllTest`,
`DatabaseTasksDropCurrentTest`, `DatabaseTasksDropCurrentThreeTierTest`.

Since PR #5545 moved the `create` / `drop` banners onto the activesupport
`stdout` / `stderr` shims, a run of `database-tasks.test.ts` printed ~30
uncaptured `Created database '...'` / `Dropped database '...'` lines. A shared
`captureStdoutAndStderr()` helper (mirroring the Ruby module) spies the shims in
`beforeEach` and restores in `afterEach`; the run is now silent.

No test names changed. 79 passed, 1 skipped.

Closes-story: database-tasks-tests-capture-stdout-for-banners
