### PR TITLE
fix(activerecord): route DatabaseTasks remote-host warning through stderr shim

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -332,7 +332,7 @@ describe("DatabaseTasksCreateAllTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
-    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(stderr, "write").mockImplementation(() => true);
     await DatabaseTasks.createAll();
     expect(created).toHaveLength(0);
   });
@@ -341,7 +341,7 @@ describe("DatabaseTasksCreateAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
     const writes: string[] = [];
-    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    vi.spyOn(stderr, "write").mockImplementation((chunk) => {
       writes.push(String(chunk));
       return true;
     });
@@ -555,7 +555,7 @@ describe("DatabaseTasksDropAllTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
-    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(stderr, "write").mockImplementation(() => true);
     await DatabaseTasks.dropAll();
     expect(dropped).toHaveLength(0);
   });
@@ -564,7 +564,7 @@ describe("DatabaseTasksDropAllTest", () => {
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
     const writes: string[] = [];
-    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    vi.spyOn(stderr, "write").mockImplementation((chunk) => {
       writes.push(String(chunk));
       return true;
     });

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -624,9 +624,7 @@ export class DatabaseTasks {
       if (this._localDatabase(c)) {
         result.push(c);
       } else {
-        const stderr = (globalThis as { process?: { stderr?: { write: (s: string) => unknown } } })
-          .process?.stderr;
-        stderr?.write?.(
+        stderr.write(
           `This task only modifies local databases. ${c.database} is on a remote host.\n`,
         );
       }


### PR DESCRIPTION
Routes the `DatabaseTasks.eachLocalConfiguration` remote-host warning through the activesupport `stderr` shim instead of reaching into `globalThis.process.stderr`, matching the rest of the file and Rails' `$stderr` write (database_tasks.rb:605).

The two "warning for remote databases" / "ignores remote databases" tests now spy on the shim, removing the `process.*` references.

Closes-story: database-tasks-remote-warning-bypasses-stderr-shim
