### PR TITLE
fix(activerecord): pin the uuid_default cover to the adapter-specific arm

### DIFF
--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -11,12 +11,15 @@
  *
  * The predicate is stubbed false on a real adapter and `createTable` is
  * intercepted, so the DDL is emitted and asserted without laying anything on
- * the shared per-worker database.
+ * the shared per-worker database. That is also why it pins
+ * `loadAdapterSpecificSchema` rather than `loadSchema`: the uuid tables live
+ * wholly inside the adapter-specific arm, and `loadSchema`'s canonical half
+ * would lay schema.rb's mirror on that database for real.
  */
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
 class StopLoad extends Error {}
@@ -59,9 +62,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
-        StopLoad,
-      );
+      await expect(
+        loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
+      ).rejects.toBeInstanceOf(StopLoad);
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(
-        loadSchema(async () => probe as unknown as AbstractAdapter),
-      ).rejects.toBeInstanceOf(StopLoad);
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
+        StopLoad,
+      );
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(


### PR DESCRIPTION
`origin/main` at `374f2670c` did not type-check:

```text
load-schema-helper-uuid-default.trails.test.ts(63,20) error TS2345:
Argument of type '() => Promise<AbstractAdapter>' is not assignable
to parameter of type 'AbstractAdapter'.
```

#5676 rewrote the uuid_default cover to call `loadSchema(async () => probe)`
while #5678 landed `loadSchema(adapter: DatabaseAdapter)`. Neither PR touched
the other's file, so both were green on their own base and the breakage existed
only in the merged result.

## The fix is not the obvious one

The deleted thunk was carrying semantics, not just a type. The pre-#5678
signature was an overload where the function form deliberately **skipped the
canonical half**:

```ts
export async function loadSchema(
  adapterOrCanonicalArm: DatabaseAdapter | (() => Promise<DatabaseAdapter>),
)
```

So simply passing the adapter type-checks but switches `loadCanonicalSchema`
back on, which tries to lay schema.rb's mirror on the shared per-worker
database through a proxy whose `createTable` is stubbed out. That is a real CI
failure, not a flake — `AssertionError: expected StatementInvalid: relation
"1_need_quotin… to be an instance of StopLoad`.

This pins `loadAdapterSpecificSchema` instead. The uuid tables
(`chat_messages`, `uuid_parents`, `uuid_children`) live wholly inside
`postgresql_specific_schema.rb`, and `load-schema-helper.ts:538` documents that
export as being for exactly this — "the trails-only tests that pin the arm's own
content". #5678 was right to remove the overload; Rails
(`vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21`) has one
mechanism and needs no seam.

Four lines added to the file header record why the cover pins the arm rather
than `loadSchema`, so the next reshaping of this seam does not undo it.

## Verification

`pnpm build` clean on the merge result. The test is `describeIfPg`, so it skips
unless `ARCONN=postgresql` is set — which is why the first push looked green
locally and failed in CI. Re-ran against a real pg17 on an isolated compose
project with `ARCONN` set: 1 passed.

api:compare / test:compare delta is non-negative by construction — the file is
`*.trails.test.ts` (outside the test:compare population) and no ported method
surface or test title changes.

Closes-story: main-broken-load-schema-thunk-vs-adapter-signature
