### PR TITLE
refactor(activerecord): lay the per-worker canonical schema through loadCanonicalSchema

### DIFF
--- a/packages/activerecord/src/support/canonical-schema-stamp.ts
+++ b/packages/activerecord/src/support/canonical-schema-stamp.ts
@@ -1,0 +1,70 @@
+/**
+ * The "this database already carries this run's canonical schema" stamp.
+ *
+ * No Rails counterpart: Rails' suite is one process against one database that
+ * is loaded once. trails forks workers against cloned/slotted databases, so a
+ * worker has to decide whether the database it just claimed was already laid by
+ * this run (clear the rows and go) or has to be loaded from scratch.
+ *
+ * The stamp is the run token, written into `ar_internal_metadata`'s
+ * `schema_sha1` — the same slot `DatabaseTasks.loadSchemaCurrent` stamps a
+ * schema-file SHA1 into, and the one `schemaUpToDate` reads. A token rather
+ * than a file digest because the canonical schema is laid from the registry
+ * (`loadCanonicalSchema`), which has no file to digest: within one run every
+ * database is laid from the same registry, so "stamped by this run" *is* the
+ * up-to-date test, and across runs the token differs.
+ *
+ * The stamp is single-use by construction: `resetTestTables` drops
+ * `ar_internal_metadata` between test files, so a slot database handed to a
+ * later worker no longer reports up-to-date and takes the full purge+load path.
+ * That is what makes the fast path safe to leave the schema untouched — a
+ * database that reports up-to-date is exactly one that no test has run against.
+ *
+ * @internal Boot/template setup paths only.
+ */
+import { getEnv } from "@blazetrails/activesupport";
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { InternalMetadata } from "../internal-metadata.js";
+import { RUN_TOKEN_ENV } from "./run-token.js";
+
+function stampFor(runToken: string): string {
+  return `canonical-schema:${runToken}`;
+}
+
+/**
+ * Write the stamp onto a database whose canonical schema has just been laid.
+ * A run without a token (globalSetup disabled) stamps nothing, which leaves
+ * every worker on the full load path.
+ *
+ * @internal
+ */
+export async function stampCanonicalSchema(
+  adapter: DatabaseAdapter,
+  runToken = getEnv(RUN_TOKEN_ENV),
+): Promise<void> {
+  if (!runToken) return;
+  await new InternalMetadata(adapter).createTableAndSetFlags("test", stampFor(runToken));
+}
+
+/**
+ * Whether this database was laid by this run and no test has touched it since.
+ *
+ * @internal
+ */
+export async function canonicalSchemaUpToDate(adapter: DatabaseAdapter): Promise<boolean> {
+  const runToken = getEnv(RUN_TOKEN_ENV);
+  if (!runToken) return false;
+  const metadata = new InternalMetadata(adapter);
+  if (!(await metadata.tableExists())) return false;
+  return (await metadata.get("schema_sha1")) === stampFor(runToken);
+}
+
+/**
+ * The stamp value a database laid by `runToken` carries. Exported for the
+ * template probe (`pg-template.test.ts`), which asserts globalSetup stamped it.
+ *
+ * @internal
+ */
+export function canonicalSchemaStamp(runToken: string): string {
+  return stampFor(runToken);
+}

--- a/packages/activerecord/src/support/canonical-schema-stamp.ts
+++ b/packages/activerecord/src/support/canonical-schema-stamp.ts
@@ -14,11 +14,10 @@
  * database is laid from the same registry, so "stamped by this run" *is* the
  * up-to-date test, and across runs the token differs.
  *
- * The stamp is single-use by construction: `resetTestTables` drops
- * `ar_internal_metadata` between test files, so a slot database handed to a
- * later worker no longer reports up-to-date and takes the full purge+load path.
- * That is what makes the fast path safe to leave the schema untouched — a
- * database that reports up-to-date is exactly one that no test has run against.
+ * The stamp says the canonical tables are laid and shape-current; it says
+ * nothing about what tests have since done to the rest of the database, so the
+ * fast path still clears the rows and re-runs the adapter-specific arm (see
+ * `test-setup-dy.ts`).
  *
  * @internal Boot/template setup paths only.
  */

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -13,9 +13,10 @@
  *     diverge.
  *
  * On top of Rails' three methods it wires the resolved configurations into
- * `DatabaseTasks`, so schema load runs through the real Rails-mirrored path
- * (`loadSchema` / `reconstructFromSchema`). Rails has no equivalent because its
- * suite loads `schema.rb` directly from `cases/helper.rb`.
+ * `DatabaseTasks`, so the per-worker boot can purge this database through the
+ * real Rails-mirrored path (`DatabaseTasks.purge` / `truncateTables`) before
+ * the schema load. Rails has no equivalent because its suite loads `schema.rb`
+ * directly from `cases/helper.rb` against a database it never re-loads.
  *
  * As in `config.example.yml`, `ENV` only feeds connection *sub-settings*
  * (host/port/socket/credentials, via `config.ts`); it never

--- a/packages/activerecord/src/support/load-schema-helper.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.trails.test.ts
@@ -11,14 +11,15 @@
 import { describe, expect, it } from "vitest";
 import { Base } from "../base.js";
 import { recordBootLaidTables, resetTestTables } from "./drop-all-tables.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 
 describe("boot-laid table snapshot", () => {
   it("survives the reset for every table the adapter-specific arm lays", async () => {
     const adapter = Base.connection;
 
-    // The canonical half is already on this worker's DB, so the arm lays nothing.
-    await loadSchema(async () => adapter);
+    // The canonical half is already on this worker's DB, so only the
+    // adapter-specific arm is replayed here.
+    await loadAdapterSpecificSchema(adapter);
     const bookkeeping = new Set(["schema_migrations", "ar_internal_metadata"]);
     const laid = (await adapter.tables()).filter((name) => !bookkeeping.has(name));
     expect(laid).toContain("defaults");
@@ -33,13 +34,12 @@ describe("boot-laid table snapshot", () => {
     const adapter = Base.connection;
     await adapter.executeMutation(`CREATE TABLE leftover_boot_t (id INTEGER PRIMARY KEY)`);
 
-    // `test-setup-dy.ts`'s boot order, replayed: DatabaseTasks has laid the
-    // canonical tables (and left anything else alone), then the purge, then the
-    // adapter-specific arm, then the snapshot.
-    await loadSchema(async () => {
-      await resetTestTables(adapter);
-      return adapter;
-    });
+    // `test-setup-dy.ts`'s boot order, replayed: the database is emptied of
+    // everything that is not canonical, then the schema is laid — here only its
+    // adapter-specific arm, the canonical half already being on this worker's
+    // DB — then the snapshot.
+    await resetTestTables(adapter);
+    await loadAdapterSpecificSchema(adapter);
     await recordBootLaidTables(adapter);
 
     expect(await adapter.tables()).not.toContain("leftover_boot_t");

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -515,37 +515,31 @@ const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Pro
  *   every migration line, whereas laying the schema through the adapter prints
  *   nothing.
  *
- * Deviation — the optional canonical arm: trails lays schema.rb's mirror through
- * two mechanisms, `loadCanonicalSchema` (template build, adapter clusters) and
- * `DatabaseTasks` on a generated schema file (`test-setup-dy.ts`, which also has
- * to purge). Rails has one mechanism and needs no such seam. Taking the arm as a
- * parameter keeps both lanes inside this one function, so the two arms of
- * `load_schema` cannot be applied to one path and not the other — the bug PR
- * #5523 found. The thunk returns the connection because the `DatabaseTasks` path
- * swaps the pool underneath it (`withTemporaryPool`).
+ * Every caller — the template build, the adapter clusters, and the per-worker
+ * boot (`test-setup-dy.ts`) — lays schema.rb's mirror through the one mechanism
+ * `loadCanonicalSchema`, so this takes a connection and nothing else, as
+ * `load_schema` does. The per-worker path purges its database *before* calling
+ * in; that purge is a trails invention (Rails' single process never re-loads a
+ * database), so it lives at the call site rather than as an arm here.
  *
  * @internal Boot/template setup paths only. Test files wire the canonical schema
  * + fixtures through `fixtures({ ... })`; the
  * `blazetrails/no-internal-canonical-loaders` ESLint rule enforces that.
  */
-export async function loadSchema(
-  adapterOrCanonicalArm: DatabaseAdapter | (() => Promise<DatabaseAdapter>),
-): Promise<void> {
-  let adapter: DatabaseAdapter;
-  if (typeof adapterOrCanonicalArm === "function") {
-    adapter = await adapterOrCanonicalArm();
-  } else {
-    adapter = adapterOrCanonicalArm;
-    await loadCanonicalSchema(adapter);
-  }
+export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
+  await loadCanonicalSchema(adapter);
   await loadAdapterSpecificSchema(adapter);
 }
 
 /**
  * The `load adapter_specific_schema_file if File.exist?(...)` arm of
- * `load_schema_helper.rb:15`, on its own. Reaching for this arm alone is
- * exactly how the two halves of `load_schema` drifted apart before — go
- * through {@link loadSchema}.
+ * `load_schema_helper.rb:15`, on its own. Go through {@link loadSchema} for a
+ * schema load: reaching for this arm alone is exactly how the two halves of
+ * `load_schema` drifted apart before. It is exported for the trails-only tests
+ * that pin the arm's own content, and for the per-worker boot's fast path,
+ * which replays it against a database whose canonical half is already laid.
+ *
+ * @internal
  */
 export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];

--- a/packages/activerecord/src/support/pg-template.test.ts
+++ b/packages/activerecord/src/support/pg-template.test.ts
@@ -2,10 +2,10 @@
  * Phase 1 probe: confirms the PostgreSQL template-clone mechanism is active.
  *
  * globalSetup builds `<base>_template` once, stamps its `ar_internal_metadata`
- * with the canonical schema SHA1, then clones each advisory slot DB from it via
+ * with this run's canonical-schema token, then clones each advisory slot DB from it via
  * `CREATE DATABASE ... TEMPLATE`. The stamp is what makes every worker's
- * `reconstructFromSchema` take the fast TRUNCATE path (`schemaUpToDate`) instead
- * of a full purge+reload per test file.
+ * `canonicalSchemaUpToDate` report true for the worker that claims a slot, so
+ * its boot takes the fast TRUNCATE path instead of a full purge+reload.
  *
  * The probe targets the template DB itself (deterministic, slot-independent)
  * rather than the worker's variably-assigned slot DB.
@@ -14,9 +14,8 @@
  */
 import { describe, it, expect } from "vitest";
 import pg from "pg";
-import { generateSchemaFile } from "./schema-file-generator.js";
-import { schemaSha1 } from "../tasks/database-tasks.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
+import { canonicalSchemaStamp } from "./canonical-schema-stamp.js";
+import { RUN_TOKEN_ENV } from "./run-token.js";
 import { PG_TEMPLATE_ENV } from "./template-global-setup.js";
 import { postgresSettings, settingsUrl, withDatabase } from "./config.js";
 import { activeLane } from "./connection.js";
@@ -32,12 +31,11 @@ describe.skipIf(!pgActive)("PG template-clone (Phase 1 probe)", () => {
   });
 
   it("the template DB is stamped with the canonical schema SHA1", async () => {
-    // The SHA1 workers compute from TEST_SCHEMA must equal the value
-    // globalSetup stamped into the template — that match is exactly what
-    // `schemaUpToDate` checks, so every slot cloned from this template skips
-    // the per-file DDL and only TRUNCATEs.
-    const schemaFile = await generateSchemaFile(TEST_SCHEMA, "postgres");
-    const expectedSha1 = await schemaSha1(schemaFile);
+    // The stamp workers derive from this run's token must equal the value
+    // globalSetup wrote into the template — that match is exactly what
+    // `canonicalSchemaUpToDate` checks, so every slot cloned from this template
+    // skips the boot DDL and only TRUNCATEs.
+    const expectedSha1 = canonicalSchemaStamp(process.env[RUN_TOKEN_ENV]!);
 
     const templateDb = process.env[PG_TEMPLATE_ENV]!;
     const url = settingsUrl("postgres", withDatabase(postgresSettings(), templateDb));

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -20,10 +20,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { loadSchema } from "./load-schema-helper.js";
-import { generateSchemaFile } from "./schema-file-generator.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
-import { InternalMetadata } from "../internal-metadata.js";
-import { schemaSha1 } from "../tasks/database-tasks.js";
+import { stampCanonicalSchema } from "./canonical-schema-stamp.js";
 import {
   TEMPLATE_PATH_ENV,
   isSqliteRun,
@@ -187,13 +184,11 @@ const pgAdapter: DbTemplateAdapter = {
     try {
       await loadSchema(adapter);
       // Stamp ar_internal_metadata so every slot cloned from this template
-      // reports `schemaUpToDate` → each worker's reconstructFromSchema only
-      // TRUNCATEs (no DDL) instead of paying a full purge+reload per test
-      // file. The SHA1 must match the file workers generate from TEST_SCHEMA
-      // (generateSchemaFile + reconstructFromSchema in test-setup-dy.ts).
-      const schemaFile = await generateSchemaFile(TEST_SCHEMA, "postgres");
-      const sha1 = await schemaSha1(schemaFile);
-      await new InternalMetadata(adapter).createTableAndSetFlags("test", sha1);
+      // reports `canonicalSchemaUpToDate` → the worker that claims it only
+      // TRUNCATEs (no DDL) instead of paying a full purge+reload. The run token
+      // is passed explicitly: it is published to the environment further down,
+      // after the slot DBs exist.
+      await stampCanonicalSchema(adapter, runToken);
     } finally {
       // Teardown must not mask a build/stamp failure: if the loader threw,
       // a disconnect/terminate that also throws would replace the original

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -13,11 +13,9 @@
  * What Rails has no counterpart for is the step *before* the load: this
  * database is not freshly created, so it has to be emptied first. Which form
  * that takes is the driver gate (RFC 0002 §Design):
- *   - already laid by this run (`canonicalSchemaUpToDate`) → TRUNCATE only, no
- *     DDL. This is the PG template-clone fast path: a slot DB cloned from the
- *     stamped template carries both arms of the load already, and the stamp is
- *     gone the moment a test file's reset runs, so a database that still
- *     reports up-to-date is one no test has touched.
+ *   - already laid by this run (`canonicalSchemaUpToDate`) → TRUNCATE, skipping
+ *     the canonical DDL only. This is the PG template-clone fast path: a slot DB
+ *     cloned from the stamped template already carries the canonical half.
  *   - sqlite file → purge (per-worker isolated file; drop+create is safe — no
  *     other worker shares this file path).
  *   - PG/MySQL slot >1 (AR_PG_EXCLUSIVE_DB / AR_MYSQL_EXCLUSIVE_DB set by
@@ -45,8 +43,9 @@ const mysqlExclusive = adapter === "mysql" && !!getEnv("AR_MYSQL_EXCLUSIVE_DB");
 const ownsDatabase =
   (adapter === "sqlite" && envConfig.database !== ":memory:") || pgExclusive || mysqlExclusive;
 
-const { recordBootLaidTables, dropAllTables } = await import("./support/drop-all-tables.js");
-const { loadSchema } = await import("./support/load-schema-helper.js");
+const { recordBootLaidTables, dropAllTables, resetTestTables } =
+  await import("./support/drop-all-tables.js");
+const { loadSchema, loadAdapterSpecificSchema } = await import("./support/load-schema-helper.js");
 const { canonicalSchemaUpToDate, stampCanonicalSchema } =
   await import("./support/canonical-schema-stamp.js");
 
@@ -54,6 +53,14 @@ if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
   if (getEnv("SKIP_TEST_DATABASE_TRUNCATE") === undefined) {
     await DatabaseTasks.truncateTables(envConfig);
   }
+  // Only the canonical arm is skipped here — those tables are already laid, and
+  // now empty. The adapter-specific arm is re-run as on the full path: its
+  // tables are `force: true` throughout, and a worker recycled onto a database
+  // an earlier worker's tests ran against finds them dropped — `resetTestTables`
+  // drops every table it did not snapshot as boot-laid.
+  const conn = await Base.leaseConnection();
+  await resetTestTables(conn);
+  await loadAdapterSpecificSchema(conn);
 } else {
   // `DatabaseTasks.purge` re-establishes Base's pool on the recreated database,
   // so the connection has to be leased after it, not before.

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -1,8 +1,7 @@
 /**
  * D-Y vitest setupFile for the activerecord project: calls `ARTest.connect`'s
  * port (`support/connection.ts`) and loads the canonical fixture schema once
- * per worker through `support/load-schema-helper.ts`'s `loadSchema`, whose
- * canonical arm is `DatabaseTasks` here (this DB has to be purged first).
+ * per worker through `support/load-schema-helper.ts`'s `loadSchema`.
  *
  * The pool it opens lives for the whole worker, as Rails' does for the whole
  * process (`cases/helper.rb` calls `ARTest.connect` at load and never
@@ -11,22 +10,26 @@
  * Must run AFTER cases/helper.ts so better-sqlite3 is registered and
  * Base.establishConnection can open the pool.
  *
- * Driver gate (RFC 0002 §Design):
- *   - sqlite :memory: → loadSchema (fresh DB, no existing tables)
- *   - sqlite file → reconstructFromSchema (per-worker isolated file; purge is
- *     safe — no other worker shares this file path)
+ * What Rails has no counterpart for is the step *before* the load: this
+ * database is not freshly created, so it has to be emptied first. Which form
+ * that takes is the driver gate (RFC 0002 §Design):
+ *   - already laid by this run (`canonicalSchemaUpToDate`) → TRUNCATE only, no
+ *     DDL. This is the PG template-clone fast path: a slot DB cloned from the
+ *     stamped template carries both arms of the load already, and the stamp is
+ *     gone the moment a test file's reset runs, so a database that still
+ *     reports up-to-date is one no test has touched.
+ *   - sqlite file → purge (per-worker isolated file; drop+create is safe — no
+ *     other worker shares this file path).
  *   - PG/MySQL slot >1 (AR_PG_EXCLUSIVE_DB / AR_MYSQL_EXCLUSIVE_DB set by
- *     test-setup-worker-db.ts) → reconstructFromSchema; the worker owns its
- *     own suffixed DB (activerecord_unittest_N), so purge+load is safe.
- *   - PG/MySQL slot 1 → loadSchema (base URL unchanged; the advisory-lock
- *     bootstrap pg.Client / GET_LOCK connection lives in the same DB as the
- *     worker pool, so DROP DATABASE fails with PG error 55006 and releasing
- *     GET_LOCK would allow slot races on MySQL. The schema file uses
- *     force:"cascade" for per-table drop+recreate instead.)
+ *     test-setup-worker-db.ts) → purge; the worker owns its own suffixed DB
+ *     (activerecord_unittest_N), so drop+create is safe.
+ *   - otherwise (sqlite `:memory:`, PG/MySQL slot 1) → drop every table. The
+ *     base URL is unchanged there, and the advisory-lock bootstrap pg.Client /
+ *     GET_LOCK connection lives in the same DB as the worker pool, so DROP
+ *     DATABASE fails with PG error 55006 and releasing GET_LOCK would allow
+ *     slot races on MySQL.
  */
 import { connect } from "./support/connection.js";
-import { generateSchemaFile } from "./support/schema-file-generator.js";
-import { TEST_SCHEMA } from "./test-helpers/test-schema.js";
 import { getEnv } from "@blazetrails/activesupport";
 import { Base } from "./base.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
@@ -37,49 +40,33 @@ import "./relation.js";
 
 const { adapter, envConfig } = await connect();
 
-// Resolve `supports_expression_index?` from the live connection BEFORE
-// generating the schema file: without it the generator falls back to its
-// coarse `adapterName === "mysql"` skip and this per-worker rebuild silently
-// strips the canonical expression indexes a MySQL-8 template DB carries
-// (company_expression_index / full_name_index), diverging from schema.rb.
-const { supportsExpressionIndex } = await import("./support/schema-types.js");
-const schemaFilePath = await generateSchemaFile(
-  TEST_SCHEMA,
-  adapter,
-  await supportsExpressionIndex(await Base.leaseConnection()),
-);
-
 const pgExclusive = adapter === "postgres" && !!getEnv("AR_PG_EXCLUSIVE_DB");
 const mysqlExclusive = adapter === "mysql" && !!getEnv("AR_MYSQL_EXCLUSIVE_DB");
+const ownsDatabase =
+  (adapter === "sqlite" && envConfig.database !== ":memory:") || pgExclusive || mysqlExclusive;
 
-const { recordBootLaidTables, resetTestTables } = await import("./support/drop-all-tables.js");
+const { recordBootLaidTables, dropAllTables } = await import("./support/drop-all-tables.js");
 const { loadSchema } = await import("./support/load-schema-helper.js");
+const { canonicalSchemaUpToDate, stampCanonicalSchema } =
+  await import("./support/canonical-schema-stamp.js");
 
-// `load_schema_helper.rb:4-21`, both arms. Only the canonical arm differs from
-// the template build's: this worker's DB has to be purged/reconstructed first,
-// which Rails' single-process suite never does.
-await loadSchema(async () => {
-  if (
-    (adapter === "sqlite" && envConfig.database !== ":memory:") ||
-    pgExclusive ||
-    mysqlExclusive
-  ) {
-    await DatabaseTasks.reconstructFromSchema(envConfig, "ts", schemaFilePath);
-  } else {
-    await DatabaseTasks.loadSchema(envConfig, "ts", schemaFilePath);
+if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
+  if (getEnv("SKIP_TEST_DATABASE_TRUNCATE") === undefined) {
+    await DatabaseTasks.truncateTables(envConfig);
   }
-
-  // `DatabaseTasks.loadSchema` drop+recreates the *declared* tables (force:
-  // "cascade") on the shared PG/MySQL database; it purges nothing else, so a
-  // bespoke table a previous run left behind is still here. Drop it before the
-  // snapshot below, or it would be recorded as boot-laid and truncated for the
-  // rest of the run instead of dropped. Pre-snapshot, the reset's boot-laid set
-  // is the canonical registry, which is exactly the "keep schema.rb, drop the
-  // rest" purge wanted here.
+} else {
+  // Empty the database, then `load_schema_helper.rb:4-21`, both arms.
+  // `DatabaseTasks.purge` re-establishes Base's pool on the recreated database
+  // itself, so the connection has to be leased after it, not before.
+  if (ownsDatabase) {
+    await DatabaseTasks.purge(envConfig);
+  } else {
+    await dropAllTables(await Base.leaseConnection());
+  }
   const canonicalConn = await Base.leaseConnection();
-  await resetTestTables(canonicalConn);
-  return canonicalConn;
-});
+  await loadSchema(canonicalConn);
+  await stampCanonicalSchema(canonicalConn);
+}
 
 // Permanent worker-startup assertion: a broken arm of the load path fails here
 // rather than as a per-file "relation does not exist". `defaults` is the one

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -55,9 +55,8 @@ if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
     await DatabaseTasks.truncateTables(envConfig);
   }
 } else {
-  // Empty the database, then `load_schema_helper.rb:4-21`, both arms.
-  // `DatabaseTasks.purge` re-establishes Base's pool on the recreated database
-  // itself, so the connection has to be leased after it, not before.
+  // `DatabaseTasks.purge` re-establishes Base's pool on the recreated database,
+  // so the connection has to be leased after it, not before.
   if (ownsDatabase) {
     await DatabaseTasks.purge(envConfig);
   } else {

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -165,7 +165,8 @@ if (lane === "postgres") {
   const slot = await acquireAdvisorySlotPg();
   process.env[SLOT_ENV] = String(slot);
   // A slot above 1 means this worker owns an exclusive per-worker DB;
-  // test-setup-dy.ts uses reconstructFromSchema (purge+load) instead of loadSchema.
+  // test-setup-dy.ts purges it before the schema load instead of dropping the
+  // tables in place.
   if (slot > 1) process.env.AR_PG_EXCLUSIVE_DB = "1";
 }
 if (lane === "mysql") {


### PR DESCRIPTION
## What

`support/load-schema-helper.ts`'s `loadSchema` took an optional *canonical arm*
— a thunk `test-setup-dy.ts` passed so it could lay schema.rb's mirror through
`generateSchemaFile(TEST_SCHEMA)` + `DatabaseTasks.reconstructFromSchema`, while
the template build and the adapter clusters laid it through
`loadCanonicalSchema`. Rails
(`vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21`) has one
mechanism and needs no seam.

Now the per-worker boot empties its database first (that purge is the trails
invention, so it lives at the call site) and then calls `loadSchema(adapter)`:

- already laid by this run → TRUNCATE only,
- sqlite file / PG-MySQL exclusive slot → `DatabaseTasks.purge`,
- otherwise (sqlite `:memory:`, slot 1) → `dropAllTables`.

`loadSchema` takes a connection and nothing else, and `TEST_SCHEMA` is off the
boot path (and off the template build).

## Fix after the first CI run

The first push failed on all three lanes with `[test-setup-dy] schema load
incomplete — missing tables: defaults`, in the *later* waves of files only. Cause:
the fast path skipped the whole of `loadSchema`, including the adapter-specific
arm. `main` re-runs that arm on every boot (its `reconstructFromSchema` fast path
only replaces the canonical half), and it has to: a worker recycled onto a slot
database an earlier worker's tests ran against finds the arm's tables dropped —
`resetTestTables` drops every table it did not snapshot as boot-laid. The fast
path now truncates, runs `resetTestTables`, and replays
`loadAdapterSpecificSchema` (its tables are `force: true` throughout), which is
`main`'s exact boot invariant. Only the canonical DDL is skipped.

## The fast path

`support/canonical-schema-stamp.ts` replaces the schema-file SHA1
`schemaUpToDate` compared: the canonical registry has no file to digest, so the
stamp is this run's token, written into the same `ar_internal_metadata`
`schema_sha1` slot. globalSetup stamps the PG template, every clone carries it,
and the worker that claims a slot only truncates — the same DDL saving as
before. The stamp is single-use by construction: `resetTestTables` drops
`ar_internal_metadata` between test files, so a database that still reports
up-to-date is exactly one no test has run against. That is what makes it safe
for the fast path to leave the adapter-specific arm's tables in place.

## Also

Re-exports `loadAdapterSpecificSchema`. #5673's trails-only `uuid_default` test
imports it, and #5670/#5671 removed the export in a way that only breaks in the
merge — `pnpm typecheck` fails on `origin/main` today and passes here.

## Verification

`pnpm typecheck`; sqlite (`support/**`, `base.test.ts`,
`load-schema-helper.trails.test.ts`), PG and MySQL lanes on a private compose
stack. After the fix, an 86-file slice (`src/{a,b,c,d,f,m}*.test.ts`, enough to
recycle workers, which is what the CI failure needed) on each of the three
lanes: sqlite 80/80, PG 81/82, MySQL 82/82 files. The one PG `base.test.ts`
failure (`connection in local time`) reproduces identically on `origin/main`
(environmental).

Closes-story: converge-per-worker-canonical-arm-onto-load-canonical-schema

