### PR TITLE
refactor(activerecord): retire the write-only Base._modelsByName map

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -286,7 +286,7 @@ export const modelRegistry = new ModelRegistry();
 /**
  * Find the framework `Base` class in `model`'s prototype chain without
  * importing the `Base` value (which would create a module-init cycle). `Base`
- * is the single class that *owns* the static `_modelsByName` map; subclasses
+ * is the single class that *owns* the `_isActiveRecordBase` sentinel; subclasses
  * inherit it. Falls back to `null` for the (impossible-in-practice) case of a
  * class that never reaches `Base`.
  * @internal
@@ -294,7 +294,7 @@ export const modelRegistry = new ModelRegistry();
 function frameworkBase(model: typeof Base): typeof Base | null {
   let c: unknown = model;
   while (typeof c === "function" && c !== Function.prototype) {
-    if (Object.prototype.hasOwnProperty.call(c, "_modelsByName")) return c as typeof Base;
+    if (Object.prototype.hasOwnProperty.call(c, "_isActiveRecordBase")) return c as typeof Base;
     c = Object.getPrototypeOf(c);
   }
   return null;
@@ -330,8 +330,7 @@ function guardCanonicalNameShadow(name: string, model: typeof Base): void {
  *
  * Deliberately narrow: it does NOT write `modelRegistry` (the constant table is
  * the wider, fallback-only namespace — `registerSubclass` and `Base.adapter=`
- * must not promote a throwaway subclass into association resolution) and it does
- * NOT write `_modelsByName`, which its own callers still own.
+ * must not promote a throwaway subclass into association resolution).
  * @internal
  */
 export function registerModelConstant(name: string, model: typeof Base): void {
@@ -376,7 +375,7 @@ export function registerModel(
       // STI subclass: its direct prototype is another AR model, not the
       // framework `Base` (a base model's prototype is `Base` directly). We
       // locate `Base` by walking the chain for the class that *owns*
-      // `_modelsByName` — `Base` declares it; every subclass inherits it —
+      // `_isActiveRecordBase` — `Base` declares it; every subclass inherits it —
       // rather than importing the `Base` value (that would create an
       // associations.ts ⇄ base.ts module-init cycle).
       const proto = Object.getPrototypeOf(m) as typeof Base;
@@ -389,7 +388,6 @@ export function registerModel(
   if (typeof nameOrModel === "string") {
     if (!model) throw new Error("registerModel(name, model) requires a model class");
     modelRegistry.set(nameOrModel, model);
-    model._modelsByName.set(nameOrModel, model);
     // Attach registry key so counter-cache pending-map lookup can match it.
     const keys: string[] = model._registryKeys ?? [];
     if (!keys.includes(nameOrModel)) keys.push(nameOrModel);
@@ -397,7 +395,6 @@ export function registerModel(
     flushPendingCounterCacheColumns(model);
   } else {
     modelRegistry.set(nameOrModel.name, nameOrModel);
-    nameOrModel._modelsByName.set(nameOrModel.name, nameOrModel);
     // A namespaced model carries its Ruby module path via `static moduleName`;
     // derive the `::`-qualified registry key from it (e.g.
     // "MyApplication::Billing::Firm") so cross-namespace `className` resolution

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -995,7 +995,6 @@ export class Base extends Model {
    * AR model without requiring explicit registerModel() calls.
    * @internal
    */
-  static _modelsByName: Map<string, typeof Base> = new Map();
   static _connectionHandler: ConnectionHandler = new ConnectionHandler();
   static _configPath: string | null = null;
   static _abstractClass = false;
@@ -1358,7 +1357,6 @@ export class Base extends Model {
     // adapter with the schema reset below never run.
     if (this !== Base && this.name) {
       registerModelConstant(this.name, this);
-      Base._modelsByName.set(this.name, this);
     }
     this._adapter = adapter;
 

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -90,6 +90,18 @@ describe("registerModel canonical-name shadow guard", () => {
     expect(safeConstantize("RfDroppedXyz")).toBeUndefined();
   });
 
+  it("leaves no per-class map holding a model the registry has dropped", () => {
+    class RfNoSideMapXyz extends Base {}
+    registerModel(RfNoSideMapXyz);
+    modelRegistry.delete("RfNoSideMapXyz");
+
+    const holders = Object.getOwnPropertyNames(Base).filter((key) => {
+      const value = Object.getOwnPropertyDescriptor(Base, key)?.value;
+      return value instanceof Map && [...value.values()].includes(RfNoSideMapXyz);
+    });
+    expect(holders).toEqual([]);
+  });
+
   it("leaves no model constants behind when the registry is cleared", () => {
     const saved = [...modelRegistry.entries()];
     try {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -267,5 +267,4 @@ export async function resetTestAdapterState(): Promise<void> {
       { preventPermanentCheckout: true },
     );
   }
-  Base._modelsByName.clear();
 }

--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -893,11 +893,10 @@ describe("useFixtures encryption add-on is opt-in", () => {
     const originalModel = entry.model;
     const order: string[] = [];
     // A minimal class (not a bare object): `resolveFixtureNames` now folds in
-    // `registerModel`, which writes the model's static `_modelsByName` map, so
-    // the stub must carry that shape. `tableName` keeps the resolver happy.
+    // `registerModel`, so the stub must look like an AR model class.
+    // `tableName` keeps the resolver happy.
     class StubModel {
       static tableName = "encrypted_books";
-      static _modelsByName = new Map<string, unknown>();
     }
     const stubModel = StubModel as unknown as typeof Base;
     entry.addOn = vi.fn(async () => {

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -501,10 +501,10 @@ function useFixtures(
       // `resolveFixtureNames` (fixtures-register-model-on-resolution, #4348):
       // declaring the set is the opt-in, so no test needs a manual
       // `registerModel` call for a fixture-backed model. Idempotent. Guarded to
-      // real AR model classes (they inherit Base's static `_modelsByName`), so
+      // real AR model classes (they inherit Base's `_isActiveRecordBase`), so
       // the lightweight `{ tableName, ... }` stubs some infra tests pass through
       // the object-map form are left untouched.
-      if (model !== null && "_modelsByName" in model) {
+      if (model !== null && "_isActiveRecordBase" in model) {
         registerModel(model);
       }
       prepared.push(


### PR DESCRIPTION
Resolves RFC 0080 story `converge-models-by-name-with-model-registry` (found in review of #5511).

The story asked for a decision: is `Base._modelsByName` redundant with `modelRegistry`, or genuinely distinct? **It is redundant — and worse, write-only.** Every reference in the tree was a write or a duck-type probe:

- writes: `registerModel` (both forms), `Base.adapter=`, and `test-adapter.ts`'s `clear()`
- probes: `frameworkBase()` walked the prototype chain for the class *owning* the map, and `test-fixtures.ts` used `"_modelsByName" in model` to tell a real model class from a `{ tableName }` stub

There was no `.get`, no `.has`, no iteration anywhere in `packages/` — nothing ever resolved a name through it. That is why it could drift from the registry in both directions without any test noticing: the drift had no observable consequence, only the risk that a future reader would treat it as a resolution path.

So it is retired rather than folded into `ModelRegistry.delete`/`clear`:

- `Base._modelsByName` and all four write sites are gone, including the isolated `test-adapter.ts` teardown the story called out.
- Both probes move to `_isActiveRecordBase`, the sentinel the codebase already uses for exactly this question (`inheritance.ts:124`, `connection-handling.ts:95`, `core.ts:519`, `attribute-methods.ts:476`) — an actual marker instead of a map masquerading as one.
- `registerModelConstant`'s docblock drops its `_modelsByName` caveat; with the third map gone the registry⇒constant claim is the whole story, no asymmetry left to record.

Test (`register-model-canonical-guard.trails.test.ts`, alongside the existing delete/clear invariants): after `modelRegistry.delete(name)`, no own Map on `Base` still holds the dropped class. Written structurally rather than against the retired name so it also pins the next write-only side map anyone adds. Fails on baseline (`_modelsByName` retains it). Property descriptors are read instead of properties because several `Base` statics are throwing getters (`signedIdVerifier`).

Local runs: `register-model-canonical-guard.trails`, `counter-cache.trails`, `associations`, `test-fixtures`, `base`, `inheritance` — 436 passed, 7 skipped. `api:compare` unchanged at 11741/17536 (data layer 98.8%); `api:extra` unchanged (the retired static was `@internal`).
