### PR TITLE
test(activerecord): converge the arunit database name onto the primary

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -40,7 +40,6 @@ import {
   ARUNIT_DATABASE,
   ARUNIT2_DATABASE,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
-import { provisionSecondDatabase } from "./support/setup-second-pool.js";
 
 // Drives Rails' AdapterTest casted/non-casted bind probes against the leased
 // connection and the canonical `events` table. The insert return value is
@@ -1269,35 +1268,14 @@ describe.runIf(adapterType === "mysql")("AdapterTest", () => {
   });
 
   it("not specifying database name for cross database selects", async () => {
-    for (const database of [ARUNIT_DATABASE, ARUNIT2_DATABASE]) {
-      await adapter.execute(`DROP DATABASE IF EXISTS ${database}`);
-      await adapter.execute(`CREATE DATABASE ${database}`);
-    }
-    await adapter.execute(
-      `CREATE TABLE ${ARUNIT_DATABASE}.pirates (id INT AUTO_INCREMENT PRIMARY KEY, catchphrase VARCHAR(255), parrot_id INT, non_validated_parrot_id INT, created_on DATETIME, updated_on DATETIME)`,
-    );
-    await adapter.execute(
-      `CREATE TABLE ${ARUNIT2_DATABASE}.courses (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL, college_id INT)`,
-    );
-
-    try {
-      await runWithoutConnection(async ({ database: _database, ...exceptDatabase }) => {
-        await Base.establishConnection(exceptDatabase);
-        const connection = await leaseMysqlAdapter();
-        await connection.execute(
-          `SELECT ${ARUNIT_DATABASE}.pirates.*, ${ARUNIT2_DATABASE}.courses.* ` +
-            `FROM ${ARUNIT_DATABASE}.pirates, ${ARUNIT2_DATABASE}.courses`,
-        );
-      });
-    } finally {
+    await runWithoutConnection(async ({ database: _database, ...exceptDatabase }) => {
+      await Base.establishConnection(exceptDatabase);
       const connection = await leaseMysqlAdapter();
-      for (const database of [ARUNIT_DATABASE, ARUNIT2_DATABASE]) {
-        await connection.execute(`DROP DATABASE IF EXISTS ${database}`);
-      }
-      // ARUNIT2_DATABASE is this worker's real second database, which
-      // `ARUnit2Model` holds a pool on for the whole run.
-      await provisionSecondDatabase();
-    }
+      await connection.execute(
+        `SELECT ${ARUNIT_DATABASE}.pirates.*, ${ARUNIT2_DATABASE}.courses.* ` +
+          `FROM ${ARUNIT_DATABASE}.pirates, ${ARUNIT2_DATABASE}.courses`,
+      );
+    });
   });
 });
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -29,10 +29,9 @@ export {
  * Rails' cross-database-select probe references them by those configured
  * names rather than inventing throwaway databases. trails provisions a single
  * MySQL server, so the names are derived from its `database` sub-setting (see
- * `arunit2-config`). They are config-derived, not invented per call, and
- * `arunit` is kept off the shared primary — whose canonical tables parallel
- * test workers create and drop — because this probe drops and recreates both
- * databases it names.
+ * `arunit2-config`): `arunit` is the worker's primary database, `arunit2` its
+ * sibling, exactly the two the probe's `pirates` and `courses` tables already
+ * live in.
  */
 export const { arunit: ARUNIT_DATABASE, arunit2: ARUNIT2_DATABASE } = arunitDatabaseNames(
   mysqlSettings().database,

--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from "vitest";
 import { arunitDatabaseNames } from "./arunit2-config.js";
 
 describe("arunit2-config", () => {
-  it("arunitDatabaseNames suffixes the primary database name", () => {
+  it("arunitDatabaseNames spells the two databases as expand_config does", () => {
     expect(arunitDatabaseNames("activerecord_unittest")).toEqual({
-      arunit: "activerecord_unittest_arunit",
+      arunit: "activerecord_unittest",
       arunit2: "activerecord_unittest2",
     });
   });
 
   it("carries the worker isolation slot into the arunit2 database name", () => {
     expect(arunitDatabaseNames("activerecord_unittest_3")).toEqual({
-      arunit: "activerecord_unittest_3_arunit",
+      arunit: "activerecord_unittest_3",
       arunit2: "activerecord_unittest2_3",
     });
     expect(arunitDatabaseNames("activerecord_unittest_32").arunit2).toBe(

--- a/packages/activerecord/src/support/arunit2-config.ts
+++ b/packages/activerecord/src/support/arunit2-config.ts
@@ -32,8 +32,6 @@
  */
 const SLOT_SUFFIX = /_\d+$/;
 
-const ARUNIT_SUFFIX = "_arunit";
-
 /**
  * The config-derived `arunit` / `arunit2` database names for a primary
  * database, mirroring how `ARTest.test_configuration_hashes` exposes two named
@@ -48,12 +46,12 @@ const ARUNIT_SUFFIX = "_arunit";
  * 32's own database. Written this way slot 3 gets `activerecord_unittest2_3`,
  * which no slot can collide with, since primary names never carry the `2`.
  *
- * `arunit` keeps a `_arunit` suffix and so is *not* the primary database,
- * unlike Rails'. It exists for the MySQL cross-database-select probe
- * (`adapter_test.rb`), which drops and recreates both databases it names — on
- * the primary that would destroy the worker's canonical schema mid-run,
- * something Rails can afford only because its `arunit` is not shared with
- * parallel workers.
+ * `arunit` is the primary database itself, as `expand_config` defaults it
+ * (`activerecord_unittest`). Rails' only consumer of these two names — the
+ * MySQL cross-database-select probe (`adapter_test.rb:160-172`) — reads the
+ * tables the two databases already carry (`pirates` in the primary,
+ * `courses` in arunit2) and creates no databases of its own, so nothing here
+ * needs a throwaway database to drop.
  */
 export function arunitDatabaseNames(primaryDatabase: string): {
   arunit: string;
@@ -61,5 +59,5 @@ export function arunitDatabaseNames(primaryDatabase: string): {
 } {
   const slot = SLOT_SUFFIX.exec(primaryDatabase)?.[0] ?? "";
   const base = slot === "" ? primaryDatabase : primaryDatabase.slice(0, -slot.length);
-  return { arunit: `${primaryDatabase}${ARUNIT_SUFFIX}`, arunit2: `${base}2${slot}` };
+  return { arunit: primaryDatabase, arunit2: `${base}2${slot}` };
 }

--- a/packages/activerecord/src/support/arunit2-config.ts
+++ b/packages/activerecord/src/support/arunit2-config.ts
@@ -11,9 +11,10 @@
  * trails provisions a single server per adapter, so rather than maintaining a
  * separate config file we derive the two database names from the primary
  * connection's `database` sub-setting. This keeps the names config-derived
- * (not invented per call) and dedicated to the cross-pool work — off the
- * shared primary database whose canonical tables parallel workers create and
- * drop.
+ * (not invented per call): `arunit` is that primary database, the one
+ * `ActiveRecord::Base` is established on (`connection.rb:31-33`) and the one
+ * `expand_config` defaults to `activerecord_unittest` (`config.rb:26-35`), and
+ * `arunit2` its sibling.
  *
  * The *connection names* are already first-class: `support/connection.ts`
  * publishes `arunit`, `arunit2` and `arunit_without_prepared_statements` as


### PR DESCRIPTION
Converges the `arunit` database name onto Rails' `expand_config` default —
the primary test database itself (`test/support/config.rb:28`).

`arunitDatabaseNames` returned a throwaway `<primary>_arunit` because the MySQL
cross-database-select probe dropped and recreated both databases it named, which
on the primary would destroy the worker canonical schema mid-run.

That drop/create dance was a trails invention. Rails' probe
(`adapter_test.rb:160-172`) creates nothing: it selects from the `pirates` and
`courses` tables the two configured databases already carry — `pirates` in the
primary canonical schema, `courses` in `arunit2` (laid down by
`provisionSecondDatabase`). Dropping the dance removes the only reason `arunit`
had to be a throwaway, so it is now the primary, and the probe is a literal
port of the Rails test.

Verified against a live MySQL 8: the whole `adapter.test.ts` file passes on the
mysql2 lane (70 passed, 3 gated).

Closes-story: arunit-database-name-diverges-from-expand-config
