### PR TITLE
build(scripts): give the scripts tree a tsconfig and typed lint coverage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -831,7 +831,13 @@ export default defineConfig(
   //  - no-floating-promises: catches a dropped Promise statement — a bare
   //    `record.save()` whose result nobody awaits.
   {
-    files: ["packages/activemodel/src/**/*.ts", "packages/activerecord/src/**/*.ts"],
+    files: [
+      "packages/activemodel/src/**/*.ts",
+      "packages/activerecord/src/**/*.ts",
+      // `scripts/**` is full of async fs and `execFile` work, and now has a
+      // program (scripts/tsconfig.json) for these rules to read types from.
+      "scripts/**/*.ts",
+    ],
     rules: {
       "@typescript-eslint/no-misused-promises": [
         "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -834,8 +834,6 @@ export default defineConfig(
     files: [
       "packages/activemodel/src/**/*.ts",
       "packages/activerecord/src/**/*.ts",
-      // `scripts/**` is full of async fs and `execFile` work, and now has a
-      // program (scripts/tsconfig.json) for these rules to read types from.
       "scripts/**/*.ts",
     ],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -795,11 +795,6 @@ export default defineConfig(
   // ── no-unnecessary-type-assertion: scoped typed-lint block (projectService only, not recommendedTypeChecked) ──
   {
     files: ["**/*.ts"],
-    // `scripts/**` is run by tsx and belongs to no tsconfig program, so the
-    // project service cannot resolve any of its ~500 `.ts` files — each one
-    // would be a parse error rather than a lint result. The tree is linted by
-    // every untyped rule; only this typed block skips it.
-    ignores: ["scripts/**"],
     languageOptions: {
       parserOptions: {
         projectService: {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "lint-staged": "^16.0.0",
     "playwright-core": "^1.60.0",
     "prettier": "3.8.1",
+    "tinyglobby": "0.2.16",
     "ts-morph": "^28.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       prettier:
         specifier: 3.8.1
         version: 3.8.1
+      tinyglobby:
+        specifier: 0.2.16
+        version: 0.2.16
       ts-morph:
         specifier: ^28.0.0
         version: 28.0.0

--- a/scripts/api-compare/arity-exclude.ts
+++ b/scripts/api-compare/arity-exclude.ts
@@ -51,7 +51,7 @@ export function parseArityExcludes(text: string): ArityExcludeEntry[] {
     }
     const e = row as Partial<ArityExcludeEntry>;
     for (const field of ["package", "rubyFile", "rubyName"] as const) {
-      if (typeof e[field] !== "string" || e[field]!.length === 0) {
+      if (typeof e[field] !== "string" || e[field].length === 0) {
         throw new Error(`arity-exclude.json[${i}]: "${field}" must be a non-empty string`);
       }
     }

--- a/scripts/api-compare/body-pins.test.ts
+++ b/scripts/api-compare/body-pins.test.ts
@@ -94,7 +94,7 @@ describe("diffPins", () => {
     const { drift, stale } = diffPins([record({ rubyName: "store" })], [pin()]);
     expect(drift).toEqual([]);
     expect(stale).toHaveLength(1);
-    expect(stale[0]!.rubyName).toBe("save");
+    expect(stale[0].rubyName).toBe("save");
   });
 });
 

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -22,10 +22,10 @@ describe("parseJsdoc", () => {
     ].join("\n");
     const { rest, entries } = parseJsdoc(comment);
     expect(entries.map((e) => e.call)).toEqual(["default_scoped", "merge!"]);
-    expect(entries[0]!.reason).toBe(
+    expect(entries[0].reason).toBe(
       "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed.",
     );
-    expect(entries[0]!.rawLines).toHaveLength(2);
+    expect(entries[0].rawLines).toHaveLength(2);
     expect(rest.join("\n")).toContain("Mirrors Rails");
     expect(rest.join("\n")).not.toContain("@missingRailsCall");
   });
@@ -56,7 +56,7 @@ describe("parseJsdoc", () => {
 
   it("accepts the generator's placeholder reason", () => {
     const { entries } = parseJsdoc(`/**\n * @missingRailsCall a — ${DEFAULT_TAG_REASON}\n */`);
-    expect(entries[0]!.reason).toBe(DEFAULT_TAG_REASON);
+    expect(entries[0].reason).toBe(DEFAULT_TAG_REASON);
   });
 });
 
@@ -65,7 +65,7 @@ describe("reconcile", () => {
     const { entries } = parseJsdoc("/**\n * @missingRailsCall a — kept note\n */");
     const r = reconcile(entries, new Set(["a", "b"]), reasonFor);
     expect(r.kept.map((e) => e.call)).toEqual(["a"]);
-    expect(r.kept[0]!.reason).toBe("kept note");
+    expect(r.kept[0].reason).toBe("kept note");
     expect(r.added.map((e) => e.call)).toEqual(["b"]);
     expect(r.dropped).toEqual([]);
     const r2 = reconcile(entries, new Set(), reasonFor);
@@ -74,7 +74,7 @@ describe("reconcile", () => {
 
   it("falls back to the placeholder when a curated reason is blank", () => {
     const r = reconcile([], new Set(["a"]), () => "  ");
-    expect(r.added[0]!.reason).toBe(DEFAULT_TAG_REASON);
+    expect(r.added[0].reason).toBe(DEFAULT_TAG_REASON);
   });
 });
 
@@ -147,7 +147,7 @@ describe("reconcileFileText", () => {
     expect(second.text).toBeNull();
     const { entries } = parseJsdoc(first);
     expect(entries).toHaveLength(1);
-    expect(entries[0]!.reason).toContain("@primary_key and calls");
+    expect(entries[0].reason).toContain("@primary_key and calls");
   });
 
   it("tags constructors (Ruby initialize) and reports unmatched expectations", () => {

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -120,7 +120,7 @@ export function parseJsdoc(
       // em-dash, so trailing whitespace would otherwise read as a non-empty
       // reason and slide past the empty-reason gate below. `rawLines` keeps
       // the line verbatim, so idempotency is unaffected.
-      open = { call: m[1]!, reason: (m[2] ?? "").trim(), rawLines: [line] };
+      open = { call: m[1], reason: (m[2] ?? "").trim(), rawLines: [line] };
       entries.push(open);
       tagLineOf.set(open, index);
       continue;
@@ -198,12 +198,12 @@ export function renderJsdoc(rest: string[], entries: TagEntry[], indent: string)
   // Order entries by call name (code-unit order, matching the ratchet).
   const ordered = [...entries].sort((a, b) => (a.call < b.call ? -1 : a.call > b.call ? 1 : 0));
   let body = rest.slice();
-  if (body.length === 0 || !body[0]!.trimStart().startsWith("/**")) {
+  if (body.length === 0 || !body[0].trimStart().startsWith("/**")) {
     body = [`${indent}/**`, `${indent} */`];
   }
   // Normalize a one-line `/** ... */` comment to block form when tags exist.
   if (ordered.length > 0 && body.length === 1) {
-    const one = body[0]!;
+    const one = body[0];
     const inner = one.replace(/^\s*\/\*\*\s?/, "").replace(/\s*\*\/\s*$/, "");
     body = [`${indent}/**`, ...(inner ? [`${indent} * ${inner}`] : []), `${indent} */`];
   }

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1020,8 +1020,8 @@ export function blazetrailsDepKeys(pkg: string): string[] {
       Record<string, string>
     >;
     const allDeps = {
-      ...((pkgJson["dependencies"] as Record<string, string>) ?? {}),
-      ...((pkgJson["peerDependencies"] as Record<string, string>) ?? {}),
+      ...(pkgJson["dependencies"] ?? {}),
+      ...(pkgJson["peerDependencies"] ?? {}),
     };
     const keys: string[] = [];
     for (const dep of Object.keys(allDeps)) {

--- a/scripts/api-compare/conventions-doc.ts
+++ b/scripts/api-compare/conventions-doc.ts
@@ -45,4 +45,4 @@ async function main(): Promise<void> {
   console.log(`Wrote ${rel}`);
 }
 
-main();
+void main();

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -375,7 +375,7 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
     push(pkg, tsFile, m.name, m.noRailsEquivalent);
   for (const [pkg, tsPkg] of Object.entries(ts.packages)) {
     for (const container of [tsPkg.classes, tsPkg.modules]) {
-      for (const c of Object.values(container) as ClassInfo[]) {
+      for (const c of Object.values(container)) {
         if (!c.file || c.reExportedFrom) continue;
         for (const m of c.instanceMethods) pushMethod(pkg, c.file, m);
         for (const m of c.classMethods) pushMethod(pkg, c.file, m);
@@ -944,7 +944,7 @@ export function buildCrossPackageModules(ruby: ApiManifest): {
   const modules: Record<string, ClassInfo> = {};
   const pkgByFqn: Record<string, string> = {};
   for (const [pkgName, pkg] of Object.entries(ruby.packages)) {
-    for (const [fqn, info] of Object.entries(pkg.modules) as [string, ClassInfo][]) {
+    for (const [fqn, info] of Object.entries(pkg.modules)) {
       modules[fqn] = info;
       pkgByFqn[fqn] = pkgName;
     }
@@ -1058,7 +1058,7 @@ function buildPackageReport(
 
   // Pre-fold ASC's `::ClassMethods` submodules into their parent's
   // classMethods (mirrors compare.ts:759-773). Mutates rubyPkg.modules.
-  const foldedFqns = foldClassMethodsModules(rubyPkg.modules as Record<string, ClassInfo>);
+  const foldedFqns = foldClassMethodsModules(rubyPkg.modules);
 
   const moduleFqnByShort = new Map<string, string[]>();
   for (const fqn of Object.keys(rubyPkg.modules)) {
@@ -1078,22 +1078,22 @@ function buildPackageReport(
   // file's allow-set like any other entity — deliberately NOT mirroring
   // compare.ts's use of the same filter.
   const rubyFiles = new Map<string, RubyEntity[]>();
-  for (const [fqn, info] of Object.entries(rubyPkg.classes) as [string, ClassInfo][]) {
+  for (const [fqn, info] of Object.entries(rubyPkg.classes)) {
     if (!info.file) continue;
     pushTo(rubyFiles, info.file, { fqn, info });
   }
-  for (const [fqn, info] of Object.entries(rubyPkg.modules) as [string, ClassInfo][]) {
+  for (const [fqn, info] of Object.entries(rubyPkg.modules)) {
     if (!info.file) continue;
     pushTo(rubyFiles, info.file, { fqn, info, ...(foldedFqns.has(fqn) ? { nameOnly: true } : {}) });
   }
 
   const tsClassesByFile = new Map<string, ClassInfo[]>();
   const tsModulesByFile = new Map<string, ClassInfo[]>();
-  for (const c of Object.values(tsPkg.classes) as ClassInfo[]) {
+  for (const c of Object.values(tsPkg.classes)) {
     if (!c.file || c.reExportedFrom) continue;
     pushTo(tsClassesByFile, c.file, c);
   }
-  for (const m of Object.values(tsPkg.modules) as ClassInfo[]) {
+  for (const m of Object.values(tsPkg.modules)) {
     if (!m.file || m.reExportedFrom) continue;
     pushTo(tsModulesByFile, m.file, m);
   }
@@ -1140,7 +1140,7 @@ function buildPackageReport(
         : collectAllowedNames(
             rubyFiles.get(rubyFile) ?? [],
             pkg,
-            rubyPkg.modules as Record<string, ClassInfo>,
+            rubyPkg.modules,
             moduleFqnByShort,
             crossPackageModules,
             crossPackagePkgByFqn,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1055,7 +1055,7 @@ export function extractFromProgram(
           // Strip `as const` / other type assertions to reach the raw literal.
           let init = valDecl.initializer;
           while (ts.isAsExpression(init) || ts.isSatisfiesExpression(init)) {
-            init = (init as ts.AsExpression | ts.SatisfiesExpression).expression;
+            init = init.expression;
           }
           if (ts.isObjectLiteralExpression(init)) {
             pushMethods(harvestObjectLiteralMethods(init, checker, hostInfo.file ?? ""));
@@ -1171,7 +1171,7 @@ export function extractFromProgram(
         if (valDecl && ts.isVariableDeclaration(valDecl) && valDecl.initializer) {
           let init = valDecl.initializer;
           while (ts.isAsExpression(init) || ts.isSatisfiesExpression(init)) {
-            init = (init as ts.AsExpression | ts.SatisfiesExpression).expression;
+            init = init.expression;
           }
           if (ts.isObjectLiteralExpression(init)) {
             pushMethods(harvestObjectLiteralMethods(init, checker, hostInfo.file ?? ""));

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2573,5 +2573,5 @@ if (
   process.argv[1] &&
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
 ) {
-  main();
+  void main();
 }

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -136,7 +136,7 @@ export function keyOf(k: CallMismatchKey): string {
 // Ruby call name (the part before the arrow), which is what SIGNIFICANT_CALLS
 // gates and what a burndown story names when it converges.
 export function callOf(missing: string): string {
-  return missing.split("→")[0]!.trim();
+  return missing.split("→")[0].trim();
 }
 
 export function flattenArtifact(artifact: Artifact): CallMismatchKey[] {

--- a/scripts/api-compare/lint-calls.ts
+++ b/scripts/api-compare/lint-calls.ts
@@ -417,7 +417,7 @@ function crossReferenceCalls(
       if (!callCandidates) continue;
 
       significantRubyCalls.push(rubyCall);
-      const found = callCandidates.some((c) => tsCalls!.has(c));
+      const found = callCandidates.some((c) => tsCalls.has(c));
       if (!found) {
         missingCalls.push(`${callCandidates[0]} (${rubyCall})`);
       }

--- a/scripts/api-compare/lint-deps.test.ts
+++ b/scripts/api-compare/lint-deps.test.ts
@@ -425,7 +425,7 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
         new Set(),
         "activesupport",
         consumerSf,
-        checkoutBody!,
+        checkoutBody,
         { checker, taintedSymbols: tainted },
       ),
     ).toBe(true);

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -690,7 +690,7 @@ function crossReference(rubyMethods: RubyDepMethod[], tsDepMap: TsDepMap): Cross
       !info.uses &&
       rm.depRefs.some((ref) => {
         const simpleName = ref.split("::").pop() ?? "";
-        return simpleName.toLowerCase() === matchedTsName!.toLowerCase();
+        return simpleName.toLowerCase() === matchedTsName.toLowerCase();
       });
     if (info.uses || implementsProtocol) {
       compliant.push(entry);

--- a/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.test.ts
@@ -17,7 +17,7 @@ describe("lintFileText", () => {
       kind: "separated",
       tags: ["internal"],
     });
-    expect(found[0]!.detail).toContain("`a`");
+    expect(found[0].detail).toContain("`a`");
   });
 
   it("flags a detached @noRailsEquivalent block", () => {
@@ -32,7 +32,7 @@ describe("lintFileText", () => {
     );
     expect(found).toHaveLength(1);
     expect(found[0]).toMatchObject({ kind: "separated", tags: ["noRailsEquivalent"] });
-    expect(found[0]!.detail).toContain("`a`");
+    expect(found[0].detail).toContain("`a`");
   });
 
   it("accepts a block flush against its declaration", () => {

--- a/scripts/api-compare/lint-detached-jsdoc-tags.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.ts
@@ -140,7 +140,7 @@ function isCommentPosition(sourceFile: ts.SourceFile, pos: number): boolean {
 function describe(node: ts.Node): string {
   const named = ts.isVariableStatement(node) ? node.declarationList.declarations[0] : node;
   const name = (named as { name?: ts.Node }).name;
-  return name && ts.isIdentifier(name as ts.Node) ? (name as ts.Identifier).text : "the code below";
+  return name && ts.isIdentifier(name) ? name.text : "the code below";
 }
 
 export function lintFileText(fileName: string, text: string): Detachment[] {
@@ -164,7 +164,7 @@ export function lintFileText(fileName: string, text: string): Detachment[] {
       line: lineOf(start),
       tags,
       kind: "separated",
-      detail: `${gap.trim().split("\n")[0]!.slice(0, 60)} … separates it from \`${describe(node)}\``,
+      detail: `${gap.trim().split("\n")[0].slice(0, 60)} … separates it from \`${describe(node)}\``,
     });
   }
 

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import {
-  isSourceUnported,
-  isTestFileUnported,
-  UNPORTED_FILES,
-  type UnportedFile,
-} from "./unported-files.js";
+import { isSourceUnported, isTestFileUnported, UNPORTED_FILES } from "./unported-files.js";
 
 describe("isSourceUnported package scoping", () => {
   it("matches an unscoped pattern across every package", () => {
@@ -35,7 +30,7 @@ describe("UNPORTED_FILES schema", () => {
     // `package` scopes a source-path (`pattern`) or a whole-file test-path
     // (`testFile` without `tests`) exclusion to one package. Per-test entries
     // (`tests:`) match on the test description, so scoping there is pointless.
-    for (const entry of UNPORTED_FILES as UnportedFile[]) {
+    for (const entry of UNPORTED_FILES) {
       if (entry.package !== undefined) {
         expect(
           entry.pattern || (entry.testFile && !entry.tests),

--- a/scripts/build-rails-error-manifest.ts
+++ b/scripts/build-rails-error-manifest.ts
@@ -172,4 +172,4 @@ async function main() {
   console.log(`Wrote ${OUT} — ${counts}`);
 }
 
-main();
+void main();

--- a/scripts/build-rails-tosql-manifest.ts
+++ b/scripts/build-rails-tosql-manifest.ts
@@ -126,4 +126,4 @@ async function main() {
   console.log(`Wrote ${OUT} — ${counts}`);
 }
 
-main();
+void main();

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -177,7 +177,7 @@ const CRC32_TABLE = (() => {
 })();
 function fixtureIdValue(label: string): number {
   let crc = 0xffffffff;
-  for (let i = 0; i < label.length; i++) crc = CRC32_TABLE[(crc ^ label.charCodeAt(i)) & 0xff]! ^ (crc >>> 8); // prettier-ignore
+  for (let i = 0; i < label.length; i++) crc = CRC32_TABLE[(crc ^ label.charCodeAt(i)) & 0xff] ^ (crc >>> 8); // prettier-ignore
   return ((crc ^ 0xffffffff) >>> 0) % FIXTURE_MAX_ID;
 }
 
@@ -286,7 +286,7 @@ function loadRailsYaml(file: string, basename: string): { ok: true; data: Fixtur
     parsed.forEach((e, i) => {
       if (!e || typeof e !== "object") return;
       const ks = Object.keys(e);
-      if (isOmap && ks.length === 1) flat.push(...(Object.entries(e) as [string, unknown][]));
+      if (isOmap && ks.length === 1) flat.push(...(Object.entries(e)));
       else flat.push([`${basename}_${i}`, e]);
     });
     entries = flat;
@@ -630,7 +630,7 @@ export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<str
         const m = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(v);
         if (m) { out[fkCol] = m[1]; out[`${assocKey}_type`] = m[2]; }
         else out[fkCol] = v;
-      } else out[fkCol] = v as Row[string];
+      } else out[fkCol] = v;
     };
     // FK_OVERRIDES lets a fixture declare `assoc → column` when the shorthand
     // doesn't follow the `<assoc>_id` convention (e.g. `creator → captain_id`).

--- a/scripts/generate-fixture-parity-exclude.ts
+++ b/scripts/generate-fixture-parity-exclude.ts
@@ -44,4 +44,4 @@ async function main(): Promise<void> {
   console.log(`Wrote ${OUT_PATH}: ${arr.length} excluded files`);
 }
 
-main();
+void main();

--- a/scripts/generate-no-explicit-any-allowlist.ts
+++ b/scripts/generate-no-explicit-any-allowlist.ts
@@ -41,4 +41,4 @@ async function main(): Promise<void> {
   console.log(`no-explicit-any allowlist: ${src.length} src + ${test.length} test files`);
 }
 
-main();
+void main();

--- a/scripts/generate-standalone-associations-exclude.ts
+++ b/scripts/generate-standalone-associations-exclude.ts
@@ -96,4 +96,4 @@ function walk(node: AstNode, visit: (n: AstNode) => void): void {
   }
 }
 
-main();
+void main();

--- a/scripts/generate-standalone-associations-exclude.ts
+++ b/scripts/generate-standalone-associations-exclude.ts
@@ -71,7 +71,7 @@ async function main(): Promise<void> {
     } catch {
       continue; // skip unparseable files
     }
-    walk(ast as unknown as AstNode, (node) => {
+    walk(ast as AstNode, (node) => {
       if (node.type !== "CallExpression") return;
       const macro = macroOfCall(node.callee);
       if (macro === null) return;

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -55,7 +55,7 @@ function parseArgs(argv: string[]): {
       }
       frozenAt = val;
       i += 2;
-    } else if (argv[i]!.startsWith("--")) {
+    } else if (argv[i].startsWith("--")) {
       process.stderr.write(`unknown flag: ${argv[i]}\n`);
       usage();
     } else if (fixtureDir === null) {
@@ -218,7 +218,7 @@ async function main(): Promise<void> {
             visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
           ).compileWithBinds((manager as { ast: unknown }).ast);
           // Resolve QueryAttribute/BindParam wrappers to their DB value first.
-          const resolvedBinds = (bs as unknown[]).map((b) => {
+          const resolvedBinds = bs.map((b) => {
             if (b != null && typeof b === "object" && "valueForDatabase" in b) {
               const vfd = (b as { valueForDatabase?: unknown }).valueForDatabase;
               return typeof vfd === "function" ? (vfd as () => unknown).call(b) : vfd;

--- a/scripts/parity/schema/node/canonicalize.test.ts
+++ b/scripts/parity/schema/node/canonicalize.test.ts
@@ -88,9 +88,9 @@ describe("canonicalize", () => {
     expect(result.version).toBe(1);
     expect(result.tables).toHaveLength(1);
     const [table] = result.tables;
-    expect(table!.name).toBe("users");
-    expect(table!.primaryKey).toBe("id");
-    expect(table!.columns.map((c) => c.name)).toEqual([
+    expect(table.name).toBe("users");
+    expect(table.primaryKey).toBe("id");
+    expect(table.columns.map((c) => c.name)).toEqual([
       "id",
       "email",
       "name",
@@ -99,12 +99,12 @@ describe("canonicalize", () => {
       "created_at",
       "active",
     ]);
-    expect(table!.columns.find((c) => c.name === "id")!.type).toBe("integer");
-    expect(table!.columns.find((c) => c.name === "score")!.type).toBe("float");
-    expect(table!.columns.find((c) => c.name === "avatar")!.type).toBe("binary");
-    expect(table!.columns.find((c) => c.name === "created_at")!.type).toBe("datetime");
-    expect(table!.columns.find((c) => c.name === "active")!.default).toBe("1");
-    expect(table!.indexes).toHaveLength(0);
+    expect(table.columns.find((c) => c.name === "id")!.type).toBe("integer");
+    expect(table.columns.find((c) => c.name === "score")!.type).toBe("float");
+    expect(table.columns.find((c) => c.name === "avatar")!.type).toBe("binary");
+    expect(table.columns.find((c) => c.name === "created_at")!.type).toBe("datetime");
+    expect(table.columns.find((c) => c.name === "active")!.default).toBe("1");
+    expect(table.indexes).toHaveLength(0);
   });
 
   it("preserves column declaration order", () => {
@@ -147,7 +147,7 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.columns.map((c) => c.name)).toEqual(["z", "a", "m"]);
+    expect(table.columns.map((c) => c.name)).toEqual(["z", "a", "m"]);
   });
 
   it("sorts tables by name", () => {
@@ -268,7 +268,7 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.indexes.map((i) => i.name)).toEqual(["idx_posts_a", "idx_posts_z"]);
+    expect(table.indexes.map((i) => i.name)).toEqual(["idx_posts_a", "idx_posts_z"]);
   });
 
   it("represents composite PK as tuple", () => {
@@ -301,7 +301,7 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.primaryKey).toEqual(["tag_id", "taggable_id"]);
+    expect(table.primaryKey).toEqual(["tag_id", "taggable_id"]);
   });
 
   it("uses primaryKeyColumns order, not column declaration order, for composite PK", () => {
@@ -336,7 +336,7 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.primaryKey).toEqual(["b", "a"]);
+    expect(table.primaryKey).toEqual(["b", "a"]);
   });
 
   it("represents no-PK table", () => {
@@ -359,7 +359,7 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.primaryKey).toBeNull();
+    expect(table.primaryKey).toBeNull();
   });
 
   it("passes numeric string defaults through unchanged", () => {
@@ -392,8 +392,8 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.columns[0]!.default).toBe("0");
-    expect(table!.columns[1]!.default).toBe("1.5");
+    expect(table.columns[0].default).toBe("0");
+    expect(table.columns[1].default).toBe("1.5");
   });
 
   it("passes quoted string defaults through unchanged", () => {
@@ -416,7 +416,7 @@ describe("canonicalize", () => {
       },
     };
     const [table] = canonicalize(native).tables;
-    expect(table!.columns[0]!.default).toBe("'active'");
+    expect(table.columns[0].default).toBe("'active'");
   });
 
   it("throws on unknown SQL type", () => {

--- a/scripts/parity/schema/node/canonicalize.ts
+++ b/scripts/parity/schema/node/canonicalize.ts
@@ -102,7 +102,7 @@ function canonicalizeTable(name: string, native: NativeTable): CanonicalTable {
     pkCols.length === 0
       ? null
       : pkCols.length === 1
-        ? pkCols[0]!
+        ? pkCols[0]
         : (pkCols as [string, string, ...string[]]);
 
   // Columns in declaration order (D1)
@@ -148,7 +148,7 @@ export function canonicalize(native: NativeDump): CanonicalSchema {
   const tables: CanonicalTable[] = Object.keys(native)
     .filter((name) => !FILTERED_TABLES.has(name))
     .sort()
-    .map((name) => canonicalizeTable(name, native[name]!));
+    .map((name) => canonicalizeTable(name, native[name]));
 
   return { version: 1, tables };
 }

--- a/scripts/parity/translate/arel.ts
+++ b/scripts/parity/translate/arel.ts
@@ -44,7 +44,7 @@ function parseArgs(): { fixture?: string; dryRun: boolean; force: boolean } {
         process.stderr.write("--fixture requires a fixture name (e.g. --fixture arel-06)\n");
         usage();
       }
-      if (!/^arel-\d{2}$/.test(val!)) {
+      if (!/^arel-\d{2}$/.test(val)) {
         process.stderr.write(`--fixture value must match arel-NN (e.g. arel-06), got: ${val}\n`);
         usage();
       }
@@ -63,7 +63,7 @@ function parseSchemaSql(dir: string): FixtureInfo {
   const sql = readFileSync(join(dir, "schema.sql"), "utf8");
   const fixtureMatch = sql.match(/-- Fixture for statement: (\S+)/);
   const queryMatch = sql.match(/-- Query: (.+)/);
-  const tables = [...sql.matchAll(/CREATE TABLE (\w+)/g)].map((m) => m[1]!.toLowerCase());
+  const tables = [...sql.matchAll(/CREATE TABLE (\w+)/g)].map((m) => m[1].toLowerCase());
 
   if (!fixtureMatch) {
     process.stderr.write(
@@ -77,9 +77,9 @@ function parseSchemaSql(dir: string): FixtureInfo {
   }
 
   // Strip trailing Ruby inline comments (# ...) so they don't land in generated files.
-  const query = queryMatch[1]!.replace(/\s*#.*$/, "").trim();
+  const query = queryMatch[1].replace(/\s*#.*$/, "").trim();
 
-  return { name: fixtureMatch[1]!, query, tables };
+  return { name: fixtureMatch[1], query, tables };
 }
 
 /**

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -664,12 +664,12 @@ describe("compareTranscriptions", () => {
   });
 
   it("says nothing about a documented divergence", () => {
-    const table = [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()][0]!;
+    const table = [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()][0];
     expect(compareTranscriptions({}, { [table]: { name: "string" } })).toEqual([]);
   });
 
   it("flags an allow-list entry the transcriptions have converged on", () => {
-    const table = [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()][0]!;
+    const table = [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()][0];
     const converged = { [table]: { name: "string" } };
     expect(staleDivergenceAllowances(converged, converged)).toContain(table);
     // Still divergent (registry-only) — the allowance is doing its job.
@@ -770,5 +770,5 @@ describe("against the canonical registry", () => {
 });
 
 function columnsOfRegistry(registry: Schema, table: string, column: string) {
-  return (registry[table] as Record<string, ColumnSpec>)[column]!;
+  return (registry[table] as Record<string, ColumnSpec>)[column];
 }

--- a/scripts/schema-compare/parse-schema-rb.ts
+++ b/scripts/schema-compare/parse-schema-rb.ts
@@ -116,7 +116,7 @@ function parseName(token: string): string | null {
     /^"([^"]+)"$/.exec(trimmed) ??
     /^'([^']+)'$/.exec(trimmed) ??
     /^:([A-Za-z_][A-Za-z0-9_]*)$/.exec(trimmed);
-  return match ? match[1]! : null;
+  return match ? match[1] : null;
 }
 
 /**
@@ -130,7 +130,7 @@ function splitArgs(args: string): string[] {
   let inDouble = false;
   let current = "";
   for (let i = 0; i < args.length; i++) {
-    const ch = args[i]!;
+    const ch = args[i];
     if (ch === "\\") {
       current += ch + (args[i + 1] ?? "");
       i++;
@@ -202,10 +202,10 @@ function parseTablePrimaryKey(args: string[]): string[] | false | null {
   for (const arg of args) {
     const idMatch = /^\s*id:\s*(.+)$/.exec(arg);
     // `id: :integer` narrows the implicit PK's type but keeps the name `id`.
-    if (idMatch && idMatch[1]!.trim() === "false") return false;
+    if (idMatch && idMatch[1].trim() === "false") return false;
     const pkMatch = /^\s*primary_key:\s*(.+)$/.exec(arg);
     if (!pkMatch) continue;
-    const value = pkMatch[1]!.trim();
+    const value = pkMatch[1].trim();
     if (value.startsWith("[")) {
       const inner = value.slice(1, -1);
       const names = splitArgs(inner)
@@ -235,7 +235,7 @@ function applyColumnLine(table: RailsTable, body: string): void {
     table.dynamic = true;
     return;
   }
-  const macro = macroMatch[1]!;
+  const macro = macroMatch[1];
   const args = splitArgs(macroMatch[2] ?? "");
 
   if (IGNORED_MACROS.has(macro)) return;
@@ -300,7 +300,7 @@ function applyColumnLine(table: RailsTable, body: string): void {
   }
   const options = parseOptions(args.slice(declared));
   for (let i = 0; i < declared; i++) {
-    addColumn(table, parseName(args[i]!)!, macro, options);
+    addColumn(table, parseName(args[i])!, macro, options);
   }
 }
 
@@ -335,7 +335,7 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
   let pendingEach: { variable: string; names: string[] } | null = null;
 
   for (let li = 0; li < lines.length; li++) {
-    const line = stripComment(lines[li]!).trim();
+    const line = stripComment(lines[li]).trim();
     if (line === "") continue;
 
     if (table === null) {
@@ -343,10 +343,10 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
       // inside it can resolve its block variable to the literal names.
       const eachMatch = /^\[(.+)\]\.each\s+do\s*\|(\w+)\|\s*$/.exec(line);
       if (eachMatch) {
-        const names = splitArgs(eachMatch[1]!)
+        const names = splitArgs(eachMatch[1])
           .map((token) => parseName(token))
           .filter((n): n is string => n !== null);
-        pendingEach = names.length > 0 ? { variable: eachMatch[2]!, names } : null;
+        pendingEach = names.length > 0 ? { variable: eachMatch[2], names } : null;
         continue;
       }
       if (pendingEach && /^end\b/.test(line)) {
@@ -361,7 +361,7 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
       // table in a SECOND database; it is not a redefinition of the primary
       // `dogs` and must not clobber that one's columns.
       const onOtherConnection = !/^create_table\b/.test(line);
-      let rest = createMatch[1]!;
+      let rest = createMatch[1];
       // `create_table(t, force: true) { }` — parenthesised args, brace block.
       const parenthesised = rest.startsWith("(");
       let braceBlock = false;
@@ -372,7 +372,7 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
         // the table (the PG companion schema declares two tables this way).
         let close = matchingParen(rest);
         while (close === -1 && li + 1 < lines.length) {
-          rest += " " + stripComment(lines[++li]!).trim();
+          rest += " " + stripComment(lines[++li]).trim();
           close = matchingParen(rest);
         }
         if (close === -1) {
@@ -412,8 +412,8 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
         }
         continue;
       }
-      if (onOtherConnection && tables.has(names[0]!)) continue;
-      table = build(names[0]!);
+      if (onOtherConnection && tables.has(names[0])) continue;
+      table = build(names[0]);
       depth = 1;
       continue;
     }
@@ -432,7 +432,7 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
     }
 
     const tMatch = /^t\.(.+)$/s.exec(line);
-    if (tMatch) applyColumnLine(table, tMatch[1]!);
+    if (tMatch) applyColumnLine(table, tMatch[1]);
   }
 
   // A block left open at EOF means the nesting tracker lost sync — report the

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1364,9 +1364,9 @@ describe("commitAndPush (git mutation flow)", () => {
       raceMessage: "should not be reached",
       raceExitCode: 3,
     });
-    const commitCall = execFileSyncMock.mock.calls.find((c) =>
-      (c[1] as string[]).includes("commit"),
-    ) as unknown[] | undefined;
+    const commitCall = execFileSyncMock.mock.calls.find((c) => c[1].includes("commit")) as
+      | unknown[]
+      | undefined;
     expect(commitCall).toBeDefined();
     const opts = commitCall![2] as { env?: Record<string, string> } | undefined;
     expect(opts?.env?.RFCS_NO_AUTOPUSH).toBe("1");

--- a/scripts/test-deps/build-fixture-baseline.ts
+++ b/scripts/test-deps/build-fixture-baseline.ts
@@ -82,4 +82,4 @@ async function main(): Promise<void> {
   console.log(`Wrote ${path.relative(ROOT, OUT_PATH)}`);
 }
 
-main();
+void main();

--- a/scripts/test-deps/rails-test-deps.ts
+++ b/scripts/test-deps/rails-test-deps.ts
@@ -183,7 +183,7 @@ export function parseSource(src: string): FileDeps {
       const body = lines.slice(r.start, r.end).join("\n");
       const used: Record<string, Set<string>> = {};
       for (const m of body.matchAll(callRe)) {
-        const records = collectRecordArgs(body, m.index! + m[0].length - 1);
+        const records = collectRecordArgs(body, m.index + m[0].length - 1);
         if (records.length === 0) continue;
         const bucket = (used[accessorToDeclared.get(m[1]) ?? m[1]] ??= new Set());
         for (const rec of records) bucket.add(rec);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,14 +1,3 @@
-// The `scripts/` tree is run by tsx and had no tsconfig, so it belonged to no
-// program and the ESLint project service could not type-check any of it. This
-// project exists for that: `noEmit`, so `tsc --build` at the root (which does
-// not reference it) is unaffected.
-//
-// - `module`/`moduleResolution` are overridden because the repo root has no
-//   `"type": "module"`, so Node16 resolution would treat every script as CJS
-//   and reject its `import.meta` use.
-// - `references` mirror the root's: several scripts import package *sources*
-//   by relative path, and without the references those files would be pulled
-//   into this program instead of resolving to the packages' declarations.
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
@@ -18,7 +7,7 @@
     "noEmit": true,
     "rootDir": ".."
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "../vendor/*.ts"],
   "references": [
     {
       "path": "../packages/activesupport"

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,69 @@
+// The `scripts/` tree is run by tsx and had no tsconfig, so it belonged to no
+// program and the ESLint project service could not type-check any of it. This
+// project exists for that: `noEmit`, so `tsc --build` at the root (which does
+// not reference it) is unaffected.
+//
+// - `module`/`moduleResolution` are overridden because the repo root has no
+//   `"type": "module"`, so Node16 resolution would treat every script as CJS
+//   and reject its `import.meta` use.
+// - `references` mirror the root's: several scripts import package *sources*
+//   by relative path, and without the references those files would be pulled
+//   into this program instead of resolving to the packages' declarations.
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "composite": true,
+    "noEmit": true,
+    "rootDir": ".."
+  },
+  "include": ["**/*.ts"],
+  "references": [
+    {
+      "path": "../packages/activesupport"
+    },
+    {
+      "path": "../packages/tse-compiler"
+    },
+    {
+      "path": "../packages/arel"
+    },
+    {
+      "path": "../packages/activemodel"
+    },
+    {
+      "path": "../packages/trails-tsc"
+    },
+    {
+      "path": "../packages/activerecord"
+    },
+    {
+      "path": "../packages/rack"
+    },
+    {
+      "path": "../packages/actionview"
+    },
+    {
+      "path": "../packages/actionpack"
+    },
+    {
+      "path": "../packages/trailties"
+    },
+    {
+      "path": "../packages/globalid"
+    },
+    {
+      "path": "../packages/did-you-mean"
+    },
+    {
+      "path": "../packages/html-sanitizer"
+    },
+    {
+      "path": "../packages/nokogiri"
+    },
+    {
+      "path": "../packages/activerecord-cli"
+    }
+  ]
+}


### PR DESCRIPTION
#5700 un-ignored `scripts/**` so every untyped rule reaches the tree, but the
typed `no-unnecessary-type-assertion` block still carried
`ignores: ["scripts/**"]`: the tree is run by tsx and belonged to no tsconfig
program, so the ESLint project service returned a parse error for each of its
~500 `.ts` files instead of lint results.

## What this does

**`scripts/tsconfig.json`** gives the tree a program:

- `noEmit`, and deliberately *not* referenced from the root `tsconfig.json`, so
  `tsc --build` / `pnpm typecheck` is unchanged.
- `module: ESNext` / `moduleResolution: Bundler` override the root's Node16.
  The repo root has no `"type": "module"`, so Node16 would type every script as
  CJS and reject the `import.meta` the tree uses throughout. This models the
  *type* layer only — tsx still transpiles the tree to CJS, so top-level `await`
  is not available at runtime (see `void main()` below).
- `references` mirror the root's: several scripts import package *sources* by
  relative path, and without the references those files get pulled into this
  program (TS6307/TS4112 noise) instead of resolving to the packages'
  declarations. `vendor/*.ts` is in `include` for the same reason.

**Typed rules now reach `scripts/**`:**

- `no-unnecessary-type-assertion` — ignore removed; 83 violations, all applied
  via `--fix` (25 files, type-only changes).
- `no-floating-promises` + `no-misused-promises` — extended to `scripts/**`,
  which the story called for: the tree is full of async fs and `execFile` work.
  They find 8 dropped entrypoint promises, now `void main();`. (`await main()`
  is the nicer fix but esbuild rejects top-level await under tsx's CJS output —
  verified by running the scripts.)

**`tinyglobby`** is declared in `devDependencies`. `scripts/test-compare`
imports it, but nothing declared it — it resolved only through pnpm's store
layout.

## Deferred: 323 pre-existing type errors in the new program

`npx tsc -p scripts/tsconfig.json` reports 323 (was 384 before the `tinyglobby`
and `vendor/*.ts` fixes above). They do not block lint — type errors are not
lint results, and `pnpm lint` is green — and the project is `noEmit` and
unreferenced, so nothing else sees them either. Named reasons:

- **262 in `scripts/sync-stats/sync.ts`** — AR model statics (`attribute`,
  `where`, `findBySql`, `upsertAll`) missing on `typeof PullRequest` etc. Those
  come from the `declare` machinery the tse-compiler materializes, which plain
  `tsc` does not see. Not a sync-stats bug.
- **~25 one-error `scripts/parity/fixtures/*/query.ts`** — same `declare` root
  cause.
- **13 in `api-compare/build-freshness.ts`** — `ts.UpToDateStatusType` and
  `getUpToDateStatusOfProject`, internal TS APIs absent from the public
  `.d.ts`.
- **~25 small file-local ones** (possibly-undefined, object-literal shape,
  `parser.parseForESLint` arity in
  `generate-standalone-associations-exclude.ts`).

Fixing them is well past the 500-LOC ceiling, so it is registered as its own
story: `0064-ar-test-infra-layout-fidelity/scripts-tsconfig-program-has-384-type-errors`.

## Verification

- `npx eslint scripts` — lint results, zero parse errors, clean.
- `pnpm lint` — exit 0. Peak RSS 5.69 GB against a 5.48 GB baseline measured on
  `origin/main` on the same host (`/usr/bin/time -f %M`): +211 MB, ~4%, for
  type-checking 500 more files. Still under the 6144 MB heap #5700 set, so no
  further bump.
- `pnpm typecheck` — unchanged (runs via the pre-commit hook on both commits).
- Ran every touched entrypoint under tsx (`build-rails-error-manifest`,
  `build-rails-tosql-manifest`, `conventions-doc`,
  `generate-no-explicit-any-allowlist`) to confirm `void main()` still executes.
- `vitest run` over the 8 touched test files — 482 tests pass.

Closes-story: scripts-tree-has-no-typed-lint-coverage
