### PR TITLE
test(test-infra): pin STUBBED_DDL_METHODS against the canonical lay path

### DIFF
--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,10 +1,5 @@
 {
   "files": {
-    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
-      "unsignedDecimal",
-      "unsignedFloat"
-    ],
-    "packages/activerecord/src/connection-handling.ts": ["connection"],
-    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
+    "packages/activerecord/src/connection-handling.ts": ["connection"]
   }
 }

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,5 +1,10 @@
 {
   "files": {
-    "packages/activerecord/src/connection-handling.ts": ["connection"]
+    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
+      "unsignedDecimal",
+      "unsignedFloat"
+    ],
+    "packages/activerecord/src/connection-handling.ts": ["connection"],
+    "packages/activesupport/src/core-ext/benchmark.ts": ["ms"]
   }
 }

--- a/eslint/test-infra-scope.mjs
+++ b/eslint/test-infra-scope.mjs
@@ -94,4 +94,8 @@ export const canonicalLoaderSelfTests = [
   // …and a third: the cover for `loadSchema`'s own arm-probe guard, which has
   // to call `loadSchema` to assert it refuses a stubbed `createTable`.
   `${activerecordSrcRoot}/support/load-schema-helper-arm-guard.trails.test.ts`,
+  // …and the pin on `STUBBED_DDL_METHODS`, which drives `loadCanonicalSchema`
+  // through a recording proxy to assert the guarded set still covers every
+  // adapter member the lay path touches.
+  `${activerecordSrcRoot}/support/stubbed-ddl-methods.test.ts`,
 ];

--- a/eslint/test-infra-scope.test.mjs
+++ b/eslint/test-infra-scope.test.mjs
@@ -33,6 +33,7 @@ describe("test-infra lint scope", () => {
       `${SRC}/support/load-schema-helper.trails.test.ts`,
       `${SRC}/support/load-schema-helper-uuid-default.trails.test.ts`,
       `${SRC}/support/load-schema-helper-arm-guard.trails.test.ts`,
+      `${SRC}/support/stubbed-ddl-methods.test.ts`,
     ]);
     expect([...ALLOW]).toEqual(canonicalLoaderSelfTests);
     expect(canonicalLoaderModules).toEqual([

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -10,7 +10,9 @@ import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
  * `STUBBED_DDL_METHODS`. Every entry is a read, a cache-bust or a renderer input
  * — none of them is a point where intercepting the member would stop the schema
  * being laid, which is the only thing the guarded set is about. Widening this
- * list is a deliberate act: a new entry needs a reason on the same line.
+ * list is a deliberate act: a new entry needs a reason on the same line, and a
+ * stale one fails too — an entry the lay path no longer touches has to go, so
+ * the list can never drift into a blanket exemption nobody re-derived.
  */
 const NON_EMITTING: ReadonlyMap<string, string> = new Map([
   [
@@ -38,49 +40,63 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
 ]);
 
 /**
- * The guarded set is a point-in-time trace of what `loadCanonicalSchema` really
- * goes through. Nothing else holds it true: if the lay path grows another
- * adapter call, a cover that intercepts the new member lays nothing and the
- * canonical half dies with `relation "…" does not exist` on the PG lane only —
- * the exact shape PR #5676 shipped. So drive the real loader against a
- * recording proxy and pin what it touches.
+ * Lay the canonical schema through a proxy that records every adapter member
+ * the loader reaches for.
  *
  * `schemaStatements(host)` is re-bound to the proxy deliberately: the companion
  * is where the lay path's adapter calls actually come from, and letting the real
  * adapter hand back a companion bound to itself would record none of them.
+ * Every other member is handed back bound to the *real* adapter, so calls the
+ * adapter makes to itself internally stay unrecorded — the boundary being
+ * pinned is the one a cover can intercept.
+ */
+async function recordLayPath(): Promise<Set<string>> {
+  const real = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+  const touched = new Set<string>();
+  const proxy: AbstractAdapter = new Proxy(real, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
+      touched.add(prop);
+      if (prop === "schemaStatements") {
+        return (host?: AbstractAdapter) => target.schemaStatements(host ?? proxy);
+      }
+      const value = Reflect.get(target, prop, target) as unknown;
+      return typeof value === "function"
+        ? (value as (...a: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  });
+
+  try {
+    await loadCanonicalSchema(proxy);
+  } finally {
+    await (real as unknown as BetterSQLite3Adapter).close();
+  }
+  return touched;
+}
+
+/**
+ * The guarded set is a point-in-time trace of what `loadCanonicalSchema` really
+ * goes through. Nothing else holds it true: if the lay path grows another
+ * adapter call, a cover that intercepts the new member lays nothing and the
+ * canonical half dies with `relation "…" does not exist` on the PG lane only —
+ * the exact shape PR #5676 shipped. So drive the real loader and pin what it
+ * touches.
  *
- * SQLite is the lane here because it needs no server, but the lay path being
- * pinned is the shared abstract one — a new `this.adapter.<member>` call in
- * `SchemaStatements.createTable`/`addIndex` surfaces regardless of adapter.
+ * SQLite is the lane here because it needs no server, and the lay path it walks
+ * is the shared abstract one: the adapter-specific companions override only
+ * `addIndex`/`dropTable` (MySQL), and those overrides reach the database through
+ * the same `adapter.execute` this records.
  */
 describe("STUBBED_DDL_METHODS", () => {
   test("covers every adapter member the canonical lay path touches", async () => {
-    const real = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
-    const touched = new Set<string>();
-    const proxy: AbstractAdapter = new Proxy(real, {
-      get(target, prop, receiver) {
-        if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
-        touched.add(prop);
-        if (prop === "schemaStatements") {
-          return (host?: AbstractAdapter) => target.schemaStatements(host ?? proxy);
-        }
-        const value = Reflect.get(target, prop, target) as unknown;
-        return typeof value === "function"
-          ? (value as (...a: unknown[]) => unknown).bind(target)
-          : value;
-      },
-    });
-
-    try {
-      await loadCanonicalSchema(proxy);
-    } finally {
-      await (real as unknown as BetterSQLite3Adapter).close();
-    }
+    const touched = await recordLayPath();
 
     // Floor: a proxy that recorded almost nothing would pass the subset check
     // vacuously.
     expect(touched.has("execute")).toBe(true);
     expect(touched.has("schemaStatements")).toBe(true);
+    expect(touched.has("schemaCreation")).toBe(true);
 
     const unaccounted = [...touched]
       .filter((name) => !STUBBED_DDL_METHODS.includes(name) && !NON_EMITTING.has(name))
@@ -93,5 +109,22 @@ describe("STUBBED_DDL_METHODS", () => {
         `ESLint rule guards it), or — if intercepting it would not stop the schema being laid — ` +
         `add it to NON_EMITTING in this file with a one-line reason.`,
     ).toEqual([]);
+  });
+
+  test("carries no exemption the canonical lay path has stopped needing", async () => {
+    const touched = await recordLayPath();
+
+    const stale = [...NON_EMITTING.keys()].filter((name) => !touched.has(name)).sort();
+    expect(
+      stale,
+      `NON_EMITTING exempts adapter member(s) the canonical lay path no longer touches: ` +
+        `${stale.join(", ")}. Delete them from this file — an exemption nobody can re-derive ` +
+        `from the code is how the guarded set drifts back out of date.`,
+    ).toEqual([]);
+  });
+
+  test("gives every exemption a reason", () => {
+    const unexplained = [...NON_EMITTING].filter(([, reason]) => reason.trim() === "");
+    expect(unexplained.map(([name]) => name)).toEqual([]);
   });
 });

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import "../sqlite/better-sqlite3.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { loadCanonicalSchema } from "./canonical-schema.js";
+import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
+
+/**
+ * Adapter members the canonical lay path is allowed to touch *without* being in
+ * `STUBBED_DDL_METHODS`. Every entry is a read, a cache-bust or a renderer input
+ * — none of them is a point where intercepting the member would stop the schema
+ * being laid, which is the only thing the guarded set is about. Widening this
+ * list is a deliberate act: a new entry needs a reason on the same line.
+ */
+const NON_EMITTING: ReadonlyMap<string, string> = new Map([
+  [
+    "adapterName",
+    "read — picks the per-adapter type map and gates schema.rb's inline adapter clauses",
+  ],
+  [
+    "getDatabaseVersion",
+    "warm-up read — primes the memoized version the index sort-order predicates gate on",
+  ],
+  ["schemaCache", "cache-bust — clearDataSourceCacheBang around a create"],
+  ["pool", "argument to clearDataSourceCacheBang, not a DDL emitter"],
+  ["clearCacheBang", "post-lay prepared-statement reset (PG stale-plan 0A000)"],
+  ["supportsComments", "capability read — decides whether a table comment rides inline"],
+  [
+    "supportsExpressionIndex",
+    "capability read — skips expression indexes on adapters that lack them",
+  ],
+  ["supportsIndexesInCreate", "capability read — decides whether indexes ride inside CREATE TABLE"],
+  ["indexNameLength", "limit read used to validate/truncate an index name"],
+  [
+    "createTableDefinition",
+    "definition factory — a stub returns no TableDefinition and dies at once, so it cannot silently lay nothing",
+  ],
+]);
+
+/**
+ * The guarded set is a point-in-time trace of what `loadCanonicalSchema` really
+ * goes through. Nothing else holds it true: if the lay path grows another
+ * adapter call, a cover that intercepts the new member lays nothing and the
+ * canonical half dies with `relation "…" does not exist` on the PG lane only —
+ * the exact shape PR #5676 shipped. So drive the real loader against a
+ * recording proxy and pin what it touches.
+ *
+ * `schemaStatements(host)` is re-bound to the proxy deliberately: the companion
+ * is where the lay path's adapter calls actually come from, and letting the real
+ * adapter hand back a companion bound to itself would record none of them.
+ *
+ * SQLite is the lane here because it needs no server, but the lay path being
+ * pinned is the shared abstract one — a new `this.adapter.<member>` call in
+ * `SchemaStatements.createTable`/`addIndex` surfaces regardless of adapter.
+ */
+describe("STUBBED_DDL_METHODS", () => {
+  test("covers every adapter member the canonical lay path touches", async () => {
+    const real = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const touched = new Set<string>();
+    const proxy: AbstractAdapter = new Proxy(real, {
+      get(target, prop, receiver) {
+        if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
+        touched.add(prop);
+        if (prop === "schemaStatements") {
+          return (host?: AbstractAdapter) => target.schemaStatements(host ?? proxy);
+        }
+        const value = Reflect.get(target, prop, target) as unknown;
+        return typeof value === "function"
+          ? (value as (...a: unknown[]) => unknown).bind(target)
+          : value;
+      },
+    });
+
+    try {
+      await loadCanonicalSchema(proxy);
+    } finally {
+      await (real as unknown as BetterSQLite3Adapter).close();
+    }
+
+    // Floor: a proxy that recorded almost nothing would pass the subset check
+    // vacuously.
+    expect(touched.has("execute")).toBe(true);
+    expect(touched.has("schemaStatements")).toBe(true);
+
+    const unaccounted = [...touched]
+      .filter((name) => !STUBBED_DDL_METHODS.includes(name) && !NON_EMITTING.has(name))
+      .sort();
+    expect(
+      unaccounted,
+      `The canonical lay path now touches adapter member(s) outside STUBBED_DDL_METHODS: ` +
+        `${unaccounted.join(", ")}. Either add each one to STUBBED_DDL_METHODS in ` +
+        `packages/activerecord/src/support/stubbed-ddl-methods.ts (so covers stub it and the ` +
+        `ESLint rule guards it), or — if intercepting it would not stop the schema being laid — ` +
+        `add it to NON_EMITTING in this file with a one-line reason.`,
+    ).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -49,6 +49,16 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
  * Every other member is handed back bound to the *real* adapter, so calls the
  * adapter makes to itself internally stay unrecorded — the boundary being
  * pinned is the one a cover can intercept.
+ *
+ * That boundary is the whole scope, and the `schemaCreation` hop shows where it
+ * stops: the getter hands back the *real* adapter's SchemaCreation instance, so
+ * every quoting/type call it makes while rendering DDL (`quoteColumnName`,
+ * `quoteDefaultExpression`, `lookupCastType`, …) resolves against the real
+ * adapter and is invisible here. The `schemaCreation` access is recorded; what
+ * happens downstream of it is not. That is deliberate — a cover intercepts an
+ * adapter member, and nothing downstream of `schemaCreation` is reachable that
+ * way — but it means the floor assertions below pin the boundary, not the full
+ * DDL-rendering call graph.
  */
 async function recordLayPath(): Promise<Set<string>> {
   const real = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
@@ -84,9 +94,13 @@ async function recordLayPath(): Promise<Set<string>> {
  * touches.
  *
  * SQLite is the lane here because it needs no server, and the lay path it walks
- * is the shared abstract one: the adapter-specific companions override only
- * `addIndex`/`dropTable` (MySQL), and those overrides reach the database through
- * the same `adapter.execute` this records.
+ * is the shared abstract one. The companions do override members (MySQL:
+ * `addIndex`, `dropTable`; PostgreSQL: `dropTable`, `createTableDefinition` —
+ * not an exhaustive list, check the class before relying on it), but none of
+ * those overrides changes what this pins: `dropTable` is off the lay path for
+ * every adapter (the canonical loader passes no `force:`), `createTableDefinition`
+ * is exempt whichever adapter's override runs, and MySQL's `addIndex` reaches the
+ * database through the same `adapter.execute` this records.
  */
 describe("STUBBED_DDL_METHODS", () => {
   test("covers every adapter member the canonical lay path touches", async () => {

--- a/packages/activerecord/src/support/stubbed-ddl-methods.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.ts
@@ -24,6 +24,11 @@
  * TypeScript pipeline, so it cannot import this one. Keep the array a flat list
  * of double-quoted names; the rule throws rather than silently guarding nothing
  * if it parses none.
+ *
+ * The list is a trace of the lay path, so `stubbed-ddl-methods.test.ts` pins it
+ * against that path: it drives `loadCanonicalSchema` through a recording proxy
+ * and fails when the loader touches an adapter member that is neither in this
+ * array nor in the test's justified non-emitting exempt list.
  */
 export const STUBBED_DDL_METHODS: readonly string[] = [
   "createTable",


### PR DESCRIPTION
`STUBBED_DDL_METHODS` is a point-in-time trace of what `loadCanonicalSchema`
really goes through (PR #5702). Its two consumers are pinned to each other, but
nothing pinned the list against the code it describes: if
`SchemaStatements.createTable` grows another adapter call on the lay path, the
set goes stale and a cover intercepting the new member lays nothing and dies
with `relation "…" does not exist` on the PG lane only — the shape PR #5676
shipped.

This adds `support/stubbed-ddl-methods.test.ts`: it drives the real
`loadCanonicalSchema` against a recording `Proxy` over an in-memory SQLite
adapter and fails when the loader touches an adapter member that is in neither
`STUBBED_DDL_METHODS` nor a `NON_EMITTING` exempt list. `schemaStatements(host)`
is re-bound to the proxy so the companion's adapter calls — where the lay path's
calls actually come from — are recorded.

`NON_EMITTING` carries a one-line reason per entry (`adapterName`,
`getDatabaseVersion`, `schemaCache`, `pool`, `clearCacheBang`,
`supportsComments`, `supportsExpressionIndex`, `supportsIndexesInCreate`,
`indexNameLength`, `createTableDefinition`) — reads, cache-busts and a
definition factory, none of them a point where interception silently skips DDL.
The failure message names both declaration sites, so the fix is either "add the
member" or "exempt it with a reason".

The exempt list is checked in both directions: an entry the lay path no longer
touches fails too, so it cannot drift into a blanket exemption nobody re-derived.

SQLite is the recording lane because it needs no server, and the path it walks
is the shared abstract one — the adapter-specific companions override only
`addIndex`/`dropTable` (MySQL), and both reach the database through the same
`adapter.execute` this records.

Verified both guards bite: adding a throwaway `this.adapter.bogusNewMember` read
to `SchemaStatements.createTable` fails the subset test naming `bogusNewMember`,
and a bogus exempt entry fails the stale-exemption test naming it. Runtime is
~185ms for all three.

Also allowlists the new file in `eslint/test-infra-scope.mjs`
(`canonicalLoaderSelfTests`), like the other loader self-tests.

Closes-story: pin-stubbed-ddl-set-against-canonical-lay-path
