### PR TITLE
docs(activerecord): lead loadAdapterSpecificSchema's docstring with its carve-out

### DIFF
--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -12,6 +12,13 @@
  * The predicate is stubbed false on a real adapter and `createTable` is
  * intercepted, so the DDL is emitted and asserted without laying anything on
  * the shared per-worker database.
+ *
+ * That interception is why this calls `loadAdapterSpecificSchema` rather than
+ * `loadSchema`: `loadSchema` would run `loadCanonicalSchema` through the same
+ * proxy, so the canonical tables are never created and the first canonical
+ * statement referencing one fails with `StatementInvalid: relation ... does not
+ * exist`. It only shows up on the PG lane, so do not "fix" this to `loadSchema`
+ * on the strength of a green unit run (PR #5676, reverted by #5688).
  */
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -533,11 +533,23 @@ export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
 
 /**
  * The `load adapter_specific_schema_file if File.exist?(...)` arm of
- * `load_schema_helper.rb:15`, on its own. Go through {@link loadSchema} for a
- * schema load: reaching for this arm alone is exactly how the two halves of
- * `load_schema` drifted apart before. It is exported for the trails-only tests
- * that pin the arm's own content, and for the per-worker boot's fast path,
- * which replays it against a database whose canonical half is already laid.
+ * `load_schema_helper.rb:15`, on its own.
+ *
+ * Which entry point a caller wants turns on whether it really lays schema:
+ *
+ * - **Call this arm** when the canonical half is already on the database, or
+ *   when it must never reach the database at all — the per-worker boot's fast
+ *   path (`test-setup-dy.ts`) is the former; a trails-only cover that stubs or
+ *   proxies `createTable` to capture the emitted DDL is the latter. Routing
+ *   such a cover through {@link loadSchema} makes `loadCanonicalSchema` run
+ *   first against the same stub, so the canonical tables are never actually
+ *   created and the first statement referencing one dies with
+ *   `StatementInvalid: relation ... does not exist`. That is PG-lane-only, so
+ *   the unit lane stays green and only CI catches it (PR #5676, reverted by
+ *   #5688).
+ * - **Call {@link loadSchema}** for anything that performs a real schema load.
+ *   Splitting a real load into its halves is how the two arms drifted apart
+ *   before, so do not reach for this one to hand-roll `load_schema`.
  *
  * @internal
  */


### PR DESCRIPTION
`loadAdapterSpecificSchema`'s docstring opened with an unconditional-sounding ban ("reaching for this arm alone is exactly how the two halves of `load_schema` drifted apart before") and buried the carve-out at the end. PR #5676 acted on the ban and rewrote the uuid-default cover to `loadSchema`, which broke it; #5688 reverted.

The docstring now leads with the condition — a caller that stubs or proxies a DDL emitter to assert on emitted SQL calls the arm; a caller that really lays schema calls `loadSchema` — and names why the trap is expensive (PG-lane-only, so the unit lane stays green). The uuid-default cover repeats the rule at the call site so it is visible without opening the definition.

Docs only; no behavior change.

Closes-story: clarify-load-schema-arm-entry-point-guidance