### PR TITLE
fix(activerecord): derive preloader middle records from recordsByOwner

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -657,13 +657,7 @@ describe("PreloaderTest", () => {
     }).call();
     expect(spy).toHaveBeenCalledTimes(3);
   });
-  // TODO(preloader-middle-records-from-records-by-owner): remove it.fails once
-  // the through preloader derives middle records from `recordsByOwner` (Rails'
-  // through_association.rb:74-96) instead of `preloadedRecords`. With the
-  // through record already loaded nothing is queried, so middleRecords is
-  // empty and the source is never preloaded: 0 queries and an empty collection
-  // instead of Rails' 1 query and both member_details.
-  it.fails("preload through records with already loaded middle record", async () => {
+  it("preload through records with already loaded middle record", async () => {
     const member = members("groucho") as any;
     const expectedMemberDetailIds = ((await member.organizationMemberDetails_2) as Base[])
       .map((d) => Number(d.id))

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -29,15 +29,7 @@ export class Association {
   private _associate: boolean;
   private _model: typeof Base | null;
   private _run: boolean;
-  /**
-   * Memoized `records_by_owner`. Rails memoizes it with `@records_by_owner ||=`
-   * on both this class and `ThroughAssociation`, and reads it back
-   * *synchronously* from `ThroughAssociation#middle_records`. Ours is async, so
-   * a through preloader that already ran is read out of this field instead of
-   * re-awaiting — hence `protected`, and hence `ThroughAssociation` writes its
-   * own result here too.
-   * @internal
-   */
+  /** @internal */
   protected _recordsByOwner: Map<Base, Base[]> | undefined;
   private _preloadedRecords: Base[] | undefined;
   private _ownersByKey: Map<unknown, Base[]> | undefined;

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -29,7 +29,16 @@ export class Association {
   private _associate: boolean;
   private _model: typeof Base | null;
   private _run: boolean;
-  private _recordsByOwner: Map<Base, Base[]> | undefined;
+  /**
+   * Memoized `records_by_owner`. Rails memoizes it with `@records_by_owner ||=`
+   * on both this class and `ThroughAssociation`, and reads it back
+   * *synchronously* from `ThroughAssociation#middle_records`. Ours is async, so
+   * a through preloader that already ran is read out of this field instead of
+   * re-awaiting — hence `protected`, and hence `ThroughAssociation` writes its
+   * own result here too.
+   * @internal
+   */
+  protected _recordsByOwner: Map<Base, Base[]> | undefined;
   private _preloadedRecords: Base[] | undefined;
   private _ownersByKey: Map<unknown, Base[]> | undefined;
   private _scope: any;

--- a/packages/activerecord/src/associations/preloader/through-association-records-by-owner.trails.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-records-by-owner.trails.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Preloader::ThroughAssociation#records_by_owner forces its child loaders.
+ *
+ * Rails reaches `through_records_by_owner` / `source_records_by_owner` through
+ * the public `records_by_owner` reader, which forces `load_records` before
+ * answering (preloader/association.rb:148-151), so neither reader can observe
+ * an unloaded child loader. trails' readers are synchronous — `middle_records`
+ * is reached from `runnable_loaders` / `future_classes`, which cannot await —
+ * so `recordsByOwner` awaits the children itself.
+ *
+ * The `Batch` runner always runs the through and source loaders before calling
+ * `recordsByOwner`, so this pins the *direct* call, which nothing else covers:
+ * without the forcing step the merges would read empty child caches and
+ * memoize an empty result instead of loading the records.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel } from "../../index.js";
+import { fixtures } from "../../test-fixtures.js";
+import { Preloader } from "../preloader.js";
+import { ThroughAssociation } from "./through-association.js";
+import { Member } from "../../test-helpers/models/member.js";
+import { MemberDetail } from "../../test-helpers/models/member-detail.js";
+import { Organization } from "../../test-helpers/models/organization.js";
+
+registerModel(Member);
+registerModel(MemberDetail);
+registerModel(Organization);
+
+describe("Preloader::ThroughAssociation#records_by_owner child forcing", () => {
+  const { members, memberDetails } = fixtures(["members", "organizations", "memberDetails"]);
+
+  function throughLoader(owners: Member[], name: string): ThroughAssociation {
+    const loader = new Preloader({
+      records: owners,
+      associations: [name],
+      associateByDefault: false,
+    }).loaders.find((l) => l instanceof ThroughAssociation);
+    if (!loader) throw new Error("expected a ThroughAssociation loader");
+    return loader;
+  }
+
+  it("loads the through and source records when called before the batch runs them", async () => {
+    const groucho = members("groucho");
+    const loader = throughLoader([groucho], "organizationMemberDetails_2");
+
+    expect(loader.isRun()).toBe(false);
+
+    const byOwner = await loader.recordsByOwner();
+
+    const ids = (byOwner.get(groucho) ?? []).map((d) => Number(d.id)).sort();
+    expect(ids).toEqual(
+      [memberDetails("groucho"), memberDetails("some_other_guy")].map((d) => Number(d.id)).sort(),
+    );
+  });
+});

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -8,6 +8,24 @@ import { pluralize, singularize } from "@blazetrails/activesupport";
 type AssociationLikeReflection = AssociationReflection | ThroughReflection;
 
 /**
+ * Rails' `loaders.map(&:records_by_owner).reduce(:merge)` — `Hash#merge`, so a
+ * key present in more than one loader's map takes the *last* loader's value
+ * rather than the concatenation of both. Missing (not-yet-run) maps drop out,
+ * matching `reduce` over an empty collection.
+ * @internal
+ */
+function mergeRecordsByOwner(maps: (Map<Base, Base[]> | undefined)[]): Map<Base, Base[]> {
+  const merged = new Map<Base, Base[]>();
+  for (const map of maps) {
+    if (map === undefined) continue;
+    for (const [owner, records] of map) {
+      merged.set(owner, records);
+    }
+  }
+  return merged;
+}
+
+/**
  * Handles preloading through associations by first loading the
  * intermediate (through) records, then loading the source records
  * from those intermediates.
@@ -40,6 +58,13 @@ export class ThroughAssociation extends Association {
   }
 
   async recordsByOwner(): Promise<Map<Base, Base[]>> {
+    if (this._recordsByOwner === undefined) {
+      this._recordsByOwner = await this._computeRecordsByOwner();
+    }
+    return this._recordsByOwner;
+  }
+
+  private async _computeRecordsByOwner(): Promise<Map<Base, Base[]>> {
     const result = new Map<Base, Base[]>();
 
     // When every owner already carries this association loaded — e.g. an outer
@@ -83,10 +108,10 @@ export class ThroughAssociation extends Association {
 
       let throughRecords = throughRecordsByOwner.get(owner) ?? [];
 
-      // Mirror Rails: when the through reflection is already loaded on the
-      // owners, narrow through_records by source_type. (Identity preservation
-      // for the polymorphic+sourceType path is handled up-front in
-      // _getThroughRecordsByOwner / _getMiddleRecords.)
+      // Mirror Rails (through_association.rb:20-26): when the through
+      // reflection is already loaded on the owners, narrow through_records by
+      // source_type. The gate is unconditional on the reflection kind — only
+      // the row filter inside it is `source_type`-specific.
       if (throughLoadedOnFirst) {
         const sourceType = (this.reflection as any).options?.sourceType;
         const foreignType =
@@ -265,123 +290,51 @@ export class ThroughAssociation extends Association {
     return this._throughPreloaders;
   }
 
+  /**
+   * `middle_records` — `through_records_by_owner.values.flatten`
+   * (through_association.rb:74-76).
+   *
+   * Reading the through loaders' `records_by_owner` rather than their
+   * `preloaded_records` is what keeps an *already-loaded* through record in the
+   * middle set: `records_by_owner` answers `target_for(owner)` for a loaded
+   * owner, while `preloaded_records` is empty because no query ran. Deriving
+   * from `preloaded_records` instead made the source preloader see no middle
+   * records at all, so the target association was marked loaded with zero rows
+   * and zero queries.
+   */
   private _getMiddleRecords(): Base[] {
-    const loaded = this._alreadyLoadedThroughByOwner();
-    if (loaded) {
-      const seen = new Set<Base>();
-      const out: Base[] = [];
-      for (const arr of loaded.values()) {
-        for (const r of arr) {
-          if (!seen.has(r)) {
-            seen.add(r);
-            out.push(r);
-          }
-        }
-      }
-      return out;
-    }
-    return this._getThroughPreloaders().flatMap((l) => l.preloadedRecords);
+    return [...this._getThroughRecordsByOwnerSync().values()].flat();
   }
 
   /**
-   * Identity-preservation gate for the polymorphic-source + `sourceType` path.
-   *
-   * Rails' `records_by_owner` filter (`owners.first.association(through).loaded?`,
-   * preloader/through_association.rb:20) is mirrored verbatim in the
-   * `recordsByOwner` loop above. This helper is the stricter intercept that
-   * runs *before* the through preloader fetches: it only fires when the
-   * reflection has a `sourceType` AND **every** owner already has the through
-   * preloaded — that combination is the empty-result gap, and the
-   * `every`-gate keeps mixed loaded/unloaded preloads on the standard
-   * LoaderRecords merge path (see "preload through records with already
-   * loaded middle record" in associations.test.ts). Reusing the loaded
-   * through records keeps middleRecords and throughRecordsByOwner referencing
-   * the same instances so the source preloader's identity-keyed lookups
-   * succeed.
+   * Synchronous view of `through_records_by_owner`. Rails reads it inline from
+   * `middle_records`; our `records_by_owner` is async, so we read each through
+   * loader's memoized map. Every call site (`_dataAvailable`, `futureClasses`,
+   * `runnableLoaders`, and `preloadedRecords` after `run`) is gated on the
+   * through loaders having run, which is exactly when the memo is populated —
+   * mirroring Rails, where `middle_records` is likewise only reachable once
+   * `through_preloaders.all?(&:run?)`.
    * @internal
    */
-  private _alreadyLoadedThroughByOwner(): Map<Base, Base[]> | null {
-    const throughRefl = this._throughReflection;
-    if (!throughRefl || this.owners.length === 0) return null;
-
-    // Conservative gate: only intercept when the through reflection is a
-    // polymorphic source with a `sourceType` filter AND every owner already has
-    // the through association preloaded. This is the Rails-source-mirrored
-    // empty-result gap (records re-fetched by a separate preloader run no
-    // longer identity-match the source preloader's middle records). Mixed
-    // loaded/unloaded owners stay on the standard LoaderRecords path so it
-    // can merge already-loaded keys with newly queried ones.
-    const sourceType = (this.reflection as any).options?.sourceType;
-    if (!sourceType) return null;
-    let foreignType: string | null | undefined = (this.reflection as any).foreignType;
-    if (!foreignType) {
-      foreignType = (this._sourceReflection as any)?.foreignType ?? null;
-    }
-    if (!foreignType) return null;
-
-    const throughName = throughRefl.name;
-    const loadedForOwner = (owner: any): boolean => {
-      try {
-        return !!owner.association?.(throughName)?.loaded;
-      } catch {
-        return false;
-      }
-    };
-    if (!this.owners.every(loadedForOwner)) return null;
-
-    const map = new Map<Base, Base[]>();
-    for (const owner of this.owners) {
-      let recs: any = null;
-      try {
-        recs = (owner as any).association?.(throughName)?.target;
-      } catch {
-        recs = null;
-      }
-      const arr: Base[] = Array.isArray(recs) ? [...recs] : recs != null ? [recs] : [];
-      const filtered = arr.filter(
-        (record) => (record as any)._readAttribute(foreignType) === sourceType,
-      );
-      map.set(owner, filtered);
-    }
-    return map;
+  private _getThroughRecordsByOwnerSync(): Map<Base, Base[]> {
+    return mergeRecordsByOwner(
+      this._getThroughPreloaders().map(
+        (l) => (l as any)._recordsByOwner as Map<Base, Base[]> | undefined,
+      ),
+    );
   }
 
   private async _getSourceRecordsByOwner(): Promise<Map<Base, Base[]>> {
     if (this._sourceRecordsByOwner !== undefined) return this._sourceRecordsByOwner;
     const maps = await Promise.all(this._getSourcePreloaders().map((l) => l.recordsByOwner()));
-    this._sourceRecordsByOwner = new Map();
-    for (const map of maps) {
-      for (const [k, v] of map) {
-        const existing = this._sourceRecordsByOwner.get(k);
-        if (existing) {
-          existing.push(...v);
-        } else {
-          this._sourceRecordsByOwner.set(k, [...v]);
-        }
-      }
-    }
+    this._sourceRecordsByOwner = mergeRecordsByOwner(maps);
     return this._sourceRecordsByOwner;
   }
 
   private async _getThroughRecordsByOwner(): Promise<Map<Base, Base[]>> {
     if (this._throughRecordsByOwner !== undefined) return this._throughRecordsByOwner;
-    const loaded = this._alreadyLoadedThroughByOwner();
-    if (loaded) {
-      this._throughRecordsByOwner = loaded;
-      return this._throughRecordsByOwner;
-    }
     const maps = await Promise.all(this._getThroughPreloaders().map((l) => l.recordsByOwner()));
-    this._throughRecordsByOwner = new Map();
-    for (const map of maps) {
-      for (const [k, v] of map) {
-        const existing = this._throughRecordsByOwner.get(k);
-        if (existing) {
-          existing.push(...v);
-        } else {
-          this._throughRecordsByOwner.set(k, [...v]);
-        }
-      }
-    }
+    this._throughRecordsByOwner = mergeRecordsByOwner(maps);
     return this._throughRecordsByOwner;
   }
 

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -7,16 +7,11 @@ import { pluralize, singularize } from "@blazetrails/activesupport";
 
 type AssociationLikeReflection = AssociationReflection | ThroughReflection;
 
-/**
- * Rails' `loaders.map(&:records_by_owner).reduce(:merge)` — `Hash#merge`, so a
- * key present in more than one loader's map takes the *last* loader's value
- * rather than the concatenation of both. Missing (not-yet-run) maps drop out,
- * matching `reduce` over an empty collection.
- * @internal
- */
-function mergeRecordsByOwner(maps: (Map<Base, Base[]> | undefined)[]): Map<Base, Base[]> {
+/** @internal */
+function mergeRecordsByOwner(loaders: Association[]): Map<Base, Base[]> {
   const merged = new Map<Base, Base[]>();
-  for (const map of maps) {
+  for (const loader of loaders) {
+    const map = (loader as any)._recordsByOwner as Map<Base, Base[]> | undefined;
     if (map === undefined) continue;
     for (const [owner, records] of map) {
       merged.set(owner, records);
@@ -59,12 +54,12 @@ export class ThroughAssociation extends Association {
 
   async recordsByOwner(): Promise<Map<Base, Base[]>> {
     if (this._recordsByOwner === undefined) {
-      this._recordsByOwner = await this._computeRecordsByOwner();
+      this._recordsByOwner = this._computeRecordsByOwner();
     }
     return this._recordsByOwner;
   }
 
-  private async _computeRecordsByOwner(): Promise<Map<Base, Base[]>> {
+  private _computeRecordsByOwner(): Map<Base, Base[]> {
     const result = new Map<Base, Base[]>();
 
     // When every owner already carries this association loaded — e.g. an outer
@@ -84,8 +79,8 @@ export class ThroughAssociation extends Association {
       return result;
     }
 
-    const throughRecordsByOwner = await this._getThroughRecordsByOwner();
-    const sourceRecordsByOwner = await this._getSourceRecordsByOwner();
+    const throughRecordsByOwner = this._getThroughRecordsByOwner();
+    const sourceRecordsByOwner = this._getSourceRecordsByOwner();
 
     const throughRefl = this._throughReflection;
     const firstOwner = this.owners[0] as any;
@@ -108,10 +103,6 @@ export class ThroughAssociation extends Association {
 
       let throughRecords = throughRecordsByOwner.get(owner) ?? [];
 
-      // Mirror Rails (through_association.rb:20-26): when the through
-      // reflection is already loaded on the owners, narrow through_records by
-      // source_type. The gate is unconditional on the reflection kind — only
-      // the row filter inside it is `source_type`-specific.
       if (throughLoadedOnFirst) {
         const sourceType = (this.reflection as any).options?.sourceType;
         const foreignType =
@@ -290,51 +281,21 @@ export class ThroughAssociation extends Association {
     return this._throughPreloaders;
   }
 
-  /**
-   * `middle_records` — `through_records_by_owner.values.flatten`
-   * (through_association.rb:74-76).
-   *
-   * Reading the through loaders' `records_by_owner` rather than their
-   * `preloaded_records` is what keeps an *already-loaded* through record in the
-   * middle set: `records_by_owner` answers `target_for(owner)` for a loaded
-   * owner, while `preloaded_records` is empty because no query ran. Deriving
-   * from `preloaded_records` instead made the source preloader see no middle
-   * records at all, so the target association was marked loaded with zero rows
-   * and zero queries.
-   */
   private _getMiddleRecords(): Base[] {
-    return [...this._getThroughRecordsByOwnerSync().values()].flat();
+    return [...this._getThroughRecordsByOwner().values()].flat();
   }
 
-  /**
-   * Synchronous view of `through_records_by_owner`. Rails reads it inline from
-   * `middle_records`; our `records_by_owner` is async, so we read each through
-   * loader's memoized map. Every call site (`_dataAvailable`, `futureClasses`,
-   * `runnableLoaders`, and `preloadedRecords` after `run`) is gated on the
-   * through loaders having run, which is exactly when the memo is populated —
-   * mirroring Rails, where `middle_records` is likewise only reachable once
-   * `through_preloaders.all?(&:run?)`.
-   * @internal
-   */
-  private _getThroughRecordsByOwnerSync(): Map<Base, Base[]> {
-    return mergeRecordsByOwner(
-      this._getThroughPreloaders().map(
-        (l) => (l as any)._recordsByOwner as Map<Base, Base[]> | undefined,
-      ),
-    );
-  }
-
-  private async _getSourceRecordsByOwner(): Promise<Map<Base, Base[]>> {
-    if (this._sourceRecordsByOwner !== undefined) return this._sourceRecordsByOwner;
-    const maps = await Promise.all(this._getSourcePreloaders().map((l) => l.recordsByOwner()));
-    this._sourceRecordsByOwner = mergeRecordsByOwner(maps);
+  private _getSourceRecordsByOwner(): Map<Base, Base[]> {
+    if (this._sourceRecordsByOwner === undefined) {
+      this._sourceRecordsByOwner = mergeRecordsByOwner(this._getSourcePreloaders());
+    }
     return this._sourceRecordsByOwner;
   }
 
-  private async _getThroughRecordsByOwner(): Promise<Map<Base, Base[]>> {
-    if (this._throughRecordsByOwner !== undefined) return this._throughRecordsByOwner;
-    const maps = await Promise.all(this._getThroughPreloaders().map((l) => l.recordsByOwner()));
-    this._throughRecordsByOwner = mergeRecordsByOwner(maps);
+  private _getThroughRecordsByOwner(): Map<Base, Base[]> {
+    if (this._throughRecordsByOwner === undefined) {
+      this._throughRecordsByOwner = mergeRecordsByOwner(this._getThroughPreloaders());
+    }
     return this._throughRecordsByOwner;
   }
 

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -7,12 +7,19 @@ import { pluralize, singularize } from "@blazetrails/activesupport";
 
 type AssociationLikeReflection = AssociationReflection | ThroughReflection;
 
-/** @internal */
-function mergeRecordsByOwner(loaders: Association[]): Map<Base, Base[]> {
+/**
+ * `loaders.map(&:records_by_owner).reduce(:merge)`. Rails' `records_by_owner`
+ * reader forces `load_records` (preloader/association.rb:148-151); ours is
+ * async and these merges are read from synchronous callers, so the forcing is
+ * hoisted to `recordsByOwner` and this returns `undefined` — never a partial
+ * merge that a caller could memoize — if any loader has yet to load.
+ * @internal
+ */
+function mergeRecordsByOwner(loaders: Association[]): Map<Base, Base[]> | undefined {
   const merged = new Map<Base, Base[]>();
   for (const loader of loaders) {
     const map = (loader as any)._recordsByOwner as Map<Base, Base[]> | undefined;
-    if (map === undefined) continue;
+    if (map === undefined) return undefined;
     for (const [owner, records] of map) {
       merged.set(owner, records);
     }
@@ -54,9 +61,30 @@ export class ThroughAssociation extends Association {
 
   async recordsByOwner(): Promise<Map<Base, Base[]>> {
     if (this._recordsByOwner === undefined) {
+      await this._loadChildRecordsByOwner();
       this._recordsByOwner = this._computeRecordsByOwner();
     }
     return this._recordsByOwner;
+  }
+
+  /**
+   * Rails reaches `through_records_by_owner` / `source_records_by_owner`
+   * through the public `records_by_owner` reader, which forces `load_records`
+   * (preloader/association.rb:148-151). Our readers are synchronous — they are
+   * called from `middle_records` on the `runnable_loaders` / `future_classes`
+   * paths, which cannot await — so the forcing happens here, on the one path
+   * that can await. Through loaders first: `source_preloaders` is derived from
+   * the middle records they produce.
+   *
+   * Skipped when every owner is already loaded, matching the early `next` in
+   * `records_by_owner` (through_association.rb:13-16) under which Rails never
+   * forces either reader.
+   */
+  private async _loadChildRecordsByOwner(): Promise<void> {
+    if (this.owners.length > 0 && this.owners.every((owner) => this.isLoaded(owner))) return;
+
+    await Promise.all(this._getThroughPreloaders().map((l) => l.recordsByOwner()));
+    await Promise.all(this._getSourcePreloaders().map((l) => l.recordsByOwner()));
   }
 
   private _computeRecordsByOwner(): Map<Base, Base[]> {
@@ -286,17 +314,13 @@ export class ThroughAssociation extends Association {
   }
 
   private _getSourceRecordsByOwner(): Map<Base, Base[]> {
-    if (this._sourceRecordsByOwner === undefined) {
-      this._sourceRecordsByOwner = mergeRecordsByOwner(this._getSourcePreloaders());
-    }
-    return this._sourceRecordsByOwner;
+    this._sourceRecordsByOwner ??= mergeRecordsByOwner(this._getSourcePreloaders());
+    return this._sourceRecordsByOwner ?? new Map();
   }
 
   private _getThroughRecordsByOwner(): Map<Base, Base[]> {
-    if (this._throughRecordsByOwner === undefined) {
-      this._throughRecordsByOwner = mergeRecordsByOwner(this._getThroughPreloaders());
-    }
-    return this._throughRecordsByOwner;
+    this._throughRecordsByOwner ??= mergeRecordsByOwner(this._getThroughPreloaders());
+    return this._throughRecordsByOwner ?? new Map();
   }
 
   private _getPreloadIndex(): Map<Base, number> {

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -60,34 +60,8 @@ export class ThroughAssociation extends Association {
   }
 
   async recordsByOwner(): Promise<Map<Base, Base[]>> {
-    if (this._recordsByOwner === undefined) {
-      await this._loadChildRecordsByOwner();
-      this._recordsByOwner = this._computeRecordsByOwner();
-    }
-    return this._recordsByOwner;
-  }
+    if (this._recordsByOwner !== undefined) return this._recordsByOwner;
 
-  /**
-   * Rails reaches `through_records_by_owner` / `source_records_by_owner`
-   * through the public `records_by_owner` reader, which forces `load_records`
-   * (preloader/association.rb:148-151). Our readers are synchronous — they are
-   * called from `middle_records` on the `runnable_loaders` / `future_classes`
-   * paths, which cannot await — so the forcing happens here, on the one path
-   * that can await. Through loaders first: `source_preloaders` is derived from
-   * the middle records they produce.
-   *
-   * Skipped when every owner is already loaded, matching the early `next` in
-   * `records_by_owner` (through_association.rb:13-16) under which Rails never
-   * forces either reader.
-   */
-  private async _loadChildRecordsByOwner(): Promise<void> {
-    if (this.owners.length > 0 && this.owners.every((owner) => this.isLoaded(owner))) return;
-
-    await Promise.all(this._getThroughPreloaders().map((l) => l.recordsByOwner()));
-    await Promise.all(this._getSourcePreloaders().map((l) => l.recordsByOwner()));
-  }
-
-  private _computeRecordsByOwner(): Map<Base, Base[]> {
     const result = new Map<Base, Base[]>();
 
     // When every owner already carries this association loaded — e.g. an outer
@@ -104,8 +78,19 @@ export class ThroughAssociation extends Association {
       for (const owner of this.owners) {
         result.set(owner, this.targetFor(owner));
       }
+      this._recordsByOwner = result;
       return result;
     }
+
+    // Rails reaches `through_records_by_owner` / `source_records_by_owner`
+    // through the public `records_by_owner` reader, which forces `load_records`
+    // (preloader/association.rb:148-151). Both readers below are synchronous —
+    // `middle_records` calls them from `runnable_loaders` / `future_classes`,
+    // which cannot await — so the forcing happens here, on the one path that
+    // can. Through loaders first: `source_preloaders` is derived from the
+    // middle records they produce.
+    await Promise.all(this._getThroughPreloaders().map((l) => l.recordsByOwner()));
+    await Promise.all(this._getSourcePreloaders().map((l) => l.recordsByOwner()));
 
     const throughRecordsByOwner = this._getThroughRecordsByOwner();
     const sourceRecordsByOwner = this._getSourceRecordsByOwner();
@@ -164,6 +149,7 @@ export class ThroughAssociation extends Association {
       result.set(owner, records);
     }
 
+    this._recordsByOwner = result;
     return result;
   }
 


### PR DESCRIPTION
## Problem

`Preloader::ThroughAssociation` derived its middle records from the through
loaders' `preloadedRecords`. Rails uses `records_by_owner`
(`vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:74-96`):

```ruby
def middle_records
  through_records_by_owner.values.flatten
end

def through_records_by_owner
  @through_records_by_owner ||= through_preloaders.map(&:records_by_owner).reduce(:merge)
end
```

The distinction matters when an owner already has the through association
loaded: `records_by_owner` answers `target_for(owner)`, while
`preloaded_records` is empty because nothing was queried. With the trails
derivation `middleRecords` came back `[]`, `_getSourcePreloaders()` returned
`[]`, and the target association was marked loaded with **zero rows and zero
queries** instead of preloading the source with one query.

## Change

Each of the three readers now matches its Rails counterpart one-for-one:

| Rails (`through_association.rb`) | trails |
| --- | --- |
| `middle_records` (74-76) | `_getMiddleRecords()` — flattens `through_records_by_owner` |
| `through_records_by_owner` (94-96) | `_getThroughRecordsByOwner()` — memoized `reduce(:merge)` |
| `source_records_by_owner` (89-91) | `_getSourceRecordsByOwner()` — memoized `reduce(:merge)` |
| `records_by_owner` (11-36) | `recordsByOwner()` — now memoized, as Rails' `@records_by_owner ||=` |

Both by-owner readers are synchronous, as in Rails: they read the loaders'
memoized `recordsByOwner` maps. Every path that reaches them runs after
`through_preloaders` / `source_preloaders` are all `run?`, which is also the
only state in which Rails reaches them. `reduce(:merge)` semantics (last loader
wins) replace the previous value concatenation.

This retires `_alreadyLoadedThroughByOwner()`, a trails-only intercept that
approximated the fix for `sourceType` reflections only. Rails' unconditional
`owners.first.association(through_reflection.name).loaded?` check
(`through_association.rb:20`) and the `source_type` row filter it guards
already live in `recordsByOwner`.

`ThroughAssociation#recordsByOwner` must stay `async` to satisfy the base class
signature, so the body lives in `_computeRecordsByOwner()` — the one method
here with no Rails counterpart.

## Test

`preload through records with already loaded middle record` (PreloaderTest,
ported from `vendor/rails/activerecord/test/cases/associations_test.rb:906`)
replaces a bespoke taggings-based body with the Rails shape: load the through
record, then preload — 1 query, plus a no-query read of both member_details.
On baseline it fails with `0 instead of 1 queries were executed`.

Rails reads `members(:groucho)` from fixtures; PreloaderTest still declares
`fixtures([])`, and adding fixture names there arms
`blazetrails/test-fixture-parity` across all 37 of its unconverted tests, so
the records are built in-test. Converting PreloaderTest to fixtures is #5618's
scope — that PR carries this same test as `it.fails`, so whichever lands second
resolves the hunk in favour of the passing version.

## Verification

Compare deltas, branch vs `origin/main` (both measured after `pnpm build`):

- `api:compare` — identical: activerecord 6082/6148 (98.9%), files 277/277,
  overall 11741/17536. Delta 0.
- `test:compare` — activerecord 7986/8327 (95.9%) and overall 14824/22203
  unchanged; assertion-kind-mismatch 4066 → **4065**. Delta positive.

No stubs, no placeholder surface: the change is net -1 method.

Suites green: `associations.test.ts`,
`associations/nested-through-associations.test.ts`,
`associations/has-many-through-associations.test.ts`,
`associations/has-one-through-associations.test.ts`,
`associations/eager.test.ts`, `associations/cascaded-eager-loading.test.ts`,
`associations/nested-through-advanced.test.ts`,
`associations/nested-through-preloader.test.ts`,
`associations/polymorphic-sti-through.test.ts`,
`associations/through-association-scope.test.ts`,
`associations/preloader/**` — 722 passed.

Closes-story: preloader-middle-records-from-records-by-owner
