### PR TITLE
chore(api-compare): audit the wide-ratchet cross-file / mixin-attribution bucket

### DIFF
--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entity, Mismatch } from "./audit-cross-file-calls.js";
+import {
+  buildPackageIndex,
+  candidateNames,
+  classifyRow,
+  includeGraphFiles,
+  isCrossFile,
+} from "./audit-cross-file-calls.js";
+
+function entity(
+  name: string,
+  file: string,
+  methods: { name: string; calls?: string[] }[],
+  edges: { includes?: string[]; extends?: string[] } = {},
+): Entity {
+  return {
+    name,
+    file,
+    includes: edges.includes ?? [],
+    extends: edges.extends ?? [],
+    instanceMethods: methods,
+    classMethods: [],
+  };
+}
+
+function mismatch(tsFile: string, tsName: string, rubyFile = "adapter.rb"): Mismatch {
+  return { package: "activerecord", tsFile, tsName, rubyFile, rubyName: tsName, missing: [] };
+}
+
+describe("candidateNames", () => {
+  it("reads every TS candidate off a missing-call row", () => {
+    expect(candidateNames("any? → isAny|any")).toEqual(["isAny", "any"]);
+  });
+});
+
+describe("includeGraphFiles", () => {
+  it("walks includes and extends transitively", () => {
+    const index = buildPackageIndex([
+      entity("Adapter", "adapter.ts", [], { includes: ["Quoting"] }),
+      entity("Quoting", "quoting.ts", [], { extends: ["Base"] }),
+      entity("Base", "base.ts", []),
+    ]);
+    expect([...includeGraphFiles("adapter.ts", index)].sort()).toEqual(["base.ts", "quoting.ts"]);
+  });
+
+  it("does not reach a collaborator that no recorded edge names", () => {
+    const index = buildPackageIndex([
+      entity("Adapter", "pg-adapter.ts", []),
+      entity("PgSchemaStatements", "pg/schema-statements-class.ts", []),
+    ]);
+    expect(includeGraphFiles("pg-adapter.ts", index).size).toBe(0);
+  });
+});
+
+describe("classifyRow", () => {
+  const index = buildPackageIndex([
+    entity("Adapter", "adapter.ts", [{ name: "indexes", calls: ["pg"] }], {
+      includes: ["Quoting"],
+    }),
+    entity("Quoting", "quoting.ts", [{ name: "indexes", calls: ["quotedScope"] }]),
+    entity("Other", "other.ts", [{ name: "indexes", calls: ["schemaQuery"] }]),
+    entity("Shell", "shell.ts", [{ name: "onlyHere" }]),
+  ]);
+
+  it("resolves through the recorded include graph", () => {
+    expect(
+      classifyRow(mismatch("adapter.ts", "indexes"), "quoted_scope → quotedScope", index),
+    ).toEqual({ bucket: "include-graph", resolvedIn: "quoting.ts" });
+  });
+
+  it("marks a same-named body no edge reaches as a collaborator", () => {
+    expect(
+      classifyRow(mismatch("adapter.ts", "indexes"), "schema_query → schemaQuery", index),
+    ).toEqual({ bucket: "collaborator", resolvedIn: "other.ts" });
+  });
+
+  it("keeps a call no definition makes as a real divergence", () => {
+    expect(
+      classifyRow(mismatch("adapter.ts", "indexes"), "presence → presence", index).bucket,
+    ).toBe("divergence");
+  });
+
+  it("reports a sole definition with no call-set as unported", () => {
+    expect(classifyRow(mismatch("shell.ts", "onlyHere"), "presence → presence", index).bucket).toBe(
+      "unported",
+    );
+  });
+});
+
+describe("isCrossFile", () => {
+  const row = {
+    package: "activerecord",
+    tsName: "indexes",
+    call: "",
+    bucket: "divergence" as const,
+  };
+
+  it("flags a Ruby file name-matched against a different TS file", () => {
+    expect(
+      isCrossFile({
+        ...row,
+        tsFile: "connection-adapters/postgresql-adapter.ts",
+        rubyFile: "connection_adapters/postgresql/schema_statements.rb",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag a same-stem pair across the naming conventions", () => {
+    expect(
+      isCrossFile({
+        ...row,
+        tsFile: "connection-adapters/postgresql-adapter.ts",
+        rubyFile: "connection_adapters/postgresql_adapter.rb",
+      }),
+    ).toBe(false);
+  });
+});

--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -86,6 +86,26 @@ describe("classifyRow", () => {
     ).toBe("divergence");
   });
 
+  it("resolves a body ported as a mixed-in file function", () => {
+    const withFunctions = buildPackageIndex(
+      [entity("Model", "model.ts", [{ name: "aliasAttribute", calls: [] }])],
+      { "attribute-methods.ts": [{ name: "aliasAttribute", calls: ["attributeAliases"] }] },
+    );
+    expect(
+      classifyRow(
+        mismatch("model.ts", "aliasAttribute"),
+        "attribute_aliases → attributeAliases",
+        withFunctions,
+      ),
+    ).toEqual({ bucket: "collaborator", resolvedIn: "attribute-methods.ts" });
+  });
+
+  it("does not call a row unported when the name is defined outside the paired file", () => {
+    expect(
+      classifyRow(mismatch("quoting.ts", "indexes"), "presence → presence", index).bucket,
+    ).toBe("divergence");
+  });
+
   it("reports a sole definition with no call-set as unported", () => {
     expect(classifyRow(mismatch("shell.ts", "onlyHere"), "presence → presence", index).bucket).toBe(
       "unported",

--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -31,7 +31,11 @@ function mismatch(tsFile: string, tsName: string, rubyFile = "adapter.rb"): Mism
 
 describe("candidateNames", () => {
   it("reads every TS candidate off a missing-call row", () => {
-    expect(candidateNames("any? → isAny|any")).toEqual(["isAny", "any"]);
+    expect(candidateNames("quoted_scope → quotedScope")).toEqual(["quotedScope"]);
+  });
+
+  it("admits the JS-native alias the gate itself accepts", () => {
+    expect(candidateNames("any? → isAny|any")).toEqual(["isAny", "any", "some"]);
   });
 });
 

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -1,30 +1,8 @@
-/**
- * One-off audit for RFC 0083 story `audit-wide-cross-file-mixin-attribution`.
- *
- * Classifies every (row, call) pair in output/call-mismatches-wide.json by
- * WHERE — if anywhere — the Rails call the paired TS body omits is actually
- * made in the port, so `resolve-wide-candidates-through-include-graph` can
- * widen candidate resolution without suppressing real fidelity gaps.
- *
- * Buckets (see rfcs/0083-.../cross-file-audit.md in the tasks repo):
- *   include-graph   the same-named TS method on a class reachable from the
- *                   paired class through the RECORDED includes/extends graph
- *                   makes the call — resolvable, and the only safe widening;
- *   collaborator    a same-named method elsewhere in the package makes the
- *                   call, but no include/extends edge reaches it (the trails
- *                   `this.pgSchemaStatements()` delegation shape);
- *   divergence      the call is made by no definition of that name anywhere in
- *                   the package — a real gap the gate must keep flagging;
- *   unported        the paired body is the only definition and has no call-set
- *                   at all (nothing was ported to compare against).
- *
- * Reproduce:  pnpm api:compare --wide-calls && pnpm tsx
- *             scripts/api-compare/audit-cross-file-calls.ts
- */
 import { promises as fs } from "fs";
 import * as path from "path";
 
 import { OUTPUT_DIR } from "./config.js";
+import { jsEnumerableAliases } from "./enumerable-idioms.js";
 
 export type Method = { name: string; file?: string; calls?: string[] };
 export type Entity = {
@@ -56,19 +34,14 @@ export type Row = {
   rubyFile: string;
   call: string;
   bucket: Bucket;
-  /** File whose same-named body makes the call, for the resolvable buckets. */
   resolvedIn?: string;
 };
 
-/** Definitions of one TS method name across a package, with their call-sets. */
 type Definition = { entity: string; file: string; calls: Set<string> };
 
 export type PackageIndex = {
-  /** Every entity declared in a file, by file path. */
   entitiesByFile: Map<string, Entity[]>;
-  /** Entities by bare declaration name — how `includes`/`extends` spell them. */
   entitiesByName: Map<string, Entity[]>;
-  /** Every definition of a method name, anywhere in the package. */
   definitionsByName: Map<string, Definition[]>;
 };
 
@@ -98,12 +71,6 @@ function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   else map.set(key, [value]);
 }
 
-/**
- * Files reachable from the entities declared in `tsFile` by walking ONLY the
- * recorded `includes`/`extends` names, transitively. Names that resolve to no
- * entity in the package (a cross-package mixin, an inline object literal) drop
- * out — this walk never falls back to filename or directory proximity.
- */
 export function includeGraphFiles(tsFile: string, index: PackageIndex): Set<string> {
   const files = new Set<string>();
   const seen = new Set<string>();
@@ -140,15 +107,15 @@ export function classifyRow(
   return { bucket: "collaborator", resolvedIn: makesCall[0].file };
 }
 
-/** `belongs_to → belongsTo|belongsToMany` → the TS candidate names. */
 export function candidateNames(call: string): string[] {
   const arrow = call.indexOf("→");
   if (arrow < 0) return [];
-  return call
+  const mapped = call
     .slice(arrow + 1)
     .split("|")
     .map((c) => c.trim())
     .filter((c) => c.length > 0);
+  return [...new Set([...mapped, ...jsEnumerableAliases(call.slice(0, arrow).trim())])];
 }
 
 export function classify(mismatches: Mismatch[], indexes: Map<string, PackageIndex>): Row[] {
@@ -172,12 +139,6 @@ export function classify(mismatches: Mismatch[], indexes: Map<string, PackageInd
   return rows;
 }
 
-/**
- * A row is CROSS-FILE (the RFC 0083 mixin-attribution split) when the Ruby file
- * the method was extracted from does not correspond to the TS file it was
- * name-matched against — `postgresql/schema_statements.rb` charged against
- * `postgresql-adapter.ts`. Same-stem pairs are ordinary same-file rows.
- */
 export function isCrossFile(row: Row): boolean {
   return tsStem(row.tsFile) !== rubyStem(row.rubyFile);
 }
@@ -190,12 +151,6 @@ function tsStem(tsFile: string): string {
   return tsFile.replace(/\.ts$/, "");
 }
 
-/**
- * Rows a maximally permissive include-graph rule would silence: the candidate
- * is called by ANY method on ANY class reachable through includes/extends,
- * regardless of name. Measured to bound the sibling story's ceiling; NOT a
- * recommendation — see the report's resolution rule.
- */
 function countAnyMethodInGraph(rows: Row[], indexes: Map<string, PackageIndex>): number {
   const callsByFile = new Map<string, Map<string, Set<string>>>();
   for (const [pkg, index] of indexes) {
@@ -254,20 +209,13 @@ async function main(): Promise<void> {
   const report = {
     totalRows: rows.length,
     crossFileRows: crossFile.length,
-    /** Widest rule the sibling story could implement — see the report. */
     anyMethodInIncludeGraph: countAnyMethodInGraph(rows, indexes),
     resolvableAnywhereByName: resolvable.length,
-    /**
-     * Resolvable rows whose paired body forwards to its own name (the
-     * `isDelegatingWrapper` shape) but is larger than DELEGATION_MAX_CALLS —
-     * the population a threshold raise, rather than a graph walk, would reach.
-     */
     resolvableWrapperShaped: resolvable.filter((r) =>
       (indexes.get(r.package)!.definitionsByName.get(r.tsName) ?? [])
         .filter((d) => d.file === r.tsFile)
         .some((d) => d.calls.has(r.tsName) && d.calls.size > 3),
     ).length,
-    /** Rows whose paired TS file declares no includes/extends edge at all. */
     rowsWithNoGraphEdge: rows.filter(
       (r) => includeGraphFiles(r.tsFile, indexes.get(r.package)!).size === 0,
     ).length,

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -1,0 +1,299 @@
+/**
+ * One-off audit for RFC 0083 story `audit-wide-cross-file-mixin-attribution`.
+ *
+ * Classifies every (row, call) pair in output/call-mismatches-wide.json by
+ * WHERE — if anywhere — the Rails call the paired TS body omits is actually
+ * made in the port, so `resolve-wide-candidates-through-include-graph` can
+ * widen candidate resolution without suppressing real fidelity gaps.
+ *
+ * Buckets (see rfcs/0083-.../cross-file-audit.md in the tasks repo):
+ *   include-graph   the same-named TS method on a class reachable from the
+ *                   paired class through the RECORDED includes/extends graph
+ *                   makes the call — resolvable, and the only safe widening;
+ *   collaborator    a same-named method elsewhere in the package makes the
+ *                   call, but no include/extends edge reaches it (the trails
+ *                   `this.pgSchemaStatements()` delegation shape);
+ *   divergence      the call is made by no definition of that name anywhere in
+ *                   the package — a real gap the gate must keep flagging;
+ *   unported        the paired body is the only definition and has no call-set
+ *                   at all (nothing was ported to compare against).
+ *
+ * Reproduce:  pnpm api:compare --wide-calls && pnpm tsx
+ *             scripts/api-compare/audit-cross-file-calls.ts
+ */
+import { promises as fs } from "fs";
+import * as path from "path";
+
+import { OUTPUT_DIR } from "./config.js";
+
+export type Method = { name: string; file?: string; calls?: string[] };
+export type Entity = {
+  name: string;
+  file: string;
+  includes: string[];
+  extends: string[];
+  instanceMethods: Method[];
+  classMethods: Method[];
+};
+type TsApi = {
+  packages: Record<string, { classes: Record<string, Entity>; modules: Record<string, Entity> }>;
+};
+export type Mismatch = {
+  package: string;
+  tsFile: string;
+  tsName: string;
+  rubyFile: string;
+  rubyName: string;
+  missing: string[];
+};
+
+export type Bucket = "include-graph" | "collaborator" | "divergence" | "unported";
+
+export type Row = {
+  package: string;
+  tsFile: string;
+  tsName: string;
+  rubyFile: string;
+  call: string;
+  bucket: Bucket;
+  /** File whose same-named body makes the call, for the resolvable buckets. */
+  resolvedIn?: string;
+};
+
+/** Definitions of one TS method name across a package, with their call-sets. */
+type Definition = { entity: string; file: string; calls: Set<string> };
+
+export type PackageIndex = {
+  /** Every entity declared in a file, by file path. */
+  entitiesByFile: Map<string, Entity[]>;
+  /** Entities by bare declaration name — how `includes`/`extends` spell them. */
+  entitiesByName: Map<string, Entity[]>;
+  /** Every definition of a method name, anywhere in the package. */
+  definitionsByName: Map<string, Definition[]>;
+};
+
+export function buildPackageIndex(entities: Entity[]): PackageIndex {
+  const index: PackageIndex = {
+    entitiesByFile: new Map(),
+    entitiesByName: new Map(),
+    definitionsByName: new Map(),
+  };
+  for (const entity of entities) {
+    push(index.entitiesByFile, entity.file, entity);
+    push(index.entitiesByName, entity.name, entity);
+    for (const method of [...entity.instanceMethods, ...entity.classMethods]) {
+      push(index.definitionsByName, method.name, {
+        entity: entity.name,
+        file: method.file ?? entity.file,
+        calls: new Set(method.calls ?? []),
+      });
+    }
+  }
+  return index;
+}
+
+function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const existing = map.get(key);
+  if (existing) existing.push(value);
+  else map.set(key, [value]);
+}
+
+/**
+ * Files reachable from the entities declared in `tsFile` by walking ONLY the
+ * recorded `includes`/`extends` names, transitively. Names that resolve to no
+ * entity in the package (a cross-package mixin, an inline object literal) drop
+ * out — this walk never falls back to filename or directory proximity.
+ */
+export function includeGraphFiles(tsFile: string, index: PackageIndex): Set<string> {
+  const files = new Set<string>();
+  const seen = new Set<string>();
+  const queue = [...(index.entitiesByFile.get(tsFile) ?? [])];
+  while (queue.length > 0) {
+    const entity = queue.pop()!;
+    for (const name of [...entity.includes, ...entity.extends]) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      for (const target of index.entitiesByName.get(name) ?? []) {
+        files.add(target.file);
+        queue.push(target);
+      }
+    }
+  }
+  return files;
+}
+
+export function classifyRow(
+  mismatch: Mismatch,
+  call: string,
+  index: PackageIndex,
+): { bucket: Bucket; resolvedIn?: string } {
+  const candidates = candidateNames(call);
+  const definitions = index.definitionsByName.get(mismatch.tsName) ?? [];
+  const makesCall = definitions.filter((d) => candidates.some((c) => d.calls.has(c)));
+  if (makesCall.length === 0) {
+    const ownIsEmpty = definitions.every((d) => d.file !== mismatch.tsFile || d.calls.size === 0);
+    return { bucket: definitions.length <= 1 && ownIsEmpty ? "unported" : "divergence" };
+  }
+  const reachable = includeGraphFiles(mismatch.tsFile, index);
+  const viaGraph = makesCall.find((d) => reachable.has(d.file));
+  if (viaGraph) return { bucket: "include-graph", resolvedIn: viaGraph.file };
+  return { bucket: "collaborator", resolvedIn: makesCall[0].file };
+}
+
+/** `belongs_to → belongsTo|belongsToMany` → the TS candidate names. */
+export function candidateNames(call: string): string[] {
+  const arrow = call.indexOf("→");
+  if (arrow < 0) return [];
+  return call
+    .slice(arrow + 1)
+    .split("|")
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0);
+}
+
+export function classify(mismatches: Mismatch[], indexes: Map<string, PackageIndex>): Row[] {
+  const rows: Row[] = [];
+  for (const mismatch of mismatches) {
+    const index = indexes.get(mismatch.package);
+    if (!index) continue;
+    for (const call of mismatch.missing) {
+      const { bucket, resolvedIn } = classifyRow(mismatch, call, index);
+      rows.push({
+        package: mismatch.package,
+        tsFile: mismatch.tsFile,
+        tsName: mismatch.tsName,
+        rubyFile: mismatch.rubyFile,
+        call,
+        bucket,
+        resolvedIn,
+      });
+    }
+  }
+  return rows;
+}
+
+/**
+ * A row is CROSS-FILE (the RFC 0083 mixin-attribution split) when the Ruby file
+ * the method was extracted from does not correspond to the TS file it was
+ * name-matched against — `postgresql/schema_statements.rb` charged against
+ * `postgresql-adapter.ts`. Same-stem pairs are ordinary same-file rows.
+ */
+export function isCrossFile(row: Row): boolean {
+  return tsStem(row.tsFile) !== rubyStem(row.rubyFile);
+}
+
+function rubyStem(rubyFile: string): string {
+  return rubyFile.replace(/\.rb$/, "").replace(/_/g, "-");
+}
+
+function tsStem(tsFile: string): string {
+  return tsFile.replace(/\.ts$/, "");
+}
+
+/**
+ * Rows a maximally permissive include-graph rule would silence: the candidate
+ * is called by ANY method on ANY class reachable through includes/extends,
+ * regardless of name. Measured to bound the sibling story's ceiling; NOT a
+ * recommendation — see the report's resolution rule.
+ */
+function countAnyMethodInGraph(rows: Row[], indexes: Map<string, PackageIndex>): number {
+  const callsByFile = new Map<string, Map<string, Set<string>>>();
+  for (const [pkg, index] of indexes) {
+    const perFile = new Map<string, Set<string>>();
+    for (const definitions of index.definitionsByName.values()) {
+      for (const definition of definitions) {
+        let set = perFile.get(definition.file);
+        if (!set) perFile.set(definition.file, (set = new Set()));
+        for (const call of definition.calls) set.add(call);
+      }
+    }
+    callsByFile.set(pkg, perFile);
+  }
+  let count = 0;
+  for (const row of rows) {
+    if (row.bucket !== "divergence" && row.bucket !== "unported") continue;
+    const index = indexes.get(row.package);
+    if (!index) continue;
+    const candidates = candidateNames(row.call);
+    const perFile = callsByFile.get(row.package)!;
+    for (const file of includeGraphFiles(row.tsFile, index)) {
+      const calls = perFile.get(file);
+      if (calls && candidates.some((c) => calls.has(c))) {
+        count++;
+        break;
+      }
+    }
+  }
+  return count;
+}
+
+function tally<T>(values: T[], key: (value: T) => string): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(key(value), (counts.get(key(value)) ?? 0) + 1);
+  return [...counts].sort((a, b) => b[1] - a[1]);
+}
+
+async function main(): Promise<void> {
+  const api = JSON.parse(await fs.readFile(path.join(OUTPUT_DIR, "ts-api.json"), "utf8")) as TsApi;
+  const artifact = JSON.parse(
+    await fs.readFile(path.join(OUTPUT_DIR, "call-mismatches-wide.json"), "utf8"),
+  ) as { mismatches: Mismatch[] };
+
+  const indexes = new Map<string, PackageIndex>();
+  for (const [pkg, entry] of Object.entries(api.packages)) {
+    indexes.set(
+      pkg,
+      buildPackageIndex([...Object.values(entry.classes), ...Object.values(entry.modules)]),
+    );
+  }
+
+  const rows = classify(artifact.mismatches, indexes);
+  const crossFile = rows.filter((r) => isCrossFile(r));
+  const resolvable = rows.filter((r) => r.bucket !== "divergence" && r.bucket !== "unported");
+
+  const report = {
+    totalRows: rows.length,
+    crossFileRows: crossFile.length,
+    /** Widest rule the sibling story could implement — see the report. */
+    anyMethodInIncludeGraph: countAnyMethodInGraph(rows, indexes),
+    resolvableAnywhereByName: resolvable.length,
+    /**
+     * Resolvable rows whose paired body forwards to its own name (the
+     * `isDelegatingWrapper` shape) but is larger than DELEGATION_MAX_CALLS —
+     * the population a threshold raise, rather than a graph walk, would reach.
+     */
+    resolvableWrapperShaped: resolvable.filter((r) =>
+      (indexes.get(r.package)!.definitionsByName.get(r.tsName) ?? [])
+        .filter((d) => d.file === r.tsFile)
+        .some((d) => d.calls.has(r.tsName) && d.calls.size > 3),
+    ).length,
+    /** Rows whose paired TS file declares no includes/extends edge at all. */
+    rowsWithNoGraphEdge: rows.filter(
+      (r) => includeGraphFiles(r.tsFile, indexes.get(r.package)!).size === 0,
+    ).length,
+    byBucket: Object.fromEntries(tally(crossFile, (r) => r.bucket)),
+    allRowsByBucket: Object.fromEntries(tally(rows, (r) => r.bucket)),
+    byPackage: Object.fromEntries(tally(crossFile, (r) => `${r.package}/${r.bucket}`)),
+    crossFileTopFiles: Object.fromEntries(
+      tally(crossFile, (r) => `${r.bucket} ${r.tsFile}`).slice(0, 20),
+    ),
+    resolvableTopFiles: Object.fromEntries(
+      tally(resolvable, (r) => `${r.bucket} ${r.tsFile} → ${r.resolvedIn ?? "?"}`).slice(0, 20),
+    ),
+    divergenceTopFiles: Object.fromEntries(
+      tally(
+        rows.filter((r) => r.bucket === "divergence"),
+        (r) => `${r.package}/${r.tsFile}`,
+      ).slice(0, 20),
+    ),
+    unportedTopFiles: Object.fromEntries(
+      tally(
+        rows.filter((r) => r.bucket === "unported"),
+        (r) => `${r.package}/${r.tsFile}`,
+      ).slice(0, 15),
+    ),
+  };
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (require.main === module) void main();

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -4,6 +4,10 @@ import * as path from "path";
 import { OUTPUT_DIR } from "./config.js";
 import { jsEnumerableAliases } from "./enumerable-idioms.js";
 
+// Mirrors the gate's own, unexported DELEGATION_MAX_CALLS (compare.ts:295) —
+// keep in step if that threshold ever moves.
+const DELEGATION_MAX_CALLS = 3;
+
 export type Method = { name: string; file?: string; calls?: string[] };
 export type Entity = {
   name: string;
@@ -14,7 +18,14 @@ export type Entity = {
   classMethods: Method[];
 };
 type TsApi = {
-  packages: Record<string, { classes: Record<string, Entity>; modules: Record<string, Entity> }>;
+  packages: Record<
+    string,
+    {
+      classes: Record<string, Entity>;
+      modules: Record<string, Entity>;
+      fileFunctions: Record<string, Method[]>;
+    }
+  >;
 };
 export type Mismatch = {
   package: string;
@@ -45,7 +56,10 @@ export type PackageIndex = {
   definitionsByName: Map<string, Definition[]>;
 };
 
-export function buildPackageIndex(entities: Entity[]): PackageIndex {
+export function buildPackageIndex(
+  entities: Entity[],
+  fileFunctions: Record<string, Method[]> = {},
+): PackageIndex {
   const index: PackageIndex = {
     entitiesByFile: new Map(),
     entitiesByName: new Map(),
@@ -58,6 +72,15 @@ export function buildPackageIndex(entities: Entity[]): PackageIndex {
       push(index.definitionsByName, method.name, {
         entity: entity.name,
         file: method.file ?? entity.file,
+        calls: new Set(method.calls ?? []),
+      });
+    }
+  }
+  for (const [file, methods] of Object.entries(fileFunctions)) {
+    for (const method of methods) {
+      push(index.definitionsByName, method.name, {
+        entity: file,
+        file: method.file ?? file,
         calls: new Set(method.calls ?? []),
       });
     }
@@ -98,8 +121,9 @@ export function classifyRow(
   const definitions = index.definitionsByName.get(mismatch.tsName) ?? [];
   const makesCall = definitions.filter((d) => candidates.some((c) => d.calls.has(c)));
   if (makesCall.length === 0) {
-    const ownIsEmpty = definitions.every((d) => d.file !== mismatch.tsFile || d.calls.size === 0);
-    return { bucket: definitions.length <= 1 && ownIsEmpty ? "unported" : "divergence" };
+    const own = definitions.filter((d) => d.file === mismatch.tsFile);
+    const hollow = own.length === definitions.length && own.every((d) => d.calls.size === 0);
+    return { bucket: own.length > 0 && hollow ? "unported" : "divergence" };
   }
   const reachable = includeGraphFiles(mismatch.tsFile, index);
   const viaGraph = makesCall.find((d) => reachable.has(d.file));
@@ -198,7 +222,10 @@ async function main(): Promise<void> {
   for (const [pkg, entry] of Object.entries(api.packages)) {
     indexes.set(
       pkg,
-      buildPackageIndex([...Object.values(entry.classes), ...Object.values(entry.modules)]),
+      buildPackageIndex(
+        [...Object.values(entry.classes), ...Object.values(entry.modules)],
+        entry.fileFunctions,
+      ),
     );
   }
 
@@ -211,13 +238,16 @@ async function main(): Promise<void> {
     crossFileRows: crossFile.length,
     anyMethodInIncludeGraph: countAnyMethodInGraph(rows, indexes),
     resolvableAnywhereByName: resolvable.length,
-    resolvableWrapperShaped: resolvable.filter((r) =>
+    resolvableForwardersAboveDelegationCap: resolvable.filter((r) =>
       (indexes.get(r.package)!.definitionsByName.get(r.tsName) ?? [])
         .filter((d) => d.file === r.tsFile)
-        .some((d) => d.calls.has(r.tsName) && d.calls.size > 3),
+        .some((d) => d.calls.has(r.tsName) && d.calls.size > DELEGATION_MAX_CALLS),
     ).length,
     rowsWithNoGraphEdge: rows.filter(
       (r) => includeGraphFiles(r.tsFile, indexes.get(r.package)!).size === 0,
+    ).length,
+    rowsWithNoDefinition: rows.filter(
+      (r) => (indexes.get(r.package)!.definitionsByName.get(r.tsName) ?? []).length === 0,
     ).length,
     byBucket: Object.fromEntries(tally(crossFile, (r) => r.bucket)),
     allRowsByBucket: Object.fromEntries(tally(rows, (r) => r.bucket)),


### PR DESCRIPTION
Audit only — no product code, no gate change, no baseline change (expected and
measured wide-row delta 0).

Adds `scripts/api-compare/audit-cross-file-calls.ts`, the script that produced
the RFC 0083 cross-file / mixin-attribution audit. The report is in the tasks
repo at `rfcs/0083-wide-call-ratchet-noise-reduction/cross-file-audit.md`.

## What the audit found

The bucket is not 1606 rows, and the recorded include/extends graph does not
resolve it. Of 5034 (row, call) pairs in `output/call-mismatches-wide.json`:

| Bucket        | Rows | Meaning                                                                |
| ------------- | ---: | ---------------------------------------------------------------------- |
| divergence    | 4713 | no definition of that TS name anywhere in the package makes the call   |
| collaborator  |  292 | same-named body elsewhere makes it; no include/extends edge reaches it |
| include-graph |   28 | reachable through the recorded graph — the resolvable population       |
| unported      |    1 | paired body is the only definition and has no call-set                 |

73% of flagged rows sit in a TS file that declares no include/extends edge at
all. trails reaches `PostgreSQLSchemaStatements` from `PostgreSQLAdapter` by an
accessor call (`this.pgSchemaStatements()`) — a delegation edge, which
`extract-ts-api.ts` does not record. So the projected −1100 to −1600 for
`resolve-wide-candidates-through-include-graph` is not reachable by any
include-graph rule; the honest expected delta is **−28**.

Resolution is measured at least as generously as the gate itself: the index
covers `classes`, `modules` and `fileFunctions` (trails' `include` convention
ports mixin bodies as `this`-typed file functions), and a candidate counts as
made when the other body calls the mapped TS name or any `jsEnumerableAliases`
analogue of the Ruby call — the same alias path `significantMissingCalls` uses.

The looser rules that would remove more are unsound: name-only resolution
credits `abstract-mysql-adapter.ts` with calls made in
`postgresql/schema-statements-class.ts`, and `cache/file-store.ts` with
`cache/memory-store.ts` — sibling implementations, not collaborators. The report
states the exact resolution rule and what it must NOT resolve through
(proximity, same-name-anywhere, name-agnostic reachability, cross-package,
unresolved edge names), and recommends re-scoping or closing the sibling story
on that basis.

## Review round 1

- **`resolvableWrapperShaped` inverted vs. its name** — renamed to
  `resolvableForwardersAboveDelegationCap`; the `> 3` condition was the intent
  (forwarders `isDelegatingWrapper` *rejects*), the name was wrong.
- **Bare `3`** — now a named `DELEGATION_MAX_CALLS` constant with a one-line
  anchor to `compare.ts:295`, the only comment in the file.
- **"unported" could absorb rows with no indexed definition** — correct, and it
  was material: 303 rows had no definition in the index because it read only
  `classes`/`modules` and missed `fileFunctions`. Fixed; `rowsWithNoDefinition`
  is now 0, `unported` drops 306 → 1, `include-graph` rises 10 → 28. Report
  numbers updated throughout and the earlier figures noted as the artifact they
  were.

## Reproduce

```sh
pnpm build
API_COMPARE_FORCE=1 pnpm api:compare --wide-calls
pnpm tsx scripts/api-compare/audit-cross-file-calls.ts
```

Closes-story: audit-wide-cross-file-mixin-attribution
