### PR TITLE
fix(activerecord): drop the duplicated xml override on PostgreSQL::Table

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -563,12 +563,6 @@ export class Table extends AbstractTable {
     this._pgSchema = schema;
   }
 
-  async xml(...names: string[]): Promise<void>;
-  async xml(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
-  async xml(...args: unknown[]): Promise<void> {
-    await this.definedColumn("xml" as ColumnType, args);
-  }
-
   exclusionConstraint(expression: string, options?: ExclusionConstraintOptions): Promise<void> {
     this._requireConstraint("addExclusionConstraint");
     return this._pgSchema.addExclusionConstraint!(this._pgTableName, expression, options);


### PR DESCRIPTION
`main` @92de18fb is red across every typecheck-dependent job (Leaf Tests, Unit
Tests, Build & Type Check, all AR adapter lanes, Website, api/test compare).

Root cause: #5624 ported `PostgreSQL::ColumnMethods` onto `PostgreSQL::Table`,
which contributed an `xml` column method. The pre-existing hand-rolled `xml`
override at the top of the class was left in place, so tsc emitted
`Duplicate function implementation` (plus `Function implementation name must
be 'xml'` on the member following the orphaned overload signatures).

Fix: delete the stale override. The ported `ColumnMethods#xml` is the
Rails-faithful one and routes through `definedPgColumn` → `this.column`, same
as its siblings — no behavior change.

Verified: `pnpm test:types` is green (99 tests, no type errors); it reproduced
the 7 unhandled `TypeCheckError`s before the change.

Closes-story: red-92de18fb
