### PR TITLE
refactor(activerecord): name cacheSql's ported block param `block`

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -193,7 +193,7 @@ export interface QueryCacheHost extends DatabaseStatementsHost {
     sql: string,
     name: string | null | undefined,
     binds: unknown[],
-    execute: () => Promise<Record<string, unknown>[]>,
+    block: () => Promise<Record<string, unknown>[]>,
   ): Promise<Record<string, unknown>[]>;
 }
 
@@ -701,12 +701,12 @@ function cacheSql(
   sql: string,
   name: string | null | undefined,
   binds: unknown[],
-  execute: () => Promise<Record<string, unknown>[]>,
+  block: () => Promise<Record<string, unknown>[]>,
 ): Promise<Record<string, unknown>[]> {
   const qc = this._queryCache;
-  if (!qc) return execute();
+  if (!qc) return block();
   const key = sqlCacheKey(sql, binds);
-  return qc.computeIfAbsent(key, execute);
+  return qc.computeIfAbsent(key, block);
 }
 
 /**


### PR DESCRIPTION
Rails' `cache_sql` takes a block and yields for the cache-miss path; the trails
port threads that path as an explicit trailing parameter. It was spelled
`execute`, which is not in api:compare's `TRAILING_CALLBACK_NAMES`
(`scripts/api-compare/arity.ts`), so the ported-block strip did not apply and
`cacheSql` showed up as an arity mismatch against both
`connection_adapters/abstract_adapter.rb` and
`connection_adapters/abstract/query_cache.rb` — the last two unexcluded
activerecord arity pairs.

Rename the parameter to the conventional `block` spelling so the existing strip
applies. Deliberately *not* widening `TRAILING_CALLBACK_NAMES` with `execute`:
it is a plausible genuine value arg elsewhere and would weaken the check
repo-wide. No exclusion entry needed either.

## Verification

`API_COMPARE_FORCE=1 pnpm api:compare` → `scripts/api-compare/output/arity-mismatches.json`
now has **zero** activerecord entries (81 remain across other packages).
`query-cache.test.ts` + `query-cache.trails.test.ts` pass (69 passed, 9 skipped).

Closes-story: arity-cache-sql-ported-block-param
