### PR TITLE
fix(activerecord): drop the invented ifNotExists guard in sqlite addForeignKey

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -14,6 +14,12 @@ import { AbstractAdapter } from "../abstract-adapter.js";
 import { ForeignKeyDefinition } from "./schema-definitions.js";
 import { fixtures } from "../../test-fixtures.js";
 import { ambientConnection, withRocketTables } from "../../support/rocket-tables.js";
+import { adapterType } from "../../test-adapter.js";
+
+// sqlite3/schema_statements.rb:56-63 overrides add_foreign_key without the
+// abstract `if_not_exists` short-circuit, so the guard's no-op behavior is
+// only observable on the adapters that use the abstract implementation.
+const guardsIfNotExists = adapterType !== "sqlite";
 
 let adapter: AbstractSQLite3Adapter | undefined;
 
@@ -413,18 +419,38 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(opts).toContain("ifNotExists");
   });
 
-  it("addForeignKey with ifNotExists is a no-op when the FK already exists", async () => {
-    const conn = await ambientConnection();
-    await withRocketTables(conn, async () => {
-      await conn.addForeignKey("astronauts", "rockets", { column: "rocket_id" });
-      const before = (await conn.foreignKeys("astronauts")).length;
-      await conn.addForeignKey("astronauts", "rockets", {
-        column: "rocket_id",
-        ifNotExists: true,
+  it.skipIf(!guardsIfNotExists)(
+    "addForeignKey with ifNotExists is a no-op when the FK already exists",
+    async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { column: "rocket_id" });
+        const before = (await conn.foreignKeys("astronauts")).length;
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          ifNotExists: true,
+        });
+        expect((await conn.foreignKeys("astronauts")).length).toBe(before);
       });
-      expect((await conn.foreignKeys("astronauts")).length).toBe(before);
-    });
-  });
+    },
+  );
+
+  it.skipIf(guardsIfNotExists)(
+    "addForeignKey with ifNotExists re-adds the FK on SQLite (no override guard)",
+    async () => {
+      const conn = await ambientConnection();
+      await withRocketTables(conn, async () => {
+        await conn.addForeignKey("astronauts", "rockets", { column: "rocket_id" });
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          ifNotExists: true,
+        });
+        const fks = await conn.foreignKeys("astronauts");
+        expect(fks.length).toBe(2);
+        expect(fks.every((fk) => fk.toTable === "rockets" && fk.column === "rocket_id")).toBe(true);
+      });
+    },
+  );
 
   it("addForeignKey with ifNotExists creates the FK when none exists", async () => {
     const conn = await ambientConnection();
@@ -454,38 +480,41 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     });
   });
 
-  it("addForeignKey with ifNotExists is a no-op when a composite FK already exists", async () => {
-    // The composite `column: [...]` must match the existing FK by value, not by
-    // array identity. foreignKeys() reports composite columns as arrays (Rails
-    // parity), and the ifNotExists guard routes through foreignKeyExists ->
-    // isDefinedFor for an element-wise compare.
-    const conn = await ambientConnection();
-    await conn.createTable("rockets", { force: true, primaryKey: ["tenant_id", "id"] }, (t) => {
-      t.integer("tenant_id");
-      t.integer("id");
-    });
-    await conn.createTable("astronauts", { force: true }, (t) => {
-      t.integer("rocket_id");
-      t.integer("rocket_tenant_id");
-    });
-    try {
-      await conn.addForeignKey("astronauts", "rockets", {
-        column: ["rocket_tenant_id", "rocket_id"],
-        primaryKey: ["tenant_id", "id"],
+  it.skipIf(!guardsIfNotExists)(
+    "addForeignKey with ifNotExists is a no-op when a composite FK already exists",
+    async () => {
+      // The composite `column: [...]` must match the existing FK by value, not by
+      // array identity. foreignKeys() reports composite columns as arrays (Rails
+      // parity), and the ifNotExists guard routes through foreignKeyExists ->
+      // isDefinedFor for an element-wise compare.
+      const conn = await ambientConnection();
+      await conn.createTable("rockets", { force: true, primaryKey: ["tenant_id", "id"] }, (t) => {
+        t.integer("tenant_id");
+        t.integer("id");
       });
-      expect((await conn.foreignKeys("astronauts"))[0].column).toEqual([
-        "rocket_tenant_id",
-        "rocket_id",
-      ]);
-      const before = (await conn.foreignKeys("astronauts")).length;
-      await conn.addForeignKey("astronauts", "rockets", {
-        column: ["rocket_tenant_id", "rocket_id"],
-        primaryKey: ["tenant_id", "id"],
-        ifNotExists: true,
+      await conn.createTable("astronauts", { force: true }, (t) => {
+        t.integer("rocket_id");
+        t.integer("rocket_tenant_id");
       });
-      expect((await conn.foreignKeys("astronauts")).length).toBe(before);
-    } finally {
-      await conn.dropTable("astronauts", "rockets", { ifExists: true });
-    }
-  });
+      try {
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: ["rocket_tenant_id", "rocket_id"],
+          primaryKey: ["tenant_id", "id"],
+        });
+        expect((await conn.foreignKeys("astronauts"))[0].column).toEqual([
+          "rocket_tenant_id",
+          "rocket_id",
+        ]);
+        const before = (await conn.foreignKeys("astronauts")).length;
+        await conn.addForeignKey("astronauts", "rockets", {
+          column: ["rocket_tenant_id", "rocket_id"],
+          primaryKey: ["tenant_id", "id"],
+          ifNotExists: true,
+        });
+        expect((await conn.foreignKeys("astronauts")).length).toBe(before);
+      } finally {
+        await conn.dropTable("astronauts", "rockets", { ifExists: true });
+      }
+    },
+  );
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -16,9 +16,6 @@ import { fixtures } from "../../test-fixtures.js";
 import { ambientConnection, withRocketTables } from "../../support/rocket-tables.js";
 import { adapterType } from "../../test-adapter.js";
 
-// sqlite3/schema_statements.rb:56-63 overrides add_foreign_key without the
-// abstract `if_not_exists` short-circuit, so the guard's no-op behavior is
-// only observable on the adapters that use the abstract implementation.
 const guardsIfNotExists = adapterType !== "sqlite";
 
 let adapter: AbstractSQLite3Adapter | undefined;
@@ -483,10 +480,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
   it.skipIf(!guardsIfNotExists)(
     "addForeignKey with ifNotExists is a no-op when a composite FK already exists",
     async () => {
-      // The composite `column: [...]` must match the existing FK by value, not by
-      // array identity. foreignKeys() reports composite columns as arrays (Rails
-      // parity), and the ifNotExists guard routes through foreignKeyExists ->
-      // isDefinedFor for an element-wise compare.
       const conn = await ambientConnection();
       await conn.createTable("rockets", { force: true, primaryKey: ["tenant_id", "id"] }, (t) => {
         t.integer("tenant_id");

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2183,17 +2183,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
+    // sqlite3/schema_statements.rb:56-63 is a full override of the abstract
+    // add_foreign_key: it has exactly these two statements, so the abstract
+    // `if_not_exists` short-circuit (abstract/schema_statements.rb:1174) does
+    // not apply on SQLite. `ifNotExists: true` falls through to the rebuild,
+    // which SQLite accepts even when an identical FK already exists.
     assertValidDeferrable(options.deferrable);
 
-    if (options.ifNotExists === true) {
-      // foreignKeyExists routes through foreignKeyFor/isDefinedFor, which
-      // compares `column` element-wise, so composite (array) columns match by
-      // value rather than by array identity (a bare `===` is always false for
-      // distinct array instances). Mirrors the abstract addForeignKey guard.
-      if (await this.foreignKeyExists(fromTable, toTable, { column: options.column })) {
-        return;
-      }
-    }
     await this.alterTable(fromTable, undefined, undefined, undefined, (definition) => {
       definition.foreignKey(
         this.schemaStatements().stripTableNamePrefixAndSuffix(toTable),

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2183,11 +2183,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
-    // sqlite3/schema_statements.rb:56-63 is a full override of the abstract
-    // add_foreign_key: it has exactly these two statements, so the abstract
-    // `if_not_exists` short-circuit (abstract/schema_statements.rb:1174) does
-    // not apply on SQLite. `ifNotExists: true` falls through to the rebuild,
-    // which SQLite accepts even when an identical FK already exists.
     assertValidDeferrable(options.deferrable);
 
     await this.alterTable(fromTable, undefined, undefined, undefined, (definition) => {


### PR DESCRIPTION
Rails's SQLite `add_foreign_key` (`sqlite3/schema_statements.rb:56-63`) is a full override of the abstract implementation with exactly two statements — `assert_valid_deferrable` then the `alter_table` block. It carries no `if_not_exists` short-circuit, so on SQLite `add_foreign_key(..., if_not_exists: true)` falls through to the table rebuild rather than no-opping (`foreign_key_test.rb:803` only asserts nothing raised).

trails carried a trails-only `ifNotExists` guard calling `foreignKeyExists` in the SQLite override (surfaced while porting the prefix-strip fix in #5606). It is an invention, and its extra reflection query is observable in query-count assertions, so this deletes it.

- Removed the guard; the comment at the call site names the Rails lines on both sides of the divergence.
- The two trails-invented no-op tests in `schema-statements-on-adapter.test.ts` assert the abstract guard's behavior, so they are now gated off SQLite.
- Added a SQLite-only case pinning the fall-through (the FK is re-added, giving two identical FKs — SQLite accepts this).

`migration/foreign-key.test.ts`, `migration/references-foreign-key.test.ts`, `schema-statements-on-adapter.test.ts`, and `schema-statements-privates.test.ts` pass locally on sqlite; pg/mysql via CI.

Closes-story: sqlite-add-foreign-key-if-not-exists-guard-is-not-in-rails
