### PR TITLE
refactor(activerecord): ride canonical arunit2 pool instead of scratch databases

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -44,7 +44,7 @@ import { markForDestruction, isMarkedForDestruction } from "./autosave-associati
 import { Preloader } from "./associations/preloader.js";
 import { Batch } from "./associations/preloader/batch.js";
 import { LoaderQuery } from "./associations/preloader/association.js";
-import { scratchDatabasePath } from "./support/scratch-database.js";
+import { OtherDog } from "./test-helpers/models/other-dog.js";
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -1003,65 +1003,20 @@ describe("PreloaderTest", () => {
     }).call();
     expect(spy).toHaveBeenCalledTimes(2);
   });
-  // Mirrors Rails' Dog (primary connection) and OtherDog (ARUnit2Model — a
-  // second database), both backed by a table named `dogs`. A polymorphic
-  // preload over comments pointing at each must run two queries rather than
-  // batch them together, because LoaderQuery#hashKey distinguishes loaders by
-  // connection identity.
   it("multi database polymorphic preload with same table name", async () => {
-    // Second database base (Rails: ARUnit2Model connected to arunit2 DB).
-    // Kept inline so connectsTo doesn't pollute the shared canonical ARUnit2Model.
-    class AnimalsBase extends Base {
-      static {
-        this.abstractClass = true;
-      }
-    }
-    class OtherDog extends AnimalsBase {
-      static {
-        this.tableName = "dogs";
-      }
-    }
-    registerModel("OtherDog", OtherDog);
+    registerModel(OtherDog);
 
-    // Rails' arunit2 is a file, not `:memory:` — the loaders must be
-    // distinguished by connection identity, and a real second database on disk
-    // is what makes that distinction observable.
-    const [secondaryPool] = AnimalsBase.connectsTo({
-      database: {
-        writing: {
-          adapter: "sqlite3",
-          database: await scratchDatabasePath("associations-animals"),
-          pool: 1,
-        },
-      },
-    });
-    try {
-      await secondaryPool.adapterReady;
-      // Canonical dogs shape in the secondary database.
-      await (
-        await OtherDog.leaseConnection()
-      ).executeMutation(
-        // It lives in this test's own scratch database file, not the shared
-        // per-worker one, so there is nothing to leak into.
-        // eslint-disable-next-line blazetrails/require-table-teardown
-        "CREATE TABLE `dogs` (`id` INTEGER PRIMARY KEY, `trainer_id` INTEGER, " +
-          "`breeder_id` INTEGER, `dog_lover_id` INTEGER, `alias` VARCHAR(255))",
-      );
+    const dogComment = new (Comment as any)({ origin_id: 1, origin_type: "Dog" });
+    const otherDogComment = new (Comment as any)({ origin_id: 1, origin_type: "OtherDog" });
 
-      const dogComment = new (Comment as any)({ origin_id: 1, origin_type: "Dog" });
-      const otherDogComment = new (Comment as any)({ origin_id: 1, origin_type: "OtherDog" });
-
-      // Same table name, same key, same id — these two loaders would coalesce
-      // into a single query were it not for their distinct connections.
-      const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsInBatch");
-      await new Preloader({
-        records: [dogComment, otherDogComment],
-        associations: ["origin"],
-      }).call();
-      expect(spy).toHaveBeenCalledTimes(2);
-    } finally {
-      Base.connectionHandler.removeConnectionPool("AnimalsBase");
-    }
+    // Same table name, same key, same id — these two loaders would coalesce
+    // into a single query were it not for their distinct connections.
+    const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsInBatch");
+    await new Preloader({
+      records: [dogComment, otherDogComment],
+      associations: ["origin"],
+    }).call();
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it("preload with available records", async () => {

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1009,8 +1009,6 @@ describe("PreloaderTest", () => {
     const dogComment = new (Comment as any)({ origin_id: 1, origin_type: "Dog" });
     const otherDogComment = new (Comment as any)({ origin_id: 1, origin_type: "OtherDog" });
 
-    // Same table name, same key, same id — these two loaders would coalesce
-    // into a single query were it not for their distinct connections.
     const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsInBatch");
     await new Preloader({
       records: [dogComment, otherDogComment],

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -7,18 +7,9 @@ import { Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import { scratchDatabasePath } from "./support/scratch-database.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
-
-// Rails takes `ActiveRecord::Base.connection_pool` and
-// `ARUnit2Model.connection_pool` — two *different* databases, both file-backed
-// (`arunit` / `arunit2`). The point of the test is that the two schema_migration
-// tables are independent, so each adapter gets its own on-disk database rather
-// than a private `:memory:` one.
-async function makeSqliteAdapter(label: string): Promise<DatabaseAdapter> {
-  const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
-  return new BetterSQLite3Adapter(await scratchDatabasePath(label));
-}
+import { Base } from "./base.js";
+import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 
 function sensor(
   version: string,
@@ -53,8 +44,8 @@ describe("MultiDbMigratorTest", () => {
   let migrationsB: MigrationProxy[];
 
   beforeEach(async () => {
-    adapterA = await makeSqliteAdapter("multi-db-migrator-a");
-    adapterB = await makeSqliteAdapter("multi-db-migrator-b");
+    adapterA = await Base.leaseConnection();
+    adapterB = await ARUnit2Model.leaseConnection();
     smA = new SchemaMigration(adapterA);
     smB = new SchemaMigration(adapterB);
     await smA.createTable();
@@ -93,11 +84,12 @@ describe("MultiDbMigratorTest", () => {
     ];
   });
 
-  // The databases are files now, so the handles have to be released — a leaked
-  // one keeps the WAL sidecars alive past the run.
+  // `multi_db_migrator_test.rb:58-59`. Rails names `@pool_q` on the first line —
+  // a typo that makes it a no-op there; ours must really clear both, because
+  // trails shares the arunit database across every file in the worker.
   afterEach(async () => {
-    await adapterA.close();
-    await adapterB.close();
+    await smA.deleteAllVersions();
+    await smB.deleteAllVersions();
   });
 
   it("schema migration is different for different connections", async () => {

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -84,24 +84,16 @@ describe("MultiDbMigratorTest", () => {
     ];
   });
 
-  // `multi_db_migrator_test.rb:58-59`. Rails names `@pool_q` on the first line —
-  // a typo that makes it a no-op there; ours must really clear both, because
-  // trails shares the arunit database across every file in the worker.
   afterEach(async () => {
     await smA.deleteAllVersions();
     await smB.deleteAllVersions();
   });
 
-  it("schema migration is different for different connections", async () => {
-    const migratorA = new Migrator(adapterA, migrationsA);
-    const migratorB = new Migrator(adapterB, migrationsB);
-
-    await migratorA.up();
-    const versionsA = await migratorA.getAllVersions();
-    const versionsB = await migratorB.getAllVersions();
-
-    expect(versionsA).toEqual(["1", "2", "3"]);
-    expect(versionsB).toEqual([]);
+  it("schema migration is different for different connections", () => {
+    expect(smA).not.toBe(smB);
+    expect(adapterA).not.toBe(adapterB);
+    expect(Base.connectionPool().poolConfig.connectionDescriptor.name).toBe("Base");
+    expect(ARUnit2Model.connectionPool().poolConfig.connectionDescriptor.name).toBe("ARUnit2Model");
   });
 
   it("finds migrations", () => {

--- a/packages/activerecord/src/multi-db-migrator.trails.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.trails.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Migrator } from "./index.js";
+import { SchemaMigration } from "./schema-migration.js";
+import type { MigrationProxy } from "./migration.js";
+import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { Base } from "./base.js";
+import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
+
+function noopMigration(version: string, name: string): MigrationProxy {
+  return { version, name, migration: () => ({ up: async () => {}, down: async () => {} }) };
+}
+
+describe("MultiDbMigratorTest (trails)", () => {
+  let adapterA: DatabaseAdapter;
+  let adapterB: DatabaseAdapter;
+  let smA: SchemaMigration;
+  let smB: SchemaMigration;
+
+  beforeEach(async () => {
+    adapterA = await Base.leaseConnection();
+    adapterB = await ARUnit2Model.leaseConnection();
+    smA = new SchemaMigration(adapterA);
+    smB = new SchemaMigration(adapterB);
+    await smA.createTable();
+    await smB.createTable();
+    await smA.deleteAllVersions();
+    await smB.deleteAllVersions();
+  });
+
+  afterEach(async () => {
+    await smA.deleteAllVersions();
+    await smB.deleteAllVersions();
+  });
+
+  it("records versions only in the migrated connection's schema_migrations", async () => {
+    const migratorA = new Migrator(adapterA, [
+      noopMigration("1", "ValidPeopleHaveLastNames"),
+      noopMigration("2", "WeNeedReminders"),
+      noopMigration("3", "InnocentJointable"),
+    ]);
+    const migratorB = new Migrator(adapterB, [noopMigration("1", "PeopleHaveHobbies")]);
+
+    await migratorA.up();
+
+    expect(await migratorA.getAllVersions()).toEqual(["1", "2", "3"]);
+    expect(await migratorB.getAllVersions()).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/multi-db-migrator.trails.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.trails.test.ts
@@ -3,11 +3,12 @@ import { Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 import { Base } from "./base.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 
 function noopMigration(version: string, name: string): MigrationProxy {
-  return { version, name, migration: () => ({ up: async () => {}, down: async () => {} }) };
+  return { version, name, migration: () => anonymousMigration(name, version) };
 }
 
 describe("MultiDbMigratorTest (trails)", () => {

--- a/packages/activerecord/src/support/scratch-database.ts
+++ b/packages/activerecord/src/support/scratch-database.ts
@@ -1,19 +1,23 @@
 /**
- * On-disk scratch sqlite databases for tests whose Rails counterpart runs
- * against a *distinct* database rather than `ActiveRecord::Base`'s own.
+ * On-disk scratch sqlite databases for the sqlite arm of
+ * {@link ../support/isolated-database.js openIsolatedDatabase}.
  *
- * Rails never opens a `:memory:` database in these spots — `arunit` and
- * `arunit2` are both files in `config.example.yml`, so a test that needs a
- * second, independent database (`MultiDbMigratorTest`'s two pools, the
- * `AnimalsBase` pool behind `OtherDog`) gets a file, and a test that mutates a
- * schema `ActiveRecord::Base` shares (`AdapterPreventWritesTest`'s
- * create/drop of `subscribers`) gets one too rather than scribbling on the
- * worker's canonical database.
+ * This is a trails-only construct: Rails' suite has exactly two databases,
+ * `arunit` and `arunit2` (`config.example.yml:83-91`), both fixed files reused
+ * across runs. A test needing a second database rides `ARUnit2Model`'s pool —
+ * `MultiDbMigratorTest` takes `ARUnit2Model.connection_pool`
+ * (`multi_db_migrator_test.rb:23`) and `OtherDog < ARUnit2Model`
+ * (`test/models/other_dog.rb`) is a canonical model, not an inline one. Both of
+ * those ride the canonical pair here too.
  *
- * `:memory:` is the wrong stand-in for either: it silently makes every
- * connection its own private database, which is exactly the divergence RFC
- * 0029 exists to remove. A file path keeps the "two adapters, one database"
- * and "two databases, one process" distinctions real.
+ * What remains is the case Rails genuinely has no counterpart for: a suite that
+ * wipes a database wholesale. Rails runs it in its own process against its own
+ * `arunit`; trails shares one database per *vitest worker* across files, so it
+ * needs a throwaway. Converging that away is story
+ * `converge-isolated-database-onto-canonical-pools`.
+ *
+ * `:memory:` is the wrong stand-in: it silently makes every connection its own
+ * private database, which is exactly the divergence RFC 0029 exists to remove.
  *
  * @internal
  */


### PR DESCRIPTION
## Problem

The story was "sweep the temp sqlite DBs that leak on non-sqlite lanes". The
right fix turned out to be deleting the temp databases, not sweeping them.

Rails' AR suite has exactly two databases — `arunit` and `arunit2`
(`config.example.yml:83-91`), fixed files reused across runs. It has no notion
of a per-test temp database. trails was minting one per test-file label in
tmpdir:

| Rails | trails (before) |
|---|---|
| `MultiDbMigratorTest` rides `Base.connection_pool` + `ARUnit2Model.connection_pool` (`multi_db_migrator_test.rb:22-23`) | two `BetterSQLite3Adapter`s on `/tmp/ar-test-*.sqlite` |
| `OtherDog < ARUnit2Model` (`test/models/other_dog.rb`) | inline `AnimalsBase`/`OtherDog` + `connectsTo` declared inside the `it()`, shadowing the canonical model |
| `schema.rb:1462` — `OtherDog.lease_connection.create_table :dogs` | hand-rolled `CREATE TABLE dogs` via `executeMutation`, with a lint suppression |

trails already had every canonical piece: `ARUnit2Model`, a real second pool on
every lane (`connection.ts:407-408`), the `OtherDog` model file, and
`setup-second-pool.ts`'s `createOtherDogsTable` mirroring `schema.rb:1462` —
run for every test file by `test-setup-dy.ts:87`. The scratch databases weren't
filling a gap, they were bypassing it.

## Change

- `multi-db-migrator.test.ts` takes `Base.leaseConnection()` and
  `ARUnit2Model.leaseConnection()`. Teardown clears versions on both, per
  `multi_db_migrator_test.rb:58-59` (Rails names `@pool_q` there — a typo that
  makes its first line a no-op; ours must really clear both, since trails
  shares the arunit database across files in a worker).
- Riding the canonical pools also makes Rails' *own* assertions portable, so
  `schema migration is different for different connections` now ports
  `multi_db_migrator_test.rb:71-76` — distinct `SchemaMigration`s, distinct
  connections, and the two pools' `connection_descriptor.name`. (`"Base"`
  rather than `"ActiveRecord::Base"`: `PoolConfig`'s primary normalization,
  `pool-config.ts:270`.) The version-independence check it replaced was a
  TS-only extra, so it moves to `multi-db-migrator.trails.test.ts` per the
  repo convention.
- `associations.test.ts` uses the canonical `OtherDog`; the inline model, the
  `connectsTo` pool, the scratch file and the hand-rolled DDL all go.
  `registerModel(OtherDog)` stays — trails' registry is what stands in for
  Ruby constant autoload, and polymorphic `origin_type` resolution fails
  without it.
- `scratch-database.ts`'s docblock no longer claims these callers.

## Verification

- `multi-db-migrator.test.ts` (7), its trails sibling (1) and
  `associations.test.ts` (148) pass on sqlite and on PG (local PG via an
  isolated compose project).
- `ls /tmp/ar-test-*` before/after a PG run: no new files. The leak the story
  was filed for is gone at the source.
- The ported assertions are real guards, not no-ops: pointing `adapterB` back
  at `Base.leaseConnection()` fails 4 tests.
- `api:compare` 11741/17536 (67%) and `test:compare` 14824/22203 (66.8%)
  unchanged; `multi_db_migrator_test.rb` 8/8 ✓, `associations_test.rb` 128 ✓,
  activerecord 0 misplaced.

## Follow-ups (registered, not fanned out)

- `converge-isolated-database-onto-canonical-pools` — `isolated-database.ts`
  (via `drop-all-tables.test.ts`) is the last `scratchDatabasePath` caller. Its
  rationale is a real harness constraint: Rails forks a process per suite,
  trails shares one database per worker across files.
- `port-preloadertest-fixture-declaration` — Rails' `PreloaderTest` declares 20
  fixture sets (`associations_test.rb:803-806`) and this test reads
  `dogs(:sophie)` / `other_dogs(:lassie)`; ours still builds records inline.
  Adding the sets piecemeal fails ~12 sibling tests, so the declaration has to
  be ported wholesale.

## Supersedes

Closes #5590, which made the temp-file sweep lane-wide. That hardened the
deviation instead of removing it.

Closes-story: sweep-temp-sqlite-dbs-on-non-sqlite-lanes
