### PR TITLE
fix(ci): guard raw control bytes beyond ESLint's reach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,20 @@ jobs:
               | xargs -r -d '\n' npx --yes prettier@3.8.1 --check --ignore-unknown
           fi
 
+      # Raw-control-byte guard for everything ESLint does not parse (.json, .rb,
+      # .md, .yml, .sql, ...). A control byte makes grep/ripgrep skip the file
+      # silently, so audits get a wrong answer rather than an error; the ESLint
+      # rule blazetrails/no-raw-control-bytes covers only JS/TS. Unconditional
+      # like Prettier above: it scans the whole tracked tree in well under a
+      # second, so there is nothing to gain from a diff gate. `--self-test` is
+      # the regression cover (a raw-NUL fixture must fail, its escaped form must
+      # pass) and runs here so it cannot be skipped.
+      - name: Raw control bytes
+        if: ${{ !cancelled() }}
+        run: |
+          scripts/ci/check-control-bytes.sh --self-test
+          scripts/ci/check-control-bytes.sh
+
       # RFC 0011 Phase 4 guardrail. AR work tracking moved to the tasks repo;
       # `docs/activerecord/` is frozen so the two-source-of-truth split can't
       # self-heal. Fail any PR that adds or modifies a file under that path,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,14 +540,6 @@ jobs:
               | xargs -r -d '\n' npx --yes prettier@3.8.1 --check --ignore-unknown
           fi
 
-      # Raw-control-byte guard for everything ESLint does not parse (.json, .rb,
-      # .md, .yml, .sql, ...). A control byte makes grep/ripgrep skip the file
-      # silently, so audits get a wrong answer rather than an error; the ESLint
-      # rule blazetrails/no-raw-control-bytes covers only JS/TS. Unconditional
-      # like Prettier above: it scans the whole tracked tree in well under a
-      # second, so there is nothing to gain from a diff gate. `--self-test` is
-      # the regression cover (a raw-NUL fixture must fail, its escaped form must
-      # pass) and runs here so it cannot be skipped.
       - name: Raw control bytes
         if: ${{ !cancelled() }}
         run: |

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -7,9 +7,5 @@ export default {
     return cmds;
   },
   "*.{json,md,yml,yaml,css,scss}": ["prettier --write"],
-  // The non-JS/TS half of blazetrails/no-raw-control-bytes: ESLint only parses
-  // JS/TS, and a raw control byte anywhere else hides the file from grep just
-  // as silently. CI's Preflight job runs the same script over the whole tree,
-  // so this is the fast local echo, not the gate.
   "*": ["scripts/ci/check-control-bytes.sh"],
 };

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -7,4 +7,9 @@ export default {
     return cmds;
   },
   "*.{json,md,yml,yaml,css,scss}": ["prettier --write"],
+  // The non-JS/TS half of blazetrails/no-raw-control-bytes: ESLint only parses
+  // JS/TS, and a raw control byte anywhere else hides the file from grep just
+  // as silently. CI's Preflight job runs the same script over the whole tree,
+  // so this is the fast local echo, not the gate.
+  "*": ["scripts/ci/check-control-bytes.sh"],
 };

--- a/eslint/no-raw-control-bytes.mjs
+++ b/eslint/no-raw-control-bytes.mjs
@@ -13,6 +13,10 @@
  * string, `\x1b`) so the source stays plain text. Tab and the line
  * terminators are allowed as literal bytes — they are ordinary whitespace and
  * do not trip binary detection.
+ *
+ * This rule only reaches files ESLint parses. `scripts/ci/check-control-bytes.sh`
+ * enforces the same byte set over every other tracked source (.json, .rb, .md,
+ * .yml, .sql, ...); keep the two byte sets in step.
  */
 
 // C0 controls (except \t \n \r) plus DEL and the C1 range. Matching control

--- a/eslint/no-raw-control-bytes.mjs
+++ b/eslint/no-raw-control-bytes.mjs
@@ -13,10 +13,6 @@
  * string, `\x1b`) so the source stays plain text. Tab and the line
  * terminators are allowed as literal bytes — they are ordinary whitespace and
  * do not trip binary detection.
- *
- * This rule only reaches files ESLint parses. `scripts/ci/check-control-bytes.sh`
- * enforces the same byte set over every other tracked source (.json, .rb, .md,
- * .yml, .sql, ...); keep the two byte sets in step.
  */
 
 // C0 controls (except \t \n \r) plus DEL and the C1 range. Matching control

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1833,7 +1833,7 @@ class ApiExtractor
   # `#{name_local}` with a sentinel, then scans for `def <sentinel>` occurrences.
   # The sentinel is NUL (never present in Ruby source), so the `\s+` in the scan
   # can't ambiguously consume it the way a whitespace marker could.
-  SENTINEL = " "
+  SENTINEL = "\0"
   def codegen_def_forms(body, name_local)
     template = codegen_template(body, name_local)
     return [] unless template

--- a/scripts/ci/check-control-bytes.sh
+++ b/scripts/ci/check-control-bytes.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CONTROL_RE='[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]|\xC2[\x80-\x9F]'
-BINARY_RE='\.(png|jpe?g|gif|webp|ico|pdf|zip|gz|tgz|woff2?|ttf|otf|eot|mp3|mp4|wasm|tsbuildinfo)$|(^|/)packages/rack/test/multipart/'
+BINARY_RE='\.(png|jpe?g)$|(^|/)packages/rack/test/multipart/'
 
 usage() {
   cat <<'MSG'
@@ -56,7 +56,7 @@ selfTest() {
   trap 'rm -rf "$selfTestDir"' EXIT
 
   selfTestCase 'a raw NUL' flagged 'SENTINEL = "\x00"\n'
-  selfTestCase 'the same NUL written as an escape' clean 'SENTINEL = "\\\\0"\n'
+  selfTestCase 'the same NUL written as an escape' clean 'SENTINEL = "\\0"\n'
   selfTestCase 'a raw ESC' flagged 'colour = "\x1becho"\n'
   selfTestCase 'a raw DEL' flagged 'del = "\x7f"\n'
   selfTestCase 'a raw C1 NEL (U+0085)' flagged 'nel = "\xc2\x85"\n'

--- a/scripts/ci/check-control-bytes.sh
+++ b/scripts/ci/check-control-bytes.sh
@@ -1,45 +1,32 @@
 #!/usr/bin/env bash
-# Repo-wide raw-control-byte guard — the non-JS/TS half of
-# `blazetrails/no-raw-control-bytes` (eslint/no-raw-control-bytes.mjs).
-#
-# The ESLint rule only reaches files ESLint parses. A raw control byte in any
-# other tracked text source hides it from grep exactly the same way: `grep -rn`
-# returns nothing and `rg -n` prints only "binary file matches", while tooling
-# reading via `readFile(..., "utf8")` is unaffected — so an audit silently gets
-# a wrong answer instead of an error. That is how the NUL in
-# `scripts/api-compare/extract-ruby-api.rb` (and, before it, in
-# canonical-table-rebuild.ts) survived unnoticed. Intended control characters
-# must be written as escapes.
-#
-# Usage:
-#   scripts/ci/check-control-bytes.sh            # scan every tracked file
-#   scripts/ci/check-control-bytes.sh path...    # scan the given paths (lint-staged)
-#   scripts/ci/check-control-bytes.sh --self-test
 set -euo pipefail
 
-# Same byte set as the ESLint rule: C0 except tab/LF/CR, plus DEL and C1. C1 is
-# matched in its UTF-8 encoding (C2 80..C2 9F) rather than as bare 80..9F, which
-# under LC_ALL=C would hit the continuation byte of every ordinary multibyte
-# character.
 CONTROL_RE='[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]|\xC2[\x80-\x9F]'
-
-# Paths that are legitimately byte-exact. They are excluded rather than escaped
-# — there is no plain-text form of a PNG. `packages/rack/test/multipart/` holds
-# Rack's verbatim HTTP wire fixtures (raw ESC-encoded ISO-2022-JP bodies, an
-# extensionless `binary` blob); rewriting a byte there would change what is
-# being parsed.
 BINARY_RE='\.(png|jpe?g|gif|webp|ico|pdf|zip|gz|tgz|woff2?|ttf|otf|eot|mp3|mp4|wasm|tsbuildinfo)$|(^|/)packages/rack/test/multipart/'
 
-# Prints offending `file:line:text` (control bytes rendered via `cat -v`) and
-# returns 1 when any NUL-separated path on stdin carries a control byte. The
-# hits go through a temp file rather than `$(...)`, which would strip the NUL
-# bytes this check exists to surface.
+usage() {
+  cat <<'MSG'
+Usage:
+  check-control-bytes.sh              scan every tracked file
+  check-control-bytes.sh PATH...      scan the given paths
+  check-control-bytes.sh --self-test  run the scanner's own fixture cases
+
+Fails when a tracked text source carries a raw control byte (C0 except
+tab/LF/CR, plus DEL and C1), which makes grep and ripgrep treat the file as
+binary and skip it while utf8 reads stay unaffected. Write the byte as an
+escape, e.g. "\0". This is the non-JS/TS half of the ESLint rule
+blazetrails/no-raw-control-bytes; keep the two byte sets in step.
+MSG
+}
+
+if ! printf 'x' | grep -qP 'x' 2>/dev/null; then
+  echo "check-control-bytes: requires GNU grep with -P (PCRE) support." >&2
+  exit 2
+fi
+
 scanPaths() {
   local out status=0
   out=$(mktemp)
-  # Emptiness of the output, not the exit status: with `-r` and no surviving
-  # candidates xargs exits 0 without ever running grep, which would otherwise
-  # read as "matches found".
   LC_ALL=C xargs -0 -r grep -anHP "$CONTROL_RE" >"$out" || true
   if [ -s "$out" ]; then
     cat -v "$out"
@@ -50,48 +37,72 @@ scanPaths() {
 }
 
 selfTestDir=""
+selfTestStatus=0
+
+selfTestCase() {
+  local label=$1 expectation=$2 body=$3 actual=flagged file="$selfTestDir/fixture"
+  printf '%b' "$body" >"$file"
+  if printf '%s\0' "$file" | scanPaths >/dev/null; then
+    actual=clean
+  fi
+  if [ "$actual" != "$expectation" ]; then
+    echo "self-test FAILED: $label was reported $actual, expected $expectation" >&2
+    selfTestStatus=1
+  fi
+}
+
 selfTest() {
-  local status=0
   selfTestDir=$(mktemp -d)
   trap 'rm -rf "$selfTestDir"' EXIT
 
-  printf 'SENTINEL = "\0"\n' >"$selfTestDir/bad.rb"
-  if printf '%s\0' "$selfTestDir/bad.rb" | scanPaths >/dev/null; then
-    echo "self-test FAILED: a raw NUL fixture was not flagged" >&2
-    status=1
-  fi
+  selfTestCase 'a raw NUL' flagged 'SENTINEL = "\x00"\n'
+  selfTestCase 'the same NUL written as an escape' clean 'SENTINEL = "\\\\0"\n'
+  selfTestCase 'a raw ESC' flagged 'colour = "\x1becho"\n'
+  selfTestCase 'a raw DEL' flagged 'del = "\x7f"\n'
+  selfTestCase 'a raw C1 NEL (U+0085)' flagged 'nel = "\xc2\x85"\n'
+  selfTestCase 'tab, LF and CR' clean 'ok\t= 1\r\n'
+  selfTestCase 'multibyte UTF-8 with C1-ranged continuation bytes' clean 'em = "\xe2\x80\x94 \xc3\xa9"\n'
 
-  printf 'SENTINEL = "\\0"\n' >"$selfTestDir/good.rb"
-  if ! printf '%s\0' "$selfTestDir/good.rb" | scanPaths; then
-    echo "self-test FAILED: the escaped fixture was flagged" >&2
-    status=1
-  fi
-
-  [ "$status" -eq 0 ] && echo "check-control-bytes: self-test passed."
-  return "$status"
+  [ "$selfTestStatus" -eq 0 ] && echo "check-control-bytes: self-test passed."
+  return "$selfTestStatus"
 }
 
-if [ "${1:-}" = "--self-test" ]; then
-  selfTest
-  exit
-fi
+case "${1:-}" in
+  --self-test)
+    selfTest
+    exit
+    ;;
+  -h | --help)
+    usage
+    exit
+    ;;
+  --)
+    shift
+    ;;
+  -*)
+    echo "check-control-bytes: unknown option $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+candidates=$(mktemp)
+trap 'rm -f "$candidates"' EXIT
 
 if [ "$#" -gt 0 ]; then
-  listPaths() { printf '%s\0' "$@" | grep -zvE "$BINARY_RE"; }
+  printf '%s\0' "$@" >"$candidates"
 else
-  listPaths() { git ls-files -z | grep -zvE "$BINARY_RE"; }
+  git ls-files -z >"$candidates"
+  if [ ! -s "$candidates" ]; then
+    echo "check-control-bytes: git ls-files listed nothing; refusing to pass." >&2
+    exit 1
+  fi
 fi
 
-# `|| true` because `grep -zv` exits 1 when every candidate was excluded, and
-# under `pipefail` that would otherwise read as a scan failure.
-if { listPaths "$@" || true; } | scanPaths; then
-  echo "check-control-bytes: no raw control bytes in tracked sources."
+if { grep -zvE "$BINARY_RE" <"$candidates" || true; } | scanPaths; then
+  echo "check-control-bytes: no raw control bytes found."
 else
-  cat >&2 <<'MSG'
-
-Raw control bytes above make grep/ripgrep treat those files as binary and skip
-them. Write the byte as an escape (e.g. "\0"), or — if the file is genuinely
-binary — add it to BINARY_RE in scripts/ci/check-control-bytes.sh.
-MSG
+  echo >&2
+  usage >&2
   exit 1
 fi

--- a/scripts/ci/check-control-bytes.sh
+++ b/scripts/ci/check-control-bytes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Repo-wide raw-control-byte guard — the non-JS/TS half of
+# `blazetrails/no-raw-control-bytes` (eslint/no-raw-control-bytes.mjs).
+#
+# The ESLint rule only reaches files ESLint parses. A raw control byte in any
+# other tracked text source hides it from grep exactly the same way: `grep -rn`
+# returns nothing and `rg -n` prints only "binary file matches", while tooling
+# reading via `readFile(..., "utf8")` is unaffected — so an audit silently gets
+# a wrong answer instead of an error. That is how the NUL in
+# `scripts/api-compare/extract-ruby-api.rb` (and, before it, in
+# canonical-table-rebuild.ts) survived unnoticed. Intended control characters
+# must be written as escapes.
+#
+# Usage:
+#   scripts/ci/check-control-bytes.sh            # scan every tracked file
+#   scripts/ci/check-control-bytes.sh path...    # scan the given paths (lint-staged)
+#   scripts/ci/check-control-bytes.sh --self-test
+set -euo pipefail
+
+# Same byte set as the ESLint rule: C0 except tab/LF/CR, plus DEL and C1. C1 is
+# matched in its UTF-8 encoding (C2 80..C2 9F) rather than as bare 80..9F, which
+# under LC_ALL=C would hit the continuation byte of every ordinary multibyte
+# character.
+CONTROL_RE='[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]|\xC2[\x80-\x9F]'
+
+# Paths that are legitimately byte-exact. They are excluded rather than escaped
+# — there is no plain-text form of a PNG. `packages/rack/test/multipart/` holds
+# Rack's verbatim HTTP wire fixtures (raw ESC-encoded ISO-2022-JP bodies, an
+# extensionless `binary` blob); rewriting a byte there would change what is
+# being parsed.
+BINARY_RE='\.(png|jpe?g|gif|webp|ico|pdf|zip|gz|tgz|woff2?|ttf|otf|eot|mp3|mp4|wasm|tsbuildinfo)$|(^|/)packages/rack/test/multipart/'
+
+# Prints offending `file:line:text` (control bytes rendered via `cat -v`) and
+# returns 1 when any NUL-separated path on stdin carries a control byte. The
+# hits go through a temp file rather than `$(...)`, which would strip the NUL
+# bytes this check exists to surface.
+scanPaths() {
+  local out status=0
+  out=$(mktemp)
+  # Emptiness of the output, not the exit status: with `-r` and no surviving
+  # candidates xargs exits 0 without ever running grep, which would otherwise
+  # read as "matches found".
+  LC_ALL=C xargs -0 -r grep -anHP "$CONTROL_RE" >"$out" || true
+  if [ -s "$out" ]; then
+    cat -v "$out"
+    status=1
+  fi
+  rm -f "$out"
+  return "$status"
+}
+
+selfTestDir=""
+selfTest() {
+  local status=0
+  selfTestDir=$(mktemp -d)
+  trap 'rm -rf "$selfTestDir"' EXIT
+
+  printf 'SENTINEL = "\0"\n' >"$selfTestDir/bad.rb"
+  if printf '%s\0' "$selfTestDir/bad.rb" | scanPaths >/dev/null; then
+    echo "self-test FAILED: a raw NUL fixture was not flagged" >&2
+    status=1
+  fi
+
+  printf 'SENTINEL = "\\0"\n' >"$selfTestDir/good.rb"
+  if ! printf '%s\0' "$selfTestDir/good.rb" | scanPaths; then
+    echo "self-test FAILED: the escaped fixture was flagged" >&2
+    status=1
+  fi
+
+  [ "$status" -eq 0 ] && echo "check-control-bytes: self-test passed."
+  return "$status"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  selfTest
+  exit
+fi
+
+if [ "$#" -gt 0 ]; then
+  listPaths() { printf '%s\0' "$@" | grep -zvE "$BINARY_RE"; }
+else
+  listPaths() { git ls-files -z | grep -zvE "$BINARY_RE"; }
+fi
+
+# `|| true` because `grep -zv` exits 1 when every candidate was excluded, and
+# under `pipefail` that would otherwise read as a scan failure.
+if { listPaths "$@" || true; } | scanPaths; then
+  echo "check-control-bytes: no raw control bytes in tracked sources."
+else
+  cat >&2 <<'MSG'
+
+Raw control bytes above make grep/ripgrep treat those files as binary and skip
+them. Write the byte as an escape (e.g. "\0"), or — if the file is genuinely
+binary — add it to BINARY_RE in scripts/ci/check-control-bytes.sh.
+MSG
+  exit 1
+fi


### PR DESCRIPTION
`blazetrails/no-raw-control-bytes` (#5688) only reaches files ESLint parses. A
raw control byte in any other tracked source hides it from grep exactly the same
way — `grep -rn` returns nothing, `rg -n` prints only "binary file matches" — and
the failure is silent, because tooling reading via `readFile(..., "utf8")` is
unaffected. An audit gets a wrong answer instead of an error.

`scripts/ci/check-control-bytes.sh` closes that gap over every tracked file
(`.json`, `.rb`, `.md`, `.yml`, `.sql`, and everything else), matching the ESLint
rule's byte set: C0 except tab/LF/CR, plus DEL and C1.

It found one immediately: `scripts/api-compare/extract-ruby-api.rb` carried a raw
NUL as its codegen `SENTINEL`, now written as `"\0"`.

### Where it runs

CI's `Preflight` job as an ungated step (like Prettier) — the whole-tree scan is
well under a second, so there is nothing to gain from a diff gate. Also wired
into lint-staged as the fast local echo, where it is passed the staged paths.

### Regression cover

`--self-test` writes seven fixtures and asserts flagged/clean for each: a raw
NUL, that same NUL written as an escape, a raw ESC, a raw DEL, a raw C1 NEL
(U+0085), literal tab/LF/CR, and multibyte UTF-8. It runs as part of the same CI
step, so the cover cannot be skipped.

Verified discriminating, not just green — three mutations of `CONTROL_RE` each
fail a distinct case:

| mutation | failing case |
| --- | --- |
| drop `\x00` from the C0 range | `a raw NUL was reported clean` |
| drop `\x7F` | `a raw DEL was reported clean` |
| match C1 as bare `[\x80-\x9F]` | `multibyte UTF-8 ... was reported flagged` |

That last one is why C1 is matched in its UTF-8 encoding (`\xC2[\x80-\x9F]`)
rather than as bare `80..9F`: under `LC_ALL=C` the naive form hits the
continuation byte of every ordinary multibyte character (`—` is `E2 80 94`).

The `extract-ruby-api.rb` fix is independently baselined: reverting only that
line makes the repo-wide scan fail.

### Notes on the failure modes

- Hits go through a temp file rather than `$(...)`, which would strip the very
  NUL bytes this exists to surface.
- Offenders are detected by output emptiness, not grep's exit status: with `-r`
  and no surviving candidates, `xargs` exits 0 without ever running grep.
- An empty `git ls-files` refuses to pass rather than reporting a clean tree.
- Missing `grep -P` exits 2 with a message instead of silently matching nothing.
- `shellcheck` clean.

### Exclusions

`BINARY_RE` excludes only what the tree actually contains and cannot express as
text: `.png` / `.jpg`, and `packages/rack/test/multipart/` — Rack's verbatim HTTP
wire fixtures (raw ESC-encoded ISO-2022-JP bodies, an extensionless `binary`
blob) where rewriting a byte would change what is being parsed. Speculative
entries for formats not in the repo are deliberately omitted; the failure
message names `BINARY_RE` so the first genuinely-binary addition is a one-line
change. `.tsbuildinfo` needs no entry — it is gitignored, so `git ls-files` never
offers it.

Closes-story: extend-control-byte-guard-beyond-eslint-reach
