### PR TITLE
fix(activerecord): stamp the run token into PG/MySQL slot databases and advisory-lock keys

### DIFF
--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -89,9 +89,9 @@ describe("config", () => {
     // (config.example.yml:12-20) plus MYSQL_PREPARED_STATEMENTS
     // (config.example.yml:7-11,27-31) and hard-codes the credential and database;
     // its postgresql: entries carry no fields so libpq reads PG* itself
-    // (config.example.yml:74-81). AR_DB_SLOT is the one trails addition — the
-    // per-worker database copy Rails has no analogue for. Re-widening this set
-    // is a decision, not a detail.
+    // (config.example.yml:74-81). AR_DB_SLOT and AR_TEST_RUN_TOKEN are the two
+    // trails additions — the per-worker, per-run database copy Rails has no
+    // analogue for. Re-widening this set is a decision, not a detail.
     const seen: string[] = [];
     const recording = (env: Record<string, string>) => (key: string) => {
       seen.push(key);
@@ -107,13 +107,14 @@ describe("config", () => {
         "MYSQL_SOCK",
         "MYSQL_PREPARED_STATEMENTS",
         "AR_DB_SLOT",
+        "AR_TEST_RUN_TOKEN",
       ]),
     );
 
     seen.length = 0;
     postgresSettings(recording({}));
     expect(new Set(seen)).toEqual(
-      new Set(["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "AR_DB_SLOT"]),
+      new Set(["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "AR_DB_SLOT", "AR_TEST_RUN_TOKEN"]),
     );
   });
 
@@ -127,9 +128,24 @@ describe("config", () => {
   });
 
   it("suffixes the database with the worker isolation slot above slot 1", () => {
+    // No run token: globalSetup provisioned nothing, so the historical
+    // shared-base-plus-`_N` naming stands.
     expect(postgresSettings(reader({ AR_DB_SLOT: "1" })).database).toBe("activerecord_unittest");
     expect(postgresSettings(reader({ AR_DB_SLOT: "4" })).database).toBe("activerecord_unittest_4");
     expect(mysqlSettings(reader({ AR_DB_SLOT: "2" })).database).toBe("activerecord_unittest_2");
+  });
+
+  it("stamps the run token into the database name, slot 1 included", () => {
+    // With a run token stamped, slot 1 stops aliasing the bare base database:
+    // that alias is what made two concurrent runs collide on the un-suffixed
+    // name, leaving globalSetup free to DROP a live run's database.
+    const stamped = (slot: string) =>
+      postgresSettings(reader({ AR_DB_SLOT: slot, AR_TEST_RUN_TOKEN: "aaax1" })).database;
+    expect(stamped("1")).toBe("activerecord_unittest_aaax1_1");
+    expect(stamped("4")).toBe("activerecord_unittest_aaax1_4");
+    expect(mysqlSettings(reader({ AR_DB_SLOT: "2", AR_TEST_RUN_TOKEN: "bbbx2" })).database).toBe(
+      "activerecord_unittest_bbbx2_2",
+    );
   });
 
   it("treats an empty sub-setting as unset rather than as an empty value", () => {

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -69,6 +69,7 @@
  */
 
 import { getEnv } from "@blazetrails/activesupport";
+import { RUN_TOKEN_ENV, slotDatabaseName } from "./run-token.js";
 
 /** The public backend lane a named connection drives. */
 export type TestAdapterName = "sqlite" | "postgres" | "mysql";
@@ -131,12 +132,15 @@ export interface ServerSettings {
 
 /**
  * Per-worker database isolation slot, published by `test-setup-worker-db.ts`
- * after it wins an advisory lock. Slot 1 (or unset) is the shared base
- * database; higher slots get a `_N`-suffixed database of their own.
+ * after it wins an advisory lock. Every slot — slot 1 included — gets a
+ * database of its own.
  *
  * Applying the suffix here — rather than rewriting a URL env var in place —
  * means every consumer derives the same worker database from one signal,
- * instead of racing to read a mutated string.
+ * instead of racing to read a mutated string. `AR_TEST_RUN_TOKEN` is the
+ * second half of that signal: `globalSetup` stamps it before workers fork, and
+ * both the provisioning loops and the workers compute the identical name from
+ * the pair.
  */
 export const SLOT_ENV = "AR_DB_SLOT";
 
@@ -149,7 +153,12 @@ function applySlot(database: string, read: EnvReader): string {
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new Error(`${SLOT_ENV} must be >= 1, got ${slot}`);
   }
-  return slot > 1 ? `${database}_${slot}` : database;
+  const runToken = present(read, RUN_TOKEN_ENV);
+  // No run token means `globalSetup` provisioned nothing — a bare adapter
+  // script or a harness-less connection. There is no per-run database to point
+  // at, so the historical shared-base-plus-`_N` naming stands.
+  if (runToken === undefined) return slot > 1 ? `${database}_${slot}` : database;
+  return slotDatabaseName(database, runToken, slot);
 }
 
 /**

--- a/packages/activerecord/src/support/quote-database-name.test.ts
+++ b/packages/activerecord/src/support/quote-database-name.test.ts
@@ -5,28 +5,17 @@ import { runTokenOfDatabase, slotDatabaseName } from "./run-token.js";
 const BASE = "activerecord_unittest";
 
 describe("quoting a database name for harness DDL", () => {
-  it("wraps an ordinary name in the adapter's identifier quotes", () => {
-    expect(quotePgDatabaseName(slotDatabaseName(BASE, "rabc000001", 2))).toBe(
-      '"activerecord_unittest_rabc000001_2"',
-    );
-    expect(quoteMysqlDatabaseName(slotDatabaseName(BASE, "rabc000001", 2))).toBe(
-      "`activerecord_unittest_rabc000001_2`",
-    );
-  });
-
   it("doubles an embedded quote character rather than emitting it raw", () => {
     // `quote_column_name`'s rule — postgresql/quoting.rb:46-48,
     // mysql/quoting.rb:46-48.
+    expect(quotePgDatabaseName(slotDatabaseName(BASE, "rabc000001", 2))).toBe(
+      '"activerecord_unittest_rabc000001_2"',
+    );
     expect(quotePgDatabaseName('we"ird')).toBe('"we""ird"');
     expect(quoteMysqlDatabaseName("we`ird")).toBe("`we``ird`");
-  });
-
-  it("leaves a dot alone instead of splitting it into a qualified name", () => {
-    // Rails' MySQL `quote_table_name` adds `.gsub(".", "`.`")`, which is right
-    // for a table and wrong for a database — it would corrupt the very name the
-    // sweep is trying to drop.
+    // Rails' MySQL `quote_table_name` also splits on dots; that is right for a
+    // table and wrong for a database, so a dot stays put.
     expect(quoteMysqlDatabaseName("a.b")).toBe("`a.b`");
-    expect(quotePgDatabaseName("a.b")).toBe('"a.b"');
   });
 
   it("keeps a sweepable leftover sweepable when its suffix carries a quote", () => {

--- a/packages/activerecord/src/support/quote-database-name.test.ts
+++ b/packages/activerecord/src/support/quote-database-name.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { quoteMysqlDatabaseName, quotePgDatabaseName } from "./quote-database-name.js";
+import { runTokenOfDatabase, slotDatabaseName } from "./run-token.js";
+
+const BASE = "activerecord_unittest";
+
+describe("quoting a database name for harness DDL", () => {
+  it("wraps an ordinary name in the adapter's identifier quotes", () => {
+    expect(quotePgDatabaseName(slotDatabaseName(BASE, "rabc000001", 2))).toBe(
+      '"activerecord_unittest_rabc000001_2"',
+    );
+    expect(quoteMysqlDatabaseName(slotDatabaseName(BASE, "rabc000001", 2))).toBe(
+      "`activerecord_unittest_rabc000001_2`",
+    );
+  });
+
+  it("doubles an embedded quote character rather than emitting it raw", () => {
+    // `quote_column_name`'s rule — postgresql/quoting.rb:46-48,
+    // mysql/quoting.rb:46-48.
+    expect(quotePgDatabaseName('we"ird')).toBe('"we""ird"');
+    expect(quoteMysqlDatabaseName("we`ird")).toBe("`we``ird`");
+  });
+
+  it("leaves a dot alone instead of splitting it into a qualified name", () => {
+    // Rails' MySQL `quote_table_name` adds `.gsub(".", "`.`")`, which is right
+    // for a table and wrong for a database — it would corrupt the very name the
+    // sweep is trying to drop.
+    expect(quoteMysqlDatabaseName("a.b")).toBe("`a.b`");
+    expect(quotePgDatabaseName("a.b")).toBe('"a.b"');
+  });
+
+  it("keeps a sweepable leftover sweepable when its suffix carries a quote", () => {
+    // The regression: `runTokenOfDatabase` matches on the run-token *prefix*,
+    // so everything after it is unconstrained. Interpolating such a name raw
+    // made `DROP DATABASE` a syntax error, and globalSetup then failed on every
+    // subsequent run instead of reclaiming the leftover.
+    const leftover = `${slotDatabaseName(BASE, "rabc000001", 1)}"; SELECT 1; --`;
+    expect(runTokenOfDatabase(BASE, leftover)).toBe("rabc000001");
+
+    const sql = `DROP DATABASE IF EXISTS ${quotePgDatabaseName(leftover)}`;
+    expect(sql).toBe(
+      `DROP DATABASE IF EXISTS "activerecord_unittest_rabc000001_1""; SELECT 1; --"`,
+    );
+    // One identifier, so nothing after it can be read as a second statement.
+    expect(sql.split('"').length - 1).toBe(4);
+  });
+});

--- a/packages/activerecord/src/support/quote-database-name.ts
+++ b/packages/activerecord/src/support/quote-database-name.ts
@@ -1,0 +1,41 @@
+/**
+ * Identifier quoting for a database name in harness-built DDL.
+ *
+ * Rails quotes the name `drop_database` is handed rather than interpolating it
+ * (`postgresql/schema_statements.rb:53-54`,
+ * `abstract_mysql_adapter.rb:292-293`, both via `quote_table_name`). The escape
+ * rule is `quote_column_name`'s — double the quote character
+ * (`postgresql/quoting.rb:46-48`, `mysql/quoting.rb:46-48`) — which is the
+ * spelling trails' own ported `DatabaseTasks.drop` already uses
+ * (`tasks/postgresql-database-tasks.ts:354`, `tasks/mysql-database-tasks.ts:355`).
+ * These are the same rule for `globalSetup`, which builds its DDL against the
+ * raw `pg` / `mysql2` drivers instead of through an adapter and so cannot reach
+ * those methods.
+ *
+ * Load-bearing on the sweep paths in `template-global-setup.ts`: those build
+ * DDL from names read back out of `pg_database` / `information_schema.schemata`,
+ * not from names this codebase composed. A leftover carrying a quote character
+ * after the run token would otherwise turn every future `globalSetup` into a
+ * syntax error instead of being dropped — wedging the server for exactly the
+ * sweep that exists to unwedge it.
+ *
+ * Rails calls `quote_table_name`, whose MySQL spelling adds a
+ * `.gsub(".", "`.`")` qualified-name split. That part is deliberately NOT
+ * mirrored here: a database name is never schema-qualified, and splitting on a
+ * dot would corrupt precisely the dotted leftover this exists to drop.
+ *
+ * Hard rules (RFC 0023): no `node:*` imports, no `process.*`, async fs only —
+ * none needed here.
+ *
+ * @internal
+ */
+
+/** `quote_column_name`'s rule for PostgreSQL (`postgresql/quoting.rb:46-48`). */
+export function quotePgDatabaseName(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/** `quote_column_name`'s rule for MySQL/MariaDB (`mysql/quoting.rb:46-48`). */
+export function quoteMysqlDatabaseName(name: string): string {
+  return `\`${name.replace(/`/g, "``")}\``;
+}

--- a/packages/activerecord/src/support/quote-database-name.ts
+++ b/packages/activerecord/src/support/quote-database-name.ts
@@ -2,30 +2,23 @@
  * Identifier quoting for a database name in harness-built DDL.
  *
  * Rails quotes the name `drop_database` is handed rather than interpolating it
- * (`postgresql/schema_statements.rb:53-54`,
- * `abstract_mysql_adapter.rb:292-293`, both via `quote_table_name`). The escape
- * rule is `quote_column_name`'s — double the quote character
- * (`postgresql/quoting.rb:46-48`, `mysql/quoting.rb:46-48`) — which is the
- * spelling trails' own ported `DatabaseTasks.drop` already uses
- * (`tasks/postgresql-database-tasks.ts:354`, `tasks/mysql-database-tasks.ts:355`).
- * These are the same rule for `globalSetup`, which builds its DDL against the
- * raw `pg` / `mysql2` drivers instead of through an adapter and so cannot reach
- * those methods.
+ * (`postgresql/schema_statements.rb:53-54`, `abstract_mysql_adapter.rb:292-293`,
+ * both via `quote_table_name`); the escape rule is `quote_column_name`'s —
+ * double the quote character. `globalSetup` builds its DDL against the raw
+ * `pg` / `mysql2` drivers rather than through an adapter, so it cannot reach
+ * those methods and repeats the rule here, as trails' ported
+ * `DatabaseTasks.drop` already does.
  *
- * Load-bearing on the sweep paths in `template-global-setup.ts`: those build
- * DDL from names read back out of `pg_database` / `information_schema.schemata`,
- * not from names this codebase composed. A leftover carrying a quote character
- * after the run token would otherwise turn every future `globalSetup` into a
- * syntax error instead of being dropped — wedging the server for exactly the
- * sweep that exists to unwedge it.
+ * Load-bearing on the sweeps in `template-global-setup.ts`, which build DDL
+ * from names read out of `pg_database` / `information_schema.schemata` rather
+ * than names this codebase composed. A leftover carrying a quote character
+ * after the run token would otherwise make `DROP DATABASE` a syntax error,
+ * wedging every future run on the sweep meant to unwedge it.
  *
- * Rails calls `quote_table_name`, whose MySQL spelling adds a
- * `.gsub(".", "`.`")` qualified-name split. That part is deliberately NOT
- * mirrored here: a database name is never schema-qualified, and splitting on a
- * dot would corrupt precisely the dotted leftover this exists to drop.
- *
- * Hard rules (RFC 0023): no `node:*` imports, no `process.*`, async fs only —
- * none needed here.
+ * Rails' MySQL `quote_table_name` also splits on dots into a qualified name.
+ * That is deliberately not mirrored: a database name is never
+ * schema-qualified, and the split would corrupt the dotted leftover being
+ * dropped.
  *
  * @internal
  */

--- a/packages/activerecord/src/support/run-token.test.ts
+++ b/packages/activerecord/src/support/run-token.test.ts
@@ -15,6 +15,10 @@ const BASE = "activerecord_unittest";
 
 describe("run token", () => {
   it("carries the run start time so a name alone can be aged out", () => {
+    // Regression: an earlier spelling split the two halves on a literal "x",
+    // which `Date.now().toString(36)` itself contains for most of any given
+    // day — the parsed start time was then garbage, and the stale sweep would
+    // happily drop a concurrent run's live databases.
     const before = Date.now();
     const startedAt = runTokenStartedAt(newRunToken());
     expect(startedAt).not.toBeNull();
@@ -30,8 +34,8 @@ describe("run token", () => {
 
 describe("slot database names", () => {
   it("stamps the run token into every slot, slot 1 included", () => {
-    expect(slotDatabaseName(BASE, "abcx1", 1)).toBe("activerecord_unittest_abcx1_1");
-    expect(slotDatabaseName(BASE, "abcx1", 4)).toBe("activerecord_unittest_abcx1_4");
+    expect(slotDatabaseName(BASE, "rabc000001", 1)).toBe("activerecord_unittest_rabc000001_1");
+    expect(slotDatabaseName(BASE, "rabc000001", 4)).toBe("activerecord_unittest_rabc000001_4");
   });
 
   it("two runs never name the same slot database", () => {
@@ -42,9 +46,13 @@ describe("slot database names", () => {
   });
 
   it("reads the run token back off a stamped name", () => {
-    expect(runTokenOfDatabase(BASE, "activerecord_unittest_abcx1_2")).toBe("abcx1");
-    expect(runTokenOfDatabase(BASE, "activerecord_unittest_abcx1_2_arunit2")).toBe("abcx1");
-    expect(runTokenOfDatabase(BASE, "activerecord_unittest_abcx1_template")).toBe("abcx1");
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest_rabc000001_2")).toBe("rabc000001");
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest_rabc000001_2_arunit2")).toBe(
+      "rabc000001",
+    );
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest_rabc000001_template")).toBe(
+      "rabc000001",
+    );
     expect(runTokenOfDatabase(BASE, BASE)).toBeNull();
     expect(runTokenOfDatabase(BASE, "activerecord_unittest_2")).toBeNull();
   });
@@ -55,8 +63,8 @@ describe("drop targets", () => {
   // DROP `activerecord_unittest_2..N` unconditionally, so a second run wiped
   // the first run's databases out from under its live workers.
   it("never targets a database belonging to a different run token", () => {
-    const mine = "aaax1";
-    const theirs = "bbbx2";
+    const mine = "raaa000001";
+    const theirs = "rbbb000002";
     const names = [
       BASE,
       "activerecord_unittest_2",
@@ -70,26 +78,26 @@ describe("drop targets", () => {
     ];
 
     expect(ownRunDatabases(BASE, mine, names)).toEqual([
-      "activerecord_unittest_aaax1_1",
-      "activerecord_unittest_aaax1_2",
-      "activerecord_unittest_aaax1_2_arunit2",
+      "activerecord_unittest_raaa000001_1",
+      "activerecord_unittest_raaa000001_2",
+      "activerecord_unittest_raaa000001_2_arunit2",
     ]);
   });
 });
 
 describe("stale sweep", () => {
   const now = Date.now();
-  const tokenAt = (millis: number): string => `${millis.toString(36)}x9zz`;
+  const tokenAt = (millis: number): string => `r${millis.toString(36)}zzzzzz`;
 
   it("reclaims databases orphaned by a killed run", () => {
     const orphan = slotDatabaseName(BASE, tokenAt(now - STALE_DB_AGE_MS - 1), 3);
-    expect(staleRunDatabases(BASE, "aaax1", [orphan], now)).toEqual([orphan]);
+    expect(staleRunDatabases(BASE, "raaa000001", [orphan], now)).toEqual([orphan]);
   });
 
   it("leaves a concurrent run's live databases alone", () => {
     const live = slotDatabaseName(BASE, tokenAt(now - 60_000), 3);
-    const mine = slotDatabaseName(BASE, "aaax1", 1);
-    expect(staleRunDatabases(BASE, "aaax1", [live, mine, BASE], now)).toEqual([]);
+    const mine = slotDatabaseName(BASE, "raaa000001", 1);
+    expect(staleRunDatabases(BASE, "raaa000001", [live, mine, BASE], now)).toEqual([]);
   });
 });
 
@@ -111,8 +119,8 @@ describe("advisory lock keys", () => {
   });
 
   it("gives two runs disjoint GET_LOCK names on MySQL", () => {
-    expect(mysqlAdvisoryLockName("aaax1", 2)).toBe("ar_test_slot_aaax1_2");
-    expect(mysqlAdvisoryLockName("bbbx2", 2)).not.toBe(mysqlAdvisoryLockName("aaax1", 2));
+    expect(mysqlAdvisoryLockName("raaa000001", 2)).toBe("ar_test_slot_raaa000001_2");
+    expect(mysqlAdvisoryLockName("rbbb000002", 2)).not.toBe(mysqlAdvisoryLockName("raaa000001", 2));
   });
 
   it("stays inside MySQL's 64-character lock-name limit", () => {

--- a/packages/activerecord/src/support/run-token.test.ts
+++ b/packages/activerecord/src/support/run-token.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  STALE_DB_AGE_MS,
+  mysqlAdvisoryLockName,
+  newRunToken,
+  ownRunDatabases,
+  pgAdvisoryLockKey,
+  runTokenOfDatabase,
+  runTokenStartedAt,
+  slotDatabaseName,
+  staleRunDatabases,
+} from "./run-token.js";
+
+const BASE = "activerecord_unittest";
+
+describe("run token", () => {
+  it("carries the run start time so a name alone can be aged out", () => {
+    const before = Date.now();
+    const startedAt = runTokenStartedAt(newRunToken());
+    expect(startedAt).not.toBeNull();
+    expect(startedAt!).toBeGreaterThanOrEqual(before - 1000);
+    expect(startedAt!).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it("mints a distinct token per call", () => {
+    const tokens = new Set(Array.from({ length: 50 }, () => newRunToken()));
+    expect(tokens.size).toBe(50);
+  });
+});
+
+describe("slot database names", () => {
+  it("stamps the run token into every slot, slot 1 included", () => {
+    expect(slotDatabaseName(BASE, "abcx1", 1)).toBe("activerecord_unittest_abcx1_1");
+    expect(slotDatabaseName(BASE, "abcx1", 4)).toBe("activerecord_unittest_abcx1_4");
+  });
+
+  it("two runs never name the same slot database", () => {
+    const [a, b] = [newRunToken(), newRunToken()];
+    for (let slot = 1; slot <= 8; slot++) {
+      expect(slotDatabaseName(BASE, a, slot)).not.toBe(slotDatabaseName(BASE, b, slot));
+    }
+  });
+
+  it("reads the run token back off a stamped name", () => {
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest_abcx1_2")).toBe("abcx1");
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest_abcx1_2_arunit2")).toBe("abcx1");
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest_abcx1_template")).toBe("abcx1");
+    expect(runTokenOfDatabase(BASE, BASE)).toBeNull();
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest_2")).toBeNull();
+  });
+});
+
+describe("drop targets", () => {
+  // The regression this whole story exists to prevent: globalSetup used to
+  // DROP `activerecord_unittest_2..N` unconditionally, so a second run wiped
+  // the first run's databases out from under its live workers.
+  it("never targets a database belonging to a different run token", () => {
+    const mine = "aaax1";
+    const theirs = "bbbx2";
+    const names = [
+      BASE,
+      "activerecord_unittest_2",
+      slotDatabaseName(BASE, mine, 1),
+      slotDatabaseName(BASE, mine, 2),
+      `${slotDatabaseName(BASE, mine, 2)}_arunit2`,
+      slotDatabaseName(BASE, theirs, 1),
+      slotDatabaseName(BASE, theirs, 2),
+      "postgres",
+      "template1",
+    ];
+
+    expect(ownRunDatabases(BASE, mine, names)).toEqual([
+      "activerecord_unittest_aaax1_1",
+      "activerecord_unittest_aaax1_2",
+      "activerecord_unittest_aaax1_2_arunit2",
+    ]);
+  });
+});
+
+describe("stale sweep", () => {
+  const now = Date.now();
+  const tokenAt = (millis: number): string => `${millis.toString(36)}x9zz`;
+
+  it("reclaims databases orphaned by a killed run", () => {
+    const orphan = slotDatabaseName(BASE, tokenAt(now - STALE_DB_AGE_MS - 1), 3);
+    expect(staleRunDatabases(BASE, "aaax1", [orphan], now)).toEqual([orphan]);
+  });
+
+  it("leaves a concurrent run's live databases alone", () => {
+    const live = slotDatabaseName(BASE, tokenAt(now - 60_000), 3);
+    const mine = slotDatabaseName(BASE, "aaax1", 1);
+    expect(staleRunDatabases(BASE, "aaax1", [live, mine, BASE], now)).toEqual([]);
+  });
+});
+
+describe("advisory lock keys", () => {
+  it("gives two runs disjoint key spaces on PG", () => {
+    const [a, b] = [newRunToken(), newRunToken()];
+    expect(pgAdvisoryLockKey(a, 1)).not.toEqual(pgAdvisoryLockKey(b, 1));
+    expect(pgAdvisoryLockKey(a, 1)).toEqual(pgAdvisoryLockKey(a, 1));
+  });
+
+  it("keeps PG keys inside the signed 32-bit range PostgreSQL accepts", () => {
+    for (let i = 0; i < 200; i++) {
+      const [classId, objId] = pgAdvisoryLockKey(newRunToken(), 3);
+      expect(Number.isInteger(classId)).toBe(true);
+      expect(classId).toBeGreaterThanOrEqual(-(2 ** 31));
+      expect(classId).toBeLessThanOrEqual(2 ** 31 - 1);
+      expect(objId).toBe(3);
+    }
+  });
+
+  it("gives two runs disjoint GET_LOCK names on MySQL", () => {
+    expect(mysqlAdvisoryLockName("aaax1", 2)).toBe("ar_test_slot_aaax1_2");
+    expect(mysqlAdvisoryLockName("bbbx2", 2)).not.toBe(mysqlAdvisoryLockName("aaax1", 2));
+  });
+
+  it("stays inside MySQL's 64-character lock-name limit", () => {
+    expect(mysqlAdvisoryLockName(newRunToken(), 99).length).toBeLessThanOrEqual(64);
+  });
+});

--- a/packages/activerecord/src/support/run-token.ts
+++ b/packages/activerecord/src/support/run-token.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-run identity for the AR test harness: the token `globalSetup` stamps
+ * before any worker forks, and the naming rules every lane derives from it.
+ *
+ * The sqlite lane already carried a run token so that two vitest invocations in
+ * different worktrees could not touch each other's temp DB files
+ * (`sqlite-template.ts`). PG and MySQL had no such discriminator: every run
+ * named its slot databases `activerecord_unittest`, `activerecord_unittest_2`,
+ * … and `globalSetup` opened with `DROP DATABASE IF EXISTS` on each, so a
+ * second run against the same server dropped the first run's databases out from
+ * under its live workers. The advisory locks that hand out slots are
+ * server-wide too, so the two runs also shared one slot pool.
+ *
+ * This module is the single signal both lanes derive from, mirroring the
+ * property `config.ts` documents: nothing rewrites a URL or a database name in
+ * place — the token goes into the environment once and every consumer computes
+ * the same name from it.
+ *
+ * Naming: `<base>_<runToken>_<slot>` for a slot database, plus
+ * `<base>_<runToken>_template` for the PG clone template, and whatever a suite
+ * appends to a slot name (`_arunit2`, via `arunit2-config.ts`). Every database
+ * a run creates therefore starts with `<base>_<runToken>_`, which is what makes
+ * "drop only my own" expressible as a prefix test.
+ *
+ * Hard rules (RFC 0023): no `node:*` imports, no `process.*`, async fs only —
+ * none of which this module needs.
+ *
+ * @internal
+ */
+
+/** Env var: per-run token, stamped by `globalSetup` before workers fork. */
+export const RUN_TOKEN_ENV = "AR_TEST_RUN_TOKEN";
+
+/**
+ * Age past which a run's leftovers are assumed orphaned by a killed run and
+ * swept. No AR test run comes near this, so the cutoff cannot pull a database
+ * (or a temp file) out from under a *concurrent* run — which a blanket
+ * prefix-drop would, since parallel worktrees share one server and one tmpdir.
+ */
+export const STALE_DB_AGE_MS = 6 * 60 * 60 * 1000;
+
+// `<base36 millis>x<base36 random>`. The leading millis is not decoration: a
+// database name is all the stale sweep has to go on — unlike a temp file, a
+// PostgreSQL database carries no mtime to compare against the cutoff.
+const TOKEN_PATTERN = "[0-9a-z]+x[0-9a-z]+";
+
+/** A fresh token for this vitest invocation. */
+export function newRunToken(): string {
+  const random = Math.floor(Math.random() * 36 ** 6).toString(36);
+  return `${Date.now().toString(36)}x${random}`;
+}
+
+/** When the run that minted `runToken` started, or `null` if unparseable. */
+export function runTokenStartedAt(runToken: string): number | null {
+  const split = runToken.indexOf("x");
+  if (split <= 0) return null;
+  const millis = parseInt(runToken.slice(0, split), 36);
+  return Number.isFinite(millis) && millis > 0 ? millis : null;
+}
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** The prefix every database one run creates from `base` shares. */
+export function runDatabasePrefix(base: string, runToken: string): string {
+  return `${base}_${runToken}_`;
+}
+
+/**
+ * The database for one advisory-lock slot.
+ *
+ * Slot 1 gets `<base>_<token>_1` like every other slot — it deliberately no
+ * longer aliases the bare `activerecord_unittest`. That alias is exactly what
+ * made two concurrent runs collide on the un-suffixed name, and keeping it
+ * would leave the one database `globalSetup` DROPs shared between runs. The
+ * bare base name is now used only when no run token is stamped at all (see
+ * `applySlot` in `config.ts`).
+ */
+export function slotDatabaseName(base: string, runToken: string, slot: number): string {
+  return `${runDatabasePrefix(base, runToken)}${slot}`;
+}
+
+/** The run token a database name carries, or `null` if it carries none. */
+export function runTokenOfDatabase(base: string, name: string): string | null {
+  const match = new RegExp(`^${escapeRegExp(base)}_(${TOKEN_PATTERN})_`).exec(name);
+  return match?.[1] ?? null;
+}
+
+/**
+ * The subset of `names` this run owns — the only databases `globalSetup` and
+ * its teardown may ever DROP. A name minted by a different run (or an
+ * unstamped name such as the bare `activerecord_unittest` a developer keeps by
+ * hand) is never in it.
+ */
+export function ownRunDatabases(base: string, runToken: string, names: string[]): string[] {
+  return names.filter((name) => runTokenOfDatabase(base, name) === runToken);
+}
+
+/**
+ * Databases orphaned by runs that were killed before their teardown ran (a
+ * `^C`-ed vitest). Foreign token *and* older than {@link STALE_DB_AGE_MS}, so a
+ * concurrent run's live databases are out of reach.
+ */
+export function staleRunDatabases(
+  base: string,
+  runToken: string,
+  names: string[],
+  now: number = Date.now(),
+): string[] {
+  return names.filter((name) => {
+    const token = runTokenOfDatabase(base, name);
+    if (token === null || token === runToken) return false;
+    const startedAt = runTokenStartedAt(token);
+    return startedAt !== null && now - startedAt >= STALE_DB_AGE_MS;
+  });
+}
+
+/**
+ * The advisory-lock key pair for a slot: `pg_try_advisory_lock(classId, objId)`
+ * with the run token hashed into the class half, so a second concurrent run
+ * scans a disjoint key space instead of exhausting this run's slot pool.
+ * PostgreSQL advisory-lock keys are signed 32-bit, hence the `| 0`.
+ */
+export function pgAdvisoryLockKey(runToken: string, slot: number): [number, number] {
+  let hash = 0;
+  for (let i = 0; i < runToken.length; i++) {
+    hash = (Math.imul(hash, 31) + runToken.charCodeAt(i)) | 0;
+  }
+  return [hash, slot];
+}
+
+/** The `GET_LOCK` name for a slot — per-run for the same reason. */
+export function mysqlAdvisoryLockName(runToken: string, slot: number): string {
+  return `ar_test_slot_${runToken}_${slot}`;
+}

--- a/packages/activerecord/src/support/run-token.ts
+++ b/packages/activerecord/src/support/run-token.ts
@@ -39,22 +39,30 @@ export const RUN_TOKEN_ENV = "AR_TEST_RUN_TOKEN";
  */
 export const STALE_DB_AGE_MS = 6 * 60 * 60 * 1000;
 
-// `<base36 millis>x<base36 random>`. The leading millis is not decoration: a
-// database name is all the stale sweep has to go on — unlike a temp file, a
-// PostgreSQL database carries no mtime to compare against the cutoff.
-const TOKEN_PATTERN = "[0-9a-z]+x[0-9a-z]+";
+// `r<base36 millis><base36 random>`, the random half fixed-width so the two
+// halves split without a separator — every character base36 produces is itself
+// a legal separator candidate, so there is no safe one to pick.
+//
+// The leading millis is not decoration: a database name is all the stale sweep
+// has to go on — unlike a temp file, a PostgreSQL database carries no mtime to
+// compare against the cutoff. The `r` prefix is what keeps a legacy unstamped
+// leftover like `activerecord_unittest_2_arunit2` from parsing as a run token
+// whose "start time" is the epoch, which would make the sweep drop it.
+const RANDOM_LENGTH = 6;
+const TOKEN_PATTERN = "r[0-9a-z]+";
 
 /** A fresh token for this vitest invocation. */
 export function newRunToken(): string {
-  const random = Math.floor(Math.random() * 36 ** 6).toString(36);
-  return `${Date.now().toString(36)}x${random}`;
+  const random = Math.floor(Math.random() * 36 ** RANDOM_LENGTH)
+    .toString(36)
+    .padStart(RANDOM_LENGTH, "0");
+  return `r${Date.now().toString(36)}${random}`;
 }
 
 /** When the run that minted `runToken` started, or `null` if unparseable. */
 export function runTokenStartedAt(runToken: string): number | null {
-  const split = runToken.indexOf("x");
-  if (split <= 0) return null;
-  const millis = parseInt(runToken.slice(0, split), 36);
+  if (!runToken.startsWith("r") || runToken.length <= RANDOM_LENGTH + 1) return null;
+  const millis = parseInt(runToken.slice(1, -RANDOM_LENGTH), 36);
   return Number.isFinite(millis) && millis > 0 ? millis : null;
 }
 

--- a/packages/activerecord/src/support/sqlite-template.ts
+++ b/packages/activerecord/src/support/sqlite-template.ts
@@ -40,7 +40,10 @@ import type { FsAdapter } from "@blazetrails/activesupport/fs-adapter";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import { getOsAsync } from "@blazetrails/activesupport";
 import { betterSqlite3Driver } from "../sqlite/better-sqlite3.js";
+import { RUN_TOKEN_ENV, STALE_DB_AGE_MS } from "./run-token.js";
 import { activeLane } from "./connection.js";
+
+export { RUN_TOKEN_ENV };
 
 /** WAL sidecars sqlite writes alongside a file DB, plus the DB file itself. */
 const DB_FILE_SUFFIXES = ["", "-wal", "-shm"] as const;
@@ -96,14 +99,6 @@ export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
  * the template, the per-worker clones and their `_2` arunit2 siblings.
  */
 export const TEMP_DB_PREFIX = "ar-test-";
-
-/**
- * Age past which an `ar-test-*` file in tmpdir is assumed to be orphaned by an
- * earlier run and swept. No AR test run comes near this, so the cutoff cannot
- * pull a file out from under a *concurrent* run — which a blanket
- * prefix-unlink would, since parallel worktrees share one tmpdir.
- */
-const STALE_DB_AGE_MS = 6 * 60 * 60 * 1000;
 
 /** Temp-dir entries the harness owns, or `[]` when the fs adapter can't list. */
 async function tempDbEntries(fs: FsAdapter): Promise<string[]> {
@@ -172,8 +167,6 @@ export async function sweepStaleDbFiles(): Promise<void> {
 
 /** Env var: absolute path of the canonical template DB built by globalSetup. */
 export const TEMPLATE_PATH_ENV = "AR_TEST_TEMPLATE_PATH";
-/** Env var: per-run token (stamped by globalSetup) so concurrent worktrees don't collide. */
-export const RUN_TOKEN_ENV = "AR_TEST_RUN_TOKEN";
 /** Env var: per-worker restored DB path (stamped by the worker setupFile). */
 export const WORKER_DB_ENV = "AR_TEST_WORKER_DB";
 

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -25,13 +25,20 @@ import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 import { InternalMetadata } from "../internal-metadata.js";
 import { schemaSha1 } from "../tasks/database-tasks.js";
 import {
-  RUN_TOKEN_ENV,
   TEMPLATE_PATH_ENV,
   isSqliteRun,
   sweepRunDbFiles,
   sweepStaleDbFiles,
   templatePathFor,
 } from "./sqlite-template.js";
+import {
+  RUN_TOKEN_ENV,
+  newRunToken,
+  ownRunDatabases,
+  runDatabasePrefix,
+  slotDatabaseName,
+  staleRunDatabases,
+} from "./run-token.js";
 import { slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 import {
   driverConfig,
@@ -102,7 +109,7 @@ const sqliteAdapter: DbTemplateAdapter = {
 
     await sweepStaleDbFiles();
 
-    const runToken = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    const runToken = newRunToken();
     const templatePath = await templatePathFor(runToken);
 
     const adapter = new BetterSQLite3Adapter(templatePath);
@@ -133,20 +140,43 @@ async function pgTerminateConnections(admin: pg.Client, dbName: string): Promise
   );
 }
 
+async function pgDatabaseNames(admin: pg.Client): Promise<string[]> {
+  const res = await admin.query<{ datname: string }>("SELECT datname FROM pg_database");
+  return res.rows.map((row) => row.datname);
+}
+
+async function pgDropDatabases(admin: pg.Client, names: string[]): Promise<void> {
+  // Sequential: DROP DATABASE takes an exclusive lock on the server's shared
+  // catalogs, so concurrent drops serialize anyway and only add deadlock risk.
+  for (const name of names) {
+    await pgTerminateConnections(admin, name);
+    await admin.query(`DROP DATABASE IF EXISTS "${name}"`);
+  }
+}
+
 const pgAdapter: DbTemplateAdapter = {
   isActive: () => activeLane() === "postgres",
 
   async provision() {
     const settings = postgresSettings();
-    const templateDb = `${settings.database}_template`;
+    // Unstamped, because nothing has stamped `RUN_TOKEN_ENV` yet: `applySlot`
+    // falls through to the bare `activerecord_unittest` in the main process.
+    // That bare name is the *base* every per-run name is built from — it is
+    // never itself provisioned or dropped.
+    const base = settings.database;
+    const runToken = newRunToken();
+    const templateDb = `${runDatabasePrefix(base, runToken)}template`;
 
     // Derive both connections from the settings rather than rewriting the URL
     // string: a socket-directory PGHOST does not survive `new URL()` surgery.
     const admin = new pg.Client(settingsUrl("postgres", withDatabase(settings, "postgres")));
     await admin.connect();
 
-    await pgTerminateConnections(admin, templateDb);
-    await admin.query(`DROP DATABASE IF EXISTS "${templateDb}"`);
+    // Reclaim what killed runs left behind, before anything of this run exists
+    // — the PG analogue of `sweepStaleDbFiles`. Only foreign tokens older than
+    // the cutoff, so a concurrent run's live databases are out of reach.
+    await pgDropDatabases(admin, staleRunDatabases(base, runToken, await pgDatabaseNames(admin)));
+
     await admin.query(`CREATE DATABASE "${templateDb}"`);
 
     const adapter = new PostgreSQLAdapter({
@@ -175,21 +205,28 @@ const pgAdapter: DbTemplateAdapter = {
       }
     }
 
+    // No DROP in front of the CREATE: the names carry this run's token, so
+    // nothing can be occupying them — and a DROP here could only ever hit
+    // another run's live database.
     for (let slot = 1; slot <= slotCount(); slot++) {
-      const slotDb = slot === 1 ? settings.database : `${settings.database}_${slot}`;
-      await pgTerminateConnections(admin, slotDb);
-      await admin.query(`DROP DATABASE IF EXISTS "${slotDb}"`);
+      const slotDb = slotDatabaseName(base, runToken, slot);
       await admin.query(`CREATE DATABASE "${slotDb}" TEMPLATE "${templateDb}"`);
     }
 
     process.env[PG_TEMPLATE_ENV] = templateDb;
+    process.env[RUN_TOKEN_ENV] = runToken;
     await admin.end();
 
     return async () => {
       const cleanup = new pg.Client(settingsUrl("postgres", withDatabase(settings, "postgres")));
       await cleanup.connect();
-      await pgTerminateConnections(cleanup, templateDb);
-      await cleanup.query(`DROP DATABASE IF EXISTS "${templateDb}"`);
+      // Every database this run created — the template, the slot DBs, and the
+      // `_arunit2` siblings suites create off a slot name — shares the run's
+      // prefix, so one filtered sweep reclaims the lot.
+      await pgDropDatabases(
+        cleanup,
+        ownRunDatabases(base, runToken, await pgDatabaseNames(cleanup)),
+      );
       await cleanup.end();
     };
   },
@@ -207,13 +244,30 @@ const pgAdapter: DbTemplateAdapter = {
 
 export const MYSQL_TEMPLATE_ENV = "AR_TEST_MYSQL_TEMPLATE";
 
+async function mysqlDatabaseNames(admin: mysql.Connection): Promise<string[]> {
+  // Aliased: MySQL and MariaDB disagree on the case of `SCHEMA_NAME` in the
+  // result set, and `SHOW DATABASES` names its column `Database`.
+  const [rows] = await admin.query<mysql.RowDataPacket[]>(
+    "SELECT schema_name AS name FROM information_schema.schemata",
+  );
+  return rows.map((row) => String((row as { name: string }).name));
+}
+
+async function mysqlDropDatabases(admin: mysql.Connection, names: string[]): Promise<void> {
+  for (const name of names) {
+    await admin.query(`DROP DATABASE IF EXISTS \`${name}\``);
+  }
+}
+
 const mysqlAdapter: DbTemplateAdapter = {
   isActive: () => activeLane() === "mysql",
 
   async provision() {
     const { Mysql2Adapter } = await import("../connection-adapters/mysql2-adapter.js");
     const settings = mysqlSettings();
+    // Unstamped in the main process, exactly as on the PG path above.
     const baseDb = settings.database;
+    const runToken = newRunToken();
     const n = slotCount();
 
     // Built from the config hash rather than a URL so a socket-configured run
@@ -222,16 +276,24 @@ const mysqlAdapter: DbTemplateAdapter = {
     // through Mysql2Adapter, so it does not get the adapter's `username` → `user`
     // or `socket` → `socketPath` mappings — spell the driver-native keys here.
     const { database: _adminDb, username, socket, ...adminOpts } = driverConfig(settings);
-    // CREATE DATABASE for all slots first (sequential — DDL against the same
-    // server, DROP/CREATE must not race with themselves).
-    const admin = await mysql.createConnection({
+    const adminOptions = {
       ...adminOpts,
       user: username,
       ...(socket === undefined ? {} : { socketPath: socket }),
-    } as mysql.ConnectionOptions);
+    } as mysql.ConnectionOptions;
+    // CREATE DATABASE for all slots first (sequential — DDL against the same
+    // server, CREATE must not race with itself).
+    const admin = await mysql.createConnection(adminOptions);
+    // Reclaim what killed runs left behind — the MySQL analogue of
+    // `sweepStaleDbFiles`; foreign tokens past the cutoff only.
+    await mysqlDropDatabases(
+      admin,
+      staleRunDatabases(baseDb, runToken, await mysqlDatabaseNames(admin)),
+    );
+    // No DROP in front of the CREATE: the names carry this run's token, so
+    // nothing can be occupying them.
     for (let slot = 1; slot <= n; slot++) {
-      const slotDb = slot === 1 ? settings.database : `${settings.database}_${slot}`;
-      await admin.query(`DROP DATABASE IF EXISTS \`${slotDb}\``);
+      const slotDb = slotDatabaseName(baseDb, runToken, slot);
       await admin.query(`CREATE DATABASE \`${slotDb}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`);
     }
     await admin.end();
@@ -243,7 +305,7 @@ const mysqlAdapter: DbTemplateAdapter = {
     await Promise.all(
       Array.from({ length: n }, (_, i) => i + 1).map(async (slot) => {
         const adapter = new Mysql2Adapter({
-          ...driverConfig(withDatabase(settings, slot === 1 ? baseDb : `${baseDb}_${slot}`)),
+          ...driverConfig(withDatabase(settings, slotDatabaseName(baseDb, runToken, slot))),
           connectionLimit: 1,
           flags: ["FOUND_ROWS"],
         }) as unknown as DatabaseAdapter;
@@ -254,7 +316,18 @@ const mysqlAdapter: DbTemplateAdapter = {
     );
 
     process.env[MYSQL_TEMPLATE_ENV] = "1";
-    return undefined;
+    process.env[RUN_TOKEN_ENV] = runToken;
+
+    return async () => {
+      const cleanup = await mysql.createConnection(adminOptions);
+      // Slot DBs plus the `_arunit2` siblings suites create off a slot name —
+      // all share this run's prefix, so one filtered sweep reclaims the lot.
+      await mysqlDropDatabases(
+        cleanup,
+        ownRunDatabases(baseDb, runToken, await mysqlDatabaseNames(cleanup)),
+      );
+      await cleanup.end();
+    };
   },
 };
 

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -39,6 +39,7 @@ import {
   slotDatabaseName,
   staleRunDatabases,
 } from "./run-token.js";
+import { quoteMysqlDatabaseName, quotePgDatabaseName } from "./quote-database-name.js";
 import { slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 import {
   driverConfig,
@@ -150,7 +151,7 @@ async function pgDropDatabases(admin: pg.Client, names: string[]): Promise<void>
   // catalogs, so concurrent drops serialize anyway and only add deadlock risk.
   for (const name of names) {
     await pgTerminateConnections(admin, name);
-    await admin.query(`DROP DATABASE IF EXISTS "${name}"`);
+    await admin.query(`DROP DATABASE IF EXISTS ${quotePgDatabaseName(name)}`);
   }
 }
 
@@ -177,7 +178,7 @@ const pgAdapter: DbTemplateAdapter = {
     // the cutoff, so a concurrent run's live databases are out of reach.
     await pgDropDatabases(admin, staleRunDatabases(base, runToken, await pgDatabaseNames(admin)));
 
-    await admin.query(`CREATE DATABASE "${templateDb}"`);
+    await admin.query(`CREATE DATABASE ${quotePgDatabaseName(templateDb)}`);
 
     const adapter = new PostgreSQLAdapter({
       connectionString: settingsUrl("postgres", withDatabase(settings, templateDb)),
@@ -210,7 +211,9 @@ const pgAdapter: DbTemplateAdapter = {
     // another run's live database.
     for (let slot = 1; slot <= slotCount(); slot++) {
       const slotDb = slotDatabaseName(base, runToken, slot);
-      await admin.query(`CREATE DATABASE "${slotDb}" TEMPLATE "${templateDb}"`);
+      await admin.query(
+        `CREATE DATABASE ${quotePgDatabaseName(slotDb)} TEMPLATE ${quotePgDatabaseName(templateDb)}`,
+      );
     }
 
     process.env[PG_TEMPLATE_ENV] = templateDb;
@@ -255,7 +258,7 @@ async function mysqlDatabaseNames(admin: mysql.Connection): Promise<string[]> {
 
 async function mysqlDropDatabases(admin: mysql.Connection, names: string[]): Promise<void> {
   for (const name of names) {
-    await admin.query(`DROP DATABASE IF EXISTS \`${name}\``);
+    await admin.query(`DROP DATABASE IF EXISTS ${quoteMysqlDatabaseName(name)}`);
   }
 }
 
@@ -291,7 +294,9 @@ const mysqlAdapter: DbTemplateAdapter = {
     );
     for (let slot = 1; slot <= n; slot++) {
       const slotDb = slotDatabaseName(baseDb, runToken, slot);
-      await admin.query(`CREATE DATABASE \`${slotDb}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`);
+      await admin.query(
+        `CREATE DATABASE ${quoteMysqlDatabaseName(slotDb)} CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`,
+      );
     }
     await admin.end();
 

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -284,14 +284,11 @@ const mysqlAdapter: DbTemplateAdapter = {
     // CREATE DATABASE for all slots first (sequential — DDL against the same
     // server, CREATE must not race with itself).
     const admin = await mysql.createConnection(adminOptions);
-    // Reclaim what killed runs left behind — the MySQL analogue of
-    // `sweepStaleDbFiles`; foreign tokens past the cutoff only.
+    // Stale sweep, as on the PG path above.
     await mysqlDropDatabases(
       admin,
       staleRunDatabases(baseDb, runToken, await mysqlDatabaseNames(admin)),
     );
-    // No DROP in front of the CREATE: the names carry this run's token, so
-    // nothing can be occupying them.
     for (let slot = 1; slot <= n; slot++) {
       const slotDb = slotDatabaseName(baseDb, runToken, slot);
       await admin.query(`CREATE DATABASE \`${slotDb}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`);
@@ -320,8 +317,6 @@ const mysqlAdapter: DbTemplateAdapter = {
 
     return async () => {
       const cleanup = await mysql.createConnection(adminOptions);
-      // Slot DBs plus the `_arunit2` siblings suites create off a slot name —
-      // all share this run's prefix, so one filtered sweep reclaims the lot.
       await mysqlDropDatabases(
         cleanup,
         ownRunDatabases(baseDb, runToken, await mysqlDatabaseNames(cleanup)),

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -14,8 +14,12 @@
  * every consumer derives the same worker database from one signal instead of
  * reading a mutated string.
  *
- *   PG:      pg_try_advisory_lock(N)
- *   MariaDB: GET_LOCK('ar_test_slot_N', 0)  — 0-second timeout = non-blocking
+ *   PG:      pg_try_advisory_lock(hash(runToken), N)
+ *   MariaDB: GET_LOCK('ar_test_slot_<runToken>_N', 0) — 0s timeout = non-blocking
+ *
+ * Both keys carry the run token because advisory locks are server-wide, not
+ * database-scoped: without it, a second concurrent run against the same server
+ * competes for — and exhausts — this run's pool of `workers + headroom` locks.
  *
  * Idempotent: the claimed slot is cached on globalThis so re-evaluation
  * (e.g. hot-module reloading in vitest watch mode) returns the same slot
@@ -37,7 +41,17 @@ import "./sqlite/better-sqlite3.js";
 import { WORKER_DB_ENV, ensureWorkerClone } from "./support/sqlite-template.js";
 import { slotPoolSize, workerForkCount } from "./support/ar-db-slots.js";
 import { SLOT_ENV, mysqlSettings, postgresSettings } from "./support/config.js";
+import { RUN_TOKEN_ENV, mysqlAdvisoryLockName, pgAdvisoryLockKey } from "./support/run-token.js";
 import { activeLane } from "./support/connection.js";
+
+// The run token globalSetup stamped before this worker forked. Advisory locks
+// are server-wide, not database-scoped, so keying them on the bare slot number
+// let a second concurrent run exhaust this run's slot pool. Deriving the key
+// from the token gives each run a disjoint key space. Empty when globalSetup
+// did not run, which is still a single consistent key space for that run.
+function runToken(): string {
+  return process.env[RUN_TOKEN_ENV] ?? "";
+}
 
 // Shared by all evaluations of this module within the same worker process.
 const g = globalThis as typeof globalThis & {
@@ -87,8 +101,8 @@ async function acquireAdvisorySlotPg(): Promise<number> {
   for (let attempt = 0; attempt < SLOT_RETRY_ATTEMPTS; attempt++) {
     for (let slot = 1; slot <= slots; slot++) {
       const res = await client.query<{ locked: boolean }>(
-        "SELECT pg_try_advisory_lock($1) AS locked",
-        [slot],
+        "SELECT pg_try_advisory_lock($1, $2) AS locked",
+        pgAdvisoryLockKey(runToken(), slot),
       );
       if (res.rows[0]?.locked) {
         g.__arAdvisorySlotPg = slot;
@@ -127,7 +141,7 @@ async function acquireAdvisorySlotMysql(): Promise<number> {
 
   for (let attempt = 0; attempt < SLOT_RETRY_ATTEMPTS; attempt++) {
     for (let slot = 1; slot <= slots; slot++) {
-      const lockName = `ar_test_slot_${slot}`;
+      const lockName = mysqlAdvisoryLockName(runToken(), slot);
       // GET_LOCK returns 1 when acquired, 0 when timeout (0 s = non-blocking).
       const [rows] = await conn.query<mysql.RowDataPacket[]>("SELECT GET_LOCK(?, 0) AS acquired", [
         lockName,


### PR DESCRIPTION
Within one vitest run every worker already gets its own database. Across two
concurrent runs on one PG/MySQL server they did not: the slot databases carried
no per-run discriminator, so run B's `globalSetup` DROPped and recreated
`activerecord_unittest`, `activerecord_unittest_2`, … while run A's workers were
connected to them, and both runs competed for one server-wide pool of advisory
locks. The sqlite lane already solved this with a run token; this ports the same
idea to PG and MySQL.

## What changed

`support/run-token.ts` (new) is the single signal both lanes derive from: it
owns `AR_TEST_RUN_TOKEN`, mints the token, and holds every naming rule built on
it. `sqlite-template.ts` now sources `RUN_TOKEN_ENV` / `STALE_DB_AGE_MS` from
there instead of declaring its own, so all four lanes share one token format.

- **Database names.** Every database a run creates is
  `<base>_<runToken>_<slot>`, plus `<base>_<runToken>_template` for the PG clone
  template and the `_arunit2` siblings suites derive off a slot name. `applySlot`
  in `config.ts` computes the identical name in the workers from the same
  `(token, slot)` pair — the "derive from one signal, never rewrite a URL string"
  property is preserved.
- **Advisory-lock keys.** PG moves to the two-int
  `pg_try_advisory_lock(hash(runToken), slot)`; MySQL's `GET_LOCK` name becomes
  `ar_test_slot_<runToken>_<slot>`. Two runs now scan disjoint key spaces, so a
  second run cannot exhaust the first's pool.
- **DROP is scoped to the run.** The provisioning loops no longer `DROP DATABASE
  IF EXISTS` ahead of each `CREATE`: the names carry this run's token, so nothing
  can be occupying them and a DROP there could only ever hit another run's live
  database. Every drop now goes through `ownRunDatabases`, which filters by token.
- **Teardown + stale sweep.** Both lanes gained a teardown that drops the run's
  databases (the analogue of `sweepRunDbFiles`), and `globalSetup` opens with a
  stale sweep of foreign-token databases older than `STALE_DB_AGE_MS` — the
  analogue of `sweepStaleDbFiles`, for runs killed before teardown. MySQL had no
  teardown at all before, so repeated local runs accumulated databases.

## Decision: slot 1 no longer aliases the base database

`applySlot` used to treat slot 1 as "the shared base database"
(`activerecord_unittest`). That alias is precisely what made two runs collide on
the un-suffixed name, so with a run token stamped slot 1 now gets
`<base>_<token>_1` like every other slot, and the bare `activerecord_unittest` is
never provisioned, connected to, or dropped by a stamped run. It stays the *base*
the per-run names are built from. When no token is stamped at all — a bare
adapter script, or a harness-less connection — the historical
shared-base-plus-`_N` naming still stands, and `config.test.ts` pins both paths.

## Verification

Two concurrent runs against one server on default ports, PG and MySQL:

- **PG, on `main`:** run A dies with
  `23505 Key (datname)=(activerecord_unittest_template) already exists` — the
  documented failure signature.
- **PG, with this change:** both runs pass (236 tests each), and the server is
  left with only the bare `activerecord_unittest`.
- **MySQL, with this change:** both runs pass, server likewise clean.

`run-token.test.ts` covers the drop-target rule directly ("never targets a
database belonging to a different run token") plus the stale-sweep cutoff and the
lock-key derivation. Behaviour for a single run is unchanged: fork count, slot
pool sizing and `ar-db-forks-parity.test.ts` all still hold, and the
`activerecord_unittest_3` + `"2"` → `activerecord_unittest_32` trap
`arunit2-config.ts` documents is untouched. CI is unaffected — each job already
gets its own service container, so no workflow edit.

One bug the tests caught while writing them: the token first split its two halves
on a literal `x`, which `Date.now().toString(36)` itself contains most of any
given day. The parsed start time was then garbage and the stale sweep would have
dropped a concurrent run's live databases. The halves now split on a fixed-width
random suffix, and the `r` prefix keeps a legacy unstamped leftover from parsing
as a token.

## Rails anchor

These files have no Rails counterpart in the compare populations — Rails runs a
single database prepared by `db:test:prepare`, and `test/config.yml` has no knob
for parallel slot databases. The nearest analogue is
`activerecord/lib/active_record/test_databases.rb:11-14`, which suffixes the
configured name with the worker index alone:

    db_config._database = "#{db_config.database}-#{i}"

No run token, because Rails' parallelism is one process tree against one server.
trails needs the extra discriminator only because several agents run vitest
concurrently against a shared local server — which is why the token is stamped
in `globalSetup` rather than pushed into `config.ts`'s Rails-mirroring
`expand_config` surface. `support/config.ts` already documents `SLOT_ENV` as
"the one addition with no Rails counterpart"; `AR_TEST_RUN_TOKEN` joins it there
and nothing about the mirrored `ARTest.config` shape changes.

## Merge checks

- **Rails fidelity** — n/a by construction, per the anchor above; no
  Rails-mirroring method was added, moved or removed.
- **No stubs** — every exported function has a real body; no TODO/FIXME/
  placeholder in the diff.
- **api:compare / test:compare delta** — **0, non-negative**. None of the seven
  changed files appears in `output/api-comparison.json` (all are harness files
  outside the Rails-mapped population), and no `*.test.ts` in the test-compare
  population changed — `run-token.test.ts` lives in `src/support/`, which that
  population excludes. Data-layer 7723/7816 and overall 11741/17536 are
  unmoved. The advisory `api:extra` audit gains 9 novel entries for
  `run-token.ts`, in line with its unallowlisted peers there (`config.ts` 9,
  `sqlite-template.ts` 7); that report is fact-finding and is not CI-gated.

## Review fix: identifier quoting on the sweep paths

The sweeps build DDL from names read out of `pg_database` /
`information_schema.schemata`, not from names this codebase composed, and
`runTokenOfDatabase` matches on the run-token *prefix* — everything after it is
unconstrained. A leftover such as `activerecord_unittest_<token>_1"evil` was
therefore interpolated raw into `DROP DATABASE`, making it a syntax error and
wedging every future `globalSetup` on the sweep meant to unwedge it.

`support/quote-database-name.ts` (new) applies the rule Rails' `drop_database`
uses on both adapters (`postgresql/schema_statements.rb:53-54`,
`abstract_mysql_adapter.rb:292-293`, via `quote_table_name`), whose escape is
`quote_column_name`'s doubled quote character (`postgresql/quoting.rb:46-48`,
`mysql/quoting.rb:46-48`) — the same spelling trails' ported
`DatabaseTasks.drop` already uses. `globalSetup` runs against the raw `pg` /
`mysql2` drivers rather than an adapter, so it cannot reach those methods.
All six `CREATE`/`DROP DATABASE` sites now route through it.

Rails' MySQL `quote_table_name` additionally splits on dots into a qualified
name; that part is deliberately not mirrored, since a database name is never
schema-qualified and the split would corrupt exactly the dotted leftover being
dropped. Noted at the call site.

Verified on a live server both ways: with a stale `..._1"evil` database planted,
the unquoted spelling dies with `42601 syntax error at or near "evil"` before
any test runs, and the quoted one sweeps it and passes. The MySQL equivalent
(a backtick in the name) sweeps clean too.

Closes-story: stamp-run-token-into-pg-mysql-slot-databases


