### PR TITLE
test(eslint): guard the canonical-loader ban's module matcher against file moves

### DIFF
--- a/eslint/no-internal-canonical-loaders.mjs
+++ b/eslint/no-internal-canonical-loaders.mjs
@@ -46,18 +46,34 @@ export const BANNED = new Set(["ensureCanonicalTables", "loadCanonicalSchema", "
 // Test files permitted to import the banned loaders (they test them directly).
 export const ALLOW = new Set(canonicalLoaderSelfTests);
 
-const canonicalModuleRe = new RegExp(`(?:^|/)(?:${canonicalLoaderModules.join("|")})(?:\\.js)?$`);
+/**
+ * True when `source` resolves to one of the canonical-schema test helper
+ * modules. Matched on the basename regardless of directory depth, so a
+ * same-directory import from inside `support/` (`./canonical-schema.js`) is
+ * caught and not just the `../../support/canonical-schema.js` form; the
+ * basenames are unique in the repo, so basename matching is safe.
+ *
+ * An ESLint rule runs synchronously with no filesystem access, so the module
+ * list cannot be derived from where the BANNED symbols actually live; it is
+ * pinned instead by the guard test in this rule's `*.test.mjs`, which reads the
+ * real `support/` tree and fails when a module exports a BANNED symbol and is
+ * not listed in `canonicalLoaderModules`. Without that guard a file move — the
+ * way `ensureCanonicalTables` moved into `canonical-table-rebuild.ts` — reopens
+ * the ban silently: a banned symbol imported from an unlisted module is simply
+ * not reported.
+ */
+export function isCanonicalSchemaModule(source) {
+  return canonicalLoaderModuleSet.has(moduleBasename(source));
+}
 
-/** True when `source` resolves to one of the canonical-schema test helper modules. */
-function isCanonicalSchemaModule(source) {
-  // Match on the module basename regardless of directory depth so a
-  // same-directory import from inside support/ (`./canonical-schema.js`)
-  // is caught, not just the `../../support/canonical-schema.js` form. The
-  // basenames are unique in the repo, so basename matching is safe.
-  // `canonical-table-rebuild` is listed because `ensureCanonicalTables` moved
-  // there when the schema.rb transcription split from the drop/rebuild
-  // machinery; omitting it would leave the ban open under the new path.
-  return canonicalModuleRe.test(source);
+const canonicalLoaderModuleSet = new Set(canonicalLoaderModules);
+
+/** `"../support/canonical-schema.js"` → `"canonical-schema"`. */
+export function moduleBasename(source) {
+  return source
+    .split("/")
+    .pop()
+    .replace(/\.[cm]?js$/, "");
 }
 
 /** @type {import("eslint").Rule.RuleModule} */

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -3,7 +3,12 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { RuleTester } from "eslint";
 import { describe, it, expect } from "vitest";
-import rule, { BANNED, isCanonicalSchemaModule } from "./no-internal-canonical-loaders.mjs";
+import rule, {
+  BANNED,
+  isCanonicalSchemaModule,
+  moduleBasename,
+} from "./no-internal-canonical-loaders.mjs";
+import { canonicalLoaderModules } from "./test-infra-scope.mjs";
 
 const FILENAME = "packages/activerecord/src/dirty.test.ts";
 const OWN_TEST = "packages/activerecord/src/support/canonical-schema.test.ts";
@@ -96,11 +101,6 @@ tester.run("no-internal-canonical-loaders", rule, {
   ],
 });
 
-// Guard: the rule's module matcher is a literal basename list, and a banned
-// symbol imported from an unmatched module is simply not reported — so a file
-// move that relocates a loader would reopen the ban with no lint error and no
-// failing test. This reads the real support/ tree and fails when a module
-// exports a BANNED symbol the matcher does not match.
 const supportDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
@@ -110,7 +110,7 @@ const supportDir = path.join(
   "support",
 );
 
-/** Names exported by `source`, for the export forms used in support/. */
+/** Names exported by `source`, covering the export forms used in `support/`. */
 function exportedNames(source) {
   const names = new Set();
   for (const [, name] of source.matchAll(
@@ -121,28 +121,57 @@ function exportedNames(source) {
   for (const [, clause] of source.matchAll(/^export\s*\{([^}]*)\}/gm)) {
     for (const entry of clause.split(",")) {
       const parts = entry.trim().split(/\s+as\s+/);
-      const name = (parts[1] ?? parts[0] ?? "").trim();
+      const name = (parts.at(-1) ?? "").trim();
       if (name) names.add(name);
     }
   }
   return names;
 }
 
+/**
+ * Walks the whole `support/` tree, not just its top level: the rule matches on
+ * basename regardless of directory depth, so a loader moved into a
+ * `support/<subdir>/` module is exactly the silent-reopen case being guarded.
+ */
+async function* supportSources(dir = supportDir) {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== "node_modules" && entry.name !== "dist") yield* supportSources(full);
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      yield full;
+    }
+  }
+}
+
+/** Repo-relative path → the BANNED symbols that module exports. */
+async function bannedExportsBySupportModule() {
+  const byModule = new Map();
+  for await (const file of supportSources()) {
+    const source = await fs.readFile(file, "utf8");
+    const banned = [...exportedNames(source)].filter((name) => BANNED.has(name)).sort();
+    if (banned.length > 0) byModule.set(path.relative(supportDir, file), banned);
+  }
+  return byModule;
+}
+
 describe("no-internal-canonical-loaders module matcher", () => {
   it("matches every support/ module that exports a banned loader", async () => {
     const unmatched = [];
-    for (const entry of await fs.readdir(supportDir, { withFileTypes: true })) {
-      if (!entry.isFile() || !entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) {
-        continue;
-      }
-      const source = await fs.readFile(path.join(supportDir, entry.name), "utf8");
-      const exported = [...exportedNames(source)].filter((name) => BANNED.has(name));
-      if (exported.length === 0) continue;
-      const specifier = `./${entry.name.replace(/\.ts$/, ".js")}`;
-      if (!isCanonicalSchemaModule(specifier)) {
-        unmatched.push(`${entry.name} exports ${exported.sort().join(", ")}`);
+    for (const [file, banned] of await bannedExportsBySupportModule()) {
+      if (!isCanonicalSchemaModule(`./${file.replace(/\.ts$/, ".js")}`)) {
+        unmatched.push(`${file} exports ${banned.join(", ")}`);
       }
     }
     expect(unmatched).toEqual([]);
+  });
+
+  it("lists no module that has stopped exporting a banned loader", async () => {
+    const found = new Set(
+      [...(await bannedExportsBySupportModule()).keys()].map((file) =>
+        moduleBasename(file.replace(/\.ts$/, "")),
+      ),
+    );
+    expect(canonicalLoaderModules.filter((module) => !found.has(module))).toEqual([]);
   });
 });

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -1,5 +1,9 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
 import { RuleTester } from "eslint";
-import rule from "./no-internal-canonical-loaders.mjs";
+import { describe, it, expect } from "vitest";
+import rule, { BANNED, isCanonicalSchemaModule } from "./no-internal-canonical-loaders.mjs";
 
 const FILENAME = "packages/activerecord/src/dirty.test.ts";
 const OWN_TEST = "packages/activerecord/src/support/canonical-schema.test.ts";
@@ -90,4 +94,55 @@ tester.run("no-internal-canonical-loaders", rule, {
       ],
     },
   ],
+});
+
+// Guard: the rule's module matcher is a literal basename list, and a banned
+// symbol imported from an unmatched module is simply not reported — so a file
+// move that relocates a loader would reopen the ban with no lint error and no
+// failing test. This reads the real support/ tree and fails when a module
+// exports a BANNED symbol the matcher does not match.
+const supportDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "packages",
+  "activerecord",
+  "src",
+  "support",
+);
+
+/** Names exported by `source`, for the export forms used in support/. */
+function exportedNames(source) {
+  const names = new Set();
+  for (const [, name] of source.matchAll(
+    /^export\s+(?:declare\s+)?(?:async\s+)?(?:function\*?|const|let|var|class)\s+([A-Za-z_$][\w$]*)/gm,
+  )) {
+    names.add(name);
+  }
+  for (const [, clause] of source.matchAll(/^export\s*\{([^}]*)\}/gm)) {
+    for (const entry of clause.split(",")) {
+      const parts = entry.trim().split(/\s+as\s+/);
+      const name = (parts[1] ?? parts[0] ?? "").trim();
+      if (name) names.add(name);
+    }
+  }
+  return names;
+}
+
+describe("no-internal-canonical-loaders module matcher", () => {
+  it("matches every support/ module that exports a banned loader", async () => {
+    const unmatched = [];
+    for (const entry of await fs.readdir(supportDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) {
+        continue;
+      }
+      const source = await fs.readFile(path.join(supportDir, entry.name), "utf8");
+      const exported = [...exportedNames(source)].filter((name) => BANNED.has(name));
+      if (exported.length === 0) continue;
+      const specifier = `./${entry.name.replace(/\.ts$/, ".js")}`;
+      if (!isCanonicalSchemaModule(specifier)) {
+        unmatched.push(`${entry.name} exports ${exported.sort().join(", ")}`);
+      }
+    }
+    expect(unmatched).toEqual([]);
+  });
 });


### PR DESCRIPTION
`no-internal-canonical-loaders`' module matcher was an inline hardcoded basename
alternation. A banned symbol imported from an unmatched module is simply not
reported, so any file move that relocates a loader (the way `ensureCanonicalTables`
moved into `canonical-table-rebuild.ts` in #5522) reopens the ban silently — no
lint error, no failing test. The rule's own unit tests are hand-written specifier
strings, so they can't catch it either.

- Replaces the regex with a `moduleBasename` helper plus a set lookup against
  `canonicalLoaderModules` from `eslint/test-infra-scope.mjs` (the shared scope
  declaration #5672 introduced) — same behavior, no regex to keep in sync, and
  no second copy of the module list.
- Adds a guard test that walks the real `packages/activerecord/src/support/`
  tree recursively, collects modules exporting a `BANNED` symbol, and fails when
  one is not matched by the rule — plus the converse, failing on a listed module that has
  stopped exporting a banned symbol so the list can't rot in the other direction.

An ESLint rule runs synchronously with no filesystem access, so the module set
can't be derived at lint time; the guard pins it instead — the escape hatch the
acceptance criteria allow.

Both directions verified on synthetic regressions: adding
`support/zz-moved-loader.ts` exporting `loadCanonicalSchema` fails the guard with
`zz-moved-loader.ts exports loadCanonicalSchema`; a nested
`support/zzsub/moved-loader.ts` exporting `loadSchema` fails it too (the rule
matches on basename at any depth, so the guard walks the tree at any depth); and
adding a stale `zz-gone` entry to `LOADER_MODULES` fails the converse test. Both pass without the change.
Behavior for the three currently-matched modules is unchanged and all existing
valid/invalid cases still pass (14/14).

Closes-story: canonical-loader-ban-module-matcher-is-hardcoded
