### PR TITLE
feat(api-compare): record accessor-forwarding delegation edges in extract-ts-api

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -404,6 +404,56 @@ describe("body call capture", () => {
     ]);
   });
 
+  it("records the delegation edge of an accessor-forwarding method", () => {
+    // The `PostgreSQLAdapter` → `PostgreSQLSchemaStatements` shape: trails puts
+    // the Rails `PostgreSQL::SchemaStatements` port in its own class and reaches
+    // it through an accessor, so the port is invisible to includes/extends.
+    const cls = extractFromSource(
+      `class PostgreSQLSchemaStatements {
+         indexes(tableName) { return []; }
+         databaseExists(name) { return true; }
+       }
+       class PostgreSQLAdapter {
+         private pgSchemaStatements(): PostgreSQLSchemaStatements { return this.stmts; }
+         indexes(tableName) { return this.pgSchemaStatements().indexes(tableName); }
+         async databaseExists(name) { return await this.pgSchemaStatements().databaseExists(name); }
+       }`,
+      "PostgreSQLAdapter",
+    );
+    const byName = Object.fromEntries(cls.instanceMethods.map((m) => [m.name, m.delegatesTo]));
+    expect(byName["indexes"]).toBe("PostgreSQLSchemaStatements");
+    expect(byName["databaseExists"]).toBe("PostgreSQLSchemaStatements");
+    expect(byName["pgSchemaStatements"]).toBeUndefined();
+    expect(cls.delegatesTo).toEqual(["PostgreSQLSchemaStatements"]);
+  });
+
+  it("records no delegation edge for a differently-named or in-class forward", () => {
+    // Only a SAME-NAMED forward off another object models a moved Rails module;
+    // a rename-forward and plain `this.helper()` dispatch are ordinary bodies.
+    const cls = extractFromSource(
+      `class Helper { indexes(t) { return []; } indexNames(t) { return []; } }
+       class Foo {
+         private helper(): Helper { return this.h; }
+         indexes(t) { return this.helper().indexNames(t); }
+         columns(t) { return this.loadColumns(t); }
+       }`,
+    );
+    expect(cls.instanceMethods.every((m) => m.delegatesTo === undefined)).toBe(true);
+    expect(cls.delegatesTo).toBeUndefined();
+  });
+
+  it("records no delegation edge when the accessor's type is unresolved", () => {
+    // Resolution is checker-only: an accessor with no resolvable declaring type
+    // records nothing rather than falling back to a name- or path-based guess,
+    // which would cross-credit sibling adapter implementations.
+    const cls = extractFromSource(
+      `class Foo {
+         indexes(t) { return this.untyped().indexes(t); }
+       }`,
+    );
+    expect(cls.instanceMethods.find((m) => m.name === "indexes")!.delegatesTo).toBeUndefined();
+  });
+
   it("does NOT suppress a same-named delegation whose receiver is unbound", () => {
     // A receiver that resolves to no symbol (only possible for a genuinely unbound
     // identifier — non-compiling code) fails toward tracking: keep the extracted

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -442,6 +442,32 @@ describe("body call capture", () => {
     expect(cls.delegatesTo).toBeUndefined();
   });
 
+  it("records the delegation edge of a property-accessor forward and a static forward", () => {
+    const cls = extractFromSource(
+      `class Stmts { indexes(t) { return []; } static reset() {} }
+       class Foo {
+         private readonly stmts: Stmts;
+         indexes(t) { return this.stmts.indexes(t); }
+         static reset() { return this.stmts.reset(); }
+       }`,
+    );
+    expect(cls.instanceMethods.find((m) => m.name === "indexes")!.delegatesTo).toBe("Stmts");
+    expect(cls.delegatesTo).toEqual(["Stmts"]);
+  });
+
+  it("records no delegation edge when the target type lacks the forwarded member", () => {
+    // The forward must land on a declaration of the same name; a receiver typed
+    // as something that does not declare it names no port to credit.
+    const cls = extractFromSource(
+      `class Stmts { columns(t) { return []; } }
+       class Foo {
+         private stmts(): Stmts { return this.s; }
+         indexes(t) { return this.stmts().indexes(t); }
+       }`,
+    );
+    expect(cls.instanceMethods.find((m) => m.name === "indexes")!.delegatesTo).toBeUndefined();
+  });
+
   it("records no delegation edge when the accessor's type is unresolved", () => {
     // Resolution is checker-only: an accessor with no resolvable declaring type
     // records nothing rather than falling back to a name- or path-based guess,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1790,6 +1790,9 @@ export function extractClass(
   // `Class.helper(...)` call site and must not be merged in.
   const delegations: { method: MethodInfo; helper: string }[] = [];
   const instanceCallsByName = new Map<string, string[]>();
+  // Accessor-forwarding edges (RFC 0083), unioned onto the class alongside
+  // includes/extends. See delegationTargetName.
+  const delegationTargets = new Set<string>();
 
   if (node.heritageClauses) {
     for (const clause of node.heritageClauses) {
@@ -1827,6 +1830,8 @@ export function extractClass(
         namespaceSelfDelegationName(member.body, checker) === memberName
           ? undefined
           : extractCalls(member.body);
+      const delegatesTo = delegationTargetName(member.body, memberName, name, checker);
+      if (delegatesTo) delegationTargets.add(delegatesTo);
       const method: MethodInfo = {
         name: memberName,
         visibility,
@@ -1838,6 +1843,7 @@ export function extractClass(
         ...tagged,
         ...(optionKeys !== undefined ? { optionKeys } : {}),
         ...(calls !== undefined ? { calls } : {}),
+        ...(delegatesTo !== undefined ? { delegatesTo } : {}),
       };
       // Only instance methods are reachable via `this.helper(...)` and only
       // instance methods delegate through it — record both on the instance side.
@@ -1939,6 +1945,7 @@ export function extractClass(
     file,
     includes,
     extends: extendsArr,
+    ...(delegationTargets.size > 0 ? { delegatesTo: [...delegationTargets].sort() } : {}),
     instanceMethods,
     classMethods,
     ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
@@ -2343,6 +2350,67 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
  * extracted into a one-line private helper reads as equivalent to inlining it.
  * Concrete repro: `buildStatementPool() { return this.makeStatementPool(c); }`.
  */
+/**
+ * If `body` is a whole-body forward to the SAME-NAMED method of another object
+ * reached off `this` — `return this.acc().name(...)`, its `await` form, or the
+ * property form `return this.acc.name(...)` — return the name of the class /
+ * interface that declares the receiver, else undefined.
+ *
+ * The target is resolved from the accessor's return type through the checker.
+ * Name- or path-based alternatives are unsound here: they would credit
+ * `abstract-mysql-adapter.ts` with calls made in
+ * `postgresql/schema-statements-class.ts` (sibling implementations of one
+ * interface), which is exactly the per-adapter fidelity gap the wide gate
+ * exists to catch. The resolved type must actually declare `name`, so an
+ * accessor whose type the checker cannot resolve records no edge.
+ */
+function delegationTargetName(
+  body: ts.Node | undefined,
+  name: string,
+  hostName: string,
+  checker: ts.TypeChecker,
+): string | undefined {
+  if (!body || !ts.isBlock(body) || body.statements.length !== 1) return undefined;
+  const stmt = body.statements[0];
+  let expr = ts.isReturnStatement(stmt)
+    ? stmt.expression
+    : ts.isExpressionStatement(stmt)
+      ? stmt.expression
+      : undefined;
+  if (expr && ts.isAwaitExpression(expr)) expr = expr.expression;
+  if (!expr || !ts.isCallExpression(expr)) return undefined;
+
+  // Callee must be `<receiver>.<name>` with `<name>` identical to the forwarding
+  // method — a differently-named callee is ordinary collaboration, not the
+  // Rails-module-moved-to-a-class shape this edge models.
+  const callee = expr.expression;
+  if (!ts.isPropertyAccessExpression(callee) || !ts.isIdentifier(callee.name)) return undefined;
+  if (callee.name.text !== name) return undefined;
+
+  // The receiver is `this.acc()` or `this.acc` — never a bare `this` (that is
+  // in-class dispatch) and never a free identifier (namespace delegation, see
+  // namespaceSelfDelegationName).
+  let receiver = callee.expression;
+  if (ts.isCallExpression(receiver) && receiver.arguments.length === 0) {
+    receiver = receiver.expression;
+  }
+  if (
+    !ts.isPropertyAccessExpression(receiver) ||
+    receiver.expression.kind !== ts.SyntaxKind.ThisKeyword
+  ) {
+    return undefined;
+  }
+
+  const type = checker.getTypeAtLocation(callee.expression);
+  if (!type.getProperty(name)) return undefined;
+  const targetName = type.getSymbol()?.getName();
+  if (!targetName || targetName === hostName) return undefined;
+  // Anonymous/structural types carry synthetic symbol names; they name no
+  // declaring module a consumer could resolve.
+  if (targetName.startsWith("__")) return undefined;
+  return targetName;
+}
+
 function delegatedHelper(body: ts.Node | undefined): string | undefined {
   if (!body || !ts.isBlock(body) || body.statements.length !== 1) return undefined;
   const stmt = body.statements[0];

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1790,8 +1790,6 @@ export function extractClass(
   // `Class.helper(...)` call site and must not be merged in.
   const delegations: { method: MethodInfo; helper: string }[] = [];
   const instanceCallsByName = new Map<string, string[]>();
-  // Accessor-forwarding edges (RFC 0083), unioned onto the class alongside
-  // includes/extends. See delegationTargetName.
   const delegationTargets = new Set<string>();
 
   if (node.heritageClauses) {
@@ -2350,6 +2348,26 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
  * extracted into a one-line private helper reads as equivalent to inlining it.
  * Concrete repro: `buildStatementPool() { return this.makeStatementPool(c); }`.
  */
+function delegatedHelper(body: ts.Node | undefined): string | undefined {
+  if (!body || !ts.isBlock(body) || body.statements.length !== 1) return undefined;
+  const stmt = body.statements[0];
+  const expr = ts.isReturnStatement(stmt)
+    ? stmt.expression
+    : ts.isExpressionStatement(stmt)
+      ? stmt.expression
+      : undefined;
+  if (!expr || !ts.isCallExpression(expr)) return undefined;
+  const callee = expr.expression;
+  if (
+    ts.isPropertyAccessExpression(callee) &&
+    callee.expression.kind === ts.SyntaxKind.ThisKeyword &&
+    ts.isIdentifier(callee.name)
+  ) {
+    return callee.name.text;
+  }
+  return undefined;
+}
+
 /**
  * If `body` is a whole-body forward to the SAME-NAMED method of another object
  * reached off `this` — `return this.acc().name(...)`, its `await` form, or the
@@ -2409,26 +2427,6 @@ function delegationTargetName(
   // declaring module a consumer could resolve.
   if (targetName.startsWith("__")) return undefined;
   return targetName;
-}
-
-function delegatedHelper(body: ts.Node | undefined): string | undefined {
-  if (!body || !ts.isBlock(body) || body.statements.length !== 1) return undefined;
-  const stmt = body.statements[0];
-  const expr = ts.isReturnStatement(stmt)
-    ? stmt.expression
-    : ts.isExpressionStatement(stmt)
-      ? stmt.expression
-      : undefined;
-  if (!expr || !ts.isCallExpression(expr)) return undefined;
-  const callee = expr.expression;
-  if (
-    ts.isPropertyAccessExpression(callee) &&
-    callee.expression.kind === ts.SyntaxKind.ThisKeyword &&
-    ts.isIdentifier(callee.name)
-  ) {
-    return callee.name.text;
-  }
-  return undefined;
 }
 
 /**

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -108,6 +108,17 @@ export interface MethodInfo {
    * See extract-ts-api.ts and extra-surface.ts `collectTsFileNames`.
    */
   declaredIn?: string;
+  /**
+   * TS-side only (RFC 0083): the class/module this method forwards to when its
+   * whole body is `return this.<accessor>().<sameName>(...)`. trails does not
+   * mix a Rails module into its host class the way Ruby `include` does — the
+   * PostgreSQL schema-statements port lives in `PostgreSQLSchemaStatements` and
+   * `PostgreSQLAdapter` reaches it through `this.pgSchemaStatements()`. The
+   * target name is resolved from the accessor's RETURN TYPE via the checker,
+   * never from filename proximity (sibling adapters would cross-credit each
+   * other). See extract-ts-api.ts `delegationTargetName`.
+   */
+  delegatesTo?: string;
 }
 
 export interface ClassInfo {
@@ -117,6 +128,14 @@ export interface ClassInfo {
   reExportedFrom?: string;
   includes: string[];
   extends: string[];
+  /**
+   * TS-side only (RFC 0083): sorted union of every `MethodInfo.delegatesTo` on
+   * this class — the accessor-forwarding counterpart of `includes`/`extends`,
+   * recorded so a consumer can walk the delegation graph the same way it walks
+   * the include graph. No consumer reads it yet (compare.ts is untouched);
+   * `resolve-wide-candidates-through-include-graph` is the consumer story.
+   */
+  delegatesTo?: string[];
   instanceMethods: MethodInfo[];
   classMethods: MethodInfo[];
   /**


### PR DESCRIPTION
Records a **delegation edge** per method in `extract-ts-api`: when a body's whole
content forwards to the same-named method of another object reached off `this`
(`return this.pgSchemaStatements().indexes(tableName)`), the extractor resolves
the accessor's **return type through the checker** and records the declaring
class.

This reaches the bucket RFC 0083 described: trails does not mix
`PostgreSQL::SchemaStatements` into `PostgreSQLAdapter`, it puts the port in
`PostgreSQLSchemaStatements` and reaches it through an accessor, so the port is
invisible to `includes`/`extends` (`PostgreSQLAdapter.includes` is exactly
`["DatabaseAdapter"]`). Resolution is checker-only — the name/path alternatives
the audit rejected would cross-credit sibling adapter implementations.

## Shape

- `MethodInfo.delegatesTo?: string` — the declaring class of the forward target.
- `ClassInfo.delegatesTo?: string[]` — sorted union, recorded alongside
  `includes`/`extends`.

Recorded only when the callee name is identical to the forwarding method, the
receiver is `this.<accessor>()` / `this.<accessor>`, and the resolved type
actually declares that member. An unresolvable accessor records nothing.

Covered by five `extract-ts-api.test.ts` cases: the `PostgreSQLAdapter` →
`PostgreSQLSchemaStatements` shape (call + `await` forms), the property-accessor
and static forms, and three negatives — rename-forward / in-class `this.helper()`
dispatch, a target type lacking the forwarded member, and an unresolvable
accessor.

On the real tree: 132 entities carry an edge (147 edges);
`PostgreSQLAdapter` gets `["PostgreSQLSchemaStatements", "SchemaStatements",
"TransactionManager"]` from 90 forwarding methods.

## No consumer change

`compare.ts` is untouched. `pnpm api:calls:wide` after regenerating artifacts:
`OK (3498 baselined, 3233 unreviewed <= mark 3233)` — delta 0.

## How many wide rows the edge WOULD resolve

Measured against the regenerated `call-mismatches-wide.json` (3693 rows) by
re-running `audit-cross-file-calls.ts`'s classification with the graph traversal
widened to follow `delegatesTo`:

| metric | include-graph only | + delegation edges |
| --- | --- | --- |
| strict (same-named definition in a reachable file makes the call) | 25 | **25** |
| loose (ANY method in a reachable file makes the call) | 378 | **663** |
| rows whose reachable file-set grows | — | 1129 |
| rows with NO graph edge at all that gain one | — | 412 |

**The strict number is 0 additional rows.** The delegation edge does widen the
graph substantially (1129 rows reach more files, 412 previously-unreachable rows
gain an edge, and the loose metric nearly doubles: 378 → 663), but the flagged
rows sitting in a delegating file are not the delegating methods themselves —
the wide gate already picks the delegate's file as the candidate for those, so
its rows are already attributed to `schema-statements-class.ts`. What remains in
`postgresql-adapter.ts` are non-forwarding methods, which the new edge does not
help.

`resolve-wide-candidates-through-include-graph` should be re-scoped against this:
the delegation edge alone buys 0 rows under same-name resolution. The +285 loose
delta is the ceiling available *if* that story relaxes resolution from
same-named-definition to any-method-in-the-graph — which is a separate soundness
decision, not something this edge decides.

Closes-story: record-delegation-edges-in-ts-extractor
