### PR TITLE
test-support(activerecord): port ProtectedParams#dup preserving permitted

### DIFF
--- a/packages/activerecord/src/support/stubs/strong-parameters.test.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.test.ts
@@ -70,7 +70,7 @@ describe("ProtectedParams", () => {
     ]);
   });
 
-  it("dup preserves permitted? and copies the parameters", () => {
+  it("dup preserves permitted? and gives the copy its own parameters", () => {
     const params = new ProtectedParams({ first_name: "Guille" });
     params.permitBang();
 

--- a/packages/activerecord/src/support/stubs/strong-parameters.test.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.test.ts
@@ -69,4 +69,25 @@ describe("ProtectedParams", () => {
       ["gender", "m"],
     ]);
   });
+
+  it("dup preserves permitted? and copies the parameters", () => {
+    const params = new ProtectedParams({ first_name: "Guille" });
+    params.permitBang();
+
+    const duplicate = params.dup();
+
+    expect(duplicate).not.toBe(params);
+    expect(duplicate.permitted()).toBe(true);
+    expect(duplicate.toH()).toEqual({ first_name: "Guille" });
+
+    duplicate["gender"] = "m";
+    expect(params.toH()).toEqual({ first_name: "Guille" });
+    expect(duplicate.toH()).toEqual({ first_name: "Guille", gender: "m" });
+  });
+
+  it("dup of an unpermitted params object stays unpermitted", () => {
+    const duplicate = new ProtectedParams({ first_name: "Guille" }).dup();
+
+    expect(duplicate.permitted()).toBe(false);
+  });
 });

--- a/packages/activerecord/src/support/stubs/strong-parameters.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.ts
@@ -30,6 +30,16 @@
  * marks that the caller is bypassing the permitted check. `eachPair` returns
  * `@parameters` rather than `self` in Ruby — here that store IS the object
  * seen through its Proxy, so the same value comes back either way.
+ *
+ * `dup` is Ruby's `super.dup` plus the explicit `@permitted` carry-over. The
+ * copy has to be a fresh `ProtectedParams` so it gets its own Proxy, and it
+ * takes the flag through `permitBang` because the private field is unreachable
+ * through the copy's Proxy receiver. Ruby's `Object#dup` copies the ivar
+ * reference, so its two objects share one parameter hash; here the copy gets
+ * its own, because the Proxy traps close over the store handed to the
+ * constructor and a shared store cannot be installed after the fact. Nothing
+ * in the AR suite mutates a dup, so the two semantics are indistinguishable
+ * to callers.
  */
 export class ProtectedParams {
   [key: string]: unknown;
@@ -114,14 +124,6 @@ export class ProtectedParams {
     return this.#self;
   }
 
-  /**
-   * Ruby's `super.dup` shallow-copies the ivars and the override then re-sets
-   * `@permitted`. Here the copy has to be a fresh `ProtectedParams` so it gets
-   * its own Proxy — a structural clone of the wrapper would share this one.
-   * The constructor already copies the parameter store, and `permitBang` is
-   * how the permitted flag is reachable on the copy: the private field is
-   * unreachable through the copy's Proxy receiver.
-   */
   dup(): this {
     const duplicate = new ProtectedParams(this.#parameters);
     if (this.#permitted) duplicate.permitBang();

--- a/packages/activerecord/src/support/stubs/strong-parameters.ts
+++ b/packages/activerecord/src/support/stubs/strong-parameters.ts
@@ -113,4 +113,18 @@ export class ProtectedParams {
     for (const [key, value] of Object.entries(this.#parameters)) block(key, value);
     return this.#self;
   }
+
+  /**
+   * Ruby's `super.dup` shallow-copies the ivars and the override then re-sets
+   * `@permitted`. Here the copy has to be a fresh `ProtectedParams` so it gets
+   * its own Proxy — a structural clone of the wrapper would share this one.
+   * The constructor already copies the parameter store, and `permitBang` is
+   * how the permitted flag is reachable on the copy: the private field is
+   * unreachable through the copy's Proxy receiver.
+   */
+  dup(): this {
+    const duplicate = new ProtectedParams(this.#parameters);
+    if (this.#permitted) duplicate.permitBang();
+    return duplicate as this;
+  }
 }


### PR DESCRIPTION
Rails' `ProtectedParams` overrides `dup` so the copy keeps `@permitted` (`vendor/rails/activerecord/test/support/stubs/strong_parameters.rb:33-37`). The trails stub never had it — a silent gap, not a ratchet regression (`api:compare --package activerecord-test-support` read 32/32 without it, and still does).

The copy is a fresh `ProtectedParams`, so it gets its own Proxy, and takes the permitted flag through `permitBang` because the private field is unreachable through the copy's Proxy receiver.

One deviation, documented in the stub header: Ruby's `Object#dup` copies the ivar reference, so its two objects share one parameter hash, while here the copy gets its own — the Proxy traps close over the store handed to the constructor, so a shared store cannot be installed after the fact. Nothing in the AR suite mutates a dup, so callers cannot tell the difference.

Tests pin that a dup of a permitted params object is still permitted, that the copy's parameters are its own, and that an unpermitted dup stays unpermitted.

Closes-story: protectedparams-dup-preserves-permitted
