### PR TITLE
refactor(eslint): converge the test-infra lint scope lists onto one declaration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ import requireTableTeardown from "./eslint/require-table-teardown.mjs";
 import requireCanonicalRebuild from "./eslint/require-canonical-rebuild.mjs";
 import noRawSql from "./eslint/no-raw-sql.mjs";
 import { noRawSqlFiles, noRawSqlIgnores } from "./eslint/no-raw-sql-scope.mjs";
+import { testInfraExemptIgnores } from "./eslint/test-infra-scope.mjs";
 import noStandaloneAssociations from "./eslint/no-standalone-associations.mjs";
 import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.mjs";
 import noExplicitAnyDisable from "./eslint/no-explicit-any-disable.mjs";
@@ -469,14 +470,7 @@ export default defineConfig(
   //    test. See eslint/require-table-teardown.mjs. ──
   {
     files: ["packages/activerecord/src/**/*.test.ts"],
-    ignores: [
-      "packages/activerecord/src/test-helpers/**",
-      "packages/activerecord/src/support/**",
-      "packages/activerecord/src/fixtures.test.ts",
-      "packages/activerecord/src/naked-fixtures.test.ts",
-      "packages/activerecord/src/test-fixtures.test.ts",
-      "packages/activerecord/src/test-fixtures/**",
-    ],
+    ignores: [...testInfraExemptIgnores],
     rules: {
       "blazetrails/require-table-teardown": ["error", { rawSql: true }],
     },
@@ -506,12 +500,7 @@ export default defineConfig(
   {
     files: ["packages/activerecord/src/**/*.test.ts"],
     ignores: [
-      "packages/activerecord/src/test-helpers/**",
-      "packages/activerecord/src/support/**",
-      "packages/activerecord/src/fixtures.test.ts",
-      "packages/activerecord/src/naked-fixtures.test.ts",
-      "packages/activerecord/src/test-fixtures.test.ts",
-      "packages/activerecord/src/test-fixtures/**",
+      ...testInfraExemptIgnores,
       ...requireCanonicalRebuildExclude.privateAdapter,
       ...requireCanonicalRebuildExclude.nonExecuting,
     ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -470,7 +470,7 @@ export default defineConfig(
   //    test. See eslint/require-table-teardown.mjs. ──
   {
     files: ["packages/activerecord/src/**/*.test.ts"],
-    ignores: [...testInfraExemptIgnores],
+    ignores: testInfraExemptIgnores,
     rules: {
       "blazetrails/require-table-teardown": ["error", { rawSql: true }],
     },

--- a/eslint/no-internal-canonical-loaders.mjs
+++ b/eslint/no-internal-canonical-loaders.mjs
@@ -28,6 +28,7 @@
  */
 
 import path from "path";
+import { canonicalLoaderModules, canonicalLoaderSelfTests } from "./test-infra-scope.mjs";
 
 /** Repo-relative path under packages/; null if outside the repo tree. */
 export function repoRel(filename) {
@@ -43,11 +44,9 @@ export function repoRel(filename) {
 export const BANNED = new Set(["ensureCanonicalTables", "loadCanonicalSchema", "loadSchema"]);
 
 // Test files permitted to import the banned loaders (they test them directly).
-export const ALLOW = new Set([
-  "packages/activerecord/src/support/canonical-schema.test.ts",
-  "packages/activerecord/src/support/canonical-table-rebuild.test.ts",
-  "packages/activerecord/src/support/load-schema-helper.test.ts",
-]);
+export const ALLOW = new Set(canonicalLoaderSelfTests);
+
+const canonicalModuleRe = new RegExp(`(?:^|/)(?:${canonicalLoaderModules.join("|")})(?:\\.js)?$`);
 
 /** True when `source` resolves to one of the canonical-schema test helper modules. */
 function isCanonicalSchemaModule(source) {
@@ -58,9 +57,7 @@ function isCanonicalSchemaModule(source) {
   // `canonical-table-rebuild` is listed because `ensureCanonicalTables` moved
   // there when the schema.rb transcription split from the drop/rebuild
   // machinery; omitting it would leave the ban open under the new path.
-  return /(?:^|\/)(?:canonical-schema|canonical-table-rebuild|load-schema-helper)(?:\.js)?$/.test(
-    source,
-  );
+  return canonicalModuleRe.test(source);
 }
 
 /** @type {import("eslint").Rule.RuleModule} */

--- a/eslint/no-raw-sql-scope.mjs
+++ b/eslint/no-raw-sql-scope.mjs
@@ -9,8 +9,10 @@
  * from the globs below: rename a scoped-out file, edit exactly this file.
  */
 
+import { activerecordSrcRoot } from "./test-infra-scope.mjs";
+
 /** Root the rule and its scope globs are anchored to (repo-relative). */
-export const noRawSqlRoot = "packages/activerecord/src";
+export const noRawSqlRoot = activerecordSrcRoot;
 
 /** Files the rule applies to (repo-relative glob). */
 export const noRawSqlFiles = [`${noRawSqlRoot}/**/*.ts`];

--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -1,0 +1,55 @@
+/**
+ * Single source of truth for the activerecord test-infra lint scope.
+ *
+ * `require-table-teardown` and `require-canonical-rebuild` both exempt the same
+ * set of test-infra paths (those files exercise createTable/dropTable and the
+ * canonical loaders as the subject under test), and
+ * `no-internal-canonical-loaders` allowlists the canonical loaders' own unit
+ * tests. Those lists used to be spelled out separately in each config block and
+ * inside the rule, so any RFC-0064 test-infra file move had to touch several of
+ * them — and a miss stayed silent until CI lint ran (that is what bit PR #5395).
+ * They now all derive from the declarations below: move a test-infra file, edit
+ * exactly this file.
+ *
+ * `no-raw-sql`'s own scope lives in eslint/no-raw-sql-scope.mjs and shares the
+ * root constant from here.
+ */
+
+/** Root every scope list below is anchored to (repo-relative). */
+export const activerecordSrcRoot = "packages/activerecord/src";
+
+/**
+ * Test-infra paths exempt from the table-lifecycle rules, relative to
+ * `activerecordSrcRoot`. `fixtures.ts` / `test-fixtures.ts` are anchored as
+ * exact ported files rather than by basename — see no-raw-sql-scope.mjs.
+ */
+export const testInfraExemptGlobs = [
+  "test-helpers/**",
+  "support/**",
+  "fixtures.test.ts",
+  "naked-fixtures.test.ts",
+  "test-fixtures.test.ts",
+  "test-fixtures/**",
+];
+
+/** The same list as repo-relative globs, for flat-config `ignores`. */
+export const testInfraExemptIgnores = testInfraExemptGlobs.map(
+  (glob) => `${activerecordSrcRoot}/${glob}`,
+);
+
+/**
+ * Internal canonical-schema loader modules, by basename (they live in
+ * `support/`, which the exemption list above already scopes out wholesale).
+ * `no-internal-canonical-loaders` matches imports against these and allowlists
+ * their own unit tests.
+ */
+export const canonicalLoaderModules = [
+  "canonical-schema",
+  "canonical-table-rebuild",
+  "load-schema-helper",
+];
+
+/** Each loader module's own unit test (repo-relative), allowed to import it. */
+export const canonicalLoaderSelfTests = canonicalLoaderModules.map(
+  (name) => `${activerecordSrcRoot}/support/${name}.test.ts`,
+);

--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -23,7 +23,7 @@ export const activerecordSrcRoot = "packages/activerecord/src";
  * `activerecordSrcRoot`. `fixtures.ts` / `test-fixtures.ts` are anchored as
  * exact ported files rather than by basename — see no-raw-sql-scope.mjs.
  */
-export const testInfraExemptGlobs = [
+const testInfraExemptGlobs = [
   "test-helpers/**",
   "support/**",
   "fixtures.test.ts",

--- a/eslint/test-infra-scope.test.mjs
+++ b/eslint/test-infra-scope.test.mjs
@@ -1,3 +1,4 @@
+import { stat } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   activerecordSrcRoot,
@@ -36,6 +37,16 @@ describe("test-infra lint scope", () => {
       "canonical-table-rebuild",
       "load-schema-helper",
     ]);
+  });
+
+  // A stale entry is invisible at lint time — ESLint silently matches nothing —
+  // so an RFC 0064 file move that skipped this file would go unnoticed, which is
+  // the failure mode the single source of truth exists to prevent.
+  it("names paths that still exist", async () => {
+    for (const entry of [...testInfraExemptIgnores, ...canonicalLoaderSelfTests]) {
+      const target = entry.replace(/\/\*\*$/, "");
+      await expect(stat(target), target).resolves.toBeTruthy();
+    }
   });
 
   it("shares one root with the no-raw-sql scope", () => {

--- a/eslint/test-infra-scope.test.mjs
+++ b/eslint/test-infra-scope.test.mjs
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  activerecordSrcRoot,
+  canonicalLoaderModules,
+  canonicalLoaderSelfTests,
+  testInfraExemptIgnores,
+} from "./test-infra-scope.mjs";
+import { noRawSqlRoot } from "./no-raw-sql-scope.mjs";
+import { ALLOW } from "./no-internal-canonical-loaders.mjs";
+
+const SRC = "packages/activerecord/src";
+
+describe("test-infra lint scope", () => {
+  // Pinned to the literal lists the two config blocks and the rule carried
+  // before they were converged, so the convergence stays behaviour-preserving.
+  it("exposes the exemption globs the table-lifecycle config blocks apply", () => {
+    expect(testInfraExemptIgnores).toEqual([
+      `${SRC}/test-helpers/**`,
+      `${SRC}/support/**`,
+      `${SRC}/fixtures.test.ts`,
+      `${SRC}/naked-fixtures.test.ts`,
+      `${SRC}/test-fixtures.test.ts`,
+      `${SRC}/test-fixtures/**`,
+    ]);
+  });
+
+  it("allowlists exactly the canonical loaders' own unit tests", () => {
+    expect(canonicalLoaderSelfTests).toEqual([
+      `${SRC}/support/canonical-schema.test.ts`,
+      `${SRC}/support/canonical-table-rebuild.test.ts`,
+      `${SRC}/support/load-schema-helper.test.ts`,
+    ]);
+    expect([...ALLOW]).toEqual(canonicalLoaderSelfTests);
+    expect(canonicalLoaderModules).toEqual([
+      "canonical-schema",
+      "canonical-table-rebuild",
+      "load-schema-helper",
+    ]);
+  });
+
+  it("shares one root with the no-raw-sql scope", () => {
+    expect(activerecordSrcRoot).toBe(SRC);
+    expect(noRawSqlRoot).toBe(activerecordSrcRoot);
+  });
+});


### PR DESCRIPTION
`require-table-teardown` and `require-canonical-rebuild` each carried an
identical six-glob test-infra exemption list, and `no-internal-canonical-loaders`
hardcoded the canonical loaders' `support/` paths inside the rule. Every RFC 0064
test-infra file move had to touch all of them, and a miss stayed silent until CI
lint ran — which is what bit #5395.

`eslint/test-infra-scope.mjs` (following the `no-raw-sql-scope.mjs` pattern from
#5408) now declares the root, the exemption globs, and the canonical loader
module basenames once. Both config blocks consume `testInfraExemptIgnores`, the
loaders rule derives its `ALLOW` set and its module regex from
`canonicalLoaderModules`, and `no-raw-sql-scope`'s root is the shared constant.

`test-infra-scope.test.mjs` pins the derived lists to the literals the config and
rule carried before, and `stat()`s every path they name — a stale entry matches
nothing at lint time, so an RFC 0064 move that skipped this file would otherwise
stay invisible, which is the exact failure mode the single source of truth exists
to prevent.

Behaviour-preserving: classified all 1549 `.ts` files under
`packages/activerecord/src` with `ESLint#calculateConfigForFile` before and after
for `require-table-teardown`, `require-canonical-rebuild`, and `no-raw-sql` —
output identical.

Closes-story: converge-test-infra-lint-scope-lists
