### PR TITLE
test(activerecord): pin no-floating-rejection for unloaded displacement removal

### DIFF
--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -47,6 +47,28 @@ async function pirateWithFailingRemoval(): Promise<Base> {
   return pirate;
 }
 
+/**
+ * The same rigging for the *unloaded* path: the has_one is never loaded, so the
+ * writer takes the `find_target?` decision through
+ * `prepareDetachDisplacedForSyncBuild` and parks the thunk's promise after the
+ * build. The row exists in the DB but nothing has ever read it.
+ */
+async function pirateWithFailingUnloadedRemoval(): Promise<Base> {
+  const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+  await Ship.create({
+    name: "Nights Dirty Lightning",
+    pirate_id: (pirate as unknown as { id: number }).id,
+  });
+
+  const assoc = pirate.association("ship") as unknown as {
+    detachDisplacedTarget: () => Promise<void>;
+    isLoaded(): boolean;
+  };
+  expect(assoc.isLoaded()).toBe(false);
+  assoc.detachDisplacedTarget = () => Promise.reject(new Error("removal exploded"));
+  return pirate;
+}
+
 describe("nested-attributes displacement removal failure", () => {
   fixtures(["pirates", "ships"]);
 
@@ -125,6 +147,21 @@ describe("nested-attributes displacement removal failure", () => {
 
     // The captured promise resolves *to* the error rather than rejecting, so a
     // never-drained removal cannot surface as an unhandled rejection.
+    const pending = (pirate as unknown as RemovalHost)._pendingDisplacedRemovals ?? [];
+    expect(pending).toHaveLength(1);
+    await expect(pending[0]).resolves.toBeInstanceOf(Error);
+  });
+
+  it("does not leave a floating rejection when an unloaded removal is never drained", async () => {
+    const pirate = await pirateWithFailingUnloadedRemoval();
+
+    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+
+    // The unloaded path parks the thunk's promise rather than a loaded target's
+    // removal, but it funnels through the same capture: the parked value must
+    // resolve *to* the error, never reject.
     const pending = (pirate as unknown as RemovalHost)._pendingDisplacedRemovals ?? [];
     expect(pending).toHaveLength(1);
     await expect(pending[0]).resolves.toBeInstanceOf(Error);

--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -47,12 +47,6 @@ async function pirateWithFailingRemoval(): Promise<Base> {
   return pirate;
 }
 
-/**
- * The same rigging for the *unloaded* path: the has_one is never loaded, so the
- * writer takes the `find_target?` decision through
- * `prepareDetachDisplacedForSyncBuild` and parks the thunk's promise after the
- * build. The row exists in the DB but nothing has ever read it.
- */
 async function pirateWithFailingUnloadedRemoval(): Promise<Base> {
   const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
   await Ship.create({
@@ -159,9 +153,6 @@ describe("nested-attributes displacement removal failure", () => {
       name: "Davy Jones Gold Dagger",
     };
 
-    // The unloaded path parks the thunk's promise rather than a loaded target's
-    // removal, but it funnels through the same capture: the parked value must
-    // resolve *to* the error, never reject.
     const pending = (pirate as unknown as RemovalHost)._pendingDisplacedRemovals ?? [];
     expect(pending).toHaveLength(1);
     await expect(pending[0]).resolves.toBeInstanceOf(Error);


### PR DESCRIPTION
`parkDisplacedRemoval` captures the rejection of a backgrounded displacement
removal so a never-drained one cannot surface as an unhandled rejection. The
existing "does not leave a floating rejection" test pinned that only for the
**loaded** path (`HasOneAssociation#detachDisplacedTarget`'s promise).

PR #5642 reworked the **unloaded** path: the writer takes the `find_target?`
decision before `assoc.build` via `prepareDetachDisplacedForSyncBuild` and parks
the thunk's promise after the build. Same funnel, but nothing locked it.

This adds a trails test for the unloaded thunk path: a never-loaded has_one on a
persisted owner whose removal rejects, assigned through the synchronous
`shipAttributes` setter and never drained, leaves a *resolved* entry in
`_pendingDisplacedRemovals`.

Verified failing on a baseline where the unloaded promise is pushed onto
`_pendingDisplacedRemovals` raw (no rejection capture): the new test fails with
an unhandled `removal exploded`; restored, all 6 pass.

Closes-story: unloaded-displacement-removal-floating-rejection-untested
