### PR TITLE
feat(eslint): honour the SIMILAR TO ESCAPE character inside bracket expressions

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -516,9 +516,12 @@ function bracketSource(pattern, start, escapeChar) {
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
     if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
-    if (ch === escapeChar || ch === "\\") {
+    // A backslash that does not escape here is still refused rather than
+    // emitted: it is a literal to PostgreSQL but an escape to JS.
+    if (ch === "\\" && ch !== escapeChar) return null;
+    if (ch === escapeChar) {
       const next = pattern[i + 1];
-      if (ch !== escapeChar || next === undefined || !ARE_SHORTHANDS.has(next)) return null;
+      if (next === undefined || !ARE_SHORTHANDS.has(next)) return null;
       if (source.endsWith("-") && source.length - 1 > bodyStart) return null;
       if (pattern[i + 2] === "-" && (pattern[i + 3] ?? "]") !== "]") return null;
       source += `\\${next}`;

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -468,20 +468,38 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * emitting it doubled would credit `exd` for `~ '^ex[\d]'` — a name the filter
  * does not select.
  *
- * `areEscapes` says which reading applies, so the caller that knows the engine
- * decides. The `~` / `~*` path sets it: those patterns are read by ARE, where a
- * bracketed `ARE_SHORTHANDS` member means exactly what the same shorthand means
- * in a JS character class, so `[\d]` translates. Every other backslash inside
- * brackets still refuses — the complements (`[\W]`), `\b` (backspace here, not
- * a word boundary), a back reference (`[\1]`), and a bare `[\\]`, whose ARE
- * meaning is a literal backslash but whose bare-POSIX one is two of them. A
- * shorthand used as a range endpoint (`[a-\d]`, `[\d-z]`) is refused too: ARE
- * rejects it outright, while JS's Annex B grammar quietly reads the `-` as a
- * literal and would credit a name containing one. Unset (the `SIMILAR TO`
- * path), any backslash refuses: that grammar carries its own `ESCAPE`
- * character, and how it composes with a bracketed backslash is unsettled.
+ * `escapeChar` is the character that introduces an escape here, so the caller
+ * that knows the engine decides which reading applies. The `~` / `~*` path
+ * passes the backslash ARE spells its escapes with, where a bracketed
+ * `ARE_SHORTHANDS` member means exactly what the same shorthand means in a JS
+ * character class, so `[\d]` translates. Every other escape inside brackets
+ * refuses — the complements (`[\W]`), `\b` (backspace here, not a word
+ * boundary), a back reference (`[\1]`), and a bare `[\\]`, whose ARE meaning is
+ * a literal backslash but whose bare-POSIX one is two of them. A shorthand used
+ * as a range endpoint (`[a-\d]`, `[\d-z]`) is refused too: ARE rejects it
+ * outright, while JS's Annex B grammar quietly reads the `-` as a literal and
+ * would credit a name containing one.
+ *
+ * The `SIMILAR TO` path passes its own `ESCAPE` character, which PostgreSQL
+ * applies inside bracket expressions as well — settled against a live server
+ * (17.7), since the grammar in the docs does not say either way:
+ * `'ex_5' SIMILAR TO 'ex_[\d]%'` is TRUE under the default backslash escape and
+ * `'ex_d'` is not, so the escape+letter pair reaches the underlying ARE as the
+ * class shorthand; `'ex_5' SIMILAR TO 'ex_[#d]%' ESCAPE '#'` is TRUE the same
+ * way. It follows that a backslash which is NOT the escape character is a plain
+ * literal there (`[\d]` under `ESCAPE '#'` selects a backslash or a `d`, and
+ * TRUE for neither digit nor `\d`'s JS meaning), so it must refuse rather than
+ * translate — the JS class would otherwise be the wider of the two.
+ *
+ * An escape character with structural meaning inside a bracket expression
+ * (`[`, `]`, `^`, `-`) refuses the expression outright: `ESCAPE '^'` makes
+ * `[^d]` the digits rather than a negated class, and the members are parsed
+ * before the escape could be honoured.
  */
-function bracketSource(pattern, start, areEscapes = false) {
+const BRACKET_STRUCTURAL = new Set(["[", "]", "^", "-"]);
+
+function bracketSource(pattern, start, escapeChar) {
+  if (BRACKET_STRUCTURAL.has(escapeChar)) return null;
   let source = "[";
   let i = start + 1;
   if (pattern[i] === "^") {
@@ -498,9 +516,9 @@ function bracketSource(pattern, start, areEscapes = false) {
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
     if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
-    if (ch === "\\") {
+    if (ch === escapeChar || ch === "\\") {
       const next = pattern[i + 1];
-      if (!areEscapes || next === undefined || !ARE_SHORTHANDS.has(next)) return null;
+      if (ch !== escapeChar || next === undefined || !ARE_SHORTHANDS.has(next)) return null;
       if (source.endsWith("-") && source.length - 1 > bodyStart) return null;
       if (pattern[i + 2] === "-" && (pattern[i + 3] ?? "]") !== "]") return null;
       source += `\\${next}`;
@@ -559,7 +577,7 @@ function posixRegexpSource(pattern) {
   while (i < pattern.length) {
     const ch = pattern[i];
     if (ch === "[") {
-      const bracket = bracketSource(pattern, i, true);
+      const bracket = bracketSource(pattern, i, "\\");
       if (bracket === null) return null;
       source += bracket.source;
       i = bracket.next;
@@ -613,6 +631,12 @@ function regexpPrefixMatcher(pattern, caseInsensitive) {
  * matches the entire name: in `'ex|tmp%'` the `%` belongs to the second branch
  * only, so a prefix reading of the alternation would credit `exFOO`, which the
  * filter does not select.
+ *
+ * `escapeChar` reaches `bracketSource` too, because PostgreSQL honours the
+ * `ESCAPE` character inside a bracket expression and hands the pair to the
+ * underlying ARE — so `[\d]` under the default backslash escape (the one
+ * `sanitize_sql_like` emits) is the digits, exactly as on the `~` path, while a
+ * backslash that is not the escape character is a literal there and refuses.
  */
 function similarPrefixMatcher(pattern, escapeChar, caseInsensitive) {
   let source = "";
@@ -625,7 +649,7 @@ function similarPrefixMatcher(pattern, escapeChar, caseInsensitive) {
       source += next.replace(JS_METACHAR_RE, "\\$&");
       i += 2;
     } else if (ch === "[") {
-      const bracket = bracketSource(pattern, i);
+      const bracket = bracketSource(pattern, i, escapeChar);
       if (bracket === null) return null;
       source += bracket.source;
       i = bracket.next;

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -987,6 +987,19 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
     },
+    // The same for a range: `[a-d]` under `ESCAPE '-'` is the digits, since the
+    // `-` escapes the `d` before it can be read as the middle of a range.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[a-d]%' ESCAPE '-'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
+    },
     // An ESCAPE character with structural meaning inside a bracket expression
     // refuses it: `[^d]` under `ESCAPE '^'` is the digits, not a negated class.
     {

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -988,17 +988,19 @@ tester.run("require-table-teardown", rule, {
       errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
     },
     // The same for a range: `[a-d]` under `ESCAPE '-'` is the digits, since the
-    // `-` escapes the `d` before it can be read as the middle of a range.
+    // `-` escapes the `d` before it can be read as the middle of a range — so
+    // reading it as a range would credit `ex_b`, which the filter does not
+    // select.
     {
       code:
-        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        'await adapter.exec(`CREATE TABLE "ex_b" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
         "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[a-d]%' ESCAPE '-'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
-      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_b" } }],
     },
     // An ESCAPE character with structural meaning inside a bracket expression
     // refuses it: `[^d]` under `ESCAPE '^'` is the digits, not a negated class.

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -190,6 +190,25 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // PostgreSQL applies the ESCAPE character inside a bracket expression too,
+    // so a bracketed shorthand under the default backslash escape is the ARE
+    // class it is on the `~` path: `SIMILAR TO 'ex_[\d]%'` sweeps `ex_1`.
+    'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\d]%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // The same holds for a non-backslash ESCAPE character: `[#d]` under
+    // `ESCAPE '#'` reaches the ARE as `[\d]` and selects `ex_1`.
+    'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[#d]%' ESCAPE '#'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A bracket expression and a bounded repeat are spelled alike in JS.
     'await adapter.exec(`CREATE TABLE "ex12_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -954,13 +973,27 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_-" } }],
     },
-    // `SIMILAR TO` carries its own ESCAPE character, and how that composes with
-    // a backslash inside brackets is unsettled, so that path still refuses.
+    // A backslash that is NOT the pattern's ESCAPE character is a literal
+    // backslash inside a `SIMILAR TO` bracket expression, so `[\d]` selects a
+    // backslash or a `d` and crediting the digits would be the wider reading.
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
-        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\d]%'`,\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\d]%' ESCAPE '#'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
+    },
+    // An ESCAPE character with structural meaning inside a bracket expression
+    // refuses it: `[^d]` under `ESCAPE '^'` is the digits, not a negated class.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[^d]%' ESCAPE '^'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +


### PR DESCRIPTION
Settles the deferred question from #5589: does a `SIMILAR TO` pattern's `ESCAPE` character apply inside a bracket expression?

It does. Probed against PostgreSQL 17.7, since the documented grammar does not say either way:

```
'ex_5' SIMILAR TO 'ex_[\d]%'              -> t    'ex_d' -> f   'ex_\' -> f
'ex_5' SIMILAR TO 'ex_[\d]%' ESCAPE '#'   -> f    'ex_d' -> t   'ex_\' -> t
'ex_5' SIMILAR TO 'ex_[#d]%' ESCAPE '#'   -> t    'ex_d' -> f
'ex_5' SIMILAR TO 'ex_[a-d]%' ESCAPE '-'  -> t    'ex_b' -> f
```

The escape character is consumed inside the class and the pair is handed to the underlying ARE as a class shorthand. It follows that a backslash which is *not* the escape character is a plain literal there.

So `bracketSource` now takes the escape character rather than an `areEscapes` flag (the `~` path passes `\`), which:

- lets `SIMILAR TO 'ex_[\d]%'` credit its sweep instead of reporting its creates as noise — the under-acceptance #5589 fixed on the `~` path;
- refuses a bare backslash under a non-backslash `ESCAPE`, where the JS class would be the wider of the two;
- fixes two existing over-credits, where the rule credited names the filter does not select: `[#d]` under `ESCAPE '#'` is the digits rather than `{#, d}`, and `[a-d]` under `ESCAPE '-'` is the digits rather than the range `a`–`d`;
- refuses outright when the escape character is structural in the class grammar (`[`, `]`, `^`, `-`), since the members are parsed before the escape could be honoured — `[^d]` under `ESCAPE '^'` is the digits, not a negated class.

The finding is recorded at the call site. Rule tests pin each case; four of them fail against the rule on `main`.

Closes-story: require-table-teardown-settle-similar-to-bracket-escape
