### PR TITLE
fix(activerecord): route every change_table through update_table_definition

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -71,15 +71,8 @@ import {
   CreateIndexDefinition,
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
-import type {
-  ColumnOptions,
-  RemoveForeignKeyOptions,
-  SchemaStatementsLike,
-} from "./abstract/schema-definitions.js";
-import {
-  TableDefinition as MysqlTableDefinition,
-  Table as MysqlTable,
-} from "./mysql/schema-definitions.js";
+import type { ColumnOptions, RemoveForeignKeyOptions } from "./abstract/schema-definitions.js";
+import { TableDefinition as MysqlTableDefinition } from "./mysql/schema-definitions.js";
 import {
   dataSourceSql as mysqlDataSourceSql,
   extractForeignKeyAction as mysqlExtractForeignKeyAction,
@@ -258,18 +251,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return optionsForm
       ? super.removeForeignKey(fromTable, opts)
       : super.removeForeignKey(fromTable, toTableOrOptions, opts);
-  }
-
-  /**
-   * Override `SchemaStatements#updateTableDefinition` to instantiate the
-   * MySQL-specific {@link MysqlTable} subclass, so `changeTable` blocks expose
-   * MySQL's `ColumnMethods` (`t.unsignedInteger`, `t.unsignedFloat`, ...).
-   *
-   * Mirrors: `ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#update_table_definition`
-   * @internal
-   */
-  updateTableDefinition(tableName: string, base?: unknown): MysqlTable {
-    return new MysqlTable(tableName, (base ?? this) as SchemaStatementsLike);
   }
 
   protected _mariadb = false;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1663,12 +1663,13 @@ export class Table {
     columnOrOptions: string | string[] | { column?: string | string[]; name?: string } = {},
     options: { column?: string | string[]; name?: string } = {},
   ): Promise<void> {
-    const optionHash =
-      typeof columnOrOptions === "string" || Array.isArray(columnOrOptions)
-        ? options
-        : columnOrOptions;
+    const isColumn = typeof columnOrOptions === "string" || Array.isArray(columnOrOptions);
+    // `remove_index(column_name = nil, **options)`: an options-only call leaves
+    // column_name nil rather than passing the hash as the column.
+    const columnName = isColumn ? columnOrOptions : undefined;
+    const optionHash = isColumn ? options : columnOrOptions;
     this.raiseOnIfExistOptions(optionHash as Record<string, unknown>);
-    await this._schema.removeIndex(this._tableName, columnOrOptions, options);
+    await this._schema.removeIndex(this._tableName, columnName, optionHash);
   }
   async references(...refNames: string[]): Promise<void>;
   async references(...args: [...refNames: string[], options: AddReferenceOptions]): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1667,7 +1667,9 @@ export class Table {
     // `remove_index(column_name = nil, **options)`: an options-only call leaves
     // column_name nil rather than passing the hash as the column.
     const columnName = isColumn ? columnOrOptions : undefined;
-    const optionHash = isColumn ? options : columnOrOptions;
+    // Ruby's `**options` collects the hash from either position, so an explicit
+    // nil column with the options behind it keeps them.
+    const optionHash = isColumn ? options : { ...columnOrOptions, ...options };
     this.raiseOnIfExistOptions(optionHash as Record<string, unknown>);
     await this._schema.removeIndex(this._tableName, columnName, optionHash);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -508,7 +508,9 @@ export class SchemaStatements {
       opts = options;
     } else {
       columnName = undefined;
-      opts = columnOrOptions;
+      // Ruby's `**options` collects the hash whether it arrived as the sole
+      // argument or behind an explicit nil column.
+      opts = { ...columnOrOptions, ...options };
     }
 
     // Rails: `return if options[:if_exists] && !index_exists?(...)` — only an

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -319,10 +319,10 @@ export class Table extends AbstractTable {
     super(tableName, schema);
   }
 
-  // Mirrors `define_column_methods :blob, :tinyblob, …, :unsigned_decimal` —
-  // the MySQL::ColumnMethods list mixed into both TableDefinition and Table.
-  // The `unsigned_<type>` type is normalized to its base type + `unsigned: true`
-  // by MySQL::TableDefinition#newColumnDefinition along the addColumn/alter path.
+  // Mirrors the column-type methods MySQL::ColumnMethods mixes into both
+  // TableDefinition and Table. The `unsigned_<type>` type is normalized to its
+  // base type + `unsigned: true` by MySQL::TableDefinition#newColumnDefinition
+  // along the addColumn/alter path.
   async blob(...args: unknown[]): Promise<void> {
     await this.definedColumn("blob" as ColumnType, args);
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -319,27 +319,55 @@ export class Table extends AbstractTable {
     super(tableName, schema);
   }
 
-  // Mirrors the column-type methods MySQL::ColumnMethods mixes into both
-  // TableDefinition and Table. The `unsigned_<type>` type is normalized to its
-  // base type + `unsigned: true` by MySQL::TableDefinition#newColumnDefinition
-  // along the addColumn/alter path.
-  async unsignedInteger(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "unsigned_integer" as ColumnType, options);
+  // Mirrors `define_column_methods :blob, :tinyblob, …, :unsigned_decimal` —
+  // the MySQL::ColumnMethods list mixed into both TableDefinition and Table.
+  // The `unsigned_<type>` type is normalized to its base type + `unsigned: true`
+  // by MySQL::TableDefinition#newColumnDefinition along the addColumn/alter path.
+  async blob(...args: unknown[]): Promise<void> {
+    await this.definedColumn("blob" as ColumnType, args);
   }
 
-  async unsignedBigint(name: string, options: ColumnOptions = {}): Promise<void> {
-    await this.column(name, "unsigned_bigint" as ColumnType, options);
+  async tinyblob(...args: unknown[]): Promise<void> {
+    await this.definedColumn("tinyblob" as ColumnType, args);
+  }
+
+  async mediumblob(...args: unknown[]): Promise<void> {
+    await this.definedColumn("mediumblob" as ColumnType, args);
+  }
+
+  async longblob(...args: unknown[]): Promise<void> {
+    await this.definedColumn("longblob" as ColumnType, args);
+  }
+
+  async tinytext(...args: unknown[]): Promise<void> {
+    await this.definedColumn("tinytext" as ColumnType, args);
+  }
+
+  async mediumtext(...args: unknown[]): Promise<void> {
+    await this.definedColumn("mediumtext" as ColumnType, args);
+  }
+
+  async longtext(...args: unknown[]): Promise<void> {
+    await this.definedColumn("longtext" as ColumnType, args);
+  }
+
+  async unsignedInteger(...args: unknown[]): Promise<void> {
+    await this.definedColumn("unsigned_integer" as ColumnType, args);
+  }
+
+  async unsignedBigint(...args: unknown[]): Promise<void> {
+    await this.definedColumn("unsigned_bigint" as ColumnType, args);
   }
 
   /** @deprecated */
-  async unsignedFloat(name: string, options: ColumnOptions = {}): Promise<void> {
+  async unsignedFloat(...args: unknown[]): Promise<void> {
     deprecator().warn(UNSIGNED_FLOAT_DEPRECATION);
-    await this.column(name, "unsigned_float" as ColumnType, options);
+    await this.definedColumn("unsigned_float" as ColumnType, args);
   }
 
   /** @deprecated */
-  async unsignedDecimal(name: string, options: ColumnOptions = {}): Promise<void> {
+  async unsignedDecimal(...args: unknown[]): Promise<void> {
     deprecator().warn(UNSIGNED_DECIMAL_DEPRECATION);
-    await this.column(name, "unsigned_decimal" as ColumnType, options);
+    await this.definedColumn("unsigned_decimal" as ColumnType, args);
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -9,13 +9,13 @@ import { presence } from "@blazetrails/activesupport";
 import { Version } from "../abstract-adapter.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { TypeMetadata } from "./type-metadata.js";
-import { TableDefinition } from "./schema-definitions.js";
+import { TableDefinition, Table as MysqlTable } from "./schema-definitions.js";
 import { Column } from "./column.js";
 import { SchemaStatements as BaseSchemaStatements } from "../abstract/schema-statements.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./schema-creation.js";
 import { CreateIndexDefinition, ForeignKeyDefinition } from "../abstract/schema-definitions.js";
 import { quoteColumnName, unquoteIdentifier } from "./quoting.js";
-import type { AddIndexOptions } from "../abstract/schema-definitions.js";
+import type { AddIndexOptions, SchemaStatementsLike } from "../abstract/schema-definitions.js";
 
 /**
  * MySQL-specific SchemaStatements subclass. Extends the base `dropTable` to support
@@ -30,6 +30,19 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
   private _mysqlSchemaCreation?: MysqlSchemaCreation;
   override get schemaCreation(): MysqlSchemaCreation {
     return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this.adapter));
+  }
+
+  /**
+   * Instantiate the MySQL-specific {@link MysqlTable} so `change_table` blocks
+   * expose MySQL's `ColumnMethods` (`t.unsignedInteger`, `t.longblob`, ...).
+   * This is the single home for the override: `AbstractMysqlAdapter` picks it up
+   * through `include(AbstractMysqlAdapter, MysqlSchemaStatements)`, so both the
+   * adapter-direct and `Migration#schema` paths reach it.
+   *
+   * Mirrors: MySQL::SchemaStatements#update_table_definition
+   */
+  override updateTableDefinition(tableName: string, base?: unknown): MysqlTable {
+    return new MysqlTable(tableName, (base ?? this) as SchemaStatementsLike);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -32,15 +32,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this.adapter));
   }
 
-  /**
-   * Instantiate the MySQL-specific {@link MysqlTable} so `change_table` blocks
-   * expose MySQL's `ColumnMethods` (`t.unsignedInteger`, `t.longblob`, ...).
-   * This is the single home for the override: `AbstractMysqlAdapter` picks it up
-   * through `include(AbstractMysqlAdapter, MysqlSchemaStatements)`, so both the
-   * adapter-direct and `Migration#schema` paths reach it.
-   *
-   * Mirrors: MySQL::SchemaStatements#update_table_definition
-   */
+  /** Mirrors: MySQL::SchemaStatements#update_table_definition */
   override updateTableDefinition(tableName: string, base?: unknown): MysqlTable {
     return new MysqlTable(tableName, (base ?? this) as SchemaStatementsLike);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -109,10 +109,9 @@ import {
   UniqueConstraintDefinition,
   TableDefinition as PgTableDefinition,
   AlterTable as PgAlterTable,
-  Table as PgTable,
+  type Table as PgTable,
   type ExclusionConstraintOptions,
   type UniqueConstraintOptions,
-  type SchemaStatementsConstraintLike,
 } from "./postgresql/schema-definitions.js";
 import { TypeMetadata as PgTypeMetadata } from "./postgresql/type-metadata.js";
 import {
@@ -4728,8 +4727,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return new PgSchemaCreation(this);
   }
 
-  updateTableDefinition(tableName: string, base: unknown): PgTable {
-    return new PgTable(tableName, base as SchemaStatementsConstraintLike);
+  updateTableDefinition(tableName: string, base?: unknown): PgTable {
+    return this.pgSchemaStatements().updateTableDefinition(tableName, base ?? this);
   }
 
   createSchemaDumper(source: SchemaSource, options: Record<string, unknown> = {}): PgSchemaDumper {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -101,15 +101,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     return this.adapter as unknown as PgSchemaAdapter;
   }
 
-  /**
-   * Instantiate the PostgreSQL-specific {@link PgTable} so `change_table` blocks
-   * expose PG's `ColumnMethods` (`t.citext`, `t.hstore`, `t.serial`, ...) and
-   * constraint helpers. This is the single home for the override;
-   * `PostgreSQLAdapter#updateTableDefinition` delegates here so the
-   * adapter-direct and `Migration#schema` paths agree.
-   *
-   * Mirrors: PostgreSQL::SchemaStatements#update_table_definition
-   */
+  /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */
   override updateTableDefinition(tableName: string, base?: unknown): PgTable {
     return new PgTable(tableName, (base ?? this) as SchemaStatementsConstraintLike);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -22,6 +22,8 @@ import { unquoteIdentifier, splitQuotedIdentifier, Name, Utils } from "./utils.j
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./schema-statements.js";
 import {
   type AlterTable as PgAlterTable,
+  Table as PgTable,
+  type SchemaStatementsConstraintLike,
   ExclusionConstraintDefinition,
   type ExclusionConstraintOptions,
   UniqueConstraintDefinition,
@@ -97,6 +99,19 @@ interface PgSchemaAdapter {
 export class PostgreSQLSchemaStatements extends SchemaStatements {
   private get pg(): PgSchemaAdapter {
     return this.adapter as unknown as PgSchemaAdapter;
+  }
+
+  /**
+   * Instantiate the PostgreSQL-specific {@link PgTable} so `change_table` blocks
+   * expose PG's `ColumnMethods` (`t.citext`, `t.hstore`, `t.serial`, ...) and
+   * constraint helpers. This is the single home for the override;
+   * `PostgreSQLAdapter#updateTableDefinition` delegates here so the
+   * adapter-direct and `Migration#schema` paths agree.
+   *
+   * Mirrors: PostgreSQL::SchemaStatements#update_table_definition
+   */
+  override updateTableDefinition(tableName: string, base?: unknown): PgTable {
+    return new PgTable(tableName, (base ?? this) as SchemaStatementsConstraintLike);
   }
 
   override async dropTable(...args: Parameters<SchemaStatements["dropTable"]>): Promise<void> {

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -473,6 +473,37 @@ describe("CommandRecorder", () => {
       expect(second.args[1]).toBe("name");
     });
 
+    it("removeIndex with an options hash records a nil column, not the hash", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await t.removeIndex({ name: "index_fruits_on_kind" });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
+      ]);
+    });
+
+    it("removeIndex with a column inverts back to addIndex", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", async (t) => {
+          await t.removeIndex("kind");
+        });
+      });
+      expect(recorder.commands).toEqual([{ cmd: "addIndex", args: ["fruits", "kind"] }]);
+    });
+
+    it("raises IrreversibleMigration when removeIndex lacks a column", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await expect(
+        recorder.revert(async () => {
+          await recorder.changeTable("fruits", async (t) => {
+            await t.removeIndex({ name: "index_fruits_on_kind" });
+          });
+        }),
+      ).rejects.toThrow(IrreversibleMigration);
+    });
+
     it("raises IrreversibleMigration when remove lacks type", async () => {
       const recorder = new CommandRecorder(abstractDelegate);
       await expect(

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -483,6 +483,16 @@ describe("CommandRecorder", () => {
       ]);
     });
 
+    it("removeIndex with an explicit nil column keeps the second-argument options", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await t.removeIndex(undefined, { name: "index_fruits_on_kind" });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
+      ]);
+    });
+
     it("removeIndex with a column inverts back to addIndex", async () => {
       const recorder = new CommandRecorder(abstractDelegate);
       await recorder.revert(async () => {

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -1,7 +1,25 @@
 import { describe, it, expect } from "vitest";
-import { CommandRecorder, withAdapterColumnMethods } from "./command-recorder.js";
-import type { RecorderTableProxy } from "./command-recorder.js";
+import { CommandRecorder } from "./command-recorder.js";
 import { IrreversibleMigration } from "../migration.js";
+import { Table } from "../connection-adapters/abstract/schema-definitions.js";
+import { Table as PgTable } from "../connection-adapters/postgresql/schema-definitions.js";
+import { Table as MysqlTable } from "../connection-adapters/mysql/schema-definitions.js";
+
+// Stand-ins for the connection adapter CommandRecorder delegates to: Rails'
+// `change_table` only needs `update_table_definition` (plus `supports_bulk_alter?`
+// on the bulk path), and it is that method which decides whose `ColumnMethods`
+// the yielded Table carries.
+const abstractDelegate = {
+  updateTableDefinition: (tableName: string, base: unknown) => new Table(tableName, base as never),
+};
+const pgDelegate = {
+  updateTableDefinition: (tableName: string, base: unknown) =>
+    new PgTable(tableName, base as never),
+};
+const mysqlDelegate = {
+  updateTableDefinition: (tableName: string, base: unknown) =>
+    new MysqlTable(tableName, base as never),
+};
 
 describe("CommandRecorder", () => {
   it("records commands", () => {
@@ -423,32 +441,34 @@ describe("CommandRecorder", () => {
 
   describe("invert change table (non-bulk)", () => {
     it("accepts (tableName, fn) without explicit options", async () => {
-      const recorder = new CommandRecorder();
+      const recorder = new CommandRecorder(abstractDelegate);
       // short form: no options argument
       await recorder.changeTable("fruits", async (t) => {
-        t.string("name");
+        await t.string("name");
       });
       expect(recorder.commands[0].cmd).toBe("addColumn");
     });
 
-    it("remove with multiple columns records individual removeColumn per name", async () => {
-      const recorder = new CommandRecorder();
+    // Rails' Table#remove forwards the whole name list to
+    // `@base.remove_columns(name, *column_names, **options)`, so the recorder
+    // sees one `remove_columns` — inverted by `invert_remove_columns` into
+    // `add_columns` (command_recorder.rb:233-239).
+    it("remove with multiple columns records a single removeColumns", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
       await recorder.changeTable("fruits", async (t) => {
-        t.remove("name", "kind", { type: "string" });
+        await t.remove("name", "kind", { type: "string" });
       });
-      expect(recorder.commands).toHaveLength(2);
-      expect(recorder.commands[0].cmd).toBe("removeColumn");
-      expect(recorder.commands[0].args).toEqual(["fruits", "name", "string"]);
-      expect(recorder.commands[1].cmd).toBe("removeColumn");
-      expect(recorder.commands[1].args).toEqual(["fruits", "kind", "string"]);
+      expect(recorder.commands).toEqual([
+        { cmd: "removeColumns", args: ["fruits", "name", "kind", { type: "string" }] },
+      ]);
     });
 
     it("reverts string + rename inside change_table block", async () => {
-      const recorder = new CommandRecorder();
+      const recorder = new CommandRecorder(abstractDelegate);
       await recorder.revert(async () => {
         await recorder.changeTable("fruits", async (t) => {
-          t.string("name");
-          t.rename("kind", "cultivar");
+          await t.string("name");
+          await t.rename("kind", "cultivar");
         });
       });
       // Reversed order and inverted: renameColumn first, then removeColumn
@@ -462,11 +482,11 @@ describe("CommandRecorder", () => {
     });
 
     it("raises IrreversibleMigration when remove lacks type", async () => {
-      const recorder = new CommandRecorder();
+      const recorder = new CommandRecorder(abstractDelegate);
       await expect(
         recorder.revert(async () => {
           await recorder.changeTable("fruits", async (t) => {
-            t.remove("kind"); // no type → not reversible
+            await t.remove("kind"); // no type → not reversible
           });
         }),
       ).rejects.toThrow(IrreversibleMigration);
@@ -477,7 +497,7 @@ describe("CommandRecorder", () => {
     // Mirrors Rails: the PG `ColumnMethods` mixin exposes `t.serial` /
     // `t.bigserial` (SERIAL/BIGSERIAL) inside change_table — shorthands the
     // adapter advertises via columnMethodNames() beyond NATIVE_DATABASE_TYPES.
-    const pgLike = { columnMethodNames: () => ["serial", "bigserial"] };
+    const pgLike = pgDelegate;
 
     it("records addColumn for t.serial and t.bigserial (up adds)", async () => {
       const recorder = new CommandRecorder(pgLike);
@@ -505,8 +525,24 @@ describe("CommandRecorder", () => {
       ]);
     });
 
+    // Rails' `define_column_methods` list — the source of the shorthands — never
+    // includes `primary_key`: that is a dedicated method taking the column type
+    // as its second argument (abstract/schema_definitions.rb:308), so a generic
+    // shorthand routing it to `column(name, "primary_key")` would diverge.
+    it("never exposes primary_key as a generic column shorthand", async () => {
+      const recorder = new CommandRecorder(pgDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        // The snake spelling only ever appeared as a native-type hash key.
+        expect((t as unknown as Record<string, unknown>)["primary_key"]).toBeUndefined();
+        await t.primaryKey("token", "uuid");
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "addColumn", args: ["fruits", "token", "uuid", { primaryKey: true }] },
+      ]);
+    });
+
     it("records the snake_case type for PG bitVarying (multi-word shorthand)", async () => {
-      const recorder = new CommandRecorder({ columnMethodNames: () => ["bitVarying"] });
+      const recorder = new CommandRecorder(pgDelegate);
       await recorder.changeTable("fruits", async (t) => {
         await (t as any).bitVarying("mask");
       });
@@ -525,9 +561,7 @@ describe("CommandRecorder", () => {
     // Rails' `define_column_methods` records (`unsignedInteger` ->
     // `unsigned_integer`); single-token shorthands (mediumtext, longblob) are
     // unchanged.
-    const mysqlLike = {
-      columnMethodNames: () => ["unsignedInteger", "mediumtext", "longblob"],
-    };
+    const mysqlLike = mysqlDelegate;
 
     it("records addColumn for MySQL shorthands (up adds)", async () => {
       const recorder = new CommandRecorder(mysqlLike);
@@ -560,12 +594,12 @@ describe("CommandRecorder", () => {
 
   describe("bulk invert change table", () => {
     it("records two changeTable commands from revert + revert-of-revert", async () => {
-      const delegate = { supportsBulkAlter: () => true };
+      const delegate = { ...abstractDelegate, supportsBulkAlter: () => true };
       const recorder = new CommandRecorder(delegate);
 
-      const block = async (t: RecorderTableProxy) => {
-        t.string("name");
-        t.rename("kind", "cultivar");
+      const block = async (t: Table) => {
+        await t.string("name");
+        await t.rename("kind", "cultivar");
       };
 
       await recorder.revert(async () => {
@@ -584,29 +618,5 @@ describe("CommandRecorder", () => {
       expect(recorder.commands[1].cmd).toBe("changeTable");
       expect(recorder.commands[1].args[0]).toBe("fruits");
     });
-  });
-});
-
-describe("withAdapterColumnMethods", () => {
-  // The shorthand set is Rails' `define_column_methods` list, exposed as
-  // `columnMethodNames()` — not the native-type hash, whose keys include
-  // `primary_key`. Rails defines `primary_key(name, type = :primary_key,
-  // **options)` separately (abstract/schema_definitions.rb:308): it takes the
-  // second argument as the column type and merges `primary_key: true`, so a
-  // generic shorthand routing it to `column(name, "primary_key")` would diverge.
-  it("never exposes primary_key as a generic column shorthand", () => {
-    const calls: Array<[string, string]> = [];
-    const base = { column: (name: string, type: string) => calls.push([name, type]) };
-    const proxy = withAdapterColumnMethods(base, ["primary_key", "primaryKey", "uuid"]) as Record<
-      string,
-      unknown
-    >;
-
-    expect(proxy["primary_key"]).toBeUndefined();
-    expect(proxy["primaryKey"]).toBeUndefined();
-    expect(typeof proxy["uuid"]).toBe("function");
-
-    (proxy["uuid"] as (n: string) => void)("token");
-    expect(calls).toEqual([["token", "uuid"]]);
   });
 });

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -5,10 +5,6 @@ import { Table } from "../connection-adapters/abstract/schema-definitions.js";
 import { Table as PgTable } from "../connection-adapters/postgresql/schema-definitions.js";
 import { Table as MysqlTable } from "../connection-adapters/mysql/schema-definitions.js";
 
-// Stand-ins for the connection adapter CommandRecorder delegates to: Rails'
-// `change_table` only needs `update_table_definition` (plus `supports_bulk_alter?`
-// on the bulk path), and it is that method which decides whose `ColumnMethods`
-// the yielded Table carries.
 const abstractDelegate = {
   updateTableDefinition: (tableName: string, base: unknown) => new Table(tableName, base as never),
 };
@@ -449,10 +445,6 @@ describe("CommandRecorder", () => {
       expect(recorder.commands[0].cmd).toBe("addColumn");
     });
 
-    // Rails' Table#remove forwards the whole name list to
-    // `@base.remove_columns(name, *column_names, **options)`, so the recorder
-    // sees one `remove_columns` — inverted by `invert_remove_columns` into
-    // `add_columns` (command_recorder.rb:233-239).
     it("remove with multiple columns records a single removeColumns", async () => {
       const recorder = new CommandRecorder(abstractDelegate);
       await recorder.changeTable("fruits", async (t) => {
@@ -525,14 +517,9 @@ describe("CommandRecorder", () => {
       ]);
     });
 
-    // Rails' `define_column_methods` list — the source of the shorthands — never
-    // includes `primary_key`: that is a dedicated method taking the column type
-    // as its second argument (abstract/schema_definitions.rb:308), so a generic
-    // shorthand routing it to `column(name, "primary_key")` would diverge.
     it("never exposes primary_key as a generic column shorthand", async () => {
       const recorder = new CommandRecorder(pgDelegate);
       await recorder.changeTable("fruits", async (t) => {
-        // The snake spelling only ever appeared as a native-type hash key.
         expect((t as unknown as Record<string, unknown>)["primary_key"]).toBeUndefined();
         await t.primaryKey("token", "uuid");
       });

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -117,10 +117,6 @@ export class CommandRecorder {
         "changeTable requires a callback. Rails change_table always takes a block.",
       );
     }
-    // Mirrors Rails: the adapter builds its own `Table` subclass over the
-    // recorder as `base`, so the block sees the adapter's `ColumnMethods`
-    // (`t.citext`, `t.unsignedInteger`, ...) while every operation lands in
-    // `record()` via the generated recordable methods below.
     const delegate = this._delegate as {
       supportsBulkAlter?(): boolean;
       updateTableDefinition(tableName: string, base: unknown): Table;
@@ -675,15 +671,7 @@ export class CommandRecorder {
   }
 }
 
-/**
- * Rails' `CommandRecorder::ReversibleAndIrreversibleMethods` — every migration
- * method the recorder answers by recording the call. Rails generates them with
- * `class_eval "def #{method}(*args, &block); record(:\"#{method}\", args, &block); end"`
- * (`migration/command_recorder.rb:125-132`); we install the same bodies onto the
- * prototype below. They are what makes the recorder usable as a `Table`'s
- * `base`, the way `change_table` yields `delegate.update_table_definition(
- * table_name, self)`.
- */
+/** Mirrors: ActiveRecord::Migration::CommandRecorder::ReversibleAndIrreversibleMethods */
 const REVERSIBLE_AND_IRREVERSIBLE_METHODS = [
   "createTable",
   "createJoinTable",
@@ -730,13 +718,7 @@ const REVERSIBLE_AND_IRREVERSIBLE_METHODS = [
   "dropVirtualTable",
 ] as const;
 
-// Installed on the prototype rather than declared on the class: the only caller
-// is a `Table` reaching them through its `base`, which is already typed as the
-// schema-statements host, so no declaration merging (and no
-// no-unsafe-declaration-merging suppression) is needed to reach them.
 for (const method of REVERSIBLE_AND_IRREVERSIBLE_METHODS) {
-  // `changeTable` and the `add_belongs_to` / `remove_belongs_to` aliases are
-  // spelled out in the class body; Ruby's class_eval would clobber them.
   if (method in CommandRecorder.prototype) continue;
   (CommandRecorder.prototype as unknown as Record<string, unknown>)[method] = function (
     this: CommandRecorder,

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -4,9 +4,8 @@
  * Mirrors: ActiveRecord::Migration::CommandRecorder
  */
 
-import { ArgumentError } from "@blazetrails/activemodel";
-import { underscore } from "@blazetrails/activesupport";
 import { IrreversibleMigration } from "../migration.js";
+import type { Table } from "../connection-adapters/abstract/schema-definitions.js";
 import {
   findJoinTableName as _findJoinTableName,
   joinTableName as _joinTableName,
@@ -108,8 +107,8 @@ export class CommandRecorder {
    */
   async changeTable(
     tableName: string,
-    fnOrOptions: ((t: RecorderTableProxy) => Promise<void> | void) | Record<string, unknown>,
-    fn?: (t: RecorderTableProxy) => Promise<void> | void,
+    fnOrOptions: ((t: Table) => Promise<void> | void) | Record<string, unknown>,
+    fn?: (t: Table) => Promise<void> | void,
   ): Promise<void> {
     const options: Record<string, unknown> = typeof fnOrOptions === "function" ? {} : fnOrOptions;
     const callback = typeof fnOrOptions === "function" ? fnOrOptions : fn;
@@ -118,33 +117,27 @@ export class CommandRecorder {
         "changeTable requires a callback. Rails change_table always takes a block.",
       );
     }
-    const supportsBulk =
-      typeof (this._delegate as any)?.supportsBulkAlter === "function" &&
-      (this._delegate as any).supportsBulkAlter() === true;
-
-    // Mirrors Rails: the adapter mixes its `ColumnMethods` module into the
-    // change_table proxy. `columnMethodNames()` exposes that explicit
-    // `define_column_methods` list (adapter-agnostic) — e.g. PG adds
-    // `serial`/`bigserial` beyond its native types.
+    // Mirrors Rails: the adapter builds its own `Table` subclass over the
+    // recorder as `base`, so the block sees the adapter's `ColumnMethods`
+    // (`t.citext`, `t.unsignedInteger`, ...) while every operation lands in
+    // `record()` via the generated recordable methods below.
     const delegate = this._delegate as {
-      columnMethodNames?(): string[];
-      nativeDatabaseTypes?(): Record<string, unknown>;
+      supportsBulkAlter?(): boolean;
+      updateTableDefinition(tableName: string, base: unknown): Table;
     };
-    const columnTypes =
-      delegate?.columnMethodNames?.() ?? Object.keys(delegate?.nativeDatabaseTypes?.() ?? {});
+    const supportsBulk =
+      typeof delegate?.supportsBulkAlter === "function" && delegate.supportsBulkAlter() === true;
 
     if (options["bulk"] && supportsBulk) {
       // Bulk path: sub-recorder captures commands, parent stores a single
       // changeTable entry that invertChangeTable knows how to flip.
       const sub = new CommandRecorder(this._delegate);
-      const proxy = withAdapterColumnMethods(new RecorderTableProxy(tableName, sub), columnTypes);
-      await callback(proxy);
+      await callback(delegate.updateTableDefinition(tableName, sub));
       this.record("changeTable", [tableName, sub.commands]);
     } else {
       // Non-bulk: route operations directly through this recorder so the
       // enclosing revert() block can invert them individually.
-      const proxy = withAdapterColumnMethods(new RecorderTableProxy(tableName, this), columnTypes);
-      await callback(proxy);
+      await callback(delegate.updateTableDefinition(tableName, this));
     }
   }
 
@@ -683,213 +676,72 @@ export class CommandRecorder {
 }
 
 /**
- * Table proxy used inside CommandRecorder#changeTable blocks. Routes each
- * Table-style method call to recorder.record() so the parent recorder (or
- * revert block) can capture and optionally invert the individual operations.
- *
- * Mirrors: the Table object yielded by CommandRecorder#change_table in Rails
- * (non-bulk path: `yield delegate.update_table_definition(table_name, self)`).
+ * Rails' `CommandRecorder::ReversibleAndIrreversibleMethods` — every migration
+ * method the recorder answers by recording the call. Rails generates them with
+ * `class_eval "def #{method}(*args, &block); record(:\"#{method}\", args, &block); end"`
+ * (`migration/command_recorder.rb:125-132`); we install the same bodies onto the
+ * prototype below. They are what makes the recorder usable as a `Table`'s
+ * `base`, the way `change_table` yields `delegate.update_table_definition(
+ * table_name, self)`.
  */
-export class RecorderTableProxy {
-  constructor(
-    private _tableName: string,
-    private _recorder: CommandRecorder,
-  ) {}
+const REVERSIBLE_AND_IRREVERSIBLE_METHODS = [
+  "createTable",
+  "createJoinTable",
+  "renameTable",
+  "addColumn",
+  "removeColumn",
+  "renameIndex",
+  "renameColumn",
+  "addIndex",
+  "removeIndex",
+  "addTimestamps",
+  "removeTimestamps",
+  "changeColumnDefault",
+  "addReference",
+  "removeReference",
+  "transaction",
+  "dropJoinTable",
+  "dropTable",
+  "executeBlock",
+  "enableExtension",
+  "disableExtension",
+  "changeColumn",
+  "execute",
+  "removeColumns",
+  "changeColumnNull",
+  "addForeignKey",
+  "removeForeignKey",
+  "changeColumnComment",
+  "changeTableComment",
+  "addCheckConstraint",
+  "removeCheckConstraint",
+  "addExclusionConstraint",
+  "removeExclusionConstraint",
+  "addUniqueConstraint",
+  "removeUniqueConstraint",
+  "createEnum",
+  "dropEnum",
+  "renameEnum",
+  "addEnumValue",
+  "renameEnumValue",
+  "createSchema",
+  "dropSchema",
+  "createVirtualTable",
+  "dropVirtualTable",
+] as const;
 
-  private _col(name: string, type: string, options: Record<string, unknown>): void {
-    this._recorder.record("addColumn", [this._tableName, name, type, options]);
-  }
-
-  // Mirrors Rails Table#column: the target every ColumnMethods shorthand
-  // (t.hstore, t.jsonb, ...) delegates to. withAdapterColumnMethods routes
-  // adapter-specific column-type calls here.
-  column(name: string, type: string, options: Record<string, unknown> = {}): void {
-    this._col(name, type, options);
-  }
-
-  string(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "string", options);
-  }
-  text(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "text", options);
-  }
-  integer(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "integer", options);
-  }
-  float(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "float", options);
-  }
-  decimal(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "decimal", options);
-  }
-  boolean(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "boolean", options);
-  }
-  date(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "date", options);
-  }
-  datetime(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "datetime", options);
-  }
-  bigint(name: string, options: Record<string, unknown> = {}): void {
-    this._col(name, "bigint", options);
-  }
-
-  rename(oldName: string, newName: string): void {
-    this._recorder.record("renameColumn", [this._tableName, oldName, newName]);
-  }
-
-  remove(...args: [...string[], Record<string, unknown>] | string[]): void {
-    const last = args[args.length - 1];
-    const hasOpts = typeof last === "object" && last !== null;
-    const options = hasOpts ? (args.pop() as Record<string, unknown>) : {};
-    const names = args as string[];
-    // Emit one removeColumn per name (mirrors Rails Table#remove -> remove_columns
-    // iterating remove_column). This avoids the removeColumns arg-shape mismatch
-    // with Migration.removeColumns (strings only, no trailing options).
-    for (const name of names) {
-      const colArgs: unknown[] = [this._tableName, name];
-      if (options["type"]) {
-        colArgs.push(options["type"]);
-        const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "type"));
-        if (Object.keys(rest).length > 0) colArgs.push(rest);
-      } else if (Object.keys(options).length > 0) {
-        // Forward options (e.g. ifExists) even without type so replay semantics
-        // are preserved. Inversion still raises IrreversibleMigration (no type).
-        colArgs.push(options);
-      }
-      this._recorder.record("removeColumn", colArgs);
-    }
-  }
-
-  change(name: string, type: string, options: Record<string, unknown> = {}): void {
-    this._recorder.record("changeColumn", [this._tableName, name, type, options]);
-  }
-
-  changeDefault(name: string, value: unknown): void {
-    this._recorder.record("changeColumnDefault", [this._tableName, name, value]);
-  }
-
-  changeNull(name: string, nullable: boolean, defaultValue?: unknown): void {
-    const args: unknown[] = [this._tableName, name, nullable];
-    if (defaultValue !== undefined) args.push(defaultValue);
-    this._recorder.record("changeColumnNull", args);
-  }
-
-  index(columns: string | string[], options: Record<string, unknown> = {}): void {
-    this._recorder.record("addIndex", [this._tableName, columns, options]);
-  }
-
-  // Mirrors Rails Table#remove_index(column_name = nil, **options) ->
-  // @base.remove_index(name, column_name, **options). Recording the column is
-  // what lets invert_remove_index reconstruct the add_index.
-  removeIndex(
-    columnOrOptions?: string | string[] | Record<string, unknown>,
-    options: Record<string, unknown> = {},
+// Installed on the prototype rather than declared on the class: the only caller
+// is a `Table` reaching them through its `base`, which is already typed as the
+// schema-statements host, so no declaration merging (and no
+// no-unsafe-declaration-merging suppression) is needed to reach them.
+for (const method of REVERSIBLE_AND_IRREVERSIBLE_METHODS) {
+  // `changeTable` and the `add_belongs_to` / `remove_belongs_to` aliases are
+  // spelled out in the class body; Ruby's class_eval would clobber them.
+  if (method in CommandRecorder.prototype) continue;
+  (CommandRecorder.prototype as unknown as Record<string, unknown>)[method] = function (
+    this: CommandRecorder,
+    ...args: unknown[]
   ): void {
-    const isColumn = typeof columnOrOptions === "string" || Array.isArray(columnOrOptions);
-    const column = isColumn ? columnOrOptions : undefined;
-    const opts = isColumn ? options : (columnOrOptions ?? {});
-    const args: unknown[] = [this._tableName, column];
-    if (Object.keys(opts).length > 0) args.push(opts);
-    this._recorder.record("removeIndex", args);
-  }
-
-  // Mirrors Rails Table#references / #belongs_to -> @base.add_reference per name.
-  references(...args: [...string[], Record<string, unknown>] | string[]): void {
-    const last = args[args.length - 1];
-    const hasOpts = typeof last === "object" && last !== null && !Array.isArray(last);
-    const options = hasOpts ? (args.pop() as Record<string, unknown>) : {};
-    for (const refName of args as string[]) {
-      this._recorder.record("addReference", [this._tableName, refName, options]);
-    }
-  }
-
-  belongsTo(...args: [...string[], Record<string, unknown>] | string[]): void {
-    this.references(...args);
-  }
-
-  timestamps(options: Record<string, unknown> = {}): void {
-    this._recorder.record("addTimestamps", [this._tableName, options]);
-  }
-
-  removeTimestamps(options: Record<string, unknown> = {}): void {
-    this._recorder.record("removeTimestamps", [this._tableName, options]);
-  }
-}
-
-// nativeDatabaseTypes keys that Rails does NOT expose as plain column-type
-// shorthands via `define_column_methods`. `primary_key` is a dedicated method
-// (`abstract/schema_definitions.rb:308` — `primary_key(name, type = :primary_key,
-// **options)` merges `primary_key: true` and takes the second argument as the
-// column type), so routing it to a bare `column(name, "primary_key")` would
-// diverge. Both spellings are excluded: the native-type hashes key it
-// `primary_key`, the trails DSL method is `primaryKey`.
-const NON_COLUMN_METHOD_TYPES = new Set(["primaryKey", "primary_key"]);
-
-/**
- * Wrap a change_table proxy so adapter-specific column-type shorthands
- * (`t.hstore`, `t.jsonb`, `t.uuid`, ...) resolve to `column(name, type,
- * options)`.
- *
- * Mirrors Rails: the connection adapter mixes its `ColumnMethods` module into
- * the Table object yielded by `change_table`, where each shorthand generated by
- * `define_column_methods` (`abstract/schema_definitions.rb:332`) is
- * `def type(*names, **options); raise ArgumentError if names.empty?; names.each
- * { column(name, :type, **options) }`. We reproduce that arity (multi-name,
- * raise-on-empty) and delegate to `#column`.
- *
- * The shorthand set is the adapter's `columnMethodNames()` — its explicit
- * `define_column_methods` list (`postgresql/schema_definitions.rb:185`), which
- * for PG adds `serial`/`bigserial` (SERIAL/BIGSERIAL pseudo-types absent from
- * `NATIVE_DATABASE_TYPES`) on top of the native types. This keeps the proxy
- * adapter-agnostic while matching Rails' `ColumnMethods` mixin exactly.
- */
-export function withAdapterColumnMethods<T extends object>(
-  proxy: T,
-  columnTypes: Iterable<string>,
-): T {
-  const types = new Set(columnTypes);
-  return new Proxy(proxy, {
-    get(target, prop, receiver) {
-      if (
-        typeof prop === "string" &&
-        !(prop in target) &&
-        types.has(prop) &&
-        !NON_COLUMN_METHOD_TYPES.has(prop)
-      ) {
-        const col = target as {
-          column(name: string, type: string, options: Record<string, unknown>): unknown;
-        };
-        return (...args: unknown[]): unknown => {
-          const last = args[args.length - 1];
-          const options =
-            last !== null && typeof last === "object" && !Array.isArray(last)
-              ? (args.pop() as Record<string, unknown>)
-              : {};
-          const names = args as string[];
-          if (names.length === 0) {
-            throw new ArgumentError(`Missing column name(s) for ${prop}`);
-          }
-          // Rails' `define_column_methods` generates `def type(...);
-          // column(name, :type, ...)` where `:type` is the snake_case native
-          // type name. trails uses camelCase JS method names, so normalize
-          // multi-word shorthands (`unsignedInteger` -> `unsigned_integer`,
-          // `bitVarying` -> `bit_varying`) back to the snake symbol Rails would
-          // record. Single-token shorthands (serial, jsonb, ...) are unchanged.
-          const type = underscore(prop);
-          const results = names.map((name) => col.column(name, type, options));
-          // Table#column is async (non-recording path); RecorderTableProxy#column
-          // is sync. Return a Promise when any call is thenable so callers can
-          // await, mirroring Rails' synchronous per-name iteration.
-          return results.some(
-            (r) => r != null && typeof (r as { then?: unknown }).then === "function",
-          )
-            ? Promise.all(results)
-            : results[results.length - 1];
-        };
-      }
-      return Reflect.get(target, prop, receiver);
-    },
-  });
+    this.record(method, args);
+  };
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/command-recorder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/command-recorder.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration/command-recorder.ts",
-    "rubyName": "change_table",
-    "call": "update_table_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration/command-recorder.ts",
     "rubyName": "find_join_table_name",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

Rails builds the object `change_table` yields exactly one way — `update_table_definition(table_name, base)` — on all three entry points
(`abstract/schema_statements.rb:510-517`, `migration/command_recorder.rb:136-145`). trails had three different constructions, two of which never
reached the adapter's `Table` subclass:

1. **Adapter-direct / `Migration#schema`.** `updateTableDefinition` was overridden on the *adapter* classes (`postgresql-adapter.ts:4731`,
   `abstract-mysql-adapter.ts:271`), not on the `PostgreSQLSchemaStatements` / `MysqlSchemaStatements` companions that `Migration#schema` and
   `SchemaStatements#changeTable` actually use.
2. **CommandRecorder.** `CommandRecorder#changeTable` yielded `RecorderTableProxy` wrapped in `withAdapterColumnMethods` — two trails inventions
   that re-implemented `Table` and synthesized `ColumnMethods` from a `columnMethodNames()` name list.

## How

- `updateTableDefinition` now has one home per adapter, on the SchemaStatements companion. `PostgreSQLAdapter#updateTableDefinition` delegates to
  `pgSchemaStatements()`; `AbstractMysqlAdapter` picks the MySQL one up through the existing `include(AbstractMysqlAdapter, MysqlSchemaStatements)`,
  so its class-body copy is gone.
- `CommandRecorder#changeTable` yields `delegate.updateTableDefinition(tableName, recorder)` (sub-recorder on the bulk path), as Rails does.
- To make the recorder usable as a `Table`'s `base`, Rails' `ReversibleAndIrreversibleMethods` generation is ported: each name gets a prototype
  method that `record()`s the call — the same bodies Rails writes with `class_eval` (`command_recorder.rb:125-132`). That retires
  `RecorderTableProxy` **and** `withAdapterColumnMethods` (also unhooked from `Migration#changeTable`, which now goes through
  `connection.updateTableDefinition` too).
- `MySQL::Table` gains the rest of its `ColumnMethods` list (`blob`, `tinyblob`, `mediumblob`, `longblob`, `tinytext`, `mediumtext`, `longtext`) —
  Rails mixes the identical `define_column_methods` list into `MySQL::Table` and `MySQL::TableDefinition` (`mysql/schema_definitions.rb:44-47`,
  `:56`, `:102`) — and the `unsigned_*` methods take Rails' `(*names, **options)` arity via `definedColumn`.

## Behavior change worth reviewing

`RecorderTableProxy#remove` emitted one `removeColumn` per name to dodge an arg-shape mismatch. Rails' `Table#remove` forwards the whole list to
`@base.remove_columns(name, *column_names, **options)`, so the recorder now sees a single `removeColumns`, inverted by `invert_remove_columns` into
`add_columns` (`command_recorder.rb:233-239`). The trails-only test name that pinned the old shape is updated; `IrreversibleMigration` without a
`:type` still raises. The `withAdapterColumnMethods` describe is re-pointed onto the real yielded Table: `primary_key` is still never a generic
column shorthand, and `t.primaryKey(name, type)` is Rails' dedicated method (`abstract/schema_definitions.rb:308`).

## Verification

- Re-verified after rebasing onto `main` @ #5627 (post-#5626). `pnpm typecheck`, `pnpm lint` clean. No stubs, no TODO/FIXME added.
- CI's `Rails API/Test Comparison` failed on the **wide call-mismatches ratchet**: `activerecord migration/command-recorder.ts change_table
  update_table_definition` was a baselined omission, and this PR makes `changeTable` actually call `update_table_definition`, so the entry converged
  and had to go. Removed that single entry by hand rather than reseeding (a local `--write` diverges from CI's run); `api:calls:wide` now reports OK
  (4791 baselined), `api:calls` OK (14 baselined), `api:reasons` clean — all still green after the rebase.
- `api:compare`: activerecord **6082/6148** methods, files **277/277** — unchanged. (`PostgreSQL::SchemaStatements#update_table_definition` is
  still reported as a *move* — expected `postgresql/schema-statements.ts`, found on the adapter — because the companion class lives in
  `postgresql/schema-statements-class.ts` package-wide. Pre-existing and unchanged by this PR.)
- `test:compare`: activerecord **8035/8327**, overall **14873/22203** — unchanged; only the `extra (TS only)` bucket moves (+4, the new
  trails-only `removeIndex` tests). Every test name touched or added is trails-only (Rails' are all `test_invert_*`), so the matched population
  is untouched.
- sqlite3: `schema-dumper.test.ts`, `migration.test.ts`, `migration.trails.test.ts`, `migration/**`, `invertible-migration.test.ts`, `active-record-schema.test.ts`,
  `comment.test.ts`, `adapters/sqlite3/virtual-column*.test.ts`, `connection-adapters/{mysql,postgresql}/**` — green.
- PostgreSQL (own compose stack): the same suites plus `citext.test.ts`, `hstore.test.ts`, `enum.test.ts`,
  `adapters/postgresql/virtual-column.test.ts`, `create-unlogged-tables.test.ts` — 525 passed / 8 skipped on the post-rebase re-run.
- MySQL (own compose stack): `migration/change-table.test.ts`, `command-recorder.test.ts`, `invertible-migration.test.ts`,
  `migration/columns.test.ts`, `abstract-mysql-adapter/{active-schema,unsigned-type}.test.ts` — 142 passed / 11 skipped on the post-rebase re-run.

## Review responses

### `Table#removeIndex` passed the options hash as the column — fixed

Correct, and it was a real regression from routing the recorder through the real `Table`. `remove_index(column_name = nil, **options)` keeps the hash
in `**options` and calls `@base.remove_index(name, column_name, **options)` (`abstract/schema_definitions.rb:842-844`), so an options-only call must
leave the column nil. `Table#removeIndex` now splits the two and forwards `(tableName, undefined, options)`. `SchemaStatements#removeIndex` needed a
matching tweak: its hash branch discarded the third argument, so `(table, nil, opts)` silently lost the options — it now merges them the way Ruby's
`**options` collects the hash from either position.

A follow-up on the same method: `Table#removeIndex(undefined, { name: … })` still dropped the second-argument options, because the `= {}` parameter
default turns an explicit `undefined` into `{}` and the non-column branch then read the options off *that*. Ruby's `**options` collects the hash from
either position, so the non-column branch now merges both — the same shape `SchemaStatements#removeIndex` uses. (One detail in the report differs:
`raiseOnIfExistOptions` received `{}`, not `undefined`, for the same default-parameter reason; the dropped-options half was exactly right.)

The recorded shape is now `["removeIndex", [table, undefined, { name: … }]]`, and `invertRemoveIndex` raises
`IrreversibleMigration` ("only reversible if given a :column option") exactly as `invert_remove_index` does (`command_recorder.rb:251-259`).
Four tests added; three of them fail on the pre-fix tree (verified by stashing only the source files and re-running).

### The bulk branch still uses the trails command shape — justification, not a fix

Agreed on the facts; the two halves of Rails' bulk branch cannot be separated, and together they need a change this PR should not carry.

Rails inverts *inside* the sub-recorder (`recorder.reverting = @reverting`) and appends the parent entry with a bare
`@commands << [:change_table, [table_name], -> t { bulk_change_table(table_name, commands) }]` — note `@commands <<`, **not** `record`
(`command_recorder.rb:136-143`). trails does the mirror image: the sub-recorder stays raw and `record("changeTable", …)` inverts the stored sub-list
via `invertChangeTable` on the way out. Same output, opposite route.

So copying `reverting` alone is not a partial improvement, it is a bug: `record()` inverts when `@reverting`, so a reverting sub-recorder plus a
`record`ed parent entry double-inverts. Getting to Rails' shape requires the parent entry to be appended raw and carry a **callable** third element
— and trails' command list is `{ cmd, args }` with no block slot anywhere (`record`, `replay`, `inverse`, `inverseOf`, `_dispatchInvert`, and
`invertCreateTable`/`invertDropTable`, which currently smuggle blocks as a trailing positional arg, all assume it). Adding that slot also makes
`invertChangeTable` — which has no Rails counterpart — dead code.

That is a recorder-core refactor with its own blast radius, and it is the same change needed to make `SchemaStatements#changeTable`'s bulk branch use
`CommandRecorder.new(self)` instead of its ad-hoc `Proxy` (`schema_statements.rb:511-514`). Both are registered together as
`change-table-bulk-paths-use-real-command-recorder` (RFC 0005) with the `file:line` above.

## Not done, and why

- **`citext.test.ts` "change table supports json"**: the AC asked for `t.citext("username")` — that spelling is already on `main` (landed with
  #5624's `PostgreSQL::ColumnMethods` port), and this PR keeps it working through the companion. The remaining `TODO` there is a *different*
  deferral: restoring `assert_equal :citext, Citext.columns_hash["username"].type` still fails against real PG because the synchronous
  `columnsHash()` has no `username` entry after DDL inside `connection.transaction()`. I checked that directly rather than assuming; it is
  unrelated to `update_table_definition`, so the comment is left untouched.
- **Both bulk paths** — see the review response above; registered as `change-table-bulk-paths-use-real-command-recorder` (RFC 0005).

## Overlap note — resolved by the rebase

The `migration.ts` hunk this PR previously shared with #5626 is gone: #5626 merged, so `Migration#changeTable` already goes through
`connection.updateTableDefinition` on `main` (with a `this.schema.updateTableDefinition` fallback, which is better than the version I had).
Rebased onto it and took `main`'s side of both conflicts — **this branch no longer touches `migration.ts` at all**. `withAdapterColumnMethods` and
`RecorderTableProxy` are deleted here, and nothing on `main` references either any more.

## Size

544 LOC (217+/327−), net −110, just over the 500 ceiling — the overage is the deletion of the two inventions. Rebased onto `main` after #5625, which independently removed the duplicate `PostgreSQL::Table#xml` this branch had
also fixed.

Closes-story: change-table-recorder-and-adapter-direct-yield-adapter-table
