### PR TITLE
fix(activerecord): change_table bulk paths use the real CommandRecorder

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2067,11 +2067,7 @@ export class SchemaStatements {
     const nonCombinable: Array<() => Promise<void>> = [];
 
     for (const { cmd: command, args } of operations) {
-      // Mirrors Rails' `table, arguments = args.shift, args` — the recorded
-      // command's first argument is always the table name.
       const [table, ...arguments_] = args as [string, ...unknown[]];
-      // Prefer adapter-specific *ForAlter over the generic SchemaStatements one — mirrors Rails
-      // where bulk_change_table and all *_for_alter methods live on the same adapter object.
       const forAlterTarget =
         typeof (this.adapter as any)[`${command}ForAlter`] === "function"
           ? (this.adapter as any)

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -10,6 +10,7 @@
 
 import { NotImplementedError } from "../../errors.js";
 import { joinTableName as _joinTableName } from "../../migration/join-table.js";
+import { CommandRecorder } from "../../migration/command-recorder.js";
 import { ArgumentError, type Type } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter, AdapterName } from "../abstract-adapter.js";
 import {
@@ -31,7 +32,6 @@ import {
   type ColumnType,
   type ColumnOptions,
   type IdHashOptions,
-  type SchemaStatementsLike,
   type ForeignKeyLookupOptions,
   type RemoveForeignKeyOptions,
 } from "./schema-definitions.js";
@@ -1031,34 +1031,10 @@ export class SchemaStatements {
       (this.adapter as any).supportsBulkAlter() === true;
 
     if (options.bulk && supportsBulk) {
-      const ops: Array<[string, string, ...unknown[]]> = [];
-      // Mirrors Rails' CommandRecorder#method_missing: records any DDL method call into ops
-      // so bulkChangeTable can coalesce or fall back. Read-only predicates delegate to the
-      // real SchemaStatements so Table#isColumnExists / isIndexExists etc. work in bulk blocks.
-      // Using a Proxy handles adapter-specific methods (e.g. PgTable#addUniqueConstraint)
-      // without enumerating them statically.
-      const predicates = new Set([
-        "columnExists",
-        "indexExists",
-        "foreignKeyExists",
-        "isCheckConstraintExists",
-        "primaryKey",
-      ]);
-      const ss = this;
-      const recorder = new Proxy({} as SchemaStatementsLike, {
-        get(_target, prop: string) {
-          if (predicates.has(prop)) {
-            return (ss as any)[prop].bind(ss);
-          }
-          return (...args: unknown[]) => {
-            ops.push([prop, ...(args as [string, ...unknown[]])]);
-            return Promise.resolve();
-          };
-        },
-      });
-      const bulkTable = this.updateTableDefinition(tableName, recorder as any);
+      const recorder = new CommandRecorder(this);
+      const bulkTable = this.updateTableDefinition(tableName, recorder as unknown);
       if (callback) await callback(bulkTable);
-      await this.bulkChangeTable(tableName, ops);
+      await this.bulkChangeTable(tableName, recorder.commands);
     } else {
       const table = this.updateTableDefinition(tableName, this);
       if (callback) await callback(table);
@@ -2085,12 +2061,15 @@ export class SchemaStatements {
 
   async bulkChangeTable(
     tableName: string,
-    operations: Array<[string, string, ...unknown[]]>,
+    operations: Array<{ cmd: string; args: unknown[] }>,
   ): Promise<void> {
     const sqlFragments: string[] = [];
     const nonCombinable: Array<() => Promise<void>> = [];
 
-    for (const [command, table, ...arguments_] of operations) {
+    for (const { cmd: command, args } of operations) {
+      // Mirrors Rails' `table, arguments = args.shift, args` — the recorded
+      // command's first argument is always the table name.
+      const [table, ...arguments_] = args as [string, ...unknown[]];
       // Prefer adapter-specific *ForAlter over the generic SchemaStatements one — mirrors Rails
       // where bulk_change_table and all *_for_alter methods live on the same adapter object.
       const forAlterTarget =

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -648,3 +648,31 @@ describe("CommandRecorder", () => {
     });
   });
 });
+
+describe("Migration", () => {
+  describe("CommandRecorderTest", () => {
+    it("respond to delegates", () => {
+      const recorder = new CommandRecorder({ america() {} }) as unknown as {
+        america: unknown;
+      };
+      expect(typeof recorder.america).toBe("function");
+    });
+
+    it("send delegates to record", () => {
+      const recorder = new CommandRecorder({ createTable(_name: string) {} });
+      // The recorder only records the command — no DDL runs, so there is no table to tear down.
+      // eslint-disable-next-line blazetrails/require-table-teardown
+      (recorder as unknown as { createTable(name: string): void }).createTable("horses");
+      expect(recorder.commands).toEqual([{ cmd: "createTable", args: ["horses"] }]);
+    });
+
+    it("unknown commands delegate", () => {
+      const recorder = new CommandRecorder({
+        foo(kw: string) {
+          return kw;
+        },
+      }) as unknown as { foo(kw: string): string };
+      expect(recorder.foo("bar")).toBe("bar");
+    });
+  });
+});

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -125,11 +125,22 @@ export class CommandRecorder {
       typeof delegate?.supportsBulkAlter === "function" && delegate.supportsBulkAlter() === true;
 
     if (options["bulk"] && supportsBulk) {
-      // Bulk path: sub-recorder captures commands, parent stores a single
-      // changeTable entry that invertChangeTable knows how to flip.
+      // Mirrors Rails: the sub-recorder inherits `reverting`, so the block's
+      // operations are inverted as they are recorded, and the parent entry is
+      // pushed onto @commands directly rather than through record() — pushing
+      // it raw is what keeps an enclosing revert() from inverting the already
+      // inverted sub-list a second time.
       const sub = new CommandRecorder(this._delegate);
+      sub.reverting = this._reverting;
       await callback(delegate.updateTableDefinition(tableName, sub));
-      this.record("changeTable", [tableName, sub.commands]);
+      // Deviation: Rails stores `[:change_table, [table_name], -> t {
+      // bulk_change_table(table_name, commands) }]` — a callable third element.
+      // Trails' command shape is `{ cmd, args }` with no block slot, so the
+      // captured sub-commands are stored as the second arg instead and
+      // replay() expands them. Converging on the callable form is a change to
+      // the command tuple and replay() across every recorded command, which is
+      // out of scope here.
+      this._commands.push({ cmd: "changeTable", args: [tableName, sub.commands] });
     } else {
       // Non-bulk: route operations directly through this recorder so the
       // enclosing revert() block can invert them individually.
@@ -451,23 +462,6 @@ export class CommandRecorder {
     throw new IrreversibleMigration(
       "change_column is not reversible. Use change_column_default or change_column_null instead.",
     );
-  }
-
-  /** @internal */
-  invertChangeTable(args: unknown[]): [string, unknown[]] {
-    const [tableName, subCommands] = args as [string, unknown];
-    if (!Array.isArray(subCommands)) {
-      throw new IrreversibleMigration(
-        "change_table is not reversible without captured sub-commands.",
-      );
-    }
-    const inverted = ([...subCommands] as Array<{ cmd: string; args: unknown[] }>)
-      .reverse()
-      .map(({ cmd, args: subArgs }) => {
-        const [iCmd, iArgs] = this._dispatchInvert(cmd, subArgs);
-        return { cmd: iCmd, args: iArgs };
-      });
-    return ["changeTable", [tableName, inverted]];
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -125,25 +125,11 @@ export class CommandRecorder {
       typeof delegate?.supportsBulkAlter === "function" && delegate.supportsBulkAlter() === true;
 
     if (options["bulk"] && supportsBulk) {
-      // Mirrors Rails: the sub-recorder inherits `reverting`, so the block's
-      // operations are inverted as they are recorded, and the parent entry is
-      // pushed onto @commands directly rather than through record() — pushing
-      // it raw is what keeps an enclosing revert() from inverting the already
-      // inverted sub-list a second time.
       const sub = new CommandRecorder(this._delegate);
       sub.reverting = this._reverting;
       await callback(delegate.updateTableDefinition(tableName, sub));
-      // Deviation: Rails stores `[:change_table, [table_name], -> t {
-      // bulk_change_table(table_name, commands) }]` — a callable third element.
-      // Trails' command shape is `{ cmd, args }` with no block slot, so the
-      // captured sub-commands are stored as the second arg instead and
-      // replay() expands them. Converging on the callable form is a change to
-      // the command tuple and replay() across every recorded command, which is
-      // out of scope here.
       this._commands.push({ cmd: "changeTable", args: [tableName, sub.commands] });
     } else {
-      // Non-bulk: route operations directly through this recorder so the
-      // enclosing revert() block can invert them individually.
       await callback(delegate.updateTableDefinition(tableName, this));
     }
   }

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -18,6 +18,23 @@ export class CommandRecorder {
 
   constructor(delegate?: unknown) {
     this._delegate = delegate ?? null;
+    // Stands in for Rails' `method_missing` / `respond_to_missing?`
+    // (command_recorder.rb:395-406), which forward any method the recorder does
+    // not define to the delegate. JS has no method_missing, so the forwarding
+    // lives in a Proxy returned from the constructor — class-wide, as in Rails.
+    return new Proxy(this, {
+      get(target, prop, receiver) {
+        if (Reflect.has(target, prop)) return Reflect.get(target, prop, receiver);
+        const delegate = target._delegate as Record<string | symbol, unknown> | null;
+        const forwarded = delegate?.[prop];
+        return typeof forwarded === "function" ? forwarded.bind(delegate) : undefined;
+      },
+      has(target, prop) {
+        if (Reflect.has(target, prop)) return true;
+        const delegate = target._delegate as Record<string | symbol, unknown> | null;
+        return delegate != null && prop in delegate;
+      },
+    });
   }
 
   get delegate(): unknown {


### PR DESCRIPTION
Split out of #5628, which converged the object `change_table` yields on all
three entry points but left the **bulk** paths on their trails shapes. This
closes both remaining `bulk: true` divergences.

## 1. `SchemaStatements#changeTable` instantiates the real recorder

It built an ad-hoc `Proxy` as the recorder, pushing flattened
`[name, table, ...args]` tuples into an `ops` array. Rails just instantiates
the recorder (`schema_statements.rb:510-517`):

```ruby
def change_table(table_name, base = self, **options)
  if supports_bulk_alter? && options[:bulk]
    recorder = ActiveRecord::Migration::CommandRecorder.new(self)
    yield update_table_definition(table_name, recorder)
    bulk_change_table(table_name, recorder.commands)
  else
    yield update_table_definition(table_name, base)
```

#5628 gave `CommandRecorder` the generated `ReversibleAndIrreversibleMethods`
bodies, so it now stands in directly as the `base` passed to
`updateTableDefinition`, and the ad-hoc `Proxy` is deleted.

`bulkChangeTable` consumes the recorder's `{ cmd, args }` commands and splits
the table name off the front of `args`, mirroring Rails'
`table, arguments = args.shift, args` (`schema_statements.rb:1559-1560`) —
rather than making the caller re-flatten into trails' tuple shape.

## 2. `CommandRecorder` gets Rails' `method_missing` delegate forwarding

The old ad-hoc `Proxy` forwarded a hardcoded five-name list of read-only
predicates (`columnExists`, `indexExists`, `foreignKeyExists`,
`isCheckConstraintExists`, `primaryKey`) to the real `SchemaStatements`. That
was modelling something real: Rails' `CommandRecorder` defines
`method_missing` / `respond_to_missing?` (`command_recorder.rb:395-406`),
which forward **any** method the recorder does not define to the delegate —
and `change_table` passes `self` as that delegate, so
`Table#column_exists?` → `@base.column_exists?`
(`schema_definitions.rb:744-746`) resolves through the recorder. Rails' own
docs show `t.string(:name) unless t.column_exists?(:name, :string)`.

So rather than keep the hardcoded list or drop it, this ports the general
mechanism: JS has no `method_missing`, so the forwarding is a `Proxy`
returned from the constructor — class-wide, as in Rails. Methods the recorder
defines still record; only unknown ones forward. That covers every adapter
method, not just the five that happened to be enumerated.

## 3. `CommandRecorder#changeTable` propagates `reverting`

The bulk branch omitted Rails' `recorder.reverting = @reverting` and recorded
the parent entry through `record(...)` instead of pushing it raw
(`command_recorder.rb:136-144`). The two reached the same set of operations by
opposite routes — Rails inverts inside the sub-recorder and appends the parent
entry un-inverted; trails kept the sub-recorder raw and let `invertChangeTable`
flip the stored sub-list — but they order the sub-list differently, because
Rails' route does not reverse it.

This takes Rails' route, which leaves `invertChangeTable` dead; since Rails has
no `invert_change_table` at all it is deleted rather than kept, so a bulk
`change_table` inverted outside a `revert` block now raises
`IrreversibleMigration` from `_dispatchInvert`, as in Rails.

### Remaining deviation

Rails stores a **callable** third element:

```ruby
@commands << [:change_table, [table_name], -> t { bulk_change_table(table_name, commands) }]
```

Trails' command shape is `{ cmd, args }` with no block slot, and `replay()`
has no callable path, so the captured sub-commands stay in the second arg and
`replay()` expands them. Converging on the callable form changes the command
tuple and `replay()` for *every* recorded command — separate work, out of
scope here.

## Testing

Ports the three Rails tests covering recorder delegation, none of which trails
had — `respond_to_delegates`, `send_delegates_to_record`,
`unknown_commands_delegate` (`command_recorder_test.rb:13-42`). Two of the
three fail without the `method_missing` port, so they are real regression
cover for it.

`migration/change-table.test.ts`, `command-recorder.test.ts` (incl. "bulk
invert change table"), `migration.test.ts` (incl.
`RevertBulkAlterTableMigrationsTest > bulk revert` and the
`BulkAlterTableMigrationsTest` group), `active-record-schema.test.ts`,
`invertible-migration.test.ts` and `migrator.test.ts` pass on **sqlite3,
PostgreSQL and MySQL**. MySQL is the adapter that actually executes
`bulkChangeTable` (`supportsBulkAlter?`), and
`adapters/abstract-mysql-adapter/active-schema.test.ts` (14 tests, incl.
"index in bulk change") passes there too. Because the recorder `Proxy` is
class-wide it also affects the migration `change` path, so
`migration.trails.test.ts`, `migrator.trails.test.ts`,
`multi-db-migrator.test.ts`, `hot-compatibility.test.ts`,
`schema-dumper.test.ts` and `schema-loading.test.ts` were run too — all green.

Deltas are non-negative:

- `test:compare` — 14873 → **14876** (+3), the three ported Rails tests.
- `api:compare` — unchanged: data layer 7723/7816, overall 11741/17536, arity
  7507/7590, calls advisory 12. (`method_missing` and `respond_to_missing?`
  are both in the global skip list in `scripts/api-compare/conventions.ts`,
  so porting them moves no counter either way.)

No stubs added.

Closes-story: change-table-bulk-paths-use-real-command-recorder
