### PR TITLE
feat(activerecord): reject async callbacks on the sync afterInitialize/afterFind registrars

### DIFF
--- a/packages/activerecord/src/callbacks-sync-only-types.test.ts
+++ b/packages/activerecord/src/callbacks-sync-only-types.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Trails-only compile-time tests: `afterInitialize` / `afterFind` are the two
+ * AR callback chains trails runs synchronously (`strict: "sync"`), so their
+ * registrars must reject `Promise`-returning callbacks at the type level. No
+ * Rails counterpart — Ruby has no such distinction.
+ *
+ * These assertions are checked by `tsc`; the runtime body only exists so the
+ * file participates in the typecheck the same way the rest of the suite does.
+ */
+import { describe, it, expect } from "vitest";
+import { Base } from "./index.js";
+import { afterFind, afterInitialize } from "./callbacks.js";
+
+class SyncOnlyCallbackModel extends Base {
+  static override tableName = "developers";
+  declare name: string;
+}
+
+describe("sync-only callback registrar types", () => {
+  it("rejects async callbacks and accepts every sync form", () => {
+    const asyncArrow = async (record: SyncOnlyCallbackModel) => {
+      record.name = "async";
+    };
+    const promiseReturning = (record: SyncOnlyCallbackModel) => Promise.resolve(record.name);
+
+    // @ts-expect-error async callbacks are not allowed on the sync initialize chain
+    afterInitialize(SyncOnlyCallbackModel, asyncArrow);
+    // @ts-expect-error async callbacks are not allowed on the sync find chain
+    afterFind(SyncOnlyCallbackModel, asyncArrow);
+    // @ts-expect-error thenable-returning callbacks are not allowed either
+    afterInitialize(SyncOnlyCallbackModel, promiseReturning);
+    // @ts-expect-error thenable-returning callbacks are not allowed either
+    afterFind(SyncOnlyCallbackModel, promiseReturning);
+    // @ts-expect-error inline async arrows are rejected the same way
+    afterInitialize(SyncOnlyCallbackModel, async () => {});
+
+    const seen: string[] = [];
+
+    afterInitialize(SyncOnlyCallbackModel, () => {
+      seen.push("statement-body");
+    });
+    // Value-returning arrow, as used by test-helpers/models/bulb.ts.
+    afterInitialize(SyncOnlyCallbackModel, (record) => (record.name = "red"));
+    afterInitialize(SyncOnlyCallbackModel, () => false);
+    afterFind(SyncOnlyCallbackModel, function (record) {
+      seen.push(record.name);
+      return;
+    });
+    afterFind(SyncOnlyCallbackModel, (record) => record.name);
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/callbacks.trails.test.ts
+++ b/packages/activerecord/src/callbacks.trails.test.ts
@@ -1,12 +1,3 @@
-/**
- * Trails-only compile-time tests: `afterInitialize` / `afterFind` are the two
- * AR callback chains trails runs synchronously (`strict: "sync"`), so their
- * registrars must reject `Promise`-returning callbacks at the type level. No
- * Rails counterpart — Ruby has no such distinction.
- *
- * These assertions are checked by `tsc`; the runtime body only exists so the
- * file participates in the typecheck the same way the rest of the suite does.
- */
 import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import { afterFind, afterInitialize } from "./callbacks.js";
@@ -39,7 +30,6 @@ describe("sync-only callback registrar types", () => {
     afterInitialize(SyncOnlyCallbackModel, () => {
       seen.push("statement-body");
     });
-    // Value-returning arrow, as used by test-helpers/models/bulb.ts.
     afterInitialize(SyncOnlyCallbackModel, (record) => (record.name = "red"));
     afterInitialize(SyncOnlyCallbackModel, () => false);
     afterFind(SyncOnlyCallbackModel, function (record) {

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -165,29 +165,13 @@ export function afterDestroy<T extends ModelCtor>(
   registerCallback(modelClass, "after", "destroy", fn, options);
 }
 
-/**
- * Rejects a `Promise`-returning callback at compile time while leaving every
- * other return type (including value-returning arrows like `(r) => (r.c = "x")`)
- * alone.
- *
- * A plain `void` return type would not work: TypeScript's void-return
- * assignability rule accepts `async (r) => {}` against `(r) => void`, so the
- * guard would silently be a no-op. Constraining `R extends void | boolean`
- * rejects async but also rejects the value-returning arrows real callers use.
- *
- * @internal
- */
+/** @internal */
 type SyncOnly<R> = R extends PromiseLike<unknown> ? never : R;
 
 /**
  * Register an after_find callback. Fires on every record loaded from the DB.
  *
  * Rails defines :find with only: :after, so there is no before_find or around_find.
- *
- * This chain runs synchronously (`strict: "sync"` at every call site in
- * base.ts), because Rails fires it from `init_with` on the hot read path and
- * JS constructors cannot await — so async callbacks are rejected here rather
- * than throwing at runtime on the first record loaded.
  *
  * Mirrors: ActiveRecord::Callbacks.after_find
  */
@@ -203,8 +187,6 @@ export function afterFind<T extends ModelCtor, R>(
  * Register an after_initialize callback. Fires on every new or loaded record.
  *
  * Rails defines :initialize with only: :after, so there is no before_initialize or around_initialize.
- *
- * Runs synchronously — see the note on {@link afterFind}.
  *
  * Mirrors: ActiveRecord::Callbacks.after_initialize
  */

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -166,15 +166,34 @@ export function afterDestroy<T extends ModelCtor>(
 }
 
 /**
+ * Rejects a `Promise`-returning callback at compile time while leaving every
+ * other return type (including value-returning arrows like `(r) => (r.c = "x")`)
+ * alone.
+ *
+ * A plain `void` return type would not work: TypeScript's void-return
+ * assignability rule accepts `async (r) => {}` against `(r) => void`, so the
+ * guard would silently be a no-op. Constraining `R extends void | boolean`
+ * rejects async but also rejects the value-returning arrows real callers use.
+ *
+ * @internal
+ */
+type SyncOnly<R> = R extends PromiseLike<unknown> ? never : R;
+
+/**
  * Register an after_find callback. Fires on every record loaded from the DB.
  *
  * Rails defines :find with only: :after, so there is no before_find or around_find.
  *
+ * This chain runs synchronously (`strict: "sync"` at every call site in
+ * base.ts), because Rails fires it from `init_with` on the hot read path and
+ * JS constructors cannot await — so async callbacks are rejected here rather
+ * than throwing at runtime on the first record loaded.
+ *
  * Mirrors: ActiveRecord::Callbacks.after_find
  */
-export function afterFind<T extends ModelCtor>(
+export function afterFind<T extends ModelCtor, R>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: (record: InstanceType<T>) => SyncOnly<R>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "find", fn, options);
@@ -185,11 +204,13 @@ export function afterFind<T extends ModelCtor>(
  *
  * Rails defines :initialize with only: :after, so there is no before_initialize or around_initialize.
  *
+ * Runs synchronously — see the note on {@link afterFind}.
+ *
  * Mirrors: ActiveRecord::Callbacks.after_initialize
  */
-export function afterInitialize<T extends ModelCtor>(
+export function afterInitialize<T extends ModelCtor, R>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: (record: InstanceType<T>) => SyncOnly<R>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "initialize", fn, options);


### PR DESCRIPTION
Types the two synchronous AR callback registrars — `afterInitialize` and
`afterFind` — to reject `Promise`-returning callbacks at compile time.

These are the only chains trails runs with `strict: "sync"` (every call site in
`base.ts`), because Rails fires `_run_initialize_callbacks` from `initialize` /
`init_with` / `initialize_dup` and JS constructors cannot await. The runtime
already throws on a thenable, but the registrars were typed
`void | Promise<void>`, so `Model.afterInitialize(async (r) => {})` typechecked
and only blew up on the first record constructed.

The guard is a conditional rejection with an unconstrained `R`:

```ts
type SyncOnly<R> = R extends PromiseLike<unknown> ? never : R;
```

A plain `void` return type would be a silent no-op (TS's void-return
assignability accepts async arrows), and `R extends void | boolean` rejects the
value-returning arrows real callers use (e.g. `bulb.ts:31`).

- Every existing registration still compiles (`pnpm typecheck` clean).
- New trails-only test file pins both directions; the `@ts-expect-error`s fail
  loudly if the guard ever regresses to a no-op.
- Other registrars stay on `void | Promise<void>` — their chains are genuinely
  async. The runtime `strict: "sync"` throw stays for untyped callers.

Closes-story: sync-only-callback-registrar-types
