### PR TITLE
feat(activerecord): port ColumnMethods#primary_key onto TableDefinition and Table

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -4,6 +4,7 @@ import {
   CheckConstraintDefinition,
   ReferenceDefinition,
   TableDefinition,
+  Table,
   type ReferenceDefinitionConnection,
 } from "./schema-definitions.js";
 import { SchemaDumper } from "../../schema-dumper.js";
@@ -207,5 +208,42 @@ describe("TableDefinition column methods", () => {
     expect(() => (td.string as (o: object) => unknown)({ limit: 40 })).toThrow(
       "Missing column name(s) for string",
     );
+  });
+});
+
+describe("ColumnMethods#primary_key", () => {
+  it("merges primary_key: true and honours the type argument on create_table", () => {
+    const td = new TableDefinition("posts", { id: false });
+    td.primaryKey("id", "uuid", { default: "gen_random_uuid()" });
+
+    expect(td.columns.map((c) => c.name)).toEqual(["id"]);
+    expect(td.columns[0].type).toBe("uuid");
+    expect(td.columns[0].options.primaryKey).toBe(true);
+    expect(td.columns[0].options.default).toBe("gen_random_uuid()");
+  });
+
+  it("defaults the type to primary_key", () => {
+    const td = new TableDefinition("posts", { id: false });
+    td.primaryKey("id");
+
+    expect(td.columns[0].type).toBe("primary_key");
+    expect(td.columns[0].options.primaryKey).toBe(true);
+  });
+
+  it("adds a primary key column through change_table", async () => {
+    const calls: unknown[][] = [];
+    const schema = {
+      addColumn: (...args: unknown[]) => {
+        calls.push(args);
+        return Promise.resolve();
+      },
+    } as unknown as ConstructorParameters<typeof Table>[1];
+    const t = new Table("delete_me", schema);
+
+    await t.primaryKey("id", "primary_key", { comment: "Primary key comment" });
+
+    expect(calls).toEqual([
+      ["delete_me", "id", "primary_key", { comment: "Primary key comment", primaryKey: true }],
+    ]);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1109,6 +1109,10 @@ export class TableDefinition {
     return name === "timestamp" ? "datetime" : fallback;
   }
 
+  primaryKey(name: string, type: ColumnType = "primary_key", options: ColumnOptions = {}): this {
+    return this.column(name, type, { ...options, primaryKey: true });
+  }
+
   column(
     name: string,
     type: ColumnType,
@@ -1747,8 +1751,12 @@ export class Table {
     return this._require("isCheckConstraintExists").call(this._schema, this._tableName, options);
   }
 
-  async primaryKey(): Promise<string | string[] | null> {
-    return this._require("primaryKey").call(this._schema, this._tableName);
+  async primaryKey(
+    name: string,
+    type: ColumnType = "primary_key",
+    options: ColumnOptions = {},
+  ): Promise<void> {
+    await this.column(name, type, { ...options, primaryKey: true });
   }
 
   async add(columnName: string, type: ColumnType, options?: ColumnOptions): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -319,15 +319,6 @@ export class Table extends AbstractTable {
     super(tableName, schema);
   }
 
-  /**
-   * Returns the primary key column name for this table.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Table#primary_key
-   */
-  override async primaryKey(): Promise<string | string[] | null> {
-    return super.primaryKey();
-  }
-
   // Mirrors the column-type methods MySQL::ColumnMethods mixes into both
   // TableDefinition and Table. The `unsigned_<type>` type is normalized to its
   // base type + `unsigned: true` by MySQL::TableDefinition#newColumnDefinition


### PR DESCRIPTION
Resolves RFC 0005 story `port-column-methods-primary-key-helper` (surfaced in #5570 review).

Rails defines `primary_key` on `ColumnMethods` separately from `define_column_methods` (`vendor/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:306-309`):

```ruby
def primary_key(name, type = :primary_key, **options)
  column(name, type, **options.merge(primary_key: true))
end
```

trails had no faithful path for `t.primary_key("id", "uuid")` — the type argument and the `primary_key: true` merge were both unreachable.

- `TableDefinition.primaryKey(name, type = "primary_key", options)` delegates to `column()` with `{ ...options, primaryKey: true }` (create_table side).
- `Table.primaryKey` (the change_table proxy) gets the same signature, delegating to its own async `column()` → `addColumn`.

**Name clash resolved by deleting a trails invention.** `Table.primaryKey()` was an async reader returning the table's PK name, and `MySQL::Table` overrode it with a body that only called `super` under a `Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Table#primary_key` claim. Rails' `Table` (schema_definitions.rb:716-957) and `MySQL::Table` (`mysql/schema_definitions.rb`) have no such method — the only `primary_key` either exposes is the `ColumnMethods` helper. Neither reader had a caller in `packages/` (the `adapter.primaryKey()` / `Model.primaryKey` call sites are unrelated surfaces), so both are removed rather than renamed.

`NON_COLUMN_METHOD_TYPES` in `migration/command-recorder.ts` is untouched: the dedicated method must keep being excluded from the generic `define_column_methods` shorthand set, which is exactly what makes these real methods reachable through the change_table proxy.

Tests (three cases in `schema-definitions.trails.test.ts`, the trails-only companion): the type argument and merge take effect on create_table, the type defaults to `primary_key`, and change_table forwards `["delete_me", "id", "primary_key", { comment: …, primaryKey: true }]` to `addColumn` — mirroring `change_table_test.rb:118-123`, which asserts the same `add_column` shape (Rails' `first: true` swapped for `comment:`, since column positioning is not a ported `ColumnOptions` key).

Local runs: `schema-definitions.trails`, `abstract/schema-definitions`, `mysql/schema-creation`, `sqlite3/schema-definitions`, `migration/command-recorder`, `migration/change-schema`, `migration/columns` — 245 passed, 7 skipped. `api:compare` unchanged at 11741/17536 (data layer 98.8%); eslint clean on all three files.
