### PR TITLE
feat(eslint): require table teardown to survive a failed assertion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -474,7 +474,9 @@ export default defineConfig(
   //    carpet-bomb dropAllTables() is forbidden. Leaked tables collide with
   //    sibling files under parallel forks. test-helpers/** is exempt — those
   //    tests exercise createTable/dropTable/dropAllTables as the subject under
-  //    test. See eslint/require-table-teardown.mjs. ──
+  //    test. Each drop must also sit where a failed assertion still reaches it
+  //    — an afterEach/afterAll or a finally (`failureSafe`, on by default), as
+  //    Rails' `teardown` does. See eslint/require-table-teardown.mjs. ──
   {
     files: ["packages/activerecord/src/**/*.test.ts"],
     ignores: testInfraExemptIgnores,

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -79,7 +79,9 @@
  * body*, are judged: one at file scope, in a `beforeAll`, or in a shared helper
  * has no assertion positioned to skip it, and a helper's callers are not
  * knowable lexically. A prefix sweep names no table, so it contributes no drop
- * here either way. A table created against a throwaway SQLite `:memory:`
+ * here either way — but a name a sweep does cover is exempt, since the sweep
+ * tears it down whatever the test did, so an explicit happy-path drop beside it
+ * is belt-and-braces. A table created against a throwaway SQLite `:memory:`
  * database is exempt — it dies with its adapter, so its drop is an assertion
  * about `dropTable`, not cleanup. Bookkeeping is per name, file-wide, like the rest of the
  * rule: a name created both in a `:memory:` test and against the shared
@@ -1188,6 +1190,10 @@ const rule = {
         for (const [name, node] of unguardedDrops) {
           if (!created.has(name) || safelyDropped.has(name)) continue;
           if (memoryLocal.has(name)) continue;
+          // A sweep tears the name down whatever the test did, so an explicit
+          // happy-path drop alongside it is belt-and-braces, not a leak — the
+          // same exemption the missing-teardown half grants these names.
+          if (prefixes.some((p) => p.test(name))) continue;
           context.report({
             node,
             messageId: "unguardedTeardown",

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -52,19 +52,14 @@
  * ── Failure-safe teardown ──────────────────────────────────────────────────
  * Being dropped *somewhere* in the file is not enough: a `dropTable` at the end
  * of an `it` body only runs when every assertion above it passed, so a failing
- * test strands the table in the shared per-worker database — poisoning every
- * later file, which is precisely what the global `resetTestTables` sweep in
- * `cases/helper.ts` still exists to absorb. Rails gets this for free from
- * `teardown`: `vendor/rails/activerecord/test/cases/migration_test.rb:53-67`
- * drops `things awesome_things prefix_things_suffix p_awesome_things_s` in a
- * `teardown do` block, and `:1231-1233` spells the swallowing form
- * `teardown { drop_table(:delete_me) rescue nil }` — both run whether or not
- * the test blew up.
+ * test strands the table in the shared per-worker database. Rails gets this for
+ * free from `teardown` — `vendor/rails/activerecord/test/cases/migration_test.rb:53-67`,
+ * and the swallowing form at `:1231-1233`
+ * (`teardown { drop_table(:delete_me) rescue nil }`).
  *
- * So when the `failureSafe` option is on (the default), a created table needs
- * at least one drop sitting where a thrown assertion still reaches it: inside
- * an `afterEach`/`afterAll` callback, or inside a `finally` block. One such
- * drop settles the name — a file may also drop it on the happy path.
+ * So with the `failureSafe` option on (the default), a created table needs at
+ * least one drop a thrown assertion still reaches: in an `afterEach`/`afterAll`
+ * callback, or in a `finally`. One such drop settles the name.
  *
  *   ✗  it("…", async () => {
  *        await conn.createTable("widgets", t => …);
@@ -74,27 +69,21 @@
  *
  *   ✓  it("…", async () => {
  *        await conn.createTable("widgets", t => …);
- *        try {
- *          expect(await conn.tableExistsQ("widgets")).toBe(true);
- *        } finally {
- *          await conn.dropTable("widgets");
- *        }
+ *        try { … } finally { await conn.dropTable("widgets"); }
  *      });
  *
- * The check runs on the same per-name bookkeeping as the missing-teardown half,
- * so a raw `exec("DROP TABLE …")` in an `afterAll` guards a helper-created
- * table and vice versa. It reports at the unguarded drop (the line that has to
- * move), and only for tables the file itself creates — a drop of a table this
- * file never created is somebody else's cleanup. Only drops *inside a test
- * body* are judged: one that sits at file scope, in a `beforeAll`, or in a
- * shared helper is left alone, since no assertion is positioned to skip it and
- * a helper's callers are not knowable lexically. Sweeps are likewise untouched
- * — a prefix sweep satisfies the missing-teardown half without ever naming a
- * table, so it contributes no drop here to be judged.
- *
- * This replaces `scripts/bespoke-tables-inventory/inventory.ts`, a regex-based
- * on-demand script measuring the same dimension; the rule has the real AST and
- * runs on every commit.
+ * It runs on the same per-name bookkeeping as the missing-teardown half, so a
+ * raw `exec("DROP TABLE …")` in an `afterAll` guards a helper-created table and
+ * vice versa, and reports at the unguarded drop — the line that has to move.
+ * Only drops the file itself creates a table for, and only drops *inside a test
+ * body*, are judged: one at file scope, in a `beforeAll`, or in a shared helper
+ * has no assertion positioned to skip it, and a helper's callers are not
+ * knowable lexically. A prefix sweep names no table, so it contributes no drop
+ * here either way. A table created against a throwaway SQLite `:memory:`
+ * database is exempt — it dies with its adapter, so its drop is an assertion
+ * about `dropTable`, not cleanup. Bookkeeping is per name, file-wide, like the rest of the
+ * rule: a name created both in a `:memory:` test and against the shared
+ * database in the same file reads as exempt.
  *
  * ── Raw-SQL leaks ──────────────────────────────────────────────────────────
  * The schema-statement `createTable`/`dropTable` helpers are not the only way a
@@ -922,15 +911,20 @@ function analyzeDropCall(stmt, sourceCode) {
   return { stmt, awaited, receiverText, calleeNode: callee, nameNodes, optionsNode, optionsSig };
 }
 
-/** Vitest hooks that run after the test body regardless of its outcome. */
 const AFTER_HOOKS = new Set(["afterEach", "afterAll"]);
-/** The test-body callers whose bodies a thrown assertion abandons. */
-const TEST_BODIES = new Set(["it", "test"]);
+/**
+ * A call whose callback is a test body. Includes this suite's `it`-prefixed
+ * wrappers (`itIfSupports`, `itBlocked`), which are `it` with a gate in front;
+ * a `test`-prefixed *helper* (`testCopyTable`) is a plain function, not a test,
+ * so only the bare `test` counts on that side.
+ */
+function isTestBody(name) {
+  return name === "it" || name === "test" || /^it[A-Z]/.test(name ?? "");
+}
 
 /**
- * The base name a call is made through, with the modifier chain peeled off:
- * `it.skip(…)`, `it.each([…])(…)` and `it.failing.each([…])(…)` all read as
- * `it`, so a skipped or parameterized test is judged like a plain one.
+ * The base name a call is made through, with the modifier chain peeled off, so
+ * `it.skip(…)` and `it.each([…])(…)` both read as `it`.
  */
 function enclosingCallName(call) {
   let callee = call.callee;
@@ -939,8 +933,6 @@ function enclosingCallName(call) {
   return callee.type === "Identifier" ? callee.name : null;
 }
 
-/** Function scopes are where a suite builds its adapter; `:memory:` in one
- * means the tables created under it die with that adapter. */
 const FUNCTION_TYPES = new Set([
   "ArrowFunctionExpression",
   "FunctionExpression",
@@ -949,12 +941,11 @@ const FUNCTION_TYPES = new Set([
 
 /**
  * Whether the table created at `node` lives in a throwaway SQLite `:memory:`
- * database rather than the shared per-worker one. Such a table cannot outlive
- * its adapter, so a drop of it is an assertion about `dropTable`, not cleanup,
- * and failure-safety does not apply. The adapter is usually built in the test
- * body but may be built in a `beforeAll` a describe up, so every enclosing
- * function scope is read — but not the module scope, whose text is the whole
- * file and would exempt suites that only mention `:memory:` in passing.
+ * database rather than the shared per-worker one — it dies with its adapter, so
+ * failure-safety does not apply. Every enclosing function scope is read, since
+ * the adapter is often built in a `beforeAll` a describe up, but not the module
+ * scope, whose text is the whole file and would exempt suites that only mention
+ * `:memory:` in passing.
  */
 function inMemoryDatabase(node, sourceCode) {
   for (let n = node.parent; n && n.type !== "Program"; n = n.parent) {
@@ -964,16 +955,11 @@ function inMemoryDatabase(node, sourceCode) {
 }
 
 /**
- * Whether a drop at `node` still runs when an assertion above it throws.
- *
- * Only a drop inside a test body is at risk, so the lexical walk outward stops
- * at the first construct that settles the question: a `finally` block or an
- * `afterEach`/`afterAll` callback (safe — Ruby's `teardown`, and its
- * `rescue nil` spelling, in TypeScript), or an `it`/`test` callback reached
- * with neither of those in between (unsafe — the happy path). A drop that sits
- * in no test body at all — top level, a `beforeAll`, a shared helper — is left
- * alone: it is not the pattern this half of the rule models, and a helper's
- * callers are not knowable lexically.
+ * Whether a drop at `node` still runs when an assertion above it throws. The
+ * lexical walk outward stops at the first construct that settles it: a
+ * `finally` or an `afterEach`/`afterAll` callback (safe), or an `it`/`test`
+ * callback reached with neither in between (the happy path). Reaching no test
+ * body at all is safe — nothing is positioned to skip the drop.
  */
 function inFailureSafeTeardown(node) {
   let child = node;
@@ -983,7 +969,7 @@ function inFailureSafeTeardown(node) {
     if (parent.type === "CallExpression" && parent.arguments.includes(child)) {
       const name = enclosingCallName(parent);
       if (AFTER_HOOKS.has(name)) return true;
-      if (TEST_BODIES.has(name)) return false;
+      if (isTestBody(name)) return false;
     }
     child = parent;
     parent = parent.parent;
@@ -997,7 +983,7 @@ const rule = {
     fixable: "code",
     docs: {
       description:
-        'Require each createTable("name") in an activerecord test to be torn down by an explicit dropTable("name") in the same file, and forbid the carpet-bomb dropAllTables().',
+        'Require each createTable("name") in an activerecord test to be torn down by an explicit dropTable("name") in the same file, from a place a failed assertion still reaches, and forbid the carpet-bomb dropAllTables().',
     },
     schema: [
       {
@@ -1015,7 +1001,7 @@ const rule = {
     ],
     messages: {
       missingTeardown:
-        'Table `{{table}}` is created with createTable() but never torn down. Add a matching `dropTable("{{table}}")` (in afterEach/afterAll or the test body). Leaked tables collide with sibling files under parallel forks. If this is intentional, add `// eslint-disable-next-line blazetrails/require-table-teardown`.',
+        'Table `{{table}}` is created with createTable() but never torn down. Add a matching `dropTable("{{table}}")` in an afterEach/afterAll hook (or a finally block, so a failed assertion still runs it). Leaked tables collide with sibling files under parallel forks. If this is intentional, add `// eslint-disable-next-line blazetrails/require-table-teardown`.',
       noDropAllTables:
         'Avoid `dropAllTables()` — drop the specific tables this file created with `dropTable("…")` instead. The carpet-bomb teardown also wipes tables other code seeded, and hides which tables a test actually owns. If this is genuinely necessary, add `// eslint-disable-next-line blazetrails/require-table-teardown`.',
       unguardedTeardown:
@@ -1044,13 +1030,10 @@ const rule = {
     // table name → first create node seen (for the report location).
     const created = new Map();
     const dropped = new Set();
-    // Split of `dropped` by where the drop sits: a name in `safelyDropped` has
-    // at least one drop a failed assertion still reaches; `unguardedDrops`
-    // holds the first happy-path-only drop node, for the report location.
+    // `dropped` split by where the drop sits; unguardedDrops holds the first
+    // happy-path-only drop node, for the report location.
     const safelyDropped = new Set();
     const unguardedDrops = new Map();
-    // Tables created in a throwaway `:memory:` database — exempt, they cannot
-    // outlive their adapter (see inMemoryDatabase).
     const memoryLocal = new Set();
     const sweptPrefixes = [];
     let sawSweepDrop = false;
@@ -1111,9 +1094,8 @@ const rule = {
       if (checkFailureSafe && inMemoryDatabase(node, sourceCode)) memoryLocal.add(table);
     }
 
-    // Record a drop of `table` at `node`, keeping which side of the
-    // failure-safety line it fell on. A single safe drop settles the name;
-    // only a name with no safe drop at all can be reported.
+    // A single safe drop settles the name; only a name with no safe drop at
+    // all can be reported.
     function recordDrop(table, node) {
       dropped.add(table);
       if (inFailureSafeTeardown(node)) safelyDropped.add(table);
@@ -1202,8 +1184,7 @@ const rule = {
           });
         }
         if (!checkFailureSafe) return;
-        // Only tables this file creates are its to strand; a drop of a table
-        // it never created is somebody else's cleanup, not a leak of its own.
+        // A drop of a table this file never created is somebody else's cleanup.
         for (const [name, node] of unguardedDrops) {
           if (!created.has(name) || safelyDropped.has(name)) continue;
           if (memoryLocal.has(name)) continue;

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -49,6 +49,53 @@
  * The `test-helpers/**` infra tests are exempt (configured in eslint.config.mjs)
  * — they exercise createTable/dropTable/dropAllTables as the subject under test.
  *
+ * ── Failure-safe teardown ──────────────────────────────────────────────────
+ * Being dropped *somewhere* in the file is not enough: a `dropTable` at the end
+ * of an `it` body only runs when every assertion above it passed, so a failing
+ * test strands the table in the shared per-worker database — poisoning every
+ * later file, which is precisely what the global `resetTestTables` sweep in
+ * `cases/helper.ts` still exists to absorb. Rails gets this for free from
+ * `teardown`: `vendor/rails/activerecord/test/cases/migration_test.rb:53-67`
+ * drops `things awesome_things prefix_things_suffix p_awesome_things_s` in a
+ * `teardown do` block, and `:1231-1233` spells the swallowing form
+ * `teardown { drop_table(:delete_me) rescue nil }` — both run whether or not
+ * the test blew up.
+ *
+ * So when the `failureSafe` option is on (the default), a created table needs
+ * at least one drop sitting where a thrown assertion still reaches it: inside
+ * an `afterEach`/`afterAll` callback, or inside a `finally` block. One such
+ * drop settles the name — a file may also drop it on the happy path.
+ *
+ *   ✗  it("…", async () => {
+ *        await conn.createTable("widgets", t => …);
+ *        expect(await conn.tableExistsQ("widgets")).toBe(true);  // throws…
+ *        await conn.dropTable("widgets");                        // …never runs
+ *      });
+ *
+ *   ✓  it("…", async () => {
+ *        await conn.createTable("widgets", t => …);
+ *        try {
+ *          expect(await conn.tableExistsQ("widgets")).toBe(true);
+ *        } finally {
+ *          await conn.dropTable("widgets");
+ *        }
+ *      });
+ *
+ * The check runs on the same per-name bookkeeping as the missing-teardown half,
+ * so a raw `exec("DROP TABLE …")` in an `afterAll` guards a helper-created
+ * table and vice versa. It reports at the unguarded drop (the line that has to
+ * move), and only for tables the file itself creates — a drop of a table this
+ * file never created is somebody else's cleanup. Only drops *inside a test
+ * body* are judged: one that sits at file scope, in a `beforeAll`, or in a
+ * shared helper is left alone, since no assertion is positioned to skip it and
+ * a helper's callers are not knowable lexically. Sweeps are likewise untouched
+ * — a prefix sweep satisfies the missing-teardown half without ever naming a
+ * table, so it contributes no drop here to be judged.
+ *
+ * This replaces `scripts/bespoke-tables-inventory/inventory.ts`, a regex-based
+ * on-demand script measuring the same dimension; the rule has the real AST and
+ * runs on every commit.
+ *
  * ── Raw-SQL leaks ──────────────────────────────────────────────────────────
  * The schema-statement `createTable`/`dropTable` helpers are not the only way a
  * test seeds a bespoke table: many tests hand a raw `CREATE TABLE …` string to
@@ -875,6 +922,75 @@ function analyzeDropCall(stmt, sourceCode) {
   return { stmt, awaited, receiverText, calleeNode: callee, nameNodes, optionsNode, optionsSig };
 }
 
+/** Vitest hooks that run after the test body regardless of its outcome. */
+const AFTER_HOOKS = new Set(["afterEach", "afterAll"]);
+/** The test-body callers whose bodies a thrown assertion abandons. */
+const TEST_BODIES = new Set(["it", "test"]);
+
+/**
+ * The base name a call is made through, with the modifier chain peeled off:
+ * `it.skip(…)`, `it.each([…])(…)` and `it.failing.each([…])(…)` all read as
+ * `it`, so a skipped or parameterized test is judged like a plain one.
+ */
+function enclosingCallName(call) {
+  let callee = call.callee;
+  while (callee.type === "CallExpression") callee = callee.callee;
+  while (callee.type === "MemberExpression") callee = callee.object;
+  return callee.type === "Identifier" ? callee.name : null;
+}
+
+/** Function scopes are where a suite builds its adapter; `:memory:` in one
+ * means the tables created under it die with that adapter. */
+const FUNCTION_TYPES = new Set([
+  "ArrowFunctionExpression",
+  "FunctionExpression",
+  "FunctionDeclaration",
+]);
+
+/**
+ * Whether the table created at `node` lives in a throwaway SQLite `:memory:`
+ * database rather than the shared per-worker one. Such a table cannot outlive
+ * its adapter, so a drop of it is an assertion about `dropTable`, not cleanup,
+ * and failure-safety does not apply. The adapter is usually built in the test
+ * body but may be built in a `beforeAll` a describe up, so every enclosing
+ * function scope is read — but not the module scope, whose text is the whole
+ * file and would exempt suites that only mention `:memory:` in passing.
+ */
+function inMemoryDatabase(node, sourceCode) {
+  for (let n = node.parent; n && n.type !== "Program"; n = n.parent) {
+    if (FUNCTION_TYPES.has(n.type) && sourceCode.getText(n).includes(":memory:")) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether a drop at `node` still runs when an assertion above it throws.
+ *
+ * Only a drop inside a test body is at risk, so the lexical walk outward stops
+ * at the first construct that settles the question: a `finally` block or an
+ * `afterEach`/`afterAll` callback (safe — Ruby's `teardown`, and its
+ * `rescue nil` spelling, in TypeScript), or an `it`/`test` callback reached
+ * with neither of those in between (unsafe — the happy path). A drop that sits
+ * in no test body at all — top level, a `beforeAll`, a shared helper — is left
+ * alone: it is not the pattern this half of the rule models, and a helper's
+ * callers are not knowable lexically.
+ */
+function inFailureSafeTeardown(node) {
+  let child = node;
+  let parent = node.parent;
+  while (parent) {
+    if (parent.type === "TryStatement" && parent.finalizer === child) return true;
+    if (parent.type === "CallExpression" && parent.arguments.includes(child)) {
+      const name = enclosingCallName(parent);
+      if (AFTER_HOOKS.has(name)) return true;
+      if (TEST_BODIES.has(name)) return false;
+    }
+    child = parent;
+    parent = parent.parent;
+  }
+  return true;
+}
+
 const rule = {
   meta: {
     type: "problem",
@@ -890,6 +1006,9 @@ const rule = {
           // Also balance raw `CREATE TABLE`/`DROP TABLE` SQL strings (default).
           // Set false to grandfather a file with a raw-create backlog.
           rawSql: { type: "boolean" },
+          // Also require each drop to sit where a failed assertion still runs
+          // it — an afterEach/afterAll hook or a finally block (default).
+          failureSafe: { type: "boolean" },
         },
         additionalProperties: false,
       },
@@ -899,6 +1018,8 @@ const rule = {
         'Table `{{table}}` is created with createTable() but never torn down. Add a matching `dropTable("{{table}}")` (in afterEach/afterAll or the test body). Leaked tables collide with sibling files under parallel forks. If this is intentional, add `// eslint-disable-next-line blazetrails/require-table-teardown`.',
       noDropAllTables:
         'Avoid `dropAllTables()` — drop the specific tables this file created with `dropTable("…")` instead. The carpet-bomb teardown also wipes tables other code seeded, and hides which tables a test actually owns. If this is genuinely necessary, add `// eslint-disable-next-line blazetrails/require-table-teardown`.',
+      unguardedTeardown:
+        "Table `{{table}}` is only dropped on the happy path — a failing assertion above this drop skips it and strands the table in the shared per-worker database. Move the drop into an `afterEach`/`afterAll` hook or a `finally` block, as Rails does with `teardown` (vendor/rails/activerecord/test/cases/migration_test.rb:53-67). If the drop is itself the subject under test, add `// eslint-disable-next-line blazetrails/require-table-teardown` with the reason.",
       preferTableList:
         'Merge adjacent dropTable() calls into a single dropTable("a", "b") list call — shorter teardown code, one call instead of N.',
     },
@@ -908,6 +1029,9 @@ const rule = {
     // Raw-SQL scanning is on by default; `rawSql: false` grandfathers a file
     // with an un-torn-down raw-create backlog (it still gets the helper check).
     const checkRawSql = context.options[0]?.rawSql !== false;
+    // Where the drop sits is checked by default; `failureSafe: false` keeps
+    // only the "is it dropped at all" half.
+    const checkFailureSafe = context.options[0]?.failureSafe !== false;
 
     const sourceCode = context.sourceCode ?? context.getSourceCode();
     // Arming SUPPRESSES reports here, so a loop binding counts only when the
@@ -920,6 +1044,14 @@ const rule = {
     // table name → first create node seen (for the report location).
     const created = new Map();
     const dropped = new Set();
+    // Split of `dropped` by where the drop sits: a name in `safelyDropped` has
+    // at least one drop a failed assertion still reaches; `unguardedDrops`
+    // holds the first happy-path-only drop node, for the report location.
+    const safelyDropped = new Set();
+    const unguardedDrops = new Map();
+    // Tables created in a throwaway `:memory:` database — exempt, they cannot
+    // outlive their adapter (see inMemoryDatabase).
+    const memoryLocal = new Set();
     const sweptPrefixes = [];
     let sawSweepDrop = false;
 
@@ -974,14 +1106,26 @@ const rule = {
       });
     }
 
+    function recordCreate(table, node) {
+      if (!created.has(table)) created.set(table, node);
+      if (checkFailureSafe && inMemoryDatabase(node, sourceCode)) memoryLocal.add(table);
+    }
+
+    // Record a drop of `table` at `node`, keeping which side of the
+    // failure-safety line it fell on. A single safe drop settles the name;
+    // only a name with no safe drop at all can be reported.
+    function recordDrop(table, node) {
+      dropped.add(table);
+      if (inFailureSafeTeardown(node)) safelyDropped.add(table);
+      else if (!unguardedDrops.has(table)) unguardedDrops.set(table, node);
+    }
+
     // Scan an execution sink's string/template arguments for raw CREATE/DROP
     // TABLE statements, folding their names into the same create/drop balance.
     function recordText(text, node, nextTexts) {
       const endIsDynamic = nextTexts !== null;
-      for (const table of rawCreateNames(text, endIsDynamic)) {
-        if (!created.has(table)) created.set(table, node);
-      }
-      for (const table of rawDropNames(text, endIsDynamic)) dropped.add(table);
+      for (const table of rawCreateNames(text, endIsDynamic)) recordCreate(table, node);
+      for (const table of rawDropNames(text, endIsDynamic)) recordDrop(table, node);
       sweptPrefixes.push(...sweepPrefixMatchers(text));
       if (hasDynamicDropName(text, nextTexts)) sawSweepDrop = true;
     }
@@ -1018,9 +1162,9 @@ const rule = {
           context.report({ node, messageId: "noDropAllTables" });
         } else if (name === "createTable") {
           const table = createdTableName(node);
-          if (table !== null && !created.has(table)) created.set(table, node);
+          if (table !== null) recordCreate(table, node);
         } else if (name === "dropTable") {
-          for (const table of droppedTableNames(node)) dropped.add(table);
+          for (const table of droppedTableNames(node)) recordDrop(table, node);
           // The helper spelling of a sweep's drop half: `dropTable(row.name)`
           // names no table itself, so it arms only when its argument traces
           // back to a sink-derived row binding. A fixed name arms nothing.
@@ -1054,6 +1198,18 @@ const rule = {
           context.report({
             node,
             messageId: "missingTeardown",
+            data: { table: name },
+          });
+        }
+        if (!checkFailureSafe) return;
+        // Only tables this file creates are its to strand; a drop of a table
+        // it never created is somebody else's cleanup, not a leak of its own.
+        for (const [name, node] of unguardedDrops) {
+          if (!created.has(name) || safelyDropped.has(name)) continue;
+          if (memoryLocal.has(name)) continue;
+          context.report({
+            node,
+            messageId: "unguardedTeardown",
             data: { table: name },
           });
         }

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -30,6 +30,9 @@ tester.run("require-table-teardown", rule, {
     // A modifier chain still reads as a test body — and this one is guarded.
     'it.skip("x", async () => { await ctx.createTable("widgets", () => {}); });\n' +
       'afterAll(async () => { await ctx.dropTable("widgets"); });',
+    // A `test`-prefixed helper is a plain function, not a test body.
+    'function testCopyTable() {\n  ctx.createTable("widgets", () => {});\n' +
+      '  ctx.dropTable("widgets");\n}',
     // Drops outside any test body are not the modelled pattern.
     'beforeAll(async () => { await ctx.createTable("widgets", () => {}); });\n' +
       'beforeAll(async () => { await ctx.dropTable("widgets"); });',
@@ -43,6 +46,16 @@ tester.run("require-table-teardown", rule, {
     'describe("s", () => {\n  beforeAll(() => { driver = open(":memory:"); });\n' +
       '  it("x", async () => {\n    await driver.exec("CREATE TABLE t (id int)");\n' +
       '    await driver.exec("DROP TABLE t");\n  });\n});',
+    // A prefix sweep names no table, so it satisfies the missing-teardown half
+    // without leaving an unguarded drop behind to report.
+    'it("x", async () => {\n' +
+      '  await adapter.exec(`CREATE TABLE "ex_int" (id int)`);\n' +
+      "  const rows = await adapter.execute(\n" +
+      "    `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+      "  );\n" +
+      "  for (const t of rows) {\n" +
+      '    await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "  }\n});",
     // failureSafe: false keeps only the "is it dropped at all" half.
     {
       code:
@@ -569,6 +582,16 @@ tester.run("require-table-teardown", rule, {
         'it("x", async () => {\n' +
         '  await ctx.createTable("widgets", () => {});\n' +
         '  try { await ctx.dropTable("widgets"); } catch (e) {}\n' +
+        "});",
+      errors: [{ messageId: "unguardedTeardown", data: { table: "widgets" } }],
+    },
+    // An `it`-prefixed wrapper (itIfSupports, itBlocked) is `it` with a gate in
+    // front, so its body is a test body too.
+    {
+      code:
+        'itIfSupports("virtual", "x", async () => {\n' +
+        '  await ctx.createTable("widgets", () => {});\n' +
+        '  await ctx.dropTable("widgets");\n' +
         "});",
       errors: [{ messageId: "unguardedTeardown", data: { table: "widgets" } }],
     },

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -11,6 +11,45 @@ const tester = new RuleTester({
 
 tester.run("require-table-teardown", rule, {
   valid: [
+    // ── failureSafe ──
+    // A drop in an afterAll/afterEach hook survives a failing assertion.
+    'it("x", async () => { await ctx.createTable("widgets", () => {}); });\n' +
+      'afterAll(async () => { await ctx.dropTable("widgets"); });',
+    'it("x", async () => { await ctx.createTable("widgets", () => {}); });\n' +
+      'afterEach(async () => { await ctx.dropTable("widgets"); });',
+    // A finally block inside the test body is the in-test equivalent.
+    'it("x", async () => {\n  await ctx.createTable("widgets", () => {});\n' +
+      '  try { expect(1).toBe(1); } finally { await ctx.dropTable("widgets"); }\n});',
+    // Raw-SQL drop in a hook guards a helper-created table (cross-mechanism).
+    'it("x", async () => { await ctx.createTable("widgets", () => {}); });\n' +
+      'afterAll(async () => { await adapter.exec("DROP TABLE widgets"); });',
+    // One safe drop settles the name even alongside a happy-path drop.
+    'it("x", async () => {\n  await ctx.createTable("widgets", () => {});\n' +
+      '  await ctx.dropTable("widgets");\n});\n' +
+      'afterAll(async () => { await ctx.dropTable("widgets"); });',
+    // A modifier chain still reads as a test body — and this one is guarded.
+    'it.skip("x", async () => { await ctx.createTable("widgets", () => {}); });\n' +
+      'afterAll(async () => { await ctx.dropTable("widgets"); });',
+    // Drops outside any test body are not the modelled pattern.
+    'beforeAll(async () => { await ctx.createTable("widgets", () => {}); });\n' +
+      'beforeAll(async () => { await ctx.dropTable("widgets"); });',
+    // A table the file drops but never creates is somebody else's cleanup.
+    'it("x", async () => { await ctx.dropTable("widgets"); });',
+    // A table in a throwaway `:memory:` database dies with its adapter, so a
+    // happy-path drop strands nothing — whether the adapter is built in the
+    // test body or a describe up, in a beforeAll.
+    'it("x", async () => {\n  const a = new BetterSQLite3Adapter(":memory:");\n' +
+      '  await a.exec("CREATE TABLE t (id int)");\n  await a.exec("DROP TABLE t");\n});',
+    'describe("s", () => {\n  beforeAll(() => { driver = open(":memory:"); });\n' +
+      '  it("x", async () => {\n    await driver.exec("CREATE TABLE t (id int)");\n' +
+      '    await driver.exec("DROP TABLE t");\n  });\n});',
+    // failureSafe: false keeps only the "is it dropped at all" half.
+    {
+      code:
+        'it("x", async () => {\n  await ctx.createTable("widgets", () => {});\n' +
+        '  await ctx.dropTable("widgets");\n});',
+      options: [{ failureSafe: false }],
+    },
     // Create + drop in the same test body.
     'await adapter.createTable("widgets", () => {});\nawait adapter.dropTable("widgets");',
     // Create in beforeAll, drop in afterAll — different hooks, same name.
@@ -502,6 +541,68 @@ tester.run("require-table-teardown", rule, {
       "}",
   ],
   invalid: [
+    // ── failureSafe ──
+    // The drop trails the assertions in the test body: a failure above it
+    // strands `widgets` in the shared per-worker database.
+    {
+      code:
+        'it("x", async () => {\n' +
+        '  await ctx.createTable("widgets", () => {});\n' +
+        '  expect(await ctx.tableExistsQ("widgets")).toBe(true);\n' +
+        '  await ctx.dropTable("widgets");\n' +
+        "});",
+      errors: [{ messageId: "unguardedTeardown", data: { table: "widgets" } }],
+    },
+    // Same for a raw-SQL drop on the happy path.
+    {
+      code:
+        'it("x", async () => {\n' +
+        '  await adapter.exec("CREATE TABLE widgets (id int)");\n' +
+        '  await adapter.exec("DROP TABLE widgets");\n' +
+        "});",
+      errors: [{ messageId: "unguardedTeardown", data: { table: "widgets" } }],
+    },
+    // A `try` whose drop sits in the `try` half, not the `finally`, is not
+    // guarded — only the finalizer runs after a throw.
+    {
+      code:
+        'it("x", async () => {\n' +
+        '  await ctx.createTable("widgets", () => {});\n' +
+        '  try { await ctx.dropTable("widgets"); } catch (e) {}\n' +
+        "});",
+      errors: [{ messageId: "unguardedTeardown", data: { table: "widgets" } }],
+    },
+    // A modifier chain (it.each) is still a test body.
+    {
+      code:
+        'it.each([1])("x", async () => {\n' +
+        '  await ctx.createTable("widgets", () => {});\n' +
+        '  await ctx.dropTable("widgets");\n' +
+        "});",
+      errors: [{ messageId: "unguardedTeardown", data: { table: "widgets" } }],
+    },
+    // A `:memory:` mention outside every enclosing function scope does not
+    // exempt: the module-scope constant may belong to another suite entirely.
+    {
+      code:
+        'const MEM = ":memory:";\n' +
+        'it("x", async () => {\n' +
+        '  await ctx.createTable("widgets", () => {});\n' +
+        '  await ctx.dropTable("widgets");\n' +
+        "});",
+      errors: [{ messageId: "unguardedTeardown", data: { table: "widgets" } }],
+    },
+    // Each table is judged on its own drops: `a` is guarded, `b` is not.
+    {
+      code:
+        'it("x", async () => {\n' +
+        '  await ctx.createTable("a", () => {});\n' +
+        '  await ctx.createTable("b", () => {});\n' +
+        '  await ctx.dropTable("b");\n' +
+        "});\n" +
+        'afterAll(async () => { await ctx.dropTable("a"); });',
+      errors: [{ messageId: "unguardedTeardown", data: { table: "b" } }],
+    },
     // Dropping the truncated prefix of a spaced quoted name is not a teardown
     // of the real table — the create is still reported by its full name.
     {

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -56,6 +56,18 @@ tester.run("require-table-teardown", rule, {
       "  for (const t of rows) {\n" +
       '    await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
       "  }\n});",
+    // …and a name the sweep covers stays exempt even with a belt-and-braces
+    // happy-path drop beside it: the sweep runs whatever the test did.
+    "afterAll(async () => {\n" +
+      "  const rows = await adapter.execute(\n" +
+      "    `SELECT tablename FROM pg_tables WHERE tablename LIKE 'ex_%'`,\n" +
+      "  );\n" +
+      "  for (const t of rows) {\n" +
+      '    await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}"`);\n' +
+      "  }\n});\n" +
+      'it("x", async () => {\n' +
+      '  await ctx.createTable("ex_int", () => {});\n' +
+      '  await ctx.dropTable("ex_int");\n});',
     // failureSafe: false keeps only the "is it dropped at all" half.
     {
       code:

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -189,7 +189,9 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       // Stub mode: the DROP is instrumented and returned, never executed, so
       // the canonical `people` survives and needs no rebuild. The disable also
       // covers the "drop tables" case below — the rule reports a table once.
-      // eslint-disable-next-line blazetrails/require-canonical-rebuild
+      // No DDL reaches the database either, so there is nothing for a
+      // failure-safe teardown to clean up.
+      // eslint-disable-next-line blazetrails/require-canonical-rebuild, blazetrails/require-table-teardown
       const sqls = await captureSql(() => adapter.dropTable("people"), { stub: adapter });
       expect(sqls[0]).toBe("DROP TABLE `people`");
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -189,8 +189,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       // Stub mode: the DROP is instrumented and returned, never executed, so
       // the canonical `people` survives and needs no rebuild. The disable also
       // covers the "drop tables" case below — the rule reports a table once.
-      // No DDL reaches the database either, so there is nothing for a
-      // failure-safe teardown to clean up.
+      // Nothing reaches the database, so there is nothing to tear down either.
       // eslint-disable-next-line blazetrails/require-canonical-rebuild, blazetrails/require-table-teardown
       const sqls = await captureSql(() => adapter.dropTable("people"), { stub: adapter });
       expect(sqls[0]).toBe("DROP TABLE `people`");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -162,6 +162,12 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         await adapter.createTable("temp_table", { temporary: true });
         // if it doesn't properly say DROP TEMPORARY TABLE, the transaction commit
         // will complain that no transaction is active
+        //
+        // The drop stays on the happy path because it IS the assertion: moving
+        // it to a teardown would issue a plain DROP TABLE outside the
+        // transaction, which is the failure mode under test. The table is
+        // session-scoped either way, so it cannot strand.
+        // eslint-disable-next-line blazetrails/require-table-teardown
         await adapter.dropTable("temp_table", { temporary: true });
       });
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -163,10 +163,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         // if it doesn't properly say DROP TEMPORARY TABLE, the transaction commit
         // will complain that no transaction is active
         //
-        // The drop stays on the happy path because it IS the assertion: moving
-        // it to a teardown would issue a plain DROP TABLE outside the
-        // transaction, which is the failure mode under test. The table is
-        // session-scoped either way, so it cannot strand.
+        // So the drop IS the assertion and stays here; the table is
+        // session-scoped either way and cannot strand.
         // eslint-disable-next-line blazetrails/require-table-teardown
         await adapter.dropTable("temp_table", { temporary: true });
       });

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
@@ -25,6 +25,7 @@ describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
   beforeEach(async () => {
     adapter = await leaseMysqlAdapter();
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
+    await adapter.exec(`DROP TABLE IF EXISTS pq_ddl`);
     await adapter.exec(
       `CREATE TABLE pq (id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, nick varchar(255))`,
     );

--- a/packages/activerecord/src/adapters/postgresql/json.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/json.test.ts
@@ -50,10 +50,13 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(
         `CREATE TABLE "json_default_test" ("id" SERIAL PRIMARY KEY, "config" JSON DEFAULT '{}')`,
       );
-      await adapter.executeMutation(`INSERT INTO "json_default_test" DEFAULT VALUES`);
-      const rows = await adapter.execute(`SELECT "config" FROM "json_default_test"`);
-      expect(JSON.parse(rows[0].config as string)).toEqual({});
-      await adapter.exec(`DROP TABLE IF EXISTS "json_default_test"`);
+      try {
+        await adapter.executeMutation(`INSERT INTO "json_default_test" DEFAULT VALUES`);
+        const rows = await adapter.execute(`SELECT "config" FROM "json_default_test"`);
+        expect(JSON.parse(rows[0].config as string)).toEqual({});
+      } finally {
+        await adapter.exec(`DROP TABLE IF EXISTS "json_default_test"`);
+      }
     });
 
     it("json type cast", async () => {
@@ -122,9 +125,12 @@ describeIfPg("PostgreSQLAdapter", () => {
     await adapter.exec(
       `CREATE TABLE "jsonb_default_test" ("id" SERIAL PRIMARY KEY, "data" JSONB DEFAULT '[]')`,
     );
-    await adapter.executeMutation(`INSERT INTO "jsonb_default_test" DEFAULT VALUES`);
-    const rows = await adapter.execute(`SELECT "data" FROM "jsonb_default_test"`);
-    expect(JSON.parse(rows[0].data as string)).toEqual([]);
-    await adapter.exec(`DROP TABLE IF EXISTS "jsonb_default_test"`);
+    try {
+      await adapter.executeMutation(`INSERT INTO "jsonb_default_test" DEFAULT VALUES`);
+      const rows = await adapter.execute(`SELECT "data" FROM "jsonb_default_test"`);
+      expect(JSON.parse(rows[0].data as string)).toEqual([]);
+    } finally {
+      await adapter.exec(`DROP TABLE IF EXISTS "jsonb_default_test"`);
+    }
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -21,6 +21,7 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
+    await adapter.exec(`DROP TABLE IF EXISTS pq_ddl`);
     await adapter.exec(`CREATE TABLE pq (id serial primary key, nick character varying(255))`);
     connection = await Base.leaseConnection();
   });

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -960,15 +960,18 @@ describeIfPg("PostgreSQLAdapter", () => {
           this.attribute("id", "integer");
         }
       }
-      await Article.loadSchema();
-      await (Article as any).create({ title: "zOMG, welcome to my blorgh!" });
-      const welcome = await (Article as any).last();
-      expect(welcome.title).toBe("zOMG, welcome to my blorgh!");
-      // Not the canonical `articles`: the search path set at the top of this
-      // test puts both the createTable above and this drop in "my.schema", so
-      // public.articles is never touched and needs no canonical rebuild.
-      // eslint-disable-next-line blazetrails/require-canonical-rebuild
-      await adapter.dropTable("articles", { ifExists: true });
+      try {
+        await Article.loadSchema();
+        await (Article as any).create({ title: "zOMG, welcome to my blorgh!" });
+        const welcome = await (Article as any).last();
+        expect(welcome.title).toBe("zOMG, welcome to my blorgh!");
+      } finally {
+        // Not the canonical `articles`: the search path set at the top of this
+        // test puts both the createTable above and this drop in "my.schema", so
+        // public.articles is never touched and needs no canonical rebuild.
+        // eslint-disable-next-line blazetrails/require-canonical-rebuild
+        await adapter.dropTable("articles", { ifExists: true });
+      }
     });
   });
 

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -110,6 +110,9 @@ describeIfPg("PostgreSQLAdapter", () => {
           t.virtual("invalid", { type: "string", as: "LOWER(name)" });
         }),
       ).rejects.toThrow(/does not support VIRTUAL.*Specify 'stored: true'/s);
+      // The createTable above is expected to reject, so `bad_virtual` is never
+      // created; this trailing drop is already a swallowed best-effort.
+      // eslint-disable-next-line blazetrails/require-table-teardown
       await adapter.dropTable("bad_virtual", { ifExists: true }).catch(() => {});
     });
 

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -110,8 +110,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           t.virtual("invalid", { type: "string", as: "LOWER(name)" });
         }),
       ).rejects.toThrow(/does not support VIRTUAL.*Specify 'stored: true'/s);
-      // The createTable above is expected to reject, so `bad_virtual` is never
-      // created; this trailing drop is already a swallowed best-effort.
+      // The createTable above rejects, so `bad_virtual` is never created.
       // eslint-disable-next-line blazetrails/require-table-teardown
       await adapter.dropTable("bad_virtual", { ifExists: true }).catch(() => {});
     });

--- a/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
@@ -91,6 +91,9 @@ describeIfSqlite("SQLite3TransactionTest", () => {
     await conn2.rollbackDbTransaction();
 
     await conn1.rollbackDbTransaction();
+    // Permanently skipped, and SHARED_CACHE_DB is an in-memory database that
+    // dies with the connection — nothing can strand.
+    // eslint-disable-next-line blazetrails/require-table-teardown
     await conn1.exec(`DROP TABLE IF EXISTS "zines"`);
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
@@ -91,8 +91,7 @@ describeIfSqlite("SQLite3TransactionTest", () => {
     await conn2.rollbackDbTransaction();
 
     await conn1.rollbackDbTransaction();
-    // Permanently skipped, and SHARED_CACHE_DB is an in-memory database that
-    // dies with the connection — nothing can strand.
+    // SHARED_CACHE_DB is in-memory and dies with the connection.
     // eslint-disable-next-line blazetrails/require-table-teardown
     await conn1.exec(`DROP TABLE IF EXISTS "zines"`);
   });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -94,7 +94,9 @@ describe("PostgreSQLAdapter#execQuery", () => {
     const result = await adapter.execQuery("CREATE TABLE x (id int)");
     expect(result).toBeInstanceOf(Result);
     expect(result.length).toBe(0);
-    // Balances require-table-teardown; the mock driver makes this a no-op.
+    // Balances require-table-teardown; the mock driver makes this a no-op, so
+    // no teardown can be needed either.
+    // eslint-disable-next-line blazetrails/require-table-teardown
     await adapter.execQuery("DROP TABLE IF EXISTS x");
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -94,8 +94,7 @@ describe("PostgreSQLAdapter#execQuery", () => {
     const result = await adapter.execQuery("CREATE TABLE x (id int)");
     expect(result).toBeInstanceOf(Result);
     expect(result.length).toBe(0);
-    // Balances require-table-teardown; the mock driver makes this a no-op, so
-    // no teardown can be needed either.
+    // Balances require-table-teardown; the mock driver makes this a no-op.
     // eslint-disable-next-line blazetrails/require-table-teardown
     await adapter.execQuery("DROP TABLE IF EXISTS x");
   });

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -752,8 +752,7 @@ describe("DDL cache-invalidation safety-net", () => {
     });
 
     const ss = new SchemaStatements(adapter as any);
-    // The adapter is a mock whose execute() only records; no DDL reaches a
-    // database, so there is nothing to tear down.
+    // The adapter is a mock: no DDL reaches a database.
     // eslint-disable-next-line blazetrails/require-table-teardown
     await ss.dropTable("posts");
 

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -752,6 +752,9 @@ describe("DDL cache-invalidation safety-net", () => {
     });
 
     const ss = new SchemaStatements(adapter as any);
+    // The adapter is a mock whose execute() only records; no DDL reaches a
+    // database, so there is nothing to tear down.
+    // eslint-disable-next-line blazetrails/require-table-teardown
     await ss.dropTable("posts");
 
     expect(cache.isCached("posts")).toBe(false);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1227,22 +1227,28 @@ describe("MigrationTest", () => {
     const savedSuffix = Base.tableNameSuffix;
     Base.tableNamePrefix = "prefix_";
     Base.tableNameSuffix = "_suffix";
-    try {
-      class WeNeedReminders extends Migration {
-        async up() {
-          await this.createTable("reminders", (t) => {
-            t.text("content");
-          });
-        }
-        async down() {
-          // Reverting is the behaviour under test; the suite's own teardown
-          // drops the table again if this never runs.
-          // eslint-disable-next-line blazetrails/require-table-teardown
-          await this.dropTable("reminders");
-        }
+    class WeNeedReminders extends Migration {
+      async up() {
+        await this.createTable("reminders", (t) => {
+          t.text("content");
+        });
       }
-
-      const m = new WeNeedReminders();
+      async down() {
+        await this.dropTable("reminders");
+      }
+    }
+    // Exercises addColumn + renameTable (both args prefixed per Rails method_missing)
+    // and change()-based reversal without double-applying prefix/suffix.
+    class ChangeBased extends Migration {
+      async change() {
+        await this.createTable("widgets", (t) => t.string("name"));
+        await this.addColumn("widgets", "price", "integer");
+        await this.renameTable("widgets", "gadgets");
+      }
+    }
+    const m = new WeNeedReminders();
+    const cb = new ChangeBased();
+    try {
       await m.run(adapter, "up");
       // Use adapter quoting so MySQL (no ANSI_QUOTES) works alongside PG/SQLite.
       const qt = adapter.quoteTableName("prefix_reminders_suffix");
@@ -1254,16 +1260,6 @@ describe("MigrationTest", () => {
       await m.run(adapter, "down");
       expect(await m.tableExists("reminders")).toBe(false);
 
-      // Exercises addColumn + renameTable (both args prefixed per Rails method_missing)
-      // and change()-based reversal without double-applying prefix/suffix.
-      class ChangeBased extends Migration {
-        async change() {
-          await this.createTable("widgets", (t) => t.string("name"));
-          await this.addColumn("widgets", "price", "integer");
-          await this.renameTable("widgets", "gadgets");
-        }
-      }
-      const cb = new ChangeBased();
       await cb.run(adapter, "up");
       expect(await cb.tableExists("gadgets")).toBe(true);
       expect(await cb.columnExists("gadgets", "price")).toBe(true);
@@ -1271,6 +1267,13 @@ describe("MigrationTest", () => {
       expect(await cb.tableExists("gadgets")).toBe(false);
       expect(await cb.tableExists("widgets")).toBe(false);
     } finally {
+      // An assertion above skips the migrations' own `down`, and the file's
+      // afterAll drops the UNPREFIXED names — nothing there would reach
+      // `prefix_reminders_suffix` / `prefix_widgets_suffix`. Migration#dropTable
+      // applies the prefix and suffix (still set at this point) exactly as the
+      // migrations did, so these drops name the physical tables.
+      await m.dropTable("reminders", { ifExists: true });
+      await cb.dropTable("widgets", "gadgets", { ifExists: true });
       Base.tableNamePrefix = savedPrefix;
       Base.tableNameSuffix = savedSuffix;
     }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1235,8 +1235,8 @@ describe("MigrationTest", () => {
           });
         }
         async down() {
-          // Reverting the migration is the behaviour under test; the suite's
-          // own teardown drops the table again if this never runs.
+          // Reverting is the behaviour under test; the suite's own teardown
+          // drops the table again if this never runs.
           // eslint-disable-next-line blazetrails/require-table-teardown
           await this.dropTable("reminders");
         }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1235,6 +1235,9 @@ describe("MigrationTest", () => {
           });
         }
         async down() {
+          // Reverting the migration is the behaviour under test; the suite's
+          // own teardown drops the table again if this never runs.
+          // eslint-disable-next-line blazetrails/require-table-teardown
           await this.dropTable("reminders");
         }
       }

--- a/packages/activerecord/src/migration/change-schema.test.ts
+++ b/packages/activerecord/src/migration/change-schema.test.ts
@@ -565,8 +565,7 @@ describe("Migration", () => {
       await connection.createTable("sobrinho");
       expect(await connection.tableExists("testings")).toBeTruthy();
       expect(await connection.tableExists("sobrinho")).toBeTruthy();
-      // Dropping both names in one call is the assertion, so it stays in the
-      // test body.
+      // Dropping both names in one call is the assertion.
       // eslint-disable-next-line blazetrails/require-table-teardown
       await connection.dropTable("testings", "sobrinho", { ifExists: true });
       expect(await connection.tableExists("testings")).toBeFalsy();

--- a/packages/activerecord/src/migration/change-schema.test.ts
+++ b/packages/activerecord/src/migration/change-schema.test.ts
@@ -565,6 +565,9 @@ describe("Migration", () => {
       await connection.createTable("sobrinho");
       expect(await connection.tableExists("testings")).toBeTruthy();
       expect(await connection.tableExists("sobrinho")).toBeTruthy();
+      // Dropping both names in one call is the assertion, so it stays in the
+      // test body.
+      // eslint-disable-next-line blazetrails/require-table-teardown
       await connection.dropTable("testings", "sobrinho", { ifExists: true });
       expect(await connection.tableExists("testings")).toBeFalsy();
       expect(await connection.tableExists("sobrinho")).toBeFalsy();

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -530,9 +530,12 @@ describe("PrimaryKeyAnyTypeTest", () => {
       precision: 6,
       force: true,
     });
-    const schema = await SchemaDumper.dumpTableSchema(Base.connection as any, "scheduled_logs");
-    expect(schema).toMatch(/createTable\("scheduled_logs", \{ id: "timestamp"/);
-    await (Base.connection as any).dropTable("scheduled_logs", { ifExists: true });
+    try {
+      const schema = await SchemaDumper.dumpTableSchema(Base.connection as any, "scheduled_logs");
+      expect(schema).toMatch(/createTable\("scheduled_logs", \{ id: "timestamp"/);
+    } finally {
+      await (Base.connection as any).dropTable("scheduled_logs", { ifExists: true });
+    }
   });
 });
 

--- a/packages/activerecord/src/sqlite/libsql.test.ts
+++ b/packages/activerecord/src/sqlite/libsql.test.ts
@@ -132,6 +132,8 @@ describe("SqliteDriver — libsql local-file round-trip", () => {
       await probe.prepare("SELECT label FROM gadgets WHERE id = ?")
     ).get([1])) as { label: string };
     expect(row.label).toBe("alpha");
+    // dbPath is a per-test temporary file, so a stranded table dies with it.
+    // eslint-disable-next-line blazetrails/require-table-teardown
     await probe.exec("DROP TABLE IF EXISTS gadgets");
     await probe.close();
   });
@@ -147,6 +149,8 @@ describe("SqliteDriver — libsql local-file round-trip", () => {
     try {
       const conn = await libsqlDriver.open({ database: `file:${relName}` });
       await conn.exec("CREATE TABLE t (x INTEGER)");
+      // Same: a throwaway cwd-relative database the finally below unlinks.
+      // eslint-disable-next-line blazetrails/require-table-teardown
       await conn.exec("DROP TABLE IF EXISTS t");
       await conn.close();
       expect(libsqlDriver.databaseExists?.({ database: `file:${relName}` })).toBe(true);

--- a/packages/activerecord/src/sqlite/libsql.test.ts
+++ b/packages/activerecord/src/sqlite/libsql.test.ts
@@ -132,7 +132,7 @@ describe("SqliteDriver — libsql local-file round-trip", () => {
       await probe.prepare("SELECT label FROM gadgets WHERE id = ?")
     ).get([1])) as { label: string };
     expect(row.label).toBe("alpha");
-    // dbPath is a per-test temporary file, so a stranded table dies with it.
+    // dbPath is a per-test temporary file; a stranded table dies with it.
     // eslint-disable-next-line blazetrails/require-table-teardown
     await probe.exec("DROP TABLE IF EXISTS gadgets");
     await probe.close();
@@ -149,7 +149,7 @@ describe("SqliteDriver — libsql local-file round-trip", () => {
     try {
       const conn = await libsqlDriver.open({ database: `file:${relName}` });
       await conn.exec("CREATE TABLE t (x INTEGER)");
-      // Same: a throwaway cwd-relative database the finally below unlinks.
+      // Same: a throwaway database the finally below unlinks.
       // eslint-disable-next-line blazetrails/require-table-teardown
       await conn.exec("DROP TABLE IF EXISTS t");
       await conn.close();

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -45,8 +45,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
         "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR(255) PRIMARY KEY NOT NULL)",
       );
       await adapter.executeMutation("INSERT INTO schema_migrations (version) VALUES ('1')");
-      // dbFile lives under a per-test tmpdir, so nothing can reach the shared
-      // per-worker database.
+      // dbFile lives under a per-test tmpdir, not the shared worker database.
       // eslint-disable-next-line blazetrails/require-table-teardown
       await adapter.executeMutation("DROP TABLE IF EXISTS ar_internal_metadata");
     } finally {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -45,6 +45,9 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
         "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR(255) PRIMARY KEY NOT NULL)",
       );
       await adapter.executeMutation("INSERT INTO schema_migrations (version) VALUES ('1')");
+      // dbFile lives under a per-test tmpdir, so nothing can reach the shared
+      // per-worker database.
+      // eslint-disable-next-line blazetrails/require-table-teardown
       await adapter.executeMutation("DROP TABLE IF EXISTS ar_internal_metadata");
     } finally {
       await adapter.close();


### PR DESCRIPTION
`require-table-teardown` already proved every created table is dropped somewhere
in the file. It did not model *where* the drop sits: a `dropTable` at the end of
an `it` body is skipped the moment an assertion above it throws, stranding the
table in the shared per-worker database for every file that runs after it. Rails
gets this for free from `teardown` —
`vendor/rails/activerecord/test/cases/migration_test.rb:53-67` (a `teardown do`
dropping `things awesome_things prefix_things_suffix p_awesome_things_s`) and
`:1231-1233` (`teardown { drop_table(:delete_me) rescue nil }`).

## What this does

- New `failureSafe` option (default on). A created table needs at least one drop
  in an `afterEach`/`afterAll` callback or a `finally` block. It rides the same
  per-name create/drop bookkeeping as the missing-teardown half, so a raw
  `exec("DROP TABLE …")` in an `afterAll` guards a helper-created table and vice
  versa. Reports at the unguarded drop — the line that has to move.
- Scoped to drops **inside a test body**: one at file scope, in a `beforeAll`,
  or in a shared helper is left alone, since no assertion is positioned to skip
  it and a helper's callers are not knowable lexically.
- Tables created against a throwaway SQLite `:memory:` database are exempt —
  they die with their adapter, so the drop is an assertion about `dropTable`,
  not cleanup. Every enclosing function scope is read (the adapter is often
  built in a `beforeAll` a describe up), but not the module scope, whose text is
  the whole file.
- A test body is `it`/`test` *and* this suite's `it`-prefixed wrappers —
  `itIfSupports` (233 call sites) and `itBlocked` are `it` with a gate in front,
  so a happy-path drop in one is judged like any other. A `test`-prefixed helper
  (`testCopyTable`) is a plain function and stays out.
- Rule tests for both polarities (203 in the file), including the `:memory:`
  carve-out and its module-scope limit, the `it`-prefixed wrappers, and a prefix
  sweep contributing no drop to judge.
- `missingTeardown`'s advice no longer offers "or the test body" as a place to
  put the drop — the same spot this half rejects.

## The 17 reports it found

Four were real happy-path leaks, fixed by moving the drop into a `finally` or
the file's existing `afterEach`: `json_default_test` / `jsonb_default_test`
(postgresql/json), `"my.schema".articles` (postgresql/schema), `pq_ddl` (both
perform-query suites), `scheduled_logs` (primary-keys).

The rest are benign and carry the reason at the call site, as
`eslint-disable-next-line`: stub/mock drops that execute no DDL (`people`, `x`,
`posts`), a `DROP TEMPORARY TABLE` that IS the assertion (`temp_table`), a
create expected to reject (`bad_virtual`), a multi-table drop that is the assertion (`sobrinho`), a
permanently-skipped shared-cache in-memory test (`zines`), and per-test tmpdir
databases (`gadgets`, `t`, `ar_internal_metadata`). Those cover the five
`REVIEWED` entries the story names — `horses` is already guarded and needed
nothing.

`migration.test.ts` ("add drop table with prefix and suffix") turned out to be a
real leak rather than a benign one, so it has no suppression: `freshAdapter()`
returns `Base.connection`, and under the test's `prefix_`/`_suffix` the tables
are physically `prefix_reminders_suffix` / `prefix_widgets_suffix` /
`prefix_gadgets_suffix`, none of which the file's (unprefixed) afterAll list
reaches. Both migrations are hoisted above the `try` so the `finally` tears them
down through `Migration#dropTable`, which applies the same prefix and suffix.

`unguardedTeardown` also shares the prefix-sweep exemption `missingTeardown`
has: a swept name is torn down whatever the test did, so an explicit happy-path
drop beside the sweep is belt-and-braces, not a leak. Regression test included —
it fails on the baseline.

## Note on `scripts/bespoke-tables-inventory/`

The story also asks for that script and its `bespoke:tables:inventory` npm
script to be deleted. They do not exist on `main` — they arrive with #5698,
which is still open. This PR branches from `main` and does not stack on it, so
the deletion is left to whichever of the two lands second; I'll follow up once
#5698 merges. Note the script only ever saw helper `createTable` calls, never
raw `CREATE TABLE` SQL, so the rule covers strictly more than it did.

Closes-story: fold-failure-safe-teardown-into-require-table-teardown
