### PR TITLE
fix(test-compare): keep a positive adapter set in a pure-conjunction gate

### DIFF
--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -27,7 +27,8 @@ import { TimeWithZone, getZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 import { MigrationContext } from "./migration.js";
-import { describeIfSupports } from "./support/supports.js";
+import { itIfSupports } from "./support/supports.js";
+import { describeIfPg } from "./support/describe-if-pg.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { fixtures } from "./test-fixtures.js";
 import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
@@ -1185,21 +1186,25 @@ describe("DirtyTest", () => {
 // Mirrors: activerecord/test/cases/dirty_test.rb
 //   if current_adapter?(:PostgreSQLAdapter) && supports_identity_columns?
 // ==========================================================================
-describeIfSupports("identity_columns", "DirtyTest", () => {
+describeIfPg("DirtyTest", () => {
   fixtures([], { useTransactionalTests: false });
 
-  it("partial insert off with changed composite identity primary key attribute", async () => {
-    const klass = class extends Base {
-      static {
-        this.tableName = "cpk_postgresql_identity_table";
-      }
-    };
-    await klass.loadSchema();
+  itIfSupports(
+    "identity_columns",
+    "partial insert off with changed composite identity primary key attribute",
+    async () => {
+      const klass = class extends Base {
+        static {
+          this.tableName = "cpk_postgresql_identity_table";
+        }
+      };
+      await klass.loadSchema();
 
-    await withPartialWrites(klass, false, async () => {
-      const record = (await klass.createBang({ another_id: 10 })) as Rec;
-      expect(record.another_id).toBe(10);
-      expect(record.id).not.toBeNull();
-    });
-  });
+      await withPartialWrites(klass, false, async () => {
+        const record = (await klass.createBang({ another_id: 10 })) as Rec;
+        expect(record.another_id).toBe(10);
+        expect(record.id).not.toBeNull();
+      });
+    },
+  );
 });

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -189,13 +189,10 @@ const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   optimizer_hints: withMysql([], mysql.supportsOptimizerHints),
   // `supports_transaction_isolation?`: PostgreSQL + MySQL + SQLite (sqlite3_adapter.rb:147).
   // The Rails test (transaction_isolation_test.rb:20) ANDs this with
-  // !current_adapter?(:SQLite3Adapter). The test:compare Ruby extractor drops the
-  // adapter half of such mixed adapter+feature conditions (extract-ruby-tests.rb:462),
-  // so the canonical railsGate is feature-only `transaction_isolation`. Match it
-  // with a bare itIfSupports("transaction_isolation") where the body is adapter-
-  // agnostic; only add .skipIf(adapterType === "sqlite") when a subtest genuinely
-  // must not run on SQLite (a real body need, not gate-matching) — note that doing
-  // so re-introduces an adapter restriction the extractor will flag as wrong-gate.
+  // !current_adapter?(:SQLite3Adapter). The test:compare extractors keep the
+  // adapter half of such pure-conjunction conditions, so the canonical railsGate
+  // is `adapters=[mysql,postgresql] features=[transaction_isolation]`. Match it
+  // with `itIfSupports.skipIf(adapterType === "sqlite")("transaction_isolation", …)`.
   transaction_isolation: ALL,
 };
 

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -15,12 +15,6 @@ import { adapterType } from "./test-adapter.js";
 import { describeIfSupports, itIfSupports } from "./support/supports.js";
 import { dumpTableSchema } from "./support/schema-dumping-helper.js";
 
-// The MariaDB CI stand-in for the mysql lane — see the gate note on
-// "insert record populates primary key". Lane-gated so the pg/sqlite lanes never
-// open a MySQL connection.
-const mariadbStandIn =
-  adapterType === "mysql" ? (await import("./support/mysql-server-version.js")).isMariaDb : false;
-
 // In Rails, AbstractAdapter includes SchemaStatements, so introspection
 // methods (views, viewExists, tableExists, isDataSourceExists) live directly
 // on the connection object. Cast once here; all helpers pass through.
@@ -266,23 +260,11 @@ describe("UpdateableViewTest", () => {
     expect((newBook as any).name).toBe("Rails in Action");
   });
 
-  // Rails gates this `features=[insert_returning,views]` on `adapters=[mysql,
-  // postgresql]` — the class body is `current_adapter?(:Mysql2Adapter,
-  // :TrilogyAdapter, :PostgreSQLAdapter)` (view_test.rb:158) — so `skipIf` carries
-  // exactly that, which is what the test:compare gate extractor compares against.
-  //
-  // Rails' *effective* set is narrower: the test adds
-  // `current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) && supports_insert_returning?`
-  // (view_test.rb:197), and intersected with the class guard that is PostgreSQL
-  // alone. The Ruby extractor drops that second adapter clause on a mixed
-  // adapter+feature condition (extract-ruby-tests.rb:629-640), so the narrowing
-  // cannot live in `skipIf` without reporting a wrong-gate. It rides
-  // `mariadbStandIn` instead: MySQL 8 is already excluded by lacking
-  // insert_returning, so MariaDB is the only MySQL-family server that would
-  // otherwise reach a test Rails never runs on MySQL at all. Story
-  // ruby-gate-extractor-drops-conjoined-adapter-set moves this back into the
-  // skipIf once the extractor intersects the two clauses.
-  itIfSupports.skipIf(adapterType === "sqlite" || mariadbStandIn)(
+  // view_test.rb:197 gates the method itself with
+  // `current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) && supports_insert_returning?`,
+  // which intersects with the class guard (mysql + postgresql) down to
+  // PostgreSQL alone.
+  itIfSupports.skipIf(adapterType !== "postgres")(
     "insert_returning,views",
     "insert record populates primary key",
     async () => {

--- a/scripts/test-compare/extract-ruby-gates.test.ts
+++ b/scripts/test-compare/extract-ruby-gates.test.ts
@@ -146,6 +146,42 @@ describe("Ruby extractor gate detection", () => {
     expect(g["or compound"]).toEqual({ features: ["insert_returning"], source: ["class"] });
   });
 
+  it("keeps a positive adapter set conjoined with a feature, intersecting the class guard", () => {
+    const g = rubyGates({
+      // Mirrors view_test.rb:158/197 — a method-level
+      // `current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) && supports_insert_returning?`
+      // nested in a mysql+postgresql class guard. The true run-on set is the
+      // intersection: PostgreSQL.
+      "cases/view_test.rb": `
+        if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
+          def test_insert_record_populates_primary_key; end if current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) && supports_insert_returning?
+        end
+      `,
+      "cases/bar_test.rb": `
+        def test_pg_and_feature; end if current_adapter?(:PostgreSQLAdapter) && supports_insert_returning?
+        def test_pg_or_feature; end if current_adapter?(:PostgreSQLAdapter) || supports_insert_returning?
+        def test_unless_pg_and_feature; end unless current_adapter?(:PostgreSQLAdapter) && supports_insert_returning?
+      `,
+    });
+    expect(g["insert record populates primary key"]).toEqual({
+      adapters: ["postgresql"],
+      features: ["insert_returning"],
+      source: ["class"],
+    });
+    expect(g["pg and feature"]).toEqual({
+      adapters: ["postgresql"],
+      features: ["insert_returning"],
+      source: ["class"],
+    });
+    // `||` → the run-on set is a union no single adapter set captures → dropped.
+    expect(g["pg or feature"]).toEqual({ features: ["insert_returning"], source: ["class"] });
+    // `unless (A && feature)` negates the conjunction into that same union.
+    expect(g["unless pg and feature"]).toEqual({
+      guards: ["no_insert_returning"],
+      source: ["class"],
+    });
+  });
+
   it("does not emit an adapter exclusion under `unless` (negation → disjunction)", () => {
     const g = rubyGates({
       // `unless feature && !sqlite` runs when `!feature || sqlite` — a disjunction

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -628,13 +628,22 @@ class TestExtractor
       gate[:adapters] = []
     end
     # A POSITIVE adapter set isn't sound — and must be dropped — when the
-    # condition mixes it with a feature/guard (`supports_X? && current_adapter?`
-    # could be `&&` or `||`; the run-on set differs), or with a negated adapter
-    # under `||` (`current_adapter?(:A) || !current_adapter?(:B)` is the
-    # complement of B, not A). A pure positive `||` (`A || B`) stays sound — it
-    # is the union the concat already collected.
+    # condition mixes it with a feature under `||` or on the run-when-false path
+    # (`current_adapter?(:A) || supports_X?` runs on a union no single adapter
+    # set captures, and `unless A && supports_X?` negates the conjunction into
+    # exactly such a union); when it mixes with a guard at all (a guard is a
+    # runtime predicate the extractor deliberately treats as non-comparable, so
+    # a partial adapter restriction alongside it would over-claim); or when it
+    # mixes with a negated adapter under `||` (`current_adapter?(:A) ||
+    # !current_adapter?(:B)` is the complement of B, not A). A pure positive
+    # `||` (`A || B`) stays sound — it is the union the concat already
+    # collected. A pure CONJUNCTION with a feature (`if A && supports_X?`) is
+    # also sound: the test runs on `A ∩ supports_X?`, which the adapter set plus
+    # the feature gate expresses exactly — the same reasoning the
+    # negated-adapter branch below uses.
     mixed = !adapters.empty? &&
-            (!(acc[:features].empty? && acc[:guards].empty?) ||
+            (!acc[:guards].empty? ||
+             (!acc[:features].empty? && (acc[:has_or] || !positive)) ||
              (acc[:has_or] && !neg_adapters.empty?))
     if !adapters.empty? && !mixed
       gate[:adapters] = positive ? adapters : (ALL_ADAPTERS - adapters)

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -152,13 +152,14 @@ describe("gates.ts pure helpers", () => {
       source: ["test"],
     });
     // POSITIVE adapter + feature: `adapterType !== "mysql"` runs when true (a
-    // positive mysql set), and mixing a positive adapter set with a feature is
-    // unsound (`&&` vs `||` changes the run-on set), so the adapter set is
-    // dropped and only the feature survives — mirroring the Ruby extractor's
-    // `mixed` rule (positive `adapter_syms` + feature → drop the adapter set).
+    // positive mysql set). In the standard skip idiom the run condition is the
+    // pure conjunction `mysql && expression_index?`, so the intersection is
+    // exactly what runs — both dimensions survive, mirroring the Ruby
+    // extractor's `mixed` rule for `current_adapter?(…) && supports_X?`.
     expect(
       gateFromGuardExpr('adapterType !== "mysql" || !adapterSupports("expression_index")', false),
     ).toEqual({
+      adapters: ["mysql"],
       features: ["expression_index"],
       source: ["test"],
     });

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -165,6 +165,51 @@ describe("gates.ts pure helpers", () => {
     });
   });
 
+  it("drops the adapter set when the RUN condition is a disjunction", () => {
+    // `runIf(A || B)` runs on `mysql ∪ default_expression?` and the De Morgan
+    // twin `skipIf(A && B)` runs on the same union — neither is one adapter set,
+    // so the adapter half goes, mirroring the Ruby extractor's `has_or` rule.
+    expect(
+      gateFromGuardExpr('adapterType === "mysql" || adapterSupports("default_expression")', true),
+    ).toEqual({
+      features: ["default_expression"],
+      source: ["test"],
+    });
+    expect(
+      gateFromGuardExpr('adapterType !== "mysql" && !adapterSupports("default_expression")', false),
+    ).toEqual({
+      features: ["default_expression"],
+      source: ["test"],
+    });
+    // An adapter EXCLUSION is deliberately NOT tightened here — it is
+    // pre-existing behavior whose Ruby counterpart is looser still
+    // (foreign_key_test.rb:96 hides its second conjunct behind `send`, so Ruby
+    // emits the bare exclusion). Pinned so the scope stays explicit; tracked as
+    // `ts-gate-exclusion-ignores-run-disjunction`.
+    expect(
+      gateFromGuardExpr('adapterType === "sqlite" && !adapterSupports("insert_returning")', false),
+    ).toEqual({
+      adapters: ["mysql", "postgresql"],
+      features: ["insert_returning"],
+      source: ["test"],
+    });
+    // The conjunctive forms of the same two guards keep both dimensions.
+    expect(
+      gateFromGuardExpr('adapterType === "mysql" && adapterSupports("default_expression")', true),
+    ).toEqual({
+      adapters: ["mysql"],
+      features: ["default_expression"],
+      source: ["test"],
+    });
+    expect(
+      gateFromGuardExpr('adapterType !== "mysql" || !adapterSupports("default_expression")', false),
+    ).toEqual({
+      adapters: ["mysql"],
+      features: ["default_expression"],
+      source: ["test"],
+    });
+  });
+
   it("records a mariadb guard for isMariaDb terms, dropping nothing else", () => {
     // Guard-only: `it.skipIf(isMariaDb)` (mysql2-adapter.test.ts idiom).
     expect(gateFromGuardExpr("isMariaDb", false)).toEqual({

--- a/scripts/test-compare/gate-mismatch.test.ts
+++ b/scripts/test-compare/gate-mismatch.test.ts
@@ -80,4 +80,31 @@ describe("classifyGateMismatch", () => {
     // same adapter AND same feature → agree
     expect(classifyGateMismatch(pgJson, { ...pgJson, source: ["wrapper"] }, false)).toBeNull();
   });
+
+  it("compares the intersected set from a pure-`&&` adapter+feature condition", () => {
+    // view_test.rb:197 — `current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
+    // && supports_insert_returning?` under a mysql+postgresql class guard; the
+    // extractor now keeps the intersection instead of dropping the adapter half.
+    const railsGate: TestGate = {
+      adapters: ["postgresql"],
+      features: ["insert_returning", "views"],
+      source: ["class"],
+    };
+    // matching TS gate (`itIfSupports.skipIf(adapterType !== "postgres")`) agrees
+    expect(
+      classifyGateMismatch(railsGate, { ...railsGate, source: ["test", "wrapper"] }, false),
+    ).toBeNull();
+    // the pre-fix TS gate, which ran the test on MySQL too, is a wrong-gate
+    expect(
+      classifyGateMismatch(
+        railsGate,
+        {
+          adapters: ["mysql", "postgresql"],
+          features: ["insert_returning", "views"],
+          source: ["test", "wrapper"],
+        },
+        false,
+      ),
+    ).toBe("wrong-gate");
+  });
 });

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -139,10 +139,13 @@ export function gateFromWrapper(name: string, featureArg?: string | null): TestG
  *     conjunction `!sqlite && insert_returning?`, so BOTH the adapter exclusion
  *     `[mysql,postgresql]` and the feature set are sound and emitted.
  *   - POSITIVE (`adapterType !== "mysql" || !adapterSupports("expression_index")`)
- *     → mixing a positive adapter set with a feature is unsound (the run-on set
- *     differs under `&&` vs `||`), so the adapter set is DROPPED and only the
- *     feature set survives — exactly as Ruby drops a positive `adapter_syms` set
- *     whenever the condition also carries a feature or guard.
+ *     → the run condition is again a pure conjunction (`mysql && expression_index?`),
+ *     so the adapter set and the feature set are BOTH sound and emitted — the
+ *     intersection is exactly what runs. Mirrors Ruby keeping a positive
+ *     `adapter_syms` set alongside a feature in a pure `&&` condition.
+ *   - A `mariadb` GUARD is different: it is a runtime predicate neither side can
+ *     evaluate statically, so a positive adapter set mixed with one is dropped
+ *     rather than over-claiming a partial restriction (Ruby does the same).
  * Anything with neither adapter nor feature resolves to a `guards: ["unknown"]`
  * gate so the comparison knows the test is conditional without inventing an
  * adapter set.
@@ -191,9 +194,10 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   if (/isMaria[Dd]b\b/.test(text)) guards.push("mariadb");
 
   // The `mixed` rule (see the docstring): a POSITIVE adapter set is unsound and
-  // must be dropped once the compound also carries a feature or guard; an
-  // adapter EXCLUSION composes soundly and stays. Mirrors `gate_from_run_condition`.
-  const mixed = adapterIsPositive && (guards.length > 0 || featureMatches.length > 0);
+  // must be dropped once the compound also carries a non-comparable guard; an
+  // adapter EXCLUSION, and a positive set intersected with a feature, compose
+  // soundly and stay. Mirrors `gate_from_run_condition`.
+  const mixed = adapterIsPositive && guards.length > 0;
   const gate: TestGate = { source: ["test"] };
   if (adapters && !mixed) gate.adapters = adapters;
   if (featureMatches.length) gate.features = sortedUnique(featureMatches);

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -161,7 +161,8 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   // adapterType term is supported (the suite's idiom); the first is used. In the
   // standard skip idiom `skipIf(A || B || …)` (run iff every term is false) the
   // adapter term's contribution is evaluated in isolation — exactly the
-  // single-term polarity below — and likewise for `runIf(A && B && …)`.
+  // single-term polarity below — and likewise for `runIf(A && B && …)`. Any
+  // other shape makes the run-on set a disjunction; see `runIsDisjunctive`.
   const adapterMatch = text.match(/adapterType\s*(===|!==)\s*["']([a-z0-9]+)["']/);
   let adapters: GateAdapter[] | undefined;
   let adapterIsPositive = false;
@@ -193,11 +194,24 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   const guards: string[] = [];
   if (/isMaria[Dd]b\b/.test(text)) guards.push("mariadb");
 
-  // The `mixed` rule (see the docstring): a POSITIVE adapter set is unsound and
-  // must be dropped once the compound also carries a non-comparable guard; an
-  // adapter EXCLUSION, and a positive set intersected with a feature, compose
-  // soundly and stay. Mirrors `gate_from_run_condition`.
-  const mixed = adapterIsPositive && guards.length > 0;
+  // The TS twin of the Ruby extractor's `has_or`. The run condition is `expr`
+  // for `runIf` and `!expr` for `skipIf`, so the operator that makes the run-on
+  // set a DISJUNCTION differs by form: `||` under `runIf`, and (by De Morgan)
+  // `&&` under `skipIf`. Deliberately coarse and textual, like
+  // `scan_run_condition`, which sets `has_or` for a `||` anywhere in the
+  // condition sexp rather than only at the top level.
+  const runIsDisjunctive = runsWhenTrue ? text.includes("||") : text.includes("&&");
+
+  // The `mixed` rule (see the docstring): a POSITIVE adapter set is dropped when
+  // the compound carries a non-comparable guard, and — since the set is only
+  // sound as the INTERSECTION `adapter ∩ feature` — also when a feature rides
+  // along on a disjunctive run condition, where the real run-on set is the union
+  // `adapter ∪ feature`. That second clause is the twin of Ruby gating the same
+  // case on `!acc[:has_or]`. An adapter EXCLUSION is left alone here: it is
+  // pre-existing behavior with its own (looser) Ruby counterpart, tracked
+  // separately as `ts-gate-exclusion-ignores-run-disjunction`.
+  const mixed =
+    adapterIsPositive && (guards.length > 0 || (featureMatches.length > 0 && runIsDisjunctive));
   const gate: TestGate = { source: ["test"] };
   if (adapters && !mixed) gate.adapters = adapters;
   if (featureMatches.length) gate.features = sortedUnique(featureMatches);


### PR DESCRIPTION
## What

`extract-ruby-tests.rb`'s `mixed` rule dropped a POSITIVE adapter set whenever
the run condition also carried a feature predicate, reasoning that the
combinator could be `&&` or `||`. For a pure conjunction that is too
conservative: `A && supports_x?` runs on `A ∩ supports_x?`, which the gate
expresses exactly — the same argument the negated-adapter branch immediately
below already makes (`positive && !acc[:has_or]` → `base - neg_adapters`).

A positive adapter set now survives `mixed` when the condition is a pure
conjunction with a feature on the run-when-true path. It is still dropped:

- under `||` — the run-on set is a union no single adapter set captures;
- under `unless` — negation turns the conjunction into exactly that union;
- alongside a **guard** (`mariadb?`, `prepared_statements`) — a guard is a
  runtime predicate the extractor deliberately treats as non-comparable, so a
  partial adapter restriction next to one would over-claim.

`gates.ts` carries the mirrored rule for the TS side (`skipIf(A || B)` /
`runIf(A && B)` are likewise pure conjunctions on the run side).

The concrete miss this fixes — `vendor/rails/activerecord/test/cases/view_test.rb:197`:

```ruby
def test_insert_record_populates_primary_key
  ...
end if current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) && supports_insert_returning?
```

inside a `current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)`
class guard (view_test.rb:158). True run-on set: PostgreSQL only. It now
extracts `adapters=[postgresql] features=[insert_returning,views]` instead of
keeping only the class guard.

## Blast radius: exactly 3 gates on each side, pairwise

Re-running each extractor against `origin/main` and diffing every test's gate:

| Rails test | before | after |
| --- | --- | --- |
| `view_test.rb` insert_record_populates_primary_key | `adapters=[mysql,postgresql] features=[insert_returning,views]` | `adapters=[postgresql] features=[insert_returning,views]` |
| `dirty_test.rb` partial_insert_off_with_changed_composite_identity_primary_key_attribute | `features=[identity_columns]` | `adapters=[postgresql] features=[identity_columns]` |
| `migration/columns_test.rb` change_column_null_does_not_change_default_functions | `features=[default_expression]` | `adapters=[mysql] features=[default_expression]` |

3 of 22 910 Rails gates change; nothing else in any package moves. The TS
extractor changes exactly the 3 matching gates, so the two sides stay in
lockstep.

## TS gates brought to Rails' real run-on set

- `view.test.ts` — `insert record populates primary key`:
  `skipIf(adapterType === "sqlite")` → `skipIf(adapterType !== "postgres")`.
- `dirty.test.ts` — `partial insert off with changed composite identity primary
  key attribute`: `describeIfSupports("identity_columns", …)` →
  `describeIfPg(…)` + `itIfSupports("identity_columns", …)`, mirroring
  `if current_adapter?(:PostgreSQLAdapter) && supports_identity_columns?`.
- `migration/columns.test.ts` — no code change; its existing
  `adapterType !== "mysql"` term now survives the TS `mixed` rule and lines up
  with Rails' `adapters=[mysql]`.

**No runtime behavior changes.** Both edited gates were already unreachable off
PostgreSQL through the feature check alone — `identity_columns: ["postgres"]`
and `insert_returning: ["postgres", "sqlite"]` in `support/supports.ts`, with
`views` excluding SQLite. The edits make the *declared* gate say what the suite
was already doing, so the extracted metadata matches Rails.

Also refreshed a stale `supports.ts` note that still described the old
(adapter-dropping) rule and cited a line number that has since moved.

## Verification

- `pnpm test:compare --gates` output is **byte-identical** before/after: 0
  gate mismatches, unchanged totals (14824/22203). An intermediate run with only
  the Ruby side changed surfaced exactly the three `wrong-gate` entries above,
  confirming the new gates are the ones doing the work.
- New unit coverage: pure-`&&` adapter+feature in `extract-ruby-gates.test.ts`,
  including the real `view_test.rb` class-guard nesting and the `||` / `unless`
  counter-cases that must still drop the adapter set; the mirrored TS case in
  `extract-ts-gates.test.ts`; the classifier case in `gate-mismatch.test.ts`.
  The existing `prepared_statements` and `mariadb` guard tests still assert the
  drop, unchanged.
- `pnpm vitest run packages/activerecord/src/{dirty,view}.test.ts` passes.

## Review follow-up: `has_or` on the TS side

`gateFromGuardExpr` serves both `skipIf` and `runIf` and had no twin of the Ruby
extractor's `has_or`, so the new intersection rule fired on compounds whose run
condition is a **union**. Fixed: the run condition is `expr` for `runIf` and
`!expr` for `skipIf`, so the disjunction marker is `||` under `runIf` and (by De
Morgan) `&&` under `skipIf`. Both of the shapes raised in review now drop the
adapter side:

| guard | run-on set | extracted |
| --- | --- | --- |
| `runIf(adapterType === "mysql" \|\| adapterSupports("default_expression"))` | `mysql ∪ default_expression?` | `features=[default_expression]` |
| `skipIf(adapterType !== "mysql" && !adapterSupports("default_expression"))` | same union | `features=[default_expression]` |
| `runIf(adapterType === "mysql" && adapterSupports("default_expression"))` | `mysql ∩ default_expression?` | `adapters=[mysql] features=[default_expression]` |
| `skipIf(adapterType !== "mysql" \|\| !adapterSupports("default_expression"))` | same intersection | `adapters=[mysql] features=[default_expression]` |

The check is scoped to the positive-adapter-plus-feature case this PR
introduces. An adapter EXCLUSION under a disjunctive run condition is left
alone: it is pre-existing behavior whose Ruby counterpart is looser still.
`foreign_key_test.rb:96` reads
`current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && !@connection.send(:supports_rename_index?)`,
and `call_ident_name` cannot see through `send`, so Ruby records no feature,
`has_or` stays false, and it emits the bare exclusion `[postgresql,sqlite]` —
the two sides agree today only by matching error. Tightening one alone opens a
`wrong-gate` on `migration/foreign-key.test.ts` (verified: an unscoped version of
this check did exactly that). Filed as story
`0064/ts-gate-exclusion-ignores-run-disjunction`, with the current behavior
pinned by test so the scope is explicit rather than accidental.

Re-verified after the fix: still exactly 3 Rails gates and the 3 matching TS
gates changed, and `--gates` output is byte-identical to the `origin/main`
baseline.

## Rebased on #5585 — retires its stand-in workaround

PR #5585 landed while this was open and added a runtime `mariadbStandIn` guard
to the very test this PR fixes, with a note deferring to this story:

> The Ruby extractor drops that second adapter clause on a mixed adapter+feature
> condition (extract-ruby-tests.rb:629-640), so the narrowing cannot live in
> `skipIf` without reporting a wrong-gate. It rides `mariadbStandIn` instead […]
> Story ruby-gate-extractor-drops-conjoined-adapter-set moves this back into the
> `skipIf` once the extractor intersects the two clauses.

That is exactly what this PR does, so the workaround is removed: the narrowing
moves back into `skipIf(adapterType !== "postgres")`, and the `mariadbStandIn`
const — plus its lane-gated dynamic import of `mysql-server-version.js` — is
gone. #5585 also confirms the MariaDB exposure was real, not hypothetical.

Re-verified after the rebase against the **new** `origin/main`: `--gates` output
byte-identical, 0 gate mismatches, unchanged totals.

Closes-story: ruby-gate-extractor-drops-conjoined-adapter-set
