### PR TITLE
fix(activerecord): call loadAdapterSpecificSchema directly from the uuid_default cover

### DIFF
--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -16,7 +16,7 @@
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
 class StopLoad extends Error {}
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
-        StopLoad,
-      );
+      await expect(
+        loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
+      ).rejects.toBeInstanceOf(StopLoad);
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(
-        loadSchema(async () => probe as unknown as AbstractAdapter),
-      ).rejects.toBeInstanceOf(StopLoad);
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
+        StopLoad,
+      );
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(


### PR DESCRIPTION
`pnpm build` fails on main @374f2670, which fails the Guides Code Type Check job at its `pnpm build` step (and every other job that builds).

Three PRs raced on the same cover. #5673 added `load-schema-helper-uuid-default.trails.test.ts`, calling `loadAdapterSpecificSchema` directly. #5670 landed concurrently and left that arm unexported, so #5676 rewrote the cover to go through `loadSchema` with a thunk. #5677 then exported the arm after all — for exactly this cover — and #5678 changed `loadSchema` to take an adapter rather than a thunk, leaving main with `TS2345: Argument of type '() => Promise<AbstractAdapter>' is not assignable to parameter of type 'AbstractAdapter'`.

Fix: undo #5676's detour and call `loadAdapterSpecificSchema` directly again. Routing this cover through `loadSchema` is wrong on its own terms, not just a type mismatch — `loadSchema` lays the canonical half first, and the cover proxies `createTable` to capture DDL without touching the shared per-worker database, so the canonical statements reference tables that were never really laid and the test dies on `StatementInvalid: relation "1_need_quoting..." does not exist`. That is a PG-lane-only failure, invisible to the unit lane. `loadAdapterSpecificSchema`'s docstring carves out this exact exception: it "is exported for the trails-only tests that pin the arm's own content."

The `canonicalLoaderSelfTests` allowlist entry #5676 added stays — the `no-internal-canonical-loaders` ban matches the module, not the named export, so importing the arm still needs it.

Verified: `pnpm build` clean; `pnpm guides:typecheck` 17/17 blocks clean; the cover passes against a real pg17 (`ARCONN=postgresql`) and fails there without this change.

Closes-story: red-374f2670
