### PR TITLE
feat(api-compare): extend the detached-JSDoc lint to scripts/

### DIFF
--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -16,7 +16,7 @@
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
 class StopLoad extends Error {}
@@ -60,7 +60,7 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
       });
 
       await expect(
-        loadSchema(async () => probe as unknown as AbstractAdapter),
+        loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
       ).rejects.toBeInstanceOf(StopLoad);
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {

--- a/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { lintFileText } from "./lint-detached-jsdoc-tags.js";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { lintFileText, listLintedFiles, main } from "./lint-detached-jsdoc-tags.js";
 
 describe("lintFileText", () => {
   it("flags a line comment between an @internal block and its declaration", () => {
@@ -94,5 +97,59 @@ describe("lintFileText", () => {
       ].join("\n"),
     );
     expect(found.map((d) => d.line)).toEqual([1, 4]);
+  });
+});
+
+describe("listLintedFiles", () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "api-detached-"));
+    const write = async (rel: string) => {
+      const abs = path.join(dir, rel);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, "");
+    };
+    await write(path.join("packages", "activerecord", "src", "base.ts"));
+    await write(path.join("packages", "activerecord", "src", "base.test.ts"));
+    await write(path.join("packages", "activerecord", "src", "dist", "base.ts"));
+    await write(path.join("packages", "arel", "no-src-dir.ts"));
+    await write(path.join("scripts", "start-worktree.ts"));
+    await write(path.join("scripts", "api-compare", "extract-ts-api.ts"));
+    await write(path.join("scripts", "api-compare", "extract-ts-api.test.ts"));
+    await write(path.join("scripts", "api-compare", "conventions.rb"));
+    await write(path.join("scripts", "api-compare", "dist", "build.ts"));
+    await write(path.join("scripts", "node_modules", "dep", "index.ts"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("adds every nested .ts under scripts to the packages population", async () => {
+    const files = await listLintedFiles(path.join(dir, "packages"), path.join(dir, "scripts"));
+    expect(files.map((f) => path.relative(dir, f))).toEqual([
+      path.join("packages", "activerecord", "src", "base.test.ts"),
+      path.join("packages", "activerecord", "src", "base.ts"),
+      path.join("scripts", "api-compare", "extract-ts-api.test.ts"),
+      path.join("scripts", "api-compare", "extract-ts-api.ts"),
+      path.join("scripts", "start-worktree.ts"),
+    ]);
+  });
+
+  it("keeps the packages population when the scripts directory does not exist", async () => {
+    const files = await listLintedFiles(path.join(dir, "packages"), path.join(dir, "missing"));
+    expect(files.map((f) => path.relative(dir, f))).toEqual([
+      path.join("packages", "activerecord", "src", "base.test.ts"),
+      path.join("packages", "activerecord", "src", "base.ts"),
+    ]);
+  });
+});
+
+describe("main", () => {
+  // Parses ~3.6k files, which lands within a few hundred ms of vitest's 5s
+  // default — the generous timeout keeps a slow machine from failing it.
+  it("passes over the committed tree", { timeout: 60_000 }, async () => {
+    expect(await main()).toBe(0);
   });
 });

--- a/scripts/api-compare/lint-detached-jsdoc-tags.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.ts
@@ -36,8 +36,11 @@
  *     is inert there too, but JSDoc on statements is legitimate prose in this
  *     tree and flagging it would be noise.
  *
- * Population: every `.ts` file under `packages/<pkg>/src`, the same set
- * `api:reasons` checks — that is exactly where a tag has api-compare meaning.
+ * Population: every `.ts` file under `packages/<pkg>/src` — the set
+ * `api:reasons` checks, where a tag has api-compare meaning — plus every `.ts`
+ * under `scripts/`, where the motivating defect actually lived (PR 5654, in
+ * `extract-ts-api.ts`). The api-compare tooling tags its own helpers
+ * `@internal`, and a detached block there misleads a reader just the same.
  * `*.test.ts` is included (a detached tag misleads a reader wherever it sits),
  * so a block quoted inside a string or template literal has to be excluded
  * explicitly; see `isCommentPosition`.
@@ -54,10 +57,24 @@ import { fileURLToPath } from "url";
 import * as ts from "typescript";
 import { ROOT_DIR } from "./config.js";
 import { listSourceFiles } from "./lint-missing-rails-call-reasons.js";
+import { COMMITTED_TS_FILES, walkTsFiles } from "./ts-file-walk.js";
 
 const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
+const SCRIPTS_DIR = path.join(ROOT_DIR, "scripts");
 const SIGNIFICANT_TAGS = new Set(["internal", "noRailsEquivalent"]);
 const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
+
+/** The files this lint reads: both trees, sorted for stable output. Both are
+ *  the committed population — `listSourceFiles` is packages-shaped
+ *  (`<packagesDir>/<pkg>/src`), so `scripts/`, which has no `<pkg>/src` layer,
+ *  is walked flat instead. */
+export async function listLintedFiles(packagesDir: string, scriptsDir: string): Promise<string[]> {
+  const [packageFiles, scriptFiles] = await Promise.all([
+    listSourceFiles(packagesDir),
+    walkTsFiles(scriptsDir, COMMITTED_TS_FILES),
+  ]);
+  return [...packageFiles, ...scriptFiles].sort();
+}
 
 export interface Detachment {
   file: string;
@@ -171,7 +188,7 @@ export function lintFileText(fileName: string, text: string): Detachment[] {
 }
 
 export async function main(): Promise<number> {
-  const files = await listSourceFiles(PACKAGES_DIR);
+  const files = await listLintedFiles(PACKAGES_DIR, SCRIPTS_DIR);
   const found: Detachment[] = [];
   for (const abs of files) {
     found.push(...lintFileText(path.relative(ROOT_DIR, abs), await fs.readFile(abs, "utf-8")));

--- a/scripts/api-compare/ts-file-walk.test.ts
+++ b/scripts/api-compare/ts-file-walk.test.ts
@@ -6,6 +6,7 @@ import {
   COMMITTED_TS_FILES,
   COMPARED_TS_FILES,
   walkPackageTsFiles,
+  walkTsFiles,
   walkTsFilesSync,
 } from "./ts-file-walk.js";
 
@@ -63,6 +64,30 @@ describe("walkTsFilesSync", () => {
 
   it("returns no files for a missing directory", () => {
     expect(walkTsFilesSync(path.join(root, "missing"), COMPARED_TS_FILES)).toEqual([]);
+  });
+});
+
+describe("walkTsFiles", () => {
+  it("lists the committed population under a flat root, pruning skipDirs", async () => {
+    expect(rel(await walkTsFiles(srcDir, COMMITTED_TS_FILES))).toEqual([
+      "model.test.ts",
+      "model.ts",
+      path.join("nested", "helper.ts"),
+      "types.d.ts",
+    ]);
+  });
+
+  it("drops tests and declarations for the compared population", async () => {
+    expect(rel(await walkTsFiles(srcDir, COMPARED_TS_FILES))).toEqual([
+      path.join("dist", "model.ts"),
+      "model.ts",
+      path.join("nested", "helper.ts"),
+      path.join("node_modules", "dep.ts"),
+    ]);
+  });
+
+  it("returns no files for a missing directory", async () => {
+    expect(await walkTsFiles(path.join(root, "missing"), COMMITTED_TS_FILES)).toEqual([]);
   });
 });
 

--- a/scripts/api-compare/ts-file-walk.ts
+++ b/scripts/api-compare/ts-file-walk.ts
@@ -61,6 +61,23 @@ export function walkTsFilesSync(
   return results;
 }
 
+/** Every file of `population` under `dir`, recursively, in `readdir` order.
+ *  The flat async counterpart to `walkTsFilesSync`, for roots with no
+ *  `<pkg>/src` layer (`api:detached` walks `scripts/` with it). A missing
+ *  directory yields no files rather than throwing. */
+export async function walkTsFiles(dir: string, population: TsFilePopulation): Promise<string[]> {
+  let names: string[];
+  try {
+    names = await fsPromises.readdir(dir, { recursive: true });
+  } catch {
+    return [];
+  }
+  return names
+    .filter((name) => population.includeFile(path.basename(name)))
+    .filter((name) => !name.split(path.sep).some((seg) => population.skipDirs.has(seg)))
+    .map((name) => path.join(dir, name));
+}
+
 /** Every file of `population` under `<packagesDir>/<pkg>/src`, sorted for
  *  stable output. Missing directories yield no files rather than throwing. */
 export async function walkPackageTsFiles(
@@ -76,19 +93,7 @@ export async function walkPackageTsFiles(
     return [];
   }
   const perPackage = await Promise.all(
-    pkgs.map(async (pkg) => {
-      const srcDir = path.join(packagesDir, pkg, "src");
-      let names: string[];
-      try {
-        names = await fsPromises.readdir(srcDir, { recursive: true });
-      } catch {
-        return [];
-      }
-      return names
-        .filter((name) => population.includeFile(path.basename(name)))
-        .filter((name) => !name.split(path.sep).some((seg) => population.skipDirs.has(seg)))
-        .map((name) => path.join(srcDir, name));
-    }),
+    pkgs.map((pkg) => walkTsFiles(path.join(packagesDir, pkg, "src"), population)),
   );
   return perPackage.flat().sort();
 }


### PR DESCRIPTION
## What

`pnpm api:detached` now also checks every `.ts` under `scripts/`.

The lint (#5668) read only `packages/<pkg>/src` — the population `api:reasons`
uses, chosen because that is where `@internal` / `@noRailsEquivalent` carry
api-compare meaning. But the defect that motivated it happened in
`scripts/api-compare/extract-ts-api.ts` (#5654: a helper inserted between
`memberVisibility`'s JSDoc block and its signature), i.e. in the one tree the
lint did not read. The api-compare tooling tags its own helpers `@internal`, and
a detached block there is just as misleading to a reader.

## How

`listSourceFiles` is packages-shaped (`<packagesDir>/<pkg>/src`) and `scripts/`
has no `<pkg>/src` layer, so it needs a flat walk.

**Rebased onto #5679**, which unified api-compare's tree-walkers into
`ts-file-walk.ts` with two named populations. That supersedes the walker
extraction this PR originally carried, so it is dropped — this PR now builds on
`ts-file-walk.ts` instead. That module exposes a sync flat walk
(`walkTsFilesSync`) and an async packages-shaped one (`walkPackageTsFiles`), but
not the quadrant `api:detached` needs: a **flat async** walk (the lint scripts
are bound by the async-fs hard rule). So this adds `walkTsFiles(dir, population)`
and folds `walkPackageTsFiles`' per-package body onto it, keeping the flat
traversal written once. `api:detached` composes its two trees via
`listLintedFiles`, both on the `COMMITTED_TS_FILES` population.

`lintFileText` is unchanged and `api:reasons` is untouched (3095 files). Same CI
step, no new job.

## Result

The extended population adds **501 files** (3095 → 3596) and finds **zero**
detachments — the `scripts/` tree is already clean, so no fixes or
registrations were needed and the gate stays green.

Tests: `walkTsFiles` gets its own coverage in `ts-file-walk.test.ts` (both
populations, `skipDirs` pruning, missing directory), and `listLintedFiles` is
covered in the lint's test (nesting under both trees, `*.test.ts` included,
`dist`/`node_modules` excluded, missing `scripts/` degrading to the packages
population). The whole-tree `main` test carries an explicit timeout — it parses
~3.6k files and now runs ~6.6s, over vitest's 5s default.

## Included fix: the uuid_default cover (#5676 regression)

This PR originally carried a one-line typecheck patch here. Investigating a PG
lane failure showed that patch was treating a symptom, so it is replaced by the
actual fix.

#5676 rerouted `load-schema-helper-uuid-default.trails.test.ts` from
`loadAdapterSpecificSchema(probe)` to `loadSchema(async () => probe)`. That is
wrong twice over:

1. `loadSchema` takes a `DatabaseAdapter`, not a factory — so the file stopped
   typechecking, breaking `tsc --build` repo-wide. husky's pre-commit is not
   diff-scoped, so this blocked **every** unrelated commit in the repo.
2. `loadSchema` also lays the whole **canonical** half. This cover is
   deliberately designed not to do that — it stubs `createTable` to capture DDL
   "without laying anything on the shared per-worker database" (its own header).
   With `createTable` intercepted, the first canonical statement referencing an
   intercepted table dies with
   `StatementInvalid: relation "1_need_quoting…" does not exist`.

Fixing only (1) leaves (2), which is what the PG lane caught. So this restores
#5673's call. `loadAdapterSpecificSchema`'s own docstring sanctions exactly this
use: *"exported for the trails-only tests that pin the arm's own content."* No
lint requires routing through `loadSchema` — #5676 only added an eslint scope
entry, which stays.

**Baselined on a real PG lane** (own compose stack, per the isolated-ports
recipe): the test fails on `origin/main` with
`TypeError: this.adapter.quoteTableName is not a function`, and passes with this
change. It was red on main independent of this PR, in both the typecheck and PG
jobs.

Closes-story: extend-detached-jsdoc-lint-to-scripts

---

## Review response

**Re: the third tree-walker note (non-blocking).** Registered as
`0080-api-compare-jsdoc-metadata/unify-api-compare-ts-tree-walkers`, and #5679
has since landed that work in full, so the story is closed as complete and this
PR is rebased onto it. For the record, the audit found **four** walkers, not
three: `lint-deps.ts` and `lint-calls.ts` each carried a private `getAllTsFiles`
byte-identical to the other, on top of the exported one in `extract-ts-api.ts`.

Correcting an earlier version of this description (and a re-review bullet) that
said the `getAllTsFiles` duplicates were still deferred — they are **not**.
Verified on current `main`: `lint-deps.ts:306` and `lint-calls.ts:81` now call
`walkTsFilesSync(pkgSrcDir, COMPARED_TS_FILES)` with the private copies deleted,
and `extract-ts-api.ts:2563` is a one-line delegation to the same primitive.
Nothing is outstanding. #5679 also preserved the committed-vs-compared
population split and the sync/async constraint the story flagged as the things
not to collapse; `walkTsFiles` in this PR fills the one quadrant it left open.
