### PR TITLE
test(activerecord): drive the adapter prevent-writes suites through a pooled scope

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
@@ -16,11 +16,11 @@ import {
   leaseMysqlAdapter,
   Mysql2Adapter,
 } from "../abstract-mysql-adapter/test-helper.js";
+import { Base } from "../../base.js";
 import { ReadOnlyError } from "../../errors.js";
 
 describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
   let adapter: Mysql2Adapter;
-  let originalPool: unknown;
 
   beforeEach(async () => {
     adapter = await leaseMysqlAdapter();
@@ -32,24 +32,8 @@ describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    // The adapter is the shared leased connection, so the swapped-in
-    // prevent-writes pool has to come back off before anything else uses it.
-    if (originalPool !== undefined) {
-      (adapter as Mysql2Adapter & { pool: unknown }).pool = originalPool;
-      originalPool = undefined;
-    }
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
   });
-
-  function preventWrites(a: Mysql2Adapter): void {
-    originalPool = (a as Mysql2Adapter & { pool: unknown }).pool;
-    (
-      a as Mysql2Adapter & { pool: { preventWrites?: boolean; connectionDescriptor?: unknown } }
-    ).pool = {
-      preventWrites: true,
-      connectionDescriptor: { name: "ActiveRecord::Base" },
-    };
-  }
 
   it("execute runs a non-row-returning statement and returns no rows", async () => {
     // mysql2 returns a ResultSetHeader (no rows array) for DDL and a bare
@@ -92,16 +76,16 @@ describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
   });
 
   it("errors when a write is routed through executeMutation while preventing writes", async () => {
-    // The guard lives in preprocess_query's check_if_write_query, so it reaches
-    // every write through the shared primitive.
-    preventWrites(adapter);
-    await expect(adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`)).rejects.toThrow(
-      ReadOnlyError,
-    );
+    await Base.whilePreventingWrites(async () => {
+      await expect(adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`)).rejects.toThrow(
+        ReadOnlyError,
+      );
+    });
   });
 
   it("does not prevent a read routed through execute while preventing writes", async () => {
-    preventWrites(adapter);
-    await expect(adapter.execute(`SELECT * FROM pq`)).resolves.toEqual([]);
+    await Base.whilePreventingWrites(async () => {
+      await expect(adapter.execute(`SELECT * FROM pq`)).resolves.toEqual([]);
+    });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -10,15 +10,19 @@
  */
 import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { Base } from "../../base.js";
+import type { AbstractAdapter } from "../../connection-adapters/abstract-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
 
 describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
   let adapter: PostgreSQLAdapter;
+  let connection: AbstractAdapter;
 
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
     await adapter.exec(`CREATE TABLE pq (id serial primary key, nick character varying(255))`);
+    connection = await Base.leaseConnection();
   });
 
   afterEach(async () => {
@@ -26,15 +30,6 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
     await adapter.close();
   });
-
-  function preventWrites(a: PostgreSQLAdapter): void {
-    (
-      a as PostgreSQLAdapter & { pool: { preventWrites?: boolean; connectionDescriptor?: unknown } }
-    ).pool = {
-      preventWrites: true,
-      connectionDescriptor: { name: "ActiveRecord::Base" },
-    };
-  }
 
   it("execute runs a non-row-returning statement and returns no rows", async () => {
     // node-pg does not throw on a statement with no result columns, so DDL and a
@@ -76,17 +71,17 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
   });
 
   it("errors when a write is routed through executeMutation while preventing writes", async () => {
-    // The guard lives in preprocess_query's check_if_write_query, so it reaches
-    // every write through the shared primitive.
-    preventWrites(adapter);
-    await expect(adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`)).rejects.toThrow(
-      ReadOnlyError,
-    );
+    await Base.whilePreventingWrites(async () => {
+      await expect(
+        connection.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`),
+      ).rejects.toThrow(ReadOnlyError);
+    });
   });
 
   it("does not prevent a read routed through execute while preventing writes", async () => {
-    preventWrites(adapter);
-    await expect(adapter.execute(`SELECT * FROM pq`)).resolves.toEqual([]);
+    await Base.whilePreventingWrites(async () => {
+      await expect(connection.execute(`SELECT * FROM pq`)).resolves.toEqual([]);
+    });
   });
 
   it("re-applies the session timezone on a reconnected session", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-prevent-writes.test.ts
@@ -1,108 +1,117 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import { describeIfPg } from "./test-helper.js";
+import { Base } from "../../base.js";
+import type { AbstractAdapter } from "../../connection-adapters/abstract-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
+import { withExampleTable as withDdlHelperTable } from "../../support/ddl-helper.js";
+import { fixtures } from "../../test-fixtures.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
-  let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
-    adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    await adapter.exec(`DROP TABLE IF EXISTS ex`);
-    await adapter.exec(`CREATE TABLE ex (id serial primary key, data character varying(255))`);
-  });
-  afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS ex`);
-    await adapter.close();
-  });
-
-  // isPreventingWrites() checks pool.preventWrites before _config, and pool
-  // is a public property — safer than reaching into protected _config.
-  function preventWrites(a: PostgreSQLAdapter): void {
-    (
-      a as PostgreSQLAdapter & { pool: { preventWrites?: boolean; connectionDescriptor?: unknown } }
-    ).pool = {
-      preventWrites: true,
-      connectionDescriptor: { name: "ActiveRecord::Base" },
-    };
-  }
-
-  function allowWrites(a: PostgreSQLAdapter): void {
-    (
-      a as PostgreSQLAdapter & { pool: { preventWrites?: boolean; connectionDescriptor?: unknown } }
-    ).pool = {
-      preventWrites: false,
-      connectionDescriptor: { name: "ActiveRecord::Base" },
-    };
-  }
-
   describe("PostgreSQLAdapterPreventWritesTest", () => {
-    it("doesnt error when a read query with cursors is called while preventing writes", async () => {
-      preventWrites(adapter);
-      await adapter.beginTransaction();
-      try {
-        await adapter.execute("DECLARE cur_ex CURSOR FOR SELECT * FROM ex");
-        await adapter.execute("FETCH cur_ex");
-        await adapter.execute("MOVE cur_ex");
-        await adapter.execute("CLOSE cur_ex");
-      } finally {
-        await adapter.rollback();
-      }
+    fixtures([], { useTransactionalTests: false });
+
+    let connection: AbstractAdapter;
+
+    beforeEach(async () => {
+      connection = await Base.leaseConnection();
     });
 
+    function withExampleTable<T>(fn: () => Promise<T> | T): Promise<T> {
+      return withDdlHelperTable(
+        connection,
+        "ex",
+        "id serial primary key, number integer, data character varying(255)",
+        fn,
+      );
+    }
+
     it("errors when an insert query is called while preventing writes", async () => {
-      preventWrites(adapter);
-      await expect(
-        adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')"),
-      ).rejects.toBeInstanceOf(ReadOnlyError);
+      await withExampleTable(async () => {
+        await Base.whilePreventingWrites(async () => {
+          await expect(
+            connection.execute("INSERT INTO ex (data) VALUES ('138853948594')"),
+          ).rejects.toBeInstanceOf(ReadOnlyError);
+        });
+      });
     });
 
     it("errors when an update query is called while preventing writes", async () => {
-      allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
-      preventWrites(adapter);
-      await expect(
-        adapter.execute("UPDATE ex SET data = '9989' WHERE data = '138853948594'"),
-      ).rejects.toBeInstanceOf(ReadOnlyError);
+      await withExampleTable(async () => {
+        await connection.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+
+        await Base.whilePreventingWrites(async () => {
+          await expect(
+            connection.execute("UPDATE ex SET data = '9989' WHERE data = '138853948594'"),
+          ).rejects.toBeInstanceOf(ReadOnlyError);
+        });
+      });
     });
 
     it("errors when a delete query is called while preventing writes", async () => {
-      allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
-      preventWrites(adapter);
-      await expect(
-        adapter.execute("DELETE FROM ex WHERE data = '138853948594'"),
-      ).rejects.toBeInstanceOf(ReadOnlyError);
+      await withExampleTable(async () => {
+        await connection.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+
+        await Base.whilePreventingWrites(async () => {
+          await expect(
+            connection.execute("DELETE FROM ex where data = '138853948594'"),
+          ).rejects.toBeInstanceOf(ReadOnlyError);
+        });
+      });
     });
 
     it("doesnt error when a select query is called while preventing writes", async () => {
-      allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
-      preventWrites(adapter);
-      const rows = await adapter.execute("SELECT * FROM ex WHERE data = '138853948594'");
-      expect(rows).toHaveLength(1);
+      await withExampleTable(async () => {
+        await connection.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+
+        await Base.whilePreventingWrites(async () => {
+          const rows = await connection.execute("SELECT * FROM ex WHERE data = '138853948594'");
+          expect(rows).toHaveLength(1);
+        });
+      });
     });
 
     it("doesnt error when a show query is called while preventing writes", async () => {
-      preventWrites(adapter);
-      const rows = await adapter.execute("SHOW TIME ZONE");
-      expect(rows).toHaveLength(1);
+      await Base.whilePreventingWrites(async () => {
+        const rows = await connection.execute("SHOW TIME ZONE");
+        expect(rows).toHaveLength(1);
+      });
     });
 
     it("doesnt error when a set query is called while preventing writes", async () => {
-      preventWrites(adapter);
-      await expect(adapter.execute("SET standard_conforming_strings = on")).resolves.toBeDefined();
+      await Base.whilePreventingWrites(async () => {
+        expect(await connection.execute("SET standard_conforming_strings = on")).toEqual([]);
+      });
     });
 
     it("doesnt error when a read query with leading chars is called while preventing writes", async () => {
-      allowWrites(adapter);
-      await adapter.execute("INSERT INTO ex (data) VALUES ('138853948594')");
-      preventWrites(adapter);
-      const rows = await adapter.execute(
-        "/*action:index*/(\n( SELECT * FROM ex WHERE data = '138853948594' ) )",
-      );
-      expect(rows).toHaveLength(1);
+      await withExampleTable(async () => {
+        await connection.execute("INSERT INTO ex (data) VALUES ('138853948594')");
+
+        await Base.whilePreventingWrites(async () => {
+          const rows = await connection.execute(
+            "/*action:index*/(\n( SELECT * FROM ex WHERE data = '138853948594' ) )",
+          );
+          expect(rows).toHaveLength(1);
+        });
+      });
+    });
+
+    it("doesnt error when a read query with cursors is called while preventing writes", async () => {
+      await withExampleTable(async () => {
+        await Base.whilePreventingWrites(async () => {
+          await connection.transaction(async () => {
+            expect(await connection.execute("DECLARE cur_ex CURSOR FOR SELECT * FROM ex")).toEqual(
+              [],
+            );
+            expect(await connection.execute("FETCH cur_ex")).toEqual([]);
+            expect(await connection.execute("MOVE cur_ex")).toEqual([]);
+            expect(await connection.execute("CLOSE cur_ex")).toEqual([]);
+          });
+        });
+      });
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter-preventing-writes.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter-preventing-writes.trails.test.ts
@@ -22,16 +22,6 @@ describeIfSqlite("AbstractAdapter#isPreventingWrites with no connection descript
     });
   });
 
-  it("still consults pool.preventWrites when the pool carries a descriptor", () => {
-    (
-      adapter as unknown as {
-        pool: { preventWrites?: boolean; connectionDescriptor?: unknown };
-      }
-    ).pool = { preventWrites: true, connectionDescriptor: { name: "ActiveRecord::Base" } };
-
-    expect(adapter.isPreventingWrites()).toBe(true);
-  });
-
   it("still reports preventing writes for a standalone replica", async () => {
     const replica = new BetterSQLite3Adapter({ database: ":memory:", replica: true } as never);
     try {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1418,9 +1418,6 @@ export class AbstractAdapter implements Quoting {
     if (this.isReplica()) return true;
     if (this.connectionDescriptor === null) return false;
     const pool = this.pool as any;
-    if (pool?.preventWrites === true) return true;
-    if (pool?.dbConfig?.preventWrites === true) return true;
-    if (this._config.preventWrites === true) return true;
     // Mirrors Rails: connection_descriptor.current_preventing_writes →
     // Base.preventing_writes?(class_name). Walks the stack in reverse and
     // returns the entry's prevent_writes flag when (a) it includes Base by


### PR DESCRIPTION
## What

The three ported prevent-writes suites drove the readonly guard by assigning a
fake pool onto their adapter, which short-circuited on
`AbstractAdapter#isPreventingWrites`'s trails-invented `pool?.preventWrites`
branch — so the connection-descriptor path they exist to cover was never
exercised.

- `adapters/postgresql/postgresql-adapter-prevent-writes.test.ts` now mirrors
  `postgresql_adapter_prevent_writes_test.rb` line for line: `setup` is
  `Base.leaseConnection()`, every example wraps its assertion in
  `Base.whilePreventingWrites`, the suite's private `with_example_table` forwards
  to `DdlHelper#with_example_table` with Rails' definition, the examples are in
  Rails' file order, and the assertions match Rails' shapes (`[]` entries for the
  cursor/`SET` statements, count `1` for the reads). `fixtures([], {
  useTransactionalTests: false })` wires the handler without a wrapping
  savepoint, since the deliberate-`ReadOnlyError` examples would otherwise leave
  PostgreSQL in `25P02` for the per-test `CREATE TABLE ex`.
- The two `*-perform-query.trails.test.ts` suites drive their prevent-writes
  examples the same way. The MySQL suite's adapter was already the leased
  connection, so its `originalPool` save/restore dance goes away too; the PG
  suite keeps its standalone adapter for the reconnect example and leases a
  pooled connection for the guard examples.

No test was renamed or reworded.

## isPreventingWrites

With the stubs gone, the three invented branches —
`pool?.preventWrites`, `pool?.dbConfig?.preventWrites`, `_config.preventWrites` —
have **no remaining producer** anywhere in the tree (the only writers were the
deleted helpers; `ConnectionHandler#preventWrites` is a separate Rails-real
accessor, not a pool field), so all three are retired. What is left is exactly
`abstract_adapter.rb:227-232`:

```ts
if (this.isReplica()) return true;
if (this.connectionDescriptor === null) return false;
// descriptor-stack walk
```

#5612 has since merged, and it landed the nil-descriptor return in Rails'
position (immediately after `replica?`) while patching the fake pools to carry a
`connectionDescriptor` so they would survive it. Those patches are deleted here
along with the pools themselves, so the ordering acceptance criterion is met with
no invented branch left in front of the walk.

**One test removed:** `abstract-adapter-preventing-writes.trails.test.ts`'s
`"still consults pool.preventWrites when the pool carries a descriptor"` (added
by #5612) asserted the `pool?.preventWrites` branch directly, so it cannot
survive that branch's retirement — which is this story's acceptance criterion.
The file's other two examples (nil descriptor ⇒ `false`; standalone replica ⇒
`true`) are untouched and still pass.

## Review gates

- **Matches Rails** — setup, scope wrapper, DDL helper, example order and
  assertion shapes follow the Rails test file; `isPreventingWrites` is now
  Rails' two branches plus the descriptor walk.
- **No stubs** — none added; three branches and their fake-pool drivers removed.
- **Compare delta non-negative** — `test:compare`
  `postgresql_adapter_prevent_writes_test.rb` 8/8, 0 misplaced; overall
  14824/22203, with **3 fewer** assertion mismatches than `origin/main`
  (count 1984→1983, kind 4064→4062) and no change in pass count.
  `api:compare` unchanged: Data layer 7723/7816 methods, files 409/409.

## Verified

Rebased onto `main` (post-#5612). sqlite lane 365 passed / 32 skipped across the
prevent-writes and sqlite3 adapter suites; PG lane 167 passed / 8 skipped; MySQL
lane 40 passed / 2 skipped — including `adapter-prevent-writes`,
`base-prevent-writes`, `connection-handling`, `connection-swapping-nested`,
`database-selector`, `shard-keys`, `connection-handler`, and
`abstract-adapter-preventing-writes.trails`.

Closes-story: converge-adapter-prevent-writes-tests-onto-pooled-scope
