### PR TITLE
test(activerecord): give the drop-all FK-chain test real foreign keys

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -174,13 +174,21 @@ describe("dropAllTables", () => {
 
   it("drops 3-table FK chain without error", async () => {
     const int = dropAdapter.adapterName === "mysql" ? "INT" : "INTEGER";
+    // Real REFERENCES, plus rows: an empty referencing table lets sqlite drop
+    // the parent happily, so the constraint alone would leave the guard
+    // vacuous on that lane.
     await dropAdapter.executeMutation(`CREATE TABLE fk_parent (id ${int} PRIMARY KEY)`);
     await dropAdapter.executeMutation(
-      `CREATE TABLE fk_child (id ${int} PRIMARY KEY, parent_id ${int})`,
+      // Table-level FOREIGN KEY, not column-level REFERENCES: MySQL parses the
+      // inline form and then silently discards it.
+      `CREATE TABLE fk_child (id ${int} PRIMARY KEY, parent_id ${int}, FOREIGN KEY (parent_id) REFERENCES fk_parent(id))`,
     );
     await dropAdapter.executeMutation(
-      `CREATE TABLE fk_grandchild (id ${int} PRIMARY KEY, child_id ${int})`,
+      `CREATE TABLE fk_grandchild (id ${int} PRIMARY KEY, child_id ${int}, FOREIGN KEY (child_id) REFERENCES fk_child(id))`,
     );
+    await dropAdapter.executeMutation(`INSERT INTO fk_parent (id) VALUES (1)`);
+    await dropAdapter.executeMutation(`INSERT INTO fk_child (id, parent_id) VALUES (1, 1)`);
+    await dropAdapter.executeMutation(`INSERT INTO fk_grandchild (id, child_id) VALUES (1, 1)`);
     await dropAllTables(dropAdapter);
     expect(await tableCount(dropAdapter)).toBe(0);
   });

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -174,13 +174,8 @@ describe("dropAllTables", () => {
 
   it("drops 3-table FK chain without error", async () => {
     const int = dropAdapter.adapterName === "mysql" ? "INT" : "INTEGER";
-    // Real REFERENCES, plus rows: an empty referencing table lets sqlite drop
-    // the parent happily, so the constraint alone would leave the guard
-    // vacuous on that lane.
     await dropAdapter.executeMutation(`CREATE TABLE fk_parent (id ${int} PRIMARY KEY)`);
     await dropAdapter.executeMutation(
-      // Table-level FOREIGN KEY, not column-level REFERENCES: MySQL parses the
-      // inline form and then silently discards it.
       `CREATE TABLE fk_child (id ${int} PRIMARY KEY, parent_id ${int}, FOREIGN KEY (parent_id) REFERENCES fk_parent(id))`,
     );
     await dropAdapter.executeMutation(

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -50,7 +50,8 @@ function bootLaidTableNames(): ReadonlySet<string> {
  * Drops every user table/view/matview in the database. Idempotent; per-DROP
  * errors are swallowed so teardown noise never aborts the sequence.
  * PG covers all schemas in `current_schemas(false)` (not just `public`).
- * MySQL uses a pinned pool connection with `FOREIGN_KEY_CHECKS=0`.
+ * MySQL uses a pinned pool connection with `FOREIGN_KEY_CHECKS=0`; sqlite
+ * flips `PRAGMA foreign_keys` off for the sweep.
  */
 export async function dropAllTables(adapter: DatabaseAdapter): Promise<void> {
   await resetTables(adapter, "drop-all");
@@ -254,22 +255,34 @@ async function resetSqliteTables(
   bootLaid: ReadonlySet<string>,
 ): Promise<void> {
   const toTruncate: string[] = [];
-  for (const { name } of (await adapter.execute(
-    `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
-  )) as { name: string }[]) {
-    try {
-      await adapter.executeMutation(`DROP VIEW IF EXISTS "${name}"`);
-    } catch {}
-  }
-  for (const { name } of (await adapter.execute(
-    `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
-  )) as { name: string }[]) {
-    if (mode === "reset" && bootLaid.has(name)) {
-      toTruncate.push(name);
-      continue;
+  // sqlite connections boot with `PRAGMA foreign_keys = ON` (Rails'
+  // DEFAULT_PRAGMAS), so dropping a referenced table before its referencing one
+  // raises and the table survives the sweep. MySQL gets this from
+  // FOREIGN_KEY_CHECKS=0 and PG from CASCADE; sqlite needs the pragma flipped.
+  const oldForeignKeys = Object.values((await adapter.execute(`PRAGMA foreign_keys`))[0] ?? {})[0];
+  await adapter.execute(`PRAGMA foreign_keys = OFF`);
+  try {
+    for (const { name } of (await adapter.execute(
+      `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
+    )) as { name: string }[]) {
+      try {
+        await adapter.executeMutation(`DROP VIEW IF EXISTS "${name}"`);
+      } catch {}
     }
+    for (const { name } of (await adapter.execute(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
+    )) as { name: string }[]) {
+      if (mode === "reset" && bootLaid.has(name)) {
+        toTruncate.push(name);
+        continue;
+      }
+      try {
+        await adapter.executeMutation(`DROP TABLE IF EXISTS "${name}"`);
+      } catch {}
+    }
+  } finally {
     try {
-      await adapter.executeMutation(`DROP TABLE IF EXISTS "${name}"`);
+      await adapter.execute(`PRAGMA foreign_keys = ${String(oldForeignKeys ?? 1)}`);
     } catch {}
   }
   await truncateNonEmpty(adapter, toTruncate);

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -50,8 +50,8 @@ function bootLaidTableNames(): ReadonlySet<string> {
  * Drops every user table/view/matview in the database. Idempotent; per-DROP
  * errors are swallowed so teardown noise never aborts the sequence.
  * PG covers all schemas in `current_schemas(false)` (not just `public`).
- * MySQL uses a pinned pool connection with `FOREIGN_KEY_CHECKS=0`; sqlite
- * flips `PRAGMA foreign_keys` off for the sweep.
+ * MySQL uses a pinned pool connection with `FOREIGN_KEY_CHECKS=0`; sqlite goes
+ * through `disableReferentialIntegrity`.
  */
 export async function dropAllTables(adapter: DatabaseAdapter): Promise<void> {
   await resetTables(adapter, "drop-all");
@@ -255,13 +255,7 @@ async function resetSqliteTables(
   bootLaid: ReadonlySet<string>,
 ): Promise<void> {
   const toTruncate: string[] = [];
-  // sqlite connections boot with `PRAGMA foreign_keys = ON` (Rails'
-  // DEFAULT_PRAGMAS), so dropping a referenced table before its referencing one
-  // raises and the table survives the sweep. MySQL gets this from
-  // FOREIGN_KEY_CHECKS=0 and PG from CASCADE; sqlite needs the pragma flipped.
-  const oldForeignKeys = Object.values((await adapter.execute(`PRAGMA foreign_keys`))[0] ?? {})[0];
-  await adapter.execute(`PRAGMA foreign_keys = OFF`);
-  try {
+  await adapter.disableReferentialIntegrity(async () => {
     for (const { name } of (await adapter.execute(
       `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
     )) as { name: string }[]) {
@@ -280,10 +274,6 @@ async function resetSqliteTables(
         await adapter.executeMutation(`DROP TABLE IF EXISTS "${name}"`);
       } catch {}
     }
-  } finally {
-    try {
-      await adapter.execute(`PRAGMA foreign_keys = ${String(oldForeignKeys ?? 1)}`);
-    } catch {}
-  }
+  });
   await truncateNonEmpty(adapter, toTruncate);
 }


### PR DESCRIPTION
`drops 3-table FK chain without error` named the thing it protects — that
`dropAllTables` can drop a referencing table's target without erroring — but its
DDL declared plain integer columns and no foreign keys. Dropping the three in
any order succeeded on every lane, so the test passed with the FK-escape logic
removed: a no-op guard in the shape of a regression test.

## What changed

- The chain now carries table-level `FOREIGN KEY` constraints (not the inline
  column-level `REFERENCES` form — MySQL parses and then silently discards it),
  plus one row per table so sqlite's row-triggered enforcement bites too.
- `resetSqliteTables` runs its drop pass inside
  `adapter.disableReferentialIntegrity(...)`. sqlite had **no** FK escape at
  all: connections boot with `foreign_keys = ON` (Rails' DEFAULT_PRAGMAS), so
  with real constraints the sweep left referenced tables behind. PG has
  `CASCADE` and MySQL has `FOREIGN_KEY_CHECKS=0`; Rails' own answer for sqlite
  is `disable_referential_integrity`
  (`vendor/rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:255`),
  which trails already ports on the adapter — so the sweep calls that rather
  than hand-rolling a `PRAGMA foreign_keys` save/restore.

## Regression bite confirmed on all three lanes

With each lane's escape neutralized, the test fails (tables survive the sweep):

| lane | neutralized | result |
| --- | --- | --- |
| sqlite | `disableReferentialIntegrity` wrapper bypassed | fails (8 survive) |
| postgres | `DROP TABLE … CASCADE` → `DROP TABLE …` | fails (2 survive) |
| mysql | `SET FOREIGN_KEY_CHECKS=0` → `=1` | fails (2 survive) |

Unneutralized, the file passes 10/10 on sqlite, PG and MySQL locally. Tables
still ride the arunit2 pool and are cleaned up by the existing
`afterEach(provisionSecondDatabase)`; the test name is unchanged.

## Gates

- `test:compare`: 14876/22203 — unchanged vs `main` (delta 0).
- `api:compare`: 11788/17536 (67.2%) — unchanged; `src/support/**` sits outside
  both compare populations.
- No stubs; no comments added.

Closes-story: drop-all-tables-fk-chain-test-declares-no-fks
