### PR TITLE
test(eslint): guard arm-content covers against loadSchema misroute

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,7 @@ import { noRawSqlFiles, noRawSqlIgnores } from "./eslint/no-raw-sql-scope.mjs";
 import { testInfraExemptIgnores } from "./eslint/test-infra-scope.mjs";
 import noStandaloneAssociations from "./eslint/no-standalone-associations.mjs";
 import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.mjs";
+import noLoadSchemaWithStubbedDdl from "./eslint/no-load-schema-with-stubbed-ddl.mjs";
 import noExplicitAnyDisable from "./eslint/no-explicit-any-disable.mjs";
 import noRawControlBytes from "./eslint/no-raw-control-bytes.mjs";
 import { readFileSync } from "node:fs";
@@ -235,6 +236,7 @@ export default defineConfig(
           "no-raw-sql": noRawSql,
           "no-standalone-associations": noStandaloneAssociations,
           "no-internal-canonical-loaders": noInternalCanonicalLoaders,
+          "no-load-schema-with-stubbed-ddl": noLoadSchemaWithStubbedDdl,
           "no-explicit-any-disable": noExplicitAnyDisable,
           "no-raw-control-bytes": noRawControlBytes,
           // Off by default — opt in per project (see eslint/manifest-complete.mjs).
@@ -555,6 +557,20 @@ export default defineConfig(
     files: ["packages/activerecord/src/**/*.test.ts"],
     rules: {
       "blazetrails/no-internal-canonical-loaders": "error",
+    },
+  },
+
+  // ── no-load-schema-with-stubbed-ddl: a test that stubs `createTable` lays
+  //    nothing on the database, so `loadSchema`'s canonical half would query
+  //    tables that were never created (PR #5676). Those arm-content covers must
+  //    call `loadAdapterSpecificSchema` directly. The self-test allowlist in
+  //    no-internal-canonical-loaders lets `loadSchema` into exactly these
+  //    files, so this rule is what closes the hole.
+  //    See eslint/no-load-schema-with-stubbed-ddl.mjs. ──
+  {
+    files: ["packages/activerecord/src/**/*.test.ts"],
+    rules: {
+      "blazetrails/no-load-schema-with-stubbed-ddl": "error",
     },
   },
 

--- a/eslint/no-load-schema-with-stubbed-ddl.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.mjs
@@ -27,15 +27,35 @@ export const STUBBED_DDL_METHODS = new Set(["createTable"]);
 export const BANNED_LOADER = "loadSchema";
 
 /**
- * True when `node` names a stubbed DDL emitter: either a string literal
- * (`prop === "createTable"`, the Proxy-trap form) or a non-computed object
- * property key (`{ createTable: async () => {} }`, the spy/stub-object form).
+ * True when `node` names a stubbed DDL emitter: a string literal or a
+ * non-computed object property key.
  */
 export function namesStubbedDdlMethod(node) {
   if (node.type === "Literal") return STUBBED_DDL_METHODS.has(node.value);
   if (node.type === "Identifier") return STUBBED_DDL_METHODS.has(node.name);
   return false;
 }
+
+/**
+ * True when a `"createTable"` literal sits in an *interception* position — the
+ * Proxy-trap dispatch shapes `prop === "createTable"`, `case "createTable":`,
+ * and `["createTable"].includes(prop)`.
+ *
+ * Merely mentioning the name (`migration.methodMissing("createTable")`, a test
+ * title, an SQL assertion) does not arm the rule: it would make an unrelated
+ * `loadSchema` in the same file a spurious error, and the detection here is
+ * file-scoped, so a loose match is expensive.
+ */
+export function isInterceptionPosition(node) {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (parent.type === "BinaryExpression") return COMPARISONS.has(parent.operator);
+  if (parent.type === "SwitchCase") return parent.test === node;
+  if (parent.type === "ArrayExpression") return true;
+  return false;
+}
+
+const COMPARISONS = new Set(["===", "==", "!==", "!="]);
 
 /** @type {import("eslint").Rule.RuleModule} */
 const rule = {
@@ -59,7 +79,7 @@ const rule = {
 
     return {
       Literal(node) {
-        if (stubbedMethod === null && namesStubbedDdlMethod(node)) {
+        if (stubbedMethod === null && namesStubbedDdlMethod(node) && isInterceptionPosition(node)) {
           stubbedMethod = node.value;
         }
       },

--- a/eslint/no-load-schema-with-stubbed-ddl.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.mjs
@@ -1,0 +1,102 @@
+/**
+ * ESLint rule: no-load-schema-with-stubbed-ddl
+ *
+ * `loadSchema` (support/load-schema-helper.ts) runs the canonical half first
+ * and then the adapter-specific arm. A cover that intercepts `createTable` to
+ * capture emitted DDL never lays anything on the shared per-worker database, so
+ * the canonical half queries tables that were never created and dies with
+ * `StatementInvalid: relation "…" does not exist`. Such covers must call
+ * `loadAdapterSpecificSchema` directly — the carve-out its docstring already
+ * describes in prose.
+ *
+ * PR #5676 rerouted `load-schema-helper-uuid-default.trails.test.ts` through
+ * `loadSchema` exactly that way. Nothing caught it: the file is
+ * `describeIfPg`-gated, so the break was PG-lane-only and surfaced only in a
+ * ~500s CI shard, and the file is allowlisted out of
+ * `no-internal-canonical-loaders` (it is one of load-schema-helper's own
+ * self-tests, so importing `loadSchema` there is not banned outright).
+ *
+ * This rule closes that hole lexically, in the unit lane: in a test file that
+ * stubs `createTable`, any reference to `loadSchema` is an error.
+ */
+
+/** The DDL emitter whose interception makes the canonical half unsafe. */
+export const STUBBED_DDL_METHODS = new Set(["createTable"]);
+
+/** The loader that must not be reached for once a DDL emitter is stubbed. */
+export const BANNED_LOADER = "loadSchema";
+
+/**
+ * True when `node` names a stubbed DDL emitter: either a string literal
+ * (`prop === "createTable"`, the Proxy-trap form) or a non-computed object
+ * property key (`{ createTable: async () => {} }`, the spy/stub-object form).
+ */
+export function namesStubbedDdlMethod(node) {
+  if (node.type === "Literal") return STUBBED_DDL_METHODS.has(node.value);
+  if (node.type === "Identifier") return STUBBED_DDL_METHODS.has(node.name);
+  return false;
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid `loadSchema` in a test file that stubs `createTable`; such arm-content covers must call `loadAdapterSpecificSchema` directly.",
+    },
+    schema: [],
+    messages: {
+      misrouted:
+        'This file stubs `{{method}}`, so nothing is really laid on the database — `loadSchema` would run the canonical half first and fail with `relation "…" does not exist` (PR #5676). Call `loadAdapterSpecificSchema` directly instead.',
+    },
+  },
+
+  create(context) {
+    let stubbedMethod = null;
+    const loaderRefs = [];
+    const seen = new Set();
+
+    return {
+      Literal(node) {
+        if (stubbedMethod === null && namesStubbedDdlMethod(node)) {
+          stubbedMethod = node.value;
+        }
+      },
+      Property(node) {
+        if (node.computed) return;
+        if (stubbedMethod === null && namesStubbedDdlMethod(node.key)) {
+          stubbedMethod = node.key.name ?? node.key.value;
+        }
+      },
+      Identifier(node) {
+        if (node.name !== BANNED_LOADER) return;
+        // `Model.loadSchema()` is ActiveRecord's own per-model reflection load,
+        // not the test-infra helper — only bare references to the helper count.
+        const parent = node.parent;
+        if (parent?.type === "MemberExpression" && parent.property === node && !parent.computed) {
+          return;
+        }
+        if (parent?.type === "Property" && parent.key === node && !parent.computed) return;
+        // A shorthand import specifier (`import { loadSchema }`) has the same
+        // Identifier node visited twice, as `imported` and as `local`.
+        const at = `${node.range[0]}:${node.range[1]}`;
+        if (seen.has(at)) return;
+        seen.add(at);
+        loaderRefs.push(node);
+      },
+      "Program:exit"() {
+        if (stubbedMethod === null) return;
+        for (const node of loaderRefs) {
+          context.report({
+            node,
+            messageId: "misrouted",
+            data: { method: stubbedMethod },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint/no-load-schema-with-stubbed-ddl.test.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.test.mjs
@@ -1,0 +1,114 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { RuleTester } from "eslint";
+import { describe, it, expect } from "vitest";
+import { Linter } from "eslint";
+import rule from "./no-load-schema-with-stubbed-ddl.mjs";
+
+const FILENAME = "packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts";
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: (await import("typescript-eslint")).parser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("no-load-schema-with-stubbed-ddl", rule, {
+  valid: [
+    // The arm-direct shape this cover must keep: createTable stubbed, the
+    // adapter-specific arm called directly.
+    {
+      filename: FILENAME,
+      code: `
+        import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
+        const probe = new Proxy(adapter, {
+          get(target, prop) {
+            if (prop === "createTable") return async () => {};
+            return Reflect.get(target, prop, target);
+          },
+        });
+        await loadAdapterSpecificSchema(probe);
+      `,
+    },
+    // loadSchema with no DDL emitter stubbed is the ordinary schema load.
+    {
+      filename: "packages/activerecord/src/support/load-schema-helper.test.ts",
+      code: `
+        import { loadSchema } from "./load-schema-helper.js";
+        await loadSchema(adapter);
+      `,
+    },
+    // A createTable call is not a stub — only naming it as an intercepted
+    // member is.
+    {
+      filename: FILENAME,
+      code: `
+        import { loadSchema } from "./load-schema-helper.js";
+        await adapter.createTable("posts", {}, (t) => {});
+        await loadSchema(adapter);
+      `,
+    },
+    // `Model.loadSchema()` is AR's own reflection load, unrelated to the
+    // test-infra helper — migration.test.ts pairs it with a createTable stub.
+    {
+      filename: "packages/activerecord/src/migration.test.ts",
+      code: `
+        const delegate = { createTable: () => "hi mom!" };
+        await BigNumber.loadSchema();
+      `,
+    },
+  ],
+  invalid: [
+    // The #5676 shape: Proxy trap on createTable + loadSchema.
+    {
+      filename: FILENAME,
+      code: `
+        import { loadSchema } from "./load-schema-helper.js";
+        const probe = new Proxy(adapter, {
+          get(target, prop) {
+            if (prop === "createTable") return async () => {};
+            return Reflect.get(target, prop, target);
+          },
+        });
+        await loadSchema(probe);
+      `,
+      errors: [{ messageId: "misrouted" }, { messageId: "misrouted" }],
+    },
+    // The stub-object form of the same mistake.
+    {
+      filename: FILENAME,
+      code: `
+        const stub = { createTable: async () => {} };
+        await loadSchema(stub);
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+  ],
+});
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+
+describe("the real arm-content cover", () => {
+  it("is clean under the rule", async () => {
+    const file = path.join(repoRoot, FILENAME);
+    const code = await fs.readFile(file, "utf8");
+    const linter = new Linter();
+    const messages = linter.verify(code, {
+      plugins: { blazetrails: { rules: { "no-load-schema-with-stubbed-ddl": rule } } },
+      languageOptions: {
+        parser: (await import("typescript-eslint")).parser,
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+      rules: { "blazetrails/no-load-schema-with-stubbed-ddl": "error" },
+    });
+    expect(messages).toEqual([]);
+    // Guards the fixture itself: if the cover stops stubbing createTable the
+    // rule would pass vacuously here.
+    expect(code).toContain('"createTable"');
+  });
+});

--- a/eslint/no-load-schema-with-stubbed-ddl.test.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.test.mjs
@@ -60,6 +60,15 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
         await BigNumber.loadSchema();
       `,
     },
+    // Naming the method without intercepting it is not a stub.
+    {
+      filename: "packages/activerecord/src/migration.test.ts",
+      code: `
+        import { loadSchema } from "./support/load-schema-helper.js";
+        expect(migration.methodMissing("createTable")).toBe("hi mom!");
+        await loadSchema(adapter);
+      `,
+    },
   ],
   invalid: [
     // The #5676 shape: Proxy trap on createTable + loadSchema.
@@ -86,6 +95,32 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
       `,
       errors: [{ messageId: "misrouted" }],
     },
+    // The other two interception dispatch shapes.
+    {
+      filename: FILENAME,
+      code: `
+        const probe = new Proxy(adapter, {
+          get(target, prop) {
+            switch (prop) {
+              case "createTable":
+                return async () => {};
+            }
+            return Reflect.get(target, prop, target);
+          },
+        });
+        await loadSchema(probe);
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+    {
+      filename: FILENAME,
+      code: `
+        const intercepted = ["createTable", "dropTable"];
+        if (intercepted.includes(prop)) return async () => {};
+        await loadSchema(probe);
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
   ],
 });
 
@@ -109,6 +144,6 @@ describe("the real arm-content cover", () => {
     expect(messages).toEqual([]);
     // Guards the fixture itself: if the cover stops stubbing createTable the
     // rule would pass vacuously here.
-    expect(code).toContain('"createTable"');
+    expect(code).toContain('prop === "createTable"');
   });
 });


### PR DESCRIPTION
A test that stubs `createTable` to capture emitted DDL lays nothing on the
shared per-worker database, so `loadSchema`'s canonical half queries tables
that were never created and dies with `relation "…" does not exist`. PR #5676
did exactly that to `load-schema-helper-uuid-default.trails.test.ts`; #5687
reverted it. Nothing caught it mechanically: the file is `describeIfPg`-gated
(so the break was PG-lane-only, visible only in a ~500s CI shard), and it is
allowlisted out of `no-internal-canonical-loaders` as one of
`load-schema-helper`'s own self-tests, so importing `loadSchema` there was legal.

New lint rule `no-load-schema-with-stubbed-ddl`, wired over
`packages/activerecord/src/**/*.test.ts`: in a file that intercepts
`createTable`, any bare `loadSchema` reference is an error.

Two narrowings keep it free of false positives across the whole AR test tree:

- A `"createTable"` literal arms the rule only in an *interception* position —
  `prop === "createTable"`, `case "createTable":`, or a membership array — plus
  the stub-object key form `{ createTable: … }`. A bare mention
  (`methodMissing("createTable")`, a test title, an SQL assertion) does not.
  The detection is file-scoped, so a loose match would be expensive.
- Member calls are exempt: `Model.loadSchema()` is AR's own per-model
  reflection load, which `migration.test.ts` legitimately pairs with a
  `createTable` delegate stub.

Verified by synthetic regression in `eslint/no-load-schema-with-stubbed-ddl.test.mjs`
(the #5676 shape errors, the arm-direct shape is clean), plus a case that lints
the real cover file and asserts it still carries the interception, so the check
can't pass vacuously. Also confirmed out-of-band: rewriting the real file's
`loadAdapterSpecificSchema` back to `loadSchema` trips the rule at both the
import and the call site. Rule tests run in the unit lane — no live PG required.

Closes-story: arm-cover-misroute-through-loadschema-is-pg-lane-only
