### PR TITLE
fix(activerecord): re-lay the canonical schema when restoring the worker connection

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -19,13 +19,10 @@ import {
 import { setTrailsRoot } from "@blazetrails/activesupport";
 import { adapterType } from "./test-adapter.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
+import { restoreWorkerConnection } from "./support/connection.js";
 import * as nodeFs from "node:fs";
 import * as nodeOs from "node:os";
 import * as nodePath from "node:path";
-
-async function restoreWorkerConnection(): Promise<void> {
-  await Base.establishConnection("arunit");
-}
 
 describe("ConnectionHandlingTest", () => {
   // The opted-out cases assert the pool releases its connection, which
@@ -320,19 +317,15 @@ describe("ConnectionHandlingTest", () => {
   // never the verbatim URL string. establish_connection({ adapter, url })
   // must mirror that shape, matching the resolver's "url removed from hash".
   // Only the primary pool exercises this path, so `Base`'s is swapped and
-  // restored; under ARCONN=sqlite3_mem the restore would hand the worker a
-  // fresh, EMPTY database, hence the skip.
-  it.skipIf(inMemoryDb())(
-    "establish_connection with a url stores a UrlConfig with discrete fields",
-    async () => {
-      await Base.establishConnection({ adapter: "sqlite3", url: "sqlite3:db/discrete.sqlite3" });
-      const config = Base.connectionDbConfig();
-      expect(config.adapter).toBe("sqlite3");
-      expect(config.database).toBe("db/discrete.sqlite3");
-      expect(config.configurationHash).not.toHaveProperty("url");
-      await restoreWorkerConnection();
-    },
-  );
+  // restored.
+  it("establish_connection with a url stores a UrlConfig with discrete fields", async () => {
+    await Base.establishConnection({ adapter: "sqlite3", url: "sqlite3:db/discrete.sqlite3" });
+    const config = Base.connectionDbConfig();
+    expect(config.adapter).toBe("sqlite3");
+    expect(config.database).toBe("db/discrete.sqlite3");
+    expect(config.configurationHash).not.toHaveProperty("url");
+    await restoreWorkerConnection();
+  });
 
   it("is_connected?", async () => {
     const pool = Base.connectionPool();
@@ -386,9 +379,9 @@ describe("ConnectionHandlingTest", () => {
   });
 
   // Both cases below remove `Base`'s pool: only the primary pool can be
-  // observed going away (a subclass falls back to `Base`'s). Same restore and
-  // in-memory skip as above.
-  it.skipIf(inMemoryDb())("remove_connection removes the pool", async () => {
+  // observed going away (a subclass falls back to `Base`'s). Same restore as
+  // above.
+  it("remove_connection removes the pool", async () => {
     const ambientDbConfig = Base.connectionDbConfig();
     expect(Base.connectionPool()).toBeTruthy();
     // Mirrors Rails `remove_connection`: returns the removed pool's db_config.
@@ -398,7 +391,7 @@ describe("ConnectionHandlingTest", () => {
     await restoreWorkerConnection();
   });
 
-  it.skipIf(inMemoryDb())("remove_connection returns undefined when no pool exists", async () => {
+  it("remove_connection returns undefined when no pool exists", async () => {
     Base.removeConnection();
     expect(Base.removeConnection()).toBeUndefined();
     await restoreWorkerConnection();

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -316,8 +316,6 @@ describe("ConnectionHandlingTest", () => {
   // UrlConfig, so configuration_hash carries the parsed discrete fields and
   // never the verbatim URL string. establish_connection({ adapter, url })
   // must mirror that shape, matching the resolver's "url removed from hash".
-  // Only the primary pool exercises this path, so `Base`'s is swapped and
-  // restored.
   it("establish_connection with a url stores a UrlConfig with discrete fields", async () => {
     await Base.establishConnection({ adapter: "sqlite3", url: "sqlite3:db/discrete.sqlite3" });
     const config = Base.connectionDbConfig();
@@ -378,9 +376,6 @@ describe("ConnectionHandlingTest", () => {
     expect(() => Base.clearCacheBang()).not.toThrow();
   });
 
-  // Both cases below remove `Base`'s pool: only the primary pool can be
-  // observed going away (a subclass falls back to `Base`'s). Same restore as
-  // above.
   it("remove_connection removes the pool", async () => {
     const ambientDbConfig = Base.connectionDbConfig();
     expect(Base.connectionPool()).toBeTruthy();

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -33,7 +33,8 @@ import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
 import { arunitDatabaseNames } from "./arunit2-config.js";
-import { loadSchema } from "./load-schema-helper.js";
+import { loadAdapterSpecificSchema, loadSchema } from "./load-schema-helper.js";
+import { stampCanonicalSchema } from "./canonical-schema-stamp.js";
 import {
   CONNECTION_LANES,
   DEFAULT_CONNECTION,
@@ -416,6 +417,8 @@ export async function connect(): Promise<TestDatabaseConfig> {
 
 const CANONICAL_PROBE_TABLE = "posts";
 
+const ADAPTER_SPECIFIC_PROBE_TABLE = "defaults";
+
 /**
  * Give the worker back its `arunit` pool after a test displaced `Base`'s,
  * re-running `connect`'s `establish_connection :arunit` (`connection.rb:32`).
@@ -427,12 +430,30 @@ const CANONICAL_PROBE_TABLE = "posts";
  * schema has to be laid again. The probe, not the lane, decides: a pool that
  * was merely disconnected and reopened on a file lane still has its tables, and
  * `loadSchema` issues no drops, so it must only run against an empty database.
+ *
+ * Both halves of `load_schema` are probed separately, as the per-worker boot
+ * treats them (`test-setup-dy.ts`): canonical tables being present does not
+ * imply the adapter-specific ones are, so a database that kept `posts` but lost
+ * `defaults` re-runs the adapter-specific arm alone. Running the canonical arm
+ * there instead would fail on the surviving tables, since it issues no drops.
+ *
+ * The reload stamps as the boot's full-load arm does, so a database laid here
+ * is indistinguishable from one laid at boot: `canonicalSchemaUpToDate` is read
+ * by a *starting* worker, and an unstamped in-memory database would be a state
+ * boot never produces.
  */
 export async function restoreWorkerConnection(): Promise<void> {
   await Base.establishConnection("arunit");
   const connection = (await Base.leaseConnection()) as unknown as {
     tableExists(name: string): Promise<boolean>;
   };
-  if (await connection.tableExists(CANONICAL_PROBE_TABLE)) return;
-  await loadSchema(await Base.leaseConnection());
+  if (!(await connection.tableExists(CANONICAL_PROBE_TABLE))) {
+    const adapter = await Base.leaseConnection();
+    await loadSchema(adapter);
+    await stampCanonicalSchema(adapter);
+    return;
+  }
+  if (!(await connection.tableExists(ADAPTER_SPECIFIC_PROBE_TABLE))) {
+    await loadAdapterSpecificSchema(await Base.leaseConnection());
+  }
 }

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -33,6 +33,7 @@ import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
 import { arunitDatabaseNames } from "./arunit2-config.js";
+import { loadSchema } from "./load-schema-helper.js";
 import {
   CONNECTION_LANES,
   DEFAULT_CONNECTION,
@@ -411,4 +412,36 @@ export async function connect(): Promise<TestDatabaseConfig> {
   await ARUnit2Model.establishConnection("arunit2");
 
   return { configs, adapter, envConfig };
+}
+
+/**
+ * The table every canonical schema load lays first; its absence is what tells
+ * {@link restoreWorkerConnection} the worker database came back empty.
+ */
+const CANONICAL_PROBE_TABLE = "posts";
+
+/**
+ * Give the worker back its `arunit` pool after a test displaced `Base`'s,
+ * re-running `connect`'s `establish_connection :arunit` (`connection.rb:32`).
+ *
+ * Rails has no counterpart: its suite is one process against one file-backed
+ * database, so re-establishing always lands on a database that still holds the
+ * schema. Under `ARCONN=sqlite3_mem` the displaced connection *was* the
+ * database — re-establishing opens a brand-new, EMPTY `:memory:` one — so the
+ * schema has to be laid again. The probe, not the lane, decides: a pool that
+ * was merely disconnected and reopened on a file lane still has its tables, and
+ * `loadSchema` issues no drops, so it must only run against an empty database.
+ */
+export async function restoreWorkerConnection(): Promise<void> {
+  await Base.establishConnection("arunit");
+  // Leased, not `withConnection`-scoped, as the per-worker boot leases
+  // (`test-setup-dy.ts`): on `:memory:` the connection *is* the database, so
+  // handing it back to the pool risks taking the freshly laid schema with it.
+  // Cast because `tableExists` is on the concrete adapter class, not the
+  // `DatabaseAdapter` interface.
+  const connection = (await Base.leaseConnection()) as unknown as {
+    tableExists(name: string): Promise<boolean>;
+  };
+  if (await connection.tableExists(CANONICAL_PROBE_TABLE)) return;
+  await loadSchema(await Base.leaseConnection());
 }

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -414,10 +414,6 @@ export async function connect(): Promise<TestDatabaseConfig> {
   return { configs, adapter, envConfig };
 }
 
-/**
- * The table every canonical schema load lays first; its absence is what tells
- * {@link restoreWorkerConnection} the worker database came back empty.
- */
 const CANONICAL_PROBE_TABLE = "posts";
 
 /**
@@ -434,11 +430,6 @@ const CANONICAL_PROBE_TABLE = "posts";
  */
 export async function restoreWorkerConnection(): Promise<void> {
   await Base.establishConnection("arunit");
-  // Leased, not `withConnection`-scoped, as the per-worker boot leases
-  // (`test-setup-dy.ts`): on `:memory:` the connection *is* the database, so
-  // handing it back to the pool risks taking the freshly laid schema with it.
-  // Cast because `tableExists` is on the concrete adapter class, not the
-  // `DatabaseAdapter` interface.
   const connection = (await Base.leaseConnection()) as unknown as {
     tableExists(name: string): Promise<boolean>;
   };


### PR DESCRIPTION
Under `ARCONN=sqlite3_mem` the displaced connection *is* the database, so `restoreWorkerConnection` (`Base.establishConnection("arunit")`) handed the worker a brand-new, EMPTY `:memory:` DB — every later case in that worker lost its tables. PR #5658 papered over it by gating three trails-only cases behind `it.skipIf(inMemoryDb())`, and the same hazard stayed live in the `resolveConfigForConnection` afterEach, which restores on every lane.

The helper now lives next to `connect()` in `support/connection.ts` (its Rails anchor is `connection.rb:32`) and probes for the canonical schema, re-laying it through `loadSchema` when the database came back empty. The probe — not the lane — decides, so a pool that was merely disconnected and reopened on a file lane keeps its tables, and `loadSchema` (which issues no drops) only ever runs against an empty database. It leases the connection rather than scoping it through `withConnection`, as the per-worker boot does: on `:memory:` handing the connection back risks taking the freshly laid schema with it.

The three cases drop their `skipIf(inMemoryDb())` gates.

Verified: `connection-handling.test.ts` green on both lanes; on `sqlite3_mem`, green with `unsafe-raw-sql.test.ts` + `base-prevent-writes.test.ts` sharing the worker. Baselined by stubbing the probe to always skip the reload — 22 failures on the mem lane.

Closes-story: restore-worker-connection-yields-empty-db-on-in-memory-lane