### PR TITLE
refactor(activerecord): build sqlite copy_table's CREATE TABLE from a TableDefinition

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2328,7 +2328,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // already raises StatementInvalid naming the table (foreign_key_test.rb:322).
     const fromPrimaryKey = await this.primaryKey(tableName);
     const sourceColumns = (await this.columns(tableName)) as Sqlite3Column[];
-    const definition = this.copyTableDefinition(tableName, fromPrimaryKey, sourceColumns, rename);
+    const definition = new SQLite3TableDefinition(tableName, {
+      id: false,
+      adapter: this,
+      ...(Array.isArray(fromPrimaryKey) ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
+    });
+    this.copyTableColumns(definition, fromPrimaryKey, sourceColumns, rename);
 
     // Attached before the block runs, as in Rails' alter_table lambda
     // (sqlite3_adapter.rb:566-583) — that ordering is what lets remove_column
@@ -2540,31 +2545,15 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     await this.execCopyTable(`DROP TABLE ${quoteTableName(from)}`);
   }
 
-  /**
-   * The `create_table(to, **options) do |definition| ... end` body of Rails'
-   * copy_table (sqlite3_adapter.rb:599-648): reflect the source table's columns
-   * and hand each one to the definition as *options*, so type resolution,
-   * default-expression quoting and primary-key handling all stay in
-   * schema_creation. alter_table shares it — its first move is copy_table's
-   * verbatim, and its second builds the same definition off the same reflection.
-   * @internal
-   */
-  private copyTableDefinition(
-    to: string,
+  /** @internal */
+  private copyTableColumns(
+    definition: SQLite3TableDefinition,
     fromPrimaryKey: string | string[] | null,
     sourceColumns: Sqlite3Column[],
     rename: Record<string, string> = {},
-    options: { temporary?: boolean } = {},
-  ): SQLite3TableDefinition {
+  ): void {
     const renamed = (name: string): string => rename[name] ?? name;
     const compositePk = Array.isArray(fromPrimaryKey);
-
-    const definition = new SQLite3TableDefinition(to, {
-      id: false,
-      adapter: this,
-      ...(options.temporary ? { temporary: true } : {}),
-      ...(compositePk ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
-    });
 
     for (const column of sourceColumns) {
       const columnOptions: Record<string, unknown> = {
@@ -2585,16 +2574,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         const deserialized: unknown = this.lookupCastTypeFromColumn(column).deserialize(
           column.default,
         );
-        // Rails: `default = -> { column.default_function } if default.nil?`. The
-        // extra `defaultFunction` guard is trails-only: quoteDefaultExpression
-        // rejects a callable returning null, where Ruby's `quote(nil)` yields NULL.
         columnOptions.default =
           deserialized == null && defaultFunction != null ? () => defaultFunction : deserialized;
       }
 
-      // Left null rather than coerced to "" for a typeless (BLOB affinity)
-      // column: typeToSql renders a null type as the empty string, matching
-      // Rails' `type_to_sql(nil)` -> `nil.to_s`, but rejects a blank string.
       const columnType = column.isVirtual()
         ? "virtual"
         : column.isBigint()
@@ -2602,33 +2585,41 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
           : column.type;
       definition.column(renamed(column.name), columnType as ColumnType, columnOptions);
     }
-
-    return definition;
   }
 
   /** @internal */
   private async copyTable(
     from: string,
     to: string,
-    options: { rename?: Record<string, string>; temporary?: boolean } = {},
+    options: {
+      rename?: Record<string, string>;
+      temporary?: boolean;
+      force?: boolean | "cascade";
+    } = {},
     block?: (definition: SQLite3TableDefinition) => void,
   ): Promise<void> {
     const fromPrimaryKey = await this.primaryKey(from);
     const rename = options.rename ?? {};
-    const definition = this.copyTableDefinition(
+    const renamed = (name: string): string => rename[name] ?? name;
+    const sourceColumns = (await this.columns(from)) as Sqlite3Column[];
+    const { rename: _rename, ...createOptions } = options;
+
+    let definition!: SQLite3TableDefinition;
+    await this.createTable(
       to,
-      fromPrimaryKey,
-      (await this.columns(from)) as Sqlite3Column[],
-      rename,
-      { temporary: options.temporary },
+      {
+        ...createOptions,
+        id: false,
+        ...(Array.isArray(fromPrimaryKey) ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
+      },
+      (td) => {
+        definition = td as SQLite3TableDefinition;
+        this.copyTableColumns(definition, fromPrimaryKey, sourceColumns, rename);
+        block?.(definition);
+      },
     );
 
-    block?.(definition);
-
-    await this.execCopyTable(await this.schemaCreation.accept(definition));
     await this.copyTableIndexes(from, to, rename);
-    // Rails: columns_to_copy rejects the columns whose options carry `:as` —
-    // generated columns are computed, never inserted into (sqlite3_adapter.rb:645).
     const columnsToCopy = definition.columns
       .filter((col) => (col.options as Record<string, unknown>)["as"] === undefined)
       .map((col) => col.name);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2562,7 +2562,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         scale: column.scale,
         null: column.null,
         collation: column.collation,
-        primaryKey: !compositePk && column.name === fromPrimaryKey,
+        primaryKey: !compositePk && renamed(column.name) === fromPrimaryKey,
       };
 
       if (column.isVirtual()) {
@@ -2600,7 +2600,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   ): Promise<void> {
     const fromPrimaryKey = await this.primaryKey(from);
     const rename = options.rename ?? {};
-    const renamed = (name: string): string => rename[name] ?? name;
     const sourceColumns = (await this.columns(from)) as Sqlite3Column[];
     const { rename: _rename, ...createOptions } = options;
 
@@ -2610,7 +2609,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       {
         ...createOptions,
         id: false,
-        ...(Array.isArray(fromPrimaryKey) ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
+        ...(Array.isArray(fromPrimaryKey) ? { primaryKey: fromPrimaryKey } : {}),
       },
       (td) => {
         definition = td as SQLite3TableDefinition;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2328,50 +2328,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // already raises StatementInvalid naming the table (foreign_key_test.rb:322).
     const fromPrimaryKey = await this.primaryKey(tableName);
     const sourceColumns = (await this.columns(tableName)) as Sqlite3Column[];
-    const compositePk = Array.isArray(fromPrimaryKey);
-
-    const definition = new SQLite3TableDefinition(tableName, {
-      id: false,
-      adapter: this,
-      ...(compositePk ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
-    });
-
-    for (const column of sourceColumns) {
-      const columnOptions: Record<string, unknown> = {
-        limit: column.limit,
-        precision: column.precision,
-        scale: column.scale,
-        null: column.null,
-        collation: column.collation,
-        primaryKey: !compositePk && column.name === fromPrimaryKey,
-      };
-
-      if (column.isVirtual()) {
-        columnOptions.as = column.defaultFunction;
-        columnOptions.stored = column.isVirtualStored();
-        columnOptions.type = column.type;
-      } else if (column.hasDefault && !column.autoIncrement) {
-        const defaultFunction = column.defaultFunction;
-        const deserialized: unknown = this.lookupCastTypeFromColumn(column).deserialize(
-          column.default,
-        );
-        // Rails: `default = -> { column.default_function } if default.nil?`. The
-        // extra `defaultFunction` guard is trails-only: quoteDefaultExpression
-        // rejects a callable returning null, where Ruby's `quote(nil)` yields NULL.
-        columnOptions.default =
-          deserialized == null && defaultFunction != null ? () => defaultFunction : deserialized;
-      }
-
-      // Left null rather than coerced to "" for a typeless (BLOB affinity)
-      // column: typeToSql renders a null type as the empty string, matching
-      // Rails' `type_to_sql(nil)` -> `nil.to_s`, but rejects a blank string.
-      const columnType = column.isVirtual()
-        ? "virtual"
-        : column.isBigint()
-          ? "bigint"
-          : column.type;
-      definition.column(renamed(column.name), columnType as ColumnType, columnOptions);
-    }
+    const definition = this.copyTableDefinition(tableName, fromPrimaryKey, sourceColumns, rename);
 
     // Attached before the block runs, as in Rails' alter_table lambda
     // (sqlite3_adapter.rb:566-583) — that ordering is what lets remove_column
@@ -2577,10 +2534,76 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     from: string,
     to: string,
     options: { rename?: Record<string, string>; temporary?: boolean } = {},
-    block?: (colDefs: string[]) => void,
+    block?: (definition: SQLite3TableDefinition) => void,
   ): Promise<void> {
     await this.copyTable(from, to, options, block);
     await this.execCopyTable(`DROP TABLE ${quoteTableName(from)}`);
+  }
+
+  /**
+   * The `create_table(to, **options) do |definition| ... end` body of Rails'
+   * copy_table (sqlite3_adapter.rb:599-648): reflect the source table's columns
+   * and hand each one to the definition as *options*, so type resolution,
+   * default-expression quoting and primary-key handling all stay in
+   * schema_creation. alter_table shares it — its first move is copy_table's
+   * verbatim, and its second builds the same definition off the same reflection.
+   * @internal
+   */
+  private copyTableDefinition(
+    to: string,
+    fromPrimaryKey: string | string[] | null,
+    sourceColumns: Sqlite3Column[],
+    rename: Record<string, string> = {},
+    options: { temporary?: boolean } = {},
+  ): SQLite3TableDefinition {
+    const renamed = (name: string): string => rename[name] ?? name;
+    const compositePk = Array.isArray(fromPrimaryKey);
+
+    const definition = new SQLite3TableDefinition(to, {
+      id: false,
+      adapter: this,
+      ...(options.temporary ? { temporary: true } : {}),
+      ...(compositePk ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
+    });
+
+    for (const column of sourceColumns) {
+      const columnOptions: Record<string, unknown> = {
+        limit: column.limit,
+        precision: column.precision,
+        scale: column.scale,
+        null: column.null,
+        collation: column.collation,
+        primaryKey: !compositePk && column.name === fromPrimaryKey,
+      };
+
+      if (column.isVirtual()) {
+        columnOptions.as = column.defaultFunction;
+        columnOptions.stored = column.isVirtualStored();
+        columnOptions.type = column.type;
+      } else if (column.hasDefault && !column.autoIncrement) {
+        const defaultFunction = column.defaultFunction;
+        const deserialized: unknown = this.lookupCastTypeFromColumn(column).deserialize(
+          column.default,
+        );
+        // Rails: `default = -> { column.default_function } if default.nil?`. The
+        // extra `defaultFunction` guard is trails-only: quoteDefaultExpression
+        // rejects a callable returning null, where Ruby's `quote(nil)` yields NULL.
+        columnOptions.default =
+          deserialized == null && defaultFunction != null ? () => defaultFunction : deserialized;
+      }
+
+      // Left null rather than coerced to "" for a typeless (BLOB affinity)
+      // column: typeToSql renders a null type as the empty string, matching
+      // Rails' `type_to_sql(nil)` -> `nil.to_s`, but rejects a blank string.
+      const columnType = column.isVirtual()
+        ? "virtual"
+        : column.isBigint()
+          ? "bigint"
+          : column.type;
+      definition.column(renamed(column.name), columnType as ColumnType, columnOptions);
+    }
+
+    return definition;
   }
 
   /** @internal */
@@ -2588,55 +2611,28 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     from: string,
     to: string,
     options: { rename?: Record<string, string>; temporary?: boolean } = {},
-    block?: (colDefs: string[]) => void,
+    block?: (definition: SQLite3TableDefinition) => void,
   ): Promise<void> {
-    const fromPk = await this.primaryKey(from);
-    const fromCols = await this.columns(from);
+    const fromPrimaryKey = await this.primaryKey(from);
     const rename = options.rename ?? {};
-    const pkCols: string[] = Array.isArray(fromPk) ? fromPk : fromPk ? [fromPk] : [];
-    const compositePk = pkCols.length > 1;
-    const colDefs: string[] = [];
-    const contentCols: string[] = [];
-    for (const col of fromCols) {
-      const sqlite3Col = col as Sqlite3Column;
-      const destName = rename[col.name] ?? col.name;
-      const sqlType = col.sqlTypeMetadata?.sqlType ?? "TEXT";
-      let def = `${quoteColumnName(destName)} ${sqlType}`;
-      if (col.collation) def += ` COLLATE ${quoteColumnName(col.collation)}`;
-      if (sqlite3Col.isVirtual()) {
-        // Re-emit the GENERATED clause so the copy stays a generated column
-        // (Rails copy_table passes as:/stored:/type: through to create_table).
-        def += ` GENERATED ALWAYS AS (${col.defaultFunction})`;
-        def += sqlite3Col.isVirtualStored() ? " STORED" : " VIRTUAL";
-      } else {
-        if (!compositePk && pkCols.includes(col.name)) def += " PRIMARY KEY";
-        if (!col.null) def += " NOT NULL";
-        if (!sqlite3Col.autoIncrement) {
-          if (col.default !== null && col.default !== undefined) {
-            def += ` DEFAULT ${this.quoteDefault(col.default)}`;
-          } else if (col.defaultFunction) {
-            // Rails swaps in `-> { column.default_function }` when the
-            // deserialized default is nil (sqlite3_adapter.rb:630), and a proc
-            // default is emitted raw by quote_default_expression. Without this
-            // a `DEFAULT CURRENT_TIMESTAMP` column loses its default in the copy.
-            def += ` DEFAULT ${col.defaultFunction}`;
-          }
-        }
-        // Generated columns are computed, never copied as content (Rails rejects
-        // columns whose options carry `:as`).
-        contentCols.push(destName);
-      }
-      colDefs.push(def);
-    }
-    if (compositePk) {
-      const renamedPks = pkCols.map((c) => rename[c] ?? c);
-      colDefs.push(`PRIMARY KEY(${renamedPks.map((n) => quoteColumnName(n)).join(", ")})`);
-    }
-    if (block) block(colDefs);
-    const prefix = options.temporary ? "CREATE TEMPORARY TABLE" : "CREATE TABLE";
-    await this.execCopyTable(`${prefix} ${quoteTableName(to)} (${colDefs.join(", ")})`);
+    const definition = this.copyTableDefinition(
+      to,
+      fromPrimaryKey,
+      (await this.columns(from)) as Sqlite3Column[],
+      rename,
+      { temporary: options.temporary },
+    );
+
+    block?.(definition);
+
+    await this.execCopyTable(await this.schemaCreation.accept(definition));
     await this.copyTableIndexes(from, to, rename);
-    await this.copyTableContents(from, to, contentCols, rename);
+    // Rails: columns_to_copy rejects the columns whose options carry `:as` —
+    // generated columns are computed, never inserted into (sqlite3_adapter.rb:645).
+    const columnsToCopy = definition.columns
+      .filter((col) => (col.options as Record<string, unknown>)["as"] === undefined)
+      .map((col) => col.name);
+    await this.copyTableContents(from, to, columnsToCopy, rename);
   }
 
   /** @internal */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -164,6 +164,13 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table",
+    "call": "collation",
+    "reason": "Satisfied by copyTableColumns, the extracted body of copy_table's create_table block; the wide gate is lexical per method, and these column reads sit alongside the already-baselined bigint?/column/limit/type reads from the same loop."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "copy_table",
     "call": "column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -171,8 +178,8 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table",
-    "call": "create_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "default",
+    "reason": "Satisfied by copyTableColumns, the extracted body of copy_table's create_table block; the wide gate is lexical per method, and these column reads sit alongside the already-baselined bigint?/column/limit/type reads from the same loop."
   },
   {
     "package": "activerecord",
@@ -199,14 +206,14 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table",
-    "call": "primary_keys",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "null",
+    "reason": "Satisfied by copyTableColumns, the extracted body of copy_table's create_table block; the wide gate is lexical per method, and these column reads sit alongside the already-baselined bigint?/column/limit/type reads from the same loop."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table",
-    "call": "reject",
+    "call": "primary_keys",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -215,6 +222,13 @@
     "rubyName": "copy_table",
     "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "copy_table",
+    "call": "virtual?",
+    "reason": "Satisfied by copyTableColumns, the extracted body of copy_table's create_table block; the wide gate is lexical per method, and these column reads sit alongside the already-baselined bigint?/column/limit/type reads from the same loop."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## What

`copyTable` no longer hand-concatenates column SQL. It now mirrors Rails'
`copy_table` (`sqlite3_adapter.rb:599-648`): `options[:id] = false`, then
`create_table(to, **options)` with a block that reflects the source table's
columns onto the definition, so type resolution, default-expression quoting and
primary-key handling all happen in `schema_creation`.

`alterTable` already carried the Rails column-options loop verbatim (#5527), so
the loop lives in one shared private helper and both callers use it.

Consequences, all subsumed by the convergence:

- Column options travel as options (`limit`, `precision`, `scale`, `null`,
  `collation`, `primaryKey`, `as`/`stored`, `default`) instead of pre-rendered
  `COLLATE` / `PRIMARY KEY` / `NOT NULL` / `DEFAULT` / `GENERATED ALWAYS AS`
  fragments.
- Defaults go through `lookupCastTypeFromColumn(column).deserialize(...)` with
  the `-> { column.default_function }` substitution instead of reading
  `col.default` / `col.defaultFunction` off the reflected column.
- Composite PKs come from the definition's `primaryKey`, not a trailing
  `PRIMARY KEY(...)` string.
- `temporary:` and `force:` reach `create_table` as Rails passes them, rather
  than a hand-picked `CREATE TEMPORARY TABLE` prefix and a dropped `force`.
- `columnsToCopy` is derived from the definition, rejecting `as:` columns, as
  Rails does.

## Compare gates

- `api:compare`: no new extra surface (the shared helper is private
  `@internal`); `copy_table` drops out of `call-mismatches.json` now that the
  port calls `create_table` the way Rails does. No ported method removed or
  renamed.
- `test:compare`: no test files touched — delta 0.

## Testing

Green locally on sqlite3, both the file and `sqlite3_mem` lanes:
`adapters/sqlite3/` (incl. `copy-table.test.ts`), `connection-adapters/` (incl.
`sqlite3-introspection.test.ts`), `migration/`, `migration.test.ts`,
`schema-dumper.test.ts`. Typeless (BLOB-affinity) round-trip stays covered by
the existing collation/introspection tests.

Closes-story: sqlite-copy-table-hand-builds-create-table-instead-of-definition

## Review follow-up (both comments fixed)

- `copyTableColumns` now compares the **renamed** name against the source PK
  (`primaryKey: renamed(column.name) === fromPrimaryKey`), matching
  `column_name == from_primary_key` at `sqlite3_adapter.rb:608-620`. Rails' own
  consequence — renaming a single PK column drops the PK from the copy — is
  reproduced rather than papered over; Rails' only PK-rename test
  (`test_mysql_rename_column_preserves_auto_increment`) is MySQL-gated, so
  SQLite has no coverage asserting otherwise.
- `copyTable` passes the composite PK array **unrenamed**
  (`primaryKey: fromPrimaryKey`), matching `@definition.primary_keys
  from_primary_key` at `sqlite3_adapter.rb:602-606`.

`alterTable`'s own definition keeps `fromPrimaryKey.map(renamed)`, and that is
not the same call: Rails' `alter_table` passes `:rename` to the **first**
`move_table` only, so its second `copy_table` reflects the buffer and its
`from_primary_key` is already the renamed name (`sqlite3_adapter.rb:586-592`).
trails' documented deviation is that the second definition is re-derived from
the source reflection instead of the buffer, so `.map(renamed)` is what stands
in for `primary_key(buffer)` there. The two differ only when a PK member is
renamed, which now fails in the first move exactly as it does in Rails.

## Wide call-gate rebaseline

The wide call ratchet is lexical per method, so moving copy_table's column loop
into `copyTableColumns` made `copy_table` "lose" four column reads it still
makes: `collation`, `default`, `null`, `virtual?`. They join their siblings from
the same loop (`bigint?`, `column`, `limit`, `type`,
`lookup_cast_type_from_column`, `deserialize`, `primary_keys`), which were
already baselined, with a reason naming the extraction.

Two entries were **removed** — `copy_table → create_table` and
`copy_table → reject` — both genuinely converged by this PR, which is the point
of the change.
