### PR TITLE
fix(activerecord): issue nested-attributes displacement load after build

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -529,6 +529,15 @@ export class HasOneAssociation extends SingularAssociation {
    * marks the association loaded, so the writer takes the decision here, before
    * the build, and invokes the thunk after it.
    *
+   * The writer invokes the thunk only when `build` returns normally, which
+   * would suppress a query for a throw from the `set_new_record` half — Rails
+   * reaches everything past has_one_association.rb:62 with `load_target`
+   * already run. That half is unreachable on this path: `raise_on_type_mismatch!`
+   * (:60) is the sole pre-`load_target` raise and cannot fire for a record the
+   * association built from its own reflection, and with
+   * `buildDisplacementOwnedByCaller` set the remainder is `setNewRecord`'s
+   * in-memory foreign-key/inverse writes.
+   *
    * `protected` for the same reason as `buildDisplacementOwnedByCaller`: this is
    * association-internal bookkeeping, not API surface. The writer lives outside
    * the class hierarchy and reaches it through its duck-typed handle.

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -273,8 +273,9 @@ export class HasOneAssociation extends SingularAssociation {
    * `detachDisplacedTarget`) and the nested-attributes writer
    * (nested-attributes.ts, a synchronous property setter that starts
    * `detachDisplacedTarget` — for a loaded target — or
-   * `detachDisplacedForSyncBuild` — for an unloaded one, which runs the leading
-   * `load_target` itself — at assignment, and drains it in its `save` wrapper).
+   * `prepareDetachDisplacedForSyncBuild` — for an unloaded one, which runs the
+   * leading `load_target` itself — around the build, and drains it in its `save`
+   * wrapper).
    * Both call `build` on their way through, and without this flag `build` would
    * re-run the load and start a *second*, concurrent removal of the same row.
    *
@@ -517,11 +518,16 @@ export class HasOneAssociation extends SingularAssociation {
    * in memory; this covers the row that only ever existed in the DB.
    *
    * The synchronous writer (`pirate.shipAttributes = {...}`) cannot await the
-   * SELECT, so it calls this at assignment — Rails' timing for *issuing* the
-   * query — and parks the returned promise on the owner, draining it in the
-   * `save` wrapper exactly like `detachDisplacedTarget`'s. Null when Rails would
-   * issue no query at all (`find_target?`) or when the target is already loaded,
+   * SELECT, so it parks the promise on the owner and drains it in the `save`
+   * wrapper exactly like `detachDisplacedTarget`'s. Null when Rails would issue
+   * no query at all (`find_target?`) or when the target is already loaded,
    * which keeps the writer synchronous on those paths.
+   *
+   * Returns a *thunk* rather than the promise: Rails reaches `load_target` from
+   * `set_new_record`, i.e. after `build_record`, so a build that raises issues
+   * no query. The gate (`find_target?`) stops being observable once `build`
+   * marks the association loaded, so the writer takes the decision here, before
+   * the build, and invokes the thunk after it.
    *
    * `protected` for the same reason as `buildDisplacementOwnedByCaller`: this is
    * association-internal bookkeeping, not API surface. The writer lives outside
@@ -534,10 +540,10 @@ export class HasOneAssociation extends SingularAssociation {
    *
    * @internal
    */
-  protected detachDisplacedForSyncBuild(): Promise<void> | null {
+  protected prepareDetachDisplacedForSyncBuild(): (() => Promise<void>) | null {
     if (this.loaded) return null;
     if (!this.needsTargetLoadForBuild()) return null;
-    return this.findThenDetachDisplaced();
+    return () => this.findThenDetachDisplaced();
   }
 
   private async findThenDetachDisplaced(): Promise<void> {

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -149,6 +149,37 @@ describe("has_one displacement via the synchronous build path", () => {
     expect(() => assoc.build({ bogus_attribute: 1 })).toThrow();
   });
 
+  it("issues no displacement query when the nested-attributes build raises", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+
+    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
+    const assoc = refetched.association("ship") as unknown as { build(a: object): unknown };
+    assoc.build = () => {
+      throw new Error("build exploded");
+    };
+
+    expect(() => {
+      (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
+        name: "Davy Jones Gold Dagger",
+      };
+    }).toThrow("build exploded");
+
+    // Rails is `build_record(...)` then `set_new_record` → `load_target`, so a
+    // raising build leaves the row untouched and nothing parked to drain.
+    expect(
+      (refetched as unknown as { _pendingDisplacedRemovals?: unknown[] })
+        ._pendingDisplacedRemovals ?? [],
+    ).toHaveLength(0);
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
+      (pirate as unknown as { id: number }).id,
+    );
+  });
+
   it("leaves the displaced record cached when its removal fails", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
     await Ship.create({

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -158,6 +158,13 @@ describe("has_one displacement via the synchronous build path", () => {
 
     const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
     const assoc = refetched.association("ship") as unknown as { build(a: object): unknown };
+    // A pure ordering guard, not user-visible behavior: `build` is stubbed
+    // because the production path has no reachable raise left to provoke —
+    // `assertNestedAttributesAreKnown` pre-empts the unknown-attribute one, and
+    // the post-`build_record` raises Rails *does* query before are unreachable
+    // here (see `prepareDetachDisplacedForSyncBuild`). It pins that the query is
+    // issued downstream of the construction, so a future raise added to
+    // `build_record` cannot regress the order.
     assoc.build = () => {
       throw new Error("build exploded");
     };

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -189,7 +189,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    *
    * @internal
    */
-  protected override detachDisplacedForSyncBuild(): Promise<void> | null {
+  protected override prepareDetachDisplacedForSyncBuild(): (() => Promise<void>) | null {
     return null;
   }
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -680,7 +680,7 @@ interface OneToOneAssociation {
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
   detachDisplacedTarget?(displaced: Base | null): Promise<void>;
-  detachDisplacedForSyncBuild?(): Promise<void> | null;
+  prepareDetachDisplacedForSyncBuild?(): (() => Promise<void>) | null;
 }
 
 /**
@@ -916,20 +916,14 @@ export function assignNestedAttributesForOneToOneAssociation(
         const displaced = assoc.isLoaded?.() === false ? null : existing;
         // Rails' `replace` opens with `load_target`, so an association that was
         // never loaded still discovers the row in the DB and removes it. That
-        // SELECT is issued here, at assignment (Rails' timing), and only its
-        // completion is deferred to the same drain — see
-        // `HasOneAssociation#detachDisplacedForSyncBuild`.
-        //
-        // Rails reaches `load_target` from `set_new_record`, i.e. just AFTER
-        // `build_record`; this issues it just before. It has to: the load is
-        // gated on `find_target?`, which `build` falsifies by marking the
-        // association loaded, so there is no post-build moment at which the
-        // decision is still observable. The window the swap opens is a build
-        // that throws after a query Rails would not have run —
-        // `assertNestedAttributesAreKnown` above already raised for the
-        // attribute errors that reach this path.
-        const unloadedRemoval = assoc.detachDisplacedForSyncBuild?.() ?? null;
-        if (unloadedRemoval) parkDisplacedRemoval(record, unloadedRemoval);
+        // SELECT is issued just AFTER the build, where Rails reaches
+        // `load_target` — from `set_new_record`, i.e. after `build_record` — so
+        // a build that raises queries nothing. Only its completion is deferred
+        // to the same drain; see
+        // `HasOneAssociation#prepareDetachDisplacedForSyncBuild`. The decision
+        // to issue it has to be taken here, before the build, because `build`
+        // marks the association loaded and so falsifies its `find_target?` gate.
+        const startUnloadedRemoval = assoc.prepareDetachDisplacedForSyncBuild?.() ?? null;
         // `HasOneAssociation#build` runs the removal itself for direct callers
         // (returning a promise they can await). This writer is synchronous and
         // owns the removal through `detachDisplacedAtAssignment` below, so
@@ -942,6 +936,7 @@ export function assignNestedAttributesForOneToOneAssociation(
         } finally {
           assoc.buildDisplacementOwnedByCaller = false;
         }
+        if (startUnloadedRemoval) parkDisplacedRemoval(record, startUnloadedRemoval());
         detachDisplacedAtAssignment(record, assoc, displaced);
       }
     }


### PR DESCRIPTION
Rails' `SingularAssociation#build` is `build_record(attributes, &block); set_new_record(record)` (singular_association.rb:29-33), and only `set_new_record` -> `replace(record, false)` reaches `load_target` (has_one_association.rb:59-62). So a build that raises never issues the displacement SELECT.

The nested-attributes writer issued it *before* `assoc.build`, because the load is gated on `find_target?` and `build` falsifies that gate by marking the association loaded.

This splits the decision from the query: `prepareDetachDisplacedForSyncBuild` (was `detachDisplacedForSyncBuild`) takes the gate decision synchronously and returns a thunk; the writer invokes it after the build. The call-site deviation note is gone.

Regression test in `has-one-sync-build-displacement.trails.test.ts` — a raising build parks no removal and leaves the row attached; verified failing on the pre-fix baseline.

Closes-story: nested-attributes-displacement-load-precedes-record-construction
