### PR TITLE
refactor(activerecord): name the sqlite arunit database from configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ eslint/.tmp-*.json
 # vitest coverage reports (reporting-only CI job)
 coverage/
 
-# Stray sqlite files from tests whose config names a relative database
-# (db/primary.sqlite3 etc. — config values only, never checked-in databases)
+# Sqlite databases whose config names a relative path: the sqlite3 lane's
+# fixture database (support/config.ts, Rails' FIXTURES_ROOT/fixture_database
+# .sqlite3) plus stray db/primary.sqlite3 etc. — never checked-in databases
 /db/

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -174,6 +174,15 @@ export const ARUNIT_DATABASE = "activerecord_unittest";
 export const SQLITE_FIXTURE_DATABASE = "db/fixture_database.sqlite3";
 
 /**
+ * The `sqlite3.arunit2` database `config.example.yml:89` names —
+ * `<%= FIXTURES_ROOT %>/fixture_database_2.sqlite3`. Rails spells the second
+ * sqlite file out rather than deriving it, and `expand_config` fills a
+ * `database` in only when the entry carries none
+ * (`test/support/config.rb:30-36`), so it is a configured name here too.
+ */
+export const SQLITE_FIXTURE_DATABASE_2 = "db/fixture_database_2.sqlite3";
+
+/**
  * The credential `config.example.yml` hard-codes on both `mysql2.arunit` and
  * `mysql2.arunit2` (`config.example.yml:4,24`), provisioned by
  * `db:mysql:build_user` (`activerecord/Rakefile:227-235`) — `CREATE USER`, no

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -160,6 +160,20 @@ function applySlot(database: string, read: EnvReader): string {
 export const ARUNIT_DATABASE = "activerecord_unittest";
 
 /**
+ * The `sqlite3.arunit` database `config.example.yml:85` names —
+ * `<%= FIXTURES_ROOT %>/fixture_database.sqlite3`, a fixed file reused across
+ * runs. trails has no `FIXTURES_ROOT` (see the module docs above), so the name
+ * is relative and the sqlite driver resolves it against the working directory,
+ * as it resolves any relative `database:`. `db/` is gitignored.
+ *
+ * It is a plain configured name on purpose: the previous spelling derived a
+ * `<tmpdir>/ar-test-fallback-<run token>-<worker slot>.sqlite` path from the
+ * process, so the database was neither configuration nor stable across runs —
+ * something Rails' yml never does.
+ */
+export const SQLITE_FIXTURE_DATABASE = "db/fixture_database.sqlite3";
+
+/**
  * The credential `config.example.yml` hard-codes on both `mysql2.arunit` and
  * `mysql2.arunit2` (`config.example.yml:4,24`), provisioned by
  * `db:mysql:build_user` (`activerecord/Rakefile:227-235`) — `CREATE USER`, no

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -125,7 +125,12 @@ describe("connect", () => {
 
   // `config.example.yml:88-90` spells the second sqlite file out rather than
   // deriving it, and `expand_config` fills a `database` in only when the entry
-  // carries none (`support/config.rb:30-36`).
+  // carries none (`support/config.rb:30-36`). The third entry carries none on
+  // every lane, and Rails defaults it to `activerecord_unittest` — the same
+  // name `arunit` defaults to (`support/config.rb:28-29`), i.e. the same
+  // database. `expandConfig` keeps that identity by pointing it at whatever
+  // `arunit` resolved to, because trails' `arunit` name is worker-scoped where
+  // Rails' is a constant.
   it("names the configured second database on the sqlite3 arunit2 entry", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -3,7 +3,7 @@ import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
 import { connect, testConfigurationHashes } from "./connection.js";
-import { SQLITE_FIXTURE_DATABASE } from "./config.js";
+import { SQLITE_FIXTURE_DATABASE, SQLITE_FIXTURE_DATABASE_2 } from "./config.js";
 
 // Only the cases asserting `connect`'s own side effects call it; everything
 // that merely checks which entry `ARCONN` resolves to uses
@@ -121,6 +121,20 @@ describe("connect", () => {
     const { envConfig } = await testConfigurationHashes();
     expect(envConfig.database).toBe(SQLITE_FIXTURE_DATABASE);
     expect(envConfig.pool).toBe(5);
+  });
+
+  // `config.example.yml:88-90` spells the second sqlite file out rather than
+  // deriving it, and `expand_config` fills a `database` in only when the entry
+  // carries none (`support/config.rb:30-36`).
+  it("names the configured second database on the sqlite3 arunit2 entry", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    vi.stubEnv("AR_TEST_WORKER_DB", "");
+    const { configurationHashes } = await testConfigurationHashes();
+    expect(configurationHashes.map((c) => c.database)).toEqual([
+      SQLITE_FIXTURE_DATABASE,
+      SQLITE_FIXTURE_DATABASE_2,
+      SQLITE_FIXTURE_DATABASE,
+    ]);
   });
 
   // `config.example.yml:85` names one fixed file, reused across runs; nothing

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
-import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
 import { Base } from "../base.js";
 import { connect, testConfigurationHashes } from "./connection.js";
+import { SQLITE_FIXTURE_DATABASE } from "./config.js";
 
 // Only the cases asserting `connect`'s own side effects call it; everything
 // that merely checks which entry `ARCONN` resolves to uses
@@ -119,30 +119,24 @@ describe("connect", () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
     const { envConfig } = await testConfigurationHashes();
-    expect(envConfig.database).not.toBe(":memory:");
-    expect(envConfig.database).toMatch(/\.sqlite$/);
+    expect(envConfig.database).toBe(SQLITE_FIXTURE_DATABASE);
     expect(envConfig.pool).toBe(5);
   });
 
-  it("reuses one fallback database path across calls", async () => {
+  // `config.example.yml:85` names one fixed file, reused across runs; nothing
+  // about the running process (a run token, a worker slot, a tmpdir) may enter
+  // the name.
+  it("names the same configured database on every call", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
     const first = (await testConfigurationHashes()).envConfig.database;
+    vi.stubEnv("AR_TEST_RUN_TOKEN", "some-other-run");
+    vi.stubEnv("VITEST_POOL_ID", "7");
     const second = (await testConfigurationHashes()).envConfig.database;
     expect(second).toBe(first);
   });
 
-  it("registers the fallback database for cleanup on exit", async () => {
-    vi.stubEnv("ARCONN", "sqlite3");
-    vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const database = String((await testConfigurationHashes()).envConfig.database);
-
-    const before = new Set(process.listeners("exit"));
-    await registerDbFileCleanupOnExit(database);
-    expect(process.listeners("exit").filter((fn) => !before.has(fn))).toHaveLength(0);
-  });
-
-  it("prefers AR_TEST_WORKER_DB over the fallback database", async () => {
+  it("prefers AR_TEST_WORKER_DB over the configured fixture database", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
     const { envConfig } = await testConfigurationHashes();

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -147,8 +147,9 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
     adapter: "sqlite3",
     lane: "sqlite",
     // `config.example.yml:83-91`: two file databases, both `timeout`/`strict`.
-    // Rails names them under FIXTURES_ROOT; ours are the worker database and
-    // its derived sibling, filled in by `expandConfig`.
+    // Rails names both under FIXTURES_ROOT; ours is the configured fixture
+    // database (or this worker's clone of it) plus the sibling `expandConfig`
+    // derives.
     build: async () => {
       const shared = { ...(await sqliteHash()), timeout: 5000, strict: true };
       return { arunit: shared, arunit2: { ...shared, database: undefined } };
@@ -331,20 +332,12 @@ export async function testConfigurationHashes(): Promise<{
 }
 
 /**
- * The `sqlite3.arunit` database of `config.example.yml:83-91`: a fixed
- * configured file, reused across runs, exactly as Rails names
- * `<%= FIXTURES_ROOT %>/fixture_database.sqlite3`. The only difference is which
- * root it hangs off — trails has no `FIXTURES_ROOT` (`config.ts`), so the name
- * is repo-relative ({@link SQLITE_FIXTURE_DATABASE}) and the sqlite driver
- * resolves it the way it resolves any relative `database:`.
+ * The `sqlite3.arunit` database of `config.example.yml:83-91`
+ * ({@link SQLITE_FIXTURE_DATABASE}).
  *
- * The directory is created because Rails' `test/fixtures` is a checked-in
- * directory and ours is a gitignored build output; sqlite will not create a
- * missing parent for a file DB.
- *
- * This replaces a per-process `<tmpdir>/ar-test-fallback-<token>.sqlite` path,
- * which had no counterpart in Rails: the database name is configuration, not a
- * function of the process that happens to read it.
+ * The directory is created because Rails' `test/fixtures` is checked in and
+ * ours is a gitignored build output; sqlite will not create a missing parent
+ * for a file DB.
  */
 async function fixtureDatabase(): Promise<string> {
   const fs = await getFsAsync();
@@ -359,8 +352,7 @@ async function fixtureDatabase(): Promise<string> {
  * `AR_TEST_WORKER_DB` is the per-worker template clone the setupFile publishes
  * (`support/sqlite-template.ts`) — trails' stand-in for Rails' one
  * already-prepared database, since vitest forks workers where Rails does not.
- * With no worker clone (a setup-free single-file run) the entry names the
- * configured fixture database, as `config.example.yml` always does.
+ * With no worker clone the entry names the configured fixture database.
  */
 async function sqliteHash(): Promise<Record<string, unknown>> {
   const workerDb = getEnv("AR_TEST_WORKER_DB");

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -22,8 +22,8 @@
  * selects the backend.
  */
 
-import { getEnv, getOsAsync } from "@blazetrails/activesupport";
-import { getPathAsync } from "@blazetrails/activesupport/fs-adapter";
+import { getEnv } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../base.js";
 import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
@@ -39,6 +39,7 @@ import {
   mysqlPreparedStatements,
   mysqlSettings,
   postgresSettings,
+  SQLITE_FIXTURE_DATABASE,
   type ConnectionName,
   type EnvReader,
   type ServerSettings,
@@ -329,30 +330,43 @@ export async function testConfigurationHashes(): Promise<{
   return { adapter: connection.lane, envConfig, configurationHashes };
 }
 
-async function fallbackDatabasePath(): Promise<string> {
-  const g = globalThis as typeof globalThis & { __arFallbackDbPath?: string };
-  if (g.__arFallbackDbPath) return g.__arFallbackDbPath;
+/**
+ * The `sqlite3.arunit` database of `config.example.yml:83-91`: a fixed
+ * configured file, reused across runs, exactly as Rails names
+ * `<%= FIXTURES_ROOT %>/fixture_database.sqlite3`. The only difference is which
+ * root it hangs off — trails has no `FIXTURES_ROOT` (`config.ts`), so the name
+ * is repo-relative ({@link SQLITE_FIXTURE_DATABASE}) and the sqlite driver
+ * resolves it the way it resolves any relative `database:`.
+ *
+ * The directory is created because Rails' `test/fixtures` is a checked-in
+ * directory and ours is a gitignored build output; sqlite will not create a
+ * missing parent for a file DB.
+ *
+ * This replaces a per-process `<tmpdir>/ar-test-fallback-<token>.sqlite` path,
+ * which had no counterpart in Rails: the database name is configuration, not a
+ * function of the process that happens to read it.
+ */
+async function fixtureDatabase(): Promise<string> {
+  const fs = await getFsAsync();
   const path = await getPathAsync();
-  const os = await getOsAsync();
-  const runToken =
-    getEnv("AR_TEST_RUN_TOKEN") ||
-    `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
-  const slot = getEnv("VITEST_POOL_ID") || getEnv("VITEST_WORKER_ID") || "1";
-  const token = `${runToken}-${slot}`;
-  const dbPath = path.join(os.tmpdir(), `ar-test-fallback-${token}.sqlite`);
-  // Imported lazily: `sqlite-template.ts` imports `activeLane` from this
-  // module, and a static import here would close that cycle at module-init time.
-  const { registerDbFileCleanupOnExit } = await import("./sqlite-template.js");
-  await registerDbFileCleanupOnExit(dbPath);
-  g.__arFallbackDbPath = dbPath;
-  return dbPath;
+  await fs.mkdir?.(path.dirname(SQLITE_FIXTURE_DATABASE), { recursive: true });
+  return SQLITE_FIXTURE_DATABASE;
 }
 
+/**
+ * The `sqlite3` connection's shared entry hash.
+ *
+ * `AR_TEST_WORKER_DB` is the per-worker template clone the setupFile publishes
+ * (`support/sqlite-template.ts`) — trails' stand-in for Rails' one
+ * already-prepared database, since vitest forks workers where Rails does not.
+ * With no worker clone (a setup-free single-file run) the entry names the
+ * configured fixture database, as `config.example.yml` always does.
+ */
 async function sqliteHash(): Promise<Record<string, unknown>> {
   const workerDb = getEnv("AR_TEST_WORKER_DB");
   return {
     adapter: "sqlite3",
-    database: workerDb || (await fallbackDatabasePath()),
+    database: workerDb || (await fixtureDatabase()),
     timeout: 5000,
     strict: true,
   };

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -40,6 +40,7 @@ import {
   mysqlSettings,
   postgresSettings,
   SQLITE_FIXTURE_DATABASE,
+  SQLITE_FIXTURE_DATABASE_2,
   type ConnectionName,
   type EnvReader,
   type ServerSettings,
@@ -146,14 +147,7 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3: {
     adapter: "sqlite3",
     lane: "sqlite",
-    // `config.example.yml:83-91`: two file databases, both `timeout`/`strict`.
-    // Rails names both under FIXTURES_ROOT; ours is the configured fixture
-    // database (or this worker's clone of it) plus the sibling `expandConfig`
-    // derives.
-    build: async () => {
-      const shared = { ...(await sqliteHash()), timeout: 5000, strict: true };
-      return { arunit: shared, arunit2: { ...shared, database: undefined } };
-    },
+    build: sqliteEntries,
   },
   sqlite3_mem: {
     adapter: "sqlite3",
@@ -332,35 +326,35 @@ export async function testConfigurationHashes(): Promise<{
 }
 
 /**
- * The `sqlite3.arunit` database of `config.example.yml:83-91`
- * ({@link SQLITE_FIXTURE_DATABASE}).
+ * The `sqlite3` connection's two entries, mirroring `config.example.yml:83-91`:
+ * `arunit` and `arunit2` each name their own file, with `timeout` and `strict`.
+ *
+ * `AR_TEST_WORKER_DB` is the per-worker template clone the setupFile publishes
+ * (`support/sqlite-template.ts`) — trails' stand-in for Rails' one
+ * already-prepared database, since vitest forks workers where Rails does not.
+ * Only that clone leaves `arunit2` for `expandConfig` to derive; the configured
+ * pair is spelled out here as the yml spells it, since `expand_config` fills a
+ * `database` in only when the entry carries none (`support/config.rb:30-36`).
  *
  * The directory is created because Rails' `test/fixtures` is checked in and
  * ours is a gitignored build output; sqlite will not create a missing parent
  * for a file DB.
  */
-async function fixtureDatabase(): Promise<string> {
+async function sqliteEntries(): Promise<Record<"arunit" | "arunit2", Record<string, unknown>>> {
+  const options = { adapter: "sqlite3", timeout: 5000, strict: true };
+  const workerDb = getEnv("AR_TEST_WORKER_DB");
+  if (workerDb) {
+    return {
+      arunit: { ...options, database: workerDb },
+      arunit2: { ...options, database: undefined },
+    };
+  }
   const fs = await getFsAsync();
   const path = await getPathAsync();
   await fs.mkdir?.(path.dirname(SQLITE_FIXTURE_DATABASE), { recursive: true });
-  return SQLITE_FIXTURE_DATABASE;
-}
-
-/**
- * The `sqlite3` connection's shared entry hash.
- *
- * `AR_TEST_WORKER_DB` is the per-worker template clone the setupFile publishes
- * (`support/sqlite-template.ts`) — trails' stand-in for Rails' one
- * already-prepared database, since vitest forks workers where Rails does not.
- * With no worker clone the entry names the configured fixture database.
- */
-async function sqliteHash(): Promise<Record<string, unknown>> {
-  const workerDb = getEnv("AR_TEST_WORKER_DB");
   return {
-    adapter: "sqlite3",
-    database: workerDb || (await fixtureDatabase()),
-    timeout: 5000,
-    strict: true,
+    arunit: { ...options, database: SQLITE_FIXTURE_DATABASE },
+    arunit2: { ...options, database: SQLITE_FIXTURE_DATABASE_2 },
   };
 }
 

--- a/packages/activerecord/src/support/sqlite-template.ts
+++ b/packages/activerecord/src/support/sqlite-template.ts
@@ -70,11 +70,6 @@ const cleanupG = globalThis as typeof globalThis & { __arDbCleanupPaths?: Set<st
  * globalSetup's teardown is what guarantees the files go away; this listener
  * only makes them go away *sooner* when a worker does exit cleanly.
  *
- * Callers that must stay `process`-free (`support/connection.ts`, whose
- * fallback DB otherwise lingers in tmpdir after every setup-free run) route
- * their cleanup through here — this module already carries the `process`
- * exception documented at the top of the file.
- *
  * The de-dupe set hangs off `globalThis`, not module scope: vitest's
  * `isolate: true` reloads the module graph per test file, so a module-level
  * set would re-register — and leak — one exit listener per file.
@@ -99,8 +94,7 @@ export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
 /**
  * Shared filename prefix of every temp sqlite DB the AR test harness creates:
  * the template, the per-worker clones, the scratch databases
- * (`support/scratch-database.ts`), the setup-free fallback DB
- * (`support/connection.ts`) and their `_arunit2` siblings.
+ * (`support/scratch-database.ts`) and their `_arunit2` siblings.
  */
 export const TEMP_DB_PREFIX = "ar-test-";
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -7,7 +7,7 @@
  *   - ARCONN=postgresql → PostgreSQLAdapter
  *   - ARCONN=mysql2     → Mysql2Adapter
  *   - (default)         → SQLite3Adapter (the per-worker template clone, or the
- *     run-scoped fallback file `support/connection.ts` resolves)
+ *     configured fixture database `support/connection.ts` resolves)
  *
  * RFC 0059 retired the standing sidecar `_pool`: Rails has no sidecar test
  * pool (`grep -r sidecar vendor/rails/activerecord/test` = 0 hits) — every
@@ -70,13 +70,13 @@ export type LeasedTestAdapter = DatabaseAdapter & {
 //
 // It is the `arunit` entry `connect()` establishes the primary pool from, so
 // the two cannot drift; resolved with top-level await because the sqlite3
-// database is only known asynchronously (`fallbackDatabasePath()`).
+// database is only known asynchronously (`sqliteHash()`).
 //
 // Order-dependent: this snapshot and `connect()` resolve the entry separately
 // and agree only because `test-setup-worker-db.ts` stamps AR_TEST_WORKER_DB /
 // AR_DB_SLOT before anything imports this module. A module in that setupFile's
 // graph reaching test-adapter.ts (or adapter-helper.ts, which imports it) would
-// snapshot the fallback database while Base rides the worker clone —
+// snapshot the fixture database while Base rides the worker clone —
 // `test-adapter.trails.test.ts` asserts the two stay equal.
 const _primaryConfiguration: Record<string, unknown> = {
   ...(await testConfigurationHashes()).envConfig.configurationHash,


### PR DESCRIPTION
Converges the sqlite3 lane's `arunit` database name onto configuration.

`fallbackDatabasePath` minted `<tmpdir>/ar-test-fallback-<runToken>-<slot>.sqlite` whenever `AR_TEST_WORKER_DB` was unset, inventing its own random token when `AR_TEST_RUN_TOKEN` was absent — so the file was not stable across runs, not stable within a machine, and stamped with a token the globalSetup sweep does not know (only the 6h age gate ever collected it). Rails names a fixed file, `<%= FIXTURES_ROOT %>/fixture_database.sqlite3` (`config.example.yml:83-91`), reused across runs.

Now `SQLITE_FIXTURE_DATABASE` (`support/config.ts`) names `db/fixture_database.sqlite3` — a plain configured, repo-relative name the sqlite driver resolves like any relative `database:`; `db/` is gitignored and created on demand (Rails' `test/fixtures` is checked in, ours is not). The per-worker template clone (`AR_TEST_WORKER_DB`) still wins when the worker bootstrap publishes one, so normal runs are unchanged.

No `ar-test-fallback-*` file is minted on any lane; verified a setup-free single-file run (`sqlite-drivers` project, no setupFiles) still connects and creates `db/fixture_database.sqlite3`. The temp-file sweep is not widened — the deviation is removed rather than hardened (cf. #5590).

Closes-story: converge-sqlite-fallback-database-path
