### PR TITLE
feat(activerecord): port Column/SqlTypeMetadata/Message/Binary::Data #==

### DIFF
--- a/packages/activemodel/src/type/binary.trails.test.ts
+++ b/packages/activemodel/src/type/binary.trails.test.ts
@@ -27,10 +27,6 @@ describe("BinaryTypeTrails", () => {
   });
 
   it("Data#equals compares bytes, not the decoded string", () => {
-    // binary.rb:56 `other == to_s || super` compares against the raw binary
-    // String, so it is a byte comparison. Routing through our `toString()`
-    // instead would UTF-8-decode: both of these byte strings decode to a pair
-    // of U+FFFD replacements and would wrongly compare equal.
     const a = new BinaryData(new Uint8Array([0x80, 0x81]));
     const b = new BinaryData(new Uint8Array([0x82, 0x83]));
     expect(a.equals(b)).toBe(false);
@@ -46,8 +42,6 @@ describe("BinaryTypeTrails", () => {
   });
 
   it("Data#equals is false for values Ruby would fall through to identity on", () => {
-    // The `|| super` arm is Object#== — identity — so a non-string, non-byte
-    // `other` can never match.
     const data = new BinaryData("1");
     expect(data.equals(1)).toBe(false);
     expect(data.equals(null)).toBe(false);

--- a/packages/activemodel/src/type/binary.trails.test.ts
+++ b/packages/activemodel/src/type/binary.trails.test.ts
@@ -25,4 +25,33 @@ describe("BinaryTypeTrails", () => {
     expect(result).toBeInstanceOf(BinaryData);
     expect(result!.bytes).toEqual(bytes);
   });
+
+  it("Data#equals compares bytes, not the decoded string", () => {
+    // binary.rb:56 `other == to_s || super` compares against the raw binary
+    // String, so it is a byte comparison. Routing through our `toString()`
+    // instead would UTF-8-decode: both of these byte strings decode to a pair
+    // of U+FFFD replacements and would wrongly compare equal.
+    const a = new BinaryData(new Uint8Array([0x80, 0x81]));
+    const b = new BinaryData(new Uint8Array([0x82, 0x83]));
+    expect(a.equals(b)).toBe(false);
+    expect(a.equals(new BinaryData(new Uint8Array([0x80, 0x81])))).toBe(true);
+  });
+
+  it("Data#equals accepts the byte sources that stand in for a Ruby String", () => {
+    const data = new BinaryData("hello");
+    expect(data.equals("hello")).toBe(true);
+    expect(data.equals(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]))).toBe(true);
+    expect(data.equals("hell")).toBe(false);
+    expect(data.equals("hellO")).toBe(false);
+  });
+
+  it("Data#equals is false for values Ruby would fall through to identity on", () => {
+    // The `|| super` arm is Object#== — identity — so a non-string, non-byte
+    // `other` can never match.
+    const data = new BinaryData("1");
+    expect(data.equals(1)).toBe(false);
+    expect(data.equals(null)).toBe(false);
+    expect(data.equals(undefined)).toBe(false);
+    expect(data.equals(data)).toBe(true);
+  });
 });

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -97,4 +97,33 @@ export class Data {
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
   }
+
+  /**
+   * Mirrors: Data#== (binary.rb:56) — `other == to_s || super`.
+   *
+   * Ruby's left arm compares `other` against the raw binary String, so it is a
+   * BYTE comparison; another `Data` recurses one level and lands on
+   * `String#==`, again on bytes. Our `toString()` UTF-8-decodes and is lossy
+   * (`de ad be ef` → U+FFFD replacements), so the port must walk `bytes`
+   * rather than route through it. `Uint8Array` is our stand-in for a
+   * binary-encoded Ruby String (see the constructor), and a `string` is
+   * encoded to compare on the same footing.
+   *
+   * The `|| super` arm — `Object#==`, identity — needs no separate case: an
+   * identical `Data` already matches byte-for-byte, and anything that is
+   * neither a byte source nor a string can never be identical to a `Data`.
+   */
+  equals(other: unknown): boolean {
+    let otherBytes: Uint8Array;
+    if (other instanceof Data) otherBytes = other.bytes;
+    else if (other instanceof Uint8Array) otherBytes = other;
+    else if (typeof other === "string") otherBytes = textEncoder.encode(other);
+    else return false;
+
+    if (this.bytes.length !== otherBytes.length) return false;
+    for (let i = 0; i < this.bytes.length; i++) {
+      if (this.bytes[i] !== otherBytes[i]) return false;
+    }
+    return true;
+  }
 }

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -98,21 +98,6 @@ export class Data {
       .join("");
   }
 
-  /**
-   * Mirrors: Data#== (binary.rb:56) — `other == to_s || super`.
-   *
-   * Ruby's left arm compares `other` against the raw binary String, so it is a
-   * BYTE comparison; another `Data` recurses one level and lands on
-   * `String#==`, again on bytes. Our `toString()` UTF-8-decodes and is lossy
-   * (`de ad be ef` → U+FFFD replacements), so the port must walk `bytes`
-   * rather than route through it. `Uint8Array` is our stand-in for a
-   * binary-encoded Ruby String (see the constructor), and a `string` is
-   * encoded to compare on the same footing.
-   *
-   * The `|| super` arm — `Object#==`, identity — needs no separate case: an
-   * identical `Data` already matches byte-for-byte, and anything that is
-   * neither a byte source nor a string can never be identical to a `Data`.
-   */
   equals(other: unknown): boolean {
     let otherBytes: Uint8Array;
     if (other instanceof Data) otherBytes = other.bytes;

--- a/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
@@ -4,14 +4,6 @@ import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { Column as PostgreSQLColumn } from "./postgresql/column.js";
 import { Column as SQLite3Column } from "./sqlite3/column.js";
 
-/**
- * Trails-only coverage for the `==` ports on `Column`, its PostgreSQL/SQLite3
- * subclasses, and `SqlTypeMetadata`. Rails ships no test that exercises those
- * methods directly (`pnpm rails:find "test_.*equal"` turns up nothing in the
- * adapter suites — they are only reached indirectly, through schema-cache
- * comparisons), so these live here rather than under an invented Rails name.
- */
-
 function meta(overrides: NonNullable<ConstructorParameters<typeof SqlTypeMetadata>[0]> = {}) {
   return new SqlTypeMetadata({ sqlType: "varchar(255)", type: "string", limit: 255, ...overrides });
 }
@@ -38,9 +30,6 @@ describe("ColumnEqualityTrails", () => {
   });
 
   it("ignores primaryKey, which Rails' Column does not carry", () => {
-    // column.rb:75 compares name/default/sql_type_metadata/null/default_function/
-    // collation/comment and nothing else; `primaryKey` is a trails-side flag, so
-    // folding it in would make two columns Rails calls equal compare unequal.
     const a = new Column("id", null, meta(), false, { primaryKey: true });
     const b = new Column("id", null, meta(), false, { primaryKey: false });
     expect(a.equals(b)).toBe(true);
@@ -71,11 +60,9 @@ describe("ColumnEqualityTrails", () => {
   });
 
   it("narrows the guard to the adapter class in PostgreSQL::Column", () => {
-    // postgresql/column.rb:64's `other.is_a?(Column)` resolves to
-    // PostgreSQL::Column, so the check is one-way: the base class still accepts
-    // a PG column whose shared attributes match.
     const pg = new PostgreSQLColumn("id", null, { sqlType: "integer", type: "integer" }, false);
-    const base = new Column("id", null, new SqlTypeMetadata({ sqlType: "integer", type: "integer" }), false); // prettier-ignore
+    const metadata = new SqlTypeMetadata({ sqlType: "integer", type: "integer" });
+    const base = new Column("id", null, metadata, false);
     expect(pg.equals(base)).toBe(false);
     expect(base.equals(pg)).toBe(true);
   });
@@ -99,8 +86,6 @@ describe("ColumnEqualityTrails", () => {
     expect(plain.equals(new SQLite3Column("id", null, opts, false, { autoIncrement: true }))).toBe(
       false,
     );
-    // sqlite3/column.rb:53 folds `rowid` into `hash` but :46 leaves it out of
-    // `==` — keep that asymmetry rather than "fixing" it.
     expect(plain.equals(new SQLite3Column("id", null, opts, false, { rowid: true }))).toBe(true);
   });
 

--- a/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { Column } from "./column.js";
+import { SqlTypeMetadata } from "./sql-type-metadata.js";
+import { Column as PostgreSQLColumn } from "./postgresql/column.js";
+import { Column as SQLite3Column } from "./sqlite3/column.js";
+
+/**
+ * Trails-only coverage for the `==` ports on `Column`, its PostgreSQL/SQLite3
+ * subclasses, and `SqlTypeMetadata`. Rails ships no test that exercises those
+ * methods directly (`pnpm rails:find "test_.*equal"` turns up nothing in the
+ * adapter suites — they are only reached indirectly, through schema-cache
+ * comparisons), so these live here rather than under an invented Rails name.
+ */
+
+function meta(overrides: NonNullable<ConstructorParameters<typeof SqlTypeMetadata>[0]> = {}) {
+  return new SqlTypeMetadata({ sqlType: "varchar(255)", type: "string", limit: 255, ...overrides });
+}
+
+describe("ColumnEqualityTrails", () => {
+  it("compares every attribute Rails compares", () => {
+    const base = () =>
+      new Column("title", "hi", meta(), false, { comment: "c", collation: "utf8" });
+    expect(base().equals(base())).toBe(true);
+
+    expect(base().equals(new Column("other", "hi", meta(), false, { comment: "c" }))).toBe(false);
+    expect(base().equals(new Column("title", "bye", meta(), false, { comment: "c" }))).toBe(false);
+    expect(base().equals(new Column("title", "hi", meta({ limit: 10 }), false))).toBe(false);
+    expect(base().equals(new Column("title", "hi", meta(), true, { comment: "c" }))).toBe(false);
+    expect(base().equals(new Column("title", "hi", meta(), false, { comment: "other" }))).toBe(
+      false,
+    );
+    expect(base().equals(new Column("title", "hi", meta(), false, { collation: "ascii" }))).toBe(
+      false,
+    );
+    expect(
+      base().equals(new Column("title", "hi", meta(), false, { defaultFunction: "now()" })),
+    ).toBe(false);
+  });
+
+  it("ignores primaryKey, which Rails' Column does not carry", () => {
+    // column.rb:75 compares name/default/sql_type_metadata/null/default_function/
+    // collation/comment and nothing else; `primaryKey` is a trails-side flag, so
+    // folding it in would make two columns Rails calls equal compare unequal.
+    const a = new Column("id", null, meta(), false, { primaryKey: true });
+    const b = new Column("id", null, meta(), false, { primaryKey: false });
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it("is not equal to a non-Column", () => {
+    const column = new Column("title", null, meta());
+    expect(column.equals(null)).toBe(false);
+    expect(column.equals("title")).toBe(false);
+    expect(column.equals({ name: "title" })).toBe(false);
+  });
+
+  it("treats a null sqlTypeMetadata as equal only to another null one", () => {
+    expect(new Column("a", null, null).equals(new Column("a", null, null))).toBe(true);
+    expect(new Column("a", null, null).equals(new Column("a", null, meta()))).toBe(false);
+    expect(new Column("a", null, meta()).equals(new Column("a", null, null))).toBe(false);
+  });
+
+  it("compares SqlTypeMetadata by value", () => {
+    expect(meta().equals(meta())).toBe(true);
+    expect(meta().equals(meta({ sqlType: "text" }))).toBe(false);
+    expect(meta().equals(meta({ type: "text" }))).toBe(false);
+    expect(meta().equals(meta({ limit: 10 }))).toBe(false);
+    expect(meta().equals(meta({ precision: 2 }))).toBe(false);
+    expect(meta().equals(meta({ scale: 2 }))).toBe(false);
+    expect(meta().equals(null)).toBe(false);
+    expect(meta().equals({ sqlType: "varchar(255)" })).toBe(false);
+  });
+
+  it("narrows the guard to the adapter class in PostgreSQL::Column", () => {
+    // postgresql/column.rb:64's `other.is_a?(Column)` resolves to
+    // PostgreSQL::Column, so the check is one-way: the base class still accepts
+    // a PG column whose shared attributes match.
+    const pg = new PostgreSQLColumn("id", null, { sqlType: "integer", type: "integer" }, false);
+    const base = new Column("id", null, new SqlTypeMetadata({ sqlType: "integer", type: "integer" }), false); // prettier-ignore
+    expect(pg.equals(base)).toBe(false);
+    expect(base.equals(pg)).toBe(true);
+  });
+
+  it("compares the PostgreSQL identity and serial flags", () => {
+    const opts = { sqlType: "integer", type: "integer" };
+    const plain = new PostgreSQLColumn("id", null, opts, false);
+    expect(plain.equals(new PostgreSQLColumn("id", null, opts, false))).toBe(true);
+    expect(plain.equals(new PostgreSQLColumn("id", null, opts, false, { serial: true }))).toBe(
+      false,
+    );
+    expect(plain.equals(new PostgreSQLColumn("id", null, opts, false, { identity: "a" }))).toBe(
+      false,
+    );
+  });
+
+  it("compares the SQLite3 autoIncrement flag", () => {
+    const opts = { sqlType: "integer", type: "integer" };
+    const plain = new SQLite3Column("id", null, opts, false);
+    expect(plain.equals(new SQLite3Column("id", null, opts, false))).toBe(true);
+    expect(plain.equals(new SQLite3Column("id", null, opts, false, { autoIncrement: true }))).toBe(
+      false,
+    );
+    // sqlite3/column.rb:53 folds `rowid` into `hash` but :46 leaves it out of
+    // `==` — keep that asymmetry rather than "fixing" it.
+    expect(plain.equals(new SQLite3Column("id", null, opts, false, { rowid: true }))).toBe(true);
+  });
+
+  it("does not equal a sibling adapter's column", () => {
+    const opts = { sqlType: "integer", type: "integer" };
+    const pg = new PostgreSQLColumn("id", null, opts, false);
+    const sqlite = new SQLite3Column("id", null, opts, false);
+    expect(pg.equals(sqlite)).toBe(false);
+    expect(sqlite.equals(pg)).toBe(false);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -109,6 +109,39 @@ export class Column {
   }
 
   /**
+   * Value equality over the attributes Rails compares.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Column#== (column.rb:75)
+   *
+   * The guard is `other.is_a?(Column)`, NOT `self.class == other.class`, so a
+   * subclass instance can equal a base one from the base receiver's side —
+   * subclass `==` narrows the guard to its own class and calls `super`.
+   *
+   * `primaryKey` is deliberately absent: Rails' Column has no such attribute
+   * (it is a trails-side flag), so comparing it would diverge.
+   *
+   * Ruby aliases `eql?` to this and pairs it with `hash` (column.rb:87); both
+   * are in api-compare's `SKIP_GROUPS` as Ruby value-protocol methods with no
+   * meaningful TS surface, so `equals` is the whole port.
+   */
+  equals(other: unknown): boolean {
+    return (
+      other instanceof Column &&
+      this.name === other.name &&
+      // Reflected defaults are primitives or null in trails (the adapters
+      // stringify before constructing the Column), so `===` stands in for
+      // Ruby's `==`; `?? null` keeps an absent default from splitting into
+      // distinct null/undefined values the way Ruby's single nil cannot.
+      (this.default ?? null) === (other.default ?? null) &&
+      metadataEquals(this.sqlTypeMetadata, other.sqlTypeMetadata) &&
+      this.null === other.null &&
+      this.defaultFunction === other.defaultFunction &&
+      this.collation === other.collation &&
+      this.comment === other.comment
+    );
+  }
+
+  /**
    * Whether this is a virtual/generated column.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::Column#virtual?
@@ -160,6 +193,17 @@ export class Column {
   toString(): string {
     return this.name;
   }
+}
+
+/**
+ * Ruby's `sql_type_metadata == other.sql_type_metadata` (column.rb:79) works on
+ * nil too, where a TS `null` has no `equals` to call.
+ *
+ * @internal
+ */
+function metadataEquals(a: SqlTypeMetadata | null, b: SqlTypeMetadata | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.equals(b);
 }
 
 export interface ColumnJSON {

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -108,30 +108,10 @@ export class Column {
     return this.isAutoIncrementedByDb() || this.defaultFunction !== null;
   }
 
-  /**
-   * Value equality over the attributes Rails compares.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::Column#== (column.rb:75)
-   *
-   * The guard is `other.is_a?(Column)`, NOT `self.class == other.class`, so a
-   * subclass instance can equal a base one from the base receiver's side —
-   * subclass `==` narrows the guard to its own class and calls `super`.
-   *
-   * `primaryKey` is deliberately absent: Rails' Column has no such attribute
-   * (it is a trails-side flag), so comparing it would diverge.
-   *
-   * Ruby aliases `eql?` to this and pairs it with `hash` (column.rb:87); both
-   * are in api-compare's `SKIP_GROUPS` as Ruby value-protocol methods with no
-   * meaningful TS surface, so `equals` is the whole port.
-   */
   equals(other: unknown): boolean {
     return (
       other instanceof Column &&
       this.name === other.name &&
-      // Reflected defaults are primitives or null in trails (the adapters
-      // stringify before constructing the Column), so `===` stands in for
-      // Ruby's `==`; `?? null` keeps an absent default from splitting into
-      // distinct null/undefined values the way Ruby's single nil cannot.
       (this.default ?? null) === (other.default ?? null) &&
       metadataEquals(this.sqlTypeMetadata, other.sqlTypeMetadata) &&
       this.null === other.null &&
@@ -195,12 +175,7 @@ export class Column {
   }
 }
 
-/**
- * Ruby's `sql_type_metadata == other.sql_type_metadata` (column.rb:79) works on
- * nil too, where a TS `null` has no `equals` to call.
- *
- * @internal
- */
+/** @internal */
 function metadataEquals(a: SqlTypeMetadata | null, b: SqlTypeMetadata | null): boolean {
   if (a === null || b === null) return a === b;
   return a.equals(b);

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -119,4 +119,21 @@ export class Column extends BaseColumn {
   get isEnum(): boolean {
     return this.sqlTypeMetadata?.type === "enum";
   }
+
+  /**
+   * Mirrors: PostgreSQL::Column#== (postgresql/column.rb:64) — the base
+   * comparison plus the two PostgreSQL flags. The `is_a?(Column)` guard there
+   * resolves to PostgreSQL::Column (lexical scope), so a base Column never
+   * equals a PG one from this side even when every shared attribute matches.
+   *
+   * `eql?` (alias) and `hash` (:72) are in api-compare's `SKIP_GROUPS`.
+   */
+  override equals(other: unknown): boolean {
+    return (
+      other instanceof Column &&
+      super.equals(other) &&
+      this.isIdentity === other.isIdentity &&
+      this.isSerial === other.isSerial
+    );
+  }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -120,14 +120,6 @@ export class Column extends BaseColumn {
     return this.sqlTypeMetadata?.type === "enum";
   }
 
-  /**
-   * Mirrors: PostgreSQL::Column#== (postgresql/column.rb:64) — the base
-   * comparison plus the two PostgreSQL flags. The `is_a?(Column)` guard there
-   * resolves to PostgreSQL::Column (lexical scope), so a base Column never
-   * equals a PG one from this side even when every shared attribute matches.
-   *
-   * `eql?` (alias) and `hash` (:72) are in api-compare's `SKIP_GROUPS`.
-   */
   override equals(other: unknown): boolean {
     return (
       other instanceof Column &&

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -37,16 +37,6 @@ export class SqlTypeMetadata implements Deduplicable {
     this.scale = options.scale ?? null;
   }
 
-  /**
-   * Mirrors: SqlTypeMetadata#== (sql_type_metadata.rb:19) — an `is_a?` guard
-   * plus attribute-by-attribute value equality.
-   *
-   * Ruby aliases `eql?` to this and pairs it with `hash`
-   * (sql_type_metadata.rb:27); both are in api-compare's `SKIP_GROUPS` (Ruby
-   * value-protocol methods with no meaningful TS surface), and the `hash` role
-   * — feeding `Deduplicable`'s identity map — is carried by `deduplicateKey`
-   * below. So `equals` is the whole port.
-   */
   equals(other: unknown): boolean {
     return (
       other instanceof SqlTypeMetadata &&

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -37,6 +37,27 @@ export class SqlTypeMetadata implements Deduplicable {
     this.scale = options.scale ?? null;
   }
 
+  /**
+   * Mirrors: SqlTypeMetadata#== (sql_type_metadata.rb:19) — an `is_a?` guard
+   * plus attribute-by-attribute value equality.
+   *
+   * Ruby aliases `eql?` to this and pairs it with `hash`
+   * (sql_type_metadata.rb:27); both are in api-compare's `SKIP_GROUPS` (Ruby
+   * value-protocol methods with no meaningful TS surface), and the `hash` role
+   * — feeding `Deduplicable`'s identity map — is carried by `deduplicateKey`
+   * below. So `equals` is the whole port.
+   */
+  equals(other: unknown): boolean {
+    return (
+      other instanceof SqlTypeMetadata &&
+      this.sqlType === other.sqlType &&
+      this.type === other.type &&
+      this.limit === other.limit &&
+      this.precision === other.precision &&
+      this.scale === other.scale
+    );
+  }
+
   deduplicateKey(): string {
     return JSON.stringify([this.sqlType, this.type, this.limit, this.precision, this.scale]);
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -65,16 +65,6 @@ export class Column extends BaseColumn {
     return super.hasDefault && !this.isVirtual();
   }
 
-  /**
-   * Mirrors: SQLite3::Column#== (sqlite3/column.rb:46) — the base comparison
-   * plus `auto_increment?`. The `is_a?(Column)` guard there resolves to
-   * SQLite3::Column (lexical scope), so a base Column never equals one of
-   * these from this side.
-   *
-   * Rails' paired `hash` (:53) also folds in `rowid`, but `==` does not —
-   * keep the asymmetry rather than "fixing" it. `eql?`/`hash` are both in
-   * api-compare's `SKIP_GROUPS`.
-   */
   override equals(other: unknown): boolean {
     return (
       other instanceof Column && super.equals(other) && this.autoIncrement === other.autoIncrement

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -64,4 +64,20 @@ export class Column extends BaseColumn {
   override get hasDefault(): boolean {
     return super.hasDefault && !this.isVirtual();
   }
+
+  /**
+   * Mirrors: SQLite3::Column#== (sqlite3/column.rb:46) — the base comparison
+   * plus `auto_increment?`. The `is_a?(Column)` guard there resolves to
+   * SQLite3::Column (lexical scope), so a base Column never equals one of
+   * these from this side.
+   *
+   * Rails' paired `hash` (:53) also folds in `rowid`, but `==` does not —
+   * keep the asymmetry rather than "fixing" it. `eql?`/`hash` are both in
+   * api-compare's `SKIP_GROUPS`.
+   */
+  override equals(other: unknown): boolean {
+    return (
+      other instanceof Column && super.equals(other) && this.autoIncrement === other.autoIncrement
+    );
+  }
 }

--- a/packages/activerecord/src/encryption/message-equality.trails.test.ts
+++ b/packages/activerecord/src/encryption/message-equality.trails.test.ts
@@ -27,10 +27,18 @@ describe("MessageEqualityTrails", () => {
     expect(new Message("hello").equals(new Message(Buffer.from("hellO")))).toBe(false);
   });
 
-  it("is not equal to a non-Message", () => {
-    expect(new Message("x").equals(null)).toBe(false);
-    expect(new Message("x").equals("x")).toBe(false);
-    expect(new Message("x").equals({ payload: "x", headers: new Properties() })).toBe(false);
+  it("compares any message-like object, without a class guard", () => {
+    const message = new Message("x");
+    message.addHeader("iv", "some iv");
+    expect(message.equals({ payload: "x", headers: new Properties({ iv: "some iv" }) })).toBe(true);
+    expect(message.equals({ payload: "x", headers: { iv: "some iv" } })).toBe(true);
+    expect(message.equals({ payload: "y", headers: { iv: "some iv" } })).toBe(false);
+    expect(message.equals({ payload: "x", headers: {} })).toBe(false);
+  });
+
+  it("raises on a value that carries no payload, as Ruby's NoMethodError does", () => {
+    expect(() => new Message("x").equals(null as never)).toThrow();
+    expect(() => new Message("x").equals("x" as never)).toThrow();
   });
 
   it("compares nested Messages in headers by value", () => {
@@ -58,6 +66,22 @@ describe("MessageEqualityTrails", () => {
     expect(new Properties({ a: "1", b: "2" }).equals(new Properties({ a: "1" }))).toBe(false);
     expect(new Properties().equals(new Properties())).toBe(true);
     expect(new Properties().equals(null)).toBe(false);
+  });
+
+  it("Properties#equals compares against the backing hash, not just a wrapper", () => {
+    expect(new Properties({ a: "1" }).equals({ a: "1" })).toBe(true);
+    expect(new Properties({ a: "1" }).equals({ a: "2" })).toBe(false);
+    expect(new Properties({ a: "1" }).equals({ b: "1" })).toBe(false);
+    expect(new Properties({ a: "1" }).equals({ a: "1", b: "2" })).toBe(false);
+    expect(new Properties({ a: "1", b: "2" }).equals({ a: "1" })).toBe(false);
+    expect(new Properties().equals({})).toBe(true);
+    expect(new Properties({ a: "1" }).equals(new Map([["a", "1"]]))).toBe(true);
+  });
+
+  it("Properties#equals is false for a value Ruby's Hash#== rejects outright", () => {
+    expect(new Properties({ a: "1" }).equals("a")).toBe(false);
+    expect(new Properties({ a: "1" }).equals(5)).toBe(false);
+    expect(new Properties({ a: "1" }).equals(new Message("a"))).toBe(false);
   });
 
   it("Properties#equals compares raw header bytes on value", () => {

--- a/packages/activerecord/src/encryption/message-equality.trails.test.ts
+++ b/packages/activerecord/src/encryption/message-equality.trails.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Message } from "./message.js";
+import { Properties } from "./properties.js";
+
+/**
+ * Trails-only coverage for `Message#==` (message.rb:21) and the `==` that
+ * `Properties` delegates to its data hash (properties.rb:20). Rails exercises
+ * them only indirectly, through the serializer round trips
+ * (`message_serializer_test.rb:14` / `:22`, both `assert_equal message,
+ * deserialized_message`) — those assertions are ported in place; the edge cases
+ * below have no Rails test to be named after.
+ */
+describe("MessageEqualityTrails", () => {
+  it("compares payload and headers", () => {
+    const build = () => {
+      const message = new Message("some payload");
+      message.addHeader("key_1", "1");
+      return message;
+    };
+    expect(build().equals(build())).toBe(true);
+
+    const otherPayload = new Message("other payload");
+    otherPayload.addHeader("key_1", "1");
+    expect(build().equals(otherPayload)).toBe(false);
+
+    const otherHeaderValue = new Message("some payload");
+    otherHeaderValue.addHeader("key_1", "2");
+    expect(build().equals(otherHeaderValue)).toBe(false);
+
+    expect(build().equals(new Message("some payload"))).toBe(false);
+  });
+
+  it("compares string and Buffer payloads on bytes", () => {
+    // Ruby has one String type for both; trails splits it into `string` and
+    // `Buffer`, and a serialize→deserialize round trip returns the Buffer form,
+    // so the two must not compare unequal purely on JS type.
+    expect(new Message("hello").equals(new Message(Buffer.from("hello")))).toBe(true);
+    expect(new Message("hello").equals(new Message(Buffer.from("hellO")))).toBe(false);
+  });
+
+  it("is not equal to a non-Message", () => {
+    expect(new Message("x").equals(null)).toBe(false);
+    expect(new Message("x").equals("x")).toBe(false);
+    expect(new Message("x").equals({ payload: "x", headers: new Properties() })).toBe(false);
+  });
+
+  it("compares nested Messages in headers by value", () => {
+    const build = () => {
+      const message = new Message("outer");
+      const nested = new Message("inner");
+      nested.addHeader("some_header", "some value");
+      message.headers.set("other_message", nested);
+      return message;
+    };
+    expect(build().equals(build())).toBe(true);
+
+    const differentNested = new Message("outer");
+    const nested = new Message("inner");
+    nested.addHeader("some_header", "other value");
+    differentNested.headers.set("other_message", nested);
+    expect(build().equals(differentNested)).toBe(false);
+  });
+
+  it("Properties#equals is Hash equality — same size and same per-key values", () => {
+    expect(new Properties({ a: "1" }).equals(new Properties({ a: "1" }))).toBe(true);
+    expect(new Properties({ a: "1" }).equals(new Properties({ a: "2" }))).toBe(false);
+    expect(new Properties({ a: "1" }).equals(new Properties({ b: "1" }))).toBe(false);
+    expect(new Properties({ a: "1" }).equals(new Properties({ a: "1", b: "2" }))).toBe(false);
+    expect(new Properties({ a: "1", b: "2" }).equals(new Properties({ a: "1" }))).toBe(false);
+    expect(new Properties().equals(new Properties())).toBe(true);
+    expect(new Properties().equals(null)).toBe(false);
+  });
+
+  it("Properties#equals compares raw header bytes on value", () => {
+    const withBuffer = new Properties({ iv: Buffer.from("some iv") });
+    expect(withBuffer.equals(new Properties({ iv: Buffer.from("some iv") }))).toBe(true);
+    expect(withBuffer.equals(new Properties({ iv: Buffer.from("other iv") }))).toBe(false);
+    expect(withBuffer.equals(new Properties({ iv: "some iv" }))).toBe(true);
+  });
+});

--- a/packages/activerecord/src/encryption/message-equality.trails.test.ts
+++ b/packages/activerecord/src/encryption/message-equality.trails.test.ts
@@ -2,14 +2,6 @@ import { describe, it, expect } from "vitest";
 import { Message } from "./message.js";
 import { Properties } from "./properties.js";
 
-/**
- * Trails-only coverage for `Message#==` (message.rb:21) and the `==` that
- * `Properties` delegates to its data hash (properties.rb:20). Rails exercises
- * them only indirectly, through the serializer round trips
- * (`message_serializer_test.rb:14` / `:22`, both `assert_equal message,
- * deserialized_message`) — those assertions are ported in place; the edge cases
- * below have no Rails test to be named after.
- */
 describe("MessageEqualityTrails", () => {
   it("compares payload and headers", () => {
     const build = () => {
@@ -31,9 +23,6 @@ describe("MessageEqualityTrails", () => {
   });
 
   it("compares string and Buffer payloads on bytes", () => {
-    // Ruby has one String type for both; trails splits it into `string` and
-    // `Buffer`, and a serialize→deserialize round trip returns the Buffer form,
-    // so the two must not compare unequal purely on JS type.
     expect(new Message("hello").equals(new Message(Buffer.from("hello")))).toBe(true);
     expect(new Message("hello").equals(new Message(Buffer.from("hellO")))).toBe(false);
   });

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
@@ -23,8 +23,6 @@ describe("ActiveRecord::Encryption::MessagePackMessageSerializerTest", () => {
     message.headers.set("key_1", "1");
 
     const deserialized = serializer.load(serializer.dump(message));
-    // Rails asserts `assert_equal message, deserialized_message`
-    // (message_pack_message_serializer_test.rb:15) — i.e. Message#==.
     expect(message.equals(deserialized)).toBe(true);
   });
 

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.test.ts
@@ -23,7 +23,9 @@ describe("ActiveRecord::Encryption::MessagePackMessageSerializerTest", () => {
     message.headers.set("key_1", "1");
 
     const deserialized = serializer.load(serializer.dump(message));
-    expect(deserialized).toEqual(message);
+    // Rails asserts `assert_equal message, deserialized_message`
+    // (message_pack_message_serializer_test.rb:15) — i.e. Message#==.
+    expect(message.equals(deserialized)).toBe(true);
   });
 
   it("serializes messages with nested messages in their headers", () => {
@@ -34,7 +36,7 @@ describe("ActiveRecord::Encryption::MessagePackMessageSerializerTest", () => {
     message.headers.set("other_message", nested);
 
     const deserialized = serializer.load(serializer.dump(message));
-    expect(deserialized).toEqual(message);
+    expect(message.equals(deserialized)).toBe(true);
   });
 
   it("detects random data and raises a decryption error", () => {

--- a/packages/activerecord/src/encryption/message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-serializer.test.ts
@@ -14,8 +14,6 @@ describe("ActiveRecord::Encryption::MessageSerializerTest", () => {
     // strings; the consumer interprets them.
     expect(loaded.payload.toString()).toBe("hello");
     expect((loaded.headers.get("iv") as Buffer).toString()).toBe("test-iv");
-    // Rails' assertion is `assert_equal message, deserialized_message`
-    // (message_serializer_test.rb:14) — i.e. Message#==.
     expect(message.equals(loaded)).toBe(true);
   });
 
@@ -33,8 +31,6 @@ describe("ActiveRecord::Encryption::MessageSerializerTest", () => {
     const nested = loaded.headers.get("nested") as Message;
     expect(nested).toBeInstanceOf(Message);
     expect(nested.payload.toString()).toBe("inner-payload");
-    // message_serializer_test.rb:22 `assert_equal message, deserialized_message`
-    // — the nested Message must compare through Properties#== too.
     expect(outer.equals(loaded)).toBe(true);
   });
 

--- a/packages/activerecord/src/encryption/message-serializer.test.ts
+++ b/packages/activerecord/src/encryption/message-serializer.test.ts
@@ -14,6 +14,9 @@ describe("ActiveRecord::Encryption::MessageSerializerTest", () => {
     // strings; the consumer interprets them.
     expect(loaded.payload.toString()).toBe("hello");
     expect((loaded.headers.get("iv") as Buffer).toString()).toBe("test-iv");
+    // Rails' assertion is `assert_equal message, deserialized_message`
+    // (message_serializer_test.rb:14) — i.e. Message#==.
+    expect(message.equals(loaded)).toBe(true);
   });
 
   it("serializes messages with nested messages in their headers", () => {
@@ -30,6 +33,9 @@ describe("ActiveRecord::Encryption::MessageSerializerTest", () => {
     const nested = loaded.headers.get("nested") as Message;
     expect(nested).toBeInstanceOf(Message);
     expect(nested.payload.toString()).toBe("inner-payload");
+    // message_serializer_test.rb:22 `assert_equal message, deserialized_message`
+    // — the nested Message must compare through Properties#== too.
+    expect(outer.equals(loaded)).toBe(true);
   });
 
   it("won't load classes from JSON", () => {

--- a/packages/activerecord/src/encryption/message.ts
+++ b/packages/activerecord/src/encryption/message.ts
@@ -17,6 +17,26 @@ export class Message {
     this.headers = new Properties();
   }
 
+  /**
+   * Mirrors: Message#== (message.rb:21) —
+   * `payload == other_message.payload && headers == other_message.headers`.
+   *
+   * Rails takes `other_message` untyped and would `NoMethodError` on anything
+   * else; a `false` for a non-Message is the closer analogue of the `==` a
+   * caller like `assert_equal` expects here.
+   *
+   * The payload is Ruby's one binary String, which trails splits into
+   * `string` (text) and `Buffer` (raw cipher bytes) — both stand in for the
+   * same Ruby value, so they compare on bytes rather than by JS type.
+   */
+  equals(other: unknown): boolean {
+    if (!(other instanceof Message)) return false;
+    return (
+      Buffer.from(this.payload).equals(Buffer.from(other.payload)) &&
+      this.headers.equals(other.headers)
+    );
+  }
+
   addHeader(key: string, value: unknown): void {
     this.headers.set(key, value);
   }

--- a/packages/activerecord/src/encryption/message.ts
+++ b/packages/activerecord/src/encryption/message.ts
@@ -17,18 +17,6 @@ export class Message {
     this.headers = new Properties();
   }
 
-  /**
-   * Mirrors: Message#== (message.rb:21) —
-   * `payload == other_message.payload && headers == other_message.headers`.
-   *
-   * Rails takes `other_message` untyped and would `NoMethodError` on anything
-   * else; a `false` for a non-Message is the closer analogue of the `==` a
-   * caller like `assert_equal` expects here.
-   *
-   * The payload is Ruby's one binary String, which trails splits into
-   * `string` (text) and `Buffer` (raw cipher bytes) — both stand in for the
-   * same Ruby value, so they compare on bytes rather than by JS type.
-   */
   equals(other: unknown): boolean {
     if (!(other instanceof Message)) return false;
     return (

--- a/packages/activerecord/src/encryption/message.ts
+++ b/packages/activerecord/src/encryption/message.ts
@@ -17,11 +17,10 @@ export class Message {
     this.headers = new Properties();
   }
 
-  equals(other: unknown): boolean {
-    if (!(other instanceof Message)) return false;
+  equals(otherMessage: { payload: string | Buffer; headers: Properties | object }): boolean {
     return (
-      Buffer.from(this.payload).equals(Buffer.from(other.payload)) &&
-      this.headers.equals(other.headers)
+      Buffer.from(this.payload).equals(Buffer.from(otherMessage.payload)) &&
+      this.headers.equals(otherMessage.headers)
     );
   }
 

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -21,11 +21,12 @@ export class Properties {
   }
 
   equals(other: unknown): boolean {
-    if (!(other instanceof Properties)) return false;
-    if (this._data.size !== other._data.size) return false;
-    for (const [key, value] of this._data) {
-      if (!other._data.has(key)) return false;
-      if (!valuesEqual(value, other._data.get(key))) return false;
+    const otherEntries = hashEntriesOf(other);
+    if (otherEntries === null) return false;
+    if (this._data.size !== otherEntries.length) return false;
+    for (const [key, value] of otherEntries) {
+      if (!this._data.has(key)) return false;
+      if (!valuesEqual(this._data.get(key), value)) return false;
     }
     return true;
   }
@@ -139,6 +140,16 @@ export class Properties {
   private get data(): Map<string, unknown> {
     return this._data;
   }
+}
+
+/** @internal */
+function hashEntriesOf(value: unknown): [string, unknown][] | null {
+  if (value instanceof Properties) return [...value.entries()];
+  if (value instanceof Map) return [...(value as Map<string, unknown>).entries()];
+  if (typeof value !== "object" || value === null) return null;
+  const proto = Object.getPrototypeOf(value) as object | null;
+  if (proto !== Object.prototype && proto !== null) return null;
+  return Object.entries(value);
 }
 
 /** @internal */

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -20,6 +20,26 @@ export class Properties {
     }
   }
 
+  /**
+   * Mirrors: `delegate :==, to: :data` (properties.rb:20) — Hash equality,
+   * which in Ruby is same-size plus per-key `==` on the values.
+   *
+   * Values are the types `validate_value_type` admits plus nested `Message`s
+   * (message_serializer_test.rb:19 stores one), so the per-value comparison
+   * dispatches to `Message#equals` and to byte equality for the Buffers a
+   * deserialized payload carries — both of which are what Ruby's `==` reaches
+   * for those same values.
+   */
+  equals(other: unknown): boolean {
+    if (!(other instanceof Properties)) return false;
+    if (this._data.size !== other._data.size) return false;
+    for (const [key, value] of this._data) {
+      if (!other._data.has(key)) return false;
+      if (!valuesEqual(value, other._data.get(key))) return false;
+    }
+    return true;
+  }
+
   get(key: string): unknown {
     return this._data.get(key);
   }
@@ -129,6 +149,40 @@ export class Properties {
   private get data(): Map<string, unknown> {
     return this._data;
   }
+}
+
+/**
+ * Ruby's `Hash#==` compares each value with `value == other_value`, dispatching
+ * on the value's own class. `equals` is the TS spelling of that `==`, so
+ * duck-typing on it is the faithful analogue of the dynamic dispatch — and it
+ * keeps this module from importing `Message` (which imports us), the same cycle
+ * `validateValueType` above sidesteps by shape-checking.
+ *
+ * @internal
+ */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  // Ruby has ONE String type for both text and raw bytes; trails splits it into
+  // `string` and `Buffer` (a serialize→deserialize round trip hands back
+  // Buffers where the original held strings), so both stand in for the same
+  // Ruby value and must compare equal.
+  if (Buffer.isBuffer(a) || Buffer.isBuffer(b)) {
+    if (!isBinaryish(a) || !isBinaryish(b)) return false;
+    return Buffer.from(a as string | Buffer).equals(Buffer.from(b as string | Buffer));
+  }
+  if (typeof a === "object" && a !== null && typeof (a as Equatable).equals === "function") {
+    return (a as Equatable).equals(b);
+  }
+  return false;
+}
+
+interface Equatable {
+  equals(other: unknown): boolean;
+}
+
+/** @internal */
+function isBinaryish(value: unknown): boolean {
+  return typeof value === "string" || Buffer.isBuffer(value);
 }
 
 function _typeNameFor(value: unknown): string {

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -20,16 +20,6 @@ export class Properties {
     }
   }
 
-  /**
-   * Mirrors: `delegate :==, to: :data` (properties.rb:20) — Hash equality,
-   * which in Ruby is same-size plus per-key `==` on the values.
-   *
-   * Values are the types `validate_value_type` admits plus nested `Message`s
-   * (message_serializer_test.rb:19 stores one), so the per-value comparison
-   * dispatches to `Message#equals` and to byte equality for the Buffers a
-   * deserialized payload carries — both of which are what Ruby's `==` reaches
-   * for those same values.
-   */
   equals(other: unknown): boolean {
     if (!(other instanceof Properties)) return false;
     if (this._data.size !== other._data.size) return false;
@@ -151,21 +141,9 @@ export class Properties {
   }
 }
 
-/**
- * Ruby's `Hash#==` compares each value with `value == other_value`, dispatching
- * on the value's own class. `equals` is the TS spelling of that `==`, so
- * duck-typing on it is the faithful analogue of the dynamic dispatch — and it
- * keeps this module from importing `Message` (which imports us), the same cycle
- * `validateValueType` above sidesteps by shape-checking.
- *
- * @internal
- */
+/** @internal */
 function valuesEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
-  // Ruby has ONE String type for both text and raw bytes; trails splits it into
-  // `string` and `Buffer` (a serialize→deserialize round trip hands back
-  // Buffers where the original held strings), so both stand in for the same
-  // Ruby value and must compare equal.
   if (Buffer.isBuffer(a) || Buffer.isBuffer(b)) {
     if (!isBinaryish(a) || !isBinaryish(b)) return false;
     return Buffer.from(a as string | Buffer).equals(Buffer.from(b as string | Buffer));

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -64,15 +64,39 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // connection_adapters/postgresql/type_metadata.rb:20 `def ==(other)` →
   // connection-adapters/postgresql/type-metadata.ts `equals`.
   "ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata": { "==": ["equals"] },
+  // connection_adapters/column.rb:75 `def ==(other)` →
+  // connection-adapters/column.ts `Column#equals`. The aliased `eql?` and the
+  // paired `hash` (:87) are SKIP_GROUPS members, so `==` is the only mapped
+  // member of the trio.
+  "ActiveRecord::ConnectionAdapters::Column": { "==": ["equals"] },
+  // connection_adapters/sql_type_metadata.rb:19 `def ==(other)` →
+  // connection-adapters/sql-type-metadata.ts `equals`.
+  "ActiveRecord::ConnectionAdapters::SqlTypeMetadata": { "==": ["equals"] },
+  // connection_adapters/postgresql/column.rb:64 `def ==(other)` →
+  // connection-adapters/postgresql/column.ts `Column#equals`.
+  "ActiveRecord::ConnectionAdapters::PostgreSQL::Column": { "==": ["equals"] },
+  // connection_adapters/sqlite3/column.rb:46 `def ==(other)` →
+  // connection-adapters/sqlite3/column.ts `Column#equals`.
+  "ActiveRecord::ConnectionAdapters::SQLite3::Column": { "==": ["equals"] },
+  // encryption/message.rb:21 `def ==(other_message)` →
+  // encryption/message.ts `equals`.
+  "ActiveRecord::Encryption::Message": { "==": ["equals"] },
+  // active_model/type/binary.rb:56 `def ==(other)` →
+  // activemodel/src/type/binary.ts `Data#equals`.
+  "ActiveModel::Type::Binary::Data": { "==": ["equals"] },
   // connection_adapters/postgresql/utils.rb:30 `def ==(o)` →
   // connection-adapters/postgresql/utils.ts `Name#equals`.
   "ActiveRecord::ConnectionAdapters::PostgreSQL::Name": { "==": ["equals"] },
   // connection_adapters/statement_pool.rb:23 `def [](key)` / :31 `def []=(sql, stmt)`
   // → connection-adapters/statement-pool.ts `get` / `set`.
   "ActiveRecord::ConnectionAdapters::StatementPool": { "[]": ["get"], "[]=": ["set"] },
-  // encryption/properties.rb:20 `delegate :[], to: :data` / :50 `def []=(key, value)`
-  // → encryption/properties.ts `get` / `set`.
-  "ActiveRecord::Encryption::Properties": { "[]": ["get"], "[]=": ["set"] },
+  // encryption/properties.rb:20 `delegate :==, :[], to: :data` / :50
+  // `def []=(key, value)` → encryption/properties.ts `equals` / `get` / `set`.
+  "ActiveRecord::Encryption::Properties": {
+    "==": ["equals"],
+    "[]": ["get"],
+    "[]=": ["set"],
+  },
   // abstract/schema_definitions.rb:421 `def [](name)` →
   // connection-adapters/abstract/schema-definitions.ts `TableDefinition#get`.
   "ActiveRecord::ConnectionAdapters::TableDefinition": { "[]": ["get"] },


### PR DESCRIPTION
## What

Rails defines `==` on `ConnectionAdapters::Column` (plus its PostgreSQL and
SQLite3 subclasses), `SqlTypeMetadata`, `Encryption::Message` and
`ActiveModel::Type::Binary::Data`. None of them had a TS equality member under
any spelling, so value equality was simply absent — reference equality passed
where Rails compares attributes.

Each is now ported as `equals`, faithful to the Rails body:

| Rails | trails |
| --- | --- |
| `connection_adapters/column.rb:75` | `connection-adapters/column.ts` `Column#equals` |
| `connection_adapters/postgresql/column.rb:64` | `connection-adapters/postgresql/column.ts` `Column#equals` |
| `connection_adapters/sqlite3/column.rb:46` | `connection-adapters/sqlite3/column.ts` `Column#equals` |
| `connection_adapters/sql_type_metadata.rb:19` | `connection-adapters/sql-type-metadata.ts` `equals` |
| `encryption/message.rb:21` | `encryption/message.ts` `equals` |
| `encryption/properties.rb:20` (`delegate :==, to: :data`) | `encryption/properties.ts` `equals` |
| `activemodel/type/binary.rb:56` | `activemodel/src/type/binary.ts` `Data#equals` |

`Properties#==` was not in the story list but `Message#==` compares headers
through it, so it is ported here too.

The matching `(fqn, "==") → ["equals"]` entries are added to
`scripts/api-compare/operator-order-spelling.ts`, each cited against the Rails
line and the TS member.

## Fidelity notes

- The guard is Rails' `other.is_a?(Column)`, **not** `self.class == other.class`
  — so the subclass narrows the guard to its own class (lexical constant
  resolution) and the relation is deliberately one-way: `base.equals(pgColumn)`
  is true where `pgColumn.equals(base)` is false. Covered by a test.
- `primaryKey` is excluded: Rails' `Column` has no such attribute (it is a
  trails-side flag), so folding it in would diverge.
- `sqlite3/column.rb:53` folds `rowid` into `hash` but `:46` leaves it out of
  `==`. The asymmetry is preserved, not "fixed".
- `Data#==` is `other == to_s || super`, which in Ruby is a **byte** comparison
  against the binary String. Our `toString()` UTF-8-decodes and is lossy, so
  the port walks `bytes` instead — otherwise two distinct byte strings that both
  decode to U+FFFD replacements would compare equal.
- Ruby's paired `eql?` (alias) and `hash` are `SKIP_GROUPS` members in
  api-compare (Ruby value-protocol methods with no meaningful TS surface); the
  `hash` role for `SqlTypeMetadata` is already carried by `deduplicateKey`.
  Justified at each call site.
- Ruby has one String type for both text and raw bytes; trails splits it into
  `string` and `Buffer`, and a serialize→deserialize round trip returns the
  Buffer form. Both stand in for the same Ruby value, so `Message`/`Properties`
  compare payloads and header bytes on value rather than JS type.

## Tests

Rails has no test that exercises these `==` methods directly (`pnpm rails:find
"test_.*equal"` finds nothing in the adapter suites). The ones that do reach
them are the serializer round trips — `message_serializer_test.rb:14` / `:22`
and `message_pack_message_serializer_test.rb:15` / `:33`, all
`assert_equal message, deserialized_message` — and those ported tests now
assert through `Message#equals`, which is what Rails' `assert_equal` invokes.
The remaining edge cases have no Rails test to be named after, so they live in
`column-equality.trails.test.ts`, `message-equality.trails.test.ts` and the
existing `binary.trails.test.ts`.

`pnpm api:compare` stays green and `pnpm api:extra` gains no new entries — the
new members are mapped, and the three helpers are `@internal`.

Closes-story: adapter-column-and-message-equality-operators-unported