### PR TITLE
fix(activerecord): strip the table name prefix in sqlite addForeignKey

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2431,12 +2431,8 @@ export class SchemaStatements {
     const prefix: string = adapter.tableNamePrefix ?? globalTableNamePrefix();
     const suffix: string = adapter.tableNameSuffix ?? globalTableNameSuffix();
     const str = String(tableName);
-    if (prefix || suffix) {
-      const re = new RegExp(`^${prefix}(.+)${suffix}$`);
-      const m = str.match(re);
-      if (m) return m[1];
-    }
-    return str;
+    const m = str.match(new RegExp(`${prefix}(.+)${suffix}`));
+    return m ? m[1] : str;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -32,4 +32,12 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
     expect(foreignKeys.length).toBe(1);
     expect(foreignKeys[0].toTable).toBe("p_rockets_s");
   });
+
+  it("reflects the singly prefixed table for a schema qualified toTable", async () => {
+    await adapter.addForeignKey("p_astronauts_s", "main.p_rockets_s", { column: "rocket_id" });
+
+    const foreignKeys = await adapter.foreignKeys("p_astronauts_s");
+    expect(foreignKeys.length).toBe(1);
+    expect(foreignKeys[0].toTable).toBe("p_rockets_s");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { Base } from "../base.js";
+
+// trails-only coverage: Rails' SQLite `add_foreign_key` strips the table name
+// prefix/suffix off `to_table` before `definition.foreign_key`
+// (sqlite3/schema_statements.rb:60), because `TableDefinition#foreign_key` ->
+// `new_foreign_key_definition` re-applies it. Rails' own
+// ForeignKeyTest#test_add_foreign_key_with_prefix passes unprefixed names, so it
+// never observes the double application; passing the real (already-prefixed)
+// table name — what the schema dumper emits — does.
+describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => {
+  let adapter: AbstractSQLite3Adapter;
+
+  beforeEach(async () => {
+    adapter = new BetterSQLite3Adapter(":memory:");
+    Base.tableNamePrefix = "p_";
+    Base.tableNameSuffix = "_s";
+    await adapter.createTable("p_rockets_s", { force: true }, (t) => {
+      t.string("name");
+    });
+    await adapter.createTable("p_astronauts_s", { force: true }, (t) => {
+      t.integer("rocket_id");
+    });
+  });
+
+  afterEach(async () => {
+    Base.tableNamePrefix = "";
+    Base.tableNameSuffix = "";
+    await adapter.dropTable("p_astronauts_s", "p_rockets_s", { ifExists: true });
+    await adapter.close();
+  });
+
+  it("reflects the singly prefixed table", async () => {
+    await adapter.addForeignKey("p_astronauts_s", "p_rockets_s", { column: "rocket_id" });
+
+    const foreignKeys = await adapter.foreignKeys("p_astronauts_s");
+    expect(foreignKeys.length).toBe(1);
+    expect(foreignKeys[0].toTable).toBe("p_rockets_s");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -3,13 +3,6 @@ import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { Base } from "../base.js";
 
-// trails-only coverage: Rails' SQLite `add_foreign_key` strips the table name
-// prefix/suffix off `to_table` before `definition.foreign_key`
-// (sqlite3/schema_statements.rb:60), because `TableDefinition#foreign_key` ->
-// `new_foreign_key_definition` re-applies it. Rails' own
-// ForeignKeyTest#test_add_foreign_key_with_prefix passes unprefixed names, so it
-// never observes the double application; passing the real (already-prefixed)
-// table name — what the schema dumper emits — does.
 describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => {
   let adapter: AbstractSQLite3Adapter;
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2192,7 +2192,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       }
     }
     await this.alterTable(fromTable, (definition) => {
-      definition.foreignKey(toTable, options);
+      // TableDefinition#foreignKey re-applies the table name prefix/suffix, so
+      // strip it here or a configured prefix lands on toTable twice.
+      definition.foreignKey(
+        this.schemaStatements().stripTableNamePrefixAndSuffix(toTable),
+        options,
+      );
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -20,6 +20,7 @@ import {
 } from "./abstract/native-database-types.js";
 import { TableDefinition as SQLite3TableDefinition } from "./sqlite3/schema-definitions.js";
 import {
+  assertValidDeferrable,
   dataSourceSql as sqliteDataSourceSql,
   extractValueFromDefault as sqliteExtractValueFromDefault,
   indexes as sqliteIndexes,
@@ -2182,6 +2183,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
+    assertValidDeferrable(options.deferrable);
+
     if (options.ifNotExists === true) {
       // foreignKeyExists routes through foreignKeyFor/isDefinedFor, which
       // compares `column` element-wise, so composite (array) columns match by
@@ -2192,8 +2195,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       }
     }
     await this.alterTable(fromTable, (definition) => {
-      // TableDefinition#foreignKey re-applies the table name prefix/suffix, so
-      // strip it here or a configured prefix lands on toTable twice.
       definition.foreignKey(
         this.schemaStatements().stripTableNamePrefixAndSuffix(toTable),
         options,

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -8,6 +8,7 @@
  * (via alterTable rebuild). The functions below delegate to the adapter.
  */
 
+import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import type { CheckConstraintDefinition } from "../abstract/schema-definitions.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
@@ -318,8 +319,8 @@ export function assertValidDeferrable(deferrable: unknown): void {
     deferrable === "deferred"
   )
     return;
-  throw new Error(
-    `deferrable must be "immediate" or "deferred", got: ${JSON.stringify(deferrable)}`,
+  throw new ArgumentError(
+    `deferrable must be \`"immediate"\` or \`"deferred"\`, got: \`${JSON.stringify(deferrable)}\``,
   );
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -9,20 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "add_foreign_key",
-    "call": "assert_valid_deferrable",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "add_foreign_key",
-    "call": "strip_table_name_prefix_and_suffix",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "alter_table",
     "call": "check_constraint",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/schema-statements.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
-    "rubyName": "add_foreign_key",
-    "call": "strip_table_name_prefix_and_suffix",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
     "rubyName": "assert_valid_deferrable",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

SQLite's `add_foreign_key` strips the table name prefix/suffix off `to_table`
before handing it to the definition, because `TableDefinition#foreign_key` ->
`new_foreign_key_definition` re-applies it
(`vendor/rails/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb:56-63`).
trails passed `toTable` straight through, so with a configured
`Base.tableNamePrefix` the prefix landed twice and the table rebuild failed with
`no such table: main.p_p_rockets`. `removeForeignKey` on the same adapter
already routed through `stripTableNamePrefixAndSuffix`, so the two halves
disagreed.

## Changes

- `sqlite3-adapter.ts` `addForeignKey` strips the prefix/suffix before
  `definition.foreignKey` (schema_statements.rb:60).
- Same method now calls `assertValidDeferrable(options.deferrable)`, the
  method's first line in Rails (schema_statements.rb:57). The ported helper
  already existed in `sqlite3/schema-statements.ts` but nothing wired it up.
- New trails-only regression test adding an FK under a configured prefix *and*
  suffix using the real (already-prefixed) table name — the shape the schema
  dumper emits, and the one Rails' own `add_foreign_key_with_prefix` never
  exercises since it passes unprefixed names. Fails on baseline with
  `SQLITE_ERROR` (`no such table: main.p_p_rockets_s`).

## Verification

- `migration/foreign-key.test.ts` green on sqlite (71 passed, 12 skipped),
  including `add foreign key with prefix` / `with suffix`.
- `sqlite3/schema-statements.test.ts` + the new file green.
- `pnpm api:compare` runs clean after a fresh build; `pnpm test:compare`
  Overall line is byte-identical to baseline (`14824/22203`, `762/1044` files,
  `198 misplaced`, `4018 extra`) — the `.trails.test.ts` file adds no extra
  surface.

Closes-story: sqlite-add-foreign-key-strips-table-name-prefix
