### PR TITLE
refactor(activerecord): route Migration#changeTable through the SchemaStatements companion

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { MysqlSchemaStatements } from "./schema-statements.js";
+import { Table as MysqlTable } from "./schema-definitions.js";
+
+// Rails defines MySQL::SchemaStatements#update_table_definition on the module the
+// adapter includes, so the inherited change_table yields MySQL::Table. In trails
+// the module is a companion class, and Migration#schema hands back that companion
+// — this pins the override on the companion rather than on the adapter.
+describe("MysqlSchemaStatements#changeTable", () => {
+  it("yields the MySQL Table subclass", async () => {
+    const ss = new MysqlSchemaStatements({ adapterName: "mysql" } as never);
+    let yielded: unknown;
+    await ss.changeTable("things", (t) => {
+      yielded = t;
+    });
+    expect(yielded).toBeInstanceOf(MysqlTable);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
@@ -2,10 +2,6 @@ import { describe, it, expect } from "vitest";
 import { MysqlSchemaStatements } from "./schema-statements.js";
 import { Table as MysqlTable } from "./schema-definitions.js";
 
-// Rails defines MySQL::SchemaStatements#update_table_definition on the module the
-// adapter includes, so the inherited change_table yields MySQL::Table. In trails
-// the module is a companion class, and Migration#schema hands back that companion
-// — this pins the override on the companion rather than on the adapter.
 describe("MysqlSchemaStatements#changeTable", () => {
   it("yields the MySQL Table subclass", async () => {
     const ss = new MysqlSchemaStatements({ adapterName: "mysql" } as never);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { PostgreSQLSchemaStatements } from "./schema-statements-class.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
+import { Table as PgTable } from "./schema-definitions.js";
 
 interface FakeOptions {
   logger?: { warn: (msg: string) => void };
@@ -231,5 +232,17 @@ describe("PostgreSQLSchemaStatements#typeToSql enum validation", () => {
     expect(() => ss.typeToSql("enum")).toThrow(
       new ArgumentError("enum_type is required for enums"),
     );
+  });
+});
+
+describe("PostgreSQLSchemaStatements#changeTable", () => {
+  it("yields the PostgreSQL Table subclass", async () => {
+    const { adapter } = makeAdapter();
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    let yielded: unknown;
+    await ss.changeTable("things", (t) => {
+      yielded = t;
+    });
+    expect(yielded).toBeInstanceOf(PgTable);
   });
 });

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -217,9 +217,6 @@ describe("MigrationTest", () => {
     const seen: unknown[] = [];
     class M extends Migration {}
     const m = new M();
-    // Rails reaches update_table_definition through the SchemaStatements module the
-    // adapter includes; trails models that module as the companion `schemaStatements()`
-    // returns, so an adapter-specific Table must come from there.
     const companion = {
       updateTableDefinition(tableName: string, base: unknown) {
         seen.push([tableName, base]);

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -217,11 +217,20 @@ describe("MigrationTest", () => {
     const seen: unknown[] = [];
     class M extends Migration {}
     const m = new M();
-    (m as unknown as { _connectionOverride: unknown })._connectionOverride = {
+    // Rails reaches update_table_definition through the SchemaStatements module the
+    // adapter includes; trails models that module as the companion `schemaStatements()`
+    // returns, so an adapter-specific Table must come from there.
+    const companion = {
       updateTableDefinition(tableName: string, base: unknown) {
         seen.push([tableName, base]);
         return new AdapterTable(tableName, base as never);
       },
+    };
+    (m as unknown as { _connectionOverride: unknown })._connectionOverride = {
+      quoteIdentifier: (n: string) => n,
+      quoteTableName: (n: string) => n,
+      quoteDefaultExpression: (v: unknown) => String(v),
+      schemaStatements: () => companion,
     };
 
     let yielded: unknown;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -995,12 +995,7 @@ export abstract class Migration {
       await this.schema.changeTable(tname, options, callback);
       return;
     }
-    const delegate = this.connection as unknown as {
-      updateTableDefinition?(tableName: string, base: unknown): Table;
-    };
-    const table = delegate.updateTableDefinition
-      ? delegate.updateTableDefinition(tableName, this)
-      : this.schema.updateTableDefinition(tableName, this);
+    const table = this.schema.updateTableDefinition(tableName, this);
     if (callback) await callback(table);
   }
 


### PR DESCRIPTION
`update_table_definition` in Rails lives once per adapter, in the
`SchemaStatements` module the adapter includes
(`abstract/schema_statements.rb:1472`, `postgresql/schema_statements.rb:880`,
`mysql/schema_statements.rb:103`). trails already carries the PG/MySQL
overrides on the companion classes (`PostgreSQLSchemaStatements`,
`MysqlSchemaStatements`) that `Migration#schema` hands back — but
`Migration#changeTable` still probed the connection for an optional
adapter-level `updateTableDefinition` and fell back to the companion. That
optional-probe dispatch has no Rails counterpart.

- `Migration#changeTable` now calls `this.schema.updateTableDefinition(...)`
  unconditionally; the probe and fallback are gone.
- No duplicate definition on the adapter classes: `MysqlSchemaStatements` owns
  the MySQL override, and `PostgreSQLAdapter#updateTableDefinition` remains a
  one-line delegate to `pgSchemaStatements()` (needed by
  `CommandRecorder#changeTable`, which mirrors Rails' `delegate` being the
  connection) rather than a re-implementation.
- Companion-level coverage added: `PostgreSQLSchemaStatements#changeTable`
  yields `PostgreSQL::Table` and `MysqlSchemaStatements#changeTable` yields
  `MySQL::Table`.
- `migration.trails.test.ts` "changeTable yields the adapter's
  updateTableDefinition result" keeps its name and now stubs the connection's
  `schemaStatements()` companion, which is the surface Rails' `include`
  corresponds to.

Closes-story: update-table-definition-single-home-per-adapter
