### PR TITLE
test(activerecord): use Rails' database literals in ConnectionHandlerTest

### DIFF
--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -97,7 +97,7 @@ describe("ConnectionHandlerTest", () => {
     const localHandler = new ConnectionHandler();
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     localHandler.establishConnection(config, {
       owner: "Base",
@@ -112,7 +112,7 @@ describe("ConnectionHandlerTest", () => {
     const localHandler = new ConnectionHandler();
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     localHandler.establishConnection(config, { owner: "Base", role: "writing" });
     localHandler.establishConnection(config, { owner: "Base", role: "reading" });
@@ -130,7 +130,7 @@ describe("ConnectionHandlerTest", () => {
       const localHandler = new ConnectionHandler();
       const config = new HashConfig("development", "primary", {
         adapter: "sqlite3",
-        database: "dev.db",
+        database: "test/db/primary.sqlite3",
       });
       localHandler.establishConnection(config, {
         owner: "Base",
@@ -151,7 +151,7 @@ describe("ConnectionHandlerTest", () => {
   it("establish connection with primary works without deprecation", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const pool = handler.establishConnection(config);
     expect(pool.dbConfig.name).toBe("primary");
@@ -160,7 +160,7 @@ describe("ConnectionHandlerTest", () => {
   it("establish connection using 3 level config defaults to default env primary db", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const pool = handler.establishConnection(config);
     expect(pool.dbConfig.envName).toBe("development");
@@ -170,7 +170,7 @@ describe("ConnectionHandlerTest", () => {
   it("establish connection using 2 level config defaults to default env primary db", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const pool = handler.establishConnection(config);
     expect(pool.dbConfig.envName).toBe("development");
@@ -179,10 +179,10 @@ describe("ConnectionHandlerTest", () => {
   it("establish connection using two level configurations", async () => {
     const config = new HashConfig("test", "primary", {
       adapter: "sqlite3",
-      database: "test.db",
+      database: "test/db/primary.sqlite3",
     });
     const pool = handler.establishConnection(config);
-    expect(pool.dbConfig.database).toBe("test.db");
+    expect(pool.dbConfig.database).toBe("test/db/primary.sqlite3");
   });
 
   it("establish connection using top level key in two level config", async () => {
@@ -199,7 +199,7 @@ describe("ConnectionHandlerTest", () => {
   it("establish connection with string owner name", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, { owner: "MyModel" });
     const pool = handler.retrieveConnectionPool("MyModel");
@@ -233,7 +233,7 @@ describe("ConnectionHandlerTest", () => {
   it("retrieve connection", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary");
@@ -253,12 +253,12 @@ describe("ConnectionHandlerTest", () => {
   it("retrieve connection pool", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, { owner: "primary" });
     const pool = handler.retrieveConnectionPool("primary");
     expect(pool).toBeTruthy();
-    expect(pool!.dbConfig.database).toBe("dev.db");
+    expect(pool!.dbConfig.database).toBe("test/db/primary.sqlite3");
   });
 
   it("retrieve connection pool with invalid id", async () => {
@@ -269,11 +269,11 @@ describe("ConnectionHandlerTest", () => {
   it("connection pools", async () => {
     const config1 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const config2 = new HashConfig("development", "animals", {
       adapter: "sqlite3",
-      database: "animals.db",
+      database: "test/db/common.sqlite3",
     });
     handler.establishConnection(config1, { owner: "primary" });
     handler.establishConnection(config2, { owner: "animals" });
@@ -349,11 +349,11 @@ describe("ConnectionHandlerTest", () => {
   it("remove connection should not remove parent", async () => {
     const config1 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "primary.db",
+      database: "test/db/primary.sqlite3",
     });
     const config2 = new HashConfig("development", "child", {
       adapter: "sqlite3",
-      database: "child.db",
+      database: "test/db/readonly.sqlite3",
     });
     handler.establishConnection(config1, { owner: "primary" });
     handler.establishConnection(config2, { owner: "child" });
@@ -365,7 +365,7 @@ describe("ConnectionHandlerTest", () => {
   it("establish connection returns same pool for same config", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const pool1 = handler.establishConnection(config, {
       owner: "primary",
@@ -377,11 +377,11 @@ describe("ConnectionHandlerTest", () => {
   it("supports multiple roles for the same owner", async () => {
     const writing = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "primary.db",
+      database: "test/db/primary.sqlite3",
     });
     const reading = new HashConfig("development", "primary_replica", {
       adapter: "sqlite3",
-      database: "replica.db",
+      database: "test/db/readonly.sqlite3",
     });
     handler.establishConnection(writing, {
       owner: "primary",
@@ -396,18 +396,18 @@ describe("ConnectionHandlerTest", () => {
     expect(writingPool).toBeTruthy();
     expect(readingPool).toBeTruthy();
     expect(writingPool).not.toBe(readingPool);
-    expect(writingPool!.dbConfig.database).toBe("primary.db");
-    expect(readingPool!.dbConfig.database).toBe("replica.db");
+    expect(writingPool!.dbConfig.database).toBe("test/db/primary.sqlite3");
+    expect(readingPool!.dbConfig.database).toBe("test/db/readonly.sqlite3");
   });
 
   it("supports multiple shards for the same owner and role", async () => {
     const shard1 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "shard1.db",
+      database: "test/db/primary.sqlite3",
     });
     const shard2 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "shard2.db",
+      database: "test/db/readonly.sqlite3",
     });
     handler.establishConnection(shard1, {
       owner: "primary",
@@ -427,11 +427,11 @@ describe("ConnectionHandlerTest", () => {
   it("re-establishing connection disconnects old pool", async () => {
     const config1 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "old.db",
+      database: "test/db/primary.sqlite3",
     });
     const config2 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "new.db",
+      database: "test/db/readonly.sqlite3",
     });
     const oldPool = handler.establishConnection(config1, {
       owner: "primary",
@@ -442,7 +442,7 @@ describe("ConnectionHandlerTest", () => {
     });
     expect(disconnectSpy).toHaveBeenCalled();
     expect(newPool).not.toBe(oldPool);
-    expect(newPool.dbConfig.database).toBe("new.db");
+    expect(newPool.dbConfig.database).toBe("test/db/readonly.sqlite3");
     expect(handler.connectionPools).toHaveLength(1);
   });
 
@@ -474,7 +474,7 @@ describe("ConnectionHandlerTest", () => {
   it("connection pool names", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, { owner: "primary" });
     expect(handler.connectionPoolNames()).toContain("primary");
@@ -483,7 +483,7 @@ describe("ConnectionHandlerTest", () => {
   it("each connection pool", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, { owner: "primary" });
     const pools: unknown[] = [];
@@ -543,7 +543,7 @@ describe("ConnectionHandlerTest", () => {
   it("remove connection pool", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, { owner: "primary" });
     expect(handler.retrieveConnectionPool("primary")).toBeTruthy();
@@ -565,11 +565,11 @@ describe("ConnectionHandlerTest", () => {
   it("connection pool list filtered by role", async () => {
     const config1 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const config2 = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev-read.db",
+      database: "test/db/readonly.sqlite3",
     });
     handler.establishConnection(config1, {
       owner: "primary",
@@ -611,7 +611,7 @@ describe("ConnectionHandlerTest", () => {
   it("each connection pool with null role", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, { owner: "primary" });
     const pools: unknown[] = [];
@@ -622,7 +622,7 @@ describe("ConnectionHandlerTest", () => {
   it("re-establishing with same config object returns existing pool without disconnect", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const pool1 = handler.establishConnection(config, {
       owner: "primary",
@@ -638,7 +638,7 @@ describe("ConnectionHandlerTest", () => {
   it("re-establishing with same config and clobber true disconnects old pool", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     const pool1 = handler.establishConnection(config, {
       owner: "primary",
@@ -667,7 +667,7 @@ describe("ConnectionHandlerTest", () => {
   it("retrieve connection pool strict mode raises with role in message", async () => {
     const config = new HashConfig("development", "primary", {
       adapter: "sqlite3",
-      database: "dev.db",
+      database: "test/db/primary.sqlite3",
     });
     handler.establishConnection(config, {
       owner: "primary",


### PR DESCRIPTION
## What

`connection-handler.test.ts` carried ~19 config-only database literals that
were trails inventions — `dev.db`, `animals.db`, `replica.db`, `dev-read.db`,
`primary.db`, `child.db`, `shard1.db`/`shard2.db`, `old.db`/`new.db`,
`test.db` — none of which appear anywhere in
`vendor/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb`.

PR #5705 already repointed the six tests that actually *lease* a connection at
`ambientPoolConfiguration()`. The remainder are never connected through (same
as Rails), but the values still diverged, so a reader couldn't match a trails
test to its Rails counterpart by config, and a test copied from a neighbour
would inherit an invented name.

This PR repoints all of them at the literals Rails uses in that file:
`test/db/primary.sqlite3`, `test/db/readonly.sqlite3`, `test/db/common.sqlite3`
(`connection_handler_test.rb:38-45, 123, 141-146, 165-168, 184, 198-199, 214`).
Where a test depends on two configs being *distinct* (multiple roles, multiple
shards, re-establish-disconnects-old-pool), the pair becomes
primary/readonly rather than collapsing to one value.

These paths sit under a nonexistent `test/db/` directory, so unlike `dev.db`
they cannot silently materialize a database file in the repo root if a future
edit does lease through one.

## Not in scope

The story also mentions `connection-handling.test.ts` (`db/common.sqlite3`,
`db/foo.sqlite3`, `db/discrete.sqlite3`) and `core.trails.test.ts`
(`db/global.sqlite3`, `db/hijacked.sqlite3`). Those occurrences are all in
trails-only tests with no Rails counterpart (`core.trails.test.ts` is
trails-only by construction; the `connection-handling.test.ts` ones are
prose-named URL/backfill tests), and the story scopes the sweep to "where a
Rails counterpart exists" — so they are left alone.

## Review follow-up (resolved on main)

Review flagged that `validates db configuration and raises on invalid adapter`
did not match its Rails counterpart at `connection_handler_test.rb:66-78` —
Rails installs `{ "adapter" => "ridiculous" }` and asserts `AdapterNotFound`,
while trails asserted `/does not specify adapter/` on a config with only a
`database` key (the missing-adapter branch, not the unresolvable-adapter one).
It was out of scope here, so it was registered as a separate story.

#5717 landed that fix on main independently while this PR was in review. On
rebase the two changes collided on exactly that line; the conflict is resolved
in favour of main's version, and this PR no longer touches that test at all
(diff is now 35 LOC, down from 36). The follow-up story is closed as done
against #5717.

## Verification

- `pnpm vitest run packages/activerecord/src/connection-adapters/connection-handler.test.ts` — 46 passed, 5 skipped.
- `git status` clean after the run (no stray `.db` files).
- `pnpm test:compare` — `connection_handler_test.rb` stays at **22/22 ✓**.
- Test names and assertion structure unchanged; only literal values moved.

Closes-story: converge-connection-handler-test-config-literals-onto-rails
