### PR TITLE
fix(activerecord): route the uuid_default cover through loadSchema

### DIFF
--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -55,7 +55,5 @@ export const canonicalLoaderSelfTests = [
   // `load-schema-helper` has a second self-test: the trails-only guard on the
   // boot-laid table snapshot the adapter-specific arm feeds.
   `${activerecordSrcRoot}/support/load-schema-helper.trails.test.ts`,
-  // ...and a third: the cover on the PG arm's non-pgcrypto `uuid_default`
-  // branch, which drives the adapter-specific half against a probe adapter.
   `${activerecordSrcRoot}/support/load-schema-helper-uuid-default.trails.test.ts`,
 ];

--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -55,4 +55,7 @@ export const canonicalLoaderSelfTests = [
   // `load-schema-helper` has a second self-test: the trails-only guard on the
   // boot-laid table snapshot the adapter-specific arm feeds.
   `${activerecordSrcRoot}/support/load-schema-helper.trails.test.ts`,
+  // ...and a third: the cover on the PG arm's non-pgcrypto `uuid_default`
+  // branch, which drives the adapter-specific half against a probe adapter.
+  `${activerecordSrcRoot}/support/load-schema-helper-uuid-default.trails.test.ts`,
 ];

--- a/eslint/test-infra-scope.test.mjs
+++ b/eslint/test-infra-scope.test.mjs
@@ -31,6 +31,7 @@ describe("test-infra lint scope", () => {
       `${SRC}/support/canonical-table-rebuild.test.ts`,
       `${SRC}/support/load-schema-helper.test.ts`,
       `${SRC}/support/load-schema-helper.trails.test.ts`,
+      `${SRC}/support/load-schema-helper-uuid-default.trails.test.ts`,
     ]);
     expect([...ALLOW]).toEqual(canonicalLoaderSelfTests);
     expect(canonicalLoaderModules).toEqual([

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -16,7 +16,7 @@
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
+import { loadSchema } from "./load-schema-helper.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
 class StopLoad extends Error {}
@@ -59,8 +59,10 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
+      // The already-laid-canonical arm (the thunk overload), so only the
+      // adapter-specific half of `load_schema` runs against the probe.
       await expect(
-        loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
+        loadSchema(async () => probe as unknown as AbstractAdapter),
       ).rejects.toBeInstanceOf(StopLoad);
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -59,8 +59,6 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      // The already-laid-canonical arm (the thunk overload), so only the
-      // adapter-specific half of `load_schema` runs against the probe.
       await expect(
         loadSchema(async () => probe as unknown as AbstractAdapter),
       ).rejects.toBeInstanceOf(StopLoad);


### PR DESCRIPTION
`origin/main` did not type-check: #5673 added
`load-schema-helper-uuid-default.trails.test.ts` importing
`loadAdapterSpecificSchema`, while #5670 rewrote the helper so that arm is
deliberately not exported. Each branch was green on its own base; only the
merge is broken, so every PR opened against main failed Build & Type Check.

Rather than re-exporting the private arm, the test now uses the seam that
already exists for this: `loadSchema`'s thunk overload — the
canonical-half-already-laid arm (the same one
`load-schema-helper.trails.test.ts` uses). The test's probe adapter is exactly
that situation, so only the adapter-specific half runs.

The file is also added to `canonicalLoaderSelfTests` — it is a third
`load-schema-helper` self-test, and `no-internal-canonical-loaders` bans
`loadSchema` imports in test files outside that allowlist.

`pnpm build` is clean. The test itself is PG-only and skips locally; CI's pg
lane exercises it.

Closes-story: main-broken-load-adapter-specific-schema-not-exported
