### PR TITLE
fix(docker): mount db data dirs on tmpfs in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,11 @@ the harness connects as `username: rails` with no password
 `ARTest.expand_config` fills in (`test/support/config.rb:28-34`).
 `docker-compose.yml` and the CI service containers provision that user the way
 `rake db:mysql:build_user` does (`activerecord/Rakefile:227-235`) — so
-`docker compose up` is all a local run needs. On Postgres, Rails' entries carry
+`docker compose up` is all a local run needs. Both services keep their data
+directory on `tmpfs`, matching the CI service containers: the test databases are
+throwaway, and keeping per-DDL fsync traffic in RAM is what keeps DDL-heavy
+files inside their default timeouts. Restarting a container therefore re-runs
+the init scripts from an empty datadir. On Postgres, Rails' entries carry
 no credential at all, so `PGUSER` / `PGPASSWORD` stay unset unless you set them
 and `pg` resolves libpq's own defaults.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,6 @@ services:
       POSTGRES_INITDB_ARGS: "--no-sync"
     volumes:
       - ./scripts/db-init/postgres:/docker-entrypoint-initdb.d:ro
-    # tmpfs: keeps the data dir in RAM so per-DDL fsync traffic never hits
-    # disk. Mirrors CI (.github/workflows/ci.yml), where a side-by-side
-    # experiment measured ~17% faster on this DDL-heavy suite. Without it,
-    # DDL-heavy files (e.g. drop-all-tables.test.ts) blow their default
-    # vitest timeouts locally. The DB is throwaway per-run.
     tmpfs:
       - /var/lib/postgresql/data
     healthcheck:
@@ -34,8 +29,6 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - ./scripts/db-init/mysql:/docker-entrypoint-initdb.d:ro
-    # tmpfs: see the postgres service above — same rationale, same CI mirror
-    # (--mount type=tmpfs,destination=/var/lib/mysql).
     tmpfs:
       - /var/lib/mysql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,16 @@ services:
       # Rails' postgresql: entries carry no credential (config.example.yml:74-81),
       # so the `rails` role created by the init script below has no password.
       POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_INITDB_ARGS: "--no-sync"
     volumes:
       - ./scripts/db-init/postgres:/docker-entrypoint-initdb.d:ro
+    # tmpfs: keeps the data dir in RAM so per-DDL fsync traffic never hits
+    # disk. Mirrors CI (.github/workflows/ci.yml), where a side-by-side
+    # experiment measured ~17% faster on this DDL-heavy suite. Without it,
+    # DDL-heavy files (e.g. drop-all-tables.test.ts) blow their default
+    # vitest timeouts locally. The DB is throwaway per-run.
+    tmpfs:
+      - /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
@@ -26,6 +34,10 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - ./scripts/db-init/mysql:/docker-entrypoint-initdb.d:ro
+    # tmpfs: see the postgres service above — same rationale, same CI mirror
+    # (--mount type=tmpfs,destination=/var/lib/mysql).
+    tmpfs:
+      - /var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 2s


### PR DESCRIPTION
`docker-compose.yml`'s `mysql:8` and `postgres:17` services kept their data
dirs on disk, so every DDL fsynced. CI already mounts both on tmpfs
(`.github/workflows/ci.yml`, `--mount type=tmpfs,destination=...`) with a
measured ~17% suite win, so only local `docker compose` runs paid the cost —
`packages/activerecord/src/support/drop-all-tables.test.ts` blew its 5s test /
30s hook timeouts locally, taking ~40s of test time for the same DDL.

This adds `tmpfs:` mounts for `/var/lib/mysql` and `/var/lib/postgresql/data`,
plus `POSTGRES_INITDB_ARGS: --no-sync` to match CI's initdb knob. The
databases are throwaway per-run, so losing them on container stop is fine.

## Verification

With the new compose file up (isolated project, mysql2 lane), at default
timeouts:

```
✓ packages/activerecord/src/support/drop-all-tables.test.ts (10 tests) 625ms
Test Files  1 passed (1)
```

Closes-story: docker-compose-db-services-lack-ci-tmpfs
