### PR TITLE
test(activerecord): un-gate the arunit2 cross-pool suites on PG/MySQL

### DIFF
--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1183,8 +1183,6 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     }).not.toThrow();
   });
 
-  // `Professor`/`Course` live in the `arunit2` second database, which
-  // `withSecondPool` provisions on every lane.
   it("alternate database", async () => {
     const professor = await Professor.create({ name: "Plum" });
     const course = await Course.create({ name: "Forensics" });

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -38,7 +38,6 @@ import { PublisherArticle, PublisherMagazine } from "../test-helpers/models/publ
 import { Professor } from "../test-helpers/models/professor.js";
 import { Course } from "../test-helpers/models/course.js";
 import { withSecondPool } from "../support/setup-second-pool.js";
-import { isSqliteRun } from "../support/sqlite-template.js";
 
 // Test-file-local models mirroring the Rails fixture file's inline class
 // definitions (has_and_belongs_to_many_associations_test.rb:63-90).
@@ -1184,9 +1183,9 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     }).not.toThrow();
   });
 
-  // `Professor`/`Course` live in the `arunit2` second database. Gated to SQLite
-  // like `MultipleDbTest`; un-gating both is its own story.
-  it.skipIf(!isSqliteRun())("alternate database", async () => {
+  // `Professor`/`Course` live in the `arunit2` second database, which
+  // `withSecondPool` provisions on every lane.
+  it("alternate database", async () => {
     const professor = await Professor.create({ name: "Plum" });
     const course = await Course.create({ name: "Forensics" });
     expect(await (professor as any).courses.count()).toBe(0);

--- a/packages/activerecord/src/base-prevent-writes.test.ts
+++ b/packages/activerecord/src/base-prevent-writes.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import { ReadOnlyError } from "./errors.js";
 import { fixtures } from "./test-fixtures.js";
-import { isSqliteRun } from "./support/sqlite-template.js";
 import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Professor } from "./test-helpers/models/professor.js";
@@ -73,7 +72,7 @@ describe("BasePreventWritesTest", () => {
     });
   });
 
-  it.skipIf(!isSqliteRun())("preventing writes applies to all connections in block", async () => {
+  it("preventing writes applies to all connections in block", async () => {
     await rebuildCanonicalTables(ARUnit2Model.connection, ["professors"]);
 
     const conn1Error = await Base.whilePreventingWrites(async () => {


### PR DESCRIPTION
The habtm `alternate database` test and `base-prevent-writes.test.ts`'s
`preventing writes applies to all connections in block` were
`skipIf(!isSqliteRun())` because nothing provisioned a second named database on
the PG/MySQL servers. `provisionSecondDatabase`
(`packages/activerecord/src/support/setup-second-pool.ts`) issues `CREATE
DATABASE` and rebuilds the arunit2 tables on every lane now, so the gate has no
reason left. Rails runs both against two real databases with no adapter gate.

`MultipleDbTest` was already un-gated by #5447; no gates remain in that file.
No test was renamed or reworded.

Verified locally on all three lanes (isolated compose stack for PG/MySQL): the
three suites pass on sqlite, postgresql and mysql2, including `MultipleDbTest`'s
`exception contains correct pool` cross-pool assertions.

Closes-story: ungate-multiple-db-suites-for-pg-mysql
