### PR TITLE
fix(api-compare): fail on an unbuilt package instead of reporting shifted advisory totals

### DIFF
--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -153,16 +153,50 @@ describe("staleBuilds", () => {
     expect(await staleBuilds([rootFor(packagesDir, "activerecord")])).toEqual([]);
   });
 
-  it("ignores a package that was never built", async () => {
+  it("reports a package that was never built", async () => {
     const root = mkTmp();
     const packagesDir = path.join(root, "packages");
     const pkg = buildPackage(packagesDir, "arel");
-    // A dist-less package resolves to nothing at every commit — consistent,
-    // so not a mixed tree. tsc alone would call this up to date (the surviving
-    // tsbuildinfo vouches for it), which is why the check is ours.
+    // A dist-less package is NOT harmlessly consistent: importers can't resolve
+    // the types it declares, so advisory totals shift the moment a build lands
+    // (option keys printed 103 unbuilt vs 104 built on the same tree). tsc alone
+    // calls this up to date — the surviving tsbuildinfo vouches for it — which
+    // is why the check is ours.
     fs.rmSync(path.join(pkg, "dist"), { recursive: true });
 
-    expect(await staleBuilds([rootFor(packagesDir, "arel")])).toEqual([]);
+    expect(await staleBuilds([rootFor(packagesDir, "arel")])).toEqual([
+      { dir: "arel", status: "NotBuilt" },
+    ]);
+  });
+
+  it("reports every package of a wholly unbuilt tree", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    for (const name of ["activesupport", "arel"]) {
+      fs.rmSync(path.join(buildPackage(packagesDir, name), "dist"), { recursive: true });
+    }
+    // The state a freshly created worktree is in before its first `pnpm build`,
+    // and the one the guard used to wave through entirely.
+    expect(await staleBuilds([...rootsOf(packagesDir, "activesupport", "arel")])).toEqual([
+      { dir: "activesupport", status: "NotBuilt" },
+      { dir: "arel", status: "NotBuilt" },
+    ]);
+  });
+
+  it("reports a REFERENCED workspace that was never built", async () => {
+    const root = mkTmp();
+    const packagesDir = path.join(root, "packages");
+    const tse = buildPackage(packagesDir, "tse-compiler", {
+      "index.ts": "export const compileJs = 1;\n",
+    });
+    buildPackage(packagesDir, "actionview", { "index.ts": "export const a = 1;\n" }, [
+      "tse-compiler",
+    ]);
+    fs.rmSync(path.join(tse, "dist"), { recursive: true });
+
+    expect(await staleBuilds([rootFor(packagesDir, "actionview")])).toEqual([
+      { dir: "tse-compiler", status: "NotBuilt" },
+    ]);
   });
 
   it("returns an empty list when there are no roots", async () => {
@@ -347,5 +381,24 @@ describe("staleBuildMessage", () => {
     expect(message).toContain("packages/actionview — OutOfDateRoots");
     expect(message).toContain("pnpm build");
     expect(message).toContain("API_COMPARE_ALLOW_STALE_BUILD=1");
+  });
+
+  it("explains that FORCE does not cover build state", () => {
+    const message = staleBuildMessage([{ dir: "arel", status: "OutOfDateWithSelf" }]);
+    expect(message).toContain("API_COMPARE_FORCE=1 does NOT fix this");
+  });
+
+  it("calls out unbuilt packages separately from stale ones", () => {
+    const message = staleBuildMessage([
+      { dir: "activemodel", status: "NotBuilt" },
+      { dir: "arel", status: "OutOfDateWithSelf" },
+    ]);
+    expect(message).toContain("packages/activemodel — NotBuilt");
+    expect(message).toContain("1 of those have no dist at all");
+  });
+
+  it("omits the unbuilt paragraph when every package merely went stale", () => {
+    const message = staleBuildMessage([{ dir: "arel", status: "OutOfDateWithSelf" }]);
+    expect(message).not.toContain("no dist at all");
   });
 });

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -14,7 +14,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import ts from "typescript";
-import { staleBuilds, staleBuildMessage, manifestIsStale } from "./build-freshness.js";
+import { NOT_BUILT, staleBuilds, staleBuildMessage, manifestIsStale } from "./build-freshness.js";
 import type { PackageRoots } from "./config.js";
 
 const tmpDirs: string[] = [];
@@ -165,7 +165,7 @@ describe("staleBuilds", () => {
     fs.rmSync(path.join(pkg, "dist"), { recursive: true });
 
     expect(await staleBuilds([rootFor(packagesDir, "arel")])).toEqual([
-      { dir: "arel", status: "NotBuilt" },
+      { dir: "arel", status: NOT_BUILT },
     ]);
   });
 
@@ -178,8 +178,8 @@ describe("staleBuilds", () => {
     // The state a freshly created worktree is in before its first `pnpm build`,
     // and the one the guard used to wave through entirely.
     expect(await staleBuilds([...rootsOf(packagesDir, "activesupport", "arel")])).toEqual([
-      { dir: "activesupport", status: "NotBuilt" },
-      { dir: "arel", status: "NotBuilt" },
+      { dir: "activesupport", status: NOT_BUILT },
+      { dir: "arel", status: NOT_BUILT },
     ]);
   });
 
@@ -195,7 +195,7 @@ describe("staleBuilds", () => {
     fs.rmSync(path.join(tse, "dist"), { recursive: true });
 
     expect(await staleBuilds([rootFor(packagesDir, "actionview")])).toEqual([
-      { dir: "tse-compiler", status: "NotBuilt" },
+      { dir: "tse-compiler", status: NOT_BUILT },
     ]);
   });
 
@@ -390,11 +390,19 @@ describe("staleBuildMessage", () => {
 
   it("calls out unbuilt packages separately from stale ones", () => {
     const message = staleBuildMessage([
-      { dir: "activemodel", status: "NotBuilt" },
+      { dir: "activemodel", status: NOT_BUILT },
       { dir: "arel", status: "OutOfDateWithSelf" },
     ]);
     expect(message).toContain("packages/activemodel — NotBuilt");
     expect(message).toContain("1 of those have no dist at all");
+  });
+
+  it("says MISSING rather than stale when nothing was built at all", () => {
+    // The fresh-worktree case: calling a tree that was never built "stale"
+    // sends the reader looking for a checkout that never happened.
+    const message = staleBuildMessage([{ dir: "arel", status: NOT_BUILT }]);
+    expect(message).toContain("against a missing build");
+    expect(message).not.toContain("against a stale build");
   });
 
   it("omits the unbuilt paragraph when every package merely went stale", () => {

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -1,6 +1,7 @@
 /**
- * Guard against measuring `api:compare` / `api:extra` against a BUILD that
- * belongs to a different commit than the checked-out sources.
+ * Guard against measuring `api:compare` / `api:extra` against a BUILD that does
+ * not correspond to the checked-out sources — one belonging to a different
+ * commit, or (see `staleBuilds`) no build at all.
  *
  * The TS extractor compiles each package with the real module resolver, so an
  * `import … from "@blazetrails/activesupport"` resolves through pnpm's
@@ -168,10 +169,13 @@ async function hasDeclarations(dir: string): Promise<boolean> {
  * benign ("resolves to nothing at every commit, so it's consistent"), and that
  * is measurably false: on an UNBUILT worktree the extractor cannot resolve a
  * type an importer pulls from a sibling package's declarations, so the method
- * carrying it silently drops out of the advisory populations. `serializableHash`
- * (activerecord/serialization.ts), whose options type comes from activemodel,
- * is one such — the option-key summary prints 103 pairs on an unbuilt tree and
- * 104 on the same tree after `pnpm build`. A run-order-dependent total is
+ * carrying it silently leaves whichever population needed that type.
+ * `serializableHash` (activerecord/serialization.ts) takes its options type
+ * from activemodel, and the option-key summary prints 103 pairs on an unbuilt
+ * tree against 104 on the same tree after `pnpm build`. (Only the option-key
+ * total moved on that tree — arity, literals and calls were identical — but
+ * nothing confines the mechanism to option keys; any total read off a
+ * cross-package type can move the same way.) A run-order-dependent total is
  * exactly the fabricated ±1 this guard exists to prevent, so an unbuilt package
  * has to fail the same way a stale one does.
  *
@@ -189,12 +193,10 @@ export async function staleBuilds(roots: readonly PackageRoots[]): Promise<Stale
     });
   }
   const candidates = referenceClosure([...seeds.values()]);
-  const checked = await Promise.all(
-    candidates.map(async (project) => ((await hasDeclarations(project.distDir)) ? project : null)),
-  );
-  const built = checked.filter((project): project is Project => project !== null);
+  const hasDist = await Promise.all(candidates.map((project) => hasDeclarations(project.distDir)));
+  const built = candidates.filter((_, i) => hasDist[i]);
   const stale: StaleBuild[] = candidates
-    .filter((project) => !built.includes(project))
+    .filter((_, i) => !hasDist[i])
     .map((project) => ({ dir: project.dir, status: NOT_BUILT }));
 
   if (built.length > 0) {
@@ -274,21 +276,30 @@ async function newestSourceMtime(dir: string): Promise<number> {
 /** The operator-facing failure text for a non-empty `staleBuilds` result. */
 export function staleBuildMessage(stale: StaleBuild[]): string {
   const missing = stale.filter((entry) => entry.status === NOT_BUILT).length;
+  const noun = missing === stale.length ? "a missing build" : "a stale build";
   return [
-    `api:compare would measure ${stale.length} package(s) against a stale build:`,
+    `api:compare would measure ${stale.length} package(s) against ${noun}:`,
     ...stale.map((entry) => `  packages/${entry.dir} — ${entry.status}`),
     "",
-    "Cross-package imports resolve through packages/<pkg>/dist/*.d.ts, which git",
-    "does not update on checkout, so these totals would mix one commit's sources",
-    "with another commit's build output. Run `pnpm build` and re-run.",
+    "Cross-package imports resolve through packages/<pkg>/dist/*.d.ts, so what",
+    "the extractor sees depends on those declarations. Run `pnpm build` and",
+    "re-run.",
+    ...(missing < stale.length
+      ? [
+          "",
+          "git does not update dist on checkout, so a stale one makes these totals",
+          "mix one commit's sources with another commit's build output.",
+        ]
+      : []),
     ...(missing > 0
       ? [
           "",
           `${missing} of those have no dist at all. An unbuilt package does not`,
-          "resolve to nothing harmlessly: types an importer pulls from it go",
-          "unresolved, and the methods carrying them drop out of the advisory",
-          "option-key and arity populations, so the totals move on the next run",
-          "purely because a build happened in between.",
+          "resolve to nothing harmlessly: a type an importer pulls from it goes",
+          "unresolved, and the method carrying it drops out of the advisory",
+          "populations — the option-key summary alone moves by a pair — so the",
+          "totals change on the next run purely because a build happened in",
+          "between.",
         ]
       : []),
     "",

--- a/scripts/api-compare/build-freshness.ts
+++ b/scripts/api-compare/build-freshness.ts
@@ -42,11 +42,18 @@ import * as path from "path";
 import ts from "typescript";
 import type { PackageRoots } from "./config.js";
 
+/**
+ * Reported for a project that has no `dist` at all. Not one of tsc's statuses —
+ * tsc calls such a project up to date whenever its `tsconfig.tsbuildinfo`
+ * survived — so the guard mints it itself. See `staleBuilds`.
+ */
+export const NOT_BUILT = "NotBuilt";
+
 /** One package whose build does not correspond to its checked-out sources. */
 export interface StaleBuild {
   /** Directory name under `packages/` (not the api-compare package key). */
   dir: string;
-  /** `tsc`'s own verdict, e.g. `OutOfDateWithSelf` — quoted in the message. */
+  /** `tsc`'s own verdict, e.g. `OutOfDateWithSelf`, or `NotBuilt`. */
   status: string;
 }
 
@@ -157,11 +164,20 @@ async function hasDeclarations(dir: string): Promise<boolean> {
  * the manifest and must not be able to block a run. Roots sharing a directory
  * (the four actionpack packages) share one tsconfig and collapse to one report.
  *
- * A root with no `dist` is NOT stale: nothing was built, so nothing can be out
- * of date and cross-package imports fail to resolve uniformly at every commit.
- * That check is ours rather than tsc's on purpose — tsc reports a project whose
+ * A root with no `dist` is reported as `NotBuilt`. It was once treated as
+ * benign ("resolves to nothing at every commit, so it's consistent"), and that
+ * is measurably false: on an UNBUILT worktree the extractor cannot resolve a
+ * type an importer pulls from a sibling package's declarations, so the method
+ * carrying it silently drops out of the advisory populations. `serializableHash`
+ * (activerecord/serialization.ts), whose options type comes from activemodel,
+ * is one such — the option-key summary prints 103 pairs on an unbuilt tree and
+ * 104 on the same tree after `pnpm build`. A run-order-dependent total is
+ * exactly the fabricated ±1 this guard exists to prevent, so an unbuilt package
+ * has to fail the same way a stale one does.
+ *
+ * `NotBuilt` is ours rather than tsc's on purpose — tsc reports a project whose
  * `dist` was deleted but whose `tsconfig.tsbuildinfo` survives as up to date,
- * so deferring to it would let a half-removed build through.
+ * so deferring to it would let a removed build through.
  */
 export async function staleBuilds(roots: readonly PackageRoots[]): Promise<StaleBuild[]> {
   const seeds = new Map<string, Project>();
@@ -177,18 +193,21 @@ export async function staleBuilds(roots: readonly PackageRoots[]): Promise<Stale
     candidates.map(async (project) => ((await hasDeclarations(project.distDir)) ? project : null)),
   );
   const built = checked.filter((project): project is Project => project !== null);
-  if (built.length === 0) return [];
+  const stale: StaleBuild[] = candidates
+    .filter((project) => !built.includes(project))
+    .map((project) => ({ dir: project.dir, status: NOT_BUILT }));
 
-  const builder = ts.createSolutionBuilder(
-    ts.createSolutionBuilderHost(ts.sys),
-    built.map((project) => project.configPath),
-    {},
-  );
-  const stale: StaleBuild[] = [];
-  for (const project of built) {
-    const status = builder.getUpToDateStatusOfProject(project.configPath);
-    if (STALE_STATUSES.has(status.type)) {
-      stale.push({ dir: project.dir, status: ts.UpToDateStatusType[status.type] });
+  if (built.length > 0) {
+    const builder = ts.createSolutionBuilder(
+      ts.createSolutionBuilderHost(ts.sys),
+      built.map((project) => project.configPath),
+      {},
+    );
+    for (const project of built) {
+      const status = builder.getUpToDateStatusOfProject(project.configPath);
+      if (STALE_STATUSES.has(status.type)) {
+        stale.push({ dir: project.dir, status: ts.UpToDateStatusType[status.type] });
+      }
     }
   }
   return stale.sort((a, b) => (a.dir < b.dir ? -1 : a.dir > b.dir ? 1 : 0));
@@ -254,6 +273,7 @@ async function newestSourceMtime(dir: string): Promise<number> {
 
 /** The operator-facing failure text for a non-empty `staleBuilds` result. */
 export function staleBuildMessage(stale: StaleBuild[]): string {
+  const missing = stale.filter((entry) => entry.status === NOT_BUILT).length;
   return [
     `api:compare would measure ${stale.length} package(s) against a stale build:`,
     ...stale.map((entry) => `  packages/${entry.dir} — ${entry.status}`),
@@ -261,7 +281,20 @@ export function staleBuildMessage(stale: StaleBuild[]): string {
     "Cross-package imports resolve through packages/<pkg>/dist/*.d.ts, which git",
     "does not update on checkout, so these totals would mix one commit's sources",
     "with another commit's build output. Run `pnpm build` and re-run.",
-    "Set API_COMPARE_ALLOW_STALE_BUILD=1 to measure anyway (totals are not a",
-    "trustworthy baseline).",
+    ...(missing > 0
+      ? [
+          "",
+          `${missing} of those have no dist at all. An unbuilt package does not`,
+          "resolve to nothing harmlessly: types an importer pulls from it go",
+          "unresolved, and the methods carrying them drop out of the advisory",
+          "option-key and arity populations, so the totals move on the next run",
+          "purely because a build happened in between.",
+        ]
+      : []),
+    "",
+    "API_COMPARE_FORCE=1 does NOT fix this — it clears the extractor caches",
+    "(local mtime-keyed and shared content-keyed) and nothing else; build state",
+    "is not a cache. Set API_COMPARE_ALLOW_STALE_BUILD=1 to measure anyway",
+    "(totals are not a trustworthy baseline).",
   ].join("\n");
 }

--- a/scripts/api-compare/orchestrate.ts
+++ b/scripts/api-compare/orchestrate.ts
@@ -30,6 +30,14 @@
  * `API_COMPARE_FORCE=1` forces full regeneration end-to-end (ts-extract and
  * ruby-extract honor it via their own gates; fetch drops its offline
  * fast-path). `API_COMPARE_REFRESH=1` re-clones sources via fetch --refresh.
+ *
+ * What FORCE does NOT cover: `packages/*\/dist`. It clears exactly the caches
+ * this pipeline owns — the local mtime-keyed ts cache, the shared content-keyed
+ * cache, and the ruby manifest's mtime gate. The compiled declarations siblings
+ * resolve imports through are BUILD OUTPUT, not a cache, and nothing here
+ * rebuilds them; a run against an unbuilt or stale `dist` reports different
+ * totals no matter how forced it is. That is build-freshness.ts's job, which
+ * aborts the run before any extraction.
  */
 import { execFile } from "node:child_process";
 import { readFile, stat, writeFile } from "node:fs/promises";


### PR DESCRIPTION
## What

`api:compare`'s advisory option-key total drifted between the first run in a
session and later runs on the *same* tree (103 pairs / 64 differing vs 104 /
65), with `API_COMPARE_FORCE=1` set on every run. The story's prime suspect was
the shared extractor cache. It is not a cache at all.

## Root cause

The variable is `packages/*/dist`. The TS extractor compiles each package with
the real module resolver, so an importer's surface depends on its siblings'
emitted declarations. `staleBuilds` explicitly waved a dist-less project
through, on the theory that "nothing was built, so nothing can be out of date
and cross-package imports fail to resolve uniformly at every commit".

That premise is false. On an unbuilt tree a type pulled from a sibling goes
unresolved, and the method carrying it silently leaves the population that
needed it.

## Reproduction (deterministic, one unchanged tree)

| tree state | option keys | arity | literals | calls |
| --- | --- | --- | --- | --- |
| fresh worktree, no `dist` | 103 pairs, 64 differ | 7547/7627 | 591, 0 differ | 3074, 12 omit |
| same tree after `pnpm build` | **104 pairs, 65 differ** | 7547/7627 | 591, 0 differ | 3074, 12 omit |

Diffing `output/options-key-mismatches.json` across the two runs isolates the
single pair that appears: activerecord `serialization.rb#serializable_hash` →
`serialization.ts#serializableHash`, whose options type is declared in
activemodel and therefore only resolves through
`packages/activemodel/dist/*.d.ts`.

Only the option-key total moved on this tree; nothing confines the mechanism to
option keys, but nothing else was observed to move, and the PR does not claim
otherwise.

The layer is neither the local mtime-keyed cache nor the shared content-keyed
one — `API_COMPARE_FORCE=1` bypasses both, and both runs above were forced.

## Fix

`staleBuilds` now reports a project in the reference closure with no `dist` as
`NotBuilt`, alongside tsc's own out-of-date statuses, so `extract-ts-api`
aborts before extracting rather than printing totals a later run contradicts.
That covers the seed packages and the referenced-but-not-api-compared
workspaces (`tse-compiler`) equally. `API_COMPARE_ALLOW_STALE_BUILD=1` remains
the escape hatch. CI runs `pnpm build` in the api-compare job before extraction,
so nothing there changes.

The failure text adapts to which case fired: a wholly unbuilt tree is reported
as "a missing build" and does not mention checkout staleness, because a fresh
worktree has no checkout to blame.

## `API_COMPARE_FORCE=1` scope

Confirmed it clears exactly what it claims: the local mtime-keyed ts cache, the
shared cross-worktree content-keyed cache, and the ruby manifest's mtime gate.
It does not and cannot cover build output. Both the failure text and
`orchestrate.ts`'s header now say so explicitly, so the next agent chasing a
drifting total doesn't re-derive this.

## Tests

`build-freshness.test.ts` — the "ignores a package that was never built" case
is inverted (it encoded the wrong premise), plus wholly-unbuilt-tree,
unbuilt-referenced-workspace, and message-wording cases. These build real tsc
projects, as the rest of the file does. Verified end-to-end by removing
`packages/arel/dist` and confirming the run aborts with the new message.

Closes-story: api-compare-advisory-totals-drift-cold-vs-warm-run
