### PR TITLE
fix(activerecord): change_table yields the adapter's Table subclass on the migration path

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -7,6 +7,7 @@ import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.j
 import { Base, Schema } from "../../index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { fixtures } from "../../test-fixtures.js";
+import type { Table as PgTable } from "../../connection-adapters/postgresql/schema-definitions.js";
 
 // Rails: class PostgresqlEnum < ActiveRecord::Base
 //   enum :current_mood, { sad: "sad", okay: "ok", happy: "happy", aliased_field: "happy" }, prefix: true
@@ -218,7 +219,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       await Schema.define(adapter, async (schema) => {
         await schema.createEnum("color", ["blue", "green"]);
         await schema.changeTable("postgresql_enums", async (t) => {
-          await t.column("best_color", "color", { default: "blue", null: false });
+          await (t as PgTable).enum("best_color", {
+            enum_type: "color",
+            default: "blue",
+            null: false,
+          });
         });
       });
       PostgresqlEnum.resetColumnInformation();

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -165,7 +165,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       class HstoreMigration extends Migration {
         async change() {
           await this.changeTable("hstores", async (t) => {
-            await (t as any).hstore("keys");
+            await (t as PgTable).hstore("keys");
           });
         }
       }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1598,6 +1598,31 @@ export class Table {
   async json(...args: unknown[]): Promise<void> {
     await this.definedColumn("json", args);
   }
+  async time(...names: string[]): Promise<void>;
+  async time(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async time(...args: unknown[]): Promise<void> {
+    await this.definedColumn("time", args);
+  }
+  async timestamp(...names: string[]): Promise<void>;
+  async timestamp(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async timestamp(...args: unknown[]): Promise<void> {
+    await this.definedColumn("timestamp", args);
+  }
+  async binary(...names: string[]): Promise<void>;
+  async binary(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async binary(...args: unknown[]): Promise<void> {
+    await this.definedColumn("binary", args);
+  }
+  async blob(...names: string[]): Promise<void>;
+  async blob(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async blob(...args: unknown[]): Promise<void> {
+    await this.definedColumn("binary", args);
+  }
+  async numeric(...names: string[]): Promise<void>;
+  async numeric(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
+  async numeric(...args: unknown[]): Promise<void> {
+    await this.definedColumn("decimal", args);
+  }
   async char(...names: string[]): Promise<void>;
   async char(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
   async char(...args: unknown[]): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -563,12 +563,6 @@ export class Table extends AbstractTable {
     this._pgSchema = schema;
   }
 
-  async xml(...names: string[]): Promise<void>;
-  async xml(...args: [...names: string[], options: ColumnOptions]): Promise<void>;
-  async xml(...args: unknown[]): Promise<void> {
-    await this.definedColumn("xml" as ColumnType, args);
-  }
-
   exclusionConstraint(expression: string, options?: ExclusionConstraintOptions): Promise<void> {
     this._requireConstraint("addExclusionConstraint");
     return this._pgSchema.addExclusionConstraint!(this._pgTableName, expression, options);

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -17,6 +17,7 @@ import { SchemaMigration } from "./schema-migration.js";
 import { newRawTestAdapter } from "./test-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
+import { Table } from "./connection-adapters/abstract/schema-definitions.js";
 import { fixtures } from "./test-fixtures.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
@@ -210,5 +211,25 @@ describe("MigrationTest", () => {
     } finally {
       Migration.verbose = verboseWas;
     }
+  });
+  it("changeTable yields the adapter's updateTableDefinition result", async () => {
+    class AdapterTable extends Table {}
+    const seen: unknown[] = [];
+    class M extends Migration {}
+    const m = new M();
+    (m as unknown as { _connectionOverride: unknown })._connectionOverride = {
+      updateTableDefinition(tableName: string, base: unknown) {
+        seen.push([tableName, base]);
+        return new AdapterTable(tableName, base as never);
+      },
+    };
+
+    let yielded: unknown;
+    await m.changeTable("people", (t) => {
+      yielded = t;
+    });
+
+    expect(yielded).toBeInstanceOf(AdapterTable);
+    expect(seen).toEqual([["people", m]]);
   });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -27,7 +27,7 @@ import {
   assertSchemaAdapter,
   type JoinTableOptions,
 } from "./connection-adapters/abstract/schema-statements.js";
-import { CommandRecorder, withAdapterColumnMethods } from "./migration/command-recorder.js";
+import { CommandRecorder } from "./migration/command-recorder.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
@@ -995,17 +995,12 @@ export abstract class Migration {
       await this.schema.changeTable(tname, options, callback);
       return;
     }
-    // Build Table against Migration (not SchemaStatements) so that
-    // per-operation recording in addColumn/removeColumn/etc. still applies.
-    // Wrap so adapter column-type shorthands (t.hstore, t.jsonb, ...) resolve,
-    // mirroring Rails' adapter ColumnMethods mixin on the yielded Table.
-    const delegate = this.connection as {
-      columnMethodNames?(): string[];
-      nativeDatabaseTypes?(): Record<string, unknown>;
+    const delegate = this.connection as unknown as {
+      updateTableDefinition?(tableName: string, base: unknown): Table;
     };
-    const columnTypes =
-      delegate.columnMethodNames?.() ?? Object.keys(delegate.nativeDatabaseTypes?.() ?? {});
-    const table = withAdapterColumnMethods(new Table(tableName, this), columnTypes);
+    const table = delegate.updateTableDefinition
+      ? delegate.updateTableDefinition(tableName, this)
+      : this.schema.updateTableDefinition(tableName, this);
     if (callback) await callback(table);
   }
 


### PR DESCRIPTION
## What

`Migration#changeTable` built the **abstract** `Table` and wrapped it in
`withAdapterColumnMethods` — a trails-invented Proxy that synthesized column-type
shorthands from `columnMethodNames()`. Rails' `change_table` yields
`update_table_definition(table_name, base)`: the **adapter's** `Table` subclass,
with `base` the migration (`abstract/schema_statements.rb:510-517`,
`postgresql/schema_statements.rb:880`). So migration blocks never saw
`PostgreSQL::Table`, and `t.enum` synthesized `column(name, "enum", { enum_type })`
where `typeToSql` raised `enumType is required for enums` — `enum_test.rb`'s
`test_schema_load` had to spell the column out as `t.column("best_color", "color", …)`
and `hstore_test.rb`'s `test_hstore_migration` reached `hstore` through the Proxy.

## How

- `Migration#changeTable` yields `connection.updateTableDefinition(tableName, this)`
  (SchemaStatements' base when the adapter has no override), keeping the migration
  as `base` so per-operation recording in `addColumn` / `removeColumn` / … still
  applies.
- `Table` gains the abstract `ColumnMethods` shorthands the Proxy was standing in
  for and #5624 did not add: `binary`, `time`, `timestamp`, plus Rails'
  `alias :blob :binary` / `alias :numeric :decimal` (`abstract/schema_definitions.rb:324-330`).
  The PG and MySQL subclasses already carry their own lists as of #5624.
- Drops a duplicate `xml` definition on `PostgreSQL::Table` introduced by #5624 —
  `origin/main` currently fails `tsc --build` on it, so nothing branched off main
  can go green without this.

## Coverage

- `enum.test.ts` "schema load" → `t.enum("best_color", { enum_type: "color", … })`;
  `hstore.test.ts` "hstore migration" → typed `PgTable#hstore`. Both workarounds
  and their deviation comments are gone, and both fail on baseline.
- `migration.trails.test.ts` pins the dispatch itself: the yielded object is the
  adapter's subclass, constructed with the migration as `base`.
- `api:compare`: activerecord 6082/6148 methods, 277/277 files — identical to
  baseline (measured against `main` + the `xml` dedupe, since `main` alone does not
  build). `api:extra` novel unchanged (activerecord 540; 9 for
  `abstract/schema-definitions.ts`, 1 for `postgresql/schema-definitions.ts`).
- `test:compare`: 14873/22203, 763/1044 files — identical to `main`.
- Suites run green on sqlite / PG / MySQL: `migration`, `migration.trails`,
  `migration/change-table`, `migration/change-schema`, `command-recorder`,
  `abstract/schema-definitions`, PG `enum` / `hstore` / `citext`, MySQL
  `unsigned-type` / `active-schema`.

## Not in scope

`withAdapterColumnMethods` is **not** retired: `CommandRecorder#changeTable` still
yields `RecorderTableProxy` rather than a Table built over the recorder, which is
where Rails' recorder path also goes through `update_table_definition`. Registered
as `change-table-recorder-yields-adapter-table` (RFC 0005).

Closes-story: migration-change-table-yields-adapter-table
