### PR TITLE
fix(arel): make SelectManager#joinSources a method

### DIFF
--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -195,9 +195,7 @@ export class JoinAssociation extends JoinPart {
         // of emitting a duplicate `posts` that yields ambiguous columns — Rails'
         // `join_scope.arel(alias_tracker.aliases)` (join_dependency.rb:56).
         const sources: Nodes.Node[] = scope?.arel
-          ? // Copied: `joinSources()` returns Arel's live `source.right`, and the
-            // constraint rewrite below replaces its last element in place.
-            ([...scope.arel(aliasTracker).joinSources()] as Nodes.Node[])
+          ? ([...scope.arel(aliasTracker).joinSources()] as Nodes.Node[])
           : [];
         // `this.joinSources` accumulates flat across the chain (consumed by the
         // single-step `has_one`/`has_many` path, whose chain is length 1). The

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -195,7 +195,9 @@ export class JoinAssociation extends JoinPart {
         // of emitting a duplicate `posts` that yields ambiguous columns — Rails'
         // `join_scope.arel(alias_tracker.aliases)` (join_dependency.rb:56).
         const sources: Nodes.Node[] = scope?.arel
-          ? (scope.arel(aliasTracker).joinSources as Nodes.Node[])
+          ? // Copied: `joinSources()` returns Arel's live `source.right`, and the
+            // constraint rewrite below replaces its last element in place.
+            ([...scope.arel(aliasTracker).joinSources()] as Nodes.Node[])
           : [];
         // `this.joinSources` accumulates flat across the chain (consumed by the
         // single-step `has_one`/`has_many` path, whose chain is length 1). The

--- a/packages/activerecord/src/associations/left-outer-join-association.test.ts
+++ b/packages/activerecord/src/associations/left-outer-join-association.test.ts
@@ -162,7 +162,7 @@ describe("LeftOuterJoinAssociationTest", () => {
     const comments = new Table("comments");
     const postsTable = new Table("posts");
     const constraint = comments.get("post_id").eq(postsTable.get("id"));
-    const arelJoin = comments.outerJoin(comments).on(constraint).joinSources[0];
+    const arelJoin = comments.outerJoin(comments).on(constraint).joinSources()[0];
 
     expect(await Author.leftOuterJoins("posts").joins(arelJoin).count()).toBe(17);
   });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3195,5 +3195,8 @@ export function buildWithJoinNode(
     throw new ActiveRecordError("Cannot build CTE join node with composite primary keys");
   }
   const pk = mc?.primaryKey ?? "id";
-  return table.join(withTable, kind).on(withTable.get(fk).eq(table.get(pk))).joinSources[0];
+  return table
+    .join(withTable, kind)
+    .on(withTable.get(fk).eq(table.get(pk)))
+    .joinSources()[0];
 }

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -17,7 +17,7 @@ describe("SelectManagerTest", () => {
   const visitor = new Visitors.ToSql(testConnection);
   it("join sources", () => {
     const mgr = users.project(star);
-    expect(mgr.joinSources).toEqual([]);
+    expect(mgr.joinSources()).toEqual([]);
   });
 
   describe("backwards compatibility", () => {
@@ -1240,7 +1240,7 @@ describe("SelectManagerTest", () => {
 
   it("returns empty array when no joins", () => {
     const manager = users.project("*");
-    expect(manager.joinSources).toEqual([]);
+    expect(manager.joinSources()).toEqual([]);
   });
 
   it("returns join nodes after join()", () => {
@@ -1248,8 +1248,8 @@ describe("SelectManagerTest", () => {
       .project("*")
       .join(posts)
       .on(users.attr("id").eq(posts.attr("user_id")));
-    expect(manager.joinSources.length).toBe(1);
-    expect(manager.joinSources[0]).toBeInstanceOf(Nodes.InnerJoin);
+    expect(manager.joinSources().length).toBe(1);
+    expect(manager.joinSources()[0]).toBeInstanceOf(Nodes.InnerJoin);
   });
 
   it("returns multiple join nodes", () => {
@@ -1260,9 +1260,9 @@ describe("SelectManagerTest", () => {
       .on(users.attr("id").eq(posts.attr("user_id")))
       .outerJoin(comments)
       .on(posts.attr("id").eq(comments.attr("post_id")));
-    expect(manager.joinSources.length).toBe(2);
-    expect(manager.joinSources[0]).toBeInstanceOf(Nodes.InnerJoin);
-    expect(manager.joinSources[1]).toBeInstanceOf(Nodes.OuterJoin);
+    expect(manager.joinSources().length).toBe(2);
+    expect(manager.joinSources()[0]).toBeInstanceOf(Nodes.InnerJoin);
+    expect(manager.joinSources()[1]).toBeInstanceOf(Nodes.OuterJoin);
   });
 
   it("returns the FROM source", () => {
@@ -1311,7 +1311,7 @@ describe("SelectManagerTest", () => {
       const mgr = users
         .project(star)
         .fullOuterJoin(posts, users.get("id").eq(posts.get("user_id")));
-      expect(mgr.joinSources[0]).toBeInstanceOf(Nodes.FullOuterJoin);
+      expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.FullOuterJoin);
       expect(mgr.toSql()).toContain("FULL OUTER JOIN");
     });
 
@@ -1319,7 +1319,7 @@ describe("SelectManagerTest", () => {
       const mgr = users
         .project(star)
         .rightOuterJoin(posts, users.get("id").eq(posts.get("user_id")));
-      expect(mgr.joinSources[0]).toBeInstanceOf(Nodes.RightOuterJoin);
+      expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.RightOuterJoin);
       expect(mgr.toSql()).toContain("RIGHT OUTER JOIN");
     });
   });

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -16,8 +16,9 @@ describe("SelectManagerTest", () => {
   const posts = new Table("posts");
   const visitor = new Visitors.ToSql(testConnection);
   it("join sources", () => {
-    const mgr = users.project(star);
-    expect(mgr.joinSources()).toEqual([]);
+    const manager = new SelectManager();
+    manager.joinSources().push(new Nodes.StringJoin(new Nodes.Quoted("foo")));
+    expect(manager.toSql()).toBe("SELECT FROM 'foo'");
   });
 
   describe("backwards compatibility", () => {

--- a/packages/arel/src/select-manager.trails.test.ts
+++ b/packages/arel/src/select-manager.trails.test.ts
@@ -13,7 +13,7 @@ describe("SelectManagerTest (trails)", () => {
   it("promotes a SqlLiteral relation to a StringJoin", () => {
     const mgr = new SelectManager(users);
     mgr.join(new Nodes.SqlLiteral("comments ON comments.user_id = users.id"));
-    expect(mgr.joinSources[0]).toBeInstanceOf(Nodes.StringJoin);
+    expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.StringJoin);
     expect(mgr.toSql()).toContain("comments ON comments.user_id = users.id");
   });
 
@@ -32,7 +32,7 @@ describe("SelectManagerTest (trails)", () => {
   it("promotes a bare string relation to a StringJoin", () => {
     const mgr = new SelectManager(users);
     mgr.join("comments ON comments.user_id = users.id");
-    expect(mgr.joinSources[0]).toBeInstanceOf(Nodes.StringJoin);
+    expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.StringJoin);
   });
 
   // Trails-only coverage for Arel::SelectManager#lock's `case` arms

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -433,8 +433,9 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#join_sources
    */
-  get joinSources(): Join[] {
-    return [...this.core.source.right] as Join[];
+  joinSources(): Join[] {
+    // Rails returns the live `@ctx.source.right` array, not a copy.
+    return this.core.source.right as Join[];
   }
 
   /**

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -434,7 +434,6 @@ export class SelectManager extends TreeManager {
    * Mirrors: Arel::SelectManager#join_sources
    */
   joinSources(): Join[] {
-    // Rails returns the live `@ctx.source.right` array, not a copy.
     return this.core.source.right as Join[];
   }
 

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -85,57 +85,8 @@ export class MySQL extends ToSql {
     node: Nodes.SelectCore,
     collector: SQLString,
   ): SQLString {
-    collector.append("SELECT");
-
-    this.emitOptimizerHints(node, collector);
-
-    if (node.setQuantifier) {
-      collector.append(" ");
-      this.visit(node.setQuantifier, collector);
-    }
-
-    if (node.projections.length > 0) {
-      collector.append(" ");
-      this.injectJoin(node.projections, ", ", collector);
-    }
-
-    // MySQL emits FROM DUAL for empty FROM.
-    if (node.source.left) {
-      collector.append(" FROM ");
-      this.visit(node.source, collector);
-    } else {
-      collector.append(" FROM DUAL");
-    }
-
-    if (node.wheres.length > 0) {
-      collector.append(" WHERE ");
-      const conditions = node.wheres.length === 1 ? node.wheres[0] : new Nodes.And(node.wheres);
-      this.visit(conditions, collector);
-    }
-
-    if (node.groups.length > 0) {
-      collector.append(" GROUP BY ");
-      this.injectJoin(node.groups, ", ", collector);
-    }
-
-    if (node.havings.length > 0) {
-      collector.append(" HAVING ");
-      const conditions = node.havings.length === 1 ? node.havings[0] : new Nodes.And(node.havings);
-      this.visit(conditions, collector);
-    }
-
-    if (node.windows.length > 0) {
-      collector.append(" WINDOW ");
-      this.injectJoin(node.windows, ", ", collector);
-    }
-
-    // Mirrors base ToSql#visitArelNodesSelectCore — emits the optional
-    // SQL comment after WINDOW. Rails' MySQL visitor (mysql.rb) inherits
-    // the SelectCore visitor from to_sql.rb; Trails overrides for the
-    // FROM DUAL behavior so the comment emission has to be replicated.
-    this.maybeVisit(node.comment ?? null, collector);
-
-    return collector;
+    node.froms ??= new Nodes.SqlLiteral("DUAL", { retryable: true });
+    return super.visitArelNodesSelectCore(node, collector);
   }
 
   protected override visitArelNodesConcat(node: Nodes.Concat, collector: SQLString): SQLString {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -454,7 +454,7 @@ export class ToSql extends Visitor {
 
     this.collectNodesFor(node.projections, " ", ", ", collector);
 
-    if (node.source.left) {
+    if (node.source && !node.source.isEmpty()) {
       collector.append(" FROM ");
       this.visit(node.source, collector);
     }
@@ -1051,9 +1051,9 @@ export class ToSql extends Visitor {
 
   private visitArelNodesJoinSource(node: Nodes.JoinSource, collector: SQLString): SQLString {
     if (node.left) this.visit(node.left, collector);
-    for (const join of node.right) {
-      collector.append(" ");
-      this.visit(join, collector);
+    if (node.right.length > 0) {
+      if (node.left) collector.append(" ");
+      this.injectJoin(node.right, " ", collector);
     }
     return collector;
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
@@ -163,13 +163,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_JoinSource",
-    "call": "inject_join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_LessThan",
     "call": "unboundable?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/parity/canonical/query-known-gaps.json
+++ b/scripts/parity/canonical/query-known-gaps.json
@@ -39,10 +39,6 @@
     "side": "diff",
     "reason": "has_many with a default scope does not embed the scope condition in the JOIN ON clause: Rails resolves joins(:published_books) to INNER JOIN \"books\" ON \"books\".\"status\" = 'published' AND \"books\".\"author_id\" = ...; Trails emits only INNER JOIN \"books\" ON \"books\".\"author_id\" = ... (scope condition dropped). Real fix: _resolveAssociationJoin must apply the association's :scope condition to the JOIN ON predicate when building the join for a scoped has_many."
   },
-  "ar-153": {
-    "side": "trails-missing",
-    "reason": "Table#join(...).on(...).joinSources() crashes: Arel's Table#join returns a SelectManager whose ast.cores is undefined (the join builder path does not populate cores), so calling joinSources() throws TypeError: Cannot read properties of undefined (reading 'cores'). Rails returns a fully-formed join-sources array from the same call. Real fix: Table#join must build a SelectManager with a populated SelectCore so joinSources() can read the join list."
-  },
   "ar-154": {
     "side": "trails-missing",
     "reason": "group() does not accept Arel node arguments: group(new Nodes.NamedFunction(...)) throws TypeError: col.trim is not a function because the group implementation calls .trim() on each argument assuming strings. Rails accepts any Arel::Node in group() and passes it to the GROUP BY clause via the Arel visitor. Real fix: the groupBang implementation must handle Arel node arguments by calling .toSql() (or passing them directly to the Arel manager) instead of treating them as strings."

--- a/scripts/parity/fixtures/ar-87/query.ts
+++ b/scripts/parity/fixtures/ar-87/query.ts
@@ -4,6 +4,7 @@ const authors = Author.arelTable;
 const books = Book.arelTable;
 const joinSources = books
   .join(authors)
-  .on(books.get("author_id").eq(authors.get("id"))).joinSources;
+  .on(books.get("author_id").eq(authors.get("id")))
+  .joinSources();
 
 export default Book.joins(...joinSources);


### PR DESCRIPTION
`Arel::SelectManager#join_sources` is a **method** in Rails
(`vendor/rails/activerecord/lib/arel/select_manager.rb:244-246`); trails
exposed `joinSources` as a getter. Faithful ports that call `.joinSources()`
therefore threw `is not a function` — the failure behind parity fixture
`ar-153` in the `query-parity-trails` job.

## Changes

- `SelectManager#joinSources` is now a method.
- The defensive copy (`[...]`) is **dropped** — Rails returns the live
  `@ctx.source.right` array. Only one caller mutates the result
  (`join-association.ts`, which rewrites the last element in place to append
  constraints); it now copies at its own call site, with a comment saying why.
- All call sites updated (`packages/`, `scripts/`): `query-methods.ts`,
  `join-association.ts`, arel + AR tests, and parity fixture `ar-87`.
- `ar-153` removed from `scripts/parity/canonical/query-known-gaps.json`.

## Verification

- `ar-153` dumps on both sides and the JSON is **byte-identical** to the Rails
  dump: `SELECT books.*, authors.name AS author_name FROM "books" INNER JOIN
  "authors" ON "books"."author_id" = "authors"."id" AND "authors"."active" = 1`.
  `ar-87` still dumps clean.
- `select-manager.test.ts` + `select-manager.trails.test.ts` (180),
  `eager.test.ts`, `has-many-through-associations.test.ts`,
  `left-outer-join-association.test.ts` (401), `parity/query/diff.test.ts`.
- `tsc --build` clean.

Closes-story: arel-join-sources-getter-should-be-method

## Follow-up from review

The reviewer cited Rails' `select_manager_test.rb:7-10`, whose `test_join_sources`
**mutates** the array `join_sources` returns and asserts `SELECT FROM 'foo'`. Our
ported body only asserted emptiness. Converging it onto Rails' body exposed two
visitor divergences that the weaker assertion hid:

- `visit_Arel_Nodes_SelectCore` gates `" FROM "` on `!o.source.empty?`
  (`to_sql.rb:157`); trails gated on `source.left`, so a source carrying only
  joins emitted no `FROM` at all.
- `visit_Arel_Nodes_JoinSource` emits the separating space only when there is a
  left, then `inject_join`s the joins (`to_sql.rb:509-517`); trails prefixed
  every join with a space, doubling it when left was absent.

Both now mirror Rails. Full arel suite (1463) and the AR `associations/` +
`relation/` suites (2681) pass; `api:compare` and `test:compare` totals are
byte-identical to the pre-change run, and `ar-153` still diffs identical to the
Rails dump.

### Round 2: MySQL visitor

Fixed as reported. Rails' MySQL `SelectCore` override is two lines — set
`o.froms ||= Arel.sql("DUAL")`, then `super` (`mysql.rb:29-31`) — so the base
`SelectCore`/`JoinSource` path still emits whatever joins the source carries.
trails had reimplemented the entire base body to special-case FROM DUAL, which
dropped `source.right` whenever `source.left` was absent (and hand-duplicated
projections / WHERE / GROUP / HAVING / WINDOW / comment emission).

The override now delegates to `super`, matching Rails:

- join-only source → `SELECT FROM DUAL 'foo'` (previously `SELECT FROM DUAL`,
  joins dropped)
- empty source → `SELECT FROM DUAL` (unchanged)
- normal source → `SELECT * FROM "users"` (unchanged)

Net effect is ~50 lines of duplicated base-visitor body deleted. `api:compare`
and `test:compare` totals still identical; arel suite (1463) and AR
`associations/` + `relation/` (2681) pass.
