### PR TITLE
fix(eslint): enforce and discover canonical loaders across the whole workspace

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,10 @@ import requireTableTeardown from "./eslint/require-table-teardown.mjs";
 import requireCanonicalRebuild from "./eslint/require-canonical-rebuild.mjs";
 import noRawSql from "./eslint/no-raw-sql.mjs";
 import { noRawSqlFiles, noRawSqlIgnores } from "./eslint/no-raw-sql-scope.mjs";
-import { testInfraExemptIgnores } from "./eslint/test-infra-scope.mjs";
+import {
+  canonicalLoaderEnforcedGlobs,
+  testInfraExemptIgnores,
+} from "./eslint/test-infra-scope.mjs";
 import noStandaloneAssociations from "./eslint/no-standalone-associations.mjs";
 import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.mjs";
 import noExplicitAnyDisable from "./eslint/no-explicit-any-disable.mjs";
@@ -550,9 +553,14 @@ export default defineConfig(
   //    rebuildCanonicalTables is intentionally allowed (documented shared shield).
   //    Only canonical-schema.test.ts / canonical-table-rebuild.test.ts may
   //    import them, to test them directly (allowlisted in the rule).
+  //    Enforced across every workspace package, not just activerecord: the
+  //    loaders are matched by module basename, so a test file in another
+  //    package reaching for one would otherwise never be linted at all.
+  //    (scripts/ is in this config's top-level `ignores`, so no rule reaches
+  //    it — see canonicalLoaderUnenforceableRoots.)
   //    See eslint/no-internal-canonical-loaders.mjs. ──
   {
-    files: ["packages/activerecord/src/**/*.test.ts"],
+    files: canonicalLoaderEnforcedGlobs,
     rules: {
       "blazetrails/no-internal-canonical-loaders": "error",
     },

--- a/eslint/no-internal-canonical-loaders.mjs
+++ b/eslint/no-internal-canonical-loaders.mjs
@@ -30,10 +30,15 @@
 import path from "path";
 import { canonicalLoaderModules, canonicalLoaderSelfTests } from "./test-infra-scope.mjs";
 
-/** Repo-relative path under packages/; null if outside the repo tree. */
+/**
+ * Repo-relative path under one of the enforced roots; null if outside them.
+ * `scripts/` counts as well as `packages/`: the rule is wired to both, so a
+ * self-test living outside `packages/` still has to key its allowlist entry the
+ * same way.
+ */
 export function repoRel(filename) {
   const norm = filename.replace(/\\/g, "/");
-  const m = norm.match(/(?:^|\/)(packages\/.+)$/);
+  const m = norm.match(/(?:^|\/)((?:packages|scripts)\/.+)$/);
   return m ? m[1] : null;
 }
 

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -8,7 +8,12 @@ import rule, {
   isCanonicalSchemaModule,
   moduleBasename,
 } from "./no-internal-canonical-loaders.mjs";
-import { canonicalLoaderModules, canonicalLoaderScanRoots } from "./test-infra-scope.mjs";
+import {
+  canonicalLoaderEnforcedGlobs,
+  canonicalLoaderModules,
+  canonicalLoaderScanRoots,
+  canonicalLoaderUnenforceableRoots,
+} from "./test-infra-scope.mjs";
 
 const FILENAME = "packages/activerecord/src/dirty.test.ts";
 const OWN_TEST = "packages/activerecord/src/support/canonical-schema.test.ts";
@@ -87,6 +92,13 @@ tester.run("no-internal-canonical-loaders", rule, {
     {
       filename: "packages/activerecord/src/support/schema-file-generator.test.ts",
       code: 'import { loadCanonicalSchema } from "./canonical-schema.js";',
+      errors: [{ messageId: "banned", data: { name: "loadCanonicalSchema" } }],
+    },
+    // A test file in another workspace package is linted too — the rule is
+    // wired to every scan root, not just activerecord.
+    {
+      filename: "packages/activesupport/src/schema-wiring.test.ts",
+      code: 'import { loadCanonicalSchema } from "../../activerecord/src/support/canonical-schema.js";',
       errors: [{ messageId: "banned", data: { name: "loadCanonicalSchema" } }],
     },
     // Both banned symbols in one import → one report each.
@@ -220,6 +232,29 @@ describe("no-internal-canonical-loaders module matcher", () => {
     expect([...trees]).toEqual(
       expect.arrayContaining(["packages/activerecord", "packages/activesupport", "scripts"]),
     );
+  });
+
+  // Discovery is not enforcement: widening the scan roots above keeps the
+  // pinned module list honest, but the rule only runs against files matching
+  // its `files` glob in eslint.config.mjs. A config still scoped to
+  // packages/activerecord would leave a test file in another package importing
+  // a banned loader completely unlinted — the hole this story is about.
+  it("wires the rule to every scan root eslint can lint", async () => {
+    const config = (await import("../eslint.config.mjs")).default;
+    const blocks = config.filter(
+      (block) => block.rules?.["blazetrails/no-internal-canonical-loaders"],
+    );
+    expect(blocks.flatMap((block) => block.files ?? [])).toEqual(canonicalLoaderEnforcedGlobs);
+
+    const globallyIgnored = config.flatMap((block) => (block.files ? [] : (block.ignores ?? [])));
+    const unlintable = canonicalLoaderScanRoots.filter((root) =>
+      globallyIgnored.includes(`${root}/**`),
+    );
+    expect(unlintable).toEqual(canonicalLoaderUnenforceableRoots);
+    for (const root of canonicalLoaderScanRoots) {
+      const enforced = canonicalLoaderEnforcedGlobs.some((glob) => glob.startsWith(`${root}/`));
+      expect([root, enforced]).toEqual([root, !unlintable.includes(root)]);
+    }
   });
 
   // Without this the allowlist is a silent hole of its own: if model-schema.ts

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -8,7 +8,7 @@ import rule, {
   isCanonicalSchemaModule,
   moduleBasename,
 } from "./no-internal-canonical-loaders.mjs";
-import { activerecordSrcRoot, canonicalLoaderModules } from "./test-infra-scope.mjs";
+import { canonicalLoaderModules, canonicalLoaderScanRoots } from "./test-infra-scope.mjs";
 
 const FILENAME = "packages/activerecord/src/dirty.test.ts";
 const OWN_TEST = "packages/activerecord/src/support/canonical-schema.test.ts";
@@ -101,19 +101,16 @@ tester.run("no-internal-canonical-loaders", rule, {
   ],
 });
 
-const srcDir = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-  ...activerecordSrcRoot.split("/"),
-);
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 /**
- * Modules outside the loader set that legitimately export a BANNED name.
- * `model-schema.ts` is Rails' own `ActiveRecord::ModelSchema#load_schema` —
- * unrelated to `support/load-schema-helper.ts`, and the rule already lets it
- * through because it matches on module basename as well as symbol.
+ * Modules outside the loader set that legitimately export a BANNED name,
+ * repo-relative. `model-schema.ts` is Rails' own
+ * `ActiveRecord::ModelSchema#load_schema` — unrelated to
+ * `support/load-schema-helper.ts`, and the rule already lets it through because
+ * it matches on module basename as well as symbol.
  */
-const nonLoaderBannedExporters = new Set(["model-schema.ts"]);
+const nonLoaderBannedExporters = new Set(["packages/activerecord/src/model-schema.ts"]);
 
 /** Names exported by `source`, covering the export forms used in activerecord. */
 function exportedNames(source) {
@@ -133,34 +130,42 @@ function exportedNames(source) {
   return names;
 }
 
+const SKIPPED_DIRS = new Set(["node_modules", "dist", "vendor", ".git", "coverage"]);
+
 /**
- * Walks the whole activerecord `src/` tree, not just `support/`: the rule
- * matches on basename regardless of directory, so a loader relocated out of
- * `support/` (into `test-helpers/`, say) is exactly the silent-reopen case
- * being guarded — the same hole as `support/<subdir>/`, one level up.
+ * Walks every workspace package and the top-level `scripts/` tree, not just
+ * `packages/activerecord/src`: the rule matches on module basename with no
+ * package anchoring, so a loader relocated into another package (a new
+ * `packages/ar-test-infra/`, say) or into a `scripts/` helper is exactly the
+ * silent-reopen case being guarded — the same hole as `support/<subdir>/`, two
+ * levels up.
  */
-async function* srcSources(dir = srcDir) {
+async function* workspaceSources(dir) {
   for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name !== "node_modules" && entry.name !== "dist") yield* srcSources(full);
-    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      if (!SKIPPED_DIRS.has(entry.name)) yield* workspaceSources(full);
+    } else if (/\.(m?ts|mjs)$/.test(entry.name) && !/\.test\.(m?ts|mjs)$/.test(entry.name)) {
       yield full;
     }
   }
 }
 
 /**
- * src-relative path → the BANNED symbols that module exports, for every module
- * in the tree including the non-loader exporters. Walked once and shared: the
- * tree is ~1550 files, so each extra walk costs real time.
+ * Repo-relative path → the BANNED symbols that module exports, for every module
+ * in the workspace including the non-loader exporters. Walked once and shared:
+ * the scan covers ~2100 files, so each extra walk costs real time.
  */
 const bannedExportsBySrcModule = (async () => {
   const byModule = new Map();
-  for await (const file of srcSources()) {
-    const source = await fs.readFile(file, "utf8");
-    const banned = [...exportedNames(source)].filter((name) => BANNED.has(name)).sort();
-    if (banned.length > 0) byModule.set(path.relative(srcDir, file), banned);
+  for (const root of canonicalLoaderScanRoots) {
+    for await (const file of workspaceSources(path.join(repoRoot, root))) {
+      const source = await fs.readFile(file, "utf8");
+      const banned = [...exportedNames(source)].filter((name) => BANNED.has(name)).sort();
+      if (banned.length > 0) {
+        byModule.set(path.relative(repoRoot, file).replace(/\\/g, "/"), banned);
+      }
+    }
   }
   return byModule;
 })();
@@ -173,10 +178,10 @@ async function loaderCandidates() {
 }
 
 describe("no-internal-canonical-loaders module matcher", () => {
-  it("matches every activerecord module that exports a banned loader", async () => {
+  it("matches every workspace module that exports a banned loader", async () => {
     const unmatched = [];
     for (const [file, banned] of await loaderCandidates()) {
-      if (!isCanonicalSchemaModule(`./${file.replace(/\.ts$/, ".js")}`)) {
+      if (!isCanonicalSchemaModule(`./${file.replace(/\.m?ts$/, ".js")}`)) {
         unmatched.push(`${file} exports ${banned.join(", ")}`);
       }
     }
@@ -185,7 +190,7 @@ describe("no-internal-canonical-loaders module matcher", () => {
 
   it("lists no module that has stopped exporting a banned loader", async () => {
     const found = new Set(
-      (await loaderCandidates()).map(([file]) => moduleBasename(file.replace(/\.ts$/, ""))),
+      (await loaderCandidates()).map(([file]) => moduleBasename(file.replace(/\.m?ts$/, ""))),
     );
     expect(canonicalLoaderModules.filter((module) => !found.has(module))).toEqual([]);
   });

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -133,6 +133,14 @@ function exportedNames(source) {
 const SKIPPED_DIRS = new Set(["node_modules", "dist", "vendor", ".git", "coverage"]);
 
 /**
+ * Every JS/TS spelling a module could use, not just `.ts`: a loader moved into
+ * `scripts/` would be `.mjs`, and pinning the extension set to the one the
+ * activerecord tree happens to use would leave a fresh hole of the same shape.
+ */
+const SOURCE_EXTENSION = /\.[cm]?[jt]sx?$/;
+const TEST_MODULE = /\.test\.[cm]?[jt]sx?$/;
+
+/**
  * Walks every workspace package and the top-level `scripts/` tree, not just
  * `packages/activerecord/src`: the rule matches on module basename with no
  * package anchoring, so a loader relocated into another package (a new
@@ -145,7 +153,7 @@ async function* workspaceSources(dir) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (!SKIPPED_DIRS.has(entry.name)) yield* workspaceSources(full);
-    } else if (/\.(m?ts|mjs)$/.test(entry.name) && !/\.test\.(m?ts|mjs)$/.test(entry.name)) {
+    } else if (SOURCE_EXTENSION.test(entry.name) && !TEST_MODULE.test(entry.name)) {
       yield full;
     }
   }
@@ -156,32 +164,38 @@ async function* workspaceSources(dir) {
  * in the workspace including the non-loader exporters. Walked once and shared:
  * the scan covers ~2100 files, so each extra walk costs real time.
  */
-const bannedExportsBySrcModule = (async () => {
+const scan = (async () => {
   const byModule = new Map();
+  const trees = new Set();
   for (const root of canonicalLoaderScanRoots) {
     for await (const file of workspaceSources(path.join(repoRoot, root))) {
+      const rel = path.relative(repoRoot, file).replace(/\\/g, "/");
+      trees.add(
+        rel
+          .split("/")
+          .slice(0, root === "packages" ? 2 : 1)
+          .join("/"),
+      );
       const source = await fs.readFile(file, "utf8");
       const banned = [...exportedNames(source)].filter((name) => BANNED.has(name)).sort();
-      if (banned.length > 0) {
-        byModule.set(path.relative(repoRoot, file).replace(/\\/g, "/"), banned);
-      }
+      if (banned.length > 0) byModule.set(rel, banned);
     }
   }
-  return byModule;
+  return { byModule, trees };
 })();
+
+const bannedExportsByModule = scan.then(({ byModule }) => byModule);
 
 /** The same map with the sanctioned non-loader exporters dropped. */
 async function loaderCandidates() {
-  return [...(await bannedExportsBySrcModule)].filter(
-    ([file]) => !nonLoaderBannedExporters.has(file),
-  );
+  return [...(await bannedExportsByModule)].filter(([file]) => !nonLoaderBannedExporters.has(file));
 }
 
 describe("no-internal-canonical-loaders module matcher", () => {
   it("matches every workspace module that exports a banned loader", async () => {
     const unmatched = [];
     for (const [file, banned] of await loaderCandidates()) {
-      if (!isCanonicalSchemaModule(`./${file.replace(/\.m?ts$/, ".js")}`)) {
+      if (!isCanonicalSchemaModule(`./${file.replace(SOURCE_EXTENSION, "")}`)) {
         unmatched.push(`${file} exports ${banned.join(", ")}`);
       }
     }
@@ -190,16 +204,29 @@ describe("no-internal-canonical-loaders module matcher", () => {
 
   it("lists no module that has stopped exporting a banned loader", async () => {
     const found = new Set(
-      (await loaderCandidates()).map(([file]) => moduleBasename(file.replace(/\.m?ts$/, ""))),
+      (await loaderCandidates()).map(([file]) =>
+        moduleBasename(file.replace(SOURCE_EXTENSION, "")),
+      ),
     );
     expect(canonicalLoaderModules.filter((module) => !found.has(module))).toEqual([]);
+  });
+
+  // The walk is what makes the two tests above guards rather than vacuous
+  // truths: if it silently stopped covering a tree, nothing else here would
+  // notice. Pin that it reaches past activerecord into a sibling package and
+  // into scripts/.
+  it("scans every workspace package and the scripts tree", async () => {
+    const { trees } = await scan;
+    expect([...trees]).toEqual(
+      expect.arrayContaining(["packages/activerecord", "packages/activesupport", "scripts"]),
+    );
   });
 
   // Without this the allowlist is a silent hole of its own: if model-schema.ts
   // moves or stops exporting `loadSchema`, the stale entry would keep excusing
   // a path nobody is checking.
   it("allowlists only non-loader modules that still export a banned name", async () => {
-    const exporters = await bannedExportsBySrcModule;
+    const exporters = await bannedExportsByModule;
     expect([...nonLoaderBannedExporters].filter((file) => !exporters.has(file))).toEqual([]);
   });
 });

--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -31,6 +31,29 @@ export const activerecordSrcRoot = "packages/activerecord/src";
 export const canonicalLoaderScanRoots = ["packages", "scripts"];
 
 /**
+ * `files` globs the `no-internal-canonical-loaders` rule is wired to.
+ *
+ * Discovery and enforcement are two surfaces: the scan above keeps the rule's
+ * pinned module list honest, but the rule only ever runs against files matching
+ * these globs, so a test file outside them could import a banned loader and
+ * never be linted at all. Both are derived from the same roots so widening one
+ * widens the other; the pin in `no-internal-canonical-loaders.test.mjs` fails if
+ * `eslint.config.mjs` drifts from this list.
+ */
+export const canonicalLoaderEnforcedGlobs = ["packages/**/*.test.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"];
+
+/**
+ * Scan roots ESLint cannot enforce in, because `eslint.config.mjs` puts them in
+ * its top-level `ignores` — no rule runs there at all, so a glob for them would
+ * be a lie. They stay in the discovery scan: a loader *module* relocated into
+ * one is still caught and forced into `canonicalLoaderModules`. The pin in
+ * `no-internal-canonical-loaders.test.mjs` re-derives this from the config's
+ * real ignore list, so un-ignoring `scripts/` fails until enforcement widens
+ * with it.
+ */
+export const canonicalLoaderUnenforceableRoots = ["scripts"];
+
+/**
  * Test-infra paths exempt from the table-lifecycle rules, relative to
  * `activerecordSrcRoot`. `fixtures.ts` / `test-fixtures.ts` are anchored as
  * exact ported files rather than by basename — see no-raw-sql-scope.mjs.

--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -19,6 +19,18 @@
 export const activerecordSrcRoot = "packages/activerecord/src";
 
 /**
+ * Repo-relative roots the `no-internal-canonical-loaders` guard test walks when
+ * hunting for modules that export a banned loader.
+ *
+ * `isCanonicalSchemaModule` matches on module basename with no package
+ * anchoring, so a loader relocated into ANY workspace package — or into a
+ * top-level `scripts/` helper — is invisible to the rule's pinned module list
+ * and reopens the ban silently. Scanning only `packages/activerecord/src` left
+ * exactly that hole one level up, so the scan spans the whole workspace.
+ */
+export const canonicalLoaderScanRoots = ["packages", "scripts"];
+
+/**
  * Test-infra paths exempt from the table-lifecycle rules, relative to
  * `activerecordSrcRoot`. `fixtures.ts` / `test-fixtures.ts` are anchored as
  * exact ported files rather than by basename — see no-raw-sql-scope.mjs.


### PR DESCRIPTION
`isCanonicalSchemaModule` matches a canonical loader on module basename alone,
with no package anchoring, so the rule's pinned module list is the only thing
keeping the ban closed. PR #5687 widened the guard's scan root from
`packages/activerecord/src/support/` to `packages/activerecord/src`, but that
still stopped at one package.

The hole has two halves, and both are closed here:

**Enforcement.** The rule was wired to `files: ["packages/activerecord/src/**/*.test.ts"]`,
so a test file in any other package importing a banned loader was never linted
at all — no basename list could help. It is now wired to
`canonicalLoaderEnforcedGlobs` (`packages/**/*.test.{ts,tsx,mts,cts,js,jsx,mjs,cjs}`).
`repoRel` accepts `scripts/` alongside `packages/` so allowlist keys stay
uniform.

`scripts/` cannot be enforced: `eslint.config.mjs` puts `scripts/**` in its
top-level `ignores`, so no rule runs there. Rather than ship a glob that lies,
it is declared as `canonicalLoaderUnenforceableRoots`, and the config pin below
re-derives that set from the config's real ignore list — un-ignoring `scripts/`
fails the test until enforcement widens with it. It stays in the discovery scan,
so a loader *module* relocated there is still caught.

**Discovery.** The guard test now walks every workspace package plus `scripts/`
(`canonicalLoaderScanRoots`) and accepts every JS/TS module spelling rather than
the `.ts` the activerecord tree happens to use — a `scripts/` loader would be
`.mjs`. `nonLoaderBannedExporters` is re-keyed to repo-relative paths.

Two new non-vacuity pins: one asserts the walk actually reaches
`packages/activerecord`, `packages/activesupport` and `scripts`; one asserts the
`files` glob in `eslint.config.mjs` matches the scan roots ESLint can lint. The
second is the guard for exactly the defect review caught — widening discovery
while leaving enforcement scoped to activerecord now fails.

Verified (each fails before, passes after):
- `packages/arel/src/probe.test.ts` importing `loadSchema` from the activerecord
  loader is now reported by `npx eslint`; on `main`'s glob it lints clean.
- Synthetic relocated loaders in `packages/arel/src/moved-loader.ts`,
  `scripts/moved-loader-2.mjs` and `packages/rack/src/moved-three.cjs` are each
  reported by path; guard goes green once deleted.
- Narrowing the config glob back to `packages/activerecord/src/**/*.test.ts`
  fails the new config pin; dropping `"scripts"` from the scan roots fails the
  coverage pin.
- `npx eslint "packages/*/src/**/*.test.ts"` reports zero
  `no-internal-canonical-loaders` violations, so the widened glob adds no
  existing failures.

Measured cost: the matcher test goes from ~290ms to ~540ms in-test (~990ms for
the file, ~5.9s wall including transform/setup) — the scan covers ~2115 non-test
modules versus ~1550 before. Acceptable for a lint-rule unit test.

Closes-story: canonical-loader-guard-stops-at-the-activerecord-package
