### PR TITLE
fix(activerecord): surface INSERT ... RETURNING rows on MariaDB

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1286,14 +1286,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       }
     }
 
-    // NB: Rails appends `RETURNING` here (outside the raw-alias branch), but
-    // trails `InsertAll#execute` consumes this SQL via `executeMutation`, which
-    // returns an affected-row count. The mysql2 driver returns a result set
-    // (no affectedRows) for a RETURNING statement, so emitting it would make
-    // `insertAll` return undefined on MariaDB >= 10.5. Surfacing MySQL RETURNING
-    // needs `execute` reworked to read the result set (Rails' exec_insert_all) —
-    // tracked separately. SQLite/PG carry the tail because their executeMutation
-    // tolerates RETURNING and still yields a count.
+    const returning = insert.returning();
+    if (returning) sql += ` RETURNING ${returning}`;
     return sql;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -559,8 +559,16 @@ export function execInsert(
  * bound INSERT through the adapter's bind-aware internalExecQuery (which
  * materializes the transaction) to hand back the whole Result, dirtying the
  * transaction as executeMutation would. Returns undefined when the caller should
- * keep its fast path (≤1 returning column, or sql_for_insert produced no
- * RETURNING clause — e.g. MySQL 8, which lacks INSERT ... RETURNING).
+ * keep its fast path (fewer than `minColumns` returning columns, or
+ * sql_for_insert produced no RETURNING clause — e.g. MySQL 8, which lacks
+ * INSERT ... RETURNING).
+ *
+ * `minColumns` defaults to 2 because an adapter whose executeMutation reports a
+ * usable generated id (SQLite’s `last_insert_rowid`) can serve a single-column
+ * primary-key read-back from it. MySQL passes 1: mysql2’s `insertId` is 0
+ * whenever the database populates the primary key by something other than
+ * AUTO_INCREMENT (a trigger, or an updateable view’s base table), so even one
+ * returning column has to come off the result set.
  *
  * @internal
  */
@@ -571,8 +579,9 @@ export async function execInsertReturningReadback(
   binds: unknown[],
   pk: string | false | null | undefined,
   returning: string[] | null | undefined,
+  minColumns = 2,
 ): Promise<Result | undefined> {
-  if (!returning || returning.length <= 1) return undefined;
+  if (!returning || returning.length < minColumns) return undefined;
   // Gate on the capability flag sql_for_insert itself checks
   // (supports_insert_returning?) rather than sniffing the generated SQL — on a
   // backend without INSERT ... RETURNING (MySQL 8) sql_for_insert appends

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -620,13 +620,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   /**
    * Mirrors Rails' abstract `exec_insert` → `sql_for_insert` → `internal_exec_query`
-   * for the multi-column RETURNING read-back. MariaDB supports `INSERT ...
-   * RETURNING`, but the `executeMutation` write primitive returns only the
-   * generated id, so a multi-column auto-populated-columns list (Rails
-   * `_create_record` zips every returning column) would lose the non-PK values.
-   * Route that case through `execQuery` — bind-aware, and its `withRawConnection`
-   * materializes and dirties the transaction — to hand back the full `Result`.
-   * Single-column / no-RETURNING inserts (and MySQL 8, which lacks insert
+   * for the RETURNING read-back. MariaDB supports `INSERT ... RETURNING`, but the
+   * `executeMutation` write primitive returns only mysql2's `insertId`, which is
+   * 0 unless the primary key came from AUTO_INCREMENT — so every requested
+   * returning column has to come off the result set (hence `minColumns` 1, unlike
+   * SQLite, whose `last_insert_rowid` can still serve a single-column PK).
+   * Route that case through the bind-aware `internalExecQuery`, whose
+   * `withRawConnection` materializes and dirties the transaction, to hand back
+   * the full `Result`. No-RETURNING inserts (and MySQL 8, which lacks insert
    * returning, so `sql_for_insert` appends nothing) keep the `executeMutation`
    * path via `super`.
    */
@@ -645,6 +646,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       binds,
       pk,
       returning,
+      1,
     );
     if (readback !== undefined) return readback;
     return super.execInsert(sql, name, binds, pk, sequenceName, returning);

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -38,6 +38,7 @@ import { Developer } from "./test-helpers/models/developer.js";
 import { Measurement } from "./test-helpers/models/measurement.js";
 import { Ship } from "./test-helpers/models/ship.js";
 import { Speedometer } from "./test-helpers/models/speedometer.js";
+import { escapeRegExp, quoteColumnName } from "./support/quote-regex.js";
 
 // Adapter capability gates (mirror Rails' supports_* predicates / current_adapter?).
 // Feature-gated tests use itIfSupports(...) / adapterSupports(...) so the
@@ -78,6 +79,14 @@ async function assertInsertAllReturningAlias(): Promise<void> {
   });
   expect(result.columns).toContain("title");
   expect(await Book.count()).toBe(before + 1);
+}
+
+// The RETURNING identifier is quoted by the active adapter (`"id"` on
+// PG/SQLite, `` `id` `` on the MySQL family), so build the pattern the way Rails
+// does with `Regexp.escape(quote_column_name(...))` rather than hard-coding
+// double quotes.
+function returningRe(column: string): RegExp {
+  return new RegExp(`RETURNING ${escapeRegExp(quoteColumnName(column))}`);
 }
 
 function getYear(val: unknown): number {
@@ -1042,12 +1051,12 @@ describe("InsertAllTest", () => {
   it.skipIf(!supportsInsertReturning)(
     "insert all returning uses schema-cache primary keys not the model primary key",
     async () => {
-      await assertQueriesMatch(/RETURNING "id"/, undefined, false, async () => {
+      await assertQueriesMatch(returningRe("id"), undefined, false, async () => {
         await DivergentPrimaryKeyBook.insertAll([
           { name: "Divergent", isbn: "9990000000001", author_id: 1 },
         ]);
       });
-      await assertNoQueriesMatch(/RETURNING "isbn"/, false, async () => {
+      await assertNoQueriesMatch(returningRe("isbn"), false, async () => {
         await DivergentPrimaryKeyBook.insertAll([
           { name: "Divergent II", isbn: "9990000000002", author_id: 1 },
         ]);

--- a/packages/activerecord/src/support/mysql-server-version.ts
+++ b/packages/activerecord/src/support/mysql-server-version.ts
@@ -75,6 +75,15 @@ export const supportsDefaultExpression = mariaDb
 export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13") === true;
 
 /**
+ * Mirrors AbstractMysqlAdapter#supports_insert_returning?
+ * (abstract_mysql_adapter.rb:173): MariaDB ≥ 10.5 only; never MySQL. Feeds the
+ * `insert_returning` entry in support/supports.ts, which cannot bake the answer
+ * into a static adapterType table — the mysql lane may be MySQL 8 (false) or the
+ * MariaDB CI stand-in (true).
+ */
+export const supportsInsertReturning = mariaDb && _serverVersion?.gte("10.5.0") === true;
+
+/**
  * Mirrors AbstractMysqlAdapter#supports_rename_index?
  * (abstract_mysql_adapter.rb:896-901): MariaDB ≥ 10.5.2, MySQL ≥ 5.7.6. Lets a
  * test reproduce Rails' `skip "Cannot drop index, needed in a foreign key

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -45,10 +45,12 @@ type Backend = (typeof ALL)[number];
 // MySQL 8 (true) locally but the MariaDB stand-in (false) in CI. Probe the
 // server once, on the mysql lane only — the dynamic import keeps the probe's
 // connection attempt off the pg/sqlite lanes.
-const mysqlExpressionIndex =
+const mysqlServerSupports =
   adapterType === "mysql"
-    ? (await import("./mysql-server-version.js")).supportsExpressionIndex
-    : false;
+    ? await import("./mysql-server-version.js")
+    : { supportsExpressionIndex: false, supportsInsertReturning: false };
+const mysqlExpressionIndex = mysqlServerSupports.supportsExpressionIndex;
+const mysqlInsertReturning = mysqlServerSupports.supportsInsertReturning;
 
 const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // Available on every backend we test (pg17 / mysql:8 / recent sqlite).
@@ -109,10 +111,12 @@ const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // `supports_pgcrypto_uuid?`: PostgreSQL database_version >= 9.4.0 (pg17 qualifies);
   // PostgreSQL-only (abstract default false). (postgresql_adapter.rb:299)
   pgcrypto_uuid: ["postgres"],
-  // `supports_insert_returning?`: PostgreSQL true; MySQL only for MariaDB ≥ 10.5 (mysql:8
-  // is not MariaDB → false); SQLite ≥ 3.35.0 (current node sqlite qualifies → true).
+  // `supports_insert_returning?`: PostgreSQL true; SQLite ≥ 3.35.0 (current node
+  // sqlite qualifies → true); MySQL family per the live-server probe above
+  // (MariaDB ≥ 10.5 only), since the mysql lane may be MySQL 8 (false) or the
+  // MariaDB CI stand-in (true).
   // (postgresql_adapter.rb:264, abstract_mysql_adapter.rb:173, sqlite3_adapter.rb:187)
-  insert_returning: ["postgres", "sqlite"],
+  insert_returning: mysqlInsertReturning ? ALL : ["postgres", "sqlite"],
   // `supports_text_column_with_default?`: MySQL only for MariaDB ≥ 10.2.1 (mysql:8 is not
   // MariaDB → false); all other adapters true. (adapter_helper.rb:42)
   text_column_with_default: ["postgres", "sqlite"],

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -260,11 +260,15 @@ describe("UpdateableViewTest", () => {
     expect((newBook as any).name).toBe("Rails in Action");
   });
 
-  // Rails gates this `features=[insert_returning,views]` (runs on mysql +
-  // postgresql; SQLite excluded by the outer view block). Carry both features so
-  // the extracted gate is `mysql,postgresql|insert_returning,views`; at runtime
-  // MySQL (mysql:8, not MariaDB) lacks insert_returning, so itIfSupports skips it.
-  itIfSupports.skipIf(adapterType === "sqlite")(
+  // Rails gates this `current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) &&
+  // supports_insert_returning?` (view_test.rb:197) — the MySQL family is excluded
+  // by name, and rightly so: a MariaDB view reports no `auto_increment` Extra for
+  // the base table's key (SHOW FULL FIELDS), so the column is not auto-populated,
+  // no RETURNING column is requested, and LAST_INSERT_ID() through a view is 0.
+  // SQLite is excluded on top of Rails by the outer view block (trails creates no
+  // view on that lane). Both features are carried so the extracted gate keeps
+  // `insert_returning,views`.
+  itIfSupports.skipIf(adapterType === "sqlite" || adapterType === "mysql")(
     "insert_returning,views",
     "insert record populates primary key",
     async () => {


### PR DESCRIPTION
`AbstractMysqlAdapter#supports_insert_returning?` answers `true` on MariaDB
>= 10.5, but the write path never surfaced the rows: `insert_all` /
`upsert_all` with `returning:` yielded an empty `Result`, and a
trigger-populated primary key came back as `0`.

Two separate holes, both deliberate deferrals with stale rationale:

1. `AbstractMysqlAdapter#buildInsertSql` dropped the `RETURNING` tail that
   `abstract_mysql_adapter.rb:680` appends. Its comment said `InsertAll#execute`
   consumes the SQL via `executeMutation` — no longer true: `execute` routes
   through `exec_insert_all` -> `internalExecQuery`, which already reads the
   result set. Restoring the tail fixes all six `insert-all.test.ts` failures.
2. `Mysql2Adapter#execInsert` kept its `executeMutation` fast path for a single
   returning column, on the assumption that the driver's generated id can stand
   in for it. mysql2's `insertId` is `0` whenever the key is not
   `AUTO_INCREMENT`, so `execInsertReturningReadback` now takes the column
   threshold that makes it fire — MySQL passes 1, SQLite keeps 2 (its
   `last_insert_rowid` genuinely can serve a single-column PK).

`support/supports.ts`'s `insert_returning` entry moves from a static
`adapterType` table to the live-server probe in `mysql-server-version.ts`
(MariaDB >= 10.5), the same seam `expression_index` already uses — the mysql
lane may be MySQL 8 (false) or the MariaDB CI stand-in (true), and the static
answer was skipping these tests regardless of which server was behind it.

Two test-side corrections that the newly-live gate exposed:

- `view.test.ts`'s "insert record populates primary key" is gated off the MySQL
  family, matching Rails' `current_adapter?(:PostgreSQLAdapter,
  :SQLite3Adapter) && supports_insert_returning?` (`view_test.rb:197`). The port
  had claimed Rails runs it on mysql; it does not, and for good reason — a
  MariaDB view reports no `auto_increment` Extra for the base table's key
  (verified with `SHOW FULL FIELDS`), so no column is auto-populated, no
  RETURNING column is requested, and `LAST_INSERT_ID()` through a view is 0.
- The trails-only `RETURNING "id"` assertion regex is built from the adapter's
  `quoteColumnName` (the `quote-regex.ts` helper) so it matches backticks too.

No test renamed; no new skips among the seven tests the story listed.

## Verification

Ran against a local `mariadb:11` (11.8.6) container matching the CI service,
plus regression runs on `mysql:8` (8.4.9), `postgres:17`, and the sqlite
default, over `insert-all`, `persistence`, `view`, `supports`,
`abstract-mysql-adapter`, `mysql2-adapter`, `timestamp`, and `transactions`.

- MariaDB, before: 7 failures (6 in `insert-all.test.ts`, 1 in
  `persistence.test.ts`) once `insert_returning` derives live.
- MariaDB, after: all green.
- PostgreSQL / SQLite: green, unchanged.
- MySQL 8: one pre-existing failure, `"upsert and db warnings"` (a
  `'VALUES function' is deprecated` SQLWarning from MySQL 8.4). Confirmed
  identical on unmodified `origin/main`, and unreachable from this change —
  MySQL 8 is not MariaDB, so `supports_insert_returning?` stays false and no
  RETURNING tail is emitted. There is no mysql:8 CI lane.

`pnpm test:compare` shows no gate regression: `insert_all_test.rb` and
`view_test.rb` both still reconcile fully.

## Note on #5585

The story's third acceptance criterion asks that `supports.ts` drop
#5585's hold-at-`false` and that the `KNOWN_DIVERGENCES` entry in
`supports-live-adapter.trails.test.ts` be deleted. #5585 is still open, so
neither exists on `main` yet — this PR branches from `main` and makes the entry
live-derived directly. Whichever of the two merges second will rebase; the
merge conflict is confined to the one `insert_returning` line, and the
`KNOWN_DIVERGENCES` map should end up empty either way.

Closes-story: mariadb-insert-returning-rows-dropped
