### PR TITLE
fix(activerecord): make destroyAssociationAsyncJob's accessor reachable

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -138,7 +138,13 @@ export interface AssociationOptions {
   className?: string;
   primaryKey?: string | string[];
   queryConstraints?: string[];
-  dependent?: "destroy" | "nullify" | "delete" | "restrictWithException" | "restrictWithError";
+  dependent?:
+    | "destroy"
+    | "destroyAsync"
+    | "nullify"
+    | "delete"
+    | "restrictWithException"
+    | "restrictWithError";
   inverseOf?: string | false;
   through?: string;
   source?: string;

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -995,7 +995,7 @@ export class Association {
   }
 
   private enqueueDestroyAssociation(options: Record<string, unknown>): void {
-    const jobClass = (this.owner.constructor as any).destroyAssociationAsyncJob;
+    const jobClass = (this.owner.constructor as any).destroyAssociationAsyncJob();
     if (jobClass) {
       const ownerAny = this.owner as any;
       ownerAny._afterCommitJobs ??= [];

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -7,7 +7,7 @@
 
 import { ArgumentError } from "@blazetrails/activemodel";
 import { throwAbort } from "@blazetrails/activesupport";
-import { RecordNotDestroyed } from "../../errors.js";
+import { ConfigurationError, RecordNotDestroyed } from "../../errors.js";
 import * as Reflection from "../../reflection.js";
 import { beforeDestroy } from "../../callbacks.js";
 
@@ -260,18 +260,15 @@ export class Association {
   }
 
   static checkDependentOptions(dependent: string, model: any): void {
+    if (dependent === "destroyAsync" && !model.destroyAssociationAsyncJob()) {
+      throw new ConfigurationError(
+        "A valid destroyAssociationAsyncJob is required to use `dependent: destroyAsync` on associations",
+      );
+    }
     const validOptions = this.validDependentOptions();
     if (!validOptions.includes(dependent)) {
       throw new Error(
         `The :dependent option must be one of ${validOptions.join(", ")}, but is :${dependent}`,
-      );
-    }
-    if (
-      dependent === "destroyAsync" &&
-      !(model._destroyAssociationAsyncJob ?? model.destroyAssociationAsyncJob)
-    ) {
-      throw new Error(
-        "A valid destroyAssociationAsyncJob is required to use `dependent: destroyAsync` on associations",
       );
     }
   }

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -267,7 +267,7 @@ export class Association {
     }
     const validOptions = this.validDependentOptions();
     if (!validOptions.includes(dependent)) {
-      throw new Error(
+      throw new ArgumentError(
         `The :dependent option must be one of ${validOptions.join(", ")}, but is :${dependent}`,
       );
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4375,6 +4375,26 @@ export class Base extends Model {
   // Mirrors: ActiveRecord::Core.shard_selector (core.rb:104).
   static shardSelector: unknown = null;
 
+  // The job class backing `dependent: :destroy_async`, read through the
+  // `destroyAssociationAsyncJob` accessor (core.ts).
+  // Mirrors: ActiveRecord::Core._destroy_association_async_job (core.rb:24),
+  // except for the default: Rails defaults to the class *name*
+  // "ActiveRecord::DestroyAssociationAsyncJob", an ActiveJob::Base subclass.
+  // trails has no ActiveJob, so destroy_association_async_job.rb is unported
+  // (scripts/api-compare/unported-files.ts) and that constant does not exist —
+  // adopting Rails' default would make every read raise NameError. Stays null
+  // until a job framework lands; `dependent: :destroy_async` therefore fails
+  // the validity guard in Builder::Association.checkDependentOptions, which is
+  // exactly what Rails does when the configured job is missing.
+  static _destroyAssociationAsyncJob: unknown = null;
+
+  // Rails defines `def self.destroy_association_async_job` in the `included do`
+  // block (core.rb:27) and only *delegates* the instance reader to it
+  // (core.rb:37). The include() below wires the instance side; the class side
+  // has to be assigned here, or `Model.destroyAssociationAsyncJob` is undefined
+  // and every caller silently reads a missing job as "no job configured".
+  static destroyAssociationAsyncJob = _Core.destroyAssociationAsyncJob;
+
   // Maximum records destroyed per background job by `dependent: :destroy_async`.
   // nil (single job) by default, matching Rails and trails' behavior.
   // Mirrors: ActiveRecord::Core.destroy_association_async_batch_size (core.rb:47).

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4375,24 +4375,12 @@ export class Base extends Model {
   // Mirrors: ActiveRecord::Core.shard_selector (core.rb:104).
   static shardSelector: unknown = null;
 
-  // The job class backing `dependent: :destroy_async`, read through the
-  // `destroyAssociationAsyncJob` accessor (core.ts).
   // Mirrors: ActiveRecord::Core._destroy_association_async_job (core.rb:24),
-  // except for the default: Rails defaults to the class *name*
-  // "ActiveRecord::DestroyAssociationAsyncJob", an ActiveJob::Base subclass.
-  // trails has no ActiveJob, so destroy_association_async_job.rb is unported
-  // (scripts/api-compare/unported-files.ts) and that constant does not exist —
-  // adopting Rails' default would make every read raise NameError. Stays null
-  // until a job framework lands; `dependent: :destroy_async` therefore fails
-  // the validity guard in Builder::Association.checkDependentOptions, which is
-  // exactly what Rails does when the configured job is missing.
+  // minus Rails' "ActiveRecord::DestroyAssociationAsyncJob" default: that
+  // ActiveJob::Base subclass is unported (scripts/api-compare/unported-files.ts),
+  // so adopting the default would make every read raise NameError.
   static _destroyAssociationAsyncJob: unknown = null;
 
-  // Rails defines `def self.destroy_association_async_job` in the `included do`
-  // block (core.rb:27) and only *delegates* the instance reader to it
-  // (core.rb:37). The include() below wires the instance side; the class side
-  // has to be assigned here, or `Model.destroyAssociationAsyncJob` is undefined
-  // and every caller silently reads a missing job as "no job configured".
   static destroyAssociationAsyncJob = _Core.destroyAssociationAsyncJob;
 
   // Maximum records destroyed per background job by `dependent: :destroy_async`.

--- a/packages/activerecord/src/destroy-association-async-job.test.ts
+++ b/packages/activerecord/src/destroy-association-async-job.test.ts
@@ -32,8 +32,6 @@ class UnusedHasManyAsync extends Base {
   }
 }
 
-// TS-only: Rails' models resolve their job name through Ruby's real constant
-// table; trails' constantize reads the registry in activesupport/inflector.
 class ResolvableJob {}
 
 class ResolvableJobAsync extends Base {
@@ -94,10 +92,6 @@ describe("DestroyAssociationAsyncJobTest", () => {
     expect((error as Error).message).toMatch(/destroyAssociationAsyncJob/);
   });
 
-  // TS-only: core.rb:27-34 resolves a job configured as a class *name* through
-  // constantize on read and memoizes the class back onto the attribute. Rails
-  // exercises that branch via its own default; trails has no ActiveJob and so
-  // no default (base.ts), leaving the branch otherwise unreached.
   it("resolves a job configured by name and caches the class", () => {
     registerConstant("ResolvableJob", ResolvableJob);
     expect(ResolvableJobAsync.destroyAssociationAsyncJob()).toBe(ResolvableJob);

--- a/packages/activerecord/src/destroy-association-async-job.test.ts
+++ b/packages/activerecord/src/destroy-association-async-job.test.ts
@@ -1,0 +1,109 @@
+// vendor/rails/activerecord/test/activejob/destroy_association_async_job_test.rb
+import { NameError, registerConstant, unregisterConstant } from "@blazetrails/activesupport";
+import { afterAll, describe, expect, it } from "vitest";
+import { Base } from "./base.js";
+import { ConfigurationError } from "./errors.js";
+
+class UndefinedConstantAsync extends Base {
+  static _tableName = "essays";
+  static {
+    this.destroyAssociationAsyncJob("UndefinedConstantJob");
+  }
+}
+
+class UnusedBelongsToAsync extends Base {
+  static _tableName = "essays";
+  static {
+    this.destroyAssociationAsyncJob(null);
+  }
+}
+
+class UnusedHasOneAsync extends Base {
+  static _tableName = "essays";
+  static {
+    this.destroyAssociationAsyncJob(null);
+  }
+}
+
+class UnusedHasManyAsync extends Base {
+  static _tableName = "essays";
+  static {
+    this.destroyAssociationAsyncJob(null);
+  }
+}
+
+// TS-only: Rails' models resolve their job name through Ruby's real constant
+// table; trails' constantize reads the registry in activesupport/inflector.
+class ResolvableJob {}
+
+class ResolvableJobAsync extends Base {
+  static _tableName = "essays";
+  static {
+    this.destroyAssociationAsyncJob("ResolvableJob");
+  }
+}
+
+describe("DestroyAssociationAsyncJobTest", () => {
+  afterAll(() => {
+    unregisterConstant("ResolvableJob", ResolvableJob);
+  });
+
+  it("destroy_association_async_job requires valid job class", () => {
+    let error: unknown;
+    try {
+      UndefinedConstantAsync.belongsTo("essayDestroyAsync", { dependent: "destroyAsync" });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(NameError);
+    expect((error as Error).message).toMatch(
+      /destroy_association_async_job: uninitialized constant UndefinedConstantJob/,
+    );
+  });
+
+  it("belongs_to dependent destroy_async requires destroy_association_async_job", () => {
+    let error: unknown;
+    try {
+      UnusedBelongsToAsync.belongsTo("essayDestroyAsync", { dependent: "destroyAsync" });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect((error as Error).message).toMatch(/destroyAssociationAsyncJob/);
+  });
+
+  it("has_one dependent destroy_async requires destroy_association_async_job", () => {
+    let error: unknown;
+    try {
+      UnusedHasOneAsync.hasOne("essayDestroyAsync", { dependent: "destroyAsync" });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect((error as Error).message).toMatch(/destroyAssociationAsyncJob/);
+  });
+
+  it("has_many dependent destroy_async requires destroy_association_async_job", () => {
+    let error: unknown;
+    try {
+      UnusedHasManyAsync.hasMany("essayDestroyAsyncs", { dependent: "destroyAsync" });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect((error as Error).message).toMatch(/destroyAssociationAsyncJob/);
+  });
+
+  // TS-only: core.rb:27-34 resolves a job configured as a class *name* through
+  // constantize on read and memoizes the class back onto the attribute. Rails
+  // exercises that branch via its own default; trails has no ActiveJob and so
+  // no default (base.ts), leaving the branch otherwise unreached.
+  it("resolves a job configured by name and caches the class", () => {
+    registerConstant("ResolvableJob", ResolvableJob);
+    expect(ResolvableJobAsync.destroyAssociationAsyncJob()).toBe(ResolvableJob);
+    expect(ResolvableJobAsync._destroyAssociationAsyncJob).toBe(ResolvableJob);
+    expect(() =>
+      ResolvableJobAsync.hasMany("essayDestroyAsyncs", { dependent: "destroyAsync" }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Makes `Core.destroyAssociationAsyncJob`'s accessor reachable from AR's own callers.

Rails defines `def self.destroy_association_async_job` in `core.rb:27` and only *delegates* the instance reader to it (`core.rb:37`). trails wired just the instance side (via `include()` in `base.ts`), so `Model.destroyAssociationAsyncJob` was `undefined` and both callers read the static as a value instead of calling it:

- `associations/association.ts` — pushed a non-job value into `_afterCommitJobs`.
- `associations/builder/association.ts` — the "A valid destroyAssociationAsyncJob is required to use `dependent: destroyAsync`" guard could never fire.

Changes:

- `base.ts`: assign the class-side accessor, and declare `_destroyAssociationAsyncJob` explicitly.
- Both call sites now invoke the accessor.
- `checkDependentOptions` raises `ConfigurationError` (Rails: `ActiveRecord::ConfigurationError`) and checks `destroy_async` **before** the valid-options list, matching `builder/association.rb:130-138`.
- `AssociationOptions.dependent` widened to include `"destroyAsync"`, which `valid_dependent_options` has always accepted.

**No default job.** Rails defaults `_destroy_association_async_job` to the *name* `"ActiveRecord::DestroyAssociationAsyncJob"` (`core.rb:24`), an `ActiveJob::Base` subclass. trails has no ActiveJob; `destroy_association_async_job.rb` stays in `unported-files.ts`, and adopting the default would make every read raise `NameError`. The default stays omitted, with the reason recorded at the declaration rather than left implicit — so `dependent: destroyAsync` now fails the validity guard, which is exactly Rails' behavior when the configured job is missing.

Tests ported from `test/activejob/destroy_association_async_job_test.rb` (all four reachable cases; the `UnloadableBaseJob` one needs Ruby autoload semantics), plus a TS-only case exercising the string-resolution branch: assign a registered class name, read the class back, confirm it is memoized onto the attribute. All five fail on baseline (the class-side accessor does not exist there).

Closes-story: converge-destroy-association-async-job-accessor
