### PR TITLE
feat(eslint): translate a POSIX character class inside a bracket expression

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -552,7 +552,7 @@ function bracketSource(pattern, start, escapeChar) {
       if (pattern[i + 1] !== ":") return null;
       const end = pattern.indexOf(":]", i + 2);
       if (end === -1) return null;
-      const classSource = POSIX_CLASS_SOURCES[pattern.slice(i + 2, end)];
+      const classSource = POSIX_CLASS_SOURCES.get(pattern.slice(i + 2, end));
       // Every licensed spelling is a subset, so a negated class refuses; so does
       // a name not on the list (`[[:punct:]]`, a locale-extending complement, a
       // typo) and a class used as a range endpoint, which ARE rejects outright
@@ -627,17 +627,17 @@ const ARE_SHORTHANDS = new Set(["d", "w", "S"]);
  * never appear as a POSIX class name at all — the complement is spelled by
  * negating the bracket expression, which refuses wholesale (see `bracketSource`).
  */
-const POSIX_CLASS_SOURCES = {
-  alnum: "0-9A-Za-z",
-  alpha: "A-Za-z",
-  blank: " \\t",
-  digit: "\\d",
-  lower: "a-z",
-  space: " \\t\\n\\v\\f\\r",
-  upper: "A-Z",
-  word: "\\w",
-  xdigit: "0-9A-Fa-f",
-};
+const POSIX_CLASS_SOURCES = new Map([
+  ["alnum", "0-9A-Za-z"],
+  ["alpha", "A-Za-z"],
+  ["blank", " \\t"],
+  ["digit", "\\d"],
+  ["lower", "a-z"],
+  ["space", " \\t\\n\\v\\f\\r"],
+  ["upper", "A-Z"],
+  ["word", "\\w"],
+  ["xdigit", "0-9A-Fa-f"],
+]);
 
 /**
  * The JS regex source equivalent to the POSIX ERE `pattern`, or null when it

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -146,7 +146,10 @@
  * anchor, and a pattern that does not compile at all. A backslash inside a
  * bracket expression is read only in the `~` / `~*` spelling, where the engine
  * is known to be ARE and a bracketed `ARE_SHORTHANDS` member (`[\d]`) means what
- * the same shorthand means in a JS character class; anything else bracketed
+ * the same shorthand means in a JS character class; a bracketed POSIX character
+ * class translates through the subset spellings in `POSIX_CLASS_SOURCES`
+ * (`[[:digit:]]`), except under a negating `^`, where the complement of a subset
+ * would be wider; anything else bracketed
  * (`[\W]`, `[\b]`, `[\1]`, `[\\]`, a shorthand as a range endpoint) and every
  * backslash inside a `SIMILAR TO` bracket expression — whose interaction with
  * that grammar's `ESCAPE` character is unsettled — still refuses. Everything
@@ -468,9 +471,13 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * expression is unterminated or uses syntax whose JS meaning differs.
  *
  * The two halves overlap almost exactly — a leading `^` negates, `a-z` is a
- * range, a `]` in first position is a literal — but two do not, and both are
- * refused rather than guessed: a POSIX class/collating/equivalence element
- * (`[[:alpha:]]`, `[[.x.]]`, `[[=a=]]`) has no JS spelling, and a backslash
+ * range, a `]` in first position is a literal — but two do not. A POSIX
+ * character class translates only through `POSIX_CLASS_SOURCES`, whose ASCII
+ * spellings are subsets of what a non-C locale selects; a collating element or
+ * equivalence class (`[[.x.]]`, `[[=a=]]`) has no JS spelling at all and
+ * refuses. Because those spellings are subsets, a *negated* bracket expression
+ * refuses them: the complement of a subset is a superset, which would credit a
+ * name the filter does not select. And a backslash
  * means different things in the two grammars. Bare POSIX brackets read it as an
  * ordinary literal, but PostgreSQL's engine is ARE, which reads it as an escape
  * inside brackets too (`[\d]` is the digits, not a backslash and a `d`), so
@@ -520,8 +527,14 @@ function bracketSource(pattern, start, escapeChar) {
   if (BRACKET_STRUCTURAL.has(escapeChar)) return null;
   let source = "[";
   let i = start + 1;
+  // A `POSIX_CLASS_SOURCES` spelling is safe in a plain class and unsafe in a
+  // negated one: it is an ASCII subset of what a non-C locale selects, and the
+  // complement of a subset is a *superset*, which would credit a name the filter
+  // does not select. So a POSIX class refuses under `^`.
+  let negated = false;
   if (pattern[i] === "^") {
     source += "^";
+    negated = true;
     i++;
   }
   if (pattern[i] === "]") {
@@ -533,7 +546,24 @@ function bracketSource(pattern, start, escapeChar) {
   const bodyStart = source.length;
   for (; i < pattern.length && pattern[i] !== "]"; i++) {
     const ch = pattern[i];
-    if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) return null;
+    if (ch === "[" && ":.=".includes(pattern[i + 1] ?? "")) {
+      // A collating element (`[.ch.]`) or equivalence class (`[=a=]`) has no JS
+      // spelling at all, so only a character class can translate.
+      if (pattern[i + 1] !== ":") return null;
+      const end = pattern.indexOf(":]", i + 2);
+      if (end === -1) return null;
+      const classSource = POSIX_CLASS_SOURCES[pattern.slice(i + 2, end)];
+      // Every licensed spelling is a subset, so a negated class refuses; so does
+      // a name not on the list (`[[:punct:]]`, a locale-extending complement, a
+      // typo) and a class used as a range endpoint, which ARE rejects outright
+      // while JS's Annex B grammar would quietly read the `-` as a literal.
+      if (classSource === undefined || negated) return null;
+      if (source.endsWith("-") && source.length - 1 > bodyStart) return null;
+      if (pattern[end + 2] === "-" && (pattern[end + 3] ?? "]") !== "]") return null;
+      source += classSource;
+      i = end + 1;
+      continue;
+    }
     if (ch === "\\" && ch !== escapeChar) {
       source += "\\\\";
       continue;
@@ -574,6 +604,40 @@ function bracketSource(pattern, start, escapeChar) {
  * (`\Y` is ARE's *not* a word boundary, documented alongside the others).
  */
 const ARE_SHORTHANDS = new Set(["d", "w", "S"]);
+
+/**
+ * The JS character-class *body* fragment each licensed POSIX character class
+ * (`[[:digit:]]`) translates to inside a bracket expression, so
+ * `~ '^ex_[[:digit:]]'` can be translated rather than refused.
+ *
+ * This is the same argument `ARE_SHORTHANDS` records, read the other way round:
+ * ARE's class shorthands ARE these POSIX classes (`\d` is `[[:digit:]]`, `\w` is
+ * `[[:alnum:]_]`, `\s` is `[[:space:]]`), so the reasoning that licensed
+ * `[\d]` -> `\d` licenses `[[:digit:]]` -> `\d` too. A non-C database locale can
+ * extend every one of these past ASCII; the spellings here are all the ASCII
+ * reading, so each is a *subset* of what the filter selects and under-accepts at
+ * worst — never wider, which is the invariant that matters, since a wider
+ * matcher credits a name the filter does not select. (`digit` and `word` reuse
+ * the JS shorthands, which stay ASCII; the rest are spelled out because JS has
+ * no shorthand for them.)
+ *
+ * Every other class name refuses: `punct`, `graph`, `print`, `cntrl` and `ascii`
+ * are not spelled here because nothing needs them yet and each would need its
+ * own subset proof, and refusing costs only noise. Locale-extending complements
+ * never appear as a POSIX class name at all — the complement is spelled by
+ * negating the bracket expression, which refuses wholesale (see `bracketSource`).
+ */
+const POSIX_CLASS_SOURCES = {
+  alnum: "0-9A-Za-z",
+  alpha: "A-Za-z",
+  blank: " \\t",
+  digit: "\\d",
+  lower: "a-z",
+  space: " \\t\\n\\v\\f\\r",
+  upper: "A-Z",
+  word: "\\w",
+  xdigit: "0-9A-Fa-f",
+};
 
 /**
  * The JS regex source equivalent to the POSIX ERE `pattern`, or null when it

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -338,6 +338,39 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // A POSIX character class is what the ARE shorthands are defined as, so the
+    // listed ASCII spellings translate: each is a subset of what a non-C locale
+    // selects, so the matcher under-accepts at worst.
+    'await adapter.exec(`CREATE TABLE "ex_12" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:digit:]]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_a1" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename SIMILAR TO 'ex_[[:alnum:]]%'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    // A class alongside ordinary members and another class in the same
+    // expression, and one spelled out because JS has no shorthand for it.
+    'await adapter.exec(`CREATE TABLE "ex_-A" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[-[:upper:][:digit:]]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
+    'await adapter.exec(`CREATE TABLE "ex_ff" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:xdigit:]]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A static schema qualifier still leaves the interpolation in the name slot.
     'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
@@ -924,17 +957,92 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
     },
-    // A POSIX class element has no JS spelling, so it is refused, not guessed.
+    // A POSIX class name with no listed subset spelling is refused, not guessed.
     {
       code:
-        'await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+        'await adapter.exec(`CREATE TABLE "ex_." (id int)`);\n' +
         "const rows = await adapter.execute(\n" +
-        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:alpha:]]'`,\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:punct:]]'`,\n" +
         ");\n" +
         "for (const t of rows) {\n" +
         '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
         "}",
-      errors: [{ messageId: "missingTeardown", data: { table: "ex_int" } }],
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_." } }],
+    },
+    // Under a negating `^` the ASCII spelling is the *wider* of the two, so a
+    // POSIX class refuses there even when it translates unnegated.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^[:alpha:]]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_1" } }],
+    },
+    // A POSIX class as a range endpoint: ARE rejects it outright, while JS's
+    // Annex B grammar would read the `-` as a literal and credit `ex_-`.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_-" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:digit:]-a]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_-" } }],
+    },
+    // A collating element has no JS spelling at all, so it stays refused.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_c" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[.c.]]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_c" } }],
+    },
+    // An equivalence class likewise: JS cannot spell locale equivalence.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_a" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[=a=]]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_a" } }],
+    },
+    // An unterminated `[:` names no class, so the expression refuses.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_d" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:digit]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_d" } }],
+    },
+    // A translated class still credits only what it selects: `[[:digit:]]` does
+    // not select the underscore in `ex__`, so that create is still reported.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex__" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:digit:]]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex__" } }],
     },
     // A backslash inside a bracket expression is an escape to PostgreSQL's ARE
     // engine and a literal to bare POSIX. `[\d]` is read as the digits, so it

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -969,6 +969,19 @@ tester.run("require-table-teardown", rule, {
         "}",
       errors: [{ messageId: "missingTeardown", data: { table: "ex_." } }],
     },
+    // A class name that happens to name an `Object.prototype` property is still
+    // not a class name (`POSIX_CLASS_SOURCES` is a Map, not an object literal).
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_c" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[[:constructor:]]'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_c" } }],
+    },
     // Under a negating `^` the ASCII spelling is the *wider* of the two, so a
     // POSIX class refuses there even when it translates unnegated.
     {


### PR DESCRIPTION
`bracketSource` refused a bracket expression outright the moment a member opened
a POSIX class, collating element or equivalence class, so `~ '^ex_[[:digit:]]'`
and `SIMILAR TO 'ex_[[:alnum:]]%'` credited nothing and their creates were
reported as `missingTeardown` noise — the same under-acceptance #5597 removed for
a literal bracketed backslash.

A POSIX character class now translates through `POSIX_CLASS_SOURCES`, whose proof
sits next to `ARE_SHORTHANDS`: ARE's shorthands *are* the POSIX classes (`\d` is
`[[:digit:]]`, `\w` is `[[:alnum:]_]`), and the spellings listed are the ASCII
reading of each, so every one is a subset of what a non-C locale selects and
under-accepts at worst — never wider.

Still refused, each with the reason at the call site:

- any class name not listed (`[[:punct:]]`, `[[:graph:]]`, …) — nothing needs
  them and each would want its own subset proof;
- a class under a negating `^` — the complement of a subset is a *superset*,
  which would credit a name the filter does not select;
- a class as a range endpoint (`[[:digit:]-a]`) — ARE rejects it, JS's Annex B
  grammar would read the `-` as a literal;
- collating elements (`[[.c.]]`) and equivalence classes (`[[=a=]]`), which have
  no JS spelling at all, and an unterminated `[:`.

Rule tests pin the accepted names, each refusal, and a name the filter does not
select (`ex__` under `^ex_[[:digit:]]`). The four acceptance cases fail against
the rule on the merge base.

Closes-story: require-table-teardown-translate-posix-bracket-classes
