### PR TITLE
feat(activerecord): port PostgreSQL::ColumnMethods onto PostgreSQL::Table

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/citext.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/citext.test.ts
@@ -6,7 +6,10 @@ import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Base, Rollback } from "../../index.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
+import type {
+  TableDefinition as PgTableDefinition,
+  Table as PgTable,
+} from "../../connection-adapters/postgresql/schema-definitions.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
 class Citext extends Base {
@@ -58,10 +61,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("change table supports json", async () => {
       try {
         await connection.transaction(async () => {
-          // Rails: t.citext "username" — PgTable (change_table builder) lacks citext();
-          // TODO: add citext() to PgTable so this mirrors t.citext "username" exactly.
           await connection.changeTable("citexts", async (t) => {
-            await t.column("username", "citext");
+            await (t as PgTable).citext("username");
           });
           Citext.resetColumnInformation();
           // Rails: assert_equal :citext, Citext.columns_hash["username"].type (citext_test.rb:47-48)

--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -218,10 +218,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await Schema.define(adapter, async (schema) => {
         await schema.createEnum("color", ["blue", "green"]);
         await schema.changeTable("postgresql_enums", async (t) => {
-          // Rails: t.enum :best_color, enum_type: "color", ... — Migration#changeTable
-          // yields an abstract Table behind withAdapterColumnMethods rather than
-          // PostgreSQL::Table, and that shorthand drops enum_type, so name the enum
-          // type directly (ColumnType accepts arbitrary strings).
           await t.column("best_color", "color", { default: "blue", null: false });
         });
       });

--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -218,7 +218,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       await Schema.define(adapter, async (schema) => {
         await schema.createEnum("color", ["blue", "green"]);
         await schema.changeTable("postgresql_enums", async (t) => {
-          // ColumnType accepts arbitrary strings (string & {}), so no cast needed
+          // Rails: t.enum :best_color, enum_type: "color", ... — Migration#changeTable
+          // yields an abstract Table behind withAdapterColumnMethods rather than
+          // PostgreSQL::Table, and that shorthand drops enum_type, so name the enum
+          // type directly (ColumnType accepts arbitrary strings).
           await t.column("best_color", "color", { default: "blue", null: false });
         });
       });

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
+import type { Table as PgTable } from "../../connection-adapters/postgresql/schema-definitions.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Base, serialize, Migration } from "../../index.js";
 import { stringify as yamlStringify, parse as yamlParse } from "@blazetrails/activesupport/yaml";
@@ -149,7 +150,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails wraps in a transaction and raises ActiveRecord::Rollback to undo —
       // afterEach drops and recreates the table, so no manual rollback is needed.
       await connection.changeTable("hstores", async (t) => {
-        await t.column("users", "hstore", { default: "" });
+        await (t as PgTable).hstore("users", { default: "" });
       });
       Hstore.resetColumnInformation();
       await Hstore.loadSchema();
@@ -163,6 +164,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       //        end
       class HstoreMigration extends Migration {
         async change() {
+          // Migration#changeTable yields an abstract Table behind
+          // withAdapterColumnMethods (not PostgreSQL::Table), so `hstore` here is
+          // the synthesized shorthand, not PgTable#hstore.
           await this.changeTable("hstores", async (t) => {
             await (t as any).hstore("keys");
           });

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -164,9 +164,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       //        end
       class HstoreMigration extends Migration {
         async change() {
-          // Migration#changeTable yields an abstract Table behind
-          // withAdapterColumnMethods (not PostgreSQL::Table), so `hstore` here is
-          // the synthesized shorthand, not PgTable#hstore.
           await this.changeTable("hstores", async (t) => {
             await (t as any).hstore("keys");
           });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -792,8 +792,10 @@ export class Table extends AbstractTable {
   ): Promise<void>;
   async enum(...args: unknown[]): Promise<void> {
     const { names, options } = splitColumnNames(args, "enum");
-    const { enum_type: enumType, ...rest } = options as ColumnOptions & { enum_type: string };
-    for (const name of names) await this.column(name, enumType as ColumnType, rest);
+    const { enum_type: enumType, ...rest } = options as ColumnOptions & { enum_type?: string };
+    for (const name of names) {
+      await this.column(name, "enum" as ColumnType, { ...rest, enumType } as ColumnOptions);
+    }
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -598,6 +598,214 @@ export class Table extends AbstractTable {
       throw new Error(`${method} is not supported by the current schema backend`);
     }
   }
+
+  bigserial(...names: string[]): Promise<void>;
+  bigserial(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  bigserial(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("bigserial", args);
+  }
+
+  bit(...names: string[]): Promise<void>;
+  bit(...args: [...names: string[], options: ColumnOptions & { limit?: number }]): Promise<void>;
+  bit(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("bit", args);
+  }
+
+  bitVarying(...names: string[]): Promise<void>;
+  bitVarying(
+    ...args: [...names: string[], options: ColumnOptions & { limit?: number }]
+  ): Promise<void>;
+  bitVarying(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("bit_varying", args);
+  }
+
+  cidr(...names: string[]): Promise<void>;
+  cidr(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  cidr(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("cidr", args);
+  }
+
+  citext(...names: string[]): Promise<void>;
+  citext(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  citext(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("citext", args);
+  }
+
+  daterange(...names: string[]): Promise<void>;
+  daterange(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  daterange(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("daterange", args);
+  }
+
+  hstore(...names: string[]): Promise<void>;
+  hstore(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  hstore(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("hstore", args);
+  }
+
+  inet(...names: string[]): Promise<void>;
+  inet(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  inet(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("inet", args);
+  }
+
+  interval(...names: string[]): Promise<void>;
+  interval(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  interval(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("interval", args);
+  }
+
+  int4range(...names: string[]): Promise<void>;
+  int4range(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  int4range(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("int4range", args);
+  }
+
+  int8range(...names: string[]): Promise<void>;
+  int8range(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  int8range(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("int8range", args);
+  }
+
+  jsonb(...names: string[]): Promise<void>;
+  jsonb(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  jsonb(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("jsonb", args);
+  }
+
+  ltree(...names: string[]): Promise<void>;
+  ltree(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  ltree(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("ltree", args);
+  }
+
+  macaddr(...names: string[]): Promise<void>;
+  macaddr(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  macaddr(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("macaddr", args);
+  }
+
+  money(...names: string[]): Promise<void>;
+  money(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  money(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("money", args);
+  }
+
+  numrange(...names: string[]): Promise<void>;
+  numrange(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  numrange(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("numrange", args);
+  }
+
+  oid(...names: string[]): Promise<void>;
+  oid(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  oid(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("oid", args);
+  }
+
+  point(...names: string[]): Promise<void>;
+  point(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  point(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("point", args);
+  }
+
+  line(...names: string[]): Promise<void>;
+  line(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  line(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("line", args);
+  }
+
+  lseg(...names: string[]): Promise<void>;
+  lseg(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  lseg(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("lseg", args);
+  }
+
+  box(...names: string[]): Promise<void>;
+  box(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  box(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("box", args);
+  }
+
+  path(...names: string[]): Promise<void>;
+  path(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  path(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("path", args);
+  }
+
+  polygon(...names: string[]): Promise<void>;
+  polygon(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  polygon(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("polygon", args);
+  }
+
+  circle(...names: string[]): Promise<void>;
+  circle(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  circle(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("circle", args);
+  }
+
+  serial(...names: string[]): Promise<void>;
+  serial(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  serial(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("serial", args);
+  }
+
+  tsrange(...names: string[]): Promise<void>;
+  tsrange(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  tsrange(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("tsrange", args);
+  }
+
+  tstzrange(...names: string[]): Promise<void>;
+  tstzrange(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  tstzrange(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("tstzrange", args);
+  }
+
+  tsvector(...names: string[]): Promise<void>;
+  tsvector(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  tsvector(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("tsvector", args);
+  }
+
+  uuid(...names: string[]): Promise<void>;
+  uuid(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  uuid(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("uuid", args);
+  }
+
+  xml(...names: string[]): Promise<void>;
+  xml(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  xml(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("xml", args);
+  }
+
+  timestamptz(...names: string[]): Promise<void>;
+  timestamptz(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  timestamptz(...args: unknown[]): Promise<void> {
+    return this.definedPgColumn("timestamptz", args);
+  }
+
+  enum(
+    ...args: [...names: string[], options: ColumnOptions & { enum_type: string }]
+  ): Promise<void>;
+  async enum(...args: unknown[]): Promise<void> {
+    // Rails passes `:enum` plus the `enum_type:` option down to `type_to_sql`,
+    // which resolves it to the enum's name. trails' DSL has no `enum_type`
+    // plumbing through `addColumn`, so — as in abstract TableDefinition#enum
+    // (abstract/schema-definitions.ts) — the enum name is substituted for the
+    // column type up front, which produces the same DDL.
+    const { names, options } = splitColumnNames(args, "enum");
+    const { enum_type: enumType, ...rest } = options as ColumnOptions & { enum_type: string };
+    for (const name of names) await this.column(name, enumType as ColumnType, rest);
+  }
+
+  /** @internal */
+  private async definedPgColumn(type: string, args: unknown[]): Promise<void> {
+    const { names, options } = splitColumnNames(args, type);
+    for (const name of names) await this.column(name, type as ColumnType, options);
+  }
 }
 
 export class AlterTable extends AbstractAlterTable {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -791,11 +791,6 @@ export class Table extends AbstractTable {
     ...args: [...names: string[], options: ColumnOptions & { enum_type: string }]
   ): Promise<void>;
   async enum(...args: unknown[]): Promise<void> {
-    // Rails passes `:enum` plus the `enum_type:` option down to `type_to_sql`,
-    // which resolves it to the enum's name. trails' DSL has no `enum_type`
-    // plumbing through `addColumn`, so — as in abstract TableDefinition#enum
-    // (abstract/schema-definitions.ts) — the enum name is substituted for the
-    // column type up front, which produces the same DDL.
     const { names, options } = splitColumnNames(args, "enum");
     const { enum_type: enumType, ...rest } = options as ColumnOptions & { enum_type: string };
     for (const name of names) await this.column(name, enumType as ColumnType, rest);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { PostgreSQLSchemaStatements } from "./schema-statements-class.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 
@@ -214,5 +215,21 @@ describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", (
     const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
     const ss = new PostgreSQLSchemaStatements(adapter);
     expect(ss.sequenceNameFromParts("things", "id", "seq")).toBe("things_id_seq");
+  });
+});
+
+describe("PostgreSQLSchemaStatements#typeToSql enum validation", () => {
+  it("resolves an enum column to its enum type", () => {
+    const { adapter } = makeAdapter();
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    expect(ss.typeToSql("enum", { enumType: "color" })).toBe("color");
+  });
+
+  it("raises ArgumentError when enum_type is absent", () => {
+    const { adapter } = makeAdapter();
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    expect(() => ss.typeToSql("enum")).toThrow(
+      new ArgumentError("enum_type is required for enums"),
+    );
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -860,7 +860,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
           );
         break;
       case "enum":
-        if (!enumType) throw new Error("enumType is required for enums");
+        if (enumType == null) throw new ArgumentError("enum_type is required for enums");
         sql = enumType;
         break;
       default: {


### PR DESCRIPTION
Ports Rails' `PostgreSQL::ColumnMethods` onto `PostgreSQL::Table`, so the object
yielded by an adapter-direct `change_table` block exposes the PG types Rails
does — `t.uuid`, `t.jsonb`, `t.hstore`, `t.citext`, `t.inet`, the range types,
the geometric types, `t.serial` / `t.bigserial`, `t.bit` / `t.bitVarying`,
`t.timestamptz`, `t.tsvector`, `t.xml`, `t.enum`, and the rest.

`PostgreSQL::TableDefinition` already had the full list; `PostgreSQL::Table` had
none of it. Each method now forwards `(...names, options)` to `Table#column` with
the Rails type name, matching Rails' `define_column_methods` loop
(`postgresql/schema_definitions.rb:186-191`). No `sqlType` forcing is needed on
this path: PG's `type_to_sql` falls through to `type.to_s` for the names absent
from `NATIVE_DATABASE_TYPES` (`serial`, `bigserial`), exactly as in Rails.

`enum` substitutes the enum's name for the column type up front, mirroring the
existing deviation in abstract `TableDefinition#enum` — trails' DSL has no
`enum_type` plumbing through `addColumn`, and the substitution produces the same
DDL.

### Coverage

Converged the two mirrored Rails tests that pin these types on the
adapter-direct path to call the real methods instead of `t.column(...)`:

- `hstore_test.rb` `test_change_table_supports_hstore` → `t.hstore("users", { default: "" })`
- `citext_test.rb` `test_change_table_supports_json` → `t.citext("username")` (removes a standing TODO)

No trails-only companion suite was added for the types Rails does not pin.

### Out of scope (new story)

`Migration#changeTable` (migration.ts:973-1009) does **not** yield the adapter's
`Table` — it builds the abstract `Table` and wraps it in the trails-invented
`withAdapterColumnMethods` proxy keyed off `nativeDatabaseTypes`. So on the
migration path `t.serial` / `t.bigserial` are absent entirely and `t.enum` drops
`enum_type:`. That is a separate divergence from this story's surface and is
registered as `migration-change-table-yields-adapter-table` (RFC 0005); the two
affected tests keep their existing workarounds with comments naming the cause.

### Verification

- `hstore.test.ts`, `citext.test.ts`, `enum.test.ts`, `postgresql/schema-definitions.test.ts` — 120 passed against a PG 16 stack.
- `api:compare` unchanged (Data layer 7723/7816; Overall 11741/17536) and `api:extra` byte-identical vs. `origin/main` — the PG `ColumnMethods` bucket was already satisfied by `TableDefinition`.
- `test:compare` unchanged (14824/22203); no test names added or reworded.

Closes-story: pg-column-methods-on-change-table-proxy
