### PR TITLE
test(activerecord): keep the arunit2-only tables out of the primary schema

### DIFF
--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -743,9 +743,11 @@ async function main(): Promise<void> {
   // mixin wiring to first construction), so `isWrappedSchema` imports cleanly.
   let schemaColumnsByTable: SchemaColumnsByTable = {};
   if (targets.some((f) => f.startsWith(modelsDirPrefix))) {
-    const { TEST_SCHEMA } = await import("../src/test-helpers/test-schema.js");
+    const { TEST_SCHEMA, ARUNIT2_SCHEMA } = await import("../src/test-helpers/test-schema.js");
     const { isWrappedSchema } = await import("../src/support/schema-types.js");
-    schemaColumnsByTable = normalizeSchema(TEST_SCHEMA, isWrappedSchema);
+    // The arunit2-only tables live in a separate export (they are not in the
+    // primary database), but Course/College/Professor still need their columns.
+    schemaColumnsByTable = normalizeSchema({ ...TEST_SCHEMA, ...ARUNIT2_SCHEMA }, isWrappedSchema);
   }
   const associationLookup = buildModelAssociationLookup(registry);
   const globalSuperNameOf = buildGlobalSuperNameOf(registry);

--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -745,8 +745,6 @@ async function main(): Promise<void> {
   if (targets.some((f) => f.startsWith(modelsDirPrefix))) {
     const { TEST_SCHEMA, ARUNIT2_SCHEMA } = await import("../src/test-helpers/test-schema.js");
     const { isWrappedSchema } = await import("../src/support/schema-types.js");
-    // The arunit2-only tables live in a separate export (they are not in the
-    // primary database), but Course/College/Professor still need their columns.
     schemaColumnsByTable = normalizeSchema({ ...TEST_SCHEMA, ...ARUNIT2_SCHEMA }, isWrappedSchema);
   }
   const associationLookup = buildModelAssociationLookup(registry);

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -174,6 +174,14 @@ interface TableMeta {
   primaryKey?: string[];
   /** Single-column integer PK emitted inline as a serial (Rails `t.primary_key`). */
   serialPk?: string;
+  /**
+   * `schema.rb:1444-1460` creates this table through the *second* connection
+   * (`Course`/`College`/`Professor.lease_connection`), so it belongs to
+   * `arunit2` and never to the primary `arunit` database.
+   * {@link loadCanonicalSchema} skips it; `setup-second-pool.ts` lays it in
+   * arunit2 by name through `rebuildCanonicalTables`.
+   */
+  arunit2?: true;
 }
 
 /**
@@ -1761,7 +1769,10 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.bigInteger("toooooooo_long_b_id", { null: false });
   });
 
-  await define("courses", {}, (t) => {
+  // schema.rb:1444-1460 — created through the second connection
+  // (`Course`/`College`/`Professor.lease_connection`), so `arunit2: true` keeps
+  // them out of the primary database's load.
+  await define("courses", { arunit2: true }, (t) => {
     t.string("name", { null: false });
     t.integer("college_id");
     // `t.column :college_id, :integer, index: true` (schema.rb:1446); `column`
@@ -1769,15 +1780,15 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.index("college_id");
   });
 
-  await define("colleges", {}, (t) => {
+  await define("colleges", { arunit2: true }, (t) => {
     t.string("name", { null: false });
   });
 
-  await define("professors", {}, (t) => {
+  await define("professors", { arunit2: true }, (t) => {
     t.string("name", { null: false });
   });
 
-  await define("courses_professors", { id: false }, (t) => {
+  await define("courses_professors", { id: false, arunit2: true }, (t) => {
     t.integer("course_id");
     t.integer("professor_id");
   });
@@ -2093,6 +2104,9 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
  * The template DB is built once at boot, so — unlike `defineSchema` — this issues
  * no drops, no signature-cache bookkeeping, and no schema-cache warming.
  *
+ * `arunit2`-only tables are skipped: `schema.rb:1444-1460` creates them through
+ * the second connection, so Rails' primary `arunit` database never carries them.
+ *
  * @internal Plumbing for the boot/template setup paths only. Do NOT call this
  * from a `*.test.ts` file — wire the canonical schema + fixtures through the
  * `fixtures({ ... })` helper, which is the sanctioned public test surface. The
@@ -2101,6 +2115,7 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<void> {
   const { ss, typeMap } = await prepareSchema(adapter);
   for (const def of await buildCanonicalRegistry()) {
+    if (def.meta.arunit2) continue;
     await runTable(adapter, ss, typeMap, def);
   }
   // create_table/drop_table clear the connection's prepared statements in Rails;

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -1769,9 +1769,6 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.bigInteger("toooooooo_long_b_id", { null: false });
   });
 
-  // schema.rb:1444-1460 — created through the second connection
-  // (`Course`/`College`/`Professor.lease_connection`), so `arunit2: true` keeps
-  // them out of the primary database's load.
   await define("courses", { arunit2: true }, (t) => {
     t.string("name", { null: false });
     t.integer("college_id");

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -16,7 +16,7 @@
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
 class StopLoad extends Error {}
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
-        StopLoad,
-      );
+      await expect(
+        loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
+      ).rejects.toBeInstanceOf(StopLoad);
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(
-        loadSchema(async () => probe as unknown as AbstractAdapter),
-      ).rejects.toBeInstanceOf(StopLoad);
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
+        StopLoad,
+      );
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll } from "vitest";
+import { beforeAll } from "vitest";
 import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { registerModel } from "../associations.js";
@@ -64,14 +64,13 @@ export async function provisionSecondDatabase(): Promise<void> {
 /**
  * Prepares the two-database split `MultipleDbTest` asserts over. Both pools are
  * already open, so this readies only the tables: the arunit2 ones are rebuilt so
- * rows a sibling suite left behind cannot reach `College.count`, and the primary
- * copies are dropped.
+ * rows a sibling suite left behind cannot reach `College.count`, and `entrants`
+ * is rebuilt on the primary for the same reason.
  *
- * The primary copies exist because trails loads one canonical schema into the
- * primary database while Rails' `arunit` never carries these tables. Dropping
- * them is what lets `MultipleDbTest` assert that a `SELECT` on the wrong pool
- * raises; `teardownSecondPool` puts them back, because unlike Rails' second
- * database ours is shared with every sibling suite in the worker.
+ * The primary database never carries the arunit2 tables — the canonical schema
+ * skips them (`schema.rb:1444-1460` creates them through the second connection)
+ * — so there is nothing to drop here, and `MultipleDbTest`'s assertion that a
+ * `SELECT` on the wrong pool raises holds without any surgery.
  *
  * Fixture data is seeded separately via `useFixtures` in the test file.
  */
@@ -83,23 +82,8 @@ async function setupSecondPool(): Promise<void> {
   const arunit2 = await ARUnit2Model.leaseConnection();
   const primary = await Base.leaseConnection();
 
-  const ss = primary.schemaStatements();
-  await ss.dropTable("courses_professors", { ifExists: true });
-  await ss.dropTable("courses", { ifExists: true });
-  await ss.dropTable("colleges", { ifExists: true });
-  await ss.dropTable("professors", { ifExists: true });
-
   await rebuildCanonicalTables(arunit2, ARUNIT2_TABLES);
   await rebuildCanonicalTables(primary, ["entrants"]);
-}
-
-/**
- * Undoes `setupSecondPool`'s primary-database surgery: Rails' two-database
- * split dies with the process, but ours shares one primary database with every
- * sibling suite in the worker, so the dropped tables must be put back.
- */
-async function teardownSecondPool(): Promise<void> {
-  await rebuildCanonicalTables(await Base.leaseConnection(), [...ARUNIT2_TABLES, "entrants"]);
 }
 
 /**
@@ -107,5 +91,4 @@ async function teardownSecondPool(): Promise<void> {
  */
 export function withSecondPool(): void {
   beforeAll(setupSecondPool);
-  afterAll(teardownSecondPool);
 }

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -1714,27 +1714,6 @@ export const TEST_SCHEMA: Schema = {
     toooooooo_long_b_id: { type: "big_integer", null: false },
   },
 
-  // Rails declares these on alternate connections (Course/College/
-  // Professor.lease_connection). In our test suite the canonical schema
-  // loads them on the default adapter; per-connection placement is the
-  // responsibility of multi-DB tests.
-  courses: {
-    columns: {
-      name: { type: "string", null: false },
-      college_id: "integer",
-    },
-    indexes: [{ columns: "college_id" }],
-  },
-  colleges: { name: { type: "string", null: false } },
-  professors: { name: { type: "string", null: false } },
-  courses_professors: {
-    columns: {
-      course_id: "integer",
-      professor_id: "integer",
-    },
-    primaryKey: false,
-  },
-
   // to_be_linked fixtures (no corresponding model class; inline inline-map only).
   to_be_linked_accounts: {
     name: "string",
@@ -1850,6 +1829,36 @@ export const TEST_SCHEMA: Schema = {
   tenants: { tenant_id: "integer" },
   top_users: { name: "string" },
   topic2s: { title: "string" },
+};
+
+/**
+ * Mirror of `schema.rb:1444-1460` — the tables Rails creates through the
+ * *second* connection (`Course`/`College`/`Professor.lease_connection`), so they
+ * exist in `arunit2` and never in the primary `arunit` database. They are kept
+ * out of {@link TEST_SCHEMA} for that reason: `MultipleDbTest` asserts that a
+ * `SELECT` on the primary pool raises for these tables.
+ *
+ * `dogs` is deliberately absent: `schema.rb:559` puts the full-shape table in
+ * the primary database and `schema.rb:1462` a bare id-only one in arunit2, so
+ * arunit2's copy is laid by `setup-second-pool.ts` rather than from here.
+ */
+export const ARUNIT2_SCHEMA: Schema = {
+  courses: {
+    columns: {
+      name: { type: "string", null: false },
+      college_id: "integer",
+    },
+    indexes: [{ columns: "college_id" }],
+  },
+  colleges: { name: { type: "string", null: false } },
+  professors: { name: { type: "string", null: false } },
+  courses_professors: {
+    columns: {
+      course_id: "integer",
+      professor_id: "integer",
+    },
+    primaryKey: false,
+  },
 };
 
 /**


### PR DESCRIPTION
## What

`schema.rb:1444-1460` creates `colleges`/`courses`/`professors`/
`courses_professors` through the *second* connection
(`Course`/`College`/`Professor.lease_connection`), so Rails' primary `arunit`
database never carries them. trails laid one canonical schema into the primary,
so the primary carried them too — and `setupSecondPool` papered over that by
dropping the four tables from the primary for the duration of `MultipleDbTest`,
with `teardownSecondPool` putting them back. That surgery has no Rails
counterpart.

- `canonical-schema.ts`: the four `define` calls carry `arunit2: true`;
  `loadCanonicalSchema` skips them. They stay in the registry, so
  `rebuildCanonicalTables(arunit2, ARUNIT2_TABLES)` still lays them into arunit2
  by name from the one declaration site.
- `test-schema.ts`: the four entries move out of `TEST_SCHEMA` into a sibling
  `ARUNIT2_SCHEMA` export (the same shape `POSTGRESQL_SPECIFIC_SCHEMA` already
  uses for a non-primary population). `materialize-model-declares` merges both,
  so `Course`/`College`/`Professor` still get their column declares.
- `setup-second-pool.ts`: the primary drops and `teardownSecondPool` are gone.
  `MultipleDbTest`'s "exception contains correct pool" assertion now holds
  because the primary genuinely lacks the tables.

`dogs` is untouched: the full-shape table stays in the primary
(`schema.rb:559`) and `createOtherDogsTable` still lays the bare id-only one in
arunit2 (`schema.rb:1462`).

Also repairs one line in `load-schema-helper-uuid-default.trails.test.ts`:
#5676 (thunk-taking `loadSchema`) and #5678 (adapter-taking `loadSchema`) merged
against each other and left `main` failing `tsc --build`, which blocks every
commit locally.

## Testing

`multiple-db`, `base-prevent-writes`, `prepared-statement-status`,
`canonical-schema`, `canonical-table-rebuild`, `test-fixtures`,
`schema-dumper`, `drop-all-tables`, `load-schema-helper-uuid-default` — all pass.

Closes-story: arunit2-tables-should-leave-the-primary-schema


## Review follow-up

`courses_professors` is missing the two indexes Rails' `t.references :course` /
`t.references :professor` (schema.rb:1457-1460) emit by default. That predates
this PR — only the `arunit2: true` flag is new here — so it is registered as its
own story (`0064-ar-test-infra-layout-fidelity/courses-professors-references-should-carry-indexes`)
rather than widened into this diff.
