### PR TITLE
test(activerecord): gate view insert-returning pk test off the MySQL family

### DIFF
--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -260,12 +260,6 @@ describe("UpdateableViewTest", () => {
     expect((newBook as any).name).toBe("Rails in Action");
   });
 
-  // Rails gates this `current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) &&
-  // supports_insert_returning?` — the MySQL family is excluded by name: a
-  // MariaDB view reports no auto_increment Extra for the base table's key, so
-  // the column is never auto-populated and LAST_INSERT_ID() through the view is
-  // 0. SQLite is excluded here too because its views do not support DML. Carry
-  // both features so the extracted gate still reconciles view_test.rb.
   itIfSupports.skipIf(adapterType === "sqlite" || adapterType === "mysql")(
     "insert_returning,views",
     "insert record populates primary key",

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -260,11 +260,13 @@ describe("UpdateableViewTest", () => {
     expect((newBook as any).name).toBe("Rails in Action");
   });
 
-  // Rails gates this `features=[insert_returning,views]` (runs on mysql +
-  // postgresql; SQLite excluded by the outer view block). Carry both features so
-  // the extracted gate is `mysql,postgresql|insert_returning,views`; at runtime
-  // MySQL (mysql:8, not MariaDB) lacks insert_returning, so itIfSupports skips it.
-  itIfSupports.skipIf(adapterType === "sqlite")(
+  // Rails gates this `current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) &&
+  // supports_insert_returning?` — the MySQL family is excluded by name: a
+  // MariaDB view reports no auto_increment Extra for the base table's key, so
+  // the column is never auto-populated and LAST_INSERT_ID() through the view is
+  // 0. SQLite is excluded here too because its views do not support DML. Carry
+  // both features so the extracted gate still reconciles view_test.rb.
+  itIfSupports.skipIf(adapterType === "sqlite" || adapterType === "mysql")(
     "insert_returning,views",
     "insert record populates primary key",
     async () => {


### PR DESCRIPTION
Gates `UpdateableViewTest > "insert record populates primary key"` off the MySQL family, matching Rails at `vendor/rails/activerecord/test/cases/view_test.rb:197`:

```ruby
end if current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) && supports_insert_returning?
```

Once `insert_returning` became live-derived (MariaDB >= 10.5), this test armed on the MariaDB lane and failed with `expected 0 to be greater than 0`. A MariaDB view reports no `auto_increment` Extra for the base table key, so the column is never auto-populated and `LAST_INSERT_ID()` through the view is 0 — which is exactly why Rails excludes MySQL by name.

The `insert_returning,views` feature list is preserved so the test:compare gate extractor still reconciles `view_test.rb`; the test is not renamed. The stale comment claiming Rails runs this on mysql is corrected.

Closes-story: view-insert-returning-gate-excludes-mysql
