### PR TITLE
docs(api-compare): classify every @noRailsEquivalent reason as PERMANENT or CONVERGEABLE

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/routes.ts
+++ b/packages/actionpack/src/action-dispatch/journey/routes.ts
@@ -47,7 +47,12 @@ export class Routes implements Iterable<Route> {
     return this.routes[this.routes.length - 1];
   }
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/actionpack/lib/action_dispatch/journey/routes.rb:10, :35` — `include
+   *   Enumerable` plus `def each`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   */
   [Symbol.iterator](): Iterator<Route> {
     return this.routes[Symbol.iterator]();
   }

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -201,7 +201,12 @@ export class CookieJar implements Iterable<[string, string]> {
     return this;
   }
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/actionpack/lib/action_dispatch/middleware/cookies.rb:314, :340` — `include
+   *   Enumerable` plus `def each`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   */
   [Symbol.iterator](): Iterator<[string, string]> {
     return this._cookies[Symbol.iterator]();
   }

--- a/packages/actionpack/src/action-dispatch/middleware/stack.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/stack.ts
@@ -161,7 +161,12 @@ export class MiddlewareStack implements Iterable<MiddlewareEntry> {
     return [...this.entries];
   }
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/actionpack/lib/action_dispatch/middleware/stack.rb:72, :81` — `include
+   *   Enumerable` plus `def each`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   */
   [Symbol.iterator](): Iterator<MiddlewareEntry> {
     return this.entries[Symbol.iterator]();
   }

--- a/packages/actionview/src/path-set.ts
+++ b/packages/actionview/src/path-set.ts
@@ -64,7 +64,11 @@ export class PathSet implements Iterable<PathSetResolver> {
     return this.paths.includes(resolver);
   }
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/actionview/lib/action_view/path_set.rb:12, :16` —
+   *   `include Enumerable` plus `delegate :each, to: :paths`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   */
   *[Symbol.iterator](): IterableIterator<PathSetResolver> {
     for (const r of this.paths) yield r;
   }

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -314,7 +314,9 @@ export class AttributeSet {
    * Make AttributeSet iterable — yields [name, value] pairs for compatibility
    * with code that iterates `for (const [k, v] of _attributes)`.
    *
-   * @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activemodel/lib/active_model/attribute_set.rb:10` —
+   *   `delegate :each_value, to: :attributes`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
    */
   *[Symbol.iterator](): IterableIterator<[string, unknown]> {
     for (const name of this.keys()) {

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -346,7 +346,9 @@ export class Errors<TBase extends object = object> {
    * (errors.rb:103) — `each` powers the Enumerable surface in Ruby; the
    * TS analog is the iterator protocol.
    *
-   * @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activemodel/lib/active_model/errors.rb:62, :103` —
+   *   `include Enumerable` plus `def_delegators :@errors, :each`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
    */
   [Symbol.iterator](): IterableIterator<ActiveModelError> {
     return this._errors[Symbol.iterator]();

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -52,7 +52,8 @@ export async function eagerLoadBang(): Promise<void> {
  * dependency cycle (associations → CP → Relation → Base →
  * associations) that forced the late-binding in the first place.
  *
- * @noRailsEquivalent trails-only ESM module-cycle escape hatch with no Rails
+ * @noRailsEquivalent CONVERGEABLE (story: retire-initialize-associations-module-cycle-hook).
+ * trails-only ESM module-cycle escape hatch with no Rails
  * analogue: `initialize_associations` is defined nowhere in the Rails source
  * (verified by grep over vendor/rails). The associations -> CollectionProxy ->
  * Relation -> Base -> associations cycle forces CollectionProxy registration to
@@ -351,7 +352,10 @@ export function registerModelConstant(name: string, model: typeof Base): void {
  *   `_subclasses`. STI on the parent must still be enabled explicitly via
  *   `Parent.inheritanceColumn = ...` — the array form does not set it.
  *
- * @noRailsEquivalent trails-only model registry with no Rails analogue:
+ * @noRailsEquivalent PERMANENT (`vendor/rails/activerecord/lib/active_record/reflection.rb:434,
+ *   :490` — `compute_class` is `name.constantize`; ESM has no constant namespace to walk and no
+ *   autoload hook).
+ * trails-only model registry with no Rails analogue:
  * `register_model` is defined nowhere in the Rails source (verified by grep over
  * vendor/rails). Ruby resolves an association's class through constant lookup —
  * Reflection#compute_class (reflection.rb:434 and :490) into Object.const_get,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -119,11 +119,19 @@ export interface CollectionProxy<T extends Base = Base> {
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2>;
-  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activerecord/lib/active_record/relation.rb:1179` —
+   *   `def load` materializes synchronously; Ruby has no thenable to mirror).
+   * JS Promise protocol — Ruby has no thenable
+   */
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
   ): Promise<T[] | TResult>;
-  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activerecord/lib/active_record/relation.rb:1179` —
+   *   `def load` materializes synchronously; Ruby has no thenable to mirror).
+   * JS Promise protocol — Ruby has no thenable
+   */
   finally(onfinally?: (() => void) | null): Promise<T[]>;
 }
 
@@ -387,7 +395,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return (await this.loadTarget()).length;
   }
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby uses Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation/delegation.rb:101` — `each` is
+   *   delegated to the loaded records).
+   * JS iteration protocol — Ruby uses Enumerable#each
+   */
   [Symbol.iterator](): IterableIterator<T> {
     return this._target[Symbol.iterator]();
   }
@@ -4470,7 +4483,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Async iterator — allows `for await (const record of proxy)`.
    *
-   * @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation/delegation.rb:101` — the delegated
+   *   `each` is synchronous and has no async twin).
+   * JS async-iteration protocol — Ruby's Enumerable#each
    * is synchronous and has no async counterpart
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -1131,7 +1131,12 @@ export class JoinDependency {
     this.nodes.forEach(callback);
   }
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/associations/join_dependency.rb:158` — `def
+   *   each` forwarding to `join_root`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   */
   [Symbol.iterator](): Iterator<JoinPart> {
     return this.nodes[Symbol.iterator]();
   }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -166,7 +166,8 @@ export class Version {
    * Comparable operators — the only ones any caller uses — over the same
    * dotted-part comparison `<=>` performs.
    *
-   * @noRailsEquivalent Rails' `AbstractAdapter::Version` does `include Comparable` and defines only
+   * @noRailsEquivalent CONVERGEABLE (story: port-version-compare-and-retire-gte-lt).
+   * Rails' `AbstractAdapter::Version` does `include Comparable` and defines only
    *   `<=>`
    *   (abstract_adapter.rb:243-259); `>=` and `<` come from Comparable, so there is no `def gte` for
    *   the extractor to match. `gte`/`lt` are the TS spelling of those two Comparable operators over
@@ -768,7 +769,8 @@ export class AbstractAdapter implements Quoting {
    * does not exist. Concrete adapters override this with driver-specific checks.
    * The base implementation always returns false (safe default for custom adapters).
    *
-   * @noRailsEquivalent Rails recognizes the no-such-database condition inline at the connect site
+   * @noRailsEquivalent CONVERGEABLE (story: converge-no-database-error-to-connect-site).
+   * Rails recognizes the no-such-database condition inline at the connect site
    *   and raises
    *   `ActiveRecord::NoDatabaseError` there (postgresql_adapter.rb:63, sqlite3_adapter.rb:38,120) —
    *   there is no named predicate to mirror. trails needs the predicate separated from raising
@@ -1362,7 +1364,12 @@ export class AbstractAdapter implements Quoting {
     return `#<${this.constructor.name}:${hex} env_name=${q(envName)}${nameField} role=${q(this.role)}${shardField}>`;
   }
 
-  /** @noRailsEquivalent Node inspection hook — a JS runtime protocol, not a Rails method */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:174` —
+   *   Ruby's inspection hook is `def inspect`, a plain method name already matched).
+   * Node inspection hook — a JS runtime protocol, not a Rails method
+   */
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return this.inspect();
   }
@@ -1395,7 +1402,8 @@ export class AbstractAdapter implements Quoting {
    * Adapters whose `ColumnMethods` list adds more (MySQL, PostgreSQL) override
    * this and append their own names to `super.columnMethodNames()`.
    *
-   * @noRailsEquivalent Rails spells this list as the `ColumnMethods` modules'
+   * @noRailsEquivalent CONVERGEABLE (story: mark-column-method-names-internal).
+   * Rails spells this list as the `ColumnMethods` modules'
    *   `define_column_methods` metaprogramming
    *   (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a
    *   `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so
@@ -1504,7 +1512,8 @@ export class AbstractAdapter implements Quoting {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#schema_cache
    *
-   * @noRailsEquivalent Rails' `AbstractAdapter#schema_cache` returns the pool's bound reflection
+   * @noRailsEquivalent CONVERGEABLE (story: converge-schema-cache-getter-onto-bound-reflection).
+   * Rails' `AbstractAdapter#schema_cache` returns the pool's bound reflection
    *   handle
    *   (abstract_adapter.rb:298 → connection_pool.rb:285). trails' `schemaCache` getter returns the
    *   raw `SchemaCache` the adapter memoizes incidental introspection into, so the Rails-shaped bound

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -268,7 +268,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
    * `config[:statement_limit]` in AbstractMysqlAdapter#initialize.
    *
-   * @noRailsEquivalent `statement_limit` is a `database.yml` config key Rails reads as
+   * @noRailsEquivalent CONVERGEABLE (story: retire-public-statement-limit-accessor).
+   * `statement_limit` is a `database.yml` config key Rails reads as
    *   `config[:statement_limit]` in
    *   each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb,
    *   sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the
@@ -578,7 +579,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   // `:blob` is in the Rails MySQL list too, but it's already surfaced via the
   // abstract `blob`/`binary` alias, so we don't repeat it here.
   /**
-   * @noRailsEquivalent Rails spells this list as the `ColumnMethods` modules'
+   * @noRailsEquivalent CONVERGEABLE (story: mark-column-method-names-internal).
+   * Rails spells this list as the `ColumnMethods` modules'
    *   `define_column_methods` metaprogramming
    *   (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a
    *   `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -170,7 +170,8 @@ export class NullPool implements AbstractPool {
  * the schema-cache / bare-adapter fallbacks that historically keyed off
  * `pool == null` use this so a NullPool is treated the same as "no pool".
  *
- * @noRailsEquivalent Rails' `NullPool` answers the whole pool protocol, so
+ * @noRailsEquivalent CONVERGEABLE (story: converge-nullpool-protocol-retire-poolabsent-realpool).
+ * Rails' `NullPool` answers the whole pool protocol, so
  * Ruby callers never ask whether a pool is real. See above.
  */
 export function poolAbsent(pool: unknown): boolean {
@@ -184,7 +185,8 @@ export function poolAbsent(pool: unknown): boolean {
  * `adapter.pool ?? adapter` to yield a schema-cache target that can actually
  * check out a connection.
  *
- * @noRailsEquivalent NullPool-aware form of `adapter.pool ?? fallback`;
+ * @noRailsEquivalent CONVERGEABLE (story: converge-nullpool-protocol-retire-poolabsent-realpool).
+ * NullPool-aware form of `adapter.pool ?? fallback`;
  * unnecessary in Rails for the same reason as `poolAbsent`. See above.
  */
 export function realPool(pool: unknown): unknown | null {
@@ -281,7 +283,8 @@ export class ExecutorHooks {
    *
    * @internal Wiring only; called exactly once, from `index.ts`.
    *
-   * @noRailsEquivalent Wiring hook. Ruby resolves the `ActiveRecord::Base`
+   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
+   * Wiring hook. Ruby resolves the `ActiveRecord::Base`
    * constant at call time; a TS import here would be a module cycle. See
    * above.
    */
@@ -337,7 +340,8 @@ export class ConnectionPool implements ReapablePool {
    * defaults to a resolved promise for pools whose adapterFactory is
    * supplied directly.
    *
-   * @noRailsEquivalent Rails' `require` is synchronous, so
+   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
+   * Rails' `require` is synchronous, so
    * `establish_connection` returns with the adapter class resolvable;
    * trails resolves adapters via dynamic `import()`. See above.
    */
@@ -404,7 +408,12 @@ export class ConnectionPool implements ReapablePool {
     return this.inspect();
   }
 
-  /** @noRailsEquivalent Node inspection hook — a JS runtime protocol, not a Rails method */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:278`
+   *   — Ruby's inspection hook is `def inspect`, a plain method name already matched).
+   * Node inspection hook — a JS runtime protocol, not a Rails method
+   */
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return this.inspect();
   }
@@ -577,7 +586,8 @@ export class ConnectionPool implements ReapablePool {
    * asked of the *normalized* value, which is what this getter delegates to.
    * Consumed by `QueryCache.run`'s skip guard in query-cache.ts.
    *
-   * @noRailsEquivalent Rails asks `pool.db_config&.query_cache == false`
+   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
+   * Rails asks `pool.db_config&.query_cache == false`
    * inline; trails' config also accepts a "disabled" alias, so the
    * predicate must read the normalized value. See above.
    */
@@ -664,7 +674,8 @@ export class ConnectionPool implements ReapablePool {
    *
    * @internal
    *
-   * @noRailsEquivalent Sync lease for callers mirroring Rails' synchronous
+   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
+   * Sync lease for callers mirroring Rails' synchronous
    * `lease_connection` that cannot await, since trails' `leaseConnection`
    * had to become async. See above.
    */
@@ -1059,7 +1070,8 @@ export class ConnectionPool implements ReapablePool {
    *
    * @internal
    *
-   * @noRailsEquivalent Rails' `discard!` is fully synchronous and has no
+   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
+   * Rails' `discard!` is fully synchronous and has no
    * async closes to hand back. See above.
    */
   discardBangDraining(): Array<Promise<void>> {
@@ -1249,7 +1261,8 @@ export class ConnectionPool implements ReapablePool {
    *
    * @internal
    *
-   * @noRailsEquivalent Ruby's `driver.close` is synchronous, so Rails'
+   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
+   * Ruby's `driver.close` is synchronous, so Rails'
    * discard paths complete the close before returning and need no drain
    * bookkeeping. See above.
    */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -487,7 +487,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
    * `config[:statement_limit]` in PostgreSQLAdapter#initialize.
    *
-   * @noRailsEquivalent `statement_limit` is a `database.yml` config key Rails reads as
+   * @noRailsEquivalent CONVERGEABLE (story: retire-public-statement-limit-accessor).
+   * `statement_limit` is a `database.yml` config key Rails reads as
    *   `config[:statement_limit]` in
    *   each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb,
    *   sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the
@@ -2515,7 +2516,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // exposed as `change_table` shorthands. Multi-word names use the camelCase form of
   // the trails TableDefinition method (e.g. `bit_varying` -> `bitVarying`).
   /**
-   * @noRailsEquivalent Rails spells this list as the `ColumnMethods` modules'
+   * @noRailsEquivalent CONVERGEABLE (story: mark-column-method-names-internal).
+   * Rails spells this list as the `ColumnMethods` modules'
    *   `define_column_methods` metaprogramming
    *   (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a
    *   `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so
@@ -2716,7 +2718,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   /**
    * Returns true for raw pg errors that indicate the database doesn't exist (SQLSTATE 3D000).
    *
-   * @noRailsEquivalent Rails recognizes the no-such-database condition inline at the connect site
+   * @noRailsEquivalent CONVERGEABLE (story: converge-no-database-error-to-connect-site).
+   * Rails recognizes the no-such-database condition inline at the connect site
    *   and raises
    *   `ActiveRecord::NoDatabaseError` there (postgresql_adapter.rb:63, sqlite3_adapter.rb:38,120) —
    *   there is no named predicate to mirror. trails needs the predicate separated from raising
@@ -4262,7 +4265,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // ---------------------------------------------------------------------------
 
   /**
-   * @noRailsEquivalent Rails has no range-type DDL helper anywhere — ranges are created with a raw
+   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
+   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
    *   `execute("CREATE
    *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
    *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their
@@ -4279,7 +4283,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * @noRailsEquivalent Rails has no range-type DDL helper anywhere — ranges are created with a raw
+   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
+   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
    *   `execute("CREATE
    *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
    *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -297,7 +297,8 @@ export class SchemaCache {
    * `_columns` — so a cold table falls through to the async `columnsHash` path
    * rather than silently reporting an empty schema.
    *
-   * @noRailsEquivalent Rails' only accessor, `columns_hash(pool, table)`,
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Rails' only accessor, `columns_hash(pool, table)`,
    * may block on a checkout; these callers are Rails-sync and cannot await.
    * See above.
    */
@@ -311,7 +312,8 @@ export class SchemaCache {
    * only seeds `true` for tables it saw — an unchecked absent table is not
    * `false` here until `dataSourceExists` misses on it).
    *
-   * @noRailsEquivalent Rails' `data_source_exists?(pool, name)` blocks on
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Rails' `data_source_exists?(pool, name)` blocks on
    * the query; `cachedTableExists` is sync and cannot await. See above.
    */
   getCachedDataSourceExists(name: string): boolean | undefined {
@@ -355,7 +357,8 @@ export class SchemaCache {
    * behavior change beyond surfacing custom keys. Falling through keeps this a
    * strictly additive read: a table that resolved "id" before still does.
    *
-   * @noRailsEquivalent Rails' `primary_keys(pool, table)` blocks on the
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Rails' `primary_keys(pool, table)` blocks on the
    * query; `Model.primaryKey` is sync and cannot await. See above.
    */
   getCachedPrimaryKeys(tableName: string): string | string[] | null | undefined {
@@ -422,7 +425,8 @@ export class SchemaCache {
    *
    * @internal
    *
-   * @noRailsEquivalent Test-harness ledger. Rails re-reflects from a live
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Test-harness ledger. Rails re-reflects from a live
    * blocking connection at fixture teardown and needs no record of what was
    * cleared.
    */
@@ -436,7 +440,8 @@ export class SchemaCache {
    *
    * @internal
    *
-   * @noRailsEquivalent Test-harness ledger, closing the window opened by
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Test-harness ledger, closing the window opened by
    * `recordTouchedTables`. No Rails analogue, for the same reason.
    */
   takeTouchedTables(): Set<string> {
@@ -473,7 +478,8 @@ export class SchemaCache {
    * demonstrably exists — which is what lets the sync readers above answer
    * without a query.
    *
-   * @noRailsEquivalent Rails populates only via `add(pool, table_name)`,
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Rails populates only via `add(pool, table_name)`,
    * which needs a pool; the one caller is the bare-adapter path that has
    * none. See above.
    */
@@ -506,7 +512,8 @@ export class SchemaCache {
    * {@link reconcilePrimaryKeyFlags}, so the authoritative key always wins over
    * a column-reflected flag.
    *
-   * @noRailsEquivalent Test-harness seeding, no production caller: Rails'
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-test-only-sync-writers).
+   * Test-harness seeding, no production caller: Rails'
    * tests let the blocking `add` / `primary_keys` warm the map, the trails
    * ports run pool-less. See above.
    */
@@ -566,7 +573,8 @@ export class SchemaCache {
    * Production warming goes through {@link setColumns} (which sets `true` for a
    * table whose columns just came back) or the async `dataSourceExists` query.
    *
-   * @noRailsEquivalent Test-harness seeding, no production caller: Rails'
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-test-only-sync-writers).
+   * Test-harness seeding, no production caller: Rails'
    * tests let the blocking `data_source_exists?` warm the map, the trails
    * ports run pool-less. See above.
    */
@@ -732,7 +740,8 @@ export class SchemaReflection {
    * (Rails' `clear_data_source_cache!`) regardless of this flag — the next
    * load re-reflects it.
    *
-   * @noRailsEquivalent Opt-in eager DB warming. Rails has only
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Opt-in eager DB warming. Rails has only
    * `lazily_load_schema_cache` (a committed dump) because its sync
    * accessors can fall back on blocking reflection; trails' cannot. See
    * above.
@@ -782,7 +791,8 @@ export class SchemaReflection {
    * that also routes through the lone-connection `FakePool`. Don't grep Rails
    * for it.
    *
-   * @noRailsEquivalent trails-only composite of Rails'
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * trails-only composite of Rails'
    * `SchemaReflection#load!` and `SchemaCache#add_all`; Rails has no
    * `load_all!`. See above.
    */
@@ -800,7 +810,8 @@ export class SchemaReflection {
    * preloaded data from a schema_cache.json without hitting the DB.
    * External callers should not mutate the returned cache.
    *
-   * @noRailsEquivalent Sync, non-loading peek. Rails' `SchemaReflection`
+   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
+   * Sync, non-loading peek. Rails' `SchemaReflection`
    * needs none because every accessor can block on `cache(pool)`. See
    * above.
    */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -215,7 +215,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * Returns true for raw SQLite driver errors that indicate a missing or unopenable database
    * file (SQLITE_CANTOPEN).
    *
-   * @noRailsEquivalent Rails recognizes the no-such-database condition inline at the connect site
+   * @noRailsEquivalent CONVERGEABLE (story: converge-no-database-error-to-connect-site).
+   * Rails recognizes the no-such-database condition inline at the connect site
    *   and raises
    *   `ActiveRecord::NoDatabaseError` there (postgresql_adapter.rb:63, sqlite3_adapter.rb:38,120) —
    *   there is no named predicate to mirror. trails needs the predicate separated from raising
@@ -349,7 +350,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
    * `config[:statement_limit]` in `SQLite3Adapter#initialize`.
    *
-   * @noRailsEquivalent `statement_limit` is a `database.yml` config key Rails reads as
+   * @noRailsEquivalent CONVERGEABLE (story: retire-public-statement-limit-accessor).
+   * `statement_limit` is a `database.yml` config key Rails reads as
    *   `config[:statement_limit]` in
    *   each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb,
    *   sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -50,7 +50,12 @@ export class Aes256Gcm {
   // Mirrors Rails' inspect override — never expose the secret in debug output.
   // Symbol.for("nodejs.util.inspect.custom") is the stable public symbol
   // used by Node's util.inspect without importing "util" directly.
-  /** @noRailsEquivalent Node inspection hook — a JS runtime protocol, not a Rails method */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/encryption/cipher/aes256_gcm.rb:82` — Ruby's
+   *   inspection hook is `def inspect`, a plain method name already matched).
+   * Node inspection hook — a JS runtime protocol, not a Rails method
+   */
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return `Cipher {}`;
   }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -298,7 +298,12 @@ export class AdditionalValue {
     return String(this.value);
   }
 
-  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb:134`
+   *   — Ruby's `AdditionalValue` declares no coercion method and inherits `Object#to_s`).
+   * JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead
+   */
   valueOf(): unknown {
     return this.value;
   }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -207,7 +207,11 @@ export function setBaseClass(modelClass: typeof Base): void {
  * falling back to the JS `name`. Rails' `self.name` for such a model is
  * `"ClothingItem::Used"` — the value STI/polymorphic `type` columns store.
  *
- * @noRailsEquivalent Ruby resolves a model's namespace through the constant path (`Module#name`,
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activerecord/lib/active_record/model_schema.rb:302-307` —
+ *   `full_table_name_prefix`/`full_table_name_suffix` reach the namespace through `module_parents`,
+ *   i.e. Ruby's object model; JS classes carry no module path).
+ * Ruby resolves a model's namespace through the constant path (`Module#name`,
  *   `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the
  *   enclosing module object — see `full_table_name_prefix` in model_schema.rb:302-307. JS classes
  *   carry no module path and there are no module objects to respond to those readers, so trails
@@ -259,7 +263,11 @@ const moduleTableNameSuffixes = new Map<string, string>();
 /**
  * Register a module-level `table_name_prefix` (Ruby `def self.table_name_prefix`).
  *
- * @noRailsEquivalent Ruby resolves a model's namespace through the constant path (`Module#name`,
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activerecord/lib/active_record/model_schema.rb:302-307` —
+ *   `full_table_name_prefix` reads `table_name_prefix` off the enclosing module object; ESM has no
+ *   module objects to respond to it).
+ * Ruby resolves a model's namespace through the constant path (`Module#name`,
  *   `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the
  *   enclosing module object — see `full_table_name_prefix` in model_schema.rb:302-307. JS classes
  *   carry no module path and there are no module objects to respond to those readers, so trails
@@ -274,7 +282,11 @@ export function registerModuleTableNamePrefix(moduleName: string, prefix: string
 /**
  * Register a module-level `table_name_suffix` (Ruby `def self.table_name_suffix`).
  *
- * @noRailsEquivalent Ruby resolves a model's namespace through the constant path (`Module#name`,
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activerecord/lib/active_record/model_schema.rb:302-307` —
+ *   `full_table_name_suffix` reads `table_name_suffix` off the enclosing module object; ESM has no
+ *   module objects to respond to it).
+ * Ruby resolves a model's namespace through the constant path (`Module#name`,
  *   `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the
  *   enclosing module object — see `full_table_name_prefix` in model_schema.rb:302-307. JS classes
  *   carry no module path and there are no module objects to respond to those readers, so trails
@@ -374,7 +386,9 @@ export function demodulize(name: string): string {
  * Mirrors the implicit subclass registration Rails does via Ruby's
  * inherited hook.
  *
- * @noRailsEquivalent Stands in for Ruby's `inherited` hook (inheritance.rb:287), which Rails uses
+ * @noRailsEquivalent PERMANENT (`vendor/rails/activerecord/lib/active_record/inheritance.rb:287` —
+ *   the `inherited` hook; JS has no class-definition hook).
+ * Stands in for Ruby's `inherited` hook (inheritance.rb:287), which Rails uses
  *   to register each subclass with the DescendantsTracker. TypeScript has no class-definition hook, so subclasses call
  *   `registerSubclass(Klass)` from a static initializer block instead. CLAUDE.md already routes Ruby
  *   lifecycle hooks to a no-TS-equivalent skip; SKIP_GROUPS is keyed by *Ruby* name and only

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2908,7 +2908,10 @@ export class Relation<T extends Base> {
   /**
    * Async iterator support — allows `for await (const record of relation)`.
    *
-   * @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each is synchronous
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation/delegation.rb:101` — the delegated
+   *   `each` is synchronous and has no async twin).
+   * JS async-iteration protocol — Ruby's Enumerable#each is synchronous
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
     const records = await this.toArray();
@@ -7632,11 +7635,19 @@ export interface Relation<T extends Base> {
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2>;
-  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activerecord/lib/active_record/relation.rb:1179` —
+   *   `def load` materializes synchronously; Ruby has no thenable to mirror).
+   * JS Promise protocol — Ruby has no thenable
+   */
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
   ): Promise<T[] | TResult>;
-  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activerecord/lib/active_record/relation.rb:1179` —
+   *   `def load` materializes synchronously; Ruby has no thenable to mirror).
+   * JS Promise protocol — Ruby has no thenable
+   */
   finally(onfinally?: (() => void) | null): Promise<T[]>;
 }
 

--- a/packages/activerecord/src/relation/batches/batch-enumerator.ts
+++ b/packages/activerecord/src/relation/batches/batch-enumerator.ts
@@ -44,7 +44,12 @@ export class BatchEnumerator<T extends BatchRelation> {
     this.relation = options?.relation ?? null;
   }
 
-  /** @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each is synchronous */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation/batches/batch_enumerator.rb:6, :108` —
+   *   `include Enumerable` plus a synchronous `def each`).
+   * JS async-iteration protocol — Ruby's Enumerable#each is synchronous
+   */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
     yield* this._generator();
   }
@@ -141,11 +146,21 @@ export interface BatchEnumerator<T extends BatchRelation> {
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2>;
-  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation/batches/batch_enumerator.rb:108` —
+   *   `def each` is synchronous; Ruby has no thenable to mirror).
+   * JS Promise protocol — Ruby has no thenable
+   */
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
   ): Promise<T[] | TResult>;
-  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation/batches/batch_enumerator.rb:108` —
+   *   `def each` is synchronous; Ruby has no thenable to mirror).
+   * JS Promise protocol — Ruby has no thenable
+   */
   finally(onfinally?: (() => void) | null): Promise<T[]>;
 }
 

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -116,7 +116,11 @@ export class Result {
     return new Result(columns, rowArrays);
   }
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activerecord/lib/active_record/result.rb:37, :128`
+   *   — `include Enumerable` plus `def each`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   */
   [Symbol.iterator](): IterableIterator<Record<string, unknown>> {
     return this.hashRows()[Symbol.iterator]();
   }

--- a/packages/activesupport/src/core-ext/string/output-safety.ts
+++ b/packages/activesupport/src/core-ext/string/output-safety.ts
@@ -145,7 +145,12 @@ export class SafeBuffer {
     return this._value.length;
   }
 
-  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activesupport/lib/active_support/core_ext/string/output_safety.rb:138` — `def
+   *   to_s` is the Ruby coercion hook).
+   * JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead
+   */
   valueOf(): string {
     return this._value;
   }

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -568,7 +568,11 @@ export class Scalar {
     return String(this.value);
   }
 
-  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/activesupport/lib/active_support/duration.rb:353,
+   *   :377` — `def to_s` and `def to_i` are the Ruby coercion hooks).
+   * JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead
+   */
   valueOf(): number {
     return this.value;
   }

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -170,7 +170,11 @@ const _constants = new Map<string, unknown>();
 const _privateConstants = new Set<string>();
 
 /**
- * @noRailsEquivalent The registration half of Ruby's constant table. `class Foo`
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activesupport/lib/active_support/inflector/methods.rb:289` — `constantize` walks
+ *   Ruby's constant namespace; ESM has neither a constant namespace nor an autoload hook, so
+ *   application code must register what exists).
+ * The registration half of Ruby's constant table. `class Foo`
  * writes Ruby's global constant namespace as a side effect of definition; ESM
  * classes are module-local bindings with no such namespace, so a JS host names
  * its classes explicitly. Only registration is invented — lookup goes through
@@ -181,7 +185,10 @@ export function registerConstant(name: string, value: unknown): void {
 }
 
 /**
- * @noRailsEquivalent The removal half of the invented constant table (see
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activesupport/lib/active_support/inflector/methods.rb:289` — the registry stands
+ *   in for Ruby's constant namespace, which `remove_const` unwinds; ESM has no constant namespace).
+ * The removal half of the invented constant table (see
  * {@link registerConstant}). Ruby constants are removed with
  * `Object.send(:remove_const, …)`, which has no ESM analogue; trails needs it so
  * a registry teardown cannot leave a name resolvable through
@@ -199,7 +206,10 @@ export function unregisterConstant(name: string, expected: unknown): void {
 }
 
 /**
- * @noRailsEquivalent The visibility half of Ruby's constant table, mirroring
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activesupport/lib/active_support/inflector/methods.rb:289` — `constantize`
+ *   honours Ruby's `private_constant` visibility; ESM has no constant visibility to consult).
+ * The visibility half of Ruby's constant table, mirroring
  * `Module#private_constant` (a language feature Rails calls, not one it
  * defines). Ruby's constant table carries per-constant visibility;
  * trails' invented table (see {@link registerConstant}) is flat, so the private

--- a/packages/activesupport/src/string-inquirer.ts
+++ b/packages/activesupport/src/string-inquirer.ts
@@ -30,7 +30,12 @@ export class StringInquirer {
   toString(): string {
     return this._value;
   }
-  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
+  /**
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activesupport/lib/active_support/string_inquirer.rb:21` — `class
+   *   StringInquirer < String`, so Ruby coerces through String itself).
+   * JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead
+   */
   valueOf(): string {
     return this._value;
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -934,7 +934,10 @@ export class TimeWithZone {
   /**
    * valueOf for comparison operators to work
    *
-   * @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activesupport/lib/active_support/time_with_zone.rb:200, :469` — `def to_s` and
+   *   `def to_i` are the Ruby coercion hooks).
+   * JS primitive-coercion protocol — Ruby coerces through
    * to_s/to_i instead
    */
   valueOf(): number {

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -13,7 +13,12 @@ import type { MessageVerifier } from "@blazetrails/activesupport/message-verifie
 /**
  * Duck-typed model interface; globalid stays AR-agnostic.
  *
- * @noRailsEquivalent CONVERGEABLE (story: extra-surface-skip-duck-typed-interface-members).
+ * @noRailsEquivalent PERMANENT (`vendor/globalid/lib/global_id/locator.rb:165`, `:196` — Ruby's
+ *   `BaseLocator` calls `model_class.find` / `model_class.where` on an undeclared duck type;
+ *   TypeScript needs a declared interface to type the same collaborator, and no Ruby entity maps
+ *   onto it. The interface-level tag is the end state of
+ *   `extra-surface-skip-duck-typed-interface-members` (PR #5467), which chose declaration-level
+ *   marking over a member-by-member rule.)
  * Declares the Active Record surface Rails' BaseLocator
  * calls duck-typed — `model_class.find gid.model_id` and
  * `model_class.where(primary_key => ids)` on the ignore_missing path. Ruby

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -13,7 +13,8 @@ import type { MessageVerifier } from "@blazetrails/activesupport/message-verifie
 /**
  * Duck-typed model interface; globalid stays AR-agnostic.
  *
- * @noRailsEquivalent Declares the Active Record surface Rails' BaseLocator
+ * @noRailsEquivalent CONVERGEABLE (story: extra-surface-skip-duck-typed-interface-members).
+ * Declares the Active Record surface Rails' BaseLocator
  * calls duck-typed — `model_class.find gid.model_id` and
  * `model_class.where(primary_key => ids)` on the ignore_missing path. Ruby
  * needs no such declaration, so neither the interface nor any member of it has

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -78,7 +78,8 @@ export class SignedGlobalID {
   /**
    * The raw GID URI string, e.g. `gid://MyApp/User/1`
    *
-   * @noRailsEquivalent Inherited from GlobalID in Ruby (`attr_reader :uri`);
+   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
+   * Inherited from GlobalID in Ruby (`attr_reader :uri`);
    * re-declared because the TS classes are peers, not a hierarchy. See the
    * `create` entry for this file.
    */
@@ -117,7 +118,8 @@ export class SignedGlobalID {
    *
    * Mirrors: GlobalID.create
    *
-   * @noRailsEquivalent Rails' `SignedGlobalID < GlobalID` inherits
+   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
+   * Rails' `SignedGlobalID < GlobalID` inherits
    * `GlobalID.create` (polymorphic `new`). In TS the two are peer classes —
    * SignedGlobalID's fields (verifier/purpose/expiresAt) come from options its
    * base has no notion of — so `create` is re-declared here. Unifying them
@@ -293,7 +295,8 @@ export class SignedGlobalID {
   /**
    * Mirrors: GlobalID#model_id
    *
-   * @noRailsEquivalent Inherited from GlobalID in Ruby (`delegate :model_id, to: :uri`);
+   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
+   * Inherited from GlobalID in Ruby (`delegate :model_id, to: :uri`);
    * re-declared because the TS classes are peers, not a hierarchy. See the
    * `create` entry for this file.
    */
@@ -304,7 +307,8 @@ export class SignedGlobalID {
   /**
    * Mirrors: GlobalID#model_name
    *
-   * @noRailsEquivalent Inherited from GlobalID in Ruby (`delegate :model_name, to: :uri`);
+   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
+   * Inherited from GlobalID in Ruby (`delegate :model_name, to: :uri`);
    * re-declared because the TS classes are peers, not a hierarchy. See the
    * `create` entry for this file.
    */
@@ -315,7 +319,8 @@ export class SignedGlobalID {
   /**
    * Mirrors: GlobalID#params
    *
-   * @noRailsEquivalent Inherited from GlobalID in Ruby (`delegate :params, to: :uri`);
+   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
+   * Inherited from GlobalID in Ruby (`delegate :params, to: :uri`);
    * re-declared because the TS classes are peers, not a hierarchy. See the
    * `create` entry for this file.
    */
@@ -330,7 +335,8 @@ export class SignedGlobalID {
    * the peer class repeats it so a misregistered constant can't slip
    * either identity through.
    *
-   * @noRailsEquivalent Inherited from GlobalID in Ruby; re-declared because the
+   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
+   * Inherited from GlobalID in Ruby; re-declared because the
    * TS classes are peers, not a hierarchy. See the `create` entry for this
    * file.
    */

--- a/packages/globalid/src/uri/gid.ts
+++ b/packages/globalid/src/uri/gid.ts
@@ -201,7 +201,10 @@ export class GID {
   /**
    * Unlike `parse`, this skips the argument checks.
    *
-   * @noRailsEquivalent URI::GID's public initializer comes from URI::Generic,
+   * @noRailsEquivalent PERMANENT (`vendor/globalid/lib/global_id/uri/gid.rb:7` — `class GID <
+   *   Generic` inherits the initializer from Ruby's stdlib `URI::Generic`, which is out of scope to
+   *   port).
+   * URI::GID's public initializer comes from URI::Generic,
    * so gid.rb declares none. TS has no URI base class to inherit it from, and
    * the ported Rails test `new returns invalid gid when not checking`
    * (uri_gid_test.rb) constructs one directly to bypass parse validation, so

--- a/packages/rack/src/body-proxy.ts
+++ b/packages/rack/src/body-proxy.ts
@@ -24,7 +24,11 @@ export class BodyProxy {
     return this._closed;
   }
 
-  /** @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each is synchronous */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rack/lib/rack/body_proxy.rb:45` — `method_missing`
+   *   forwards the synchronous `each` to the wrapped body).
+   * JS async-iteration protocol — Ruby's Enumerable#each is synchronous
+   */
   async *[Symbol.asyncIterator](): AsyncIterator<any> {
     if (this.body && typeof this.body[Symbol.asyncIterator] === "function") {
       for await (const item of this.body) yield item;

--- a/packages/trailties/src/engine/trailties.ts
+++ b/packages/trailties/src/engine/trailties.ts
@@ -5,7 +5,11 @@ import { Trailtie } from "../trailtie.js";
 export class Trailties implements Iterable<Trailtie> {
   readonly all: Trailtie[] = Trailtie.subclasses().map((k) => k.instance());
 
-  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
+  /**
+   * @noRailsEquivalent PERMANENT (`vendor/rails/railties/lib/rails/engine/railties.rb:6, :14` —
+   *   `include Enumerable` plus `def each`).
+   * JS iteration protocol — Ruby reaches iteration through Enumerable#each
+   */
   [Symbol.iterator](): Iterator<Trailtie> {
     return this.all[Symbol.iterator]();
   }


### PR DESCRIPTION
Classifies every previously unclassified `@noRailsEquivalent` reason under
`packages/*/src` so `api:extra`'s permanence signal (PR #5648) reads a claim
for each one. Reason prose is otherwise untouched — no code, no exit-code
contract change.

`pnpm api:extra` now reports `tagged.classification`:
**39 permanent, 39 convergeable, 0 unclassified** (was 2 / 0 / 74).

Counting the tags by hand gives a different, also-correct pair of numbers:
`grep -RIna "@noRailsEquivalent" packages/*/src` shows **79 tag comments — 40
PERMANENT, 39 CONVERGEABLE**. The one-tag gap is not drift. `buildReport`
classifies only *written* tags (`tagged.filter((e) => !e.inherited)`,
extra-surface.ts:1326): `LocatorModel` is an **interface-level** tag, and since
PR #5467 such a tag reaches the comparator only as `inherited` entries spread
onto its members, so it is excluded from the classification tally while still
allowing that surface. Every written tag carries a claim, which is what the
`unclassified: 0` acceptance criterion asks for.

## How each claim was made

Dispositions come from the 2026-07-27 tag audit
(`rfcs/0080-api-compare-jsdoc-metadata/tag-audit.md`), transcribed against its
verification standard:

- **PERMANENT** claims cite the `vendor/rails` (or `vendor/globalid`,
  `vendor/rack`) `file:line` that supplies the Ruby mechanism the TS member
  cannot mirror — e.g. `include Enumerable` + `def each` for each
  `[Symbol.iterator]`, `def to_s`/`def to_i` for each `valueOf`, `def inspect`
  for each Node inspection hook, `full_table_name_prefix` (`module_parents`)
  for the `inheritance.ts` registries, `compute_class` → `name.constantize`
  for `registerModel` and the inflector's constant table.
- **CONVERGEABLE** claims name the registered story that removes the tag. All
  13 cited stories already exist (the RFC 0072 burndown) and all are still
  `ready` — no claim points at work that is already done, and none had to be
  registered here.

`globalid/locator.ts`'s `LocatorModel` is classified PERMANENT rather than
against `extra-surface-skip-duck-typed-interface-members`: that story is
**done** (PR #5467) and it chose declaration-level marking, so the surviving
interface-level tag is its end state, not surface it will remove. A TS
interface typing an undeclared Ruby duck type has no Rails counterpart by
construction.

Three tags in `relation.ts` were not in the audit's per-file listing (the file
is large enough that `grep` silently skips it); they are the `Relation`
asyncIterator / `catch` / `finally` twins of the `CollectionProxy` and
`BatchEnumerator` tags and take the same permanent disposition.

Closes-story: classify-existing-no-rails-equivalent-tag-reasons
