### PR TITLE
refactor(test-support): extend AbstractAdapter directly in FakeActiveRecordAdapter

### DIFF
--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -8,50 +8,27 @@ export interface MergeColumnOptions {
   null?: boolean;
 }
 
-/** Mirrors: FakeActiveRecordAdapter */
 export class FakeActiveRecordAdapter extends AbstractAdapter {
   static readonly columns = new Map<string, Column[]>();
 
-  /**
-   * Rails' `attr_accessor :data_sources` replaces the inherited
-   * `data_sources` method with a plain attribute; Ruby allows the reshape,
-   * TS does not (AbstractAdapter declares `dataSources(): Promise<string[]>`).
-   * The suppression keeps the Rails superclass chain and the Rails member
-   * name — the alternatives are interposing a base class that drops the
-   * member, or renaming it, and both lose what this port exists to preserve.
-   */
-  // @ts-expect-error -- deliberate Ruby-style member reshape, see above
+  // @ts-expect-error -- attr_accessor :data_sources reshapes the inherited method into an attribute
   dataSources: string[];
   primaryKeys: Record<string, string>;
 
-  private readonly _fakeColumns: Map<string, Column[]>;
+  readonly #columns: Map<string, Column[]>;
 
-  /**
-   * Mirrors: FakeActiveRecordAdapter#initialize, minus the forwarding. Rails is
-   * `def initialize(...)` + bare `super`, passing the adapter's whole argument
-   * list up; trails' AbstractAdapter constructor takes none
-   * (abstract-adapter.ts:706), so there is nothing to forward and the signature
-   * is zero-arg. Behaviourally identical to the field initializers this
-   * replaced — it exists to put the three assignments in Rails' order.
-   */
   constructor() {
     super();
     this.dataSources = [];
     this.primaryKeys = {};
-    this._fakeColumns = FakeActiveRecordAdapter.columns;
+    this.#columns = (this.constructor as typeof FakeActiveRecordAdapter).columns;
   }
 
-  /**
-   * Mirrors: FakeActiveRecordAdapter#primary_key. Synchronous in-memory
-   * lookup where AbstractAdapter's reaches the database and returns a
-   * promise; same deliberate reshape as `dataSources` above.
-   */
-  // @ts-expect-error -- deliberate Ruby-style member reshape, see dataSources
+  // @ts-expect-error -- synchronous in-memory lookup where the inherited one returns a promise
   primaryKey(table: string): string {
     return this.primaryKeys[table] ?? "id";
   }
 
-  /** Mirrors: FakeActiveRecordAdapter#merge_column */
   mergeColumn(
     tableName: string,
     name: string,
@@ -59,30 +36,23 @@ export class FakeActiveRecordAdapter extends AbstractAdapter {
     options: MergeColumnOptions = {},
   ): void {
     this.columns(tableName).push(
-      new Column(String(name), options.default, this.fetchTypeMetadata(sqlType), options.null),
+      new Column(name, options.default, this.fetchTypeMetadata(sqlType), options.null),
     );
   }
 
-  /**
-   * Mirrors: FakeActiveRecordAdapter#columns. Synchronous in-memory lookup
-   * where AbstractAdapter's reaches the database and returns a promise; same
-   * deliberate reshape as `dataSources` above.
-   */
-  // @ts-expect-error -- deliberate Ruby-style member reshape, see dataSources
+  // @ts-expect-error -- synchronous in-memory lookup where the inherited one returns a promise
   columns(tableName: string): Column[] {
-    const existing = this._fakeColumns.get(tableName);
+    const existing = this.#columns.get(tableName);
     if (existing) return existing;
     const created: Column[] = [];
-    this._fakeColumns.set(tableName, created);
+    this.#columns.set(tableName, created);
     return created;
   }
 
-  /** Mirrors: FakeActiveRecordAdapter#data_source_exists? */
   dataSourceExists(): boolean {
     return true;
   }
 
-  /** Mirrors: FakeActiveRecordAdapter#active? */
   get active(): boolean {
     return true;
   }
@@ -92,7 +62,6 @@ export class FakeActiveRecordAdapter extends AbstractAdapter {
   }
 }
 
-/** Mirrors: activerecord/test/cases/helper.rb:46 */
 export function registerFakeAdapter(): void {
   register("fake", async () => FakeActiveRecordAdapter as unknown as new () => AbstractAdapter);
 }

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -3,29 +3,24 @@ import { Column } from "../connection-adapters/column.js";
 import type { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 import { register } from "../connection-adapters.js";
 
-/**
- * Rails' fake adapter redefines inherited members with incompatible shapes:
- * `attr_accessor :data_sources` turns the `data_sources` method into a plain
- * attribute, and `primary_key` / `columns` / `active?` become synchronous
- * in-memory lookups where AbstractAdapter's reach the database. TS forbids
- * narrowing an inherited member that way, so the base is widened with those
- * members dropped — the alternative is renaming them, which would lose the
- * Rails names this port exists to preserve.
- */
-const FakeAdapterBase = AbstractAdapter as unknown as new () => Omit<
-  AbstractAdapter,
-  "dataSources" | "primaryKey" | "columns" | "active"
->;
-
 export interface MergeColumnOptions {
   default?: unknown;
   null?: boolean;
 }
 
 /** Mirrors: FakeActiveRecordAdapter */
-export class FakeActiveRecordAdapter extends FakeAdapterBase {
+export class FakeActiveRecordAdapter extends AbstractAdapter {
   static readonly columns = new Map<string, Column[]>();
 
+  /**
+   * Rails' `attr_accessor :data_sources` replaces the inherited
+   * `data_sources` method with a plain attribute; Ruby allows the reshape,
+   * TS does not (AbstractAdapter declares `dataSources(): Promise<string[]>`).
+   * The suppression keeps the Rails superclass chain and the Rails member
+   * name — the alternatives are interposing a base class that drops the
+   * member, or renaming it, and both lose what this port exists to preserve.
+   */
+  // @ts-expect-error -- deliberate Ruby-style member reshape, see above
   dataSources: string[];
   primaryKeys: Record<string, string>;
 
@@ -46,7 +41,12 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
     this._fakeColumns = FakeActiveRecordAdapter.columns;
   }
 
-  /** Mirrors: FakeActiveRecordAdapter#primary_key */
+  /**
+   * Mirrors: FakeActiveRecordAdapter#primary_key. Synchronous in-memory
+   * lookup where AbstractAdapter's reaches the database and returns a
+   * promise; same deliberate reshape as `dataSources` above.
+   */
+  // @ts-expect-error -- deliberate Ruby-style member reshape, see dataSources
   primaryKey(table: string): string {
     return this.primaryKeys[table] ?? "id";
   }
@@ -63,7 +63,12 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
     );
   }
 
-  /** Mirrors: FakeActiveRecordAdapter#columns */
+  /**
+   * Mirrors: FakeActiveRecordAdapter#columns. Synchronous in-memory lookup
+   * where AbstractAdapter's reaches the database and returns a promise; same
+   * deliberate reshape as `dataSources` above.
+   */
+  // @ts-expect-error -- deliberate Ruby-style member reshape, see dataSources
   columns(tableName: string): Column[] {
     const existing = this._fakeColumns.get(tableName);
     if (existing) return existing;
@@ -83,7 +88,7 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
   }
 
   private fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
-    return (this as unknown as AbstractAdapter).schemaStatements().fetchTypeMetadata(sqlType);
+    return this.schemaStatements().fetchTypeMetadata(sqlType);
   }
 }
 


### PR DESCRIPTION
Rails' `test/support/fake_adapter.rb` declares
`FakeActiveRecordAdapter < ActiveRecord::ConnectionAdapters::AbstractAdapter`.
trails interposed a `FakeAdapterBase` alias — `AbstractAdapter` cast to a
constructor whose type `Omit`s `dataSources | primaryKey | columns | active` —
so the port's superclass chain did not reach `AbstractAdapter` the way Rails'
does. `api:compare --package activerecord-test-support` reported
`rubySuper: AbstractAdapter / tsSuper: FakeAdapterBase` and inheritance 1/2.

The fake now extends `AbstractAdapter` directly. The reshape Ruby permits and
TS does not is localized to the three members TS actually rejects, each carrying
a one-line `@ts-expect-error`:

- `dataSources` — Rails' `attr_accessor :data_sources` replaces the inherited
  method with a plain attribute; trails declares `dataSources(): Promise<string[]>`.
- `primaryKey` / `columns` — synchronous in-memory lookups where
  AbstractAdapter's reach the database and return promises.

`active` needed no suppression: `get active(): boolean` already matches the base
getter, so the old `Omit` was over-broad there.

Three further deviations fall out with the interposed base:

- `fetchTypeMetadata` drops its `this as unknown as AbstractAdapter` cast —
  `this` now *is* an `AbstractAdapter`.
- the invented `_fakeColumns` field becomes `#columns`, mirroring Rails'
  `@columns` ivar name exactly (the ES private namespace does not collide with
  the public `columns` method).
- that field is seeded from `this.constructor`, restoring Rails'
  `@columns = self.class.columns` — the previous hardcoded
  `FakeActiveRecordAdapter.columns` resolved the base class rather than the
  receiver's.

`api:compare --package activerecord-test-support`: **32/32 methods, files 8/8,
inheritance 2/2, arity 18/18 — all 100%**.

Consumers verified green: `support/fake-adapter.test.ts`,
`json-serialization.test.ts`, `serialization.test.ts`, `modules.test.ts`,
`associations/inner-join-association.test.ts`,
`associations/left-outer-join-association.test.ts`,
`associations/cascaded-eager-loading.test.ts`.

Closes-story: converge-fake-adapter-superclass-onto-abstract-adapter


---

### Note on the dropped `String(name)` in `mergeColumn`

Raised in review: `fake_adapter.rb:22-28` does `name.to_s`, so the port should
keep `String(name)`. Holding the removal — `to_s` there is a Ruby
Symbol→String conversion that TS performs in the type system instead.

Rails' callers pass **symbols**: `contact.rb:13-20` is `column :id, "integer"`,
`column :name, "string"`, … routed through `contact.rb:29-30`
(`def column(name, ...)` → `merge_column(table_name, name, ...)`). `name.to_s`
exists to turn `:id` into `"id"` before `Column.new`, which wants a String.

In the port that conversion has already happened one layer up: the equivalent
`column()` in `test-helpers/models/contact.ts:26-33` declares `name: string`,
`mergeColumn` declares `name: string`, and `Column`'s first parameter is
`string`. Both real call sites — `contact.ts:32` and
`support/fake-adapter.test.ts:22,23,50` — pass string literals. There is no
symbol-shaped input left for `String()` to normalize, so on a `string`-typed
parameter it is a no-op.

"Non-string callers" cannot reach it without an explicit cast that defeats the
signature anyway; if such a caller is ever wanted, the fix is widening the
parameter type deliberately, not a silent coercion behind a `string`
annotation.
