### PR TITLE
test(activerecord): converge database-tasks dump-filename configs onto Rails' names

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -214,15 +214,12 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
     expect(DatabaseTasks.dumpSchemaFilename()).toBe("alt_schema.rb");
   });
   it("cache dump filename with path from db config", () => {
-    const config = new HashConfig("test", "animals", {
-      adapter: "sqlite3",
-      database: "animals.db",
-    });
-    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/animals_schema.ts");
+    const config = new HashConfig("development", "alternate", { adapter: "abstract" });
+    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/alternate_schema.ts");
   });
   it("cache dump filename with path from the argument has precedence", () => {
     process.env.SCHEMA = "override.rb";
-    const config = new HashConfig("test", "animals", { adapter: "sqlite3" });
+    const config = new HashConfig("development", "primary", { adapter: "abstract" });
     expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("override.rb");
   });
 });
@@ -1312,13 +1309,16 @@ describe("DatabaseTasksCheckSchemaFileMethods", () => {
   });
 
   it("check dump filename defaults for non primary databases", () => {
-    const config = new HashConfig("test", "animals", { adapter: "sqlite3" });
-    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/animals_schema.ts");
+    const config = new HashConfig("development", "secondary", {
+      adapter: "abstract",
+      database: "secondary-dev-db",
+    });
+    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/secondary_schema.ts");
   });
 
   it("setting schema dump to nil", () => {
     const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
+      adapter: "abstract",
       database: "dev-db",
       schemaDump: false,
     });
@@ -1327,7 +1327,10 @@ describe("DatabaseTasksCheckSchemaFileMethods", () => {
 
   it("check dump filename with schema env with non primary databases", () => {
     process.env.SCHEMA = "override.rb";
-    const config = new HashConfig("test", "animals", { adapter: "sqlite3" });
+    const config = new HashConfig("development", "secondary", {
+      adapter: "abstract",
+      database: "secondary-dev-db",
+    });
     expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("override.rb");
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -214,12 +214,12 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
     expect(DatabaseTasks.dumpSchemaFilename()).toBe("alt_schema.rb");
   });
   it("cache dump filename with path from db config", () => {
-    const config = new HashConfig("development", "alternate", { adapter: "abstract" });
+    const config = new HashConfig("development", "alternate", {});
     expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/alternate_schema.ts");
   });
   it("cache dump filename with path from the argument has precedence", () => {
     process.env.SCHEMA = "override.rb";
-    const config = new HashConfig("development", "primary", { adapter: "abstract" });
+    const config = new HashConfig("development", "primary", {});
     expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("override.rb");
   });
 });


### PR DESCRIPTION
Converges the dump-filename / schema-dump-path `HashConfig`s in
`database-tasks.test.ts` onto Rails' names and the non-connecting `abstract`
adapter, finishing what #5716 left out of scope. This is a **config-argument**
change only — no production method call in these tests is altered.

- `DatabaseTasksDumpSchemaCacheTest`: the `animals` + `sqlite3` + `animals.db`
  configs become `HashConfig("development", "alternate", {})` and
  `HashConfig("development", "primary", {})`. The `HashConfig` **shape** mirrors
  `database_tasks_test.rb:333,352` (env `development`, names `alternate` /
  `primary`, empty options hash); the assertions themselves are unchanged from
  `main` and still call `dumpSchemaFilename`, so this PR does not claim
  behavioral fidelity to those Rails tests — see the follow-up note below.
- `DatabaseTasksCheckSchemaFileMethods`: the non-primary configs use Rails'
  `secondary` / `secondary-dev-db` / `abstract`
  (`database_tasks_test.rb:1726-1735,1751-1762`) rather than the story's
  suggested `alternate` — that describe's Rails counterpart names its
  non-primary database `secondary`. Expected path: `db/secondary_schema.ts`.
  `setting schema dump to nil` also drops `sqlite3` for `abstract`
  (`database_tasks_test.rb:1738-1747`).

None of these configs ever connect, so no adapter resolution is involved.

### Known gap, registered as a follow-up

All five tests in `DatabaseTasksDumpSchemaCacheTest` call `dumpSchemaFilename`
(`database-tasks.ts:514`) where Rails calls `cache_dump_filename`
(`database_tasks_test.rb:315-359`); `cacheDumpFilename`
(`database-tasks.ts:650`) is never exercised in this file. That predates this
PR — every one of those call sites is unchanged from `origin/main` — and
fixing it means rewriting the assertions onto `schema_cache.yml` paths and the
explicit second-argument precedence call, which is outside this story's scope.
Registered as RFC 0064 story
`converge-dump-schema-cache-tests-onto-cache-dump-filename` with the full Rails
line citations.

Test names unchanged; `test:compare` for `tasks/database_tasks_test.rb` stays
77/77, and a run of the file leaves `git status` clean.

Closes-story: converge-database-tasks-dump-filename-configs-onto-rails-names
