### PR TITLE
test(activerecord): drop stale in-memory gates in connection-handling test

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -18,7 +18,6 @@ import {
 } from "./core.js";
 import { setTrailsRoot } from "@blazetrails/activesupport";
 import { adapterType } from "./test-adapter.js";
-import { inMemoryDb } from "./support/adapter-helper.js";
 import { restoreWorkerConnection } from "./support/connection.js";
 import * as nodeFs from "node:fs";
 import * as nodeOs from "node:os";
@@ -50,58 +49,46 @@ describe("ConnectionHandlingTest", () => {
     await Post.where({ title: "foo" }).deleteAll();
   });
 
-  it.skipIf(inMemoryDb())(
-    "#with_connection lease the connection for the duration of the block",
-    async () => {
-      Base.releaseConnection();
-      const pool = Base.connectionPool();
-      expect(pool.activeConnection).toBeNull();
-      await Base.withConnection((conn) => {
-        expect(conn).toBeTruthy();
-        expect(pool.activeConnection).toBeTruthy();
-      });
-    },
-  );
+  it("#with_connection lease the connection for the duration of the block", async () => {
+    Base.releaseConnection();
+    const pool = Base.connectionPool();
+    expect(pool.activeConnection).toBeNull();
+    await Base.withConnection((conn) => {
+      expect(conn).toBeTruthy();
+      expect(pool.activeConnection).toBeTruthy();
+    });
+  });
 
-  it.skipIf(inMemoryDb())(
-    "#lease_connection makes the lease permanent even inside #with_connection",
-    async () => {
-      await Base.withConnection(async () => {
-        const leased = await Base.leaseConnection();
-        expect(leased).toBeTruthy();
-      });
-      // leaseConnection makes sticky=true, so connection persists
-      expect(Base.connectionPool().activeConnection).toBeTruthy();
-      Base.releaseConnection();
-    },
-  );
-
-  it.skipIf(inMemoryDb())(
-    "#lease_connection makes the lease permanent even inside #with_connection(prevent_permanent_checkout: true)",
-    async () => {
-      Base.releaseConnection();
-      await Base.withConnection(
-        async (connection) => {
-          expect(await Base.leaseConnection()).toBe(connection);
-        },
-        { preventPermanentCheckout: true },
-      );
-      expect(Base.connectionPool().activeConnection).toBeNull();
-    },
-  );
-
-  it.skipIf(inMemoryDb())(
-    "#with_connection use the already leased connection if available",
-    async () => {
+  it("#lease_connection makes the lease permanent even inside #with_connection", async () => {
+    await Base.withConnection(async () => {
       const leased = await Base.leaseConnection();
-      await Base.withConnection((conn) => {
-        expect(conn).toBe(leased);
-      });
-      Base.releaseConnection();
-    },
-  );
+      expect(leased).toBeTruthy();
+    });
+    // leaseConnection makes sticky=true, so connection persists
+    expect(Base.connectionPool().activeConnection).toBeTruthy();
+    Base.releaseConnection();
+  });
 
-  it.skipIf(inMemoryDb())("#with_connection is reentrant", async () => {
+  it("#lease_connection makes the lease permanent even inside #with_connection(prevent_permanent_checkout: true)", async () => {
+    Base.releaseConnection();
+    await Base.withConnection(
+      async (connection) => {
+        expect(await Base.leaseConnection()).toBe(connection);
+      },
+      { preventPermanentCheckout: true },
+    );
+    expect(Base.connectionPool().activeConnection).toBeNull();
+  });
+
+  it("#with_connection use the already leased connection if available", async () => {
+    const leased = await Base.leaseConnection();
+    await Base.withConnection((conn) => {
+      expect(conn).toBe(leased);
+    });
+    Base.releaseConnection();
+  });
+
+  it("#with_connection is reentrant", async () => {
     await Base.withConnection(async (outer) => {
       await Base.withConnection((inner) => {
         expect(inner).toBe(outer);
@@ -109,111 +96,96 @@ describe("ConnectionHandlingTest", () => {
     });
   });
 
-  it.skipIf(inMemoryDb())(
-    "#connection is a soft-deprecated alias to #lease_connection",
-    async () => {
-      ActiveRecord.permanentConnectionCheckout = true;
-      Base.releaseConnection();
-      expect(Base.connectionPool().activeConnection).toBeNull();
+  it("#connection is a soft-deprecated alias to #lease_connection", async () => {
+    ActiveRecord.permanentConnectionCheckout = true;
+    Base.releaseConnection();
+    expect(Base.connectionPool().activeConnection).toBeNull();
 
-      let conn: unknown;
-      await Base.withConnection(async (connection) => {
-        conn = connection;
-        expect(Base.connectionPool().activeConnection).toBeTruthy();
-        expect(Base.connection).toBe(connection);
-        expect(Base.connection).toBe(connection);
-      });
-
+    let conn: unknown;
+    await Base.withConnection(async (connection) => {
+      conn = connection;
       expect(Base.connectionPool().activeConnection).toBeTruthy();
-      expect(Base.connection).toBe(conn);
-      Base.releaseConnection();
-    },
-  );
+      expect(Base.connection).toBe(connection);
+      expect(Base.connection).toBe(connection);
+    });
 
-  it.skipIf(inMemoryDb())(
-    "#connection emits a deprecation warning if ActiveRecord.permanent_connection_checkout == :deprecated",
-    async () => {
-      ActiveRecord.permanentConnectionCheckout = "deprecated";
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      try {
-        Base.releaseConnection();
+    expect(Base.connectionPool().activeConnection).toBeTruthy();
+    expect(Base.connection).toBe(conn);
+    Base.releaseConnection();
+  });
 
-        void Base.connection;
-        expect(warnSpy).toHaveBeenCalledTimes(1);
-        warnSpy.mockClear();
-
-        void Base.connection;
-        expect(warnSpy).not.toHaveBeenCalled();
-
-        Base.releaseConnection();
-
-        void Base.connection;
-        expect(warnSpy).toHaveBeenCalledTimes(1);
-        warnSpy.mockClear();
-        Base.releaseConnection();
-
-        await Base.withConnection(async () => {
-          void Base.connection;
-          expect(warnSpy).toHaveBeenCalledTimes(1);
-        });
-      } finally {
-        warnSpy.mockRestore();
-      }
-    },
-  );
-
-  it.skipIf(inMemoryDb())(
-    "#connection raises an error if ActiveRecord.permanent_connection_checkout == :disallowed",
-    async () => {
-      ActiveRecord.permanentConnectionCheckout = "disallowed";
+  it("#connection emits a deprecation warning if ActiveRecord.permanent_connection_checkout == :deprecated", async () => {
+    ActiveRecord.permanentConnectionCheckout = "deprecated";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
       Base.releaseConnection();
 
-      expect(() => Base.connection).toThrow(ActiveRecordError);
+      void Base.connection;
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockClear();
+
+      void Base.connection;
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      Base.releaseConnection();
+
+      void Base.connection;
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockClear();
+      Base.releaseConnection();
 
       await Base.withConnection(async () => {
-        expect(() => Base.connection).toThrow(ActiveRecordError);
+        void Base.connection;
+        expect(warnSpy).toHaveBeenCalledTimes(1);
       });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 
-      await Base.leaseConnection();
-      expect(() => Base.connection).not.toThrow();
-      Base.releaseConnection();
-    },
-  );
+  it("#connection raises an error if ActiveRecord.permanent_connection_checkout == :disallowed", async () => {
+    ActiveRecord.permanentConnectionCheckout = "disallowed";
+    Base.releaseConnection();
 
-  it.skipIf(inMemoryDb())(
-    "#connection doesn't make the lease permanent if inside #with_connection(prevent_permanent_checkout: true)",
-    async () => {
-      ActiveRecord.permanentConnectionCheckout = "disallowed";
-      Base.releaseConnection();
+    expect(() => Base.connection).toThrow(ActiveRecordError);
 
-      await Base.withConnection(
-        async (connection) => {
-          expect(Base.connection).toBe(connection);
-        },
-        { preventPermanentCheckout: true },
-      );
+    await Base.withConnection(async () => {
+      expect(() => Base.connection).toThrow(ActiveRecordError);
+    });
 
-      expect(Base.connectionPool().activeConnection).toBeNull();
-    },
-  );
+    await Base.leaseConnection();
+    expect(() => Base.connection).not.toThrow();
+    Base.releaseConnection();
+  });
 
-  it.skipIf(inMemoryDb())(
-    "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed",
-    async () => {
-      ActiveRecord.permanentConnectionCheckout = "deprecated";
-      Base.releaseConnection();
-      expect(Base.connectionPool().activeConnection).toBeNull();
+  it("#connection doesn't make the lease permanent if inside #with_connection(prevent_permanent_checkout: true)", async () => {
+    ActiveRecord.permanentConnectionCheckout = "disallowed";
+    Base.releaseConnection();
 
-      await Post.createBang({ title: "foo", body: "bar" });
-      expect(Post.connectionPool().activeConnection).toBeNull();
+    await Base.withConnection(
+      async (connection) => {
+        expect(Base.connection).toBe(connection);
+      },
+      { preventPermanentCheckout: true },
+    );
 
-      await Post.first();
-      expect(Post.connectionPool().activeConnection).toBeNull();
+    expect(Base.connectionPool().activeConnection).toBeNull();
+  });
 
-      await Post.count();
-      expect(Post.connectionPool().activeConnection).toBeNull();
-    },
-  );
+  it("common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed", async () => {
+    ActiveRecord.permanentConnectionCheckout = "deprecated";
+    Base.releaseConnection();
+    expect(Base.connectionPool().activeConnection).toBeNull();
+
+    await Post.createBang({ title: "foo", body: "bar" });
+    expect(Post.connectionPool().activeConnection).toBeNull();
+
+    await Post.first();
+    expect(Post.connectionPool().activeConnection).toBeNull();
+
+    await Post.count();
+    expect(Post.connectionPool().activeConnection).toBeNull();
+  });
 
   it("connected_to switches role for block", async () => {
     expect(currentRole.call(Base)).toBe("writing");

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -64,7 +64,6 @@ describe("ConnectionHandlingTest", () => {
       const leased = await Base.leaseConnection();
       expect(leased).toBeTruthy();
     });
-    // leaseConnection makes sticky=true, so connection persists
     expect(Base.connectionPool().activeConnection).toBeTruthy();
     Base.releaseConnection();
   });


### PR DESCRIPTION
Drops the ten stale `it.skipIf(inMemoryDb())` gates in `connection-handling.test.ts` and the now-unused `inMemoryDb` import.

These gates predate #5692, which moved `restoreWorkerConnection` into `support/connection.ts` and made it re-lay the canonical schema when the worker database comes back empty. Rails has no counterpart: `in_memory_db?` gates cases that cannot work against `:memory:`, and these lease/release cases are not among them.

Verified on the mem lane:

- `ARCONN=sqlite3_mem` on the file alone: 56/56 passing, zero skipped.
- `ARCONN=sqlite3_mem` with sibling `core.test.ts` sharing the worker: 79 passed, 1 skipped (pre-existing skip in `core.test.ts`).

Test names are untouched; the line churn is prettier collapsing the now-shorter `it(...)` calls onto single lines.

Closes-story: drop-stale-in-memory-gates-in-connection-handling-test
