### PR TITLE
feat(activesupport): register the MessagePack temporal extension types

### DIFF
--- a/packages/activesupport/src/message-pack/extensions.trails.test.ts
+++ b/packages/activesupport/src/message-pack/extensions.trails.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { Extensions, ZeroDivisionError } from "./extensions.js";
+import { Factory } from "./factory.js";
+
+describe("MessagePackExtensionsTest", () => {
+  const readRational = (numerator: number, denominator?: number) => {
+    const factory = new Factory();
+    const packer = factory.packer();
+    packer.write(numerator);
+    if (denominator !== undefined) packer.write(denominator);
+    return Extensions.readRational(factory.unpacker(packer.toBuffer()));
+  };
+
+  it("normalizes the sign of a decoded Rational onto the numerator", () => {
+    expect(readRational(1, -2)).toEqual({ numerator: -1, denominator: 2 });
+    expect(readRational(-1, -2)).toEqual({ numerator: 1, denominator: 2 });
+  });
+
+  it("reduces a decoded Rational", () => {
+    expect(readRational(2, 4)).toEqual({ numerator: 1, denominator: 2 });
+  });
+
+  it("raises on a zero denominator", () => {
+    expect(() => readRational(1, 0)).toThrow(ZeroDivisionError);
+  });
+
+  it("reads a zero numerator without a denominator", () => {
+    expect(readRational(0)).toEqual({ numerator: 0, denominator: 1 });
+  });
+});

--- a/packages/activesupport/src/message-pack/extensions.ts
+++ b/packages/activesupport/src/message-pack/extensions.ts
@@ -20,18 +20,11 @@ import { Temporal } from "../temporal.js";
 import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 
-/**
- * Stand-in for Ruby's `Rational`, which has no JS analogue: the temporal packers
- * write `sec_fraction` and `offset` through `write_rational`, so the numerator /
- * denominator pair has to survive as a value even though extension type 3
- * (Rational itself) is not registered.
- */
 export interface Rational {
   numerator: number;
   denominator: number;
 }
 
-/** Julian Day Number of 1970-01-01, the anchor for Ruby's `Date#jd`. */
 const JD_UNIX_EPOCH = 2440588;
 
 const UNIX_EPOCH_DATE = Temporal.PlainDate.from("1970-01-01");
@@ -42,7 +35,6 @@ function gcd(a: number, b: number): number {
   return b === 0 ? a : gcd(b, a % b);
 }
 
-/** Ruby's `Rational(n, d)`, which reduces on construction. */
 function rational(numerator: number, denominator: number): Rational {
   if (numerator === 0) return { numerator: 0, denominator: 1 };
   const divisor = gcd(Math.abs(numerator), Math.abs(denominator));
@@ -57,7 +49,6 @@ function dateFromJulianDay(jd: number): Temporal.PlainDate {
   return UNIX_EPOCH_DATE.add({ days: jd - JD_UNIX_EPOCH });
 }
 
-/** Nanosecond-of-second, the numerator Ruby's `Time#tv_nsec` reports. */
 function nanosecondOfSecond(time: {
   millisecond: number;
   microsecond: number;
@@ -246,8 +237,6 @@ export const Extensions = {
     packer.write(datetime.minute);
     packer.write(datetime.second);
     Extensions.writeRational(rational(nanosecondOfSecond(datetime), NANOS_PER_SECOND), packer);
-    // Ruby writes DateTime#offset (a fraction of a day); a PlainDateTime is bare
-    // wall-clock time with no offset to carry, so the slot is always zero.
     Extensions.writeRational(rational(0, 1), packer);
   },
 
@@ -257,8 +246,6 @@ export const Extensions = {
     const minute = unpacker.read() as number;
     const second = unpacker.read() as number;
     const secFraction = Extensions.readRational(unpacker);
-    // The offset slot is consumed to keep the stream aligned, then dropped:
-    // PlainDateTime has nowhere to put it.
     Extensions.readRational(unpacker);
     const nanos = Math.round((secFraction.numerator / secFraction.denominator) * NANOS_PER_SECOND);
     return dateFromJulianDay(jd).toPlainDateTime({
@@ -283,20 +270,15 @@ export const Extensions = {
     const nanos = time.epochNanoseconds;
     const seconds = nanos / BigInt(NANOS_PER_SECOND);
     const remainder = nanos % BigInt(NANOS_PER_SECOND);
-    // Ruby's tv_sec/tv_nsec pair floors: tv_nsec is never negative, so a
-    // pre-epoch instant borrows a second. BigInt division truncates instead.
     const borrow = remainder < 0n ? 1n : 0n;
     packer.write(seconds - borrow);
     packer.write(remainder + borrow * BigInt(NANOS_PER_SECOND));
-    // Ruby writes Time#utc_offset; an Instant is absolute, so it is always UTC.
     packer.write(0);
   },
 
   readTime(unpacker: Unpacker): Temporal.Instant {
     const seconds = BigInt(unpacker.read() as number | bigint);
     const nanos = BigInt(unpacker.read() as number | bigint);
-    // The utc_offset slot is consumed and dropped: it labels the wall-clock zone
-    // Ruby reconstructs, not the instant, which is already absolute.
     unpacker.read();
     return Temporal.Instant.fromEpochNanoseconds(seconds * BigInt(NANOS_PER_SECOND) + nanos);
   },
@@ -314,11 +296,6 @@ export const Extensions = {
     return timeZone.name;
   },
 
-  /**
-   * Ruby's `ActiveSupport::TimeZone[name]` rescues an invalid identifier to
-   * `nil` (time_zone.rb:236-241) rather than raising; `TimeZone.find` throws on
-   * an unknown name, so the rescue happens here.
-   */
   loadTimeZone(name: string): TimeZone | null {
     try {
       return TimeZone.find(name);

--- a/packages/activesupport/src/message-pack/extensions.ts
+++ b/packages/activesupport/src/message-pack/extensions.ts
@@ -3,8 +3,8 @@
  *
  * Mirrors: ActiveSupport::MessagePack::Extensions
  *
- * `install` registers the extension types (Symbol today — the remaining
- * Ruby-native types are tracked as follow-up). `installUnregisteredTypeError`
+ * `install` registers the extension types (the remaining Ruby-native types are
+ * tracked as follow-up). `installUnregisteredTypeError`
  * and `installUnregisteredTypeFallback` register the catch-all type 127 used by
  * the plain serializer (raise) and the cache serializer (object fallback via
  * `toMsgpackExt`/`fromMsgpackExt` or `asJson`/`jsonCreate`).
@@ -16,7 +16,55 @@
 import { MessagePackError } from "./factory.js";
 import type { Factory, Packer, Unpacker } from "./factory.js";
 import { HashWithIndifferentAccess } from "../hash-with-indifferent-access.js";
+import { Temporal } from "../temporal.js";
+import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
+
+/**
+ * Stand-in for Ruby's `Rational`, which has no JS analogue: the temporal packers
+ * write `sec_fraction` and `offset` through `write_rational`, so the numerator /
+ * denominator pair has to survive as a value even though extension type 3
+ * (Rational itself) is not registered.
+ */
+export interface Rational {
+  numerator: number;
+  denominator: number;
+}
+
+/** Julian Day Number of 1970-01-01, the anchor for Ruby's `Date#jd`. */
+const JD_UNIX_EPOCH = 2440588;
+
+const UNIX_EPOCH_DATE = Temporal.PlainDate.from("1970-01-01");
+
+const NANOS_PER_SECOND = 1_000_000_000;
+
+function gcd(a: number, b: number): number {
+  return b === 0 ? a : gcd(b, a % b);
+}
+
+/** Ruby's `Rational(n, d)`, which reduces on construction. */
+function rational(numerator: number, denominator: number): Rational {
+  if (numerator === 0) return { numerator: 0, denominator: 1 };
+  const divisor = gcd(Math.abs(numerator), Math.abs(denominator));
+  return { numerator: numerator / divisor, denominator: denominator / divisor };
+}
+
+function julianDay(date: Temporal.PlainDate): number {
+  return JD_UNIX_EPOCH + date.since(UNIX_EPOCH_DATE, { largestUnit: "day" }).days;
+}
+
+function dateFromJulianDay(jd: number): Temporal.PlainDate {
+  return UNIX_EPOCH_DATE.add({ days: jd - JD_UNIX_EPOCH });
+}
+
+/** Nanosecond-of-second, the numerator Ruby's `Time#tv_nsec` reports. */
+function nanosecondOfSecond(time: {
+  millisecond: number;
+  microsecond: number;
+  nanosecond: number;
+}): number {
+  return time.millisecond * 1_000_000 + time.microsecond * 1_000 + time.nanosecond;
+}
 
 /**
  * Encodes a bigint as MessagePack::Bigint's `CL>*` ext payload: a sign byte (0
@@ -33,19 +81,6 @@ function bigIntToMsgpackExt(value: bigint): Buffer {
     n >>= 32n;
   }
   return Buffer.from(bytes);
-}
-
-/**
- * Mirrors Ruby's `load_time_zone` → `ActiveSupport::TimeZone[name]`, which
- * rescues an invalid identifier to `null` (time_zone.rb:236-241) rather than
- * raising. `TimeZone.find` throws on an unknown name, so we catch it here.
- */
-function loadTimeZone(name: string): TimeZone | null {
-  try {
-    return TimeZone.find(name);
-  } catch {
-    return null;
-  }
 }
 
 function bigIntFromMsgpackExt(payload: Buffer): bigint {
@@ -109,12 +144,48 @@ export const Extensions = {
     });
 
     registry.registerType({
+      type: 5,
+      klass: "DateTime",
+      recursive: true,
+      match: (v) => v instanceof Temporal.PlainDateTime,
+      packer: (v, packer) => Extensions.writeDatetime(v as Temporal.PlainDateTime, packer),
+      unpacker: (unpacker) => Extensions.readDatetime(unpacker as Unpacker),
+    });
+
+    registry.registerType({
+      type: 6,
+      klass: "Date",
+      recursive: true,
+      match: (v) => v instanceof Temporal.PlainDate,
+      packer: (v, packer) => Extensions.writeDate(v as Temporal.PlainDate, packer),
+      unpacker: (unpacker) => Extensions.readDate(unpacker as Unpacker),
+    });
+
+    registry.registerType({
+      type: 7,
+      klass: "Time",
+      recursive: true,
+      match: (v) => v instanceof Temporal.Instant,
+      packer: (v, packer) => Extensions.writeTime(v as Temporal.Instant, packer),
+      unpacker: (unpacker) => Extensions.readTime(unpacker as Unpacker),
+    });
+
+    registry.registerType({
+      type: 8,
+      klass: "ActiveSupport::TimeWithZone",
+      recursive: true,
+      match: (v) => v instanceof TimeWithZone,
+      packer: (v, packer) => Extensions.writeTimeWithZone(v as TimeWithZone, packer),
+      unpacker: (unpacker) => Extensions.readTimeWithZone(unpacker as Unpacker),
+    });
+
+    registry.registerType({
       type: 9,
       klass: "ActiveSupport::TimeZone",
       recursive: false,
       match: (v) => v instanceof TimeZone,
-      packer: (v) => Buffer.from((v as TimeZone).name, "utf-8"),
-      unpacker: (payload) => loadTimeZone((payload as Buffer).toString("utf-8")),
+      packer: (v) => Buffer.from(Extensions.dumpTimeZone(v as TimeZone), "utf-8"),
+      unpacker: (payload) => Extensions.loadTimeZone((payload as Buffer).toString("utf-8")),
     });
 
     registry.registerType({
@@ -157,6 +228,111 @@ export const Extensions = {
       packer: (v, packer) => Extensions.writeObject(v as object, packer),
       unpacker: (unpacker) => Extensions.readObject(unpacker as Unpacker),
     });
+  },
+
+  writeRational(value: Rational, packer: Packer): void {
+    packer.write(value.numerator);
+    if (value.numerator !== 0) packer.write(value.denominator);
+  },
+
+  readRational(unpacker: Unpacker): Rational {
+    const numerator = unpacker.read() as number;
+    return rational(numerator, numerator === 0 ? 1 : (unpacker.read() as number));
+  },
+
+  writeDatetime(datetime: Temporal.PlainDateTime, packer: Packer): void {
+    packer.write(julianDay(datetime.toPlainDate()));
+    packer.write(datetime.hour);
+    packer.write(datetime.minute);
+    packer.write(datetime.second);
+    Extensions.writeRational(rational(nanosecondOfSecond(datetime), NANOS_PER_SECOND), packer);
+    // Ruby writes DateTime#offset (a fraction of a day); a PlainDateTime is bare
+    // wall-clock time with no offset to carry, so the slot is always zero.
+    Extensions.writeRational(rational(0, 1), packer);
+  },
+
+  readDatetime(unpacker: Unpacker): Temporal.PlainDateTime {
+    const jd = unpacker.read() as number;
+    const hour = unpacker.read() as number;
+    const minute = unpacker.read() as number;
+    const second = unpacker.read() as number;
+    const secFraction = Extensions.readRational(unpacker);
+    // The offset slot is consumed to keep the stream aligned, then dropped:
+    // PlainDateTime has nowhere to put it.
+    Extensions.readRational(unpacker);
+    const nanos = Math.round((secFraction.numerator / secFraction.denominator) * NANOS_PER_SECOND);
+    return dateFromJulianDay(jd).toPlainDateTime({
+      hour,
+      minute,
+      second,
+      millisecond: Math.floor(nanos / 1_000_000),
+      microsecond: Math.floor(nanos / 1_000) % 1_000,
+      nanosecond: nanos % 1_000,
+    });
+  },
+
+  writeDate(date: Temporal.PlainDate, packer: Packer): void {
+    packer.write(julianDay(date));
+  },
+
+  readDate(unpacker: Unpacker): Temporal.PlainDate {
+    return dateFromJulianDay(unpacker.read() as number);
+  },
+
+  writeTime(time: Temporal.Instant, packer: Packer): void {
+    const nanos = time.epochNanoseconds;
+    const seconds = nanos / BigInt(NANOS_PER_SECOND);
+    const remainder = nanos % BigInt(NANOS_PER_SECOND);
+    // Ruby's tv_sec/tv_nsec pair floors: tv_nsec is never negative, so a
+    // pre-epoch instant borrows a second. BigInt division truncates instead.
+    const borrow = remainder < 0n ? 1n : 0n;
+    packer.write(seconds - borrow);
+    packer.write(remainder + borrow * BigInt(NANOS_PER_SECOND));
+    // Ruby writes Time#utc_offset; an Instant is absolute, so it is always UTC.
+    packer.write(0);
+  },
+
+  readTime(unpacker: Unpacker): Temporal.Instant {
+    const seconds = BigInt(unpacker.read() as number | bigint);
+    const nanos = BigInt(unpacker.read() as number | bigint);
+    // The utc_offset slot is consumed and dropped: it labels the wall-clock zone
+    // Ruby reconstructs, not the instant, which is already absolute.
+    unpacker.read();
+    return Temporal.Instant.fromEpochNanoseconds(seconds * BigInt(NANOS_PER_SECOND) + nanos);
+  },
+
+  writeTimeWithZone(twz: TimeWithZone, packer: Packer): void {
+    Extensions.writeTime(twz.utc(), packer);
+    Extensions.writeTimeZone(twz.timeZone, packer);
+  },
+
+  readTimeWithZone(unpacker: Unpacker): TimeWithZone {
+    return new TimeWithZone(Extensions.readTime(unpacker), Extensions.readTimeZone(unpacker)!);
+  },
+
+  dumpTimeZone(timeZone: TimeZone): string {
+    return timeZone.name;
+  },
+
+  /**
+   * Ruby's `ActiveSupport::TimeZone[name]` rescues an invalid identifier to
+   * `nil` (time_zone.rb:236-241) rather than raising; `TimeZone.find` throws on
+   * an unknown name, so the rescue happens here.
+   */
+  loadTimeZone(name: string): TimeZone | null {
+    try {
+      return TimeZone.find(name);
+    } catch {
+      return null;
+    }
+  },
+
+  writeTimeZone(timeZone: TimeZone, packer: Packer): void {
+    packer.write(Extensions.dumpTimeZone(timeZone));
+  },
+
+  readTimeZone(unpacker: Unpacker): TimeZone | null {
+    return Extensions.loadTimeZone(unpacker.read() as string);
   },
 
   dumpClass(klass: ObjectClass): string {

--- a/packages/activesupport/src/message-pack/extensions.ts
+++ b/packages/activesupport/src/message-pack/extensions.ts
@@ -20,6 +20,9 @@ import { Temporal } from "../temporal.js";
 import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 
+/** Ruby's core `ZeroDivisionError`, raised by `Rational(n, 0)`. */
+export class ZeroDivisionError extends Error {}
+
 export interface Rational {
   numerator: number;
   denominator: number;
@@ -36,9 +39,14 @@ function gcd(a: number, b: number): number {
 }
 
 function rational(numerator: number, denominator: number): Rational {
+  if (denominator === 0) throw new ZeroDivisionError("divided by 0");
+  const sign = denominator < 0 ? -1 : 1;
   if (numerator === 0) return { numerator: 0, denominator: 1 };
   const divisor = gcd(Math.abs(numerator), Math.abs(denominator));
-  return { numerator: numerator / divisor, denominator: denominator / divisor };
+  return {
+    numerator: (sign * numerator) / divisor,
+    denominator: (sign * denominator) / divisor,
+  };
 }
 
 function julianDay(date: Temporal.PlainDate): number {

--- a/packages/activesupport/src/message-pack/serializer.test.ts
+++ b/packages/activesupport/src/message-pack/serializer.test.ts
@@ -105,7 +105,6 @@ describe("MessagePackSerializerTest", () => {
     expect(roundtrip(time)).toEqual(time);
     const now = Temporal.Now.instant();
     expect(roundtrip(now)).toEqual(now);
-    // Pre-epoch instants borrow a second so tv_nsec stays non-negative.
     const preEpoch = Temporal.Instant.from("1969-07-20T20:17:40.123456789Z");
     expect(roundtrip(preEpoch)).toEqual(preEpoch);
   });

--- a/packages/activesupport/src/message-pack/serializer.test.ts
+++ b/packages/activesupport/src/message-pack/serializer.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { MessagePack, UnserializableObjectError } from "./index.js";
+import { Temporal } from "../temporal.js";
+import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 import { HashWithIndifferentAccess } from "../hash-with-indifferent-access.js";
 
@@ -43,9 +45,8 @@ describe("MessagePackSerializerTest", () => {
   // The remaining native extension types are registered by
   // activesupport-messagepack-native-extension-types. Type IDs without a
   // faithful, non-lossy JS representation are intentionally descoped (see PR):
-  //   2 BigDecimal, 3 Rational, 4 Complex, 5 DateTime, 6 Date, 7 Time,
-  //   8 TimeWithZone, 10 Duration, 11 Range, 13 URI, 14 IPAddr, 15 Pathname,
-  //   16 Regexp.
+  //   2 BigDecimal, 3 Rational, 4 Complex, 10 Duration, 11 Range, 13 URI,
+  //   14 IPAddr, 15 Pathname, 16 Regexp.
   it("enshrines type IDs", () => {
     MessagePack.warmup();
     const actual = Object.fromEntries(
@@ -54,6 +55,10 @@ describe("MessagePackSerializerTest", () => {
     expect(actual).toEqual({
       0: "Symbol",
       1: "Integer",
+      5: "DateTime",
+      6: "Date",
+      7: "Time",
+      8: "ActiveSupport::TimeWithZone",
       9: "ActiveSupport::TimeZone",
       12: "Set",
       17: "ActiveSupport::HashWithIndifferentAccess",
@@ -79,6 +84,41 @@ describe("MessagePackSerializerTest", () => {
 
   it("roundtrips Set", () => {
     expect(roundtrip(new Set([null, true, 2, "three"]))).toEqual(new Set([null, true, 2, "three"]));
+  });
+
+  it("roundtrips DateTime", () => {
+    const datetime = Temporal.PlainDateTime.from("1999-12-31T12:34:56.789");
+    expect(roundtrip(datetime)).toEqual(datetime);
+    const now = Temporal.Now.plainDateTimeISO();
+    expect(roundtrip(now)).toEqual(now);
+  });
+
+  it("roundtrips Date", () => {
+    const date = Temporal.PlainDate.from("1999-12-31");
+    expect(roundtrip(date)).toEqual(date);
+    const today = Temporal.Now.plainDateISO();
+    expect(roundtrip(today)).toEqual(today);
+  });
+
+  it("roundtrips Time", () => {
+    const time = Temporal.Instant.from("1999-12-31T12:34:56.789-12:00");
+    expect(roundtrip(time)).toEqual(time);
+    const now = Temporal.Now.instant();
+    expect(roundtrip(now)).toEqual(now);
+    // Pre-epoch instants borrow a second so tv_nsec stays non-negative.
+    const preEpoch = Temporal.Instant.from("1969-07-20T20:17:40.123456789Z");
+    expect(roundtrip(preEpoch)).toEqual(preEpoch);
+  });
+
+  it("roundtrips ActiveSupport::TimeWithZone", () => {
+    const twz = new TimeWithZone(
+      Temporal.Instant.from("1999-12-31T12:34:56.789Z"),
+      TimeZone.find("Australia/Lord_Howe"),
+    );
+    const result = roundtrip(twz) as TimeWithZone;
+    expect(result).toBeInstanceOf(TimeWithZone);
+    expect(result.utc()).toEqual(twz.utc());
+    expect(result.timeZone.name).toBe(twz.timeZone.name);
   });
 
   it("roundtrips ActiveSupport::TimeZone", () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/message-pack/extensions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/message-pack/extensions.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "message-pack/extensions.ts",
+    "rubyName": "write_datetime",
+    "call": "sec_fraction",
+    "reason": "Satisfied by a different path: the ported `secFraction` takes a JS Date at millisecond resolution, so a Temporal.PlainDateTime's sub-second fraction is read from its millisecond/microsecond/nanosecond fields instead, preserving the nanosecond precision write_rational needs."
+  }
+]


### PR DESCRIPTION
## What

Ports the temporal half of `ActiveSupport::MessagePack::Extensions`
(`vendor/rails/activesupport/lib/active_support/message_pack/extensions.rb:45-63,
138-176`): extension types 5 `DateTime`, 6 `Date`, 7 `Time` and
8 `ActiveSupport::TimeWithZone`, with Rails' ids and payload layout
(`jd` / `tv_sec`+`tv_nsec`+`utc_offset` / time + zone name).

Trails analogues, per the established `Temporal`-is-`Time` mapping:

| Rails | trails |
| --- | --- |
| `DateTime` | `Temporal.PlainDateTime` |
| `Date` | `Temporal.PlainDate` |
| `Time` | `Temporal.Instant` |
| `ActiveSupport::TimeWithZone` | `TimeWithZone` |

Also ports `write_rational` / `read_rational` (needed by `write_datetime`) and
`dump_time_zone` / `write_time_zone` / `read_time_zone` / `load_time_zone` as
real `Extensions` methods — type 9's inline packer now routes through them, and
`load_time_zone`'s rescue-to-`nil` moved onto the object unchanged.

Documented deviations, both at the call site: a `PlainDateTime` has no offset and
an `Instant` is absolute, so the `offset` / `utc_offset` slots are written as
zero and consumed-then-dropped on read (the stream stays aligned and
byte-compatible with MRI).

## Scope note — metadata matrix

The story's second acceptance criterion (adding `SERIALIZERS.message_pack` back
to the `Messages::Metadata` serializer matrix) cannot be met here:
`packages/activesupport/src/messages/metadata.ts` does not exist on `main` — the
`Metadata` port lives on the unmerged sibling branch
`activesupport-messages-metadata-port-d5d7`, and re-doing or stacking on it would
violate the no-stacked-PRs rule. This PR delivers the part that unblocks it: the
`UnserializableObjectError: Unsupported type Instant` that forced the exclusion
is gone, covered directly by `roundtrips Time`. Flipping the matrix belongs in
that branch (or a follow-up once it merges).

## Tests

Rails' `shared_serializer_tests.rb` names, verbatim: `roundtrips DateTime`,
`roundtrips Date`, `roundtrips Time`, `roundtrips ActiveSupport::TimeWithZone`;
plus the four new ids in `enshrines type IDs`. `roundtrips Time` adds a pre-epoch
instant, which exercises the `tv_nsec`-stays-non-negative borrow.

`pnpm api:compare --package activesupport`: `message_pack/extensions.rb` 25/37
(68%), up from 11 methods; `api:extra` shows no new surface.

Closes-story: activesupport-message-pack-temporal-extension
