### PR TITLE
fix(activerecord): pin the run token in the arunit2 database-name assertion

### DIFF
--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -42,10 +42,16 @@ describe("connect", () => {
 
   it("gives arunit2 its own database and disables prepared statements on the third entry", async () => {
     vi.stubEnv("ARCONN", "postgresql");
+    // The ambient environment is the one CI's globalSetup stamped, so without
+    // pinning these the expected name is whatever token this run happens to
+    // carry. Unstamped + slot 1 is the path that spells Rails' own
+    // `activerecord_unittest2`; config.test.ts pins the stamped shape.
+    vi.stubEnv("AR_TEST_RUN_TOKEN", "");
+    vi.stubEnv("AR_DB_SLOT", "1");
     const { configurationHashes } = await testConfigurationHashes();
     const [arunit, arunit2, withoutPrepared] = configurationHashes;
     expect(arunit2.database).not.toBe(arunit.database);
-    expect(arunit2.database).toMatch(/^activerecord_unittest2(_\d+)?$/);
+    expect(arunit2.database).toBe("activerecord_unittest2");
     expect(withoutPrepared.database).toBe(arunit.database);
     expect(withoutPrepared.configurationHash.preparedStatements).toBe(false);
   });

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -42,10 +42,6 @@ describe("connect", () => {
 
   it("gives arunit2 its own database and disables prepared statements on the third entry", async () => {
     vi.stubEnv("ARCONN", "postgresql");
-    // The ambient environment is the one CI's globalSetup stamped, so without
-    // pinning these the expected name is whatever token this run happens to
-    // carry. Unstamped + slot 1 is the path that spells Rails' own
-    // `activerecord_unittest2`; config.test.ts pins the stamped shape.
     vi.stubEnv("AR_TEST_RUN_TOKEN", "");
     vi.stubEnv("AR_DB_SLOT", "1");
     const { configurationHashes } = await testConfigurationHashes();


### PR DESCRIPTION
`Active Record PostgreSQL Tests`, `Active Record MariaDB Tests`, `Active Record SQLite Tests` and `Active Record SQLite :memory: Tests` are red on `main` (run 30554748628 @65a3a44), all on one assertion:

```
packages/activerecord/src/support/connection.test.ts:48
AssertionError: expected 'activerecord_unittest_rms7o1ymu71r1nm2_1'
  to match /^activerecord_unittest2(_\d+)?$/
```

## Cause

`7a9100e2` stamps a run token into the slot database names, so the primary is `activerecord_unittest_<token>_<slot>`, and `arunitDatabaseNames` derives the sibling by inserting `2` ahead of the slot suffix (`arunit2-config.ts:63`) — `activerecord_unittest_<token>2_<slot>`. That derivation is working as designed.

The stale part is the test. Unlike `config.test.ts`, which injects a `reader`, `connection.test.ts` resolves settings from the ambient environment — which under CI is the one `globalSetup` just stamped. So the name under test carried a per-run token and a slot, and the assertion was pinned to the un-stamped, slot-1 spelling. It passes locally (no token) and fails in every CI lane.

## Fix

Stub `AR_TEST_RUN_TOKEN` and `AR_DB_SLOT` in the test so the name is deterministic. Unstamped at slot 1 is exactly the path that yields Rails' own `activerecord_unittest2` (`test/support/config.rb:28`), which is what the assertion was reaching for, so it tightens from a regex to the literal name. The stamped shape stays pinned by `config.test.ts` ("stamps the run token into the database name, slot 1 included").

No production code changes; the test name is unchanged.

## Verification

Reproduced the CI failure locally on the baseline and confirmed the fix, by stamping a token into the environment:

```
# baseline
AR_TEST_RUN_TOKEN=… AR_DB_SLOT=3 pnpm vitest run …/connection.test.ts
  → expected 'activerecord_unittest_<token>2_3' to match /^activerecord_unittest2(_\d+)?$/
# with this change
  → Tests  23 passed (23)
```

Unstamped run also passes (23/23).

## Follow-up filed

While tracing this I found a separate, latent bug in the same naming rule — the arunit2 siblings are not matched by `ownRunDatabases`, so teardown never reclaims them and a concurrent run's stale sweep can see them as a foreign token. Filed as its own story rather than widened into this one; details in `0061-ci-failures/arunit2-siblings-escape-run-token-ownership`.