### PR TITLE
fix(postgresql): claim the in-flight query marker when the query reaches the wire

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1525,9 +1525,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
+    // Claim the in-flight marker here, not at `_runQuery` entry: a query that is
+    // merely queued behind a foreign one must not overwrite `_queryInFlightOwner`
+    // while that foreign query is still on the wire, or a rollback from the
+    // queued query's chain would pass `_cancelAnyRunningQuery`'s ownership guard
+    // and cancel a statement it does not own. Claiming inside the serializer also
+    // makes the *clear* exact (one holder at a time) instead of
+    // first-finisher-wins. Rails gets this for free because
+    // `cancel_any_running_query` only runs under `@connection.lock.synchronize`
+    // (transaction.rb:611 → postgresql/database_statements.rb:127).
+    this._queryInFlight = true;
+    this._queryInFlightOwner = this._transactionManager.currentLockToken;
     try {
       return await fn();
     } finally {
+      this._queryInFlight = false;
+      this._queryInFlightOwner = null;
       release();
     }
   }
@@ -1605,41 +1618,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
       return this._serializePinnedQuery(client, () => client.query(sql, binds) as Promise<R>);
     };
-    const isTxConn = client === this._rawConnection;
-    if (isTxConn) {
-      this._queryInFlight = true;
-      this._queryInFlightOwner = this._transactionManager.currentLockToken;
-    }
     try {
-      try {
-        return await attempt();
-      } catch (e) {
-        if (prepare && this._isInvalidCachedPlan(e)) {
-          // Mirrors Rails' `perform_query` rescue
-          // (postgresql/database_statements.rb:143-151): inside a transaction we
-          // can't recover (all commands would raise InFailedSQLTransaction), so
-          // raise `PreparedStatementCacheExpired` and let the transaction machinery
-          // clear the whole cache on rollback; otherwise drop just this entry and
-          // retry. `in_transaction?` is `open_transactions > 0`
-          // (postgresql_adapter.rb:908-910), so an open *lazy* (un-materialized)
-          // frame still counts — a read-only block (`transaction { record.reload }`)
-          // never emits a physical `BEGIN` because reads don't materialize.
-          if (this.openTransactions > 0) {
-            throw new PreparedStatementCacheExpired(
-              (e as { message?: string })?.message ?? "cached plan expired",
-              { sql, binds, cause: e },
-            );
-          }
-          this._poolFor(client).delete(this.sqlKey(sql));
-          return await attempt();
+      return await attempt();
+    } catch (e) {
+      if (prepare && this._isInvalidCachedPlan(e)) {
+        // Mirrors Rails' `perform_query` rescue
+        // (postgresql/database_statements.rb:143-151): inside a transaction we
+        // can't recover (all commands would raise InFailedSQLTransaction), so
+        // raise `PreparedStatementCacheExpired` and let the transaction machinery
+        // clear the whole cache on rollback; otherwise drop just this entry and
+        // retry. `in_transaction?` is `open_transactions > 0`
+        // (postgresql_adapter.rb:908-910), so an open *lazy* (un-materialized)
+        // frame still counts — a read-only block (`transaction { record.reload }`)
+        // never emits a physical `BEGIN` because reads don't materialize.
+        if (this.openTransactions > 0) {
+          throw new PreparedStatementCacheExpired(
+            (e as { message?: string })?.message ?? "cached plan expired",
+            { sql, binds, cause: e },
+          );
         }
-        throw e;
+        this._poolFor(client).delete(this.sqlKey(sql));
+        return await attempt();
       }
-    } finally {
-      if (isTxConn) {
-        this._queryInFlight = false;
-        this._queryInFlightOwner = null;
-      }
+      throw e;
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1525,15 +1525,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
-    // Claim the in-flight marker here, not at `_runQuery` entry: a query that is
-    // merely queued behind a foreign one must not overwrite `_queryInFlightOwner`
-    // while that foreign query is still on the wire, or a rollback from the
-    // queued query's chain would pass `_cancelAnyRunningQuery`'s ownership guard
-    // and cancel a statement it does not own. Claiming inside the serializer also
-    // makes the *clear* exact (one holder at a time) instead of
-    // first-finisher-wins. Rails gets this for free because
-    // `cancel_any_running_query` only runs under `@connection.lock.synchronize`
-    // (transaction.rb:611 → postgresql/database_statements.rb:127).
     this._queryInFlight = true;
     this._queryInFlightOwner = this._transactionManager.currentLockToken;
     try {


### PR DESCRIPTION
Follow-up to #5655: review feedback that was written and verified locally but
never committed before that PR merged.

#5655 added an ownership guard to `_cancelAnyRunningQuery` — it records the
`TransactionManager` lock token of the chain that issued the in-flight query
(`_queryInFlightOwner`) and only cancels when it matches the token of the chain
requesting the rollback. But as merged, `_queryInFlight` / `_queryInFlightOwner`
were claimed at the **top of `_runQuery`**, before `_serializePinnedQuery` awaits
the previous maintenance tail. A same-chain query merely *queued* behind a
foreign long-running query therefore overwrote the owner while the foreign query
was still the one on the wire; a rollback from that chain then passed the guard
and cancelled a statement it does not own.

This moves the claim/release into `_serializePinnedQuery`, after
`await prev.catch(() => {})` and before `fn()`, and drops the `isTxConn`-gated
set/clear pair from `_runQuery` (the now-redundant outer `try`/`finally`
collapses into the existing `try`/`catch`).

It also fixes the mirror hazard: with a single shared boolean the *clear* was
first-finisher-wins, so a fast queued query could clear the marker while a slow
one was still executing. Claiming inside the serializer means exactly one query
holds the marker at a time — the invariant the guard already assumes.

Rails gets this for free: `cancel_any_running_query` only ever runs inside
`@connection.lock.synchronize`
(`activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:611`
→ `.../postgresql/database_statements.rb:127`).

### Side effect

The marker now also covers the other `_serializePinnedQuery` call sites
(type-map lookups, DDL around `postgresql-adapter.ts` 1947-1977, 2434, 2799,
3434, 3442) which previously never set it. That is more accurate, not less —
those run sequentially on their own chain, so they cannot produce a spurious
same-token cancel.

### Why no regression test

No discriminating test is constructible here; three attempts all passed on the
pre-fix code, so none was shipped (a test that passes on both sides is worse
than none):

- `TransactionManager.synchronize` already serializes two public `execute` calls
  end-to-end on one adapter, so a second `execute` never reaches `_runQuery`
  while the first is on the wire. Instrumenting `_cancelAnyRunningQuery`
  confirmed it was entered with `_queryInFlight === false` — both queries had
  completed, because acquiring the TM lock for the rollback body meant waiting
  out the `pg_sleep`.
- The overlap the serializer exists to prevent (per its own docblock: "two calls
  that interleave desync the wire protocol") arises on internal/reentrant paths
  — `withRawConnection`'s reentrant branch, a chain that releases the lock with
  work still awaiting (the SAVEPOINT-vs-rollback case #5655 diagnosed) — not
  through two public `execute` calls.
- A third attempt on this PR ("rollback does not cancel a foreign query a queued
  same-chain query is waiting behind"): foreign `pg_sleep(1)` issued outside the
  TM lock, then a same-chain `execute` launched un-awaited inside
  `transactionManager.synchronize` to queue behind it, then
  `rollbackDbTransaction()`. It passed on baseline too — the inner `execute`
  blocks acquiring the TM lock the enclosing `synchronize` already holds, so it
  never reaches `_runQuery` (and so never overwrites the owner) before the
  rollback runs. Same wall the first two attempts hit; the test was dropped
  rather than shipped.

So this lands as a structural correction with the reasoning above.

### Verification

PG lane, 158 files / 2957 tests across `packages/activerecord/src/adapters/postgresql/`,
`connection-adapters/`, `transactions.test.ts`, `adapter.test.ts`: 151 passed /
7 skipped, 2849 passed / 108 skipped, no unhandled rejections at run end.

Closes-story: pg-cancel-marker-claimed-while-query-still-queued
