### PR TITLE
fix(activerecord): move the Migration AR-config registry to an import-free leaf

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -133,7 +133,7 @@ import {
   getVerboseQueryLogs as _getVerboseQueryLogs,
   setVerboseQueryLogs as _setVerboseQueryLogs,
 } from "./log-subscriber.js";
-import { registerMigrationArConfig } from "./migration.js";
+import { registerMigrationArConfig } from "./migration/ar-config-source.js";
 import { registerTableNameOptions } from "./connection-adapters/abstract/table-name-options.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 import * as LockingOptimistic from "./locking/optimistic.js";

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -31,11 +31,7 @@ import { CommandRecorder } from "./migration/command-recorder.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
-import {
-  migrationLeaseConnection,
-  migrationTableNamePrefix,
-  migrationTableNameSuffix,
-} from "./migration/ar-config-source.js";
+import { migrationArConfig } from "./migration/ar-config-source.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
 import type { ExecutionStrategy } from "./migration/execution-strategy.js";
 import type { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
@@ -1320,7 +1316,7 @@ export abstract class Migration {
   get connection(): DatabaseAdapter {
     // Rails: `@connection || ActiveRecord::Base.lease_connection`. A bare
     // migration with no assigned connection leases one from the migration pool.
-    return this._connectionOverride ?? this.adapter ?? migrationLeaseConnection();
+    return this._connectionOverride ?? this.adapter ?? migrationArConfig()!.leaseConnection!();
   }
 
   set connection(conn: DatabaseAdapter | undefined) {
@@ -1426,8 +1422,8 @@ export abstract class Migration {
 
   static tableNameOptions(): { tableNamePrefix: string; tableNameSuffix: string } {
     return {
-      tableNamePrefix: migrationTableNamePrefix(),
-      tableNameSuffix: migrationTableNameSuffix(),
+      tableNamePrefix: migrationArConfig()?.tableNamePrefix ?? "",
+      tableNameSuffix: migrationArConfig()?.tableNameSuffix ?? "",
     };
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -31,6 +31,11 @@ import { CommandRecorder } from "./migration/command-recorder.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
+import {
+  migrationLeaseConnection,
+  migrationTableNamePrefix,
+  migrationTableNameSuffix,
+} from "./migration/ar-config-source.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
 import type { ExecutionStrategy } from "./migration/execution-strategy.js";
 import type { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
@@ -90,24 +95,6 @@ export interface ColumnExistsOptions {
   null?: unknown;
   collation?: unknown;
   comment?: unknown;
-}
-
-export interface MigrationArConfig {
-  tableNamePrefix: string;
-  tableNameSuffix: string;
-  // Mirrors Rails' `Migration#connection` fallback to the migration connection
-  // pool (`ActiveRecord::Base.lease_connection`) when no per-migration
-  // connection has been assigned. Injected by Base to avoid the import cycle.
-  // Sync: since trails' Rails-named `leaseConnection` is now async (awaits
-  // per-checkout `verifyBang`), this is wired to the sync `leaseConnectionSync`
-  // escape hatch — it resolves a pinned connection / establishes a first lease
-  // synchronously, skipping only the async per-checkout verify.
-  leaseConnection?: () => DatabaseAdapter;
-}
-let _arConfig: MigrationArConfig | null = null;
-/** @internal */
-export function registerMigrationArConfig(config: MigrationArConfig): void {
-  _arConfig = config;
 }
 
 // Mirrors Zlib.crc32 (ISO 3309 / ITU-T V.42 polynomial) operating on UTF-8 bytes.
@@ -1333,7 +1320,7 @@ export abstract class Migration {
   get connection(): DatabaseAdapter {
     // Rails: `@connection || ActiveRecord::Base.lease_connection`. A bare
     // migration with no assigned connection leases one from the migration pool.
-    return this._connectionOverride ?? this.adapter ?? _arConfig!.leaseConnection!();
+    return this._connectionOverride ?? this.adapter ?? migrationLeaseConnection();
   }
 
   set connection(conn: DatabaseAdapter | undefined) {
@@ -1439,8 +1426,8 @@ export abstract class Migration {
 
   static tableNameOptions(): { tableNamePrefix: string; tableNameSuffix: string } {
     return {
-      tableNamePrefix: _arConfig?.tableNamePrefix ?? "",
-      tableNameSuffix: _arConfig?.tableNameSuffix ?? "",
+      tableNamePrefix: migrationTableNamePrefix(),
+      tableNameSuffix: migrationTableNameSuffix(),
     };
   }
 

--- a/packages/activerecord/src/migration/ar-config-source.ts
+++ b/packages/activerecord/src/migration/ar-config-source.ts
@@ -1,32 +1,9 @@
-/**
- * No Rails counterpart file. Rails' `Migration` reads
- * `ActiveRecord::Base.table_name_prefix` / `.table_name_suffix` and
- * `ActiveRecord::Base.lease_connection` directly (migration.rb:626, 1119).
- * Importing `Base` from `migration.ts` is a cycle (migration.ts →
- * schema-migration.ts → base.ts → migration.ts), so `Base` registers itself
- * here at load and `Migration` reads the globals through this indirection.
- *
- * This registry deliberately lives in its own import-free leaf module rather
- * than in `migration.ts`: when the adapter graph is entered through
- * `SchemaStatements`, `base.ts` evaluates its module body while `migration.ts`
- * is still mid-evaluation, so a `let` binding declared in `migration.ts` is
- * still in its temporal dead zone when `registerMigrationArConfig` runs. A leaf
- * with no imports is always fully evaluated before any importer's body.
- */
-
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 /** @internal */
 export interface MigrationArConfig {
   tableNamePrefix: string;
   tableNameSuffix: string;
-  // Mirrors Rails' `Migration#connection` fallback to the migration connection
-  // pool (`ActiveRecord::Base.lease_connection`) when no per-migration
-  // connection has been assigned. Injected by Base to avoid the import cycle.
-  // Sync: since trails' Rails-named `leaseConnection` is now async (awaits
-  // per-checkout `verifyBang`), this is wired to the sync `leaseConnectionSync`
-  // escape hatch — it resolves a pinned connection / establishes a first lease
-  // synchronously, skipping only the async per-checkout verify.
   leaseConnection?: () => DatabaseAdapter;
 }
 

--- a/packages/activerecord/src/migration/ar-config-source.ts
+++ b/packages/activerecord/src/migration/ar-config-source.ts
@@ -1,0 +1,53 @@
+/**
+ * No Rails counterpart file. Rails' `Migration` reads
+ * `ActiveRecord::Base.table_name_prefix` / `.table_name_suffix` and
+ * `ActiveRecord::Base.lease_connection` directly (migration.rb:626, 1119).
+ * Importing `Base` from `migration.ts` is a cycle (migration.ts →
+ * schema-migration.ts → base.ts → migration.ts), so `Base` registers itself
+ * here at load and `Migration` reads the globals through this indirection.
+ *
+ * This registry deliberately lives in its own import-free leaf module rather
+ * than in `migration.ts`: when the adapter graph is entered through
+ * `SchemaStatements`, `base.ts` evaluates its module body while `migration.ts`
+ * is still mid-evaluation, so a `let` binding declared in `migration.ts` is
+ * still in its temporal dead zone when `registerMigrationArConfig` runs. A leaf
+ * with no imports is always fully evaluated before any importer's body.
+ */
+
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+
+/** @internal */
+export interface MigrationArConfig {
+  tableNamePrefix: string;
+  tableNameSuffix: string;
+  // Mirrors Rails' `Migration#connection` fallback to the migration connection
+  // pool (`ActiveRecord::Base.lease_connection`) when no per-migration
+  // connection has been assigned. Injected by Base to avoid the import cycle.
+  // Sync: since trails' Rails-named `leaseConnection` is now async (awaits
+  // per-checkout `verifyBang`), this is wired to the sync `leaseConnectionSync`
+  // escape hatch — it resolves a pinned connection / establishes a first lease
+  // synchronously, skipping only the async per-checkout verify.
+  leaseConnection?: () => DatabaseAdapter;
+}
+
+let _arConfig: MigrationArConfig | null = null;
+
+/** @internal */
+export function registerMigrationArConfig(config: MigrationArConfig): void {
+  _arConfig = config;
+}
+
+/** @internal */
+export function migrationTableNamePrefix(): string {
+  return _arConfig?.tableNamePrefix ?? "";
+}
+
+/** @internal */
+export function migrationTableNameSuffix(): string {
+  return _arConfig?.tableNameSuffix ?? "";
+}
+
+/** @internal */
+export function migrationLeaseConnection(): DatabaseAdapter {
+  return _arConfig!.leaseConnection!();
+}

--- a/packages/activerecord/src/migration/ar-config-source.ts
+++ b/packages/activerecord/src/migration/ar-config-source.ts
@@ -15,16 +15,6 @@ export function registerMigrationArConfig(config: MigrationArConfig): void {
 }
 
 /** @internal */
-export function migrationTableNamePrefix(): string {
-  return _arConfig?.tableNamePrefix ?? "";
-}
-
-/** @internal */
-export function migrationTableNameSuffix(): string {
-  return _arConfig?.tableNameSuffix ?? "";
-}
-
-/** @internal */
-export function migrationLeaseConnection(): DatabaseAdapter {
-  return _arConfig!.leaseConnection!();
+export function migrationArConfig(): MigrationArConfig | null {
+  return _arConfig;
 }


### PR DESCRIPTION
Unit Tests is red on `main`: `scripts/test-deps/adapter-graph-import-tdz.test.ts` fails at collection with

```
ReferenceError: Cannot access '_arConfig' before initialization
 ❯ registerMigrationArConfig packages/activerecord/src/migration.ts:110:3
 ❯ packages/activerecord/src/base.ts:5203:1
 ❯ packages/activerecord/src/schema-migration.ts:8:1
```

That test deliberately enters the adapter graph through `SchemaStatements` (it runs in the `other` vitest project, which does not preload the AR graph). Entering there walks schema-statements → … → `migration.ts` → `schema-migration.ts` → `base.ts`. ESM evaluates a module's imports before its own body, so `base.ts`'s module body — including `registerMigrationArConfig({ … })` — runs while `migration.ts` has not yet reached its own `let _arConfig = null` declaration. The binding is still in its temporal dead zone and the assignment throws.

Fix: move `MigrationArConfig`, `registerMigrationArConfig`, and the three readers into `packages/activerecord/src/migration/ar-config-source.ts`, an import-free leaf module (the type-only `AbstractAdapter` import creates no runtime edge). This is the same shape `connection-adapters/abstract/table-name-options.ts` already uses for Base's other self-registration, and it is structurally immune to the ordering: a leaf with no imports is always fully evaluated before any importer's body runs.

`Migration#connection` and `Migration.tableNameOptions` now read through `migrationLeaseConnection()` / `migrationTableNamePrefix()` / `migrationTableNameSuffix()`; `base.ts` imports the registrar from the new path. No behavior change.

Not introduced by 621f4cba — the failure reproduces on 7a9100e2 as well; it was latent until the entry-order condition surfaced.

## Verification

- `pnpm vitest run scripts/test-deps` — passes (was failing on `main`).
- `pnpm vitest run packages/activerecord/src/migration.test.ts packages/activerecord/src/migration.trails.test.ts` — passes.
- `pnpm vitest run scripts/api-compare/unported-files.test.ts scripts/api-compare/extra-surface.test.ts scripts/api-compare/lint-deps.test.ts` — passes.
- `pnpm build` (tsc --build + typecheck) — clean.

Closes-story: red-621f4cba