### PR TITLE
refactor(activerecord): route the MySQL drop sweep through disableReferentialIntegrity

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -50,8 +50,7 @@ function bootLaidTableNames(): ReadonlySet<string> {
  * Drops every user table/view/matview in the database. Idempotent; per-DROP
  * errors are swallowed so teardown noise never aborts the sequence.
  * PG covers all schemas in `current_schemas(false)` (not just `public`).
- * MySQL uses a pinned pool connection with `FOREIGN_KEY_CHECKS=0`; sqlite goes
- * through `disableReferentialIntegrity`.
+ * MySQL and sqlite both go through `disableReferentialIntegrity`.
  */
 export async function dropAllTables(adapter: DatabaseAdapter): Promise<void> {
   await resetTables(adapter, "drop-all");
@@ -215,8 +214,7 @@ async function resetMysqlTables(
   // single-connection model (_client). Falls back to adapter.execute /
   // adapter.executeMutation so both paths share one implementation.
   const toTruncate: string[] = [];
-  try {
-    await adapter.execute(`SET FOREIGN_KEY_CHECKS=0`);
+  await adapter.disableReferentialIntegrity(async () => {
     const tableRows = await adapter.execute(
       `SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'`,
     );
@@ -241,12 +239,8 @@ async function resetMysqlTables(
         await adapter.executeMutation(`DROP TABLE IF EXISTS \`${name}\``);
       } catch {}
     }
-    await truncateNonEmpty(adapter, toTruncate);
-  } finally {
-    try {
-      await adapter.execute(`SET FOREIGN_KEY_CHECKS=1`);
-    } catch {}
-  }
+  });
+  await truncateNonEmpty(adapter, toTruncate);
 }
 
 async function resetSqliteTables(

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -210,9 +210,6 @@ async function resetMysqlTables(
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
 ): Promise<void> {
-  // Works with both the legacy pool model (_driverPool) and the current
-  // single-connection model (_client). Falls back to adapter.execute /
-  // adapter.executeMutation so both paths share one implementation.
   const toTruncate: string[] = [];
   await adapter.disableReferentialIntegrity(async () => {
     const tableRows = await adapter.execute(


### PR DESCRIPTION
`resetMysqlTables` in `packages/activerecord/src/support/drop-all-tables.ts`
hand-rolled the body of Rails'
`abstract_mysql_adapter.rb#disable_referential_integrity`
(`vendor/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:213`):
a bare `SET FOREIGN_KEY_CHECKS=0` up front and a hardcoded
`SET FOREIGN_KEY_CHECKS=1` in a `finally`. It now wraps the DROP VIEW / DROP
TABLE loop in `adapter.disableReferentialIntegrity(...)`, matching what PR #5680
did for the sqlite arm — so the restore recovers the prior
`@@FOREIGN_KEY_CHECKS` value and is guarded by `active?`, as Rails does.

`truncateNonEmpty` moves outside the wrapped block, as on the sqlite arm. The PG
arm is untouched: `resetPgTables` relies on `DROP TABLE … CASCADE`, and PG's
`disable_referential_integrity` toggles triggers, which does not suppress FK
dependency errors on `DROP TABLE`.

## Verification

MySQL lane, isolated compose stack: `drop-all-tables.test.ts` 10/10 pass.
Neutralizing the escape (replacing the `disableReferentialIntegrity` call with a
plain invoker) fails `drops 3-table FK chain without error`, so the guard is live.

Also included: a one-line fix to
`load-schema-helper-uuid-default.trails.test.ts`, which passed a thunk to
`loadSchema(adapter)` and broke `tsc --build` on main tip — the pre-commit hook
blocked every commit until it was corrected.

Closes-story: route-mysql-drop-sweep-through-disable-referential-integrity
