### PR TITLE
refactor(activerecord): wrap sqlite3 alterTable in the transaction helper

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2419,16 +2419,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       .filter((n) => colNames.includes(renamed(n)));
 
     // Rails: transaction { disable_referential_integrity { move_table(...) } }
-    // Use savepoint if already inside a transaction (e.g. migration),
-    // since SQLite doesn't allow nested BEGIN.
-    const alreadyInTransaction = this._inTransaction;
-    const savepointName = `alter_table_${bareTable.replace(/[^a-zA-Z0-9_]/g, "_")}`;
-    if (alreadyInTransaction) {
-      await this.createSavepoint(savepointName);
-    } else {
-      await this.beginTransaction();
-    }
-    try {
+    await this.transaction(async () => {
       await this.disableReferentialIntegrity(async () => {
         // Rails' alter_table is two move_table calls, each copy_table + drop_table
         // (sqlite3_adapter.rb:585-596). The first move is Rails' verbatim: the
@@ -2445,21 +2436,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         await this.copyTableContents(alteredTableName, tableName, originalColNames.map(renamed));
         await this.execCopyTable(`DROP TABLE ${quoteTableName(alteredTableName)}`);
       });
-
-      if (alreadyInTransaction) {
-        await this.releaseSavepoint(savepointName);
-      } else {
-        await this.commit();
-      }
-    } catch (err) {
-      if (alreadyInTransaction) {
-        await this.rollbackToSavepoint(savepointName);
-        await this.releaseSavepoint(savepointName);
-      } else {
-        await this.rollback();
-      }
-      throw err;
-    }
+    });
 
     this.schemaCache.clear();
     // The rebuild issues its DDL via driver.exec (to manage savepoint nesting),

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2418,7 +2418,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       .map((c) => c.name)
       .filter((n) => colNames.includes(renamed(n)));
 
-    // Rails: transaction { disable_referential_integrity { move_table(...) } }
     await this.transaction(async () => {
       await this.disableReferentialIntegrity(async () => {
         // Rails' alter_table is two move_table calls, each copy_table + drop_table

--- a/scripts/api-compare/call-mismatches-exclude.json
+++ b/scripts/api-compare/call-mismatches-exclude.json
@@ -71,13 +71,6 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "alter_table",
-    "call": "transaction",
-    "reason": "Confirmed equivalent (RFC 0044, transaction-wrapping-cluster): Rails wraps the table rebuild in `transaction { disable_referential_integrity { move_table(...) } }` (sqlite3_adapter.rb:586). trails' `alterTable` achieves the same atomicity via an explicit transaction boundary — `beginTransaction()` + `commit()`/`rollback()` around the `disableReferentialIntegrity` rebuild (sqlite3-adapter.ts:2312-2349), using a savepoint when already inside a transaction since SQLite forbids nested BEGIN. The wrap uses the begin/commit primitives rather than the `transaction` closure helper, so the extractor doesn't see a literal `transaction` call — false positive, no omission."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "internal-metadata.ts",
     "rubyName": "update_entry",
     "call": "update",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -37,13 +37,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "alter_table",
-    "call": "transaction",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "begin_db_transaction",
     "call": "internal_begin_transaction",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails closes `alter_table` with `transaction { disable_referential_integrity { move_table(...); move_table(...) } }` (`vendor/rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:586-591`).

trails' `alterTable` hand-rolled that: it read `this._inTransaction`, derived a savepoint name from the bare table name, and called `createSavepoint`/`beginTransaction` + `releaseSavepoint`/`commit` directly, with a `try`/`catch` rollback branch. The `transaction` helper already picks savepoint vs BEGIN for a nested call, so the branch re-implemented machinery that exists.

This calls the helper and deletes the savepoint-name derivation and the rollback branch. `alter_table -> alterTable` no longer appears in `scripts/api-compare/output/call-mismatches.json` (12 remaining, down from 13).

Tests: sqlite3 adapter suites (199 passed), `packages/activerecord/src/migration/` and `packages/activerecord/src/connection-adapters/` (2006 passed) — including the nested inside-migration path that motivated the savepoint branch.

Closes-story: sqlite-alter-table-hand-rolls-transaction-instead-of-helper
