### PR TITLE
refactor(trailties): delegate db rollback/forward/migrate:redo to DatabaseTasks

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -403,6 +403,26 @@ export class DatabaseTasks {
     adapter.schemaCache?.clear();
   }
 
+  /**
+   * Push the schema forward N migrations (default 1). Mirrors `db:forward`,
+   * whose body is `migration_connection_pool.migration_context.forward(step)`
+   * (`railties/databases.rake:275-280`) — the exact counterpart of the
+   * `db:rollback` line {@link rollback} ports. Rails has no
+   * `DatabaseTasks.forward`; trails' `MigrationContext` is the schema DSL
+   * rather than Rails' migration-set context, so the rake body lands here
+   * beside `rollback` instead of on the pool.
+   */
+  static async forward(steps: number = 1): Promise<void> {
+    if (!this.databaseConfiguration) return;
+    if (this.configsFor(this._normalizeEnv()).length === 0) return;
+    const { Migrator } = await import("../migration.js");
+    const pool = await this.migrationConnectionPool();
+    const adapter = await pool.leaseConnection();
+    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
+    await migrator.forward(steps);
+    adapter.schemaCache?.clear();
+  }
+
   // Cached sync reference to Base, populated on the first _migrationAdapter() call.
   // Lets migrationConnection() (which must be synchronous) lease from the pool
   // without a top-level import that would create a circular-dependency cycle.

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -353,7 +353,10 @@ export class DatabaseTasks {
       // Rails builds the migrator from `migration_connection_pool.migration_context`
       // (`connection_pool.rb:294-299`), i.e. from the pool's own
       // `db_config.migrations_paths` — not from a process-global list.
-      const migrator = new Migrator(adapter, this._migrationsFor(dbConfig));
+      const migrator = new Migrator(adapter, this._migrationsFor(dbConfig), {
+        environment: dbConfig.envName,
+        internalMetadataEnabled: dbConfig.useMetadataTable,
+      });
       // Rails block: `version.blank? ? (scope.blank? || scope == m.scope) : m.version == version`
       // `version` is the *method parameter* (explicit arg), NOT ENV["VERSION"].
       // The rake task always calls migrate() with no arg, so version is nil → scope filter only.
@@ -393,33 +396,28 @@ export class DatabaseTasks {
 
   /** Roll back the last N migrations (default 1). Mirrors `db:rollback`. */
   static async rollback(steps: number = 1): Promise<void> {
-    if (!this.databaseConfiguration) return;
-    if (this.configsFor(this._normalizeEnv()).length === 0) return;
-    const { Migrator } = await import("../migration.js");
-    const pool = await this.migrationConnectionPool();
-    const adapter = await pool.leaseConnection();
-    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
-    await migrator.rollback(steps);
-    adapter.schemaCache?.clear();
+    await this._stepMigrations("rollback", steps);
   }
 
-  /**
-   * Push the schema forward N migrations (default 1). Mirrors `db:forward`,
-   * whose body is `migration_connection_pool.migration_context.forward(step)`
-   * (`railties/databases.rake:275-280`) — the exact counterpart of the
-   * `db:rollback` line {@link rollback} ports. Rails has no
-   * `DatabaseTasks.forward`; trails' `MigrationContext` is the schema DSL
-   * rather than Rails' migration-set context, so the rake body lands here
-   * beside `rollback` instead of on the pool.
-   */
   static async forward(steps: number = 1): Promise<void> {
+    await this._stepMigrations("forward", steps);
+  }
+
+  private static async _stepMigrations(
+    direction: "rollback" | "forward",
+    steps: number,
+  ): Promise<void> {
     if (!this.databaseConfiguration) return;
     if (this.configsFor(this._normalizeEnv()).length === 0) return;
     const { Migrator } = await import("../migration.js");
     const pool = await this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
-    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
-    await migrator.forward(steps);
+    const dbConfig = pool.dbConfig;
+    const migrator = new Migrator(adapter, this._migrationsFor(dbConfig), {
+      environment: dbConfig.envName,
+      internalMetadataEnabled: dbConfig.useMetadataTable,
+    });
+    await migrator[direction](steps);
     adapter.schemaCache?.clear();
   }
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -960,6 +960,20 @@ describe("db subcommand CLI actions", () => {
     await program.parseAsync(["node", "trails", "db", ...args]);
   }
 
+  async function tableExists(dbFile: string, table: string): Promise<boolean> {
+    const { BetterSQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
+    const adapter = new BetterSQLite3Adapter(dbFile);
+    try {
+      const rows = await adapter.execute(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='${table}'`,
+      );
+      return rows.length === 1;
+    } finally {
+      await adapter.close();
+    }
+  }
+
   it("db version prints 0 against a fresh database", async () => {
     await runDb(["version"]);
     expect(logs).toContain("Current version: 0");
@@ -1955,11 +1969,6 @@ export class CreateDogs extends Migration {
   });
 
   it("db:rollback:namespace works", async () => {
-    // Rails' `db:rollback:<name>` rolls one database back through
-    // `with_temporary_pool_for_each { pool.migration_context.rollback(step) }`
-    // (railties/databases.rake:247-259), so each database's rollback must use
-    // that database's own migration set. `--database=<name>` is our stand-in
-    // for the generated namespace task.
     const primaryDb = path.join(tmpDir, "rollback-primary.sqlite3");
     const animalsDb = path.join(tmpDir, "rollback-animals.sqlite3");
     fs.writeFileSync(
@@ -1996,31 +2005,69 @@ export class CreateDogs extends Migration {
     await runDb(["create"]);
     await runDb(["migrate"]);
 
-    const { BetterSQLite3Adapter } =
-      await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
-    const tableExists = async (dbFile: string, table: string): Promise<boolean> => {
-      const adapter = new BetterSQLite3Adapter(dbFile);
-      try {
-        const rows = await adapter.execute(
-          `SELECT name FROM sqlite_master WHERE type='table' AND name='${table}'`,
-        );
-        return rows.length === 1;
-      } finally {
-        await adapter.close();
-      }
-    };
-
     expect(await tableExists(primaryDb, "users")).toBe(true);
     expect(await tableExists(animalsDb, "dogs")).toBe(true);
 
     await runDb(["rollback", "--database=primary"]);
     expect(await tableExists(primaryDb, "users")).toBe(false);
-    // The animals database resolves its own migration set, so rolling back
-    // primary must leave it alone.
     expect(await tableExists(animalsDb, "dogs")).toBe(true);
 
     await runDb(["rollback", "--database=animals"]);
     expect(await tableExists(animalsDb, "dogs")).toBe(false);
+  });
+
+  it("db forward and db migrate:redo step the named database", async () => {
+    const primaryDb = path.join(tmpDir, "forward-primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "forward-animals.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateDogs extends Migration {
+  async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
+  async down() { await this.dropTable("dogs"); }
+}`,
+    );
+
+    await runDb(["create"]);
+    await runDb(["migrate"]);
+    await runDb(["rollback"]);
+    expect(await tableExists(primaryDb, "users")).toBe(false);
+    expect(await tableExists(animalsDb, "dogs")).toBe(false);
+
+    await runDb(["forward", "--database=animals"]);
+    expect(await tableExists(animalsDb, "dogs")).toBe(true);
+    expect(await tableExists(primaryDb, "users")).toBe(false);
+
+    await runDb(["forward", "--database=primary"]);
+    expect(await tableExists(primaryDb, "users")).toBe(true);
+
+    logs.length = 0;
+    await runDb(["migrate:redo", "--database=animals"]);
+    expect(await tableExists(animalsDb, "dogs")).toBe(true);
+    expect(await tableExists(primaryDb, "users")).toBe(true);
+    expect(logs).toContain("All migrations are up to date.");
   });
 
   it("db migrate --database=animals targets only the named DB", async () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1954,6 +1954,75 @@ export class CreateDogs extends Migration {
     expect(fs.readFileSync(animalsSchema, "utf8")).toContain("dogs");
   });
 
+  it("db:rollback:namespace works", async () => {
+    // Rails' `db:rollback:<name>` rolls one database back through
+    // `with_temporary_pool_for_each { pool.migration_context.rollback(step) }`
+    // (railties/databases.rake:247-259), so each database's rollback must use
+    // that database's own migration set. `--database=<name>` is our stand-in
+    // for the generated namespace task.
+    const primaryDb = path.join(tmpDir, "rollback-primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "rollback-animals.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateUsers extends Migration {
+  async up() { await this.createTable("users", (t) => { t.string("name"); }); }
+  async down() { await this.dropTable("users"); }
+}`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      `import { Migration } from "@blazetrails/activerecord";
+export class CreateDogs extends Migration {
+  async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
+  async down() { await this.dropTable("dogs"); }
+}`,
+    );
+
+    await runDb(["create"]);
+    await runDb(["migrate"]);
+
+    const { BetterSQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
+    const tableExists = async (dbFile: string, table: string): Promise<boolean> => {
+      const adapter = new BetterSQLite3Adapter(dbFile);
+      try {
+        const rows = await adapter.execute(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='${table}'`,
+        );
+        return rows.length === 1;
+      } finally {
+        await adapter.close();
+      }
+    };
+
+    expect(await tableExists(primaryDb, "users")).toBe(true);
+    expect(await tableExists(animalsDb, "dogs")).toBe(true);
+
+    await runDb(["rollback", "--database=primary"]);
+    expect(await tableExists(primaryDb, "users")).toBe(false);
+    // The animals database resolves its own migration set, so rolling back
+    // primary must leave it alone.
+    expect(await tableExists(animalsDb, "dogs")).toBe(true);
+
+    await runDb(["rollback", "--database=animals"]);
+    expect(await tableExists(animalsDb, "dogs")).toBe(false);
+  });
+
   it("db migrate --database=animals targets only the named DB", async () => {
     const primaryDb = path.join(tmpDir, "primary2.sqlite3");
     const animalsDb = path.join(tmpDir, "animals2.sqlite3");

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -605,22 +605,6 @@ async function withPrefixedStdout(prefix: string, fn: () => Promise<void>): Prom
   }
 }
 
-/**
- * The `db:rollback:<name>` / `db:forward` / `db:migrate:redo` seam. Rails'
- * rake bodies drive `migration_connection_pool.migration_context`
- * (`railties/databases.rake:254,269,278`), i.e. the migration set the pool's
- * own `migrations_paths` produced — never a process-global list. The trails
- * counterpart is `DatabaseTasks.registerMigrations(migrations, config)`, which
- * `DatabaseTasks` then resolves per config via `_migrationsFor(pool.dbConfig)`;
- * `withRegisteredConfiguration` supplies the `databaseConfiguration` those
- * entry points consult before they touch a pool.
- *
- * `forEachDatabase` has already established the pool for `ctx.config`, so
- * `DatabaseTasks.migrationConnectionPool()` resolves to this database — the
- * same targeting Rails gets from `with_temporary_pool_for_each`. The trailing
- * schema dump is the rake tasks' `db:_dump[:name]` invocation, gated on
- * `dump_schema_after_migration` inside {@link dumpSchemaAfterMigrate}.
- */
 async function withMigrationTasksForDb(
   ctx: {
     adapter: DatabaseAdapter;
@@ -1022,11 +1006,6 @@ export function dbCommand(): Command {
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
-        // Rails' `db:migrate:redo` with no VERSION invokes `db:rollback`
-        // then `db:migrate` (`railties/databases.rake:132-144`). Both run
-        // against one registration so the "No migrations found." notice
-        // can't print twice, and the dump happens once at the end — Rails'
-        // `db:_dump` reenable collapses the two invocations the same way.
         await withMigrationTasksForDb(
           ctx,
           async () => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -567,15 +567,25 @@ async function withMigratorForDb(
     environment: ctx.config.envName,
     internalMetadataEnabled: ctx.config.useMetadataTable,
   });
-  // Migration output goes to stdout (Rails' Migration#write is `puts`), so the
-  // per-database prefix is applied by swapping in a stdout-wrapping process
-  // adapter for the duration of the run.
-  const prevAdapter = ctx.prefix ? getProcessAdapter() : null;
+  await withPrefixedStdout(ctx.prefix, async () => {
+    await operation(migrator);
+    if (opts?.afterOutput) await opts.afterOutput(migrator);
+  });
+  if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.raw, ctx.config);
+}
+
+/**
+ * Migration output goes to stdout (Rails' Migration#write is `puts`), so the
+ * per-database prefix is applied by swapping in a stdout-wrapping process
+ * adapter for the duration of the run.
+ */
+async function withPrefixedStdout(prefix: string, fn: () => Promise<void>): Promise<void> {
+  const prevAdapter = prefix ? getProcessAdapter() : null;
   if (prevAdapter) {
     registerProcessAdapter({
       ...prevAdapter,
       stdout: {
-        write: (chunk) => prevAdapter.stdout.write(`${ctx.prefix}${chunk}`),
+        write: (chunk) => prevAdapter.stdout.write(`${prefix}${chunk}`),
         get isTTY() {
           return prevAdapter.stdout.isTTY;
         },
@@ -589,12 +599,57 @@ async function withMigratorForDb(
     });
   }
   try {
-    await operation(migrator);
-    if (opts?.afterOutput) await opts.afterOutput(migrator);
+    await fn();
   } finally {
     if (prevAdapter) registerProcessAdapter(prevAdapter);
   }
-  if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.raw, ctx.config);
+}
+
+/**
+ * The `db:rollback:<name>` / `db:forward` / `db:migrate:redo` seam. Rails'
+ * rake bodies drive `migration_connection_pool.migration_context`
+ * (`railties/databases.rake:254,269,278`), i.e. the migration set the pool's
+ * own `migrations_paths` produced — never a process-global list. The trails
+ * counterpart is `DatabaseTasks.registerMigrations(migrations, config)`, which
+ * `DatabaseTasks` then resolves per config via `_migrationsFor(pool.dbConfig)`;
+ * `withRegisteredConfiguration` supplies the `databaseConfiguration` those
+ * entry points consult before they touch a pool.
+ *
+ * `forEachDatabase` has already established the pool for `ctx.config`, so
+ * `DatabaseTasks.migrationConnectionPool()` resolves to this database — the
+ * same targeting Rails gets from `with_temporary_pool_for_each`. The trailing
+ * schema dump is the rake tasks' `db:_dump[:name]` invocation, gated on
+ * `dump_schema_after_migration` inside {@link dumpSchemaAfterMigrate}.
+ */
+async function withMigrationTasksForDb(
+  ctx: {
+    adapter: DatabaseAdapter;
+    raw: RawConfig;
+    name: string;
+    prefix: string;
+    config: HashConfig;
+  },
+  operation: () => Promise<void>,
+  opts?: { afterPending?: (pending: number) => void },
+): Promise<void> {
+  const mDirs = await migrationsDirsForConfig(ctx.name, ctx.raw);
+  const migrations = await discoverMigrationsFromDirs(mDirs);
+  if (migrations.length === 0) {
+    console.log(`${ctx.prefix}No migrations found.`);
+    return;
+  }
+  DatabaseTasks.registerMigrations(migrations, ctx.config);
+  await withPrefixedStdout(ctx.prefix, async () => {
+    await withRegisteredConfiguration(ctx.config, operation);
+  });
+  if (opts?.afterPending) {
+    const migrator = new Migrator(ctx.adapter, migrations, {
+      environment: ctx.config.envName,
+      internalMetadataEnabled: ctx.config.useMetadataTable,
+    });
+    opts.afterPending((await migrator.pendingMigrations()).length);
+  }
+  await dumpSchemaAfterMigrate(ctx.raw, ctx.config);
 }
 
 export function dbCommand(): Command {
@@ -643,9 +698,7 @@ export function dbCommand(): Command {
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
-        await withMigratorForDb(ctx, async (migrator) => {
-          await migrator.rollback(step);
-        });
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.rollback(step));
       });
     });
 
@@ -662,9 +715,7 @@ export function dbCommand(): Command {
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
-        await withMigratorForDb(ctx, async (migrator) => {
-          await migrator.forward(step);
-        });
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.forward(step));
       });
     });
 
@@ -971,19 +1022,20 @@ export function dbCommand(): Command {
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
-        // Discover once, run rollback then migrate on the same
-        // migrator — avoids double "No migrations found." and
-        // produces the same post-migrate output as `db migrate`.
-        await withMigratorForDb(
+        // Rails' `db:migrate:redo` with no VERSION invokes `db:rollback`
+        // then `db:migrate` (`railties/databases.rake:132-144`). Both run
+        // against one registration so the "No migrations found." notice
+        // can't print twice, and the dump happens once at the end — Rails'
+        // `db:_dump` reenable collapses the two invocations the same way.
+        await withMigrationTasksForDb(
           ctx,
-          async (migrator) => {
-            await migrator.rollback(step);
-            await migrator.migrate(null);
+          async () => {
+            await DatabaseTasks.rollback(step);
+            await DatabaseTasks.migrate();
           },
           {
-            afterOutput: async (migrator) => {
-              const pending = await migrator.pendingMigrations();
-              if (pending.length === 0) {
+            afterPending: (pending) => {
+              if (pending === 0) {
                 console.log(`${ctx.prefix}All migrations are up to date.`);
               }
             },


### PR DESCRIPTION
## What

`packages/trailties/src/commands/db.ts` built its own `Migrator` per database
inside `withMigratorForDb`, so `db rollback` / `db forward` / `db migrate:redo`
never went through `DatabaseTasks`. The per-config migration resolution fixed
in #5604 (`_migrationsFor(pool.dbConfig)`, Rails'
`migration_connection_pool.migration_context`) was therefore invisible to the
CLI, and the two paths could drift.

- New `withMigrationTasksForDb` seam: discovers the config's migrations,
  registers them with `DatabaseTasks.registerMigrations(migrations, config)`
  (the same seam `db prepare` uses since #5584), and runs the operation under
  `withRegisteredConfiguration`. `forEachDatabase` has already established the
  pool, so `migrationConnectionPool()` resolves to that database — the
  targeting Rails gets from `with_temporary_pool_for_each`.
- `rollback` → `DatabaseTasks.rollback(step)`; `forward` →
  `DatabaseTasks.forward(step)`; `migrate:redo` → `rollback` then `migrate`,
  matching the no-VERSION branch of `databases.rake:132-144`.
- Per-database output prefix and the `dumpSchemaAfterMigration`-gated schema
  dump are preserved; the stdout-prefix wrapper is factored into
  `withPrefixedStdout` and shared with the untouched `withMigratorForDb`
  (still used by `db migrate` / `migrate:up` / `migrate:down`).

## Deviation: `DatabaseTasks.forward`

Rails has no `DatabaseTasks.forward` — the `db:forward` rake body is
`migration_connection_pool.migration_context.forward(step)`
(`railties/databases.rake:275-280`). trails' `MigrationContext` is the schema
DSL rather than Rails' migration-set context, so that body lands beside the
existing `DatabaseTasks.rollback` port (which ports the symmetric
`db:rollback` line) instead of on the pool. Both share one `_stepMigrations`
body.

Converging this is registered as
`0051-migration-schema-statements-fidelity/migration-context-holds-the-migration-set`:
give `MigrationContext` Rails' migration-set surface, return it from
`ConnectionPool#migrationContext`, and delete both `DatabaseTasks.rollback`
and `DatabaseTasks.forward` in favour of
`pool.migrationContext.rollback/forward(step)`. That is a structural move
across `migration.ts` and the pool, well past this PR's ceiling.

## Config threading

`DatabaseTasks.rollback` / `forward` / `migrate` built their `Migrator` with no
options, which silently dropped `use_metadata_table` and stamped
`ar_internal_metadata.environment` from `TRAILS_ENV`/`NODE_ENV` instead of the
config's env. Delegating the CLI to them would have regressed both (the CLI
threaded them explicitly), so the migrator is now built from `pool.dbConfig`.

## Test

- `db:rollback:namespace works` — ported from
  `railties/test/application/rake/multi_dbs_test.rb:827`. Migrates a
  two-database app, then rolls each back via `--database=<name>` (our stand-in
  for the generated namespace task) and asserts the other database is
  untouched.
- `db forward and db migrate:redo step the named database` — `db forward` and
  `db migrate:redo` had no end-to-end CLI coverage at all before this rewiring.

Closes-story: trailties-db-rollback-delegates-to-database-tasks
