### PR TITLE
fix(eslint): refuse an ARE shorthand inside a negated bracket expression

### DIFF
--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -148,8 +148,8 @@
  * is known to be ARE and a bracketed `ARE_SHORTHANDS` member (`[\d]`) means what
  * the same shorthand means in a JS character class; a bracketed POSIX character
  * class translates through the subset spellings in `POSIX_CLASS_SOURCES`
- * (`[[:digit:]]`), except under a negating `^`, where the complement of a subset
- * would be wider; anything else bracketed
+ * (`[[:digit:]]`). Both refuse under a negating `^`, where the complement of a
+ * subset would be wider (`[^\d]`, `[^[:digit:]]`); anything else bracketed
  * (`[\W]`, `[\b]`, `[\1]`, `[\\]`, a shorthand as a range endpoint) and every
  * backslash inside a `SIMILAR TO` bracket expression — whose interaction with
  * that grammar's `ESCAPE` character is unsettled — still refuses. Everything
@@ -476,8 +476,9 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * spellings are subsets of what a non-C locale selects; a collating element or
  * equivalence class (`[[.x.]]`, `[[=a=]]`) has no JS spelling at all and
  * refuses. Because those spellings are subsets, a *negated* bracket expression
- * refuses them: the complement of a subset is a superset, which would credit a
- * name the filter does not select. And a backslash
+ * refuses them — and refuses a bracketed `ARE_SHORTHANDS` member with them, since
+ * that shorthand IS one of those classes: the complement of a subset is a
+ * superset, which would credit a name the filter does not select. And a backslash
  * means different things in the two grammars. Bare POSIX brackets read it as an
  * ordinary literal, but PostgreSQL's engine is ARE, which reads it as an escape
  * inside brackets too (`[\d]` is the digits, not a backslash and a `d`), so
@@ -488,7 +489,8 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * that knows the engine decides which reading applies. The `~` / `~*` path
  * passes the backslash ARE spells its escapes with, where a bracketed
  * `ARE_SHORTHANDS` member means exactly what the same shorthand means in a JS
- * character class, so `[\d]` translates. Every other escape inside brackets
+ * character class, so `[\d]` translates — under a negating `^` it does not, for
+ * the subset/complement reason above. Every other escape inside brackets
  * refuses — the complements (`[\W]`), `\b` (backspace here, not a word
  * boundary), a back reference (`[\1]`), and a bare `[\\]`, whose ARE meaning is
  * a literal backslash but whose bare-POSIX one is two of them. A shorthand used
@@ -527,10 +529,11 @@ function bracketSource(pattern, start, escapeChar) {
   if (BRACKET_STRUCTURAL.has(escapeChar)) return null;
   let source = "[";
   let i = start + 1;
-  // A `POSIX_CLASS_SOURCES` spelling is safe in a plain class and unsafe in a
+  // A `POSIX_CLASS_SOURCES` spelling — and equally an `ARE_SHORTHANDS` member,
+  // which IS one of those classes — is safe in a plain class and unsafe in a
   // negated one: it is an ASCII subset of what a non-C locale selects, and the
   // complement of a subset is a *superset*, which would credit a name the filter
-  // does not select. So a POSIX class refuses under `^`.
+  // does not select. So both refuse under `^`.
   let negated = false;
   if (pattern[i] === "^") {
     source += "^";
@@ -570,7 +573,8 @@ function bracketSource(pattern, start, escapeChar) {
     }
     if (ch === escapeChar) {
       const next = pattern[i + 1];
-      if (next === undefined || !ARE_SHORTHANDS.has(next)) return null;
+      // Subset under `^` becomes superset (see the `negated` comment above).
+      if (next === undefined || !ARE_SHORTHANDS.has(next) || negated) return null;
       if (source.endsWith("-") && source.length - 1 > bodyStart) return null;
       if (pattern[i + 2] === "-" && (pattern[i + 3] ?? "]") !== "]") return null;
       source += `\\${next}`;
@@ -648,7 +652,8 @@ const POSIX_CLASS_SOURCES = new Map([
  * Alternation, grouping and the quantifiers `* + ?` are spelled identically in
  * both, as are `{n,m}` bounds and `.`; bracket expressions go through
  * `bracketSource` in its ARE reading, so a bracketed `ARE_SHORTHANDS` member
- * (`[\d]`) translates like the bare one. A backslash escape of a word character
+ * (`[\d]`) translates like the bare one — except under a negating `^`, which
+ * refuses, since the complement of a subset is a superset. A backslash escape of a word character
  * is translated only
  * for the ARE class shorthands whose JS meaning is identical (`ARE_SHORTHANDS`);
  * every other one is refused, since a back reference (`\1`) means something

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -476,9 +476,9 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * spellings are subsets of what a non-C locale selects; a collating element or
  * equivalence class (`[[.x.]]`, `[[=a=]]`) has no JS spelling at all and
  * refuses. Because those spellings are subsets, a *negated* bracket expression
- * refuses them — and refuses a bracketed `ARE_SHORTHANDS` member with them, since
- * that shorthand IS one of those classes: the complement of a subset is a
- * superset, which would credit a name the filter does not select. And a backslash
+ * refuses them — and a bracketed `ARE_SHORTHANDS` member with them, that shorthand
+ * being one of those classes: the complement of a subset is a superset, which
+ * would credit a name the filter does not select. And a backslash
  * means different things in the two grammars. Bare POSIX brackets read it as an
  * ordinary literal, but PostgreSQL's engine is ARE, which reads it as an escape
  * inside brackets too (`[\d]` is the digits, not a backslash and a `d`), so
@@ -489,8 +489,8 @@ const BOUND_RE = /^\{\d+(?:,\d*)?\}/;
  * that knows the engine decides which reading applies. The `~` / `~*` path
  * passes the backslash ARE spells its escapes with, where a bracketed
  * `ARE_SHORTHANDS` member means exactly what the same shorthand means in a JS
- * character class, so `[\d]` translates — under a negating `^` it does not, for
- * the subset/complement reason above. Every other escape inside brackets
+ * character class, so `[\d]` translates unless the expression is negated. Every
+ * other escape inside brackets
  * refuses — the complements (`[\W]`), `\b` (backspace here, not a word
  * boundary), a back reference (`[\1]`), and a bare `[\\]`, whose ARE meaning is
  * a literal backslash but whose bare-POSIX one is two of them. A shorthand used
@@ -556,10 +556,10 @@ function bracketSource(pattern, start, escapeChar) {
       const end = pattern.indexOf(":]", i + 2);
       if (end === -1) return null;
       const classSource = POSIX_CLASS_SOURCES.get(pattern.slice(i + 2, end));
-      // Every licensed spelling is a subset, so a negated class refuses; so does
-      // a name not on the list (`[[:punct:]]`, a locale-extending complement, a
-      // typo) and a class used as a range endpoint, which ARE rejects outright
-      // while JS's Annex B grammar would quietly read the `-` as a literal.
+      // A negated class refuses (see `negated`); so does a name not on the list
+      // (`[[:punct:]]`, a locale-extending complement, a typo) and a class used as
+      // a range endpoint, which ARE rejects outright while JS's Annex B grammar
+      // would quietly read the `-` as a literal.
       if (classSource === undefined || negated) return null;
       if (source.endsWith("-") && source.length - 1 > bodyStart) return null;
       if (pattern[end + 2] === "-" && (pattern[end + 3] ?? "]") !== "]") return null;
@@ -573,7 +573,8 @@ function bracketSource(pattern, start, escapeChar) {
     }
     if (ch === escapeChar) {
       const next = pattern[i + 1];
-      // Subset under `^` becomes superset (see the `negated` comment above).
+      // A negated shorthand refuses for the same reason a negated class does, the
+      // shorthand being one of those classes (see `negated`).
       if (next === undefined || !ARE_SHORTHANDS.has(next) || negated) return null;
       if (source.endsWith("-") && source.length - 1 > bodyStart) return null;
       if (pattern[i + 2] === "-" && (pattern[i + 3] ?? "]") !== "]") return null;
@@ -652,8 +653,8 @@ const POSIX_CLASS_SOURCES = new Map([
  * Alternation, grouping and the quantifiers `* + ?` are spelled identically in
  * both, as are `{n,m}` bounds and `.`; bracket expressions go through
  * `bracketSource` in its ARE reading, so a bracketed `ARE_SHORTHANDS` member
- * (`[\d]`) translates like the bare one — except under a negating `^`, which
- * refuses, since the complement of a subset is a superset. A backslash escape of a word character
+ * (`[\d]`) translates like the bare one, except under a negating `^`, which
+ * refuses (see `bracketSource`). A backslash escape of a word character
  * is translated only
  * for the ARE class shorthands whose JS meaning is identical (`ARE_SHORTHANDS`);
  * every other one is refused, since a back reference (`\1`) means something

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -314,26 +314,10 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
-    // A shorthand alongside ordinary bracket members, and under negation.
+    // A shorthand alongside ordinary bracket members.
     'await adapter.exec(`CREATE TABLE "ex_-1" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +
       "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[-\\\\S]+'`,\n" +
-      ");\n" +
-      "for (const t of rows) {\n" +
-      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
-      "}",
-    'await adapter.exec(`CREATE TABLE "ex_ab" (id int)`);\n' +
-      "const rows = await adapter.execute(\n" +
-      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^\\\\d]+'`,\n" +
-      ");\n" +
-      "for (const t of rows) {\n" +
-      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
-      "}",
-    // A `-` in first position is a literal in both grammars, even under
-    // negation, so the shorthand after it is not a range endpoint.
-    'await adapter.exec(`CREATE TABLE "ex_ab" (id int)`);\n' +
-      "const rows = await adapter.execute(\n" +
-      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^-\\\\d]+'`,\n" +
       ");\n" +
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
@@ -983,7 +967,33 @@ tester.run("require-table-teardown", rule, {
       errors: [{ messageId: "missingTeardown", data: { table: "ex_c" } }],
     },
     // Under a negating `^` the ASCII spelling is the *wider* of the two, so a
-    // POSIX class refuses there even when it translates unnegated.
+    // POSIX class refuses there even when it translates unnegated — and so does
+    // a bracketed `ARE_SHORTHANDS` member, which IS one of those classes: JS
+    // `[^\d]` matches a non-ASCII digit that ARE's complement excludes.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_ab" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^\\\\d]+'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_ab" } }],
+    },
+    // A `-` in first position is a literal in both grammars, so the shorthand
+    // after it is not a range endpoint — the negation is what refuses here.
+    {
+      code:
+        'await adapter.exec(`CREATE TABLE "ex_ab" (id int)`);\n' +
+        "const rows = await adapter.execute(\n" +
+        "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^-\\\\d]+'`,\n" +
+        ");\n" +
+        "for (const t of rows) {\n" +
+        '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+        "}",
+      errors: [{ messageId: "missingTeardown", data: { table: "ex_ab" } }],
+    },
     {
       code:
         'await adapter.exec(`CREATE TABLE "ex_1" (id int)`);\n' +

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -314,6 +314,15 @@ tester.run("require-table-teardown", rule, {
       "for (const t of rows) {\n" +
       '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "}",
+    // Negation itself translates — both grammars read a leading `^` alike. It is
+    // only the locale-extensible spellings that refuse under it.
+    'await adapter.exec(`CREATE TABLE "ex_ab" (id int)`);\n' +
+      "const rows = await adapter.execute(\n" +
+      "  `SELECT tablename FROM pg_tables WHERE tablename ~ '^ex_[^0-9]+'`,\n" +
+      ");\n" +
+      "for (const t of rows) {\n" +
+      '  await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "}",
     // A shorthand alongside ordinary bracket members.
     'await adapter.exec(`CREATE TABLE "ex_-1" (id int)`);\n' +
       "const rows = await adapter.execute(\n" +


### PR DESCRIPTION
`bracketSource` translated a bracketed `ARE_SHORTHANDS` member (`[\d]`, `[\w]`,
`[\S]`) on the argument that JS's spellings stay ASCII while ARE's are the POSIX
classes a non-C locale can extend — the JS reading is a *subset*, so it
under-accepts at worst.

That argument inverts under negation. `[^\d]` complements a subset, giving a
*superset*: a name containing a non-ASCII digit is matched by JS `[^\d]` but
excluded by ARE's, so the matcher would credit a name the filter does not
select. #5611 added exactly this refusal for `POSIX_CLASS_SOURCES` (the
`negated` flag) but left the shorthand branch alone, since two accepted cases
pinned the old behaviour. This extends the same flag to the shorthand branch and
moves those two cases (`~ '^ex_[^\d]+'`, `~ '^ex_[^-\d]+'`) to the invalid list
with their `missingTeardown` expectation. Both fail on baseline.

The subset/complement reason stays recorded once, at the `negated` declaration,
with the two branches pointing at it; the doc blocks that describe brackets
under negation now say both spellings refuse.

Closes-story: require-table-teardown-refuse-negated-bracket-shorthands
