### PR TITLE
test-support(activerecord): widen the arm-probe guard past createTable

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -568,7 +568,9 @@ export default defineConfig(
     },
   },
 
-  // ── no-load-schema-with-stubbed-ddl: a test that stubs `createTable` lays
+  // ── no-load-schema-with-stubbed-ddl: a test that stubs any DDL emitter the
+  //    canonical half goes through (see
+  //    packages/activerecord/src/support/stubbed-ddl-methods.ts) lays
   //    nothing on the database, so `loadSchema`'s canonical half would query
   //    tables that were never created (PR #5676). Those arm-content covers must
   //    call `loadAdapterSpecificSchema` directly. The self-test allowlist in
@@ -578,7 +580,7 @@ export default defineConfig(
   {
     files: ["packages/activerecord/src/**/*.test.ts"],
     // The guard cover is the one file that must do exactly what the rule
-    // forbids: it stubs `createTable` to assert `loadSchema` *refuses* such an
+    // forbids: it stubs those emitters to assert `loadSchema` *refuses* such an
     // adapter (support/load-schema-helper.ts, assertNotArmProbe) instead of
     // running its canonical half.
     ignores: ["packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts"],

--- a/eslint/no-load-schema-with-stubbed-ddl.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.mjs
@@ -2,9 +2,10 @@
  * ESLint rule: no-load-schema-with-stubbed-ddl
  *
  * `loadSchema` (support/load-schema-helper.ts) runs the canonical half first
- * and then the adapter-specific arm. A cover that intercepts `createTable` to
- * capture emitted DDL never lays anything on the shared per-worker database, so
- * the canonical half queries tables that were never created and dies with
+ * and then the adapter-specific arm. A cover that intercepts a DDL emitter to
+ * capture the SQL it would have run never lays anything on the shared per-worker
+ * database, so the canonical half queries tables that were never created and
+ * dies with
  * `StatementInvalid: relation "…" does not exist`. Such covers must call
  * `loadAdapterSpecificSchema` directly — the carve-out its docstring already
  * describes in prose.
@@ -21,23 +22,42 @@
  * error.
  */
 
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+/** The one declaration site of the guarded set, read below. */
+const DECLARATION_SITE = "packages/activerecord/src/support/stubbed-ddl-methods.ts";
+
 /**
- * The adapter members whose interception makes the canonical half unsafe.
+ * The adapter members whose interception makes the canonical half unsafe, read
+ * out of {@link DECLARATION_SITE} — the module the runtime guard in
+ * `load-schema-helper.ts` imports, and where the reasoning for reaching past
+ * `createTable` lives.
  *
- * The declaration site is
- * `packages/activerecord/src/support/stubbed-ddl-methods.ts`, which explains why
- * the set reaches past `createTable`; this rule is a plain-Node module outside
- * that package's `rootDir` and cannot import it, so the copy here is pinned
- * against it by this rule's own test.
+ * It is read rather than imported because this is a plain-Node module that
+ * ESLint loads without a TypeScript pipeline, and the declaration site sits
+ * inside `packages/activerecord`'s `rootDir` where it must stay to be importable
+ * by the guard. A second hand-maintained copy here is what the widening was
+ * supposed to end, so the file is parsed instead — a shape it is kept trivial
+ * for, and a parse that yields nothing is a hard failure rather than a rule that
+ * silently stops firing.
  */
-export const STUBBED_DDL_METHODS = new Set([
-  "createTable",
-  "dropTable",
-  "addIndex",
-  "execute",
-  "schemaCreation",
-  "schemaStatements",
-]);
+function readStubbedDdlMethods() {
+  const file = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", DECLARATION_SITE);
+  const source = readFileSync(file, "utf8");
+  const array = /STUBBED_DDL_METHODS[^=]*=\s*\[([^\]]*)\]/.exec(source);
+  const methods = array ? [...array[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]) : [];
+  if (methods.length === 0) {
+    throw new Error(
+      `no-load-schema-with-stubbed-ddl: found no STUBBED_DDL_METHODS in ${DECLARATION_SITE}. ` +
+        "The rule is derived from that array; keep it a flat list of double-quoted names.",
+    );
+  }
+  return new Set(methods);
+}
+
+export const STUBBED_DDL_METHODS = readStubbedDdlMethods();
 
 /** The loader that must not be reached for once a DDL emitter is stubbed. */
 export const BANNED_LOADER = "loadSchema";

--- a/eslint/no-load-schema-with-stubbed-ddl.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.mjs
@@ -17,11 +17,27 @@
  * self-tests, so importing `loadSchema` there is not banned outright).
  *
  * This rule closes that hole lexically, in the unit lane: in a test file that
- * stubs `createTable`, any reference to `loadSchema` is an error.
+ * stubs any of `STUBBED_DDL_METHODS`, any reference to `loadSchema` is an
+ * error.
  */
 
-/** The DDL emitter whose interception makes the canonical half unsafe. */
-export const STUBBED_DDL_METHODS = new Set(["createTable"]);
+/**
+ * The adapter members whose interception makes the canonical half unsafe.
+ *
+ * The declaration site is
+ * `packages/activerecord/src/support/stubbed-ddl-methods.ts`, which explains why
+ * the set reaches past `createTable`; this rule is a plain-Node module outside
+ * that package's `rootDir` and cannot import it, so the copy here is pinned
+ * against it by this rule's own test.
+ */
+export const STUBBED_DDL_METHODS = new Set([
+  "createTable",
+  "dropTable",
+  "addIndex",
+  "execute",
+  "schemaCreation",
+  "schemaStatements",
+]);
 
 /** The loader that must not be reached for once a DDL emitter is stubbed. */
 export const BANNED_LOADER = "loadSchema";
@@ -37,7 +53,7 @@ export function namesStubbedDdlMethod(node) {
 }
 
 /**
- * True when a `"createTable"` literal sits in an *interception* position — the
+ * True when a stubbed-DDL-method literal sits in an *interception* position — the
  * Proxy-trap dispatch shapes `prop === "createTable"`, `case "createTable":`,
  * and `["createTable"].includes(prop)`.
  *
@@ -63,7 +79,7 @@ const rule = {
     type: "problem",
     docs: {
       description:
-        "Forbid `loadSchema` in a test file that stubs `createTable`; such arm-content covers must call `loadAdapterSpecificSchema` directly.",
+        "Forbid `loadSchema` in a test file that stubs a DDL emitter; such arm-content covers must call `loadAdapterSpecificSchema` directly.",
     },
     schema: [],
     messages: {

--- a/eslint/no-load-schema-with-stubbed-ddl.test.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.test.mjs
@@ -95,6 +95,30 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
       `,
       errors: [{ messageId: "misrouted" }],
     },
+    // A member past `createTable`: `runTable` lays canonical tables through the
+    // SchemaStatements companion, which reaches the database via
+    // `adapter.execute`, so intercepting that lays nothing either.
+    {
+      filename: FILENAME,
+      code: `
+        const probe = new Proxy(adapter, {
+          get(target, prop) {
+            if (prop === "execute") return async () => [];
+            return Reflect.get(target, prop, target);
+          },
+        });
+        await loadSchema(probe);
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+    {
+      filename: FILENAME,
+      code: `
+        const stub = { schemaStatements: () => ({ createTable: async () => {} }) };
+        await loadSchema(stub);
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
     // The other two interception dispatch shapes.
     {
       filename: FILENAME,
@@ -148,13 +172,15 @@ describe("the real arm-content cover", () => {
   });
 });
 
-// The rule cannot import the TS declaration site (it is a plain-Node module,
-// and `packages/activerecord`'s rootDir is `src`), so this is what makes the
-// two sets one list: widening either without the other fails here.
+// The rule reads its set out of the TS declaration site's text rather than
+// importing it. This pins that the parse really landed: a regex that stopped
+// matching the array would otherwise leave the rule guarding a stale set, and
+// the throw only covers parsing *nothing*.
 describe("the guarded method set", () => {
-  it("matches the runtime guard's", async () => {
+  it("is the runtime guard's, parsed out of its declaration site", async () => {
     const { STUBBED_DDL_METHODS: runtimeMethods } =
       await import("../packages/activerecord/src/support/stubbed-ddl-methods.ts");
     expect([...STUBBED_DDL_METHODS].sort()).toEqual([...runtimeMethods].sort());
+    expect(STUBBED_DDL_METHODS.has("createTable")).toBe(true);
   });
 });

--- a/eslint/no-load-schema-with-stubbed-ddl.test.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.test.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import { RuleTester } from "eslint";
 import { describe, it, expect } from "vitest";
 import { Linter } from "eslint";
-import rule from "./no-load-schema-with-stubbed-ddl.mjs";
+import rule, { STUBBED_DDL_METHODS } from "./no-load-schema-with-stubbed-ddl.mjs";
 
 const FILENAME = "packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts";
 
@@ -145,5 +145,16 @@ describe("the real arm-content cover", () => {
     // Guards the fixture itself: if the cover stops stubbing createTable the
     // rule would pass vacuously here.
     expect(code).toContain('prop === "createTable"');
+  });
+});
+
+// The rule cannot import the TS declaration site (it is a plain-Node module,
+// and `packages/activerecord`'s rootDir is `src`), so this is what makes the
+// two sets one list: widening either without the other fails here.
+describe("the guarded method set", () => {
+  it("matches the runtime guard's", async () => {
+    const { STUBBED_DDL_METHODS: runtimeMethods } =
+      await import("../packages/activerecord/src/support/stubbed-ddl-methods.ts");
+    expect([...STUBBED_DDL_METHODS].sort()).toEqual([...runtimeMethods].sort());
   });
 });

--- a/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
@@ -54,6 +54,55 @@ describe("load_schema arm-probe guard", () => {
     });
   });
 
+  // `createTable` is not the only interception that lays nothing: `runTable`
+  // reaches the database through the SchemaStatements companion, so a cover
+  // that stubs the members *it* goes through is just as unsafe, and just as
+  // invisible outside the PG lane.
+  for (const method of ["dropTable", "addIndex", "execute", "schemaStatements"]) {
+    it(`rejects an adapter whose ${method} a proxy intercepts`, async () => {
+      await withAdapter(async (adapter) => {
+        const probe = new Proxy(adapter, {
+          get(target, prop) {
+            if (prop === method) return async () => {};
+            return Reflect.get(target, prop, target);
+          },
+        });
+
+        await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toThrow(
+          new RegExp(`${method} is stubbed`),
+        );
+      });
+    });
+  }
+
+  // `schemaCreation` is an accessor, not a method, so the guard compares what
+  // the real one yields rather than its identity — PostgreSQLAdapter's builds a
+  // fresh visitor per read.
+  it("rejects an adapter whose schemaCreation a proxy intercepts", async () => {
+    await withAdapter(async (adapter) => {
+      const probe = new Proxy(adapter, {
+        get(target, prop) {
+          if (prop === "schemaCreation") return { accept: async () => "" };
+          return Reflect.get(target, prop, target);
+        },
+      });
+
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).rejects.toThrow(
+        /schemaCreation is stubbed/,
+      );
+    });
+  });
+
+  it("rejects an adapter whose execute is assigned over", async () => {
+    await withAdapter(async (adapter) => {
+      (adapter as unknown as { execute: unknown }).execute = async () => [];
+
+      await expect(loadSchema(adapter as unknown as AbstractAdapter)).rejects.toThrow(
+        /execute is stubbed/,
+      );
+    });
+  });
+
   // The counterpart direction: a proxy that only observes must still load, or
   // the guard would break the pooling/logging wrappers that hand `loadSchema` a
   // wrapped connection.

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -562,15 +562,21 @@ function assertNotArmProbe(adapter: DatabaseAdapter): void {
 }
 
 /**
+ * What an accessor-backed member yields cannot be compared by identity —
+ * PostgreSQLAdapter's `schemaCreation` builds a fresh visitor on every read — so
+ * the real one and the one the caller sees are compared by prototype: a stub
+ * standing in for it is some other object, however it is shaped.
+ */
+function sameKind(seen: unknown, real: unknown): boolean {
+  if (seen == null || real == null) return seen === real;
+  return Object.getPrototypeOf(seen) === Object.getPrototypeOf(real);
+}
+
+/**
  * Only an *overridden* member counts: the prototype's own is looked up through
  * the chain, so a transparent proxy (which returns that same function) passes,
  * and an adapter carrying no prototype member at all — a hand-rolled fake — is
  * left alone rather than guessed at.
- *
- * `schemaCreation` is an accessor rather than a method, and PostgreSQLAdapter's
- * builds a fresh visitor on every read, so identity comparison is meaningless
- * there. What the real accessor yields is compared by prototype instead: a stub
- * standing in for it is some other object, however it is shaped.
  */
 function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
   const seen = (adapter as unknown as Record<string, unknown>)[method];
@@ -582,13 +588,7 @@ function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
     const descriptor = Object.getOwnPropertyDescriptor(proto, method);
     if (!descriptor) continue;
     if (descriptor.get) {
-      const real = descriptor.get.call(adapter) as unknown;
-      if (
-        seen != null &&
-        real != null &&
-        Object.getPrototypeOf(seen) === Object.getPrototypeOf(real)
-      )
-        return;
+      if (sameKind(seen, descriptor.get.call(adapter))) return;
     } else if (descriptor.value === seen) {
       return;
     }

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -5,6 +5,7 @@ import type { AbstractMysqlAdapter } from "../connection-adapters/abstract-mysql
 import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { ActiveRecordError } from "../errors.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
+import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
 
 /**
  * The ported slice of
@@ -541,35 +542,58 @@ export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
 }
 
 /**
- * Fail fast when a caller that has stubbed `createTable` — the shape every
+ * Fail fast when a caller that has stubbed a DDL emitter — the shape every
  * arm-content cover uses to capture DDL without laying it — reaches for the
  * full load. Such a caller wants {@link loadAdapterSpecificSchema}; the
  * canonical half {@link loadSchema} runs first would go on to query tables that
  * were never really laid, which surfaces as `relation "..." does not exist` on
  * the PG lane only (PR #5676, reverted by #5688).
  *
+ * The set is {@link STUBBED_DDL_METHODS}, which spells out why it reaches past
+ * `createTable` to the members `runTable` really goes through.
+ *
  * `blazetrails/no-load-schema-with-stubbed-ddl` catches the same mistake
  * lexically, inside an activerecord test file. This catches it from anywhere —
  * a stub installed through a helper, a non-test caller, a proxy the rule cannot
  * see — and at the moment it would do damage rather than at lint time.
- *
- * Only an *overridden* `createTable` counts: the prototype's own method is
- * looked up through the chain, so a transparent proxy (which returns that same
- * function) passes, and an adapter with no prototype `createTable` at all — a
- * hand-rolled fake — is left alone rather than guessed at.
  */
 function assertNotArmProbe(adapter: DatabaseAdapter): void {
-  const seen = (adapter as unknown as { createTable?: unknown }).createTable;
+  for (const method of STUBBED_DDL_METHODS) assertNotStubbed(adapter, method);
+}
+
+/**
+ * Only an *overridden* member counts: the prototype's own is looked up through
+ * the chain, so a transparent proxy (which returns that same function) passes,
+ * and an adapter carrying no prototype member at all — a hand-rolled fake — is
+ * left alone rather than guessed at.
+ *
+ * `schemaCreation` is an accessor rather than a method, and PostgreSQLAdapter's
+ * builds a fresh visitor on every read, so identity comparison is meaningless
+ * there. What the real accessor yields is compared by prototype instead: a stub
+ * standing in for it is some other object, however it is shaped.
+ */
+function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
+  const seen = (adapter as unknown as Record<string, unknown>)[method];
   for (
     let proto: object | null = Object.getPrototypeOf(adapter);
     proto !== null;
     proto = Object.getPrototypeOf(proto)
   ) {
-    const descriptor = Object.getOwnPropertyDescriptor(proto, "createTable");
+    const descriptor = Object.getOwnPropertyDescriptor(proto, method);
     if (!descriptor) continue;
-    if (descriptor.value === seen) return;
+    if (descriptor.get) {
+      const real = descriptor.get.call(adapter) as unknown;
+      if (
+        seen != null &&
+        real != null &&
+        Object.getPrototypeOf(seen) === Object.getPrototypeOf(real)
+      )
+        return;
+    } else if (descriptor.value === seen) {
+      return;
+    }
     throw new ActiveRecordError(
-      "loadSchema was handed an adapter whose createTable is stubbed. The canonical " +
+      `loadSchema was handed an adapter whose ${method} is stubbed. The canonical ` +
         "half of the load would not really lay its tables; call " +
         "loadAdapterSpecificSchema directly to cover the adapter-specific arm.",
     );

--- a/packages/activerecord/src/support/stubbed-ddl-methods.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.ts
@@ -1,0 +1,34 @@
+/**
+ * The adapter members an arm-content cover can intercept to stop
+ * `loadCanonicalSchema` from really laying its tables.
+ *
+ * `runTable` (canonical-schema.ts) does not call `adapter.createTable` — it
+ * resolves a `SchemaStatements` companion through `adapter.schemaStatements()`
+ * and lays every table through it, and that companion reaches the database via
+ * `adapter.execute` after rendering DDL through `adapter.schemaCreation`.
+ * Indexes go the same way (`emitTableIndexes` → `ss.addIndex` →
+ * `adapter.execute`), and a `force:` create drops through `dropTable` first.
+ * So a cover that intercepts any of these lays nothing, exactly as the
+ * `createTable` cover that PR #5676 routed through `loadSchema` did — the
+ * canonical half then queries tables that were never created and dies with
+ * `relation "…" does not exist`, on the PG lane only.
+ *
+ * `createTable`, `dropTable` and `addIndex` stay in the set even though the
+ * canonical half reaches past them: they are the emitters the *adapter-specific*
+ * arm calls directly, and they are the shape every existing cover stubs.
+ *
+ * This list is the single source of truth for both mechanisms that key on it:
+ * the runtime guard in `load-schema-helper.ts` and the
+ * `blazetrails/no-load-schema-with-stubbed-ddl` ESLint rule. The rule is a
+ * plain-Node `.mjs` module outside this package's `rootDir`, so it cannot
+ * import this one; `eslint/no-load-schema-with-stubbed-ddl.test.mjs` pins its
+ * copy against this one instead, which is what keeps the two in step.
+ */
+export const STUBBED_DDL_METHODS: readonly string[] = [
+  "createTable",
+  "dropTable",
+  "addIndex",
+  "execute",
+  "schemaCreation",
+  "schemaStatements",
+];

--- a/packages/activerecord/src/support/stubbed-ddl-methods.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.ts
@@ -18,11 +18,12 @@
  * arm calls directly, and they are the shape every existing cover stubs.
  *
  * This list is the single source of truth for both mechanisms that key on it:
- * the runtime guard in `load-schema-helper.ts` and the
- * `blazetrails/no-load-schema-with-stubbed-ddl` ESLint rule. The rule is a
- * plain-Node `.mjs` module outside this package's `rootDir`, so it cannot
- * import this one; `eslint/no-load-schema-with-stubbed-ddl.test.mjs` pins its
- * copy against this one instead, which is what keeps the two in step.
+ * the runtime guard in `load-schema-helper.ts`, which imports it, and the
+ * `blazetrails/no-load-schema-with-stubbed-ddl` ESLint rule, which reads the
+ * array out of this file's text — it is a plain-Node module ESLint loads with no
+ * TypeScript pipeline, so it cannot import this one. Keep the array a flat list
+ * of double-quoted names; the rule throws rather than silently guarding nothing
+ * if it parses none.
  */
 export const STUBBED_DDL_METHODS: readonly string[] = [
   "createTable",


### PR DESCRIPTION
## What

Both mechanisms that stop an arm-content cover from routing through `loadSchema`
keyed on `createTable` alone: `STUBBED_DDL_METHODS` in
`eslint/no-load-schema-with-stubbed-ddl.mjs` (#5693) and `assertNotArmProbe` in
`support/load-schema-helper.ts` (#5696).

`runTable` does not go through `adapter.createTable`: it resolves a
`SchemaStatements` companion via `adapter.schemaStatements()` and lays every
table through it, rendering DDL with `adapter.schemaCreation` and reaching the
database with `adapter.execute` (indexes likewise, via `emitTableIndexes` →
`ss.addIndex`; a `force:` create drops first). A cover intercepting any of those
laid nothing either and sailed past both guards — into the PG-lane-only
`relation "…" does not exist` this pair exists to prevent.

## Changes

- New `packages/activerecord/src/support/stubbed-ddl-methods.ts` — the one
  declaration site, carrying the reachability reasoning. The set is
  `createTable`, `dropTable`, `addIndex`, `execute`, `schemaCreation`,
  `schemaStatements`. `createTable`/`dropTable`/`addIndex` stay in it even though
  the canonical half reaches past them: they are what the *adapter-specific* arm
  calls directly, and the shape every existing cover stubs.
- The runtime guard loops that list. `assertNotStubbed` also handles an
  *accessor*-backed member now, because `schemaCreation` is a getter and PG's
  builds a fresh visitor per read — identity comparison is meaningless there, so
  what the real accessor yields is compared by prototype instead.
- The ESLint rule is **derived** from the same file rather than restating it: it
  is a plain-Node module ESLint loads with no TypeScript pipeline, and the
  declaration site must stay inside the package's `rootDir` to be importable by
  the guard, so the rule parses the array out of that file's text — and throws
  rather than silently guarding nothing if it finds none. Its test pins the parse
  against the module the guard imports, so a regex that stopped matching fails
  loudly instead of leaving a stale set.
- A cover per newly guarded member in
  `support/load-schema-helper-arm-guard.trails.test.ts`, plus two RuleTester
  cases past `createTable`.

## Verification

- Baseline check (guard reverted to `createTable` alone): the six new covers
  fail, the three pre-existing ones pass — including the transparent-proxy
  direction, which stays green throughout, so no legitimate wrapper is broken.
  Every adapter that overrides one of these members does so on its own
  prototype, which the chain walk finds first.
- The rule reports nothing new across all 99 test files that reference
  `loadSchema`; the real arm-content cover (`load-schema-helper-uuid-default`)
  is still clean under the widened set.
- Package typecheck clean; the sqlite lane boots through `loadSchema` on every
  AR file, so the widened guard is exercised by the whole suite.

Closes-story: widen-arm-probe-guard-beyond-createtable
