### PR TITLE
refactor(activerecord): retire the bare { up, down } migration proxy shape

### DIFF
--- a/packages/activerecord-cli/src/__e2e__/helpers.ts
+++ b/packages/activerecord-cli/src/__e2e__/helpers.ts
@@ -4,16 +4,18 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 export const MIGRATION_BODY = `\
-export default {
+import { Migration } from "@blazetrails/activerecord";
+
+export default class CreateUsers extends Migration {
   async up() {
     await this.connection.createTable("users", (t) => {
       t.string("name");
     });
-  },
+  }
   async down() {
     await this.connection.dropTable("users");
-  },
-};
+  }
+}
 `;
 
 export async function mkE2eTmpDir(prefix: string): Promise<string> {

--- a/packages/activerecord-cli/src/pending-migrations.test.ts
+++ b/packages/activerecord-cli/src/pending-migrations.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { run } from "./cli.js";
-import { DatabaseTasks, Migrator } from "@blazetrails/activerecord";
+import { DatabaseTasks, Migration, Migrator } from "@blazetrails/activerecord";
 import { checkPendingMigrations } from "./pending-migrations.js";
 
 const FAKE_CONFIG = `
@@ -24,12 +24,12 @@ async function makeFakeProject(): Promise<string> {
 const PROXY_A = {
   version: "20240101000001",
   name: "CreateUsers",
-  migration: () => ({}) as unknown as import("@blazetrails/activerecord").MigrationLike,
+  migration: () => new (class extends Migration {})(),
 };
 const PROXY_B = {
   version: "20240101000002",
   name: "AddIndex",
-  migration: () => ({}) as unknown as import("@blazetrails/activerecord").MigrationLike,
+  migration: () => new (class extends Migration {})(),
 };
 
 describe("PendingMigrationsTest", () => {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -329,7 +329,7 @@ export {
   NoEnvironmentInSchemaError,
 } from "./migration.js";
 export { InternalMetadata, NullInternalMetadata } from "./internal-metadata.js";
-export type { MigrationProxy, MigrationLike } from "./migration.js";
+export type { MigrationProxy } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";
 
 export {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -41,6 +41,7 @@ import { describeIfPg } from "./support/describe-if-pg.js";
 import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
 import { leaseMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
+import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 async function freshContext(): Promise<{ adapter: DatabaseAdapter; ctx: MigrationContext }> {
   const adapter = Base.connection;
@@ -630,17 +631,17 @@ describe("MigrationTest", () => {
       {
         version: "1",
         name: "First",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("First", "1"),
       },
       {
         version: "2",
         name: "Second",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Second", "2"),
       },
       {
         version: "3",
         name: "Third",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Third", "3"),
       },
     ];
     const migrator = new Migrator(adapter, migrations);
@@ -661,17 +662,17 @@ describe("MigrationTest", () => {
       {
         version: "1",
         name: "First",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("First", "1"),
       },
       {
         version: "2",
         name: "Second",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Second", "2"),
       },
       {
         version: "3",
         name: "Third",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Third", "3"),
       },
     ];
     const migrator = new Migrator(adapter, migrations);
@@ -725,7 +726,7 @@ describe("MigrationTest", () => {
       {
         version: "1",
         name: "First",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("First", "1"),
       },
     ];
     const migrator = new Migrator(adapter, migrations);
@@ -743,7 +744,7 @@ describe("MigrationTest", () => {
       {
         version: "1",
         name: "First",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("First", "1"),
       },
     ]);
     expect(withMigrations.migrations.length).toBeGreaterThan(0);
@@ -758,7 +759,7 @@ describe("MigrationTest", () => {
       {
         version: "20131219224947",
         name: "VersionCheck",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("VersionCheck", "20131219224947"),
       },
     ];
     const migrator = new Migrator(adapter, migrations);
@@ -907,22 +908,28 @@ describe("MigrationTest", () => {
       {
         version: "1",
         name: "First",
-        migration: () => ({
-          up: async () => {
-            ran.push("first");
-          },
-          down: async () => {},
-        }),
+        migration: () =>
+          anonymousMigration(
+            "First",
+            "1",
+            async () => {
+              ran.push("first");
+            },
+            async () => {},
+          ),
       },
       {
         version: "2",
         name: "Second",
-        migration: () => ({
-          up: async () => {
-            ran.push("second");
-          },
-          down: async () => {},
-        }),
+        migration: () =>
+          anonymousMigration(
+            "Second",
+            "2",
+            async () => {
+              ran.push("second");
+            },
+            async () => {},
+          ),
       },
     ];
     const migrator = new Migrator(adapter, migrations);
@@ -938,12 +945,15 @@ describe("MigrationTest", () => {
       {
         version: "100",
         name: "Broken",
-        migration: () => ({
-          up: async () => {
-            throw new Error("Something broke");
-          },
-          down: async () => {},
-        }),
+        migration: () =>
+          anonymousMigration(
+            "Broken",
+            "100",
+            async () => {
+              throw new Error("Something broke");
+            },
+            async () => {},
+          ),
       },
     ];
     const migrator = new Migrator(adapter, migrations);
@@ -962,12 +972,15 @@ describe("MigrationTest", () => {
         {
           version: "100",
           name: "Broken",
-          migration: () => ({
-            up: async () => {
-              throw new Error("Something broke");
-            },
-            down: async () => {},
-          }),
+          migration: () =>
+            anonymousMigration(
+              "Broken",
+              "100",
+              async () => {
+                throw new Error("Something broke");
+              },
+              async () => {},
+            ),
         },
       ];
       const migrator = new Migrator(adapter, migrations);
@@ -1080,7 +1093,7 @@ describe("MigrationTest", () => {
     const proxy: MigrationProxy = {
       version: "1",
       name: "M1",
-      migration: () => ({ up: async () => {}, down: async () => {} }),
+      migration: () => anonymousMigration("M1", "1"),
     };
     const migrator = new Migrator(adapter, [proxy], { environment: "staging" });
     await migrator.up();
@@ -1098,7 +1111,7 @@ describe("MigrationTest", () => {
     const proxy: MigrationProxy = {
       version: "1",
       name: "TestMigration",
-      migration: () => ({ up: async () => {}, down: async () => {} }),
+      migration: () => anonymousMigration("TestMigration", "1"),
     };
     const migrator = new Migrator(adapter, [proxy], { internalMetadataEnabled: false });
     await migrator.up();
@@ -1356,12 +1369,15 @@ describe("MigrationTest", () => {
     const proxy: MigrationProxy = {
       version: "100",
       name: "Broken",
-      migration: () => ({
-        up: async () => {
-          ran.push("ran");
-        },
-        down: async () => {},
-      }),
+      migration: () =>
+        anonymousMigration(
+          "Broken",
+          "100",
+          async () => {
+            ran.push("ran");
+          },
+          async () => {},
+        ),
     };
     const lockAdapter = makeLockAdapter({ acquires: false });
     const migrator = new Migrator(lockAdapter, [proxy]);
@@ -1374,12 +1390,15 @@ describe("MigrationTest", () => {
     const proxy: MigrationProxy = {
       version: "100",
       name: "Broken",
-      migration: () => ({
-        up: async () => {
-          ran.push("ran");
-        },
-        down: async () => {},
-      }),
+      migration: () =>
+        anonymousMigration(
+          "Broken",
+          "100",
+          async () => {
+            ran.push("ran");
+          },
+          async () => {},
+        ),
     };
     const lockAdapter = makeLockAdapter({ acquires: false });
     const migrator = new Migrator(lockAdapter, [proxy]);
@@ -1405,7 +1424,7 @@ describe("MigrationTest", () => {
         const proxy: MigrationProxy = {
           version: "200",
           name: "NoOp",
-          migration: () => ({ up: async () => {}, down: async () => {} }),
+          migration: () => anonymousMigration("NoOp", "200"),
         };
         const migrator = new Migrator(realAdapter, [proxy]);
         await migrator.migrate();

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -18,6 +18,7 @@ import { newRawTestAdapter } from "./test-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 import { fixtures } from "./test-fixtures.js";
+import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 describe("MigrationTest", () => {
   // Ride the primary schema-loaded pool (`Base.connection`); `newRawTestAdapter`
@@ -83,7 +84,7 @@ describe("MigrationTest", () => {
       {
         version: "1",
         name: "AsyncFirst",
-        migration: async () => ({ up: async () => {}, down: async () => {} }),
+        migration: async () => anonymousMigration("AsyncFirst", "1"),
       },
     ];
     const migrator = new Migrator(adapter, migrations);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -32,7 +32,7 @@ import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
-import type { ExecutionStrategy, MigrationLike } from "./migration/execution-strategy.js";
+import type { ExecutionStrategy } from "./migration/execution-strategy.js";
 import type { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
 import { registerVersion, findVersion, CURRENT_VERSION } from "./migration/compatibility.js";
 
@@ -41,7 +41,7 @@ export type {
   AddForeignKeyOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
 
-export { ExecutionStrategy, type MigrationLike } from "./migration/execution-strategy.js";
+export { ExecutionStrategy } from "./migration/execution-strategy.js";
 export { DefaultStrategy } from "./migration/default-strategy.js";
 export { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
 export {
@@ -2074,11 +2074,11 @@ export interface MigrationProxy {
   filename?: string;
   /** Mirrors: ActiveRecord::MigrationProxy#scope — engine name for copied engine migrations */
   scope?: string;
-  migration: () => MigrationLike | Promise<MigrationLike>;
+  migration: () => Migration | Promise<Migration>;
   /** @internal Mirrors: ActiveRecord::MigrationProxy#basename */
   basename?(): string;
   /** @internal Mirrors: ActiveRecord::MigrationProxy#load_migration */
-  loadMigration?(): Promise<MigrationLike>;
+  loadMigration?(): Promise<Migration>;
 }
 
 /**
@@ -2091,31 +2091,16 @@ async function loadMigrationFrom(
   mod: Record<string, unknown>,
   name: string,
   version: string,
-): Promise<MigrationLike> {
+): Promise<Migration> {
   const exported = mod[name] ?? mod.default;
   if (typeof exported === "function") {
     return new (exported as new (name?: string, version?: string) => Migration)(name, version);
   }
-  return exported as MigrationLike;
-}
-
-/** Mirrors: ActiveRecord::MigrationProxy (`migration.rb:1187`) */
-class MigrationProxyDelegate extends Migration {
-  constructor(
-    proxy: MigrationProxy,
-    private readonly _loaded: MigrationLike,
-    private readonly _execStrategy: ExecutionStrategy,
-  ) {
-    super(proxy.name, proxy.version);
-  }
-
-  override get disableDdlTransaction(): boolean {
-    return this._loaded.disableDdlTransaction ?? false;
-  }
-
-  override async execMigration(conn: DatabaseAdapter, direction: "up" | "down"): Promise<void> {
-    await this._execStrategy.exec(direction, this._loaded, conn);
-  }
+  if (exported instanceof Migration) return exported;
+  throw new Error(
+    `Migration ${name} must export a Migration class named "${name}" ` +
+      `(or a Migration instance as the default export)`,
+  );
 }
 
 /**
@@ -2126,7 +2111,6 @@ class MigrationProxyDelegate extends Migration {
  */
 type MigratorOptions = {
   environment?: string;
-  strategy?: ExecutionStrategy;
   /**
    * Set to false when the db_config opts out of metadata storage
    * (Rails' `use_metadata_table: false`). environment stamping is a
@@ -2145,7 +2129,6 @@ export class Migrator {
   private _schemaMigration: SchemaMigration;
   private _internalMetadata: InternalMetadata;
   private _environment: string;
-  private _strategy: ExecutionStrategy;
   private readonly _options: MigratorOptions;
   private readonly _direction: "up" | "down";
   private readonly _targetVersion: number | string | null;
@@ -2168,7 +2151,6 @@ export class Migrator {
       getEnv("TRAILS_ENV") ??
       getEnv("NODE_ENV") ??
       DatabaseConfigurations.defaultEnv;
-    this._strategy = options.strategy ?? new DefaultStrategy();
     this.validate(migrations);
     const normalized = migrations.map((m) => ({
       ...m,
@@ -2455,12 +2437,12 @@ export class Migrator {
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#ddl_transaction */
-  async ddlTransaction(migration: MigrationLike, fn: () => Promise<void>): Promise<void> {
+  async ddlTransaction(migration: Migration, fn: () => Promise<void>): Promise<void> {
     return this._ddlTransaction(migration, fn);
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#use_transaction? */
-  isUseTransaction(migration: MigrationLike): boolean {
+  isUseTransaction(migration: Migration): boolean {
     return this._useTransaction(migration);
   }
 
@@ -2923,15 +2905,10 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    const loaded = await proxy.migration();
     // Rails' MigrationProxy delegates migrate/announce/write to the real
-    // Migration (`migration.rb:1187`), so a subclass override is honoured. The
-    // wrapper is only for the trails-only bare `{ up, down }` proxy shape,
-    // which has no migrate/announce of its own.
-    const migration =
-      loaded instanceof Migration
-        ? loaded
-        : new MigrationProxyDelegate(proxy, loaded, this._strategy);
+    // Migration it loads (`migration.rb:1187`), so a subclass override is
+    // honoured.
+    const migration = await proxy.migration();
     migration.connection = this._adapter;
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
@@ -2972,7 +2949,7 @@ export class Migrator {
    *       end
    *     end
    */
-  private async _ddlTransaction(migration: MigrationLike, fn: () => Promise<void>): Promise<void> {
+  private async _ddlTransaction(migration: Migration, fn: () => Promise<void>): Promise<void> {
     if (this._useTransaction(migration)) {
       // Skip wrapping if the adapter is already in a transaction
       // (e.g. a caller wrapped the entire migrate in a transaction).
@@ -3004,7 +2981,7 @@ export class Migrator {
    * Mirrors Rails' `Migrator#use_transaction?`:
    * `!migration.disable_ddl_transaction && connection.supports_ddl_transactions?`
    */
-  private _useTransaction(migration: MigrationLike): boolean {
+  private _useTransaction(migration: Migration): boolean {
     if (migration.disableDdlTransaction) return false;
     // Check adapter support via the DatabaseAdapter interface.
     // SQLite returns true, PG returns true, MySQL returns false.

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2905,9 +2905,6 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    // Rails' MigrationProxy delegates migrate/announce/write to the real
-    // Migration it loads (`migration.rb:1187`), so a subclass override is
-    // honoured.
     const migration = await proxy.migration();
     migration.connection = this._adapter;
     // Rails wraps both the migration execution AND the version

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -8,15 +8,15 @@
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { Migration } from "../migration.js";
 import { ExecutionStrategy } from "./execution-strategy.js";
-import type { MigrationLike } from "./execution-strategy.js";
 
 export class DefaultStrategy extends ExecutionStrategy {
   private _adapter: DatabaseAdapter | null = null;
 
   async exec(
     direction: "up" | "down",
-    migration: MigrationLike,
+    migration: Migration,
     adapter: DatabaseAdapter,
   ): Promise<void> {
     this.migration = migration;
@@ -33,7 +33,7 @@ export class DefaultStrategy extends ExecutionStrategy {
   connection(): DatabaseAdapter {
     // Mirrors Rails: DefaultStrategy#connection → migration.connection.
     // _adapter is our exec()-time fallback; per-migration connection wins.
-    const conn = (this.migration as MigrationLike | null)?.connection ?? this._adapter;
+    const conn = (this.migration as Migration | null)?.connection ?? this._adapter;
     if (!conn)
       throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");
     return conn;

--- a/packages/activerecord/src/migration/execution-strategy.ts
+++ b/packages/activerecord/src/migration/execution-strategy.ts
@@ -8,15 +8,7 @@
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
-
-export interface MigrationLike {
-  up(): Promise<void>;
-  down(): Promise<void>;
-  /** When true, Migrator skips DDL transaction wrapping for this migration. */
-  disableDdlTransaction?: boolean;
-  /** Adapter for this migration; mirrors Rails' Migration#connection (@connection field). */
-  connection?: DatabaseAdapter;
-}
+import type { Migration } from "../migration.js";
 
 export abstract class ExecutionStrategy {
   protected migration: unknown;
@@ -27,7 +19,7 @@ export abstract class ExecutionStrategy {
 
   abstract exec(
     direction: "up" | "down",
-    migration: MigrationLike,
+    migration: Migration,
     adapter: DatabaseAdapter,
   ): Promise<void>;
 }

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -12,6 +12,7 @@ import { Base } from "./base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { fixtures } from "./test-fixtures.js";
+import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 // MIGRATIONS_ROOT — Rails reads fixture migration directories from disk; the
 // trails equivalents live under test-helpers/migrations.
@@ -28,7 +29,7 @@ function migration(name: string, version?: number): MigrationProxy {
   return {
     version: version === undefined ? (null as unknown as string) : String(version),
     name,
-    migration: () => ({ up: async () => {}, down: async () => {} }),
+    migration: () => anonymousMigration(name, version === undefined ? undefined : String(version)),
   };
 }
 
@@ -42,14 +43,17 @@ function sensors(count: number): { calls: Array<[string, number]>; migrations: M
     migrations.push({
       version: String(version),
       name: `Sensor${version}`,
-      migration: () => ({
-        up: async () => {
-          calls.push(["up", version]);
-        },
-        down: async () => {
-          calls.push(["down", version]);
-        },
-      }),
+      migration: () =>
+        anonymousMigration(
+          `Sensor${version}`,
+          String(version),
+          async () => {
+            calls.push(["up", version]);
+          },
+          async () => {
+            calls.push(["down", version]);
+          },
+        ),
     });
   }
   return { calls, migrations };
@@ -622,14 +626,17 @@ function trackedSensor(
   const proxy: MigrationProxy = {
     version: String(version),
     name: name ?? `Sensor${version}`,
-    migration: () => ({
-      up: async () => {
-        state.wentUp = true;
-      },
-      down: async () => {
-        state.wentDown = true;
-      },
-    }),
+    migration: () =>
+      anonymousMigration(
+        name ?? `Sensor${version}`,
+        String(version),
+        async () => {
+          state.wentUp = true;
+        },
+        async () => {
+          state.wentDown = true;
+        },
+      ),
   };
   return { proxy, state };
 }

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -19,27 +19,24 @@ import {
 } from "./migration.js";
 import { resetVersionRegistry } from "./migration/compatibility.js";
 import type { MigrationProxy } from "./migration.js";
-import { ExecutionStrategy, type MigrationLike } from "./migration/execution-strategy.js";
 import { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
 import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { fixtures } from "./test-fixtures.js";
+import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 function makeMigration(
   version: string,
   name: string,
-  upFn?: (adapter?: DatabaseAdapter) => Promise<void>,
-  downFn?: (adapter?: DatabaseAdapter) => Promise<void>,
+  upFn?: () => Promise<void>,
+  downFn?: () => Promise<void>,
 ): MigrationProxy {
   return {
     version,
     name,
-    migration: () => ({
-      up: upFn ?? (async () => {}),
-      down: downFn ?? (async () => {}),
-    }),
+    migration: () => anonymousMigration(name, version, upFn, downFn),
   };
 }
 
@@ -145,40 +142,6 @@ describe("Migrator trails extensions", () => {
     });
     await migrator.up();
     await expect(migrator.checkProtectedEnvironments()).resolves.toBeUndefined();
-  });
-
-  it("uses custom execution strategy", async () => {
-    const log: string[] = [];
-    class LoggingStrategy extends ExecutionStrategy {
-      async exec(
-        direction: "up" | "down",
-        migration: MigrationLike,
-        a: DatabaseAdapter,
-      ): Promise<void> {
-        log.push(`before:${direction}`);
-        migration.connection = a;
-        if (direction === "up") {
-          await migration.up();
-        } else {
-          await migration.down();
-        }
-        log.push(`after:${direction}`);
-      }
-    }
-
-    const migrator = new Migrator(
-      adapter,
-      [
-        makeMigration("1", "M1", async () => {
-          log.push("up");
-        }),
-      ],
-      {
-        strategy: new LoggingStrategy(),
-      },
-    );
-    await migrator.up();
-    expect(log).toEqual(["before:up", "up", "after:up"]);
   });
 
   it("CheckPending with PendingMigrationConnection detects pending migrations", async () => {

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -8,6 +8,7 @@ import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { scratchDatabasePath } from "./support/scratch-database.js";
+import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 // Rails takes `ActiveRecord::Base.connection_pool` and
 // `ARUnit2Model.connection_pool` — two *different* databases, both file-backed
@@ -28,14 +29,17 @@ function sensor(
     name,
     wentUp: false,
     wentDown: false,
-    migration: () => ({
-      up: async () => {
-        proxy.wentUp = true;
-      },
-      down: async () => {
-        proxy.wentDown = true;
-      },
-    }),
+    migration: () =>
+      anonymousMigration(
+        name,
+        version,
+        async () => {
+          proxy.wentUp = true;
+        },
+        async () => {
+          proxy.wentDown = true;
+        },
+      ),
   };
   return proxy;
 }
@@ -62,29 +66,29 @@ describe("MultiDbMigratorTest", () => {
       {
         version: "1",
         name: "ValidPeopleHaveLastNames",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("ValidPeopleHaveLastNames", "1"),
       },
       {
         version: "2",
         name: "WeNeedReminders",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("WeNeedReminders", "2"),
       },
       {
         version: "3",
         name: "InnocentJointable",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("InnocentJointable", "3"),
       },
     ];
     migrationsB = [
       {
         version: "1",
         name: "PeopleHaveHobbies",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("PeopleHaveHobbies", "1"),
       },
       {
         version: "2",
         name: "PeopleHaveDescriptions",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("PeopleHaveDescriptions", "2"),
       },
     ];
   });
@@ -190,12 +194,12 @@ describe("MultiDbMigratorTest", () => {
       {
         version: "1",
         name: "Foo",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Foo", "1"),
       },
       {
         version: "3",
         name: "Bar",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Bar", "3"),
       },
     ];
     const migratorA = new Migrator(adapterA, listA);
@@ -208,12 +212,12 @@ describe("MultiDbMigratorTest", () => {
       {
         version: "1",
         name: "Foo",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Foo", "1"),
       },
       {
         version: "3",
         name: "Bar",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Bar", "3"),
       },
     ];
     const migratorB = new Migrator(adapterB, listB);

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -13,6 +13,7 @@ import type { ConnectionPool } from "../connection-adapters/abstract/connection-
 import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { inMemoryDb } from "../support/adapter-helper.js";
 import { fixtures } from "../test-fixtures.js";
+import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
   it("raises an error when called with protected environment", async () => {
@@ -835,12 +836,15 @@ describe("DatabaseTasksMigrateTest", () => {
         {
           version: "1",
           name: "M1",
-          migration: () => ({
-            up: async () => {
-              migrated = true;
-            },
-            down: async () => {},
-          }),
+          migration: () =>
+            anonymousMigration(
+              "M1",
+              "1",
+              async () => {
+                migrated = true;
+              },
+              async () => {},
+            ),
         },
       ]);
       process.env.VERSION = "";
@@ -873,13 +877,13 @@ describe("DatabaseTasksMigrateScopeTest", () => {
       {
         version: "1",
         name: "Unscoped",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Unscoped", "1"),
       },
       {
         version: "2",
         name: "MysqlOnly",
         scope: "mysql",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("MysqlOnly", "2"),
       },
     ]);
   });
@@ -943,17 +947,17 @@ describe("DatabaseTasksMigrateStatusTest", () => {
       {
         version: "1",
         name: "Valid people have last names",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Valid people have last names", "1"),
       },
       {
         version: "2",
         name: "We need reminders",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("We need reminders", "2"),
       },
       {
         version: "3",
         name: "Innocent jointable",
-        migration: () => ({ up: async () => {}, down: async () => {} }),
+        migration: () => anonymousMigration("Innocent jointable", "3"),
       },
     ]);
   });

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -6,6 +6,7 @@ import { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 import { fixtures } from "./test-fixtures.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 // Build a (minimal) DatabaseConfigurations whose `configsFor` returns the
 // supplied stubbed configs. They also go through the array constructor arm so
@@ -266,12 +267,15 @@ describe("TestDatabasesTest", () => {
       {
         version: "1",
         name: "M1",
-        migration: () => ({
-          up: async () => {
-            log.push("up");
-          },
-          down: async () => {},
-        }),
+        migration: () =>
+          anonymousMigration(
+            "M1",
+            "1",
+            async () => {
+              log.push("up");
+            },
+            async () => {},
+          ),
       },
     ];
 

--- a/packages/activerecord/src/test-helpers/anonymous-migration.ts
+++ b/packages/activerecord/src/test-helpers/anonymous-migration.ts
@@ -1,0 +1,25 @@
+import { Migration } from "../migration.js";
+
+/**
+ * Build a throwaway `Migration` with the given `up` / `down` bodies — the
+ * trails stand-in for Rails' `Class.new(ActiveRecord::Migration::Current) { def
+ * up; …; end }`, which its migrator tests hand to a `MigrationProxy`. Tests
+ * must give `Migrator` a real `Migration`: `MigrationProxy#load_migration`
+ * (`migration.rb:1195`) always yields one, and `name` / `version` are the
+ * `name.constantize.new(name, version)` identity the banner prints.
+ */
+export function anonymousMigration(
+  name?: string,
+  version?: string,
+  up: (m: Migration) => Promise<void> = async () => {},
+  down: (m: Migration) => Promise<void> = async () => {},
+): Migration {
+  return new (class extends Migration {
+    override async up(): Promise<void> {
+      await up(this);
+    }
+    override async down(): Promise<void> {
+      await down(this);
+    }
+  })(name, version);
+}

--- a/packages/activerecord/src/test-helpers/anonymous-migration.ts
+++ b/packages/activerecord/src/test-helpers/anonymous-migration.ts
@@ -1,13 +1,5 @@
 import { Migration } from "../migration.js";
 
-/**
- * Build a throwaway `Migration` with the given `up` / `down` bodies — the
- * trails stand-in for Rails' `Class.new(ActiveRecord::Migration::Current) { def
- * up; …; end }`, which its migrator tests hand to a `MigrationProxy`. Tests
- * must give `Migrator` a real `Migration`: `MigrationProxy#load_migration`
- * (`migration.rb:1195`) always yields one, and `name` / `version` are the
- * `name.constantize.new(name, version)` identity the banner prints.
- */
 export function anonymousMigration(
   name?: string,
   version?: string,

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1335,36 +1335,28 @@ export class CreatePosts extends Migration {
   });
 
   it("Migrator with internalMetadataEnabled=false migrates without stamping", async () => {
-    const { Migrator } = await import("@blazetrails/activerecord");
+    const { Migration, Migrator } = await import("@blazetrails/activerecord");
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
 
     const dbFile = path.join(tmpDir, "no-metadata-migrate.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
-      // Low-level MigrationLike shape (same pattern migrator.test.ts uses)
-      // — bypasses the Migration base class so the test doesn't depend on
-      // its schema-helper wiring.
       const migrations = [
         {
           version: "20260101000000",
           name: "CreateWidgets",
-          migration: () => {
-            const m: import("@blazetrails/activerecord").MigrationLike = {
-              connection: undefined,
-              async up() {
-                if (!m.connection) throw new Error("adapter required");
-                await m.connection.executeMutation(
+          migration: () =>
+            new (class extends Migration {
+              override async up(): Promise<void> {
+                await this.connection.executeMutation(
                   `CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`,
                 );
-              },
-              async down() {
-                if (!m.connection) throw new Error("adapter required");
-                await m.connection.executeMutation(`DROP TABLE widgets`);
-              },
-            };
-            return m;
-          },
+              }
+              override async down(): Promise<void> {
+                await this.connection.executeMutation(`DROP TABLE widgets`);
+              }
+            })("CreateWidgets", "20260101000000"),
         },
       ];
       const migrator = new Migrator(adapter, migrations, {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -633,11 +633,11 @@ describe("discoverMigrations", () => {
     const migrations = await discoverMigrations(tmpDir);
     expect(migrations).toHaveLength(2);
     expect(migrations[0].version).toBe("20260101000000");
-    // discoverMigrations canonicalizes proxy.name to the underscore form
-    // (Rails-faithful) regardless of the on-disk separator.
-    expect(migrations[0].name).toBe("create_users");
+    // discoverMigrations camelizes proxy.name as Rails does
+    // (migration.rb:1311) regardless of the on-disk separator.
+    expect(migrations[0].name).toBe("CreateUsers");
     expect(migrations[1].version).toBe("20260102000000");
-    expect(migrations[1].name).toBe("add_email_to_users");
+    expect(migrations[1].name).toBe("AddEmailToUsers");
   });
 
   it("sorts migrations by version", async () => {
@@ -986,8 +986,8 @@ export class CreatePosts extends Migration {
     expect(joined).toContain("You have 1 pending migration:");
     expect(joined).toContain("20260101000000");
     // migration-loader derives the display name from the filename suffix
-    // and canonicalizes hyphen separators to underscores (Rails-faithful).
-    expect(joined).toContain("create_posts");
+    // and camelizes it as Rails does (migration.rb:1311).
+    expect(joined).toContain("CreatePosts");
     expect(joined).toContain("Run `trails db migrate` to resolve this issue.");
   });
 

--- a/packages/trailties/src/migration-loader.test.ts
+++ b/packages/trailties/src/migration-loader.test.ts
@@ -22,8 +22,8 @@ describe("discoverMigrations", () => {
     write("20260102000000_add_email_to_users.ts");
     const found = await discoverMigrations(tmpDir);
     expect(found.map((m) => `${m.version}:${m.name}`)).toEqual([
-      "20260101000000:create_posts",
-      "20260102000000:add_email_to_users",
+      "20260101000000:CreatePosts",
+      "20260102000000:AddEmailToUsers",
     ]);
   });
 

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { Migration } from "@blazetrails/activerecord";
-import type { MigrationProxy } from "@blazetrails/activerecord";
+import type { Migration, MigrationProxy } from "@blazetrails/activerecord";
 
 // Rails uses `<timestamp>_<name>` (railties/lib/rails/generators/migration.rb).
 // trailties scaffolds in TS/JS, so the extension set is `ts|js` (no `rb`).
@@ -84,20 +83,10 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
       version,
       name,
       filename: filePath,
-      migration: () =>
-        new (class extends Migration {
-          override async up(): Promise<void> {
-            await this.runLoaded("up");
-          }
-          override async down(): Promise<void> {
-            await this.runLoaded("down");
-          }
-          private async runLoaded(direction: "up" | "down"): Promise<void> {
-            const MigrationClass = await loadMigrationClass(filePath);
-            const instance = new MigrationClass();
-            await instance.run(this.connection, direction);
-          }
-        })(name, version),
+      migration: async () => {
+        const MigrationClass = await loadMigrationClass(filePath);
+        return new MigrationClass(name, version);
+      },
     });
   }
 
@@ -112,7 +101,7 @@ function isMigrationClass(value: unknown): boolean {
 
 async function loadMigrationClass(
   filePath: string,
-): Promise<new () => { run(adapter: any, direction: "up" | "down"): Promise<void> }> {
+): Promise<new (name?: string, version?: string) => Migration> {
   let mod: any;
   try {
     mod = await import(pathToFileURL(filePath).href);

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
+import { Migration } from "@blazetrails/activerecord";
 import type { MigrationProxy } from "@blazetrails/activerecord";
 
 // Rails uses `<timestamp>_<name>` (railties/lib/rails/generators/migration.rb).
@@ -83,32 +84,20 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
       version,
       name,
       filename: filePath,
-      migration: () => {
-        const loader: import("@blazetrails/activerecord").MigrationLike = {
-          connection: undefined,
-          async up(): Promise<void> {
-            const adapter = loader.connection;
-            if (!adapter)
-              throw new Error(
-                "migration-loader: migration.connection must be set before calling up()",
-              );
+      migration: () =>
+        new (class extends Migration {
+          override async up(): Promise<void> {
+            await this.runLoaded("up");
+          }
+          override async down(): Promise<void> {
+            await this.runLoaded("down");
+          }
+          private async runLoaded(direction: "up" | "down"): Promise<void> {
             const MigrationClass = await loadMigrationClass(filePath);
             const instance = new MigrationClass();
-            await instance.run(adapter, "up");
-          },
-          async down(): Promise<void> {
-            const adapter = loader.connection;
-            if (!adapter)
-              throw new Error(
-                "migration-loader: migration.connection must be set before calling down()",
-              );
-            const MigrationClass = await loadMigrationClass(filePath);
-            const instance = new MigrationClass();
-            await instance.run(adapter, "down");
-          },
-        };
-        return loader;
-      },
+            await instance.run(this.connection, direction);
+          }
+        })(name, version),
     });
   }
 

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Migration, MigrationProxy } from "@blazetrails/activerecord";
+import { camelize } from "@blazetrails/activesupport";
 
 // Rails uses `<timestamp>_<name>` (railties/lib/rails/generators/migration.rb).
 // trailties scaffolds in TS/JS, so the extension set is `ts|js` (no `rb`).
@@ -73,10 +74,11 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
     if (!match) continue;
 
     const version = match[1];
-    // Canonicalize the proxy name to the underscore form so
-    // Migrator.validate()'s duplicate-name check sees hyphen-alias and
-    // underscore-form migrations as the same logical name.
-    const name = match[2].replace(/-/g, "_");
+    // Rails camelizes the parsed name before building the proxy
+    // (migration.rb:1311); the hyphen alias is folded to the underscore form
+    // first so Migrator.validate()'s duplicate-name check sees hyphen-alias
+    // and underscore-form migrations as the same logical name.
+    const name = camelize(match[2].replace(/-/g, "_"));
     const filePath = path.join(migrationsDir, file);
 
     proxies.push({

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -1,8 +1,8 @@
 import type { VirtualFS } from "./virtual-fs.js";
 import type { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VfsModelGenerator, VfsMigrationGenerator, VfsAppGenerator } from "./vfs-generator.js";
-import type { MigrationProxy, MigrationLike } from "@blazetrails/activerecord/migration";
-import { Migrator } from "@blazetrails/activerecord/migration";
+import type { MigrationProxy } from "@blazetrails/activerecord/migration";
+import { Migration, Migrator } from "@blazetrails/activerecord/migration";
 import {
   camelize,
   getProcessAdapter,
@@ -67,15 +67,15 @@ function discoverMigrations(
           version: match[1],
           name: camelize(match[2].replace(/-/g, "_")),
           filename: file.path,
-          migration: (): MigrationLike => {
-            const m: MigrationLike = {
-              connection: undefined,
-              async up() {
-                const adapter = m.connection;
-                if (!adapter)
-                  throw new Error(
-                    "trail-cli: migration.connection must be set before calling up()",
-                  );
+          migration: (): Migration =>
+            new (class extends Migration {
+              override async up(): Promise<void> {
+                await (await this.loadRegistered()).up();
+              }
+              override async down(): Promise<void> {
+                await (await this.loadRegistered()).down();
+              }
+              private async loadRegistered(): Promise<Migration> {
                 const content = vfs.read(file.path)?.content;
                 if (!content) throw new Error(`File not found: ${file.path}`);
                 await executeCode(content);
@@ -86,31 +86,10 @@ function discoverMigrations(
                   );
                 }
                 const inner = await reg.migration();
-                inner.connection = adapter;
-                await inner.up();
-              },
-              async down() {
-                const adapter = m.connection;
-                if (!adapter)
-                  throw new Error(
-                    "trail-cli: migration.connection must be set before calling down()",
-                  );
-                const content = vfs.read(file.path)?.content;
-                if (!content) throw new Error(`File not found: ${file.path}`);
-                await executeCode(content);
-                const reg = getMigrations().find((r) => r.version === match[1]);
-                if (!reg) {
-                  throw new Error(
-                    `Migration ${match[1]} from ${file.path} did not register after execution`,
-                  );
-                }
-                const inner = await reg.migration();
-                inner.connection = adapter;
-                await inner.down();
-              },
-            };
-            return m;
-          },
+                inner.connection = this.connection;
+                return inner;
+              }
+            })(camelize(match[2].replace(/-/g, "_")), match[1]),
         },
       ];
     });

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -1,8 +1,8 @@
 import type { VirtualFS } from "./virtual-fs.js";
 import type { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VfsModelGenerator, VfsMigrationGenerator, VfsAppGenerator } from "./vfs-generator.js";
-import type { MigrationProxy } from "@blazetrails/activerecord/migration";
-import { Migration, Migrator } from "@blazetrails/activerecord/migration";
+import type { Migration, MigrationProxy } from "@blazetrails/activerecord/migration";
+import { Migrator } from "@blazetrails/activerecord/migration";
 import {
   camelize,
   getProcessAdapter,
@@ -67,29 +67,18 @@ function discoverMigrations(
           version: match[1],
           name: camelize(match[2].replace(/-/g, "_")),
           filename: file.path,
-          migration: (): Migration =>
-            new (class extends Migration {
-              override async up(): Promise<void> {
-                await (await this.loadRegistered()).up();
-              }
-              override async down(): Promise<void> {
-                await (await this.loadRegistered()).down();
-              }
-              private async loadRegistered(): Promise<Migration> {
-                const content = vfs.read(file.path)?.content;
-                if (!content) throw new Error(`File not found: ${file.path}`);
-                await executeCode(content);
-                const reg = getMigrations().find((r) => r.version === match[1]);
-                if (!reg) {
-                  throw new Error(
-                    `Migration ${match[1]} from ${file.path} did not register after execution`,
-                  );
-                }
-                const inner = await reg.migration();
-                inner.connection = this.connection;
-                return inner;
-              }
-            })(camelize(match[2].replace(/-/g, "_")), match[1]),
+          migration: async (): Promise<Migration> => {
+            const content = vfs.read(file.path)?.content;
+            if (!content) throw new Error(`File not found: ${file.path}`);
+            await executeCode(content);
+            const reg = getMigrations().find((r) => r.version === match[1]);
+            if (!reg) {
+              throw new Error(
+                `Migration ${match[1]} from ${file.path} did not register after execution`,
+              );
+            }
+            return reg.migration();
+          },
         },
       ];
     });


### PR DESCRIPTION
Retires the trails-only bare `{ up, down }` migration proxy shape, the last
piece left after #5525.

- `MigrationProxy#migration` (and `loadMigration`) now yield a real
  `Migration`, as Rails' `MigrationProxy#load_migration`
  (`migration.rb:1195`, `name.constantize.new(name, version)`) always does.
  `loadMigrationFrom` raises when a migration module exports neither a
  `Migration` class nor a `Migration` instance.
- The structural `MigrationLike` type is deleted; `ExecutionStrategy#exec`,
  `Migrator#ddlTransaction` / `#isUseTransaction` and the proxy interface take
  `Migration`.
- `MigrationProxyDelegate` is deleted — `Migrator#_runMigration` now delegates
  to the loaded `Migration` unconditionally (`migration.rb:1187`).
- The Migrator-level `strategy:` option is **removed**, converging on Rails:
  Rails' `Migrator` has no strategy at all; execution strategy is per-Migration
  (`Migration#execution_strategy`), which trails already has. With the wrapper
  gone the option had no execution path left, so the trails-only
  "uses custom execution strategy" test in `migrator.trails.test.ts` goes with
  it.

Callers converted to real `Migration` subclasses: `trailties`'
`migration-loader`, the website's `trail-cli` VFS loader, the `activerecord-cli`
E2E migration body, and the AR test suites (via a new
`test-helpers/anonymous-migration.ts` — the stand-in for Rails'
`Class.new(ActiveRecord::Migration::Current) { def up; …; end }`). Passing
`name`/`version` through means the migration banners now print the proxy
identity everywhere, as Rails does.

The banner tests from #5525 ("Migrator drives migrations through
Migration#migrate") pass unchanged.

Diff is ~213/280 (add/del) across 16 files — a hair over the 500-LOC ceiling in
raw churn, but it is one indivisible type-narrowing: every call site had to move
in the same commit or the build breaks.

Closes-story: retire-bare-up-down-migration-proxy-shape
