### PR TITLE
feat(api-compare): exempt novel interface declaration names from extra surface

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -293,7 +293,8 @@ report). They therefore share:
   Ruby counterpart by construction, so neither can its members, and Ruby writes
   no such declaration to compare against. Classes are excluded from that spread
   — a tagged class name is an extractor-shape artifact whose members do have
-  Ruby counterparts.
+  Ruby counterparts. Most interface declaration names never need the tag at
+  all; see "Interface declaration names are exempt by kind" below.
 - **Grammar** — free prose after the tag; where a key token precedes the
   reason it is em-dash-separated (`@missingRailsCall` takes a Ruby call name
   as that token, `@noRailsEquivalent` takes none); continuation lines with no
@@ -417,6 +418,43 @@ method ported into the wrong file) is a misplaced port: relocate it to its
 Rails-layout file, do not tag it. Tagging a moved extra asserts something
 false, and the stale-tag gate enforces the boundary mechanically where it
 can.
+
+### Interface declaration names are exempt by kind
+
+A **novel** `interface` DECLARATION name is not extra surface and needs no tag.
+The exemption is applied by the scorer (`collectInterfaceOnlyNames` in
+`extra-surface.ts`), not by anything written in the source.
+
+Why by kind: an `interface` is type-only, and ours exist because TypeScript has
+to write down the shape Ruby leaves to duck typing — 582 of the 604 interface
+declaration names scored when PR 5653 first counted declarations were `…Options`
+bags, `…Host` collaborator seams, `…Like` structural stand-ins and the like. A
+Ruby counterpart is impossible by construction, which is the same reasoning that
+already spreads a tagged interface's tag to its members. The alternative was
+~600 near-identical `@noRailsEquivalent` tags, whose volume would have drowned
+the tag report this RFC exists to make readable.
+
+Why only when novel: a TS `interface` is sometimes a real port of a Ruby
+module's shape, and a blanket exemption would hide that drift. So the exemption
+stops at names Rails never uses. If the name appears anywhere in the Rails
+source, it stays scored as a `moved` extra — a `Quoting` or `TypeMap` interface
+in a file whose Rails counterpart doesn't declare it is precisely the
+misplacement the report is for, and it stays tag-able like any other extra.
+
+Two boundaries follow from the extra set being a flat set of bare names:
+
+- A name a class, namespace, member, or file function in the same file also
+  declares is **not** exempt — one name carries one verdict, and exempting on
+  the interface's behalf would absolve the other declaration silently.
+- An interface's MEMBERS are not exempt. Only the declaration name is; members
+  still need the declaration-level tag described above, which is why tagging an
+  exempt-by-kind interface is still meaningful. The tag check runs _before_ the
+  by-kind exemption, so such a tag keeps matching its own name and never goes
+  stale.
+
+`api:extra` prints the count it dropped ("Excluded by kind: N") and reports it
+per package as `totalInterfaceExempt` in the JSON, so the one allowance with no
+tag to count stays measurable.
 
 ### Permanence claim: open the reason with `PERMANENT` or `CONVERGEABLE`
 

--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -445,7 +445,11 @@ Two boundaries follow from the extra set being a flat set of bare names:
 
 - A name a class, namespace, member, or file function in the same file also
   declares is **not** exempt — one name carries one verdict, and exempting on
-  the interface's behalf would absolve the other declaration silently.
+  the interface's behalf would absolve the other declaration silently. This
+  includes the `namespace` half of a declaration-merged `interface` +
+  `namespace` pair: the extractor collapses the pair into one entry carrying
+  `isInterface`, so it also records `declaredAsNamespace` to keep the
+  non-interface half visible here.
 - An interface's MEMBERS are not exempt. Only the declaration name is; members
   still need the declaration-level tag described above, which is why tagging an
   exempt-by-kind interface is still meaningful. The tag check runs _before_ the

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1585,6 +1585,17 @@ describe("buildReport — interface declaration names", () => {
     expect(report.packages[0].totalInterfaceExempt).toBe(1);
   });
 
+  it("still scores a name a merged interface+namespace declares, in either order", () => {
+    // Declaration merging collapses the pair into ONE entry carrying
+    // `isInterface`; `declaredAsNamespace` is what keeps the namespace half —
+    // a real non-interface declaration of the name — visible here.
+    const ts = tsWith([{ name: "Locator", isInterface: true }]);
+    ts.packages.activemodel.modules["foo.ts:Locator:0"].declaredAsNamespace = true;
+    const report = run(ruby, ts);
+    expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Locator", kind: "novel" }]);
+    expect(report.packages[0].totalInterfaceExempt).toBe(0);
+  });
+
   it("keeps a tag on an exempt-by-kind interface matching, so the tag is not stale", () => {
     const ts = tsWith([{ name: "ConnectionHost", isInterface: true, members: ["tsOnlyHelper"] }]);
     ts.packages.activemodel.modules["foo.ts:ConnectionHost:0"].noRailsEquivalent =

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1572,6 +1572,19 @@ describe("buildReport — interface declaration names", () => {
     expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Adapter", kind: "novel" }]);
   });
 
+  it("exempts a name shared only with surface the report does not count", () => {
+    // `@internal` and `_`-prefixed members are not surface, so the interface is
+    // still the file's only contributor of the name. Both collectors read one
+    // walk, so they cannot disagree about that.
+    const ts = tsWith([{ name: "Adapter", isInterface: true }, { name: "Other" }]);
+    ts.packages.activemodel.modules["foo.ts:Other:1"].instanceMethods = [
+      { ...method("Adapter"), internal: true },
+    ];
+    const report = run(ruby, ts);
+    expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Other", kind: "novel" }]);
+    expect(report.packages[0].totalInterfaceExempt).toBe(1);
+  });
+
   it("keeps a tag on an exempt-by-kind interface matching, so the tag is not stale", () => {
     const ts = tsWith([{ name: "ConnectionHost", isInterface: true, members: ["tsOnlyHelper"] }]);
     ts.packages.activemodel.modules["foo.ts:ConnectionHost:0"].noRailsEquivalent =

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1489,6 +1489,103 @@ describe("buildReport — declaration names", () => {
   });
 });
 
+describe("buildReport — interface declaration names", () => {
+  const run = (ruby: ApiManifest, ts: ApiManifest) =>
+    buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+
+  const ruby: ApiManifest = {
+    source: "ruby",
+    generatedAt: "",
+    packages: {
+      activemodel: {
+        classes: {
+          "ActiveModel::Foo": rubyClass({ name: "Foo", file: "foo.rb" }),
+          // Declared in a DIFFERENT Rails file: a TS interface of this name in
+          // foo.ts is misplaced surface, not an impossible-by-construction shape.
+          "ActiveModel::Quoting": rubyClass({ name: "Quoting", file: "quoting.rb" }),
+        },
+        modules: {},
+      },
+    },
+  };
+
+  const tsWith = (decls: { name: string; isInterface?: boolean; members?: string[] }[]) => ({
+    source: "typescript" as const,
+    generatedAt: "",
+    packages: {
+      activemodel: {
+        classes: {},
+        modules: Object.fromEntries(
+          decls.map((d, i) => [
+            `foo.ts:${d.name}:${i}`,
+            {
+              name: d.name,
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: (d.members ?? []).map((m) => method(m)),
+              classMethods: [],
+              ...(d.isInterface === true ? { isInterface: true } : {}),
+            },
+          ]),
+        ),
+      },
+    },
+  });
+
+  it("exempts a novel interface declaration name by kind, with no tag", () => {
+    const report = run(ruby, tsWith([{ name: "ConnectionHost", isInterface: true }]));
+    expect(report.packages[0].extraFiles).toEqual([]);
+    expect(report.packages[0].totalInterfaceExempt).toBe(1);
+  });
+
+  it("still scores an interface declaration name Rails uses elsewhere", () => {
+    const report = run(ruby, tsWith([{ name: "Quoting", isInterface: true }]));
+    expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Quoting", kind: "moved" }]);
+    expect(report.packages[0].totalInterfaceExempt).toBe(0);
+  });
+
+  it("still scores a novel class or namespace declaration name", () => {
+    const report = run(ruby, tsWith([{ name: "QueryLogger" }]));
+    expect(report.packages[0].extraFiles[0].extras).toEqual([
+      { name: "QueryLogger", kind: "novel" },
+    ]);
+  });
+
+  it("still scores an interface's members, which the exemption does not reach", () => {
+    const report = run(
+      ruby,
+      tsWith([{ name: "ConnectionHost", isInterface: true, members: ["tsOnlyHelper"] }]),
+    );
+    expect(report.packages[0].extraFiles[0].extras).toEqual([
+      { name: "tsOnlyHelper", kind: "novel" },
+    ]);
+  });
+
+  it("does not exempt a name a class in the same file also declares", () => {
+    const report = run(ruby, tsWith([{ name: "Adapter", isInterface: true }, { name: "Adapter" }]));
+    expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Adapter", kind: "novel" }]);
+  });
+
+  it("keeps a tag on an exempt-by-kind interface matching, so the tag is not stale", () => {
+    const ts = tsWith([{ name: "ConnectionHost", isInterface: true, members: ["tsOnlyHelper"] }]);
+    ts.packages.activemodel.modules["foo.ts:ConnectionHost:0"].noRailsEquivalent =
+      "PERMANENT duck-typed collaborator shape";
+    const report = run(ruby, ts);
+    expect(report.tagged.stale).toEqual([]);
+    expect(report.tagged.matched).toBe(1);
+    // The tag check runs first, so the name lands in Allowed rather than in
+    // the by-kind exemption — and its members keep inheriting the reason.
+    expect(report.packages[0].totalInterfaceExempt).toBe(0);
+    expect(report.packages[0].totalAllowlisted).toBe(2);
+  });
+});
+
 describe("buildReport — re-export clones", () => {
   it("charges a barrel only with the classes it declares itself", () => {
     const ruby: ApiManifest = {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -443,6 +443,12 @@ interface PackageTotals {
   totalMoved: number;
   totalAllowlisted: number;
   /**
+   * Names dropped by the interface-declaration kind exemption
+   * (`collectInterfaceOnlyNames`). Reported so the exemption stays measurable:
+   * it is the one allowance with no per-declaration tag to count.
+   */
+  totalInterfaceExempt: number;
+  /**
    * The `rubyFile === null` slice of the totals above — files no Rails file
    * maps onto. Broken out so a consumer can tell how much of a package's
    * extra surface comes from that population (it was unmeasured before this
@@ -511,6 +517,11 @@ TS files that no Rails file maps onto are scored too, with an empty allowed
 set — every public name in them is extra. Trees mirroring Rails' test/ code
 (test-helpers/, support/, cases/, fixture corpora) are held out, since the Ruby
 extractor reads lib/ only. The NoCntrp column reports that slice separately.
+
+A novel \`interface\` DECLARATION name is exempt by kind and needs no tag: it is a
+type-only shape Ruby leaves to duck typing, so no Ruby counterpart is possible.
+An interface name that does appear in Rails stays scored (as moved) — that is
+the drift case a blanket exemption would hide.
 
 Reasoned exceptions: an extra is allowed by tagging its TS declaration
 \`@noRailsEquivalent <reason>\` in JSDoc. Allowed extras are subtracted from the
@@ -607,6 +618,11 @@ export function parseArgs(argv: string[]): CliArgs {
  * entity name the matched `.rb` declares, so a faithfully ported class is not
  * extra. Synthesized pseudo-modules are excluded — their `<fn>__mixin` name is
  * an extractor artifact, not source text.
+ *
+ * Interface declaration names are collected here like any other; the
+ * kind-level exemption that removes most of them is applied by the scorer,
+ * which needs the novel/moved verdict this function cannot see (see
+ * `collectInterfaceOnlyNames`).
  */
 export function collectTsFileNames(
   file: string,
@@ -646,6 +662,59 @@ export function collectTsFileNames(
   }
   for (const fn of fileFunctions ?? []) push(fn);
   return out;
+}
+
+/**
+ * The names a file contributes ONLY as an `interface` declaration — nothing
+ * else in the file declares or defines that name.
+ *
+ * RFC 0080 policy, decided here: an interface declaration name is exempt from
+ * extra surface BY KIND, but only when it is also **novel** (the name appears
+ * nowhere in the Rails source — the scorer applies that half). The reasoning
+ * is the one `collectTaggedEntries` already applies to a tagged interface's
+ * members: an `interface` is type-only, and the overwhelming majority of ours
+ * exist because TS must write down a shape Ruby leaves to duck typing
+ * (`…Options` bags, `…Host` collaborator seams, `…Like` structural stand-ins).
+ * A Ruby counterpart is impossible by construction, and the alternative was
+ * ~600 near-identical `@noRailsEquivalent` tags, whose sheer volume would
+ * drown the tag report the same RFC exists to make readable.
+ *
+ * The novelty half answers the counter-argument — a TS `interface` is
+ * sometimes a real port of a Ruby module's shape, and a blanket exemption
+ * would hide that drift. If the name exists anywhere in Rails, the exemption
+ * does NOT apply: a `Quoting` or `TypeMap` interface declared in a file whose
+ * Rails counterpart doesn't declare it is precisely the misplacement this
+ * report is for, and it stays scored (as `moved`) and stays tag-able. Only
+ * names Rails never uses at all — which therefore cannot be a drifting port of
+ * anything — drop out.
+ *
+ * Names shared with a member or with a class/namespace declaration are NOT
+ * exempt: the extra set is a flat Set of bare names (see `allowKeyOf`), so one
+ * name carries one verdict, and exempting on the interface's behalf would
+ * silently absolve the non-interface declaration sharing it.
+ */
+export function collectInterfaceOnlyNames(
+  file: string,
+  classes: ClassInfo[],
+  modules: ClassInfo[],
+  fileFunctions: MethodInfo[] | undefined,
+): Set<string> {
+  const interfaces = new Set<string>();
+  const others = new Set<string>();
+  for (const c of [...classes, ...modules]) {
+    if (c.file !== file) continue;
+    if (c.synthesizedMixin === true) {
+      for (const m of [...c.instanceMethods, ...c.classMethods]) {
+        if (m.declaredIn === undefined) others.add(m.name);
+      }
+      continue;
+    }
+    (c.isInterface === true ? interfaces : others).add(c.name);
+    for (const m of [...c.instanceMethods, ...c.classMethods]) others.add(m.name);
+  }
+  for (const fn of fileFunctions ?? []) others.add(fn.name);
+  for (const name of others) interfaces.delete(name);
+  return interfaces;
 }
 
 /**
@@ -966,6 +1035,7 @@ function buildPackageReport(
     totalNovel: 0,
     totalMoved: 0,
     totalAllowlisted: 0,
+    totalInterfaceExempt: 0,
     noCounterpartFiles: 0,
     noCounterpartExtras: 0,
     noCounterpartNovel: 0,
@@ -1049,6 +1119,7 @@ function buildPackageReport(
 
     const tsNames = collectTsFileNames(expectedTs, classes, modules, fileFns);
     if (tsNames.size === 0) continue;
+    const interfaceOnly = collectInterfaceOnlyNames(expectedTs, classes, modules, fileFns);
 
     const allowed =
       rubyFile === null
@@ -1067,6 +1138,7 @@ function buildPackageReport(
     let novelCount = 0;
     let movedCount = 0;
     let allowlistedCount = 0;
+    let interfaceExemptCount = 0;
     for (const name of tsNames) {
       if (allowed.has(name)) continue;
       const allowKey = allowKeyOf({ package: pkg, tsFile: expectedTs, name });
@@ -1076,12 +1148,21 @@ function buildPackageReport(
         continue;
       }
       const kind: ExtraKind = globalRubyCandidates.has(name) ? "moved" : "novel";
+      // Exempt by kind — see `collectInterfaceOnlyNames`. Deliberately AFTER
+      // the tag check: an interface tagged to cover its MEMBERS keeps matching
+      // its own name, so the tag doesn't go stale and the inheritance in
+      // `collectTaggedEntries` keeps working.
+      if (kind === "novel" && interfaceOnly.has(name)) {
+        interfaceExemptCount++;
+        continue;
+      }
       if (novelOnly && kind !== "novel") continue;
       extras.push({ name, kind });
       if (kind === "novel") novelCount++;
       else movedCount++;
     }
     result.totalAllowlisted += allowlistedCount;
+    result.totalInterfaceExempt += interfaceExemptCount;
     if (extras.length === 0) continue;
 
     // Sort novel before moved, then alphabetical — novel is the higher-signal
@@ -1227,6 +1308,11 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
   }
   console.log(
     `${p.dim}  NoCntrp = the slice of Total from TS files no Rails file maps onto (scored with an empty allowed set).${p.reset}`,
+  );
+  const interfaceExempt = report.packages.reduce((n, pkg) => n + pkg.totalInterfaceExempt, 0);
+  console.log(
+    `${p.dim}  Excluded by kind: ${interfaceExempt} novel \`interface\` declaration name(s) — type-only shapes Ruby ` +
+      `leaves to duck typing. An interface name Rails DOES use stays scored as moved.${p.reset}`,
   );
   console.log(
     `\n${p.dim}@noRailsEquivalent tags: ${report.tagged.total} tag(s), ` +

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -661,7 +661,14 @@ function walkTsFileSurface(
     if (c.file !== file) continue;
     const skipForeign = c.synthesizedMixin === true;
     if (!skipForeign && !c.name.startsWith("_")) {
-      out.push({ name: c.name, interfaceDeclaration: c.isInterface === true });
+      // `declaredAsNamespace` matters because declaration merging collapses an
+      // `interface` and a same-named `namespace` into one entry: the merged
+      // entry carries `isInterface`, but the namespace half is a real
+      // non-interface declaration of the name and must stay scored.
+      out.push({
+        name: c.name,
+        interfaceDeclaration: c.isInterface === true && c.declaredAsNamespace !== true,
+      });
     }
     for (const m of [...c.instanceMethods, ...c.classMethods]) {
       if (skipForeign && m.declaredIn !== undefined) continue;
@@ -697,7 +704,9 @@ function walkTsFileSurface(
  * anything — drop out.
  *
  * Names shared with a member or with a class/namespace declaration are NOT
- * exempt: the extra set is a flat Set of bare names (see `allowKeyOf`), so one
+ * exempt — including the `namespace` half of a declaration-merged
+ * `interface`+`namespace` pair, which the extractor collapses into one entry
+ * (`declaredAsNamespace`): the extra set is a flat Set of bare names (see `allowKeyOf`), so one
  * name carries one verdict, and exempting on the interface's behalf would
  * silently absolve the non-interface declaration sharing it.
  */

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -631,36 +631,44 @@ export function collectTsFileNames(
   fileFunctions: MethodInfo[] | undefined,
 ): Set<string> {
   const out = new Set<string>();
-  const push = (m: MethodInfo): void => {
+  for (const { name } of walkTsFileSurface(file, classes, modules, fileFunctions)) out.add(name);
+  return out;
+}
+
+/** One public name a file contributes, and whether an `interface` declared it. */
+interface SurfaceName {
+  name: string;
+  interfaceDeclaration: boolean;
+}
+
+/**
+ * The single walk both collectors read, so what counts as surface and what
+ * counts as an interface-only name can never disagree about a file.
+ */
+function walkTsFileSurface(
+  file: string,
+  classes: ClassInfo[],
+  modules: ClassInfo[],
+  fileFunctions: MethodInfo[] | undefined,
+): SurfaceName[] {
+  const out: SurfaceName[] = [];
+  const pushMember = (m: MethodInfo): void => {
     if (m.internal === true) return;
     if (m.name.startsWith("_")) return;
-    out.add(m.name);
+    out.push({ name: m.name, interfaceDeclaration: false });
   };
-  const pushDeclaration = (c: ClassInfo): void => {
-    if (c.synthesizedMixin === true) return;
-    if (c.name.startsWith("_")) return;
-    out.add(c.name);
-  };
-  for (const c of classes) {
+  for (const c of [...classes, ...modules]) {
     if (c.file !== file) continue;
-    pushDeclaration(c);
-    for (const m of c.instanceMethods) push(m);
-    for (const m of c.classMethods) push(m);
-  }
-  for (const m of modules) {
-    if (m.file !== file) continue;
-    pushDeclaration(m);
-    const skipForeign = m.synthesizedMixin === true;
-    for (const im of m.instanceMethods) {
-      if (skipForeign && im.declaredIn !== undefined) continue;
-      push(im);
+    const skipForeign = c.synthesizedMixin === true;
+    if (!skipForeign && !c.name.startsWith("_")) {
+      out.push({ name: c.name, interfaceDeclaration: c.isInterface === true });
     }
-    for (const cm of m.classMethods) {
-      if (skipForeign && cm.declaredIn !== undefined) continue;
-      push(cm);
+    for (const m of [...c.instanceMethods, ...c.classMethods]) {
+      if (skipForeign && m.declaredIn !== undefined) continue;
+      pushMember(m);
     }
   }
-  for (const fn of fileFunctions ?? []) push(fn);
+  for (const fn of fileFunctions ?? []) pushMember(fn);
   return out;
 }
 
@@ -701,18 +709,14 @@ export function collectInterfaceOnlyNames(
 ): Set<string> {
   const interfaces = new Set<string>();
   const others = new Set<string>();
-  for (const c of [...classes, ...modules]) {
-    if (c.file !== file) continue;
-    if (c.synthesizedMixin === true) {
-      for (const m of [...c.instanceMethods, ...c.classMethods]) {
-        if (m.declaredIn === undefined) others.add(m.name);
-      }
-      continue;
-    }
-    (c.isInterface === true ? interfaces : others).add(c.name);
-    for (const m of [...c.instanceMethods, ...c.classMethods]) others.add(m.name);
+  for (const { name, interfaceDeclaration } of walkTsFileSurface(
+    file,
+    classes,
+    modules,
+    fileFunctions,
+  )) {
+    (interfaceDeclaration ? interfaces : others).add(name);
   }
-  for (const fn of fileFunctions ?? []) others.add(fn.name);
   for (const name of others) interfaces.delete(name);
   return interfaces;
 }

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2249,4 +2249,10 @@ describe("extractFromProgram — interface merged with a namespace of the same n
     expect(merged.instanceMethods.map((m) => m.name).sort()).toEqual(["locate", "use"]);
     expect(merged.interfaceMembers).toEqual(["locate"]);
   });
+
+  it("records the namespace half, which the interface-only kind exemption must not absolve", () => {
+    expect(entry(`${IFACE}\n${NAMESPACE}`).declaredAsNamespace).toBe(true);
+    expect(entry(`${NAMESPACE}\n${IFACE}`).declaredAsNamespace).toBe(true);
+    expect(entry(IFACE).declaredAsNamespace).toBeUndefined();
+  });
 });

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2255,4 +2255,17 @@ describe("extractFromProgram — interface merged with a namespace of the same n
     expect(entry(`${NAMESPACE}\n${IFACE}`).declaredAsNamespace).toBe(true);
     expect(entry(IFACE).declaredAsNamespace).toBeUndefined();
   });
+
+  it("records an `export * as` binding of the name over an existing entry", () => {
+    const info = extractFromFiles("/p", {
+      "other.ts": `export function use(name: string): void {}`,
+      "locator.ts": `${IFACE}\nexport * as Locator from "./other.js";`,
+    });
+    const merged = info.modules["locator.ts:Locator"];
+    expect(merged.declaredAsNamespace).toBe(true);
+    // The existing entry's members survive — the re-export only adds the
+    // namespace binding, it does not replace the interface.
+    expect(merged.instanceMethods.map((m) => m.name)).toEqual(["locate"]);
+    expect(merged.isInterface).toBe(true);
+  });
 });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -542,7 +542,14 @@ export function extractFromProgram(
         if (node.exportClause && ts.isNamespaceExport(node.exportClause)) {
           const name = node.exportClause.name.text;
           const modKey = `${relPath}:${name}`;
-          if (info.modules[modKey]) return;
+          const existing = info.modules[modKey];
+          if (existing) {
+            // An interface/namespace declaration already owns the entry; keep
+            // its members, but still record this namespace binding of the name
+            // (same reason as the `export namespace` merge branch above).
+            existing.declaredAsNamespace = true;
+            return;
+          }
           info.modules[modKey] = {
             name,
             file: relPath,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -529,6 +529,9 @@ export function extractFromProgram(
             if (!existingNames.has(m.name)) existing.instanceMethods.push(m);
           }
           existing.noRailsEquivalent ??= extracted.noRailsEquivalent;
+          // Merging into an `interface` half leaves `isInterface` true; record
+          // the namespace half so consumers can still see it (see ClassInfo).
+          existing.declaredAsNamespace = true;
         } else {
           info.modules[modKey] = extracted;
         }
@@ -547,6 +550,7 @@ export function extractFromProgram(
             extends: [],
             instanceMethods: [],
             classMethods: [],
+            declaredAsNamespace: true,
           };
           fileHasClassOrModule = true;
         } else if (
@@ -2080,6 +2084,7 @@ function extractNamespace(
     extends: [],
     instanceMethods,
     classMethods: [],
+    declaredAsNamespace: true,
     ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
   };
 }

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -126,6 +126,15 @@ export interface ClassInfo {
    * `collectTaggedEntries` in extra-surface.ts.
    */
   isInterface?: boolean;
+  /**
+   * TS-side only: a `namespace` (or `export * as`) declaration of this name
+   * contributed to this entry. Declaration merging collapses an `interface`
+   * and a same-named `namespace` into ONE entry, so `isInterface` alone cannot
+   * say whether a non-interface declaration of the name also exists — and the
+   * interface-declaration kind exemption in extra-surface.ts must not absolve
+   * the namespace half.
+   */
+  declaredAsNamespace?: boolean;
   interfaceMembers?: string[];
   /**
    * Reason prose of an `@noRailsEquivalent` tag written on the class /


### PR DESCRIPTION
## Decision

**An `interface` declaration name is exempt from extra surface BY KIND — but
only when it is novel.**

PR 5653 made class/interface/namespace declaration names count as extra
surface, and 604 of the resulting extras were TypeScript-only `interface`
declarations (178 `…Options`, 77 `…Host`, 29 `…Like`, …). These are type-only
shapes that exist because TS has to write down what Ruby leaves to duck typing,
so a Ruby counterpart is impossible by construction — the same reasoning
`collectTaggedEntries` already applies to a tagged interface's members. Tagging
them individually would mean ~600 near-identical `@noRailsEquivalent` tags,
whose volume would drown the tag report RFC 0080 exists to make readable.

The story's counter-argument — a TS `interface` is sometimes a real port of a
Ruby module's shape, and a blanket exemption would hide that drift — is
answered by the novelty half. If the name appears anywhere in the Rails source
the exemption does not apply: a `Quoting` or `TypeMap` interface in a file whose
Rails counterpart doesn't declare it stays scored as `moved` and stays tag-able.
That is 22 of the 604 today. Only names Rails never uses at all — which
therefore cannot be a drifting port of anything — drop out.

## Changes

- `walkTsFileSurface` (`extra-surface.ts`): the single walk both
  `collectTsFileNames` and the new `collectInterfaceOnlyNames` read, so what
  counts as surface and what counts as interface-only cannot drift apart.
- `collectInterfaceOnlyNames`: the names a file contributes ONLY as an
  `interface` declaration. A name a class, namespace, member, or file function
  in the same file also declares is not exempt — the extra set is a flat set of
  bare names, so one name carries one verdict.
- `ClassInfo.declaredAsNamespace` (extractor): declaration merging collapses an
  `interface` and a same-named `namespace` into ONE entry carrying
  `isInterface`, so that flag alone cannot say whether a non-interface
  declaration of the name also exists. The extractor now records the namespace
  half — in either declaration order, and for `export * as` — and such entries
  are excluded from the exemption, since the namespace half is real
  non-interface surface.
- The scorer skips those names when the verdict is `novel`, **after** the tag
  check: an interface tagged to cover its MEMBERS keeps matching its own name,
  so the tag doesn't go stale and the member inheritance keeps working.
- `totalInterfaceExempt` per package in the JSON, plus an "Excluded by kind"
  line in the human report — the one allowance with no tag to count stays
  measurable.
- The decision is written down in
  `docs/infrastructure/api-build-stub-generation-plan.md` where the tag grammar
  lives.

## Re-measure

`pnpm api:extra` exits 0, no stale tags (79 tags, 79 matched, +2 inherited —
unchanged). Total extras **4804 → 4222**; 582 excluded by kind. (Both figures
from the same forced re-extraction — the 4781 quoted when this PR opened came
from a cached ts-api.json.)

Closes-story: interface-declaration-names-need-a-kind-level-policy

