### PR TITLE
refactor(activerecord): drop raiseOnAssignToAttrReadonly get/set wrappers

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -3,13 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, afterAll, afterEach, vi } from "vitest";
-import {
-  ActiveRecord,
-  Base,
-  NotImplementedError,
-  ReadonlyAttributeError,
-  getRaiseOnAssignToAttrReadonly,
-} from "./index.js";
+import { ActiveRecord, Base, NotImplementedError, ReadonlyAttributeError } from "./index.js";
 import { TableNotSpecified, ActiveRecordError } from "./errors.js";
 
 import { adapterType } from "./test-adapter.js";
@@ -1083,7 +1077,7 @@ describe("BasicsTest", () => {
     expect(ConcreteModel.readonlyAttributes).toContain("code");
   });
   it("readonly attributes when configured to not raise", async () => {
-    const prev = getRaiseOnAssignToAttrReadonly();
+    const prev = ActiveRecord.raiseOnAssignToAttrReadonly;
     ActiveRecord.raiseOnAssignToAttrReadonly = false;
     try {
       class NonRaisingPost extends Base {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -230,11 +230,7 @@ export {
   TableNotSpecified,
   AsynchronousQueryInsideTransactionError,
 } from "./errors.js";
-export {
-  ReadonlyAttributeError,
-  getRaiseOnAssignToAttrReadonly,
-  setRaiseOnAssignToAttrReadonly,
-} from "./readonly-attributes.js";
+export { ReadonlyAttributeError } from "./readonly-attributes.js";
 export { RecordInvalid } from "./validations.js";
 export {
   AssociationNotFoundError,

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -15,23 +15,6 @@ import { ActiveRecord } from "./ar-config.js";
  * Mirrors: ActiveRecord::ReadonlyAttributeError (defined alongside
  * HasReadonlyAttributes in Rails' readonly_attributes.rb).
  */
-/**
- * Reads `ActiveRecord.raise_on_assign_to_attr_readonly` — the canonical module
- * flag lives in `ar-config.ts` (default false, active_record.rb:343). These two
- * wrappers keep the historic `getRaiseOnAssignToAttrReadonly`/
- * `setRaiseOnAssignToAttrReadonly` public surface in place while the home is the
- * single `ActiveRecord.raiseOnAssignToAttrReadonly` accessor.
- *
- * Mirrors: ActiveRecord.raise_on_assign_to_attr_readonly
- */
-export function getRaiseOnAssignToAttrReadonly(): boolean {
-  return ActiveRecord.raiseOnAssignToAttrReadonly;
-}
-
-export function setRaiseOnAssignToAttrReadonly(value: boolean): void {
-  ActiveRecord.raiseOnAssignToAttrReadonly = value;
-}
-
 export class ReadonlyAttributeError extends ActiveRecordError {
   readonly attribute: string;
   constructor(attribute: string) {


### PR DESCRIPTION
Deletes the trails-only `getRaiseOnAssignToAttrReadonly` /
`setRaiseOnAssignToAttrReadonly` re-spellings left behind by #5564. Both were
one-line delegates to `ActiveRecord.raiseOnAssignToAttrReadonly`, which is the
Rails-spelled home (`singleton_class.attr_accessor :raise_on_assign_to_attr_readonly`,
`vendor/rails/activerecord/lib/active_record.rb:342-343`).

- removed from `readonly-attributes.ts` and the `index.ts` export list
- the one remaining caller (`base.test.ts`) now reads
  `ActiveRecord.raiseOnAssignToAttrReadonly` directly

Public-API break by design: compile-time and total, with a Rails-spelled
replacement — same class as the `export let` deletions RFC 0081 already settled.

Closes-story: unexport-raise-on-assign-to-attr-readonly-wrappers
