### PR TITLE
refactor(actionpack): converge http/cache predicates onto the is prefix

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -546,14 +546,14 @@ describe("Response Cache::Response wiring", () => {
     const res = new Response();
     const t = new Date("1994-11-06T08:49:37Z");
     res.lastModified = t;
-    expect(res.hasLastModified).toBe(true);
+    expect(res.isLastModified).toBe(true);
     expect(res.getHeader("Last-Modified")).toBe("Sun, 06 Nov 1994 08:49:37 GMT");
     expect(res.lastModified?.getTime()).toBe(t.getTime());
   });
 
   it("lastModified returns undefined when absent", () => {
     const res = new Response();
-    expect(res.hasLastModified).toBe(false);
+    expect(res.isLastModified).toBe(false);
     expect(res.lastModified).toBeUndefined();
   });
 
@@ -561,7 +561,7 @@ describe("Response Cache::Response wiring", () => {
     const res = new Response();
     const t = new Date("1994-11-06T08:49:37Z");
     res.date = t;
-    expect(res.hasDate).toBe(true);
+    expect(res.isDate).toBe(true);
     expect(res.date?.getTime()).toBe(t.getTime());
   });
 
@@ -572,7 +572,7 @@ describe("Response Cache::Response wiring", () => {
     expect(e.startsWith('W/"')).toBe(true);
     expect(res.isWeakEtag()).toBe(true);
     expect(res.isStrongEtag()).toBe(false);
-    expect(res.hasEtag).toBe(true);
+    expect(res.isEtag).toBe(true);
     // Case-insensitive read: same value via any casing.
     expect(res.getHeader("etag")).toBe(e);
     expect(res.getHeader("ETAG")).toBe(e);

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -572,7 +572,7 @@ describe("Response Cache::Response wiring", () => {
     expect(e.startsWith('W/"')).toBe(true);
     expect(res.isWeakEtag()).toBe(true);
     expect(res.isStrongEtag()).toBe(false);
-    expect(res.isEtag).toBe(true);
+    expect(res.isEtag).toBe(e);
     // Case-insensitive read: same value via any casing.
     expect(res.getHeader("etag")).toBe(e);
     expect(res.getHeader("ETAG")).toBe(e);

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -26,8 +26,6 @@ const MUST_REVALIDATE = "must-revalidate",
 
 export const CacheConfig = { strictFreshness: false };
 
-// --- Request -----------------------------------------------------------------
-
 export interface RequestCacheHost {
   getHeader(name: string): string | undefined;
 }
@@ -76,16 +74,10 @@ export function fresh(this: RequestCacheHost, response: CacheResponseLike): bool
   return ok;
 }
 
-// --- Response ----------------------------------------------------------------
-
 export interface ResponseCacheHost {
   getHeader(key: string): string | undefined;
   setHeader(key: string, value: string): void;
-  hasHeader?(key: string): boolean;
-}
-
-function hdrSet(host: ResponseCacheHost, key: string): boolean {
-  return host.hasHeader ? host.hasHeader(key) : host.getHeader(key) !== undefined;
+  hasHeader(key: string): boolean;
 }
 
 const RFC1123_RE =
@@ -128,12 +120,10 @@ export function parseRfc2822Date(s: string | undefined): Date | undefined {
     h = Number(hh),
     mi = Number(mm),
     s2 = Number(ss);
-  // Rails' Time.rfc2822 raises ArgumentError on out-of-range components.
   if (d < 1 || d > 31 || h > 23 || mi > 59 || s2 > 60) return undefined;
   let year = Number(yr);
   if (year < 50) year += 2000;
   else if (year < 1000) year += 1900;
-  // Round-trip-validate calendar day (rejects 31 Feb, 30 Feb, etc.).
   // boundary: probe Date used only to read normalized UTC components.
   const probe = new Date(Date.UTC(year, MONTHS[mon], d));
   if (probe.getUTCMonth() !== MONTHS[mon] || probe.getUTCDate() !== d) return undefined;
@@ -173,10 +163,8 @@ export function parseHttpDate(s: string | undefined): Date | undefined {
     h = Number(hh),
     mi = Number(mm),
     s2 = Number(ss);
-  // Rails' Time.httpdate raises ArgumentError on out-of-range components.
   if (d < 1 || d > 31 || h > 23 || mi > 59 || s2 > 60) return undefined;
   const yr = Number(year);
-  // Round-trip-validate calendar day (rejects 31 Feb, 30 Feb, etc.).
   // boundary: probe Date used only to read normalized UTC components.
   const probe = new Date(Date.UTC(yr, MONTHS[mon], d));
   if (probe.getUTCMonth() !== MONTHS[mon] || probe.getUTCDate() !== d) return undefined;
@@ -190,6 +178,7 @@ type R = ResponseCacheHost;
 export class Response {
   declare getHeader: ResponseCacheHost["getHeader"];
   declare setHeader: ResponseCacheHost["setHeader"];
+  declare hasHeader: ResponseCacheHost["hasHeader"];
 
   get lastModified(): Date | undefined {
     return parseHttpDate(this.getHeader(LAST_MODIFIED));
@@ -217,16 +206,14 @@ export class Response {
 }
 
 export function isLastModified(this: R) {
-  return hdrSet(this, LAST_MODIFIED);
+  return this.hasHeader(LAST_MODIFIED);
 }
 export function isDate(this: R) {
-  return hdrSet(this, DATE);
+  return this.hasHeader(DATE);
 }
-/** Rails' `Cache::Response#weak_etag=`. */
 export function weakEtag(this: R, v: unknown) {
   this.setHeader(ETAG, generateWeakEtag(v));
 }
-/** Rails' `Cache::Response#strong_etag=`. */
 export function strongEtag(this: R, v: unknown) {
   this.setHeader(ETAG, generateStrongEtag(v));
 }
@@ -234,8 +221,7 @@ export function isEtag(this: R) {
   return !!this.getHeader(ETAG);
 }
 export function isWeakEtag(this: R) {
-  const e = this.getHeader(ETAG);
-  return !!e && e.startsWith('W/"');
+  return isEtag.call(this) && this.getHeader(ETAG)!.startsWith('W/"');
 }
 export function isStrongEtag(this: R) {
   return isEtag.call(this) && !isWeakEtag.call(this);
@@ -287,7 +273,6 @@ export function cacheControlHeaders(this: ResponseCacheHost): CacheControlHash {
   return result;
 }
 
-/** Rails' `attr_reader :cache_control` — returns the parsed hash. */
 export function cacheControl(this: ResponseCacheHost): CacheControlHash {
   return cacheControlHeaders.call(this);
 }

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -217,14 +217,15 @@ export function weakEtag(this: R, v: unknown) {
 export function strongEtag(this: R, v: unknown) {
   this.setHeader(ETAG, generateStrongEtag(v));
 }
-export function isEtag(this: R) {
-  return !!this.getHeader(ETAG);
+export function isEtag(this: R): string | undefined {
+  return this.getHeader(ETAG);
 }
 export function isWeakEtag(this: R) {
-  return isEtag.call(this) && this.getHeader(ETAG)!.startsWith('W/"');
+  const etag = isEtag.call(this);
+  return etag !== undefined && etag.startsWith('W/"');
 }
 export function isStrongEtag(this: R) {
-  return isEtag.call(this) && !isWeakEtag.call(this);
+  return isEtag.call(this) !== undefined && !isWeakEtag.call(this);
 }
 
 /** @internal */

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -284,7 +284,10 @@ export function prepareCacheControlBang(this: ResponseCacheHost): CacheControlHa
 }
 
 export function handleConditionalGetBang(this: ResponseCacheHost): void {
-  if ((isEtag.call(this) || isLastModified.call(this)) && !this.getHeader(CACHE_CONTROL)) {
+  if (
+    (isEtag.call(this) !== undefined || isLastModified.call(this)) &&
+    !this.getHeader(CACHE_CONTROL)
+  ) {
     this.setHeader(CACHE_CONTROL, DEFAULT_CACHE_CONTROL);
   }
 }

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -286,7 +286,7 @@ export function prepareCacheControlBang(this: ResponseCacheHost): CacheControlHa
 export function handleConditionalGetBang(this: ResponseCacheHost): void {
   if (
     (isEtag.call(this) !== undefined || isLastModified.call(this)) &&
-    !this.getHeader(CACHE_CONTROL)
+    this.getHeader(CACHE_CONTROL) === undefined
   ) {
     this.setHeader(CACHE_CONTROL, DEFAULT_CACHE_CONTROL);
   }

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -216,10 +216,10 @@ export class Response {
   }
 }
 
-export function hasLastModified(this: R) {
+export function isLastModified(this: R) {
   return hdrSet(this, LAST_MODIFIED);
 }
-export function hasDate(this: R) {
+export function isDate(this: R) {
   return hdrSet(this, DATE);
 }
 /** Rails' `Cache::Response#weak_etag=`. */
@@ -230,7 +230,7 @@ export function weakEtag(this: R, v: unknown) {
 export function strongEtag(this: R, v: unknown) {
   this.setHeader(ETAG, generateStrongEtag(v));
 }
-export function hasEtag(this: R) {
+export function isEtag(this: R) {
   return !!this.getHeader(ETAG);
 }
 export function isWeakEtag(this: R) {
@@ -238,7 +238,7 @@ export function isWeakEtag(this: R) {
   return !!e && e.startsWith('W/"');
 }
 export function isStrongEtag(this: R) {
-  return hasEtag.call(this) && !isWeakEtag.call(this);
+  return isEtag.call(this) && !isWeakEtag.call(this);
 }
 
 /** @internal */
@@ -298,7 +298,7 @@ export function prepareCacheControlBang(this: ResponseCacheHost): CacheControlHa
 }
 
 export function handleConditionalGetBang(this: ResponseCacheHost): void {
-  if ((hasEtag.call(this) || hasLastModified.call(this)) && !this.getHeader(CACHE_CONTROL)) {
+  if ((isEtag.call(this) || isLastModified.call(this)) && !this.getHeader(CACHE_CONTROL)) {
     this.setHeader(CACHE_CONTROL, DEFAULT_CACHE_CONTROL);
   }
 }

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -16,9 +16,9 @@ import {
   generateWeakEtag as _generateWeakEtag,
   Response as CacheResponse,
   handleConditionalGetBang as _handleConditionalGetBang,
-  hasDate as _hasDate,
-  hasEtag as _hasEtag,
-  hasLastModified as _hasLastModified,
+  isDate as _isDate,
+  isEtag as _isEtag,
+  isLastModified as _isLastModified,
   isStrongEtag as _isStrongEtag,
   mergeAndNormalizeCacheControlBang as _mergeAndNormalizeCacheControlBang,
   isWeakEtag as _isWeakEtag,
@@ -342,9 +342,9 @@ export class Response {
   declare lastModified: Date | undefined;
   declare date: Date | undefined;
   declare etag: string | undefined;
-  declare readonly hasLastModified: boolean;
-  declare readonly hasDate: boolean;
-  declare readonly hasEtag: boolean;
+  declare readonly isLastModified: boolean;
+  declare readonly isDate: boolean;
+  declare readonly isEtag: boolean;
   declare weakEtag: (validators: unknown) => void;
   declare strongEtag: (validators: unknown) => void;
   declare isWeakEtag: () => boolean;
@@ -648,21 +648,21 @@ for (const name of ["lastModified", "date", "etag"] as const) {
     configurable: true,
   });
 }
-Object.defineProperty(Response.prototype, "hasLastModified", {
+Object.defineProperty(Response.prototype, "isLastModified", {
   get(this: Response) {
-    return _hasLastModified.call(this);
+    return _isLastModified.call(this);
   },
   configurable: true,
 });
-Object.defineProperty(Response.prototype, "hasDate", {
+Object.defineProperty(Response.prototype, "isDate", {
   get(this: Response) {
-    return _hasDate.call(this);
+    return _isDate.call(this);
   },
   configurable: true,
 });
-Object.defineProperty(Response.prototype, "hasEtag", {
+Object.defineProperty(Response.prototype, "isEtag", {
   get(this: Response) {
-    return _hasEtag.call(this);
+    return _isEtag.call(this);
   },
   configurable: true,
 });

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -344,7 +344,7 @@ export class Response {
   declare etag: string | undefined;
   declare readonly isLastModified: boolean;
   declare readonly isDate: boolean;
-  declare readonly isEtag: boolean;
+  declare readonly isEtag: string | undefined;
   declare weakEtag: (validators: unknown) => void;
   declare strongEtag: (validators: unknown) => void;
   declare isWeakEtag: () => boolean;

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/cache.json
@@ -9,13 +9,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/cache.ts",
-    "rubyName": "date?",
-    "call": "has_header?",
-    "reason": "Satisfied by a different path: the body calls the local hdrSet helper, which forwards to hasHeader when the host provides it and falls back to a getHeader undefined check, because ResponseCacheHost declares hasHeader as optional."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/cache.ts",
     "rubyName": "etag?",
     "call": "etag",
     "reason": "Satisfied by a different path: the body reads the ETag header directly via getHeader rather than going through the etag accessor, which is a class getter here and not callable as a module function."
@@ -33,13 +26,6 @@
     "rubyName": "if_modified_since",
     "call": "rfc2822",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/cache.ts",
-    "rubyName": "last_modified?",
-    "call": "has_header?",
-    "reason": "Satisfied by a different path: the body calls the local hdrSet helper, which forwards to hasHeader when the host provides it and falls back to a getHeader undefined check, because ResponseCacheHost declares hasHeader as optional."
   },
   {
     "package": "actiondispatch",
@@ -74,13 +60,6 @@
     "tsFile": "http/cache.ts",
     "rubyName": "weak_etag?",
     "call": "etag",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/cache.ts",
-    "rubyName": "weak_etag?",
-    "call": "etag?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/cache.json
@@ -9,6 +9,20 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/cache.ts",
+    "rubyName": "date?",
+    "call": "has_header?",
+    "reason": "Satisfied by a different path: the body calls the local hdrSet helper, which forwards to hasHeader when the host provides it and falls back to a getHeader undefined check, because ResponseCacheHost declares hasHeader as optional."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/cache.ts",
+    "rubyName": "etag?",
+    "call": "etag",
+    "reason": "Satisfied by a different path: the body reads the ETag header directly via getHeader rather than going through the etag accessor, which is a class getter here and not callable as a module function."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/cache.ts",
     "rubyName": "generate_strong_etag",
     "call": "hexdigest",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -16,23 +30,16 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/cache.ts",
-    "rubyName": "handle_conditional_get!",
-    "call": "etag?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/cache.ts",
-    "rubyName": "handle_conditional_get!",
-    "call": "last_modified?",
-    "reason": "Satisfied by a different path: the body calls hasLastModified (our spelling of last_modified?); the mapped candidates for the predicate are is/lastModified, and the lastModified accessor's setter is what promoted it past the args gate."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/cache.ts",
     "rubyName": "if_modified_since",
     "call": "rfc2822",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/cache.ts",
+    "rubyName": "last_modified?",
+    "call": "has_header?",
+    "reason": "Satisfied by a different path: the body calls the local hdrSet helper, which forwards to hasHeader when the host provides it and falls back to a getHeader undefined check, because ResponseCacheHost declares hasHeader as optional."
   },
   {
     "package": "actiondispatch",
@@ -60,13 +67,6 @@
     "tsFile": "http/cache.ts",
     "rubyName": "merge_and_normalize_cache_control!",
     "call": "merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/cache.ts",
-    "rubyName": "strong_etag?",
-    "call": "etag?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## What

`packages/actionpack/src/action-dispatch/http/cache.ts` exported Rails'
`Cache::Response#last_modified?`, `#date?` and `#etag?`
(`vendor/rails/actionpack/lib/action_dispatch/http/cache.rb:77`, `:91`, `:129`)
as `hasLastModified` / `hasDate` / `hasEtag`. `scripts/api-compare/conventions.ts`
maps a Ruby `foo?` onto an `is`-prefixed TS name, so all three landed as novel
extra surface. Renamed to `isLastModified` / `isDate` / `isEtag`, including the
`Response` prototype wiring and `declare`s in `http/response.ts` and the call
sites (`handleConditionalGetBang`, `isStrongEtag`, `dispatch/response.test.ts`).

## Body convergence

Matching the predicates by name also made the wide call-set comparison read
their *bodies* for the first time, surfacing three divergences. Two are
converged rather than baselined:

- `last_modified?` / `date?` now call `hasHeader` directly, as `cache.rb:77`
  and `:91` do. `hasHeader` becomes **required** on `ResponseCacheHost` and the
  `hdrSet` fallback helper is deleted — the only real host, `Response`, has
  always implemented it (`http/response.ts:483`).
- `weak_etag?` now goes through `isEtag` before inspecting the value, as
  `cache.rb:133` does.
- `etag?` returns the ETag string or `undefined` rather than a coerced boolean,
  matching `cache.rb:129` (`def etag?; etag; end`); `weak_etag?` /
  `strong_etag?` consume that value for truthiness the way `cache.rb:133`
  and `:139` do. `Response#isEtag` widens to `string | undefined`.
- `handle_conditional_get!` tests that value against `undefined` rather than
  with JS truthiness. `cache.rb:195` is `if (etag? || last_modified?)` and Ruby
  treats `""` as truthy, so a present-but-empty `ETag` header must still take
  the branch. Its `Cache-Control` guard compares against `undefined` for the
  same reason: `!self._cache_control` aliases Rack's `cache_control` reader
  (`response.rb:93`), so an empty header is truthy in Ruby and is *not*
  overwritten.

Two more instances of that truthiness class survive on the `Cache::Request`
side (`etagMatches`, `fresh` — an empty `If-None-Match` picks a different
branch than Rails), plus one on the response side (`cacheControlSegments`
returns `undefined` where Rails yields `[]`). All three are pre-existing and
outside this diff, so they are registered as
`converge-cache-request-empty-header-truthiness` under RFC 0072 rather than
widened into this PR.

`etag? -> etag` stays baselined: Rails' `etag` reader is a
`Rack::Response::Helpers` method, and it is a class getter on both our
`Response` classes (`http/cache.ts`, `packages/rack/src/response.ts`), so there
is no function for the call-set extractor to see.

Comments in `cache.ts` that only restated the line beneath them are removed.
The `// boundary:` comments stay — `eslint/no-native-date` reads them as
suppressions.

## Deltas

- `http/cache.ts` novel extra surface: **3 -> 0** (`actiondispatch` novel
  183 -> 180). The 3 remaining `moved` entries are pre-existing
  `getHeader` / `hasHeader` / `setHeader`.
- Wide-call baseline for `actiondispatch/http/cache.json`: **12 -> 9** entries.
  Removed `handle_conditional_get! -> last_modified?`,
  `handle_conditional_get! -> etag?`, `strong_etag? -> etag?`,
  `weak_etag? -> etag?`; added `etag? -> etag`.
- `test:compare`: unchanged — no test name is added, removed or reworded.
- No stubs, no placeholder interfaces.

## Verification

- `pnpm build` clean; `lint-call-mismatches-wide` OK (4788 baselined),
  `lint-call-mismatches` OK (14 baselined), `lint-body-pins` OK.
- `pnpm vitest run` on `http/cache.test.ts`, `dispatch/response.test.ts`,
  `http/filter-parameters.test.ts` — 111 passed, 16 skipped.

Closes-story: converge-http-cache-predicates-onto-is-prefix
