### PR TITLE
feat(schema-compare): verify the transcription that lays the tables

### DIFF
--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -26,7 +26,7 @@ import type {
   AddForeignKeyOptions,
 } from "../connection-adapters/abstract/schema-definitions.js";
 import type { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
-import type { ColumnSpec } from "./schema-types.js";
+import type { AnyPrimitiveColumnSpec, ColumnSpec, Schema } from "./schema-types.js";
 import {
   COLUMN_TYPE_MAP_MYSQL,
   COLUMN_TYPE_MAP_PG,
@@ -2152,4 +2152,58 @@ export async function canonicalForeignKeyDependents(): Promise<Map<string, strin
   }
   _dependents = dependents;
   return dependents;
+}
+
+/**
+ * Declarative view of the registry: table -> column -> `ColumnSpec`, derived by
+ * replaying every `create_table` block against a probe that records columns
+ * instead of emitting DDL. This is what lets `schema:compare` diff the
+ * transcription that actually lays the tables against `schema.rb`, rather than
+ * only the parallel `TEST_SCHEMA` map (which lays nothing).
+ *
+ * The replay pins the SQLite adapter deliberately: it is the one adapter whose
+ * type map is a near-identity and whose column path applies no adapter munging
+ * (no MySQL `DATETIME(6)` upgrade, no `serial` PK rewrite), so what comes back
+ * is the *declared* shape rather than one adapter's rendering of it. For the
+ * same reason the probe is built with no `serialPk` and no composite-PK set —
+ * both only add adapter-side spellings (`serial`, an implied `null: false`)
+ * that `schema.rb` does not state.
+ *
+ * @internal Read by `scripts/schema-compare/compare.ts`. Lives here, next to the
+ * registry it replays, for the same reason as
+ * {@link canonicalForeignKeyDependents}: `TableBuilder` stays file-local.
+ */
+export async function canonicalRegistrySchema(): Promise<Schema> {
+  const schema: Schema = {};
+  for (const def of await buildCanonicalRegistry()) {
+    const columns: Record<string, ColumnSpec> = {};
+    const probe = {
+      column: (name: string, type: string, options: Record<string, unknown> = {}) => {
+        columns[name] = specFromColumnCall(type, options);
+      },
+      foreignKey: () => {},
+    } as unknown as TableDefinition;
+    def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null, null));
+    schema[def.name] = columns;
+  }
+  return schema;
+}
+
+/** Rebuilds a `ColumnSpec` from the `t.column(name, type, options)` call the
+ *  replay observed, undoing the one type-map rename SQLite applies. */
+function specFromColumnCall(type: string, options: Record<string, unknown>): ColumnSpec {
+  const spec: Exclude<ColumnSpec, string> = {
+    type: (type === "bigint" ? "big_integer" : type) as AnyPrimitiveColumnSpec,
+  };
+  if (typeof options["limit"] === "number") spec.limit = options["limit"];
+  if ("precision" in options) spec.precision = options["precision"] as number | null;
+  if (typeof options["scale"] === "number") spec.scale = options["scale"];
+  if (typeof options["null"] === "boolean") spec.null = options["null"];
+  const defaultValue = options["default"];
+  if (typeof defaultValue === "function") {
+    spec.defaultFunction = (defaultValue as () => string)();
+  } else if (defaultValue !== undefined) {
+    spec.default = defaultValue;
+  }
+  return spec;
 }

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -2167,14 +2167,23 @@ export async function canonicalForeignKeyDependents(): Promise<Map<string, strin
  * (no MySQL `DATETIME(6)` upgrade, no `serial` PK rewrite), so what comes back
  * is the *declared* shape rather than one adapter's rendering of it. The probe
  * is likewise built with no `serialPk` and no composite-PK set, so `col`'s
- * generic branch runs for every column: the composite-PK branch only forces the
- * `null: false` a PK carries anyway, and the `serialPk` branch *discards* the
- * declared options wholesale in favour of `serialIdType` + `{primaryKey: true}`
- * — a rendering, not a declaration. Taking the generic branch is therefore the
- * right reading, but only while no `serialPk` column declares something that
- * branch would have thrown away; {@link assertSerialPkIsPlainInteger} fails loudly
- * the moment one does, rather than letting the replay report a shape the real
- * DDL never had.
+ * generic branch runs for every column — both of the branches it skips rewrite
+ * what was declared:
+ *   - `serialPk` *discards* the declared options wholesale in favour of
+ *     `serialIdType` + `{primaryKey: true}`;
+ *   - the composite-PK branch forces `null: false`, which is a trails addition,
+ *     not something `schema.rb` states. Rails' `visit_PrimaryKeyDefinition`
+ *     (schema_creation.rb:79-81) emits nothing but `PRIMARY KEY (a, b)`, and
+ *     schema.rb:243-250 declares `cpk_books.author_id` as a bare `t.integer`.
+ *     Our NOT NULL exists so SQLite (which admits NULLs in a non-INTEGER PK)
+ *     matches the other adapters; whether that is faithful is a live question,
+ *     tracked separately — reporting the *declared* shape keeps this comparator
+ *     honest about schema.rb either way, which is what it exists to check.
+ * Taking the generic branch is therefore the right reading, but only while no
+ * PK column declares something those branches would have rewritten;
+ * {@link assertSerialPkIsPlainInteger} and {@link assertCompositePkDeclaresNoNull}
+ * fail loudly the moment one does, rather than letting the replay report a shape
+ * the real DDL never had.
  *
  * @internal Read by `scripts/schema-compare/compare.ts`. Lives here, next to the
  * registry it replays, for the same reason as
@@ -2193,6 +2202,11 @@ export async function canonicalRegistrySchema(): Promise<Schema> {
     def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null, null));
     if (def.meta.serialPk !== undefined) {
       assertSerialPkIsPlainInteger(def.name, def.meta.serialPk, columns[def.meta.serialPk]);
+    }
+    if (def.meta.primaryKey !== undefined && def.meta.serialPk === undefined) {
+      for (const column of def.meta.primaryKey) {
+        assertCompositePkDeclaresNoNull(def.name, column, columns[column]);
+      }
     }
     schema[def.name] = columns;
   }
@@ -2216,8 +2230,7 @@ function assertSerialPkIsPlainInteger(
   column: string,
   spec: ColumnSpec | undefined,
 ): void {
-  if (spec === undefined || typeof spec === "string") return;
-  const { type, null: nullable, ...rest } = spec;
+  const { type, null: nullable, ...rest } = declaredSpec(table, column, spec);
   const extras = Object.keys(rest);
   if (type === "integer" && extras.length === 0 && (nullable === undefined || nullable === false)) {
     return;
@@ -2228,6 +2241,57 @@ function assertSerialPkIsPlainInteger(
       `primaryKey: true — the declared type/options would never reach the DDL. Teach ` +
       `canonicalRegistrySchema to model the rendered form before declaring it this way.`,
   );
+}
+
+/**
+ * Guard the composite-PK branch the replay likewise skips. That branch overrides
+ * whatever the column declared with `null: false`, so "declared" and "rendered"
+ * agree only where the declaration says nothing about nullability (every live
+ * composite-PK column today) or already says `null: false`. A column declared
+ * `null: true` would be reported nullable here while the DDL made it NOT NULL —
+ * precisely the silent mis-report {@link assertSerialPkIsPlainInteger} exists to
+ * prevent.
+ */
+function assertCompositePkDeclaresNoNull(
+  table: string,
+  column: string,
+  spec: ColumnSpec | undefined,
+): void {
+  if (declaredSpec(table, column, spec).null !== true) return;
+  throw new ActiveRecordError(
+    `canonical registry: composite-PK column ${table}.${column} declares null: true, but the ` +
+      `composite-PK path overrides it to null: false — the declared shape would never reach ` +
+      `the DDL. Teach canonicalRegistrySchema to model the rendered form before declaring it ` +
+      `this way.`,
+  );
+}
+
+/**
+ * The object form of a column the replay recorded. A missing entry means `meta`
+ * names a primary-key column no `t.<type>()` call in the block declares — a
+ * typo'd name that would otherwise sail past both guards — and the shorthand
+ * string form is unreachable because {@link specFromColumnCall} always builds the
+ * object form; both are raised rather than skipped, so neither can rot into a
+ * silent no-op.
+ */
+function declaredSpec(
+  table: string,
+  column: string,
+  spec: ColumnSpec | undefined,
+): Exclude<ColumnSpec, string> {
+  if (spec === undefined) {
+    throw new ActiveRecordError(
+      `canonical registry: ${table} names ${column} as a primary key, but its create_table ` +
+        `block declares no such column.`,
+    );
+  }
+  if (typeof spec === "string") {
+    throw new ActiveRecordError(
+      `canonical registry: ${table}.${column} was recorded as the shorthand "${spec}"; the ` +
+        `replay probe is expected to build the object form.`,
+    );
+  }
+  return spec;
 }
 
 /** Rebuilds a `ColumnSpec` from the `t.column(name, type, options)` call the

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -20,6 +20,7 @@
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { ActiveRecordError } from "../errors.js";
 import type {
   TableDefinition,
   AddIndexOptions,
@@ -2164,10 +2165,16 @@ export async function canonicalForeignKeyDependents(): Promise<Map<string, strin
  * The replay pins the SQLite adapter deliberately: it is the one adapter whose
  * type map is a near-identity and whose column path applies no adapter munging
  * (no MySQL `DATETIME(6)` upgrade, no `serial` PK rewrite), so what comes back
- * is the *declared* shape rather than one adapter's rendering of it. For the
- * same reason the probe is built with no `serialPk` and no composite-PK set —
- * both only add adapter-side spellings (`serial`, an implied `null: false`)
- * that `schema.rb` does not state.
+ * is the *declared* shape rather than one adapter's rendering of it. The probe
+ * is likewise built with no `serialPk` and no composite-PK set, so `col`'s
+ * generic branch runs for every column: the composite-PK branch only forces the
+ * `null: false` a PK carries anyway, and the `serialPk` branch *discards* the
+ * declared options wholesale in favour of `serialIdType` + `{primaryKey: true}`
+ * — a rendering, not a declaration. Taking the generic branch is therefore the
+ * right reading, but only while no `serialPk` column declares something that
+ * branch would have thrown away; {@link assertSerialPkIsPlainInteger} fails loudly
+ * the moment one does, rather than letting the replay report a shape the real
+ * DDL never had.
  *
  * @internal Read by `scripts/schema-compare/compare.ts`. Lives here, next to the
  * registry it replays, for the same reason as
@@ -2184,9 +2191,43 @@ export async function canonicalRegistrySchema(): Promise<Schema> {
       foreignKey: () => {},
     } as unknown as TableDefinition;
     def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null, null));
+    if (def.meta.serialPk !== undefined) {
+      assertSerialPkIsPlainInteger(def.name, def.meta.serialPk, columns[def.meta.serialPk]);
+    }
     schema[def.name] = columns;
   }
   return schema;
+}
+
+/**
+ * Guard the one place the replay's generic branch and the real `serialPk` branch
+ * can disagree. `TableBuilder.col` renders a `serialPk` column as
+ * `serialIdType(primitive, adapter)` with `{primaryKey: true}` and nothing else,
+ * so a declared `limit`/`default`/`precision`/`scale` never reaches the DDL, and
+ * a `big_integer` declaration becomes `bigserial`/`bigint`/`integer` by adapter.
+ * A plain `t.integer(pk)` (optionally spelling out the `null: false` a primary
+ * key has regardless) is the only form where "declared" and "rendered" agree,
+ * which is every live `serialPk` column today. Anything else must teach
+ * {@link canonicalRegistrySchema} how to compare the rendered form instead of
+ * being silently mis-reported.
+ */
+function assertSerialPkIsPlainInteger(
+  table: string,
+  column: string,
+  spec: ColumnSpec | undefined,
+): void {
+  if (spec === undefined || typeof spec === "string") return;
+  const { type, null: nullable, ...rest } = spec;
+  const extras = Object.keys(rest);
+  if (type === "integer" && extras.length === 0 && (nullable === undefined || nullable === false)) {
+    return;
+  }
+  throw new ActiveRecordError(
+    `canonical registry: serialPk column ${table}.${column} is declared as ` +
+      `${JSON.stringify(spec)}, but the serialPk path emits only serialIdType(...) with ` +
+      `primaryKey: true — the declared type/options would never reach the DDL. Teach ` +
+      `canonicalRegistrySchema to model the rendered form before declaring it this way.`,
+  );
 }
 
 /** Rebuilds a `ColumnSpec` from the `t.column(name, type, options)` call the

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -15,6 +15,7 @@ import {
   TRANSCRIPTION_DIVERGENCE_ALLOW_LIST,
   compareTranscriptions,
   describeSpec,
+  staleDivergenceAllowances,
   unresolvedCallSites,
 } from "./compare.js";
 import { canonicalRegistrySchema } from "../../packages/activerecord/src/support/canonical-schema.js";
@@ -667,6 +668,14 @@ describe("compareTranscriptions", () => {
     expect(compareTranscriptions({}, { [table]: { name: "string" } })).toEqual([]);
   });
 
+  it("flags an allow-list entry the transcriptions have converged on", () => {
+    const table = [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()][0]!;
+    const converged = { [table]: { name: "string" } };
+    expect(staleDivergenceAllowances(converged, converged)).toContain(table);
+    // Still divergent (registry-only) — the allowance is doing its job.
+    expect(staleDivergenceAllowances({}, converged)).not.toContain(table);
+  });
+
   it("treats the two spellings of a SQL default as one thing", () => {
     expect(describeSpec({ type: "datetime", defaultFunction: "CURRENT_TIMESTAMP" })).toBe(
       "datetime default=fn",
@@ -697,6 +706,10 @@ describe("against the canonical registry", () => {
 
   it("keeps the two transcriptions of schema.rb in sync", async () => {
     expect(compareTranscriptions(TEST_SCHEMA, await canonicalRegistrySchema())).toEqual([]);
+  });
+
+  it("carries no divergence allowance the transcriptions have outgrown", async () => {
+    expect(staleDivergenceAllowances(TEST_SCHEMA, await canonicalRegistrySchema())).toEqual([]);
   });
 
   it("recovers the declared column shape rather than one adapter's rendering", async () => {

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -708,6 +708,40 @@ describe("against the canonical registry", () => {
     expect(compareTranscriptions(TEST_SCHEMA, await canonicalRegistrySchema())).toEqual([]);
   });
 
+  it("keeps every serialPk column in the form the replay can read", async () => {
+    // The serialPk path discards declared options, so the replay's generic
+    // branch is only a faithful reading while every such column is a plain
+    // integer; canonicalRegistrySchema throws rather than report a shape the
+    // DDL never had.
+    const registry = await canonicalRegistrySchema();
+    expect(describeSpec(columnsOfRegistry(registry, "fk_test_has_pk", "pk_id"))).toBe(
+      "integer null=false",
+    );
+    expect(describeSpec(columnsOfRegistry(registry, "bulbs", "ID"))).toBe("integer");
+  });
+
+  it("counts a baseline entry stale only when neither transcription invents it", async () => {
+    const { tables, sources, ambiguous } = await loadRailsTables();
+    const registryFindings = compareSchemas(
+      await canonicalRegistrySchema(),
+      tables,
+      sources,
+      ambiguous,
+    );
+    const baseline = await readBaseline();
+    // Union: an entry either side still invents is NOT prunable, so staleness
+    // over both findings can only be a subset of staleness over one of them.
+    const union = applyBaseline(
+      [...compareSchemas(TEST_SCHEMA, tables, sources, ambiguous), ...registryFindings],
+      baseline,
+    ).stale;
+    const testSchemaOnly = applyBaseline(
+      compareSchemas(TEST_SCHEMA, tables, sources, ambiguous),
+      baseline,
+    ).stale;
+    expect(union.every((key) => testSchemaOnly.includes(key))).toBe(true);
+  });
+
   it("carries no divergence allowance the transcriptions have outgrown", async () => {
     expect(staleDivergenceAllowances(TEST_SCHEMA, await canonicalRegistrySchema())).toEqual([]);
   });

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -12,11 +12,15 @@ import {
   partitionFindings,
   readBaseline,
   SCHEMA_FILES,
+  TRANSCRIPTION_DIVERGENCE_ALLOW_LIST,
+  compareTranscriptions,
+  describeSpec,
   unresolvedCallSites,
 } from "./compare.js";
+import { canonicalRegistrySchema } from "../../packages/activerecord/src/support/canonical-schema.js";
 import { TEST_SCHEMA } from "../../packages/activerecord/src/test-helpers/test-schema.js";
 import type { Finding } from "./compare.js";
-import type { Schema } from "../../packages/activerecord/src/support/schema-types.js";
+import type { ColumnSpec, Schema } from "../../packages/activerecord/src/support/schema-types.js";
 
 const parse = (rb: string) => parseSchemaRb(`ActiveRecord::Schema.define do\n${rb}\nend\n`);
 const columnsOfTable = (rb: string, table: string) => [...parse(rb).get(table)!.columns.keys()];
@@ -626,3 +630,87 @@ describe("against the adapter-specific companion schemas", () => {
     expect(columns.has("char2_concatenated")).toBe(true); // MySQL only, not in PG
   });
 });
+
+describe("compareTranscriptions", () => {
+  it("reports a table only one transcription declares", () => {
+    expect(compareTranscriptions({ posts: { title: "string" } }, {})).toEqual([
+      "posts — declared by TEST_SCHEMA, not laid by the registry",
+    ]);
+    expect(compareTranscriptions({}, { posts: { title: "string" } })).toEqual([
+      "posts — laid by the registry, absent from TEST_SCHEMA",
+    ]);
+  });
+
+  it("reports a column only one transcription declares", () => {
+    expect(
+      compareTranscriptions(
+        { posts: { title: "string" } },
+        { posts: { title: "string", body: "text" } },
+      ),
+    ).toEqual(["posts.body — declared only by canonical-registry"]);
+  });
+
+  it("reports a column whose type or options differ", () => {
+    expect(
+      compareTranscriptions({ posts: { title: "string" } }, { posts: { title: "text" } }),
+    ).toEqual(["posts.title — TEST_SCHEMA string, canonical-registry text"]);
+    expect(
+      compareTranscriptions(
+        { posts: { title: { type: "string", null: false } } },
+        { posts: { title: "string" } },
+      ),
+    ).toEqual(["posts.title — TEST_SCHEMA string null=false, canonical-registry string"]);
+  });
+
+  it("says nothing about a documented divergence", () => {
+    const table = [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()][0]!;
+    expect(compareTranscriptions({}, { [table]: { name: "string" } })).toEqual([]);
+  });
+
+  it("treats the two spellings of a SQL default as one thing", () => {
+    expect(describeSpec({ type: "datetime", defaultFunction: "CURRENT_TIMESTAMP" })).toBe(
+      "datetime default=fn",
+    );
+    // precision: null is a declared value, not an omission (the bare-DATETIME request).
+    expect(describeSpec({ type: "datetime", precision: null })).toBe("datetime precision=null");
+  });
+});
+
+// The registry — not TEST_SCHEMA — is what lays every table at boot, so the same
+// invention gate has to hold over it, and the two must not drift apart.
+describe("against the canonical registry", () => {
+  it("keeps the registry free of inventions outside the committed baseline", async () => {
+    const { tables, sources, ambiguous } = await loadRailsTables();
+    const findings = compareSchemas(await canonicalRegistrySchema(), tables, sources, ambiguous);
+    const { regressions } = applyBaseline(findings, await readBaseline());
+    expect(verdicts(regressions)).toEqual([]);
+  });
+
+  it("keeps the registry's column-option divergences at or below the committed ceiling", async () => {
+    const { tables, sources, ambiguous } = await loadRailsTables();
+    expect(
+      optionRegressions(
+        compareSchemas(await canonicalRegistrySchema(), tables, sources, ambiguous),
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps the two transcriptions of schema.rb in sync", async () => {
+    expect(compareTranscriptions(TEST_SCHEMA, await canonicalRegistrySchema())).toEqual([]);
+  });
+
+  it("recovers the declared column shape rather than one adapter's rendering", async () => {
+    const registry = await canonicalRegistrySchema();
+    // big_integer, not SQLite's `bigint` spelling; a declared limit survives.
+    expect(describeSpec(columnsOfRegistry(registry, "admin_users", "settings"))).toBe(
+      "string limit=1024 null=true",
+    );
+    expect(describeSpec(columnsOfRegistry(registry, "aircraft", "manufactured_at"))).toBe(
+      "datetime precision=null default=fn",
+    );
+  });
+});
+
+function columnsOfRegistry(registry: Schema, table: string, column: string) {
+  return (registry[table] as Record<string, ColumnSpec>)[column]!;
+}

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -720,6 +720,17 @@ describe("against the canonical registry", () => {
     expect(describeSpec(columnsOfRegistry(registry, "bulbs", "ID"))).toBe("integer");
   });
 
+  it("reports a composite-PK column with the nullability schema.rb declares", async () => {
+    // Rails' visit_PrimaryKeyDefinition (schema_creation.rb:79-81) emits only
+    // PRIMARY KEY (a, b), and schema.rb:243-250 declares cpk_books.author_id as
+    // a bare t.integer — so the declared view is nullable. The registry's
+    // NOT NULL forcing is a trails addition tracked separately; the replay must
+    // not paper over it, and assertCompositePkDeclaresNoNull raises if a column
+    // ever declares a nullability that branch would override.
+    const registry = await canonicalRegistrySchema();
+    expect(describeSpec(columnsOfRegistry(registry, "cpk_books", "author_id"))).toBe("integer");
+  });
+
   it("counts a baseline entry stale only when neither transcription invents it", async () => {
     const { tables, sources, ambiguous } = await loadRailsTables();
     const registryFindings = compareSchemas(

--- a/scripts/schema-compare/compare.ts
+++ b/scripts/schema-compare/compare.ts
@@ -1,6 +1,14 @@
-// schema:compare — structural parity check of TEST_SCHEMA
-// (packages/activerecord/src/test-helpers/test-schema.ts) against the vendored
-// vendor/rails/activerecord/test/schema/schema.rb it is documented to mirror.
+// schema:compare — structural parity check of the two hand transcriptions of
+// vendor/rails/activerecord/test/schema/schema.rb against the vendored source
+// they are documented to mirror, and against each other:
+//   * TEST_SCHEMA (packages/activerecord/src/test-helpers/test-schema.ts) — the
+//     declarative map, read by the canonical-table ESLint rule and
+//     fixtures:compare;
+//   * the canonical registry (packages/activerecord/src/support/
+//     canonical-schema.ts) — the `create_table` sequence that actually lays
+//     every table at boot.
+// Checking only the first left the one that builds the database unverified, so
+// both are diffed against schema.rb and a third check fails when they disagree.
 //
 // Two verdicts:
 //   INVENTED (fatal)    — a table or column present in TEST_SCHEMA that
@@ -16,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import { TEST_SCHEMA } from "../../packages/activerecord/src/test-helpers/test-schema.js";
 import type { ColumnSpec, Schema } from "../../packages/activerecord/src/support/schema-types.js";
 import { columnsOf } from "../../packages/activerecord/src/support/schema-types.js";
+import { canonicalRegistrySchema } from "../../packages/activerecord/src/support/canonical-schema.js";
 import type { RailsColumnOptions, RailsTable } from "./parse-schema-rb.js";
 import { parseSchemaRbWithCoverage } from "./parse-schema-rb.js";
 import { writeJsonManifest } from "../api-compare/write-json-manifest.js";
@@ -93,6 +102,26 @@ export const TABLE_ALLOW_LIST: ReadonlyMap<string, string> = new Map([
  * schema.rb block, keyed `table.column`. Same rules as TABLE_ALLOW_LIST.
  */
 export const COLUMN_ALLOW_LIST: ReadonlyMap<string, string> = new Map([]);
+
+/** How each transcription is named in finding details and report lines. */
+export const TEST_SCHEMA_LABEL = "TEST_SCHEMA";
+export const REGISTRY_LABEL = "canonical-registry";
+
+/**
+ * Tables the canonical registry lays that TEST_SCHEMA does not declare (or vice
+ * versa). Both transcribe the same `schema.rb`, so a divergence is a bug by
+ * default — an entry here is a documented exception with a reason, and the list
+ * is expected to shrink, not grow.
+ */
+export const TRANSCRIPTION_DIVERGENCE_ALLOW_LIST: ReadonlyMap<string, string> = new Map([
+  [
+    "courses",
+    "arunit2-only: schema.rb:1444-1460 creates it through the second connection, so only the registry (which can skip it per-database) carries it.",
+  ],
+  ["colleges", "arunit2-only, same as courses."],
+  ["professors", "arunit2-only, same as courses."],
+  ["courses_professors", "arunit2-only, same as courses."],
+]);
 
 /** Rails column type → the `ColumnSpec` type TEST_SCHEMA would spell it with. */
 const RAILS_TYPE_TO_SPEC: Readonly<Record<string, string>> = {
@@ -214,18 +243,22 @@ function displayPrecision(precision: number | null | undefined): string {
  *     the documented bare-DATETIME request that suppresses MySQL's
  *     auto-precision upgrade for `DEFAULT CURRENT_TIMESTAMP`.
  */
-export function optionMismatches(rails: RailsColumnOptions, spec: ColumnSpec): string[] {
+export function optionMismatches(
+  rails: RailsColumnOptions,
+  spec: ColumnSpec,
+  label: string = TEST_SCHEMA_LABEL,
+): string[] {
   if (rails.dynamicOptions) return [];
   const opts = specOptions(spec);
   const specDefault = normalizeSpecDefault(opts);
   const detail: string[] = [];
 
   if (railsNullable(rails) !== specNullable(opts)) {
-    detail.push(`null: schema.rb ${railsNullable(rails)}, TEST_SCHEMA ${specNullable(opts)}`);
+    detail.push(`null: schema.rb ${railsNullable(rails)}, ${label} ${specNullable(opts)}`);
   }
   for (const key of ["limit", "scale"] as const) {
     if (rails[key] !== opts[key]) {
-      detail.push(`${key}: schema.rb ${rails[key] ?? "—"}, TEST_SCHEMA ${opts[key] ?? "—"}`);
+      detail.push(`${key}: schema.rb ${rails[key] ?? "—"}, ${label} ${opts[key] ?? "—"}`);
     }
   }
   const precisionIsAdapterDriven = opts.precision === null && specDefault === "fn";
@@ -233,12 +266,12 @@ export function optionMismatches(rails: RailsColumnOptions, spec: ColumnSpec): s
   if (!precisionIsAdapterDriven && railsPrecision !== opts.precision) {
     detail.push(
       `precision: schema.rb ${displayPrecision(railsPrecision)}, ` +
-        `TEST_SCHEMA ${displayPrecision(opts.precision)}`,
+        `${label} ${displayPrecision(opts.precision)}`,
     );
   }
   const railsDefault = normalizeRailsDefault(rails.default);
   if (railsDefault !== specDefault) {
-    detail.push(`default: schema.rb ${railsDefault}, TEST_SCHEMA ${specDefault}`);
+    detail.push(`default: schema.rb ${railsDefault}, ${label} ${specDefault}`);
   }
   return detail;
 }
@@ -252,6 +285,7 @@ export function compareSchemas(
   railsTables: ReadonlyMap<string, RailsTable>,
   sources?: ReadonlyMap<string, string[]>,
   ambiguous?: ReadonlySet<string>,
+  label: string = TEST_SCHEMA_LABEL,
 ): Finding[] {
   const findings: Finding[] = [];
 
@@ -302,14 +336,14 @@ export function compareSchemas(
           verdict: "SHAPE",
           table: tableName,
           column: columnName,
-          detail: `${source ?? "schema.rb"} says ${railsColumn.type}, TEST_SCHEMA says ${tsType}`,
+          detail: `${source ?? "schema.rb"} says ${railsColumn.type}, ${label} says ${tsType}`,
           source,
         });
         // A type divergence makes the options incomparable (a limit on a
         // string means nothing against an integer), so stop at the type.
         continue;
       }
-      const mismatches = optionMismatches(railsColumn.options, spec);
+      const mismatches = optionMismatches(railsColumn.options, spec, label);
       if (mismatches.length > 0) {
         findings.push({
           verdict: "OPTION",
@@ -329,13 +363,83 @@ export function compareSchemas(
         verdict: "UNPORTED-COLUMN",
         table: tableName,
         column: columnName,
-        detail: `declared in ${source ?? "schema.rb"}, absent from TEST_SCHEMA`,
+        detail: `declared in ${source ?? "schema.rb"}, absent from ${label}`,
         source,
       });
     }
   }
 
   return findings;
+}
+
+/** The column options both transcriptions must agree on, in report order. */
+const COMPARED_SPEC_KEYS = ["limit", "precision", "scale", "null"] as const;
+
+/**
+ * The comparable shape of a `ColumnSpec`: its type plus the options that reach
+ * the DDL. A `defaultFunction` collapses to the `fn` tag {@link
+ * normalizeSpecDefault} already uses, so the two spellings of "SQL default" are
+ * compared as one thing.
+ */
+export function describeSpec(spec: ColumnSpec): string {
+  const opts = specOptions(spec);
+  const parts = [specType(spec)];
+  for (const key of COMPARED_SPEC_KEYS) {
+    if (opts[key] !== undefined) parts.push(`${key}=${JSON.stringify(opts[key])}`);
+  }
+  const defaultValue = normalizeSpecDefault(opts);
+  if (defaultValue !== "none") parts.push(`default=${defaultValue}`);
+  return parts.join(" ");
+}
+
+/**
+ * Divergences between the two hand transcriptions: tables one declares and the
+ * other does not, columns present on only one side, and columns whose declared
+ * type or options differ. Both are meant to be the same `schema.rb` written
+ * twice, so any divergence is fatal unless
+ * {@link TRANSCRIPTION_DIVERGENCE_ALLOW_LIST} documents it — this is what makes
+ * the hand-sync requirement enforced rather than merely written down.
+ *
+ * Pure: the caller supplies both sides.
+ */
+export function compareTranscriptions(testSchema: Schema, registry: Schema): string[] {
+  const divergences: string[] = [];
+  const tableNames = [...new Set([...Object.keys(testSchema), ...Object.keys(registry)])].sort();
+
+  for (const table of tableNames) {
+    if (TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.has(table)) continue;
+    const inTestSchema = testSchema[table];
+    const inRegistry = registry[table];
+    if (!inRegistry) {
+      divergences.push(`${table} — declared by ${TEST_SCHEMA_LABEL}, not laid by the registry`);
+      continue;
+    }
+    if (!inTestSchema) {
+      divergences.push(`${table} — laid by the registry, absent from ${TEST_SCHEMA_LABEL}`);
+      continue;
+    }
+    const tsColumns = columnsOf(inTestSchema);
+    const registryColumns = columnsOf(inRegistry);
+    for (const column of [
+      ...new Set([...Object.keys(tsColumns), ...Object.keys(registryColumns)]),
+    ].sort()) {
+      const tsSpec = tsColumns[column];
+      const registrySpec = registryColumns[column];
+      if (tsSpec === undefined || registrySpec === undefined) {
+        const side = tsSpec === undefined ? REGISTRY_LABEL : TEST_SCHEMA_LABEL;
+        divergences.push(`${table}.${column} — declared only by ${side}`);
+        continue;
+      }
+      const ts = describeSpec(tsSpec);
+      const registryDescription = describeSpec(registrySpec);
+      if (ts !== registryDescription) {
+        divergences.push(
+          `${table}.${column} — ${TEST_SCHEMA_LABEL} ${ts}, ${REGISTRY_LABEL} ${registryDescription}`,
+        );
+      }
+    }
+  }
+  return divergences;
 }
 
 function formatFinding(finding: Finding): string {
@@ -523,6 +627,16 @@ export async function main(): Promise<void> {
     return;
   }
 
+  const registry = await canonicalRegistrySchema();
+  const registryFindings = compareSchemas(
+    registry,
+    railsTables,
+    sources,
+    ambiguous,
+    REGISTRY_LABEL,
+  );
+  const divergences = compareTranscriptions(TEST_SCHEMA, registry);
+
   const { regressions, known, stale } = applyBaseline(findings, await readBaseline());
   const { shape, option, optionFatal } = partitionFindings(findings);
   const optionCount = findings.filter((f) => f.verdict === "OPTION").length;
@@ -560,11 +674,31 @@ export async function main(): Promise<void> {
     );
   }
 
+  // The registry is the transcription that actually lays the tables, so its
+  // inventions are gated exactly like TEST_SCHEMA's — against the same baseline,
+  // which the two share because they transcribe the same schema.rb. `reseed`
+  // only ever writes TEST_SCHEMA's debt, so a registry-only invention cannot be
+  // blessed into the baseline: it has to be removed.
+  const registryBaseline = applyBaseline(registryFindings, await readBaseline());
+  const registryOptionFatal = optionRegressions(registryFindings);
+  for (const finding of [...registryBaseline.regressions, ...registryOptionFatal]) {
+    console.log(formatFinding(finding));
+  }
+  for (const divergence of divergences) {
+    console.log(`FAIL  TRANSCRIPTION-DRIFT ${divergence}`);
+  }
+
   console.log(
     `\n${Object.keys(TEST_SCHEMA).length} TEST_SCHEMA tables vs ${railsTables.size} canonical-schema tables — ` +
       `new-inventions=${regressions.length} baselined=${known.length} ` +
       `option-divergences=${optionCount} (ceiling ${OPTION_DEBT_CEILING}) shape-warnings=${shape.length}` +
       (process.argv.includes("--verbose") ? "" : " (--verbose to list shape warnings)"),
+  );
+  console.log(
+    `${Object.keys(registry).length} canonical-registry tables — ` +
+      `new-inventions=${registryBaseline.regressions.length} baselined=${registryBaseline.known.length} ` +
+      `option-divergences=${registryFindings.filter((f) => f.verdict === "OPTION").length} ` +
+      `transcription-drift=${divergences.length}`,
   );
 
   if (regressions.length > 0) {
@@ -581,7 +715,29 @@ export async function main(): Promise<void> {
         "the ceiling in scripts/schema-compare/compare.ts down to the new (lower) count.",
     );
   }
-  if (regressions.length > 0 || optionFatal.length > 0) process.exit(1);
+  if (registryBaseline.regressions.length > 0 || registryOptionFatal.length > 0) {
+    console.log(
+      "\nThe canonical registry (packages/activerecord/src/support/canonical-schema.ts) is the " +
+        "transcription that lays every table at boot; it mirrors the same schema.rb. Fix the " +
+        "create_table block — the baseline records TEST_SCHEMA debt only and will not absorb it.",
+    );
+  }
+  if (divergences.length > 0) {
+    console.log(
+      `\n${divergences.length} divergence(s) between the two transcriptions of schema.rb. They are ` +
+        "hand-synced: edit TEST_SCHEMA and the canonical registry together, or document the " +
+        "exception in TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.",
+    );
+  }
+  if (
+    regressions.length > 0 ||
+    optionFatal.length > 0 ||
+    registryBaseline.regressions.length > 0 ||
+    registryOptionFatal.length > 0 ||
+    divergences.length > 0
+  ) {
+    process.exit(1);
+  }
 }
 
 // Run as a script when invoked directly, but stay importable from tests.

--- a/scripts/schema-compare/compare.ts
+++ b/scripts/schema-compare/compare.ts
@@ -619,30 +619,40 @@ export async function main(): Promise<void> {
   }
 
   const findings = compareSchemas(TEST_SCHEMA, railsTables, sources, ambiguous);
+  const registry = await canonicalRegistrySchema();
+  const registryFindings = compareSchemas(
+    registry,
+    railsTables,
+    sources,
+    ambiguous,
+    REGISTRY_LABEL,
+  );
+  const divergences = compareTranscriptions(TEST_SCHEMA, registry);
+  // One baseline covers both transcriptions, so every read of it — reseed,
+  // regression check, staleness — works off the union of their findings. Scoping
+  // any of the three to TEST_SCHEMA alone would prune an entry the registry side
+  // still needs and turn its baselined debt into a regression on the next run.
+  const allFindings = [...findings, ...registryFindings];
 
   if (process.argv.includes("--write")) {
-    const invented = findings.filter(isFatal);
+    const invented = allFindings.filter(isFatal);
+    const keysFor = (verdict: Verdict): string[] =>
+      [...new Set(invented.filter((f) => f.verdict === verdict).map(baselineKey))].sort();
     const next: Baseline = {
-      tables: invented
-        .filter((f) => f.verdict === "INVENTED-TABLE")
-        .map(baselineKey)
-        .sort(),
-      columns: invented
-        .filter((f) => f.verdict === "INVENTED-COLUMN")
-        .map(baselineKey)
-        .sort(),
+      tables: keysFor("INVENTED-TABLE"),
+      columns: keysFor("INVENTED-COLUMN"),
     };
     // A reseed exists to record that debt SHRANK. Letting it grow would let a
     // red gate be "fixed" by blessing the very invention it caught — which
     // silently retires the guard-rail this whole tool exists to be.
-    const { regressions } = applyBaseline(findings, await readBaseline());
+    const { regressions } = applyBaseline(allFindings, await readBaseline());
     if (regressions.length > 0 && !process.argv.includes("--allow-growth")) {
       console.error(
         `refusing to grow the baseline by ${regressions.length} new invention(s):\n` +
           regressions.map((f) => `  ${baselineKey(f)}`).join("\n") +
           "\n\nThe baseline records pre-existing debt only. Remove the table/column from " +
-          "TEST_SCHEMA, or add it to schema.rb upstream. Pass --allow-growth only when a " +
-          "vendored-Rails bump legitimately removed canonical schema.",
+          "TEST_SCHEMA or the canonical registry, or add it to schema.rb upstream. Pass " +
+          "--allow-growth only when a vendored-Rails bump legitimately removed canonical schema.",
       );
       process.exit(1);
     }
@@ -653,18 +663,9 @@ export async function main(): Promise<void> {
     return;
   }
 
-  const registry = await canonicalRegistrySchema();
-  const registryFindings = compareSchemas(
-    registry,
-    railsTables,
-    sources,
-    ambiguous,
-    REGISTRY_LABEL,
-  );
-  const divergences = compareTranscriptions(TEST_SCHEMA, registry);
-
   const baseline = await readBaseline();
-  const { regressions, known, stale } = applyBaseline(findings, baseline);
+  const { regressions, known } = applyBaseline(findings, baseline);
+  const { stale } = applyBaseline(allFindings, baseline);
   const { shape, option, optionFatal } = partitionFindings(findings);
   const optionCount = findings.filter((f) => f.verdict === "OPTION").length;
 
@@ -697,7 +698,8 @@ export async function main(): Promise<void> {
   }
   for (const key of stale) {
     console.log(
-      `note  BASELINE-STALE  ${key} — no longer invented; drop it with pnpm schema:compare:reseed`,
+      `note  BASELINE-STALE  ${key} — invented by neither transcription; drop it with ` +
+        `pnpm schema:compare:reseed`,
     );
   }
 

--- a/scripts/schema-compare/compare.ts
+++ b/scripts/schema-compare/compare.ts
@@ -10,14 +10,17 @@
 // Checking only the first left the one that builds the database unverified, so
 // both are diffed against schema.rb and a third check fails when they disagree.
 //
-// Two verdicts:
-//   INVENTED (fatal)    — a table or column present in TEST_SCHEMA that
+// Three verdicts:
+//   INVENTED (fatal)    — a table or column present in a transcription that
 //                         schema.rb does not declare. This is the guard-rail:
 //                         it is how the `encrypted_posts` near-miss and
 //                         vendor-bump drift get caught mechanically.
+//   TRANSCRIPTION-DRIFT — the two transcriptions disagree about a table or a
+//     (fatal)             column's declared shape. Fatal because they are
+//                         hand-synced: nothing but this check couples them.
 //   SHAPE  (report-only) — a shared table whose column types diverge, or a
-//                         Rails column TEST_SCHEMA has not ported yet. Printed
-//                         but non-fatal; tightening these is follow-up work.
+//                         Rails column a transcription has not ported yet.
+//                         Printed but non-fatal; tightening these is follow-up.
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -400,6 +403,13 @@ export function describeSpec(spec: ColumnSpec): string {
  * {@link TRANSCRIPTION_DIVERGENCE_ALLOW_LIST} documents it — this is what makes
  * the hand-sync requirement enforced rather than merely written down.
  *
+ * Scope is the column shape only. Indexes, foreign keys, and table-level
+ * primary-key metadata are declared in structurally different ways on the two
+ * sides (`t.foreignKey` / `t.index` calls versus a `references:` option and a
+ * separate index list), so diffing them here would manufacture findings rather
+ * than catch drift; they stay uncompared until a later story reconciles the two
+ * spellings.
+ *
  * Pure: the caller supplies both sides.
  */
 export function compareTranscriptions(testSchema: Schema, registry: Schema): string[] {
@@ -440,6 +450,22 @@ export function compareTranscriptions(testSchema: Schema, registry: Schema): str
     }
   }
   return divergences;
+}
+
+/**
+ * Allow-list entries that no longer name a divergence — the two transcriptions
+ * have converged on the table. Reported so the list ratchets down instead of
+ * accumulating stale exemptions, exactly as `stale` does for the invention
+ * baseline.
+ */
+export function staleDivergenceAllowances(testSchema: Schema, registry: Schema): string[] {
+  return [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()]
+    .filter((table) => {
+      const both = testSchema[table] !== undefined && registry[table] !== undefined;
+      const neither = testSchema[table] === undefined && registry[table] === undefined;
+      return both || neither;
+    })
+    .sort();
 }
 
 function formatFinding(finding: Finding): string {
@@ -637,7 +663,8 @@ export async function main(): Promise<void> {
   );
   const divergences = compareTranscriptions(TEST_SCHEMA, registry);
 
-  const { regressions, known, stale } = applyBaseline(findings, await readBaseline());
+  const baseline = await readBaseline();
+  const { regressions, known, stale } = applyBaseline(findings, baseline);
   const { shape, option, optionFatal } = partitionFindings(findings);
   const optionCount = findings.filter((f) => f.verdict === "OPTION").length;
 
@@ -679,13 +706,19 @@ export async function main(): Promise<void> {
   // which the two share because they transcribe the same schema.rb. `reseed`
   // only ever writes TEST_SCHEMA's debt, so a registry-only invention cannot be
   // blessed into the baseline: it has to be removed.
-  const registryBaseline = applyBaseline(registryFindings, await readBaseline());
+  const registryBaseline = applyBaseline(registryFindings, baseline);
   const registryOptionFatal = optionRegressions(registryFindings);
   for (const finding of [...registryBaseline.regressions, ...registryOptionFatal]) {
     console.log(formatFinding(finding));
   }
   for (const divergence of divergences) {
     console.log(`FAIL  TRANSCRIPTION-DRIFT ${divergence}`);
+  }
+  for (const table of staleDivergenceAllowances(TEST_SCHEMA, registry)) {
+    console.log(
+      `note  ALLOWANCE-STALE  ${table} — the transcriptions agree; drop it from ` +
+        "TRANSCRIPTION_DIVERGENCE_ALLOW_LIST",
+    );
   }
 
   console.log(


### PR DESCRIPTION
The `schema:compare` gate read only `TEST_SCHEMA`, the declarative map that no longer creates any table. The transcription that does create every table at boot — `buildCanonicalRegistry` in `packages/activerecord/src/support/canonical-schema.ts` — was unverified: a column added there with the wrong type, or a table `schema.rb` does not declare, passed the gate untouched. The two are hand-synced and nothing enforced it.

## What changed

- `canonicalRegistrySchema()` (canonical-schema.ts) replays every `create_table` block against a recording probe — the same pattern `canonicalForeignKeyDependents` already uses, so `TableBuilder` stays file-local — and returns the declared table → column → `ColumnSpec` view. It pins the SQLite adapter and passes no `serialPk`/composite-PK set so the result is the *declared* shape, not one adapter's rendering of it.
- `compare.ts` now runs three checks: `TEST_SCHEMA` vs `schema.rb` (unchanged), the registry vs `schema.rb` against the same invention baseline and `OPTION_DEBT_CEILING`, and `compareTranscriptions` — table set, column set, and per-column type/options — between the two. Any of them failing exits non-zero.
- Finding details take a side label, so registry findings read `canonical-registry` rather than `TEST_SCHEMA`.
- `assertSerialPkIsPlainInteger` guards the one branch the replay does not take. `TableBuilder.col`'s `serialPk` path discards the declared options in favour of `serialIdType(...)` + `primaryKey: true`, so reading the generic branch is the right *declared* shape only while no `serialPk` column declares something that path would throw away. That held by coincidence, not construction; it now raises instead.
- `assertCompositePkDeclaresNoNull` does the same for the composite-PK branch, which overrides the declared nullability with `null: false`. Checking that against Rails: the forcing is a trails addition — `visit_PrimaryKeyDefinition` (`schema_creation.rb:79-81`) emits only `PRIMARY KEY (a, b)`, and `schema.rb:243-250` declares `cpk_books.author_id` as a bare `t.integer`. The replay keeps reporting the declared (nullable) shape, which is what makes the schema.rb comparison honest; whether the DDL should carry the NOT NULL at all is pre-existing behaviour, now tracked as `composite-pk-not-null-forcing-is-not-in-schema-rb` under RFC 0064.
- One baseline covers both transcriptions, so every read of it works off the union of their findings — reseed writes both sides' inventions, the growth check sees both, and `BASELINE-STALE` fires only when neither invents the entry. Otherwise a stale note derived from `TEST_SCHEMA` alone could recommend pruning the registry's live debt, turning it into a regression on the next run. Reseed output is unchanged (79 tables, 1 column).
- `TRANSCRIPTION_DIVERGENCE_ALLOW_LIST` documents the only live divergence: the four arunit2-only tables (`courses`, `colleges`, `professors`, `courses_professors`), which only the registry carries because it can skip them per-database. `staleDivergenceAllowances` reports an entry the two have since converged on, so the list ratchets down like the invention baseline.

The registry's findings against `schema.rb` are identical to `TEST_SCHEMA`'s today (79 baselined tables, 1 baselined column, the same 4 `parrots` OPTION divergences), so the shared baseline needs no growth. `--write` still reseeds from `TEST_SCHEMA` only, so a registry-only invention cannot be blessed into the baseline — it has to be removed.

## Scope

The drift check compares column shape (type, `limit`, `precision`, `scale`, `null`, `default`). Indexes, foreign keys, and table-level primary-key metadata are declared in structurally different ways on the two sides (`t.foreignKey` / `t.index` calls versus a `references:` option and a separate index list), so diffing them here would manufacture findings rather than catch drift; the comparator says so at the call site. `TEST_SCHEMA` itself is untouched — its eslint / fixtures-compare / test consumers are unaffected.

## Stats-DB output

Existing report lines are byte-identical. One new summary line is appended:

```
321 canonical-registry tables — new-inventions=0 baselined=80 option-divergences=4 transcription-drift=0
```

Deliberate: it is the new gate's counterpart to the existing summary.

## Verification

- `pnpm schema:compare` green.
- Injecting a column into a registry `create_table` block fails the gate with `FAIL TRANSCRIPTION-DRIFT admin_regions.bogus_drift — declared only by canonical-registry` (reverted).
- Declaring `t.integer("ID", { limit: 8 })` on the `bulbs` serialPk column, and `{ null: true }` on `cpk_books.author_id`, each abort the run with the relevant guard's message (both reverted).
- `pnpm vitest run scripts/schema-compare/compare.test.ts` — 78 tests pass, including new coverage of `compareTranscriptions`, `describeSpec`, `staleDivergenceAllowances`, the PK-branch guards, and the registry-vs-`schema.rb` invention/option gates.

Closes-story: schema-compare-verifies-the-unused-transcription
