### PR TITLE
test(eslint): guard the control-byte sets against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,9 @@ jobs:
           # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
           # to the root config must still run the guard.
           # scripts/ci/check-control-bytes.sh is named for the same reason:
-          # eslint/no-raw-control-bytes.drift.test.mjs guards its byte set
-          # against the ESLint rule's, and scripts/ci/ is carved out of the
-          # infra sweep, so an isolated change to the script must still run
-          # the guard.
+          # eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
+          # its byte set and the ESLint rule's, and scripts/ci/ is carved out
+          # of the infra sweep (INFRA_CARVEOUT_RE).
           UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,12 @@ jobs:
           # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
           # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
           # to the root config must still run the guard.
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          # scripts/ci/check-control-bytes.sh is named for the same reason:
+          # eslint/no-raw-control-bytes.drift.test.mjs guards its byte set
+          # against the ESLint rule's, and scripts/ci/ is carved out of the
+          # infra sweep, so an isolated change to the script must still run
+          # the guard.
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,

--- a/eslint/no-raw-control-bytes.drift.test.mjs
+++ b/eslint/no-raw-control-bytes.drift.test.mjs
@@ -1,0 +1,76 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect } from "vitest";
+
+/**
+ * `blazetrails/no-raw-control-bytes` and `scripts/ci/check-control-bytes.sh`
+ * enforce the same byte set over disjoint halves of the tree, but express it
+ * in two alphabets: the rule matches decoded codepoints, the script matches
+ * raw bytes under `LC_ALL=C`, so C1 has to be re-encoded as UTF-8. Widening
+ * one alone leaves the other narrower — a silent hole in exactly the guard
+ * that exists to prevent silently wrong answers. Both sides are derived from
+ * their real sources here rather than restated.
+ */
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** Pull a `const CONTROL_RE = ...` definition out of a source file. */
+async function readControlRe(file, pattern) {
+  const source = await fs.readFile(path.join(here, "..", file), "utf8");
+  const match = source.match(pattern);
+  expect(match, `no CONTROL_RE found in ${file}`).not.toBeNull();
+  return match[1];
+}
+
+/** Codepoints the ESLint rule's regex flags. */
+function eslintFlagged(literal) {
+  const [, body, flags] = literal.match(/^\/(.*)\/([a-z]*)$/u);
+  const re = new RegExp(body, flags.replace("g", ""));
+  return codePoints().filter((cp) => re.test(String.fromCodePoint(cp)));
+}
+
+/**
+ * Codepoints the shell regex flags. PCRE `\xNN` under `LC_ALL=C` is
+ * a byte, so encoding each codepoint as UTF-8 and mapping those bytes 1:1 to
+ * latin-1 characters lets the shell pattern run unmodified as a JS regex.
+ */
+function shellFlagged(pattern) {
+  const re = new RegExp(pattern, "u");
+  const encoder = new TextEncoder();
+  return codePoints().filter((cp) => {
+    const bytes = encoder.encode(String.fromCodePoint(cp));
+    return re.test(String.fromCharCode(...bytes));
+  });
+}
+
+/**
+ * The whole of Unicode, not just latin-1: a plausible widening reaches for
+ * U+FEFF or the U+2028/U+2029 line separators, and those are precisely the
+ * ones whose UTF-8 re-encoding on the shell side is easy to get wrong.
+ */
+function codePoints() {
+  return Array.from({ length: 0x110000 }, (_unused, cp) => cp);
+}
+
+describe("no-raw-control-bytes", () => {
+  it("forbids the same bytes as scripts/ci/check-control-bytes.sh", async () => {
+    const eslintLiteral = await readControlRe(
+      "eslint/no-raw-control-bytes.mjs",
+      /^const CONTROL_RE = (\/.*\/[a-z]*);$/mu,
+    );
+    const shellPattern = await readControlRe(
+      "scripts/ci/check-control-bytes.sh",
+      /^CONTROL_RE='(.*)'$/mu,
+    );
+
+    const flagged = eslintFlagged(eslintLiteral);
+    expect(flagged).toEqual(shellFlagged(shellPattern));
+    // Anchor the shared set so a matching pair of edits still has to be
+    // deliberate: C0 except tab/LF/CR, plus DEL and C1.
+    expect(flagged).toHaveLength(62);
+    expect(flagged).not.toContain(0x09);
+    expect(flagged).toContain(0x00);
+    expect(flagged).toContain(0x7f);
+    expect(flagged).toContain(0x9f);
+  });
+});

--- a/eslint/no-raw-control-bytes.drift.test.mjs
+++ b/eslint/no-raw-control-bytes.drift.test.mjs
@@ -1,76 +1,57 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { describe, it, expect } from "vitest";
+import { beforeAll, describe, it, expect } from "vitest";
 
-/**
- * `blazetrails/no-raw-control-bytes` and `scripts/ci/check-control-bytes.sh`
- * enforce the same byte set over disjoint halves of the tree, but express it
- * in two alphabets: the rule matches decoded codepoints, the script matches
- * raw bytes under `LC_ALL=C`, so C1 has to be re-encoded as UTF-8. Widening
- * one alone leaves the other narrower — a silent hole in exactly the guard
- * that exists to prevent silently wrong answers. Both sides are derived from
- * their real sources here rather than restated.
- */
-const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-/** Pull a `const CONTROL_RE = ...` definition out of a source file. */
+const ESLINT_RULE_FILE = "eslint/no-raw-control-bytes.mjs";
+const SHELL_SCANNER_FILE = "scripts/ci/check-control-bytes.sh";
+const EVERY_UNICODE_CODE_POINT = Array.from({ length: 0x110000 }, (_unused, cp) => cp);
+
 async function readControlRe(file, pattern) {
-  const source = await fs.readFile(path.join(here, "..", file), "utf8");
+  const source = await fs.readFile(path.join(repoRoot, file), "utf8");
   const match = source.match(pattern);
-  expect(match, `no CONTROL_RE found in ${file}`).not.toBeNull();
+  expect(match, `no CONTROL_RE definition found in ${file}`).not.toBeNull();
   return match[1];
 }
 
-/** Codepoints the ESLint rule's regex flags. */
-function eslintFlagged(literal) {
+function codePointsFlaggedByRegexLiteral(literal) {
   const [, body, flags] = literal.match(/^\/(.*)\/([a-z]*)$/u);
   const re = new RegExp(body, flags.replace("g", ""));
-  return codePoints().filter((cp) => re.test(String.fromCodePoint(cp)));
+  return EVERY_UNICODE_CODE_POINT.filter((cp) => re.test(String.fromCodePoint(cp)));
 }
 
-/**
- * Codepoints the shell regex flags. PCRE `\xNN` under `LC_ALL=C` is
- * a byte, so encoding each codepoint as UTF-8 and mapping those bytes 1:1 to
- * latin-1 characters lets the shell pattern run unmodified as a JS regex.
- */
-function shellFlagged(pattern) {
+function codePointsFlaggedByBytePattern(pattern) {
   const re = new RegExp(pattern, "u");
   const encoder = new TextEncoder();
-  return codePoints().filter((cp) => {
-    const bytes = encoder.encode(String.fromCodePoint(cp));
-    return re.test(String.fromCharCode(...bytes));
-  });
-}
-
-/**
- * The whole of Unicode, not just latin-1: a plausible widening reaches for
- * U+FEFF or the U+2028/U+2029 line separators, and those are precisely the
- * ones whose UTF-8 re-encoding on the shell side is easy to get wrong.
- */
-function codePoints() {
-  return Array.from({ length: 0x110000 }, (_unused, cp) => cp);
+  return EVERY_UNICODE_CODE_POINT.filter((cp) =>
+    re.test(String.fromCharCode(...encoder.encode(String.fromCodePoint(cp)))),
+  );
 }
 
 describe("no-raw-control-bytes", () => {
-  it("forbids the same bytes as scripts/ci/check-control-bytes.sh", async () => {
-    const eslintLiteral = await readControlRe(
-      "eslint/no-raw-control-bytes.mjs",
-      /^const CONTROL_RE = (\/.*\/[a-z]*);$/mu,
-    );
-    const shellPattern = await readControlRe(
-      "scripts/ci/check-control-bytes.sh",
-      /^CONTROL_RE='(.*)'$/mu,
-    );
+  let flaggedByRule;
+  let flaggedByScanner;
 
-    const flagged = eslintFlagged(eslintLiteral);
-    expect(flagged).toEqual(shellFlagged(shellPattern));
-    // Anchor the shared set so a matching pair of edits still has to be
-    // deliberate: C0 except tab/LF/CR, plus DEL and C1.
-    expect(flagged).toHaveLength(62);
-    expect(flagged).not.toContain(0x09);
-    expect(flagged).toContain(0x00);
-    expect(flagged).toContain(0x7f);
-    expect(flagged).toContain(0x9f);
+  beforeAll(async () => {
+    flaggedByRule = codePointsFlaggedByRegexLiteral(
+      await readControlRe(ESLINT_RULE_FILE, /^const CONTROL_RE = (\/.*\/[a-z]*);$/mu),
+    );
+    flaggedByScanner = codePointsFlaggedByBytePattern(
+      await readControlRe(SHELL_SCANNER_FILE, /^CONTROL_RE='(.*)'$/mu),
+    );
+  });
+
+  it("flags the same code points as check-control-bytes.sh", () => {
+    expect(flaggedByRule).toEqual(flaggedByScanner);
+  });
+
+  it("flags C0 except tab, LF and CR, plus DEL and C1", () => {
+    const c0 = EVERY_UNICODE_CODE_POINT.slice(0x00, 0x20).filter(
+      (cp) => cp !== 0x09 && cp !== 0x0a && cp !== 0x0d,
+    );
+    const c1 = EVERY_UNICODE_CODE_POINT.slice(0x80, 0xa0);
+    expect(flaggedByRule).toEqual([...c0, 0x7f, ...c1]);
   });
 });


### PR DESCRIPTION
`blazetrails/no-raw-control-bytes` and `scripts/ci/check-control-bytes.sh`
enforce the same byte set — C0 except tab/LF/CR, plus DEL and C1 — over
disjoint halves of the tree, but express it twice in two alphabets: the rule
matches decoded UTF-16 codepoints, the script matches raw bytes under
`LC_ALL=C`, so C1 has to be re-encoded as UTF-8 (`\xC2[\x80-\x9F]`). Nothing
enforced that they stay equivalent; the script's `usage()` note to "keep the
two byte sets in step" is a comment, not a gate.

`eslint/no-raw-control-bytes.drift.test.mjs` derives both sets from their real
sources rather than restating either: it pulls each `CONTROL_RE` out of its
file, runs the shell pattern as a JS regex over UTF-8 bytes mapped 1:1 to
latin-1 characters (PCRE `\xNN` under `LC_ALL=C` is a byte), and compares the
flagged codepoint sets over all of Unicode — not just 0x00-0xFF, since a
plausible widening reaches for U+FEFF or U+2028/U+2029, exactly the ones whose
UTF-8 re-encoding is easy to get wrong. Verified it fails when either side is
edited alone (adding `﻿` to the rule; adding `\x09` to the script).

`scripts/ci/` is carved out of the infra sweep (`INFRA_CARVEOUT_RE`), so the
script is now named in `UNIT_TESTS_PKGS_RE` alongside the existing `eslint/`
clause — an isolated change to either side runs the guard.

Closes-story: control-byte-guards-drift-between-eslint-and-shell
