### PR TITLE
feat(api-compare): extract params and option keys for synthesized __mixin members

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1599,6 +1599,102 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(ctor.line).toBe(5);
   });
 
+  it("extracts parameters onto a synthesized __mixin member", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new () => object) {
+          class M extends Base {
+            writeAttribute(name: string, value?: unknown): void {}
+            get attributes(): object { return {}; }
+          }
+          return M;
+        }
+      `,
+    });
+    const mixin = info.modules["attributes.ts:Attributes__mixin"];
+    expect(mixin.instanceMethods.find((m) => m.name === "writeAttribute")!.params).toEqual([
+      { name: "name", kind: "required", type: "string" },
+      { name: "value", kind: "optional", type: "unknown" },
+    ]);
+    expect(mixin.instanceMethods.find((m) => m.name === "attributes")!.params).toEqual([]);
+  });
+
+  it("extracts parameters onto a foreign synthesized __mixin member", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `
+        export class Base {
+          dispose(reason: string): void {}
+        }
+      `,
+      "attributes.ts": `
+        import { Base } from "./base.js";
+        export function Attributes(B: typeof Base) {
+          class M extends B {}
+          return M;
+        }
+      `,
+    });
+    const dispose = info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+      (m) => m.name === "dispose",
+    )!;
+    expect(dispose.declaredIn).toBe("base.ts");
+    expect(dispose.params).toEqual([{ name: "reason", kind: "required", type: "string" }]);
+  });
+
+  it("extracts option keys onto a synthesized __mixin member", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new () => object) {
+          class M extends Base {
+            reload(options: { lock?: boolean; readonly?: boolean }): void {}
+          }
+          return M;
+        }
+      `,
+    });
+    expect(
+      info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+        (m) => m.name === "reload",
+      )!.optionKeys,
+    ).toEqual(["lock", "readonly"]);
+  });
+
+  it("extracts parameters onto a synthesized __mixin constructor", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new () => object) {
+          class M extends Base {
+            constructor(attrs: object, options: { strict?: boolean } = {}) { super(); }
+          }
+          return M;
+        }
+      `,
+    });
+    const ctor = info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+      (m) => m.name === "constructor",
+    )!;
+    expect(ctor.params.map((p) => [p.name, p.kind])).toEqual([
+      ["attrs", "required"],
+      ["options", "optional"],
+    ]);
+    expect(ctor.optionKeys).toEqual(["strict"]);
+  });
+
+  it("leaves a synthesized __mixin constructor's params empty when the inner class declares none", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new () => object) {
+          class M extends Base {}
+          return M;
+        }
+      `,
+    });
+    const ctor = info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+      (m) => m.name === "constructor",
+    )!;
+    expect(ctor.params).toEqual([]);
+  });
+
   it("records the reason on tagged namespace members", () => {
     const info = extractFromFiles("/p", {
       "locator.ts": `

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -700,10 +700,19 @@ export function extractFromProgram(
         // tag copied off an inherited base-class method would never match here
         // and would read as stale on top of its correct match on the base file.
         const noRailsEquivalent = declFile === relPath ? noRailsEquivalentReason(decl) : undefined;
+        // Params/optionKeys are structural, not provenance: unlike the JSDoc
+        // reason they describe the member's own arity, which the arity check
+        // compares against the Ruby entry regardless of which file declared it.
+        // So a FOREIGN member gets them too — the same shape the base class's
+        // own entry reports.
+        const declParams = parameterListOf(decl);
+        const propOptionKeys =
+          declParams !== undefined ? extractOptionKeys(declParams, checker) : undefined;
         mixinMethods.push({
           name: prop.name,
           visibility,
-          params: [],
+          params: declParams !== undefined ? extractParameters(declParams) : [],
+          ...(propOptionKeys !== undefined ? { optionKeys: propOptionKeys } : {}),
           isStatic: false,
           line,
           file: relPath,
@@ -734,10 +743,13 @@ export function extractFromProgram(
         const ctorVisibility = ctorDecl !== undefined ? memberVisibility(ctorDecl) : "public";
         const ctorReason = ownCtor !== undefined ? noRailsEquivalentReason(ownCtor) : undefined;
         const ctorNode = ctorDecl ?? node;
+        const ctorOptionKeys =
+          ctorDecl !== undefined ? extractOptionKeys(ctorDecl.parameters, checker) : undefined;
         mixinMethods.push({
           name: "constructor",
           visibility: ctorVisibility,
-          params: [],
+          params: ctorDecl !== undefined ? extractParameters(ctorDecl.parameters) : [],
+          ...(ctorOptionKeys !== undefined ? { optionKeys: ctorOptionKeys } : {}),
           isStatic: false,
           line:
             ctorNode.getSourceFile().getLineAndCharacterOfPosition(ctorNode.getStart()).line + 1,
@@ -2506,6 +2518,20 @@ function getMemberName(member: ts.ClassElement): string | undefined {
  * Returns the effective visibility of a class member, treating
  * `#`-prefixed private fields as `private`.
  */
+/**
+ * Parameter list of a member declaration reached through the type checker
+ * (the synthesized `__mixin` walker has a symbol, not a syntax node, so it
+ * can't branch on the declaration kind inline). Mirrors the top-level class
+ * walker's split: methods and set accessors carry parameters; getters and
+ * property declarations report none, so they get `undefined` here and the
+ * caller falls back to `[]`.
+ */
+function parameterListOf(decl: ts.Declaration): ts.NodeArray<ts.ParameterDeclaration> | undefined {
+  if (ts.isMethodDeclaration(decl) || ts.isMethodSignature(decl)) return decl.parameters;
+  if (ts.isSetAccessorDeclaration(decl)) return decl.parameters;
+  return undefined;
+}
+
 function memberVisibility(member: ts.ClassElement): "public" | "private" | "protected" {
   if (hasModifier(member, ts.SyntaxKind.PrivateKeyword)) return "private";
   if (hasModifier(member, ts.SyntaxKind.ProtectedKeyword)) return "protected";

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -700,19 +700,10 @@ export function extractFromProgram(
         // tag copied off an inherited base-class method would never match here
         // and would read as stale on top of its correct match on the base file.
         const noRailsEquivalent = declFile === relPath ? noRailsEquivalentReason(decl) : undefined;
-        // Params/optionKeys are structural, not provenance: unlike the JSDoc
-        // reason they describe the member's own arity, which the arity check
-        // compares against the Ruby entry regardless of which file declared it.
-        // So a FOREIGN member gets them too — the same shape the base class's
-        // own entry reports.
-        const declParams = parameterListOf(decl);
-        const propOptionKeys =
-          declParams !== undefined ? extractOptionKeys(declParams, checker) : undefined;
         mixinMethods.push({
           name: prop.name,
           visibility,
-          params: declParams !== undefined ? extractParameters(declParams) : [],
-          ...(propOptionKeys !== undefined ? { optionKeys: propOptionKeys } : {}),
+          ...declarationArity(decl, checker),
           isStatic: false,
           line,
           file: relPath,
@@ -743,13 +734,10 @@ export function extractFromProgram(
         const ctorVisibility = ctorDecl !== undefined ? memberVisibility(ctorDecl) : "public";
         const ctorReason = ownCtor !== undefined ? noRailsEquivalentReason(ownCtor) : undefined;
         const ctorNode = ctorDecl ?? node;
-        const ctorOptionKeys =
-          ctorDecl !== undefined ? extractOptionKeys(ctorDecl.parameters, checker) : undefined;
         mixinMethods.push({
           name: "constructor",
           visibility: ctorVisibility,
-          params: ctorDecl !== undefined ? extractParameters(ctorDecl.parameters) : [],
-          ...(ctorOptionKeys !== undefined ? { optionKeys: ctorOptionKeys } : {}),
+          ...declarationArity(ctorDecl, checker),
           isStatic: false,
           line:
             ctorNode.getSourceFile().getLineAndCharacterOfPosition(ctorNode.getStart()).line + 1,
@@ -2515,23 +2503,38 @@ function getMemberName(member: ts.ClassElement): string | undefined {
 }
 
 /**
- * Returns the effective visibility of a class member, treating
- * `#`-prefixed private fields as `private`.
+ * Arity of a member the `__mixin` walker reached through the type checker: it
+ * holds a symbol's declaration rather than a syntax node, so the kind split
+ * the top-level class walker gets for free happens here instead — methods and
+ * set accessors carry parameters, getters and property declarations report
+ * none. Unlike the JSDoc reason, this is extracted for a FOREIGN declaration
+ * too: arity is the member's own signature, which the arity check compares
+ * against the Ruby entry whichever file declared it.
  */
-/**
- * Parameter list of a member declaration reached through the type checker
- * (the synthesized `__mixin` walker has a symbol, not a syntax node, so it
- * can't branch on the declaration kind inline). Mirrors the top-level class
- * walker's split: methods and set accessors carry parameters; getters and
- * property declarations report none, so they get `undefined` here and the
- * caller falls back to `[]`.
- */
+function declarationArity(
+  decl: ts.Declaration | undefined,
+  checker: ts.TypeChecker,
+): { params: ParamInfo[]; optionKeys?: string[] | null } {
+  const parameters = decl !== undefined ? parameterListOf(decl) : undefined;
+  if (parameters === undefined) return { params: [] };
+  const optionKeys = extractOptionKeys(parameters, checker);
+  return {
+    params: extractParameters(parameters),
+    ...(optionKeys !== undefined ? { optionKeys } : {}),
+  };
+}
+
 function parameterListOf(decl: ts.Declaration): ts.NodeArray<ts.ParameterDeclaration> | undefined {
   if (ts.isMethodDeclaration(decl) || ts.isMethodSignature(decl)) return decl.parameters;
-  if (ts.isSetAccessorDeclaration(decl)) return decl.parameters;
+  if (ts.isSetAccessorDeclaration(decl) || ts.isConstructorDeclaration(decl))
+    return decl.parameters;
   return undefined;
 }
 
+/**
+ * Returns the effective visibility of a class member, treating
+ * `#`-prefixed private fields as `private`.
+ */
 function memberVisibility(member: ts.ClassElement): "public" | "private" | "protected" {
   if (hasModifier(member, ts.SyntaxKind.PrivateKeyword)) return "private";
   if (hasModifier(member, ts.SyntaxKind.ProtectedKeyword)) return "protected";


### PR DESCRIPTION
## What

The synthesized `__mixin` walker reaches members through the type checker
(`instanceType.getProperties()` / the construct signature) rather than the
syntax tree, so it pushed every member and constructor with a hard-coded
`params: []`. For the repo's 22 synthesized `__mixin` modules, every entry
reported zero parameters to the advisory arity check — a mixin member whose
Ruby counterpart takes arguments could never be reported correctly, and a
genuine divergence could never be caught.

Both push sites now extract from the declaration already in hand (`decl` /
`ctorDecl`) via a single `declarationArity` helper, mirroring the top-level
class walker's split: methods and set accessors carry parameters; getters and
property declarations report none. `optionKeys` was in reach on the same
parameter lists (the walker already has `checker`), so it is covered too.

**Foreign members:** params and option keys ARE extracted for inherited
members. That is the deliberate split — unlike the JSDoc `noRailsEquivalent`
reason (#5468 gated it on the declaration living in THIS file so a copied tag
never reads as stale), arity is structural: it describes the member's own
signature, which the arity check compares against the Ruby entry regardless of
which file declared it. A foreign member now reports the same shape its base
class's own entry does.

## Arity re-baseline

Same corpus, `API_COMPARE_FORCE=1 pnpm api:compare`, before → after:

```
before  arity: 7546/7627 (98.9%, 4 excluded)   81 arity mismatches
after   arity: 7547/7627 (99%,   4 excluded)   80 arity mismatches
```

The denominator is unchanged (7627 pairs were already being compared — they
were just being compared against a fabricated `()`). Exactly one mismatch
clears, and it was a false one:

```
activesupport  callbacks.rb halted_callback_hook (filter, name)
            vs callbacks.ts haltedCallbackHook   ()   →  (filter, name)
```

No mismatch appears that did not exist before, i.e. no mixin member's real
arity diverges from its Ruby counterpart today. The option-keys summary is
unchanged in both counts and contents — 104 pairs compared, 15 likely-real, 65
differ on main and on this branch, and the set of reported mismatches is
byte-identical (0 added, 0 removed). No mixin member has an options-shaped
trailing parameter yet, so the new `optionKeys` path is live but currently
silent. `pnpm api:arity` still passes on the 4 existing reasoned exclusions,
and no checked-in baseline or ratchet file moved.

## Tests

Five extractor tests: own-member params (with a getter asserted still empty),
foreign-member params, own-member option keys, constructor params + option
keys, and an implicit constructor staying at `[]`.

Closes-story: synthesized-mixin-members-report-zero-params
