### PR TITLE
perf(test-infra): stamp the sqlite and MySQL templates for the boot fast path

### DIFF
--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -59,12 +59,19 @@ function slotCount(): number {
   return workerForkCount() <= 1 ? 1 : slotPoolSize();
 }
 
+// Lay the canonical schema and stamp it, so the worker that claims this
+// database reports `canonicalSchemaUpToDate` and boots on the TRUNCATE fast
+// path instead of purging and re-laying what globalSetup just laid. The run
+// token is passed explicitly because `RUN_TOKEN_ENV` is only published to the
+// environment after provisioning finishes.
 async function buildTemplateSchema(
   adapter: DatabaseAdapter,
+  runToken: string,
   close: () => Promise<void>,
 ): Promise<void> {
   try {
     await loadSchema(adapter);
+    await stampCanonicalSchema(adapter, runToken);
   } finally {
     await close();
   }
@@ -111,7 +118,9 @@ const sqliteAdapter: DbTemplateAdapter = {
     const templatePath = await templatePathFor(runToken);
 
     const adapter = new BetterSQLite3Adapter(templatePath);
-    await buildTemplateSchema(adapter as unknown as DatabaseAdapter, () => adapter.close());
+    await buildTemplateSchema(adapter as unknown as DatabaseAdapter, runToken, () =>
+      adapter.close(),
+    );
 
     process.env[TEMPLATE_PATH_ENV] = templatePath;
     process.env[RUN_TOKEN_ENV] = runToken;
@@ -306,7 +315,7 @@ const mysqlAdapter: DbTemplateAdapter = {
           connectionLimit: 1,
           flags: ["FOUND_ROWS"],
         }) as unknown as DatabaseAdapter;
-        await buildTemplateSchema(adapter, async () => {
+        await buildTemplateSchema(adapter, runToken, async () => {
           await (adapter as unknown as { disconnect(): Promise<void> }).disconnect?.();
         });
       }),

--- a/packages/activerecord/src/support/template-stamp.test.ts
+++ b/packages/activerecord/src/support/template-stamp.test.ts
@@ -1,30 +1,37 @@
 /**
- * The sqlite half of `pg-template.test.ts`: confirms globalSetup stamped the
- * canonical-schema template its workers clone, which is what puts the worker
- * that claims a clone on `test-setup-dy.ts`'s TRUNCATE fast path instead of a
- * purge + full canonical reload.
+ * The sqlite/MySQL companion to `pg-template.test.ts`: the canonical-schema
+ * stamp is what puts a booting worker on `test-setup-dy.ts`'s TRUNCATE fast
+ * path instead of a purge + full canonical reload, so both ends of it are
+ * pinned here — globalSetup laying it, and the fast path leaving it behind.
  *
- * Only sqlite is probed. MySQL is stamped by the same `buildTemplateSchema`
- * helper, but it has no `CREATE DATABASE ... TEMPLATE` primitive, so globalSetup
- * lays the schema straight into each slot DB — and the first worker to boot onto
- * a slot consumes the stamp (`resetTestTables` drops `ar_internal_metadata`
- * along with the other bookkeeping tables). There is therefore no MySQL artifact
- * a test can read the stamp back off. The sqlite template file is never booted
- * onto, so it keeps its stamp for the whole run.
+ * The first probe is lane-specific because only sqlite has a stamped artifact a
+ * test can read back: its template file is cloned per worker and never booted
+ * onto, so it keeps its stamp for the whole run. PG's equivalent (the template
+ * DB) is covered by `pg-template.test.ts`. MySQL has no `CREATE DATABASE ...
+ * TEMPLATE` primitive, so globalSetup stamps the slot DBs workers boot onto
+ * directly, and the first boot consumes the stamp — nothing survives to assert.
  *
- * Skipped automatically off the sqlite lane.
+ * The second probe covers every lane, MySQL included, by replaying the fast
+ * path's arm against the worker's own database.
  */
 import { describe, it, expect } from "vitest";
 import "../sqlite/better-sqlite3.js";
+import { Base } from "../base.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { InternalMetadata } from "../internal-metadata.js";
-import { canonicalSchemaStamp } from "./canonical-schema-stamp.js";
+import {
+  canonicalSchemaStamp,
+  canonicalSchemaUpToDate,
+  stampCanonicalSchema,
+} from "./canonical-schema-stamp.js";
+import { resetTestTables } from "./drop-all-tables.js";
+import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
 import { RUN_TOKEN_ENV } from "./run-token.js";
 import { TEMPLATE_PATH_ENV, isSqliteRun } from "./sqlite-template.js";
 
-const runToken = process.env[RUN_TOKEN_ENV];
-const templatePath = process.env[TEMPLATE_PATH_ENV];
-const sqliteActive = isSqliteRun() && !!templatePath;
+const runToken = process.env[RUN_TOKEN_ENV] ?? "";
+const templatePath = process.env[TEMPLATE_PATH_ENV] ?? "";
+const sqliteActive = isSqliteRun() && !!templatePath && !!runToken;
 
 describe.skipIf(!sqliteActive)("sqlite template stamp", () => {
   it("the template file is stamped with the canonical schema SHA1", async () => {
@@ -32,10 +39,30 @@ describe.skipIf(!sqliteActive)("sqlite template stamp", () => {
     try {
       const metadata = new InternalMetadata(adapter);
       expect(await metadata.get("schema_sha1"), "template must carry the stamped schema_sha1").toBe(
-        canonicalSchemaStamp(runToken!),
+        canonicalSchemaStamp(runToken),
       );
     } finally {
       await adapter.close();
     }
+  });
+});
+
+describe.skipIf(!runToken)("boot fast path stamp", () => {
+  it("leaves the database stamped for the next worker recycled onto it", async () => {
+    // Replays `test-setup-dy.ts`'s fast-path arm verbatim. `resetTestTables`
+    // drops `ar_internal_metadata` along with the other bookkeeping tables, so
+    // without the re-stamp that arm ends with, the stamp is single-use per
+    // database and every recycled worker pays the full purge+reload. Running
+    // the arm here is safe: it is the same reset the suite runs between tests,
+    // and it re-lays the adapter-specific tables it drops.
+    const connection = await Base.leaseConnection();
+    await resetTestTables(connection);
+    // The hazard the re-stamp answers, asserted rather than assumed: the reset
+    // takes the stamp with it, so the arm is not self-sustaining without it.
+    expect(await canonicalSchemaUpToDate(connection)).toBe(false);
+
+    await loadAdapterSpecificSchema(connection);
+    await stampCanonicalSchema(connection);
+    expect(await canonicalSchemaUpToDate(await Base.leaseConnection())).toBe(true);
   });
 });

--- a/packages/activerecord/src/support/template-stamp.test.ts
+++ b/packages/activerecord/src/support/template-stamp.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The sqlite half of `pg-template.test.ts`: confirms globalSetup stamped the
+ * canonical-schema template its workers clone, which is what puts the worker
+ * that claims a clone on `test-setup-dy.ts`'s TRUNCATE fast path instead of a
+ * purge + full canonical reload.
+ *
+ * Only sqlite is probed. MySQL is stamped by the same `buildTemplateSchema`
+ * helper, but it has no `CREATE DATABASE ... TEMPLATE` primitive, so globalSetup
+ * lays the schema straight into each slot DB — and the first worker to boot onto
+ * a slot consumes the stamp (`resetTestTables` drops `ar_internal_metadata`
+ * along with the other bookkeeping tables). There is therefore no MySQL artifact
+ * a test can read the stamp back off. The sqlite template file is never booted
+ * onto, so it keeps its stamp for the whole run.
+ *
+ * Skipped automatically off the sqlite lane.
+ */
+import { describe, it, expect } from "vitest";
+import "../sqlite/better-sqlite3.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import { InternalMetadata } from "../internal-metadata.js";
+import { canonicalSchemaStamp } from "./canonical-schema-stamp.js";
+import { RUN_TOKEN_ENV } from "./run-token.js";
+import { TEMPLATE_PATH_ENV, isSqliteRun } from "./sqlite-template.js";
+
+const runToken = process.env[RUN_TOKEN_ENV];
+const templatePath = process.env[TEMPLATE_PATH_ENV];
+const sqliteActive = isSqliteRun() && !!templatePath;
+
+describe.skipIf(!sqliteActive)("sqlite template stamp", () => {
+  it("the template file is stamped with the canonical schema SHA1", async () => {
+    const adapter = new BetterSQLite3Adapter(templatePath);
+    try {
+      const metadata = new InternalMetadata(adapter);
+      expect(await metadata.get("schema_sha1"), "template must carry the stamped schema_sha1").toBe(
+        canonicalSchemaStamp(runToken!),
+      );
+    } finally {
+      await adapter.close();
+    }
+  });
+});

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -14,8 +14,10 @@
  * database is not freshly created, so it has to be emptied first. Which form
  * that takes is the driver gate (RFC 0002 §Design):
  *   - already laid by this run (`canonicalSchemaUpToDate`) → TRUNCATE, skipping
- *     the canonical DDL only. This is the PG template-clone fast path: a slot DB
- *     cloned from the stamped template already carries the canonical half.
+ *     the canonical DDL only. All three lanes reach it: globalSetup stamps what
+ *     it lays (a PG slot cloned from the stamped template, the sqlite template
+ *     file each worker clones, each MySQL slot DB), and this arm re-stamps, so
+ *     a worker recycled onto a database an earlier worker used takes it too.
  *   - sqlite file → purge (per-worker isolated file; drop+create is safe — no
  *     other worker shares this file path).
  *   - PG/MySQL slot >1 (AR_PG_EXCLUSIVE_DB / AR_MYSQL_EXCLUSIVE_DB set by
@@ -61,6 +63,13 @@ if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
   const conn = await Base.leaseConnection();
   await resetTestTables(conn);
   await loadAdapterSpecificSchema(conn);
+  // Re-stamp: `resetTestTables` drops `ar_internal_metadata` along with the
+  // other bookkeeping tables, so the stamp this boot consumed is gone. What is
+  // left behind is the same state the full-load arm below stamps — canonical
+  // plus adapter-specific, laid and empty — so the next worker recycled onto
+  // this database is entitled to the same fast path. Without this the stamp is
+  // single-use per database and every recycle pays the full purge+reload.
+  await stampCanonicalSchema(conn);
 } else {
   // `DatabaseTasks.purge` re-establishes Base's pool on the recreated database,
   // so the connection has to be leased after it, not before.


### PR DESCRIPTION
globalSetup lays the canonical schema on all three lanes, but only PostgreSQL
stamped it, so every sqlite and MySQL worker boot purged the database
globalSetup had just laid and re-laid the whole canonical registry — the DDL the
template build exists to buy once per run.

## What changed

- `buildTemplateSchema` (the shared helper both the sqlite template file and
  each MySQL slot DB go through) now calls `stampCanonicalSchema` after
  `loadSchema`. The run token is passed explicitly because `RUN_TOKEN_ENV` is
  only published to the environment after provisioning finishes.
- `test-setup-dy.ts`'s fast path **re-stamps** at the end. `resetTestTables`
  drops `ar_internal_metadata` along with the other bookkeeping tables, so the
  stamp was single-use per database: the first worker onto a slot went fast and
  every recycled worker after it paid the full purge+reload. What the fast path
  leaves behind is exactly what the full-load arm stamps (canonical +
  adapter-specific, laid and empty), so the next worker is entitled to the same
  treatment. This is where most of the win below comes from, and it benefits PG
  as well.
- New `support/template-stamp.test.ts`, two probes. The first mirrors
  `pg-template.test.ts` and asserts globalSetup stamped the sqlite template file
  — sqlite is the only lane with a stamped artifact a test can read back, since
  its template file is cloned per worker and never booted onto. (MySQL has no
  `CREATE DATABASE ... TEMPLATE` primitive, so its stamp lands directly on slot
  DBs that workers boot onto and consume.) The second runs on every lane,
  MySQL included: it replays the fast path's arm against the worker's own
  database and asserts both halves of the invariant the re-stamp rests on —
  that `resetTestTables` does take the stamp with it, and that the arm as a
  whole leaves the database up-to-date again.

## Measurements

Same host, same subsets, 4 forks. `setup` is the number this change moves;
wall-clock follows it out of the noise.

sqlite — `src/associations` + `src/relation` (139 files):

| | setup | wall |
| --- | --- | --- |
| baseline | 198.2s | 302.2s |
| stamp only | 188.3s | 294.8s |
| stamp + re-stamp | **180.0s** | **286.9s** |

MySQL — `src/relation` (50 files), two runs per arm:

| | setup | wall |
| --- | --- | --- |
| baseline | 166.5 / 169.1s | 228.2 / 235.5s |
| stamp only | 163.8 / 165.5s | 235.9 / 233.8s |
| stamp + re-stamp | **148.4s** | **228.5s** |

Neither lane regresses, so both stay stamped. Stamping alone was a wash on
MySQL (~2% of setup, inside wall-clock noise) precisely because the stamp was
consumed on first boot; with the re-stamp it is ~11% of setup.

## Correctness

Worker recycling was the thing #5678's first CI run got wrong. The boot
assertion in `test-setup-dy.ts` (`accounts`/`topics`/`posts`/`defaults`) covers
both halves and is unchanged — a recycled worker taking the fast path still runs
`resetTestTables` + `loadAdapterSpecificSchema`, so the adapter-specific tables
an earlier worker's tests dropped come back.

One coverage limit worth stating plainly: the second probe pins the arm's
composition, not the production call site — a worker's post-boot state is not
deterministically observable from a test file, because boot happens once per
worker and later files' between-test resets clear the stamp again. Deleting the
`stampCanonicalSchema` line in `test-setup-dy.ts` would cost the speedup without
turning a test red. The wall-clock table above is the check on that.

Green on all three lanes locally: sqlite `associations`+`relation` (138 files)
and `support`+`migration`+`tasks` (42 files); MySQL `relation` (49) and
`support`+`migration`+`tasks` (42); PostgreSQL `relation`+`support`+`migration`
(91). The migrator and `internal-metadata` suites are in that set deliberately:
they are the ones that manage `ar_internal_metadata` per-test, and the re-stamp
makes the fast path leave it present at boot exactly as the full-load arm
already did.

Closes-story: stamp-sqlite-and-mysql-templates-for-the-boot-fast-path
