### PR TITLE
feat(api-compare): report the permanence claim of @noRailsEquivalent tags

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -416,6 +416,52 @@ Rails-layout file, do not tag it. Tagging a moved extra asserts something
 false, and the stale-tag gate enforces the boundary mechanically where it
 can.
 
+### Permanence claim: open the reason with `PERMANENT` or `CONVERGEABLE`
+
+The RFC 0080 tag audit found 42 of 79 `@noRailsEquivalent` tags describing
+**convergeable** surface — unfinished porting, a fixable collision, a
+comparator gap — not the language- or runtime-level fact the bar above
+demands. Every one passed `api:extra` cleanly for as long as it existed,
+because each reason was accurate about its mechanism and merely drew
+"therefore permanent" from it. `api:extra` gates the opposite direction only:
+a **stale** tag (one on a name that no longer flags) fails the run; a tag that
+should never have been written does not.
+
+So the reason states its claim as a leading token:
+
+```text
+@noRailsEquivalent PERMANENT. Rails gains these bodies with `include SchemaStatements`…
+@noRailsEquivalent CONVERGEABLE — <mechanism>; story <story-slug>.
+```
+
+`classifyReason` (`extra-surface.ts`) reads the first word; anything else is
+**unclassified**, and `api:extra` reports the unclassified count, a
+per-package breakdown, and the names, alongside the existing tag totals
+(`tagged.classification` in the JSON report). This is **advisory** — the exit
+code still fails on stale entries and on empty reasons only. Most of the
+population predates the convention, so failing on unclassified tags would
+block unrelated work; the signal lands first, and a ratchet or gate is a
+follow-up once the population is classified.
+
+A `CONVERGEABLE` tag is a documented exception to "not for deferred work"
+above, not a licence for it: it is written only alongside a registered story
+that removes it, and the reason names that story.
+
+### Re-audit cadence
+
+The 2026-07-27 audit happened because a story was written for it; nothing
+scheduled the next one, which is how a batch of tags can re-accumulate the
+same debt silently. The standing cadence is therefore:
+
+- **Every two quarters**, or **whenever `tagged.total` grows by 10 or more
+  since the last audit** (whichever comes first), register a re-audit story
+  under RFC 0080 and apply the bar above to every tag added since.
+- The owner is whoever schedules RFC 0080 work; the trigger is checkable from
+  the `api:extra` JSON report alone (`tagged.total` plus
+  `tagged.classification.unclassified`), which the stats DB already ingests.
+- An audit's output is one disposition per tag and a story per convergeable
+  one — never a bulk edit, which is what keeps each removal reviewable.
+
 ### Tag configuration
 
 Both tags are machinery, not user documentation, so the docs-site

--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -457,8 +457,8 @@ same debt silently. The standing cadence is therefore:
   since the last audit** (whichever comes first), register a re-audit story
   under RFC 0080 and apply the bar above to every tag added since.
 - The owner is whoever schedules RFC 0080 work; the trigger is checkable from
-  the `api:extra` JSON report alone (`tagged.total` plus
-  `tagged.classification.unclassified`), which the stats DB already ingests.
+  the `api:extra` JSON report alone — `tagged.total`, which the stats DB
+  already ingests, plus `tagged.classification.unclassified`.
 - An audit's output is one disposition per tag and a story per convergeable
   one — never a bulk edit, which is what keeps each removal reviewable.
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -8,6 +8,7 @@ import {
   parseArgs,
   collectTsFileNames,
   collectTaggedEntries,
+  classifyReason,
 } from "./extra-surface.js";
 import { extractFromProgram } from "./extract-ts-api.js";
 
@@ -1501,7 +1502,26 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     expect(pkg.totalNovel).toBe(0);
     expect(pkg.totalAllowlisted).toBe(1);
     expect(pkg.extraFiles).toEqual([]);
-    expect(report.tagged).toEqual({ total: 1, matched: 1, inheritedMatched: 0, stale: [] });
+    expect(report.tagged).toEqual({
+      total: 1,
+      matched: 1,
+      inheritedMatched: 0,
+      stale: [],
+      classification: {
+        permanent: 0,
+        convergeable: 0,
+        unclassified: 1,
+        unclassifiedByPackage: { activemodel: 1 },
+        unclassifiedEntries: [
+          {
+            package: "activemodel",
+            tsFile: "foo.ts",
+            name: "tsOnlyHelper",
+            reason: "public registry seam, no Rails counterpart",
+          },
+        ],
+      },
+    });
     expect(report).not.toHaveProperty("allowlist");
   });
 
@@ -1560,7 +1580,21 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     const report = run(m);
     expect(report.packages[0].totalNovel).toBe(0);
     expect(report.packages[0].totalAllowlisted).toBe(1);
-    expect(report.tagged).toEqual({ total: 0, matched: 0, inheritedMatched: 1, stale: [] });
+    expect(report.tagged).toEqual({
+      total: 0,
+      matched: 0,
+      inheritedMatched: 1,
+      stale: [],
+      // Inherited entries repeat one declaration's reason, so they are not
+      // classified — the claim is counted once, where it is written.
+      classification: {
+        permanent: 0,
+        convergeable: 0,
+        unclassified: 0,
+        unclassifiedByPackage: {},
+        unclassifiedEntries: [],
+      },
+    });
   });
 
   it("does not extend a merged interface's tag to the namespace half's members", () => {
@@ -1831,7 +1865,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
       novelOnly: false,
       topN: 50,
     });
-    expect(report.tagged).toEqual({
+    expect(report.tagged).toMatchObject({
       total: 1,
       matched: 1,
       inheritedMatched: 0,
@@ -1879,7 +1913,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
       { source: "typescript", generatedAt: "", packages: { activerecord: tsPkg } },
       { filterPkg: null, excludeGlobs: [], novelOnly: false, topN: 50 },
     );
-    expect(report.tagged).toEqual({ total: 1, matched: 1, inheritedMatched: 0, stale: [] });
+    expect(report.tagged).toMatchObject({ total: 1, matched: 1, inheritedMatched: 0, stale: [] });
     expect(report.packages[0].totalAllowlisted).toBe(1);
     expect(report.packages[0].totalNovel).toBe(0);
   });
@@ -2021,5 +2055,105 @@ describe("buildReport — TS files with no Rails counterpart", () => {
       topN: 50,
     });
     expect(report.packages[0].extraFiles).toEqual([]);
+  });
+});
+
+describe("classifyReason", () => {
+  it("reads a leading PERMANENT or CONVERGEABLE token", () => {
+    expect(classifyReason("PERMANENT. Rails gains these bodies with `include`")).toBe("permanent");
+    expect(classifyReason("CONVERGEABLE — see story port-constantize")).toBe("convergeable");
+    expect(classifyReason("  PERMANENT: JS iteration protocol")).toBe("permanent");
+  });
+
+  it("treats a reason stating no claim as unclassified", () => {
+    expect(classifyReason("Rails nests this class inside NullPool")).toBe("unclassified");
+    expect(classifyReason("")).toBe("unclassified");
+  });
+
+  it("requires the token on a word boundary, not as a prefix of prose", () => {
+    // The audit's failure mode is prose that is accurate about a mechanism and
+    // reads as a permanence claim without making one; only the exact token is
+    // a claim.
+    expect(classifyReason("PERMANENTLY divergent accessor")).toBe("unclassified");
+    expect(classifyReason("Permanent: JS-only")).toBe("unclassified");
+  });
+});
+
+describe("buildReport — permanence classification", () => {
+  const run = (reason: string) => {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Foo": rubyClass({
+              name: "Foo",
+              file: "foo.rb",
+              instance: [method("bar")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const tsManifest: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [
+                method("bar"),
+                { ...method("tsOnlyHelper"), noRailsEquivalent: reason },
+              ],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    return buildReport(ruby, tsManifest, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+  };
+
+  it("counts a PERMANENT tag as classified", () => {
+    const c = run("PERMANENT. JS iteration protocol, no Ruby method to mirror").tagged
+      .classification;
+    expect(c).toEqual({
+      permanent: 1,
+      convergeable: 0,
+      unclassified: 0,
+      unclassifiedByPackage: {},
+      unclassifiedEntries: [],
+    });
+  });
+
+  it("counts a CONVERGEABLE tag apart from an unclassified one", () => {
+    expect(run("CONVERGEABLE — story registered").tagged.classification.convergeable).toBe(1);
+    expect(run("Rails has no such accessor").tagged.classification.unclassified).toBe(1);
+  });
+
+  it("keeps an unclassified tag allowed and non-stale — the signal is advisory", () => {
+    const report = run("Rails has no such accessor");
+    expect(report.tagged.stale).toEqual([]);
+    expect(report.packages[0].totalAllowlisted).toBe(1);
+    expect(report.packages[0].totalNovel).toBe(0);
+  });
+
+  it("breaks unclassified tags down by package", () => {
+    expect(run("Rails has no such accessor").tagged.classification.unclassifiedByPackage).toEqual({
+      activemodel: 1,
+    });
   });
 });

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -9,7 +9,9 @@ import {
   collectTsFileNames,
   collectTaggedEntries,
   classifyReason,
+  printClassificationBlock,
 } from "./extra-surface.js";
+import type { TaggedEntry, TaggedSummary } from "./extra-surface.js";
 import { extractFromProgram } from "./extract-ts-api.js";
 
 function method(name: string, internal = false): MethodInfo {
@@ -2155,5 +2157,67 @@ describe("buildReport — permanence classification", () => {
     expect(run("Rails has no such accessor").tagged.classification.unclassifiedByPackage).toEqual({
       activemodel: 1,
     });
+  });
+});
+
+describe("printClassificationBlock", () => {
+  const plain = { red: "", yellow: "", dim: "", bold: "", reset: "" };
+  const entry = (pkg: string, name: string): TaggedEntry => ({
+    package: pkg,
+    tsFile: `${name}.ts`,
+    name,
+    reason: "no claim",
+  });
+
+  const capture = (tagged: TaggedSummary, maxDetail = 40): string => {
+    const lines: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((line: string) => void lines.push(line));
+    printClassificationBlock(tagged, plain, maxDetail);
+    spy.mockRestore();
+    return lines.join("\n");
+  };
+
+  const summary = (unclassifiedEntries: TaggedEntry[]): TaggedSummary => {
+    const unclassifiedByPackage: Record<string, number> = {};
+    for (const e of unclassifiedEntries) {
+      unclassifiedByPackage[e.package] = (unclassifiedByPackage[e.package] ?? 0) + 1;
+    }
+    return {
+      total: unclassifiedEntries.length + 3,
+      matched: unclassifiedEntries.length + 3,
+      inheritedMatched: 0,
+      stale: [],
+      classification: {
+        permanent: 2,
+        convergeable: 1,
+        unclassified: unclassifiedEntries.length,
+        unclassifiedByPackage,
+        unclassifiedEntries,
+      },
+    };
+  };
+
+  it("prints only the split when every tag states a claim", () => {
+    const out = capture(summary([]));
+    expect(out).toContain("2 PERMANENT, 1 CONVERGEABLE, 0 unclassified");
+    expect(out).not.toContain("Unclassified by package");
+  });
+
+  it("breaks the unclassified tags down by package, most first, and names them", () => {
+    const out = capture(
+      summary([entry("activerecord", "aa"), entry("activerecord", "bb"), entry("arel", "cc")]),
+    );
+    expect(out).toContain("Unclassified by package: activerecord 2, arel 1");
+    expect(out).toContain("activerecord  aa.ts  aa");
+    expect(out).toContain("arel  cc.ts  cc");
+  });
+
+  it("elides names past --max-detail", () => {
+    const out = capture(summary([entry("arel", "aa"), entry("arel", "bb")]), 1);
+    expect(out).toContain("arel  aa.ts  aa");
+    expect(out).not.toContain("bb.ts");
+    expect(out).toContain("… +1 more");
   });
 });

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -44,6 +44,9 @@
  *      that is a declaration rather than a member still has an inline form.
  *      On an `interface` the declaration tag additionally covers every member
  *      — see `collectTaggedEntries`.
+ *   6. Classify each written tag's permanence claim — see `classifyReason`.
+ *      Advisory only: the count of tags that never state one is reported so a
+ *      batch of new tags is visible, but it does not affect the exit code.
  *
  * Manifests are produced by `pnpm api:compare`; if they're missing the
  * script bails with a hint (same convention as `api:moves`).
@@ -274,6 +277,40 @@ export interface TaggedEntry {
   inherited?: boolean;
 }
 
+/**
+ * The permanence claim a tag's reason makes about itself.
+ *
+ * `permanent` — a language-level or runtime-level fact no port can remove.
+ * `convergeable` — unfinished porting, a fixable collision, a comparator gap:
+ * the tag is a placeholder for work, and the reason should name its story.
+ * `unclassified` — the reason makes no claim either way.
+ */
+export type Permanence = "permanent" | "convergeable" | "unclassified";
+
+const PERMANENCE_TOKENS: Record<string, Permanence> = {
+  PERMANENT: "permanent",
+  CONVERGEABLE: "convergeable",
+};
+
+/**
+ * Read the leading classification token off a `@noRailsEquivalent` reason.
+ *
+ * The tag audit (RFC 0080) found 42 of 79 tags describing convergeable
+ * surface: each reason was factually accurate about its mechanism and merely
+ * drew "therefore permanent" from it, so nothing in the report could tell the
+ * two populations apart. Requiring the claim to be stated as a token makes an
+ * unstated one countable — a tag that says neither word is `unclassified`
+ * rather than assumed permanent.
+ *
+ * The token must be the reason's first word (uppercase, on a word boundary, so
+ * prose like "PERMANENTLY" does not qualify); any punctuation may follow it.
+ */
+export function classifyReason(reason: string): Permanence {
+  const first = /^\s*([A-Z]+)\b/.exec(reason);
+  if (!first) return "unclassified";
+  return PERMANENCE_TOKENS[first[1]] ?? "unclassified";
+}
+
 export function allowKeyOf(e: { package: string; tsFile: string; name: string }): string {
   return `${e.package} ${e.tsFile} ${e.name}`;
 }
@@ -418,6 +455,20 @@ interface TaggedSummary {
    */
   inheritedMatched: number;
   stale: TaggedEntry[];
+  /**
+   * Permanence claims across the WRITTEN tags (`total`) — advisory, never part
+   * of the exit code. An inherited entry repeats its interface declaration's
+   * reason, so counting it would multiply one claim by the interface's member
+   * count.
+   */
+  classification: {
+    permanent: number;
+    convergeable: number;
+    /** Tags stating no claim. Listed too, since acting on them needs the names. */
+    unclassified: number;
+    unclassifiedByPackage: Record<string, number>;
+    unclassifiedEntries: TaggedEntry[];
+  };
 }
 
 interface Report {
@@ -453,7 +504,9 @@ extractor reads lib/ only. The NoCntrp column reports that slice separately.
 Reasoned exceptions: an extra is allowed by tagging its TS declaration
 \`@noRailsEquivalent <reason>\` in JSDoc. Allowed extras are subtracted from the
 novel/moved counts and reported as an "Allowed" total; a tag on a name that no
-longer flags is STALE and fails the run.
+longer flags is STALE and fails the run. A reason opening with PERMANENT or
+CONVERGEABLE states its permanence claim; the count of tags stating neither is
+reported (advisory — it never affects the exit code).
 
 Requires: pnpm api:compare must have run first to produce
   scripts/api-compare/output/{rails-api.json,ts-api.json}.
@@ -1106,6 +1159,33 @@ function padNumCell(n: number, colored: string, width: number): string {
   return " ".repeat(gap) + colored;
 }
 
+/**
+ * Advisory-only: prints the permanence split and names the unclassified tags.
+ * Deliberately NOT a gate — most of the population predates the convention, so
+ * failing on it would block every unrelated PR. See `classifyReason`.
+ */
+function printClassificationBlock(tagged: TaggedSummary, p: Palette, maxDetail: number): void {
+  const c = tagged.classification;
+  console.log(
+    `${p.dim}  permanence claims: ${c.permanent} PERMANENT, ${c.convergeable} CONVERGEABLE, ` +
+      `${c.unclassified} unclassified.${p.reset}`,
+  );
+  if (c.unclassified === 0) return;
+  const byPkg = Object.entries(c.unclassifiedByPackage)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([pkg, n]) => `${pkg} ${n}`)
+    .join(", ");
+  console.log(
+    `${p.dim}  Unclassified by package: ${byPkg}. Open each reason with PERMANENT ` +
+      `(a language- or runtime-level fact no port can remove) or CONVERGEABLE ` +
+      `(unfinished porting, a fixable collision, a comparator gap — name the story).${p.reset}`,
+  );
+  const shown = maxDetail > 0 ? c.unclassifiedEntries.slice(0, maxDetail) : c.unclassifiedEntries;
+  for (const e of shown) console.log(`${p.dim}    ${e.package}  ${e.tsFile}  ${e.name}${p.reset}`);
+  const elided = c.unclassifiedEntries.length - shown.length;
+  if (elided > 0) console.log(`${p.dim}    … +${elided} more${p.reset}`);
+}
+
 function printHumanReport(report: Report, topN: number, maxDetail: number): void {
   const { palette: p } = pickPalette();
 
@@ -1138,6 +1218,7 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
         : "") +
       ` — allowed extras are subtracted from the counts above.${p.reset}`,
   );
+  printClassificationBlock(report.tagged, p, maxDetail);
 
   console.log(
     `\n${p.bold}Top ${Math.min(topN, report.topN.length)} most-divergent files${p.reset}  ${p.dim}(ranked by novel count, then total)${p.reset}`,
@@ -1238,11 +1319,25 @@ export function buildReport(
   const inheritedKeys = new Set(tagged.filter((e) => e.inherited).map(allowKeyOf));
   const inheritedMatched = [...matchedTagKeys].filter((k) => inheritedKeys.has(k)).length;
 
+  const written = tagged.filter((e) => !e.inherited);
+  const unclassifiedEntries = written.filter((e) => classifyReason(e.reason) === "unclassified");
+  const unclassifiedByPackage: Record<string, number> = {};
+  for (const e of unclassifiedEntries) {
+    unclassifiedByPackage[e.package] = (unclassifiedByPackage[e.package] ?? 0) + 1;
+  }
+
   const taggedSummary: TaggedSummary = {
-    total: tagged.filter((e) => !e.inherited).length,
+    total: written.length,
     matched: matchedTagKeys.size - inheritedMatched,
     inheritedMatched,
     stale: staleTagged,
+    classification: {
+      permanent: written.filter((e) => classifyReason(e.reason) === "permanent").length,
+      convergeable: written.filter((e) => classifyReason(e.reason) === "convergeable").length,
+      unclassified: unclassifiedEntries.length,
+      unclassifiedByPackage,
+      unclassifiedEntries,
+    },
   };
   return {
     generatedAt: new Date().toISOString(),

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -443,7 +443,7 @@ interface PackageTotals {
   extraFiles: ExtraFile[];
 }
 
-interface TaggedSummary {
+export interface TaggedSummary {
   /** Tags actually WRITTEN in the source — inherited entries excluded. */
   total: number;
   /** Written tags that matched an extra. */
@@ -1108,7 +1108,7 @@ function buildPackageReport(
   return result;
 }
 
-interface Palette {
+export interface Palette {
   red: string;
   yellow: string;
   dim: string;
@@ -1164,7 +1164,11 @@ function padNumCell(n: number, colored: string, width: number): string {
  * Deliberately NOT a gate — most of the population predates the convention, so
  * failing on it would block every unrelated PR. See `classifyReason`.
  */
-function printClassificationBlock(tagged: TaggedSummary, p: Palette, maxDetail: number): void {
+export function printClassificationBlock(
+  tagged: TaggedSummary,
+  p: Palette,
+  maxDetail: number,
+): void {
   const c = tagged.classification;
   console.log(
     `${p.dim}  permanence claims: ${c.permanent} PERMANENT, ${c.convergeable} CONVERGEABLE, ` +
@@ -1320,9 +1324,14 @@ export function buildReport(
   const inheritedMatched = [...matchedTagKeys].filter((k) => inheritedKeys.has(k)).length;
 
   const written = tagged.filter((e) => !e.inherited);
-  const unclassifiedEntries = written.filter((e) => classifyReason(e.reason) === "unclassified");
+  const claims: Record<Permanence, number> = { permanent: 0, convergeable: 0, unclassified: 0 };
+  const unclassifiedEntries: TaggedEntry[] = [];
   const unclassifiedByPackage: Record<string, number> = {};
-  for (const e of unclassifiedEntries) {
+  for (const e of written) {
+    const claim = classifyReason(e.reason);
+    claims[claim]++;
+    if (claim !== "unclassified") continue;
+    unclassifiedEntries.push(e);
     unclassifiedByPackage[e.package] = (unclassifiedByPackage[e.package] ?? 0) + 1;
   }
 
@@ -1332,9 +1341,9 @@ export function buildReport(
     inheritedMatched,
     stale: staleTagged,
     classification: {
-      permanent: written.filter((e) => classifyReason(e.reason) === "permanent").length,
-      convergeable: written.filter((e) => classifyReason(e.reason) === "convergeable").length,
-      unclassified: unclassifiedEntries.length,
+      permanent: claims.permanent,
+      convergeable: claims.convergeable,
+      unclassified: claims.unclassified,
       unclassifiedByPackage,
       unclassifiedEntries,
     },


### PR DESCRIPTION
Closing finding of the `@noRailsEquivalent` tag audit (RFC 0080): `api:extra`
gates exactly one direction — a **stale** tag (on a name that no longer flags)
fails the run. Nothing catches the inverse, a tag on surface that still flags
and should never have been written. That inverse was 42 of 79 tags at audit
time, each reason accurate about its mechanism and merely drawing "therefore
permanent" from it.

## Mechanism chosen: the classification token

The story offered two candidates. This PR lands the **token**, not the
per-package count ratchet, because a count ratchet only says a batch arrived —
it cannot tell a batch of genuine JS-protocol extras from a batch of deferred
porting, which is the distinction the audit had to make by hand. The token
makes each tag state its own claim, so the unclassified count is a burndown
list with names on it rather than a number to bump. The ratchet stays available
as a follow-up, and is strictly easier to add once the population is classified.

## What lands

- `classifyReason` reads a leading `PERMANENT` / `CONVERGEABLE` token off a
  tag's reason (word boundary, exact token — `PERMANENTLY` and `Permanent:`
  do not qualify, since the audit's failure mode is prose that reads as a
  claim without making one). Anything else is `unclassified`.
- `tagged.classification` in the report: counts per claim, an
  `unclassifiedByPackage` breakdown, and the entries themselves. The human
  report prints the split, the breakdown, and the names (capped by
  `--max-detail`). On today's tree that reads 2 PERMANENT, 0 CONVERGEABLE,
  74 unclassified.
- Inherited entries — the members an `interface` declaration tag covers — are
  not classified: they repeat one written reason, so counting them would
  multiply a single claim by the interface's member count. This matches how
  `total` already counts written tags only.
- The convention and a re-audit cadence — every two quarters, or whenever
  `tagged.total` grows by 10+, whichever comes first, owned by whoever
  schedules RFC 0080 work — recorded in
  `docs/infrastructure/api-build-stub-generation-plan.md` and in the RFC.

## What deliberately does not land

No gate. 76 tags exist today and most predate the convention, so failing on
unclassified ones would block unrelated work. The exit-code contract is
unchanged: stale entries and empty reasons still fail, the report stays
advisory, and the JSON shape is additive under one new key, so the stats-DB
consumer is unaffected.

Closes-story: detect-no-rails-equivalent-tags-excusing-convergeable-surface
