### PR TITLE
fix(postgresql): only cancel an in-flight query the rolling-back chain owns

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -292,6 +292,29 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    // The other half of the invariant: a query the rolling-back chain itself
+    // abandoned is still cancelled, so the guard above is a narrowing and not
+    // a removal of Rails' cancel_any_running_query.
+    it("rollback cancels an in-flight query the same chain abandoned", async () => {
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        let slowError: unknown;
+        let slow!: Promise<unknown>;
+        await other.transactionManager.synchronize(async () => {
+          await other.beginDbTransaction();
+          slow = other.execute("SELECT pg_sleep(5) AS slept").catch((e) => {
+            slowError = e;
+          });
+          await new Promise<void>((r) => setTimeout(r, 100));
+          await other.rollbackDbTransaction();
+        });
+        await slow;
+        expect(slowError).toBeInstanceOf(QueryCanceled);
+      } finally {
+        await other.close();
+      }
+    });
+
     it("translate exception serialization failure", async () => {
       await adapter.exec(`CREATE TABLE "ex_ser" ("id" SERIAL PRIMARY KEY, "val" INTEGER)`);
       await adapter.executeMutation(`INSERT INTO "ex_ser" (val) VALUES (0)`);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -270,6 +270,28 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.rollback().catch(() => {});
       }
     });
+    // Regression for RFC 0061 pg-query-canceled-unhandled-rejection: rolling
+    // back must not fire a CancelRequest at a query some *other* async chain
+    // put on the wire. `_cancelAnyRunningQuery` used to cancel whatever was
+    // in flight, which rejected a promise the rollback didn't own — and when
+    // that chain had been dropped (an aborted save cascade), nobody observed
+    // the rejection and vitest reported an unattributed run-end
+    // `QueryCanceled`. The rollback waits behind the query instead.
+    it("rollback does not cancel a query issued by another chain", async () => {
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        await other.beginDbTransaction();
+        // Issued outside the TransactionManager lock the rollback below takes,
+        // standing in for the foreign chain.
+        const foreign = other.execute("SELECT pg_sleep(0.5) AS slept");
+        await new Promise<void>((r) => setTimeout(r, 100));
+        await other.rollbackDbTransaction();
+        await expect(foreign).resolves.toHaveLength(1);
+      } finally {
+        await other.close();
+      }
+    });
+
     it("translate exception serialization failure", async () => {
       await adapter.exec(`CREATE TABLE "ex_ser" ("id" SERIAL PRIMARY KEY, "val" INTEGER)`);
       await adapter.executeMutation(`INSERT INTO "ex_ser" (val) VALUES (0)`);

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1203,7 +1203,10 @@ export class TransactionManager {
    * @internal
    */
   get currentLockToken(): symbol | null {
-    return this._lockStorage().getStore() ?? null;
+    // Reads `_lockOwner` directly rather than through `_lockStorage()`: this
+    // runs on every pinned query and must not install a storage (nor swap one
+    // out from under a live holder) as a side effect of merely asking.
+    return this._lockOwner?.getStore() ?? null;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1191,6 +1191,22 @@ export class TransactionManager {
   }
 
   /**
+   * The lock token of the async chain currently executing inside
+   * {@link synchronize}, or `null` when the caller holds no lock. Rails needs
+   * no such accessor — its `@connection.lock` is a mutex over *threads*, so a
+   * connection can only ever have one unit of work touching it. trails' lock
+   * is per async chain, and a chain that returns while work it started is
+   * still awaiting releases the lock with a query still on the wire; this
+   * token is how a later holder tells "a query I issued" from "a query some
+   * other live chain issued" (see PostgreSQLAdapter#_cancelAnyRunningQuery).
+   *
+   * @internal
+   */
+  get currentLockToken(): symbol | null {
+    return this._lockStorage().getStore() ?? null;
+  }
+
+  /**
    * Run `fn` under the per-connection lock that serializes
    * {@link withinNewTransaction}. Mirrors Rails'
    * `@connection.lock.synchronize do … end` so callers can extend the lock

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -404,6 +404,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _client: pg.Client | null = null;
   private _inTransaction = false;
   private _queryInFlight = false;
+  // The TransactionManager lock token of the chain that issued the query
+  // `_queryInFlight` refers to — see `_cancelAnyRunningQuery`.
+  private _queryInFlightOwner: symbol | null = null;
   private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
   private _maxIdentifierLength: number | null = null;
@@ -1602,7 +1605,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       return this._serializePinnedQuery(client, () => client.query(sql, binds) as Promise<R>);
     };
     const isTxConn = client === this._rawConnection;
-    if (isTxConn) this._queryInFlight = true;
+    if (isTxConn) {
+      this._queryInFlight = true;
+      this._queryInFlightOwner = this._transactionManager.currentLockToken;
+    }
     try {
       try {
         return await attempt();
@@ -1629,7 +1635,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         throw e;
       }
     } finally {
-      if (isTxConn) this._queryInFlight = false;
+      if (isTxConn) {
+        this._queryInFlight = false;
+        this._queryInFlightOwner = null;
+      }
     }
   }
 
@@ -2194,6 +2203,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // Sends a CancelRequest to abort any in-flight query on the transaction connection
   // before issuing ROLLBACK / ROLLBACK AND CHAIN, so the rollback isn't blocked
   // waiting for a long-running query to finish. Best-effort: errors are swallowed.
+  //
+  // INVARIANT: only ever cancels a query *this* unit of work issued. Rails gets
+  // that for free — `@connection.lock` is a thread mutex, so the only query that
+  // can be on the wire when a rollback reaches here is one the rolling-back
+  // thread itself started and abandoned (Timeout/Interrupt). trails' lock is per
+  // async chain and a chain can release it with work still awaiting, so a
+  // *foreign* chain's query is routinely mid-flight here. Cancelling that one
+  // rejects a promise this rollback does not own, and when the foreign chain has
+  // been dropped (an aborted save cascade, a connection heading back to the
+  // pool) nobody observes the rejection — it surfaces at run end as an
+  // unattributed `QueryCanceled: canceling statement due to user request`
+  // (RFC 0061 pg-query-canceled-unhandled-rejection). Skipping the cancel is
+  // safe: `_serializePinnedQuery` already sequences our ROLLBACK behind whatever
+  // is on the wire, so we wait instead of corrupting someone else's query.
   private _cancelAnyRunningQuery(): void {
     type PgClientWithPid = pg.Client & {
       processID?: number | null;
@@ -2206,6 +2229,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     };
     const txClient = this._client as PgClientWithPid | null;
     if (!this._queryInFlight || txClient?.processID == null) return;
+    const owner = this._transactionManager.currentLockToken;
+    if (owner === null || owner !== this._queryInFlightOwner) return;
     try {
       // Open a FRESH TCP connection to send a CancelRequest — mirrors
       // libpq PQcancel / Ruby PG::Connection#cancel: new socket, send

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2217,6 +2217,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // (RFC 0061 pg-query-canceled-unhandled-rejection). Skipping the cancel is
   // safe: `_serializePinnedQuery` already sequences our ROLLBACK behind whatever
   // is on the wire, so we wait instead of corrupting someone else's query.
+  //
+  // A null token means the caller holds no lock at all (`resetBang` on pool
+  // checkin, or a direct `beginDbTransaction`/`rollbackDbTransaction` pair on a
+  // bare adapter): ownership is unprovable, so those paths also wait on the
+  // serializer rather than cancel.
   private _cancelAnyRunningQuery(): void {
     type PgClientWithPid = pg.Client & {
       processID?: number | null;


### PR DESCRIPTION
## Problem

"Active Record PostgreSQL Tests" shards failed intermittently with **every test
passing** and a single run-end vitest failure:

```text
⎯⎯ Unhandled Rejection ⎯⎯
QueryCanceled: canceling statement due to user request
```

## Root cause (evidence, not a guess)

The three `pg_cancel_backend` test call sites named in the story are red
herrings — all three target a pid they own and attach a handler to the query
they cancel. Looping them locally against PG never reproduced it.

The failing CI job's log (run 30564528294 attempt 1, shard 2) attributes the
rejection to `associations/collection-proxy.test.ts` — a file with no cancel of
its own — and shows a **pooled** connection (`role: 'writing'`, `envName:
'arunit'`). The cancel therefore came from trails itself: `PostgreSQLAdapter#_cancelAnyRunningQuery`,
which sends a real libpq CancelRequest before `ROLLBACK` /
`ROLLBACK AND CHAIN` / `resetBang`.

Instrumenting `_cancelAnyRunningQuery` and running the PG shard locally caught
it deterministically in that same file, in
`CollectionProxy#appendBang — persisted record left dirty by a failed save`:

- in flight: `SAVEPOINT "active_record_1"`, issued by
  `BelongsToAssociation.loadTarget` → `selectAll` → `withRawConnection` →
  `TransactionManager#materializeTransactions` → `SavepointTransaction#materializeBang`;
- cancelling it: `TransactionManager#_rollbackTransactionInner` →
  `RealTransaction#rollback` → `execRollbackDbTransaction` →
  `_cancelAnyRunningQuery`, having just taken the lock **fresh** (non-reentrant
  branch) — i.e. a different logical unit of work.

Rails cannot hit this: `@connection.lock` is a mutex over *threads*, so the only
query that can be on the wire when a rollback reaches `cancel_any_running_query`
is one the rolling-back thread itself started and abandoned (Timeout/Interrupt).
trails' lock is per async chain, and a chain that returns while work it started
is still awaiting releases the lock with a query still running. The cancel then
rejects a promise the rollback does not own — and when that chain has been
dropped (an aborted save cascade, a connection heading back to the pool via
`resetBang`), nobody observes the rejection, so it lands at run end attributed
to no test.

Not cross-worker: every cancel path targets a pid/secret-key pair from its own
`pg.Client`.

## Fix

Record the `TransactionManager` lock token of the chain that issued the
in-flight query (`_queryInFlightOwner`, set alongside the existing
`_queryInFlight` in `_runQuery`) and cancel only when it matches the token of
the chain now asking for the cancel. The invariant — *only ever cancel a query
this unit of work issued* — is documented at the call site.

Skipping the cancel is safe: `_serializePinnedQuery` already chains every query
on the pinned client onto one tail, so the `ROLLBACK` sequences behind whatever
is on the wire instead of corrupting it. No global `unhandledRejection` handler,
no loosening of vitest's unhandled-error reporting, no test renamed or deleted.

`TransactionManager#currentLockToken` is a new `@internal` accessor (Rails needs
no equivalent — see its doc comment for why).

## Verification

- Regression test `rollback does not cancel a query issued by another chain`
  fails on baseline with `promise rejected "QueryCanceled: canceling statement
  due to user request" instead of resolving`, passes with the fix.
- Companion test `rollback cancels an in-flight query the same chain abandoned`
  pins the other branch, so the guard is a *narrowing* of Rails'
  `cancel_any_running_query` and not a silent removal of it.
- 25x loop of `collection-proxy.test.ts`, `adapters/postgresql/transaction.test.ts`,
  `postgresql-adapter.test.ts`, `postgresql-adapter.trails.test.ts` and
  `adapter.test.ts` against PG — 25/25 clean, no unhandled rejection.
- `pnpm api:compare` and `pnpm test:compare` clean, no manifest drift.
- CI green (both PG shards, MySQL, SQLite, lint, gates).

Note: `TransactionManager#currentLockToken` reads `_lockOwner` directly rather
than through `_lockStorage()` — it runs on every pinned query and must not
install a storage (nor swap one out from under a live holder) as a side effect
of being read.

Closes-story: pg-query-canceled-unhandled-rejection
