### PR TITLE
fix(test-compare): drop an adapter exclusion under a disjunctive run condition

### DIFF
--- a/scripts/test-compare/extract-ruby-gates.test.ts
+++ b/scripts/test-compare/extract-ruby-gates.test.ts
@@ -182,6 +182,31 @@ describe("Ruby extractor gate detection", () => {
     });
   });
 
+  it("reads a supports_X? predicate reached through send", () => {
+    const g = rubyGates({
+      // Mirrors migration/foreign_key_test.rb:96 — `supports_rename_index?` is
+      // private, so the test reaches it via `send`. Without seeing through it the
+      // skip guard looks feature-free and emits an unsound `[postgresql,sqlite]`.
+      "cases/bar_test.rb": `
+        class BarTest < ActiveRecord::TestCase
+          def test_rename_index_send
+            skip "x" if current_adapter?(:Mysql2Adapter) && !@connection.send(:supports_rename_index?)
+          end
+          def test_send_only
+            skip "x" unless @connection.send(:supports_rename_index?)
+          end
+        end
+      `,
+    });
+    // The feature makes the compound `mixed`, so the adapter set is dropped; the
+    // skip-if polarity inverts the feature into a `no_` guard.
+    expect(g["rename index send"]).toEqual({
+      guards: ["no_rename_index"],
+      source: ["body-skip"],
+    });
+    expect(g["send only"]).toEqual({ features: ["rename_index"], source: ["body-skip"] });
+  });
+
   it("does not emit an adapter exclusion under `unless` (negation → disjunction)", () => {
     const g = rubyGates({
       // `unless feature && !sqlite` runs when `!feature || sqlite` — a disjunction

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -694,6 +694,17 @@ class TestExtractor
       elsif name =~ /\Asupports_.+\?\z/
         acc[:features] << name.sub(/\Asupports_/, "").sub(/\?\z/, "")
         return
+      elsif name == "send" || name == "public_send"
+        # `@connection.send(:supports_rename_index?)` (foreign_key_test.rb) — a
+        # feature predicate reached through `send` because it is private. Read the
+        # symbol argument so the feature is recorded, exactly as the direct call
+        # would be; otherwise the condition looks feature-free and a compound like
+        # `mysql? && !send(:supports_rename_index?)` emits an unsound adapter set.
+        syms = extract_symbol_args(node).grep(/\Asupports_.+\?\z/)
+        unless syms.empty?
+          syms.each { |s| acc[:features] << s.sub(/\Asupports_/, "").sub(/\?\z/, "") }
+          return
+        end
       elsif name == "prepared_statements" || name == "prepared_statements?"
         # A runtime predicate (per-connection config) the extractor cannot
         # evaluate statically. Recording it as a guard makes any compound that

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -165,7 +165,7 @@ describe("gates.ts pure helpers", () => {
     });
   });
 
-  it("drops the adapter set when the RUN condition is a disjunction", () => {
+  it("drops the adapter set, positive or exclusion, when the RUN condition is a disjunction", () => {
     // `runIf(A || B)` runs on `mysql ∪ default_expression?` and the De Morgan
     // twin `skipIf(A && B)` runs on the same union — neither is one adapter set,
     // so the adapter half goes, mirroring the Ruby extractor's `has_or` rule.
@@ -181,16 +181,28 @@ describe("gates.ts pure helpers", () => {
       features: ["default_expression"],
       source: ["test"],
     });
-    // An adapter EXCLUSION is deliberately NOT tightened here — it is
-    // pre-existing behavior whose Ruby counterpart is looser still
-    // (foreign_key_test.rb:96 hides its second conjunct behind `send`, so Ruby
-    // emits the bare exclusion). Pinned so the scope stays explicit; tracked as
-    // `ts-gate-exclusion-ignores-run-disjunction`.
+    // An adapter EXCLUSION goes the same way: `skipIf(sqlite && !insert_returning?)`
+    // runs when `!sqlite || insert_returning?`, so the test DOES run on SQLite
+    // wherever the feature holds and the `[mysql,postgresql]` exclusion is unsound.
     expect(
       gateFromGuardExpr('adapterType === "sqlite" && !adapterSupports("insert_returning")', false),
     ).toEqual({
-      adapters: ["mysql", "postgresql"],
       features: ["insert_returning"],
+      source: ["test"],
+    });
+    // foreign-key.test.ts:1130 — `skipIf(adapterType === "mysql" && !supportsRenameIndex)`
+    // runs when `!mysql || supportsRenameIndex`. Nothing but the adapter term is
+    // recognized, so dropping the exclusion leaves the `unknown` fallback —
+    // matching the Ruby side, which drops the same set once
+    // `send(:supports_rename_index?)` is seen.
+    expect(gateFromGuardExpr('adapterType === "mysql" && !supportsRenameIndex', false)).toEqual({
+      guards: ["unknown"],
+      source: ["test"],
+    });
+    // `runIf` mirrors it: the run condition is the expression itself, so `||` is
+    // what makes the exclusion unsound there.
+    expect(gateFromGuardExpr('adapterType !== "mysql" || supportsRenameIndex', true)).toEqual({
+      guards: ["unknown"],
       source: ["test"],
     });
     // The conjunctive forms of the same two guards keep both dimensions.

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -137,7 +137,11 @@ export function gateFromWrapper(name: string, featureArg?: string | null): TestG
  *     the De-Morgan'd skip form of Rails' `if supports_insert_returning? &&
  *     !current_adapter?(:SQLite3Adapter)`) → the run condition is the pure
  *     conjunction `!sqlite && insert_returning?`, so BOTH the adapter exclusion
- *     `[mysql,postgresql]` and the feature set are sound and emitted.
+ *     `[mysql,postgresql]` and the feature set are sound and emitted. When the
+ *     run condition is instead a DISJUNCTION (`skipIf(adapterType === "mysql" &&
+ *     !supportsRenameIndex)` runs when `!mysql || supportsRenameIndex`) the
+ *     exclusion is unsound — the test does run on the excluded adapter wherever
+ *     the other term holds — so it too is dropped.
  *   - POSITIVE (`adapterType !== "mysql" || !adapterSupports("expression_index")`)
  *     → the run condition is again a pure conjunction (`mysql && expression_index?`),
  *     so the adapter set and the feature set are BOTH sound and emitted — the
@@ -207,11 +211,14 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   // sound as the INTERSECTION `adapter ∩ feature` — also when a feature rides
   // along on a disjunctive run condition, where the real run-on set is the union
   // `adapter ∪ feature`. That second clause is the twin of Ruby gating the same
-  // case on `!acc[:has_or]`. An adapter EXCLUSION is left alone here: it is
-  // pre-existing behavior with its own (looser) Ruby counterpart, tracked
-  // separately as `ts-gate-exclusion-ignores-run-disjunction`.
-  const mixed =
-    adapterIsPositive && (guards.length > 0 || (featureMatches.length > 0 && runIsDisjunctive));
+  // case on `!acc[:has_or]`. An adapter EXCLUSION is sound only while the run
+  // condition stays a conjunction, so it is dropped whenever the condition is
+  // disjunctive — the test does run on the excluded adapter wherever the other
+  // term holds. That is the twin of Ruby's negated-adapter branch, likewise
+  // gated on `!acc[:has_or]`.
+  const mixed = adapterIsPositive
+    ? guards.length > 0 || (featureMatches.length > 0 && runIsDisjunctive)
+    : runIsDisjunctive;
   const gate: TestGate = { source: ["test"] };
   if (adapters && !mixed) gate.adapters = adapters;
   if (featureMatches.length) gate.features = sortedUnique(featureMatches);


### PR DESCRIPTION
`gateFromGuardExpr` kept an adapter **exclusion** even when the run condition was
a disjunction. `packages/activerecord/src/migration/foreign-key.test.ts:1130`:

```ts
it.skipIf(adapterType === "mysql" && !supportsRenameIndex)("rename reference column of child table", ...)
```

runs when `!mysql || supportsRenameIndex`, yet the extractor emitted
`adapters=[postgresql,sqlite]` — claiming the test never runs on MySQL when it
runs there wherever the feature holds.

## The rule

Rebased onto #5602, which introduced `runIsDisjunctive` (the TS twin of Ruby's
`has_or`) and scoped it to the positive-adapter case on purpose. This extends the
same predicate to the exclusion case — an exclusion is sound only while the run
condition stays a conjunction:

```ts
const mixed = adapterIsPositive
  ? guards.length > 0 || (featureMatches.length > 0 && runIsDisjunctive)
  : runIsDisjunctive;
```

That is the exact twin of Ruby's negated-adapter branch, already gated on
`!acc[:has_or]`, and it reuses #5602's deliberately coarse textual check rather
than adding a second, differently-precise notion of "disjunctive".

## Keeping both extractors in lockstep

Ruby agreed with the old TS answer only because it was wrong the same way:
`foreign_key_test.rb:96` reaches the *private* `supports_rename_index?` via
`@connection.send(...)`, which `call_ident_name` does not see through, so no
feature was recorded and the bare exclusion survived. `scan_run_condition` now
reads a `supports_X?` symbol argument of `send` / `public_send`, so the Ruby side
records the feature, trips `mixed`, and drops the same adapter set.

Both sides now:

| side  | before | after |
| ----- | ------ | ----- |
| Rails | `adapters=[postgresql,sqlite] features=[foreign_keys]` | `features=[foreign_keys] guards=[no_rename_index]` |
| TS    | `adapters=[postgresql,sqlite] features=[foreign_keys]` | `features=[foreign_keys] guards=[unknown]` |

`pnpm test:compare --gates` diffed against `origin/main` (post-#5602):
**identical**. Gate-mismatch stays at 0, and no other TS test matches the
exclusion-under-disjunction shape (`skipIf`/`runIf` with `adapterType` and a
top-level `&&` — one site suite-wide).

The other `send(:supports_` site in the Rails suite,
`abstract_mysql_adapter/connection_test.rb:188`, is an in-body `if`/`else`, not a
skip guard, so no gate shifts there — confirmed by the unchanged `--gates` output.

## Why the TS test keeps its local boolean

`supportsRenameIndex` comes from `support/mysql-server-version.js`, not from
`adapterSupports("rename_index")`. Switching the call site would make the TS gate
carry `features=[foreign_keys,rename_index]` while the Rails side inverts its
feature into `guards=[no_rename_index]` (skip-if polarity) and keeps
`features=[foreign_keys]` — a `wrong-gate`. The guard expression is left as-is
deliberately.

The pin #5602 left at "an adapter EXCLUSION is deliberately NOT tightened here"
is replaced by the tightened expectations, in the same test.

Closes-story: ts-gate-exclusion-ignores-run-disjunction
