### PR TITLE
fix(test-compare): read supports_X? polarity in a pure conjunction

### DIFF
--- a/scripts/test-compare/extract-ruby-gates.test.ts
+++ b/scripts/test-compare/extract-ruby-gates.test.ts
@@ -210,6 +210,27 @@ describe("Ruby extractor gate detection", () => {
     });
   });
 
+  it("separates the polarities of two conjoined feature predicates", () => {
+    const g = rubyGates({
+      // Mirrors insert_all_test.rb:282/403 — the only sites in the vendored suite
+      // that conjoin a positive and a negated feature. `skip unless X` runs when X
+      // holds, so this runs on adapters that DO skip-on-duplicate and do NOT
+      // support a conflict target.
+      "cases/insert_all_test.rb": `
+        class InsertAllTest < ActiveRecord::TestCase
+          def test_insert_all_and_upsert_all_with_composite_pk
+            skip unless supports_insert_on_duplicate_skip? && !supports_insert_conflict_target?
+          end
+        end
+      `,
+    });
+    expect(g["insert all and upsert all with composite pk"]).toEqual({
+      features: ["insert_on_duplicate_skip"],
+      guards: ["no_insert_conflict_target"],
+      source: ["body-skip"],
+    });
+  });
+
   it("reads a supports_X? predicate reached through send", () => {
     const g = rubyGates({
       // Mirrors migration/foreign_key_test.rb:96 — `supports_rename_index?` is

--- a/scripts/test-compare/extract-ruby-gates.test.ts
+++ b/scripts/test-compare/extract-ruby-gates.test.ts
@@ -182,6 +182,34 @@ describe("Ruby extractor gate detection", () => {
     });
   });
 
+  it("inverts a negated feature predicate in a pure `if` conjunction", () => {
+    const g = rubyGates({
+      "cases/bar_test.rb": `
+        def test_pg_and_not_feature; end if current_adapter?(:PostgreSQLAdapter) && !supports_insert_returning?
+        def test_pg_or_not_feature; end if current_adapter?(:PostgreSQLAdapter) || !supports_insert_returning?
+        def test_unless_pg_and_not_feature; end unless current_adapter?(:PostgreSQLAdapter) && !supports_insert_returning?
+      `,
+    });
+    // The adapter set survives the pure conjunction, so a polarity-blind
+    // `features: [insert_returning]` would claim "runs on PostgreSQL WHERE
+    // insert_returning IS supported" — the opposite of the truth. The negated
+    // predicate becomes a `no_` guard, the same vocabulary the `unless` path uses.
+    expect(g["pg and not feature"]).toEqual({
+      adapters: ["postgresql"],
+      guards: ["no_insert_returning"],
+      source: ["class"],
+    });
+    // `||` → run-on set is a union; the adapter set is dropped and the feature
+    // stays polarity-blind (the conservative "this capability is involved" claim).
+    expect(g["pg or not feature"]).toEqual({ features: ["insert_returning"], source: ["class"] });
+    // `unless` keeps its own handling: the whole conjunction is negated, so the
+    // feature list is inverted wholesale as before.
+    expect(g["unless pg and not feature"]).toEqual({
+      guards: ["no_insert_returning"],
+      source: ["class"],
+    });
+  });
+
   it("reads a supports_X? predicate reached through send", () => {
     const g = rubyGates({
       // Mirrors migration/foreign_key_test.rb:96 — `supports_rename_index?` is

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -606,8 +606,20 @@ class TestExtractor
   # Derive a gate from a condition under which the test RUNS. `positive` is
   # whether the body runs when the condition is true (`if` → true, `unless` → false).
   def gate_from_run_condition(cond, positive)
-    acc = { adapter_syms: [], neg_adapter_syms: [], features: [], guards: [], has_or: false }
+    acc = { adapter_syms: [], neg_adapter_syms: [], features: [], neg_features: [], guards: [],
+            has_or: false }
     scan_run_condition(cond, acc)
+
+    # A NEGATED feature predicate is only separable on the run-when-true path of a
+    # pure conjunction (`if current_adapter?(:X) && !supports_y?`): there the test
+    # runs on `X ∩ ¬y`, which the adapter set plus a `no_y` guard states exactly.
+    # Anywhere else (a `||` disjunction, or the `unless` path where the whole
+    # conjunction is negated) the run-on set isn't that intersection, so the
+    # polarity-blind lumping stays — it is the same conservative "this capability
+    # is involved" claim the comparison already relies on.
+    split_feature_polarity = positive && !acc[:has_or]
+    features = split_feature_polarity ? acc[:features] : acc[:features] + acc[:neg_features]
+    inverted_features = split_feature_polarity ? acc[:neg_features] : []
 
     adapters = acc[:adapter_syms].map { |s| ADAPTER_SYMBOL_MAP[s] }.compact.uniq
     neg_adapters = acc[:neg_adapter_syms].map { |s| ADAPTER_SYMBOL_MAP[s] }.compact.uniq
@@ -624,7 +636,7 @@ class TestExtractor
     # Restricted to pure adapter conditions: a compound like `if Trilogy &&
     # supports_x?` keeps its feature/guard gate instead — conservative, but
     # comparable, and no such compound exists in the Rails suite today.
-    if trilogy_only && positive && acc[:features].empty? && acc[:guards].empty?
+    if trilogy_only && positive && features.empty? && inverted_features.empty? && acc[:guards].empty?
       gate[:adapters] = []
     end
     # A POSITIVE adapter set isn't sound — and must be dropped — when the
@@ -643,7 +655,7 @@ class TestExtractor
     # negated-adapter branch below uses.
     mixed = !adapters.empty? &&
             (!acc[:guards].empty? ||
-             (!acc[:features].empty? && (acc[:has_or] || !positive)) ||
+             (!features.empty? && (acc[:has_or] || !positive)) ||
              (acc[:has_or] && !neg_adapters.empty?))
     if !adapters.empty? && !mixed
       gate[:adapters] = positive ? adapters : (ALL_ADAPTERS - adapters)
@@ -658,12 +670,15 @@ class TestExtractor
       base = gate[:adapters] || ALL_ADAPTERS
       gate[:adapters] = base - neg_adapters
     end
-    unless acc[:features].empty?
+    unless features.empty?
       if positive
-        gate[:features] = acc[:features].uniq
+        gate[:features] = features.uniq
       else
-        gate[:guards] = (gate[:guards] || []) + acc[:features].map { |f| "no_#{f}" }
+        gate[:guards] = (gate[:guards] || []) + features.map { |f| "no_#{f}" }
       end
+    end
+    unless inverted_features.empty?
+      gate[:guards] = (gate[:guards] || []) + inverted_features.uniq.map { |f| "no_#{f}" }
     end
     unless acc[:guards].empty?
       gate[:guards] = ((gate[:guards] || []) + acc[:guards]).uniq
@@ -673,7 +688,8 @@ class TestExtractor
 
   # Scan a condition sexp for adapter / feature / guard predicates. `negated`
   # tracks the boolean parity of `!`/`not` wrappers so a `!current_adapter?(...)`
-  # is recorded as an adapter EXCLUSION rather than an inclusion.
+  # is recorded as an adapter EXCLUSION rather than an inclusion, and a
+  # `!supports_X?` lands in `neg_features` rather than claiming the capability.
   def scan_run_condition(node, acc, negated = false)
     return unless node.is_a?(Array)
     if node[0] == :unary && (node[1] == :! || node[1] == :not)
@@ -692,7 +708,8 @@ class TestExtractor
         (negated ? acc[:neg_adapter_syms] : acc[:adapter_syms]).concat(extract_symbol_args(node))
         return
       elsif name =~ /\Asupports_.+\?\z/
-        acc[:features] << name.sub(/\Asupports_/, "").sub(/\?\z/, "")
+        bucket = negated ? acc[:neg_features] : acc[:features]
+        bucket << name.sub(/\Asupports_/, "").sub(/\?\z/, "")
         return
       elsif name == "send" || name == "public_send"
         # `@connection.send(:supports_rename_index?)` (foreign_key_test.rb) — a
@@ -702,7 +719,8 @@ class TestExtractor
         # `mysql? && !send(:supports_rename_index?)` emits an unsound adapter set.
         syms = extract_symbol_args(node).grep(/\Asupports_.+\?\z/)
         unless syms.empty?
-          syms.each { |s| acc[:features] << s.sub(/\Asupports_/, "").sub(/\?\z/, "") }
+          bucket = negated ? acc[:neg_features] : acc[:features]
+          syms.each { |s| bucket << s.sub(/\Asupports_/, "").sub(/\?\z/, "") }
           return
         end
       elsif name == "prepared_statements" || name == "prepared_statements?"

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -610,16 +610,16 @@ class TestExtractor
             has_or: false }
     scan_run_condition(cond, acc)
 
-    # A NEGATED feature predicate is only separable on the run-when-true path of a
+    # A NEGATED feature predicate only decomposes on the run-when-true path of a
     # pure conjunction (`if current_adapter?(:X) && !supports_y?`): there the test
-    # runs on `X ∩ ¬y`, which the adapter set plus a `no_y` guard states exactly.
-    # Anywhere else (a `||` disjunction, or the `unless` path where the whole
-    # conjunction is negated) the run-on set isn't that intersection, so the
-    # polarity-blind lumping stays — it is the same conservative "this capability
-    # is involved" claim the comparison already relies on.
-    split_feature_polarity = positive && !acc[:has_or]
-    features = split_feature_polarity ? acc[:features] : acc[:features] + acc[:neg_features]
-    inverted_features = split_feature_polarity ? acc[:neg_features] : []
+    # runs on `X ∩ ¬y`, which a surviving adapter set plus a `no_y` guard states
+    # exactly — while lumping `y` into `:features` would claim the OPPOSITE
+    # capability alongside that adapter set. Elsewhere the run-on set isn't that
+    # intersection, so the polarity-blind lumping stays.
+    split = positive && !acc[:has_or]
+    features = split ? acc[:features] : acc[:features] + acc[:neg_features]
+    inverted_features = split ? acc[:neg_features] : []
+    any_feature = !features.empty? || !inverted_features.empty?
 
     adapters = acc[:adapter_syms].map { |s| ADAPTER_SYMBOL_MAP[s] }.compact.uniq
     neg_adapters = acc[:neg_adapter_syms].map { |s| ADAPTER_SYMBOL_MAP[s] }.compact.uniq
@@ -636,7 +636,7 @@ class TestExtractor
     # Restricted to pure adapter conditions: a compound like `if Trilogy &&
     # supports_x?` keeps its feature/guard gate instead — conservative, but
     # comparable, and no such compound exists in the Rails suite today.
-    if trilogy_only && positive && features.empty? && inverted_features.empty? && acc[:guards].empty?
+    if trilogy_only && positive && !any_feature && acc[:guards].empty?
       gate[:adapters] = []
     end
     # A POSITIVE adapter set isn't sound — and must be dropped — when the
@@ -655,7 +655,7 @@ class TestExtractor
     # negated-adapter branch below uses.
     mixed = !adapters.empty? &&
             (!acc[:guards].empty? ||
-             (!features.empty? && (acc[:has_or] || !positive)) ||
+             (any_feature && (acc[:has_or] || !positive)) ||
              (acc[:has_or] && !neg_adapters.empty?))
     if !adapters.empty? && !mixed
       gate[:adapters] = positive ? adapters : (ALL_ADAPTERS - adapters)

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -187,6 +187,23 @@ describe("gates.ts pure helpers", () => {
     });
   });
 
+  it("separates the polarities of two conjoined feature predicates", () => {
+    // The TS twin of insert_all_test.rb:282 (`skip unless
+    // supports_insert_on_duplicate_skip? && !supports_insert_conflict_target?`),
+    // as insert-all.test.ts writes it: an `itIfSupports` wrapper carrying the
+    // positive feature plus a `.skipIf` carrying the negated one. Under `skipIf`
+    // the run condition is the negation, so the conflict target is run-NEGATED.
+    expect(
+      mergeGate(gateFromWrapper("itIfSupports", "insert_on_duplicate_skip") ?? undefined, {
+        ...gateFromGuardExpr('adapterSupports("insert_conflict_target")', false),
+      }),
+    ).toEqual({
+      features: ["insert_on_duplicate_skip"],
+      guards: ["no_insert_conflict_target"],
+      source: ["test", "wrapper"],
+    });
+  });
+
   it("combines an adapterType term and feature predicates in one compound guard", () => {
     // De-Morgan'd skip form of Rails `if supports_insert_returning? &&
     // !current_adapter?(:SQLite3Adapter)` → adapters [mysql,postgresql] + feature.

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -116,19 +116,23 @@ describe("gates.ts pure helpers", () => {
     });
   });
 
-  it("extracts adapterSupports() feature predicates polarity-blind", () => {
-    // skipIf(!adapterSupports("insert_returning")) → feature gate
+  it("extracts adapterSupports() feature predicates at run-condition polarity", () => {
+    // skipIf(!adapterSupports("insert_returning")) → runs where the feature IS
+    // supported → feature gate.
     expect(gateFromGuardExpr('!adapterSupports("insert_returning")', false)).toEqual({
       features: ["insert_returning"],
       source: ["test"],
     });
     // Positive form, no `!` (skipIf(adapterSupports("x")) — runs where the
-    // feature is absent) collects the same feature: polarity is not inspected.
+    // feature is ABSENT). The run condition is `!adapterSupports("x")`, so this
+    // is a `no_` guard, exactly what Ruby's `skip if supports_x?` emits. (It used
+    // to collect `features: [x]`, inverting the claim against the Rails side.)
     expect(gateFromGuardExpr('adapterSupports("insert_conflict_target")', false)).toEqual({
-      features: ["insert_conflict_target"],
+      guards: ["no_insert_conflict_target"],
       source: ["test"],
     });
-    // Negation is ignored (mirrors Ruby `skip unless a? && !b?` listing both):
+    // Both terms run-positive (mirrors Ruby `skip unless a? && !b?` — under
+    // `skipIf` the `||` De-Morgans into a conjunction, so each `!` cancels):
     // multiple calls in one compound expression union into the feature set.
     expect(
       gateFromGuardExpr(
@@ -137,6 +141,48 @@ describe("gates.ts pure helpers", () => {
       ),
     ).toEqual({
       features: ["insert_conflict_target", "partial_index"],
+      source: ["test"],
+    });
+  });
+
+  it("inverts a negated feature predicate in a pure run-when-true conjunction", () => {
+    // `runIf(adapterType === "postgresql" && !adapterSupports("insert_returning"))`
+    // is the TS twin of Rails' `if current_adapter?(:PostgreSQLAdapter) &&
+    // !supports_insert_returning?`. The adapter set survives (the conjunction is
+    // pure), so lumping the feature in polarity-blind would emit "runs on
+    // postgresql WHERE insert_returning is supported" — the exact opposite claim.
+    // It becomes a `no_` guard instead, matching the Ruby extractor.
+    expect(
+      gateFromGuardExpr(
+        'adapterType === "postgresql" && !adapterSupports("insert_returning")',
+        true,
+      ),
+    ).toEqual({
+      adapters: ["postgresql"],
+      guards: ["no_insert_returning"],
+      source: ["test"],
+    });
+    // A POSITIVE feature in the same shape is unchanged — the intersection
+    // `postgresql ∩ insert_returning?` is exactly what the two dimensions state.
+    expect(
+      gateFromGuardExpr(
+        'adapterType === "postgresql" && adapterSupports("insert_returning")',
+        true,
+      ),
+    ).toEqual({
+      adapters: ["postgresql"],
+      features: ["insert_returning"],
+      source: ["test"],
+    });
+    // Disjunctive run condition → polarity-blind lumping stays (the run-on set is
+    // a union no adapter/feature pair captures; the adapter set is dropped).
+    expect(
+      gateFromGuardExpr(
+        'adapterType === "postgresql" || !adapterSupports("insert_returning")',
+        true,
+      ),
+    ).toEqual({
+      features: ["insert_returning"],
       source: ["test"],
     });
   });

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -147,6 +147,9 @@ export function gateFromWrapper(name: string, featureArg?: string | null): TestG
  *     so the adapter set and the feature set are BOTH sound and emitted — the
  *     intersection is exactly what runs. Mirrors Ruby keeping a positive
  *     `adapter_syms` set alongside a feature in a pure `&&` condition.
+ *   - A feature's own polarity is read the same way: while the run condition is a
+ *     pure conjunction, a run-NEGATED predicate becomes a `no_<feature>` guard
+ *     instead of an inverted `features` entry (see below).
  *   - A `mariadb` GUARD is different: it is a runtime predicate neither side can
  *     evaluate statically, so a positive adapter set mixed with one is dropped
  *     rather than over-claiming a partial restriction (Ruby does the same).
@@ -182,26 +185,29 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
     }
   }
 
-  // `adapterSupports("feature")` calls — the TS analog of Rails' `supports_X?`
-  // feature predicates.
-  //
-  // Polarity is read at RUN-CONDITION level: the run condition is `expr` under
-  // `runIf` and `!expr` under `skipIf`, so a term's effective negation is its
-  // textual `!` flipped by the form. While the run condition is a pure
-  // CONJUNCTION each term's polarity stands on its own, and a run-negated
-  // feature becomes a `no_<feature>` guard — Rails' own vocabulary from the
-  // `unless` path, which `gate_from_run_condition` emits for the same shapes.
-  // That is what keeps the two extractors in lockstep on
-  // `if current_adapter?(:X) && !supports_y?` (and its De-Morgan'd skip twin):
-  // the adapter set survives the pure conjunction, so lumping the negated
-  // predicate into `features` would state the exact OPPOSITE capability
-  // alongside it.
-  //
-  // When the run condition is a DISJUNCTION the terms no longer decompose, and
-  // the collection stays polarity-blind — the conservative "this capability is
-  // involved" claim the comparison has always relied on, matching the Ruby
-  // extractor listing every `supports_X?` it finds regardless of negation.
+  // The TS twin of the Ruby extractor's `has_or`. The run condition is `expr`
+  // for `runIf` and `!expr` for `skipIf`, so the operator that makes the run-on
+  // set a DISJUNCTION differs by form: `||` under `runIf`, and (by De Morgan)
+  // `&&` under `skipIf`. Deliberately coarse and textual, like
+  // `scan_run_condition`, which sets `has_or` for a `||` anywhere in the
+  // condition sexp rather than only at the top level.
   const runIsDisjunctive = runsWhenTrue ? text.includes("||") : text.includes("&&");
+
+  // `adapterSupports("feature")` calls — the TS analog of Rails' `supports_X?`
+  // feature predicates. Polarity is read at RUN-CONDITION level, so a term's
+  // effective negation is its textual `!` flipped by the `skipIf` form.
+  //
+  // While the run condition is a pure CONJUNCTION each term stands on its own,
+  // and a run-negated feature becomes a `no_<feature>` guard — Rails' own
+  // vocabulary, which `gate_from_run_condition` emits for the same shapes. That
+  // is what keeps the extractors in lockstep on `if current_adapter?(:X) &&
+  // !supports_y?`: the adapter set survives the pure conjunction, so lumping `y`
+  // into `features` would state the OPPOSITE capability alongside it.
+  //
+  // Under a DISJUNCTION the terms no longer decompose, so collection stays
+  // polarity-blind — the conservative "this capability is involved" claim,
+  // matching Ruby listing every `supports_X?` regardless of negation.
+  const splitFeaturePolarity = !runIsDisjunctive;
   const featureTerms = [
     ...text.matchAll(/(!\s*)?adapterSupports\(\s*["']([a-z0-9_]+)["']\s*\)/g),
   ].map((m) => {
@@ -209,26 +215,17 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
     return { negated: runsWhenTrue ? negatedInText : !negatedInText, name: m[2] };
   });
   const featureMatches = featureTerms
-    .filter((t) => !(!runIsDisjunctive && t.negated))
+    .filter((t) => !splitFeaturePolarity || !t.negated)
     .map((t) => t.name);
-  const invertedFeatures = runIsDisjunctive
-    ? []
-    : featureTerms.filter((t) => t.negated).map((t) => `no_${t.name}`);
+  const invertedFeatures = splitFeaturePolarity
+    ? featureTerms.filter((t) => t.negated).map((t) => `no_${t.name}`)
+    : [];
 
   // `isMariaDb` (test-helper boolean) / `isMariadb()` (adapter method) — the
   // TS analogs of Rails' `mariadb?` predicate, which the Ruby extractor records
   // as a `mariadb` guard. Polarity-blind, like the feature predicates above.
   const guards: string[] = [];
   if (/isMaria[Dd]b\b/.test(text)) guards.push("mariadb");
-
-  // The TS twin of the Ruby extractor's `has_or`. The run condition is `expr`
-  // for `runIf` and `!expr` for `skipIf`, so the operator that makes the run-on
-  // set a DISJUNCTION differs by form: `||` under `runIf`, and (by De Morgan)
-  // `&&` under `skipIf`. Deliberately coarse and textual, like
-  // `scan_run_condition`, which sets `has_or` for a `||` anywhere in the
-  // condition sexp rather than only at the top level.
-  //
-  // (`runIsDisjunctive` is computed above, next to the feature terms that need it.)
 
   // The `mixed` rule (see the docstring): a POSITIVE adapter set is dropped when
   // the compound carries a non-comparable guard, and — since the set is only
@@ -246,10 +243,9 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   const gate: TestGate = { source: ["test"] };
   if (adapters && !mixed) gate.adapters = adapters;
   if (featureMatches.length) gate.features = sortedUnique(featureMatches);
-  // `invertedFeatures` is deliberately kept out of `guards` above: `guards` is the
-  // non-comparable-runtime-predicate bucket that DROPS a positive adapter set via
-  // `mixed`, and a `no_<feature>` term must not do that — the adapter set is sound
-  // precisely because the conjunction is pure.
+  // `invertedFeatures` merges in only here: `guards` is the bucket `mixed` reads
+  // to DROP a positive adapter set, and a `no_<feature>` must not do that — the
+  // adapter set is sound precisely because the conjunction is pure.
   const allGuards = [...guards, ...invertedFeatures];
   if (allGuards.length) gate.guards = sortedUnique(allGuards);
   if (!gate.adapters && !gate.features && !gate.guards) gate.guards = ["unknown"];

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -183,14 +183,37 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   }
 
   // `adapterSupports("feature")` calls — the TS analog of Rails' `supports_X?`
-  // feature predicates. Collected polarity-blind (any `!`/`||` negation is
-  // ignored), exactly as the Ruby extractor's `scan_run_condition` lists every
-  // `supports_X?` it finds in the run condition regardless of negation. This
-  // lets `it.skipIf(!adapterSupports("a") || adapterSupports("b"))(...)` carry
-  // the same feature set Rails derives from `skip unless a? && !b?`.
-  const featureMatches = [...text.matchAll(/adapterSupports\(\s*["']([a-z0-9_]+)["']\s*\)/g)].map(
-    (m) => m[1],
-  );
+  // feature predicates.
+  //
+  // Polarity is read at RUN-CONDITION level: the run condition is `expr` under
+  // `runIf` and `!expr` under `skipIf`, so a term's effective negation is its
+  // textual `!` flipped by the form. While the run condition is a pure
+  // CONJUNCTION each term's polarity stands on its own, and a run-negated
+  // feature becomes a `no_<feature>` guard — Rails' own vocabulary from the
+  // `unless` path, which `gate_from_run_condition` emits for the same shapes.
+  // That is what keeps the two extractors in lockstep on
+  // `if current_adapter?(:X) && !supports_y?` (and its De-Morgan'd skip twin):
+  // the adapter set survives the pure conjunction, so lumping the negated
+  // predicate into `features` would state the exact OPPOSITE capability
+  // alongside it.
+  //
+  // When the run condition is a DISJUNCTION the terms no longer decompose, and
+  // the collection stays polarity-blind — the conservative "this capability is
+  // involved" claim the comparison has always relied on, matching the Ruby
+  // extractor listing every `supports_X?` it finds regardless of negation.
+  const runIsDisjunctive = runsWhenTrue ? text.includes("||") : text.includes("&&");
+  const featureTerms = [
+    ...text.matchAll(/(!\s*)?adapterSupports\(\s*["']([a-z0-9_]+)["']\s*\)/g),
+  ].map((m) => {
+    const negatedInText = Boolean(m[1]);
+    return { negated: runsWhenTrue ? negatedInText : !negatedInText, name: m[2] };
+  });
+  const featureMatches = featureTerms
+    .filter((t) => !(!runIsDisjunctive && t.negated))
+    .map((t) => t.name);
+  const invertedFeatures = runIsDisjunctive
+    ? []
+    : featureTerms.filter((t) => t.negated).map((t) => `no_${t.name}`);
 
   // `isMariaDb` (test-helper boolean) / `isMariadb()` (adapter method) — the
   // TS analogs of Rails' `mariadb?` predicate, which the Ruby extractor records
@@ -204,7 +227,8 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   // `&&` under `skipIf`. Deliberately coarse and textual, like
   // `scan_run_condition`, which sets `has_or` for a `||` anywhere in the
   // condition sexp rather than only at the top level.
-  const runIsDisjunctive = runsWhenTrue ? text.includes("||") : text.includes("&&");
+  //
+  // (`runIsDisjunctive` is computed above, next to the feature terms that need it.)
 
   // The `mixed` rule (see the docstring): a POSITIVE adapter set is dropped when
   // the compound carries a non-comparable guard, and — since the set is only
@@ -222,7 +246,12 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   const gate: TestGate = { source: ["test"] };
   if (adapters && !mixed) gate.adapters = adapters;
   if (featureMatches.length) gate.features = sortedUnique(featureMatches);
-  if (guards.length) gate.guards = guards;
+  // `invertedFeatures` is deliberately kept out of `guards` above: `guards` is the
+  // non-comparable-runtime-predicate bucket that DROPS a positive adapter set via
+  // `mixed`, and a `no_<feature>` term must not do that — the adapter set is sound
+  // precisely because the conjunction is pure.
+  const allGuards = [...guards, ...invertedFeatures];
+  if (allGuards.length) gate.guards = sortedUnique(allGuards);
   if (!gate.adapters && !gate.features && !gate.guards) gate.guards = ["unknown"];
   return gate;
 }


### PR DESCRIPTION
Both gate extractors recorded `supports_X?` / `adapterSupports("x")` predicates polarity-blind. That was harmless while a positive adapter set was dropped next to any feature, but PR #5602 made the adapter set survive a pure conjunction — so the two dimensions are now emitted together and a NEGATED feature inverts the claim:

```ruby
if current_adapter?(:PostgreSQLAdapter) && !supports_insert_returning?
```

extracted `adapters=[postgresql] features=[insert_returning]` — "runs on PostgreSQL where insert_returning IS supported", the exact opposite of the truth. `gateFromGuardExpr` was blind in the same way.

## Rule

Track feature polarity and emit Rails' own `no_<feature>` guard vocabulary — the one `gate_from_run_condition` already produces on the `unless` path — for a run-negated predicate, but only while the run condition is a pure conjunction. That is the only shape where the terms decompose: the adapter set survives, so an inverted `features` entry would sit next to it and state the opposite capability. Under `||` the polarity-blind lumping stays (the conservative "this capability is involved" claim), as does the `unless` path's own wholesale inversion.

The TS twin reads polarity at RUN-CONDITION level (the run condition is `!expr` under `skipIf`), which additionally closes a pre-existing asymmetry the Ruby fix surfaced: `skipIf(adapterSupports("x"))` collected `features: [x]` where Ruby's equivalent `skip if supports_x?` already emitted `no_x`.

## Verification

`pnpm test:compare --gates` output is **byte-identical before and after** — gate-mismatch stays at 0. Exactly two gates move, and they move identically on both sides: `insert_all_test.rb:282/403`'s `skip unless supports_insert_on_duplicate_{skip,update}? && !supports_insert_conflict_target?` and their `insert-all.test.ts` twins.

```
features=[insert_conflict_target, insert_on_duplicate_skip]
  → features=[insert_on_duplicate_skip] guards=[no_insert_conflict_target]
```

i.e. the two sites that were actually inverted are now correct, in lockstep. A JSON diff of both extractor outputs confirms those are the only 2 of 22910 (Rails) and 2 of 30054 (TS) gates that changed.

## Coverage

New unit tests on both sides for `if current_adapter?(:X) && !supports_y?` and for the real-world two-polarity conjunction above, each asserting the `||` and `unless` shapes are left alone. The TS pin that fixed the old `skipIf(adapterSupports("x")) → features` behavior is updated deliberately, with the reason in place.

## Known residual (out of scope, zero sites)

Ruby's `unless` path still inverts its whole feature list textually, so `skip if !supports_x?` would emit `no_x` where TS emits `features: [x]`. Ruby cannot split there without being wrong in the other direction — `unless A && !B` runs on `!A || B`, a disjunction its textual `has_or` does not see. The vendored suite has no test in that shape (the only conjoined-polarity sites are the two above), and the story scopes the `unless` path out as already having its own handling.

Closes-story: gate-extractors-ignore-feature-predicate-polarity
