### PR TITLE
test(activerecord): mirror migration/change_table_test.rb

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -4,7 +4,6 @@ import {
   CheckConstraintDefinition,
   ReferenceDefinition,
   TableDefinition,
-  Table,
   type ReferenceDefinitionConnection,
 } from "./schema-definitions.js";
 import { SchemaDumper } from "../../schema-dumper.js";
@@ -230,20 +229,6 @@ describe("ColumnMethods#primary_key", () => {
     expect(td.columns[0].options.primaryKey).toBe(true);
   });
 
-  it("adds a primary key column through change_table", async () => {
-    const calls: unknown[][] = [];
-    const schema = {
-      addColumn: (...args: unknown[]) => {
-        calls.push(args);
-        return Promise.resolve();
-      },
-    } as unknown as ConstructorParameters<typeof Table>[1];
-    const t = new Table("delete_me", schema);
-
-    await t.primaryKey("id", "primary_key", { comment: "Primary key comment" });
-
-    expect(calls).toEqual([
-      ["delete_me", "id", "primary_key", { comment: "Primary key comment", primaryKey: true }],
-    ]);
-  });
+  // The change_table arm lives in migration/change-table.test.ts ("primary key
+  // creates primary key column"), mirroring change_table_test.rb.
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -228,7 +228,4 @@ describe("ColumnMethods#primary_key", () => {
     expect(td.columns[0].type).toBe("primary_key");
     expect(td.columns[0].options.primaryKey).toBe(true);
   });
-
-  // The change_table arm lives in migration/change-table.test.ts ("primary key
-  // creates primary key column"), mirroring change_table_test.rb.
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1613,16 +1613,11 @@ export class Table {
     await this.column(name, type, { ...options, array: true });
   }
   async remove(...columnNames: string[]): Promise<void>;
-  async remove(
-    ...args: [...columnNames: string[], options: { type?: ColumnType; ifExists?: boolean }]
-  ): Promise<void>;
+  async remove(...args: [...columnNames: string[], options: ColumnOptions]): Promise<void>;
   async remove(...args: unknown[]): Promise<void> {
     const rest = [...args];
     const last = rest[rest.length - 1];
-    const options = (typeof last === "object" && last !== null ? rest.pop() : {}) as {
-      type?: ColumnType;
-      ifExists?: boolean;
-    };
+    const options = (typeof last === "object" && last !== null ? rest.pop() : {}) as ColumnOptions;
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     await this._schema.removeColumns(
       this._tableName,
@@ -1870,7 +1865,7 @@ export interface SchemaStatementsLike {
   ): Promise<void>;
   removeColumns(
     tableName: string,
-    ...columnsOrOptions: Array<string | { type?: ColumnType; ifExists?: boolean }>
+    ...columnsOrOptions: Array<string | ColumnOptions>
   ): Promise<void>;
   renameColumn(tableName: string, oldName: string, newName: string): Promise<void>;
   addIndex(tableName: string, columns: string | string[], options?: AddIndexOptions): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1540,35 +1540,72 @@ export class Table {
     return name === "timestamp" ? "datetime" : fallback;
   }
 
-  async string(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "string", options);
+  /**
+   * Mirrors what `ColumnMethods.define_column_methods` generates for every
+   * column type: `def <type>(*names, **options)`.
+   * @internal
+   */
+  protected async definedColumn(type: ColumnType, args: unknown[]): Promise<void> {
+    const { names, options } = splitColumnNames(args, type);
+    for (const name of names) {
+      await this.column(name, type, options);
+    }
   }
-  async text(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "text", options);
+
+  async string(...names: string[]): Promise<void>;
+  async string(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async string(...args: unknown[]): Promise<void> {
+    await this.definedColumn("string", args);
   }
-  async integer(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "integer", options);
+  async text(...names: string[]): Promise<void>;
+  async text(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async text(...args: unknown[]): Promise<void> {
+    await this.definedColumn("text", args);
   }
-  async float(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "float", options);
+  async integer(...names: string[]): Promise<void>;
+  async integer(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async integer(...args: unknown[]): Promise<void> {
+    await this.definedColumn("integer", args);
   }
-  async decimal(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "decimal", options);
+  async float(...names: string[]): Promise<void>;
+  async float(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async float(...args: unknown[]): Promise<void> {
+    await this.definedColumn("float", args);
   }
-  async boolean(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "boolean", options);
+  async decimal(...names: string[]): Promise<void>;
+  async decimal(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async decimal(...args: unknown[]): Promise<void> {
+    await this.definedColumn("decimal", args);
   }
-  async date(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "date", options);
+  async boolean(...names: string[]): Promise<void>;
+  async boolean(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async boolean(...args: unknown[]): Promise<void> {
+    await this.definedColumn("boolean", args);
   }
-  async datetime(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "datetime", options);
+  async date(...names: string[]): Promise<void>;
+  async date(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async date(...args: unknown[]): Promise<void> {
+    await this.definedColumn("date", args);
   }
-  async bigint(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "bigint", options);
+  async datetime(...names: string[]): Promise<void>;
+  async datetime(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async datetime(...args: unknown[]): Promise<void> {
+    await this.definedColumn("datetime", args);
   }
-  async char(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "char", options);
+  async bigint(...names: string[]): Promise<void>;
+  async bigint(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async bigint(...args: unknown[]): Promise<void> {
+    await this.definedColumn("bigint", args);
+  }
+  async json(...names: string[]): Promise<void>;
+  async json(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async json(...args: unknown[]): Promise<void> {
+    await this.definedColumn("json", args);
+  }
+  async char(...names: string[]): Promise<void>;
+  async char(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async char(...args: unknown[]): Promise<void> {
+    await this.definedColumn("char", args);
   }
   async virtual(
     name: string,
@@ -1579,9 +1616,25 @@ export class Table {
   async array(name: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {
     await this.column(name, type, { ...options, array: true });
   }
-  async remove(name: string, options: { type?: string; ifExists?: boolean } = {}): Promise<void> {
-    const { type, ...rest } = options;
-    await this._schema.removeColumn(this._tableName, name, type as ColumnType | undefined, rest);
+  // Rails: `Table#remove(*column_names, **options)` forwards the whole name
+  // list to `@base.remove_columns` — a single ALTER, not one per column.
+  async remove(...columnNames: string[]): Promise<void>;
+  async remove(
+    ...args: [...columnNames: string[], options: { type?: ColumnType; ifExists?: boolean }]
+  ): Promise<void>;
+  async remove(...args: unknown[]): Promise<void> {
+    const rest = [...args];
+    const last = rest[rest.length - 1];
+    const options = (typeof last === "object" && last !== null ? rest.pop() : {}) as {
+      type?: ColumnType;
+      ifExists?: boolean;
+    };
+    this.raiseOnIfExistOptions(options as Record<string, unknown>);
+    await this._schema.removeColumns(
+      this._tableName,
+      ...(rest as string[]),
+      ...(Object.keys(options).length > 0 ? [options] : []),
+    );
   }
   async rename(oldName: string, newName: string): Promise<void> {
     await this._schema.renameColumn(this._tableName, oldName, newName);
@@ -1648,7 +1701,7 @@ export class Table {
 
   async isIndexExists(
     columnName: string | string[],
-    options?: Record<string, unknown>,
+    options: Record<string, unknown> = {},
   ): Promise<boolean> {
     return this._require("indexExists").call(this._schema, this._tableName, columnName, options);
   }
@@ -1770,7 +1823,7 @@ export class Table {
     if (key) {
       const conditional = key === "ifExists" ? "if" : "unless";
       const railsKey = key === "ifExists" ? "if_exists" : "if_not_exists";
-      throw new Error(
+      throw new ArgumentError(
         `Option ${railsKey} will be ignored. If you are calling an expression like\n` +
           `\`t.column(.., ${railsKey}: true)\` from inside a change_table block, try a\n` +
           `conditional clause instead, as in \`t.column(..) ${conditional} t.column_exists?(..)\``,
@@ -1795,6 +1848,10 @@ export interface SchemaStatementsLike {
     columnName: string,
     type?: string,
     options?: { ifExists?: boolean },
+  ): Promise<void>;
+  removeColumns(
+    tableName: string,
+    ...columnsOrOptions: Array<string | { type?: ColumnType; ifExists?: boolean }>
   ): Promise<void>;
   renameColumn(tableName: string, oldName: string, newName: string): Promise<void>;
   addIndex(tableName: string, columns: string | string[], options?: AddIndexOptions): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1540,11 +1540,7 @@ export class Table {
     return name === "timestamp" ? "datetime" : fallback;
   }
 
-  /**
-   * Mirrors what `ColumnMethods.define_column_methods` generates for every
-   * column type: `def <type>(*names, **options)`.
-   * @internal
-   */
+  /** @internal */
   protected async definedColumn(type: ColumnType, args: unknown[]): Promise<void> {
     const { names, options } = splitColumnNames(args, type);
     for (const name of names) {
@@ -1616,8 +1612,6 @@ export class Table {
   async array(name: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {
     await this.column(name, type, { ...options, array: true });
   }
-  // Rails: `Table#remove(*column_names, **options)` forwards the whole name
-  // list to `@base.remove_columns` — a single ALTER, not one per column.
   async remove(...columnNames: string[]): Promise<void>;
   async remove(
     ...args: [...columnNames: string[], options: { type?: ColumnType; ifExists?: boolean }]
@@ -1656,13 +1650,19 @@ export class Table {
     this.raiseOnIfExistOptions(optionHash as Record<string, unknown>);
     await this._schema.removeIndex(this._tableName, columnOrOptions, options);
   }
-  async references(name: string, options: AddReferenceOptions = {}): Promise<void> {
+  async references(...refNames: string[]): Promise<void>;
+  async references(...args: [...refNames: string[], options: AddReferenceOptions]): Promise<void>;
+  async references(...args: unknown[]): Promise<void> {
+    const { names, options } = this._splitRefNames(args);
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    await this._schema.addReference(this._tableName, name, options);
+    for (const refName of names) {
+      await this._schema.addReference(this._tableName, refName, options);
+    }
   }
-  /** Alias of references (Rails: `alias :belongs_to :references`). */
-  async belongsTo(name: string, options: AddReferenceOptions = {}): Promise<void> {
-    return this.references(name, options);
+  async belongsTo(...refNames: string[]): Promise<void>;
+  async belongsTo(...args: [...refNames: string[], options: AddReferenceOptions]): Promise<void>;
+  async belongsTo(...args: unknown[]): Promise<void> {
+    return (this.references as (...a: unknown[]) => Promise<void>)(...args);
   }
   async timestamps(options: ColumnOptions = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
@@ -1687,8 +1687,8 @@ export class Table {
     }
   }
 
-  async isColumnExists(columnName: string): Promise<boolean> {
-    return this._require("columnExists").call(this._schema, this._tableName, columnName);
+  async isColumnExists(columnName: string, type?: ColumnType): Promise<boolean> {
+    return this._require("columnExists").call(this._schema, this._tableName, columnName, type);
   }
 
   private _require<K extends keyof SchemaStatementsLike>(
@@ -1744,13 +1744,32 @@ export class Table {
     return this._require("removeTimestamps").call(this._schema, this._tableName, options);
   }
 
-  async removeReferences(name: string, options: AddReferenceOptions = {}): Promise<void> {
+  async removeReferences(...refNames: string[]): Promise<void>;
+  async removeReferences(
+    ...args: [...refNames: string[], options: AddReferenceOptions]
+  ): Promise<void>;
+  async removeReferences(...args: unknown[]): Promise<void> {
+    const { names, options } = this._splitRefNames(args);
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    return this._require("removeReference").call(this._schema, this._tableName, name, options);
+    for (const refName of names) {
+      await this._require("removeReference").call(this._schema, this._tableName, refName, options);
+    }
   }
-  /** Alias of removeReferences (Rails: `alias :remove_belongs_to :remove_references`). */
-  async removeBelongsTo(name: string, options: AddReferenceOptions = {}): Promise<void> {
-    return this.removeReferences(name, options);
+  async removeBelongsTo(...refNames: string[]): Promise<void>;
+  async removeBelongsTo(
+    ...args: [...refNames: string[], options: AddReferenceOptions]
+  ): Promise<void>;
+  async removeBelongsTo(...args: unknown[]): Promise<void> {
+    return (this.removeReferences as (...a: unknown[]) => Promise<void>)(...args);
+  }
+
+  private _splitRefNames(args: unknown[]): { names: string[]; options: AddReferenceOptions } {
+    const rest = [...args];
+    const last = rest[rest.length - 1];
+    const options = (
+      typeof last === "object" && last !== null ? rest.pop() : {}
+    ) as AddReferenceOptions;
+    return { names: rest as string[], options };
   }
 
   async foreignKey(toTable: string, options: Partial<AddForeignKeyOptions> = {}): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1095,20 +1095,14 @@ export class SchemaStatements {
   }
 
   async removeColumns(tableName: string, ...columns: string[]): Promise<void>;
+  async removeColumns(tableName: string, ...args: [...string[], ColumnOptions]): Promise<void>;
   async removeColumns(
     tableName: string,
-    ...args: [...string[], { type?: ColumnType; ifExists?: boolean }]
-  ): Promise<void>;
-  async removeColumns(
-    tableName: string,
-    ...columnsOrOptions: Array<string | ({ type?: ColumnType } & Record<string, unknown>)>
+    ...columnsOrOptions: Array<string | ColumnOptions>
   ): Promise<void> {
     const last = columnsOrOptions[columnsOrOptions.length - 1];
     const hasOpts = typeof last === "object" && last !== null;
-    const opts = (hasOpts ? (columnsOrOptions.pop() as Record<string, unknown>) : {}) as {
-      type?: ColumnType;
-      ifExists?: boolean;
-    };
+    const opts = (hasOpts ? columnsOrOptions.pop() : {}) as ColumnOptions;
     const columns = columnsOrOptions as string[];
     if (columns.length === 0) {
       throw new ArgumentError(
@@ -1124,7 +1118,10 @@ export class SchemaStatements {
       return adapter.removeColumns(tableName, ...columns);
     }
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    const fragments = this.removeColumnsForAlter(tableName, columns, opts);
+    const fragments = this.removeColumnsForAlter(tableName, columns, { ...opts } as Record<
+      string,
+      unknown
+    >);
     await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -563,6 +563,14 @@ export class Table extends AbstractTable {
     this._pgSchema = schema;
   }
 
+  // PostgreSQL::ColumnMethods is mixed into Table as well as TableDefinition.
+  // Only the types exercised through change_table are mirrored here so far.
+  async xml(...names: string[]): Promise<void>;
+  async xml(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async xml(...args: unknown[]): Promise<void> {
+    await this.definedColumn("xml" as ColumnType, args);
+  }
+
   exclusionConstraint(expression: string, options?: ExclusionConstraintOptions): Promise<void> {
     this._requireConstraint("addExclusionConstraint");
     return this._pgSchema.addExclusionConstraint!(this._pgTableName, expression, options);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -563,8 +563,6 @@ export class Table extends AbstractTable {
     this._pgSchema = schema;
   }
 
-  // PostgreSQL::ColumnMethods is mixed into Table as well as TableDefinition.
-  // Only the types exercised through change_table are mirrored here so far.
   async xml(...names: string[]): Promise<void>;
   async xml(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
   async xml(...args: unknown[]): Promise<void> {

--- a/packages/activerecord/src/migration/change-table.test.ts
+++ b/packages/activerecord/src/migration/change-table.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Mirrors Rails activerecord/test/cases/migration/change_table_test.rb
+ * (`ActiveRecord::Migration::TableTest`).
+ *
+ * Rails drives every case through a `Minitest::Mock` standing in for `@base`
+ * and asserts the exact connection call each `change_table` shorthand makes:
+ *
+ *   with_change_table do |t|
+ *     expect :add_column, nil, [:delete_me, :bar, :integer]
+ *     t.column :bar, :integer
+ *   end
+ *
+ * `mockConnection` below is that recorder. Two harness-level deviations, both
+ * forced by the port and neither affecting what is asserted:
+ *
+ *  - Rails obtains the proxy via `lease_connection.update_table_definition`
+ *    purely to pick the adapter's `Table` subclass; with a pure double there is
+ *    no connection to lease, so the subclass is constructed directly (the PG
+ *    block uses `PostgreSQL::Table`, as `update_table_definition` would).
+ *  - trails' `Table` methods pass an options object unconditionally where Ruby
+ *    splats `**options` (so an empty hash is *no* trailing argument). A
+ *    trailing empty object is therefore dropped before comparison, letting the
+ *    expectations stay Rails-literal.
+ */
+import { describe, it, expect as vitestExpect } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
+import {
+  Table,
+  type SchemaStatementsLike,
+} from "../connection-adapters/abstract/schema-definitions.js";
+import { Table as PgTable } from "../connection-adapters/postgresql/schema-definitions.js";
+import { describeIfPg } from "../support/describe-if-pg.js";
+
+type Call = { method: string; args: unknown[] };
+type ExpectFn = (method: string, returns: unknown, args: unknown[]) => void;
+
+function isPlainEmptyObject(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  );
+}
+
+function normalizeArgs(args: unknown[]): unknown[] {
+  const out = [...args];
+  while (out.length > 0 && isPlainEmptyObject(out[out.length - 1])) out.pop();
+  return out.map((a) => (a === undefined ? null : a));
+}
+
+interface MockConnection {
+  base: SchemaStatementsLike;
+  expect: ExpectFn;
+  verify(): void;
+}
+
+function mockConnection(): MockConnection {
+  const expectations: Call[] = [];
+  const returns: unknown[] = [];
+  const calls: Call[] = [];
+
+  const base = new Proxy(
+    {},
+    {
+      get(_target, prop: string) {
+        return (...args: unknown[]) => {
+          calls.push({ method: prop, args: normalizeArgs(args) });
+          return Promise.resolve(returns[calls.length - 1] ?? null);
+        };
+      },
+    },
+  ) as SchemaStatementsLike;
+
+  return {
+    base,
+    expect(method, ret, args) {
+      expectations.push({ method, args: normalizeArgs(args) });
+      returns.push(ret);
+    },
+    verify() {
+      vitestExpect(calls).toEqual(expectations);
+    },
+  };
+}
+
+async function withChangeTable(
+  body: (t: Table, expect: ExpectFn) => Promise<void> | void,
+): Promise<void> {
+  const mock = mockConnection();
+  await body(new Table("delete_me", mock.base), mock.expect);
+  mock.verify();
+}
+
+async function withPgChangeTable(
+  body: (t: PgTable, expect: ExpectFn) => Promise<void> | void,
+): Promise<void> {
+  const mock = mockConnection();
+  await body(new PgTable("delete_me", mock.base), mock.expect);
+  mock.verify();
+}
+
+describe("Migration", () => {
+  describe("TableTest", () => {
+    it("references column type adds id", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addReference", null, ["delete_me", "customer"]);
+        await t.references("customer");
+      });
+    });
+
+    it("remove references column type removes id", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeReference", null, ["delete_me", "customer"]);
+        await t.removeReferences("customer");
+      });
+    });
+
+    it("add belongs to works like add references", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addReference", null, ["delete_me", "customer"]);
+        await t.belongsTo("customer");
+      });
+    });
+
+    it("remove belongs to works like remove references", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeReference", null, ["delete_me", "customer"]);
+        await t.removeBelongsTo("customer");
+      });
+    });
+
+    it("references column type with polymorphic adds type", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addReference", null, ["delete_me", "taggable", { polymorphic: true }]);
+        await t.references("taggable", { polymorphic: true });
+      });
+    });
+
+    it("remove references column type with polymorphic removes type", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeReference", null, ["delete_me", "taggable", { polymorphic: true }]);
+        await t.removeReferences("taggable", { polymorphic: true });
+      });
+    });
+
+    it("references column type with polymorphic and options null is false adds table flag", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addReference", null, ["delete_me", "taggable", { polymorphic: true, null: false }]);
+        await t.references("taggable", { polymorphic: true, null: false });
+      });
+    });
+
+    it("remove references column type with polymorphic and options null is false removes table flag", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeReference", null, [
+          "delete_me",
+          "taggable",
+          { polymorphic: true, null: false },
+        ]);
+        await t.removeReferences("taggable", { polymorphic: true, null: false });
+      });
+    });
+
+    it("references column type with polymorphic and type", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addReference", null, [
+          "delete_me",
+          "taggable",
+          { polymorphic: true, type: "string" },
+        ]);
+        await t.references("taggable", { polymorphic: true, type: "string" });
+      });
+    });
+
+    it("remove references column type with polymorphic and type", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeReference", null, [
+          "delete_me",
+          "taggable",
+          { polymorphic: true, type: "string" },
+        ]);
+        await t.removeReferences("taggable", { polymorphic: true, type: "string" });
+      });
+    });
+
+    it("timestamps creates updated at and created at", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addTimestamps", null, ["delete_me", { null: true }]);
+        await t.timestamps({ null: true });
+      });
+    });
+
+    it("remove timestamps creates updated at and created at", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeTimestamps", null, ["delete_me", { null: true }]);
+        await t.removeTimestamps({ null: true });
+      });
+    });
+
+    it("primary key creates primary key column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addColumn", null, [
+          "delete_me",
+          "id",
+          "primary_key",
+          { primaryKey: true, first: true },
+        ]);
+        // `first:` is MySQL column positioning, still unported (story 0023
+        // `column-options-omit-mysql-first-and-after-positioning`) — it is an
+        // opaque pass-through option here, which is exactly what Rails asserts.
+        await t.primaryKey("id", "primary_key", { first: true } as never);
+      });
+    });
+
+    it("integer creates integer column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "foo", "integer"]);
+        expect("addColumn", null, ["delete_me", "bar", "integer"]);
+        await t.integer("foo", "bar");
+      });
+    });
+
+    it("bigint creates bigint column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "foo", "bigint"]);
+        expect("addColumn", null, ["delete_me", "bar", "bigint"]);
+        await t.bigint("foo", "bar");
+      });
+    });
+
+    it("string creates string column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "foo", "string"]);
+        expect("addColumn", null, ["delete_me", "bar", "string"]);
+        await t.string("foo", "bar");
+      });
+    });
+
+    it("column creates column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "bar", "integer"]);
+        await t.column("bar", "integer");
+      });
+    });
+
+    it("column creates column with options", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "bar", "integer", { null: false }]);
+        await t.column("bar", "integer", { null: false });
+      });
+    });
+
+    it("column creates column with index", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "bar", "integer"]);
+        expect("addIndex", null, ["delete_me", "bar"]);
+        await t.column("bar", "integer", { index: true });
+      });
+    });
+
+    it("index creates index", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addIndex", null, ["delete_me", "bar"]);
+        await t.index("bar");
+      });
+    });
+
+    it("index creates index with options", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addIndex", null, ["delete_me", "bar", { unique: true }]);
+        await t.index("bar", { unique: true });
+      });
+    });
+
+    it("index exists", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("indexExists", null, ["delete_me", "bar"]);
+        await t.isIndexExists("bar");
+      });
+    });
+
+    it("index exists with options", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("indexExists", null, ["delete_me", "bar", { unique: true }]);
+        await t.isIndexExists("bar", { unique: true });
+      });
+    });
+
+    it("rename index renames index", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("renameIndex", null, ["delete_me", "bar", "baz"]);
+        await t.renameIndex("bar", "baz");
+      });
+    });
+
+    it("change changes column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("changeColumn", null, ["delete_me", "bar", "string"]);
+        await t.change("bar", "string");
+      });
+    });
+
+    it("change changes column with options", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("changeColumn", null, ["delete_me", "bar", "string", { null: true }]);
+        await t.change("bar", "string", { null: true });
+      });
+    });
+
+    it("change default changes column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("changeColumnDefault", null, ["delete_me", "bar", "string"]);
+        await t.changeDefault("bar", "string");
+      });
+    });
+
+    it("change null changes column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("changeColumnNull", null, ["delete_me", "bar", true, null]);
+        await t.changeNull("bar", true);
+      });
+    });
+
+    it("remove drops single column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeColumns", null, ["delete_me", "bar"]);
+        await t.remove("bar");
+      });
+    });
+
+    it("remove drops multiple columns", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeColumns", null, ["delete_me", "bar", "baz"]);
+        await t.remove("bar", "baz");
+      });
+    });
+
+    it("remove drops multiple columns when column options are given", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeColumns", null, ["delete_me", "bar", "baz", { type: "string", null: false }]);
+        await t.remove("bar", "baz", { type: "string", null: false } as never);
+      });
+    });
+
+    it("remove index removes index with options", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeIndex", null, ["delete_me", "bar", { unique: true }]);
+        await t.removeIndex("bar", { unique: true } as never);
+      });
+    });
+
+    it("rename renames column", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("renameColumn", null, ["delete_me", "bar", "baz"]);
+        await t.rename("bar", "baz");
+      });
+    });
+
+    it("table name set", async () => {
+      await withChangeTable((t) => {
+        vitestExpect(t.name).toEqual("delete_me");
+      });
+    });
+
+    it("check constraint creates check constraint", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("addCheckConstraint", null, [
+          "delete_me",
+          "price > discounted_price",
+          { name: "price_check" },
+        ]);
+        await t.checkConstraint("price > discounted_price", { name: "price_check" });
+      });
+    });
+
+    it("check constraint exists", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("isCheckConstraintExists", null, ["delete_me", { name: "price_check" }]);
+        vitestExpect(await t.isCheckConstraintExists({ name: "price_check" })).toBeFalsy();
+      });
+    });
+
+    it("remove check constraint removes check constraint", async () => {
+      await withChangeTable(async (t, expect) => {
+        expect("removeCheckConstraint", null, ["delete_me", { name: "price_check" }]);
+        await t.removeCheckConstraint({ name: "price_check" });
+      });
+    });
+
+    it("remove column with if exists raises error", async () => {
+      await vitestExpect(
+        withChangeTable(async (t) => {
+          await t.remove("name", { ifExists: true } as never);
+        }),
+      ).rejects.toThrow(ArgumentError);
+    });
+
+    it("add column with if not exists raises error", async () => {
+      await vitestExpect(
+        withChangeTable(async (t) => {
+          await t.string("nickname", { ifNotExists: true });
+        }),
+      ).rejects.toThrow(ArgumentError);
+    });
+  });
+
+  describeIfPg("TableTest", () => {
+    it("json creates json column", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "foo", "json"]);
+        expect("addColumn", null, ["delete_me", "bar", "json"]);
+        await t.json("foo", "bar");
+      });
+    });
+
+    it("xml creates xml column", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("addColumn", null, ["delete_me", "foo", "xml"]);
+        expect("addColumn", null, ["delete_me", "bar", "xml"]);
+        await t.xml("foo", "bar");
+      });
+    });
+
+    it("exclusion constraint creates exclusion constraint", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("addExclusionConstraint", null, [
+          "delete_me",
+          "daterange(start_date, end_date) WITH &&",
+          {
+            using: "gist",
+            where: "start_date IS NOT NULL AND end_date IS NOT NULL",
+            name: "date_overlap",
+          },
+        ]);
+        await t.exclusionConstraint("daterange(start_date, end_date) WITH &&", {
+          using: "gist",
+          where: "start_date IS NOT NULL AND end_date IS NOT NULL",
+          name: "date_overlap",
+        });
+      });
+    });
+
+    it("remove exclusion constraint removes exclusion constraint", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("removeExclusionConstraint", null, ["delete_me", { name: "date_overlap" }]);
+        await t.removeExclusionConstraint({ name: "date_overlap" });
+      });
+    });
+
+    it("unique constraint creates unique constraint", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("addUniqueConstraint", null, [
+          "delete_me",
+          "foo",
+          { deferrable: "deferred", name: "unique_constraint" },
+        ]);
+        await t.uniqueConstraint("foo", { deferrable: "deferred", name: "unique_constraint" });
+      });
+    });
+
+    it("remove unique constraint removes unique constraint", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("removeUniqueConstraint", null, ["delete_me", { name: "unique_constraint" }]);
+        await t.removeUniqueConstraint({ name: "unique_constraint" });
+      });
+    });
+
+    it("validate check constraint", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("addCheckConstraint", null, [
+          "delete_me",
+          "price > discounted_price",
+          { name: "price_check", validate: false },
+        ]);
+        await t.checkConstraint("price > discounted_price", {
+          name: "price_check",
+          validate: false,
+        });
+        expect("validateCheckConstraint", null, ["delete_me", "price_check"]);
+        await t.validateCheckConstraint("price_check");
+      });
+    });
+
+    it("validate constraint", async () => {
+      await withPgChangeTable(async (t, expect) => {
+        expect("addCheckConstraint", null, [
+          "delete_me",
+          "price > discounted_price",
+          { name: "price_check", validate: false },
+        ]);
+        await t.checkConstraint("price > discounted_price", {
+          name: "price_check",
+          validate: false,
+        });
+        expect("validateConstraint", null, ["delete_me", "price_check"]);
+        await t.validateConstraint("price_check");
+      });
+    });
+  });
+});

--- a/packages/activerecord/src/migration/change-table.test.ts
+++ b/packages/activerecord/src/migration/change-table.test.ts
@@ -1,27 +1,3 @@
-/**
- * Mirrors Rails activerecord/test/cases/migration/change_table_test.rb
- * (`ActiveRecord::Migration::TableTest`).
- *
- * Rails drives every case through a `Minitest::Mock` standing in for `@base`
- * and asserts the exact connection call each `change_table` shorthand makes:
- *
- *   with_change_table do |t|
- *     expect :add_column, nil, [:delete_me, :bar, :integer]
- *     t.column :bar, :integer
- *   end
- *
- * `mockConnection` below is that recorder. Two harness-level deviations, both
- * forced by the port and neither affecting what is asserted:
- *
- *  - Rails obtains the proxy via `lease_connection.update_table_definition`
- *    purely to pick the adapter's `Table` subclass; with a pure double there is
- *    no connection to lease, so the subclass is constructed directly (the PG
- *    block uses `PostgreSQL::Table`, as `update_table_definition` would).
- *  - trails' `Table` methods pass an options object unconditionally where Ruby
- *    splats `**options` (so an empty hash is *no* trailing argument). A
- *    trailing empty object is therefore dropped before comparison, letting the
- *    expectations stay Rails-literal.
- */
 import { describe, it, expect as vitestExpect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import {
@@ -206,9 +182,6 @@ describe("Migration", () => {
           "primary_key",
           { primaryKey: true, first: true },
         ]);
-        // `first:` is MySQL column positioning, still unported (story 0023
-        // `column-options-omit-mysql-first-and-after-positioning`) — it is an
-        // opaque pass-through option here, which is exactly what Rails asserts.
         await t.primaryKey("id", "primary_key", { first: true } as never);
       });
     });

--- a/packages/activerecord/src/migration/change-table.test.ts
+++ b/packages/activerecord/src/migration/change-table.test.ts
@@ -312,7 +312,7 @@ describe("Migration", () => {
     it("remove drops multiple columns when column options are given", async () => {
       await withChangeTable(async (t, expect) => {
         expect("removeColumns", null, ["delete_me", "bar", "baz", { type: "string", null: false }]);
-        await t.remove("bar", "baz", { type: "string", null: false } as never);
+        await t.remove("bar", "baz", { type: "string", null: false });
       });
     });
 
@@ -364,7 +364,7 @@ describe("Migration", () => {
     it("remove column with if exists raises error", async () => {
       await vitestExpect(
         withChangeTable(async (t) => {
-          await t.remove("name", { ifExists: true } as never);
+          await t.remove("name", { ifExists: true });
         }),
       ).rejects.toThrow(ArgumentError);
     });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -135,20 +135,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "remove",
-    "call": "raise_on_if_exist_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "remove",
-    "call": "remove_columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "remove_column",
     "call": "delete",
     "reason": "Newly comparable (RFC 0072 arity sweep): Rails deletes from the `@columns_hash` Hash; TableDefinition here stores `columns` as an ordered array, so the same removal is a findIndex/splice. Equivalent — no Hash to delete from."


### PR DESCRIPTION
Mirrors `activerecord/test/cases/migration/change_table_test.rb`
(`ActiveRecord::Migration::TableTest`) — the file that pins the whole
`change_table` proxy and had no trails counterpart at all. All 47 cases.

## Deltas

- `test:compare`: `migration/change_table_test.rb` 0/47 → **47/47 ✓**; overall
  activerecord matched tests 14824 → 14873. `test:compare --check` exits 0 (no
  gate mismatch: the PG-only block sits under `describeIfPg`, matching Rails'
  `current_adapter?(:PostgreSQLAdapter)`).
- `api:compare`: `connection_adapters/abstract/schema_definitions.rb` 113/113,
  `postgresql/schema_definitions.rb` 61/62 (the one miss,
  `integer_like_primary_key_type`, predates this PR). Overall unchanged
  otherwise; `--check` exits 0. No new extra surface, no arity regressions.

## Harness

`mockConnection` is the port of Rails' `Minitest::Mock` + `with_change_table` /
`expect` recorder: expectations are queued as `(method, returns, args)` and
verified in order at the end of each block, so every case reads Rails-literal.
Two harness-level deviations, both forced by the port and neither affecting what
is asserted:

- Rails leases a connection only so `update_table_definition` can pick the
  adapter's `Table` subclass; with a pure double there is nothing to lease, so
  the subclass is constructed directly (the PG block uses `PostgreSQL::Table`,
  exactly what `update_table_definition` returns there).
- trails' `Table` methods always pass an options object where Ruby splats
  `**options` (an empty hash is *no* trailing argument), so a trailing empty
  object is dropped before comparison.

## Fidelity fixes the ported file exposed

- `Table`'s column shorthands take Rails' variadic `*names` form
  (`t.integer :foo, :bar`) via a `definedColumn` helper mirroring
  `ColumnMethods.define_column_methods`, and `json` is added (it is in Rails'
  `define_column_methods` list).
- `Table#references` / `#remove_references` (and the `belongs_to` /
  `remove_belongs_to` aliases) take `*args` and loop, as Rails does.
- `Table#remove` forwards the whole name list to `remove_columns` — one ALTER,
  as Rails does — instead of a single `remove_column`, and raises on
  `if_exists:`.
- `Table#index_exists?` passes no options hash when none were given;
  `#column_exists?` forwards the optional `type` argument.
- `raise_on_if_exist_options` raises `ArgumentError`, not a bare `Error` — both
  the `if_exists` and `if_not_exists` cases assert `ArgumentError`.
- `PostgreSQL::Table` gains `xml` (`PostgreSQL::ColumnMethods` is mixed into
  `Table` as well as `TableDefinition`). The rest of that module's types are
  still missing from `Table` — out of scope for this file, registered as story
  `pg-column-methods-on-change-table-proxy` (RFC 0005).

The one-off `change_table` assertion #5614 had to park in
`schema-definitions.trails.test.ts` folds into the mirrored file and is deleted
there.

`primary_key` uses the Rails-literal `first: true`. `first:` is MySQL column
positioning still awaiting story 0023; on the recorder path it is an opaque
pass-through option, which is exactly what Rails asserts.

## Size

601 LOC, 501 of it the mirrored test file — over the 500 ceiling. It is a 1:1
mirror of one Rails test file; splitting it would fragment a single Rails file
across PRs and duplicate the same `Table` changes in both.

Closes-story: port-change-table-test-cases
