### PR TITLE
chore(ci): narrow the rails test user's MySQL grants to the suite's databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1137,12 +1137,13 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
-      # Mirrors rake db:mysql:build_user / db:postgresql:build
-      # (activerecord/Rakefile:227-241,258-262): the suite connects as Rails'
-      # own `rails` user, not as the image superuser. CREATEDB (rather than
-      # Rails' plain GRANT) is what trails adds — each vitest worker creates its
-      # own AR_DB_SLOT copy of the database, which Rails' single-database run
-      # never needs.
+      # Mirrors rake db:postgresql:build (activerecord/Rakefile:258-262): the
+      # suite connects as Rails' own `rails` user, not as the image superuser.
+      # CREATEDB is what trails adds — each vitest worker creates its own
+      # AR_DB_SLOT copy of the database, which Rails' single-database run never
+      # needs. SUPERUSER is a permanent deviation the suite's untrusted
+      # extensions (postgres_fdw, pg_hint_plan) require; see
+      # scripts/db-init/postgres/01-rails-role.sql for the full reasoning.
       - name: Provision Rails' test role
         run: |
           psql -h localhost -U postgres -d activerecord_unittest \
@@ -1220,17 +1221,24 @@ jobs:
       # rake db:mysql:build_user (activerecord/Rakefile:227-235): CREATE USER
       # with no IDENTIFIED BY — Rails' `rails` user has no password — then
       # GRANT. Rails grants on the test database plus
-      # inexistent_activerecord_unittest; trails grants globally instead because
-      # each vitest worker creates its own AR_DB_SLOT copy of the database,
-      # which Rails' single-database run never needs.
+      # inexistent_activerecord_unittest; the first grant is widened to an
+      # `activerecord_unittest%` pattern (not to *.*) because each vitest worker
+      # creates its own AR_DB_SLOT copy of the database, which Rails'
+      # single-database run never needs. Mirrors
+      # scripts/db-init/mysql/01-rails-user.sql — keep the two in step.
+      # Heredoc, not -e "...": the backtick-quoted pattern would otherwise be
+      # command substitution in the double-quoted shell word.
       - name: Provision Rails' test user
         run: |
-          mysql -h 127.0.0.1 -uroot -e "
+          mysql -h 127.0.0.1 -uroot <<'SQL'
             CREATE USER IF NOT EXISTS 'rails'@'%';
-            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%';
+            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
+            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
             CREATE USER IF NOT EXISTS 'rails'@'localhost';
-            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'localhost';
-            FLUSH PRIVILEGES;"
+            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
+            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';
+            FLUSH PRIVILEGES;
+          SQL
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a
@@ -1300,17 +1308,24 @@ jobs:
       # rake db:mysql:build_user (activerecord/Rakefile:227-235): CREATE USER
       # with no IDENTIFIED BY — Rails' `rails` user has no password — then
       # GRANT. Rails grants on the test database plus
-      # inexistent_activerecord_unittest; trails grants globally instead because
-      # each vitest worker creates its own AR_DB_SLOT copy of the database,
-      # which Rails' single-database run never needs.
+      # inexistent_activerecord_unittest; the first grant is widened to an
+      # `activerecord_unittest%` pattern (not to *.*) because each vitest worker
+      # creates its own AR_DB_SLOT copy of the database, which Rails'
+      # single-database run never needs. Mirrors
+      # scripts/db-init/mysql/01-rails-user.sql — keep the two in step.
+      # Heredoc, not -e "...": the backtick-quoted pattern would otherwise be
+      # command substitution in the double-quoted shell word.
       - name: Provision Rails' test user
         run: |
-          mysql -h 127.0.0.1 -uroot -e "
+          mysql -h 127.0.0.1 -uroot <<'SQL'
             CREATE USER IF NOT EXISTS 'rails'@'%';
-            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%';
+            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
+            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
             CREATE USER IF NOT EXISTS 'rails'@'localhost';
-            GRANT ALL PRIVILEGES ON *.* TO 'rails'@'localhost';
-            FLUSH PRIVILEGES;"
+            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
+            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';
+            FLUSH PRIVILEGES;
+          SQL
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1137,18 +1137,13 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
-      # Mirrors rake db:postgresql:build (activerecord/Rakefile:258-262): the
-      # suite connects as Rails' own `rails` user, not as the image superuser.
-      # CREATEDB is what trails adds — each vitest worker creates its own
-      # AR_DB_SLOT copy of the database, which Rails' single-database run never
-      # needs. SUPERUSER is a permanent deviation the suite's untrusted
-      # extensions (postgres_fdw, pg_hint_plan) require; see
-      # scripts/db-init/postgres/01-rails-role.sql for the full reasoning.
+      # Service containers can't mount /docker-entrypoint-initdb.d, so feed the
+      # compose init script by hand — same file, so CI and local provisioning
+      # can't drift.
       - name: Provision Rails' test role
         run: |
           psql -h localhost -U postgres -d activerecord_unittest \
-            -c "CREATE ROLE rails LOGIN CREATEDB SUPERUSER" \
-            -c "ALTER DATABASE activerecord_unittest OWNER TO rails"
+            -v ON_ERROR_STOP=1 -f scripts/db-init/postgres/01-rails-role.sql
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a
@@ -1218,27 +1213,11 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
-      # rake db:mysql:build_user (activerecord/Rakefile:227-235): CREATE USER
-      # with no IDENTIFIED BY — Rails' `rails` user has no password — then
-      # GRANT. Rails grants on the test database plus
-      # inexistent_activerecord_unittest; the first grant is widened to an
-      # `activerecord_unittest%` pattern (not to *.*) because each vitest worker
-      # creates its own AR_DB_SLOT copy of the database, which Rails'
-      # single-database run never needs. Mirrors
-      # scripts/db-init/mysql/01-rails-user.sql — keep the two in step.
-      # Heredoc, not -e "...": the backtick-quoted pattern would otherwise be
-      # command substitution in the double-quoted shell word.
+      # Service containers can't mount /docker-entrypoint-initdb.d, so feed the
+      # compose init script by hand — same file, so CI and local provisioning
+      # can't drift.
       - name: Provision Rails' test user
-        run: |
-          mysql -h 127.0.0.1 -uroot <<'SQL'
-            CREATE USER IF NOT EXISTS 'rails'@'%';
-            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
-            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
-            CREATE USER IF NOT EXISTS 'rails'@'localhost';
-            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
-            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';
-            FLUSH PRIVILEGES;
-          SQL
+        run: mysql -h 127.0.0.1 -uroot < scripts/db-init/mysql/01-rails-user.sql
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a
@@ -1305,27 +1284,11 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build
       - run: pnpm build
-      # rake db:mysql:build_user (activerecord/Rakefile:227-235): CREATE USER
-      # with no IDENTIFIED BY — Rails' `rails` user has no password — then
-      # GRANT. Rails grants on the test database plus
-      # inexistent_activerecord_unittest; the first grant is widened to an
-      # `activerecord_unittest%` pattern (not to *.*) because each vitest worker
-      # creates its own AR_DB_SLOT copy of the database, which Rails'
-      # single-database run never needs. Mirrors
-      # scripts/db-init/mysql/01-rails-user.sql — keep the two in step.
-      # Heredoc, not -e "...": the backtick-quoted pattern would otherwise be
-      # command substitution in the double-quoted shell word.
+      # Service containers can't mount /docker-entrypoint-initdb.d, so feed the
+      # compose init script by hand — same file, so CI and local provisioning
+      # can't drift.
       - name: Provision Rails' test user
-        run: |
-          mysql -h 127.0.0.1 -uroot <<'SQL'
-            CREATE USER IF NOT EXISTS 'rails'@'%';
-            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
-            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
-            CREATE USER IF NOT EXISTS 'rails'@'localhost';
-            GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
-            GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';
-            FLUSH PRIVILEGES;
-          SQL
+        run: mysql -h 127.0.0.1 -uroot < scripts/db-init/mysql/01-rails-user.sql
       # Trailing slash is load-bearing: the bare `packages/activerecord` filter
       # is a substring match that also sweeps in packages/activerecord-cli/**.
       # Those already run in the dedicated step below, so the slash avoids a

--- a/scripts/db-init/mysql/01-rails-user.sql
+++ b/scripts/db-init/mysql/01-rails-user.sql
@@ -3,15 +3,25 @@
 -- IDENTIFIED BY, so the user has no password — which is what
 -- `username: rails` in test/config.example.yml:4,24 connects as.
 --
--- Rails grants on the test database plus inexistent_activerecord_unittest;
--- this grants globally instead, because each vitest worker creates its own
--- AR_DB_SLOT copy of the database (activerecord_unittest_2, _3, …) and
--- Rails' single-database run never needs that.
+-- Rails grants on the test database plus inexistent_activerecord_unittest.
+-- The first grant is widened to an `activerecord_unittest%` pattern rather
+-- than the literal database because each vitest worker creates its own
+-- AR_DB_SLOT copy (activerecord_unittest_<token>_1, _2, …) alongside the
+-- arunit2 database activerecord_unittest2 — all of which share that prefix.
+-- It is not widened past it: with no grant on *.*, the user still cannot
+-- touch `mysql` or anything outside the suite's namespace.
+--
+-- inexistent_activerecord_unittest is granted literally, exactly as Rails
+-- does, so connecting to it fails with "Unknown database" rather than "access
+-- denied" (abstract-mysql-adapter/connection.test.ts, mysql2-adapter.test.ts).
 CREATE USER IF NOT EXISTS 'rails'@'%';
-GRANT ALL PRIVILEGES ON *.* TO 'rails'@'%';
--- MYSQL_SOCK is a first-class sub-setting here (config.example.yml:18-19), and
--- a socket connection authenticates as 'rails'@'localhost', which '%' does not
--- cover. Rails' rake task grants only '%' because its own runs are over TCP.
+GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
+GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
+-- PERMANENT DEVIATION: MYSQL_SOCK is a first-class sub-setting here
+-- (config.example.yml:18-19), and a socket connection authenticates as
+-- 'rails'@'localhost', which '%' does not cover. Rails' rake task grants only
+-- '%' because its own runs are over TCP. Same narrowed grants.
 CREATE USER IF NOT EXISTS 'rails'@'localhost';
-GRANT ALL PRIVILEGES ON *.* TO 'rails'@'localhost';
+GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
+GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';
 FLUSH PRIVILEGES;

--- a/scripts/db-init/mysql/01-rails-user.sql
+++ b/scripts/db-init/mysql/01-rails-user.sql
@@ -1,26 +1,23 @@
--- Rails' `rails` test user, as `rake db:mysql:build_user` provisions it
--- (vendor/rails/activerecord/Rakefile:227-235): CREATE USER with no
--- IDENTIFIED BY, so the user has no password — which is what
--- `username: rails` in test/config.example.yml:4,24 connects as.
+-- rake db:mysql:build_user (vendor/rails/activerecord/Rakefile:227-235), which
+-- CREATEs the user with no IDENTIFIED BY — `username: rails` in
+-- test/config.example.yml:4,24 connects with no password.
 --
--- Rails grants on the test database plus inexistent_activerecord_unittest.
--- The first grant is widened to an `activerecord_unittest%` pattern rather
--- than the literal database because each vitest worker creates its own
--- AR_DB_SLOT copy (activerecord_unittest_<token>_1, _2, …) alongside the
--- arunit2 database activerecord_unittest2 — all of which share that prefix.
--- It is not widened past it: with no grant on *.*, the user still cannot
--- touch `mysql` or anything outside the suite's namespace.
+-- Rails' grant is on the literal test database. Widened here to the
+-- `activerecord_unittest%` pattern, which is what lets the user CREATE its own
+-- AR_DB_SLOT copies (activerecord_unittest_<token>_1, _2, …, and the arunit2
+-- database activerecord_unittest2) — Rails' single-database run never needs
+-- that. Deliberately not widened to *.*: `mysql` stays unreachable.
 --
--- inexistent_activerecord_unittest is granted literally, exactly as Rails
--- does, so connecting to it fails with "Unknown database" rather than "access
--- denied" (abstract-mysql-adapter/connection.test.ts, mysql2-adapter.test.ts).
+-- Rails' second grant is reproduced literally: it is what makes a connection to
+-- inexistent_activerecord_unittest fail with "Unknown database" instead of
+-- "access denied", which abstract-mysql-adapter/connection.test.ts and
+-- mysql2-adapter.test.ts assert on.
 CREATE USER IF NOT EXISTS 'rails'@'%';
 GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
--- PERMANENT DEVIATION: MYSQL_SOCK is a first-class sub-setting here
--- (config.example.yml:18-19), and a socket connection authenticates as
--- 'rails'@'localhost', which '%' does not cover. Rails' rake task grants only
--- '%' because its own runs are over TCP. Same narrowed grants.
+-- PERMANENT DEVIATION: Rails grants only '%' because its runs are over TCP.
+-- MYSQL_SOCK is a first-class sub-setting here (config.example.yml:18-19) and a
+-- socket connection authenticates as 'rails'@'localhost', which '%' misses.
 CREATE USER IF NOT EXISTS 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';

--- a/scripts/db-init/mysql/01-rails-user.sql
+++ b/scripts/db-init/mysql/01-rails-user.sql
@@ -12,13 +12,21 @@
 -- inexistent_activerecord_unittest fail with "Unknown database" instead of
 -- "access denied", which abstract-mysql-adapter/connection.test.ts and
 -- mysql2-adapter.test.ts assert on.
+--
+-- ar_cli_e2e% is trails-only, with no Rails counterpart: the activerecord-cli
+-- E2E suite drives `ar db:create` as this same user against a throwaway
+-- ar_cli_e2e_<hrtime> database (activerecord-cli/src/__e2e__/*-happy-path.test.ts).
+-- Postgres needs no equivalent — that role has CREATEDB, which is not
+-- per-database.
 CREATE USER IF NOT EXISTS 'rails'@'%';
 GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
+GRANT ALL PRIVILEGES ON `ar_cli_e2e%`.* TO 'rails'@'%';
 -- PERMANENT DEVIATION: Rails grants only '%' because its runs are over TCP.
 -- MYSQL_SOCK is a first-class sub-setting here (config.example.yml:18-19) and a
 -- socket connection authenticates as 'rails'@'localhost', which '%' misses.
 CREATE USER IF NOT EXISTS 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';
+GRANT ALL PRIVILEGES ON `ar_cli_e2e%`.* TO 'rails'@'localhost';
 FLUSH PRIVILEGES;

--- a/scripts/db-init/mysql/01-rails-user.sql
+++ b/scripts/db-init/mysql/01-rails-user.sql
@@ -3,30 +3,36 @@
 -- test/config.example.yml:4,24 connects with no password.
 --
 -- Rails' grant is on the literal test database. Widened here to the
--- `activerecord_unittest%` pattern, which is what lets the user CREATE its own
+-- `activerecord\_unittest%` pattern, which is what lets the user CREATE its own
 -- AR_DB_SLOT copies (activerecord_unittest_<token>_1, _2, …, and the arunit2
 -- database activerecord_unittest2) — Rails' single-database run never needs
 -- that. Deliberately not widened to *.*: `mysql` stays unreachable.
 --
--- Rails' second grant is reproduced literally: it is what makes a connection to
--- inexistent_activerecord_unittest fail with "Unknown database" instead of
--- "access denied", which abstract-mysql-adapter/connection.test.ts and
--- mysql2-adapter.test.ts assert on.
+-- The underscores are backslash-escaped because MySQL reads `_` and `%` in a
+-- database-level GRANT as LIKE wildcards (dev.mysql.com/doc/en/grant.html).
+-- Left bare, the pattern would also authorize names like activerecordXunittest_1
+-- — broader than this file means. Only the trailing % is a wildcard on purpose.
 --
--- ar_cli_e2e% is trails-only, with no Rails counterpart: the activerecord-cli
+-- Rails' second grant is reproduced literally, bare underscores and all, since
+-- it is a verbatim port of the Rakefile statement: it is what makes a
+-- connection to inexistent_activerecord_unittest fail with "Unknown database"
+-- instead of "access denied", which abstract-mysql-adapter/connection.test.ts
+-- and mysql2-adapter.test.ts assert on.
+--
+-- ar\_cli\_e2e% is trails-only, with no Rails counterpart: the activerecord-cli
 -- E2E suite drives `ar db:create` as this same user against a throwaway
 -- ar_cli_e2e_<hrtime> database (activerecord-cli/src/__e2e__/*-happy-path.test.ts).
 -- Postgres needs no equivalent — that role has CREATEDB, which is not
 -- per-database.
 CREATE USER IF NOT EXISTS 'rails'@'%';
-GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'%';
+GRANT ALL PRIVILEGES ON `activerecord\_unittest%`.* TO 'rails'@'%';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'%';
-GRANT ALL PRIVILEGES ON `ar_cli_e2e%`.* TO 'rails'@'%';
+GRANT ALL PRIVILEGES ON `ar\_cli\_e2e%`.* TO 'rails'@'%';
 -- PERMANENT DEVIATION: Rails grants only '%' because its runs are over TCP.
 -- MYSQL_SOCK is a first-class sub-setting here (config.example.yml:18-19) and a
 -- socket connection authenticates as 'rails'@'localhost', which '%' misses.
 CREATE USER IF NOT EXISTS 'rails'@'localhost';
-GRANT ALL PRIVILEGES ON `activerecord_unittest%`.* TO 'rails'@'localhost';
+GRANT ALL PRIVILEGES ON `activerecord\_unittest%`.* TO 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* TO 'rails'@'localhost';
-GRANT ALL PRIVILEGES ON `ar_cli_e2e%`.* TO 'rails'@'localhost';
+GRANT ALL PRIVILEGES ON `ar\_cli\_e2e%`.* TO 'rails'@'localhost';
 FLUSH PRIVILEGES;

--- a/scripts/db-init/postgres/01-rails-role.sql
+++ b/scripts/db-init/postgres/01-rails-role.sql
@@ -1,22 +1,19 @@
--- Rails' `postgresql:` connection entries carry no credential at all
--- (vendor/rails/activerecord/test/config.example.yml:74-81) — `rake
--- db:postgresql:build` (Rakefile:258-262) creates no role at all, it just runs
--- createdb as the local user. This role is the container equivalent: a
--- passwordless `rails` role, reachable because the container runs with
--- POSTGRES_HOST_AUTH_METHOD=trust. PERMANENT DEVIATION: a passwordless role
--- cannot otherwise connect over TCP, and there is no "local user" inside a
--- service container to inherit.
+-- rake db:postgresql:build (vendor/rails/activerecord/Rakefile:258-262) creates
+-- no role at all — it runs createdb as the local user, and Rails' postgresql:
+-- entries carry no credential (test/config.example.yml:74-81).
 --
--- CREATEDB: each vitest worker creates its own AR_DB_SLOT copy of the database
--- (activerecord_unittest_<token>_1, _2, …), which Rails' single-database run
--- never needs.
+-- PERMANENT DEVIATION, the whole file: a service container has no "local user"
+-- to inherit, so the equivalent is a passwordless `rails` role, reachable
+-- because the container runs POSTGRES_HOST_AUTH_METHOD=trust.
 --
--- SUPERUSER: PERMANENT DEVIATION, and it cannot be dropped. Rails' local user
--- is a superuser by construction (it owns the cluster it initdb'd), and the
--- suite installs extensions that are *not* trusted, so database ownership plus
--- CREATEDB is not enough: postgres_fdw (adapters/postgresql/foreign-table.test.ts,
--- which also CREATE SERVERs) and pg_hint_plan
--- (adapters/postgresql/optimizer-hints.test.ts) both require superuser. Only
--- the trusted extensions (hstore, citext) would work under a plain owner.
+-- CREATEDB is what each vitest worker needs to create its own AR_DB_SLOT copy
+-- of the database (activerecord_unittest_<token>_1, _2, …).
+--
+-- SUPERUSER cannot be narrowed away: Rails' local user is a superuser by
+-- construction (it initdb'd the cluster), and the suite installs extensions
+-- that are not trusted, for which owning the database is not enough —
+-- postgres_fdw (adapters/postgresql/foreign-table.test.ts, which also CREATEs a
+-- SERVER) and pg_hint_plan (adapters/postgresql/optimizer-hints.test.ts). Only
+-- the trusted ones (hstore, citext) would work under a plain owner.
 CREATE ROLE rails LOGIN CREATEDB SUPERUSER;
 ALTER DATABASE activerecord_unittest OWNER TO rails;

--- a/scripts/db-init/postgres/01-rails-role.sql
+++ b/scripts/db-init/postgres/01-rails-role.sql
@@ -1,11 +1,22 @@
 -- Rails' `postgresql:` connection entries carry no credential at all
 -- (vendor/rails/activerecord/test/config.example.yml:74-81) — `rake
--- db:postgresql:build` (Rakefile:258-262) just runs createdb as the local
--- user. This role is the container equivalent: a passwordless `rails` role,
--- reachable because the container runs with POSTGRES_HOST_AUTH_METHOD=trust.
+-- db:postgresql:build` (Rakefile:258-262) creates no role at all, it just runs
+-- createdb as the local user. This role is the container equivalent: a
+-- passwordless `rails` role, reachable because the container runs with
+-- POSTGRES_HOST_AUTH_METHOD=trust. PERMANENT DEVIATION: a passwordless role
+-- cannot otherwise connect over TCP, and there is no "local user" inside a
+-- service container to inherit.
 --
--- CREATEDB is what trails adds on top of Rails' setup: each vitest worker
--- creates its own AR_DB_SLOT copy of the database (activerecord_unittest_2,
--- _3, …), which Rails' single-database run never needs.
+-- CREATEDB: each vitest worker creates its own AR_DB_SLOT copy of the database
+-- (activerecord_unittest_<token>_1, _2, …), which Rails' single-database run
+-- never needs.
+--
+-- SUPERUSER: PERMANENT DEVIATION, and it cannot be dropped. Rails' local user
+-- is a superuser by construction (it owns the cluster it initdb'd), and the
+-- suite installs extensions that are *not* trusted, so database ownership plus
+-- CREATEDB is not enough: postgres_fdw (adapters/postgresql/foreign-table.test.ts,
+-- which also CREATE SERVERs) and pg_hint_plan
+-- (adapters/postgresql/optimizer-hints.test.ts) both require superuser. Only
+-- the trusted extensions (hstore, citext) would work under a plain owner.
 CREATE ROLE rails LOGIN CREATEDB SUPERUSER;
 ALTER DATABASE activerecord_unittest OWNER TO rails;


### PR DESCRIPTION
Rails' `db:mysql:build_user` (`vendor/rails/activerecord/Rakefile:227-235`)
grants only on the test database plus `inexistent_activerecord_unittest`, and
`db:postgresql:build` (`Rakefile:258-262`) creates no role at all. trails'
provisioning was broader on three axes. This narrows the one that can be
narrowed, records the other two as permanent at their call sites, and makes CI
and docker-compose provision from the same file.

## Narrowed

`GRANT ALL PRIVILEGES ON *.*` → `` `activerecord\_unittest%`.* ``, plus Rails'
literal `inexistent_activerecord_unittest.*` grant.

Every database the AR suite touches shares that prefix: the bare
`activerecord_unittest`, the arunit2 `activerecord_unittest2`, and every
`AR_DB_SLOT` copy (`activerecord_unittest_<token>_N`, `slotDatabaseName` in
`packages/activerecord/src/support/run-token.ts`). A database-level grant on a
pattern is what permits `CREATE DATABASE` for matching names, so the slot
machinery keeps working with no grant on `*.*`.

Literal underscores are backslash-escaped, because MySQL reads `_` and `%` in a
database-level GRANT as LIKE wildcards; only the trailing `%` is a wildcard on
purpose. Rails' own `inexistent_activerecord_unittest` grant stays bare, as a
verbatim port of the Rakefile statement.

One more namespace is granted, `ar_cli_e2e%`: the activerecord-cli E2E suite
drives `ar db:create` as this same user against a throwaway
`ar_cli_e2e_<hrtime>` database. MariaDB CI caught its absence in the first
revision. Postgres needs no counterpart — `CREATEDB` is not per-database, which
is why only the MySQL legs failed.

## One source of truth

The three CI provisioning steps re-stated the SQL inline (two identical MySQL
copies) next to the copies in `scripts/db-init/`. CI now pipes those same files
into the service containers — the containers can't mount
`/docker-entrypoint-initdb.d`, but they can read the repo after checkout. CI and
local provisioning can't drift, and each deviation is documented exactly once.

## Recorded as permanent

- **`'rails'@'localhost'`** — `MYSQL_SOCK` is a first-class sub-setting here
  (`config.example.yml:18-19`); a socket connection authenticates as
  `localhost`, which `'%'` does not cover. Rails' rake task grants only `'%'`
  because its runs are over TCP.
- **Postgres role with `CREATEDB SUPERUSER`** — a service container has no
  "local user" to inherit, so the equivalent of Rails' setup is a passwordless
  role plus `trust`. `SUPERUSER` specifically cannot be narrowed away: the suite
  installs extensions that are not trusted, for which owning the database is not
  enough — `postgres_fdw` (`adapters/postgresql/foreign-table.test.ts`, which
  also `CREATE SERVER`s) and `pg_hint_plan`
  (`adapters/postgresql/optimizer-hints.test.ts`).

## Verified

Against `mysql:8` and `postgres:17`, applying the scripts exactly as both CI and
compose do:

- slot `CREATE DATABASE` → DDL → `DROP DATABASE`, and `activerecord_unittest2`: OK
- socket login authenticates as `rails@localhost`: OK
- `CREATE DATABASE evil` → `ERROR 1044 Access denied`
- `SELECT FROM mysql.user` → `ERROR 1142 denied`
- connecting to `inexistent_activerecord_unittest` → `ERROR 1049 Unknown
  database`, not access-denied — the point of Rails' second grant, and what
  `abstract-mysql-adapter/connection.test.ts` and `mysql2-adapter.test.ts`
  assert
- the SUPERUSER claim: as a plain `CREATEDB` owner, `CREATE EXTENSION hstore`
  succeeds but `postgres_fdw` fails with "Must be superuser to create this
  extension"
- the underscore escaping: the escaped patterns still allow the slot, arunit2
  and `ar_cli_e2e` databases, and now deny `activerecordXunittest_1` /
  `arXcliYe2e_1`, which the bare patterns did grant
- the `ar_cli_e2e%` regression, against the failing revision: it denies
  `CREATE DATABASE ar_cli_e2e_123456789`, and the current script allows it with
  every check above unchanged

Closes-story: rails-test-user-grants-broader-than-build-user
