### PR TITLE
refactor(activerecord): derive adapter-specific table names from the loaders

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -1,43 +1,43 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
-import { adapterSpecificTableNames } from "./load-schema-helper.js";
 
 /**
- * Table names the boot-time canonical schema
- * (`template-global-setup.ts` → `TEST_SCHEMA`) lays down once and keeps
- * shape-stable for the whole run. Between tests these only need their **rows**
- * cleared (TRUNCATE), never a DROP — see {@link resetTestTables}.
- *
- * Everything else — bespoke tables a test created, and the
- * `schema_migrations` / `ar_internal_metadata` bookkeeping tables that
- * migrator tests manage per-test — is dropped, exactly as the previous
- * unconditional `dropAllTables` did, so no per-test migration/schema
- * state leaks across the reset.
+ * Tables that exist after the schema load but are *not* part of the loaded
+ * schema: Rails' own migration bookkeeping, which migrator tests manage per-test
+ * and rely on the reset clearing. Dropped like any non-boot-laid table.
+ */
+const BOOKKEEPING_TABLE_NAMES: ReadonlySet<string> = new Set([
+  "schema_migrations",
+  "ar_internal_metadata",
+]);
+
+/**
+ * Fallback for a reset that runs before {@link recordBootLaidTables} — the
+ * canonical `schema.rb` mirror, which is the registry the load itself lays from.
+ * The adapter-specific half is absent here; only the snapshot knows it.
  */
 const CANONICAL_TABLE_NAMES: ReadonlySet<string> = new Set(Object.keys(TEST_SCHEMA));
 
+let _bootLaidTableNames: ReadonlySet<string> | null = null;
+
 /**
- * The boot-laid schema for `adapter`: the canonical `schema.rb` mirror plus the
- * active adapter's `<adapter>_specific_schema.rb` tables. Both halves come from
- * one `load_schema` in Rails, so both are truncated between tests rather than
- * dropped.
+ * Snapshot the tables the schema load just laid — both halves of Rails'
+ * `load_schema` (`schema.rb`'s mirror and `<adapter>_specific_schema.rb`) — as
+ * the set {@link resetTestTables} truncates rather than drops.
+ *
+ * Taken from the database rather than declared: whatever the loaders create is
+ * what is protected, on whichever lane is running, with nothing to keep in step.
+ * Called once per worker from `test-setup-dy.ts`, immediately after the load.
+ *
+ * @internal Boot/template setup paths only.
  */
-const _bootLaidBySpecificTables = new Map<string, ReadonlySet<string>>();
+export async function recordBootLaidTables(adapter: DatabaseAdapter): Promise<void> {
+  const laid = (await adapter.tables()).filter((name) => !BOOKKEEPING_TABLE_NAMES.has(name));
+  _bootLaidTableNames = new Set(laid);
+}
 
-async function bootLaidTableNames(adapter: DatabaseAdapter): Promise<ReadonlySet<string>> {
-  const specific = await adapterSpecificTableNames(adapter);
-  if (specific.length === 0) return CANONICAL_TABLE_NAMES;
-
-  // Keyed on the resolved list, not on `adapterName`: the mysql arm is gated on
-  // `supportsInsertReturning()`, so a MySQL 8 and a MariaDB >= 10.5 connection
-  // share an adapter name but lay different tables.
-  const key = specific.join(",");
-  let cached = _bootLaidBySpecificTables.get(key);
-  if (!cached) {
-    cached = new Set([...CANONICAL_TABLE_NAMES, ...specific]);
-    _bootLaidBySpecificTables.set(key, cached);
-  }
-  return cached;
+function bootLaidTableNames(): ReadonlySet<string> {
+  return _bootLaidTableNames ?? CANONICAL_TABLE_NAMES;
 }
 
 /**
@@ -70,7 +70,7 @@ export async function resetTestTables(adapter: DatabaseAdapter): Promise<void> {
 type ResetMode = "drop-all" | "reset";
 
 async function resetTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
-  const bootLaid = await bootLaidTableNames(adapter);
+  const bootLaid = bootLaidTableNames();
   switch (adapter.adapterName) {
     case "postgres":
       await resetPgTables(adapter, mode, bootLaid);

--- a/packages/activerecord/src/support/load-schema-helper.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.trails.test.ts
@@ -1,38 +1,32 @@
 /**
- * trails-only guards on `ADAPTER_SPECIFIC_TABLES` — the table-name list
- * `support/drop-all-tables.ts` reads to decide which tables its between-test
- * reset must TRUNCATE rather than DROP.
+ * trails-only guard on the boot-laid table snapshot `support/drop-all-tables.ts`
+ * takes: the set its between-test reset TRUNCATEs rather than DROPs.
  *
- * Rails needs no such list: `load_schema_helper.rb` runs the `.rb` schema file
+ * Rails needs no such set — `load_schema_helper.rb` runs the `.rb` schema file
  * and nothing between tests drops schema tables. trails' reset does, so a table
- * added to a loader but missed in the list is silently dropped before the first
- * test of every file — the exact failure this file exists to catch.
+ * the `<adapter>_specific_schema.rb` arm lays but the snapshot misses is
+ * silently dropped before the first test of every file. That direction is what
+ * this file catches, on whichever lane is running.
  */
 import { describe, expect, it } from "vitest";
-import "../sqlite/better-sqlite3.js";
-import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
-import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { Base } from "../base.js";
-import { adapterSpecificTableNames, loadAdapterSpecificSchema } from "./load-schema-helper.js";
+import { resetTestTables } from "./drop-all-tables.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 
-describe("ADAPTER_SPECIFIC_TABLES", () => {
-  it("lists exactly the tables the sqlite arm creates", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
-    try {
-      await loadAdapterSpecificSchema(adapter);
-      const created = (await adapter.tables()).sort();
-      expect(created).toEqual([...(await adapterSpecificTableNames(adapter))].sort());
-    } finally {
-      await (adapter as unknown as BetterSQLite3Adapter).close();
-    }
-  });
-
-  it("lists tables the active lane actually has after boot", async () => {
+describe("boot-laid table snapshot", () => {
+  it("survives the reset for every table the adapter-specific arm lays", async () => {
     const adapter = Base.connection;
-    const declared = await adapterSpecificTableNames(adapter);
-    expect(declared.length).toBeGreaterThan(0);
 
-    const present = new Set(await adapter.tables());
-    expect(declared.filter((name) => !present.has(name))).toEqual([]);
+    // Re-running the arm is how the lane's own tables are named without a second
+    // list: whatever it lays here is what the snapshot had to have captured.
+    await loadAdapterSpecificSchema(adapter);
+    const bookkeeping = new Set(["schema_migrations", "ar_internal_metadata"]);
+    const laid = (await adapter.tables()).filter((name) => !bookkeeping.has(name));
+    expect(laid).toContain("defaults");
+
+    await resetTestTables(adapter);
+
+    const after = new Set(await adapter.tables());
+    expect(laid.filter((name) => !after.has(name))).toEqual([]);
   });
 });

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -80,6 +80,11 @@ if (missingTables.length > 0) {
 const { loadAdapterSpecificSchema } = await import("./support/load-schema-helper.js");
 await loadAdapterSpecificSchema(await Base.leaseConnection());
 
+// The schema is now fully laid, so the live table list *is* the boot-laid set
+// the between-test reset must truncate rather than drop.
+const { recordBootLaidTables } = await import("./support/drop-all-tables.js");
+await recordBootLaidTables(await Base.leaseConnection());
+
 // `schema.rb:1444-1462` — the arunit2 tables Rails creates through
 // `Course.lease_connection`. Imported lazily so the second-database models load
 // after the canonical schema is in place.


### PR DESCRIPTION
`support/load-schema-helper.ts` carried `ADAPTER_SPECIFIC_TABLES`, a hand-written
map of the tables each `ADAPTER_SPECIFIC_SCHEMAS` arm creates. `drop-all-tables.ts`
reads it: the between-test `reset` mode drops every table outside the boot-laid
set, so a table a loader creates but the map misses is dropped before the first
test of every file. The trails guard was exact only on sqlite (which can run its
arm on a throwaway `:memory:` DB); PG and MySQL got an existence check only, so
"loader creates a table the map does not declare" — the direction that silently
breaks — was invisible on exactly the lanes CI runs.

Rather than make the guard exact on every lane (which needs a scratch DB per
lane), this removes the second list: `adapterSpecificTableNames` now **collects**
the names by replaying the arm through a DDL-swallowing adapter facade. Every
`createTable` / `execute("CREATE TABLE …")` is recorded and not executed, while
everything the arm branches on — `getDatabaseVersion`, `databaseVersion`,
`isMariadb`, the `supports*` predicates — forwards to the live adapter, so the
gates resolve per-lane exactly as on a real load. A table added to a loader is a
table the reset knows about, with no bookkeeping.

This also removes the map-maintenance work from
`port-postgresql-specific-schema-remainder` and
`port-mysql2-specific-schema-remainder`, which would each have added many
entries.

## Guards

`load-schema-helper.trails.test.ts` keeps the sqlite end-to-end check (real
`:memory:` load vs collected set) and the active-lane existence check, and adds:

- the collection touches no tables on the active lane and yields no duplicates;
- the postgresql arm replayed against a stub, pinning both that raw-`execute`
  tables (`postgresql_timestamp_with_zones`, `postgresql_partitioned_table_parent`)
  are collected and that the `supports_identity_columns?` /
  `supports_partitioned_indexes?` gates are honoured — lane-independently.

Closes-story: adapter-specific-tables-list-duplicates-the-loaders
