### PR TITLE
refactor(activerecord): remove has_one pendingRemovalTarget parking state

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -68,23 +68,19 @@ export class HasOne extends SingularAssociation {
           typeof assoc.needsTargetLoadForBuild === "function" &&
           assoc.needsTargetLoadForBuild()
         ) {
-          // `loadTargetForBuild` caches the direct-FK target for a plain has_one
-          // (the record `remove_target!` will detach), but a has_one_through
-          // overrides it to load the *through* proxy — Rails' has_one_through
-          // `replace` runs no `load_target`/`remove_target!` on the target; its
+          // `loadTargetForBuild` caches the direct-FK target for a plain
+          // has_one, but a has_one_through overrides it to load the *through*
+          // proxy — Rails' has_one_through `replace` runs no
+          // `load_target`/`remove_target!` on the target; its
           // `create_through_record` loads the through instead, and the through's
-          // `detachDisplacedOnBuild` is a no-op. With the load done, `build`
-          // itself owns the removal: it runs `remove_target!` on the now-cached
-          // displaced target before `setNewRecord` promotes the new record, and
-          // returns a promise for the caller to `await`.
+          // `detachDisplacedOnBuild` is a no-op. With the target cached, `build`
+          // owns the removal and returns the promise to `await`.
           return assoc.loadTargetForBuild().then(() => assoc.build(...args));
         }
-        // The target may already be loaded (so `needsTargetLoadForBuild` is
-        // false): Rails' `set_new_record` → `replace` still runs `remove_target!`
-        // on it, detaching the prior record (FK nullified / destroyed per
-        // `:dependent`). `build` returns a Promise for that case only — a
-        // new-record / no-target build keeps its synchronous return (the shape
-        // the STI-build tests assert).
+        // An already-loaded target still gets `remove_target!` (FK nullified /
+        // destroyed per `:dependent`), so `build` returns a Promise for that
+        // case only — a new-record / no-target build keeps its synchronous
+        // return, the shape the STI-build tests assert.
         return assoc.build(...args);
       },
       writable: true,

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -68,31 +68,24 @@ export class HasOne extends SingularAssociation {
           typeof assoc.needsTargetLoadForBuild === "function" &&
           assoc.needsTargetLoadForBuild()
         ) {
-          // `loadTargetForBuild` loads the direct-FK target for a plain has_one
+          // `loadTargetForBuild` caches the direct-FK target for a plain has_one
           // (the record `remove_target!` will detach), but a has_one_through
           // overrides it to load the *through* proxy — Rails' has_one_through
           // `replace` runs no `load_target`/`remove_target!` on the target; its
-          // `create_through_record` loads the through instead. The through's
-          // `detachDisplacedTarget` is a no-op, so the proxy passed as
-          // `displaced` here is inert.
-          return assoc.loadTargetForBuild().then((displaced: unknown) => {
-            const record = buildOwningDisplacement(assoc, args);
-            return assoc.detachDisplacedTarget(displaced).then(() => record);
-          });
+          // `create_through_record` loads the through instead, and the through's
+          // `detachDisplacedOnBuild` is a no-op. With the load done, `build`
+          // itself owns the removal: it runs `remove_target!` on the now-cached
+          // displaced target before `setNewRecord` promotes the new record, and
+          // returns a promise for the caller to `await`.
+          return assoc.loadTargetForBuild().then(() => assoc.build(...args));
         }
         // The target may already be loaded (so `needsTargetLoadForBuild` is
         // false): Rails' `set_new_record` → `replace` still runs `remove_target!`
         // on it, detaching the prior record (FK nullified / destroyed per
-        // `:dependent`). That removal needs an `await`, so return a Promise for
-        // the loaded-target case only — a new-record / no-target build keeps its
-        // synchronous return (the shape the STI-build tests assert).
-        const displaced =
-          typeof assoc.isLoaded === "function" && assoc.isLoaded() ? assoc.target : null;
-        const record = buildOwningDisplacement(assoc, args);
-        if (displaced && typeof assoc.detachDisplacedTarget === "function") {
-          return assoc.detachDisplacedTarget(displaced).then(() => record);
-        }
-        return record;
+        // `:dependent`). `build` returns a Promise for that case only — a
+        // new-record / no-target build keeps its synchronous return (the shape
+        // the STI-build tests assert).
+        return assoc.build(...args);
       },
       writable: true,
       configurable: true,
@@ -257,24 +250,5 @@ export class HasOne extends SingularAssociation {
         }
       });
     }
-  }
-}
-
-/**
- * Run `association.build` with the association's own displaced-record removal
- * suppressed: this accessor awaits `detachDisplacedTarget` itself (with Rails'
- * target-on-failure semantics), and a second, concurrent removal of the same
- * row would double-destroy it. `HasOneAssociation#build` keeps the removal for
- * the direct `record.association(name).build(...)` callers, which have no other
- * hook to run it from.
- *
- * @internal
- */
-function buildOwningDisplacement(assoc: any, args: unknown[]): any {
-  assoc.buildDisplacementOwnedByCaller = true;
-  try {
-    return assoc.build(...args);
-  } finally {
-    assoc.buildDisplacementOwnedByCaller = false;
   }
 }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -325,12 +325,21 @@ export class HasOneAssociation extends SingularAssociation {
     if (this.buildDisplacementOwnedByCaller) return null;
     const displaced = this.loaded ? this.target : null;
     if (!displaced || sameRecord(displaced, record)) return null;
-    // A displaced record that was never persisted keys no row: `remove_target!`'s
-    // in-memory half already ran in `setNewRecord`, and its `target.save` is
-    // gated on `target.persisted?` (has_one_association.rb:108). Returning null
-    // keeps repeated `build`s (the common `assoc.build()` twice shape)
-    // synchronous.
-    if ((displaced as { isPersisted?: () => boolean }).isPersisted?.() !== true) return null;
+    // Only the nullify arm may skip an unpersisted displaced record. Rails gates
+    // on `target.persisted?` inside that arm's `target.save`
+    // (has_one_association.rb:108) and inside `:destroy`'s `target.destroy`
+    // (:100) — but `:delete` calls `target.delete` unconditionally (:97), and
+    // `:destroy` still writes `destroyed_by_association` (:99) before its gate.
+    // The nullify arm's remaining work is in-memory and `setNewRecord` already
+    // ran it, so skipping there is a true no-op — and it is what keeps repeated
+    // `build`s (the common `assoc.build()` twice shape) synchronous.
+    const dependent = (this.reflection.options.dependent as string) ?? "";
+    if (
+      dependent !== "delete" &&
+      dependent !== "destroy" &&
+      (displaced as { isPersisted?: () => boolean }).isPersisted?.() !== true
+    )
+      return null;
     return this.detachDisplacedTarget();
   }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -267,21 +267,20 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   /**
-   * Set by the callers that own Rails' leading `load_target` and the
-   * `remove_target!` that follows it themselves — the `build#{name}` accessor
-   * (builder/has-one.ts, which runs `loadTargetForBuild` and awaits
-   * `detachDisplacedTarget`) and the nested-attributes writer
-   * (nested-attributes.ts, a synchronous property setter that starts
+   * Set by the one caller that owns Rails' leading `load_target` and the
+   * `remove_target!` that follows it itself: the nested-attributes writer
+   * (nested-attributes.ts), a synchronous property setter that starts
    * `detachDisplacedTarget` — for a loaded target — or
    * `prepareDetachDisplacedForSyncBuild` — for an unloaded one, which runs the
    * leading `load_target` itself — around the build, and drains it in its `save`
-   * wrapper).
-   * Both call `build` on their way through, and without this flag `build` would
-   * re-run the load and start a *second*, concurrent removal of the same row.
+   * wrapper.
+   * It calls `build` on its way through, and without this flag `build` would
+   * re-run the load and start a *second*, concurrent removal of the same row —
+   * and would return a promise the synchronous setter cannot hand back.
    *
    * `protected` because it is association-internal bookkeeping, not API surface;
-   * the two callers reach it through their existing duck-typed handles on the
-   * association (both live outside the class hierarchy).
+   * the writer reaches it through its existing duck-typed handle on the
+   * association (it lives outside the class hierarchy).
    *
    * @internal
    */
@@ -316,16 +315,15 @@ export class HasOneAssociation extends SingularAssociation {
    * `build` hand the caller a promise to `await` — the only way a synchronous
    * return can expose an inline write in JS.
    *
-   * `detachDisplacedTarget` supplies the remaining guards (a different,
-   * non-destroyed record) and Rails' target-on-failure semantics.
+   * `detachDisplacedTarget` supplies the remaining guards (a non-destroyed
+   * record) and, by running before `setNewRecord`, Rails' target-on-failure
+   * semantics.
    *
    * @internal
    */
-  protected override detachDisplacedOnBuild(
-    displaced: Base | null,
-    record: Base | null,
-  ): Promise<void> | null {
+  protected override detachDisplacedOnBuild(record: Base | null): Promise<void> | null {
     if (this.buildDisplacementOwnedByCaller) return null;
+    const displaced = this.loaded ? this.target : null;
     if (!displaced || sameRecord(displaced, record)) return null;
     // A displaced record that was never persisted keys no row: `remove_target!`'s
     // in-memory half already ran in `setNewRecord`, and its `target.save` is
@@ -333,7 +331,7 @@ export class HasOneAssociation extends SingularAssociation {
     // keeps repeated `build`s (the common `assoc.build()` twice shape)
     // synchronous.
     if ((displaced as { isPersisted?: () => boolean }).isPersisted?.() !== true) return null;
-    return this.detachDisplacedTarget(displaced);
+    return this.detachDisplacedTarget();
   }
 
   /**
@@ -419,18 +417,18 @@ export class HasOneAssociation extends SingularAssociation {
     // key) must raise before any removal runs, exactly as Rails' `build_record`
     // raises before `set_new_record`. An UNLOADED target is surfaced by
     // `replace`'s leading `load_target`, ported through
-    // `loadDisplacedTargetForCreate`.
-    const [displaced, loadError] = await this.loadDisplacedTargetForCreate();
+    // `loadDisplacedTargetForCreate`, which caches the row as `this.target` —
+    // `super._createRecord` then removes it (via `detachDisplacedOnBuild`)
+    // before `setNewRecord` promotes the freshly created record, exactly where
+    // Rails' `remove_target!` sits inside `replace`.
+    const loadError = await this.loadDisplacedTargetForCreate();
+    // A failed load leaves nothing cached, so `super._createRecord` detaches
+    // nothing: the build succeeded, so Rails would have reached `load_target`
+    // — and every exception but `RecordNotFound` propagates out of it
+    // (association.rb:189-195). Re-raise here, at the point Rails raises:
+    // after `build_record` and `record.save`.
     const record = await super._createRecord(attributes, shouldRaise, block);
-    // The build succeeded, so Rails would have reached `load_target` — and every
-    // exception but `RecordNotFound` propagates out of it (association.rb:189-195).
-    // Re-raise here, at the point Rails raises: after `build_record` and
-    // `record.save`, before `remove_target!` detaches anything.
     if (loadError) throw loadError;
-    // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
-    // now the freshly created record; detach the displaced (previously attached)
-    // one, matching `remove_target!` inside Rails' `replace`.
-    await this.detachDisplacedTarget(displaced);
     return record;
   }
 
@@ -442,8 +440,9 @@ export class HasOneAssociation extends SingularAssociation {
    * when Rails' would, and overridden by has_one_through to load the *through*
    * proxy, since Rails' through `replace` issues no target load.
    *
-   * Returns the displaced record and, separately, any error the load raised —
-   * the caller re-raises it only once `super._createRecord` has succeeded. The
+   * The load caches the displaced record as `this.target`, so the removal that
+   * follows needs no handle on it. Returns any error the load raised — the
+   * caller re-raises it only once `super._createRecord` has succeeded. The
    * load must run FIRST (it is what surfaces the row to detach, and it has to
    * precede the new record's FK write), but Rails reaches `load_target` only
    * from `set_new_record`, i.e. *after* `build_record`. So a malformed
@@ -456,12 +455,13 @@ export class HasOneAssociation extends SingularAssociation {
    *
    * @internal
    */
-  private async loadDisplacedTargetForCreate(): Promise<[Base | null, unknown]> {
-    if (!this.needsTargetLoadForBuild()) return [this.loaded ? this.target : null, null];
+  private async loadDisplacedTargetForCreate(): Promise<unknown> {
+    if (!this.needsTargetLoadForBuild()) return null;
     try {
-      return [(await this.loadTargetForBuild()) as Base | null, null];
+      await this.loadTargetForBuild();
+      return null;
     } catch (error) {
-      return [null, error];
+      return error;
     }
   }
 
@@ -472,21 +472,21 @@ export class HasOneAssociation extends SingularAssociation {
    * destroy/delete it per `:dependent`). Our sync `replace`/`setNewRecord`
    * cannot `await` that write, so every caller that materializes a replacement
    * — the `build#{name}` / `create#{name}` accessors, `association(name).build`,
-   * and the nested-attributes writer — runs it here, *after* the replacement is
-   * already cached as `this.target`. A no-op unless a *different*,
-   * non-destroyed record was displaced.
+   * and the nested-attributes writer — runs it here, on the record the
+   * association is currently caching. A no-op unless a non-destroyed record is
+   * cached.
    *
-   * The removal reaches `displaced` through `pendingRemovalTarget` instead of
-   * parking it on `this.target` for the duration: the nested-attributes property setter is
-   * synchronous and returns to its caller mid-removal, so a parked target would
-   * be briefly observable as `assoc.target` reverting to the displaced record
-   * (Rails' own nested-attributes tests read the new target right after the
-   * assignment). Rails' target-on-failure semantics — `self.target = record`
-   * runs only after the transaction block, so a raising `remove_target!` (e.g.
-   * a failed nullify save, has_one_association.rb:102-108) leaves the OLD
-   * record cached — are preserved by restoring the target in the `catch`
-   * instead, which is observable at exactly the same moment the caller sees the
-   * error.
+   * It takes no argument and removes `this.target`, exactly as Rails'
+   * `remove_target!` does. The awaited callers (`build`, `_createRecord`, the
+   * `build#{name}` accessor) run it *before* installing the replacement, so
+   * Rails' target-on-failure semantics fall out for free: `self.target = record`
+   * (:84) is never reached when `remove_target!` raises (e.g. a failed nullify
+   * save, has_one_association.rb:102-108). The one synchronous caller — the
+   * nested-attributes property setter, which cannot await — starts the removal
+   * here and *then* builds: `removeTargetBang` reads `this.target` on entry,
+   * before its first `await`, so the swap that follows in the same synchronous
+   * slice cannot disturb the in-flight removal and the setter's caller never
+   * sees the target revert.
    *
    * No `isPersisted` pre-screen: Rails' `remove_target!` gates on persistence
    * only inside its `:destroy` and nullify arms; the `:delete` arm calls
@@ -496,20 +496,12 @@ export class HasOneAssociation extends SingularAssociation {
    *
    * @internal
    */
-  async detachDisplacedTarget(displaced: Base | null): Promise<void> {
+  async detachDisplacedTarget(): Promise<void> {
+    const displaced = this.target;
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
-    if (sameRecord(displaced, this.target)) return;
-    try {
-      this.pendingRemovalTarget = displaced;
-      await this.removeTargetBang((this.reflection.options.dependent as string) ?? "");
-    } catch (error) {
-      this.target = displaced;
-      throw error;
-    }
+    await this.removeTargetBang((this.reflection.options.dependent as string) ?? "");
   }
-
-  private pendingRemovalTarget: Base | null = null;
 
   /**
    * The unloaded half of the nested-attributes writer's `remove_target!`.
@@ -559,7 +551,19 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   private async findThenDetachDisplaced(): Promise<void> {
-    await this.detachDisplacedTarget(await this.doAsyncFindTarget());
+    // The synchronous build has already installed the replacement by the time
+    // the find resolves, so run Rails' `replace` tail in its own order now:
+    // `load_target` (just awaited) → `remove_target!` → `self.target = record`.
+    // Both writes below sit in one synchronous slice — `removeTargetBang` reads
+    // `this.target` before its first `await` — so no caller can observe the
+    // association caching the displaced record.
+    const replacement = this.target;
+    const displaced = await this.doAsyncFindTarget();
+    if (!displaced || sameRecord(displaced, replacement)) return;
+    this.target = displaced;
+    const removal = this.detachDisplacedTarget();
+    this.target = replacement;
+    await removal;
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {
@@ -665,8 +669,7 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   private async removeTargetBang(method: string): Promise<void> {
-    const target = this.pendingRemovalTarget ?? this.target;
-    this.pendingRemovalTarget = null;
+    const target = this.target;
     if (!target) return;
     if (method === "delete") {
       await ((target as any).delete?.() ?? Promise.resolve());

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -268,19 +268,21 @@ export class HasOneAssociation extends SingularAssociation {
 
   /**
    * Set by the one caller that owns Rails' leading `load_target` and the
-   * `remove_target!` that follows it itself: the nested-attributes writer
-   * (nested-attributes.ts), a synchronous property setter that starts
-   * `detachDisplacedTarget` — for a loaded target — or
-   * `prepareDetachDisplacedForSyncBuild` — for an unloaded one, which runs the
-   * leading `load_target` itself — around the build, and drains it in its `save`
-   * wrapper.
-   * It calls `build` on its way through, and without this flag `build` would
-   * re-run the load and start a *second*, concurrent removal of the same row —
-   * and would return a promise the synchronous setter cannot hand back.
+   * `remove_target!` that follows it itself: `buildThroughProxyRecord`
+   * (has-one-through-association.ts), which rebuilds a has_one_through's join
+   * record on the through proxy — itself a has_one association. Rails'
+   * `create_through_record` (has_one_through_association.rb:15-40), not
+   * `SingularAssociation#build`, owns that join row's displacement, so the
+   * proxy's own build must neither re-run the load nor start a second,
+   * concurrent removal of the same row — and must stay synchronous.
+   *
+   * The nested-attributes writer does NOT use this: it runs `buildRecord` and
+   * `setNewRecord` separately so the removal can sit between them, and so never
+   * enters `build`.
    *
    * `protected` because it is association-internal bookkeeping, not API surface;
-   * the writer reaches it through its existing duck-typed handle on the
-   * association (it lives outside the class hierarchy).
+   * the through helper reaches it through its duck-typed handle on the proxy
+   * (it lives outside the class hierarchy).
    *
    * @internal
    */
@@ -526,22 +528,22 @@ export class HasOneAssociation extends SingularAssociation {
    *
    * Returns a *thunk* rather than the promise: Rails reaches `load_target` from
    * `set_new_record`, i.e. after `build_record`, so a build that raises issues
-   * no query. The gate (`find_target?`) stops being observable once `build`
-   * marks the association loaded, so the writer takes the decision here, before
-   * the build, and invokes the thunk after it.
+   * no query. The gate (`find_target?`) stops being observable once
+   * `setNewRecord` marks the association loaded, so the writer takes the
+   * decision here, before `buildRecord`, and invokes the thunk after
+   * `setNewRecord`.
    *
-   * The writer invokes the thunk only when `build` returns normally, which
-   * would suppress a query for a throw from the `set_new_record` half — Rails
-   * reaches everything past has_one_association.rb:62 with `load_target`
+   * The writer invokes the thunk only when `buildRecord` returns normally,
+   * which would suppress a query for a throw from the `set_new_record` half —
+   * Rails reaches everything past has_one_association.rb:62 with `load_target`
    * already run. That half is unreachable on this path: `raise_on_type_mismatch!`
    * (:60) is the sole pre-`load_target` raise and cannot fire for a record the
-   * association built from its own reflection, and with
-   * `buildDisplacementOwnedByCaller` set the remainder is `setNewRecord`'s
-   * in-memory foreign-key/inverse writes.
+   * association built from its own reflection, and the remainder is
+   * `setNewRecord`'s in-memory foreign-key/inverse writes.
    *
-   * `protected` for the same reason as `buildDisplacementOwnedByCaller`: this is
-   * association-internal bookkeeping, not API surface. The writer lives outside
-   * the class hierarchy and reaches it through its duck-typed handle.
+   * `protected` because this is association-internal bookkeeping, not API
+   * surface. The writer lives outside the class hierarchy and reaches it
+   * through its duck-typed handle.
    *
    * The find deliberately goes through `doAsyncFindTarget` rather than
    * `loadTargetForBuild`: by the time it resolves, the build has already

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -417,17 +417,14 @@ export class HasOneAssociation extends SingularAssociation {
     // key) must raise before any removal runs, exactly as Rails' `build_record`
     // raises before `set_new_record`. An UNLOADED target is surfaced by
     // `replace`'s leading `load_target`, ported through
-    // `loadDisplacedTargetForCreate`, which caches the row as `this.target` —
-    // `super._createRecord` then removes it (via `detachDisplacedOnBuild`)
-    // before `setNewRecord` promotes the freshly created record, exactly where
-    // Rails' `remove_target!` sits inside `replace`.
+    // `loadDisplacedTargetForCreate`, which caches the row as `this.target`;
+    // `super._createRecord` removes it via `detachDisplacedOnBuild`.
     const loadError = await this.loadDisplacedTargetForCreate();
-    // A failed load leaves nothing cached, so `super._createRecord` detaches
-    // nothing: the build succeeded, so Rails would have reached `load_target`
-    // — and every exception but `RecordNotFound` propagates out of it
-    // (association.rb:189-195). Re-raise here, at the point Rails raises:
-    // after `build_record` and `record.save`.
     const record = await super._createRecord(attributes, shouldRaise, block);
+    // Every exception but `RecordNotFound` propagates out of `load_target`
+    // (association.rb:189-195). Re-raise at the point Rails raises: after
+    // `build_record` and `record.save`. A failed load cached nothing, so the
+    // removal above was already a no-op.
     if (loadError) throw loadError;
     return record;
   }
@@ -476,17 +473,17 @@ export class HasOneAssociation extends SingularAssociation {
    * association is currently caching. A no-op unless a non-destroyed record is
    * cached.
    *
-   * It takes no argument and removes `this.target`, exactly as Rails'
-   * `remove_target!` does. The awaited callers (`build`, `_createRecord`, the
-   * `build#{name}` accessor) run it *before* installing the replacement, so
-   * Rails' target-on-failure semantics fall out for free: `self.target = record`
-   * (:84) is never reached when `remove_target!` raises (e.g. a failed nullify
-   * save, has_one_association.rb:102-108). The one synchronous caller — the
-   * nested-attributes property setter, which cannot await — starts the removal
-   * here and *then* builds: `removeTargetBang` reads `this.target` on entry,
-   * before its first `await`, so the swap that follows in the same synchronous
-   * slice cannot disturb the in-flight removal and the setter's caller never
-   * sees the target revert.
+   * It takes no argument and removes `this.target`, as Rails' `remove_target!`
+   * does. The awaited callers run it *before* installing the replacement, so
+   * Rails' target-on-failure semantics fall out of the ordering: `self.target =
+   * record` (:84) is never reached when `remove_target!` raises (e.g. a failed
+   * nullify save, has_one_association.rb:102-108).
+   *
+   * The one synchronous caller — the nested-attributes property setter, which
+   * cannot await — starts the removal here and *then* builds. That is safe
+   * because `removeTargetBang` reads `this.target` on entry, before its first
+   * `await`: the build's swap lands in the same synchronous slice and cannot
+   * disturb the in-flight removal.
    *
    * No `isPersisted` pre-screen: Rails' `remove_target!` gates on persistence
    * only inside its `:destroy` and nullify arms; the `:delete` arm calls
@@ -551,11 +548,11 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   private async findThenDetachDisplaced(): Promise<void> {
-    // The synchronous build has already installed the replacement by the time
-    // the find resolves, so run Rails' `replace` tail in its own order now:
-    // `load_target` (just awaited) → `remove_target!` → `self.target = record`.
-    // Both writes below sit in one synchronous slice — `removeTargetBang` reads
-    // `this.target` before its first `await` — so no caller can observe the
+    // The synchronous build installed the replacement while the find was in
+    // flight, so run Rails' `replace` tail in order only now: `load_target`
+    // (just awaited) → `remove_target!` → `self.target = record`. Both writes
+    // below sit in one synchronous slice — `removeTargetBang` reads
+    // `this.target` before its first `await` — so nothing can observe the
     // association caching the displaced record.
     const replacement = this.target;
     const displaced = await this.doAsyncFindTarget();

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -25,13 +25,15 @@ import { registerModel, RecordNotSaved, type Base } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { Pirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
+import { ExclusivelyDependentFirm } from "../test-helpers/models/company.js";
 
 describe("has_one displacement via the synchronous build path", () => {
-  fixtures(["pirates", "ships"]);
+  fixtures(["pirates", "ships", "companies", "accounts"]);
 
   beforeAll(() => {
     registerModel(Pirate);
     registerModel(Ship);
+    registerModel(ExclusivelyDependentFirm);
   });
 
   it("nullifies the displaced row when nested attributes replace a loaded child", async () => {
@@ -222,5 +224,23 @@ describe("has_one displacement via the synchronous build path", () => {
 
     expect(built).not.toBeInstanceOf(Promise);
     expect((built as { name: string }).name).toBe("Black Pearl");
+  });
+
+  it("runs remove_target!'s delete arm over an unsaved displaced record", async () => {
+    // Rails' `remove_target!` calls `target.delete` unconditionally for
+    // `dependent: :delete` (has_one_association.rb:97); only the `:destroy` and
+    // nullify arms gate on `target.persisted?`. So a second build over an
+    // unsaved in-memory target still runs the delete branch — and
+    // `Persistence#delete` marks the record destroyed even with no row
+    // (persistence.rb:439-444).
+    const firm = new (ExclusivelyDependentFirm as unknown as new () => Base)();
+    const assoc = (
+      firm as unknown as { association(n: string): { build(a: object): unknown } }
+    ).association("account");
+
+    const displaced = assoc.build({ credit_limit: 10 }) as Base;
+    await assoc.build({ credit_limit: 20 });
+
+    expect((displaced as unknown as { isDestroyed(): boolean }).isDestroyed()).toBe(true);
   });
 });

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -159,15 +159,15 @@ describe("has_one displacement via the synchronous build path", () => {
     })) as Base;
 
     const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
-    const assoc = refetched.association("ship") as unknown as { build(a: object): unknown };
-    // A pure ordering guard, not user-visible behavior: `build` is stubbed
+    const assoc = refetched.association("ship") as unknown as { buildRecord(a: object): unknown };
+    // A pure ordering guard, not user-visible behavior: `buildRecord` is stubbed
     // because the production path has no reachable raise left to provoke —
     // `assertNestedAttributesAreKnown` pre-empts the unknown-attribute one, and
     // the post-`build_record` raises Rails *does* query before are unreachable
     // here (see `prepareDetachDisplacedForSyncBuild`). It pins that the query is
     // issued downstream of the construction, so a future raise added to
     // `build_record` cannot regress the order.
-    assoc.build = () => {
+    assoc.buildRecord = () => {
       throw new Error("build exploded");
     };
 
@@ -224,6 +224,44 @@ describe("has_one displacement via the synchronous build path", () => {
 
     expect(built).not.toBeInstanceOf(Promise);
     expect((built as { name: string }).name).toBe("Black Pearl");
+  });
+
+  it("leaves the displaced record attached when the build raises", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    // Rails runs `build_record` first (singular_association.rb:29-31) and only
+    // reaches `remove_target!` from `set_new_record` (has_one_association.rb:69),
+    // so a construction error — an invalid STI `type`, `SubclassNotFound` —
+    // never detaches anything.
+    const assoc = pirate.association("ship") as unknown as {
+      buildRecord: () => Base;
+      detachDisplacedTarget: () => Promise<void>;
+    };
+    let detached = false;
+    assoc.detachDisplacedTarget = () => {
+      detached = true;
+      return Promise.resolve();
+    };
+    assoc.buildRecord = () => {
+      throw new Error("build exploded");
+    };
+
+    expect(() => {
+      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+        name: "Davy Jones Gold Dagger",
+      };
+    }).toThrow("build exploded");
+
+    expect(detached).toBe(false);
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
+      (pirate as unknown as { id: number }).id,
+    );
   });
 
   it("runs remove_target!'s delete arm over an unsaved displaced record", async () => {

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -90,10 +90,20 @@ export class SingularAssociation extends Association {
     // discovers (and displaces) the row in the DB. The load has to precede
     // `setNewRecord`, which overwrites the target and marks it loaded.
     const setNewRecord = (): Base | null | Promise<Base | null> => {
-      const displaced = this.loaded ? this.target : null;
+      // Rails' `replace` order is `remove_target!` (has_one_association.rb:69)
+      // and only then `self.target = record` (:84), so the displaced record is
+      // still the cached target while it is removed — and a raising removal
+      // leaves it cached. Keep that order: `setNewRecord` runs after the removal
+      // resolves, never before.
+      const removal = this.detachDisplacedOnBuild(record);
+      if (removal) {
+        return removal.then(() => {
+          if (record) this.setNewRecord(record);
+          return record;
+        });
+      }
       if (record) this.setNewRecord(record);
-      const removal = this.detachDisplacedOnBuild(displaced, record);
-      return removal ? removal.then(() => record) : record;
+      return record;
     };
     const load = this.loadDisplacedForBuild();
     if (load) return load.then(setNewRecord);
@@ -115,7 +125,10 @@ export class SingularAssociation extends Association {
 
   /**
    * The DB half of the `remove_target!` Rails' has_one `set_new_record` runs
-   * inline — null when there is nothing to remove, which is always the case for
+   * inline. The record it removes is the association's own cached `target` —
+   * this runs before `setNewRecord`, exactly where Rails' `remove_target!` sits
+   * relative to `self.target = record`. Null when there is nothing to remove,
+   * which is always the case for
    * belongs_to (`BelongsToAssociation#replace` only writes the owner's foreign
    * key in memory). Overridden by has_one, where the returned promise both
    * performs the removal and is what widens `build`'s return so a direct
@@ -123,10 +136,7 @@ export class SingularAssociation extends Association {
    *
    * @internal
    */
-  protected detachDisplacedOnBuild(
-    _displaced: Base | null,
-    _record: Base | null,
-  ): Promise<void> | null {
+  protected detachDisplacedOnBuild(_record: Base | null): Promise<void> | null {
     return null;
   }
 
@@ -276,6 +286,12 @@ export class SingularAssociation extends Association {
     if (typeof (record as any).save === "function") {
       saved = await (record as any).save();
     }
+    // `set_new_record` → `replace` runs `remove_target!` before
+    // `self.target = record` (has_one_association.rb:69, 84), so the displaced
+    // record is removed while it is still the cached target. Null for
+    // belongs_to and for a has_one with nothing to displace.
+    const removal = this.detachDisplacedOnBuild(record);
+    if (removal) await removal;
     this.setNewRecord(record);
     if (!saved && shouldRaise) {
       throw new RecordInvalid(record);

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -90,11 +90,10 @@ export class SingularAssociation extends Association {
     // discovers (and displaces) the row in the DB. The load has to precede
     // `setNewRecord`, which overwrites the target and marks it loaded.
     const setNewRecord = (): Base | null | Promise<Base | null> => {
-      // Rails' `replace` order is `remove_target!` (has_one_association.rb:69)
-      // and only then `self.target = record` (:84), so the displaced record is
-      // still the cached target while it is removed — and a raising removal
-      // leaves it cached. Keep that order: `setNewRecord` runs after the removal
-      // resolves, never before.
+      // Rails removes before promoting: `remove_target!`
+      // (has_one_association.rb:69), then `self.target = record` (:84). That
+      // order is what leaves the displaced record cached when the removal
+      // raises.
       const removal = this.detachDisplacedOnBuild(record);
       if (removal) {
         return removal.then(() => {
@@ -125,12 +124,11 @@ export class SingularAssociation extends Association {
 
   /**
    * The DB half of the `remove_target!` Rails' has_one `set_new_record` runs
-   * inline. The record it removes is the association's own cached `target` —
-   * this runs before `setNewRecord`, exactly where Rails' `remove_target!` sits
-   * relative to `self.target = record`. Null when there is nothing to remove,
-   * which is always the case for
-   * belongs_to (`BelongsToAssociation#replace` only writes the owner's foreign
-   * key in memory). Overridden by has_one, where the returned promise both
+   * inline. It removes the association's own cached `target`, and callers run
+   * it before `setNewRecord`. Null when there is nothing to remove, which is
+   * always the case for belongs_to (`BelongsToAssociation#replace` only writes
+   * the owner's foreign key in memory). Overridden by has_one, where the
+   * returned promise both
    * performs the removal and is what widens `build`'s return so a direct
    * `record.association(name).build(...)` caller can `await` the write.
    *
@@ -287,9 +285,7 @@ export class SingularAssociation extends Association {
       saved = await (record as any).save();
     }
     // `set_new_record` → `replace` runs `remove_target!` before
-    // `self.target = record` (has_one_association.rb:69, 84), so the displaced
-    // record is removed while it is still the cached target. Null for
-    // belongs_to and for a has_one with nothing to displace.
+    // `self.target = record` (has_one_association.rb:69, 84).
     const removal = this.detachDisplacedOnBuild(record);
     if (removal) await removal;
     this.setNewRecord(record);

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -682,7 +682,7 @@ interface OneToOneAssociation {
   // Rails' `send(association_name)` — `SingularAssociation#reader`, which is
   // where trails raises strict-loading violations (singular-association.ts:210).
   readonly reader?: Base | null | Promise<Base | null>;
-  detachDisplacedTarget?(displaced: Base | null): Promise<void>;
+  detachDisplacedTarget?(): Promise<void>;
   prepareDetachDisplacedForSyncBuild?(): (() => Promise<void>) | null;
 }
 
@@ -694,9 +694,11 @@ interface OneToOneAssociation {
  * (has_one_association.rb:69) — the nested-attributes writer is a synchronous
  * property setter (`pirate.shipAttributes = {...}`), so it cannot `await` the
  * nullify save. It CAN issue it: `detachDisplacedTarget` is kicked off here,
- * inline at assignment exactly as in Rails, and only its *completion* is
- * deferred — to the nested-attributes `save` wrapper, which drains this list
- * before the parent (and its autosaved new target) is persisted. That keeps
+ * inline at assignment exactly as in Rails — and, crucially, *before* the build
+ * swaps the replacement into `assoc.target`, so the removal binds to the
+ * displaced record with no parked state. Only its *completion* is deferred — to
+ * the nested-attributes `save` wrapper, which drains the parked list before the
+ * parent (and its autosaved new target) is persisted. That keeps
  * Rails' write ordering (displaced row nullified before the replacement is
  * inserted) and, like Rails, removes the displaced record even if the owner is
  * never saved.
@@ -730,14 +732,14 @@ interface OneToOneAssociation {
  * instance.
  * @internal
  */
-function detachDisplacedAtAssignment(
-  record: Base,
-  assoc: OneToOneAssociation,
-  displaced: Base | null,
-): void {
-  if (!displaced) return;
-  if (typeof assoc.detachDisplacedTarget !== "function") return;
-  parkDisplacedRemoval(record, assoc.detachDisplacedTarget(displaced));
+function detachDisplacedAtAssignment(assoc: OneToOneAssociation): Promise<void> | null {
+  if (assoc.isLoaded?.() === false) return null;
+  if (!assoc.target) return null;
+  if (typeof assoc.detachDisplacedTarget !== "function") return null;
+  // Started BEFORE the build: `removeTargetBang` reads `this.target` on entry,
+  // before its first `await`, so the removal binds to the displaced record even
+  // though the synchronous build swaps in the replacement immediately after.
+  return assoc.detachDisplacedTarget();
 }
 
 /**
@@ -923,9 +925,6 @@ export function assignNestedAttributesForOneToOneAssociation(
       } else {
         // Rails' `build_#{name}` → `set_new_record` → `replace(record, false)`
         // removes the displaced target inline (has_one_association.rb:69).
-        // Capture it before the build overwrites `assoc.target`, then start that
-        // removal here — see `detachDisplacedAtAssignment`.
-        const displaced = assoc.isLoaded?.() === false ? null : existing;
         // Rails' `replace` opens with `load_target`, so an association that was
         // never loaded still discovers the row in the DB and removes it. That
         // SELECT is issued just AFTER the build, where Rails reaches
@@ -936,11 +935,14 @@ export function assignNestedAttributesForOneToOneAssociation(
         // to issue it has to be taken here, before the build, because `build`
         // marks the association loaded and so falsifies its `find_target?` gate.
         const startUnloadedRemoval = assoc.prepareDetachDisplacedForSyncBuild?.() ?? null;
+        // The loaded arm — started before the build, while the association
+        // still caches the displaced record. See `detachDisplacedAtAssignment`.
+        const loadedRemoval = detachDisplacedAtAssignment(assoc);
         // `HasOneAssociation#build` runs the removal itself for direct callers
         // (returning a promise they can await). This writer is synchronous and
-        // owns the removal through `detachDisplacedAtAssignment` below, so
-        // suppress the association's own — two concurrent removals of the same
-        // row would double-destroy it under `dependent: :destroy`.
+        // owns the removal, so suppress the association's own — two concurrent
+        // removals of the same row would double-destroy it under
+        // `dependent: :destroy`, and a returned promise would strand the write.
         assoc.buildDisplacementOwnedByCaller = true;
         try {
           // Never a promise with the flag set — `void` states that statically.
@@ -949,7 +951,7 @@ export function assignNestedAttributesForOneToOneAssociation(
           assoc.buildDisplacementOwnedByCaller = false;
         }
         if (startUnloadedRemoval) parkDisplacedRemoval(record, startUnloadedRemoval());
-        detachDisplacedAtAssignment(record, assoc, displaced);
+        if (loadedRemoval) parkDisplacedRemoval(record, loadedRemoval);
       }
     }
   }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -675,8 +675,11 @@ function assertNestedAttributesAreKnown(
 interface OneToOneAssociation {
   target: Base | null;
   build(attrs: Record<string, unknown>): Base | null | Promise<Base | null>;
-  /** has_one only — see `HasOneAssociation#buildDisplacementOwnedByCaller`. */
-  buildDisplacementOwnedByCaller?: boolean;
+  // Rails' `build_record` / `set_new_record` — `build`'s two halves
+  // (singular_association.rb:29-31), which this writer runs separately so the
+  // displacement removal can sit between them, where Rails puts it.
+  buildRecord(attrs: Record<string, unknown>): Base | null;
+  setNewRecord(record: Base): void;
   initializeAttributes(record: Base): void;
   isLoaded?(): boolean;
   // Rails' `send(association_name)` — `SingularAssociation#reader`, which is
@@ -935,21 +938,21 @@ export function assignNestedAttributesForOneToOneAssociation(
         // to issue it has to be taken here, before the build, because `build`
         // marks the association loaded and so falsifies its `find_target?` gate.
         const startUnloadedRemoval = assoc.prepareDetachDisplacedForSyncBuild?.() ?? null;
-        // The loaded arm — started before the build, while the association
-        // still caches the displaced record. See `detachDisplacedAtAssignment`.
+        // Rails' `SingularAssociation#build` is `build_record` then
+        // `set_new_record` (singular_association.rb:29-31), and only the second
+        // reaches `remove_target!` (has_one_association.rb:59-69). `build`
+        // fuses the two, which would let a raising `build_record` (an invalid
+        // STI `type`, `SubclassNotFound`) detach a record Rails never touches,
+        // so run the two halves separately and keep the removal between them.
+        const built = assoc.buildRecord(assignable);
+        // `remove_target!` on the still-cached displaced record.
+        // `removeTargetBang` binds `this.target` on entry, before its first
+        // `await`, so `setNewRecord` below may swap in the replacement while
+        // the removal is in flight. See `detachDisplacedAtAssignment`.
         const loadedRemoval = detachDisplacedAtAssignment(assoc);
-        // `HasOneAssociation#build` runs the removal itself for direct callers
-        // (returning a promise they can await). This writer is synchronous and
-        // owns the removal, so suppress the association's own — two concurrent
-        // removals of the same row would double-destroy it under
-        // `dependent: :destroy`, and a returned promise would strand the write.
-        assoc.buildDisplacementOwnedByCaller = true;
-        try {
-          // Never a promise with the flag set — `void` states that statically.
-          void assoc.build(assignable);
-        } finally {
-          assoc.buildDisplacementOwnedByCaller = false;
-        }
+        // Rails' `self.target = record` (:84), in memory — the DB half is the
+        // two removals parked below.
+        if (built) assoc.setNewRecord(built);
         if (startUnloadedRemoval) parkDisplacedRemoval(record, startUnloadedRemoval());
         if (loadedRemoval) parkDisplacedRemoval(record, loadedRemoval);
       }


### PR DESCRIPTION
`HasOneAssociation` carried a `pendingRemovalTarget` field: `detachDisplacedTarget`
set it immediately before calling `removeTargetBang`, which consumed it on entry.
It existed because the deferred displacement callers ran the removal *after* the
replacement was already cached as `this.target`, so the removal had to name a
record the association was no longer holding. Rails has no such field —
`remove_target!` runs inline inside `replace`'s transaction
(`has_one_association.rb:68-70`), where `self.target` IS the displaced record.

This converges the callers onto that ordering instead.

## What changed

- `removeTargetBang` reads `this.target` only; `pendingRemovalTarget` is gone.
- `detachDisplacedTarget()` takes no argument and removes `this.target`.
- `detachDisplacedOnBuild(record)` drops its `displaced` parameter and reads the
  cached target, and both `SingularAssociation#build` and
  `SingularAssociation#_createRecord` now run it **before** `setNewRecord` —
  Rails' order (`remove_target!` at :69, `self.target = record` at :84). The
  target-on-failure invariant then falls out of the ordering rather than a
  `catch` that restores the old target.
- `HasOneAssociation#_createRecord` no longer detaches by hand: its leading
  `load_target` caches the row and `super._createRecord` removes it in the right
  slot. `loadDisplacedTargetForCreate` returns just the load error.
- The `build#{name}` accessor delegates displacement to `build` itself, so
  `buildOwningDisplacement` in `builder/has-one.ts` is deleted.
- The synchronous nested-attributes writer runs `buildRecord` and
  `setNewRecord` separately — Rails' own two halves
  (singular_association.rb:29-31) — and puts the removal between them, where
  `remove_target!` sits (:69) relative to `self.target = record` (:84). `build`
  fuses the halves, so calling it would let a raising `build_record` (invalid
  STI `type`, `SubclassNotFound`) detach a record Rails never touches. `removeTargetBang` binds `this.target` on entry, before its first
  `await`, so the build's synchronous swap in the same slice cannot disturb the
  in-flight removal — and the setter's caller still reads the new target.
  `findThenDetachDisplaced` (the unloaded arm, now reached through
  `prepareDetachDisplacedForSyncBuild`) does the same within one synchronous
  slice, so no state survives the call.
- Review fix: the `isPersisted` pre-screen in `detachDisplacedOnBuild` now sits
  behind the dependent-method check. Rails gates on `target.persisted?` only in
  the `:destroy` arm (:100) and the nullify arm's `target.save` (:108) —
  `:delete` calls `target.delete` unconditionally (:97). Routing `_createRecord`
  through this hook newly subjected it to that pre-screen, so the gate had to
  narrow to the nullify arm, whose remaining work `setNewRecord` already did in
  memory.

`buildDisplacementOwnedByCaller` remains, now with a single caller:
`buildThroughProxyRecord` (has-one-through-association.ts), where the through
proxy's own build must not duplicate `create_through_record`'s displacement. Its
JSDoc — and `prepareDetachDisplacedForSyncBuild`'s, which reasoned about the
flag being set during the writer's `build` — are updated accordingly.

## Tests

`has-one-associations.test.ts`, `has-one-through-associations.test.ts`,
`has-one-sync-build-displacement.trails.test.ts`,
`nested-attributes-displaced-removal-failure.trails.test.ts` and
`nested-attributes.test.ts` pass unchanged. Two trails-only tests added, each verified to fail on the code before its fix:

- `runs remove_target!'s delete arm over an unsaved displaced record`, over the
  canonical `ExclusivelyDependentFirm#account` (`dependent: :delete`).
- `leaves the displaced record attached when the build raises` — the loaded arm
  of the ordering guard: `detachDisplacedTarget` is never called and the row
  keeps its foreign key.

One existing test changed: `issues no displacement query when the
nested-attributes build raises` (the unloaded arm, added by #5642) stubbed
`assoc.build`, which the writer no longer calls — the stub stopped biting, so it
is retargeted at `assoc.buildRecord`, the construction site it was always about.
Name and assertions unchanged.

`packages/activerecord/src/associations/` plus the nested-attributes and
autosave suites are green locally: 92 files, 2343 tests.

## Compare gates

Measured by checking the touched files out at the pre-change commit, rebuilding,
and re-running both tools:

- `api:extra` activerecord total **1863 → 1863** (774 novel / 1089 moved,
  unchanged).
- `test:compare` **14876/22203 (67%)**, unchanged — no test file renamed or
  dropped.

Closes-story: eliminate-pending-removal-target-state
