### PR TITLE
refactor(activerecord): seed fixtures through the model's connection

### DIFF
--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -9,13 +9,15 @@ import { fixtureId, defineFixtures, defineJoinTableFixtures, isFixtureRef } from
 import { fixtures } from "./test-fixtures.js";
 import { skipGlobalResetForFile } from "./support/skip-global-reset.js";
 import { withTransactionalFixtures } from "./test-fixtures/with-transactional-fixtures.js";
-import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Author } from "./test-helpers/models/author.js";
 import { Post } from "./test-helpers/models/post.js";
 import { LiveParrot, DeadParrot } from "./test-helpers/models/parrot.js";
 import { Cucumber, Cabbage, RedCabbage } from "./test-helpers/models/vegetables.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import { leaseFixtureConnection } from "./test-fixtures/fixture-connection.js";
+import {
+  leaseFixtureConnection,
+  leaseFixtureConnectionFor,
+} from "./test-fixtures/fixture-connection.js";
 
 /**
  * Resolves an entry's model thunk to its table-bearing class, registering the
@@ -772,14 +774,10 @@ describe("fixtureRegistry seeds against TEST_SCHEMA", () => {
         } else {
           if ("addOn" in entry) await entry.addOn?.();
           const ModelClass = await resolvePrimaryModel(entry);
-          // Rails' `FixtureSet` seeds through `model_class.connection`; this
-          // loop uses `Base.adapter` because it runs under transactional
-          // fixtures pinned to that connection. arunit2 models hold their own
-          // pool, so seeding them on the primary is invisible to their reload.
-          const seedAdapter =
-            ModelClass.prototype instanceof ARUnit2Model
-              ? await ModelClass.leaseConnection()
-              : Base.adapter;
+          // Rails' `FixtureSet` seeds through the set's own
+          // `model_class.connection_pool` (`fixtures.rb:665`); a primary-database
+          // model resolves back to the pinned fixture connection.
+          const seedAdapter = await leaseFixtureConnectionFor(ModelClass, Base.adapter);
           await defineFixtures(seedAdapter, ModelClass, data);
         }
       } catch (e) {

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -480,12 +480,10 @@ function useFixtures(
   // Per-test mutable state: populated in beforeEach, cleared in afterEach.
   const store: Record<string, Record<string, unknown>> = {};
   // Whether the most recent seed ran inside an open transaction (the fixture
-  // pin). Read in afterEach — see shouldDeleteFixtureRows.
-  // Per seeding connection: fixture sets whose model lives in another database
-  // seed through that model's pool, so the flag is not global to the scope.
+  // pin), keyed by seeding connection — a set whose model lives in another
+  // database seeds through that model's pool. Read in afterEach — see
+  // shouldDeleteFixtureRows.
   const seededInTransaction = new Map<DatabaseAdapter, boolean>();
-  // The connection each set was seeded through, so teardown deletes its rows
-  // from the database they actually landed in.
   const setAdapters = new Map<string, DatabaseAdapter>();
 
   // TODO(fixtures-adoption Spike S1): seed once per worker in a global beforeAll

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -37,7 +37,10 @@ import {
   withTransactionalFixtures,
   type WithTransactionalFixturesOptions,
 } from "./test-fixtures/with-transactional-fixtures.js";
-import { leaseFixtureConnection } from "./test-fixtures/fixture-connection.js";
+import {
+  leaseFixtureConnection,
+  leaseFixtureConnectionFor,
+} from "./test-fixtures/fixture-connection.js";
 
 /**
  * A tableless fixture entry: seeds rows directly into the named table with no
@@ -478,7 +481,12 @@ function useFixtures(
   const store: Record<string, Record<string, unknown>> = {};
   // Whether the most recent seed ran inside an open transaction (the fixture
   // pin). Read in afterEach — see shouldDeleteFixtureRows.
-  let seededInTransaction = false;
+  // Per seeding connection: fixture sets whose model lives in another database
+  // seed through that model's pool, so the flag is not global to the scope.
+  const seededInTransaction = new Map<DatabaseAdapter, boolean>();
+  // The connection each set was seeded through, so teardown deletes its rows
+  // from the database they actually landed in.
+  const setAdapters = new Map<string, DatabaseAdapter>();
 
   // TODO(fixtures-adoption Spike S1): seed once per worker in a global beforeAll
   // (before the pinned transaction opens) when transactional fixtures are
@@ -489,13 +497,16 @@ function useFixtures(
     // the (mutable-assignable) array after this call, which would otherwise seed a
     // different set than the accessors built below from `keys`.
     if (!fixtures) fixtures = await resolveFixtureNames(keys as readonly FixtureName[]);
-    const adapter = getAdapter();
+    const fixtureConnection = getAdapter();
     // Prepare every set (in declaration order, so a later set's ref() resolves
-    // ids a prior set registered), then insert them all through ONE
-    // insertFixturesSet — one referential-integrity toggle per load, mirroring
-    // Rails' fixtures.rb `insert` merging table_rows into one insert_fixtures_set.
-    const prepared: PreparedFixtureSet[] = [];
-    const preparedKeys: string[] = [];
+    // ids a prior set registered), then insert each connection's sets through
+    // ONE insertFixturesSet — one referential-integrity toggle per load per
+    // connection, mirroring Rails' fixtures.rb `insert`, which groups the sets
+    // by `model_class.connection_pool` and merges each group's table_rows into
+    // a single insert_fixtures_set.
+    const groups = new Map<DatabaseAdapter, { prepared: PreparedFixtureSet[]; keys: string[] }>();
+    seededInTransaction.clear();
+    setAdapters.clear();
     for (const [key, { table, model, data }] of Object.entries(fixtures)) {
       // Auto-register the (object-map) model, mirroring the by-name path's
       // `resolveFixtureNames` (fixtures-register-model-on-resolution, #4348):
@@ -507,31 +518,41 @@ function useFixtures(
       if (model !== null && "_isActiveRecordBase" in model) {
         registerModel(model);
       }
-      prepared.push(
+      const adapter = await leaseFixtureConnectionFor(model, fixtureConnection);
+      setAdapters.set(key, adapter);
+      let group = groups.get(adapter);
+      if (group === undefined) {
+        group = { prepared: [], keys: [] };
+        groups.set(adapter, group);
+      }
+      group.prepared.push(
         model === null
           ? await prepareJoinTableFixtures(adapter, table, data)
           : await prepareModelFixtures(adapter, model, data),
       );
-      preparedKeys.push(key);
+      group.keys.push(key);
     }
-    const results = await insertPreparedFixtureSets(adapter, prepared);
-    seededInTransaction = adapter.openTransactions > 0;
-    results.forEach((result, i) => {
-      store[preparedKeys[i]] = result;
-    });
+    for (const [adapter, group] of groups) {
+      const results = await insertPreparedFixtureSets(adapter, group.prepared);
+      seededInTransaction.set(adapter, adapter.openTransactions > 0);
+      results.forEach((result, i) => {
+        store[group.keys[i]] = result;
+      });
+    }
   });
 
   afterEach(async () => {
     if (!fixtures) return;
-    const adapter = getAdapter();
-    if (shouldDeleteFixtureRows(adapter, seededInTransaction)) {
-      // Delete in reverse insertion order to respect FK constraints.
-      for (const { table } of Object.values(fixtures).reverse()) {
-        try {
-          await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
-        } catch (e) {
-          if (!isTableMissingError(e)) throw e;
-        }
+    const fixtureConnection = getAdapter();
+    // Delete in reverse insertion order to respect FK constraints, each set
+    // through the connection it was seeded on.
+    for (const [key, { table }] of Object.entries(fixtures).reverse()) {
+      const adapter = setAdapters.get(key) ?? fixtureConnection;
+      if (!shouldDeleteFixtureRows(adapter, seededInTransaction.get(adapter) ?? false)) continue;
+      try {
+        await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
+      } catch (e) {
+        if (!isTableMissingError(e)) throw e;
       }
     }
     for (const key of Object.keys(store)) {

--- a/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
@@ -14,7 +14,8 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "../base.js";
 import { ActiveRecord } from "../ar-config.js";
-import { leaseFixtureConnection } from "./fixture-connection.js";
+import { leaseFixtureConnection, leaseFixtureConnectionFor } from "./fixture-connection.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 describe("fixture connection source", () => {
   afterEach(() => {
@@ -44,5 +45,35 @@ describe("fixture connection source", () => {
     } finally {
       Base._adapter = previous;
     }
+  });
+});
+
+describe("per-set fixture connection", () => {
+  const fixtureConnection = { marker: "pinned-fixture-connection" } as unknown as DatabaseAdapter;
+
+  it("seeds a model-less (join-table) set through the fixture connection", async () => {
+    expect(await leaseFixtureConnectionFor(null, fixtureConnection)).toBe(fixtureConnection);
+  });
+
+  it("seeds a primary-database model through the pinned fixture connection", async () => {
+    const pinned = leaseFixtureConnection();
+
+    expect(await leaseFixtureConnectionFor(Base, pinned)).toBe(pinned);
+  });
+
+  it("seeds a model whose pool differs through that model's own pool", async () => {
+    const secondary = { marker: "arunit2-connection" } as unknown as DatabaseAdapter;
+    const pool = { leaseConnection: async () => secondary };
+    const model = { connectionPool: () => pool };
+    const primary = leaseFixtureConnection();
+
+    expect(await leaseFixtureConnectionFor(model, primary)).toBe(secondary);
+  });
+
+  it("keeps a caller-supplied pool-less adapter for every set", async () => {
+    const pool = { leaseConnection: async () => ({}) as DatabaseAdapter };
+    const model = { connectionPool: () => pool };
+
+    expect(await leaseFixtureConnectionFor(model, fixtureConnection)).toBe(fixtureConnection);
   });
 });

--- a/packages/activerecord/src/test-fixtures/fixture-connection.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.ts
@@ -1,5 +1,6 @@
 import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { realPool, type ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 
 /**
  * The connection the fixture machinery seeds and pins through.
@@ -29,4 +30,48 @@ export function leaseFixtureConnection(): DatabaseAdapter {
   const pool = Base.connectionPool();
   if (pool.isPermanentLease()) return pool.leaseConnectionSync();
   return pool.activeConnection!;
+}
+
+/**
+ * The pool a fixture set's model seeds through, or `null` when the set has no
+ * model (join-table/tableless sets), the model is one of the lightweight
+ * `{ tableName, ... }` stubs some infra tests pass, or it has no pool
+ * established (a directly-assigned `Model.adapter`, whose `connectionPool()`
+ * throws).
+ */
+function modelFixturePool(model: unknown): ConnectionPool | null {
+  const host = model as { connectionPool?: () => ConnectionPool } | null;
+  if (host === null || typeof host.connectionPool !== "function") return null;
+  try {
+    return realPool(host.connectionPool()) as ConnectionPool | null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The connection one fixture set seeds through — Rails' `FixtureSet.insert`
+ * groups the sets by `fixture_set.model_class.connection_pool` and inserts each
+ * group through `pool.with_connection` (`fixtures.rb:665-684`), falling back to
+ * the caller's pool for model-less sets.
+ *
+ * `fixtureConnection` is that fallback here. It is also what a primary-database
+ * model must resolve back to: transactional fixtures pinned its pool, so Rails'
+ * `with_connection` inside the pin hands back the very same pinned connection.
+ * Leasing again from an identical pool would be a fresh checkout outside the
+ * pin, and its writes would survive the per-test rollback. Only a model whose
+ * pool is a *different* one — the arunit2 secondary — seeds elsewhere, which is
+ * exactly the case where seeding on the primary is invisible to the model's own
+ * reload. A caller-supplied raw adapter (no pool of its own) always wins: the
+ * suite owns that adapter and never meant fixtures to reach a pool.
+ */
+export async function leaseFixtureConnectionFor(
+  model: unknown,
+  fixtureConnection: DatabaseAdapter,
+): Promise<DatabaseAdapter> {
+  const modelPool = modelFixturePool(model);
+  if (modelPool === null) return fixtureConnection;
+  const fixturePool = realPool(fixtureConnection.pool) as ConnectionPool | null;
+  if (fixturePool === null || fixturePool === modelPool) return fixtureConnection;
+  return await modelPool.leaseConnection();
 }


### PR DESCRIPTION
Rails' `FixtureSet.insert` groups fixture sets by
`fixture_set.model_class.connection_pool` and inserts each group through
`pool.with_connection` (`fixtures.rb:665-684`). trails seeded every set through
the scope's single fixture connection, which forced an
`instanceof ARUnit2Model` special case in the registry seed loop
(`test-fixtures.test.ts`, "every registered entry seeds without error").

`leaseFixtureConnectionFor` (`test-fixtures/fixture-connection.ts`) now resolves
the connection from the set's model:

- model-less (join-table/tableless) sets → the caller's fixture connection, as
  Rails falls back to the passed-in pool;
- a model whose pool **is** the fixture connection's pool (every primary-database
  model) → that same pinned connection, because transactional fixtures pinned it
  and `with_connection` inside the pin hands back the pin. Leasing again would be
  a checkout outside the pin whose writes escape the per-test rollback;
- a model on a **different** pool (arunit2) → `pool.leaseConnection()`;
- a caller-supplied pool-less raw adapter → always wins; the suite owns it.

`useFixtures` groups its prepared sets by resolved connection and issues one
`insertFixturesSet` per group (Rails' per-pool merge), tracks the
seeded-in-transaction flag per connection, and deletes each set's rows in
teardown through the connection it was seeded on.

Verified locally (sqlite): `test-fixtures.test.ts` (54), `fixture-connection.test.ts`
(7, incl. 4 new for the helper), `fixtures.test.ts`, `naked-fixtures.test.ts`,
`multiple-db.test.ts`, `associations.test.ts` — all pass.

Closes-story: fixture-seeding-should-use-model-connection
