### PR TITLE
perf(test-infra): treat every stamped slot as an exclusive database

### DIFF
--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -137,8 +137,6 @@ describe("config", () => {
   });
 
   it("owns the slot database on every stamped slot, slot 1 included", () => {
-    // The complement of applySlot: a stamped slot names a per-run, per-worker
-    // database, so no sibling worker and no other run shares it.
     const token = "aaax1";
     expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "1", AR_TEST_RUN_TOKEN: token }))).toBe(true);
     expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "4", AR_TEST_RUN_TOKEN: token }))).toBe(true);
@@ -146,12 +144,11 @@ describe("config", () => {
   });
 
   it("does not own the slot database on an unstamped slot 1", () => {
-    // Without a run token applySlot leaves slot 1 pointing at the shared base
-    // database, which other consumers point at too — purging it is not safe.
     expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "1" }))).toBe(false);
     expect(ownsSlotDatabase(reader({}))).toBe(false);
     expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "1", AR_TEST_RUN_TOKEN: "" }))).toBe(false);
     expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "2" }))).toBe(true);
+    expect(() => ownsSlotDatabase(reader({ AR_DB_SLOT: "0" }))).toThrow(/must be >= 1/);
   });
 
   it("stamps the run token into the database name, slot 1 included", () => {

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -5,6 +5,7 @@ import {
   mysqlPreparedStatements,
   mysqlSettings,
   mysqlUrl,
+  ownsSlotDatabase,
   postgresSettings,
   postgresUrl,
   sqliteSiblingDatabase,
@@ -133,6 +134,24 @@ describe("config", () => {
     expect(postgresSettings(reader({ AR_DB_SLOT: "1" })).database).toBe("activerecord_unittest");
     expect(postgresSettings(reader({ AR_DB_SLOT: "4" })).database).toBe("activerecord_unittest_4");
     expect(mysqlSettings(reader({ AR_DB_SLOT: "2" })).database).toBe("activerecord_unittest_2");
+  });
+
+  it("owns the slot database on every stamped slot, slot 1 included", () => {
+    // The complement of applySlot: a stamped slot names a per-run, per-worker
+    // database, so no sibling worker and no other run shares it.
+    const token = "aaax1";
+    expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "1", AR_TEST_RUN_TOKEN: token }))).toBe(true);
+    expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "4", AR_TEST_RUN_TOKEN: token }))).toBe(true);
+    expect(ownsSlotDatabase(reader({ AR_TEST_RUN_TOKEN: token }))).toBe(true);
+  });
+
+  it("does not own the slot database on an unstamped slot 1", () => {
+    // Without a run token applySlot leaves slot 1 pointing at the shared base
+    // database, which other consumers point at too — purging it is not safe.
+    expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "1" }))).toBe(false);
+    expect(ownsSlotDatabase(reader({}))).toBe(false);
+    expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "1", AR_TEST_RUN_TOKEN: "" }))).toBe(false);
+    expect(ownsSlotDatabase(reader({ AR_DB_SLOT: "2" }))).toBe(true);
   });
 
   it("stamps the run token into the database name, slot 1 included", () => {

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -162,6 +162,22 @@ function applySlot(database: string, read: EnvReader): string {
 }
 
 /**
+ * Whether this worker's database is its own — no sibling worker and no other
+ * run shares it — which is what licenses the purge-and-reload setup path in
+ * `test-setup-dy.ts` instead of dropping the tables in place.
+ *
+ * This is the exact complement of {@link applySlot}: with a run token stamped,
+ * every slot (slot 1 included) gets a `<base>_<runToken>_<slot>` database of
+ * its own; without one, `applySlot` falls back to the shared base database for
+ * slot 1, which the bootstrap connection and any harness-less consumer also
+ * point at. Reading the same two env vars keeps the two answers from drifting.
+ */
+export function ownsSlotDatabase(read: EnvReader = getEnv): boolean {
+  const slot = intSetting(read, SLOT_ENV, 1);
+  return slot > 1 || present(read, RUN_TOKEN_ENV) !== undefined;
+}
+
+/**
  * The `arunit` database name `ARTest.expand_config` fills in when a connection
  * entry carries none — which is every mysql2 and postgresql entry
  * (`test/support/config.rb:28-31`, `config.example.yml:2-40,74-81`).

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -144,15 +144,20 @@ export interface ServerSettings {
  */
 export const SLOT_ENV = "AR_DB_SLOT";
 
-function applySlot(database: string, read: EnvReader): string {
-  // A malformed slot must never silently degrade to the shared base database —
-  // that is precisely the cross-worker collision slots exist to prevent, and it
-  // would surface later as an unrelated DDL or fixture failure.
+// A malformed slot must never silently degrade to the shared base database —
+// that is precisely the cross-worker collision slots exist to prevent, and it
+// would surface later as an unrelated DDL or fixture failure.
+function slotNumber(read: EnvReader): number {
   const slot = intSetting(read, SLOT_ENV, 1);
   if (slot < 1) {
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new Error(`${SLOT_ENV} must be >= 1, got ${slot}`);
   }
+  return slot;
+}
+
+function applySlot(database: string, read: EnvReader): string {
+  const slot = slotNumber(read);
   const runToken = present(read, RUN_TOKEN_ENV);
   // No run token means `globalSetup` provisioned nothing — a bare adapter
   // script or a harness-less connection. There is no per-run database to point
@@ -162,19 +167,11 @@ function applySlot(database: string, read: EnvReader): string {
 }
 
 /**
- * Whether this worker's database is its own — no sibling worker and no other
- * run shares it — which is what licenses the purge-and-reload setup path in
- * `test-setup-dy.ts` instead of dropping the tables in place.
- *
- * This is the exact complement of {@link applySlot}: with a run token stamped,
- * every slot (slot 1 included) gets a `<base>_<runToken>_<slot>` database of
- * its own; without one, `applySlot` falls back to the shared base database for
- * slot 1, which the bootstrap connection and any harness-less consumer also
- * point at. Reading the same two env vars keeps the two answers from drifting.
+ * Whether {@link applySlot} named a database this worker alone owns: every slot
+ * once a run token is stamped, only slots above 1 without one.
  */
 export function ownsSlotDatabase(read: EnvReader = getEnv): boolean {
-  const slot = intSetting(read, SLOT_ENV, 1);
-  return slot > 1 || present(read, RUN_TOKEN_ENV) !== undefined;
+  return slotNumber(read) > 1 || present(read, RUN_TOKEN_ENV) !== undefined;
 }
 
 /**

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -20,14 +20,13 @@
  *     a worker recycled onto a database an earlier worker used takes it too.
  *   - sqlite file → purge (per-worker isolated file; drop+create is safe — no
  *     other worker shares this file path).
- *   - PG/MySQL slot >1 (AR_PG_EXCLUSIVE_DB / AR_MYSQL_EXCLUSIVE_DB set by
- *     test-setup-worker-db.ts) → purge; the worker owns its own suffixed DB
- *     (activerecord_unittest_N), so drop+create is safe.
- *   - otherwise (sqlite `:memory:`, PG/MySQL slot 1) → drop every table. The
- *     base URL is unchanged there, and the advisory-lock bootstrap pg.Client /
- *     GET_LOCK connection lives in the same DB as the worker pool, so DROP
- *     DATABASE fails with PG error 55006 and releasing GET_LOCK would allow
- *     slot races on MySQL.
+ *   - PG/MySQL worker-owned DB (AR_PG_EXCLUSIVE_DB / AR_MYSQL_EXCLUSIVE_DB set
+ *     by test-setup-worker-db.ts) → purge; the worker owns its own database
+ *     (activerecord_unittest_<runToken>_N), so drop+create is safe. Every slot
+ *     qualifies once globalSetup stamps a run token — slot 1 included.
+ *   - otherwise (sqlite `:memory:`, or an unstamped PG/MySQL slot 1) → drop
+ *     every table. Without a run token slot 1 *is* the shared base database,
+ *     which other consumers point at too, so it must not be dropped.
  */
 import { connect } from "./support/connection.js";
 import { getEnv } from "@blazetrails/activesupport";

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -95,12 +95,8 @@ async function acquireAdvisorySlotPg(): Promise<number> {
     return g.__arAdvisorySlotPg;
   }
 
-  // Maintenance database, not the worker's own: advisory locks are server-wide,
-  // and a bootstrap session sitting inside the slot database would block the
-  // purge (DROP DATABASE fails with 55006 while a session is connected). Before
-  // the run token was stamped, slot 1 named the shared base database, so this
-  // connection landed in it — which is why slot 1 was excluded from the
-  // exclusive-database flag at all.
+  // A session inside the slot database would block that database's purge with
+  // PG error 55006, so hold the lock from the maintenance database instead.
   const { host, port, user, password } = postgresSettings();
   const client = new pg.Client({ host, port, user, password, database: "postgres" });
   await client.connect();
@@ -136,9 +132,7 @@ async function acquireAdvisorySlotMysql(): Promise<number> {
     return g.__arAdvisorySlotMysql;
   }
 
-  // No database selected, for the same reason as the PG path above: GET_LOCK is
-  // server-wide, and this session must not sit inside the database the worker
-  // purges.
+  // No database selected, for the same reason as the PG path above.
   const { host, port, user, password, socket } = mysqlSettings();
   const conn = await mysql.createConnection({
     host,
@@ -173,9 +167,8 @@ const lane = activeLane();
 if (lane === "postgres") {
   const slot = await acquireAdvisorySlotPg();
   process.env[SLOT_ENV] = String(slot);
-  // Owning the database — every stamped slot does, and only slots above 1 do
-  // when nothing was stamped — lets test-setup-dy.ts purge it before the schema
-  // load instead of dropping the tables in place.
+  // Owning the database lets test-setup-dy.ts purge it before the schema load
+  // instead of dropping the tables in place.
   if (ownsSlotDatabase()) process.env.AR_PG_EXCLUSIVE_DB = "1";
 }
 if (lane === "mysql") {

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -2,7 +2,8 @@
  * Vitest setupFile for the activerecord project: claims this worker's database
  * isolation slot before any test code or import runs.
  *
- * Opens a bootstrap connection to the base DB and tries an advisory lock for
+ * Opens a bootstrap connection to a maintenance DB (never a slot DB, which the
+ * worker may later drop and recreate) and tries an advisory lock for
  * slot N=1..slotPoolSize(). The pool is sized with headroom over the worker
  * count (see support/ar-db-slots.ts), so a worker recycling in between
  * files always finds a free slot. Claims the first free slot, publishes it as
@@ -40,7 +41,7 @@ import mysql from "mysql2/promise";
 import "./sqlite/better-sqlite3.js";
 import { WORKER_DB_ENV, ensureWorkerClone } from "./support/sqlite-template.js";
 import { slotPoolSize, workerForkCount } from "./support/ar-db-slots.js";
-import { SLOT_ENV, mysqlSettings, postgresSettings } from "./support/config.js";
+import { SLOT_ENV, mysqlSettings, ownsSlotDatabase, postgresSettings } from "./support/config.js";
 import { RUN_TOKEN_ENV, mysqlAdvisoryLockName, pgAdvisoryLockKey } from "./support/run-token.js";
 import { activeLane } from "./support/connection.js";
 
@@ -94,8 +95,14 @@ async function acquireAdvisorySlotPg(): Promise<number> {
     return g.__arAdvisorySlotPg;
   }
 
-  const { host, port, user, password, database } = postgresSettings();
-  const client = new pg.Client({ host, port, user, password, database });
+  // Maintenance database, not the worker's own: advisory locks are server-wide,
+  // and a bootstrap session sitting inside the slot database would block the
+  // purge (DROP DATABASE fails with 55006 while a session is connected). Before
+  // the run token was stamped, slot 1 named the shared base database, so this
+  // connection landed in it — which is why slot 1 was excluded from the
+  // exclusive-database flag at all.
+  const { host, port, user, password } = postgresSettings();
+  const client = new pg.Client({ host, port, user, password, database: "postgres" });
   await client.connect();
 
   for (let attempt = 0; attempt < SLOT_RETRY_ATTEMPTS; attempt++) {
@@ -129,13 +136,15 @@ async function acquireAdvisorySlotMysql(): Promise<number> {
     return g.__arAdvisorySlotMysql;
   }
 
-  const { host, port, user, password, database, socket } = mysqlSettings();
+  // No database selected, for the same reason as the PG path above: GET_LOCK is
+  // server-wide, and this session must not sit inside the database the worker
+  // purges.
+  const { host, port, user, password, socket } = mysqlSettings();
   const conn = await mysql.createConnection({
     host,
     port,
     user,
     password,
-    database,
     ...(socket === undefined ? {} : { socketPath: socket }),
   });
 
@@ -164,15 +173,15 @@ const lane = activeLane();
 if (lane === "postgres") {
   const slot = await acquireAdvisorySlotPg();
   process.env[SLOT_ENV] = String(slot);
-  // A slot above 1 means this worker owns an exclusive per-worker DB;
-  // test-setup-dy.ts purges it before the schema load instead of dropping the
-  // tables in place.
-  if (slot > 1) process.env.AR_PG_EXCLUSIVE_DB = "1";
+  // Owning the database — every stamped slot does, and only slots above 1 do
+  // when nothing was stamped — lets test-setup-dy.ts purge it before the schema
+  // load instead of dropping the tables in place.
+  if (ownsSlotDatabase()) process.env.AR_PG_EXCLUSIVE_DB = "1";
 }
 if (lane === "mysql") {
   const slot = await acquireAdvisorySlotMysql();
   process.env[SLOT_ENV] = String(slot);
-  if (slot > 1) process.env.AR_MYSQL_EXCLUSIVE_DB = "1";
+  if (ownsSlotDatabase()) process.env.AR_MYSQL_EXCLUSIVE_DB = "1";
 }
 
 // Phase 0 sqlite template-clone: when globalSetup built a canonical template,


### PR DESCRIPTION
PR #5638 stamped the run token into every PG/MySQL slot database name, so slot 1 is a per-worker, per-run database like slots 2..N. The exclusive-database flag still gated on `slot > 1`, so the worker that won slot 1 paid the slow drop-tables-in-place setup path for no reason.

- `ownsSlotDatabase()` (support/config.ts) is the complement of `applySlot`: owned when a run token is stamped (every slot, slot 1 included) or when the slot is above 1 (the unstamped fallback, where slot 1 genuinely *is* the shared base database and must not be purged). `test-setup-worker-db.ts` sets `AR_PG_EXCLUSIVE_DB` / `AR_MYSQL_EXCLUSIVE_DB` from it.
- The advisory-lock bootstrap connection now opens against a maintenance database (PG `postgres`; no database selected on MySQL) instead of the settings database. Once stamped, the settings database *is* the worker's own slot database, and a session inside it blocks the purge with PG error 55006 — the original reason slot 1 was excluded from the flag.

Verified locally against an isolated PG 17 and MySQL 8 compose project with `TRAILS_TEST_FORKS=3` (so slot 1 is claimed): `adapter.test.ts`, `active-record-schema.test.ts`, `adapter-prevent-writes.test.ts` green on both lanes, plus `support/config.test.ts` unit coverage for both the stamped and unstamped gates.

Closes-story: set-exclusive-db-flag-for-every-stamped-slot