### PR TITLE
refactor(api-compare): share one .ts tree-walker across api-compare scripts

### DIFF
--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -547,7 +547,7 @@ export async function loadSchema(
  * alone is exactly how the two halves of `load_schema` drifted apart before —
  * go through {@link loadSchema}.
  */
-async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
+export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
   if (adapterSpecificSchema) await adapterSpecificSchema(adapter);
 }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -29,6 +29,7 @@
 import * as ts from "typescript";
 import * as path from "path";
 import * as fs from "fs";
+import { COMPARED_TS_FILES, walkTsFilesSync } from "./ts-file-walk.js";
 import { createHash } from "node:crypto";
 import { Worker, isMainThread, parentPort, workerData } from "node:worker_threads";
 import { fileURLToPath } from "node:url";
@@ -2558,24 +2559,9 @@ function isExported(node: ts.Node): boolean {
   return hasModifier(node, ts.SyntaxKind.ExportKeyword);
 }
 
+/** The compared population: what api-compare measures against Rails. */
 export function getAllTsFiles(dir: string, excludeDirs: readonly string[] = []): string[] {
-  const results: string[] = [];
-  if (!fs.existsSync(dir)) return results;
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (excludeDirs.includes(fullPath)) continue;
-      results.push(...getAllTsFiles(fullPath, excludeDirs));
-    } else if (
-      entry.name.endsWith(".ts") &&
-      !entry.name.endsWith(".test.ts") &&
-      !entry.name.endsWith(".d.ts")
-    ) {
-      results.push(fullPath);
-    }
-  }
-  return results;
+  return walkTsFilesSync(dir, COMPARED_TS_FILES, excludeDirs);
 }
 
 // Run main() only on the main thread when invoked as a script.

--- a/scripts/api-compare/lint-calls.ts
+++ b/scripts/api-compare/lint-calls.ts
@@ -12,6 +12,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { COMPARED_TS_FILES, walkTsFilesSync } from "./ts-file-walk.js";
 import * as ts from "typescript";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { OUTPUT_DIR, packageSrcDir } from "./config.js";
@@ -77,7 +78,7 @@ type TsCallMap = Map<string, Map<string, Set<string>>>; // file -> method -> cal
 
 function analyzeTsCalls(pkgSrcDir: string): TsCallMap {
   const result: TsCallMap = new Map();
-  const allFiles = getAllTsFiles(pkgSrcDir);
+  const allFiles = walkTsFilesSync(pkgSrcDir, COMPARED_TS_FILES);
   if (allFiles.length === 0) return result;
 
   const program = ts.createProgram(allFiles, {
@@ -176,25 +177,6 @@ function getCalledMethodName(expr: ts.Expression): string | null {
     }
   }
   return null;
-}
-
-function getAllTsFiles(dir: string): string[] {
-  const results: string[] = [];
-  if (!fs.existsSync(dir)) return results;
-  const walk = (d: string) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (
-        entry.name.endsWith(".ts") &&
-        !entry.name.endsWith(".test.ts") &&
-        !entry.name.endsWith(".d.ts")
-      )
-        results.push(full);
-    }
-  };
-  walk(dir);
-  return results;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -12,6 +12,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { COMPARED_TS_FILES, walkTsFilesSync } from "./ts-file-walk.js";
 import { fileURLToPath } from "url";
 import * as ts from "typescript";
 import type { ApiManifest, ClassInfo } from "./types.js";
@@ -302,7 +303,7 @@ function analyzeTsDepUsage(
   dep: string,
 ): TsDepMap {
   const result: TsDepMap = new Map();
-  const allFiles = getAllTsFiles(pkgSrcDir);
+  const allFiles = walkTsFilesSync(pkgSrcDir, COMPARED_TS_FILES);
   if (allFiles.length === 0) return result;
 
   const program = ts.createProgram(allFiles, {
@@ -551,25 +552,6 @@ function isDeclarationName(id: ts.Identifier): boolean {
   if (ts.isSetAccessorDeclaration(parent) && parent.name === id) return true;
   if (ts.isTypeParameterDeclaration(parent) && parent.name === id) return true;
   return false;
-}
-
-function getAllTsFiles(dir: string): string[] {
-  const results: string[] = [];
-  if (!fs.existsSync(dir)) return results;
-  const walk = (d: string) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (
-        entry.name.endsWith(".ts") &&
-        !entry.name.endsWith(".test.ts") &&
-        !entry.name.endsWith(".d.ts")
-      )
-        results.push(full);
-    }
-  };
-  walk(dir);
-  return results;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/api-compare/lint-missing-rails-call-reasons.ts
+++ b/scripts/api-compare/lint-missing-rails-call-reasons.ts
@@ -27,8 +27,9 @@ const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
 const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
 
 /** Every `.ts` file under `<packagesDir>/<pkg>/src`, sorted for stable output.
- *  Includes `*.test.ts` (unlike the extractor's `getAllTsFiles`): the contract
- *  is about what is committed, not about what api-compare measures. */
+ *  The committed population — `*.test.ts` counts, unlike the extractor's
+ *  compared population: the contract is about what is committed, not about
+ *  what api-compare measures. */
 export async function listSourceFiles(packagesDir: string): Promise<string[]> {
   return walkPackageTsFiles(packagesDir, COMMITTED_TS_FILES);
 }

--- a/scripts/api-compare/lint-missing-rails-call-reasons.ts
+++ b/scripts/api-compare/lint-missing-rails-call-reasons.ts
@@ -21,39 +21,16 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { ROOT_DIR } from "./config.js";
 import { TAG, parseJsdoc } from "./build.js";
+import { COMMITTED_TS_FILES, walkPackageTsFiles } from "./ts-file-walk.js";
 
 const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
-const SKIP_DIRS = new Set(["node_modules", "dist"]);
 const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
 
 /** Every `.ts` file under `<packagesDir>/<pkg>/src`, sorted for stable output.
  *  Includes `*.test.ts` (unlike the extractor's `getAllTsFiles`): the contract
  *  is about what is committed, not about what api-compare measures. */
 export async function listSourceFiles(packagesDir: string): Promise<string[]> {
-  let pkgs: string[];
-  try {
-    pkgs = (await fs.readdir(packagesDir, { withFileTypes: true }))
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
-  } catch {
-    return [];
-  }
-  const perPackage = await Promise.all(
-    pkgs.map(async (pkg) => {
-      const srcDir = path.join(packagesDir, pkg, "src");
-      let names: string[];
-      try {
-        names = await fs.readdir(srcDir, { recursive: true });
-      } catch {
-        return [];
-      }
-      return names
-        .filter((name) => name.endsWith(".ts"))
-        .filter((name) => !name.split(path.sep).some((seg) => SKIP_DIRS.has(seg)))
-        .map((name) => path.join(srcDir, name));
-    }),
-  );
-  return perPackage.flat().sort();
+  return walkPackageTsFiles(packagesDir, COMMITTED_TS_FILES);
 }
 
 /** Run `parseJsdoc`'s empty-reason check over one file's JSDoc blocks, and

--- a/scripts/api-compare/ts-file-walk.test.ts
+++ b/scripts/api-compare/ts-file-walk.test.ts
@@ -1,0 +1,91 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  COMMITTED_TS_FILES,
+  COMPARED_TS_FILES,
+  walkPackageTsFiles,
+  walkTsFilesSync,
+} from "./ts-file-walk.js";
+
+let root: string;
+let srcDir: string;
+
+beforeAll(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "ts-file-walk-"));
+  srcDir = path.join(root, "packages", "pkg", "src");
+  await fs.mkdir(path.join(srcDir, "nested"), { recursive: true });
+  await fs.mkdir(path.join(srcDir, "dist"), { recursive: true });
+  await fs.mkdir(path.join(srcDir, "node_modules"), { recursive: true });
+  for (const rel of [
+    "model.ts",
+    "model.test.ts",
+    "types.d.ts",
+    "notes.md",
+    "nested/helper.ts",
+    "dist/model.ts",
+    "node_modules/dep.ts",
+  ]) {
+    await fs.writeFile(path.join(srcDir, rel), "");
+  }
+});
+
+afterAll(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+const rel = (files: string[]) => files.map((f) => path.relative(srcDir, f)).sort();
+
+describe("walkTsFilesSync", () => {
+  it("returns only non-test, non-declaration files for the compared population", () => {
+    expect(rel(walkTsFilesSync(srcDir, COMPARED_TS_FILES))).toEqual([
+      path.join("dist", "model.ts"),
+      "model.ts",
+      path.join("nested", "helper.ts"),
+      path.join("node_modules", "dep.ts"),
+    ]);
+  });
+
+  it("prunes full-path excludeDirs", () => {
+    expect(
+      rel(walkTsFilesSync(srcDir, COMPARED_TS_FILES, [path.join(srcDir, "nested")])),
+    ).not.toContain(path.join("nested", "helper.ts"));
+  });
+
+  it("prunes the population's skipDirs by name", () => {
+    const files = rel(walkTsFilesSync(srcDir, COMMITTED_TS_FILES));
+    expect(files).toContain("model.test.ts");
+    expect(files).toContain("types.d.ts");
+    expect(files).not.toContain(path.join("dist", "model.ts"));
+    expect(files).not.toContain(path.join("node_modules", "dep.ts"));
+  });
+
+  it("returns no files for a missing directory", () => {
+    expect(walkTsFilesSync(path.join(root, "missing"), COMPARED_TS_FILES)).toEqual([]);
+  });
+});
+
+describe("walkPackageTsFiles", () => {
+  it("lists the committed population under each package's src, sorted", async () => {
+    expect(rel(await walkPackageTsFiles(path.join(root, "packages"), COMMITTED_TS_FILES))).toEqual([
+      "model.test.ts",
+      "model.ts",
+      path.join("nested", "helper.ts"),
+      "types.d.ts",
+    ]);
+  });
+
+  it("drops tests and declarations for the compared population", async () => {
+    expect(rel(await walkPackageTsFiles(path.join(root, "packages"), COMPARED_TS_FILES))).toEqual([
+      path.join("dist", "model.ts"),
+      "model.ts",
+      path.join("nested", "helper.ts"),
+      path.join("node_modules", "dep.ts"),
+    ]);
+  });
+
+  it("returns no files for a missing packages directory", async () => {
+    expect(await walkPackageTsFiles(path.join(root, "missing"), COMMITTED_TS_FILES)).toEqual([]);
+  });
+});

--- a/scripts/api-compare/ts-file-walk.ts
+++ b/scripts/api-compare/ts-file-walk.ts
@@ -33,6 +33,8 @@ export const COMMITTED_TS_FILES: TsFilePopulation = {
 };
 
 export const COMPARED_TS_FILES: TsFilePopulation = {
+  // No name-based pruning: the extractor's callers pass the exact subtrees to
+  // skip as full-path `excludeDirs`, and its roots are package `src` dirs.
   skipDirs: new Set(),
   includeFile: (name) =>
     name.endsWith(".ts") && !name.endsWith(".test.ts") && !name.endsWith(".d.ts"),

--- a/scripts/api-compare/ts-file-walk.ts
+++ b/scripts/api-compare/ts-file-walk.ts
@@ -1,0 +1,92 @@
+/**
+ * The `.ts` tree-walking primitive shared by api-compare's scripts.
+ *
+ * There are two deliberate populations, and they are not interchangeable:
+ *
+ * - `COMMITTED_TS_FILES` — what is *committed* under `packages/<pkg>/src`.
+ *   The JSDoc lints (`api:reasons`, `api:detached`) police source text, so
+ *   `*.test.ts` and `*.d.ts` count, and only build/vendor output is skipped.
+ * - `COMPARED_TS_FILES` — what api-compare *measures against Rails*. Tests and
+ *   declaration files are not part of the ported surface, so they are out.
+ *
+ * The sync/async split below is a constraint, not an oversight: the lints must
+ * use async fs, while the extractor walks from synchronous code paths
+ * (including worker threads).
+ *
+ * Hard rules: no node:* imports, no process.* references.
+ */
+
+import * as fs from "fs";
+import * as fsPromises from "fs/promises";
+import * as path from "path";
+
+export interface TsFilePopulation {
+  /** Directory *names* pruned during traversal, at any depth. */
+  readonly skipDirs: ReadonlySet<string>;
+  /** Whether a file's basename belongs to this population. */
+  readonly includeFile: (name: string) => boolean;
+}
+
+export const COMMITTED_TS_FILES: TsFilePopulation = {
+  skipDirs: new Set(["node_modules", "dist"]),
+  includeFile: (name) => name.endsWith(".ts"),
+};
+
+export const COMPARED_TS_FILES: TsFilePopulation = {
+  skipDirs: new Set(),
+  includeFile: (name) =>
+    name.endsWith(".ts") && !name.endsWith(".test.ts") && !name.endsWith(".d.ts"),
+};
+
+/** Every file of `population` under `dir`, in `readdir` order.
+ *  `excludeDirs` holds *full paths* (not names) of subtrees to prune. */
+export function walkTsFilesSync(
+  dir: string,
+  population: TsFilePopulation,
+  excludeDirs: readonly string[] = [],
+): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (excludeDirs.includes(fullPath) || population.skipDirs.has(entry.name)) continue;
+      results.push(...walkTsFilesSync(fullPath, population, excludeDirs));
+    } else if (population.includeFile(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/** Every file of `population` under `<packagesDir>/<pkg>/src`, sorted for
+ *  stable output. Missing directories yield no files rather than throwing. */
+export async function walkPackageTsFiles(
+  packagesDir: string,
+  population: TsFilePopulation,
+): Promise<string[]> {
+  let pkgs: string[];
+  try {
+    pkgs = (await fsPromises.readdir(packagesDir, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+  const perPackage = await Promise.all(
+    pkgs.map(async (pkg) => {
+      const srcDir = path.join(packagesDir, pkg, "src");
+      let names: string[];
+      try {
+        names = await fsPromises.readdir(srcDir, { recursive: true });
+      } catch {
+        return [];
+      }
+      return names
+        .filter((name) => population.includeFile(path.basename(name)))
+        .filter((name) => !name.split(path.sep).some((seg) => population.skipDirs.has(seg)))
+        .map((name) => path.join(srcDir, name));
+    }),
+  );
+  return perPackage.flat().sort();
+}


### PR DESCRIPTION
Four independent `.ts` tree-walkers lived in `scripts/api-compare/`. This
collapses them onto one primitive with two named populations.

- New `ts-file-walk.ts` exports `walkTsFilesSync` (extractor/lint call paths)
  and `walkPackageTsFiles` (async, for the JSDoc lints), plus the two
  populations: `COMMITTED_TS_FILES` (what is committed — `*.test.ts` and
  `*.d.ts` count, `node_modules`/`dist` pruned) and `COMPARED_TS_FILES` (what
  api-compare measures against Rails — tests and declarations out).
- `lint-deps.ts` and `lint-calls.ts` no longer carry byte-identical private
  `getAllTsFiles` copies.
- `extract-ts-api.ts`'s exported `getAllTsFiles` stays as the compared-population
  wrapper, so its callers and the `excludeDirs` full-path semantics are unchanged.
- `listSourceFiles` delegates to the async walker; the async-fs hard rule is
  preserved in the lint scripts.

Behaviour-preserving: filters, traversal order, missing-directory handling and
sorting all match the previous implementations. New tests cover both populations
for the sync and async walkers.

Also unrelated but required to commit: `loadAdapterSpecificSchema` in
`load-schema-helper.ts` was imported by its `.trails.test.ts` but not exported,
breaking `tsc --build` on `main`; added the missing `export`.

Closes-story: unify-api-compare-ts-tree-walkers