### PR TITLE
docs(activerecord): reconcile the repo-root sqlite audit with the fixture databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ coverage/
 
 # Sqlite databases whose config names a relative path: the sqlite3 lane's
 # fixture database (support/config.ts, Rails' FIXTURES_ROOT/fixture_database
-# .sqlite3) plus stray db/primary.sqlite3 etc. — never checked-in databases
+# .sqlite3) plus stray db/primary.sqlite3 etc. — never checked-in databases.
+# Load-bearing, not transitional: Rails gitignores its own pair in place
+# (activerecord/.gitignore:5, /test/fixtures/*.sqlite*), so this entry is what
+# makes the configured fixture databases a legitimate writer under db/.
 /db/

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -164,7 +164,18 @@ export const ARUNIT_DATABASE = "activerecord_unittest";
  * `<%= FIXTURES_ROOT %>/fixture_database.sqlite3`, a fixed file reused across
  * runs. trails has no `FIXTURES_ROOT` (see the module docs above), so the name
  * is relative and the sqlite driver resolves it against the working directory,
- * as it resolves any relative `database:`. `db/` is gitignored.
+ * as it resolves any relative `database:`.
+ *
+ * `db/` is the deliberate stand-in for `FIXTURES_ROOT`, not a leftover: Rails
+ * writes its pair into the checked-in `test/fixtures` directory and gitignores
+ * just the files (`activerecord/.gitignore:5`, `/test/fixtures/*.sqlite*`), so
+ * a gitignored directory holding exactly these two databases is the same
+ * arrangement with the one difference trails forces — no `FIXTURES_ROOT` to
+ * anchor the path to, hence repo-relative. The `/db/` entry in the root
+ * `.gitignore` is load-bearing for that and must stay. The trails-side fixture
+ * directory (`test-helpers/fixtures/`) is not the place for them: it is
+ * compiled source, and a generated binary inside `src/` would be swept by the
+ * build.
  *
  * It is a plain configured name on purpose: the previous spelling derived a
  * `<tmpdir>/ar-test-fallback-<run token>-<worker slot>.sqlite` path from the


### PR DESCRIPTION
Reconciles the RFC 0064 repo-root sqlite audit with the fixture databases PR #5600 configured.

`tests-materialize-sqlite-files-in-repo-root` was premised on nothing intentionally writing a sqlite file under the repo root, and ended with "reassess whether the `/db/` .gitignore entry is still needed". #5600 changed that: the sqlite3 lane's `arunit` / `arunit2` are now `db/fixture_database.sqlite3` and `db/fixture_database_2.sqlite3` (`support/config.ts`), the trails spelling of Rails' `<%= FIXTURES_ROOT %>/fixture_database.sqlite3` (`config.example.yml:83-91`).

**Decision: `db/` stays.** Rails writes its pair into the checked-in `test/fixtures` directory and gitignores just the files (`vendor/rails/activerecord/.gitignore:5` — `/test/fixtures/*.sqlite*`), so a gitignored directory holding exactly these two databases is the same arrangement; the only difference trails forces is that with no `FIXTURES_ROOT` the path is repo-relative. The alternative — `packages/activerecord/src/test-helpers/fixtures/` — is compiled source, and a generated binary under `src/` would be swept by the build. Both names therefore stay put in `support/config.ts`.

Changes here are the record of that decision:

- `support/config.ts` — `SQLITE_FIXTURE_DATABASE` docs now state why `db/` is the `FIXTURES_ROOT` analogue and that the `/db/` ignore is load-bearing.
- `.gitignore` — the `/db/` comment says it is load-bearing, not transitional, citing Rails' own ignore.

The draft story `tests-materialize-sqlite-files-in-repo-root` was updated in the tasks repo (`8ec845644`): its audit now exempts the configured fixture databases and the "remove the `/db/` ignore" step is replaced by "leave it in place".

Verified: `git status` is clean after a run that materializes the pair (`/db/` covers `.sqlite3`, `-wal`, `-shm`), and `connection.test.ts` / `config.test.ts` pass.

Closes-story: reconcile-repo-root-sqlite-audit-with-fixture-databases
