### PR TITLE
test(activerecord): index courses_professors reference columns

### DIFF
--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -1788,6 +1788,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("courses_professors", { id: false, arunit2: true }, (t) => {
     t.integer("course_id");
     t.integer("professor_id");
+    t.index("course_id");
+    t.index("professor_id");
   });
 
   await define("to_be_linked_accounts", {}, (t) => {

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -1857,6 +1857,7 @@ export const ARUNIT2_SCHEMA: Schema = {
       course_id: "integer",
       professor_id: "integer",
     },
+    indexes: [{ columns: "course_id" }, { columns: "professor_id" }],
     primaryKey: false,
   },
 };


### PR DESCRIPTION
`vendor/rails/activerecord/test/schema/schema.rb:1457-1460` declares
`courses_professors` with `t.references :course` / `t.references :professor`,
and `references` defaults to `index: true`
(`schema_definitions.rb`, `ReferenceDefinition#initialize`), so Rails creates an
index on each column. trails declared neither.

Both declaration sites change together, per the two-schema-sources rule:

- `packages/activerecord/src/support/canonical-schema.ts` — two `t.index` calls,
  which take Rails' default `index_courses_professors_on_<column>` names (same
  shape as the neighbouring `courses.college_id` index).
- `packages/activerecord/src/test-helpers/test-schema.ts` — matching `indexes`
  entries on the `ARUNIT2_SCHEMA` `courses_professors` table.

Closes-story: courses-professors-references-should-carry-indexes
