### PR TITLE
fix(activerecord): export loadAdapterSpecificSchema for its trails-only cover

### DIFF
--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -545,10 +545,7 @@ export async function loadSchema(
  * The `load adapter_specific_schema_file if File.exist?(...)` arm of
  * `load_schema_helper.rb:15`, on its own. Reaching for this arm alone is
  * exactly how the two halves of `load_schema` drifted apart before — go
- * through {@link loadSchema}. The only caller outside this file is the
- * trails-only cover for the non-pgcrypto `uuid_default` branch, which has to
- * drive the adapter-specific arm against a stubbed adapter without laying the
- * canonical schema.
+ * through {@link loadSchema}.
  */
 export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -543,11 +543,14 @@ export async function loadSchema(
 
 /**
  * The `load adapter_specific_schema_file if File.exist?(...)` arm of
- * `load_schema_helper.rb:15`, on its own. Not exported: reaching for this arm
- * alone is exactly how the two halves of `load_schema` drifted apart before —
- * go through {@link loadSchema}.
+ * `load_schema_helper.rb:15`, on its own. Reaching for this arm alone is
+ * exactly how the two halves of `load_schema` drifted apart before — go
+ * through {@link loadSchema}. The only caller outside this file is the
+ * trails-only cover for the non-pgcrypto `uuid_default` branch, which has to
+ * drive the adapter-specific arm against a stubbed adapter without laying the
+ * canonical schema.
  */
-async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
+export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
   if (adapterSpecificSchema) await adapterSpecificSchema(adapter);
 }


### PR DESCRIPTION
`Virtualized DX Type Tests` is red on `main` @0498efb4:

```
packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts(19,10):
error TS2459: Module '"./load-schema-helper.js"' declares 'loadAdapterSpecificSchema'
locally, but it is not exported.
```

Two PRs merged close together and crossed: #5670 made `loadAdapterSpecificSchema`
file-local (routing everything through `loadSchema`), while #5673 added the
trails-only cover for the non-pgcrypto `uuid_default` branch, which imports that
arm directly. Neither diff conflicted, so the break only showed up on the merge
commit.

The test can't go through `loadSchema`: the `no-internal-canonical-loaders` rule
bans `loadSchema` in test files, and the plain-adapter form would lay the
canonical schema through the intercepted `createTable` before ever reaching the
PG-specific arm. So this re-exports `loadAdapterSpecificSchema` and rewrites the
JSDoc to keep the "go through `loadSchema`" guidance while naming the one caller
that legitimately needs the arm alone.

Verified: `pnpm test:types:virtualized` passes.

Closes-story: red-0498efb4
