### PR TITLE
fix(activerecord): route relation update/updateBang and _execScope through the model

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -28,6 +28,7 @@ import type {
   SignedGlobalID as SignedGlobalIDType,
 } from "@blazetrails/globalid/signed-global-id";
 import {
+  ArgumentError,
   Model,
   Type,
   pushPendingDecorator,
@@ -456,6 +457,11 @@ function _relationCtorFor(this: void, model: typeof Base): new (m: typeof Base, 
  *
  * The string sentinel is `":all"` (with leading colon) — a bare `"all"`
  * would collide with a legitimate string/slug primary-key value.
+ *
+ * Raises the real `ArgumentError` class rather than the `argumentError()`
+ * name-stamped `Error` used elsewhere in this file: `Relation#update` routes
+ * its by-id form here (relation.rb:620-636), and the ported relation tests
+ * assert `instanceof ArgumentError`.
  */
 async function performClassUpdate(
   this: typeof Base,
@@ -492,7 +498,7 @@ async function performClassUpdate(
     // update(attrs) — apply to every record in the current scope.
     const candidate = attrs ?? idOrAttrs;
     if (!isPlainObject(candidate)) {
-      throw argumentError(
+      throw new ArgumentError(
         "update: attributes must be a plain object (missing or invalid attrs for the :all / nil form)",
       );
     }
@@ -505,7 +511,7 @@ async function performClassUpdate(
     if (idOrAttrs.some((i) => i instanceof Base)) {
       // Rails raises the *array*-specific message here (distinct from the
       // single-instance message below), pointing at `pluck(:id)`/`map(&:id)`.
-      throw argumentError(
+      throw new ArgumentError(
         `You are passing an array of ActiveRecord::Base instances to \`${
           bang ? "update!" : "update"
         }\`. Please pass the ids of the objects by calling \`pluck(:id)\` or \`map(&:id)\`.`,
@@ -521,12 +527,12 @@ async function performClassUpdate(
       // user gets a readable error instead of UnknownAttributeError on
       // numeric-keyed forwarding.
       if (Array.isArray(attrs)) {
-        throw argumentError(
+        throw new ArgumentError(
           `${this.name}.update: parallel updates for composite PKs require an array-of-tuples first arg, e.g. update([[k1a,k2a],[k1b,k2b]], [attrsA, attrsB])`,
         );
       }
       if (!isPlainObject(attrs)) {
-        throw argumentError(`${this.name}.update: attributes must be a plain object`);
+        throw new ArgumentError(`${this.name}.update: attributes must be a plain object`);
       }
       const record = await this.find(idOrAttrs);
       await run(record, attrs);
@@ -537,11 +543,13 @@ async function performClassUpdate(
     if (idOrAttrs.length === 0) return [];
     const attrsArr = attrs as Record<string, unknown>[];
     if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {
-      throw argumentError("update(ids, attrs): ids and attrs must be arrays of the same length");
+      throw new ArgumentError(
+        "update(ids, attrs): ids and attrs must be arrays of the same length",
+      );
     }
     for (const a of attrsArr) {
       if (!isPlainObject(a)) {
-        throw argumentError(`${this.name}.update: every attrs entry must be a plain object`);
+        throw new ArgumentError(`${this.name}.update: every attrs entry must be a plain object`);
       }
     }
     // Mirror Rails' `id.map { |one_id| find(one_id) }.each_with_index { … }`:
@@ -560,7 +568,7 @@ async function performClassUpdate(
   }
 
   if (idOrAttrs instanceof Base) {
-    throw argumentError(
+    throw new ArgumentError(
       `You are passing an instance of ActiveRecord::Base to \`${
         bang ? "update!" : "update"
       }\`. Please pass the id of the object by calling \`.id\`.`,
@@ -568,7 +576,7 @@ async function performClassUpdate(
   }
 
   if (!isPlainObject(attrs)) {
-    throw argumentError(`${this.name}.update: attributes must be a plain object`);
+    throw new ArgumentError(`${this.name}.update: attributes must be a plain object`);
   }
   const record = await this.find(idOrAttrs);
   await run(record, attrs);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -457,11 +457,6 @@ function _relationCtorFor(this: void, model: typeof Base): new (m: typeof Base, 
  *
  * The string sentinel is `":all"` (with leading colon) — a bare `"all"`
  * would collide with a legitimate string/slug primary-key value.
- *
- * Raises the real `ArgumentError` class rather than the `argumentError()`
- * name-stamped `Error` used elsewhere in this file: `Relation#update` routes
- * its by-id form here (relation.rb:620-636), and the ported relation tests
- * assert `instanceof ArgumentError`.
  */
 async function performClassUpdate(
   this: typeof Base,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6002,10 +6002,6 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    // Rails' by-id form is `model.update(id, attributes)` — the class entry
-    // point owns the id-shape handling (arrays, CPK tuples, the
-    // "you passed a Base instance" ArgumentError), so it must not be
-    // reimplemented here as find + record.update.
     return (await (this.model as any).update(id, attrs ?? {})) as T;
   }
 
@@ -6023,7 +6019,6 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    // See update(): the by-id form dispatches to `model.update!`.
     return (await (this.model as any).updateBang(id, attrs ?? {})) as T;
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5993,16 +5993,6 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#update
    */
   async update(id?: unknown, attrs?: Record<string, unknown>): Promise<T | T[]> {
-    if (
-      id !== null &&
-      typeof id === "object" &&
-      attrs !== undefined &&
-      "_isActiveRecordBase" in ((id as any).constructor ?? {})
-    ) {
-      throw new ArgumentError(
-        `You are passing an instance of ActiveRecord::Base to \`update\`. Please pass the id of the object by calling \`.id\`.`,
-      );
-    }
     if (id === undefined || (typeof id === "object" && id !== null && attrs === undefined)) {
       // update(attrs) form — update all matching records
       const updates = (id ?? {}) as Record<string, unknown>;
@@ -6012,9 +6002,11 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    const record = await this.find(id);
-    await record.update(attrs ?? {});
-    return record;
+    // Rails' by-id form is `model.update(id, attributes)` — the class entry
+    // point owns the id-shape handling (arrays, CPK tuples, the
+    // "you passed a Base instance" ArgumentError), so it must not be
+    // reimplemented here as find + record.update.
+    return (await (this.model as any).update(id, attrs ?? {})) as T;
   }
 
   /**
@@ -6031,9 +6023,8 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    const record = await this.find(id);
-    await record.updateBang(attrs ?? {});
-    return record;
+    // See update(): the by-id form dispatches to `model.update!`.
+    return (await (this.model as any).updateBang(id, attrs ?? {})) as T;
   }
 
   /**
@@ -6583,7 +6574,7 @@ export class Relation<T extends Base> {
       typeof optionsOrCallback === "function" ? null : (optionsOrCallback.allQueries ?? null);
 
     const modelClass = this.model as any;
-    const registry = ScopeRegistry.instance();
+    const registry = modelClass.scopeRegistry();
 
     // Rails: global_scope? && all_queries == false → raise.
     if (this.isGlobalScope(registry) && allQueries === false) {
@@ -7019,7 +7010,7 @@ export class Relation<T extends Base> {
    */
   _execScope(fn: (rel: Relation<T>, ...args: unknown[]) => unknown, ...args: unknown[]): unknown {
     this._delegateToModel = true;
-    const registry = ScopeRegistry.instance();
+    const registry = (this.model as any).scopeRegistry();
     try {
       return this._scoping(null, registry, () => fn(this, ...args) || this);
     } finally {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6002,7 +6002,7 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    return (await (this.model as any).update(id, attrs ?? {})) as T;
+    return (await this.model.update(id, attrs ?? {})) as T;
   }
 
   /**
@@ -6019,7 +6019,7 @@ export class Relation<T extends Base> {
       }
       return records;
     }
-    return (await (this.model as any).updateBang(id, attrs ?? {})) as T;
+    return (await this.model.updateBang(id, attrs ?? {})) as T;
   }
 
   /**
@@ -6569,7 +6569,7 @@ export class Relation<T extends Base> {
       typeof optionsOrCallback === "function" ? null : (optionsOrCallback.allQueries ?? null);
 
     const modelClass = this.model as any;
-    const registry = modelClass.scopeRegistry();
+    const registry = this.model.scopeRegistry();
 
     // Rails: global_scope? && all_queries == false → raise.
     if (this.isGlobalScope(registry) && allQueries === false) {
@@ -7005,7 +7005,7 @@ export class Relation<T extends Base> {
    */
   _execScope(fn: (rel: Relation<T>, ...args: unknown[]) => unknown, ...args: unknown[]): unknown {
     this._delegateToModel = true;
-    const registry = (this.model as any).scopeRegistry();
+    const registry = this.model.scopeRegistry();
     try {
       return this._scoping(null, registry, () => fn(this, ...args) || this);
     } finally {


### PR DESCRIPTION
Restores the four `Per-entry verified (RFC 0072 model-accessor sweep)` wide-call
rows that PR #5728's same-file transitive closure cleared. Three were real
divergences and are converged here; the fourth is registered as a follow-up.

## Converged

- **`_execScope`** (relation.rb:552-558) and **`scoping`** (relation.rb:542) now
  resolve the registry via `model.scopeRegistry()` instead of reading
  `ScopeRegistry.instance()` directly. The story flagged a possibly-missing
  per-model registry accessor; there isn't one to port — Rails'
  `scope_registry` (scoping.rb:42) is `ScopeRegistry.instance`, the same
  execution-state-wide singleton trails already returns from
  `Base.scopeRegistry`. Only the routing was missing.
- **`update`** / **`updateBang`** (relation.rb:620-636) dispatch the by-id form
  to `model.update(id, attributes)` / `model.updateBang(...)` instead of
  `find(id)` + `record.update(...)`. Besides being the wrong code path, the
  local version reimplemented the "you are passing an instance of
  ActiveRecord::Base" `ArgumentError` and bypassed the class entry point's
  array-of-ids and composite-PK tuple handling.
- `Base.performClassUpdate` now raises the real `ArgumentError` class rather
  than the name-stamped `Error` that `argumentError()` produces, because
  `update on relation passing active record object is not permitted` asserts
  `instanceof ArgumentError` and the throw now originates there.

The three `Per-entry verified` rows for these methods are already absent from
`call-mismatches-wide-exclude/activerecord/relation.json` on current `main`, so
after rebasing this PR is source-only; `pnpm api:calls:wide` reports OK against
that baseline with these changes applied.

## Deferred

`buildJoinBuckets` (query_methods.rb:1847-1850) is not converged here. Rails
keeps one `joins_values` store and discriminates the stashed eager
JoinDependency with `joins.last.base_klass == model`; trails splits that state
across `joinsValues`, `_eagerLoadAssociations` and `_namedInnerJoinDeps`, so
the discriminator is structural and `model` is never read. Re-merging the three
stores touches construction, spawn/merge state copying and every reader — well
past this PR. Registered as
`0083-wide-call-ratchet-noise-reduction/converge-build-join-buckets-single-joins-store`,
which carries the full context so the divergence survives the baseline row's
disappearance.

## Verification

Read against vendored Rails (`relation.rb`, `scoping.rb`, `persistence.rb`).
Passing locally: `relation/update-all.test.ts`, `relations.test.ts`,
`relation.test.ts`, `relation.trails.test.ts`, `persistence.test.ts`,
`persistence.trails.test.ts`, `base.test.ts`, `finder.test.ts`, and all of
`scoping/`. `pnpm api:calls:wide` is clean after the reseed.

Closes-story: restore-rfc0072-verified-model-divergences
