### PR TITLE
feat(eslint): translate a literal backslash inside a SIMILAR TO bracket expression

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -496,9 +496,18 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * `'ex_d'` is not, so the escape+letter pair reaches the underlying ARE as the
  * class shorthand; `'ex_5' SIMILAR TO 'ex_[#d]%' ESCAPE '#'` is TRUE the same
  * way. It follows that a backslash which is NOT the escape character is a plain
- * literal there (`[\d]` under `ESCAPE '#'` selects a backslash or a `d`, and
- * TRUE for neither digit nor `\d`'s JS meaning), so it must refuse rather than
- * translate — the JS class would otherwise be the wider of the two.
+ * literal there: `'ex_5' SIMILAR TO 'ex_[\d]%' ESCAPE '#'` is FALSE while
+ * `'ex_d'` and `'ex_\'` are both TRUE, so the class is the two literals
+ * `{\, d}` — which JS spells exactly as `[\\d]`. Doubling it translates the
+ * narrow reading; emitting it bare would give JS the wider `\d`, which is why
+ * only the bare emission was ever unsafe.
+ *
+ * The same doubling settles a literal backslash used as a range endpoint,
+ * because ranges compare code points in both grammars: `[\-a]` and JS `[\\-a]`
+ * are the same U+005C–U+0061 span. A range that runs the other way (`[a-\]`)
+ * needs no decision here: `compileMatcher` catches the descending-range
+ * SyntaxError and credits nothing, which is the safe answer whichever way
+ * PostgreSQL reads it.
  *
  * An escape character with structural meaning inside a bracket expression
  * (`[`, `]`, `^`, `-`) refuses the expression outright: `ESCAPE '^'` makes
@@ -525,14 +534,6 @@ function bracketSource(pattern, start, escapeChar) {
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
     if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
-    // A backslash that does not escape here is a literal to PostgreSQL and an
-    // escape to JS, so it is doubled rather than emitted bare — `[\d]` under
-    // `ESCAPE '#'` is the two literals `{\, d}`, which JS spells `[\\d]`
-    // exactly. Verified on PostgreSQL 17.7: `'ex_5' SIMILAR TO 'ex_[\d]%'
-    // ESCAPE '#'` is false while `'ex_d'` and `'ex_\'` are both true. A range
-    // endpoint needs no separate handling for the same reason: ranges compare
-    // code points in both grammars, so `[\-a]` and JS `[\\-a]` are the same
-    // U+005C–U+0061 span.
     if (ch === "\\" && ch !== escapeChar) {
       source += "\\\\";
       continue;

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -525,9 +525,18 @@ function bracketSource(pattern, start, escapeChar) {
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
     if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
-    // A backslash that does not escape here is still refused rather than
-    // emitted: it is a literal to PostgreSQL but an escape to JS.
-    if (ch === "\\" && ch !== escapeChar) return null;
+    // A backslash that does not escape here is a literal to PostgreSQL and an
+    // escape to JS, so it is doubled rather than emitted bare — `[\d]` under
+    // `ESCAPE '#'` is the two literals `{\, d}`, which JS spells `[\\d]`
+    // exactly. Verified on PostgreSQL 17.7: `'ex_5' SIMILAR TO 'ex_[\d]%'
+    // ESCAPE '#'` is false while `'ex_d'` and `'ex_\'` are both true. A range
+    // endpoint needs no separate handling for the same reason: ranges compare
+    // code points in both grammars, so `[\-a]` and JS `[\\-a]` are the same
+    // U+005C–U+0061 span.
+    if (ch === "\\" && ch !== escapeChar) {
+      source += "\\\\";
+      continue;
+    }
     if (ch === escapeChar) {
       const next = pattern[i + 1];
       if (next === undefined || !ARE_SHORTHANDS.has(next)) return null;
@@ -648,7 +657,8 @@ function regexpPrefixMatcher(pattern, caseInsensitive) {
  * `ESCAPE` character inside a bracket expression and hands the pair to the
  * underlying ARE — so `[\d]` under the default backslash escape (the one
  * `sanitize_sql_like` emits) is the digits, exactly as on the `~` path, while a
- * backslash that is not the escape character is a literal there and refuses.
+ * backslash that is not the escape character is a literal member there and is
+ * translated as the doubled `\\`.
  */
 function similarPrefixMatcher(pattern, escapeChar, caseInsensitive) {
   let source = "";

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -209,6 +209,25 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // A backslash that is NOT the pattern's ESCAPE character is a literal
+    // member, so `[\d]` under `ESCAPE '#'` is the two literals `{\, d}` and
+    // selects `ex_d` — JS spells that class `[\\d]`.
+    'await adapter.exec(`CREATE TABLE "ex_d" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\d]%' ESCAPE '#'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // The same literal reading as a range endpoint: `[\-a]` under `ESCAPE '#'`
+    // is the U+005C–U+0061 span, so it selects `ex__`.
+    'await adapter.exec(`CREATE TABLE "ex__" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\-a]%' ESCAPE '#'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A bracket expression and a bounded repeat are spelled alike in JS.
     'await adapter.exec(`CREATE TABLE "ex12_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -1007,9 +1026,9 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_-" } }],
     },
-    // A backslash that is NOT the pattern's ESCAPE character is a literal
-    // backslash inside a `SIMILAR TO` bracket expression, so `[\d]` selects a
-    // backslash or a `d` and crediting the digits would be the wider reading.
+    // The literal reading of a non-escape backslash is the narrow one: `[\d]`
+    // under `ESCAPE '#'` selects a backslash or a `d`, never a digit, so
+    // `ex_1` goes uncredited.
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
@@ -1020,6 +1039,18 @@ tester.run("require-table-teardown", rule, {
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
+    },
+    // And the range built on it stops at U+0061, so `ex_b` is past its top end.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_b" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\-a]%' ESCAPE '#'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_b" } }],
     },
     // The same for a range: `[a-d]` under `ESCAPE '-'` is the digits, since the
     // `-` escapes the `d` before it can be read as the middle of a range — so

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -209,9 +209,8 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
-    // A backslash that is NOT the pattern's ESCAPE character is a literal
-    // member, so `[\d]` under `ESCAPE '#'` is the two literals `{\, d}` and
-    // selects `ex_d` — JS spells that class `[\\d]`.
+    // A backslash that is not the ESCAPE character is a literal member, so
+    // `[\d]` under `ESCAPE '#'` is `{\, d}` and selects `ex_d`.
     'await adapter.exec(`CREATE TABLE "ex_d" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
       "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\d]%' ESCAPE '#'`,\n" +
@@ -219,8 +218,8 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
-    // The same literal reading as a range endpoint: `[\-a]` under `ESCAPE '#'`
-    // is the U+005C–U+0061 span, so it selects `ex__`.
+    // As a range endpoint it is the same literal: `[\-a]` is U+005C–U+0061,
+    // which contains the `_` of `ex__`.
     'await adapter.exec(`CREATE TABLE "ex__" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
       "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[\\\\-a]%' ESCAPE '#'`,\n" +
@@ -1026,9 +1025,8 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_-" } }],
     },
-    // The literal reading of a non-escape backslash is the narrow one: `[\d]`
-    // under `ESCAPE '#'` selects a backslash or a `d`, never a digit, so
-    // `ex_1` goes uncredited.
+    // That literal reading is the narrow one: `[\d]` under `ESCAPE '#'` selects
+    // a backslash or a `d`, never a digit, so `ex_1` goes uncredited.
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
@@ -1051,6 +1049,19 @@ tester.run("require-table-teardown", rule, {
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_b" } }],
+    },
+    // A range running the other way (`[a-\]`) is a descending one JS will not
+    // compile, so it credits nothing rather than throwing out of the lint pass.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_a" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[a-\\\\]%' ESCAPE '#'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_a" } }],
     },
     // The same for a range: `[a-d]` under `ESCAPE '-'` is the digits, since the
     // `-` escapes the `d` before it can be read as the middle of a range — so


### PR DESCRIPTION
PR #5593 settled the `SIMILAR TO` ESCAPE-vs-bracket interaction but left one case refused: a backslash inside a bracket expression that is not the pattern's escape character. It is a literal to PostgreSQL and an escape to JS, and emitting it bare would have widened the class, so #5593 refused the whole expression.

Refusing under-accepts: a sweep filtered on such a pattern credits nothing and its creates surface as `missingTeardown` noise. The translation is provable, not a guess — verified on PostgreSQL 17.7:

```sql
'ex_5' SIMILAR TO 'ex_[\d]%' ESCAPE '#'  -> f
'ex_d' SIMILAR TO 'ex_[\d]%' ESCAPE '#'  -> t
'ex_\'  SIMILAR TO 'ex_[\d]%' ESCAPE '#'  -> t
```

So the class is the two literals `{\, d}`, which JS spells exactly `[\\d]`. `bracketSource` now doubles it instead of refusing; only the bare emission was ever unsafe.

The range interaction is settled the same way the shorthand one was, with the reasoning in the `bracketSource` doc block:

- An ascending range needs no separate handling — ranges compare code points in both grammars, so `[\-a]` and JS `[\\-a]` are the same U+005C–U+0061 span.
- A descending one (`[a-\]`) needs no decision either: JS will not compile it, so `compileMatcher` already credits nothing, which is safe whichever way PostgreSQL reads it.

Tests pin both accepted names (`ex_d`, and `ex__` via the range) and the names the filters do not select (`ex_1` for the class, `ex_b` past the range's top end, `ex_a` under the descending range). The two new valid cases fail against the rule on `main`.

Closes-story: require-table-teardown-translate-literal-bracket-backslash
