### PR TITLE
fix(scripts): clear the file-local type errors in the scripts tsconfig program

### DIFF
--- a/eslint/expected-fixtures.d.mts
+++ b/eslint/expected-fixtures.d.mts
@@ -1,0 +1,32 @@
+// Declarations for the `expected-fixtures` rule module, which is authored as
+// `.mjs` so ESLint's flat config can load it without a build step. Only
+// `scripts/test-deps/build-fixture-baseline.ts` imports it from TypeScript;
+// the rule itself and eslint.config.mjs consume the `.mjs` directly. Keep this
+// in step with the module's exports — a signature that drifts here is not
+// caught anywhere else.
+
+/** Trails test path (any separator) → Rails cases-relative path, or null. */
+export function trailsToRailsRel(absOrRelPath: string): string | null;
+
+/** Inverse of `trailsToRailsRel`. */
+export function railsToTrailsRel(railsRel: string): string;
+
+/**
+ * The camelized subset of `entry.fixtures` that at least one Rails test in
+ * `entry.tests` actually dereferences. Structurally typed rather than tied to
+ * `FileDeps` so the rule module keeps no dependency on the scripts tree.
+ */
+export function requiredFixtureSets(entry: {
+  fixtures?: string[];
+  tests?: Record<string, { fixtures?: Record<string, unknown> }>;
+}): string[];
+
+/** Walk an already-parsed ESTree program collecting all `useFixtures` keys. */
+export function collectUseFixturesKeys(programNode: unknown): {
+  found: boolean;
+  keys: Set<string>;
+};
+
+/** The ESLint rule itself, typed opaquely: no consumer in the TS program uses it. */
+declare const rule: unknown;
+export default rule;

--- a/eslint/expected-fixtures.d.mts
+++ b/eslint/expected-fixtures.d.mts
@@ -1,32 +1,16 @@
-// Declarations for the `expected-fixtures` rule module, which is authored as
-// `.mjs` so ESLint's flat config can load it without a build step. Only
-// `scripts/test-deps/build-fixture-baseline.ts` imports it from TypeScript;
-// the rule itself and eslint.config.mjs consume the `.mjs` directly. Keep this
-// in step with the module's exports — a signature that drifts here is not
-// caught anywhere else.
-
-/** Trails test path (any separator) → Rails cases-relative path, or null. */
 export function trailsToRailsRel(absOrRelPath: string): string | null;
 
-/** Inverse of `trailsToRailsRel`. */
 export function railsToTrailsRel(railsRel: string): string;
 
-/**
- * The camelized subset of `entry.fixtures` that at least one Rails test in
- * `entry.tests` actually dereferences. Structurally typed rather than tied to
- * `FileDeps` so the rule module keeps no dependency on the scripts tree.
- */
 export function requiredFixtureSets(entry: {
   fixtures?: string[];
   tests?: Record<string, { fixtures?: Record<string, unknown> }>;
 }): string[];
 
-/** Walk an already-parsed ESTree program collecting all `useFixtures` keys. */
 export function collectUseFixturesKeys(programNode: unknown): {
   found: boolean;
   keys: Set<string>;
 };
 
-/** The ESLint rule itself, typed opaquely: no consumer in the TS program uses it. */
 declare const rule: unknown;
 export default rule;

--- a/eslint/expected-fixtures.test.mjs
+++ b/eslint/expected-fixtures.test.mjs
@@ -20,12 +20,8 @@ process.env.EXPECTED_FIXTURES_EXCLUDE_PATH = TMP_EXCLUDE;
 
 // Imported AFTER env vars are set so the rule's module-level path
 // constants pick them up.
-const {
-  default: rule,
-  trailsToRailsRel,
-  collectUseFixturesKeys,
-  requiredFixtureSets,
-} = await import("./expected-fixtures.mjs");
+const mod = await import("./expected-fixtures.mjs");
+const { default: rule, trailsToRailsRel, collectUseFixturesKeys, requiredFixtureSets } = mod;
 
 beforeAll(() => {
   fs.writeFileSync(
@@ -280,3 +276,15 @@ function runCases(tester) {
     ],
   });
 }
+
+describe("expected-fixtures.d.mts", () => {
+  it("declares exactly the exports the module provides", () => {
+    const source = fs.readFileSync(path.join(__dirname, "expected-fixtures.d.mts"), "utf8");
+    const declared = [...source.matchAll(/^export function (\w+)/gm)].map((m) => m[1]).sort();
+    const actual = Object.keys(mod)
+      .filter((k) => k !== "default")
+      .sort();
+    expect(declared).toEqual(actual);
+    expect(source).toMatch(/^export default rule;$/m);
+  });
+});

--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -7,7 +7,7 @@ import {
   isForwardingRubyEntry,
   renderSig,
 } from "./arity.js";
-import type { ParamInfo } from "./types.js";
+import type { MethodInfo, ParamInfo } from "./types.js";
 
 const req = (name: string, type?: string): ParamInfo => ({ name, kind: "required", type });
 const opt = (name: string): ParamInfo => ({ name, kind: "optional", default: "…" });
@@ -312,7 +312,12 @@ describe("isForwardingRubyEntry", () => {
     // Resolution is read from the flag, not from a non-empty param list: this
     // entry is shape-identical to the unresolved case above, but its arity IS
     // known, so a TS side that grew a spurious param must still be flagged.
-    expect(isForwardingRubyEntry({ params: [], notes: "alias", aliasResolved: true })).toBe(false);
+    const entry: Pick<MethodInfo, "params" | "notes" | "aliasResolved"> = {
+      params: [],
+      notes: "alias",
+      aliasResolved: true,
+    };
+    expect(isForwardingRubyEntry(entry)).toBe(false);
   });
 
   it("checks a plain method and other extractor notes", () => {

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -413,15 +413,10 @@ describe("staleBuildMessage", () => {
 
 describe("typescript-internal.d.ts", () => {
   const declaredStatusNames = (): string[] => {
-    const source = fs.readFileSync(
-      path.join(import.meta.dirname, "typescript-internal.d.ts"),
-      "utf8",
-    );
-    const body = source.slice(
-      source.indexOf("export enum UpToDateStatusType {"),
-      source.indexOf("}", source.indexOf("export enum UpToDateStatusType {")),
-    );
-    return [...body.matchAll(/^\s{4}(\w+),$/gm)].map((m) => m[1]);
+    const source = fs.readFileSync(path.join(__dirname, "typescript-internal.d.ts"), "utf8");
+    const body = /export enum UpToDateStatusType \{([^}]*)\}/.exec(source);
+    expect(body).not.toBeNull();
+    return [...body![1].matchAll(/(\w+),/g)].map((m) => m[1]);
   };
 
   it("declares every status the installed TypeScript reports", () => {

--- a/scripts/api-compare/build-freshness.test.ts
+++ b/scripts/api-compare/build-freshness.test.ts
@@ -410,3 +410,29 @@ describe("staleBuildMessage", () => {
     expect(message).not.toContain("no dist at all");
   });
 });
+
+describe("typescript-internal.d.ts", () => {
+  const declaredStatusNames = (): string[] => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "typescript-internal.d.ts"),
+      "utf8",
+    );
+    const body = source.slice(
+      source.indexOf("export enum UpToDateStatusType {"),
+      source.indexOf("}", source.indexOf("export enum UpToDateStatusType {")),
+    );
+    return [...body.matchAll(/^\s{4}(\w+),$/gm)].map((m) => m[1]);
+  };
+
+  it("declares every status the installed TypeScript reports", () => {
+    const runtimeNames = Object.values(ts.UpToDateStatusType).filter(
+      (v): v is string => typeof v === "string",
+    );
+    expect(declaredStatusNames()).toEqual(runtimeNames);
+  });
+
+  it("declares a getUpToDateStatusOfProject the installed TypeScript still implements", () => {
+    const builder = ts.createSolutionBuilder(ts.createSolutionBuilderHost(ts.sys), [], {});
+    expect(builder.getUpToDateStatusOfProject).toBeTypeOf("function");
+  });
+});

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1516,7 +1516,9 @@ describe("buildReport — interface declaration names", () => {
     },
   };
 
-  const tsWith = (decls: { name: string; isInterface?: boolean; members?: string[] }[]) => ({
+  const tsWith = (
+    decls: { name: string; isInterface?: boolean; members?: string[] }[],
+  ): ApiManifest => ({
     source: "typescript" as const,
     generatedAt: "",
     packages: {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -28,11 +28,6 @@ import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
 const VIRTUAL = "virtual.ts";
 
-/**
- * `PackageInfo.fileFunctions` is optional because the Ruby extractor never
- * emits it; this extractor always does, and a test asking for a file's
- * functions wants the absence to fail loudly rather than read as an empty set.
- */
 function fileFunctionsOf(info: PackageInfo, file: string): MethodInfo[] {
   const fns = info.fileFunctions?.[file];
   if (fns === undefined) throw new Error(`extractor emitted no fileFunctions for ${file}`);

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -28,6 +28,17 @@ import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
 const VIRTUAL = "virtual.ts";
 
+/**
+ * `PackageInfo.fileFunctions` is optional because the Ruby extractor never
+ * emits it; this extractor always does, and a test asking for a file's
+ * functions wants the absence to fail loudly rather than read as an empty set.
+ */
+function fileFunctionsOf(info: PackageInfo, file: string): MethodInfo[] {
+  const fns = info.fileFunctions?.[file];
+  if (fns === undefined) throw new Error(`extractor emitted no fileFunctions for ${file}`);
+  return fns;
+}
+
 /** Compile an in-memory source file with no lib/resolution; return its AST + checker. */
 function compile(source: string): { sourceFile: ts.SourceFile; checker: ts.TypeChecker } {
   const sourceFile = ts.createSourceFile(VIRTUAL, source, ts.ScriptTarget.Latest, true);
@@ -1301,7 +1312,7 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
         export function quote(value: unknown): string { return ""; }
       `,
     });
-    const fns = info.fileFunctions["quoting.ts"];
+    const fns = fileFunctionsOf(info, "quoting.ts");
     expect(fns.find((f) => f.name === "dispatchQuote")!.internal).toBe(true);
     expect(fns.find((f) => f.name === "quote")!.internal).toBeUndefined();
   });
@@ -1316,7 +1327,7 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
       `,
     });
     expect(info.modules["key-normalization.ts:KeyNormalization"]).toBeUndefined();
-    expect(info.fileFunctions["key-normalization.ts"].every((f) => f.internal)).toBe(true);
+    expect(fileFunctionsOf(info, "key-normalization.ts").every((f) => f.internal)).toBe(true);
   });
 
   it("tags an @internal-tagged exported function-valued const and leaves its sibling public", () => {
@@ -1331,7 +1342,7 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
         export const secondBang = bangFinder(base);
       `,
     });
-    const fns = info.fileFunctions["finder-methods.ts"];
+    const fns = fileFunctionsOf(info, "finder-methods.ts");
     expect(fns.find((f) => f.name === "performSecondBang")!.internal).toBe(true);
     expect(fns.find((f) => f.name === "secondBang")!.internal).toBeUndefined();
   });
@@ -1409,7 +1420,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
         export function hasMany(): void {}
       `,
     });
-    const fns = info.fileFunctions["associations.ts"];
+    const fns = fileFunctionsOf(info, "associations.ts");
     expect(fns.find((f) => f.name === "registerModel")!.noRailsEquivalent).toBe(
       "public registration surface, no Rails counterpart",
     );
@@ -1425,7 +1436,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
         export { withRoutesHelpers as with };
       `,
     });
-    const fns = info.fileFunctions["routes-helpers.ts"];
+    const fns = fileFunctionsOf(info, "routes-helpers.ts");
     expect(fns.find((f) => f.name === "withRoutesHelpers")!.noRailsEquivalent).toBe(
       "`with` is an ES strict-mode reserved word",
     );
@@ -1442,7 +1453,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
         export { registerModelClass as registerModel };
       `,
     });
-    const fns = info.fileFunctions["registry.ts"];
+    const fns = fileFunctionsOf(info, "registry.ts");
     expect(fns.find((f) => f.name === "registerModelClass")!.noRailsEquivalent).toBe(
       "declared spelling, no Rails counterpart",
     );
@@ -2119,7 +2130,7 @@ function emitInventory(info: PackageInfo, file: string): EmitEntry[] {
     for (const m of c.instanceMethods) push(key, m, skipForeign);
     for (const m of c.classMethods) push(key, m, skipForeign);
   }
-  for (const m of info.fileFunctions[file] ?? []) push("<fileFunctions>", m, false);
+  for (const m of info.fileFunctions?.[file] ?? []) push("<fileFunctions>", m, false);
   // Code-unit ordering, not localeCompare: the hand-written table below must
   // not shift with the host's collation.
   return out.sort((a, b) => {
@@ -2205,7 +2216,7 @@ describe("extract-ts-api — MethodInfo emit-site inventory", () => {
       file,
       Object.values(info.classes),
       Object.values(info.modules),
-      info.fileFunctions[file],
+      info.fileFunctions?.[file],
     );
     expect(new Set([...names].filter((n) => !counted.has(n)))).toEqual(
       new Set(["Locator", "Quoting", "Registry", "Widget"]),

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -455,9 +455,6 @@ export function extractFromProgram(
   // files reach it through the container's own imports even though the entry
   // list already skipped them — filter here too or the de-overlap is a no-op.
   const excludePrefixes = excludeDirs.map((dir) => dir.replace(/\\/g, "/") + "/");
-  // `fileFunctions` / `fileConstants` are optional on `PackageInfo` because the
-  // Ruby extractor never emits them; this extractor always does, so pin them as
-  // present here rather than asserting non-null at each write below.
   const info: PackageInfo & Required<Pick<PackageInfo, "fileFunctions" | "fileConstants">> = {
     classes: {},
     modules: {},

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -455,7 +455,15 @@ export function extractFromProgram(
   // files reach it through the container's own imports even though the entry
   // list already skipped them — filter here too or the de-overlap is a no-op.
   const excludePrefixes = excludeDirs.map((dir) => dir.replace(/\\/g, "/") + "/");
-  const info: PackageInfo = { classes: {}, modules: {}, fileFunctions: {}, fileConstants: {} };
+  // `fileFunctions` / `fileConstants` are optional on `PackageInfo` because the
+  // Ruby extractor never emits them; this extractor always does, so pin them as
+  // present here rather than asserting non-null at each write below.
+  const info: PackageInfo & Required<Pick<PackageInfo, "fileFunctions" | "fileConstants">> = {
+    classes: {},
+    modules: {},
+    fileFunctions: {},
+    fileConstants: {},
+  };
   const pendingReExports: PendingReExport[] = [];
   const checker = program.getTypeChecker();
 
@@ -864,7 +872,7 @@ export function extractFromProgram(
     }
 
     const fileConstants = extractFileConstants(sourceFile);
-    if (Object.keys(fileConstants).length > 0) info.fileConstants![relPath] = fileConstants;
+    if (Object.keys(fileConstants).length > 0) info.fileConstants[relPath] = fileConstants;
 
     // If a file has exported functions but no class/interface/namespace,
     // also create a module entry from the file name for backward compat.

--- a/scripts/api-compare/typescript-internal.d.ts
+++ b/scripts/api-compare/typescript-internal.d.ts
@@ -1,16 +1,3 @@
-// `build-freshness.ts` asks a solution builder whether each referenced project
-// is up to date. `ts.UpToDateStatusType` and
-// `SolutionBuilder#getUpToDateStatusOfProject` are real, stable parts of
-// TypeScript's public runtime surface (`require("typescript").UpToDateStatusType`
-// is populated) but are marked `@internal` in the compiler sources, so the
-// shipped `typescript.d.ts` omits them. This augmentation declares the shape we
-// depend on rather than casting through `any` at each call site — an upgrade
-// that removes either member fails here, at one named place, instead of
-// silently degrading the staleness check.
-//
-// Members are declared without initializers on purpose: we consume the enum by
-// name and via its reverse map, never by numeric value, and pinning literals
-// here would encode ordering that is not ours to guarantee.
 declare module "typescript" {
   export enum UpToDateStatusType {
     Unbuildable,

--- a/scripts/api-compare/typescript-internal.d.ts
+++ b/scripts/api-compare/typescript-internal.d.ts
@@ -1,0 +1,41 @@
+// `build-freshness.ts` asks a solution builder whether each referenced project
+// is up to date. `ts.UpToDateStatusType` and
+// `SolutionBuilder#getUpToDateStatusOfProject` are real, stable parts of
+// TypeScript's public runtime surface (`require("typescript").UpToDateStatusType`
+// is populated) but are marked `@internal` in the compiler sources, so the
+// shipped `typescript.d.ts` omits them. This augmentation declares the shape we
+// depend on rather than casting through `any` at each call site — an upgrade
+// that removes either member fails here, at one named place, instead of
+// silently degrading the staleness check.
+//
+// Members are declared without initializers on purpose: we consume the enum by
+// name and via its reverse map, never by numeric value, and pinning literals
+// here would encode ordering that is not ours to guarantee.
+declare module "typescript" {
+  export enum UpToDateStatusType {
+    Unbuildable,
+    UpToDate,
+    UpToDateWithUpstreamTypes,
+    OutputMissing,
+    ErrorReadingFile,
+    OutOfDateWithSelf,
+    OutOfDateWithUpstream,
+    OutOfDateBuildInfoWithPendingEmit,
+    OutOfDateBuildInfoWithErrors,
+    OutOfDateOptions,
+    OutOfDateRoots,
+    UpstreamOutOfDate,
+    UpstreamBlocked,
+    ComputingUpstream,
+    TsVersionOutputOfDate,
+    UpToDateWithInputFileText,
+    ContainerOnly,
+    ForceBuild,
+  }
+
+  export interface SolutionBuilder<_T extends BuilderProgram> {
+    getUpToDateStatusOfProject(configFileName: string): { type: UpToDateStatusType };
+  }
+}
+
+export {};

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -37,7 +37,7 @@ export type UnportedFile = { reason: string } &
     // `className` narrows a per-test exclusion to one Ruby *Test class within
     // the file, so a GVL-only subclass can be dropped while a portable sibling
     // sharing a test name stays counted. Per-test entries never touch api:compare.
-    | { pattern?: never; testFile: string; className?: string; tests: string[] }
+    | { pattern?: never; testFile: string; className?: string; tests: string[]; package?: never }
   );
 
 export const UNPORTED_FILES: UnportedFile[] = [

--- a/scripts/deprecated-manifest-diff.test.ts
+++ b/scripts/deprecated-manifest-diff.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { diffDeprecatedManifest } from "./deprecated-manifest-diff.js";
+import type { DeprecatedManifest } from "./deprecated-manifest-diff.js";
 
-const expected = {
+const expected: DeprecatedManifest = {
   files: {
     "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
       "unsignedDecimal",

--- a/scripts/generate-standalone-associations-exclude.ts
+++ b/scripts/generate-standalone-associations-exclude.ts
@@ -50,7 +50,20 @@ function collectTsFiles(dir: string, out: string[]): void {
 }
 
 async function main(): Promise<void> {
-  const { parser } = await import("typescript-eslint");
+  // `typescript-eslint` re-exports the parser under ESLint's minimal
+  // `CompatibleParser` type, whose `parseForESLint` is declared with the text
+  // argument only. The underlying `@typescript-eslint/parser` takes parser
+  // options as a second argument, and we need them: parsed without
+  // `sourceType: "module"` every `import` in a package source is a syntax
+  // error and the whole file is skipped as unparseable.
+  const { parser } = (await import("typescript-eslint")) as unknown as {
+    parser: {
+      parseForESLint(
+        code: string,
+        options: { ecmaVersion: number; sourceType: string },
+      ): { ast: unknown };
+    };
+  };
   const parse = (code: string) =>
     parser.parseForESLint(code, { ecmaVersion: 2022, sourceType: "module" }).ast;
 

--- a/scripts/generate-standalone-associations-exclude.ts
+++ b/scripts/generate-standalone-associations-exclude.ts
@@ -50,12 +50,6 @@ function collectTsFiles(dir: string, out: string[]): void {
 }
 
 async function main(): Promise<void> {
-  // `typescript-eslint` re-exports the parser under ESLint's minimal
-  // `CompatibleParser` type, whose `parseForESLint` is declared with the text
-  // argument only. The underlying `@typescript-eslint/parser` takes parser
-  // options as a second argument, and we need them: parsed without
-  // `sourceType: "module"` every `import` in a package source is a syntax
-  // error and the whole file is skipped as unparseable.
   const { parser } = (await import("typescript-eslint")) as unknown as {
     parser: {
       parseForESLint(

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -105,9 +105,6 @@ async function main(): Promise<void> {
         }
         return {
           name: idx.name,
-          // An expression index reflects its columns as a single SQL string
-          // rather than a list (Rails' `IndexDefinition#columns` does the
-          // same); the dump shape is a list either way.
           columns: typeof idx.columns === "string" ? [idx.columns] : idx.columns,
           unique: idx.unique,
           where: idx.where ?? null,

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -105,7 +105,10 @@ async function main(): Promise<void> {
         }
         return {
           name: idx.name,
-          columns: idx.columns,
+          // An expression index reflects its columns as a single SQL string
+          // rather than a list (Rails' `IndexDefinition#columns` does the
+          // same); the dump shape is a list either way.
+          columns: typeof idx.columns === "string" ? [idx.columns] : idx.columns,
           unique: idx.unique,
           where: idx.where ?? null,
         };

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -670,7 +670,7 @@ describe("compareTranscriptions", () => {
 
   it("flags an allow-list entry the transcriptions have converged on", () => {
     const table = [...TRANSCRIPTION_DIVERGENCE_ALLOW_LIST.keys()][0];
-    const converged = { [table]: { name: "string" } };
+    const converged: Schema = { [table]: { name: "string" } };
     expect(staleDivergenceAllowances(converged, converged)).toContain(table);
     // Still divergent (registry-only) — the allowance is doing its job.
     expect(staleDivergenceAllowances({}, converged)).not.toContain(table);

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -108,7 +108,7 @@ import {
   readRfcPriority,
   rfcPriorityFlag,
   rfcPriorityMap,
-} from "./cli.ts";
+} from "./cli.js";
 
 function story(over: Partial<StoryEntry>): StoryEntry {
   return {
@@ -2795,7 +2795,7 @@ describe("newStory cluster validation", () => {
     const dir = mkdtempSync(join(tmpdir(), "tasks-test-"));
     makeRfcDir(dir, "0005-gaps", ["scaffold", "conversion"]);
     expect(() => newStory("0005-gaps", "my-story", { cluster: "tooling" }, dir)).toThrow(/exit 1/);
-    const msg = (console.error as ReturnType<typeof vi.spyOn>).mock.calls[0]?.[0] as string;
+    const msg = vi.mocked(console.error).mock.calls[0]?.[0] as string;
     expect(msg).toMatch(/tooling/);
     expect(msg).toMatch(/scaffold/);
     expect(msg).toMatch(/conversion/);
@@ -2813,7 +2813,7 @@ describe("newStory cluster validation", () => {
       `---\nrfc: "0005-gaps"\ntitle: "test"\nstatus: active\nclusters: [scaffold, conversion]\n---\n`,
     );
     expect(() => newStory("0005-gaps", "my-story", { cluster: "tooling" }, dir)).toThrow(/exit 1/);
-    const msg = (console.error as ReturnType<typeof vi.spyOn>).mock.calls[0]?.[0] as string;
+    const msg = vi.mocked(console.error).mock.calls[0]?.[0] as string;
     expect(msg).toMatch(/scaffold/);
     expect(msg).toMatch(/conversion/);
   });

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -159,7 +159,7 @@ export function normalizeRailsKind(name: string): CanonicalKind | null {
 export function normalizeTrailsKind(token: string): CanonicalKind | null {
   const neg = token.startsWith("not:");
   const bare = neg ? token.slice("not:".length) : token;
-  let kind = TRAILS_MAP[bare] ?? null;
+  let kind: CanonicalKind | null = TRAILS_MAP[bare] ?? null;
   // A helper callee that mirrors a Rails assertion name (refuteEqual, mustEqual,
   // assertNoQueries, …) — snake-case it and reuse the Rails normalizer.
   if (!kind && /^(assert|refute|must|wont|expect)/.test(bare)) {

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -70,7 +70,7 @@ function main() {
 
   for (const [pkg, files] of Object.entries(packageTestFiles)) {
     const absoluteFiles = files.map((f) => path.join(ROOT_DIR, f));
-    manifest.packages[pkg] = extractPackageTests(pkg, absoluteFiles);
+    manifest.packages[pkg] = extractPackageTests(absoluteFiles);
   }
 
   // Print summary
@@ -90,9 +90,8 @@ function main() {
   console.log(`\nWritten to ${outputPath}`);
 }
 
-function extractPackageTests(pkgName: string, files: string[]): TestPackageInfo {
+function extractPackageTests(files: string[]): TestPackageInfo {
   const pkgInfo: TestPackageInfo = {
-    name: pkgName,
     files: [],
     totalTests: 0,
   };

--- a/scripts/test-deps/build-fixture-baseline.ts
+++ b/scripts/test-deps/build-fixture-baseline.ts
@@ -25,13 +25,6 @@ const DEPS_PATH = path.join(ROOT, "scripts/test-deps/output/activerecord-test-de
 const OUT_PATH = path.join(ROOT, "eslint/expected-fixtures-exclude.json");
 const AR_SRC = path.join(ROOT, "packages/activerecord/src");
 
-/**
- * `typescript-eslint` re-exports the parser under ESLint's minimal
- * `CompatibleParser` type, whose `parseForESLint` is declared with the text
- * argument only. The underlying `@typescript-eslint/parser` takes parser
- * options as a second argument, and `collectUseFixturesKeys` needs the
- * `loc`/`range` data they turn on.
- */
 const parseForESLint = parser.parseForESLint as unknown as (
   code: string,
   options: { loc: boolean; range: boolean },

--- a/scripts/test-deps/build-fixture-baseline.ts
+++ b/scripts/test-deps/build-fixture-baseline.ts
@@ -25,6 +25,18 @@ const DEPS_PATH = path.join(ROOT, "scripts/test-deps/output/activerecord-test-de
 const OUT_PATH = path.join(ROOT, "eslint/expected-fixtures-exclude.json");
 const AR_SRC = path.join(ROOT, "packages/activerecord/src");
 
+/**
+ * `typescript-eslint` re-exports the parser under ESLint's minimal
+ * `CompatibleParser` type, whose `parseForESLint` is declared with the text
+ * argument only. The underlying `@typescript-eslint/parser` takes parser
+ * options as a second argument, and `collectUseFixturesKeys` needs the
+ * `loc`/`range` data they turn on.
+ */
+const parseForESLint = parser.parseForESLint as unknown as (
+  code: string,
+  options: { loc: boolean; range: boolean },
+) => { ast: unknown };
+
 async function main(): Promise<void> {
   // Dynamic import avoids the CJS-style top-level / static-`.mjs`-import
   // interop fragility that tsx exposes under module: Node16.
@@ -56,7 +68,7 @@ async function main(): Promise<void> {
     let foundCall = false;
     let keys = new Set<string>();
     try {
-      const ast = parser.parseForESLint(src, { loc: true, range: true }).ast;
+      const ast = parseForESLint(src, { loc: true, range: true }).ast;
       const r = collectUseFixturesKeys(ast);
       foundCall = r.found;
       keys = r.keys;


### PR DESCRIPTION
Clears every **file-local** type error in the `scripts/tsconfig.json` program
added by #5713: **323 → 284**.

Reproduce with `npx tsc --build tsconfig.json && npx tsc -p scripts/tsconfig.json`.
The `--build` first matters: without it ~60 diagnostics are TS6305
"output file has not been built from source", which are stale-`dist` artifacts
rather than real errors. (`tsc -p` on this project is also incrementally cached —
a stale cache can keep reporting errors a fix already cleared, which is worth
knowing before you chase one.)

## What's fixed (39 errors)

| file | was |
| --- | --- |
| `api-compare/build-freshness.ts` | 13 — `ts.UpToDateStatusType` / `getUpToDateStatusOfProject` |
| `api-compare/extract-ts-api{,.test}.ts` | 9 — `info.fileFunctions` possibly undefined |
| `tasks/cli.test.ts` | 3 — `.ts` import specifier, `vi.spyOn` cast |
| `test-deps/build-fixture-baseline.ts` | 3 — untyped `.mjs` import, `parseForESLint` arity |
| `api-compare/extra-surface.test.ts` | 2 — inferred literal missing `ApiManifest` fields |
| `schema-compare/compare.test.ts` | 2 — `ColumnSpec` literal widening |
| `api-compare/{arity,unported-files}.test.ts`, `deprecated-manifest-diff.test.ts`, `generate-standalone-associations-exclude.ts`, `parity/schema/node/dump.ts`, `test-compare/{assertion-kinds,extract-ts-tests}.ts` | 7 |

Two of these were real latent bugs, not just annotations:

- `parity/schema/node/dump.ts` passed an index's `columns` through unchanged,
  but an expression index reflects them as a single SQL **string**, not a list
  (`IndexDefinition#columns` is the same in Rails). `canonicalize.ts` then read
  `.length` off that string as a column count and handed the bare string on as
  a column tuple. Now normalized to a one-element list.
- `test-compare/assertion-kinds.ts` inferred `kind` as non-nullable, so the
  `?? null` guarding an unmapped token was dead at the type level and
  `normalizeRailsKind`'s `null` return could escape as a `CanonicalKind`.

## The two hand-written declaration files

Both describe code the compiler cannot check them against, so both come with a
drift test rather than a comment promising someone will keep them in step.

**`scripts/api-compare/typescript-internal.d.ts`.** `build-freshness.ts` needs
`ts.UpToDateStatusType` and `SolutionBuilder#getUpToDateStatusOfProject`. Both
are populated at runtime but marked `@internal` in the compiler sources, so the
shipped `typescript.d.ts` omits them. Declaring the shape as a module
augmentation beats casting through `any` at each site: the dependency is one
named file. Two details worth knowing while reading it:

- Enum members carry no initializers on purpose. We use the enum by name and
  via its reverse map, never by numeric value, and pinning literals would
  encode an ordering that is not ours to guarantee.
- The interface's type parameter is spelled `_T` rather than `T` because it is
  unused in the member being added and `unused-imports/no-unused-vars` rejects
  the bare name. The augmentation still merges — the tests below exercise the
  merged member.

`build-freshness.test.ts` now parses the declared member names out of the file
and compares them to `Object.values(ts.UpToDateStatusType)`, and asserts a real
solution builder still implements `getUpToDateStatusOfProject`. A TypeScript
upgrade that adds, drops, or renames a status fails there.

**`eslint/expected-fixtures.d.mts`** does the same job for the `.mjs` rule
module that `build-fixture-baseline.ts` imports (it is authored as `.mjs` so
ESLint's flat config loads it without a build step). `expected-fixtures.test.mjs`
asserts the declared export names are exactly the module's own.

## What's left (284) — registered, not papered over

Split into `0064/scripts-tsconfig-ar-declare-model-type-errors` with the
diagnosis written out. Two buckets, and they do **not** share a root cause the
way the original story assumed:

- **262 in `sync-stats/sync.ts`** — 3 × TS2307 (`@blazetrails/activerecord`
  does not resolve at all from `scripts/sync-stats/`), then 227 AR model statics
  missing on `typeof PullRequest` because the tse-compiler materializes them and
  plain `tsc` does not.
- **22 in `parity/fixtures/*/query.ts`** — Arel call-site signature gaps, e.g.
  `Model.where(<Arel node>)` matches none of `where`'s four overloads. The
  fixtures mirror their Ruby twins, so the fix belongs in the AR/Arel types.

Referencing `scripts/tsconfig.json` from the root `tsconfig.json` (so
`pnpm typecheck` holds the line) waits for that story — it would fail
`pnpm typecheck` today.

## Not covered

The `dump.ts` expression-index normalization has no unit test: `dump.ts` runs
`main()` at import time and needs a live SQLite handle, so testing it means
making the script importable. That refactor did not belong in a typecheck
cleanup.

Closes-story: scripts-tsconfig-program-has-384-type-errors
