### PR TITLE
feat(api-compare): count declaration names as extra surface

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -286,7 +286,9 @@ report). They therefore share:
   a class, interface, or namespace DECLARATION, where it justifies the
   declared name itself — the only inline form available to an extra that is a
   declaration rather than a member (e.g. a class Rails nests but TS must
-  export as a sibling). On an `interface` the declaration tag additionally
+  export as a sibling). A declaration name is scored surface in its own right
+  (`collectTsFileNames`), so such a tag matches, and goes stale, exactly like a
+  member's. On an `interface` the declaration tag additionally
   covers every MEMBER: an interface that types a duck-typed collaborator has no
   Ruby counterpart by construction, so neither can its members, and Ruby writes
   no such declaration to compare against. Classes are excluded from that spread

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1451,6 +1451,31 @@ describe("buildReport — declaration names", () => {
     expect(report.packages[0].extraFiles).toEqual([]);
   });
 
+  it("allows a folded `ClassMethods` submodule's name, which the file still declares", () => {
+    // foldClassMethodsModules merges the submodule's methods into the parent
+    // and drops it from the file's entity walk; its NAME must survive, or every
+    // ported `ClassMethods` namespace reads as drift.
+    const withConcern: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {},
+          modules: {
+            "ActiveModel::Foo": rubyClass({ name: "Foo", file: "foo.rb" }),
+            "ActiveModel::Foo::ClassMethods": rubyClass({
+              name: "ClassMethods",
+              file: "foo.rb",
+              instance: [method("build_it")],
+            }),
+          },
+        },
+      },
+    };
+    const report = run(withConcern, tsWith(["Foo", "ClassMethods"]));
+    expect(report.packages[0].extraFiles).toEqual([]);
+  });
+
   it("reports a declaration name no Ruby file declares as novel", () => {
     const report = run(ruby, tsWith(["Foo", "QueryLogger"]));
     expect(report.packages[0].extraFiles[0].extras).toEqual([

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1160,7 +1160,9 @@ describe("buildReport — novel vs moved classification", () => {
     });
     const f = report.packages[0].extraFiles.find((x) => x.tsFile === "trailtie.ts");
     expect(f).toBeDefined();
-    expect(f!.extras.map((e) => e.name)).toEqual(["genuinelyNovel"]);
+    // `Trailtie` is the declaration name, and railtie.rb declares `Railtie` —
+    // a renamed port is drift the declaration-name pass now reports.
+    expect(f!.extras.map((e) => e.name)).toEqual(["genuinelyNovel", "Trailtie"]);
   });
 
   it("resolves the unported guard against a cross-package module's OWNING package", () => {
@@ -1372,6 +1374,17 @@ describe("collectTsFileNames — `__mixin` pseudo-modules", () => {
     expect(names.has("toSlug")).toBe(false);
   });
 
+  it("does not count the `__mixin` pseudo-module's synthesized name", () => {
+    const info = extract(FILES);
+    const names = collectTsFileNames(
+      "inheritance.ts",
+      [],
+      Object.values(info.modules),
+      info.fileFunctions?.["inheritance.ts"],
+    );
+    expect(names.has("stiClassFor__mixin")).toBe(false);
+  });
+
   it("still counts the mixin function's own name as inheritance.ts surface", () => {
     const info = extract(FILES);
     const names = collectTsFileNames(
@@ -1381,6 +1394,73 @@ describe("collectTsFileNames — `__mixin` pseudo-modules", () => {
       info.fileFunctions?.["inheritance.ts"],
     );
     expect(names.has("stiClassFor")).toBe(true);
+  });
+});
+
+describe("buildReport — declaration names", () => {
+  const run = (ruby: ApiManifest, ts: ApiManifest) =>
+    buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+
+  const ruby: ApiManifest = {
+    source: "ruby",
+    generatedAt: "",
+    packages: {
+      activemodel: {
+        classes: {
+          "ActiveModel::Foo": rubyClass({ name: "Foo", file: "foo.rb" }),
+          // A class nested in a same-file parent: still a constant the file
+          // declares, so its TS port is not drift.
+          "ActiveModel::Foo::Inner": rubyClass({ name: "Inner", file: "foo.rb" }),
+          "ActiveModel::Elsewhere": rubyClass({ name: "Elsewhere", file: "elsewhere.rb" }),
+        },
+        modules: {},
+      },
+    },
+  };
+
+  const tsWith = (names: string[]): ApiManifest => ({
+    source: "typescript",
+    generatedAt: "",
+    packages: {
+      activemodel: {
+        classes: Object.fromEntries(
+          names.map((n) => [
+            `foo.ts:${n}`,
+            {
+              name: n,
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [],
+            },
+          ]),
+        ),
+        modules: {},
+      },
+    },
+  });
+
+  it("allows a declaration name the matched Ruby file declares", () => {
+    const report = run(ruby, tsWith(["Foo", "Inner"]));
+    expect(report.packages[0].extraFiles).toEqual([]);
+  });
+
+  it("reports a declaration name no Ruby file declares as novel", () => {
+    const report = run(ruby, tsWith(["Foo", "QueryLogger"]));
+    expect(report.packages[0].extraFiles[0].extras).toEqual([
+      { name: "QueryLogger", kind: "novel" },
+    ]);
+  });
+
+  it("reports a declaration name Rails declares in a DIFFERENT file as moved", () => {
+    const report = run(ruby, tsWith(["Foo", "Elsewhere"]));
+    expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Elsewhere", kind: "moved" }]);
   });
 });
 
@@ -1581,20 +1661,30 @@ describe("buildReport — @noRailsEquivalent tags", () => {
     };
     const report = run(m);
     expect(report.packages[0].totalNovel).toBe(0);
-    expect(report.packages[0].totalAllowlisted).toBe(1);
+    // `tsOnlyHelper` (inherited) plus the interface's own name `Shape`, which
+    // is extra surface in its own right and matches the written tag.
+    expect(report.packages[0].totalAllowlisted).toBe(2);
     expect(report.tagged).toEqual({
-      total: 0,
-      matched: 0,
+      total: 1,
+      matched: 1,
       inheritedMatched: 1,
       stale: [],
       // Inherited entries repeat one declaration's reason, so they are not
-      // classified — the claim is counted once, where it is written.
+      // classified — the claim is counted once, where it is written (on the
+      // declaration name).
       classification: {
         permanent: 0,
         convergeable: 0,
-        unclassified: 0,
-        unclassifiedByPackage: {},
-        unclassifiedEntries: [],
+        unclassified: 1,
+        unclassifiedByPackage: { activemodel: 1 },
+        unclassifiedEntries: [
+          {
+            package: "activemodel",
+            tsFile: "foo.ts",
+            name: "Shape",
+            reason: "duck-typed collaborator shape",
+          },
+        ],
       },
     });
   });
@@ -1613,7 +1703,9 @@ describe("buildReport — @noRailsEquivalent tags", () => {
       noRailsEquivalent: "duck-typed collaborator shape",
     };
     const report = run(m);
-    expect(report.packages[0].totalAllowlisted).toBe(1);
+    // `tsOnlyHelper` (inherited) and the declaration name `Shape` (written);
+    // `namespaceFn` stays novel.
+    expect(report.packages[0].totalAllowlisted).toBe(2);
     expect(report.packages[0].totalNovel).toBe(1);
     expect(report.tagged.inheritedMatched).toBe(1);
   });
@@ -1765,7 +1857,6 @@ describe("collectTaggedEntries", () => {
         tsFile: "locator.ts",
         name: "LocatorModel",
         reason: "duck-typed collaborator shape",
-        inherited: true,
       },
       {
         package: "globalid",

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -25,9 +25,10 @@
  *      class / interface / namespace DECLARATION name, plus top-level
  *      `fileFunctions`. Declaration names are scored on the same footing as
  *      members: step 2 allows every entity name the matched `.rb` declares, so
- *      a faithfully ported class is not extra and a trails-only one is. Filter out `internal: true` (Ruby private/protected,
- *      TS private/protected, TS `#`-prefixed fields, and `@internal` JSDoc
- *      on a top-level exported function) and
+ *      a faithfully ported class is not extra and a trails-only one is.
+ *      Filter out `internal: true` (Ruby private/protected, TS
+ *      private/protected, TS `#`-prefixed fields, and `@internal` JSDoc on a
+ *      top-level exported function) and
  *      separately filter `_`-prefixed names — the extractor keeps those as
  *      public exports; the Rails-private convention in this repo means they
  *      should not count toward extra surface.
@@ -105,6 +106,15 @@ import { manifestIsStale } from "./build-freshness.js";
 interface RubyEntity {
   fqn: string;
   info: ClassInfo;
+  /**
+   * Contribute only the entity's own constant name to the allow-set, not its
+   * methods or mixins. Used for a `Foo::ClassMethods` submodule whose methods
+   * `foldClassMethodsModules` already merged into `Foo.classMethods`: the
+   * declaration is still a constant the file declares (so a TS `ClassMethods`
+   * namespace is a faithful port, not drift), but walking it again would
+   * double-count its methods.
+   */
+  nameOnly?: boolean;
 }
 
 /**
@@ -766,7 +776,7 @@ function collectAllowedNames(
     for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
   };
 
-  for (const { fqn, info } of entities) {
+  for (const { fqn, info, nameOnly } of entities) {
     // The entity's own short name: since declaration names are TS surface
     // (`collectTsFileNames`), the Ruby constant they port has to be allowed
     // surface, or every faithfully ported class would read as drift. This
@@ -776,6 +786,7 @@ function collectAllowedNames(
     // re-attaching a sibling export.
     const short = fqn.split("::").pop();
     if (short) for (const c of rubyConstantCandidates(short)) allowed.add(c);
+    if (nameOnly) continue;
     addMethods(info.instanceMethods);
     addMethods(info.classMethods);
     for (const inc of info.includes ?? []) walkMixin(inc, fqn);
@@ -990,8 +1001,7 @@ function buildPackageReport(
   }
   for (const [fqn, info] of Object.entries(rubyPkg.modules) as [string, ClassInfo][]) {
     if (!info.file) continue;
-    if (foldedFqns.has(fqn)) continue;
-    pushTo(rubyFiles, info.file, { fqn, info });
+    pushTo(rubyFiles, info.file, { fqn, info, ...(foldedFqns.has(fqn) ? { nameOnly: true } : {}) });
   }
 
   const tsClassesByFile = new Map<string, ClassInfo[]>();

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -21,8 +21,11 @@
  *      "allowed" TS name set.
  *   3. Collect public TS names declared in the matching TS file — each
  *      class/module's *own* methods (skipping inherited surface so the
- *      diff measures this file's drift, not its ancestor's) plus top-level
- *      `fileFunctions`. Filter out `internal: true` (Ruby private/protected,
+ *      diff measures this file's drift, not its ancestor's), each
+ *      class / interface / namespace DECLARATION name, plus top-level
+ *      `fileFunctions`. Declaration names are scored on the same footing as
+ *      members: step 2 allows every entity name the matched `.rb` declares, so
+ *      a faithfully ported class is not extra and a trails-only one is. Filter out `internal: true` (Ruby private/protected,
  *      TS private/protected, TS `#`-prefixed fields, and `@internal` JSDoc
  *      on a top-level exported function) and
  *      separately filter `_`-prefixed names — the extractor keeps those as
@@ -41,9 +44,11 @@
  *      former extra-surface-allow.json sidecar is gone — and a tag on a name
  *      that no longer flags is STALE and fails the run. The tag is read on
  *      members AND on class / interface / namespace declarations, so an extra
- *      that is a declaration rather than a member still has an inline form.
- *      On an `interface` the declaration tag additionally covers every member
- *      — see `collectTaggedEntries`.
+ *      that is a declaration rather than a member has the same inline form
+ *      its members do — the declaration name is scored surface (step 3), so
+ *      such a tag matches and goes stale like any other. On an `interface` the
+ *      declaration tag additionally covers every member — see
+ *      `collectTaggedEntries`.
  *   6. Classify each written tag's permanence claim — see `classifyReason`.
  *      Advisory only: the count of tags that never state one is reported so a
  *      batch of new tags is visible, but it does not affect the exit code.
@@ -100,8 +105,6 @@ import { manifestIsStale } from "./build-freshness.js";
 interface RubyEntity {
   fqn: string;
   info: ClassInfo;
-  /** Declared inside another class in the same Ruby file (`class Outer; class Inner`). */
-  nestedInEnclosingClass?: boolean;
 }
 
 /**
@@ -268,8 +271,10 @@ export interface TaggedEntry {
   reason: string;
   /**
    * True when the entry derives from a tagged `interface` DECLARATION rather
-   * than from a tag written on this name — its members, and the interface's own
-   * name. Such entries allow extra surface like any other, but they are
+   * than from a tag written on this name — i.e. one of its MEMBERS. The
+   * interface's own name is a written tag: declaration names are extra surface
+   * (`collectTsFileNames`), so that entry can match and can go stale like any
+   * other. Inherited entries allow extra surface like any other, but they are
    * excluded from the tag total and from the stale check: the interface tag is
    * written once for the whole shape, so a member of it that happens not to
    * flag as extra is not a stale tag anyone can delete.
@@ -371,11 +376,7 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
         // LAST on purpose: a member sharing the container's name occupies the
         // same key (see the dedup note above — one key is all the extra set
         // has), so the more specific member reason wins the tie.
-        // An interface's own name is not member surface, so it never appears in
-        // the extra set `collectTsFileNames` builds and its entry can never
-        // match — flagged inherited so the stale check doesn't demand its
-        // deletion. The tag is still doing work: it covers the members below.
-        push(pkg, c.file, c.name, c.noRailsEquivalent, c.isInterface === true);
+        push(pkg, c.file, c.name, c.noRailsEquivalent);
         // A tagged `interface` covers its MEMBERS as well as its own name. An
         // interface is type-only: the ones that need the tag exist solely to
         // declare the shape of a duck-typed collaborator (e.g. globalid's
@@ -585,6 +586,17 @@ export function parseArgs(argv: string[]): CliArgs {
  * `internal: true`; class/module members take the flag from their TS
  * visibility modifier only). The Rails-private
  * convention in this repo means we filter `_`-prefix here too.
+ *
+ * A class / interface / namespace DECLARATION name counts as surface too, on
+ * the same footing as a member: `class QueryLogger` in a file whose Rails
+ * counterpart declares no such constant is exactly the drift this report
+ * exists to find, and before RFC 0080 it was invisible — which also left the
+ * declaration-level `@noRailsEquivalent` form with nothing to match unless the
+ * name happened to be re-attached as a static (see `collectTaggedEntries`).
+ * The Ruby side answers symmetrically: `collectAllowedNames` allows every
+ * entity name the matched `.rb` declares, so a faithfully ported class is not
+ * extra. Synthesized pseudo-modules are excluded — their `<fn>__mixin` name is
+ * an extractor artifact, not source text.
  */
 export function collectTsFileNames(
   file: string,
@@ -598,13 +610,20 @@ export function collectTsFileNames(
     if (m.name.startsWith("_")) return;
     out.add(m.name);
   };
+  const pushDeclaration = (c: ClassInfo): void => {
+    if (c.synthesizedMixin === true) return;
+    if (c.name.startsWith("_")) return;
+    out.add(c.name);
+  };
   for (const c of classes) {
     if (c.file !== file) continue;
+    pushDeclaration(c);
     for (const m of c.instanceMethods) push(m);
     for (const m of c.classMethods) push(m);
   }
   for (const m of modules) {
     if (m.file !== file) continue;
+    pushDeclaration(m);
     const skipForeign = m.synthesizedMixin === true;
     for (const im of m.instanceMethods) {
       if (skipForeign && im.declaredIn !== undefined) continue;
@@ -747,14 +766,16 @@ function collectAllowedNames(
     for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
   };
 
-  for (const { fqn, info, nestedInEnclosingClass } of entities) {
-    // A nested class is a constant ON its enclosing class, so a member of that
-    // name is the faithful port — spelled either as a real TS nested class or
-    // as `static readonly Inner = Inner` re-attaching a sibling export.
-    if (nestedInEnclosingClass) {
-      const short = fqn.split("::").pop();
-      if (short) for (const c of rubyConstantCandidates(short)) allowed.add(c);
-    }
+  for (const { fqn, info } of entities) {
+    // The entity's own short name: since declaration names are TS surface
+    // (`collectTsFileNames`), the Ruby constant they port has to be allowed
+    // surface, or every faithfully ported class would read as drift. This
+    // covers the nested case too — a nested class is a constant ON its
+    // enclosing class, so a member of that name is the faithful port, spelled
+    // either as a real TS nested class or as `static readonly Inner = Inner`
+    // re-attaching a sibling export.
+    const short = fqn.split("::").pop();
+    if (short) for (const c of rubyConstantCandidates(short)) allowed.add(c);
     addMethods(info.instanceMethods);
     addMethods(info.classMethods);
     for (const inc of info.includes ?? []) walkMixin(inc, fqn);
@@ -795,6 +816,10 @@ export function buildGlobalRubyCandidates(ruby: ApiManifest): Set<string> {
     }
     const entities = [...Object.values(pkg.classes), ...Object.values(pkg.modules)] as ClassInfo[];
     for (const e of entities) {
+      // Declaration names join the oracle on the same rule as methods and
+      // constants: a TS class named after a Ruby class declared in a DIFFERENT
+      // `.rb` is `moved`, not `novel`.
+      for (const c of rubyConstantCandidates(e.name)) all.add(c);
       for (const m of [...e.instanceMethods, ...e.classMethods]) {
         const candidates = rubyMethodCandidates(m.name);
         if (!candidates) continue;
@@ -956,33 +981,12 @@ function buildPackageReport(
   // coverage denominator. Extra surface is the inverse question and needs the
   // opposite answer: the nested class IS surface the enclosing file declares,
   // so counting the TS port of it as drift is wrong. It therefore enters the
-  // file's allow-set flagged `nestedInEnclosingClass` rather than being
-  // dropped — deliberately NOT mirroring compare.ts's use of the same filter.
-  const classFqnsPerFile = new Map<string, Set<string>>();
-  for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
-    if (!info.file) continue;
-    const set = classFqnsPerFile.get(info.file) ?? new Set<string>();
-    set.add(fqn);
-    classFqnsPerFile.set(info.file, set);
-  }
-  const hasEnclosingClassInFile = (fqn: string, file: string): boolean => {
-    const siblings = classFqnsPerFile.get(file);
-    if (!siblings) return false;
-    const parts = fqn.split("::");
-    for (let i = parts.length - 1; i > 0; i--) {
-      if (siblings.has(parts.slice(0, i).join("::"))) return true;
-    }
-    return false;
-  };
-
+  // file's allow-set like any other entity — deliberately NOT mirroring
+  // compare.ts's use of the same filter.
   const rubyFiles = new Map<string, RubyEntity[]>();
   for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
     if (!info.file) continue;
-    pushTo(rubyFiles, info.file, {
-      fqn,
-      info,
-      nestedInEnclosingClass: hasEnclosingClassInFile(fqn, info.file),
-    });
+    pushTo(rubyFiles, info.file, { fqn, info });
   }
   for (const [fqn, info] of Object.entries(rubyPkg.modules) as [string, ClassInfo][]) {
     if (!info.file) continue;

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2102,14 +2102,19 @@ describe("extract-ts-api — MethodInfo emit-site inventory", () => {
         .filter((e) => e.counted)
         .map((e) => e.name),
     );
-    expect(counted).toEqual(
-      collectTsFileNames(
-        file,
-        Object.values(info.classes),
-        Object.values(info.modules),
-        info.fileFunctions[file],
-      ),
+    // The inventory covers MethodInfo emit sites only, so the extra-surface
+    // set is exactly it plus the file's declaration names (the `__mixin`
+    // pseudo-module's synthesized name is not one).
+    const names = collectTsFileNames(
+      file,
+      Object.values(info.classes),
+      Object.values(info.modules),
+      info.fileFunctions[file],
     );
+    expect(new Set([...names].filter((n) => !counted.has(n)))).toEqual(
+      new Set(["Locator", "Quoting", "Registry", "Widget"]),
+    );
+    expect([...counted].filter((n) => !names.has(n))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What

`collectTsFileNames` collapsed a TS file's public surface to its MEMBER names,
so a class / interface / namespace DECLARATION name was not extra surface as
far as `api:extra` was concerned. That left the declaration-level
`@noRailsEquivalent` form (PR 5462) matchable only by accident — it matched
when the declared name also existed as a member (`NullPool.NullConfig`, a
static re-attachment) and was reported STALE otherwise, which is why PR 5467
had to demote `NullConfig`'s reason to prose and flag interface own-name
entries `inherited`.

**Decision: a declaration name IS extra surface.** Encoded symmetrically:

- `collectTsFileNames` adds each class / interface / namespace declaration's
  own name. Synthesized `<fn>__mixin` pseudo-modules are excluded — that name
  is an extractor artifact, not source text.
- `collectAllowedNames` allows every entity name the matched `.rb` declares, so
  a faithfully ported class is not drift. This subsumes the
  `nestedInEnclosingClass` special case, which is removed along with its
  per-file enclosing-class scan.
- A `Foo::ClassMethods` submodule that `foldClassMethodsModules` merged into
  its parent enters the allow-set **name-only**: the constant still counts (a
  ported `ClassMethods` namespace is faithful, not drift — 12 files), while its
  methods are not walked twice.
- `buildGlobalRubyCandidates` adds Ruby entity names, so a TS class named after
  a Ruby class declared in a different `.rb` scores `moved`, not `novel`.
- `collectTaggedEntries` no longer flags an interface's OWN-name entry
  `inherited` — it is a written tag again, so it matches and can go stale like
  any other. Member entries stay `inherited`.

`NullConfig` needs no tag after all: `NullPool::NullConfig` is declared in the
matched `connection_pool.rb`, so the declaration name is allowed surface. Its
existing `Mirrors:` comment is accurate as-is.

## Re-measured

`pnpm api:extra` exits 0 with **no stale tags**. Totals move:

| | before | after |
|---|---|---|
| files with drift | 745 | 840 |
| total extras | 3838 | 4780 |
| novel | 1493 | 2320 |
| moved | 2345 | 2460 |
| written tags | 78 | 79 |

The +942 is dominated by TS-only `interface` shapes — 180 `…Options`, 77
`…Host`, 36 `…Error`, 29 `…Like` — consistent with how their MEMBERS were
already scored, and exempted the same way, by a declaration tag. A second,
much smaller group (14) is the deliberate trails rename family (`Trailtie` for
`Railtie`, `Trails` for `Rails`); reporting a renamed port as drift is the
honest answer for a name-based comparator, and untagged extras are advisory —
they do not affect the exit code.

## Testing

- `pnpm vitest run scripts/api-compare/` — 678 passing. New cases cover a
  declaration name that is allowed, one that is novel, one that is moved, the
  folded-`ClassMethods` allowance (verified failing without the fix), and the
  `__mixin` name exclusion.
- `pnpm api:extra` exits 0; `pnpm tsc --noEmit` clean.

Closes-story: extra-surface-declaration-names-never-counted
