### PR TITLE
test(activerecord): drop the trails-only professors rebuild from base-prevent-writes

### DIFF
--- a/packages/activerecord/src/base-prevent-writes.test.ts
+++ b/packages/activerecord/src/base-prevent-writes.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import { ReadOnlyError } from "./errors.js";
 import { fixtures } from "./test-fixtures.js";
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Professor } from "./test-helpers/models/professor.js";
 
@@ -73,8 +72,6 @@ describe("BasePreventWritesTest", () => {
   });
 
   it("preventing writes applies to all connections in block", async () => {
-    await rebuildCanonicalTables(ARUnit2Model.connection, ["professors"]);
-
     const conn1Error = await Base.whilePreventingWrites(async () => {
       expect(await Bird.leaseConnection()).toBe(await Base.leaseConnection());
       expect(await ARUnit2Model.leaseConnection()).not.toBe(await Bird.leaseConnection());


### PR DESCRIPTION
`base-prevent-writes.test.ts`'s `"preventing writes applies to all connections in block"` opened with a trails-only
`rebuildCanonicalTables(ARUnit2Model.connection, ["professors"])`. Rails'
counterpart (`base_prevent_writes_test.rb:68-88`) starts straight at
`while_preventing_writes`.

The arunit2 tables (`ARUNIT2_TABLES`, which includes `professors`) are already
laid down per worker by `provisionSecondDatabase` in `test-setup-dy.ts`, so the
inline rebuild was redundant. Removing it makes the body match Rails
line-for-line and drops the file's only use of the sync `ARUnit2Model.connection`
accessor.

Verified on the sqlite lane locally as the only file in a fresh worker; CI covers
postgresql and mysql2.

Closes-story: base-prevent-writes-professors-rebuild-has-no-rails-counterpart
