### PR TITLE
feat(api-compare): fail api:extra on unclassified @noRailsEquivalent reasons

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -492,11 +492,16 @@ So the reason states its claim as a leading token:
 `classifyReason` (`extra-surface.ts`) reads the first word; anything else is
 **unclassified**, and `api:extra` reports the unclassified count, a
 per-package breakdown, and the names, alongside the existing tag totals
-(`tagged.classification` in the JSON report). This is **advisory** — the exit
-code still fails on stale entries and on empty reasons only. Most of the
-population predates the convention, so failing on unclassified tags would
-block unrelated work; the signal lands first, and a ratchet or gate is a
-follow-up once the population is classified.
+(`tagged.classification` in the JSON report), and **fails the run** when the
+count is non-zero, alongside the existing stale-entry and empty-reason
+failures.
+
+The signal landed advisory first, because 74 of the 76 tags then in the tree
+predated the convention and a gate would have blocked every unrelated PR.
+`classify-existing-no-rails-equivalent-tag-reasons` (PR #5652) brought the
+population to 0, so the gate is a **hard 0, not a ratchet on the count**: a
+ratchet re-admits exactly the unclassified debt the gate exists to stop. The
+JSON report shape is unchanged — only the exit code moved.
 
 A `CONVERGEABLE` tag is a documented exception to "not for deferred work"
 above, not a licence for it: it is written only alongside a registered story

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -10,6 +10,7 @@ import {
   collectTaggedEntries,
   classifyReason,
   printClassificationBlock,
+  gateUnclassified,
 } from "./extra-surface.js";
 import type { TaggedEntry, TaggedSummary } from "./extra-surface.js";
 import { extractFromProgram } from "./extract-ts-api.js";
@@ -2383,7 +2384,7 @@ describe("buildReport — permanence classification", () => {
     expect(run("Rails has no such accessor").tagged.classification.unclassified).toBe(1);
   });
 
-  it("keeps an unclassified tag allowed and non-stale — the signal is advisory", () => {
+  it("keeps an unclassified tag allowed and non-stale — it fails on its own gate", () => {
     const report = run("Rails has no such accessor");
     expect(report.tagged.stale).toEqual([]);
     expect(report.packages[0].totalAllowlisted).toBe(1);
@@ -2456,5 +2457,24 @@ describe("printClassificationBlock", () => {
     expect(out).toContain("arel  aa.ts  aa");
     expect(out).not.toContain("bb.ts");
     expect(out).toContain("… +1 more");
+  });
+
+  describe("gateUnclassified", () => {
+    it("passes when every tag states a claim", () => {
+      expect(gateUnclassified(summary([]))).toBeNull();
+    });
+
+    it("fails and names every unclassified tag — no ratchet, the gate is a hard 0", () => {
+      const message = gateUnclassified(summary([entry("activerecord", "aa"), entry("arel", "bb")]));
+      expect(message).toContain("2 @noRailsEquivalent tag(s) state no permanence claim");
+      expect(message).toContain("activerecord  aa.ts  aa");
+      expect(message).toContain("arel  bb.ts  bb");
+    });
+
+    it("names both tokens so the message says how to fix the tag", () => {
+      const message = gateUnclassified(summary([entry("arel", "aa")]));
+      expect(message).toContain("PERMANENT");
+      expect(message).toContain("CONVERGEABLE");
+    });
   });
 });

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -11,6 +11,7 @@ import {
   classifyReason,
   printClassificationBlock,
   gateUnclassified,
+  gateStale,
 } from "./extra-surface.js";
 import type { TaggedEntry, TaggedSummary } from "./extra-surface.js";
 import { extractFromProgram } from "./extract-ts-api.js";
@@ -2458,23 +2459,73 @@ describe("printClassificationBlock", () => {
     expect(out).not.toContain("bb.ts");
     expect(out).toContain("… +1 more");
   });
+});
 
-  describe("gateUnclassified", () => {
-    it("passes when every tag states a claim", () => {
-      expect(gateUnclassified(summary([]))).toBeNull();
-    });
+describe("gateUnclassified", () => {
+  const entry = (pkg: string, name: string): TaggedEntry => ({
+    package: pkg,
+    tsFile: `${name}.ts`,
+    name,
+    reason: "no claim",
+  });
 
-    it("fails and names every unclassified tag — no ratchet, the gate is a hard 0", () => {
-      const message = gateUnclassified(summary([entry("activerecord", "aa"), entry("arel", "bb")]));
-      expect(message).toContain("2 @noRailsEquivalent tag(s) state no permanence claim");
-      expect(message).toContain("activerecord  aa.ts  aa");
-      expect(message).toContain("arel  bb.ts  bb");
-    });
+  const summary = (
+    unclassifiedEntries: TaggedEntry[],
+    stale: TaggedEntry[] = [],
+  ): TaggedSummary => ({
+    total: unclassifiedEntries.length + 3,
+    matched: unclassifiedEntries.length + 3,
+    inheritedMatched: 0,
+    stale,
+    classification: {
+      permanent: 2,
+      convergeable: 1,
+      unclassified: unclassifiedEntries.length,
+      unclassifiedByPackage: {},
+      unclassifiedEntries,
+    },
+  });
 
-    it("names both tokens so the message says how to fix the tag", () => {
-      const message = gateUnclassified(summary([entry("arel", "aa")]));
-      expect(message).toContain("PERMANENT");
-      expect(message).toContain("CONVERGEABLE");
-    });
+  it("passes when every tag states a claim", () => {
+    expect(gateUnclassified(summary([]))).toBeNull();
+  });
+
+  it("fails and names every unclassified tag — no ratchet, the gate is a hard 0", () => {
+    const message = gateUnclassified(summary([entry("activerecord", "aa"), entry("arel", "bb")]));
+    expect(message).toContain("2 @noRailsEquivalent tag(s) state no permanence claim");
+    expect(message).toContain("activerecord  aa.ts  aa");
+    expect(message).toContain("arel  bb.ts  bb");
+  });
+
+  it("names both tokens so the message says how to fix the tag", () => {
+    const message = gateUnclassified(summary([entry("arel", "aa")]));
+    expect(message).toContain("PERMANENT");
+    expect(message).toContain("CONVERGEABLE");
+  });
+
+  it("is independent of the stale gate — a tree failing both reports both", () => {
+    const tagged = summary([entry("arel", "aa")], [entry("activerecord", "bb")]);
+    expect(gateUnclassified(tagged)).toContain("arel  aa.ts  aa");
+    expect(gateStale(tagged)).toContain("activerecord  bb.ts  bb");
+  });
+});
+
+describe("gateStale", () => {
+  it("passes when no tag is stale", () => {
+    expect(
+      gateStale({
+        total: 3,
+        matched: 3,
+        inheritedMatched: 0,
+        stale: [],
+        classification: {
+          permanent: 3,
+          convergeable: 0,
+          unclassified: 0,
+          unclassifiedByPackage: {},
+          unclassifiedEntries: [],
+        },
+      }),
+    ).toBeNull();
   });
 });

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -2511,21 +2511,39 @@ describe("gateUnclassified", () => {
 });
 
 describe("gateStale", () => {
+  const entry = (pkg: string, name: string): TaggedEntry => ({
+    package: pkg,
+    tsFile: `${name}.ts`,
+    name,
+    reason: "PERMANENT. JS-only.",
+  });
+
+  const summary = (stale: TaggedEntry[]): TaggedSummary => ({
+    total: stale.length + 3,
+    matched: 3,
+    inheritedMatched: 0,
+    stale,
+    classification: {
+      permanent: 3,
+      convergeable: 0,
+      unclassified: 0,
+      unclassifiedByPackage: {},
+      unclassifiedEntries: [],
+    },
+  });
+
   it("passes when no tag is stale", () => {
-    expect(
-      gateStale({
-        total: 3,
-        matched: 3,
-        inheritedMatched: 0,
-        stale: [],
-        classification: {
-          permanent: 3,
-          convergeable: 0,
-          unclassified: 0,
-          unclassifiedByPackage: {},
-          unclassifiedEntries: [],
-        },
-      }),
-    ).toBeNull();
+    expect(gateStale(summary([]))).toBeNull();
+  });
+
+  it("fails and names every stale tag", () => {
+    const message = gateStale(summary([entry("activerecord", "aa"), entry("arel", "bb")]));
+    expect(message).toContain("2 STALE @noRailsEquivalent tag(s)");
+    expect(message).toContain("activerecord  aa.ts  aa");
+    expect(message).toContain("arel  bb.ts  bb");
+  });
+
+  it("says to delete the tag — a stale tag is never fixed by rewording its reason", () => {
+    expect(gateStale(summary([entry("arel", "aa")]))).toContain("Delete the tag");
   });
 });

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1469,6 +1469,45 @@ export function buildReport(
   };
 }
 
+/**
+ * The staleness gate: a tag on a name that no longer flags as extra surface.
+ * Returns the failure message, or `null` when the run passes.
+ */
+export function gateStale(tagged: TaggedSummary): string | null {
+  if (tagged.stale.length === 0) return null;
+  return (
+    `\nextra-surface: ${tagged.stale.length} STALE @noRailsEquivalent tag(s) on ` +
+    "methods that no longer flag as extra surface — Rails gained the method, " +
+    "the file mapping changed, the declaration is internal or `_`-prefixed " +
+    "(never counted), a bare `@tag` word inside the reason prose truncated " +
+    "the reason and was parsed as a real JSDoc tag, or the tag covers a moved " +
+    "(misplaced) port that belongs in its Rails-layout file. Delete the tag " +
+    "next to the code:\n" +
+    tagged.stale.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
+    "\n"
+  );
+}
+
+/**
+ * The permanence gate: every written `@noRailsEquivalent` reason must open with
+ * PERMANENT or CONVERGEABLE. Hard 0 rather than a ratchet on the count — the
+ * population was brought to 0 by RFC 0080, and a ratchet re-admits exactly the
+ * unclassified debt the gate exists to stop. Returns the failure message, or
+ * `null` when the run passes.
+ */
+export function gateUnclassified(tagged: TaggedSummary): string | null {
+  const { unclassified, unclassifiedEntries } = tagged.classification;
+  if (unclassified === 0) return null;
+  return (
+    `\nextra-surface: ${unclassified} @noRailsEquivalent tag(s) state no permanence ` +
+    "claim. Open each reason with PERMANENT (a language- or runtime-level fact no " +
+    "port can remove) or CONVERGEABLE (unfinished porting, a fixable collision, a " +
+    "comparator gap — name the story):\n" +
+    unclassifiedEntries.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
+    "\n"
+  );
+}
+
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
 
@@ -1510,49 +1549,23 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     printHumanReport(report, args.topN, args.maxDetail);
   }
 
-  // Stale tags can't be judged when --exclude-glob hides whole TS files.
-  if (args.excludeGlobs.length > 0) return;
-  const staleTagged = report.tagged.stale;
-  if (staleTagged.length > 0) {
-    console.error(
-      `\nextra-surface: ${staleTagged.length} STALE @noRailsEquivalent tag(s) on ` +
-        "methods that no longer flag as extra surface — Rails gained the method, " +
-        "the file mapping changed, the declaration is internal or `_`-prefixed " +
-        "(never counted), a bare `@tag` word inside the reason prose truncated " +
-        "the reason and was parsed as a real JSDoc tag, or the tag covers a moved " +
-        "(misplaced) port that belongs in its Rails-layout file. Delete the tag " +
-        "next to the code:\n" +
-        staleTagged.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
-        "\n",
-    );
-    process.exit(1);
+  // Both gates are collected before exiting: a tree that is both stale and
+  // unclassified should report both in one run, not one CI round trip each.
+  const failures = [];
+  // Stale tags can't be judged when --exclude-glob hides whole TS files: a
+  // hidden file drops out of the extras too, so a tag that still flags there
+  // reads as stale. Classification is per-tag, and an exclusion can only hide
+  // a tag, never invent one, so that gate stays armed either way.
+  if (args.excludeGlobs.length === 0) {
+    const staleMessage = gateStale(report.tagged);
+    if (staleMessage) failures.push(staleMessage);
   }
-
   const unclassifiedMessage = gateUnclassified(report.tagged);
-  if (unclassifiedMessage) {
-    console.error(unclassifiedMessage);
-    process.exit(1);
-  }
-}
+  if (unclassifiedMessage) failures.push(unclassifiedMessage);
 
-/**
- * The permanence gate: every written `@noRailsEquivalent` reason must open with
- * PERMANENT or CONVERGEABLE. Hard 0 rather than a ratchet on the count — the
- * population was brought to 0 by RFC 0080, and a ratchet re-admits exactly the
- * unclassified debt the gate exists to stop. Returns the failure message, or
- * `null` when the run passes.
- */
-export function gateUnclassified(tagged: TaggedSummary): string | null {
-  const { unclassified, unclassifiedEntries } = tagged.classification;
-  if (unclassified === 0) return null;
-  return (
-    `\nextra-surface: ${unclassified} @noRailsEquivalent tag(s) state no permanence ` +
-    "claim. Open each reason with PERMANENT (a language- or runtime-level fact no " +
-    "port can remove) or CONVERGEABLE (unfinished porting, a fixable collision, a " +
-    "comparator gap — name the story):\n" +
-    unclassifiedEntries.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
-    "\n"
-  );
+  if (failures.length === 0) return;
+  for (const failure of failures) console.error(failure);
+  process.exit(1);
 }
 
 const invokedAsScript =

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1551,7 +1551,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   // Both gates are collected before exiting: a tree that is both stale and
   // unclassified should report both in one run, not one CI round trip each.
-  const failures = [];
+  const failures: string[] = [];
   // Stale tags can't be judged when --exclude-glob hides whole TS files: a
   // hidden file drops out of the extras too, so a tag that still flags there
   // reads as stale. Classification is per-tag, and an exclusion can only hide

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -473,10 +473,11 @@ export interface TaggedSummary {
   inheritedMatched: number;
   stale: TaggedEntry[];
   /**
-   * Permanence claims across the WRITTEN tags (`total`) — advisory, never part
-   * of the exit code. An inherited entry repeats its interface declaration's
-   * reason, so counting it would multiply one claim by the interface's member
-   * count.
+   * Permanence claims across the WRITTEN tags (`total`). An inherited entry
+   * repeats its interface declaration's reason, so counting it would multiply
+   * one claim by the interface's member count. A non-zero `unclassified` fails
+   * the run — the whole population is classified, so the gate is a hard 0, not
+   * a ratchet that would re-admit the debt it exists to stop.
    */
   classification: {
     permanent: number;
@@ -527,8 +528,7 @@ Reasoned exceptions: an extra is allowed by tagging its TS declaration
 \`@noRailsEquivalent <reason>\` in JSDoc. Allowed extras are subtracted from the
 novel/moved counts and reported as an "Allowed" total; a tag on a name that no
 longer flags is STALE and fails the run. A reason opening with PERMANENT or
-CONVERGEABLE states its permanence claim; the count of tags stating neither is
-reported (advisory — it never affects the exit code).
+CONVERGEABLE states its permanence claim; a tag stating neither fails the run.
 
 Requires: pnpm api:compare must have run first to produce
   scripts/api-compare/output/{rails-api.json,ts-api.json}.
@@ -1268,9 +1268,9 @@ function padNumCell(n: number, colored: string, width: number): string {
 }
 
 /**
- * Advisory-only: prints the permanence split and names the unclassified tags.
- * Deliberately NOT a gate — most of the population predates the convention, so
- * failing on it would block every unrelated PR. See `classifyReason`.
+ * Prints the permanence split and names the unclassified tags. Non-zero
+ * unclassified fails the run (see `gateUnclassified`); this block is the
+ * detail listing that says which tags to open. See `classifyReason`.
  */
 export function printClassificationBlock(
   tagged: TaggedSummary,
@@ -1527,6 +1527,32 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     );
     process.exit(1);
   }
+
+  const unclassifiedMessage = gateUnclassified(report.tagged);
+  if (unclassifiedMessage) {
+    console.error(unclassifiedMessage);
+    process.exit(1);
+  }
+}
+
+/**
+ * The permanence gate: every written `@noRailsEquivalent` reason must open with
+ * PERMANENT or CONVERGEABLE. Hard 0 rather than a ratchet on the count — the
+ * population was brought to 0 by RFC 0080, and a ratchet re-admits exactly the
+ * unclassified debt the gate exists to stop. Returns the failure message, or
+ * `null` when the run passes.
+ */
+export function gateUnclassified(tagged: TaggedSummary): string | null {
+  const { unclassified, unclassifiedEntries } = tagged.classification;
+  if (unclassified === 0) return null;
+  return (
+    `\nextra-surface: ${unclassified} @noRailsEquivalent tag(s) state no permanence ` +
+    "claim. Open each reason with PERMANENT (a language- or runtime-level fact no " +
+    "port can remove) or CONVERGEABLE (unfinished porting, a fixable collision, a " +
+    "comparator gap — name the story):\n" +
+    unclassifiedEntries.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
+    "\n"
+  );
 }
 
 const invokedAsScript =


### PR DESCRIPTION
Gates the `@noRailsEquivalent` permanence-claim signal that RFC 0080 landed as advisory in #5648.

`api:extra` now fails when a written tag's reason opens with neither `PERMANENT` nor `CONVERGEABLE`, alongside the existing stale-tag and empty-reason failures.

**Hard 0, not a ratchet.** #5652 brought the population to 0 (the tree now reads 56 PERMANENT, 46 CONVERGEABLE, 0 unclassified), and a ratchet on the count re-admits exactly the unclassified debt the gate exists to stop. Documented in `docs/infrastructure/api-build-stub-generation-plan.md`, which previously recorded the signal as advisory with the gate as a follow-up.

Both gates are now pure message builders (`gateStale`, `gateUnclassified`) whose failures are collected before exiting, so a tree failing both reports both in one run instead of one CI round trip each. The permanence gate stays armed under `--exclude-glob`: exclusions hide whole TS files, which is why staleness cannot be judged under them, but classification is per-tag and an exclusion can only hide a tag, never invent one.

The JSON report shape is unchanged — only the exit code moved, so the stats-DB consumer is unaffected.

Verified locally: `pnpm build && pnpm api:compare`, then `extra-surface.ts` exits 0 both plain and under `--exclude-glob`; 79 unit tests pass.

Closes-story: gate-unclassified-no-rails-equivalent-tag-reasons
