### PR TITLE
test(activerecord): pin the boot fast path's re-stamp via observable boot state

### DIFF
--- a/packages/activerecord/src/support/boot-outcome.ts
+++ b/packages/activerecord/src/support/boot-outcome.ts
@@ -1,5 +1,19 @@
+/**
+ * What this worker's boot (`test-setup-dy.ts`) actually did.
+ *
+ * No Rails counterpart: Rails boots one process against one database that is
+ * loaded once. trails picks between a TRUNCATE fast path and a full
+ * purge+reload per worker, and the fast path's closing re-stamp is what makes
+ * that fast path available to the *next* worker recycled onto the database.
+ * Boot runs once per worker and later files' between-test resets clear the
+ * stamp, so a test file has no deterministic view of post-boot database state —
+ * the boot has to hand it over. `template-stamp.test.ts` reads it back.
+ *
+ * @internal Boot path only.
+ */
 export type BootArm = "fastPath" | "fullLoad";
 
+/** @internal */
 export interface BootOutcome {
   arm: BootArm;
   stamped: boolean;
@@ -7,10 +21,17 @@ export interface BootOutcome {
 
 let outcome: BootOutcome | null = null;
 
+/** @internal */
 export function recordBootOutcome(arm: BootArm, stamped: boolean): void {
   outcome = { arm, stamped };
 }
 
+/**
+ * The recorded outcome, or null in a context that did not run the boot setup
+ * file.
+ *
+ * @internal
+ */
 export function bootOutcome(): BootOutcome | null {
   return outcome;
 }

--- a/packages/activerecord/src/support/boot-outcome.ts
+++ b/packages/activerecord/src/support/boot-outcome.ts
@@ -1,38 +1,16 @@
-/**
- * What this worker's boot (`test-setup-dy.ts`) actually did.
- *
- * No Rails counterpart: Rails boots one process against one database, so there
- * is nothing to record. trails picks between a TRUNCATE fast path and a full
- * purge+reload per worker, and the fast path's closing re-stamp is what makes
- * the fast path available to the *next* worker recycled onto the database. Boot
- * runs once per worker and later files' between-test resets clear the stamp, so
- * a test file has no deterministic view of post-boot database state — the boot
- * has to hand it over. `template-stamp.test.ts` reads it back.
- *
- * @internal Boot path only.
- */
 export type BootArm = "fastPath" | "fullLoad";
 
 export interface BootOutcome {
-  /** Which arm of the load-path gate the boot took. */
   arm: BootArm;
-  /** Whether the database reported `canonicalSchemaUpToDate` when boot finished. */
   stamped: boolean;
 }
 
 let outcome: BootOutcome | null = null;
 
-/** @internal */
 export function recordBootOutcome(arm: BootArm, stamped: boolean): void {
   outcome = { arm, stamped };
 }
 
-/**
- * The recorded outcome, or null in a context that did not run the boot setup
- * file.
- *
- * @internal
- */
 export function bootOutcome(): BootOutcome | null {
   return outcome;
 }

--- a/packages/activerecord/src/support/boot-outcome.ts
+++ b/packages/activerecord/src/support/boot-outcome.ts
@@ -1,0 +1,38 @@
+/**
+ * What this worker's boot (`test-setup-dy.ts`) actually did.
+ *
+ * No Rails counterpart: Rails boots one process against one database, so there
+ * is nothing to record. trails picks between a TRUNCATE fast path and a full
+ * purge+reload per worker, and the fast path's closing re-stamp is what makes
+ * the fast path available to the *next* worker recycled onto the database. Boot
+ * runs once per worker and later files' between-test resets clear the stamp, so
+ * a test file has no deterministic view of post-boot database state — the boot
+ * has to hand it over. `template-stamp.test.ts` reads it back.
+ *
+ * @internal Boot path only.
+ */
+export type BootArm = "fastPath" | "fullLoad";
+
+export interface BootOutcome {
+  /** Which arm of the load-path gate the boot took. */
+  arm: BootArm;
+  /** Whether the database reported `canonicalSchemaUpToDate` when boot finished. */
+  stamped: boolean;
+}
+
+let outcome: BootOutcome | null = null;
+
+/** @internal */
+export function recordBootOutcome(arm: BootArm, stamped: boolean): void {
+  outcome = { arm, stamped };
+}
+
+/**
+ * The recorded outcome, or null in a context that did not run the boot setup
+ * file.
+ *
+ * @internal
+ */
+export function bootOutcome(): BootOutcome | null {
+  return outcome;
+}

--- a/packages/activerecord/src/support/template-stamp.test.ts
+++ b/packages/activerecord/src/support/template-stamp.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect } from "vitest";
 import "../sqlite/better-sqlite3.js";
 import { Base } from "../base.js";
+import { bootOutcome } from "./boot-outcome.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { InternalMetadata } from "../internal-metadata.js";
 import {
@@ -64,5 +65,20 @@ describe.skipIf(!runToken)("boot fast path stamp", () => {
     await loadAdapterSpecificSchema(connection);
     await stampCanonicalSchema(connection);
     expect(await canonicalSchemaUpToDate(await Base.leaseConnection())).toBe(true);
+  });
+});
+
+describe.skipIf(!runToken)("boot outcome", () => {
+  it("a boot that took the fast path leaves the database stamped", () => {
+    // The production call site, which the probe above can only replay: this is
+    // the boot's own record of what it left behind (`support/boot-outcome.ts`),
+    // taken before any test file's reset could clear the stamp. Deleting the
+    // `stampCanonicalSchema` call at the end of `test-setup-dy.ts`'s fast-path
+    // arm turns this red on every lane — with globalSetup stamping the sqlite
+    // template, the PG slots and the MySQL slot DBs, a worker's first boot
+    // takes the fast path.
+    const outcome = bootOutcome();
+    expect(outcome, "boot must record which arm it took").not.toBeNull();
+    expect(outcome?.stamped, `boot arm ${outcome?.arm} must leave the database stamped`).toBe(true);
   });
 });

--- a/packages/activerecord/src/support/template-stamp.test.ts
+++ b/packages/activerecord/src/support/template-stamp.test.ts
@@ -70,13 +70,6 @@ describe.skipIf(!runToken)("boot fast path stamp", () => {
 
 describe.skipIf(!runToken)("boot outcome", () => {
   it("a boot that took the fast path leaves the database stamped", () => {
-    // The production call site, which the probe above can only replay: this is
-    // the boot's own record of what it left behind (`support/boot-outcome.ts`),
-    // taken before any test file's reset could clear the stamp. Deleting the
-    // `stampCanonicalSchema` call at the end of `test-setup-dy.ts`'s fast-path
-    // arm turns this red on every lane — with globalSetup stamping the sqlite
-    // template, the PG slots and the MySQL slot DBs, a worker's first boot
-    // takes the fast path.
     const outcome = bootOutcome();
     expect(outcome, "boot must record which arm it took").not.toBeNull();
     expect(outcome?.stamped, `boot arm ${outcome?.arm} must leave the database stamped`).toBe(true);

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -49,6 +49,10 @@ const { recordBootLaidTables, dropAllTables, resetTestTables } =
 const { loadSchema, loadAdapterSpecificSchema } = await import("./support/load-schema-helper.js");
 const { canonicalSchemaUpToDate, stampCanonicalSchema } =
   await import("./support/canonical-schema-stamp.js");
+// Boot runs once per worker and later files' resets clear the stamp, so the
+// only deterministic view a test file has of post-boot state is the one the
+// boot records here (`support/boot-outcome.ts`, read by template-stamp.test.ts).
+const { recordBootOutcome } = await import("./support/boot-outcome.js");
 
 if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
   if (getEnv("SKIP_TEST_DATABASE_TRUNCATE") === undefined) {
@@ -69,6 +73,7 @@ if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
   // this database is entitled to the same fast path. Without this the stamp is
   // single-use per database and every recycle pays the full purge+reload.
   await stampCanonicalSchema(conn);
+  await recordBootOutcome("fastPath", await canonicalSchemaUpToDate(conn));
 } else {
   // `DatabaseTasks.purge` re-establishes Base's pool on the recreated database,
   // so the connection has to be leased after it, not before.
@@ -80,6 +85,7 @@ if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
   const canonicalConn = await Base.leaseConnection();
   await loadSchema(canonicalConn);
   await stampCanonicalSchema(canonicalConn);
+  await recordBootOutcome("fullLoad", await canonicalSchemaUpToDate(canonicalConn));
 }
 
 // Permanent worker-startup assertion: a broken arm of the load path fails here

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -49,9 +49,6 @@ const { recordBootLaidTables, dropAllTables, resetTestTables } =
 const { loadSchema, loadAdapterSpecificSchema } = await import("./support/load-schema-helper.js");
 const { canonicalSchemaUpToDate, stampCanonicalSchema } =
   await import("./support/canonical-schema-stamp.js");
-// Boot runs once per worker and later files' resets clear the stamp, so the
-// only deterministic view a test file has of post-boot state is the one the
-// boot records here (`support/boot-outcome.ts`, read by template-stamp.test.ts).
 const { recordBootOutcome } = await import("./support/boot-outcome.js");
 
 if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {


### PR DESCRIPTION
PR #5706 put all three lanes on `test-setup-dy.ts`'s TRUNCATE boot fast path, and most of the measured win came from the **re-stamp** at the end of the fast-path arm — `resetTestTables` drops `ar_internal_metadata`, so without it the stamp is single-use per database and every recycled worker pays the full purge+reload. Nothing pinned that call: boot runs once per worker and later files' between-test resets clear the stamp, so a test file had no deterministic view of post-boot database state.

The boot now hands that state over. `support/boot-outcome.ts` records which arm the boot took and whether the database reported `canonicalSchemaUpToDate` when it finished; `template-stamp.test.ts` reads it back and asserts the boot left the database stamped, on all three lanes.

Verified against baseline: deleting the `stampCanonicalSchema` call at the end of the fast-path arm turns the new assertion red (`boot arm fastPath must leave the database stamped`).

Closes-story: pin-boot-fast-path-restamp-with-observable-boot-state