### PR TITLE
refactor(activerecord): port remove_target! as a HasOneAssociation method

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -136,7 +136,7 @@ export class HasOneAssociation extends SingularAssociation {
     await transactionIf(this, save, async () => {
       // `this.target` is still `displaced`, so `removeTargetBang` removes it.
       if (displaced && !(displaced as any).isDestroyed?.() && !sameRecord(displaced, record)) {
-        await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+        await this.removeTargetBang((this.reflection.options.dependent as string) ?? "");
       }
       if (record) {
         this.setOwnerAttributes(record);
@@ -500,7 +500,7 @@ export class HasOneAssociation extends SingularAssociation {
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, this.target)) return;
     try {
-      await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "", displaced);
+      await this.removeTargetBang((this.reflection.options.dependent as string) ?? "", displaced);
     } catch (error) {
       this.target = displaced;
       throw error;
@@ -646,6 +646,50 @@ export class HasOneAssociation extends SingularAssociation {
     }
   }
 
+  private async removeTargetBang(
+    method: string,
+    // Rails' `remove_target!` always acts on `self.target`, which is still the
+    // displaced record inside `replace`'s transaction (persistImmediate keeps
+    // that shape, so it takes the default). Every deferred displacement path
+    // instead removes a record while `this.target` is already the replacement —
+    // flipping the cached target back mid-await is observable to synchronous
+    // readers — so `detachDisplacedTarget` names the record explicitly.
+    target: Base | null = this.target,
+  ): Promise<void> {
+    if (!target) return;
+    if (method === "delete") {
+      await ((target as any).delete?.() ?? Promise.resolve());
+      return;
+    }
+    if (method === "destroy") {
+      // Tag the record with the association that is destroying it (so its own
+      // destroy callbacks can read `destroyed_by_association`) before
+      // destroying, and only destroy when the record is actually persisted.
+      (target as any).destroyedByAssociation = this.reflection;
+      await preloadDestroyInverseBelongsTo(this, target);
+      if (target.isPersisted()) await ((target as any).destroy?.() ?? Promise.resolve());
+      return;
+    }
+    // The `else` branch (no `dependent`, or `:nullify`): drop the foreign key on
+    // the previously associated record, clear the inverse, and save it. A plain
+    // replacement always nullifies the old record's FK; the `dependent` option
+    // only governs the owner-destroy path. A failed nullify-save aborts the
+    // replacement.
+    this.nullifyOwnerAttributes(target);
+    this.removeInverseInstance(target);
+    if (target.isPersisted() && (this.owner as any).isPersisted?.()) {
+      const saved = await ((target as any).save?.() ?? Promise.resolve(true));
+      if (saved === false) {
+        this.setOwnerAttributes(target);
+        throw new RecordNotSaved(
+          `Failed to remove the existing associated ${this.reflection.name}. ` +
+            `The record failed to save after its foreign key was set to nil.`,
+          target,
+        );
+      }
+    }
+  }
+
   private nullifyOwnerAttributes(record: Base): void {
     // Source the column list from the Rails-named helper so custom
     // foreignKey/foreignType (incl. composite PKs and polymorphic `as`)
@@ -731,53 +775,6 @@ async function preloadDestroyInverseBelongsTo(
     } catch {
       // A non-loadable back-reference (e.g. a missing FK row) is simply skipped;
       // the callback then sees an unloaded association, as it would in Rails.
-    }
-  }
-}
-
-/** @internal */
-async function removeTargetBang(
-  assoc: HasOneAssociation,
-  method: string,
-  // Rails' `remove_target!` always acts on `self.target`, which is still the
-  // displaced record inside `replace`'s transaction (persistImmediate keeps that
-  // shape, so it takes the default). Every deferred displacement path instead
-  // removes a record while `assoc.target` is already the replacement — flipping
-  // the cached target back mid-await is observable to synchronous readers — so
-  // `detachDisplacedTarget` names the record explicitly.
-  target: Base | null = assoc.target,
-): Promise<void> {
-  if (!target) return;
-  if (method === "delete") {
-    await ((target as any).delete?.() ?? Promise.resolve());
-    return;
-  }
-  if (method === "destroy") {
-    // Mirrors Rails HasOneAssociation#remove_target!: tag the record with the
-    // association that is destroying it (so its own destroy callbacks can read
-    // `destroyed_by_association`) before destroying, and only destroy when the
-    // record is actually persisted.
-    (target as any).destroyedByAssociation = assoc.reflection;
-    await preloadDestroyInverseBelongsTo(assoc, target);
-    if (target.isPersisted()) await ((target as any).destroy?.() ?? Promise.resolve());
-    return;
-  }
-  // Mirrors Rails HasOneAssociation#remove_target!'s `else` branch (no
-  // `dependent`, or `:nullify`): drop the foreign key on the previously
-  // associated record, clear the inverse, and save it. A plain replacement
-  // always nullifies the old record's FK; the `dependent` option only governs
-  // the owner-destroy path. A failed nullify-save aborts the replacement.
-  (assoc as any).nullifyOwnerAttributes(target);
-  assoc.removeInverseInstance(target);
-  if (target.isPersisted() && (assoc.owner as any).isPersisted?.()) {
-    const saved = await ((target as any).save?.() ?? Promise.resolve(true));
-    if (saved === false) {
-      (assoc as any).setOwnerAttributes(target);
-      throw new RecordNotSaved(
-        `Failed to remove the existing associated ${assoc.reflection.name}. ` +
-          `The record failed to save after its foreign key was set to nil.`,
-        target,
-      );
     }
   }
 }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -662,19 +662,11 @@ export class HasOneAssociation extends SingularAssociation {
       return;
     }
     if (method === "destroy") {
-      // Tag the record with the association that is destroying it (so its own
-      // destroy callbacks can read `destroyed_by_association`) before
-      // destroying, and only destroy when the record is actually persisted.
       (target as any).destroyedByAssociation = this.reflection;
       await preloadDestroyInverseBelongsTo(this, target);
       if (target.isPersisted()) await ((target as any).destroy?.() ?? Promise.resolve());
       return;
     }
-    // The `else` branch (no `dependent`, or `:nullify`): drop the foreign key on
-    // the previously associated record, clear the inverse, and save it. A plain
-    // replacement always nullifies the old record's FK; the `dependent` option
-    // only governs the owner-destroy path. A failed nullify-save aborts the
-    // replacement.
     this.nullifyOwnerAttributes(target);
     this.removeInverseInstance(target);
     if (target.isPersisted() && (this.owner as any).isPersisted?.()) {


### PR DESCRIPTION
Ports Rails' `HasOneAssociation#remove_target!`
(`has_one_association.rb:95-115`) as a private method on `HasOneAssociation`
named `removeTargetBang`, instead of the module-level free function that took
the association as its first argument.

- `(assoc as any).nullifyOwnerAttributes(...)` / `(assoc as any).setOwnerAttributes(...)`
  become plain `this.` calls — the `any` casts are gone.
- `api:compare` now matches it against `has_one_association.rb:95` (one fewer
  missing method on `HasOneAssociation`); arity stays green (Rails 1 arg, TS
  1..2 overlaps).
- The extra `target` parameter stays, defaulted to `this.target` and justified
  at the declaration: `persistImmediate` takes the default (Rails' shape, where
  `self.target` is still the displaced record inside `replace`'s transaction),
  while `detachDisplacedTarget` names the displaced record explicitly because
  the deferred paths run while `this.target` is already the replacement.

No behavior change. `has-one-associations.test.ts`,
`has-one-sync-build-displacement.trails.test.ts`,
`nested-attributes-displaced-removal-failure.trails.test.ts` and
`has-one-through-associations.test.ts` pass unchanged.

Closes-story: port-remove-target-bang-as-a-has-one-association-method
