### PR TITLE
test(activerecord): stop AR suites materializing sqlite files in the working tree

### DIFF
--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -526,7 +526,7 @@ describe("ConnectionHandlerTest", () => {
     const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary")!;
-    await pool.leaseConnection();
+    await (await pool.leaseConnection()).verifyBang();
     expect(handler.isConnected("primary")).toBe(true);
     pool.releaseConnection();
   });

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -231,12 +231,14 @@ describe("ConnectionHandlerTest", () => {
     expect(pool).toBeTruthy();
   });
 
+  // Rails' setup establishes the handler against the real :arunit primary
+  // config (connection_handler_test.rb:14), so the tests that actually lease a
+  // connection ride the ambient lane database. Tests below that only assert on
+  // config values keep their literal paths (Rails does the same) — but a leased
+  // literal path would materialize a SQLite file in the working tree.
   it("active connections?", async () => {
     expect(handler.activeConnections).toBe(false);
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
-    });
+    const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary")!;
     await pool.leaseConnection();
@@ -486,10 +488,7 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("clear active connections bang", async () => {
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
-    });
+    const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary")!;
     await pool.leaseConnection();
@@ -499,10 +498,7 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("clear all connections bang", async () => {
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
-    });
+    const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary")!;
     await pool.leaseConnection();
@@ -518,10 +514,7 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("retrieve connection returns a connection", async () => {
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
-    });
+    const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { owner: "primary" });
     const conn = await handler.retrieveConnection("primary");
     expect(conn).toBeTruthy();
@@ -535,10 +528,7 @@ describe("ConnectionHandlerTest", () => {
 
   it("is connected", async () => {
     expect(handler.isConnected("primary")).toBe(false);
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
-    });
+    const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary")!;
     await pool.leaseConnection();
@@ -558,10 +548,7 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("flush idle connections bang", async () => {
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
-    });
+    const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary")!;
     await pool.leaseConnection();
@@ -595,10 +582,7 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("active connections filtered by role", async () => {
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "dev.db",
-    });
+    const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, {
       owner: "primary",
       role: "writing",

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -231,11 +231,6 @@ describe("ConnectionHandlerTest", () => {
     expect(pool).toBeTruthy();
   });
 
-  // Rails' setup establishes the handler against the real :arunit primary
-  // config (connection_handler_test.rb:14), so the tests that actually lease a
-  // connection ride the ambient lane database. Tests below that only assert on
-  // config values keep their literal paths (Rails does the same) — but a leased
-  // literal path would materialize a SQLite file in the working tree.
   it("active connections?", async () => {
     expect(handler.activeConnections).toBe(false);
     const config = new HashConfig("development", "primary", ambientPoolConfiguration());

--- a/packages/activerecord/src/connection-management.test.ts
+++ b/packages/activerecord/src/connection-management.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "./base.js";
-import { HashConfig } from "./database-configurations/hash-config.js";
 import {
   ConnectionManagement,
   BodyProxy,
@@ -29,16 +28,6 @@ describe("ConnectionManagementTest", () => {
   let management: ConnectionManagement;
 
   beforeEach(async () => {
-    Base.connectionHandler.establishConnection(
-      new HashConfig("test", "primary", {
-        adapter: "sqlite3",
-        database: "test.db",
-        pool: 5,
-        reapingFrequency: null,
-      }),
-      { owner: "Base" },
-    );
-
     env = {};
     app = new App();
     management = middleware(app);

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -532,7 +532,7 @@ describe("DatabaseTasksDropAllTest", () => {
   let dropped: string[];
   beforeEach(() => {
     dropped = [];
-    DatabaseTasks.registerTask("sqlite", {
+    DatabaseTasks.registerTask("abstract", {
       drop: async (config) => {
         dropped.push(config.database ?? "unknown");
       },
@@ -546,7 +546,7 @@ describe("DatabaseTasksDropAllTest", () => {
 
   it("ignores configurations without databases", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3" },
+      development: { adapter: "abstract" },
     });
     await DatabaseTasks.dropAll();
     expect(dropped).toHaveLength(0);
@@ -554,7 +554,7 @@ describe("DatabaseTasksDropAllTest", () => {
 
   it("ignores remote databases", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
+      development: { adapter: "abstract", database: "my-db", host: "my.server.tld" },
     });
     vi.spyOn(stderr, "write").mockImplementation(() => true);
     await DatabaseTasks.dropAll();
@@ -562,7 +562,7 @@ describe("DatabaseTasksDropAllTest", () => {
   });
   it("warning for remote databases", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
+      development: { adapter: "abstract", database: "my-db", host: "my.server.tld" },
     });
     const writes: string[] = [];
     vi.spyOn(stderr, "write").mockImplementation((chunk) => {
@@ -571,32 +571,32 @@ describe("DatabaseTasksDropAllTest", () => {
     });
     await DatabaseTasks.dropAll();
     expect(writes.join("")).toMatch(
-      /This task only modifies local databases\. dev\.db is on a remote host\./,
+      /This task only modifies local databases\. my-db is on a remote host\./,
     );
   });
 
   it("drops configurations with local ip", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3", database: "dev.db", host: "127.0.0.1" },
+      development: { adapter: "abstract", database: "my-db", host: "127.0.0.1" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain("dev.db");
+    expect(dropped).toContain("my-db");
   });
 
   it("drops configurations with local host", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3", database: "dev.db", host: "localhost" },
+      development: { adapter: "abstract", database: "my-db", host: "localhost" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain("dev.db");
+    expect(dropped).toContain("my-db");
   });
 
   it("drops configurations with blank hosts", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3", database: "dev.db", host: "" },
+      development: { adapter: "abstract", database: "my-db", host: "" },
     });
     await DatabaseTasks.dropAll();
-    expect(dropped).toContain("dev.db");
+    expect(dropped).toContain("my-db");
   });
 });
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -270,11 +270,7 @@ export class DatabaseTasks {
 
   static async dropAll(): Promise<void> {
     if (!this.databaseConfiguration) return;
-    const configs = this.eachLocalConfiguration();
-    for (const config of configs) {
-      await this.checkProtectedEnvironmentsBang(config.envName);
-    }
-    for (const config of configs) {
+    for (const config of this.eachLocalConfiguration()) {
       await this.drop(config);
     }
   }
@@ -282,7 +278,6 @@ export class DatabaseTasks {
   static async dropCurrent(environment?: string): Promise<void> {
     const envs = this._environmentsFor(environment);
     for (const env of envs) {
-      await this.checkProtectedEnvironmentsBang(env);
       const configs = this.configsFor(env);
       for (const config of configs) {
         await this.drop(config);
@@ -442,7 +437,6 @@ export class DatabaseTasks {
   }
 
   static async purgeCurrent(environment?: string): Promise<void> {
-    await this.checkProtectedEnvironmentsBang(environment);
     const env = this._normalizeEnv(environment);
     const configs = this.configsFor(env);
     for (const config of configs) {
@@ -452,17 +446,12 @@ export class DatabaseTasks {
 
   static async purgeAll(): Promise<void> {
     if (!this.databaseConfiguration) return;
-    const configs = this.eachLocalConfiguration();
-    for (const config of configs) {
-      await this.checkProtectedEnvironmentsBang(config.envName);
-    }
-    for (const config of configs) {
+    for (const config of this.eachLocalConfiguration()) {
       await this.purge(config);
     }
   }
 
   static async truncateAll(environment?: string): Promise<void> {
-    await this.checkProtectedEnvironmentsBang(environment);
     const env = this._normalizeEnv(environment);
     const configs = this.configsFor(env);
     for (const config of configs) {
@@ -574,8 +563,8 @@ export class DatabaseTasks {
     const protectedEnvs = Base.protectedEnvironments ?? ["production"];
 
     // Include hidden / `databaseTasks: false` / replica configs so the
-    // guard is a superset of everything destructive callers like dropAll
-    // might touch — a hidden config stamped as production should still
+    // guard is a superset of everything a destructive task might touch —
+    // a hidden config stamped as production should still
     // block the operation even though the regular configsFor filter
     // would have hidden it.
     const configs = this.databaseConfiguration

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -836,13 +836,11 @@ export function dbCommand(): Command {
     .command("seed:replant")
     .description("Truncate all tables in the current environment and re-run seeds")
     .action(async () => {
-      // Run the truncate path first (no connection in the CLI — the
-      // DatabaseTasks.truncateAll handler opens/closes its own per-
-      // config connection). Open the seed adapter only after the
-      // protected-env guard has passed and the truncate has completed,
-      // so we don't double-connect.
+      // Open the seed adapter only after the protected-env guard has
+      // passed and the truncate has completed, so we don't double-connect.
       const raw = normalizeRawConfig(await loadDatabaseConfig());
       const config = toDbConfig(raw);
+      await runProtectedEnvCheck(config, config.envName);
       await withRegisteredConfiguration(config, async () => {
         await DatabaseTasks.truncateAll(config.envName);
       });
@@ -865,6 +863,7 @@ export function dbCommand(): Command {
       // can abort.
       const raw = normalizeRawConfig(await loadDatabaseConfig());
       const config = toDbConfig(raw);
+      await runProtectedEnvCheck(config, config.envName);
       await withRegisteredConfiguration(config, async () => {
         await DatabaseTasks.truncateAll(config.envName);
       });


### PR DESCRIPTION
## What

A `pnpm vitest run` over the activerecord suite left `dev.db`, `test.db`,
`dev_animals.db` and `test_animals.db` in the repo working tree. Audited every
suite that names a relative database path and removed the writers.

### 1. `DatabaseTasks` drop/purge/truncate connected to every config (root cause)

Rails' `drop_all` / `drop_current` / `purge_all` / `purge_current` /
`truncate_all` do **not** call `check_protected_environments!`
(`vendor/rails/activerecord/lib/active_record/tasks/database_tasks.rb:222-228,352-360`);
the rake tasks declare it as a dependency instead
(`railties/databases.rake:64,79,84`). trails had embedded the guard in the
methods, and the guard opens a temporary connection per config — so the
drop/purge tests, whose task handlers are stubs that never connect, still
created SQLite files for `dev.db` and friends.

The two CLI `truncate_all` call sites (`db truncate_all`, `db seed:replant`)
were the only callers that leaned on the in-method guard; they now call
`runProtectedEnvCheck` explicitly, like the existing `drop` / `schema:load` /
`test:prepare` paths.

### 2. `DatabaseTasksDropAllTest` converged onto Rails' abstract config

With the guard gone, the describe uses Rails' own
`"adapter" => "abstract", "database" => "my-db"`
(`database_tasks_test.rb:748`) — a config that cannot be connected through.
That is the regression cover: on baseline these tests fail with
`nonexistent 'abstract' adapter` raised from `checkProtectedEnvironmentsBang`.

### 3. `ConnectionHandlerTest` leased a literal `dev.db`

Rails' `setup` establishes the handler against the real `:arunit` primary
config (`connection_handler_test.rb:14`). The trails tests that actually lease
a connection now ride `ambientPoolConfiguration()` (the worker's lane database,
already the file's idiom); the tests that only assert on config values keep
their literal relative paths, as Rails does.

### 4. `ConnectionManagementTest` established its own `test.db`

Rails' `setup` has no `establish_connection` — it just leases the ambient
connection (`connection_management_test.rb:23-31`). Dropped the invented one.

## Verification

- Every activerecord test file naming a relative `*.db` / `*.sqlite3` path
  (35 files, 690 tests) run locally: all pass, and `git status` plus a
  `find` for stray `*.db` / `*.sqlite3` come back clean.
- `packages/trailties/src/commands/db.test.ts` (105 tests) passes.
- `api:compare` — no method/arity movement (only in-method call sites changed,
  and none of the removed calls are ones Rails makes: `call-mismatches.json`
  lists no drop/purge/truncate entry). `test:compare` — no test names touched:
  `database_tasks_test.rb` 77/77, `connection_handler_test.rb` 22/22,
  `connection_management_test.rb` 9/9.
- The configured sqlite3 fixture databases (`SQLITE_FIXTURE_DATABASE` /
  `SQLITE_FIXTURE_DATABASE_2`) and the `/db/` `.gitignore` entry are untouched,
  per the story's scope correction.

Closes-story: tests-materialize-sqlite-files-in-repo-root
