### PR TITLE
refactor(test-support): store ProtectedParams parameters off the instance

### DIFF
--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -16,7 +16,7 @@
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
 class StopLoad extends Error {}
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
-        StopLoad,
-      );
+      await expect(
+        loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
+      ).rejects.toBeInstanceOf(StopLoad);
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -59,9 +59,9 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      await expect(
-        loadSchema(async () => probe as unknown as AbstractAdapter),
-      ).rejects.toBeInstanceOf(StopLoad);
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toBeInstanceOf(
+        StopLoad,
+      );
 
       for (const name of ["chat_messages", "uuid_parents", "uuid_children"]) {
         expect(emitted.get(name)).toContain(

--- a/packages/activerecord/src/support/stubs/strong-parameters.test.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.test.ts
@@ -38,9 +38,6 @@ describe("ProtectedParams", () => {
       toH: "not a method",
       first_name: "Guille",
     });
-    // The method wins over the same-named parameter on property access (and so
-    // on spread, which reads through the same path); `toH()` is how a colliding
-    // parameter is read back.
     expect(typeof params["keys"]).toBe("function");
     expect(params["first_name"]).toBe("Guille");
     expect({ ...params }.first_name).toBe("Guille");

--- a/packages/activerecord/src/support/stubs/strong-parameters.test.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.test.ts
@@ -21,6 +21,31 @@ describe("ProtectedParams", () => {
     expect(params.toH()).toEqual({ first_name: "Guille" });
   });
 
+  it("a parameter named after a method does not shadow the method", () => {
+    const params = new ProtectedParams({
+      keys: ["shadow"],
+      permitted: true,
+      toH: "not a method",
+      first_name: "Guille",
+    });
+
+    expect(params.keys()).toEqual(["keys", "permitted", "toH", "first_name"]);
+    expect(params.permitted()).toBe(false);
+    expect(params.isEmpty()).toBe(false);
+    expect(params.toH()).toEqual({
+      keys: ["shadow"],
+      permitted: true,
+      toH: "not a method",
+      first_name: "Guille",
+    });
+    // The method wins over the same-named parameter on property access (and so
+    // on spread, which reads through the same path); `toH()` is how a colliding
+    // parameter is read back.
+    expect(typeof params["keys"]).toBe("function");
+    expect(params["first_name"]).toBe("Guille");
+    expect({ ...params }.first_name).toBe("Guille");
+  });
+
   it("permit! flips permitted? and returns self", () => {
     const params = new ProtectedParams({ first_name: "Guille" });
 

--- a/packages/activerecord/src/support/stubs/strong-parameters.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.ts
@@ -12,62 +12,60 @@
  * Ruby gets `params[key]` from `#[]` and hash iteration from the ivar. JS has
  * neither operator overloading nor a hash protocol, so the constructor returns
  * a Proxy that projects the parameters as the object's own enumerable
- * properties: `params[key]`, `{ ...params }` and `Object.keys(params)` all
- * read the parameter store. Methods declared on the class always win over a
- * same-named parameter, so a parameter called `keys` or `permitted` cannot
- * shadow the method — the hazard the own-property storage this replaces had,
- * and which Rails never has because the ivar is a separate namespace. The
- * residual deviation is the mirror image and is harmless: a parameter named
- * after a method is not reachable as `params[name]` or through spread (Ruby's
- * `#[]` would return it) — `toH()` reads it back.
+ * properties: `params[key]`, `{ ...params }` and `Object.keys(params)` all read
+ * the parameter store, which is what the AR call sites and ActiveModel's
+ * `isMassAssignmentEmpty` key count need. Every caller therefore holds the
+ * Proxy, so the methods Ruby returns `self` from return it too (`#self`), and
+ * the get trap binds methods to the raw target because private fields are
+ * unreachable through a Proxy receiver.
+ *
+ * A method declared on the class wins over a same-named parameter, so a
+ * parameter called `keys` or `permitted` cannot shadow it — the hazard the
+ * own-property storage this replaces had, and which Rails never has because
+ * the ivar is a separate namespace. The residual deviation is the mirror image
+ * and is harmless: such a parameter is not reachable as `params[name]` or
+ * through spread, where Ruby's `#[]` would return it; `toH()` reads it back.
  *
  * `toUnsafeH` is Rails' `alias to_unsafe_h to_h`: same hash, the name only
- * marks that the caller is bypassing the permitted check.
+ * marks that the caller is bypassing the permitted check. `eachPair` returns
+ * `@parameters` rather than `self` in Ruby — here that store IS the object
+ * seen through its Proxy, so the same value comes back either way.
  */
 export class ProtectedParams {
   [key: string]: unknown;
 
   #parameters: Record<string, unknown>;
   #permitted = false;
-  // The Proxy wrapper returned from the constructor. Methods that return Ruby's
-  // `self` must hand back the wrapper, not the raw target: every caller holds
-  // the wrapper, and `permitBang()` chains into it.
-  #self: ProtectedParams;
+  #self: this;
 
   constructor(parameters: Record<string, unknown> = {}) {
     this.#parameters = { ...parameters };
     const params = this.#parameters;
     const target = this;
-
-    const isMethod = (key: string | symbol): boolean =>
-      Object.hasOwn(ProtectedParams.prototype, key);
+    const isParameter = (key: string | symbol): key is string =>
+      typeof key === "string" &&
+      Object.hasOwn(params, key) &&
+      !Object.hasOwn(ProtectedParams.prototype, key);
 
     this.#self = new Proxy(this, {
       get(_t, key) {
-        if (typeof key === "string" && !isMethod(key) && Object.hasOwn(params, key)) {
-          return params[key];
-        }
+        if (isParameter(key)) return params[key];
         const value = Reflect.get(target, key);
-        // Private fields are unreachable through a Proxy receiver, so every
-        // method has to run against the raw target.
         return typeof value === "function" ? value.bind(target) : value;
       },
       set(_t, key, value) {
-        if (typeof key === "symbol") return Reflect.set(target, key, value);
-        params[key] = value;
+        if (typeof key === "string") params[key] = value;
         return true;
       },
       has(_t, key) {
-        return (typeof key === "string" && Object.hasOwn(params, key)) || Reflect.has(target, key);
+        return isParameter(key) || Reflect.has(target, key);
       },
       ownKeys() {
         return Object.keys(params);
       },
       getOwnPropertyDescriptor(_t, key) {
-        if (typeof key === "string" && Object.hasOwn(params, key)) {
-          return { value: params[key], writable: true, enumerable: true, configurable: true };
-        }
-        return undefined;
+        if (!isParameter(key)) return undefined;
+        return { value: params[key], writable: true, enumerable: true, configurable: true };
       },
       deleteProperty(_t, key) {
         if (typeof key === "string") delete params[key];
@@ -100,7 +98,7 @@ export class ProtectedParams {
 
   permitBang(): this {
     this.#permitted = true;
-    return this.#self as this;
+    return this.#self;
   }
 
   toH(): Record<string, unknown> {
@@ -111,10 +109,8 @@ export class ProtectedParams {
     return this.toH();
   }
 
-  // Ruby's `@parameters.each_pair(&block)` returns `@parameters`, not `self`;
-  // the wrapper returned here is that same store seen through its Proxy.
   eachPair(block: (key: string, value: unknown) => void): this {
     for (const [key, value] of Object.entries(this.#parameters)) block(key, value);
-    return this.#self as this;
+    return this.#self;
   }
 }

--- a/packages/activerecord/src/support/stubs/strong-parameters.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.ts
@@ -3,41 +3,87 @@
  * the forbidden-attributes tests to exercise mass-assignment protection.
  *
  * Mirrors: vendor/rails/activerecord/test/support/stubs/strong_parameters.rb
- * (`ProtectedParams`). Parameters are stored as own enumerable properties so
- * the object iterates like a hash (`Object.entries`, `Object.keys`) and
- * supports `params[key]` access, while the methods below live on the prototype
- * and stay out of the attribute set.
+ * (`ProtectedParams`). Parameters live in a private `#parameters` field — the
+ * `@parameters` ivar Rails delegates `keys` / `key?` / `has_key?` / `empty?`
+ * to over a `HashWithIndifferentAccess`. There is no indifferent access to
+ * mirror — JS object keys are strings already, so Rails' symbol/string duality
+ * has no analogue.
  *
- * Rails gets `keys` / `key?` / `has_key?` / `empty?` from
- * `delegate ..., to: :@parameters` over a `HashWithIndifferentAccess`; the own
- * properties here *are* that `@parameters` hash, so the four read straight off
- * `this`. There is no indifferent access to mirror — JS object keys are
- * strings already, so Rails' symbol/string duality has no analogue.
+ * Ruby gets `params[key]` from `#[]` and hash iteration from the ivar. JS has
+ * neither operator overloading nor a hash protocol, so the constructor returns
+ * a Proxy that projects the parameters as the object's own enumerable
+ * properties: `params[key]`, `{ ...params }` and `Object.keys(params)` all
+ * read the parameter store. Methods declared on the class always win over a
+ * same-named parameter, so a parameter called `keys` or `permitted` cannot
+ * shadow the method — the hazard the own-property storage this replaces had,
+ * and which Rails never has because the ivar is a separate namespace. The
+ * residual deviation is the mirror image and is harmless: a parameter named
+ * after a method is not reachable as `params[name]` or through spread (Ruby's
+ * `#[]` would return it) — `toH()` reads it back.
  *
  * `toUnsafeH` is Rails' `alias to_unsafe_h to_h`: same hash, the name only
  * marks that the caller is bypassing the permitted check.
- *
- * The cost of storing parameters on `this` rather than in a `@parameters` ivar
- * is that a parameter named after one of these methods shadows it — Rails has
- * no such hazard. No column in the canonical schema collides, so no test can
- * hit it today; a test that needs one must reach for a nested
- * `ProtectedParams` value instead.
  */
 export class ProtectedParams {
   [key: string]: unknown;
 
+  #parameters: Record<string, unknown>;
   #permitted = false;
+  // The Proxy wrapper returned from the constructor. Methods that return Ruby's
+  // `self` must hand back the wrapper, not the raw target: every caller holds
+  // the wrapper, and `permitBang()` chains into it.
+  #self: ProtectedParams;
 
   constructor(parameters: Record<string, unknown> = {}) {
-    Object.assign(this, parameters);
+    this.#parameters = { ...parameters };
+    const params = this.#parameters;
+    const target = this;
+
+    const isMethod = (key: string | symbol): boolean =>
+      Object.hasOwn(ProtectedParams.prototype, key);
+
+    this.#self = new Proxy(this, {
+      get(_t, key) {
+        if (typeof key === "string" && !isMethod(key) && Object.hasOwn(params, key)) {
+          return params[key];
+        }
+        const value = Reflect.get(target, key);
+        // Private fields are unreachable through a Proxy receiver, so every
+        // method has to run against the raw target.
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+      set(_t, key, value) {
+        if (typeof key === "symbol") return Reflect.set(target, key, value);
+        params[key] = value;
+        return true;
+      },
+      has(_t, key) {
+        return (typeof key === "string" && Object.hasOwn(params, key)) || Reflect.has(target, key);
+      },
+      ownKeys() {
+        return Object.keys(params);
+      },
+      getOwnPropertyDescriptor(_t, key) {
+        if (typeof key === "string" && Object.hasOwn(params, key)) {
+          return { value: params[key], writable: true, enumerable: true, configurable: true };
+        }
+        return undefined;
+      },
+      deleteProperty(_t, key) {
+        if (typeof key === "string") delete params[key];
+        return true;
+      },
+    });
+
+    return this.#self;
   }
 
   keys(): string[] {
-    return Object.keys(this);
+    return Object.keys(this.#parameters);
   }
 
   isKey(key: string): boolean {
-    return Object.hasOwn(this, key);
+    return Object.hasOwn(this.#parameters, key);
   }
 
   hasKey(key: string): boolean {
@@ -54,22 +100,21 @@ export class ProtectedParams {
 
   permitBang(): this {
     this.#permitted = true;
-    return this;
+    return this.#self as this;
   }
 
   toH(): Record<string, unknown> {
-    return { ...this };
+    return { ...this.#parameters };
   }
 
   toUnsafeH(): Record<string, unknown> {
     return this.toH();
   }
 
-  // Ruby's `@parameters.each_pair(&block)` returns `@parameters`, not `self`.
-  // Here `this` IS the parameters hash, so returning it is that same value —
-  // read the `this` as the hash, not as Ruby's `self`.
+  // Ruby's `@parameters.each_pair(&block)` returns `@parameters`, not `self`;
+  // the wrapper returned here is that same store seen through its Proxy.
   eachPair(block: (key: string, value: unknown) => void): this {
-    for (const [key, value] of Object.entries(this)) block(key, value);
-    return this;
+    for (const [key, value] of Object.entries(this.#parameters)) block(key, value);
+    return this.#self as this;
   }
 }


### PR DESCRIPTION
Rails' `ProtectedParams` keeps its parameters in a `@parameters` ivar and delegates the hash reads to it (`vendor/rails/activerecord/test/support/stubs/strong_parameters.rb:5-11`). The port spread them onto the instance instead, so a parameter named after one of the class's own methods — `keys`, `permitted`, `toH`, … — replaced that method. No canonical column collides today, so this was a latent trap rather than a live bug.

Parameters now live in a private `#parameters` field (the ivar's analogue). The constructor returns a `Proxy` that projects them as the object's own enumerable properties, so `params[key]`, `{ ...params }` and `Object.keys(params)` keep reading the parameter store — the affordances every AR call site uses (`forbidden-attributes-protection{,.trails}.test.ts`, `finder.test.ts`, `relation/where.test.ts`, and `isMassAssignmentEmpty`'s key count). Methods win over a same-named parameter, which is what removes the shadowing.

Residual deviation, documented in the file: a parameter named after a method is not reachable via `params[name]` or spread (Ruby's `#[]` would return it); `toH()` reads it back.

A regression test pins the behaviour and fails on the previous implementation (`params.keys is not a function`).

`pnpm api:compare --package activerecord-test-support` stays at 32/32.

Also included, as a necessity rather than scope creep: `main` currently fails `tsc --build` in `load-schema-helper-uuid-default.trails.test.ts`, which blocks every commit via husky. That cover stubs `createTable` to capture DDL without laying anything on the shared database, so it must call `loadAdapterSpecificSchema` directly — routing it through `loadSchema` runs `loadCanonicalSchema` first and dies with `relation "1_need_quoting…" does not exist` on the PG lane. This PR restores the direct arm call (the pre-#5676 shape), which fixes both the typecheck break and that PG failure.

Closes-story: protectedparams-parameters-shadow-its-own-methods

---

Review follow-up: `ProtectedParams#dup` (strong_parameters.rb:33-37, which preserves `@permitted`) has never been ported and no call site uses it. Pre-existing and out of scope here; registered as story `protectedparams-dup-preserves-permitted` under RFC 0064.

