### PR TITLE
fix(api-compare): preserve interface metadata when a namespace of the same name merges

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1563,6 +1563,25 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     expect(report.tagged).toEqual({ total: 0, matched: 0, inheritedMatched: 1, stale: [] });
   });
 
+  it("does not extend a merged interface's tag to the namespace half's members", () => {
+    const m = makeManifests();
+    m.ts.packages.activemodel.modules.Shape = {
+      name: "Shape",
+      file: "foo.ts",
+      includes: [],
+      extends: [],
+      instanceMethods: [method("tsOnlyHelper"), method("namespaceFn")],
+      classMethods: [],
+      isInterface: true,
+      interfaceMembers: ["tsOnlyHelper"],
+      noRailsEquivalent: "duck-typed collaborator shape",
+    };
+    const report = run(m);
+    expect(report.packages[0].totalAllowlisted).toBe(1);
+    expect(report.packages[0].totalNovel).toBe(1);
+    expect(report.tagged.inheritedMatched).toBe(1);
+  });
+
   it("does not judge tags of packages this run never scanned", () => {
     const report = buildReport(
       makeManifests("no counterpart").ruby,

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -352,10 +352,6 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
         // have Ruby counterparts, so inheriting there would mask real drift.
         // A member's own tag still wins — members are pushed first.
         if (c.isInterface === true && c.noRailsEquivalent !== undefined) {
-          // Scoped to the interface's OWN members: when an `interface Foo` is
-          // declaration-merged with a `namespace Foo` they share this entry, and
-          // the namespace's members are real exported functions whose Ruby
-          // counterparts must keep being demanded.
           const covered = c.interfaceMembers;
           for (const m of c.instanceMethods) {
             if (covered && !covered.includes(m.name)) continue;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -352,7 +352,15 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
         // have Ruby counterparts, so inheriting there would mask real drift.
         // A member's own tag still wins — members are pushed first.
         if (c.isInterface === true && c.noRailsEquivalent !== undefined) {
-          for (const m of c.instanceMethods) push(pkg, c.file, m.name, c.noRailsEquivalent, true);
+          // Scoped to the interface's OWN members: when an `interface Foo` is
+          // declaration-merged with a `namespace Foo` they share this entry, and
+          // the namespace's members are real exported functions whose Ruby
+          // counterparts must keep being demanded.
+          const covered = c.interfaceMembers;
+          for (const m of c.instanceMethods) {
+            if (covered && !covered.includes(m.name)) continue;
+            push(pkg, c.file, m.name, c.noRailsEquivalent, true);
+          }
         }
       }
     }

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2112,3 +2112,40 @@ describe("extract-ts-api — MethodInfo emit-site inventory", () => {
     );
   });
 });
+
+describe("extractFromProgram — interface merged with a namespace of the same name", () => {
+  const IFACE = `
+    /** @noRailsEquivalent duck-typed collaborator shape */
+    export interface Locator {
+      locate(gid: unknown): unknown;
+    }
+  `;
+  const NAMESPACE = `
+    export namespace Locator {
+      export function use(name: string): void {}
+    }
+  `;
+
+  const entry = (source: string): ClassInfo => {
+    const info = extractFromFiles("/p", { "locator.ts": source });
+    return info.modules["locator.ts:Locator"];
+  };
+
+  it("keeps the interface's metadata when the namespace is declared last", () => {
+    const merged = entry(`${IFACE}\n${NAMESPACE}`);
+
+    expect(merged.isInterface).toBe(true);
+    expect(merged.noRailsEquivalent).toBe("duck-typed collaborator shape");
+    expect(merged.instanceMethods.map((m) => m.name).sort()).toEqual(["locate", "use"]);
+    expect(merged.interfaceMembers).toEqual(["locate"]);
+  });
+
+  it("keeps the interface's metadata when the namespace is declared first", () => {
+    const merged = entry(`${NAMESPACE}\n${IFACE}`);
+
+    expect(merged.isInterface).toBe(true);
+    expect(merged.noRailsEquivalent).toBe("duck-typed collaborator shape");
+    expect(merged.instanceMethods.map((m) => m.name).sort()).toEqual(["locate", "use"]);
+    expect(merged.interfaceMembers).toEqual(["locate"]);
+  });
+});

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -506,6 +506,13 @@ export function extractFromProgram(
           // declarations; without this the reason is lost whenever the tagged
           // half is not the first one walked.
           existing.noRailsEquivalent ??= extracted.noRailsEquivalent;
+          existing.isInterface = true;
+          existing.interfaceMembers = [
+            ...new Set([
+              ...(existing.interfaceMembers ?? []),
+              ...(extracted.interfaceMembers ?? []),
+            ]),
+          ];
         } else {
           info.modules[modKey] = extracted;
         }
@@ -514,7 +521,17 @@ export function extractFromProgram(
         if (!isExported(node)) return;
         const name = node.name.text;
         const modKey = `${relPath}:${name}`;
-        info.modules[modKey] = extractNamespace(node, checker, relPath);
+        const extracted = extractNamespace(node, checker, relPath);
+        const existing = info.modules[modKey];
+        if (existing) {
+          const existingNames = new Set(existing.instanceMethods.map((m) => m.name));
+          for (const m of extracted.instanceMethods) {
+            if (!existingNames.has(m.name)) existing.instanceMethods.push(m);
+          }
+          existing.noRailsEquivalent ??= extracted.noRailsEquivalent;
+        } else {
+          info.modules[modKey] = extracted;
+        }
         fileHasClassOrModule = true;
       } else if (ts.isExportDeclaration(node)) {
         // Handle `export * as Foo from "./bar.js"` — namespace re-exports
@@ -1989,6 +2006,7 @@ function extractInterface(
     instanceMethods,
     classMethods: [],
     isInterface: true,
+    interfaceMembers: instanceMethods.map((m) => m.name),
     ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
   };
 }

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -127,6 +127,14 @@ export interface ClassInfo {
    */
   isInterface?: boolean;
   /**
+   * Names of the members that came from `interface` declarations. Present only
+   * when `isInterface` is set. An `interface Foo` merged with a `namespace Foo`
+   * shares one entry, and the namespace's members are real exported functions
+   * with Ruby counterparts — so container-level tag inheritance must apply to
+   * this list, never to the whole merged member set.
+   */
+  interfaceMembers?: string[];
+  /**
    * Reason prose of an `@noRailsEquivalent` tag written on the class /
    * interface / namespace DECLARATION itself, justifying the declared name as
    * deliberate trails-only surface. Members carry their own tag on

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -126,13 +126,6 @@ export interface ClassInfo {
    * `collectTaggedEntries` in extra-surface.ts.
    */
   isInterface?: boolean;
-  /**
-   * Names of the members that came from `interface` declarations. Present only
-   * when `isInterface` is set. An `interface Foo` merged with a `namespace Foo`
-   * shares one entry, and the namespace's members are real exported functions
-   * with Ruby counterparts — so container-level tag inheritance must apply to
-   * this list, never to the whole merged member set.
-   */
   interfaceMembers?: string[];
   /**
    * Reason prose of an `@noRailsEquivalent` tag written on the class /


### PR DESCRIPTION
Resolves RFC 0080 story `interface-namespace-declaration-merge-drops-metadata` (found while shipping #5467).

`extractFromFiles` merged declaration-merged **interfaces** carefully but the namespace arm right below it overwrote unconditionally:

```ts
} else if (ts.isModuleDeclaration(node) && node.name) {
  info.modules[modKey] = extractNamespace(node, checker, relPath);
```

For the legitimate TS idiom of `interface Foo` + `namespace Foo` in one file, whichever declaration the walker reached last won. Namespace last ⇒ the interface's `noRailsEquivalent` reason and `isInterface` flag were both discarded, silently dropping its members from the allowed set and re-flagging them as extra surface. Order-dependent metadata loss, not a wrong rule.

**Fix.** The namespace arm now mirrors the interface arm: union members into the existing entry, `??=` the reason, keep the entry's existing `isInterface` / `interfaceMembers`.

**The reason must NOT spread to the namespace's members** (second acceptance criterion), and that is where the interesting part is: `collectTaggedEntries` inherits a tagged interface's reason onto *all* of the container's members, which is right for a type-only interface but wrong for the namespace half — those are real exported functions whose Ruby counterparts must keep being demanded. So `ClassInfo` gains `interfaceMembers?: string[]`, recorded by `extractInterface` and unioned on merge, and the inheritance loop is scoped to it. Absent the field the behaviour is unchanged, so pure interfaces are untouched.

Tests, all three failing on baseline:

- `extract-ts-api.test.ts` — both declaration orders preserve `isInterface`, the reason, the unioned member set, and `interfaceMembers: ["locate"]`.
- `extra-surface.test.ts` — a merged entry allowlists the interface member and still reports the namespace function as novel (baseline allowlists both).

`pnpm vitest run scripts/api-compare/` — 663 passed, 28 files. `api:compare` unchanged at 11741/17536 (data layer 98.8%) and `api:extra` totals unchanged: no real file in the tree currently hits this merge, so the fix is purely defensive against the next one.
