### PR TITLE
feat(api-compare): lint JSDoc tag blocks detached from their declaration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1403,6 +1403,14 @@ jobs:
         # tag would sit undetected. See the empty-reason bullet in
         # docs/infrastructure/api-build-stub-generation-plan.md.
         run: pnpm exec tsx scripts/api-compare/lint-missing-rails-call-reasons.ts
+      - name: Detached JSDoc tag blocks gate
+        # Flags `@internal` / `@noRailsEquivalent` blocks separated from the
+        # declaration they document (a `//` comment between the block and the
+        # signature is the usual shape). The tag then stops applying to that
+        # declaration — the member reads as unjustified public surface, or the
+        # tag excuses a neighbour it was never written for, and both look
+        # exactly like "no tag was written". Read-only; no Ruby needed.
+        run: pnpm exec tsx scripts/api-compare/lint-detached-jsdoc-tags.ts
       - name: Body-pins gate
         # Source-hash pinning (RFC 0025). Fails when a pinned pair's normalized
         # Rails body digest drifts from the current vendored source

--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -332,6 +332,17 @@ report). They therefore share:
     `packages/*/src` through the same `parseJsdoc` check — read-only, no
     second parser, and with no dependency on the wide call-mismatch artifact.
 
+  Both checks read whatever TypeScript **bound** to a declaration, so a block
+  that has drifted away from its declaration passes them vacuously.
+  `pnpm api:detached` (`lint-detached-jsdoc-tags.ts`, same CI job) covers that
+  from the text side: it fails when anything other than whitespace or another
+  JSDoc block sits between an `@internal` / `@noRailsEquivalent` block and the
+  declaration it was bound to, and when such a block is bound to nothing at
+  all. It deliberately does **not** flag the insertion case — a new declaration
+  slid in between a block and the one it documented — because the result is
+  textually identical to an ordinary doc comment on the inserted declaration;
+  only the diff distinguishes them, so that one stays a review-time concern.
+
   The placeholder path is unaffected: a generator-authored placeholder is a
   non-empty reason, so it parses, round-trips byte-for-byte via `rawLines`,
   and still drops without a harvest report when the call converges. Reason

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "api:extra": "pnpm tsx scripts/api-compare/extra-surface.ts",
     "api:build": "pnpm tsx scripts/api-compare/build.ts",
     "api:reasons": "pnpm tsx scripts/api-compare/lint-missing-rails-call-reasons.ts",
+    "api:detached": "pnpm tsx scripts/api-compare/lint-detached-jsdoc-tags.ts",
     "api:calls": "pnpm tsx scripts/api-compare/lint-call-mismatches.ts",
     "api:calls:reseed": "API_COMPARE_FORCE=1 pnpm api:compare && pnpm tsx scripts/api-compare/lint-call-mismatches.ts --write",
     "api:calls:wide": "pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts",

--- a/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
@@ -319,11 +319,13 @@ export class ExceptionWrapper {
     return out;
   }
 
-  /** @internal */
-  // Rails passes `kind` straight into BacktraceCleaner#clean (which supports
-  // :silent/:noise/:all via its silencer chain). Our cleaner doesn't yet take
-  // a kind, so we always apply the local node_modules partition so the three
-  // trace getters stay distinct, then let the cleaner post-process the slice.
+  /**
+   * Rails passes `kind` straight into BacktraceCleaner#clean (which supports
+   * :silent/:noise/:all via its silencer chain). Our cleaner doesn't yet take
+   * a kind, so we always apply the local node_modules partition so the three
+   * trace getters stay distinct, then let the cleaner post-process the slice.
+   * @internal
+   */
   cleanBacktrace(kind: "silent" | "noise" | "all"): string[] {
     const lines = this.backtrace();
     const partitioned =

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -901,8 +901,8 @@ export function _enum(
 }
 
 /** Cache of per-class EnumMethods modules.
+ * JS-idiomatic equivalent of Rails' per-class `@_enum_methods_module` ivar.
  * @internal */
-// JS-idiomatic equivalent of Rails' per-class `@_enum_methods_module` ivar.
 const _enumMethodsModuleRegistry = new WeakMap<typeof import("./base.js").Base, EnumMethods>();
 
 /**

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -523,9 +523,11 @@ export function raiseNestedAttributesRecordNotFoundBang(
   );
 }
 
-/** @internal */
-// Resolve a `limit:` option to a number. A string names a method/attribute on
-// the owner (Rails `limit: :parrots_limit`); a function is invoked.
+/**
+ * Resolve a `limit:` option to a number. A string names a method/attribute on
+ * the owner (Rails `limit: :parrots_limit`); a function is invoked.
+ * @internal
+ */
 function resolveNestedLimit(
   limit: number | string | ((...args: unknown[]) => number) | undefined,
   record: Base,

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -15,12 +15,15 @@ export type { GlobalIDModel };
 
 const DEFAULT_PURPOSE = "default";
 
-/** Option keys that are NOT forwarded as GID URI params. @internal */
-// Mirrors GlobalID.create's `options.except(:app, :verifier, :for)` plus
-// the SGID-specific expiration options. Any other key — including
-// `purpose` — flows through to URI params, matching Rails: SGID does
-// not reserve `purpose` as an option, only as the internal @purpose
-// attr set via pick_purpose(:for).
+/**
+ * Option keys that are NOT forwarded as GID URI params.
+ * Mirrors GlobalID.create's `options.except(:app, :verifier, :for)` plus
+ * the SGID-specific expiration options. Any other key — including
+ * `purpose` — flows through to URI params, matching Rails: SGID does
+ * not reserve `purpose` as an option, only as the internal `purpose`
+ * attr set via pick_purpose(:for).
+ * @internal
+ */
 const KNOWN_SGID_KEYS = new Set(["app", "for", "expiresIn", "expiresAt", "verifier"]);
 
 /** Monotonic counter for stable inspect() ids; mirrors Ruby's object_id. @internal */

--- a/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
@@ -62,9 +62,22 @@ describe("lintFileText", () => {
         line: 3,
         kind: "unbound",
         tags: ["internal"],
-        detail: "bound to no declaration",
+        detail: "bound to no declaration — the tag is inert",
       },
     ]);
+  });
+
+  it("ignores a tag block quoted inside a string literal", () => {
+    const found = lintFileText(
+      "a.test.ts",
+      ['const fixture = "/** @internal */\\nfunction a() {}";', ""].join("\n"),
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("ignores a tag block quoted inside a template literal", () => {
+    const found = lintFileText("a.test.ts", "const fixture = `/** @noRailsEquivalent x */`;\n");
+    expect(found).toEqual([]);
   });
 
   it("reports each detachment in a file, in source order", () => {

--- a/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { lintFileText } from "./lint-detached-jsdoc-tags.js";
+
+describe("lintFileText", () => {
+  it("flags a line comment between an @internal block and its declaration", () => {
+    const found = lintFileText(
+      "a.ts",
+      ["/** @internal */", "// prose about the deviation", "export function a() {}", ""].join("\n"),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      file: "a.ts",
+      line: 1,
+      kind: "separated",
+      tags: ["internal"],
+    });
+    expect(found[0]!.detail).toContain("`a`");
+  });
+
+  it("flags a detached @noRailsEquivalent block", () => {
+    const found = lintFileText(
+      "a.ts",
+      [
+        "/** @noRailsEquivalent trails-only wiring seam */",
+        "/* not a doc comment */",
+        "export const a = 1;",
+        "",
+      ].join("\n"),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ kind: "separated", tags: ["noRailsEquivalent"] });
+    expect(found[0]!.detail).toContain("`a`");
+  });
+
+  it("accepts a block flush against its declaration", () => {
+    expect(lintFileText("a.ts", "/** @internal */\nexport function a() {}\n")).toEqual([]);
+  });
+
+  it("accepts consecutive JSDoc blocks, whose tags TypeScript merges", () => {
+    const found = lintFileText(
+      "a.ts",
+      ["/** @internal */", "/** more prose */", "export function a() {}", ""].join("\n"),
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("accepts a blank line between the block and its declaration", () => {
+    expect(lintFileText("a.ts", "/** @internal */\n\nexport function a() {}\n")).toEqual([]);
+  });
+
+  it("ignores blocks without an api-compare-significant tag", () => {
+    expect(
+      lintFileText("a.ts", "/** @param x nothing */\n// prose\nfunction a(x: number) {}\n"),
+    ).toEqual([]);
+  });
+
+  it("flags a significant block bound to no declaration", () => {
+    const found = lintFileText("a.ts", "export function a() {}\n\n/** @internal orphan */\n");
+    expect(found).toEqual([
+      {
+        file: "a.ts",
+        line: 3,
+        kind: "unbound",
+        tags: ["internal"],
+        detail: "bound to no declaration",
+      },
+    ]);
+  });
+
+  it("reports each detachment in a file, in source order", () => {
+    const found = lintFileText(
+      "a.ts",
+      [
+        "/** @internal */",
+        "// prose",
+        "function a() {}",
+        "/** @internal */",
+        "// prose",
+        "function b() {}",
+        "",
+      ].join("\n"),
+    );
+    expect(found.map((d) => d.line)).toEqual([1, 4]);
+  });
+});

--- a/scripts/api-compare/lint-detached-jsdoc-tags.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.ts
@@ -36,6 +36,12 @@
  *     is inert there too, but JSDoc on statements is legitimate prose in this
  *     tree and flagging it would be noise.
  *
+ * Population: every `.ts` file under `packages/<pkg>/src`, the same set
+ * `api:reasons` checks — that is exactly where a tag has api-compare meaning.
+ * `*.test.ts` is included (a detached tag misleads a reader wherever it sits),
+ * so a block quoted inside a string or template literal has to be excluded
+ * explicitly; see `isCommentPosition`.
+ *
  * Usage:
  *   pnpm api:detached
  *
@@ -95,6 +101,23 @@ function boundBlocks(sourceFile: ts.SourceFile, text: string): Map<number, Bound
   return bound;
 }
 
+/** True when `pos` falls in a token's leading trivia — i.e. it really is a
+ *  comment, and not a `/**` sequence inside a string or template literal (test
+ *  fixtures quote these blocks, and an unbound match there is not a defect). */
+function isCommentPosition(sourceFile: ts.SourceFile, pos: number): boolean {
+  let node: ts.Node = sourceFile;
+  for (;;) {
+    // JSDoc nodes appear among a token's children and start AT the comment,
+    // which would read as "inside a token" — descend past them.
+    const child = node
+      .getChildren(sourceFile)
+      .find((c) => !ts.isJSDoc(c) && pos >= c.pos && pos < c.end);
+    if (!child) break;
+    node = child;
+  }
+  return pos < node.getStart(sourceFile);
+}
+
 /** The bound declaration's name, for the report. A `VariableStatement` holds
  *  the JSDoc but its declaration holds the name, hence the descent. */
 function describe(node: ts.Node): string {
@@ -134,12 +157,13 @@ export function lintFileText(fileName: string, text: string): Detachment[] {
       new RegExp(`(^|[\\s*])@${tag}\\b`).test(match[0]),
     );
     if (tags.length === 0) continue;
+    if (!isCommentPosition(sourceFile, match.index)) continue;
     found.push({
       file: fileName,
       line: lineOf(match.index),
       tags,
       kind: "unbound",
-      detail: "bound to no declaration",
+      detail: "bound to no declaration — the tag is inert",
     });
   }
 

--- a/scripts/api-compare/lint-detached-jsdoc-tags.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env npx tsx
+/**
+ * api:detached — flag JSDoc blocks whose api-compare-significant tags
+ * (`@internal`, `@noRailsEquivalent`) are detached from the declaration they
+ * were written for.
+ *
+ * `hasInternalJsDocTag` / `noRailsEquivalentReason` (extract-ts-api.ts) read
+ * whatever TypeScript *bound* to a declaration. When a node lands between a
+ * tag block and its declaration, the tag silently stops applying to that
+ * declaration — the member reads as unjustified public surface, or the tag
+ * lands on a neighbour and excuses surface it was never written for. Both
+ * outcomes look exactly like "no tag was written", so nothing else reports
+ * them. This lint checks the *textual* shape instead of trusting the binding.
+ *
+ * Two shapes are reported:
+ *
+ *   - `separated` — something other than whitespace (a `//` comment, a
+ *     non-JSDoc block comment, a directive) sits between the tag block and the
+ *     start of the declaration TypeScript bound it to. Consecutive JSDoc
+ *     blocks on one declaration are NOT this shape: TypeScript merges their
+ *     tags, so both still apply.
+ *   - `unbound` — the block carries a significant tag but TypeScript bound it
+ *     to no node at all (e.g. it trails the last statement of a file). The tag
+ *     is inert.
+ *
+ * Two narrower variants are deliberately NOT reported:
+ *
+ *   - The *insertion* case that motivated this lint (RFC 0080): a new
+ *     declaration inserted between a block and the declaration it documented,
+ *     so the block now binds to the inserted one. It is textually
+ *     indistinguishable from an ordinary doc comment on the inserted
+ *     declaration — the only evidence is the diff, not the tree — so it is a
+ *     review-time concern, not a lint-time one. What this lint does cover is
+ *     the same defect whenever the inserted node is not itself a declaration.
+ *   - A block bound to a non-declaration node (an `if`, a `return`). The tag
+ *     is inert there too, but JSDoc on statements is legitimate prose in this
+ *     tree and flagging it would be noise.
+ *
+ * Usage:
+ *   pnpm api:detached
+ *
+ * Hard rules: no node:* imports, no process.* outside the CLI entry guard.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import * as ts from "typescript";
+import { ROOT_DIR } from "./config.js";
+import { listSourceFiles } from "./lint-missing-rails-call-reasons.js";
+
+const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
+const SIGNIFICANT_TAGS = new Set(["internal", "noRailsEquivalent"]);
+const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
+
+export interface Detachment {
+  file: string;
+  line: number;
+  tags: string[];
+  kind: "separated" | "unbound";
+  detail: string;
+}
+
+function significantTags(block: ts.JSDoc): string[] {
+  return (block.tags ?? [])
+    .map((tag) => tag.tagName.text)
+    .filter((name) => SIGNIFICANT_TAGS.has(name));
+}
+
+interface BoundBlock {
+  node: ts.Node;
+  block: ts.JSDoc;
+  siblings: ts.JSDoc[];
+}
+
+/** Every JSDoc block TypeScript bound to a node, keyed by the offset of its
+ *  `/**` (a JSDoc node's `pos` starts at the preceding node's end, not at the
+ *  comment). Recorded outermost-first so a `VariableStatement` wins over the
+ *  `VariableDeclaration` that repeats its blocks. A block bound to the
+ *  end-of-file token is deliberately left out: it documents nothing, and the
+ *  unbound pass reports it. */
+function boundBlocks(sourceFile: ts.SourceFile, text: string): Map<number, BoundBlock> {
+  const bound = new Map<number, BoundBlock>();
+  const visit = (node: ts.Node) => {
+    const siblings = (node as { jsDoc?: ts.JSDoc[] }).jsDoc;
+    if (siblings && node.kind !== ts.SyntaxKind.EndOfFileToken) {
+      for (const block of siblings) {
+        const start = text.indexOf("/**", block.pos);
+        if (start !== -1 && !bound.has(start)) bound.set(start, { node, block, siblings });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return bound;
+}
+
+/** The bound declaration's name, for the report. A `VariableStatement` holds
+ *  the JSDoc but its declaration holds the name, hence the descent. */
+function describe(node: ts.Node): string {
+  const named = ts.isVariableStatement(node) ? node.declarationList.declarations[0] : node;
+  const name = (named as { name?: ts.Node }).name;
+  return name && ts.isIdentifier(name as ts.Node) ? (name as ts.Identifier).text : "the code below";
+}
+
+export function lintFileText(fileName: string, text: string): Detachment[] {
+  if (![...SIGNIFICANT_TAGS].some((tag) => text.includes(`@${tag}`))) return [];
+  const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.ESNext, true);
+  const bound = boundBlocks(sourceFile, text);
+  const lineOf = (pos: number) => sourceFile.getLineAndCharacterOfPosition(pos).line + 1;
+  const found: Detachment[] = [];
+
+  for (const [start, { node, block, siblings }] of bound) {
+    const tags = significantTags(block);
+    if (tags.length === 0) continue;
+    // The next sibling JSDoc block bounds the gap: TypeScript merges the tags
+    // of consecutive blocks, so an intervening one is not a detachment.
+    const next = siblings.find((candidate) => candidate.pos >= block.end);
+    const gapEnd = next ? text.indexOf("/**", next.pos) : node.getStart(sourceFile);
+    const gap = text.slice(block.end, gapEnd);
+    if (gap.trim() === "") continue;
+    found.push({
+      file: fileName,
+      line: lineOf(start),
+      tags,
+      kind: "separated",
+      detail: `${gap.trim().split("\n")[0]!.slice(0, 60)} … separates it from \`${describe(node)}\``,
+    });
+  }
+
+  for (const match of text.matchAll(JSDOC_BLOCK)) {
+    if (bound.has(match.index)) continue;
+    const tags = [...SIGNIFICANT_TAGS].filter((tag) =>
+      new RegExp(`(^|[\\s*])@${tag}\\b`).test(match[0]),
+    );
+    if (tags.length === 0) continue;
+    found.push({
+      file: fileName,
+      line: lineOf(match.index),
+      tags,
+      kind: "unbound",
+      detail: "bound to no declaration",
+    });
+  }
+
+  return found.sort((a, b) => a.line - b.line);
+}
+
+export async function main(): Promise<number> {
+  const files = await listSourceFiles(PACKAGES_DIR);
+  const found: Detachment[] = [];
+  for (const abs of files) {
+    found.push(...lintFileText(path.relative(ROOT_DIR, abs), await fs.readFile(abs, "utf-8")));
+  }
+  if (found.length > 0) {
+    for (const d of found) {
+      console.error(
+        `api:detached: ${d.file}:${d.line} — @${d.tags.join(", @")} ${d.kind}: ${d.detail}`,
+      );
+    }
+    console.error(
+      `api:detached: ${found.length} detached tag block(s) — move the block flush against ` +
+        "the declaration it documents, or the tag does not apply to it.",
+    );
+    return 1;
+  }
+  console.log(`api:detached: ${files.length} file(s) checked, no detached tag blocks.`);
+  return 0;
+}
+
+async function runAsScript(): Promise<void> {
+  const self = fileURLToPath(import.meta.url);
+  const invoked = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  if (path.resolve(self) !== invoked) return;
+  process.exit(await main());
+}
+
+void runAsScript();


### PR DESCRIPTION
## What

Adds `pnpm api:detached` (`scripts/api-compare/lint-detached-jsdoc-tags.ts`): a
read-only lint that flags JSDoc blocks carrying an api-compare-significant tag
(`@internal`, `@noRailsEquivalent`) which are detached from the declaration they
document.

`hasInternalJsDocTag` / `noRailsEquivalentReason` read whatever TypeScript
*bound* to a declaration. When a `//` comment (the usual shape — annotating a
deviation right above a member) lands between the block and the signature, the
tag stops applying to that declaration: the member reads as unjustified public
surface, or the tag lands on a neighbour and excuses surface it was never
written for. Both outcomes look exactly like "no tag was written", and nothing
in CI reported either. `blazetrails/rails-private-jsdoc` fails on this shape
too, but only for the subset of members that are private in Rails.

The lint checks the **textual** shape instead of trusting the binding:

- `separated` — anything but whitespace between the block and the start of the
  declaration TypeScript bound it to. Consecutive JSDoc blocks are not this
  shape: TypeScript merges their tags, so both still apply.
- `unbound` — a significant block bound to no node at all (e.g. trailing the
  last statement of a file). The tag is inert. A `/** @internal */` quoted
  inside a string or template literal is *not* this shape — the population
  includes `*.test.ts`, which quote exactly that — so each unbound match is
  anchored to a real leading-trivia position first.

Population: every `.ts` under `packages/<pkg>/src`, the same set `api:reasons`
checks, which is where a tag has api-compare meaning.

## The narrower variant, decided

The *insertion* case that motivated the story (PR #5654: a helper inserted
between `memberVisibility`'s block and its signature, so the block rebound to
the inserted function) is deliberately **not** flagged. Once inserted, it is
textually indistinguishable from an ordinary doc comment on the inserted
declaration — the only evidence is the diff, not the tree — so it stays a
review-time concern. What the lint does cover is that same defect whenever the
inserted node is not itself a declaration. A block bound to a non-declaration
statement is likewise not flagged: JSDoc prose on statements is legitimate here
and flagging it would be noise. Both decisions are recorded in the script header
and in `docs/infrastructure/api-build-stub-generation-plan.md`.

## Existing detachments

Four in the tree, all real, all fixed here by folding the `//` prose into the
JSDoc block:

- `packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts` — `cleanBacktrace`
- `packages/activerecord/src/enum.ts` — `_enumMethodsModuleRegistry`
- `packages/activerecord/src/nested-attributes.ts` — `resolveNestedLimit`
- `packages/globalid/src/signed-global-id.ts` — `KNOWN_SGID_KEYS`

The tree is clean after them: `api:detached: 3094 file(s) checked, no detached
tag blocks.` Verified the gate is not vacuous by dropping the pre-fix
`origin/main` copy of `enum.ts` back into the tree — the lint reports it and
exits 1.

## Wiring

New step in the Rails API/Test Comparison job, next to the missing-call reasons
gate (its sibling read-only JSDoc lint). Needs no Ruby and no api-compare
artifact. Ten unit tests in `lint-detached-jsdoc-tags.test.ts` run in the
existing scripts vitest project.

Closes-story: lint-detached-jsdoc-tag-blocks
