### PR TITLE
fix(activerecord): route create_table through build_create_table_definition and set_primary_key

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -214,7 +214,7 @@ export interface AbstractAdapter {
     name: string,
     optionsOrFn?:
       | {
-          id?: boolean | "uuid" | IdHashOptions;
+          id?: boolean | ColumnType | IdHashOptions;
           primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1014,7 +1014,7 @@ export class TableDefinition {
   setPrimaryKey(
     tableName: string,
     id: boolean | ColumnType | IdHashOptions,
-    primaryKey?: string | string[],
+    primaryKey?: string | string[] | false,
     options: Record<string, unknown> = {},
   ): void {
     // Rails has no equivalent: its set_primary_key only ever runs on a fresh
@@ -1026,7 +1026,9 @@ export class TableDefinition {
 
     if (!id || this.as) return;
 
-    const pk = primaryKey ?? globalGetPrimaryKey(singularize(tableName));
+    // Rails' `primary_key || Base.get_primary_key(...)` — `||`, not `??`, so an
+    // explicit `primaryKey: false` still falls back to the conventional name.
+    const pk = primaryKey || globalGetPrimaryKey(singularize(tableName));
 
     let pkOptions: ColumnOptions = { ...(options as Partial<ColumnOptions>) };
     let pkType: ColumnType = typeof id === "string" ? id : "primary_key";

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -957,7 +957,7 @@ export class TableDefinition {
   readonly as?: string;
   readonly options?: string;
   readonly comment?: string;
-  readonly compositePrimaryKey?: string[];
+  compositePrimaryKey?: string[];
   private _id: boolean | PrimaryKeyType | IdHashOptions;
   private _adapterName: "sqlite" | "postgres" | "mysql";
   protected _adapter: SchemaQuoter;
@@ -1004,54 +1004,22 @@ export class TableDefinition {
     this.as = tdOptions.as;
     this.options = tdOptions.options;
     this.comment = tdOptions.comment;
-    if (hasCompositePk) {
-      this.compositePrimaryKey = tdOptions.primaryKey as string[];
-    }
-
-    // Mirrors Rails TableDefinition#set_primary_key: `if id && !as` — when a
-    // CTAS (`as: "SELECT ..."`) is used the SELECT defines the columns, so no
-    // auto-generated PK column should be emitted. Rails relies on this to keep
-    // `o.columns` empty in visit_TableDefinition when `as:` is set.
-    if (this._id !== false && !this.as) {
-      let pkType: ColumnType;
-      let pkOpts: ColumnOptions;
-      if (typeof this._id === "object" && this._id !== null && !Array.isArray(this._id)) {
-        // Hash form: id: { type: "string", collation: "utf8mb4_bin" }
-        // Mirrors Rails set_primary_key: outer options (incl. default) merge first,
-        // then id.except(:type) merges on top, so hash wins on collision.
-        const { type: idType, ...idRest } = this._id;
-        // Use truthiness so any falsy value (empty string, null) falls back, matching
-        // Rails' `id.delete(:type) || :primary_key`.
-        pkType = (idType || "primary_key") as string as ColumnType;
-        pkOpts = { primaryKey: true };
-        if (tdOptions.default !== undefined) pkOpts.default = tdOptions.default;
-        if (tdOptions.autoIncrement !== undefined) pkOpts.autoIncrement = tdOptions.autoIncrement;
-        // Merge id hash options (charset, collation, limit, etc.) but keep primaryKey: true.
-        // Mirrors Rails set_primary_key: outer options merge first, id hash merges on top
-        // (options.merge!(id.except(:type))), so id hash wins on collision.
-        Object.assign(pkOpts, idRest as Partial<ColumnOptions>);
-        pkOpts.primaryKey = true;
-      } else {
-        pkType = (typeof this._id === "string" ? this._id : "primary_key") as ColumnType;
-        pkOpts = { primaryKey: true };
-        if (tdOptions.default !== undefined) pkOpts.default = tdOptions.default;
-        if (tdOptions.autoIncrement !== undefined) pkOpts.autoIncrement = tdOptions.autoIncrement;
-      }
-      const pkName = pkNameOverride ?? globalGetPrimaryKey(singularize(tableName));
-      this.columns.push(this.newColumnDefinition(pkName, pkType, pkOpts));
-    }
+    const pkOptions: Record<string, unknown> = {};
+    if (tdOptions.default !== undefined) pkOptions.default = tdOptions.default;
+    if (tdOptions.autoIncrement !== undefined) pkOptions.autoIncrement = tdOptions.autoIncrement;
+    this.setPrimaryKey(
+      tableName,
+      hasCompositePk ? (tdOptions.primaryKey as string[]) : this._id,
+      pkNameOverride,
+      pkOptions,
+    );
   }
 
-  /**
-   * @todo id parameter doesn't accept the hash form `{ type, collation, ... }` that
-   *   the constructor now supports. createTable doesn't call setPrimaryKey; if a
-   *   caller uses it directly with a hash-form id it must pre-process the hash.
-   */
   setPrimaryKey(
     tableName: string,
-    id: ColumnType | false,
-    primaryKey?: string,
-    _options: Record<string, unknown> = {},
+    id: boolean | ColumnType | IdHashOptions | string[],
+    primaryKey?: string | string[],
+    options: Record<string, unknown> = {},
   ): void {
     // Remove all existing PK columns
     for (let i = this.columns.length - 1; i >= 0; i--) {
@@ -1062,9 +1030,37 @@ export class TableDefinition {
     // their columns defined by the SELECT, so never add a PK column.
     if (id === false || this.as) return;
 
-    const pkName = primaryKey ?? globalGetPrimaryKey(singularize(tableName));
-    const pkType = typeof id === "string" ? id : "primary_key";
-    this.columns.unshift(this.newColumnDefinition(pkName, pkType, { primaryKey: true }));
+    // Rails: `pk = primary_key || Base.get_primary_key(...)`, then
+    // `pk.is_a?(Array) ? primary_keys(pk) : primary_key(pk, id, **options)`.
+    // A composite PK arrives as an array through either argument — the caller
+    // that passes `primaryKey: [...]` also passes it as `id` so the `if id`
+    // guard above stays satisfied.
+    const pk = primaryKey ?? globalGetPrimaryKey(singularize(tableName));
+    if (Array.isArray(pk)) {
+      this.compositePrimaryKey = pk;
+      return;
+    }
+    if (Array.isArray(id)) {
+      this.compositePrimaryKey = id;
+      return;
+    }
+
+    // Mirrors Rails set_primary_key: outer options merge first, then
+    // `options.merge!(id.except(:type))` — the id hash wins on collision.
+    const pkOpts: ColumnOptions = { ...(options as Partial<ColumnOptions>) };
+    let pkType: ColumnType;
+    if (typeof id === "object" && id !== null) {
+      // Hash form: id: { type: "string", collation: "utf8mb4_bin" }
+      const { type: idType, ...idRest } = id;
+      // Truthiness, not nullish: matches Rails' `id.fetch(:type, :primary_key)`
+      // falling back for any falsy value.
+      pkType = (idType || "primary_key") as string as ColumnType;
+      Object.assign(pkOpts, idRest as Partial<ColumnOptions>);
+    } else {
+      pkType = typeof id === "string" ? id : "primary_key";
+    }
+    pkOpts.primaryKey = true;
+    this.columns.unshift(this.newColumnDefinition(pk, pkType, pkOpts));
   }
 
   primaryKeys(name?: string): string[] {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -964,7 +964,7 @@ export class TableDefinition {
   constructor(
     tableName: string,
     tdOptions: {
-      id?: boolean | PrimaryKeyType | IdHashOptions;
+      id?: boolean | ColumnType | IdHashOptions;
       primaryKey?: string | string[] | false;
       adapterName?: "sqlite" | "postgres" | "mysql";
       adapter?: SchemaQuoter;
@@ -1035,7 +1035,9 @@ export class TableDefinition {
     if (typeof id === "object" && id !== null) {
       const { type, ...rest } = id;
       pkOptions = { ...pkOptions, ...(rest as Partial<ColumnOptions>) };
-      pkType = type || "primary_key";
+      // Rails' `id.fetch(:type, :primary_key)` is key-presence, not truthiness:
+      // an explicitly supplied falsy type is passed through, not defaulted.
+      pkType = "type" in id ? (type as ColumnType) : "primary_key";
     }
 
     if (Array.isArray(pk)) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -958,7 +958,6 @@ export class TableDefinition {
   readonly options?: string;
   readonly comment?: string;
   compositePrimaryKey?: string[];
-  private _id: boolean | PrimaryKeyType | IdHashOptions;
   private _adapterName: "sqlite" | "postgres" | "mysql";
   protected _adapter: SchemaQuoter;
 
@@ -994,11 +993,6 @@ export class TableDefinition {
     const pkFalse = tdOptions.primaryKey === false;
     const pkNameOverride =
       typeof tdOptions.primaryKey === "string" ? tdOptions.primaryKey : undefined;
-    if (hasCompositePk || pkFalse) {
-      this._id = false;
-    } else {
-      this._id = tdOptions.id ?? true;
-    }
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;
     this.as = tdOptions.as;
@@ -1009,58 +1003,47 @@ export class TableDefinition {
     if (tdOptions.autoIncrement !== undefined) pkOptions.autoIncrement = tdOptions.autoIncrement;
     this.setPrimaryKey(
       tableName,
-      hasCompositePk ? (tdOptions.primaryKey as string[]) : this._id,
-      pkNameOverride,
+      // A composite primaryKey overrides `id: false`: Rails' guard would skip it,
+      // but trails' callers spell a composite PK as `id: false, primaryKey: [...]`.
+      hasCompositePk ? true : pkFalse ? false : (tdOptions.id ?? true),
+      hasCompositePk ? (tdOptions.primaryKey as string[]) : pkNameOverride,
       pkOptions,
     );
   }
 
   setPrimaryKey(
     tableName: string,
-    id: boolean | ColumnType | IdHashOptions | string[],
+    id: boolean | ColumnType | IdHashOptions,
     primaryKey?: string | string[],
     options: Record<string, unknown> = {},
   ): void {
-    // Remove all existing PK columns
+    // Rails has no equivalent: its set_primary_key only ever runs on a fresh
+    // definition, while trails also re-runs it over a definition rebuilt from an
+    // existing table (SQLite's copy-table path), which already carries the old PK.
     for (let i = this.columns.length - 1; i >= 0; i--) {
       if (this.columns[i].options.primaryKey) this.columns.splice(i, 1);
     }
 
-    // Mirrors Rails set_primary_key's `if id && !as` guard: CTAS tables have
-    // their columns defined by the SELECT, so never add a PK column.
-    if (id === false || this.as) return;
+    if (!id || this.as) return;
 
-    // Rails: `pk = primary_key || Base.get_primary_key(...)`, then
-    // `pk.is_a?(Array) ? primary_keys(pk) : primary_key(pk, id, **options)`.
-    // A composite PK arrives as an array through either argument — the caller
-    // that passes `primaryKey: [...]` also passes it as `id` so the `if id`
-    // guard above stays satisfied.
     const pk = primaryKey ?? globalGetPrimaryKey(singularize(tableName));
-    if (Array.isArray(pk)) {
-      this.compositePrimaryKey = pk;
-      return;
-    }
-    if (Array.isArray(id)) {
-      this.compositePrimaryKey = id;
-      return;
+
+    let pkOptions: ColumnOptions = { ...(options as Partial<ColumnOptions>) };
+    let pkType: ColumnType = typeof id === "string" ? id : "primary_key";
+    if (typeof id === "object" && id !== null) {
+      const { type, ...rest } = id;
+      pkOptions = { ...pkOptions, ...(rest as Partial<ColumnOptions>) };
+      pkType = type || "primary_key";
     }
 
-    // Mirrors Rails set_primary_key: outer options merge first, then
-    // `options.merge!(id.except(:type))` — the id hash wins on collision.
-    const pkOpts: ColumnOptions = { ...(options as Partial<ColumnOptions>) };
-    let pkType: ColumnType;
-    if (typeof id === "object" && id !== null) {
-      // Hash form: id: { type: "string", collation: "utf8mb4_bin" }
-      const { type: idType, ...idRest } = id;
-      // Truthiness, not nullish: matches Rails' `id.fetch(:type, :primary_key)`
-      // falling back for any falsy value.
-      pkType = (idType || "primary_key") as string as ColumnType;
-      Object.assign(pkOpts, idRest as Partial<ColumnOptions>);
+    if (Array.isArray(pk)) {
+      // Rails stores this as `@primary_keys = PrimaryKeyDefinition.new(pk)`; trails
+      // carries a composite PK on the definition itself, and `primaryKeys` is a
+      // reader over the built columns rather than Rails' writer.
+      this.compositePrimaryKey = pk;
     } else {
-      pkType = typeof id === "string" ? id : "primary_key";
+      this.primaryKey(pk, pkType, pkOptions);
     }
-    pkOpts.primaryKey = true;
-    this.columns.unshift(this.newColumnDefinition(pk, pkType, pkOpts));
   }
 
   primaryKeys(name?: string): string[] {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -706,3 +706,23 @@ describe("buildCreateTableDefinition routing", () => {
     expect(pkColumn(td)?.options).toMatchObject({ limit: 8 });
   });
 });
+
+describe("buildCreateTableDefinition primaryKey: false", () => {
+  it("still builds the conventional primary key column", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", { primaryKey: false });
+
+    const pk = td.columns.find((c) => c.options.primaryKey);
+    expect(pk?.name).toBe("id");
+    expect(pk?.type).toBe("primary_key");
+  });
+
+  it("emits no primary key column when id is false", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", { id: false, primaryKey: false });
+
+    expect(td.columns.find((c) => c.options.primaryKey)).toBeUndefined();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -4,7 +4,7 @@ import {
   canRemoveIndexByName,
   indexNameForRemoveFrom,
 } from "./schema-statements.js";
-import { ForeignKeyDefinition, TableDefinition } from "./schema-definitions.js";
+import { ForeignKeyDefinition, TableDefinition, type ColumnType } from "./schema-definitions.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 
 function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
@@ -724,5 +724,27 @@ describe("buildCreateTableDefinition primaryKey: false", () => {
     const td = ss.buildCreateTableDefinition("users", { id: false, primaryKey: false });
 
     expect(td.columns.find((c) => c.options.primaryKey)).toBeUndefined();
+  });
+});
+
+describe("buildCreateTableDefinition hash-form id type fetch", () => {
+  it("passes an explicitly supplied falsy type through instead of defaulting", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", {
+      id: { type: "" as unknown as ColumnType, limit: 4 },
+    });
+
+    const pk = td.columns.find((c) => c.options.primaryKey);
+    expect(pk?.type).toBe("");
+    expect(pk?.options).toMatchObject({ limit: 4 });
+  });
+
+  it("defaults to primary_key only when the type key is absent", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", { id: { limit: 4 } });
+
+    expect(td.columns.find((c) => c.options.primaryKey)?.type).toBe("primary_key");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -4,7 +4,7 @@ import {
   canRemoveIndexByName,
   indexNameForRemoveFrom,
 } from "./schema-statements.js";
-import { ForeignKeyDefinition } from "./schema-definitions.js";
+import { ForeignKeyDefinition, TableDefinition } from "./schema-definitions.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 
 function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
@@ -606,5 +606,103 @@ describe("tableExists NotImplementedError fallback", () => {
     });
 
     await expect(ss.tableExists("posts")).rejects.toThrow("connection lost");
+  });
+});
+
+describe("buildCreateTableDefinition routing", () => {
+  function pkColumn(td: TableDefinition) {
+    return td.columns.find((c) => c.options.primaryKey);
+  }
+
+  it("carries valid_primary_key_options through to the primary key column", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", {
+      id: "integer",
+      limit: 8,
+      default: 0,
+      precision: 3,
+    });
+
+    expect(pkColumn(td)?.options).toMatchObject({ limit: 8, default: 0, precision: 3 });
+  });
+
+  it("carries valid_table_definition_options through to the table definition", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", {
+      temporary: true,
+      ifNotExists: true,
+      as: undefined,
+      comment: "a table",
+      options: "ENGINE=InnoDB",
+    });
+
+    expect(td.temporary).toBe(true);
+    expect(td.ifNotExists).toBe(true);
+    expect(td.comment).toBe("a table");
+    expect(td.options).toBe("ENGINE=InnoDB");
+  });
+
+  it("expands the hash form of id onto the primary key column", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", {
+      id: { type: "string", limit: 36, collation: "utf8mb4_bin" },
+    });
+
+    const pk = pkColumn(td);
+    expect(pk?.type).toBe("string");
+    expect(pk?.options).toMatchObject({ limit: 36, collation: "utf8mb4_bin" });
+  });
+
+  it("names the primary key column from the primaryKey option", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("users", { id: "uuid", primaryKey: "guid" });
+
+    expect(pkColumn(td)?.name).toBe("guid");
+    expect(pkColumn(td)?.type).toBe("uuid");
+  });
+
+  it("records a composite primaryKey array instead of a primary key column", () => {
+    const ss = makeStatements();
+
+    const td = ss.buildCreateTableDefinition("orders", { primaryKey: ["shopId", "id"] });
+
+    expect(td.compositePrimaryKey).toEqual(["shopId", "id"]);
+    expect(pkColumn(td)).toBeUndefined();
+  });
+
+  it("builds the definition through the adapter's createTableDefinition", () => {
+    const marker = Symbol("dialect-td");
+    const createTableDefinition = vi.fn((name: string, options: Record<string, unknown>) => {
+      const td: any = new TableDefinition(name, options as any);
+      td[marker] = true;
+      return td;
+    });
+    const ss = makeStatements({ createTableDefinition });
+
+    const td = ss.buildCreateTableDefinition("users", { id: "bigint" });
+
+    expect(createTableDefinition).toHaveBeenCalledTimes(1);
+    expect((td as any)[marker]).toBe(true);
+    expect(pkColumn(td)?.type).toBe("bigint");
+  });
+
+  it("is the path createTable takes to build its definition", async () => {
+    const ss = makeStatements();
+    const spy = vi.spyOn(ss, "buildCreateTableDefinition");
+
+    // No teardown: `makeStatements` has a mocked `execute`, so no table is ever created.
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await ss.createTable("users", { id: "bigint", primaryKey: "guid", limit: 8 }, (t) => {
+      t.column("name", "string");
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const td = spy.mock.results[0].value as TableDefinition;
+    expect(pkColumn(td)?.name).toBe("guid");
+    expect(pkColumn(td)?.options).toMatchObject({ limit: 8 });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -17,7 +17,6 @@ import {
   Table,
   AlterTable,
   IndexDefinition,
-  ColumnDefinition,
   AddColumnDefinition,
   ChangeColumnDefaultDefinition,
   CreateIndexDefinition,
@@ -247,7 +246,7 @@ export class SchemaStatements {
     name: string,
     optionsOrFn?:
       | {
-          id?: boolean | "uuid" | IdHashOptions;
+          id?: boolean | ColumnType | IdHashOptions;
           primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;
@@ -259,12 +258,14 @@ export class SchemaStatements {
           temporary?: boolean;
           as?: string;
           autoIncrement?: boolean;
+          limit?: number;
+          precision?: number;
         }
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
     let options: {
-      id?: boolean | "uuid" | IdHashOptions;
+      id?: boolean | ColumnType | IdHashOptions;
       primaryKey?: string | string[] | false;
       force?: boolean | "cascade";
       ifNotExists?: boolean;
@@ -276,6 +277,8 @@ export class SchemaStatements {
       temporary?: boolean;
       as?: string;
       autoIncrement?: boolean;
+      limit?: number;
+      precision?: number;
     } = {};
     let definer: ((t: TableDefinition) => void) | undefined;
 
@@ -312,16 +315,11 @@ export class SchemaStatements {
       this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, name);
     }
 
-    // Rails: `td = create_table_definition(...)` — dispatches to the adapter's
-    // dialect-specific TableDefinition (e.g. PostgreSQL::TableDefinition with
-    // range/hstore/jsonb column methods). Every real adapter mixes in
-    // SchemaStatements, so the optional method is always present here.
-    const td = this.adapter.createTableDefinition!(name, {
-      ...options,
-      adapterName: this.adapterName,
-      adapter: this.adapter,
-    });
-    if (definer) definer(td);
+    // Rails: `td = build_create_table_definition(table_name, id:, primary_key:, **options, &block)`
+    // — which in turn dispatches to the adapter's dialect-specific
+    // TableDefinition (e.g. PostgreSQL::TableDefinition with range/hstore/jsonb
+    // column methods) and routes the primary key through `set_primary_key`.
+    const td = this.buildCreateTableDefinition(name, options, definer);
 
     // Prime the cached database version before the visitor emits DDL: inline
     // `t.index order:` runs through SchemaCreation's synchronous
@@ -1602,28 +1600,53 @@ export class SchemaStatements {
     return this.viewExists(name);
   }
 
+  /**
+   * Mirrors Rails `abstract/schema_statements.rb:333`. The two `options.extract!`
+   * calls are what split the hash: `valid_table_definition_options` reach the
+   * TableDefinition constructor, `valid_primary_key_options` reach
+   * `set_primary_key` and land on the PK column. Building the definition through
+   * `createTableDefinition` (rather than `new TableDefinition`) is what makes the
+   * adapter's own TableDefinition subclass — and therefore its dialect column
+   * methods — available inside the block.
+   */
   buildCreateTableDefinition(
     tableName: string,
     options: {
-      id?: boolean | "uuid" | false;
-      primaryKey?: string;
-      force?: boolean;
+      id?: boolean | ColumnType | IdHashOptions;
+      primaryKey?: string | string[] | false;
+      force?: boolean | "cascade";
       [key: string]: unknown;
     } = {},
     fn?: (td: TableDefinition) => void,
   ): TableDefinition {
-    const hasCustomPk = !!options.primaryKey && options.id !== false;
-    const td = new TableDefinition(tableName, {
-      id: hasCustomPk ? false : options.id,
+    const { id = true, primaryKey, force: _force, ...rest } = options;
+    const tdOptions: Record<string, unknown> = {};
+    for (const key of this.validTableDefinitionOptions()) {
+      if (rest[key] !== undefined) tdOptions[key] = rest[key];
+    }
+    const pkOptions: Record<string, unknown> = {};
+    // `autoIncrement` is not in Rails' valid_primary_key_options (it is MySQL's
+    // addition), but createTable has always accepted it dialect-agnostically.
+    for (const key of [...this.validPrimaryKeyOptions(), "autoIncrement"]) {
+      if (rest[key] !== undefined) pkOptions[key] = rest[key];
+    }
+
+    // `id: false` because Rails' create_table_definition never sees `:id` — the
+    // primary key is added afterwards by set_primary_key. Trails' constructor
+    // would otherwise build (and we would immediately discard) a default PK.
+    const ctdOptions = {
+      ...tdOptions,
+      id: false,
       adapterName: this.adapterName,
       adapter: this.adapter,
-    });
-    if (hasCustomPk) {
-      const pkType = (typeof options.id === "string" ? options.id : "primary_key") as ColumnType;
-      td.columns.unshift(
-        new ColumnDefinition(options.primaryKey as string, pkType, { primaryKey: true }),
-      );
-    }
+    };
+    const td = this.adapter.createTableDefinition
+      ? this.adapter.createTableDefinition(tableName, ctdOptions)
+      : this.createTableDefinition(tableName, ctdOptions);
+    // `primaryKey: false` is Rails' `id: false` spelling; a composite array PK is
+    // passed as both arguments so set_primary_key's `if id` guard stays satisfied.
+    const pkArg = primaryKey === false ? false : Array.isArray(primaryKey) ? primaryKey : id;
+    td.setPrimaryKey(tableName, pkArg, primaryKey === false ? undefined : primaryKey, pkOptions);
     if (fn) fn(td);
     return td;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1629,8 +1629,8 @@ export class SchemaStatements {
       tableName,
       // A composite primaryKey overrides `id: false`: Rails' guard would skip it,
       // but trails' callers spell a composite PK as `id: false, primaryKey: [...]`.
-      primaryKey === false ? false : Array.isArray(primaryKey) ? true : id,
-      primaryKey === false ? undefined : primaryKey,
+      Array.isArray(primaryKey) ? true : id,
+      primaryKey,
       pkOptions,
     );
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -315,10 +315,6 @@ export class SchemaStatements {
       this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, name);
     }
 
-    // Rails: `td = build_create_table_definition(table_name, id:, primary_key:, **options, &block)`
-    // — which in turn dispatches to the adapter's dialect-specific
-    // TableDefinition (e.g. PostgreSQL::TableDefinition with range/hstore/jsonb
-    // column methods) and routes the primary key through `set_primary_key`.
     const td = this.buildCreateTableDefinition(name, options, definer);
 
     // Prime the cached database version before the visitor emits DDL: inline
@@ -1600,15 +1596,6 @@ export class SchemaStatements {
     return this.viewExists(name);
   }
 
-  /**
-   * Mirrors Rails `abstract/schema_statements.rb:333`. The two `options.extract!`
-   * calls are what split the hash: `valid_table_definition_options` reach the
-   * TableDefinition constructor, `valid_primary_key_options` reach
-   * `set_primary_key` and land on the PK column. Building the definition through
-   * `createTableDefinition` (rather than `new TableDefinition`) is what makes the
-   * adapter's own TableDefinition subclass — and therefore its dialect column
-   * methods — available inside the block.
-   */
   buildCreateTableDefinition(
     tableName: string,
     options: {
@@ -1625,30 +1612,31 @@ export class SchemaStatements {
       if (rest[key] !== undefined) tdOptions[key] = rest[key];
     }
     const pkOptions: Record<string, unknown> = {};
-    // `autoIncrement` is not in Rails' valid_primary_key_options (it is MySQL's
-    // addition), but createTable has always accepted it dialect-agnostically.
     for (const key of [...this.validPrimaryKeyOptions(), "autoIncrement"]) {
       if (rest[key] !== undefined) pkOptions[key] = rest[key];
     }
 
-    // `id: false` because Rails' create_table_definition never sees `:id` — the
-    // primary key is added afterwards by set_primary_key. Trails' constructor
-    // would otherwise build (and we would immediately discard) a default PK.
     const ctdOptions = {
       ...tdOptions,
       id: false,
       adapterName: this.adapterName,
       adapter: this.adapter,
     };
-    const td = this.adapter.createTableDefinition
+    const tableDefinition = this.adapter.createTableDefinition
       ? this.adapter.createTableDefinition(tableName, ctdOptions)
       : this.createTableDefinition(tableName, ctdOptions);
-    // `primaryKey: false` is Rails' `id: false` spelling; a composite array PK is
-    // passed as both arguments so set_primary_key's `if id` guard stays satisfied.
-    const pkArg = primaryKey === false ? false : Array.isArray(primaryKey) ? primaryKey : id;
-    td.setPrimaryKey(tableName, pkArg, primaryKey === false ? undefined : primaryKey, pkOptions);
-    if (fn) fn(td);
-    return td;
+    tableDefinition.setPrimaryKey(
+      tableName,
+      // A composite primaryKey overrides `id: false`: Rails' guard would skip it,
+      // but trails' callers spell a composite PK as `id: false, primaryKey: [...]`.
+      primaryKey === false ? false : Array.isArray(primaryKey) ? true : id,
+      primaryKey === false ? undefined : primaryKey,
+      pkOptions,
+    );
+
+    if (fn) fn(tableDefinition);
+
+    return tableDefinition;
   }
 
   buildCreateJoinTableDefinition(

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -233,3 +233,25 @@ describe("MigrationTest", () => {
     expect(seen).toEqual([["people", m]]);
   });
 });
+
+describe("Migration#createTable id option type", () => {
+  it("accepts every Rails-valid id type the schema dumper emits", () => {
+    // The dumper emits `createTable("int_defaults", { id: "bigint", ... })`
+    // (primary-keys.test.ts asserts that string), so the public signature has to
+    // admit any ColumnType — not just "uuid". This is a compile-time guard: on a
+    // narrowed signature the assignments below fail `tsc`, not the assertion.
+    type CreateTableOptions = Extract<Parameters<Migration["createTable"]>[1], { id?: unknown }>;
+
+    const bigint: CreateTableOptions = { id: "bigint" };
+    const integer: CreateTableOptions = { id: "integer" };
+    const uuid: CreateTableOptions = { id: "uuid" };
+    const hash: CreateTableOptions = { id: { type: "string", limit: 36 } };
+
+    expect([bigint.id, integer.id, uuid.id, hash.id]).toEqual([
+      "bigint",
+      "integer",
+      "uuid",
+      { type: "string", limit: 36 },
+    ]);
+  });
+});

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -456,7 +456,7 @@ export abstract class Migration {
     name: string,
     optionsOrFn?:
       | {
-          id?: boolean | "uuid" | IdHashOptions;
+          id?: boolean | ColumnType | IdHashOptions;
           primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;
@@ -1708,7 +1708,7 @@ export class MigrationContext {
       primaryKey?: string | string[] | false;
       force?: boolean | "cascade";
       ifNotExists?: boolean;
-      id?: boolean | "uuid" | IdHashOptions;
+      id?: boolean | ColumnType | IdHashOptions;
       default?: unknown;
       options?: string;
       comment?: string;

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -72,20 +72,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "build_create_table_definition",
-    "call": "create_table_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "build_create_table_definition",
-    "call": "set_primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "bulk_change_table",
     "call": "partition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -172,13 +158,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_join_table",
     "call": "reverse_merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
-    "call": "build_create_table_definition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -641,7 +641,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "quote",
     "call": "check_int_in_range",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `checkIntInRange` is a bare alias — `export const checkIntInRange = checkIntegerRange` — so the routed call is the alias target and the extractor never sees the alias name. Nothing to converge."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/quoting.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/quoting.json
@@ -4,7 +4,7 @@
     "tsFile": "connection-adapters/postgresql/quoting.ts",
     "rubyName": "quote",
     "call": "check_int_in_range",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `checkIntInRange` is a bare alias — `export const checkIntInRange = checkIntegerRange` — so the routed call is the alias target and the extractor never sees the alias name. Nothing to converge."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-generator.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-generator.json
@@ -11,7 +11,7 @@
     "tsFile": "encryption/key-generator.ts",
     "rubyName": "generate_random_hex_key",
     "call": "generate_random_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deferred (RFC 0072 activerecord-unrouted-privates-remaining-inventory): routing `generateRandomHexKey`/`generateRandomSecret` through `generateRandomKey` sits on top of a pre-existing return-type deviation (trails returns base64, Rails returns raw bytes). That deviation has to be settled first."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/reflection.json
@@ -88,7 +88,7 @@
     "tsFile": "reflection.ts",
     "rubyName": "derive_join_table",
     "call": "derive_join_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `migration/join-table.ts#joinTableName` deliberately duplicates `model-schema.ts#deriveJoinTableName` rather than importing it — the import edge is a TDZ cycle, guarded by `scripts/test-deps/adapter-graph-import-tdz.test.ts`. Documented deviation; do not route."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -1817,7 +1817,7 @@
     "tsFile": "relation.ts",
     "rubyName": "order",
     "call": "sanitize_order_arguments",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deferred (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `orderBang`/`reorderBang` inline `disallowRawSqlBang` in a restructured body, leaving `sanitizeOrderArguments` and `checkIfMethodHasArgumentsBang` dead. Routing them is a real convergence but a whole-body restructure of the order/reorder path — its own story, not part of this sweep."
   },
   {
     "package": "activerecord",
@@ -2006,7 +2006,7 @@
     "tsFile": "relation.ts",
     "rubyName": "reorder",
     "call": "sanitize_order_arguments",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deferred (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `orderBang`/`reorderBang` inline `disallowRawSqlBang` in a restructured body, leaving `sanitizeOrderArguments` and `checkIfMethodHasArgumentsBang` dead. Routing them is a real convergence but a whole-body restructure of the order/reorder path — its own story, not part of this sweep."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
First cluster from the `activerecord-unrouted-privates-remaining-inventory` sweep: the create-table definition path.

## What was wrong

Three unrouted edges, all in the same chain:

- `createTable` never called `buildCreateTableDefinition` (Rails' `create_table` is a one-liner over it) — it built its own definition inline.
- `buildCreateTableDefinition` did `new TableDefinition(...)` instead of `createTableDefinition(...)`, so the adapter's own TableDefinition subclass (and its dialect column methods) was lost, and it forwarded **none** of `temporary` / `ifNotExists` / `options` / `as` / `comment` / `charset` / `collation`. It also reimplemented the custom-PK insert instead of calling `setPrimaryKey`.
- `setPrimaryKey` took an `_options` argument and ignored it, and could not handle the hash form of `id` or a composite array PK — that logic was inlined in the `TableDefinition` constructor.

Net effect: `limit` / `default` / `precision` (Rails' `valid_primary_key_options`) never reached the primary key column when a definition was built through `buildCreateTableDefinition`.

## What changed

`createTable` → `buildCreateTableDefinition` → `createTableDefinition` + `td.setPrimaryKey(tableName, id, primaryKey, pkOptions)`, matching `abstract/schema_statements.rb:333`. The option split is the two `options.extract!` calls, sourced from the existing `validTableDefinitionOptions()` / `validPrimaryKeyOptions()` (so MySQL's extra `unsigned` / `autoIncrement` are picked up on that dialect).

`setPrimaryKey` now carries Rails' own body rather than a hand-rolled equivalent: the `if id && !as` guard, `pk = primary_key || get_primary_key(table_name.singularize)`, the `id.is_a?(Hash)` option merge, then `primary_keys(pk)` or `primary_key(pk, id, **options)`. The constructor calls it instead of inlining PK construction, and the private `_id` field that existed only to carry the inlined version is gone.

Three deviations remain, each with a one-line reason at the call site:

1. `setPrimaryKey` strips pre-existing PK columns first — trails re-runs it over a definition rebuilt from an existing table (SQLite's copy-table path); Rails only ever runs it on a fresh definition.
2. A composite PK overrides `id: false`. Rails' `if id` guard would skip it, but trails' callers (including the canonical schema loader) spell a composite PK as `id: false, primaryKey: [...]`.
3. The array branch assigns `compositePrimaryKey` rather than calling `primaryKeys(pk)` — trails' `primaryKeys` is a reader over the built columns, not Rails' `@primary_keys` writer.

## Tests

Seven new assertions in `schema-statements-privates.test.ts`, each checking the argument reaches the built node rather than just the returned class — 5 of the 7 fail on the pre-fix implementation (verified by reverting the two source files and re-running); the 2 that pass cover behavior the constructor already had and this change must not regress.

Locally green across `connection-adapters/`, `migration/`, `adapters/sqlite3/`, `migration.test.ts`, `primary-keys.test.ts`, `composite-primary-key.test.ts`, `schema-dumper.test.ts`, `invertible-migration.test.ts`, `base.test.ts`: 2534 passed, 0 failed.

## Deltas

- `api:compare` — activerecord 6082/6148 (98.9%), unchanged against baseline (measured by stashing the diff and re-measuring).
- `test:compare` — 14873/22203, unchanged; the new assertions live in a trails-invention file and count as extra, so the matched population is untouched.
- Wide call ratchet — shrinks by 3 (`create_table -> build_create_table_definition`, `build_create_table_definition -> create_table_definition`, `build_create_table_definition -> set_primary_key`). Regenerated with `API_COMPARE_FORCE=1 pnpm api:compare --wide-calls`, then `pnpm api:calls:wide` reports OK with 4788 baselined.

Also added `reason` text to the five entries this sweep confirmed non-actionable, so the next pass does not re-derive them: `checkIntInRange` (bare alias), `deriveJoinTableName` (documented import-TDZ deviation), `sanitizeOrderArguments` x2 (needs the order/reorder body restructure — own story), `generateRandomKey` (blocked on the base64-vs-raw-bytes return-type deviation).

Closes-story: activerecord-unrouted-privates-remaining-inventory
