### PR TITLE
test(activerecord): make bespoke-table cleanup failure-safe per file

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "api:arity": "pnpm tsx scripts/api-compare/lint-arity-excludes.ts",
     "api:pins": "pnpm tsx scripts/api-compare/lint-body-pins.ts",
     "api:pins:all": "API_COMPARE_FORCE=1 pnpm api:compare && pnpm tsx scripts/api-compare/body-pins.ts --pin-all",
+    "bespoke:tables:inventory": "pnpm tsx scripts/bespoke-tables-inventory/inventory.ts",
     "fixtures:adoption:inventory": "pnpm tsx scripts/fixtures-inventory/inventory.ts",
     "fixtures:compare": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/fixtures-compare/compare.ts",
     "schema:compare": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/schema-compare/compare.ts",

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -530,9 +530,6 @@ describe("PrimaryKeyAnyTypeTest", () => {
       precision: 6,
       force: true,
     });
-    // Rails leaves the table behind (no teardown on this test); trails drops it
-    // from a `finally` so a failed assertion cannot leak it into the shared
-    // per-worker database — the Ruby `teardown` guarantee, applied locally.
     try {
       const schema = await SchemaDumper.dumpTableSchema(Base.connection as any, "scheduled_logs");
       expect(schema).toMatch(/createTable\("scheduled_logs", \{ id: "timestamp"/);

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -530,9 +530,15 @@ describe("PrimaryKeyAnyTypeTest", () => {
       precision: 6,
       force: true,
     });
-    const schema = await SchemaDumper.dumpTableSchema(Base.connection as any, "scheduled_logs");
-    expect(schema).toMatch(/createTable\("scheduled_logs", \{ id: "timestamp"/);
-    await (Base.connection as any).dropTable("scheduled_logs", { ifExists: true });
+    // Rails leaves the table behind (no teardown on this test); trails drops it
+    // from a `finally` so a failed assertion cannot leak it into the shared
+    // per-worker database — the Ruby `teardown` guarantee, applied locally.
+    try {
+      const schema = await SchemaDumper.dumpTableSchema(Base.connection as any, "scheduled_logs");
+      expect(schema).toMatch(/createTable\("scheduled_logs", \{ id: "timestamp"/);
+    } finally {
+      await (Base.connection as any).dropTable("scheduled_logs", { ifExists: true });
+    }
   });
 });
 

--- a/packages/activerecord/src/support/handler-resolved-adapter.test.ts
+++ b/packages/activerecord/src/support/handler-resolved-adapter.test.ts
@@ -8,7 +8,7 @@
  *      declarations loads its schema via lazy reflection without deadlocking
  *      on SQLite :memory: + pool size 1.
  */
-import { describe, it, beforeAll, expect } from "vitest";
+import { describe, it, afterAll, beforeAll, expect } from "vitest";
 import { Base } from "../base.js";
 import { skipGlobalResetForFile } from "./skip-global-reset.js";
 
@@ -41,10 +41,14 @@ describe("handler-resolved adapter (Phase D-0)", () => {
     await HandlerResolvedComment.loadSchema();
   });
 
-  // No afterAll(dropAllTables): the lone bespoke `handler_resolved_comments`
-  // table is non-canonical, so the next non-skip file's global truncation reset
-  // (`resetTestTables`, which DROPs every non-canonical table) clears it — no
-  // ~330-table canonical DROP fan-out needed here. (RFC 0060)
+  // Per-file teardown of the one bespoke table, the way Rails' own suite does
+  // it (`vendor/rails/activerecord/test/cases/migration_test.rb:1231-1233` —
+  // `teardown { drop_table(:delete_me) rescue nil }`), rather than leaning on
+  // the global `resetTestTables` sweep. Not `dropAllTables`: no ~330-table
+  // canonical DROP fan-out is needed here.
+  afterAll(async () => {
+    await Base.connection.dropTable("handler_resolved_comments", { ifExists: true });
+  });
 
   it("isConnectedQ() is true after setupHandlerSuite()", () => {
     expect(Base.isConnectedQ()).toBe(true);

--- a/packages/activerecord/src/support/handler-resolved-adapter.test.ts
+++ b/packages/activerecord/src/support/handler-resolved-adapter.test.ts
@@ -41,11 +41,6 @@ describe("handler-resolved adapter (Phase D-0)", () => {
     await HandlerResolvedComment.loadSchema();
   });
 
-  // Per-file teardown of the one bespoke table, the way Rails' own suite does
-  // it (`vendor/rails/activerecord/test/cases/migration_test.rb:1231-1233` —
-  // `teardown { drop_table(:delete_me) rescue nil }`), rather than leaning on
-  // the global `resetTestTables` sweep. Not `dropAllTables`: no ~330-table
-  // canonical DROP fan-out is needed here.
   afterAll(async () => {
     await Base.connection.dropTable("handler_resolved_comments", { ifExists: true });
   });

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -87,6 +87,7 @@ describe("withTransactionalFixtures (schema-cache invalidation)", () => {
   });
 
   afterAll(async () => {
+    await adapter.dropTable("cache_inval_users", { ifExists: true });
     await adapter.close();
   });
 
@@ -129,6 +130,7 @@ describe("withTransactionalFixtures (raw adapter)", () => {
   });
 
   afterAll(async () => {
+    await adapter.dropTable("raw_fixture_users", { ifExists: true });
     await adapter.close();
   });
 
@@ -159,6 +161,8 @@ describe("withTransactionalFixtures (per-table re-reflection preserves untouched
   });
 
   afterAll(async () => {
+    await adapter.dropTable("pertable_touched", { ifExists: true });
+    await adapter.dropTable("pertable_untouched", { ifExists: true });
     await adapter.close();
   });
 
@@ -194,6 +198,7 @@ describe("withTransactionalFixtures (invalidateSchemaCache: false)", () => {
   });
 
   afterAll(async () => {
+    await adapter.dropTable("opt_out_cache_users", { ifExists: true });
     await adapter.close();
   });
 

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -87,7 +87,6 @@ describe("withTransactionalFixtures (schema-cache invalidation)", () => {
   });
 
   afterAll(async () => {
-    await adapter.dropTable("cache_inval_users", { ifExists: true });
     await adapter.close();
   });
 
@@ -130,7 +129,6 @@ describe("withTransactionalFixtures (raw adapter)", () => {
   });
 
   afterAll(async () => {
-    await adapter.dropTable("raw_fixture_users", { ifExists: true });
     await adapter.close();
   });
 
@@ -161,8 +159,6 @@ describe("withTransactionalFixtures (per-table re-reflection preserves untouched
   });
 
   afterAll(async () => {
-    await adapter.dropTable("pertable_touched", { ifExists: true });
-    await adapter.dropTable("pertable_untouched", { ifExists: true });
     await adapter.close();
   });
 
@@ -198,7 +194,6 @@ describe("withTransactionalFixtures (invalidateSchemaCache: false)", () => {
   });
 
   afterAll(async () => {
-    await adapter.dropTable("opt_out_cache_users", { ifExists: true });
     await adapter.close();
   });
 

--- a/scripts/bespoke-tables-inventory/inventory.ts
+++ b/scripts/bespoke-tables-inventory/inventory.ts
@@ -156,7 +156,7 @@ function teardownBodies(src: string): string {
 function memoryLocalTables(src: string, consts: Map<string, string>): Set<string> {
   const out = new Set<string>();
   for (const body of bracketedBodies(src, /\b(?:it|test)(?:\.\w+)*\s*\(/g)) {
-    if (!/":memory:"|'"'"':memory:'"'"'/.test(body)) continue;
+    if (!/["'`]:memory:["'`]/.test(body)) continue;
     for (const name of literalNames(body, "createTable", consts)) out.add(name);
   }
   return out;

--- a/scripts/bespoke-tables-inventory/inventory.ts
+++ b/scripts/bespoke-tables-inventory/inventory.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env tsx
+/**
+ * RFC 0064 — bespoke-table cleanup inventory. Reports, per AR `*.test.ts`
+ * file, the non-canonical tables whose only teardown sits on the happy path:
+ * a `dropTable` in an `it` body, reachable only if every assertion above it
+ * passed. Rails never has this problem — its cleanup lives in `teardown`
+ * (`vendor/rails/activerecord/test/cases/migration_test.rb:53-67`, dropping
+ * `things awesome_things prefix_things_suffix p_awesome_things_s`) or in a
+ * `teardown { drop_table(:delete_me) rescue nil }` (`:1231-1233`), so a
+ * failing assertion still cleans up. A failed test that leaks its table
+ * poisons the shared per-worker DB for every later file, which is what the
+ * global `resetTestTables` sweep in `cases/helper.ts` is still there to
+ * absorb.
+ *
+ * Scope: this deliberately does NOT re-derive whether a created table is
+ * dropped at all — the `blazetrails/require-table-teardown` ESLint rule
+ * (`eslint/require-table-teardown.mjs`) owns that question, enforces it with
+ * a real AST, and currently runs with an empty exclude list. This script
+ * covers only the dimension that rule does not model: *where* the drop sits.
+ *
+ *   pnpm bespoke:tables:inventory
+ *
+ * Being regex-based it is a triage aid, not a proof: table names built by
+ * interpolation, held in arrays, or dropped through a local helper are
+ * invisible to it, and it errs toward reporting.
+ *
+ * Hard rules: async fs only, no process.* — paths derive from import.meta.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { TEST_SCHEMA } from "../../packages/activerecord/src/test-helpers/test-schema.js";
+
+const REPO = new URL("../../", import.meta.url);
+const AR_SRC = fileURLToPath(new URL("packages/activerecord/src/", REPO));
+
+interface Row {
+  file: string;
+  created: string[];
+  /** Dropped, but never from an afterEach/afterAll hook or a finally block. */
+  unguarded: string[];
+}
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = `${dir}${e.name}`;
+    if (e.isDirectory()) out.push(...(await walk(`${full}/`)));
+    else if (e.name.endsWith(".test.ts")) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Blank out comments so a commented-out `createTable("x")` (or a prose
+ * mention of one) is not counted. String literals are deliberately kept —
+ * they hold the table names we are looking for.
+ */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+/**
+ * `const TABLE_NAME = "unlogged_tests"` → the name, so
+ * `createTable(TABLE_NAME)` and `` `DROP TABLE ${TABLE_NAME}` `` resolve
+ * instead of counting as unresolvable dynamic calls.
+ */
+function stringConsts(src: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const m of src.matchAll(/\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*["'`]([^"'`\n]+)["'`]/g)) {
+    out.set(m[1], m[2]);
+  }
+  return out;
+}
+
+/**
+ * `dropTable` is variadic in Rails (`drop_table :a, :b, options`), so pull
+ * every leading name argument, not just the first.
+ */
+function literalNames(
+  src: string,
+  method: "createTable" | "dropTable",
+  consts: Map<string, string> = new Map(),
+): string[] {
+  if (method === "dropTable") {
+    const names: string[] = [];
+    for (const m of src.matchAll(/\bdropTable\(([^)]*)\)/g)) {
+      for (const a of m[1].matchAll(/["'`]([^"'`]+)["'`]|([A-Za-z_$][\w$]*)/g)) {
+        const name = a[1] ?? consts.get(a[2]);
+        if (name !== undefined) names.push(name);
+      }
+    }
+    return names;
+  }
+  const re = new RegExp(`\\b${method}\\(\\s*(?:["'\`]([^"'\`]+)["'\`]|([A-Za-z_$][\\w$]*))`, "g");
+  const names: string[] = [];
+  for (const m of src.matchAll(re)) {
+    const name = m[1] ?? consts.get(m[2]);
+    if (name !== undefined) names.push(name);
+  }
+  return names;
+}
+
+/**
+ * Raw-SQL teardown counts too: several adapter suites drop their tables with
+ * `exec("DROP TABLE IF EXISTS x; …")` rather than the schema statement.
+ */
+function rawDrops(src: string, consts: Map<string, string> = new Map()): string[] {
+  const re =
+    /\bDROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:["'`]?([A-Za-z0-9_.]+)|\$\{\s*([A-Za-z_$][\w$]*)\s*\})/gi;
+  const names: string[] = [];
+  for (const m of src.matchAll(re)) {
+    const name = m[1] ?? consts.get(m[2]);
+    if (name !== undefined) names.push(name);
+  }
+  return names;
+}
+
+/** Bodies of every construct `opener` matches, by bracket matching. */
+function bracketedBodies(src: string, opener: RegExp): string[] {
+  const out: string[] = [];
+  for (const m of src.matchAll(opener)) {
+    const open = m[0].endsWith("(") ? "(" : "{";
+    const close = open === "(" ? ")" : "}";
+    let depth = 0;
+    let i = m.index + m[0].length - 1;
+    const start = i;
+    for (; i < src.length; i++) {
+      if (src[i] === open) depth++;
+      else if (src[i] === close) {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    out.push(src.slice(start, i));
+  }
+  return out;
+}
+
+/**
+ * `afterEach(...)` / `afterAll(...)` hooks and `finally { … }` blocks — the
+ * places a drop runs even when an assertion above it failed, which is what
+ * Ruby's `teardown` (and `rescue nil`) gives Rails for free.
+ */
+function teardownBodies(src: string): string {
+  return bracketedBodies(src, /\bafter(?:Each|All)\s*\(|\bfinally\s*\{/g).join("");
+}
+
+/**
+ * Tables created inside a test body that builds its own `:memory:` SQLite
+ * adapter cannot leak into the shared per-worker database — the database dies
+ * with the adapter. Those drops are assertions about `dropTable`, not
+ * cleanup, so failure-safety does not apply to them.
+ */
+function memoryLocalTables(src: string, consts: Map<string, string>): Set<string> {
+  const out = new Set<string>();
+  for (const body of bracketedBodies(src, /\b(?:it|test)(?:\.\w+)*\s*\(/g)) {
+    if (!/":memory:"|'"'"':memory:'"'"'/.test(body)) continue;
+    for (const name of literalNames(body, "createTable", consts)) out.add(name);
+  }
+  return out;
+}
+
+/**
+ * Reviewed-benign happy-path drops, keyed `file → table`. Each of these is a
+ * drop that is the subject under test or that cannot outlive the test, so
+ * moving it into a teardown would change what the test asserts. Anything not
+ * listed here is a real leak: a failed assertion strands the table in the
+ * shared per-worker database.
+ */
+const REVIEWED: Record<string, string[]> = {
+  // `dropTable(..., { temporary: true })` inside the transaction IS the
+  // assertion — a plain DROP TABLE would abort the commit. Mirrors Rails'
+  // "drop temporary table" test; the table is session-scoped either way.
+  "packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts": ["temp_table"],
+  // The `createTable` is expected to reject, so `bad_virtual` is never
+  // created; the trailing drop is already a swallowed best-effort.
+  "packages/activerecord/src/adapters/postgresql/virtual-column.test.ts": ["bad_virtual"],
+  // Dropped by the migration's own `down`/`revert`, which is the behavior
+  // under test, and again by the suite's afterEach.
+  "packages/activerecord/src/invertible-migration.test.ts": ["horses"],
+  "packages/activerecord/src/migration.test.ts": ["reminders"],
+  // `dropTable("testings", "sobrinho")` — the multi-table drop is the
+  // assertion.
+  "packages/activerecord/src/migration/change-schema.test.ts": ["sobrinho"],
+};
+
+async function main(): Promise<void> {
+  const canonical = new Set(Object.keys(TEST_SCHEMA));
+  const files = (await walk(AR_SRC)).sort();
+  const rows: Row[] = [];
+
+  for (const file of files) {
+    const src = stripComments(await readFile(file, "utf8"));
+    if (!/\bcreateTable\(/.test(src)) continue;
+
+    const consts = stringConsts(src);
+    const created = [...new Set(literalNames(src, "createTable", consts))]
+      .filter((t) => !canonical.has(t))
+      .sort();
+    if (created.length === 0) continue;
+
+    const memoryLocal = memoryLocalTables(src, consts);
+    const teardown = teardownBodies(src);
+    const dropped = new Set([...literalNames(src, "dropTable", consts), ...rawDrops(src, consts)]);
+    const inTeardown = new Set([
+      ...literalNames(teardown, "dropTable", consts),
+      ...rawDrops(teardown, consts),
+    ]);
+
+    rows.push({
+      file: file.slice(fileURLToPath(REPO).length),
+      created,
+      unguarded: created.filter((t) => dropped.has(t) && !inTeardown.has(t) && !memoryLocal.has(t)),
+    });
+  }
+
+  const dirty = rows
+    .map((r) => ({ ...r, unguarded: r.unguarded.filter((t) => !REVIEWED[r.file]?.includes(t)) }))
+    .filter((r) => r.unguarded.length > 0);
+
+  for (const r of dirty) {
+    console.log(`${r.file}: ${r.unguarded.join(" ")}`);
+  }
+
+  console.log("");
+  console.log(`files creating non-canonical tables: ${rows.length}`);
+  console.log(`unreviewed happy-path-only cleanups: ${dirty.length}`);
+  if (dirty.length > 0) {
+    throw new Error(
+      "tables above are dropped only on the happy path — move the drop into an " +
+        "afterEach/afterAll or a finally, or add it to REVIEWED with a reason",
+    );
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  throw err;
+});


### PR DESCRIPTION
Ports Rails' per-file teardown discipline to the AR suite: bespoke-table
cleanup must run when a test **fails**, the way Ruby's `teardown` does
(`vendor/rails/activerecord/test/cases/migration_test.rb:53-67`, `:1231-1233`).

## What the audit found

The story's premise — 90 files creating 164 bespoke tables, 12 of them with no
cleanup at all — was sized by grepping for `dropTable(`. That undercounts
badly. `blazetrails/require-table-teardown` (`eslint/require-table-teardown.mjs`,
a real AST rule, currently running with an **empty** exclude list) already
enforces that every `createTable("x")` in an AR test is balanced by a
`dropTable("x")` in the same file, including raw-SQL creates and drops. The
"created but never dropped" dimension is closed and gated.

Of the 12 named files, 8 were already clean and needed no change:

- `view.test.ts`, `schema-statements-privates.test.ts`,
  `migration/command-recorder.test.ts`, `connection-adapters/abstract/schema-dumper.test.ts`
  — never create a real table (views, a stubbed adapter, a stub recorder, an
  assertion string).
- `multi-db-migrator.trails.test.ts`, `test-databases.test.ts`,
  `tasks/database-tasks.test.ts`, `tasks/database-tasks-rollback.trails.test.ts`
  — the only `createTable()` calls are the zero-arg `SchemaMigration#createTable()`
  form, which lays Rails' own internal table, not a bespoke one.
- `adapters/postgresql/create-unlogged-tables.test.ts`,
  `adapters/sqlite3/sqlite3-adapter.test.ts` — already drop everything from an
  `afterEach`, via raw SQL.
- `test-fixtures/with-transactional-fixtures.test.ts` — each `describe` builds
  its own private `new BetterSQLite3Adapter(":memory:")` and closes it in
  `afterAll`; closing destroys the database, so there is no shared DB for its
  tables to leak into. An earlier revision of this PR added `dropTable` calls
  there; they were dead code and have been reverted.

## What actually changed

- `primary-keys.test.ts` — **the one genuine leak the audit surfaced.**
  `scheduled_logs` is created and dropped through the shared `Base.connection`,
  and the drop sat after the `expect`, so a failed match stranded the table in
  the per-worker DB for every later file. Now dropped from a `finally`, which
  plays the role of Rails' `teardown { drop_table(:x) rescue nil }`
  (`vendor/rails/activerecord/test/cases/migration_test.rb:1231-1233`), with
  `ifExists: true` standing in for `rescue nil`.
- `support/handler-resolved-adapter.test.ts` — replaces the "no afterAll,
  the global sweep will get it" comment with an `afterAll` dropping
  `handler_resolved_comments`. **This closes no leak**: the global
  `resetTestTables` sweep drops every non-canonical table unconditionally, so
  the old code was already failure-safe. It is a locality change — the file
  cleans up after itself instead of deferring to the next file — which is what
  makes the sweep removable in
  `remove-global-reset-and-skip-shield-after-canonical-burndown`. Still a
  single targeted `dropTable`, not the `dropAllTables` fan-out RFC 0060 avoids.

## The inventory

`scripts/bespoke-tables-inventory/inventory.ts` (`pnpm bespoke:tables:inventory`)
measures the one dimension the lint rule does not model: **where** the drop
sits. It reports created-then-dropped tables whose only drop is reachable on
the happy path, and throws when an unreviewed one appears, so the set can be
re-measured as clusters land. Drops that are the subject under test, or that
cannot outlive the test, are listed in a `REVIEWED` constant with a reason
each; tables created inside an `it` that builds its own `:memory:` adapter are
excluded structurally. It deliberately does not re-derive create/drop balance —
that belongs to the ESLint rule. Current state: 75 files create non-canonical
tables, 0 unreviewed happy-path-only cleanups.

It is a manual triage aid (`pnpm bespoke:tables:inventory`), deliberately not
wired into CI: gating belongs in the ESLint rule, which already runs on every
commit. Folding this check into it is the follow-up story below.

No test names changed, no new bespoke tables, no canonical-schema changes (no
audited table was canonical-eligible), and the global reset plus skip shield
stay put.

## Follow-ups registered

- `0064/fold-failure-safe-teardown-into-require-table-teardown` — move the
  script's check into the ESLint rule and delete the script.
- `0064/measure-global-reset-sweep-before-removal` — instrument
  `resetTestTables` and prove the swept set is empty, the evidence
  `remove-global-reset-and-skip-shield-after-canonical-burndown` needs.

Closes-story: drop-bespoke-tables-per-file-like-rails
