### PR TITLE
refactor(activerecord): route the per-worker schema load through loadSchema

### DIFF
--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -50,6 +50,9 @@ export const canonicalLoaderModules = [
 ];
 
 /** Each loader module's own unit test (repo-relative), allowed to import it. */
-export const canonicalLoaderSelfTests = canonicalLoaderModules.map(
-  (name) => `${activerecordSrcRoot}/support/${name}.test.ts`,
-);
+export const canonicalLoaderSelfTests = [
+  ...canonicalLoaderModules.map((name) => `${activerecordSrcRoot}/support/${name}.test.ts`),
+  // `load-schema-helper` has a second self-test: the trails-only guard on the
+  // boot-laid table snapshot the adapter-specific arm feeds.
+  `${activerecordSrcRoot}/support/load-schema-helper.trails.test.ts`,
+];

--- a/eslint/test-infra-scope.test.mjs
+++ b/eslint/test-infra-scope.test.mjs
@@ -30,6 +30,7 @@ describe("test-infra lint scope", () => {
       `${SRC}/support/canonical-schema.test.ts`,
       `${SRC}/support/canonical-table-rebuild.test.ts`,
       `${SRC}/support/load-schema-helper.test.ts`,
+      `${SRC}/support/load-schema-helper.trails.test.ts`,
     ]);
     expect([...ALLOW]).toEqual(canonicalLoaderSelfTests);
     expect(canonicalLoaderModules).toEqual([

--- a/packages/activerecord/src/support/load-schema-helper.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.trails.test.ts
@@ -17,9 +17,7 @@ describe("boot-laid table snapshot", () => {
   it("survives the reset for every table the adapter-specific arm lays", async () => {
     const adapter = Base.connection;
 
-    // The canonical half is already on this worker's DB, so the arm passed here
-    // lays nothing and just hands `loadSchema` the connection to run the
-    // adapter-specific arm on.
+    // The canonical half is already on this worker's DB, so the arm lays nothing.
     await loadSchema(async () => adapter);
     const bookkeeping = new Set(["schema_migrations", "ar_internal_metadata"]);
     const laid = (await adapter.tables()).filter((name) => !bookkeeping.has(name));

--- a/packages/activerecord/src/support/load-schema-helper.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.trails.test.ts
@@ -11,13 +11,16 @@
 import { describe, expect, it } from "vitest";
 import { Base } from "../base.js";
 import { recordBootLaidTables, resetTestTables } from "./drop-all-tables.js";
-import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
+import { loadSchema } from "./load-schema-helper.js";
 
 describe("boot-laid table snapshot", () => {
   it("survives the reset for every table the adapter-specific arm lays", async () => {
     const adapter = Base.connection;
 
-    await loadAdapterSpecificSchema(adapter);
+    // The canonical half is already on this worker's DB, so the arm passed here
+    // lays nothing and just hands `loadSchema` the connection to run the
+    // adapter-specific arm on.
+    await loadSchema(async () => adapter);
     const bookkeeping = new Set(["schema_migrations", "ar_internal_metadata"]);
     const laid = (await adapter.tables()).filter((name) => !bookkeeping.has(name));
     expect(laid).toContain("defaults");
@@ -35,8 +38,10 @@ describe("boot-laid table snapshot", () => {
     // `test-setup-dy.ts`'s boot order, replayed: DatabaseTasks has laid the
     // canonical tables (and left anything else alone), then the purge, then the
     // adapter-specific arm, then the snapshot.
-    await resetTestTables(adapter);
-    await loadAdapterSpecificSchema(adapter);
+    await loadSchema(async () => {
+      await resetTestTables(adapter);
+      return adapter;
+    });
     await recordBootLaidTables(adapter);
 
     expect(await adapter.tables()).not.toContain("leftover_boot_t");

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -515,30 +515,43 @@ const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Pro
  *   every migration line, whereas laying the schema through the adapter prints
  *   nothing.
  *
+ * Deviation, and why it is a parameter rather than a second entry point: trails
+ * lays the canonical half through two different mechanisms depending on the
+ * lane — `loadCanonicalSchema` (the sqlite/PG template build, the adapter
+ * clusters) and `DatabaseTasks.reconstructFromSchema`/`loadSchema` on a
+ * generated schema file (`test-setup-dy.ts`, the per-worker DB every ordinary
+ * AR test actually rides, which also has to purge). Rails has one mechanism and
+ * so needs no such seam. Passing the canonical arm in keeps both lanes inside
+ * this one function, so the two arms of `load_schema` cannot be applied to one
+ * path and not the other — the bug PR #5523 found. The thunk returns the
+ * connection the adapter-specific arm should run on because the
+ * `DatabaseTasks` path swaps the pool underneath it (`withTemporaryPool`), so
+ * the caller cannot lease it up front.
+ *
  * @internal Boot/template setup paths only. Test files wire the canonical schema
  * + fixtures through `fixtures({ ... })`; the
  * `blazetrails/no-internal-canonical-loaders` ESLint rule enforces that.
  */
-export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
-  await loadCanonicalSchema(adapter);
+export async function loadSchema(
+  adapterOrCanonicalArm: DatabaseAdapter | (() => Promise<DatabaseAdapter>),
+): Promise<void> {
+  let adapter: DatabaseAdapter;
+  if (typeof adapterOrCanonicalArm === "function") {
+    adapter = await adapterOrCanonicalArm();
+  } else {
+    adapter = adapterOrCanonicalArm;
+    await loadCanonicalSchema(adapter);
+  }
   await loadAdapterSpecificSchema(adapter);
 }
 
 /**
  * The `load adapter_specific_schema_file if File.exist?(...)` arm of
- * `load_schema_helper.rb:15`, on its own.
- *
- * Exported because trails lays the canonical half through two different
- * mechanisms depending on the lane: {@link loadSchema} (the sqlite/PG template
- * build) and `DatabaseTasks.reconstructFromSchema`/`loadSchema` on the
- * generated schema file (`test-setup-dy.ts`, the per-worker DB every AR test
- * actually rides). The latter knows only about schema.rb's mirror and purges
- * whatever the template carried, so it has to call this arm itself — otherwise
- * the `<adapter>_specific_schema.rb` tables exist only in the template.
- *
- * @internal Boot/template setup paths only.
+ * `load_schema_helper.rb:15`, on its own. Not exported: reaching for this arm
+ * alone is exactly how the two halves of `load_schema` drifted apart before —
+ * go through {@link loadSchema}.
  */
-export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
+async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
   if (adapterSpecificSchema) await adapterSpecificSchema(adapter);
 }

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -515,18 +515,14 @@ const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Pro
  *   every migration line, whereas laying the schema through the adapter prints
  *   nothing.
  *
- * Deviation, and why it is a parameter rather than a second entry point: trails
- * lays the canonical half through two different mechanisms depending on the
- * lane — `loadCanonicalSchema` (the sqlite/PG template build, the adapter
- * clusters) and `DatabaseTasks.reconstructFromSchema`/`loadSchema` on a
- * generated schema file (`test-setup-dy.ts`, the per-worker DB every ordinary
- * AR test actually rides, which also has to purge). Rails has one mechanism and
- * so needs no such seam. Passing the canonical arm in keeps both lanes inside
- * this one function, so the two arms of `load_schema` cannot be applied to one
- * path and not the other — the bug PR #5523 found. The thunk returns the
- * connection the adapter-specific arm should run on because the
- * `DatabaseTasks` path swaps the pool underneath it (`withTemporaryPool`), so
- * the caller cannot lease it up front.
+ * Deviation — the optional canonical arm: trails lays schema.rb's mirror through
+ * two mechanisms, `loadCanonicalSchema` (template build, adapter clusters) and
+ * `DatabaseTasks` on a generated schema file (`test-setup-dy.ts`, which also has
+ * to purge). Rails has one mechanism and needs no such seam. Taking the arm as a
+ * parameter keeps both lanes inside this one function, so the two arms of
+ * `load_schema` cannot be applied to one path and not the other — the bug PR
+ * #5523 found. The thunk returns the connection because the `DatabaseTasks` path
+ * swaps the pool underneath it (`withTemporaryPool`).
  *
  * @internal Boot/template setup paths only. Test files wire the canonical schema
  * + fixtures through `fixtures({ ... })`; the

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -55,11 +55,9 @@ const mysqlExclusive = adapter === "mysql" && !!getEnv("AR_MYSQL_EXCLUSIVE_DB");
 const { recordBootLaidTables, resetTestTables } = await import("./support/drop-all-tables.js");
 const { loadSchema } = await import("./support/load-schema-helper.js");
 
-// `load_schema_helper.rb:4-21`, both arms, through the one entry point the
-// template build and the adapter clusters also use. Only the canonical arm
-// differs here: this worker's DB has to be purged/reconstructed first, which
-// Rails' single-process suite never does, so `DatabaseTasks` lays schema.rb's
-// mirror instead of `loadCanonicalSchema`.
+// `load_schema_helper.rb:4-21`, both arms. Only the canonical arm differs from
+// the template build's: this worker's DB has to be purged/reconstructed first,
+// which Rails' single-process suite never does.
 await loadSchema(async () => {
   if (
     (adapter === "sqlite" && envConfig.database !== ":memory:") ||
@@ -83,13 +81,11 @@ await loadSchema(async () => {
   return canonicalConn;
 });
 
-// Permanent worker-startup assertion: key canonical tables and at least one
-// `<adapter>_specific_schema.rb` table (`defaults`, the one table all three
-// adapter arms lay) must exist after the schema load. Failure here means an arm
-// of the load path is broken, not just the signature cache — and it surfaces at
-// worker startup instead of as a per-file "relation does not exist". Cast
-// because tableExists is on the concrete adapter class, not the DatabaseAdapter
-// interface.
+// Permanent worker-startup assertion: a broken arm of the load path fails here
+// rather than as a per-file "relation does not exist". `defaults` is the one
+// table all three `<adapter>_specific_schema.rb` arms lay, so it covers the
+// second arm. Cast because tableExists is on the concrete adapter class, not
+// the DatabaseAdapter interface.
 const _conn = (await Base.leaseConnection()) as unknown as {
   tableExists(n: string): Promise<boolean>;
 };

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -1,7 +1,8 @@
 /**
  * D-Y vitest setupFile for the activerecord project: calls `ARTest.connect`'s
  * port (`support/connection.ts`) and loads the canonical fixture schema once
- * per worker via `DatabaseTasks`.
+ * per worker through `support/load-schema-helper.ts`'s `loadSchema`, whose
+ * canonical arm is `DatabaseTasks` here (this DB has to be purged first).
  *
  * The pool it opens lives for the whole worker, as Rails' does for the whole
  * process (`cases/helper.rb` calls `ARTest.connect` at load and never
@@ -50,45 +51,57 @@ const schemaFilePath = await generateSchemaFile(
 
 const pgExclusive = adapter === "postgres" && !!getEnv("AR_PG_EXCLUSIVE_DB");
 const mysqlExclusive = adapter === "mysql" && !!getEnv("AR_MYSQL_EXCLUSIVE_DB");
-if ((adapter === "sqlite" && envConfig.database !== ":memory:") || pgExclusive || mysqlExclusive) {
-  await DatabaseTasks.reconstructFromSchema(envConfig, "ts", schemaFilePath);
-} else {
-  await DatabaseTasks.loadSchema(envConfig, "ts", schemaFilePath);
-}
 
-// Permanent worker-startup assertion: key canonical tables must exist after
-// DatabaseTasks loads the schema. Failure here means the load path is broken,
-// not just the signature cache. Cast because tableExists is on the concrete
-// adapter class, not the DatabaseAdapter interface.
+const { recordBootLaidTables, resetTestTables } = await import("./support/drop-all-tables.js");
+const { loadSchema } = await import("./support/load-schema-helper.js");
+
+// `load_schema_helper.rb:4-21`, both arms, through the one entry point the
+// template build and the adapter clusters also use. Only the canonical arm
+// differs here: this worker's DB has to be purged/reconstructed first, which
+// Rails' single-process suite never does, so `DatabaseTasks` lays schema.rb's
+// mirror instead of `loadCanonicalSchema`.
+await loadSchema(async () => {
+  if (
+    (adapter === "sqlite" && envConfig.database !== ":memory:") ||
+    pgExclusive ||
+    mysqlExclusive
+  ) {
+    await DatabaseTasks.reconstructFromSchema(envConfig, "ts", schemaFilePath);
+  } else {
+    await DatabaseTasks.loadSchema(envConfig, "ts", schemaFilePath);
+  }
+
+  // `DatabaseTasks.loadSchema` drop+recreates the *declared* tables (force:
+  // "cascade") on the shared PG/MySQL database; it purges nothing else, so a
+  // bespoke table a previous run left behind is still here. Drop it before the
+  // snapshot below, or it would be recorded as boot-laid and truncated for the
+  // rest of the run instead of dropped. Pre-snapshot, the reset's boot-laid set
+  // is the canonical registry, which is exactly the "keep schema.rb, drop the
+  // rest" purge wanted here.
+  const canonicalConn = await Base.leaseConnection();
+  await resetTestTables(canonicalConn);
+  return canonicalConn;
+});
+
+// Permanent worker-startup assertion: key canonical tables and at least one
+// `<adapter>_specific_schema.rb` table (`defaults`, the one table all three
+// adapter arms lay) must exist after the schema load. Failure here means an arm
+// of the load path is broken, not just the signature cache — and it surfaces at
+// worker startup instead of as a per-file "relation does not exist". Cast
+// because tableExists is on the concrete adapter class, not the DatabaseAdapter
+// interface.
 const _conn = (await Base.leaseConnection()) as unknown as {
   tableExists(n: string): Promise<boolean>;
 };
 const missingTables: string[] = [];
-for (const t of ["accounts", "topics", "posts"]) {
+for (const t of ["accounts", "topics", "posts", "defaults"]) {
   if (!(await _conn.tableExists(t))) missingTables.push(t);
 }
 if (missingTables.length > 0) {
   throw new Error(
-    `[test-setup-dy] DatabaseTasks schema load incomplete — missing tables: ${missingTables.join(", ")}`,
+    `[test-setup-dy] schema load incomplete — missing tables: ${missingTables.join(", ")}`,
   );
 }
-
-// `load_schema_helper.rb:15` — the adapter-specific arm. DatabaseTasks lays
-// only schema.rb's mirror, so the `<adapter>_specific_schema.rb` tables have to
-// be laid here, on the same per-worker DB (the reconstruct path purges whatever
-// the template carried).
-// `DatabaseTasks.loadSchema` drop+recreates the *declared* tables (force:
-// "cascade") on the shared PG/MySQL database; it purges nothing else, so a
-// bespoke table a previous run left behind is still here. Drop it before the
-// snapshot below, or it would be recorded as boot-laid and truncated for the
-// rest of the run instead of dropped. Pre-snapshot, the reset's boot-laid set is
-// the canonical registry, which is exactly the "keep schema.rb, drop the rest"
-// purge wanted here.
-const { recordBootLaidTables, resetTestTables } = await import("./support/drop-all-tables.js");
-await resetTestTables(await Base.leaseConnection());
-
-const { loadAdapterSpecificSchema } = await import("./support/load-schema-helper.js");
-await loadAdapterSpecificSchema(await Base.leaseConnection());
 
 await recordBootLaidTables(await Base.leaseConnection());
 


### PR DESCRIPTION
Rails loads the test schema through exactly one entry point,
`LoadSchemaHelper#load_schema`
(`vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21`): run
`schema.rb`, then the `<adapter>_specific_schema.rb` arm.

trails had two. `support/load-schema-helper.ts` `loadSchema()` (the template
build, the adapter clusters) was that port; `test-setup-dy.ts` — the per-worker
DB every ordinary AR test rides — laid schema.rb's mirror through
`DatabaseTasks` and then called `loadAdapterSpecificSchema` separately. That
second call was the PR #5523 fix for the arm never having reached the database
tests actually run against; it worked, but left the shape that caused it.

- `loadSchema` now takes either an adapter (lay the canonical registry on it, as
  before) or a thunk that lays the canonical half itself and returns the
  connection to run the adapter-specific arm on. `test-setup-dy.ts` passes the
  `DatabaseTasks` purge/reconstruct as that thunk, so both arms run inside the
  one function on every lane.
- `loadAdapterSpecificSchema` is no longer exported — reaching for one arm alone
  is how the two drifted apart.
- The worker-startup table assertion now covers `defaults`, the one table all
  three `<adapter>_specific_schema.rb` arms lay, so a regression fails at boot
  rather than as a per-file "relation does not exist".

Verified locally on the sqlite lane: `load-schema-helper.test.ts`,
`load-schema-helper.trails.test.ts`, `defaults.test.ts`, `drop-all-tables`,
and the eslint rule's own tests.

Closes-story: converge-per-worker-schema-load-onto-load-schema
