### PR TITLE
docs(postgresql): record why the in-flight marker placement has no regression test

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1525,33 +1525,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
-    // The claim sits HERE — after the tail await, so it names the query that is
-    // actually on the wire — rather than at `_runQuery` entry (#5660). That
-    // correction is untestable from outside the adapter and deliberately ships
-    // without a regression test (RFC 0061
-    // pg-in-flight-marker-regression-coverage, closed wontfix): two independent
-    // barriers keep any reachable construction from claiming the marker while a
-    // *foreign* query holds the wire, so both placements behave identically.
-    //
-    //  1. Every `_runQuery` call site (1079, 1733, 1862, 2372) sits inside a
-    //     `withRawConnection` block, and its pre-loop `awaitRawConnectionReady`
-    //     (see that override) already awaits `_maintenanceTail`. A query that
-    //     would queue behind another therefore blocks *before* `_runQuery`, so
-    //     the pre-fix claim site is unreachable while someone else is on the
-    //     wire.
-    //  2. Reaching `_runQuery` at all means holding the TransactionManager lock.
-    //     A same-chain query re-enters it and so shares the owner token (the
-    //     guard's verdict is the same either way); a different chain has to
-    //     acquire it, which serializes it end-to-end behind the query in flight.
-    //
-    // Constructions tried and rejected for passing on the pre-fix code as well:
-    // two public `execute` calls; the same with `_cancelAnyRunningQuery`
-    // instrumented; a same-chain `execute` launched un-awaited inside
-    // `transactionManager.synchronize` behind a foreign `pg_sleep`; and the
-    // two-lock-scope variant of that (chain A releases the lock with its query
-    // still in flight, chain B re-enters its own lock and queues behind it) —
-    // instrumentation showed B's query reaching `_runQuery` only after the
-    // rollback, by barrier 1.
+    // Claimed here, after the tail await, so the marker names the query that is
+    // actually on the wire rather than one still queued (#5660). No test pins
+    // this down and none can today (RFC 0061
+    // pg-in-flight-marker-regression-coverage, wontfix): every `_runQuery` call
+    // site runs inside a `withRawConnection` block whose pre-loop
+    // `awaitRawConnectionReady` already awaits `_maintenanceTail`, so a query
+    // that would queue behind another blocks before it can claim anything —
+    // and reaching `_runQuery` at all means holding the TransactionManager
+    // lock, which a same-chain query re-enters with the same owner token and a
+    // foreign chain cannot take until the wire is free. Should either barrier
+    // move, the claim must stay on this side of the await.
     this._queryInFlight = true;
     this._queryInFlightOwner = this._transactionManager.currentLockToken;
     try {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1525,17 +1525,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
-    // Claimed here, after the tail await, so the marker names the query that is
-    // actually on the wire rather than one still queued (#5660). No test pins
-    // this down and none can today (RFC 0061
+    // DEVIATION (converging, RFC 0085): this marker pair has no Rails
+    // counterpart. Rails' `cancel_any_running_query`
+    // (postgresql/database_statements.rb:127) tracks nothing — it reads the
+    // connection's own protocol state, `IDLE_TRANSACTION_STATUSES.include?
+    // (@raw_connection.transaction_status)` — and needs no owner at all,
+    // because `@lock.synchronize` wraps the whole `with_raw_connection` body
+    // (abstract_adapter.rb:984), so the only query on the wire belongs to the
+    // thread rolling back. `_queryInFlight` stands in for `transaction_status`;
+    // `_queryInFlightOwner` stands in for the lock trails releases early.
+    // Both go away once those are ported — do not build on them.
+    //
+    // Claimed here, after the tail await, so it names the query actually on the
+    // wire rather than one still queued (#5660). That correction has no
+    // regression test and can have none while the inventions stand (RFC 0061
     // pg-in-flight-marker-regression-coverage, wontfix): every `_runQuery` call
     // site runs inside a `withRawConnection` block whose pre-loop
-    // `awaitRawConnectionReady` already awaits `_maintenanceTail`, so a query
-    // that would queue behind another blocks before it can claim anything —
-    // and reaching `_runQuery` at all means holding the TransactionManager
-    // lock, which a same-chain query re-enters with the same owner token and a
-    // foreign chain cannot take until the wire is free. Should either barrier
-    // move, the claim must stay on this side of the await.
+    // `awaitRawConnectionReady` already awaits `_maintenanceTail`, and reaching
+    // `_runQuery` means holding the TransactionManager lock — two barriers that
+    // are the lock doing this serializer's job twice, which is the tell.
     this._queryInFlight = true;
     this._queryInFlightOwner = this._transactionManager.currentLockToken;
     try {
@@ -5098,9 +5106,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   isRetryableQueryError(exception: unknown): boolean {
     // Rails additionally guards on `@raw_connection.transaction_status !=
-    // PG::PQTRANS_INERROR`. node-pg does not expose the PG transaction status
-    // byte, so that guard is omitted; the abstract predicate (Deadlocked |
-    // LockWaitTimeout) is still the authoritative gate.
+    // PG::PQTRANS_INERROR`, omitted here for want of a `transaction_status`
+    // port; the abstract predicate (Deadlocked | LockWaitTimeout) is still the
+    // authoritative gate. Not a hard limit of the driver, as previously noted
+    // here: pg-protocol parses the ReadyForQuery status byte into
+    // `ReadyForQueryMessage.status` ('I' / 'T' / 'E'), emitted on
+    // `client.connection`. Porting it is RFC 0085.
     return super.isRetryableQueryError(exception);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1525,25 +1525,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
-    // DEVIATION (converging, RFC 0085): this marker pair has no Rails
-    // counterpart. Rails' `cancel_any_running_query`
-    // (postgresql/database_statements.rb:127) tracks nothing — it reads the
-    // connection's own protocol state, `IDLE_TRANSACTION_STATUSES.include?
-    // (@raw_connection.transaction_status)` — and needs no owner at all,
-    // because `@lock.synchronize` wraps the whole `with_raw_connection` body
-    // (abstract_adapter.rb:984), so the only query on the wire belongs to the
-    // thread rolling back. `_queryInFlight` stands in for `transaction_status`;
-    // `_queryInFlightOwner` stands in for the lock trails releases early.
-    // Both go away once those are ported — do not build on them.
-    //
-    // Claimed here, after the tail await, so it names the query actually on the
-    // wire rather than one still queued (#5660). That correction has no
-    // regression test and can have none while the inventions stand (RFC 0061
-    // pg-in-flight-marker-regression-coverage, wontfix): every `_runQuery` call
-    // site runs inside a `withRawConnection` block whose pre-loop
-    // `awaitRawConnectionReady` already awaits `_maintenanceTail`, and reaching
-    // `_runQuery` means holding the TransactionManager lock — two barriers that
-    // are the lock doing this serializer's job twice, which is the tell.
+    // DEVIATION (converging, RFC 0085): both fields are inventions.
+    // `_queryInFlight` stands in for `@raw_connection.transaction_status`,
+    // `_queryInFlightOwner` for the lock trails releases early — Rails'
+    // `cancel_any_running_query` (postgresql/database_statements.rb:127) needs
+    // neither. Scheduled for deletion; do not build on them. Claimed after the
+    // tail await so the marker names the query actually on the wire rather than
+    // one still queued (#5660) — a placement no test can pin down while these
+    // stand (RFC 0061 pg-in-flight-marker-regression-coverage, wontfix).
     this._queryInFlight = true;
     this._queryInFlightOwner = this._transactionManager.currentLockToken;
     try {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1525,6 +1525,33 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
+    // The claim sits HERE — after the tail await, so it names the query that is
+    // actually on the wire — rather than at `_runQuery` entry (#5660). That
+    // correction is untestable from outside the adapter and deliberately ships
+    // without a regression test (RFC 0061
+    // pg-in-flight-marker-regression-coverage, closed wontfix): two independent
+    // barriers keep any reachable construction from claiming the marker while a
+    // *foreign* query holds the wire, so both placements behave identically.
+    //
+    //  1. Every `_runQuery` call site (1079, 1733, 1862, 2372) sits inside a
+    //     `withRawConnection` block, and its pre-loop `awaitRawConnectionReady`
+    //     (see that override) already awaits `_maintenanceTail`. A query that
+    //     would queue behind another therefore blocks *before* `_runQuery`, so
+    //     the pre-fix claim site is unreachable while someone else is on the
+    //     wire.
+    //  2. Reaching `_runQuery` at all means holding the TransactionManager lock.
+    //     A same-chain query re-enters it and so shares the owner token (the
+    //     guard's verdict is the same either way); a different chain has to
+    //     acquire it, which serializes it end-to-end behind the query in flight.
+    //
+    // Constructions tried and rejected for passing on the pre-fix code as well:
+    // two public `execute` calls; the same with `_cancelAnyRunningQuery`
+    // instrumented; a same-chain `execute` launched un-awaited inside
+    // `transactionManager.synchronize` behind a foreign `pg_sleep`; and the
+    // two-lock-scope variant of that (chain A releases the lock with its query
+    // still in flight, chain B re-enters its own lock and queues behind it) —
+    // instrumentation showed B's query reaching `_runQuery` only after the
+    // rollback, by barrier 1.
     this._queryInFlight = true;
     this._queryInFlightOwner = this._transactionManager.currentLockToken;
     try {


### PR DESCRIPTION
Closes the RFC 0061 story `pg-in-flight-marker-regression-coverage` as
**wontfix**, per its second acceptance branch: the reentrant/internal paths were
exhausted and none discriminates. Rather than cement that as "the marker is
fine, just untestable", the note this ships flags the marker as a **deviation
under convergence** and points at the Rails mechanisms that replace it
(RFC 0085, filed with this PR).

### What was tried

The story's suggested construction — two lock scopes, so the owner tokens
differ: chain A releases the TransactionManager lock with its `pg_sleep` still
in flight, chain B re-enters its own lock with a query that should queue behind
A's and (pre-fix) overwrite `_queryInFlightOwner`, then rolls back. Written,
run against `main`, then run again with `postgresql-adapter.ts` reverted to
`fd500d380^`. **Passed on both.**

Instrumenting `_runQuery`'s claim site and `_cancelAnyRunningQuery` on the
pre-fix tree showed why: B's `SELECT 1` reached `_runQuery` only *after* the
ROLLBACK, ~900 ms in, once A's sleep had finished.

### Why nothing can discriminate

Two independent barriers, either of which is sufficient:

1. Every `_runQuery` call site is inside a `withRawConnection` block, and its
   pre-loop `awaitRawConnectionReady` override already `await`s
   `_maintenanceTail`. A query that would queue behind another blocks *before*
   `_runQuery`, so the pre-fix claim site is never reached while a different
   query holds the wire.
2. Reaching `_runQuery` at all means holding the TM lock. A same-chain query
   re-enters and shares the owner token, so the guard's verdict is identical
   under either placement; a different chain must acquire the lock, which
   serializes it end-to-end behind the in-flight query.

Those two barriers are the connection lock doing the serializer's job twice —
which is the actual finding here, and the reason this ends in an RFC rather than
a shrug.

### The deviation, and RFC 0085

Rails' `cancel_any_running_query`
(`postgresql/database_statements.rb:127`) tracks nothing:

```ruby
return if @raw_connection.nil? || IDLE_TRANSACTION_STATUSES.include?(@raw_connection.transaction_status)
@raw_connection.cancel
@raw_connection.block
```

It reads the connection's own libpq protocol state, and needs no ownership
concept because `@lock.synchronize` wraps the whole `with_raw_connection` body
(`abstract_adapter.rb:984`). trails' `_queryInFlight` stands in for
`transaction_status`; `_queryInFlightOwner` stands in for the lock trails
releases early; `_serializePinnedQuery` / `_maintenanceTail` stand in for the
serialization the lock would have provided. RFC 0085
`pg-cancel-query-rails-convergence` sequences the removal:
`pg-transaction-status-port` → `pg-cancel-block-drain` →
`pg-lock-scope-no-escaping-queries` → `pg-retire-pinned-query-mutex`.

This PR also corrects a factual error in `isRetryableQueryError`'s comment: it
claimed node-pg does not expose the PG transaction status byte, but
`pg-protocol` parses it into `ReadyForQueryMessage.status` and `pg.Client`
emits it on `client.connection` — which is what makes story 1 tractable.

### Changes

Comments only. No behaviour change.

Closes-story: pg-in-flight-marker-regression-coverage
