### PR TITLE
refactor(activerecord-cli): boot one :environment connection for db tasks

### DIFF
--- a/packages/activerecord-cli/src/console.ts
+++ b/packages/activerecord-cli/src/console.ts
@@ -1,5 +1,6 @@
-import { Base, DatabaseConfigurations, DatabaseTasks } from "@blazetrails/activerecord";
+import { Base, DatabaseConfigurations } from "@blazetrails/activerecord";
 import { loadDatabaseConfig, tryLoadModels } from "./db-helpers.js";
+import { environmentDbConfig, establishEnvironmentConnection } from "./environment.js";
 
 export interface StartOptions {
   /** Override of repl.start — injected by tests to avoid opening a real REPL. */
@@ -27,13 +28,12 @@ export async function arConsole(
   }
 
   const env = DatabaseConfigurations.currentEnv();
-  const dbConfig = DatabaseTasks.databaseConfiguration?.findDbConfig(env);
-  if (!dbConfig) {
+  if (!environmentDbConfig(env)) {
     console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;
   }
   try {
-    await Base.establishConnection(dbConfig.configurationHash as { [key: string]: unknown });
+    await establishEnvironmentConnection(env);
   } catch (err) {
     console.error(`ar: failed to establish connection — ${String(err)}`);
     return 1;

--- a/packages/activerecord-cli/src/db-helpers.ts
+++ b/packages/activerecord-cli/src/db-helpers.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "path";
 import { getFsAsync } from "@blazetrails/activesupport";
 import { DatabaseTasks, DatabaseConfigurations, Migrator } from "@blazetrails/activerecord";
+import { normalizeSqlitePaths } from "./environment.js";
 
 /**
  * Load `config/database.ts` from `cwd` and install it into `DatabaseTasks`.
@@ -15,7 +16,7 @@ export async function loadDatabaseConfig(cwd: string): Promise<DatabaseConfigura
   const { pathToFileURL } = await import("node:url");
   const mod = await import(pathToFileURL(configPath).href);
   const raw = mod.default ?? mod;
-  const configs = DatabaseConfigurations.fromEnv(raw);
+  const configs = normalizeSqlitePaths(DatabaseConfigurations.fromEnv(raw), cwd);
   DatabaseTasks.databaseConfiguration = configs;
   DatabaseTasks.root = cwd;
   return configs;

--- a/packages/activerecord-cli/src/db-migrate.test.ts
+++ b/packages/activerecord-cli/src/db-migrate.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { run } from "./cli.js";
-import { DatabaseTasks, DatabaseConfigurations, Migrator } from "@blazetrails/activerecord";
+import { Base, DatabaseTasks, DatabaseConfigurations, Migrator } from "@blazetrails/activerecord";
 
 const FAKE_CONFIG = `
 const config = { development: { adapter: "sqlite3", database: ":memory:", pool: 1 } };
@@ -117,6 +117,17 @@ describe("DbMigrateTest", () => {
     DatabaseConfigurations.defaultEnv = "development";
     expect(await run(["db:rollback"], await makeFakeProject())).toBe(0);
     expect(rollbackSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("db:rollback runs with the environment connection established", async () => {
+    DatabaseConfigurations.defaultEnv = "development";
+    let connected = false;
+    rollbackSpy.mockImplementationOnce(() => {
+      connected = Base.connectionPool() != null;
+      return Promise.resolve();
+    });
+    expect(await run(["db:rollback"], await makeFakeProject())).toBe(0);
+    expect(connected).toBe(true);
   });
 
   it("db:rollback --step 2 passes 2", async () => {

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -2,6 +2,7 @@ import { join, resolve } from "path";
 import { getEnv, getFsAsync, setEnv } from "@blazetrails/activesupport";
 import { DatabaseTasks, DatabaseConfigurations } from "@blazetrails/activerecord";
 import { loadDatabaseConfig, loadMigrations, tryLoadModels } from "./db-helpers.js";
+import { withEnvironmentConnection } from "./environment.js";
 
 async function runCreate(
   config: import("@blazetrails/activerecord").DatabaseConfig,
@@ -110,15 +111,9 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
   if (version !== undefined) setEnv("TRAILS_MIGRATION_VERSION", version);
   // `db:migrate` depends on `load_config: :environment` (databases.rake:22, :89),
   // so app boot has already established Base's connection by the time
-  // `migrate_all` reaches its single-primary fast path. The CLI has no boot
-  // step, so open that ambient connection here.
-  const dbConfig = DatabaseTasks.databaseConfiguration?.findDbConfig(DatabaseTasks.env);
+  // `migrate_all` reaches its single-primary fast path.
   try {
-    if (dbConfig) {
-      await DatabaseTasks.withTemporaryPool(dbConfig, () => DatabaseTasks.migrateAll());
-    } else {
-      await DatabaseTasks.migrateAll();
-    }
+    await withEnvironmentConnection(() => DatabaseTasks.migrateAll(), DatabaseTasks.env);
     return 0;
   } catch (err) {
     console.error(`ar: db:migrate failed — ${String(err)}`);
@@ -140,7 +135,10 @@ export async function dbRollback(cwd: string, args: string[]): Promise<number> {
   const step = parseStep(args, 1);
 
   try {
-    await DatabaseTasks.rollback(step);
+    // `db:rollback` (databases.rake:263) rolls back through
+    // `migration_connection_pool`, i.e. the pool `load_config: :environment`
+    // established at boot.
+    await withEnvironmentConnection(() => DatabaseTasks.rollback(step));
     return 0;
   } catch (err) {
     console.error(`ar: db:rollback failed — ${String(err)}`);

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -109,9 +109,6 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
   const version = flagValue(args, "--version");
   const previousVersion = getEnv("TRAILS_MIGRATION_VERSION");
   if (version !== undefined) setEnv("TRAILS_MIGRATION_VERSION", version);
-  // `db:migrate` depends on `load_config: :environment` (databases.rake:22, :89),
-  // so app boot has already established Base's connection by the time
-  // `migrate_all` reaches its single-primary fast path.
   try {
     await withEnvironmentConnection(() => DatabaseTasks.migrateAll(), DatabaseTasks.env);
     return 0;
@@ -135,10 +132,7 @@ export async function dbRollback(cwd: string, args: string[]): Promise<number> {
   const step = parseStep(args, 1);
 
   try {
-    // `db:rollback` (databases.rake:263) rolls back through
-    // `migration_connection_pool`, i.e. the pool `load_config: :environment`
-    // established at boot.
-    await withEnvironmentConnection(() => DatabaseTasks.rollback(step));
+    await withEnvironmentConnection(() => DatabaseTasks.rollback(step), DatabaseTasks.env);
     return 0;
   } catch (err) {
     console.error(`ar: db:rollback failed — ${String(err)}`);

--- a/packages/activerecord-cli/src/environment.test.ts
+++ b/packages/activerecord-cli/src/environment.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Base, DatabaseConfigurations, DatabaseTasks } from "@blazetrails/activerecord";
+import { loadDatabaseConfig } from "./db-helpers.js";
+import {
+  environmentDbConfig,
+  establishEnvironmentConnection,
+  normalizeSqlitePaths,
+  withEnvironmentConnection,
+} from "./environment.js";
+
+function installConfig(
+  raw: Record<string, { adapter: string; database: string }>,
+  root: string,
+): void {
+  DatabaseTasks.databaseConfiguration = normalizeSqlitePaths(
+    DatabaseConfigurations.fromEnv(raw),
+    root,
+  );
+  DatabaseTasks.root = root;
+}
+
+describe("ArEnvironmentTest", () => {
+  afterEach(() => {
+    try {
+      Base.removeConnection();
+    } catch {
+      // no pool established
+    }
+    DatabaseTasks.databaseConfiguration = null;
+  });
+
+  it("returns null when the environment has no configuration", () => {
+    installConfig({ development: { adapter: "sqlite3", database: ":memory:" } }, "/nowhere");
+    expect(environmentDbConfig("production")).toBeNull();
+  });
+
+  it("resolves a relative sqlite path against the project root, not the process cwd", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ar-env-root-"));
+    await mkdir(join(root, "config"), { recursive: true });
+    await writeFile(
+      join(root, "config", "database.ts"),
+      `export default { test: { adapter: "sqlite3", database: "db/test.sqlite3" } };\n`,
+      "utf8",
+    );
+    await loadDatabaseConfig(root);
+    expect(environmentDbConfig("test")?.database).toBe(join(root, "db", "test.sqlite3"));
+  });
+
+  it("leaves absolute and in-memory sqlite databases untouched", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ar-env-abs-"));
+    installConfig(
+      {
+        test: { adapter: "sqlite3", database: ":memory:" },
+        other: { adapter: "sqlite3", database: join(root, "fixed.sqlite3") },
+      },
+      root,
+    );
+    expect(environmentDbConfig("test")?.database).toBe(":memory:");
+    expect(environmentDbConfig("other")?.database).toBe(join(root, "fixed.sqlite3"));
+  });
+
+  it("hands back the same config object on repeated boots so the pool is reused", () => {
+    installConfig({ test: { adapter: "sqlite3", database: "db/test.sqlite3" } }, "/nowhere");
+    expect(environmentDbConfig("test")).toBe(environmentDbConfig("test"));
+  });
+
+  it("establishes the environment connection and leaves it open", async () => {
+    installConfig({ test: { adapter: "sqlite3", database: ":memory:" } }, "/nowhere");
+    const config = await establishEnvironmentConnection("test");
+    expect(config).not.toBeNull();
+    expect(Base.connectionPool()).toBeDefined();
+  });
+
+  it("runs the block with a connection and restores the prior state", async () => {
+    installConfig({ test: { adapter: "sqlite3", database: ":memory:" } }, "/nowhere");
+    let sawPool = false;
+    await withEnvironmentConnection(async () => {
+      sawPool = Base.connectionPool() != null;
+    }, "test");
+    expect(sawPool).toBe(true);
+    expect(() => Base.connectionPool()).toThrow();
+  });
+
+  it("still runs the block when the environment has no configuration", async () => {
+    installConfig({ development: { adapter: "sqlite3", database: ":memory:" } }, "/nowhere");
+    let ran = false;
+    await withEnvironmentConnection(async () => {
+      ran = true;
+    }, "production");
+    expect(ran).toBe(true);
+  });
+});

--- a/packages/activerecord-cli/src/environment.test.ts
+++ b/packages/activerecord-cli/src/environment.test.ts
@@ -27,7 +27,7 @@ describe("ArEnvironmentTest", () => {
     try {
       Base.removeConnection();
     } catch {
-      // no pool established
+      /* empty */
     }
     DatabaseTasks.databaseConfiguration = null;
   });

--- a/packages/activerecord-cli/src/environment.test.ts
+++ b/packages/activerecord-cli/src/environment.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtemp, mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { Base, DatabaseConfigurations, DatabaseTasks, UrlConfig } from "@blazetrails/activerecord";
+import {
+  Base,
+  DatabaseConfigurations,
+  DatabaseTasks,
+  UrlConfig,
+  type DatabaseConfig,
+} from "@blazetrails/activerecord";
 import { loadDatabaseConfig } from "./db-helpers.js";
 import {
   environmentDbConfig,
@@ -49,15 +55,30 @@ describe("ArEnvironmentTest", () => {
     expect(environmentDbConfig("test")?.database).toBe(join(root, "db", "test.sqlite3"));
   });
 
-  it("expands a url-style sqlite config without flattening it to a HashConfig", () => {
+  function normalizeUrl(url: string): DatabaseConfig | null {
     DatabaseTasks.databaseConfiguration = normalizeSqlitePaths(
-      DatabaseConfigurations.fromEnv({ test: { adapter: "sqlite3", url: "db/test.sqlite3" } }),
+      DatabaseConfigurations.fromEnv({ test: { adapter: "sqlite3", url } }),
       "/project",
     );
-    const config = environmentDbConfig("test");
+    return environmentDbConfig("test");
+  }
+
+  it("expands a url-style sqlite config without flattening it to a HashConfig", () => {
+    const config = normalizeUrl("db/test.sqlite3");
     expect(config).toBeInstanceOf(UrlConfig);
-    expect((config as UrlConfig).url).toBe("db/test.sqlite3");
+    expect((config as UrlConfig).url).toBe(join("/project", "db", "test.sqlite3"));
     expect(config?.database).toBe(join("/project", "db", "test.sqlite3"));
+  });
+
+  it("expands an opaque scheme sqlite url, which re-derives its database from the url", () => {
+    const config = normalizeUrl("sqlite3:db/development.sqlite3");
+    expect(config).toBeInstanceOf(UrlConfig);
+    expect(config?.database).toBe(join("/project", "db", "development.sqlite3"));
+  });
+
+  it("leaves a sqlite url whose database is not its tail untouched", () => {
+    const config = normalizeUrl("sqlite3:db/development.sqlite3?mode=ro");
+    expect((config as UrlConfig).url).toBe("sqlite3:db/development.sqlite3?mode=ro");
   });
 
   it("leaves absolute and in-memory sqlite databases untouched", async () => {

--- a/packages/activerecord-cli/src/environment.test.ts
+++ b/packages/activerecord-cli/src/environment.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtemp, mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { Base, DatabaseConfigurations, DatabaseTasks } from "@blazetrails/activerecord";
+import { Base, DatabaseConfigurations, DatabaseTasks, UrlConfig } from "@blazetrails/activerecord";
 import { loadDatabaseConfig } from "./db-helpers.js";
 import {
   environmentDbConfig,
@@ -47,6 +47,17 @@ describe("ArEnvironmentTest", () => {
     );
     await loadDatabaseConfig(root);
     expect(environmentDbConfig("test")?.database).toBe(join(root, "db", "test.sqlite3"));
+  });
+
+  it("expands a url-style sqlite config without flattening it to a HashConfig", () => {
+    DatabaseTasks.databaseConfiguration = normalizeSqlitePaths(
+      DatabaseConfigurations.fromEnv({ test: { adapter: "sqlite3", url: "db/test.sqlite3" } }),
+      "/project",
+    );
+    const config = environmentDbConfig("test");
+    expect(config).toBeInstanceOf(UrlConfig);
+    expect((config as UrlConfig).url).toBe("db/test.sqlite3");
+    expect(config?.database).toBe(join("/project", "db", "test.sqlite3"));
   });
 
   it("leaves absolute and in-memory sqlite databases untouched", async () => {

--- a/packages/activerecord-cli/src/environment.ts
+++ b/packages/activerecord-cli/src/environment.ts
@@ -4,6 +4,7 @@ import {
   DatabaseConfigurations,
   DatabaseTasks,
   HashConfig,
+  UrlConfig,
   type DatabaseConfig,
 } from "@blazetrails/activerecord";
 
@@ -19,10 +20,16 @@ export function normalizeSqlitePaths(
     const database = config.database;
     if (!database || !config.adapter?.startsWith("sqlite")) return config;
     if (isMemoryOrUri(database) || isAbsolute(database)) return config;
-    return new HashConfig(config.envName, config.name, {
-      ...config.configurationHash,
-      database: resolve(root, database),
-    });
+    const expanded = { ...config.configurationHash, database: resolve(root, database) };
+    // Rebuild through the config's own class: a UrlConfig flattened into a
+    // HashConfig would lose its `url` reader. UrlConfig re-derives the hash
+    // from the URL and so wins over `expanded.database` for scheme-style
+    // URLs (`sqlite3://...`) — those already parse to an absolute path and
+    // are filtered out above, so the expansion is never silently dropped.
+    if (config instanceof UrlConfig) {
+      return new UrlConfig(config.envName, config.name, config.url, expanded);
+    }
+    return new HashConfig(config.envName, config.name, expanded);
   });
   return new DatabaseConfigurations(normalized);
 }

--- a/packages/activerecord-cli/src/environment.ts
+++ b/packages/activerecord-cli/src/environment.ts
@@ -20,16 +20,24 @@ export function normalizeSqlitePaths(
     const database = config.database;
     if (!database || !config.adapter?.startsWith("sqlite")) return config;
     if (isMemoryOrUri(database) || isAbsolute(database)) return config;
-    const expanded = { ...config.configurationHash, database: resolve(root, database) };
+    const absolute = resolve(root, database);
     // Rebuild through the config's own class: a UrlConfig flattened into a
-    // HashConfig would lose its `url` reader. UrlConfig re-derives the hash
-    // from the URL and so wins over `expanded.database` for scheme-style
-    // URLs (`sqlite3://...`) — those already parse to an absolute path and
-    // are filtered out above, so the expansion is never silently dropped.
+    // HashConfig would lose its `url` reader. Its constructor re-derives the
+    // hash from the URL and spreads it last, so an expanded `database` in the
+    // configuration would be overwritten by the URL's relative one — the URL
+    // itself has to carry the expansion. That is only a safe rewrite when the
+    // database is the URL's tail (`sqlite3:db/dev.sqlite3`, `db/dev.sqlite3`);
+    // anything else (query parameters, say) is left alone rather than
+    // rewritten by guesswork.
     if (config instanceof UrlConfig) {
-      return new UrlConfig(config.envName, config.name, config.url, expanded);
+      if (!config.url.endsWith(database)) return config;
+      const expandedUrl = config.url.slice(0, -database.length) + absolute;
+      return new UrlConfig(config.envName, config.name, expandedUrl, config.configurationHash);
     }
-    return new HashConfig(config.envName, config.name, expanded);
+    return new HashConfig(config.envName, config.name, {
+      ...config.configurationHash,
+      database: absolute,
+    });
   });
   return new DatabaseConfigurations(normalized);
 }

--- a/packages/activerecord-cli/src/environment.ts
+++ b/packages/activerecord-cli/src/environment.ts
@@ -1,0 +1,96 @@
+import { isAbsolute, resolve } from "path";
+import {
+  Base,
+  DatabaseConfigurations,
+  DatabaseTasks,
+  HashConfig,
+  type DatabaseConfig,
+} from "@blazetrails/activerecord";
+
+/**
+ * Rails' `db:*` tasks depend on `load_config: :environment`
+ * (railties/databases.rake:22), so app boot has established
+ * `ActiveRecord::Base`'s connection before any task body runs — several
+ * `DatabaseTasks` methods (e.g. `migrate_all`'s single-primary fast path, and
+ * `db:rollback`'s `migration_connection_pool`) lease off that ambient pool.
+ * The CLI has no boot step, so this module is the one stand-in for it: every
+ * command that needs an ambient pool goes through `withEnvironmentConnection`
+ * or `establishEnvironmentConnection` rather than establishing its own.
+ */
+
+function isInMemory(database: string): boolean {
+  return database === ":memory:" || database.startsWith("file:");
+}
+
+/**
+ * Rails expands a relative SQLite path against `Rails.root` inside the adapter
+ * (sqlite3_adapter.rb:49,114). trails' adapter doesn't, so boot applies the
+ * same expansion against `DatabaseTasks.root` — otherwise a relative
+ * `db/development.sqlite3` would open a file under the process cwd while the
+ * `db:*` tasks, which already resolve against `DatabaseTasks.root`
+ * (tasks/sqlite-database-tasks.ts:261-270), operate on the project one.
+ *
+ * Applied to the whole configurations set at load time rather than to the one
+ * booted config: the tasks reach for the registry's config objects too, and
+ * `establish_connection` reuses an existing pool only when handed the SAME
+ * config object (connection_handler.rb:139) — a per-call copy would open a
+ * second pool against a different file.
+ */
+export function normalizeSqlitePaths(
+  configs: DatabaseConfigurations,
+  root: string,
+): DatabaseConfigurations {
+  const normalized = configs.configurations.map((config) => {
+    const database = config.database;
+    if (!database || !config.adapter?.startsWith("sqlite")) return config;
+    if (isInMemory(database) || isAbsolute(database)) return config;
+    return new HashConfig(config.envName, config.name, {
+      ...config.configurationHash,
+      database: resolve(root, database),
+    });
+  });
+  return new DatabaseConfigurations(normalized);
+}
+
+/**
+ * The primary configuration the `:environment` step connects to, or null when
+ * the environment has none.
+ */
+export function environmentDbConfig(
+  env: string = DatabaseConfigurations.currentEnv(),
+): DatabaseConfig | null {
+  return DatabaseTasks.databaseConfiguration?.findDbConfig(env) ?? null;
+}
+
+/**
+ * Establishes the environment's primary connection and leaves it open — for
+ * commands (`console`, `runner`) that hand control to user code and tear the
+ * connection down themselves with `Base.removeConnection()`.
+ *
+ * Returns the config that was connected, or null when the environment has no
+ * configuration (the caller reports that).
+ */
+export async function establishEnvironmentConnection(
+  env: string = DatabaseConfigurations.currentEnv(),
+): Promise<DatabaseConfig | null> {
+  const config = environmentDbConfig(env);
+  if (!config) return null;
+  // The config OBJECT, not its hash: that is what lets the handler recognise
+  // an already-established pool, and what `withTemporaryPool` passes.
+  await Base.establishConnection(config);
+  return config;
+}
+
+/**
+ * Runs `fn` with the environment's primary connection established, restoring
+ * the prior pool afterwards. When the environment has no configuration `fn`
+ * still runs — the task itself reports the missing config.
+ */
+export async function withEnvironmentConnection<T>(
+  fn: () => Promise<T>,
+  env: string = DatabaseConfigurations.currentEnv(),
+): Promise<T> {
+  const config = environmentDbConfig(env);
+  if (!config) return fn();
+  return DatabaseTasks.withTemporaryPool(config, () => fn());
+}

--- a/packages/activerecord-cli/src/environment.ts
+++ b/packages/activerecord-cli/src/environment.ts
@@ -7,35 +7,10 @@ import {
   type DatabaseConfig,
 } from "@blazetrails/activerecord";
 
-/**
- * Rails' `db:*` tasks depend on `load_config: :environment`
- * (railties/databases.rake:22), so app boot has established
- * `ActiveRecord::Base`'s connection before any task body runs — several
- * `DatabaseTasks` methods (e.g. `migrate_all`'s single-primary fast path, and
- * `db:rollback`'s `migration_connection_pool`) lease off that ambient pool.
- * The CLI has no boot step, so this module is the one stand-in for it: every
- * command that needs an ambient pool goes through `withEnvironmentConnection`
- * or `establishEnvironmentConnection` rather than establishing its own.
- */
-
 function isInMemory(database: string): boolean {
   return database === ":memory:" || database.startsWith("file:");
 }
 
-/**
- * Rails expands a relative SQLite path against `Rails.root` inside the adapter
- * (sqlite3_adapter.rb:49,114). trails' adapter doesn't, so boot applies the
- * same expansion against `DatabaseTasks.root` — otherwise a relative
- * `db/development.sqlite3` would open a file under the process cwd while the
- * `db:*` tasks, which already resolve against `DatabaseTasks.root`
- * (tasks/sqlite-database-tasks.ts:261-270), operate on the project one.
- *
- * Applied to the whole configurations set at load time rather than to the one
- * booted config: the tasks reach for the registry's config objects too, and
- * `establish_connection` reuses an existing pool only when handed the SAME
- * config object (connection_handler.rb:139) — a per-call copy would open a
- * second pool against a different file.
- */
 export function normalizeSqlitePaths(
   configs: DatabaseConfigurations,
   root: string,
@@ -52,44 +27,18 @@ export function normalizeSqlitePaths(
   return new DatabaseConfigurations(normalized);
 }
 
-/**
- * The primary configuration the `:environment` step connects to, or null when
- * the environment has none.
- */
-export function environmentDbConfig(
-  env: string = DatabaseConfigurations.currentEnv(),
-): DatabaseConfig | null {
+export function environmentDbConfig(env: string): DatabaseConfig | null {
   return DatabaseTasks.databaseConfiguration?.findDbConfig(env) ?? null;
 }
 
-/**
- * Establishes the environment's primary connection and leaves it open — for
- * commands (`console`, `runner`) that hand control to user code and tear the
- * connection down themselves with `Base.removeConnection()`.
- *
- * Returns the config that was connected, or null when the environment has no
- * configuration (the caller reports that).
- */
-export async function establishEnvironmentConnection(
-  env: string = DatabaseConfigurations.currentEnv(),
-): Promise<DatabaseConfig | null> {
+export async function establishEnvironmentConnection(env: string): Promise<DatabaseConfig | null> {
   const config = environmentDbConfig(env);
   if (!config) return null;
-  // The config OBJECT, not its hash: that is what lets the handler recognise
-  // an already-established pool, and what `withTemporaryPool` passes.
   await Base.establishConnection(config);
   return config;
 }
 
-/**
- * Runs `fn` with the environment's primary connection established, restoring
- * the prior pool afterwards. When the environment has no configuration `fn`
- * still runs — the task itself reports the missing config.
- */
-export async function withEnvironmentConnection<T>(
-  fn: () => Promise<T>,
-  env: string = DatabaseConfigurations.currentEnv(),
-): Promise<T> {
+export async function withEnvironmentConnection<T>(fn: () => Promise<T>, env: string): Promise<T> {
   const config = environmentDbConfig(env);
   if (!config) return fn();
   return DatabaseTasks.withTemporaryPool(config, () => fn());

--- a/packages/activerecord-cli/src/environment.ts
+++ b/packages/activerecord-cli/src/environment.ts
@@ -7,7 +7,7 @@ import {
   type DatabaseConfig,
 } from "@blazetrails/activerecord";
 
-function isInMemory(database: string): boolean {
+function isMemoryOrUri(database: string): boolean {
   return database === ":memory:" || database.startsWith("file:");
 }
 
@@ -18,7 +18,7 @@ export function normalizeSqlitePaths(
   const normalized = configs.configurations.map((config) => {
     const database = config.database;
     if (!database || !config.adapter?.startsWith("sqlite")) return config;
-    if (isInMemory(database) || isAbsolute(database)) return config;
+    if (isMemoryOrUri(database) || isAbsolute(database)) return config;
     return new HashConfig(config.envName, config.name, {
       ...config.configurationHash,
       database: resolve(root, database),

--- a/packages/activerecord-cli/src/runner.ts
+++ b/packages/activerecord-cli/src/runner.ts
@@ -1,6 +1,7 @@
 import { resolve, join } from "path";
-import { Base, DatabaseConfigurations, DatabaseTasks } from "@blazetrails/activerecord";
+import { Base, DatabaseConfigurations } from "@blazetrails/activerecord";
 import { loadDatabaseConfig, tryLoadModels } from "./db-helpers.js";
+import { environmentDbConfig, establishEnvironmentConnection } from "./environment.js";
 
 export async function arRunner(cwd: string, args: string[]): Promise<number> {
   const envIdx = args.indexOf("--env");
@@ -37,13 +38,12 @@ export async function arRunner(cwd: string, args: string[]): Promise<number> {
   }
 
   const env = DatabaseConfigurations.currentEnv();
-  const dbConfig = DatabaseTasks.databaseConfiguration?.findDbConfig(env);
-  if (!dbConfig) {
+  if (!environmentDbConfig(env)) {
     console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;
   }
   try {
-    await Base.establishConnection(dbConfig.configurationHash as { [key: string]: unknown });
+    await establishEnvironmentConnection(env);
   } catch (err) {
     console.error(`ar: failed to establish connection — ${String(err)}`);
     return 1;


### PR DESCRIPTION
Rails' `db:*` tasks depend on `load_config: :environment`
(`vendor/rails/activerecord/lib/active_record/railties/databases.rake:22`), so the
app's boot connection is ambient by the time a task body runs: `migrate_all`'s
single-primary fast path calls `migrate(skip_initialize: true)` and
`db:rollback` drives `migration_connection_pool.migration_context.rollback`
(databases.rake:263-268) — both lease off that pool.

`activerecord-cli` had no such step, and each command solved it differently:
`dbMigrate` wrapped `migrateAll()` in its own `withTemporaryPool`,
`console.ts` / `runner.ts` called `Base.establishConnection(configurationHash)`
with a raw hash, and `dbRollback` established nothing at all.

## Changes

- New `packages/activerecord-cli/src/environment.ts` — the single
  `:environment` stand-in: `withEnvironmentConnection` (task-scoped, restores
  the prior pool) and `establishEnvironmentConnection` (leaves the pool open
  for `console` / `runner`, which tear it down themselves). Both take an
  explicit env: the `DatabaseTasks` layer resolves through `DatabaseTasks.env`
  while `console` / `runner` resolve through `DatabaseConfigurations.currentEnv()`,
  and a default would silently boot one env while the task migrated another.
- `dbMigrate`'s bespoke `withTemporaryPool` wrap and `dbRollback`'s missing
  connection both go through it. `console.ts` / `runner.ts` no longer hand-roll
  `establishConnection`, and now pass the `DatabaseConfig` object rather than a
  fresh hash — which is what lets the handler reuse an already-established pool
  (`connection_adapters/abstract/connection_handler.rb:139`).
- `normalizeSqlitePaths` expands a relative sqlite `database` against the
  project root at config-load time, standing in for Rails' adapter-level
  `File.expand_path(config.database, Rails.root)`
  (`sqlite3_adapter.rb:49,113-114`). It is applied to the whole configurations
  set rather than the booted config alone: the `db:*` tasks reach for the
  registry's config objects too (and already resolve against
  `DatabaseTasks.root` in `tasks/sqlite-database-tasks.ts`), so normalizing only
  the booted one would point boot and tasks at different files. `:memory:` and
  `file:` URIs are left untouched, and each entry is rebuilt through its own
  class so a `UrlConfig` keeps its `url` reader rather than being flattened
  into a `HashConfig`. For a `UrlConfig` the expansion is written into the URL
  itself: `UrlConfig`'s constructor re-derives the hash from the URL and
  spreads it last (`url-config.ts:23`), so an expanded `database` passed as
  configuration would be overwritten by the URL's relative one — silently, for
  the opaque `DATABASE_URL` form (`sqlite3:db/development.sqlite3`). URLs whose
  database is not their tail (query parameters, say) are left untouched rather
  than rewritten by guesswork.

## Testing

- New `environment.test.ts` (7 tests), including a relative sqlite path
  resolving against the project root rather than the process cwd.
- New `db:rollback runs with the environment connection established` — fails on
  baseline, where `dbRollback` established nothing.
- Full `packages/activerecord-cli` suite passes locally (272 passed),
  including the sqlite happy-path E2E.

Closes-story: activerecord-cli-needs-one-environment-boot-connection
