### PR TITLE
test-support(activerecord): enforce the loadSchema arm-vs-full-load seam

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -577,6 +577,11 @@ export default defineConfig(
   //    See eslint/no-load-schema-with-stubbed-ddl.mjs. ──
   {
     files: ["packages/activerecord/src/**/*.test.ts"],
+    // The guard cover is the one file that must do exactly what the rule
+    // forbids: it stubs `createTable` to assert `loadSchema` *refuses* such an
+    // adapter (support/load-schema-helper.ts, assertNotArmProbe) instead of
+    // running its canonical half.
+    ignores: ["packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts"],
     rules: {
       "blazetrails/no-load-schema-with-stubbed-ddl": "error",
     },

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,10 +1,5 @@
 {
   "files": {
-    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
-      "unsignedDecimal",
-      "unsignedFloat"
-    ],
-    "packages/activerecord/src/connection-handling.ts": ["connection"],
-    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
+    "packages/activerecord/src/connection-handling.ts": ["connection"]
   }
 }

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,5 +1,10 @@
 {
   "files": {
-    "packages/activerecord/src/connection-handling.ts": ["connection"]
+    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
+      "unsignedDecimal",
+      "unsignedFloat"
+    ],
+    "packages/activerecord/src/connection-handling.ts": ["connection"],
+    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
   }
 }

--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -91,4 +91,7 @@ export const canonicalLoaderSelfTests = [
   // boot-laid table snapshot the adapter-specific arm feeds.
   `${activerecordSrcRoot}/support/load-schema-helper.trails.test.ts`,
   `${activerecordSrcRoot}/support/load-schema-helper-uuid-default.trails.test.ts`,
+  // …and a third: the cover for `loadSchema`'s own arm-probe guard, which has
+  // to call `loadSchema` to assert it refuses a stubbed `createTable`.
+  `${activerecordSrcRoot}/support/load-schema-helper-arm-guard.trails.test.ts`,
 ];

--- a/eslint/test-infra-scope.test.mjs
+++ b/eslint/test-infra-scope.test.mjs
@@ -32,6 +32,7 @@ describe("test-infra lint scope", () => {
       `${SRC}/support/load-schema-helper.test.ts`,
       `${SRC}/support/load-schema-helper.trails.test.ts`,
       `${SRC}/support/load-schema-helper-uuid-default.trails.test.ts`,
+      `${SRC}/support/load-schema-helper-arm-guard.trails.test.ts`,
     ]);
     expect([...ALLOW]).toEqual(canonicalLoaderSelfTests);
     expect(canonicalLoaderModules).toEqual([

--- a/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
@@ -1,0 +1,70 @@
+/**
+ * trails-only cover for `loadSchema`'s arm-probe guard.
+ *
+ * Rails needs none of this: `load_schema_helper.rb` has one mechanism, and no
+ * Ruby test stubs `create_table` to capture the DDL a schema file would emit.
+ * trails' arm-content covers do, and one of them (PR #5676) was routed through
+ * `loadSchema` in a PR that was green on its own base — the breakage existed
+ * only in the merge with #5678, and only on the PG lane.
+ * `blazetrails/no-load-schema-with-stubbed-ddl` closes that hole lexically for
+ * an activerecord test file; the guard closes it for every other caller, and
+ * this file pins it in both directions.
+ *
+ * Runs on whichever lane is active: the sqlite adapter is in-memory, and the
+ * two rejection cases throw before any DDL.
+ */
+import { describe, expect, it } from "vitest";
+import "../sqlite/better-sqlite3.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { loadSchema } from "./load-schema-helper.js";
+
+async function withAdapter(fn: (adapter: BetterSQLite3Adapter) => Promise<void>): Promise<void> {
+  const adapter = new BetterSQLite3Adapter(":memory:");
+  try {
+    await fn(adapter);
+  } finally {
+    await adapter.close();
+  }
+}
+
+describe("load_schema arm-probe guard", () => {
+  it("rejects an adapter whose createTable a proxy intercepts", async () => {
+    await withAdapter(async (adapter) => {
+      const probe = new Proxy(adapter, {
+        get(target, prop) {
+          if (prop === "createTable") return async () => {};
+          return Reflect.get(target, prop, target);
+        },
+      });
+
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toThrow(
+        /createTable is stubbed/,
+      );
+    });
+  });
+
+  it("rejects an adapter whose createTable is assigned over", async () => {
+    await withAdapter(async (adapter) => {
+      (adapter as unknown as { createTable: unknown }).createTable = async () => {};
+
+      await expect(loadSchema(adapter as unknown as AbstractAdapter)).rejects.toThrow(
+        /createTable is stubbed/,
+      );
+    });
+  });
+
+  // The counterpart direction: a proxy that only observes must still load, or
+  // the guard would break the pooling/logging wrappers that hand `loadSchema` a
+  // wrapped connection.
+  it("passes an adapter behind a transparent proxy", async () => {
+    await withAdapter(async (adapter) => {
+      const passthrough = new Proxy(adapter, {
+        get: (target, prop) => Reflect.get(target, prop, target),
+      });
+
+      await loadSchema(passthrough as unknown as AbstractAdapter);
+      expect(await passthrough.tables()).toContain("topics");
+    });
+  });
+});

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -19,6 +19,11 @@
  * statement referencing one fails with `StatementInvalid: relation ... does not
  * exist`. It only shows up on the PG lane, so do not "fix" this to `loadSchema`
  * on the strength of a green unit run (PR #5676, reverted by #5688).
+ *
+ * Gating: `describeIfPg` probes a PostgreSQL server directly rather than
+ * reading `ARCONN`, so this file runs on the sqlite lane too whenever a server
+ * is reachable — including the local run a contributor makes before pushing. It
+ * is skipped, never silently passed, when none is.
  */
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "./describe-if-pg.js";

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -3,6 +3,7 @@ import type { TableDefinition as MysqlTableDefinition } from "../connection-adap
 import type { TableDefinition as PgTableDefinition } from "../connection-adapters/postgresql/schema-definitions.js";
 import type { AbstractMysqlAdapter } from "../connection-adapters/abstract-mysql-adapter.js";
 import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { ActiveRecordError } from "../errors.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
 
 /**
@@ -525,10 +526,54 @@ const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Pro
  * @internal Boot/template setup paths only. Test files wire the canonical schema
  * + fixtures through `fixtures({ ... })`; the
  * `blazetrails/no-internal-canonical-loaders` ESLint rule enforces that.
+ *
+ * This seam — `loadSchema`, `loadCanonicalSchema`, `loadAdapterSpecificSchema`,
+ * `canonical-schema-stamp.ts` and the per-worker boot in `test-setup-dy.ts` —
+ * is reshaped by one story at a time. Five PRs touched it in one evening and
+ * three broke only in the merge, each having been green on its own base: a
+ * signature change here carries semantics its callers depend on, and no run of
+ * CI sees the combination until it lands.
  */
 export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
+  assertNotArmProbe(adapter);
   await loadCanonicalSchema(adapter);
   await loadAdapterSpecificSchema(adapter);
+}
+
+/**
+ * Fail fast when a caller that has stubbed `createTable` — the shape every
+ * arm-content cover uses to capture DDL without laying it — reaches for the
+ * full load. Such a caller wants {@link loadAdapterSpecificSchema}; the
+ * canonical half {@link loadSchema} runs first would go on to query tables that
+ * were never really laid, which surfaces as `relation "..." does not exist` on
+ * the PG lane only (PR #5676, reverted by #5688).
+ *
+ * `blazetrails/no-load-schema-with-stubbed-ddl` catches the same mistake
+ * lexically, inside an activerecord test file. This catches it from anywhere —
+ * a stub installed through a helper, a non-test caller, a proxy the rule cannot
+ * see — and at the moment it would do damage rather than at lint time.
+ *
+ * Only an *overridden* `createTable` counts: the prototype's own method is
+ * looked up through the chain, so a transparent proxy (which returns that same
+ * function) passes, and an adapter with no prototype `createTable` at all — a
+ * hand-rolled fake — is left alone rather than guessed at.
+ */
+function assertNotArmProbe(adapter: DatabaseAdapter): void {
+  const seen = (adapter as unknown as { createTable?: unknown }).createTable;
+  for (
+    let proto: object | null = Object.getPrototypeOf(adapter);
+    proto !== null;
+    proto = Object.getPrototypeOf(proto)
+  ) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, "createTable");
+    if (!descriptor) continue;
+    if (descriptor.value === seen) return;
+    throw new ActiveRecordError(
+      "loadSchema was handed an adapter whose createTable is stubbed. The canonical " +
+        "half of the load would not really lay its tables; call " +
+        "loadAdapterSpecificSchema directly to cover the adapter-specific arm.",
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Rebased onto a `main` that moved under this branch: siblings #5693 (the
`no-load-schema-with-stubbed-ddl` lint rule), #5694 (workspace-wide loader
discovery) and #5695 (the `loadAdapterSpecificSchema` carve-out docstring)
landed the *lexical* half of this seam's enforcement while it was open. The
overlapping parts of this PR — a per-symbol self-test allowlist and a duplicate
carve-out note — were dropped rather than merged. What remains is what a lexical
rule cannot reach.

**Runtime guard.** `loadSchema` now refuses an adapter whose `createTable` is
overridden — proxied or assigned over — and points the caller at
`loadAdapterSpecificSchema`. `no-load-schema-with-stubbed-ddl` sees a stub only
when it is spelled out in an activerecord `*.test.ts`; the guard also catches a
stub installed through a helper, a proxy built elsewhere, and any non-test
caller, at the moment it would do damage rather than at lint time. A transparent
proxy still loads (verified), so pooling/logging wrappers are unaffected, and an
adapter with no prototype `createTable` at all is left alone rather than guessed
at.

`load-schema-helper-arm-guard.trails.test.ts` pins all three directions and runs
on every lane (in-memory sqlite; the rejection cases throw before any DDL). It
fails on the pre-guard baseline. It is the one file exempted from
`no-load-schema-with-stubbed-ddl` in `eslint.config.mjs` — it must do exactly
what that rule forbids to assert the refusal — and is added to
`canonicalLoaderSelfTests` for the same reason.

**Story's remaining criteria, answered at the call sites.**

- `loadSchema`'s docstring records the seam's one-story-at-a-time ownership and
  why: five PRs touched it in one evening, three broke only in the merge, and no
  CI run sees the combination until it lands. This PR is itself the fourth
  instance of that.
- `loadAdapterSpecificSchema` stays exported; #5695 documents the carve-out and
  nothing here changes it.
- `describeIfPg` probes a PostgreSQL server directly rather than reading
  `ARCONN`, so the uuid_default cover runs on the sqlite lane too whenever a
  server is reachable — including a contributor's local pre-push run. Documented
  in the cover's header, which the story asked for explicitly.

Closes-story: serialize-load-schema-helper-seam-ownership
