### PR TITLE
test-support(activerecord): measure the global between-test sweep before removing it

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -76,17 +76,25 @@ export async function resetTestTables(adapter: DatabaseAdapter): Promise<void> {
 
 type ResetMode = "drop-all" | "reset";
 
+/**
+ * The array {@link resetTables} records dropped names into, or `null` when the
+ * sweep is not being measured — which is the default, and the only state CI
+ * ever runs in. See {@link recordSweptTables}.
+ *
+ * Recording waits for the boot snapshot: `test-setup-dy.ts` runs a reset of its
+ * own between the canonical load and the adapter-specific arm, and what that
+ * one drops (`defaults`, on a worker recycled onto an already-used database) is
+ * boot bookkeeping rather than a test leak. Only between-test sweeps are the
+ * measurement.
+ */
+function sweepCollector(mode: ResetMode): string[] | null {
+  if (mode !== "reset" || _bootLaidTableNames === null) return null;
+  return sweepReportDir() === undefined ? null : [];
+}
+
 async function resetTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
   const bootLaid = bootLaidTableNames();
-  // Off by default (`AR_SWEEP_REPORT` unset): `swept` stays null and the drop
-  // loops below skip recording entirely. See {@link recordSweptTables}.
-  //
-  // Only *between-test* sweeps are measured, so recording waits until the boot
-  // snapshot exists: `test-setup-dy.ts` runs a reset of its own between the
-  // canonical load and the adapter-specific arm, and everything that one drops
-  // (`defaults` on a recycled worker) is boot bookkeeping, not a test leak.
-  const swept: string[] | null =
-    mode === "reset" && _bootLaidTableNames !== null && sweepReportDir() !== undefined ? [] : null;
+  const swept = sweepCollector(mode);
   switch (adapter.adapterName) {
     case "postgres":
       await resetPgTables(adapter, mode, bootLaid, swept);
@@ -181,9 +189,9 @@ async function _resetPgTablesOnce(
   for (const { schemaname: s, name: n } of (await adapter.execute(
     `SELECT schemaname, matviewname AS name FROM pg_matviews WHERE schemaname = ${schema}`,
   )) as { schemaname: string; name: string }[]) {
-    swept?.push(`matview:${n}`);
     try {
       await adapter.executeMutation(`DROP MATERIALIZED VIEW IF EXISTS "${s}"."${n}" CASCADE`);
+      swept?.push(`matview:${n}`);
     } catch (e) {
       if (_isPgConnectionError(e)) throw e;
     }
@@ -191,9 +199,9 @@ async function _resetPgTablesOnce(
   for (const { schemaname: s, name: n } of (await adapter.execute(
     `SELECT schemaname, viewname AS name FROM pg_views WHERE schemaname = ${schema}`,
   )) as { schemaname: string; name: string }[]) {
-    swept?.push(`view:${n}`);
     try {
       await adapter.executeMutation(`DROP VIEW IF EXISTS "${s}"."${n}" CASCADE`);
+      swept?.push(`view:${n}`);
     } catch (e) {
       if (_isPgConnectionError(e)) throw e;
     }
@@ -211,9 +219,9 @@ async function _resetPgTablesOnce(
       toTruncate.push(t);
       continue;
     }
-    swept?.push(s === "public" ? t : `${s}.${t}`);
     try {
       await adapter.executeMutation(`DROP TABLE IF EXISTS "${s}"."${t}" CASCADE`);
+      swept?.push(s === "public" ? t : `${s}.${t}`);
     } catch (e) {
       if (_isPgConnectionError(e)) throw e;
     }
@@ -237,10 +245,10 @@ async function resetMysqlTables(
     );
     for (const r of viewRows as Array<{ table_name?: string; TABLE_NAME?: string }>) {
       const name = r.table_name ?? r.TABLE_NAME;
-      if (name) swept?.push(`view:${name}`);
       if (name)
         try {
           await adapter.executeMutation(`DROP VIEW IF EXISTS \`${name}\``);
+          swept?.push(`view:${name}`);
         } catch {}
     }
     for (const r of tableRows as Array<{ table_name?: string; TABLE_NAME?: string }>) {
@@ -250,9 +258,9 @@ async function resetMysqlTables(
         toTruncate.push(name);
         continue;
       }
-      swept?.push(name);
       try {
         await adapter.executeMutation(`DROP TABLE IF EXISTS \`${name}\``);
+        swept?.push(name);
       } catch {}
     }
   });
@@ -270,9 +278,9 @@ async function resetSqliteTables(
     for (const { name } of (await adapter.execute(
       `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
     )) as { name: string }[]) {
-      swept?.push(`view:${name}`);
       try {
         await adapter.executeMutation(`DROP VIEW IF EXISTS "${name}"`);
+        swept?.push(`view:${name}`);
       } catch {}
     }
     for (const { name } of (await adapter.execute(
@@ -282,9 +290,9 @@ async function resetSqliteTables(
         toTruncate.push(name);
         continue;
       }
-      swept?.push(name);
       try {
         await adapter.executeMutation(`DROP TABLE IF EXISTS "${name}"`);
+        swept?.push(name);
       } catch {}
     }
   });

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -1,5 +1,6 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
+import { recordSweptTables, sweepReportDir } from "./sweep-report.js";
 
 /**
  * Tables that exist after the schema load but are *not* part of the loaded
@@ -77,17 +78,27 @@ type ResetMode = "drop-all" | "reset";
 
 async function resetTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
   const bootLaid = bootLaidTableNames();
+  // Off by default (`AR_SWEEP_REPORT` unset): `swept` stays null and the drop
+  // loops below skip recording entirely. See {@link recordSweptTables}.
+  //
+  // Only *between-test* sweeps are measured, so recording waits until the boot
+  // snapshot exists: `test-setup-dy.ts` runs a reset of its own between the
+  // canonical load and the adapter-specific arm, and everything that one drops
+  // (`defaults` on a recycled worker) is boot bookkeeping, not a test leak.
+  const swept: string[] | null =
+    mode === "reset" && _bootLaidTableNames !== null && sweepReportDir() !== undefined ? [] : null;
   switch (adapter.adapterName) {
     case "postgres":
-      await resetPgTables(adapter, mode, bootLaid);
+      await resetPgTables(adapter, mode, bootLaid, swept);
       break;
     case "mysql":
-      await resetMysqlTables(adapter, mode, bootLaid);
+      await resetMysqlTables(adapter, mode, bootLaid, swept);
       break;
     case "sqlite":
-      await resetSqliteTables(adapter, mode, bootLaid);
+      await resetSqliteTables(adapter, mode, bootLaid, swept);
       break;
   }
+  if (swept) await recordSweptTables(adapter.adapterName, swept);
 }
 
 /**
@@ -142,16 +153,17 @@ async function resetPgTables(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
+  swept: string[] | null,
 ): Promise<void> {
   try {
-    await _resetPgTablesOnce(adapter, mode, bootLaid);
+    await _resetPgTablesOnce(adapter, mode, bootLaid, swept);
   } catch (e) {
     // exec() routes through withRawConnection, whose retry loop calls
     // reconnectBang → the PG reconnect() override on a connection error, so
     // _rawConnection is now null and the next _acquireFreshClient() will open a
     // fresh pg.Client. Retry exactly once.
     if (_isPgConnectionError(e)) {
-      await _resetPgTablesOnce(adapter, mode, bootLaid);
+      await _resetPgTablesOnce(adapter, mode, bootLaid, swept);
     } else {
       throw e;
     }
@@ -162,12 +174,14 @@ async function _resetPgTablesOnce(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
+  swept: string[] | null,
 ): Promise<void> {
   const schema = `ANY(current_schemas(false))`;
   // Views/matviews are never canonical — always drop them.
   for (const { schemaname: s, name: n } of (await adapter.execute(
     `SELECT schemaname, matviewname AS name FROM pg_matviews WHERE schemaname = ${schema}`,
   )) as { schemaname: string; name: string }[]) {
+    swept?.push(`matview:${n}`);
     try {
       await adapter.executeMutation(`DROP MATERIALIZED VIEW IF EXISTS "${s}"."${n}" CASCADE`);
     } catch (e) {
@@ -177,6 +191,7 @@ async function _resetPgTablesOnce(
   for (const { schemaname: s, name: n } of (await adapter.execute(
     `SELECT schemaname, viewname AS name FROM pg_views WHERE schemaname = ${schema}`,
   )) as { schemaname: string; name: string }[]) {
+    swept?.push(`view:${n}`);
     try {
       await adapter.executeMutation(`DROP VIEW IF EXISTS "${s}"."${n}" CASCADE`);
     } catch (e) {
@@ -196,6 +211,7 @@ async function _resetPgTablesOnce(
       toTruncate.push(t);
       continue;
     }
+    swept?.push(s === "public" ? t : `${s}.${t}`);
     try {
       await adapter.executeMutation(`DROP TABLE IF EXISTS "${s}"."${t}" CASCADE`);
     } catch (e) {
@@ -209,6 +225,7 @@ async function resetMysqlTables(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
+  swept: string[] | null,
 ): Promise<void> {
   const toTruncate: string[] = [];
   await adapter.disableReferentialIntegrity(async () => {
@@ -220,6 +237,7 @@ async function resetMysqlTables(
     );
     for (const r of viewRows as Array<{ table_name?: string; TABLE_NAME?: string }>) {
       const name = r.table_name ?? r.TABLE_NAME;
+      if (name) swept?.push(`view:${name}`);
       if (name)
         try {
           await adapter.executeMutation(`DROP VIEW IF EXISTS \`${name}\``);
@@ -232,6 +250,7 @@ async function resetMysqlTables(
         toTruncate.push(name);
         continue;
       }
+      swept?.push(name);
       try {
         await adapter.executeMutation(`DROP TABLE IF EXISTS \`${name}\``);
       } catch {}
@@ -244,12 +263,14 @@ async function resetSqliteTables(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
+  swept: string[] | null,
 ): Promise<void> {
   const toTruncate: string[] = [];
   await adapter.disableReferentialIntegrity(async () => {
     for (const { name } of (await adapter.execute(
       `SELECT name FROM sqlite_master WHERE type='view' AND name NOT LIKE 'sqlite_%'`,
     )) as { name: string }[]) {
+      swept?.push(`view:${name}`);
       try {
         await adapter.executeMutation(`DROP VIEW IF EXISTS "${name}"`);
       } catch {}
@@ -261,6 +282,7 @@ async function resetSqliteTables(
         toTruncate.push(name);
         continue;
       }
+      swept?.push(name);
       try {
         await adapter.executeMutation(`DROP TABLE IF EXISTS "${name}"`);
       } catch {}

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -54,7 +54,7 @@ function bootLaidTableNames(): ReadonlySet<string> {
  * MySQL and sqlite both go through `disableReferentialIntegrity`.
  */
 export async function dropAllTables(adapter: DatabaseAdapter): Promise<void> {
-  await resetTables(adapter, "drop-all");
+  await resetTables(adapter, "drop-all", false);
 }
 
 /**
@@ -69,32 +69,39 @@ export async function dropAllTables(adapter: DatabaseAdapter): Promise<void> {
  * `schema_migrations` / `ar_internal_metadata` bookkeeping tables (migrator
  * tests manage those per-test and rely on the reset clearing them).
  * Views/matviews are never canonical, so they are always dropped.
+ *
+ * `measure` opts a call into the RFC 0064 sweep report (which still does
+ * nothing unless `AR_SWEEP_REPORT` is set). Only the global between-test reset
+ * in `resetTestAdapterState` passes it: the boot reset in `test-setup-dy.ts`
+ * drops boot bookkeeping rather than test leaks, and this function's own unit
+ * tests drop tables they created a line earlier, so neither is a measurement.
  */
-export async function resetTestTables(adapter: DatabaseAdapter): Promise<void> {
-  await resetTables(adapter, "reset");
+export async function resetTestTables(
+  adapter: DatabaseAdapter,
+  { measure = false }: { measure?: boolean } = {},
+): Promise<void> {
+  await resetTables(adapter, "reset", measure);
 }
 
 type ResetMode = "drop-all" | "reset";
 
 /**
  * The array {@link resetTables} records dropped names into, or `null` when the
- * sweep is not being measured — which is the default, and the only state CI
- * ever runs in. See {@link recordSweptTables}.
- *
- * Recording waits for the boot snapshot: `test-setup-dy.ts` runs a reset of its
- * own between the canonical load and the adapter-specific arm, and what that
- * one drops (`defaults`, on a worker recycled onto an already-used database) is
- * boot bookkeeping rather than a test leak. Only between-test sweeps are the
- * measurement.
+ * sweep is not being measured — the default, and the only state CI ever runs
+ * in. See {@link recordSweptTables}.
  */
-function sweepCollector(mode: ResetMode): string[] | null {
-  if (mode !== "reset" || _bootLaidTableNames === null) return null;
+function sweepCollector(measure: boolean): string[] | null {
+  if (!measure) return null;
   return sweepReportDir() === undefined ? null : [];
 }
 
-async function resetTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
+async function resetTables(
+  adapter: DatabaseAdapter,
+  mode: ResetMode,
+  measure: boolean,
+): Promise<void> {
   const bootLaid = bootLaidTableNames();
-  const swept = sweepCollector(mode);
+  const swept = sweepCollector(measure);
   switch (adapter.adapterName) {
     case "postgres":
       await resetPgTables(adapter, mode, bootLaid, swept);

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -89,10 +89,15 @@ type ResetMode = "drop-all" | "reset";
  * The array {@link resetTables} records dropped names into, or `null` when the
  * sweep is not being measured — the default, and the only state CI ever runs
  * in. See {@link recordSweptTables}.
+ *
+ * A `Set` rather than an array because the pg path shares one collector across
+ * `_resetPgTablesOnce`'s connection-error retry: the retry re-queries
+ * `pg_tables`/`pg_views`, so names dropped before the error are normally gone
+ * from the second pass, but the collector must not depend on that.
  */
-function sweepCollector(measure: boolean): string[] | null {
+function sweepCollector(measure: boolean): Set<string> | null {
   if (!measure) return null;
-  return sweepReportDir() === undefined ? null : [];
+  return sweepReportDir() === undefined ? null : new Set();
 }
 
 async function resetTables(
@@ -168,7 +173,7 @@ async function resetPgTables(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
-  swept: string[] | null,
+  swept: Set<string> | null,
 ): Promise<void> {
   try {
     await _resetPgTablesOnce(adapter, mode, bootLaid, swept);
@@ -189,7 +194,7 @@ async function _resetPgTablesOnce(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
-  swept: string[] | null,
+  swept: Set<string> | null,
 ): Promise<void> {
   const schema = `ANY(current_schemas(false))`;
   // Views/matviews are never canonical — always drop them.
@@ -198,7 +203,7 @@ async function _resetPgTablesOnce(
   )) as { schemaname: string; name: string }[]) {
     try {
       await adapter.executeMutation(`DROP MATERIALIZED VIEW IF EXISTS "${s}"."${n}" CASCADE`);
-      swept?.push(`matview:${n}`);
+      swept?.add(`matview:${n}`);
     } catch (e) {
       if (_isPgConnectionError(e)) throw e;
     }
@@ -208,7 +213,7 @@ async function _resetPgTablesOnce(
   )) as { schemaname: string; name: string }[]) {
     try {
       await adapter.executeMutation(`DROP VIEW IF EXISTS "${s}"."${n}" CASCADE`);
-      swept?.push(`view:${n}`);
+      swept?.add(`view:${n}`);
     } catch (e) {
       if (_isPgConnectionError(e)) throw e;
     }
@@ -228,7 +233,7 @@ async function _resetPgTablesOnce(
     }
     try {
       await adapter.executeMutation(`DROP TABLE IF EXISTS "${s}"."${t}" CASCADE`);
-      swept?.push(s === "public" ? t : `${s}.${t}`);
+      swept?.add(s === "public" ? t : `${s}.${t}`);
     } catch (e) {
       if (_isPgConnectionError(e)) throw e;
     }
@@ -240,7 +245,7 @@ async function resetMysqlTables(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
-  swept: string[] | null,
+  swept: Set<string> | null,
 ): Promise<void> {
   const toTruncate: string[] = [];
   await adapter.disableReferentialIntegrity(async () => {
@@ -255,7 +260,7 @@ async function resetMysqlTables(
       if (name)
         try {
           await adapter.executeMutation(`DROP VIEW IF EXISTS \`${name}\``);
-          swept?.push(`view:${name}`);
+          swept?.add(`view:${name}`);
         } catch {}
     }
     for (const r of tableRows as Array<{ table_name?: string; TABLE_NAME?: string }>) {
@@ -267,7 +272,7 @@ async function resetMysqlTables(
       }
       try {
         await adapter.executeMutation(`DROP TABLE IF EXISTS \`${name}\``);
-        swept?.push(name);
+        swept?.add(name);
       } catch {}
     }
   });
@@ -278,7 +283,7 @@ async function resetSqliteTables(
   adapter: DatabaseAdapter,
   mode: ResetMode,
   bootLaid: ReadonlySet<string>,
-  swept: string[] | null,
+  swept: Set<string> | null,
 ): Promise<void> {
   const toTruncate: string[] = [];
   await adapter.disableReferentialIntegrity(async () => {
@@ -287,7 +292,7 @@ async function resetSqliteTables(
     )) as { name: string }[]) {
       try {
         await adapter.executeMutation(`DROP VIEW IF EXISTS "${name}"`);
-        swept?.push(`view:${name}`);
+        swept?.add(`view:${name}`);
       } catch {}
     }
     for (const { name } of (await adapter.execute(
@@ -299,7 +304,7 @@ async function resetSqliteTables(
       }
       try {
         await adapter.executeMutation(`DROP TABLE IF EXISTS "${name}"`);
-        swept?.push(name);
+        swept?.add(name);
       } catch {}
     }
   });

--- a/packages/activerecord/src/support/sweep-report.trails.test.ts
+++ b/packages/activerecord/src/support/sweep-report.trails.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { getFsAsync } from "@blazetrails/activesupport";
+import { _resetSweepReport, recordSweptTables, sweepReportDir } from "./sweep-report.js";
+
+// Trails-only: `AR_SWEEP_REPORT` is instrumentation for RFC 0064's measurement
+// of the global between-test sweep, with no Rails counterpart.
+describe("sweep report", () => {
+  afterEach(() => {
+    _resetSweepReport();
+  });
+
+  it("is off unless AR_SWEEP_REPORT names a directory", () => {
+    expect(sweepReportDir(() => undefined)).toBeUndefined();
+    expect(sweepReportDir(() => "")).toBeUndefined();
+    expect(sweepReportDir(() => "/tmp/sweep")).toBe("/tmp/sweep");
+  });
+
+  it("writes nothing when the report directory is unset", async () => {
+    await expect(
+      recordSweptTables("sqlite", ["leaked_table"], () => undefined),
+    ).resolves.toBeUndefined();
+  });
+
+  it("survives a filesystem that cannot write the report", async () => {
+    const fs = await getFsAsync();
+    expect(typeof fs.exists).toBe("function");
+    await expect(recordSweptTables("sqlite", [], () => undefined)).resolves.toBeUndefined();
+  });
+});

--- a/packages/activerecord/src/support/sweep-report.trails.test.ts
+++ b/packages/activerecord/src/support/sweep-report.trails.test.ts
@@ -61,6 +61,20 @@ describe("sweep report", () => {
     }
   });
 
+  it("names the report file after the injected worker id", async () => {
+    const dir = await tempReportDir();
+    try {
+      const read = (name: string) =>
+        name === "AR_SWEEP_REPORT" ? dir : name === "VITEST_POOL_ID" ? "7" : undefined;
+      await recordSweptTables("sqlite", ["octopi"], read);
+
+      const fs = await getFsAsync();
+      expect(await fs.readdir!(dir)).toEqual(["sweep-sqlite-7.json"]);
+    } finally {
+      await removeReportDir(dir);
+    }
+  });
+
   it("keeps the lanes apart", async () => {
     const dir = await tempReportDir();
     try {

--- a/packages/activerecord/src/support/sweep-report.trails.test.ts
+++ b/packages/activerecord/src/support/sweep-report.trails.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, it, afterEach } from "vitest";
-import { getFsAsync } from "@blazetrails/activesupport";
+import { getFsAsync, getOsAsync, getPathAsync } from "@blazetrails/activesupport";
 import { _resetSweepReport, recordSweptTables, sweepReportDir } from "./sweep-report.js";
 
-// Trails-only: `AR_SWEEP_REPORT` is instrumentation for RFC 0064's measurement
-// of the global between-test sweep, with no Rails counterpart.
+async function tempReportDir(): Promise<string> {
+  const fs = await getFsAsync();
+  const os = await getOsAsync();
+  const path = await getPathAsync();
+  return await fs.mkdtemp!(`${os.tmpdir()}${path.sep}sweep-report-`);
+}
+
+async function readReport(dir: string, lane: string): Promise<{ lane: string; tables: string[] }> {
+  const fs = await getFsAsync();
+  const [name] = (await fs.readdir!(dir)).filter((f) => f.startsWith(`sweep-${lane}-`));
+  return JSON.parse(await fs.readFile!(`${dir}/${name}`, "utf8")) as {
+    lane: string;
+    tables: string[];
+  };
+}
+
+async function removeReportDir(dir: string): Promise<void> {
+  const fs = await getFsAsync();
+  for (const name of await fs.readdir!(dir)) await fs.unlink!(`${dir}/${name}`);
+  await fs.rmdir!(dir);
+}
+
 describe("sweep report", () => {
   afterEach(() => {
     _resetSweepReport();
@@ -16,14 +36,42 @@ describe("sweep report", () => {
   });
 
   it("writes nothing when the report directory is unset", async () => {
-    await expect(
-      recordSweptTables("sqlite", ["leaked_table"], () => undefined),
-    ).resolves.toBeUndefined();
+    const dir = await tempReportDir();
+    try {
+      await recordSweptTables("sqlite", ["leaked_table"], () => undefined);
+      const fs = await getFsAsync();
+      expect(await fs.readdir!(dir)).toEqual([]);
+    } finally {
+      await removeReportDir(dir);
+    }
   });
 
-  it("survives a filesystem that cannot write the report", async () => {
-    const fs = await getFsAsync();
-    expect(typeof fs.exists).toBe("function");
-    await expect(recordSweptTables("sqlite", [], () => undefined)).resolves.toBeUndefined();
+  it("accumulates the swept names for the lane, sorted and deduplicated", async () => {
+    const dir = await tempReportDir();
+    try {
+      const read = (name: string) => (name === "AR_SWEEP_REPORT" ? dir : undefined);
+      await recordSweptTables("sqlite", ["octopi", "ar_internal_metadata"], read);
+      await recordSweptTables("sqlite", ["ar_internal_metadata", "bk1"], read);
+
+      const report = await readReport(dir, "sqlite");
+      expect(report.lane).toBe("sqlite");
+      expect(report.tables).toEqual(["ar_internal_metadata", "bk1", "octopi"]);
+    } finally {
+      await removeReportDir(dir);
+    }
+  });
+
+  it("keeps the lanes apart", async () => {
+    const dir = await tempReportDir();
+    try {
+      const read = (name: string) => (name === "AR_SWEEP_REPORT" ? dir : undefined);
+      await recordSweptTables("sqlite", ["octopi"], read);
+      await recordSweptTables("postgres", ["rockets"], read);
+
+      expect((await readReport(dir, "sqlite")).tables).toEqual(["octopi"]);
+      expect((await readReport(dir, "postgres")).tables).toEqual(["rockets"]);
+    } finally {
+      await removeReportDir(dir);
+    }
   });
 });

--- a/packages/activerecord/src/support/sweep-report.ts
+++ b/packages/activerecord/src/support/sweep-report.ts
@@ -1,0 +1,79 @@
+/**
+ * Off-by-default instrumentation for the global between-test sweep.
+ *
+ * RFC 0064 wants to delete the global `beforeEach` reset
+ * (`cases/helper.ts` → `resetTestAdapterState` → `resetTestTables`) on the
+ * argument that per-file teardown already drops everything a test creates.
+ * This records what the sweep *actually* drops so the argument can be checked
+ * against a full-suite run before the sweep goes away: set `AR_SWEEP_REPORT`
+ * to a directory and every dropped (i.e. non-boot-laid) table name is written
+ * there, one JSON file per worker; leave it unset and nothing runs.
+ *
+ * Env reads go through activesupport's `getEnv`; async fs only.
+ *
+ * @internal Test infrastructure only.
+ */
+import { getEnv, getFsAsync } from "@blazetrails/activesupport";
+
+type EnvReader = (name: string) => string | undefined;
+
+const REPORT_DIR_ENV = "AR_SWEEP_REPORT";
+
+/** Names swept so far in this worker, keyed by adapter lane. */
+const sweptByLane = new Map<string, Set<string>>();
+
+/** Serializes the rewrite-whole-file flushes so concurrent sweeps can't interleave. */
+let flushChain: Promise<void> = Promise.resolve();
+
+export function sweepReportDir(read: EnvReader = getEnv): string | undefined {
+  const dir = read(REPORT_DIR_ENV);
+  return dir === undefined || dir === "" ? undefined : dir;
+}
+
+/**
+ * Record the tables one sweep dropped. No-op unless `AR_SWEEP_REPORT` is set.
+ *
+ * The file is rewritten with the accumulated set rather than appended to, so a
+ * worker that is killed mid-run still leaves a readable (if partial) report.
+ */
+export async function recordSweptTables(
+  lane: string,
+  tables: readonly string[],
+  read: EnvReader = getEnv,
+): Promise<void> {
+  const dir = sweepReportDir(read);
+  if (dir === undefined || tables.length === 0) return;
+
+  let swept = sweptByLane.get(lane);
+  if (!swept) {
+    swept = new Set<string>();
+    sweptByLane.set(lane, swept);
+  }
+  const before = swept.size;
+  for (const table of tables) swept.add(table);
+  if (swept.size === before) return;
+
+  const names = [...swept].sort();
+  flushChain = flushChain.then(() => writeReport(dir, lane, names));
+  await flushChain;
+}
+
+async function writeReport(dir: string, lane: string, names: readonly string[]): Promise<void> {
+  try {
+    const fs = await getFsAsync();
+    if (!fs.mkdir || !fs.writeFile) return;
+    await fs.mkdir(dir, { recursive: true });
+    const worker = getEnv("VITEST_POOL_ID") ?? "0";
+    await fs.writeFile(
+      `${dir}/sweep-${lane}-${worker}.json`,
+      `${JSON.stringify({ lane, worker, tables: names }, null, 2)}\n`,
+    );
+  } catch {
+    // Instrumentation must never fail a test run.
+  }
+}
+
+/** Test seam: forget what this worker has recorded. @internal */
+export function _resetSweepReport(): void {
+  sweptByLane.clear();
+}

--- a/packages/activerecord/src/support/sweep-report.ts
+++ b/packages/activerecord/src/support/sweep-report.ts
@@ -18,6 +18,7 @@ import { getEnv, getFsAsync } from "@blazetrails/activesupport";
 type EnvReader = (name: string) => string | undefined;
 
 const REPORT_DIR_ENV = "AR_SWEEP_REPORT";
+const WORKER_ID_ENV = "VITEST_POOL_ID";
 
 /** Names swept so far in this worker, keyed by adapter lane. */
 const sweptByLane = new Map<string, Set<string>>();
@@ -38,11 +39,11 @@ export function sweepReportDir(read: EnvReader = getEnv): string | undefined {
  */
 export async function recordSweptTables(
   lane: string,
-  tables: readonly string[],
+  tables: Iterable<string>,
   read: EnvReader = getEnv,
 ): Promise<void> {
   const dir = sweepReportDir(read);
-  if (dir === undefined || tables.length === 0) return;
+  if (dir === undefined) return;
 
   let swept = sweptByLane.get(lane);
   if (!swept) {
@@ -54,17 +55,22 @@ export async function recordSweptTables(
   if (swept.size === before) return;
 
   const names = [...swept].sort();
-  flushChain = flushChain.then(() => writeReport(dir, lane, names));
+  flushChain = flushChain.then(() => writeReport(dir, lane, names, read));
   await flushChain;
 }
 
 /** Never throws: instrumentation must not be able to fail a test run. */
-async function writeReport(dir: string, lane: string, names: readonly string[]): Promise<void> {
+async function writeReport(
+  dir: string,
+  lane: string,
+  names: readonly string[],
+  read: EnvReader,
+): Promise<void> {
   try {
     const fs = await getFsAsync();
     if (!fs.mkdir || !fs.writeFile) return;
     await fs.mkdir(dir, { recursive: true });
-    const worker = getEnv("VITEST_POOL_ID") ?? "0";
+    const worker = read(WORKER_ID_ENV) ?? "0";
     await fs.writeFile(
       `${dir}/sweep-${lane}-${worker}.json`,
       `${JSON.stringify({ lane, worker, tables: names }, null, 2)}\n`,

--- a/packages/activerecord/src/support/sweep-report.ts
+++ b/packages/activerecord/src/support/sweep-report.ts
@@ -58,6 +58,7 @@ export async function recordSweptTables(
   await flushChain;
 }
 
+/** Never throws: instrumentation must not be able to fail a test run. */
 async function writeReport(dir: string, lane: string, names: readonly string[]): Promise<void> {
   try {
     const fs = await getFsAsync();
@@ -69,7 +70,7 @@ async function writeReport(dir: string, lane: string, names: readonly string[]):
       `${JSON.stringify({ lane, worker, tables: names }, null, 2)}\n`,
     );
   } catch {
-    // Instrumentation must never fail a test run.
+    return;
   }
 }
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -259,7 +259,7 @@ export async function resetTestAdapterState(): Promise<void> {
     const pool = Base.connectionPool();
     await pool.withConnection(
       async (adapter) => {
-        await resetTestTables(adapter);
+        await resetTestTables(adapter, { measure: true });
         // Clear schema cache on all live pool connections (mirrors Rails'
         // ConnectionPool#clear_cache!).
         pool.connections.forEach((a) => a.schemaCache?.clear());


### PR DESCRIPTION
Before RFC 0064 deletes the global `beforeEach` sweep, measure what it actually
does. The claim that per-file teardown already covers everything is an argument;
this is the measurement.

`resetTestTables` now records the tables it drops when `AR_SWEEP_REPORT=<dir>`
is set (one JSON file per worker per lane). Unset — the default, and the only
state CI ever runs in — nothing is collected and behavior is unchanged.

Only the global between-test reset is measured. `resetTestAdapterState` opts in
with `{ measure: true }`; every other caller defaults to off, which excludes two
sources of noise by construction:

- the boot reset in `test-setup-dy.ts`, between the canonical load and the
  adapter-specific arm — what it drops (`defaults`, on a worker recycled onto an
  already-used database) is boot bookkeeping, not a test leak;
- `resetTestTables`' own unit tests, which create `bespoke_reset_t` /
  `schema_migrations` a line before asking the sweep to drop them.

## Result — full AR suite, all three lanes

Lanes are named by `ARCONN`; the report files are keyed by
`adapter.adapterName`, which is the shorter name.

| lane (`ARCONN`) | report files | swept between tests |
| --- | --- | --- |
| `sqlite3` | `sweep-sqlite-*.json` | `ar_internal_metadata` |
| `postgresql` | `sweep-postgres-*.json` | `ar_internal_metadata` |
| `mysql2` | `sweep-mysql-*.json` | `ar_internal_metadata` |

No bespoke table, no view, no matview, no `schema_migrations`. Nothing a test
created survived to the next test's `beforeEach` on any lane.

`ar_internal_metadata` is dropped every sweep because it is never boot-laid
(`BOOKKEEPING_TABLE_NAMES` excludes it from the snapshot), not because a test
leaked it. That is the one thing removal has to account for: migrator tests that
expect it absent must manage it themselves, the way Rails does.

The evidence is recorded on
`remove-global-reset-and-skip-shield-after-canonical-burndown`, which is
unblocked. Its `blocked-by` counted 164 non-canonical `createTable()` calls as
the sweep's remaining work; each is dropped by its own file, so the count
overstated it — the measurement is what the sweep does, and it is nothing but
`ar_internal_metadata`.

Instrumentation stays behind the off-by-default flag so the measurement can be
repeated after any change.

Failures seen during the measurement runs, all unrelated to this diff (it is
inert without the env var) and reproduced identically on every run — not
baselined against `main`: the `activerecord-cli` sqlite happy-path E2E on all
three lanes, `BasicsTest > connection in local time` (pg), and `InsertAllTest >
upsert and db warnings` (mysql).

Closes-story: measure-global-reset-sweep-before-removal
