### PR TITLE
refactor(activerecord): derive owner foreign keys in one place

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1427,28 +1427,6 @@ function _associationForeignKeyPresent(
 }
 
 /**
- * Resolve a foreign association's (has_one / has_many / through) owner foreign
- * key from the *rich* reflection, which derives it from the class that
- * *declared* the association (`reflection.active_record`), not the owner
- * instance's class. For an STI subclass owner — e.g. a `SpecialPost` row whose
- * `has_many :special_comments` is declared on `Post` — this yields `post_id`,
- * not `special_post_id`. Mirrors Rails `reflection.foreign_key`. Returns
- * `undefined` for an unregistered association so callers keep their fallback.
- *
- * @internal
- */
-export function ownerReflectionForeignKey(
-  ctor: typeof Base,
-  assocName: string,
-): string | string[] | undefined {
-  return (
-    ctor as unknown as {
-      _reflectOnAssociation?: (n: string) => { foreignKey?: string | string[] } | undefined;
-    }
-  )._reflectOnAssociation?.(assocName)?.foreignKey;
-}
-
-/**
  * Resolve the owner-side key for an inline (no-reflection) association
  * fallback, mirroring `reflection.activeRecordPrimaryKey` semantics
  * (reflection.rb:587 `active_record_primary_key`): for a composite-FK

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -3,7 +3,7 @@ import type { AssociationDefinition } from "../associations.js";
 import { association as associationProxy } from "../associations.js";
 import { underscore, isAbortSignal } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
-import { foreignKeyPresentFor } from "./foreign-association.js";
+import { foreignKeyPresentFor, ownerForeignKeyColumns } from "./foreign-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
 import type { AssociationReflection } from "../reflection.js";
 import { RecordNotSaved, Rollback } from "../errors.js";
@@ -949,31 +949,11 @@ export class CollectionAssociation extends Association {
   // --- Private helpers ---
 
   private foreignKeyColumns(): string[] {
-    const fk = this.reflection.options.foreignKey;
-    if (typeof fk === "string") return [fk];
-    if (Array.isArray(fk)) return fk;
-    const ctor = this.owner.constructor as typeof Base & {
-      _reflectOnAssociation?: (n: string) => { foreignKey?: string | string[] } | undefined;
-    };
-    // Prefer the *rich* reflection's foreign key, derived from the class that
-    // *declared* the association (`reflection.active_record`), not the owner
-    // instance's class. `this.reflection` is the lightweight AssociationDefinition
-    // with no `foreignKey` getter, so resolve the registered Reflection the same
-    // way `foreignKeyPresent` does. For an STI subclass owner (e.g. a `SpecialPost`
-    // whose `has_many :special_comments` is declared on `Post`) this yields
-    // `post_id`, not `special_post_id` — mirrors Rails `reflection.foreign_key`.
-    const reflectionFk = ctor._reflectOnAssociation?.(this.reflection.name)?.foreignKey;
-    if (typeof reflectionFk === "string") return [reflectionFk];
-    if (Array.isArray(reflectionFk)) return reflectionFk;
-    if (this.reflection.options.as) {
-      return [`${underscore(this.reflection.options.as)}_id`];
-    }
-    // Derive composite FKs for CPK owners (mirrors findTarget)
-    const pk = this.reflection.options.primaryKey ?? ctor.primaryKey ?? "id";
-    if (Array.isArray(pk)) {
-      return pk.map((col: string) => `${underscore(ctor.name)}_${col}`);
-    }
-    return [`${underscore(ctor.name)}_id`];
+    return ownerForeignKeyColumns(
+      this.owner.constructor as typeof Base,
+      this.reflection.name,
+      this.reflection.options as Parameters<typeof ownerForeignKeyColumns>[2],
+    );
   }
 
   private foreignKeyColumn(): string {

--- a/packages/activerecord/src/associations/foreign-association.ts
+++ b/packages/activerecord/src/associations/foreign-association.ts
@@ -4,19 +4,12 @@ import type { AssociationReflection } from "../reflection.js";
 import type { Base } from "../base.js";
 
 /**
- * Resolve a foreign association's (has_one / has_many / through) owner-side
- * foreign key column(s).
+ * Mirrors `reflection.foreign_key` (reflection.rb `compute_foreign_key`),
+ * keyed on `reflection.active_record` — the class that *declared* the
+ * association. The rungs below the reflection serve trails' inline
+ * (unregistered) association fallbacks, which have no Rails counterpart.
  *
- * Rails resolves this in exactly one place — `reflection.foreign_key`
- * (reflection.rb `compute_foreign_key`), keyed on `reflection.active_record`,
- * the class that *declared* the association. For an STI subclass owner — e.g.
- * a `SpecialPost` row whose `has_many :special_comments` is declared on `Post`
- * — that yields `post_id`, not `special_post_id`.
- *
- * The rungs below the rich reflection exist only for trails' inline
- * (unregistered) association fallbacks, where no reflection is resolvable.
- *
- * @internal trails-only: the reflection rungs have no Rails counterpart.
+ * @internal
  */
 export function ownerForeignKeyColumns(
   ctor: typeof Base,
@@ -45,10 +38,8 @@ export function ownerForeignKeyColumns(
 }
 
 /**
- * The rich reflection's foreign key, derived from the class that *declared*
- * the association (`reflection.active_record`), not the owner instance's
- * class. Returns `undefined` for an unregistered association so
- * `ownerForeignKeyColumns` can fall through to its inline rungs.
+ * Mirrors `reflection.foreign_key`, returning `undefined` for an unregistered
+ * association so `ownerForeignKeyColumns` falls through to its inline rungs.
  *
  * @internal
  */

--- a/packages/activerecord/src/associations/foreign-association.ts
+++ b/packages/activerecord/src/associations/foreign-association.ts
@@ -1,5 +1,67 @@
+import { underscore } from "@blazetrails/activesupport";
+
 import type { AssociationReflection } from "../reflection.js";
 import type { Base } from "../base.js";
+
+/**
+ * Resolve a foreign association's (has_one / has_many / through) owner-side
+ * foreign key column(s).
+ *
+ * Rails resolves this in exactly one place — `reflection.foreign_key`
+ * (reflection.rb `compute_foreign_key`), keyed on `reflection.active_record`,
+ * the class that *declared* the association. For an STI subclass owner — e.g.
+ * a `SpecialPost` row whose `has_many :special_comments` is declared on `Post`
+ * — that yields `post_id`, not `special_post_id`.
+ *
+ * The rungs below the rich reflection exist only for trails' inline
+ * (unregistered) association fallbacks, where no reflection is resolvable.
+ *
+ * @internal trails-only: the reflection rungs have no Rails counterpart.
+ */
+export function ownerForeignKeyColumns(
+  ctor: typeof Base,
+  assocName: string,
+  options: {
+    foreignKey?: string | string[];
+    as?: string;
+    primaryKey?: string | string[];
+    queryConstraints?: string[];
+  },
+): string[] {
+  const fk = options.foreignKey;
+  if (typeof fk === "string") return [fk];
+  if (Array.isArray(fk)) return fk;
+
+  const reflectionFk = ownerReflectionForeignKey(ctor, assocName);
+  if (typeof reflectionFk === "string") return [reflectionFk];
+  if (Array.isArray(reflectionFk)) return reflectionFk;
+
+  if (options.as) return [`${underscore(options.as)}_id`];
+  if (options.queryConstraints) return options.queryConstraints;
+
+  const pk = options.primaryKey ?? ctor.primaryKey ?? "id";
+  if (Array.isArray(pk)) return pk.map((col) => `${underscore(ctor.name)}_${col}`);
+  return [`${underscore(ctor.name)}_id`];
+}
+
+/**
+ * The rich reflection's foreign key, derived from the class that *declared*
+ * the association (`reflection.active_record`), not the owner instance's
+ * class. Returns `undefined` for an unregistered association so
+ * `ownerForeignKeyColumns` can fall through to its inline rungs.
+ *
+ * @internal
+ */
+export function ownerReflectionForeignKey(
+  ctor: typeof Base,
+  assocName: string,
+): string | string[] | undefined {
+  return (
+    ctor as unknown as {
+      _reflectOnAssociation?: (n: string) => { foreignKey?: string | string[] } | undefined;
+    }
+  )._reflectOnAssociation?.(assocName)?.foreignKey;
+}
 
 /**
  * Mirrors `ActiveRecord::Associations::ForeignAssociation#foreign_key_present?`

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -15,7 +15,6 @@ import {
   _violatesStrictLoading,
   _wireInverseAssociation,
   applyAssociationScope,
-  ownerReflectionForeignKey,
   resolveAssocClass,
   syncToAssociationInstance,
   validateInverseOf,
@@ -29,7 +28,7 @@ import { CompositePrimaryKeyMismatchError, DeleteRestrictionError } from "./erro
 import { polymorphicName } from "../inheritance.js";
 import { RecordInvalid } from "../validations.js";
 import { CollectionAssociation, includesRecord } from "./collection-association.js";
-import { ForeignAssociation } from "./foreign-association.js";
+import { ForeignAssociation, ownerForeignKeyColumns } from "./foreign-association.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
 import { camelize, singularize, underscore } from "@blazetrails/activesupport";
 
@@ -587,18 +586,11 @@ export async function findTarget(
   }
 
   // Resolve FK columns (may be array for CPK; `:as` swaps to the
-  // polymorphic FK column). Prefer the rich reflection's foreign key so an STI
-  // subclass owner uses the declaring class's column (see
-  // `ownerReflectionForeignKey`).
-  const foreignKey = options.as
-    ? (options.foreignKey ?? `${underscore(options.as)}_id`)
-    : (options.foreignKey ??
-      ownerReflectionForeignKey(ctor, assocName) ??
-      (options.queryConstraints
-        ? options.queryConstraints
-        : Array.isArray(primaryKey)
-          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
-          : `${underscore(ctor.name)}_id`));
+  // polymorphic FK column) through the single derivation site shared with the
+  // OO association classes (see `ownerForeignKeyColumns`).
+  const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, { ...options, primaryKey });
+  const foreignKey: string | string[] =
+    foreignKeyColumns.length === 1 ? foreignKeyColumns[0] : foreignKeyColumns;
 
   // Polymorphic `:as` requires a scalar FK. A composite FK is always
   // rejected. A composite owner PK collapses to "id" when present

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -585,9 +585,6 @@ export async function findTarget(
     validateInverseOf(targetModel, assocName, options.inverseOf);
   }
 
-  // Resolve FK columns (may be array for CPK; `:as` swaps to the
-  // polymorphic FK column) through the single derivation site shared with the
-  // OO association classes (see `ownerForeignKeyColumns`).
   const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, { ...options, primaryKey });
   const foreignKey: string | string[] =
     foreignKeyColumns.length === 1 ? foreignKeyColumns[0] : foreignKeyColumns;

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -4,7 +4,11 @@ import { DeleteRestrictionError, HasOnePersistedAssignmentError } from "./errors
 import { RecordNotSaved } from "../errors.js";
 import { underscore } from "@blazetrails/activesupport";
 import { reflectOnAllAssociations } from "../reflection.js";
-import { ForeignAssociation, foreignKeyPresentFor } from "./foreign-association.js";
+import {
+  ForeignAssociation,
+  foreignKeyPresentFor,
+  ownerForeignKeyColumns,
+} from "./foreign-association.js";
 import type { AssociationReflection } from "../reflection.js";
 import { findTarget, SingularAssociation } from "./singular-association.js";
 import { polymorphicName } from "../inheritance.js";
@@ -555,30 +559,11 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   private foreignKeyColumns(): string[] {
-    const fk = this.reflection.options.foreignKey;
-    if (typeof fk === "string") return [fk];
-    if (Array.isArray(fk)) return fk;
-    const ctor = (this.owner as any).constructor;
-    if (this.reflection.options.as) {
-      return [`${underscore(this.reflection.options.as)}_id`];
-    }
-    // Rails' `reflection.foreign_key` derives from `reflection.active_record`
-    // — the class that *declared* the association — not the owner instance's
-    // class. For an STI subclass owner (a `SpecialPost` whose
-    // `has_one :very_special_comment` is declared on `Post`) that is `post_id`,
-    // not `special_post_id`. The rich reflection already applies that rule.
-    const declared = (
-      ctor as {
-        _reflectOnAssociation?: (n: string) => { foreignKey?: string | string[] } | undefined;
-      }
-    )._reflectOnAssociation?.(this.reflection.name)?.foreignKey;
-    if (typeof declared === "string") return [declared];
-    if (Array.isArray(declared)) return declared;
-    const pk = this.reflection.options.primaryKey ?? ctor.primaryKey ?? "id";
-    if (Array.isArray(pk)) {
-      return pk.map((col: string) => `${underscore(ctor.name)}_${col}`);
-    }
-    return [`${underscore(ctor.name)}_id`];
+    return ownerForeignKeyColumns(
+      this.owner.constructor as typeof Base,
+      this.reflection.name,
+      this.reflection.options as Parameters<typeof ownerForeignKeyColumns>[2],
+    );
   }
 
   private foreignKeyColumn(): string {

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -17,12 +17,12 @@ import {
   _violatesStrictLoading,
   _wireInverseAssociation,
   applyAssociationScope,
-  ownerReflectionForeignKey,
   resolveAssocClass,
   syncToAssociationInstance,
   validateInverseOf,
 } from "../associations.js";
 import { Association } from "./association.js";
+import { ownerForeignKeyColumns } from "./foreign-association.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import {
   routeThroughCheckValidity,
@@ -586,18 +586,11 @@ async function _findHasOneTarget(
   }
 
   // Resolve FK columns (may be array for CPK; `:as` swaps to the
-  // polymorphic FK column). Prefer the rich reflection's foreign key so an STI
-  // subclass owner uses the declaring class's column (see
-  // `ownerReflectionForeignKey`).
-  const foreignKey = options.as
-    ? (options.foreignKey ?? `${underscore(options.as)}_id`)
-    : (options.foreignKey ??
-      ownerReflectionForeignKey(ctor, assocName) ??
-      (options.queryConstraints
-        ? options.queryConstraints
-        : Array.isArray(primaryKey)
-          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
-          : `${underscore(ctor.name)}_id`));
+  // polymorphic FK column) through the single derivation site shared with the
+  // OO association classes (see `ownerForeignKeyColumns`).
+  const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, { ...options, primaryKey });
+  const foreignKey: string | string[] =
+    foreignKeyColumns.length === 1 ? foreignKeyColumns[0] : foreignKeyColumns;
 
   // Polymorphic `:as` requires a scalar FK. A composite FK is always
   // rejected. A composite owner PK collapses to "id" when present

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -585,9 +585,6 @@ async function _findHasOneTarget(
     validateInverseOf(targetModel, assocName, options.inverseOf);
   }
 
-  // Resolve FK columns (may be array for CPK; `:as` swaps to the
-  // polymorphic FK column) through the single derivation site shared with the
-  // OO association classes (see `ownerForeignKeyColumns`).
   const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, { ...options, primaryKey });
   const foreignKey: string | string[] =
     foreignKeyColumns.length === 1 ? foreignKeyColumns[0] : foreignKeyColumns;


### PR DESCRIPTION
Rails derives a foreign association's owner FK in exactly one place — `reflection.foreign_key`, keyed on `reflection.active_record` (the class that *declared* the association). trails re-derived it in three, each with its own copy of the `options.foreignKey` → rich reflection → `as:` → `underscore(ctor.name)_id` ladder:

- `CollectionAssociation#foreignKeyColumns`
- `HasOneAssociation#foreignKeyColumns` (this one had already drifted — it derived from the owner *instance's* class and produced `special_post_id` for an STI owner until #5356)
- `ownerReflectionForeignKey` + inline fallback in the free-function engine path

All three now call `ownerForeignKeyColumns` in `associations/foreign-association.ts` — the Rails-layout file matching where Rails resolves it. The per-class copies are gone (the remaining `foreignKeyColumns` methods are one-line delegations, no ladder). No behavior change intended.

Verified: sti-owner-through-foreign-key, has-one-associations, belongs-to-associations, has-many-associations, has-many-through-associations, autosave-association (+trails), nested-attributes (+trails, +with-callbacks), polymorphic/composite-key suites — all pass.

Closes-story: converge-foreign-key-derivation-single-site
