### PR TITLE
feat(api-compare): regenerate the wide artifact inside api:calls:wide

### DIFF
--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -11,6 +11,8 @@ import {
   parseTop,
   relPathFor,
   renderReport,
+  shouldRegenerate,
+  NO_REGEN_FLAG,
   unreviewedCount,
   writeSplitBaseline,
 } from "./lint-call-mismatches-wide.js";
@@ -325,5 +327,26 @@ describe("parseTop", () => {
     expect(() => parseTop(["--top=x"], 20)).toThrow(/positive integer/);
     expect(() => parseTop(["--top=0"], 20)).toThrow(/positive integer/);
     expect(() => parseTop(["--top=2.5"], 20)).toThrow(/positive integer/);
+  });
+});
+
+describe("shouldRegenerate", () => {
+  it("regenerates on a plain local gating run", () => {
+    expect(shouldRegenerate([], {})).toBe(true);
+  });
+
+  it("opts out under CI, which runs compare.ts --wide-calls as its own step", () => {
+    expect(shouldRegenerate([], { CI: "true" })).toBe(false);
+  });
+
+  it("opts out on the explicit flag or env escape hatch", () => {
+    expect(shouldRegenerate([NO_REGEN_FLAG], {})).toBe(false);
+    expect(shouldRegenerate([], { API_COMPARE_SKIP_WIDE_REGEN: "1" })).toBe(false);
+  });
+
+  it("leaves the read-only views and the reseed path alone", () => {
+    expect(shouldRegenerate(["--report"], {})).toBe(false);
+    expect(shouldRegenerate(["--unreviewed"], {})).toBe(false);
+    expect(shouldRegenerate(["--write"], {})).toBe(false);
   });
 });

--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -12,7 +12,9 @@ import {
   relPathFor,
   renderReport,
   shouldRegenerate,
+  regenerateArtifact,
   NO_REGEN_FLAG,
+  REGEN_SKIP_ENV,
   unreviewedCount,
   writeSplitBaseline,
 } from "./lint-call-mismatches-wide.js";
@@ -341,12 +343,20 @@ describe("shouldRegenerate", () => {
 
   it("opts out on the explicit flag or env escape hatch", () => {
     expect(shouldRegenerate([NO_REGEN_FLAG], {})).toBe(false);
-    expect(shouldRegenerate([], { API_COMPARE_SKIP_WIDE_REGEN: "1" })).toBe(false);
+    expect(shouldRegenerate([], { [REGEN_SKIP_ENV]: "1" })).toBe(false);
   });
 
   it("leaves the read-only views and the reseed path alone", () => {
     expect(shouldRegenerate(["--report"], {})).toBe(false);
     expect(shouldRegenerate(["--unreviewed"], {})).toBe(false);
     expect(shouldRegenerate(["--write"], {})).toBe(false);
+  });
+});
+
+describe("regenerateArtifact", () => {
+  it("rejects with the failing command when the regeneration exits non-zero", async () => {
+    await expect(regenerateArtifact({ PATH: "" })).rejects.toThrow(
+      /pnpm api:compare --wide-calls|spawn/,
+    );
   });
 });

--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -346,10 +346,17 @@ describe("shouldRegenerate", () => {
     expect(shouldRegenerate([], { [REGEN_SKIP_ENV]: "1" })).toBe(false);
   });
 
-  it("leaves the read-only views and the reseed path alone", () => {
+  it("leaves the read-only views alone", () => {
     expect(shouldRegenerate(["--report"], {})).toBe(false);
     expect(shouldRegenerate(["--unreviewed"], {})).toBe(false);
-    expect(shouldRegenerate(["--write"], {})).toBe(false);
+  });
+
+  it("regenerates for a bare --write, so a reseed never baselines a stale artifact", () => {
+    expect(shouldRegenerate(["--write"], {})).toBe(true);
+  });
+
+  it("skips the --write regeneration only when the reseed script already forced one", () => {
+    expect(shouldRegenerate(["--write"], { API_COMPARE_FORCE: "1" })).toBe(false);
   });
 });
 

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -58,6 +58,8 @@
  * `STALE baseline entr(ies)` on a branch that never touched it, and the fix was
  * always "re-extract, then re-run". It goes through run.sh rather than
  * compare.ts so the extraction manifests compare.ts reads are refreshed first.
+ * `--write` regenerates first too, unless API_COMPARE_FORCE is set, which is
+ * how api:calls:wide:reseed signals it already ran the forced regeneration.
  * Opt out with `--no-regen`, API_COMPARE_SKIP_WIDE_REGEN=1, or any CI value —
  * CI runs the extraction step separately and must not pay for it twice. The
  * partial-scope determinism guard runs unchanged either way.
@@ -231,12 +233,18 @@ async function pruneEmptyDirs(dir: string): Promise<boolean> {
 
 export const NO_REGEN_FLAG = "--no-regen";
 
-export const REGEN_SKIP_ARGS = [NO_REGEN_FLAG, "--report", "--unreviewed", "--write"];
+export const REGEN_SKIP_ARGS = [NO_REGEN_FLAG, "--report", "--unreviewed"];
 
 export const REGEN_SKIP_ENV = "API_COMPARE_SKIP_WIDE_REGEN";
 
+// A reseed regenerating a stale artifact is the same bug this PR fixes, one
+// severity worse: `--write` commits the stale population as the new baseline.
+// So `--write` regenerates too — except under API_COMPARE_FORCE, which is the
+// api:calls:wide:reseed script's own marker that it just ran the (forced)
+// regeneration itself.
 export function shouldRegenerate(argv: string[], env: Record<string, string | undefined>): boolean {
   if (argv.some((a) => REGEN_SKIP_ARGS.includes(a))) return false;
+  if (argv.includes("--write") && env.API_COMPARE_FORCE) return false;
   return !env.CI && env[REGEN_SKIP_ENV] !== "1";
 }
 

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -51,6 +51,11 @@
  *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write   # reseed baseline
  *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --report  # read-only grouping
  *
+ * A plain gating run first regenerates output/call-mismatches-wide.json itself
+ * (see {@link shouldRegenerate}); pass `--no-regen`, set
+ * API_COMPARE_SKIP_WIDE_REGEN=1, or run under CI= to gate the artifact already
+ * on disk. The partial-scope determinism guard still runs either way.
+ *
  * `--report` (RFC 0083) groups the baselined population by package, source
  * file, Ruby call name, and derived cause bucket, so a burndown story can be
  * scoped off a coherent slice instead of a 4794-line flat list. It never writes
@@ -65,8 +70,10 @@
  * entry guard is the sole exception, matching lint-call-mismatches.ts), async fs.
  */
 
+import { execFile } from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { promisify } from "util";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
 import {
@@ -215,6 +222,42 @@ async function pruneEmptyDirs(dir: string): Promise<boolean> {
     }
   }
   return empty;
+}
+
+// ── Self-regeneration (RFC 0083) ────────────────────────────────────────────
+// The gate reads a pre-existing output/call-mismatches-wide.json. A stale one
+// desyncs the ratchet from the working tree: a sibling PR that deletes a TS
+// method makes every baseline entry for it stop flagging, and the gate reports
+// `STALE baseline entr(ies)` for a change the current PR never made. The fix
+// was always "re-extract, then re-run", so a plain local gate run does it
+// itself. CI already runs `compare.ts --wide-calls` as its own step before this
+// one, so it opts out via CI= (any value) and never pays for the second pass.
+export const NO_REGEN_FLAG = "--no-regen";
+
+// Regeneration applies to the gating run only. `--report` / `--unreviewed` are
+// read-only views that tolerate a missing artifact, and `--write` is reached
+// through `pnpm api:calls:wide:reseed`, which regenerates (with
+// API_COMPARE_FORCE=1) ahead of it already — re-running compare here would just
+// double the cost.
+export function shouldRegenerate(argv: string[], env: Record<string, string | undefined>): boolean {
+  if (argv.some((a) => [NO_REGEN_FLAG, "--report", "--unreviewed", "--write"].includes(a))) {
+    return false;
+  }
+  return !env.CI && env.API_COMPARE_SKIP_WIDE_REGEN !== "1";
+}
+
+// Rebuild output/call-mismatches-wide.json over the full package surface. Goes
+// through `pnpm api:compare` (run.sh) rather than compare.ts directly so the
+// Ruby/TS extraction manifests compare.ts reads are produced/refreshed first —
+// invoking compare.ts alone in a fresh worktree just fails on a missing
+// rails-api.json. Out-of-process because compare.ts's main() reads process.argv
+// directly, so there is no in-process way to ask it for a wide run.
+export async function regenerateArtifact(env: Record<string, string | undefined>): Promise<void> {
+  await promisify(execFile)("pnpm", ["api:compare", "--wide-calls"], {
+    cwd: ROOT_DIR,
+    env,
+    maxBuffer: 64 * 1024 * 1024,
+  });
 }
 
 async function loadArtifact(): Promise<Artifact> {
@@ -522,6 +565,19 @@ async function runAsScript(): Promise<void> {
   const argv = process.argv.slice(2);
   const unreviewed = argv.includes("--unreviewed");
   if (!argv.includes("--report") && !unreviewed) {
+    if (shouldRegenerate(argv, process.env)) {
+      console.log("Regenerating output/call-mismatches-wide.json (compare.ts --wide-calls)…");
+      try {
+        await regenerateArtifact(process.env);
+      } catch (e) {
+        console.error(
+          `\nwide call-mismatches ratchet: could not regenerate the wide artifact: ${
+            (e as Error).message
+          }\n` + `Re-run with ${NO_REGEN_FLAG} to gate against the artifact already on disk.\n`,
+        );
+        process.exit(2);
+      }
+    }
     process.exit(await main(argv.includes("--write")));
   }
   let top: number;

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -50,11 +50,17 @@
  *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts           # gate (CI)
  *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write   # reseed baseline
  *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --report  # read-only grouping
+ *   pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --no-regen # gate the artifact on disk
  *
  * A plain gating run first regenerates output/call-mismatches-wide.json itself
- * (see {@link shouldRegenerate}); pass `--no-regen`, set
- * API_COMPARE_SKIP_WIDE_REGEN=1, or run under CI= to gate the artifact already
- * on disk. The partial-scope determinism guard still runs either way.
+ * by shelling out to `pnpm api:compare --wide-calls` (RFC 0083). Gating a stale
+ * artifact is what makes a sibling PR's deleted TS method surface here as
+ * `STALE baseline entr(ies)` on a branch that never touched it, and the fix was
+ * always "re-extract, then re-run". It goes through run.sh rather than
+ * compare.ts so the extraction manifests compare.ts reads are refreshed first.
+ * Opt out with `--no-regen`, API_COMPARE_SKIP_WIDE_REGEN=1, or any CI value —
+ * CI runs the extraction step separately and must not pay for it twice. The
+ * partial-scope determinism guard runs unchanged either way.
  *
  * `--report` (RFC 0083) groups the baselined population by package, source
  * file, Ruby call name, and derived cause bucket, so a burndown story can be
@@ -70,10 +76,9 @@
  * entry guard is the sole exception, matching lint-call-mismatches.ts), async fs.
  */
 
-import { execFile } from "child_process";
+import { spawn } from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
-import { promisify } from "util";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
 import {
@@ -224,39 +229,29 @@ async function pruneEmptyDirs(dir: string): Promise<boolean> {
   return empty;
 }
 
-// ── Self-regeneration (RFC 0083) ────────────────────────────────────────────
-// The gate reads a pre-existing output/call-mismatches-wide.json. A stale one
-// desyncs the ratchet from the working tree: a sibling PR that deletes a TS
-// method makes every baseline entry for it stop flagging, and the gate reports
-// `STALE baseline entr(ies)` for a change the current PR never made. The fix
-// was always "re-extract, then re-run", so a plain local gate run does it
-// itself. CI already runs `compare.ts --wide-calls` as its own step before this
-// one, so it opts out via CI= (any value) and never pays for the second pass.
 export const NO_REGEN_FLAG = "--no-regen";
 
-// Regeneration applies to the gating run only. `--report` / `--unreviewed` are
-// read-only views that tolerate a missing artifact, and `--write` is reached
-// through `pnpm api:calls:wide:reseed`, which regenerates (with
-// API_COMPARE_FORCE=1) ahead of it already — re-running compare here would just
-// double the cost.
+export const REGEN_SKIP_ARGS = [NO_REGEN_FLAG, "--report", "--unreviewed", "--write"];
+
+export const REGEN_SKIP_ENV = "API_COMPARE_SKIP_WIDE_REGEN";
+
 export function shouldRegenerate(argv: string[], env: Record<string, string | undefined>): boolean {
-  if (argv.some((a) => [NO_REGEN_FLAG, "--report", "--unreviewed", "--write"].includes(a))) {
-    return false;
-  }
-  return !env.CI && env.API_COMPARE_SKIP_WIDE_REGEN !== "1";
+  if (argv.some((a) => REGEN_SKIP_ARGS.includes(a))) return false;
+  return !env.CI && env[REGEN_SKIP_ENV] !== "1";
 }
 
-// Rebuild output/call-mismatches-wide.json over the full package surface. Goes
-// through `pnpm api:compare` (run.sh) rather than compare.ts directly so the
-// Ruby/TS extraction manifests compare.ts reads are produced/refreshed first —
-// invoking compare.ts alone in a fresh worktree just fails on a missing
-// rails-api.json. Out-of-process because compare.ts's main() reads process.argv
-// directly, so there is no in-process way to ask it for a wide run.
-export async function regenerateArtifact(env: Record<string, string | undefined>): Promise<void> {
-  await promisify(execFile)("pnpm", ["api:compare", "--wide-calls"], {
-    cwd: ROOT_DIR,
-    env,
-    maxBuffer: 64 * 1024 * 1024,
+export function regenerateArtifact(env: Record<string, string | undefined>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", ["api:compare", "--wide-calls"], {
+      cwd: ROOT_DIR,
+      env,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`\`pnpm api:compare --wide-calls\` exited with ${signal ?? code}`));
+    });
   });
 }
 


### PR DESCRIPTION
The wide ratchet gates whatever `output/call-mismatches-wide.json` happens to be
on disk. When a sibling PR deletes a TS method, every baseline entry for it stops
flagging and the next local run fails with `STALE baseline entr(ies)` for a change
the current branch never made — the fix was always "re-extract, then re-run".

A plain gating run now regenerates the artifact itself via `pnpm api:compare
--wide-calls` (run.sh, so the extraction manifests compare.ts reads get refreshed
first) before gating.

Opt-outs: `--no-regen`, `API_COMPARE_SKIP_WIDE_REGEN=1`, or any `CI` value.
`--report`, `--unreviewed` and `--write` are unchanged (`--write` is reached via
`api:calls:wide:reseed`, which already regenerates ahead of it).

CI is unaffected: it runs `compare.ts --wide-calls` and the gate as separate
steps, and `CI` is set there.

The partial-scope (`missingScope`) determinism guard is untouched and still runs.
Baseline row delta: 0 — verified locally, `OK (3498 baselined, 3233 unreviewed <= mark 3233)`.

Closes-story: wide-ratchet-regenerate-artifact-in-gate
