### PR TITLE
feat(api-compare): group and report the wide call-set population by cause

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "api:calls": "pnpm tsx scripts/api-compare/lint-call-mismatches.ts",
     "api:calls:reseed": "API_COMPARE_FORCE=1 pnpm api:compare && pnpm tsx scripts/api-compare/lint-call-mismatches.ts --write",
     "api:calls:wide": "pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts",
+    "api:calls:wide:report": "pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --report",
     "api:calls:wide:reseed": "API_COMPARE_FORCE=1 pnpm api:compare --wide-calls && pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write",
     "api:arity": "pnpm tsx scripts/api-compare/lint-arity-excludes.ts",
     "api:pins": "pnpm tsx scripts/api-compare/lint-body-pins.ts",

--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -8,6 +8,7 @@ import {
   bucketFor,
   indexTsMembers,
   loadSplitBaseline,
+  parseTop,
   relPathFor,
   renderReport,
   unreviewedCount,
@@ -294,7 +295,7 @@ describe("renderReport", () => {
 
   it("reports totals by package, file, call name, and unreviewed count", () => {
     const out = renderReport(entries, undefined, 20);
-    expect(out).toContain("3 baselined entr(ies) across 2 file(s)");
+    expect(out).toContain("3 entr(ies) across 2 file(s)");
     expect(out).toContain("unreviewed (reason still the seeded default): 1 of 3");
     expect(out).toMatch(/activerecord\s+2/);
     expect(out).toMatch(/activerecord\/relation\.ts\s+2/);
@@ -305,5 +306,18 @@ describe("renderReport", () => {
     const out = renderReport(entries, undefined, 1);
     expect(out).toContain("By file (top 1 of 2)");
     expect(out).not.toContain("nodes/node.ts");
+  });
+});
+
+describe("parseTop", () => {
+  it("falls back when --top is absent and parses a positive integer", () => {
+    expect(parseTop([], 20)).toBe(20);
+    expect(parseTop(["--report", "--top=5"], 20)).toBe(5);
+  });
+
+  it("rejects a non-positive or non-integer --top instead of silently defaulting", () => {
+    expect(() => parseTop(["--top=x"], 20)).toThrow(/positive integer/);
+    expect(() => parseTop(["--top=0"], 20)).toThrow(/positive integer/);
+    expect(() => parseTop(["--top=2.5"], 20)).toThrow(/positive integer/);
   });
 });

--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -3,7 +3,17 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { findDuplicateKeys, keyOf, type ExcludeEntry } from "./lint-call-mismatches.js";
-import { loadSplitBaseline, relPathFor, writeSplitBaseline } from "./lint-call-mismatches-wide.js";
+import {
+  DEFAULT_REASON,
+  bucketFor,
+  indexTsMembers,
+  loadSplitBaseline,
+  relPathFor,
+  renderReport,
+  unreviewedCount,
+  writeSplitBaseline,
+} from "./lint-call-mismatches-wide.js";
+import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 
 const entry = (
   pkg: string,
@@ -175,5 +185,125 @@ describe("emission order", () => {
     await writeSplitBaseline([...entries].reverse(), dir);
     const second = await fs.readFile(path.join(dir, "activerecord", "relation.json"), "utf-8");
     expect(second).toBe(first);
+  });
+});
+
+describe("cause buckets", () => {
+  const method = (name: string, params: number, extra: Partial<MethodInfo> = {}): MethodInfo => ({
+    name,
+    visibility: "public",
+    params: Array.from({ length: params }, (_, i) => ({ name: `a${i}`, kind: "required" })),
+    ...extra,
+  });
+
+  const container = (file: string, methods: MethodInfo[]): ClassInfo => ({
+    name: "C",
+    file,
+    includes: [],
+    extends: [],
+    instanceMethods: methods,
+    classMethods: [],
+  });
+
+  const manifest = (classes: Record<string, ClassInfo>): ApiManifest => ({
+    source: "typescript",
+    generatedAt: "now",
+    packages: { activerecord: { classes, modules: {} } },
+  });
+
+  it("buckets a same-file candidate that takes arguments", () => {
+    const index = indexTsMembers(
+      manifest({ "relation.ts:Relation": container("relation.ts", [method("buildArel", 1)]) }),
+    );
+    expect(bucketFor(entry("activerecord", "relation.ts", "to_sql", "build_arel"), index)).toBe(
+      "same-file candidate takes args",
+    );
+  });
+
+  it("buckets a same-file zero-arg member separately", () => {
+    const index = indexTsMembers(
+      manifest({ "relation.ts:Relation": container("relation.ts", [method("buildArel", 0)]) }),
+    );
+    expect(bucketFor(entry("activerecord", "relation.ts", "to_sql", "build_arel"), index)).toBe(
+      "same-file zero-arg member",
+    );
+  });
+
+  it("buckets a candidate declared in another file of the package", () => {
+    const index = indexTsMembers(
+      manifest({ "model.ts:Model": container("model.ts", [method("buildArel", 1)]) }),
+    );
+    expect(bucketFor(entry("activerecord", "relation.ts", "to_sql", "build_arel"), index)).toBe(
+      "candidate elsewhere in package",
+    );
+  });
+
+  it("buckets a call with no TS counterpart anywhere in the package", () => {
+    const index = indexTsMembers(
+      manifest({ "relation.ts:Relation": container("relation.ts", [method("toSql", 0)]) }),
+    );
+    expect(bucketFor(entry("activerecord", "relation.ts", "to_sql", "build_arel"), index)).toBe(
+      "candidate not in package",
+    );
+  });
+
+  it("matches predicate calls through their convention candidates", () => {
+    const index = indexTsMembers(
+      manifest({ "relation.ts:Relation": container("relation.ts", [method("isLoaded", 0)]) }),
+    );
+    expect(bucketFor(entry("activerecord", "relation.ts", "to_sql", "loaded?"), index)).toBe(
+      "same-file zero-arg member",
+    );
+  });
+
+  it("attributes a mixin member to its declaring file, not the pseudo-module's", () => {
+    const index = indexTsMembers(
+      manifest({
+        "relation.ts:mixin": container("relation.ts", [
+          method("buildArel", 1, { declaredIn: "model.ts" }),
+        ]),
+      }),
+    );
+    expect(bucketFor(entry("activerecord", "relation.ts", "to_sql", "build_arel"), index)).toBe(
+      "candidate elsewhere in package",
+    );
+  });
+
+  it("buckets a package the manifest does not cover at all", () => {
+    expect(
+      bucketFor(entry("arel", "nodes/node.ts", "to_sql", "visit"), indexTsMembers(manifest({}))),
+    ).toBe("candidate not in package");
+  });
+});
+
+describe("unreviewedCount", () => {
+  it("counts only entries still carrying the seeded default reason", () => {
+    const seeded = { ...entry("activerecord", "relation.ts", "a", "b"), reason: DEFAULT_REASON };
+    expect(
+      unreviewedCount([seeded, entry("activerecord", "relation.ts", "c", "d", "reviewed")]),
+    ).toBe(1);
+  });
+});
+
+describe("renderReport", () => {
+  const entries = [
+    { ...entry("activerecord", "relation.ts", "a", "b"), reason: DEFAULT_REASON },
+    entry("activerecord", "relation.ts", "c", "d", "reviewed"),
+    entry("arel", "nodes/node.ts", "e", "f", "reviewed"),
+  ];
+
+  it("reports totals by package, file, call name, and unreviewed count", () => {
+    const out = renderReport(entries, undefined, 20);
+    expect(out).toContain("3 baselined entr(ies) across 2 file(s)");
+    expect(out).toContain("unreviewed (reason still the seeded default): 1 of 3");
+    expect(out).toMatch(/activerecord\s+2/);
+    expect(out).toMatch(/activerecord\/relation\.ts\s+2/);
+    expect(out).toContain("By cause bucket: SKIPPED");
+  });
+
+  it("truncates the per-file listing to the requested top N", () => {
+    const out = renderReport(entries, undefined, 1);
+    expect(out).toContain("By file (top 1 of 2)");
+    expect(out).not.toContain("nodes/node.ts");
   });
 });

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -212,47 +212,31 @@ function sortKeys<T extends CallMismatchKey>(entries: T[]): T[] {
   return [...entries].sort(compareKeys);
 }
 
-// ── --report: grouping the wide population (RFC 0083) ──────────────────────
-
 const TS_API_PATH = path.join(OUTPUT_DIR, "ts-api.json");
 
-/**
- * Why an entry flags, derived from the TS manifest — never hand-maintained.
- *
- * The question each bucket answers is "where does the call's TS counterpart
- * live, relative to the file that was supposed to make it?":
- *   - both same-file buckets mean the port has the member and simply does not
- *     call it from this method (a real omission, or a call folded into a
- *     zero-arg accessor);
- *   - `candidate elsewhere in package` is usually a layout divergence;
- *   - `candidate not in package` is usually an unported call or tooling noise.
- */
 export type CauseBucket =
   | "same-file candidate takes args"
   | "same-file zero-arg member"
   | "candidate elsewhere in package"
   | "candidate not in package";
 
-/** One declaration site of a TS member: the file it is declared in, and
- *  whether it accepts any parameters. */
 export interface MemberSite {
   file: string;
   takesArgs: boolean;
 }
 
-/** package → TS member name → its declaration sites. */
 export type TsMemberIndex = Map<string, Map<string, MemberSite[]>>;
 
 function addSite(index: Map<string, MemberSite[]>, m: MethodInfo, fallbackFile: string): void {
-  // `declaredIn` wins: on synthesized mixin pseudo-modules the member usually
-  // belongs to a different file than the one the pseudo-module is keyed under.
+  // On a synthesized mixin pseudo-module the member is usually declared in a
+  // different file than the one the pseudo-module is keyed under, so
+  // `declaredIn` — when present — is the only correct attribution.
   const file = m.declaredIn ?? m.file ?? fallbackFile;
   if (!file) return;
   const sites = index.get(m.name) ?? index.set(m.name, []).get(m.name)!;
   sites.push({ file, takesArgs: m.params.length > 0 });
 }
 
-/** Index every TS member declaration in the manifest by package and name. */
 export function indexTsMembers(manifest: ApiManifest): TsMemberIndex {
   const out: TsMemberIndex = new Map();
   for (const [pkg, info] of Object.entries(manifest.packages)) {
@@ -272,13 +256,10 @@ export function indexTsMembers(manifest: ApiManifest): TsMemberIndex {
   return out;
 }
 
-/** The TS names a Ruby call could faithfully port to (convention candidates
- *  plus the plain camelCase spelling). */
 export function tsCandidatesFor(call: string): string[] {
   return [...new Set([...(rubyMethodToTsIgnoringSkip(call) ?? []), snakeToCamel(call)])];
 }
 
-/** Assign an entry to its cause bucket using the TS manifest index. */
 export function bucketFor(key: CallMismatchKey, index: TsMemberIndex): CauseBucket {
   const byName = index.get(key.package);
   const sites = byName ? tsCandidatesFor(key.call).flatMap((n) => byName.get(n) ?? []) : [];
@@ -296,14 +277,13 @@ function tally<T>(items: T[], keyFn: (item: T) => string): [string, number][] {
     const k = keyFn(item);
     counts.set(k, (counts.get(k) ?? 0) + 1);
   }
-  // Descending count, then key, so the listing is stable across runs.
   return [...counts].sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
 }
 
 function section(title: string, rows: [string, number][], top?: number): string {
   const shown = top === undefined ? rows : rows.slice(0, top);
   const head =
-    top !== undefined && rows.length > shown.length
+    rows.length > shown.length
       ? `${title} (top ${shown.length} of ${rows.length})`
       : `${title} (${rows.length})`;
   const width = Math.max(0, ...shown.map(([k]) => k.length));
@@ -313,23 +293,19 @@ function section(title: string, rows: [string, number][], top?: number): string 
   ].join("\n");
 }
 
-/** Count entries still carrying the seeded reason — i.e. never reviewed. */
 export function unreviewedCount(entries: ExcludeEntry[]): number {
   return entries.filter((e) => e.reason === DEFAULT_REASON).length;
 }
 
-/** Render the whole `--report` body. `index` is undefined when the TS manifest
- *  has not been built, in which case the cause-bucket section is skipped. */
 export function renderReport(
   entries: ExcludeEntry[],
   index: TsMemberIndex | undefined,
   top: number,
 ): string {
-  const unreviewed = unreviewedCount(entries);
+  const files = new Set(entries.map((e) => `${e.package} ${e.tsFile}`)).size;
   const parts = [
-    `wide call-mismatches report: ${entries.length} baselined entr(ies) across ` +
-      `${new Set(entries.map((e) => `${e.package} ${e.tsFile}`)).size} file(s)`,
-    `  unreviewed (reason still the seeded default): ${unreviewed} of ${entries.length}`,
+    `wide call-mismatches report: ${entries.length} entr(ies) across ${files} file(s)`,
+    `  unreviewed (reason still the seeded default): ${unreviewedCount(entries)} of ${entries.length}`,
     section(
       "By package",
       tally(entries, (e) => e.package),
@@ -357,9 +333,9 @@ export function renderReport(
   return parts.join("\n");
 }
 
-async function loadTsMemberIndex(): Promise<TsMemberIndex | undefined> {
+async function readJsonIfPresent<T>(file: string): Promise<T | undefined> {
   try {
-    return indexTsMembers(await readJson<ApiManifest>(TS_API_PATH));
+    return await readJson<T>(file);
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw e;
@@ -446,10 +422,6 @@ async function main(write: boolean): Promise<number> {
   return 1;
 }
 
-// Read-only sibling of `main`: never writes the baseline, always returns 0.
-// Population is the baseline plus anything the current artifact flags that the
-// baseline has not seen yet (those carry no reason, so they never count as
-// unreviewed-but-seeded).
 async function reportMain(top: number, unreviewedOnly: boolean): Promise<number> {
   const baseline = await loadBaseline();
   if (unreviewedOnly) {
@@ -461,18 +433,32 @@ async function reportMain(top: number, unreviewedOnly: boolean): Promise<number>
   }
 
   const entries = [...baseline];
-  try {
-    const { added } = diffAgainstBaseline(flattenArtifact(await loadArtifact()), baseline);
-    entries.push(...added.map((k) => ({ ...k, reason: "" })));
-    if (added.length > 0) console.log(`(including ${added.length} not-yet-baselined mismatch(es))`);
-  } catch {
+  const artifact = await readJsonIfPresent<Artifact>(ARTIFACT_PATH);
+  if (artifact === undefined) {
     console.log(
       "(baseline only — the wide artifact is missing; run `pnpm api:compare --wide-calls`)",
     );
+  } else {
+    // Not-yet-baselined mismatches carry no reason, so they are reported in the
+    // groupings without inflating the unreviewed-but-seeded count.
+    const { added } = diffAgainstBaseline(flattenArtifact(artifact), baseline);
+    entries.push(...added.map((k) => ({ ...k, reason: "" })));
+    if (added.length > 0) console.log(`(including ${added.length} not-yet-baselined mismatch(es))`);
   }
 
-  console.log(renderReport(sortKeys(entries), await loadTsMemberIndex(), top));
+  const manifest = await readJsonIfPresent<ApiManifest>(TS_API_PATH);
+  console.log(renderReport(sortKeys(entries), manifest && indexTsMembers(manifest), top));
   return 0;
+}
+
+export function parseTop(argv: string[], fallback: number): number {
+  const raw = argv.find((a) => a.startsWith("--top="))?.slice("--top=".length);
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`--top expects a positive integer, got ${JSON.stringify(raw)}`);
+  }
+  return n;
 }
 
 async function runAsScript(): Promise<void> {
@@ -481,14 +467,17 @@ async function runAsScript(): Promise<void> {
   if (path.resolve(self) !== invoked) return;
   const argv = process.argv.slice(2);
   const unreviewed = argv.includes("--unreviewed");
-  const code =
-    argv.includes("--report") || unreviewed
-      ? await reportMain(
-          Number(argv.find((a) => a.startsWith("--top="))?.slice(6)) || 20,
-          unreviewed,
-        )
-      : await main(argv.includes("--write"));
-  process.exit(code);
+  if (!argv.includes("--report") && !unreviewed) {
+    process.exit(await main(argv.includes("--write")));
+  }
+  let top: number;
+  try {
+    top = parseTop(argv, 20);
+  } catch (e) {
+    console.error(`wide call-mismatches report: ${(e as Error).message}`);
+    process.exit(2);
+  }
+  process.exit(await reportMain(top, unreviewed));
 }
 
 void runAsScript();

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -38,8 +38,15 @@
  * baseline changes.
  *
  * Usage:
- *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts          # gate (CI)
- *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write  # reseed baseline
+ *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts           # gate (CI)
+ *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write   # reseed baseline
+ *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --report  # read-only grouping
+ *
+ * `--report` (RFC 0083) groups the baselined population by package, source
+ * file, Ruby call name, and derived cause bucket, so a burndown story can be
+ * scoped off a coherent slice instead of a 4794-line flat list. It never writes
+ * the baseline and always exits 0. `--unreviewed` prints just the count of
+ * entries whose `reason` is still the seeded {@link DEFAULT_REASON}.
  *
  * `--write` regenerates the baseline from the current wide artifact, preserving
  * the `reason` of entries that still flag and dropping stale rows, then
@@ -65,6 +72,8 @@ import {
   reseed,
 } from "./lint-call-mismatches.js";
 import { reportNonCanonicalBaselines, serializeBaseline } from "./baseline-json.js";
+import { rubyMethodToTsIgnoringSkip, snakeToCamel } from "./conventions.js";
+import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 
 // The baseline is a directory of per-source-file JSON arrays (see header),
 // not a single file. Each entry lives at <BASELINE_DIR>/<package>/<tsFile
@@ -93,7 +102,7 @@ export function relPathFor(k: CallMismatchKey): string {
 // throughout the compare tooling (mirrors lint-call-mismatches.ts).
 const ARTIFACT_PATH = path.join(OUTPUT_DIR, "call-mismatches-wide.json");
 
-const DEFAULT_REASON =
+export const DEFAULT_REASON =
   "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; " +
   "bucket (b) equivalent or (c) noise pending per-cluster burndown review.";
 
@@ -203,6 +212,160 @@ function sortKeys<T extends CallMismatchKey>(entries: T[]): T[] {
   return [...entries].sort(compareKeys);
 }
 
+// ── --report: grouping the wide population (RFC 0083) ──────────────────────
+
+const TS_API_PATH = path.join(OUTPUT_DIR, "ts-api.json");
+
+/**
+ * Why an entry flags, derived from the TS manifest — never hand-maintained.
+ *
+ * The question each bucket answers is "where does the call's TS counterpart
+ * live, relative to the file that was supposed to make it?":
+ *   - both same-file buckets mean the port has the member and simply does not
+ *     call it from this method (a real omission, or a call folded into a
+ *     zero-arg accessor);
+ *   - `candidate elsewhere in package` is usually a layout divergence;
+ *   - `candidate not in package` is usually an unported call or tooling noise.
+ */
+export type CauseBucket =
+  | "same-file candidate takes args"
+  | "same-file zero-arg member"
+  | "candidate elsewhere in package"
+  | "candidate not in package";
+
+/** One declaration site of a TS member: the file it is declared in, and
+ *  whether it accepts any parameters. */
+export interface MemberSite {
+  file: string;
+  takesArgs: boolean;
+}
+
+/** package → TS member name → its declaration sites. */
+export type TsMemberIndex = Map<string, Map<string, MemberSite[]>>;
+
+function addSite(index: Map<string, MemberSite[]>, m: MethodInfo, fallbackFile: string): void {
+  // `declaredIn` wins: on synthesized mixin pseudo-modules the member usually
+  // belongs to a different file than the one the pseudo-module is keyed under.
+  const file = m.declaredIn ?? m.file ?? fallbackFile;
+  if (!file) return;
+  const sites = index.get(m.name) ?? index.set(m.name, []).get(m.name)!;
+  sites.push({ file, takesArgs: m.params.length > 0 });
+}
+
+/** Index every TS member declaration in the manifest by package and name. */
+export function indexTsMembers(manifest: ApiManifest): TsMemberIndex {
+  const out: TsMemberIndex = new Map();
+  for (const [pkg, info] of Object.entries(manifest.packages)) {
+    const byName = new Map<string, MemberSite[]>();
+    const containers: ClassInfo[] = [
+      ...Object.values(info.classes ?? {}),
+      ...Object.values(info.modules ?? {}),
+    ];
+    for (const c of containers) {
+      for (const m of [...c.instanceMethods, ...c.classMethods]) addSite(byName, m, c.file ?? "");
+    }
+    for (const [file, fns] of Object.entries(info.fileFunctions ?? {})) {
+      for (const m of fns) addSite(byName, m, file);
+    }
+    out.set(pkg, byName);
+  }
+  return out;
+}
+
+/** The TS names a Ruby call could faithfully port to (convention candidates
+ *  plus the plain camelCase spelling). */
+export function tsCandidatesFor(call: string): string[] {
+  return [...new Set([...(rubyMethodToTsIgnoringSkip(call) ?? []), snakeToCamel(call)])];
+}
+
+/** Assign an entry to its cause bucket using the TS manifest index. */
+export function bucketFor(key: CallMismatchKey, index: TsMemberIndex): CauseBucket {
+  const byName = index.get(key.package);
+  const sites = byName ? tsCandidatesFor(key.call).flatMap((n) => byName.get(n) ?? []) : [];
+  if (sites.length === 0) return "candidate not in package";
+  const sameFile = sites.filter((s) => s.file === key.tsFile);
+  if (sameFile.length === 0) return "candidate elsewhere in package";
+  return sameFile.some((s) => s.takesArgs)
+    ? "same-file candidate takes args"
+    : "same-file zero-arg member";
+}
+
+function tally<T>(items: T[], keyFn: (item: T) => string): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const k = keyFn(item);
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  // Descending count, then key, so the listing is stable across runs.
+  return [...counts].sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+}
+
+function section(title: string, rows: [string, number][], top?: number): string {
+  const shown = top === undefined ? rows : rows.slice(0, top);
+  const head =
+    top !== undefined && rows.length > shown.length
+      ? `${title} (top ${shown.length} of ${rows.length})`
+      : `${title} (${rows.length})`;
+  const width = Math.max(0, ...shown.map(([k]) => k.length));
+  return [
+    `\n${head}`,
+    ...shown.map(([k, n]) => `  ${k.padEnd(width)}  ${String(n).padStart(5)}`),
+  ].join("\n");
+}
+
+/** Count entries still carrying the seeded reason — i.e. never reviewed. */
+export function unreviewedCount(entries: ExcludeEntry[]): number {
+  return entries.filter((e) => e.reason === DEFAULT_REASON).length;
+}
+
+/** Render the whole `--report` body. `index` is undefined when the TS manifest
+ *  has not been built, in which case the cause-bucket section is skipped. */
+export function renderReport(
+  entries: ExcludeEntry[],
+  index: TsMemberIndex | undefined,
+  top: number,
+): string {
+  const unreviewed = unreviewedCount(entries);
+  const parts = [
+    `wide call-mismatches report: ${entries.length} baselined entr(ies) across ` +
+      `${new Set(entries.map((e) => `${e.package} ${e.tsFile}`)).size} file(s)`,
+    `  unreviewed (reason still the seeded default): ${unreviewed} of ${entries.length}`,
+    section(
+      "By package",
+      tally(entries, (e) => e.package),
+    ),
+    section(
+      "By file",
+      tally(entries, (e) => `${e.package}/${e.tsFile}`),
+      top,
+    ),
+    section(
+      "By Ruby call name",
+      tally(entries, (e) => e.call),
+      top,
+    ),
+  ];
+  parts.push(
+    index === undefined
+      ? `\nBy cause bucket: SKIPPED — ${path.relative(ROOT_DIR, TS_API_PATH)} is missing ` +
+          "(run `pnpm api:compare` first)."
+      : section(
+          "By cause bucket",
+          tally(entries, (e) => bucketFor(e, index)),
+        ),
+  );
+  return parts.join("\n");
+}
+
+async function loadTsMemberIndex(): Promise<TsMemberIndex | undefined> {
+  try {
+    return indexTsMembers(await readJson<ApiManifest>(TS_API_PATH));
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw e;
+  }
+}
+
 async function main(write: boolean): Promise<number> {
   const baseline = await loadBaseline();
   const artifact = await loadArtifact();
@@ -283,11 +446,48 @@ async function main(write: boolean): Promise<number> {
   return 1;
 }
 
+// Read-only sibling of `main`: never writes the baseline, always returns 0.
+// Population is the baseline plus anything the current artifact flags that the
+// baseline has not seen yet (those carry no reason, so they never count as
+// unreviewed-but-seeded).
+async function reportMain(top: number, unreviewedOnly: boolean): Promise<number> {
+  const baseline = await loadBaseline();
+  if (unreviewedOnly) {
+    console.log(
+      `wide call-mismatches: ${unreviewedCount(baseline)} of ${baseline.length} baselined ` +
+        "entr(ies) still carry the seeded default reason (unreviewed).",
+    );
+    return 0;
+  }
+
+  const entries = [...baseline];
+  try {
+    const { added } = diffAgainstBaseline(flattenArtifact(await loadArtifact()), baseline);
+    entries.push(...added.map((k) => ({ ...k, reason: "" })));
+    if (added.length > 0) console.log(`(including ${added.length} not-yet-baselined mismatch(es))`);
+  } catch {
+    console.log(
+      "(baseline only — the wide artifact is missing; run `pnpm api:compare --wide-calls`)",
+    );
+  }
+
+  console.log(renderReport(sortKeys(entries), await loadTsMemberIndex(), top));
+  return 0;
+}
+
 async function runAsScript(): Promise<void> {
   const self = fileURLToPath(import.meta.url);
   const invoked = process.argv[1] ? path.resolve(process.argv[1]) : "";
   if (path.resolve(self) !== invoked) return;
-  const code = await main(process.argv.includes("--write"));
+  const argv = process.argv.slice(2);
+  const unreviewed = argv.includes("--unreviewed");
+  const code =
+    argv.includes("--report") || unreviewed
+      ? await reportMain(
+          Number(argv.find((a) => a.startsWith("--top="))?.slice(6)) || 20,
+          unreviewed,
+        )
+      : await main(argv.includes("--write"));
   process.exit(code);
 }
 


### PR DESCRIPTION
## What

`pnpm api:calls:wide` printed only flat `+ added` / `- stale` lists. With 4791
baselined entries across 506 files there was no way to see where the population
lives or why, so no one could scope a coherent burndown chunk off it.

Adds a read-only `--report` mode (RFC 0083) to
`scripts/api-compare/lint-call-mismatches-wide.ts`, plus a
`pnpm api:calls:wide:report` script:

- totals by package, by `tsFile` (top N, `--top=N`, default 20), by Ruby call
  name, and by cause bucket;
- cause buckets derived from `output/ts-api.json`, never hand-maintained:
  `same-file candidate takes args` / `same-file zero-arg member` /
  `candidate elsewhere in package` / `candidate not in package`. Candidate TS
  names come from the shared `rubyMethodToTsIgnoringSkip` conventions plus the
  plain camelCase spelling; `declaredIn` wins over the container file so mixin
  pseudo-modules attribute to the real declaring file;
- an unreviewed count (entries whose `reason` is still `DEFAULT_REASON`), also
  available standalone as `--unreviewed` — currently 4441 of 4791;
- `--report` never writes the baseline and always exits 0. It degrades
  gracefully when the wide artifact or `ts-api.json` is absent (baseline-only /
  bucket section skipped).

An invalid `--top=` value fails loudly (exit 2) rather than silently
falling back to the default.

The gate's default output and exit codes are unchanged.

Current shape:

```
By package (13): activerecord 2868, actiondispatch 624, actioncontroller 321, …
By file: activerecord/relation.ts 338, connection-adapters/postgresql-adapter.ts 135, …
By cause bucket: candidate elsewhere in package 2577, same-file candidate takes args 1233,
                 candidate not in package 746, same-file zero-arg member 235
```

## Testing

`pnpm vitest run scripts/api-compare/lint-call-mismatches-wide.test.ts` — 21
passing, including new coverage of each bucket, the mixin `declaredIn`
attribution, predicate-candidate matching, `unreviewedCount`, and report
rendering/top-N truncation, and `--top=` parsing.

Closes-story: wide-ratchet-report-and-grouping
