### PR TITLE
feat(start-worktree): honor WORKTREES_ROOT env for off-home worktrees

### DIFF
--- a/scripts/start-worktree.sh
+++ b/scripts/start-worktree.sh
@@ -36,7 +36,7 @@ case "$GIT_COMMON_DIR" in
   *)  MAIN_GIT_DIR="$WORKTREE_ROOT/$GIT_COMMON_DIR" ;;
 esac
 MAIN_REPO="$(cd "$MAIN_GIT_DIR/.." && pwd)"
-WORKTREES_ROOT="$HOME/github/blazetrailsdev/worktrees"
+WORKTREES_ROOT="${WORKTREES_ROOT:-$HOME/github/blazetrailsdev/worktrees}"
 TARGET="$WORKTREES_ROOT/$NAME"
 
 if [[ -e "$TARGET" ]]; then
@@ -220,7 +220,7 @@ WORKTREE_CREATED=0  # success — disable EXIT-trap cleanup
 # Best-effort: failures below are warned but do not abort — the agent falls
 # back to the canonical ~/github/blazetrailsdev/tasks path via cli.ts.
 TASKS_CANONICAL="$HOME/github/blazetrailsdev/tasks"
-TASKS_WORKTREES_ROOT="$HOME/github/blazetrailsdev/tasks-worktrees"
+TASKS_WORKTREES_ROOT="${TASKS_WORKTREES_ROOT:-$(dirname "$WORKTREES_ROOT")/tasks-worktrees}"
 TASKS_WT="$TASKS_WORKTREES_ROOT/$NAME"
 
 # Run in a subshell so any unexpected failure (set -euo pipefail inside)


### PR DESCRIPTION
Makes the worktree root configurable via `WORKTREES_ROOT` (falls back to `$HOME/github/blazetrailsdev/worktrees`), so worktrees can live on a second SSD (`/mnt/theta`) instead of the primary drive. The paired per-worktree tasks checkout (`TASKS_WORKTREES_ROOT`) now derives as a sibling of `WORKTREES_ROOT`, so it follows the move automatically. Both defaults are byte-identical to current behavior.

btwhooks passes `WORKTREES_ROOT` via `env` when invoking this script (fish has no `VAR=val cmd` prefix), making `WORKTREE_DIR` the single source of truth for worker worktree placement.