### PR TITLE
fix(activerecord): resolve rollback's migrations per database config

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -6,16 +6,6 @@ import { Base } from "../base.js";
 import type { MigrationProxy } from "../migration.js";
 import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
 
-/**
- * Trails-only: Rails covers this through `db:rollback:namespace works`
- * (`vendor/rails/railties/test/application/rake/multi_dbs_test.rb:827`), which
- * shells out to rake in a generated multi-database app — there is no rake here,
- * and `trailties`' `db rollback` builds its own Migrator per database rather
- * than calling `DatabaseTasks.rollback`. So the per-config migration set that
- * `rollback` hands to the Migrator is asserted directly against
- * `DatabaseTasks`, the way `migrate` resolves it (`database-tasks.ts`,
- * `connection_pool.rb:294-299`).
- */
 describe("DatabaseTasksRollbackTest", () => {
   afterEach(() => {
     DatabaseTasks.registerMigrations([]);
@@ -23,7 +13,7 @@ describe("DatabaseTasksRollbackTest", () => {
     try {
       Base.removeConnection();
     } catch {
-      /* no pool */
+      void 0;
     }
   });
 
@@ -54,8 +44,6 @@ describe("DatabaseTasksRollbackTest", () => {
     const primary = configs.find((c) => c.name === "primary")!;
     const animals = configs.find((c) => c.name === "animals")!;
 
-    // The fallback list stands in for another database's migrations: rollback
-    // must not reach for it once the pool's own config has a set registered.
     DatabaseTasks.registerMigrations([migration("1", "Fallback")]);
     DatabaseTasks.registerMigrations([migration("2", "PrimaryOnly")], primary);
     DatabaseTasks.registerMigrations([migration("3", "AnimalsOnly")], animals);

--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { DatabaseTasks } from "./database-tasks.js";
+import { DatabaseConfigurations } from "../database-configurations.js";
+import { SchemaMigration } from "../schema-migration.js";
+import { Base } from "../base.js";
+import type { MigrationProxy } from "../migration.js";
+import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
+
+/**
+ * Trails-only: Rails covers this through `db:rollback:namespace works`
+ * (`vendor/rails/railties/test/application/rake/multi_dbs_test.rb:827`), which
+ * shells out to rake in a generated multi-database app — there is no rake here,
+ * and `trailties`' `db rollback` builds its own Migrator per database rather
+ * than calling `DatabaseTasks.rollback`. So the per-config migration set that
+ * `rollback` hands to the Migrator is asserted directly against
+ * `DatabaseTasks`, the way `migrate` resolves it (`database-tasks.ts`,
+ * `connection_pool.rb:294-299`).
+ */
+describe("DatabaseTasksRollbackTest", () => {
+  afterEach(() => {
+    DatabaseTasks.registerMigrations([]);
+    DatabaseTasks.databaseConfiguration = null;
+    try {
+      Base.removeConnection();
+    } catch {
+      /* no pool */
+    }
+  });
+
+  it("rolls back the migrations registered for the pool's database", async () => {
+    const reverted: string[] = [];
+    const migration = (version: string, name: string): MigrationProxy => ({
+      version,
+      name,
+      migration: () =>
+        anonymousMigration(
+          name,
+          version,
+          async () => {},
+          async () => {
+            reverted.push(name);
+          },
+        ),
+    });
+
+    const env = DatabaseTasks.env;
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      [env]: {
+        primary: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+        animals: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+      },
+    });
+    const configs = DatabaseTasks.configsFor(env);
+    const primary = configs.find((c) => c.name === "primary")!;
+    const animals = configs.find((c) => c.name === "animals")!;
+
+    // The fallback list stands in for another database's migrations: rollback
+    // must not reach for it once the pool's own config has a set registered.
+    DatabaseTasks.registerMigrations([migration("1", "Fallback")]);
+    DatabaseTasks.registerMigrations([migration("2", "PrimaryOnly")], primary);
+    DatabaseTasks.registerMigrations([migration("3", "AnimalsOnly")], animals);
+
+    await Base.establishConnection(primary);
+    const schemaMigration = new SchemaMigration(await Base.connectionPool().leaseConnection());
+    await schemaMigration.createTable();
+    await schemaMigration.createVersion("2");
+
+    await DatabaseTasks.rollback();
+
+    expect(reverted).toEqual(["PrimaryOnly"]);
+    expect(await schemaMigration.versions()).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -396,10 +396,6 @@ export class DatabaseTasks {
     if (!this.databaseConfiguration) return;
     if (this.configsFor(this._normalizeEnv()).length === 0) return;
     const { Migrator } = await import("../migration.js");
-    // Rails' `db:rollback` rolls back through
-    // `migration_connection_pool.migration_context` (`connection_pool.rb:294-299`),
-    // so the migration set is the one belonging to that pool's db_config —
-    // not a process-global list shared across databases.
     const pool = await this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
     const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -394,12 +394,15 @@ export class DatabaseTasks {
   /** Roll back the last N migrations (default 1). Mirrors `db:rollback`. */
   static async rollback(steps: number = 1): Promise<void> {
     if (!this.databaseConfiguration) return;
-    const configs = this.configsFor(this._normalizeEnv());
-    if (configs.length === 0) return;
-    const config = configs.find((c) => c.name === "primary") ?? configs[0];
+    if (this.configsFor(this._normalizeEnv()).length === 0) return;
     const { Migrator } = await import("../migration.js");
-    const adapter = await this._migrationAdapter();
-    const migrator = new Migrator(adapter, this._migrations);
+    // Rails' `db:rollback` rolls back through
+    // `migration_connection_pool.migration_context` (`connection_pool.rb:294-299`),
+    // so the migration set is the one belonging to that pool's db_config —
+    // not a process-global list shared across databases.
+    const pool = await this.migrationConnectionPool();
+    const adapter = await pool.leaseConnection();
+    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
     await migrator.rollback(steps);
     adapter.schemaCache?.clear();
   }
@@ -1001,7 +1004,7 @@ export class DatabaseTasks {
     const pool = Base.connectionPool();
     const adapter = await pool.leaseConnection();
     const { Migrator } = await import("../migration.js");
-    const migrator = new Migrator(adapter, this._migrations);
+    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
     // Mirrors database_tasks.rb:302-305: abort unless schema_migrations exists.
     if (!(await migrator.schemaMigrationTableExists())) {
       throw new Error("Schema migrations table does not exist yet.");
@@ -1031,9 +1034,10 @@ export class DatabaseTasks {
    * (called by `rails db:version`).
    */
   static async currentVersion(): Promise<number> {
-    const adapter = await this._migrationAdapter();
+    const pool = await this.migrationConnectionPool();
+    const adapter = await pool.leaseConnection();
     const { Migrator } = await import("../migration.js");
-    const migrator = new Migrator(adapter, this._migrations);
+    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
     return migrator.currentVersionReadOnly();
   }
 


### PR DESCRIPTION
Rails' `db:rollback` rolls back through
`migration_connection_pool.migration_context`
(`vendor/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:294-299`),
so the migration set is the one belonging to that pool's
`db_config.migrations_paths` (`hash_config.rb:50-53`).

`DatabaseTasks.rollback` was still building its `Migrator` from the
process-global `_migrations` list — it predates the
`_migrationsFor(dbConfig)` seam added in #5584 and was left out of it
because it did not reach a config through a pool: it scanned
`configsFor(env)` for `"primary"` (else the first config) and then leased
an adapter via `_migrationAdapter()`, which returns no config. So in a
multi-database app — or one whose environments carry different
`migrationsPaths` — a rollback could run another database's migrations.

`rollback` now takes both its adapter and its config from
`migrationConnectionPool()`, exactly as `migrate` does, which also retires
the invented config scan: the pool already knows which database the
migration tasks run against.

`migrateStatus` and `currentVersion` were the two siblings still on the
global list with the config in reach (`migrateStatus` already held the
pool), so they get the same treatment.

### Test

No Rails counterpart is portable here: Rails covers this via
`db:rollback:namespace works`
(`railties/test/application/rake/multi_dbs_test.rb:827`), which shells out
to rake in a generated multi-database app, and `trailties`' `db rollback`
builds its own `Migrator` per database rather than calling
`DatabaseTasks.rollback`. The new trails test asserts the seam directly:
with a fallback list plus per-config sets registered, a rollback reverts
the pool database's own migration and never reaches for the fallback.
Fails on baseline (nothing reverted — the fallback list holds no migration
matching the applied version).

Closes-story: database-tasks-rollback-uses-global-migration-list
