### PR TITLE
test(eslint): widen the canonical-loader guard scan to activerecord src

### DIFF
--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -8,7 +8,7 @@ import rule, {
   isCanonicalSchemaModule,
   moduleBasename,
 } from "./no-internal-canonical-loaders.mjs";
-import { canonicalLoaderModules } from "./test-infra-scope.mjs";
+import { activerecordSrcRoot, canonicalLoaderModules } from "./test-infra-scope.mjs";
 
 const FILENAME = "packages/activerecord/src/dirty.test.ts";
 const OWN_TEST = "packages/activerecord/src/support/canonical-schema.test.ts";
@@ -101,14 +101,19 @@ tester.run("no-internal-canonical-loaders", rule, {
   ],
 });
 
-const supportDir = path.join(
+const srcDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
-  "packages",
-  "activerecord",
-  "src",
-  "support",
+  ...activerecordSrcRoot.split("/"),
 );
+
+/**
+ * Modules outside the loader set that legitimately export a BANNED name.
+ * `model-schema.ts` is Rails' own `ActiveRecord::ModelSchema#load_schema` —
+ * unrelated to `support/load-schema-helper.ts`, and the rule already lets it
+ * through because it matches on module basename as well as symbol.
+ */
+const nonLoaderBannedExporters = new Set(["model-schema.ts"]);
 
 /** Names exported by `source`, covering the export forms used in `support/`. */
 function exportedNames(source) {
@@ -129,36 +134,39 @@ function exportedNames(source) {
 }
 
 /**
- * Walks the whole `support/` tree, not just its top level: the rule matches on
- * basename regardless of directory depth, so a loader moved into a
- * `support/<subdir>/` module is exactly the silent-reopen case being guarded.
+ * Walks the whole activerecord `src/` tree, not just `support/`: the rule
+ * matches on basename regardless of directory, so a loader relocated out of
+ * `support/` (into `test-helpers/`, say) is exactly the silent-reopen case
+ * being guarded — the same hole as `support/<subdir>/`, one level up.
  */
-async function* supportSources(dir = supportDir) {
+async function* srcSources(dir = srcDir) {
   for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name !== "node_modules" && entry.name !== "dist") yield* supportSources(full);
+      if (entry.name !== "node_modules" && entry.name !== "dist") yield* srcSources(full);
     } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
       yield full;
     }
   }
 }
 
-/** Repo-relative path → the BANNED symbols that module exports. */
-async function bannedExportsBySupportModule() {
+/** src-relative path → the BANNED symbols that module exports. */
+async function bannedExportsBySrcModule() {
   const byModule = new Map();
-  for await (const file of supportSources()) {
+  for await (const file of srcSources()) {
+    const relative = path.relative(srcDir, file);
+    if (nonLoaderBannedExporters.has(relative)) continue;
     const source = await fs.readFile(file, "utf8");
     const banned = [...exportedNames(source)].filter((name) => BANNED.has(name)).sort();
-    if (banned.length > 0) byModule.set(path.relative(supportDir, file), banned);
+    if (banned.length > 0) byModule.set(relative, banned);
   }
   return byModule;
 }
 
 describe("no-internal-canonical-loaders module matcher", () => {
-  it("matches every support/ module that exports a banned loader", async () => {
+  it("matches every activerecord module that exports a banned loader", async () => {
     const unmatched = [];
-    for (const [file, banned] of await bannedExportsBySupportModule()) {
+    for (const [file, banned] of await bannedExportsBySrcModule()) {
       if (!isCanonicalSchemaModule(`./${file.replace(/\.ts$/, ".js")}`)) {
         unmatched.push(`${file} exports ${banned.join(", ")}`);
       }
@@ -168,7 +176,7 @@ describe("no-internal-canonical-loaders module matcher", () => {
 
   it("lists no module that has stopped exporting a banned loader", async () => {
     const found = new Set(
-      [...(await bannedExportsBySupportModule()).keys()].map((file) =>
+      [...(await bannedExportsBySrcModule()).keys()].map((file) =>
         moduleBasename(file.replace(/\.ts$/, "")),
       ),
     );

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -115,7 +115,7 @@ const srcDir = path.join(
  */
 const nonLoaderBannedExporters = new Set(["model-schema.ts"]);
 
-/** Names exported by `source`, covering the export forms used in `support/`. */
+/** Names exported by `source`, covering the export forms used in activerecord. */
 function exportedNames(source) {
   const names = new Set();
   for (const [, name] of source.matchAll(
@@ -150,23 +150,32 @@ async function* srcSources(dir = srcDir) {
   }
 }
 
-/** src-relative path → the BANNED symbols that module exports. */
-async function bannedExportsBySrcModule() {
+/**
+ * src-relative path → the BANNED symbols that module exports, for every module
+ * in the tree including the non-loader exporters. Walked once and shared: the
+ * tree is ~1550 files, so each extra walk costs real time.
+ */
+const bannedExportsBySrcModule = (async () => {
   const byModule = new Map();
   for await (const file of srcSources()) {
-    const relative = path.relative(srcDir, file);
-    if (nonLoaderBannedExporters.has(relative)) continue;
     const source = await fs.readFile(file, "utf8");
     const banned = [...exportedNames(source)].filter((name) => BANNED.has(name)).sort();
-    if (banned.length > 0) byModule.set(relative, banned);
+    if (banned.length > 0) byModule.set(path.relative(srcDir, file), banned);
   }
   return byModule;
+})();
+
+/** The same map with the sanctioned non-loader exporters dropped. */
+async function loaderCandidates() {
+  return [...(await bannedExportsBySrcModule)].filter(
+    ([file]) => !nonLoaderBannedExporters.has(file),
+  );
 }
 
 describe("no-internal-canonical-loaders module matcher", () => {
   it("matches every activerecord module that exports a banned loader", async () => {
     const unmatched = [];
-    for (const [file, banned] of await bannedExportsBySrcModule()) {
+    for (const [file, banned] of await loaderCandidates()) {
       if (!isCanonicalSchemaModule(`./${file.replace(/\.ts$/, ".js")}`)) {
         unmatched.push(`${file} exports ${banned.join(", ")}`);
       }
@@ -176,10 +185,16 @@ describe("no-internal-canonical-loaders module matcher", () => {
 
   it("lists no module that has stopped exporting a banned loader", async () => {
     const found = new Set(
-      [...(await bannedExportsBySrcModule()).keys()].map((file) =>
-        moduleBasename(file.replace(/\.ts$/, "")),
-      ),
+      (await loaderCandidates()).map(([file]) => moduleBasename(file.replace(/\.ts$/, ""))),
     );
     expect(canonicalLoaderModules.filter((module) => !found.has(module))).toEqual([]);
+  });
+
+  // Without this the allowlist is a silent hole of its own: if model-schema.ts
+  // moves or stops exporting `loadSchema`, the stale entry would keep excusing
+  // a path nobody is checking.
+  it("allowlists only non-loader modules that still export a banned name", async () => {
+    const exporters = await bannedExportsBySrcModule;
+    expect([...nonLoaderBannedExporters].filter((file) => !exporters.has(file))).toEqual([]);
   });
 });

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -16,7 +16,7 @@
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
 class StopLoad extends Error {}
@@ -59,9 +59,12 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
-        StopLoad,
-      );
+      // Must call the arm directly, not loadSchema: this cover stubs
+      // createTable, so the canonical half loadSchema runs first would query
+      // tables that were never really laid (#5676 regressed exactly that).
+      await expect(
+        loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
+      ).rejects.toBeInstanceOf(StopLoad);
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(
-        loadSchema(async () => probe as unknown as AbstractAdapter),
-      ).rejects.toBeInstanceOf(StopLoad);
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
+        StopLoad,
+      );
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(


### PR DESCRIPTION
The module-matcher guard added in #5657 walked only
`packages/activerecord/src/support/`, so a loader relocated out of that tree —
most plausibly into `test-helpers/`, where the canonical models and fixtures
already live — would not be seen and the ban would reopen silently (a banned
symbol imported from an unlisted module is simply not reported). Same hole the
#5657 review caught one directory level down, one level up.

Fix: root the walk at `activerecordSrcRoot` instead of `support/`, with a
`nonLoaderBannedExporters` allowlist for `model-schema.ts` — Rails' own
`ActiveRecord::ModelSchema#load_schema`, unrelated to
`support/load-schema-helper.ts` and already let through by the rule, which
matches on module basename as well as symbol. A third case pins that allowlist:
an entry that no longer exists or no longer exports a banned name fails, so the
allowlist cannot become a silent hole of its own.

Verified against synthetic regressions (each confirmed to trip, then reverted):

- `packages/activerecord/src/test-helpers/moved-loader.ts` exporting
  `loadCanonicalSchema` → `test-helpers/moved-loader.ts exports loadCanonicalSchema`.
- a stale `gone.ts` allowlist entry → `expected [ 'gone.ts' ] to deeply equal []`.

The existing `support/`-tree cases and the converse "listed module stopped
exporting a banned loader" case keep passing.

Measured cost of the wider scan: in-test time 125ms → 287ms (1550 `.ts` files,
18M), with the tree walked once and shared across the three cases. Whole-file
wall time is unchanged at ~7–8s, dominated by vitest transform and setup.

## Also: unbreaking `load-schema-helper-uuid-default.trails.test.ts`

Included as a necessity rather than scope creep — `tsc --build` fails on `main`
here, and husky's pre-commit hook is repo-wide, so it blocks every commit.

#5676 rewrote this cover to call `loadSchema(async () => probe)`, but `loadSchema`
now takes an adapter, not a factory — hence the type error. Passing the adapter
straight through typechecked but failed the PG lane with
`StatementInvalid: relation "1_need_quoting…" does not exist`: the cover stubs
`createTable` to capture DDL *without* laying anything on the shared per-worker
database, so the canonical half `loadSchema` runs first queries tables that were
never really created.

The correct fix is the arm-direct call this file had before #5676 —
`loadAdapterSpecificSchema`, which its own docstring exports "for the trails-only
tests that pin the arm's own content". Verified green against an isolated PG 17
stack (`ARCONN=postgresql AR_DB_FORKS=2`), and a comment at the call site records
why this cover must not route through `loadSchema`.

Closes-story: canonical-loader-guard-scans-only-support-tree