### PR TITLE
fix(sync-stats): unbreak test_compare_stats parsing on nested-paren summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           # eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
           # its byte set and the ESLint rule's, and scripts/ci/ is carved out
           # of the infra sweep (INFRA_CARVEOUT_RE).
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -711,6 +711,7 @@ jobs:
           scripts/fixtures-compare
           scripts/test-deps
           scripts/rails-find
+          scripts/sync-stats
           scripts/parity
           eslint/
           scripts/strip-asany.test.ts

--- a/scripts/sync-stats/parse-test-compare.test.ts
+++ b/scripts/sync-stats/parse-test-compare.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseTestCompareFromLogs } from "./parse-test-compare.js";
 
-// Current format (post-#3825): the details parenthetical can nest parens.
 const currentFormatLog = `
 ==========================================================================================
   globalid  —  131/131 tests (100%) (48 extra (TS only))  |  6/6 files  |  0 misplaced
@@ -14,7 +13,6 @@ const currentFormatLog = `
   Overall: 141/151 tests (93.4%) (53 extra (TS only))  |  7/8 files  |  4 misplaced
 `;
 
-// Pre-#3825 format: details parenthetical, if any, had no nested parens.
 const legacyFormatLog = `
   globalid  —  131/131 tests (100%)  |  6/6 files  |  0 misplaced
   activerecord  —  900/1000 tests (90%) (12 skipped)  |  40/50 files  |  7 misplaced
@@ -71,5 +69,14 @@ describe("parseTestCompareFromLogs", () => {
 
   it("returns no packages when the summary lines are absent", () => {
     expect(parseTestCompareFromLogs("nothing to see here").size).toBe(0);
+  });
+
+  it("does not stitch a truncated summary line to the columns of the next line", () => {
+    const truncated = [
+      "  globalid  —  131/131 tests (100%)",
+      "  |  6/6 files  |  0 misplaced",
+    ].join("\n");
+
+    expect(parseTestCompareFromLogs(truncated).size).toBe(0);
   });
 });

--- a/scripts/sync-stats/parse-test-compare.test.ts
+++ b/scripts/sync-stats/parse-test-compare.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { parseTestCompareFromLogs } from "./parse-test-compare.js";
+
+// Current format (post-#3825): the details parenthetical can nest parens.
+const currentFormatLog = `
+==========================================================================================
+  globalid  —  131/131 tests (100%) (48 extra (TS only))  |  6/6 files  |  0 misplaced
+==========================================================================================
+
+==========================================================================================
+  did-you-mean  —  10/20 tests (50%) (3 skipped, 2 assertion-count-mismatch (see --assertions), 5 extra (TS only))  |  1/2 files  |  4 misplaced
+==========================================================================================
+
+  Overall: 141/151 tests (93.4%) (53 extra (TS only))  |  7/8 files  |  4 misplaced
+`;
+
+// Pre-#3825 format: details parenthetical, if any, had no nested parens.
+const legacyFormatLog = `
+  globalid  —  131/131 tests (100%)  |  6/6 files  |  0 misplaced
+  activerecord  —  900/1000 tests (90%) (12 skipped)  |  40/50 files  |  7 misplaced
+`;
+
+describe("parseTestCompareFromLogs", () => {
+  it("parses the current summary format with nested parens and hyphenated packages", () => {
+    const results = parseTestCompareFromLogs(currentFormatLog);
+
+    expect([...results.keys()]).toEqual(["globalid", "did-you-mean"]);
+    expect(results.get("globalid")).toEqual({
+      matched: 131,
+      total: 131,
+      percent: 100,
+      skipped: 0,
+      filesMapped: 6,
+      filesTotal: 6,
+      misplaced: 0,
+    });
+    expect(results.get("did-you-mean")).toEqual({
+      matched: 10,
+      total: 20,
+      percent: 50,
+      skipped: 3,
+      filesMapped: 1,
+      filesTotal: 2,
+      misplaced: 4,
+    });
+  });
+
+  it("parses the pre-#3825 summary format", () => {
+    const results = parseTestCompareFromLogs(legacyFormatLog);
+
+    expect(results.get("globalid")?.matched).toBe(131);
+    expect(results.get("activerecord")).toEqual({
+      matched: 900,
+      total: 1000,
+      percent: 90,
+      skipped: 12,
+      filesMapped: 40,
+      filesTotal: 50,
+      misplaced: 7,
+    });
+  });
+
+  it("parses raw CI logs whose lines carry an ISO timestamp prefix", () => {
+    const raw = currentFormatLog
+      .split("\n")
+      .map((line) => (line ? `2026-07-31T12:00:00.1234567Z ${line}` : line))
+      .join("\n");
+
+    expect(parseTestCompareFromLogs(raw).get("globalid")?.matched).toBe(131);
+  });
+
+  it("returns no packages when the summary lines are absent", () => {
+    expect(parseTestCompareFromLogs("nothing to see here").size).toBe(0);
+  });
+});

--- a/scripts/sync-stats/parse-test-compare.ts
+++ b/scripts/sync-stats/parse-test-compare.ts
@@ -8,29 +8,15 @@ export interface TestComparePackageStats {
   misplaced: number;
 }
 
-// The per-package summary line emitted by scripts/test-compare/test-compare.ts:
-//
-//   globalid  —  131/131 tests (100%) (48 extra (TS only))  |  6/6 files  |  0 misplaced
-//
-// The details parenthetical can itself contain parentheses ("48 extra (TS
-// only)", "3 assertion-count-mismatch (see --assertions)"), so it is captured
-// lazily up to the pipe-separated columns rather than with a paren-excluding
-// character class. Package names may be hyphenated (did-you-mean).
-//
-// Not line-anchored: raw CI logs prefix every line with an ISO timestamp, and
-// this runs against those raw logs as well as cleaned step output.
 const SUMMARY_LINE =
-  / {2}([\w-]+)\s+—\s+(\d+)\/(\d+) tests \(([\d.]+)%\)(.*?)\s+\|\s+(\d+)\/(\d+) files\s+\|\s+(\d+) misplaced/g;
+  / {2}([\w-]+)[ \t]+—[ \t]+(\d+)\/(\d+) tests \(([\d.]+)%\)(?<details>[^\n|]*?)[ \t]+\|[ \t]+(\d+)\/(\d+) files[ \t]+\|[ \t]+(\d+) misplaced/g;
 
 export function parseTestCompareFromLogs(logs: string): Map<string, TestComparePackageStats> {
   const results = new Map<string, TestComparePackageStats>();
 
-  SUMMARY_LINE.lastIndex = 0;
-  let m;
-  while ((m = SUMMARY_LINE.exec(logs)) !== null) {
+  for (const m of logs.matchAll(SUMMARY_LINE)) {
     if (m[1] === "Overall") continue;
-    const details = m[5] ?? "";
-    const skippedMatch = /(\d+)\s+skipped/.exec(details);
+    const skippedMatch = /(\d+)\s+skipped/.exec(m.groups?.details ?? "");
     results.set(m[1], {
       matched: parseInt(m[2]),
       total: parseInt(m[3]),

--- a/scripts/sync-stats/parse-test-compare.ts
+++ b/scripts/sync-stats/parse-test-compare.ts
@@ -1,0 +1,45 @@
+export interface TestComparePackageStats {
+  matched: number;
+  total: number;
+  percent: number;
+  skipped: number;
+  filesMapped: number;
+  filesTotal: number;
+  misplaced: number;
+}
+
+// The per-package summary line emitted by scripts/test-compare/test-compare.ts:
+//
+//   globalid  —  131/131 tests (100%) (48 extra (TS only))  |  6/6 files  |  0 misplaced
+//
+// The details parenthetical can itself contain parentheses ("48 extra (TS
+// only)", "3 assertion-count-mismatch (see --assertions)"), so it is captured
+// lazily up to the pipe-separated columns rather than with a paren-excluding
+// character class. Package names may be hyphenated (did-you-mean).
+//
+// Not line-anchored: raw CI logs prefix every line with an ISO timestamp, and
+// this runs against those raw logs as well as cleaned step output.
+const SUMMARY_LINE =
+  / {2}([\w-]+)\s+—\s+(\d+)\/(\d+) tests \(([\d.]+)%\)(.*?)\s+\|\s+(\d+)\/(\d+) files\s+\|\s+(\d+) misplaced/g;
+
+export function parseTestCompareFromLogs(logs: string): Map<string, TestComparePackageStats> {
+  const results = new Map<string, TestComparePackageStats>();
+
+  SUMMARY_LINE.lastIndex = 0;
+  let m;
+  while ((m = SUMMARY_LINE.exec(logs)) !== null) {
+    if (m[1] === "Overall") continue;
+    const details = m[5] ?? "";
+    const skippedMatch = /(\d+)\s+skipped/.exec(details);
+    results.set(m[1], {
+      matched: parseInt(m[2]),
+      total: parseInt(m[3]),
+      percent: parseFloat(m[4]),
+      skipped: skippedMatch ? parseInt(skippedMatch[1]) : 0,
+      filesMapped: parseInt(m[6]),
+      filesTotal: parseInt(m[7]),
+      misplaced: parseInt(m[8]),
+    });
+  }
+  return results;
+}

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -2008,8 +2008,6 @@ async function syncCompareStats(mode: "latest" | "refresh" | "backfill"): Promis
 
     const testStats = parseTestCompareFromLogs(logs);
     if (testStats.size === 0 && stepLogs.has("test_compare")) {
-      // Format drift in the test:compare summary line silently emptied this
-      // feed for six weeks once nested parens appeared (#3825). Shout instead.
       zeroParseTestCompare++;
       console.warn(
         `  WARNING: PR #${prNumber} has a test_compare step log but 0 packages parsed — summary-line format drift?`,

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1918,24 +1918,7 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
   return fetched;
 }
 
-async function syncCompareStats(mode: "latest" | "refresh" | "backfill"): Promise<number> {
-  const limitClause = mode === "latest" ? "LIMIT 50" : "";
-  const runsToProcess = await Base.adapter.execute(`
-    SELECT rjl.job_id, rjl.merge_commit_sha, rjl.pr_number
-    FROM raw_job_logs rjl
-    JOIN workflow_jobs wj ON wj.id = rjl.job_id
-    WHERE wj.name = 'Rails API/Test Comparison'
-    AND wj.conclusion = 'success'
-    AND rjl.job_id = (
-      SELECT rjl2.job_id FROM raw_job_logs rjl2
-      JOIN workflow_jobs wj2 ON wj2.id = rjl2.job_id
-      WHERE rjl2.merge_commit_sha = rjl.merge_commit_sha
-      AND wj2.name = 'Rails API/Test Comparison'
-      AND wj2.conclusion = 'success'
-      ORDER BY wj2.completed_at DESC
-      LIMIT 1
-    )
-    AND (
+const MISSING_STATS_PREDICATE = `
       NOT EXISTS (
         SELECT 1 FROM test_compare_stats tcs
         WHERE tcs.merge_commit_sha = rjl.merge_commit_sha
@@ -1967,7 +1950,29 @@ async function syncCompareStats(mode: "latest" | "refresh" | "backfill"): Promis
           ON cl.merge_commit_sha = rjl.merge_commit_sha AND cl.step_name = e.step_name
         WHERE e.required = 1 AND cl.step_name IS NULL
       )
+`;
+
+async function syncCompareStats(
+  mode: "latest" | "refresh" | "backfill" | "reparse",
+): Promise<number> {
+  const limitClause = mode === "latest" ? "LIMIT 50" : "";
+  const missingStatsClause = mode === "reparse" ? "" : `AND (${MISSING_STATS_PREDICATE})`;
+  const runsToProcess = await Base.adapter.execute(`
+    SELECT rjl.job_id, rjl.merge_commit_sha, rjl.pr_number
+    FROM raw_job_logs rjl
+    JOIN workflow_jobs wj ON wj.id = rjl.job_id
+    WHERE wj.name = 'Rails API/Test Comparison'
+    AND wj.conclusion = 'success'
+    AND rjl.job_id = (
+      SELECT rjl2.job_id FROM raw_job_logs rjl2
+      JOIN workflow_jobs wj2 ON wj2.id = rjl2.job_id
+      WHERE rjl2.merge_commit_sha = rjl.merge_commit_sha
+      AND wj2.name = 'Rails API/Test Comparison'
+      AND wj2.conclusion = 'success'
+      ORDER BY wj2.completed_at DESC
+      LIMIT 1
     )
+    ${missingStatsClause}
     ORDER BY rjl.pr_number DESC
     ${limitClause}
   `);
@@ -2332,7 +2337,7 @@ async function main() {
 
     if (reparseLogs) {
       console.log("=== Re-parsing compare stats from stored CI logs ===");
-      const logsParsed = await syncCompareStats("refresh");
+      const logsParsed = await syncCompareStats("reparse");
       console.log(`\nRe-parsed ${logsParsed} job logs.`);
       await printSummary();
       return;

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "path";
 import { Base, MigrationContext } from "@blazetrails/activerecord";
 import type { AbstractSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js";
+import { parseTestCompareFromLogs } from "./parse-test-compare.js";
 
 const REPO = "blazetrailsdev/trails";
 const [REPO_OWNER, REPO_NAME] = REPO.split("/");
@@ -1744,40 +1745,6 @@ function extractStepLogs(rawLog: string): Map<string, string> {
   return steps;
 }
 
-function parseTestCompareFromLogs(logs: string) {
-  const results = new Map<
-    string,
-    {
-      matched: number;
-      total: number;
-      percent: number;
-      skipped: number;
-      filesMapped: number;
-      filesTotal: number;
-      misplaced: number;
-    }
-  >();
-
-  const re =
-    /\s{2}(\w+)\s+—\s+(\d+)\/(\d+) tests \(([\d.]+)%\)(?:\s+\(([^)]*)\))?\s+\|\s+(\d+)\/(\d+) files\s+\|\s+(\d+) misplaced/g;
-  let m;
-  while ((m = re.exec(logs)) !== null) {
-    if (m[1] === "Overall") continue;
-    const details = m[5] ?? "";
-    const skippedMatch = /(\d+)\s+skipped/.exec(details);
-    results.set(m[1], {
-      matched: parseInt(m[2]),
-      total: parseInt(m[3]),
-      percent: parseFloat(m[4]),
-      skipped: skippedMatch ? parseInt(skippedMatch[1]) : 0,
-      filesMapped: parseInt(m[6]),
-      filesTotal: parseInt(m[7]),
-      misplaced: parseInt(m[8]),
-    });
-  }
-  return results;
-}
-
 function parseApiCompareFromLogs(logs: string) {
   const results = new Map<
     string,
@@ -2012,6 +1979,7 @@ async function syncCompareStats(mode: "latest" | "refresh" | "backfill"): Promis
 
   console.log(`Parsing compare stats from ${runsToProcess.length} job logs...`);
   let parsed = 0;
+  let zeroParseTestCompare = 0;
 
   for (const row of runsToProcess) {
     const jobId = row.job_id as number;
@@ -2039,6 +2007,14 @@ async function syncCompareStats(mode: "latest" | "refresh" | "backfill"): Promis
     }
 
     const testStats = parseTestCompareFromLogs(logs);
+    if (testStats.size === 0 && stepLogs.has("test_compare")) {
+      // Format drift in the test:compare summary line silently emptied this
+      // feed for six weeks once nested parens appeared (#3825). Shout instead.
+      zeroParseTestCompare++;
+      console.warn(
+        `  WARNING: PR #${prNumber} has a test_compare step log but 0 packages parsed — summary-line format drift?`,
+      );
+    }
     if (testStats.size > 0) {
       await TestCompareStat.upsertAll(
         [...testStats.entries()].map(([pkg, s]) => ({
@@ -2111,6 +2087,13 @@ async function syncCompareStats(mode: "latest" | "refresh" | "backfill"): Promis
         `  PR #${prNumber}: ${testStats.size} test packages (${totalTests} matched), ${apiStats.size} api packages (${totalApi} matched), ${apiPrivatesStats.size} api-privates packages (${totalApiPrivates} matched), logs: [${logSteps}]`,
       );
     }
+  }
+
+  if (zeroParseTestCompare > 0) {
+    console.warn(
+      `\n  WARNING: ${zeroParseTestCompare} job log(s) had a test_compare step but produced no package rows. ` +
+        `The test_compare_stats feed is going stale — check parseTestCompareFromLogs against the current summary format.`,
+    );
   }
 
   return parsed;
@@ -2282,6 +2265,7 @@ async function main() {
     "--missing",
     "--prs",
     "--local-reviews-only",
+    "--reparse-logs",
   ];
   const unknownFlags = args.filter(
     (a) => a.startsWith("--") && !knownFlags.includes(a.split("=")[0]),
@@ -2289,7 +2273,7 @@ async function main() {
   if (unknownFlags.length > 0) {
     console.error(`Unknown flag(s): ${unknownFlags.join(", ")}`);
     console.error(
-      "Usage: stats:sync [--latest | --refresh | --compare-only | --missing | --prs <spec> | --local-reviews-only]",
+      "Usage: stats:sync [--latest | --refresh | --compare-only | --missing | --prs <spec> | --local-reviews-only | --reparse-logs]",
     );
     process.exit(1);
   }
@@ -2310,6 +2294,7 @@ async function main() {
     }
   }
   const localReviewsOnly = args.includes("--local-reviews-only");
+  const reparseLogs = args.includes("--reparse-logs");
   const backfillMissing = args.includes("--missing");
   const isBackfill = prsSpec !== null || backfillMissing;
 
@@ -2321,7 +2306,11 @@ async function main() {
         ? "compare-only"
         : "latest";
 
-  if (localReviewsOnly) {
+  if (reparseLogs) {
+    console.log(
+      "Running reparse-logs mode: re-parsing compare stats from already-stored job logs (no GitHub API calls).\n",
+    );
+  } else if (localReviewsOnly) {
     console.log("Running local-reviews-only mode: ingesting /review-pr reviews from disk.\n");
   } else if (mode === "latest") {
     console.log(
@@ -2342,6 +2331,14 @@ async function main() {
 
   try {
     await migrateDb(adapter);
+
+    if (reparseLogs) {
+      console.log("=== Re-parsing compare stats from stored CI logs ===");
+      const logsParsed = await syncCompareStats("refresh");
+      console.log(`\nRe-parsed ${logsParsed} job logs.`);
+      await printSummary();
+      return;
+    }
 
     if (localReviewsOnly) {
       console.log("=== Ingesting local /review-pr reviews ===");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -418,6 +418,7 @@ export default defineConfig({
             "scripts/tasks/*.test.ts",
             "scripts/test-compare/*.test.ts",
             "scripts/rails-find/*.test.ts",
+            "scripts/sync-stats/*.test.ts",
             "eslint/*.test.mjs",
             "vendor/*.test.ts",
           ],


### PR DESCRIPTION
## Summary

`parseTestCompareFromLogs` parsed the per-package `test:compare` summary line with an optional details group `\(([^)]*)\)`. PR #3825 (merged 2026-06-21) added the `N extra (TS only)` annotation to that parenthetical; `[^)]*` stops at the inner `)`, the regex then needs `|` but sees `)`, and the whole line fails to match. Every package silently dropped out, so `test_compare_stats` recorded nothing for six weeks while `api_compare_stats` kept syncing.

## Changes

- Parser extracted to `scripts/sync-stats/parse-test-compare.ts` (sync.ts runs `main()` at import, so it isn't unit-testable in place).
- Details captured lazily as `[^\n|]*?` bounded by the pipe columns, so nested parens work and a truncated line can't stitch to the next line's columns.
- Package name matcher accepts hyphens — `did-you-mean` had never synced.
- `syncCompareStats` warns per-log and in summary when a `test_compare` step yields zero package rows, so future drift surfaces within one sync cycle.
- New `--reparse-logs` mode re-parses stored `raw_job_logs` with no GitHub API calls.
- `scripts/sync-stats` wired into `vitest.config.ts`, the `unit-tests` ci.yml filter list, and `UNIT_TESTS_PKGS_RE` (both halves of the `ci-suite-coverage` guard).

## Recovery-gate fix

`syncCompareStats`' reprocessing gate is keyed per `merge_commit_sha`, but rows are keyed per `(merge_commit_sha, package)`. A commit with even one row looks synced, so partial parse failures were permanently unrecoverable. `--reparse-logs` now drops that gate and revisits every stored log; `upsertAll` on `(merge_commit_sha, package)` keeps the full pass idempotent.

This was already live, not just latent: the unconditional pass recovered **800 rows** the per-commit gate had been hiding (33,591 → 34,391).

## Backfill

Ran against `stats.db`: latest `test_compare_stats` merged_at moved `2026-06-21T19:34:07Z` → `2026-07-31T01:59:16Z`; 754 rows now exist for hyphenated packages (previously 0); all 3,289 job logs re-parsed with zero drift warnings.

Closes-story: sync-stats-test-compare-regex-stale
