### PR TITLE
refactor(activerecord): name the sqlite worker-clone arunit2 sibling explicitly

### DIFF
--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -139,9 +139,9 @@ describe("MultipleDbTest", () => {
   // Rails guards these two with `unless in_memory_db?` (multiple_db_test.rb): its
   // in-memory harness can't give arunit2 a genuinely separate pool, so College
   // would resolve to Base's connection. trails' arunit2 is always a genuinely
-  // separate pool — a provisioned database on PG/MySQL, the `_2` sibling
-  // file on sqlite (`sqliteSiblingDatabase`, `support/config.ts`) — so the assertions hold and we
-  // run them. This differs from the primary-class pair, which stay skipped
+  // separate pool — a provisioned database on PG/MySQL, the `_2` sibling file
+  // on sqlite (`sqliteSiblingDatabase`, `support/config.ts`) — so the
+  // assertions hold and we run them. This differs from the primary-class pair, which stay skipped
   // because `connects_to(arunit/arunit)` is *expected* to share Base's
   // connection — which independent in-memory DBs can't do.
   it("count on custom connection", async () => {

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -139,8 +139,8 @@ describe("MultipleDbTest", () => {
   // Rails guards these two with `unless in_memory_db?` (multiple_db_test.rb): its
   // in-memory harness can't give arunit2 a genuinely separate pool, so College
   // would resolve to Base's connection. trails' arunit2 is always a genuinely
-  // separate pool — a provisioned database on PG/MySQL, the `_arunit2` sibling
-  // file on sqlite (`support/arunit2-config.ts`) — so the assertions hold and we
+  // separate pool — a provisioned database on PG/MySQL, the `_2` sibling
+  // file on sqlite (`sqliteSiblingDatabase`, `support/config.ts`) — so the assertions hold and we
   // run them. This differs from the primary-class pair, which stay skipped
   // because `connects_to(arunit/arunit)` is *expected* to share Base's
   // connection — which independent in-memory DBs can't do.

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -7,6 +7,7 @@ import {
   mysqlUrl,
   postgresSettings,
   postgresUrl,
+  sqliteSiblingDatabase,
   withDatabase,
 } from "./config.js";
 import { activeLane, connectionName } from "./connection.js";
@@ -219,5 +220,19 @@ describe("config", () => {
     expect(config).not.toHaveProperty("password");
     expect(config).not.toHaveProperty("socket");
     expect(config).not.toHaveProperty("socketPath");
+  });
+
+  it("sqliteSiblingDatabase puts _2 before the extension, as config.example.yml spells it", () => {
+    expect(sqliteSiblingDatabase("db/fixture_database.sqlite3")).toBe(
+      "db/fixture_database_2.sqlite3",
+    );
+    expect(sqliteSiblingDatabase("/tmp/ar-test-worker-abc-1.sqlite")).toBe(
+      "/tmp/ar-test-worker-abc-1_2.sqlite",
+    );
+  });
+
+  it("sqliteSiblingDatabase appends _2 when the name carries no extension", () => {
+    expect(sqliteSiblingDatabase("/tmp/ar-test-worker-abc-1")).toBe("/tmp/ar-test-worker-abc-1_2");
+    expect(sqliteSiblingDatabase("/tmp/.hidden")).toBe("/tmp/.hidden_2");
   });
 });

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -183,6 +183,21 @@ export const SQLITE_FIXTURE_DATABASE = "db/fixture_database.sqlite3";
 export const SQLITE_FIXTURE_DATABASE_2 = "db/fixture_database_2.sqlite3";
 
 /**
+ * The `arunit2` sibling of a sqlite file database, spelled the way
+ * `config.example.yml:85,89` spells its pair: the same name with `_2` before
+ * the extension. Used for the per-worker template clone, whose primary name is
+ * stamped per run and so cannot be a checked-in constant like
+ * {@link SQLITE_FIXTURE_DATABASE_2}; the sibling is still an explicit file
+ * name rather than a suffix appended after the extension.
+ */
+export function sqliteSiblingDatabase(database: string): string {
+  const dot = database.lastIndexOf(".");
+  const slash = Math.max(database.lastIndexOf("/"), database.lastIndexOf("\\"));
+  if (dot <= slash + 1) return `${database}_2`;
+  return `${database.slice(0, dot)}_2${database.slice(dot)}`;
+}
+
+/**
  * The credential `config.example.yml` hard-codes on both `mysql2.arunit` and
  * `mysql2.arunit2` (`config.example.yml:4,24`), provisioned by
  * `db:mysql:build_user` (`activerecord/Rakefile:227-235`) — `CREATE USER`, no

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -115,10 +115,6 @@ describe("connect", () => {
     expect(envConfig.pool).toBe(5);
   });
 
-  // The worker clone is trails' stand-in for Rails' one already-prepared
-  // database, so its name carries the run token and worker slot — but its
-  // arunit2 is still an explicitly named sibling file, not a suffix appended
-  // after the extension.
   it("names an explicit sibling file for the worker clone's arunit2 entry", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker-abc-1.sqlite");

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -115,6 +115,21 @@ describe("connect", () => {
     expect(envConfig.pool).toBe(5);
   });
 
+  // The worker clone is trails' stand-in for Rails' one already-prepared
+  // database, so its name carries the run token and worker slot — but its
+  // arunit2 is still an explicitly named sibling file, not a suffix appended
+  // after the extension.
+  it("names an explicit sibling file for the worker clone's arunit2 entry", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker-abc-1.sqlite");
+    const { configurationHashes } = await testConfigurationHashes();
+    expect(configurationHashes.map((c) => c.database)).toEqual([
+      "/tmp/ar-test-worker-abc-1.sqlite",
+      "/tmp/ar-test-worker-abc-1_2.sqlite",
+      "/tmp/ar-test-worker-abc-1.sqlite",
+    ]);
+  });
+
   it("falls back to a file-backed sqlite DB when AR_TEST_WORKER_DB is unset", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -41,6 +41,7 @@ import {
   postgresSettings,
   SQLITE_FIXTURE_DATABASE,
   SQLITE_FIXTURE_DATABASE_2,
+  sqliteSiblingDatabase,
   type ConnectionName,
   type EnvReader,
   type ServerSettings,
@@ -249,11 +250,11 @@ function expandConfig(
   entries: Partial<Record<ArunitEntryName, Record<string, unknown>>>,
 ): HashConfig[] {
   const primaryDatabase = String(entries.arunit?.database ?? "");
-  const secondDatabase =
-    primaryDatabase === ":memory:" ? primaryDatabase : arunitDatabaseNames(primaryDatabase).arunit2;
+  // No `:memory:` special case: both sqlite lanes spell their two databases out
+  // in the builder, so this default is only ever reached by a server adapter.
   const defaultDatabase: Record<ArunitEntryName, string> = {
     arunit: primaryDatabase,
-    arunit2: secondDatabase,
+    arunit2: arunitDatabaseNames(primaryDatabase).arunit2,
     arunit_without_prepared_statements: primaryDatabase,
   };
 
@@ -332,9 +333,11 @@ export async function testConfigurationHashes(): Promise<{
  * `AR_TEST_WORKER_DB` is the per-worker template clone the setupFile publishes
  * (`support/sqlite-template.ts`) — trails' stand-in for Rails' one
  * already-prepared database, since vitest forks workers where Rails does not.
- * Only that clone leaves `arunit2` for `expandConfig` to derive; the configured
- * pair is spelled out here as the yml spells it, since `expand_config` fills a
- * `database` in only when the entry carries none (`support/config.rb:30-36`).
+ * Its `arunit2` is the clone path's `_2` sibling ({@link sqliteSiblingDatabase})
+ * rather than a checked-in constant, because the clone name carries the run
+ * token and worker slot. Either way both entries name their own file here, as
+ * the yml does, since `expand_config` fills a `database` in only when the entry
+ * carries none (`support/config.rb:30-36`).
  *
  * The directory is created because Rails' `test/fixtures` is checked in and
  * ours is a gitignored build output; sqlite will not create a missing parent
@@ -346,7 +349,7 @@ async function sqliteEntries(): Promise<Record<"arunit" | "arunit2", Record<stri
   if (workerDb) {
     return {
       arunit: { ...options, database: workerDb },
-      arunit2: { ...options, database: undefined },
+      arunit2: { ...options, database: sqliteSiblingDatabase(workerDb) },
     };
   }
   const fs = await getFsAsync();

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -250,8 +250,6 @@ function expandConfig(
   entries: Partial<Record<ArunitEntryName, Record<string, unknown>>>,
 ): HashConfig[] {
   const primaryDatabase = String(entries.arunit?.database ?? "");
-  // No `:memory:` special case: both sqlite lanes spell their two databases out
-  // in the builder, so this default is only ever reached by a server adapter.
   const defaultDatabase: Record<ArunitEntryName, string> = {
     arunit: primaryDatabase,
     arunit2: arunitDatabaseNames(primaryDatabase).arunit2,

--- a/packages/activerecord/src/support/sqlite-template.test.ts
+++ b/packages/activerecord/src/support/sqlite-template.test.ts
@@ -85,7 +85,7 @@ describe("sweepRunDbFiles", () => {
       seed(`ar-test-worker-${run}-1.sqlite`),
       seed(`ar-test-worker-${run}-1.sqlite-wal`),
       seed(`ar-test-worker-${run}-1.sqlite-shm`),
-      seed(`ar-test-worker-${run}-1.sqlite_arunit2`),
+      seed(`ar-test-worker-${run}-1_2.sqlite`),
       seed(`ar-test-animals-${run}-2.sqlite`),
     ]);
 

--- a/packages/activerecord/src/support/sqlite-template.ts
+++ b/packages/activerecord/src/support/sqlite-template.ts
@@ -94,7 +94,7 @@ export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
 /**
  * Shared filename prefix of every temp sqlite DB the AR test harness creates:
  * the template, the per-worker clones, the scratch databases
- * (`support/scratch-database.ts`) and their `_arunit2` siblings.
+ * (`support/scratch-database.ts`) and their `_2` arunit2 siblings.
  */
 export const TEMP_DB_PREFIX = "ar-test-";
 


### PR DESCRIPTION
`config.example.yml:83-91` gives both sqlite entries their own named file, and
`expand_config` fills `database` in only when the entry carries none
(`test/support/config.rb:30-36`). PR #5600 converged the configured path; the
per-worker template-clone path still left `arunit2` as `database: undefined`, so
`expandConfig` derived it through `arunitDatabaseNames()`'s `_arunit2` suffix —
`<tmpdir>/ar-test-worker-<token>-<slot>.sqlite_arunit2`, a name Rails never
produces and whose extension is mangled.

- `sqliteSiblingDatabase` (`support/config.ts`) spells the sibling the way the
  yml spells its pair: `_2` before the extension. The clone path uses it, since
  the clone name carries the run token and worker slot and so cannot be a
  checked-in constant.
- `expandConfig` no longer special-cases sqlite: both sqlite lanes supply both
  databases in the builder, so the `:memory:` ternary is gone and the default is
  only ever reached by a server adapter.
- The `sqlite-template.ts` token sweep still collects the sibling (it matches on
  the run token, which the `_2` name keeps); its test seeds the new name.

Closes-story: converge-sqlite-worker-clone-arunit2-sibling
