### PR TITLE
test(activerecord): drive AdapterNotFound in connection-handler invalid-adapter test

### DIFF
--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -3,6 +3,7 @@ import { ConnectionHandler } from "./abstract/connection-handler.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
+import { AdapterNotFound } from "../errors.js";
 import { ambientPoolConfiguration } from "../test-adapter.js";
 
 // Mirrors ActiveRecord::TestFixtures#setup_shared_connection_pool (test_fixtures.rb:220).
@@ -79,9 +80,17 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("validates db configuration and raises on invalid adapter", async () => {
-    expect(() => handler.establishConnection({ database: "test.db" })).toThrow(
-      /does not specify adapter/,
-    );
+    const config = {
+      development: { adapter: "ridiculous" },
+    };
+    const prevConfigs = Base.configurations();
+    Base.configurations(config);
+
+    try {
+      await expect(Base.establishConnection("development")).rejects.toThrow(AdapterNotFound);
+    } finally {
+      Base.configurations(prevConfigs);
+    }
   });
 
   it("not setting writing role while using another named role raises", async () => {


### PR DESCRIPTION
`test_validates_db_configuration_and_raises_on_invalid_adapter`
(`connection_handler_test.rb:66-78`) installs
`{ "development" => { "adapter" => "ridiculous" } }` as
`ActiveRecord::Base.configurations`, calls
`establish_connection(:development)`, and asserts
`ActiveRecord::AdapterNotFound` — the config *has* an adapter key; the failure
is that the name doesn't resolve.

Our port instead called `handler.establishConnection({ database: "test.db" })`
with no adapter key and matched `/does not specify adapter/` — the
missing-adapter branch, not the unresolvable-adapter branch. `AdapterNotFound`
could have regressed undetected.

This converges the body onto Rails: stub configurations, establish by env name
off `Base`, assert `AdapterNotFound`, restore configurations in `finally`.

No implementation bug found — trails already raises `AdapterNotFound`
("Database configuration specifies nonexistent 'ridiculous' adapter…").
Verified the assertion is load-bearing by temporarily swapping in a sentinel
matcher and confirming the received error is the `AdapterNotFound` message.

Test name unchanged; `test:compare` for `connection_handler_test.rb` stays
22/22.

Closes-story: converge-connection-handler-invalid-adapter-test-onto-rails
