### PR TITLE
fix(activerecord): spell the arunit2 database as expand_config does

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -28,11 +28,11 @@ export {
  * `arunit2` — and reads both names from `ARTest.test_configuration_hashes`.
  * Rails' cross-database-select probe references them by those configured
  * names rather than inventing throwaway databases. trails provisions a single
- * MySQL server, so the names are derived from its `database` sub-setting
- * by suffixing the primary database (see `arunit2-config`). They are dedicated
- * to the cross-database probe — kept off the shared primary, whose canonical
- * tables parallel test workers create and drop — but config-derived, not
- * invented per call.
+ * MySQL server, so the names are derived from its `database` sub-setting (see
+ * `arunit2-config`). They are config-derived, not invented per call, and
+ * `arunit` is kept off the shared primary — whose canonical tables parallel
+ * test workers create and drop — because this probe drops and recreates both
+ * databases it names.
  */
 export const { arunit: ARUNIT_DATABASE, arunit2: ARUNIT2_DATABASE } = arunitDatabaseNames(
   mysqlSettings().database,

--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -3,15 +3,22 @@ import { arunitDatabaseNames } from "./arunit2-config.js";
 
 describe("arunit2-config", () => {
   it("arunitDatabaseNames suffixes the primary database name", () => {
+    // At slot 1 the arunit2 name is `expand_config`'s own literal
+    // (`test/support/config.rb:28`).
     expect(arunitDatabaseNames("activerecord_unittest")).toEqual({
       arunit: "activerecord_unittest_arunit",
-      arunit2: "activerecord_unittest_arunit2",
+      arunit2: "activerecord_unittest2",
     });
   });
 
   it("carries the worker isolation slot into the arunit2 database name", () => {
-    expect(arunitDatabaseNames("activerecord_unittest_3").arunit2).toBe(
-      "activerecord_unittest_3_arunit2",
+    // The `2` lands before the slot, so this is not slot 32's database.
+    expect(arunitDatabaseNames("activerecord_unittest_3")).toEqual({
+      arunit: "activerecord_unittest_3_arunit",
+      arunit2: "activerecord_unittest2_3",
+    });
+    expect(arunitDatabaseNames("activerecord_unittest_32").arunit2).toBe(
+      "activerecord_unittest2_32",
     );
   });
 });

--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -3,8 +3,6 @@ import { arunitDatabaseNames } from "./arunit2-config.js";
 
 describe("arunit2-config", () => {
   it("arunitDatabaseNames suffixes the primary database name", () => {
-    // At slot 1 the arunit2 name is `expand_config`'s own literal
-    // (`test/support/config.rb:28`).
     expect(arunitDatabaseNames("activerecord_unittest")).toEqual({
       arunit: "activerecord_unittest_arunit",
       arunit2: "activerecord_unittest2",
@@ -12,7 +10,6 @@ describe("arunit2-config", () => {
   });
 
   it("carries the worker isolation slot into the arunit2 database name", () => {
-    // The `2` lands before the slot, so this is not slot 32's database.
     expect(arunitDatabaseNames("activerecord_unittest_3")).toEqual({
       arunit: "activerecord_unittest_3_arunit",
       arunit2: "activerecord_unittest2_3",

--- a/packages/activerecord/src/support/arunit2-config.ts
+++ b/packages/activerecord/src/support/arunit2-config.ts
@@ -10,41 +10,56 @@
  *
  * trails provisions a single server per adapter, so rather than maintaining a
  * separate config file we derive the two database names from the primary
- * connection's `database` sub-setting by suffixing. This keeps the names
- * config-derived (not invented per call) and dedicated to the cross-pool
- * work — off the shared primary database whose canonical tables parallel
- * workers create and drop.
+ * connection's `database` sub-setting. This keeps the names config-derived
+ * (not invented per call) and dedicated to the cross-pool work — off the
+ * shared primary database whose canonical tables parallel workers create and
+ * drop.
  *
  * The *connection names* are already first-class: `support/connection.ts`
  * publishes `arunit`, `arunit2` and `arunit_without_prepared_statements` as
  * named entries on `Base.configurations`, and `connect` establishes both pools
- * by name (`connection.rb:32-33`). Only the *database names* stay
- * suffix-derived, because they must carry the per-worker isolation slot that
- * Rails' static `config.yml` has no equivalent of — a checked-in name would
- * collide across parallel workers.
+ * by name (`connection.rb:32-33`). Only the *database names* are derived,
+ * because they must carry the per-worker isolation slot that Rails' static
+ * `config.yml` has no equivalent of — a checked-in name would collide across
+ * parallel workers.
  *
  * @internal
  */
 
+/**
+ * The `_N` worker-isolation slot `support/config.ts`'s `applySlot` appends to
+ * the primary database name (slot 1 gets none).
+ */
+const SLOT_SUFFIX = /_\d+$/;
+
 const ARUNIT_SUFFIX = "_arunit";
-const ARUNIT2_SUFFIX = "_arunit2";
 
 /**
  * The config-derived `arunit` / `arunit2` database names for a primary
- * database. Both are the primary database name plus a fixed suffix, mirroring
- * how `ARTest.test_configuration_hashes` exposes two named databases.
+ * database, mirroring how `ARTest.test_configuration_hashes` exposes two named
+ * databases.
  *
- * Rails' own pair is `activerecord_unittest` / `activerecord_unittest2` — the
- * second is the first plus `"2"` (`test/support/config.rb:28`). trails cannot
- * spell it that way because the primary name already carries the per-worker
- * `AR_DB_SLOT` suffix: appending `"2"` to slot 3's `activerecord_unittest_3`
- * yields `activerecord_unittest_32`, which is slot 32's database. The `_arunit`
- * / `_arunit2` suffixes keep the pair collision-free per slot.
+ * `arunit2` is spelled the way `expand_config` spells it — the primary name
+ * plus a literal `"2"` (`test/support/config.rb:28`) — so at slot 1 (local
+ * runs and every un-sharded lane) it is Rails' own `activerecord_unittest2`.
+ * The `"2"` goes *before* the slot suffix rather than after it, which is the
+ * one unavoidable deviation: appending it to slot 3's
+ * `activerecord_unittest_3` would yield `activerecord_unittest_32`, i.e. slot
+ * 32's own database. Written this way slot 3 gets `activerecord_unittest2_3`,
+ * which no slot can collide with, since primary names never carry the `2`.
+ *
+ * `arunit` keeps a `_arunit` suffix and so is *not* the primary database,
+ * unlike Rails'. It exists for the MySQL cross-database-select probe
+ * (`adapter_test.rb`), which drops and recreates both databases it names — on
+ * the primary that would destroy the worker's canonical schema mid-run,
+ * something Rails can afford only because its `arunit` is not shared with
+ * parallel workers.
  */
 export function arunitDatabaseNames(primaryDatabase: string): {
   arunit: string;
   arunit2: string;
 } {
-  const base = primaryDatabase;
-  return { arunit: `${base}${ARUNIT_SUFFIX}`, arunit2: `${base}${ARUNIT2_SUFFIX}` };
+  const slot = SLOT_SUFFIX.exec(primaryDatabase)?.[0] ?? "";
+  const base = slot === "" ? primaryDatabase : primaryDatabase.slice(0, -slot.length);
+  return { arunit: `${primaryDatabase}${ARUNIT_SUFFIX}`, arunit2: `${base}2${slot}` };
 }

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -45,8 +45,6 @@ describe("connect", () => {
     const { configurationHashes } = await testConfigurationHashes();
     const [arunit, arunit2, withoutPrepared] = configurationHashes;
     expect(arunit2.database).not.toBe(arunit.database);
-    // `expand_config`'s literal name (`support/config.rb:28`), with any worker
-    // slot suffix trailing it.
     expect(arunit2.database).toMatch(/^activerecord_unittest2(_\d+)?$/);
     expect(withoutPrepared.database).toBe(arunit.database);
     expect(withoutPrepared.configurationHash.preparedStatements).toBe(false);

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -45,7 +45,9 @@ describe("connect", () => {
     const { configurationHashes } = await testConfigurationHashes();
     const [arunit, arunit2, withoutPrepared] = configurationHashes;
     expect(arunit2.database).not.toBe(arunit.database);
-    expect(arunit2.database).toMatch(/_arunit2$/);
+    // `expand_config`'s literal name (`support/config.rb:28`), with any worker
+    // slot suffix trailing it.
+    expect(arunit2.database).toMatch(/^activerecord_unittest2(_\d+)?$/);
     expect(withoutPrepared.database).toBe(arunit.database);
     expect(withoutPrepared.configurationHash.preparedStatements).toBe(false);
   });

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -241,8 +241,9 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
  * Rails defaults the databases to `activerecord_unittest` /
  * `activerecord_unittest2` / `activerecord_unittest` (`config.rb:27-28`);
  * trails takes them from the sub-settings instead, so `arunit` is the worker
- * database the canonical schema is loaded into, `arunit2` its derived sibling,
- * and `arunit_without_prepared_statements` shares `arunit`'s database as it
+ * database the canonical schema is loaded into and `arunit2` its derived
+ * sibling — which at slot 1 is Rails' literal `activerecord_unittest2`
+ * ({@link arunitDatabaseNames}) — and `arunit_without_prepared_statements` shares `arunit`'s database as it
  * shares `activerecord_unittest` in Rails.
  */
 function expandConfig(


### PR DESCRIPTION
Rails' `ARTest.expand_config` names the second test database
`activerecord_unittest2` — the primary name plus a literal `"2"`
(`test/support/config.rb:28`). trails used a `_arunit2` suffix instead, because
appending `"2"` *after* the per-worker `AR_DB_SLOT` suffix would turn slot 3's
`activerecord_unittest_3` into `activerecord_unittest_32`, i.e. slot 32's own
database.

This takes the first option in the story's acceptance criteria: a slot-safe
spelling that still yields Rails' literal name at slot 1. The `"2"` is inserted
*before* the slot suffix, so slot 1 (local runs and every un-sharded lane) gets
`activerecord_unittest2`, and slot 3 gets `activerecord_unittest2_3` — which no
primary name can collide with, since primary names never carry the `2`.

`arunit` keeps its `_arunit` suffix and is deliberately not the primary
database: the MySQL cross-database-select probe (`adapter_test.rb`) drops and
recreates both databases it names, which the worker's shared primary cannot
survive. That reason is now recorded at the call site rather than left to be
re-derived.

Closes-story: arunit2-database-name-diverges-from-expand-config
