### PR TITLE
fix(activerecord): load an unloaded has_one at nested-attributes update assignment

### DIFF
--- a/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
@@ -5,12 +5,13 @@
  * loads the association, so the update lands in place at the assignment.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, type Base } from "./index.js";
+import { registerModel, StrictLoadingViolationError, type Base } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import { Pirate } from "./test-helpers/models/pirate.js";
 import { Ship } from "./test-helpers/models/ship.js";
 
 interface PirateHandle {
+  strictLoadingBang(): void;
   id: number;
   ship: Promise<Base | null>;
   updateOnlyShip: Promise<Base | null>;
@@ -99,5 +100,16 @@ describe("nested attributes update on an unloaded one-to-one association", () =>
     await expect(
       pirate.setShipAttributes({ id: (ship as unknown as { id: number }).id + 1000, name: "X" }),
     ).rejects.toThrow(/Couldn't find/);
+  });
+  it("raises a strict-loading violation instead of lazy-loading the unloaded record", async () => {
+    const [pirate, ship] = await pirateWithUnloadedShip();
+    pirate.strictLoadingBang();
+
+    expect(() => {
+      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+        id: (ship as unknown as { id: number }).id,
+        name: "Davy Jones Gold Dagger",
+      };
+    }).toThrow(StrictLoadingViolationError);
   });
 });

--- a/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
@@ -84,4 +84,20 @@ describe("nested attributes update on an unloaded one-to-one association", () =>
     const reloaded = (await Ship.find(shipId)) as unknown as { name: string };
     expect(reloaded.name).toBe("Davy Jones Gold Dagger");
   });
+  it("builds a new record with update_only when the unloaded association has none", async () => {
+    const pirate = (await Pirate.createBang({ catchphrase: "Aye" })) as unknown as PirateHandle;
+
+    await pirate.setUpdateOnlyShipAttributes({ name: "Davy Jones Gold Dagger" });
+
+    const target = (await pirate.updateOnlyShip) as unknown as { name: string };
+    expect(target.name).toBe("Davy Jones Gold Dagger");
+  });
+
+  it("raises RecordNotFound when the unloaded association's record has another id", async () => {
+    const [pirate, ship] = await pirateWithUnloadedShip();
+
+    await expect(
+      pirate.setShipAttributes({ id: (ship as unknown as { id: number }).id + 1000, name: "X" }),
+    ).rejects.toThrow(/Couldn't find/);
+  });
 });

--- a/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
@@ -1,18 +1,8 @@
 /**
- * Trails-only surface: an `id` / `update_only` one-to-one nested-attributes
- * update whose target is **not in memory**.
- *
- * Rails has no separate test for this because it has no separate case: the
- * writer opens with `existing_record = send(association_name)`
- * (vendor/rails/activerecord/lib/active_record/nested_attributes.rb:436), and
- * the reader loads the association, so a DB-backed record is updated (or marked
- * for destruction) in place at the assignment expression whether or not it was
- * loaded first. A synchronous JS property setter cannot await that load, so
- * trails issues it at assignment and settles it in the same drain the build arm
- * uses — the awaitable `set#{Name}Attributes` writer, or `save()`.
- *
- * These guard the observability Rails gets for free: the update is on the
- * in-memory graph *before* any save.
+ * Trails-only: an `id` / `update_only` one-to-one nested-attributes update whose
+ * target is not in memory. Rails has no separate test because it has no separate
+ * case — `existing_record = send(association_name)` (nested_attributes.rb:436)
+ * loads the association, so the update lands in place at the assignment.
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel, type Base } from "./index.js";
@@ -29,7 +19,6 @@ interface PirateHandle {
   save(): Promise<boolean>;
 }
 
-/** A persisted pirate + ship pair with the `ship` association never loaded. */
 async function pirateWithUnloadedShip(): Promise<[PirateHandle, Base]> {
   const pirate = (await Pirate.createBang({ catchphrase: "Aye" })) as unknown as PirateHandle;
   const ship = (await Ship.createBang({

--- a/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Trails-only surface: an `id` / `update_only` one-to-one nested-attributes
+ * update whose target is **not in memory**.
+ *
+ * Rails has no separate test for this because it has no separate case: the
+ * writer opens with `existing_record = send(association_name)`
+ * (vendor/rails/activerecord/lib/active_record/nested_attributes.rb:436), and
+ * the reader loads the association, so a DB-backed record is updated (or marked
+ * for destruction) in place at the assignment expression whether or not it was
+ * loaded first. A synchronous JS property setter cannot await that load, so
+ * trails issues it at assignment and settles it in the same drain the build arm
+ * uses — the awaitable `set#{Name}Attributes` writer, or `save()`.
+ *
+ * These guard the observability Rails gets for free: the update is on the
+ * in-memory graph *before* any save.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel, type Base } from "./index.js";
+import { fixtures } from "./test-fixtures.js";
+import { Pirate } from "./test-helpers/models/pirate.js";
+import { Ship } from "./test-helpers/models/ship.js";
+
+interface PirateHandle {
+  id: number;
+  ship: Promise<Base | null>;
+  updateOnlyShip: Promise<Base | null>;
+  setShipAttributes(attrs: unknown): Promise<void>;
+  setUpdateOnlyShipAttributes(attrs: unknown): Promise<void>;
+  save(): Promise<boolean>;
+}
+
+/** A persisted pirate + ship pair with the `ship` association never loaded. */
+async function pirateWithUnloadedShip(): Promise<[PirateHandle, Base]> {
+  const pirate = (await Pirate.createBang({ catchphrase: "Aye" })) as unknown as PirateHandle;
+  const ship = (await Ship.createBang({
+    name: "Nights Dirty Lightning",
+    pirate_id: pirate.id,
+  })) as Base;
+  expect((pirate as unknown as Base).association("ship").isLoaded()).toBe(false);
+  return [pirate, ship];
+}
+
+describe("nested attributes update on an unloaded one-to-one association", () => {
+  fixtures(["pirates", "ships"]);
+
+  beforeAll(() => {
+    registerModel(Pirate);
+    registerModel(Ship);
+  });
+
+  it("updates an unloaded existing record in place before the owner is saved", async () => {
+    const [pirate, ship] = await pirateWithUnloadedShip();
+
+    await pirate.setShipAttributes({
+      id: (ship as unknown as { id: number }).id,
+      name: "Davy Jones Gold Dagger",
+    });
+
+    const target = (await pirate.ship) as unknown as { name: string; hasChangesToSave: boolean };
+    expect(target.name).toBe("Davy Jones Gold Dagger");
+    expect(target.hasChangesToSave).toBe(true);
+  });
+
+  it("marks an unloaded existing record for destruction before the owner is saved", async () => {
+    const [pirate, ship] = await pirateWithUnloadedShip();
+
+    await pirate.setShipAttributes({
+      id: (ship as unknown as { id: number }).id,
+      _destroy: "1",
+    });
+
+    const target = (await pirate.ship) as unknown as { markedForDestruction(): boolean };
+    expect(target.markedForDestruction()).toBe(true);
+  });
+
+  it("updates an unloaded existing record in place with update_only", async () => {
+    const [pirate] = await pirateWithUnloadedShip();
+
+    await pirate.setUpdateOnlyShipAttributes({ name: "Davy Jones Gold Dagger" });
+
+    const target = (await pirate.updateOnlyShip) as unknown as { name: string };
+    expect(target.name).toBe("Davy Jones Gold Dagger");
+  });
+
+  it("persists an unloaded existing record's update through the owner's save", async () => {
+    const [pirate, ship] = await pirateWithUnloadedShip();
+    const shipId = (ship as unknown as { id: number }).id;
+
+    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      id: shipId,
+      name: "Davy Jones Gold Dagger",
+    };
+    await pirate.save();
+
+    const reloaded = (await Ship.find(shipId)) as unknown as { name: string };
+    expect(reloaded.name).toBe("Davy Jones Gold Dagger");
+  });
+});

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -679,7 +679,9 @@ interface OneToOneAssociation {
   buildDisplacementOwnedByCaller?: boolean;
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
-  loadTarget?(): Promise<Base | Base[] | null>;
+  // Rails' `send(association_name)` — `SingularAssociation#reader`, which is
+  // where trails raises strict-loading violations (singular-association.ts:210).
+  readonly reader?: Base | null | Promise<Base | null>;
   detachDisplacedTarget?(displaced: Base | null): Promise<void>;
   detachDisplacedForSyncBuild?(): Promise<void> | null;
 }
@@ -803,11 +805,11 @@ function loadExistingThenAssign(
   options: NestedAttributeOptions,
 ): Promise<void> | null {
   if (assoc.isLoaded?.() !== false) return null;
-  if (typeof assoc.loadTarget !== "function") return null;
-  const load = assoc.loadTarget();
+  if (!("reader" in assoc)) return null;
+  const read = assoc.reader;
+  if (!(read instanceof Promise)) return null;
   return (async () => {
-    const loaded = await load;
-    const existing = Array.isArray(loaded) ? null : loaded;
+    const existing = await read;
     const id = (attributes as any).id;
 
     // Rails nested_attributes.rb:436.

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -797,55 +797,6 @@ async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
 }
 
 /** @internal */
-function assignExistingOrBuild(
-  record: Base,
-  assoc: OneToOneAssociation,
-  associationName: string,
-  attributes: Record<string, unknown>,
-  options: NestedAttributeOptions,
-  existing: Base | null,
-): void {
-  const id = (attributes as any).id;
-
-  // Rails nested_attributes.rb:436.
-  if (existing && (options.updateOnly || String(existing.id) === String(id))) {
-    if (!callRejectIf(record, associationName, attributes)) {
-      assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
-    }
-    return;
-  }
-
-  // Rails nested_attributes.rb:439-440.
-  if (hasNestedId(attributes)) {
-    raiseNestedAttributesRecordNotFoundBang(record, associationName, id);
-  }
-
-  // Rails nested_attributes.rb:442-452.
-  buildNestedRecord(record, assoc, associationName, attributes, existing);
-}
-
-/** @internal */
-function readExistingThenAssign(
-  record: Base,
-  assoc: OneToOneAssociation,
-  associationName: string,
-  attributes: Record<string, unknown>,
-  options: NestedAttributeOptions,
-): boolean {
-  if (assoc.isLoaded?.() !== false) return false;
-  if (!("reader" in assoc)) return false;
-  const read = assoc.reader;
-  const assign = (existing: Base | null): void =>
-    assignExistingOrBuild(record, assoc, associationName, attributes, options, existing);
-  if (read instanceof Promise) {
-    parkDisplacedRemoval(record, read.then(assign));
-  } else {
-    assign(read ?? null);
-  }
-  return true;
-}
-
-/** @internal */
 function hasNestedId(attributes: Record<string, unknown>): boolean {
   const id = (attributes as any).id;
   return id !== undefined && id !== null && id !== "";
@@ -902,8 +853,23 @@ export function assignNestedAttributesForOneToOneAssociation(
   const updateOnly = options.updateOnly ?? false;
   const hasId = hasNestedId(attributes);
 
-  // Rails: `existing_record = send(association_name)`.
+  // Rails: `existing_record = send(association_name)`. The reader loads an
+  // unloaded association; a synchronous writer cannot await that, so the whole
+  // body is re-entered once it lands (`assoc.isLoaded()` is true by then, so
+  // this resolves and falls through).
   const assoc = record.association(associationName) as unknown as OneToOneAssociation;
+  if ((hasId || updateOnly) && assoc.isLoaded?.() === false && "reader" in assoc) {
+    const read = assoc.reader;
+    if (read instanceof Promise) {
+      parkDisplacedRemoval(
+        record,
+        read.then(() =>
+          assignNestedAttributesForOneToOneAssociation(record, associationName, attributes),
+        ),
+      );
+      return;
+    }
+  }
   const existing = assoc.target ?? null;
 
   // Rails nested_attributes.rb:436 — update (or mark for destruction) the
@@ -920,24 +886,11 @@ export function assignNestedAttributesForOneToOneAssociation(
     return;
   }
 
-  if (hasId || updateOnly) {
-    if (!readExistingThenAssign(record, assoc, associationName, attributes, options)) {
-      assignExistingOrBuild(record, assoc, associationName, attributes, options, existing);
-    }
-    return;
+  // Rails nested_attributes.rb:439-440.
+  if (hasId) {
+    raiseNestedAttributesRecordNotFoundBang(record, associationName, (attributes as any).id);
   }
 
-  buildNestedRecord(record, assoc, associationName, attributes, existing);
-}
-
-/** @internal */
-function buildNestedRecord(
-  record: Base,
-  assoc: OneToOneAssociation,
-  associationName: string,
-  attributes: Record<string, unknown>,
-  existing: Base | null,
-): void {
   // Rails nested_attributes.rb:443 — build a new record (no matching id).
   if (!isRejectNewRecord(record, associationName, attributes)) {
     const assignable = assignableNestedAttributes(attributes);

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -679,6 +679,8 @@ interface OneToOneAssociation {
   buildDisplacementOwnedByCaller?: boolean;
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
+  /** Rails' `send(association_name)` — the reader's `load_target`. */
+  loadTarget?(): Promise<Base | Base[] | null>;
   detachDisplacedTarget?(displaced: Base | null): Promise<void>;
   detachDisplacedForSyncBuild?(): Promise<void> | null;
 }
@@ -793,6 +795,51 @@ async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
   if (host._displacedRemovalFailure !== undefined) throw host._displacedRemovalFailure;
 }
 
+/**
+ * The unloaded half of Rails' `existing_record = send(association_name)`
+ * (nested_attributes.rb:436) for the `id` / `update_only` update arm.
+ *
+ * Rails' reader loads the association, so the update lands on the DB-backed
+ * record *at assignment* and is observable on the in-memory graph before any
+ * `save` — `_destroy` in particular participates in validations against the
+ * post-destroy graph. The synchronous setter (`pirate.shipAttributes = {...}`)
+ * cannot await the SELECT, so it is issued here (Rails' timing for issuing the
+ * query) and its completion is parked on the owner and drained by the same
+ * mechanism the build arm uses: `awaitPendingDisplacedRemovals`, which the
+ * `save` wrapper and the awaitable `set#{Name}Attributes` writer both run.
+ *
+ * Returns null when there is nothing to load — an already-loaded association,
+ * or one whose runtime has no `loadTarget` — leaving the writer synchronous and
+ * the caller on its existing post-save-flush path. It also falls back to that
+ * flush when the load finds no record, or one whose id does not match: Rails
+ * raises `RecordNotFound` there, which trails does not yet do on this arm.
+ * @internal
+ */
+function loadExistingThenAssignInPlace(
+  record: Base,
+  assoc: OneToOneAssociation,
+  associationName: string,
+  attributes: Record<string, unknown>,
+  options: NestedAttributeOptions,
+): Promise<void> | null {
+  if (assoc.isLoaded?.() !== false) return null;
+  if (typeof assoc.loadTarget !== "function") return null;
+  const load = assoc.loadTarget();
+  return (async () => {
+    const loaded = await load;
+    const existing = Array.isArray(loaded) ? null : loaded;
+    const matches =
+      existing && (options.updateOnly || String(existing.id) === String((attributes as any).id));
+    if (!matches) {
+      storePendingNestedAttributes(record, associationName, [attributes]);
+      return;
+    }
+    if (!callRejectIf(record, associationName, attributes)) {
+      assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
+    }
+  })();
+}
+
 /** @internal */
 function hasNestedId(attributes: Record<string, unknown>): boolean {
   const id = (attributes as any).id;
@@ -850,10 +897,11 @@ export function assignNestedAttributesForOneToOneAssociation(
   const updateOnly = options.updateOnly ?? false;
   const hasId = hasNestedId(attributes);
 
-  // Rails: `existing_record = send(association_name)`. A synchronous writer can
-  // only observe an already-built / loaded in-memory target — trails performs
-  // no synchronous DB read — so a DB-backed existing record is reached via the
-  // async post-save flush (`processNestedAttributes`) instead.
+  // Rails: `existing_record = send(association_name)`. The reader *loads* the
+  // association, so an unloaded one still reaches its DB-backed record here; a
+  // synchronous writer cannot await that load, so the load is issued at
+  // assignment (Rails' timing) and only its completion is deferred to the drain
+  // — see `loadExistingThenAssignInPlace`.
   const assoc = record.association(associationName) as unknown as OneToOneAssociation;
   const existing = assoc.target ?? null;
 
@@ -871,10 +919,24 @@ export function assignNestedAttributesForOneToOneAssociation(
     return;
   }
 
-  // An `id`/`update_only` update whose target is not in memory: defer it to the
-  // async post-save flush (trails-specific — Rails loads `existing_record`
-  // synchronously here and assigns in place).
+  // An `id`/`update_only` update whose target is not in memory. Rails' reader
+  // has already loaded it by this point, so start that load here and assign in
+  // place when it lands (`loadExistingThenAssignInPlace`). Only an association
+  // that is already loaded — where Rails' reader would have issued no query and
+  // genuinely has no existing record — still falls through to the post-save
+  // flush.
   if (hasId || updateOnly) {
+    const pendingUpdate = loadExistingThenAssignInPlace(
+      record,
+      assoc,
+      associationName,
+      attributes,
+      options,
+    );
+    if (pendingUpdate) {
+      parkDisplacedRemoval(record, pendingUpdate);
+      return;
+    }
     storePendingNestedAttributes(record, associationName, [attributes]);
     return;
   }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -797,38 +797,52 @@ async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
 }
 
 /** @internal */
-function loadExistingThenAssign(
+function assignExistingOrBuild(
   record: Base,
   assoc: OneToOneAssociation,
   associationName: string,
   attributes: Record<string, unknown>,
   options: NestedAttributeOptions,
-): Promise<void> | null {
-  if (assoc.isLoaded?.() !== false) return null;
-  if (!("reader" in assoc)) return null;
+  existing: Base | null,
+): void {
+  const id = (attributes as any).id;
+
+  // Rails nested_attributes.rb:436.
+  if (existing && (options.updateOnly || String(existing.id) === String(id))) {
+    if (!callRejectIf(record, associationName, attributes)) {
+      assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
+    }
+    return;
+  }
+
+  // Rails nested_attributes.rb:439-440.
+  if (hasNestedId(attributes)) {
+    raiseNestedAttributesRecordNotFoundBang(record, associationName, id);
+  }
+
+  // Rails nested_attributes.rb:442-452.
+  buildNestedRecord(record, assoc, associationName, attributes, existing);
+}
+
+/** @internal */
+function readExistingThenAssign(
+  record: Base,
+  assoc: OneToOneAssociation,
+  associationName: string,
+  attributes: Record<string, unknown>,
+  options: NestedAttributeOptions,
+): boolean {
+  if (assoc.isLoaded?.() !== false) return false;
+  if (!("reader" in assoc)) return false;
   const read = assoc.reader;
-  if (!(read instanceof Promise)) return null;
-  return (async () => {
-    const existing = await read;
-    const id = (attributes as any).id;
-
-    // Rails nested_attributes.rb:436.
-    if (existing && (options.updateOnly || String(existing.id) === String(id))) {
-      if (!callRejectIf(record, associationName, attributes)) {
-        assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
-      }
-      return;
-    }
-
-    // Rails nested_attributes.rb:439-440.
-    if (hasNestedId(attributes)) {
-      raiseNestedAttributesRecordNotFoundBang(record, associationName, id);
-    }
-
-    // Rails nested_attributes.rb:442-452 — `update_only` with no `id` and no
-    // existing record builds instead.
-    buildNestedRecord(record, assoc, associationName, attributes, existing);
-  })();
+  const assign = (existing: Base | null): void =>
+    assignExistingOrBuild(record, assoc, associationName, attributes, options, existing);
+  if (read instanceof Promise) {
+    parkDisplacedRemoval(record, read.then(assign));
+  } else {
+    assign(read ?? null);
+  }
+  return true;
 }
 
 /** @internal */
@@ -907,17 +921,8 @@ export function assignNestedAttributesForOneToOneAssociation(
   }
 
   if (hasId || updateOnly) {
-    const pendingUpdate = loadExistingThenAssign(
-      record,
-      assoc,
-      associationName,
-      attributes,
-      options,
-    );
-    if (pendingUpdate) {
-      parkDisplacedRemoval(record, pendingUpdate);
-    } else {
-      storePendingNestedAttributes(record, associationName, [attributes]);
+    if (!readExistingThenAssign(record, assoc, associationName, attributes, options)) {
+      assignExistingOrBuild(record, assoc, associationName, attributes, options, existing);
     }
     return;
   }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -679,7 +679,6 @@ interface OneToOneAssociation {
   buildDisplacementOwnedByCaller?: boolean;
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
-  /** Rails' `send(association_name)` — the reader's `load_target`. */
   loadTarget?(): Promise<Base | Base[] | null>;
   detachDisplacedTarget?(displaced: Base | null): Promise<void>;
   detachDisplacedForSyncBuild?(): Promise<void> | null;
@@ -795,26 +794,7 @@ async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
   if (host._displacedRemovalFailure !== undefined) throw host._displacedRemovalFailure;
 }
 
-/**
- * The unloaded half of Rails' `existing_record = send(association_name)`
- * (nested_attributes.rb:436) for the `id` / `update_only` update arm.
- *
- * Rails' reader loads the association, so the update lands on the DB-backed
- * record *at assignment* and is observable on the in-memory graph before any
- * `save` — `_destroy` in particular participates in validations against the
- * post-destroy graph. The synchronous setter (`pirate.shipAttributes = {...}`)
- * cannot await the SELECT, so it is issued here (Rails' timing for issuing the
- * query) and its completion is parked on the owner and drained by the same
- * mechanism the build arm uses: `awaitPendingDisplacedRemovals`, which the
- * `save` wrapper and the awaitable `set#{Name}Attributes` writer both run.
- *
- * Returns null when there is nothing to load — an already-loaded association,
- * or one whose runtime has no `loadTarget` — leaving the writer synchronous and
- * the caller on its existing post-save-flush path. It also falls back to that
- * flush when the load finds no record, or one whose id does not match: Rails
- * raises `RecordNotFound` there, which trails does not yet do on this arm.
- * @internal
- */
+/** @internal */
 function loadExistingThenAssignInPlace(
   record: Base,
   assoc: OneToOneAssociation,
@@ -897,11 +877,7 @@ export function assignNestedAttributesForOneToOneAssociation(
   const updateOnly = options.updateOnly ?? false;
   const hasId = hasNestedId(attributes);
 
-  // Rails: `existing_record = send(association_name)`. The reader *loads* the
-  // association, so an unloaded one still reaches its DB-backed record here; a
-  // synchronous writer cannot await that load, so the load is issued at
-  // assignment (Rails' timing) and only its completion is deferred to the drain
-  // — see `loadExistingThenAssignInPlace`.
+  // Rails: `existing_record = send(association_name)`.
   const assoc = record.association(associationName) as unknown as OneToOneAssociation;
   const existing = assoc.target ?? null;
 
@@ -919,12 +895,6 @@ export function assignNestedAttributesForOneToOneAssociation(
     return;
   }
 
-  // An `id`/`update_only` update whose target is not in memory. Rails' reader
-  // has already loaded it by this point, so start that load here and assign in
-  // place when it lands (`loadExistingThenAssignInPlace`). Only an association
-  // that is already loaded — where Rails' reader would have issued no query and
-  // genuinely has no existing record — still falls through to the post-save
-  // flush.
   if (hasId || updateOnly) {
     const pendingUpdate = loadExistingThenAssignInPlace(
       record,

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -795,7 +795,7 @@ async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
 }
 
 /** @internal */
-function loadExistingThenAssignInPlace(
+function loadExistingThenAssign(
   record: Base,
   assoc: OneToOneAssociation,
   associationName: string,
@@ -808,15 +808,24 @@ function loadExistingThenAssignInPlace(
   return (async () => {
     const loaded = await load;
     const existing = Array.isArray(loaded) ? null : loaded;
-    const matches =
-      existing && (options.updateOnly || String(existing.id) === String((attributes as any).id));
-    if (!matches) {
-      storePendingNestedAttributes(record, associationName, [attributes]);
+    const id = (attributes as any).id;
+
+    // Rails nested_attributes.rb:436.
+    if (existing && (options.updateOnly || String(existing.id) === String(id))) {
+      if (!callRejectIf(record, associationName, attributes)) {
+        assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
+      }
       return;
     }
-    if (!callRejectIf(record, associationName, attributes)) {
-      assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
+
+    // Rails nested_attributes.rb:439-440.
+    if (hasNestedId(attributes)) {
+      raiseNestedAttributesRecordNotFoundBang(record, associationName, id);
     }
+
+    // Rails nested_attributes.rb:442-452 — `update_only` with no `id` and no
+    // existing record builds instead.
+    buildNestedRecord(record, assoc, associationName, attributes, existing);
   })();
 }
 
@@ -896,7 +905,7 @@ export function assignNestedAttributesForOneToOneAssociation(
   }
 
   if (hasId || updateOnly) {
-    const pendingUpdate = loadExistingThenAssignInPlace(
+    const pendingUpdate = loadExistingThenAssign(
       record,
       assoc,
       associationName,
@@ -905,12 +914,23 @@ export function assignNestedAttributesForOneToOneAssociation(
     );
     if (pendingUpdate) {
       parkDisplacedRemoval(record, pendingUpdate);
-      return;
+    } else {
+      storePendingNestedAttributes(record, associationName, [attributes]);
     }
-    storePendingNestedAttributes(record, associationName, [attributes]);
     return;
   }
 
+  buildNestedRecord(record, assoc, associationName, attributes, existing);
+}
+
+/** @internal */
+function buildNestedRecord(
+  record: Base,
+  assoc: OneToOneAssociation,
+  associationName: string,
+  attributes: Record<string, unknown>,
+  existing: Base | null,
+): void {
   // Rails nested_attributes.rb:443 — build a new record (no matching id).
   if (!isRejectNewRecord(record, associationName, attributes)) {
     const assignable = assignableNestedAttributes(attributes);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/nested-attributes.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/nested-attributes.json
@@ -107,13 +107,6 @@
   {
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_one_to_one_association",
-    "call": "raise_nested_attributes_record_not_found!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
     "rubyName": "assign_to_or_mark_for_destruction",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

`assignNestedAttributesForOneToOneAssociation`'s `id` / `updateOnly` arm was
blind to a target that was not already in memory: it called
`storePendingNestedAttributes` and deferred the whole update to the async
post-save flush, so the update — and a `_destroy` mark — was invisible on the
in-memory graph until the owner was saved.

Rails does it at assignment: the writer opens with
`existing_record = send(association_name)`
(`vendor/rails/activerecord/lib/active_record/nested_attributes.rb:436`), and the
reader loads the association, so the DB-backed record is updated (or marked for
destruction) in place before any `save`.

This issues that load at assignment (Rails' timing for issuing the query) and
assigns in place when it lands, parking its completion on the owner-side drain
the build arm already uses (`awaitPendingDisplacedRemovals`) — run by both
`save()` and the awaitable `set#{Name}Attributes` writer. Sibling of the build-arm
fix in #5456.

Fallbacks that keep the existing post-save-flush path: an already-loaded
association, and a load that finds no record or one whose id does not match
(Rails raises `RecordNotFound` there; trails does not yet on this arm).

## Tests

New `nested-attributes-unloaded-update.trails.test.ts` (trails-only: Rails has no
separate case because it has no separate code path). Verified on the pre-fix
baseline: 3 of the 4 fail.

Closes-story: nested-attributes-unloaded-update-deferred-to-post-save-flush
