### PR TITLE
fix(test-infra): catch class-body DDL stubs in the load_schema lint

### DIFF
--- a/eslint/no-load-schema-with-stubbed-ddl.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.mjs
@@ -111,6 +111,26 @@ const COMPARISONS = new Set(["===", "==", "!==", "!="]);
  * Unlike the literal shapes above there is no "interception position" to
  * qualify — a class body that defines `createTable` at all is defining the
  * emitter `runTable` will call.
+ *
+ * **Accepted false-positive surface:** a *delegating* override — a spy that
+ * records its argument and returns `super.execute(...)` — really does lay DDL,
+ * and is reported anyway. `execute` is the generic name here and the one most
+ * likely to be overridden for such a reason. Class bodies defining these
+ * members are not rare in the enforced files (the fake adapters in
+ * `connection-adapters/abstract/schema-statements-on-adapter.test.ts`, the
+ * database-tasks covers), but none of them so much as names `loadSchema`, and
+ * the rule reports only where the two meet — so the surface is empty today
+ * rather than merely tolerable.
+ *
+ * Exempting a body that calls `super.<method>` was considered and declined: the
+ * call can be conditional, wrapped, or dead, so the exemption reads as a
+ * guarantee it cannot make, and a probe would only have to write one to escape
+ * the rule entirely. Inspecting a body for what it really does is the
+ * shape-heuristic detector RFC 0025 abandoned (PR #5204), and this rule exists
+ * precisely because the runtime guard — which sees the real function — cannot
+ * make that call either. A delegating spy that trips this should move its
+ * `loadSchema` call to `loadAdapterSpecificSchema` or, if it genuinely performs
+ * a real load, carry a scoped disable naming the reason.
  */
 export function definesStubbedDdlMember(node) {
   if (node.computed) return false;

--- a/eslint/no-load-schema-with-stubbed-ddl.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.mjs
@@ -20,6 +20,14 @@
  * This rule closes that hole lexically, in the unit lane: in a test file that
  * stubs any of `STUBBED_DDL_METHODS`, any reference to `loadSchema` is an
  * error.
+ *
+ * It also carries the one interception shape the runtime guard cannot see at
+ * all — a cover that defines the emitter in a *class body*, either as a
+ * subclass override (`class Probe extends BetterSQLite3Adapter { override async
+ * createTable() {} }`) or as a standalone fake. The guard walks the prototype
+ * chain and finds that definition as the class's own, indistinguishable from
+ * PostgreSQLAdapter overriding AbstractAdapter's; see `assertNotStubbed`'s
+ * docstring. Lexically the shape is plain, so it is caught here instead.
  */
 
 import { readFileSync } from "fs";
@@ -93,6 +101,22 @@ export function isInterceptionPosition(node) {
 
 const COMPARISONS = new Set(["===", "==", "!==", "!="]);
 
+/**
+ * True when `node` is a class-body definition of a stubbed DDL emitter — the
+ * `class Probe extends BetterSQLite3Adapter { override async createTable() {} }`
+ * cover, its `createTable = async () => {}` field form, and the `get
+ * schemaCreation()` accessor form. A standalone fake adapter class counts too:
+ * it lays nothing either.
+ *
+ * Unlike the literal shapes above there is no "interception position" to
+ * qualify — a class body that defines `createTable` at all is defining the
+ * emitter `runTable` will call.
+ */
+export function definesStubbedDdlMember(node) {
+  if (node.computed) return false;
+  return namesStubbedDdlMethod(node.key);
+}
+
 /** @type {import("eslint").Rule.RuleModule} */
 const rule = {
   meta: {
@@ -122,6 +146,11 @@ const rule = {
       Property(node) {
         if (node.computed) return;
         if (stubbedMethod === null && namesStubbedDdlMethod(node.key)) {
+          stubbedMethod = node.key.name ?? node.key.value;
+        }
+      },
+      "MethodDefinition, PropertyDefinition"(node) {
+        if (stubbedMethod === null && definesStubbedDdlMember(node)) {
           stubbedMethod = node.key.name ?? node.key.value;
         }
       },

--- a/eslint/no-load-schema-with-stubbed-ddl.test.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.test.mjs
@@ -69,6 +69,18 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
         await loadSchema(adapter);
       `,
     },
+    // A class body defining an emitter is only a problem paired with the
+    // helper: a migration class laying tables through `createTable`, or an
+    // adapter cover that never routes through the full load, stays valid.
+    {
+      filename: "packages/activerecord/src/migration.test.ts",
+      code: `
+        class Probe extends BetterSQLite3Adapter {
+          override async createTable() {}
+        }
+        await loadAdapterSpecificSchema(new Probe(":memory:"));
+      `,
+    },
   ],
   invalid: [
     // The #5676 shape: Proxy trap on createTable + loadSchema.
@@ -142,6 +154,70 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
         const intercepted = ["createTable", "dropTable"];
         if (intercepted.includes(prop)) return async () => {};
         await loadSchema(probe);
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+    // The subclass-override shape, which the runtime guard cannot see: the walk
+    // finds `Probe.prototype`'s own `createTable` and it is exactly what the
+    // lookup returned, so `assertNotStubbed` returns clean. Only the class body
+    // distinguishes it from PostgreSQLAdapter overriding AbstractAdapter's, and
+    // that is lexical.
+    {
+      filename: FILENAME,
+      code: `
+        class Probe extends BetterSQLite3Adapter {
+          override async createTable() {}
+        }
+        await loadSchema(new Probe(":memory:"));
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+    // Same gap, one member per guarded emitter, in the field and accessor forms
+    // a class body can also take.
+    {
+      filename: FILENAME,
+      code: `
+        class Probe extends BetterSQLite3Adapter {
+          override async dropTable() {}
+          override async addIndex() {}
+          override async execute() { return []; }
+        }
+        await loadSchema(new Probe(":memory:"));
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+    {
+      filename: FILENAME,
+      code: `
+        class Probe extends BetterSQLite3Adapter {
+          override get schemaCreation() {
+            return { accept: async () => "" };
+          }
+        }
+        await loadSchema(new Probe(":memory:"));
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+    {
+      filename: FILENAME,
+      code: `
+        class Probe extends BetterSQLite3Adapter {
+          schemaStatements = () => fakeSchemaStatements;
+        }
+        await loadSchema(new Probe(":memory:"));
+      `,
+      errors: [{ messageId: "misrouted" }],
+    },
+    // A standalone fake adapter class lays nothing either, and the runtime
+    // guard leaves it alone by design (it compares against the prototype's own
+    // member, which here *is* the fake's).
+    {
+      filename: FILENAME,
+      code: `
+        class FakeAdapter {
+          async createTable() {}
+        }
+        await loadSchema(new FakeAdapter());
       `,
       errors: [{ messageId: "misrouted" }],
     },

--- a/eslint/no-load-schema-with-stubbed-ddl.test.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.test.mjs
@@ -81,6 +81,19 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
         await loadAdapterSpecificSchema(new Probe(":memory:"));
       `,
     },
+    // An abstract declaration defines no emitter — whichever concrete class
+    // implements it is the one that would lay nothing, and that class body arms
+    // the rule on its own.
+    {
+      filename: "packages/activerecord/src/migration.test.ts",
+      code: `
+        import { loadSchema } from "./support/load-schema-helper.js";
+        abstract class Base {
+          abstract createTable(name: string): Promise<void>;
+        }
+        await loadSchema(adapter);
+      `,
+    },
   ],
   invalid: [
     // The #5676 shape: Proxy trap on createTable + loadSchema.

--- a/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
@@ -103,6 +103,25 @@ describe("load_schema arm-probe guard", () => {
     });
   });
 
+  // The gap this guard cannot close, pinned so it is not mistaken for a bug:
+  // a class-body override is found by the walk as that class's own member and
+  // matches what the lookup returned, exactly as PostgreSQLAdapter's override
+  // of AbstractAdapter's does. `assertNotStubbed`'s docstring carries the
+  // reasoning; `blazetrails/no-load-schema-with-stubbed-ddl` catches the shape
+  // lexically instead, which is what makes this acceptable.
+  it("does not see a subclass that overrides createTable on its own prototype", async () => {
+    class Probe extends BetterSQLite3Adapter {
+      override async createTable(): Promise<void> {}
+    }
+
+    const probe = new Probe(":memory:");
+    try {
+      await expect(loadSchema(probe as unknown as AbstractAdapter)).resolves.toBeUndefined();
+    } finally {
+      await probe.close();
+    }
+  });
+
   // The counterpart direction: a proxy that only observes must still load, or
   // the guard would break the pooling/logging wrappers that hand `loadSchema` a
   // wrapped connection.

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -577,6 +577,21 @@ function sameKind(seen: unknown, real: unknown): boolean {
  * the chain, so a transparent proxy (which returns that same function) passes,
  * and an adapter carrying no prototype member at all — a hand-rolled fake — is
  * left alone rather than guessed at.
+ *
+ * **A class-body definition is out of reach here, permanently.** A cover shaped
+ * as `class Probe extends BetterSQLite3Adapter { override async createTable()
+ * {} }` — or as a standalone fake class defining the member — is found by the
+ * walk as that class's own, matching what the lookup returned, so it passes.
+ * That is not an oversight to be closed: PostgreSQLAdapter overriding
+ * AbstractAdapter's `createTable`, and Mysql2Adapter overriding
+ * AbstractMysqlAdapter's, are the *same* shape, and a real adapter is defined
+ * by nothing else at runtime — trails keeps no registry of adapter classes, and
+ * inspecting the override's body for hollowness is the shape-heuristic detector
+ * RFC 0025 built and abandoned (PR #5204). Rejecting prototype-level overrides
+ * would reject every real adapter; accepting them lets a probe through. The
+ * distinguishing signal is lexical, not runtime — which class body a `.test.ts`
+ * file wrote — so `blazetrails/no-load-schema-with-stubbed-ddl` carries that
+ * direction instead.
  */
 function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
   const seen = (adapter as unknown as Record<string, unknown>)[method];

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -591,7 +591,10 @@ function sameKind(seen: unknown, real: unknown): boolean {
  * would reject every real adapter; accepting them lets a probe through. The
  * distinguishing signal is lexical, not runtime — which class body a `.test.ts`
  * file wrote — so `blazetrails/no-load-schema-with-stubbed-ddl` carries that
- * direction instead.
+ * direction instead. That rule runs over the activerecord package's `.test.ts`
+ * files, which is where every arm-content cover lives; a class-body stub
+ * written outside them is caught by neither mechanism, and is the residual
+ * hole the two leave between them.
  */
 function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
   const seen = (adapter as unknown as Record<string, unknown>)[method];


### PR DESCRIPTION
The arm-probe guard's subclass-prototype-override gap, resolved as **not
runtime-catchable** and closed lexically instead.

`assertNotStubbed` walks the prototype chain and stops at the first prototype
owning the guarded member. A cover shaped as

```ts
class Probe extends BetterSQLite3Adapter {
  override async createTable() {}
}
```

is found there as `Probe.prototype`'s own member, matching what the lookup
returned — so it passes. That is the *same* shape as `PostgreSQLAdapter`
overriding `AbstractAdapter`'s `createTable`, and at runtime nothing else
distinguishes them: trails keeps no registry of adapter classes, and scoring the
override's body for hollowness is the shape-heuristic detector RFC 0025 built
and abandoned (PR #5204). Rejecting prototype-level overrides would reject every
real adapter.

The distinguishing signal is lexical — which class body a `.test.ts` file wrote
— so:

- `assertNotStubbed`'s docstring records the limitation and its reason, so the
  next reader does not re-derive it.
- `blazetrails/no-load-schema-with-stubbed-ddl` now arms on a class-body
  definition of any `STUBBED_DDL_METHODS` member (method, field, and accessor
  forms; subclass override and standalone fake alike), alongside the existing
  literal-interception and object-property shapes. Five new invalid cases, four
  of which fail on baseline; one new valid case pins that a class body alone is
  not an error without the helper. `eslint packages/activerecord/src/**/*.test.ts`
  reports no new violations.
- The arm-guard cover pins the runtime gap explicitly, so the pass is not later
  mistaken for a bug.

Closes-story: guard-subclass-prototype-override-of-ddl-emitters
