### PR TITLE
refactor(schema): give every *_exists? predicate one TS spelling

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -306,10 +306,10 @@ describe("AdapterTest", () => {
 
   it("data source exists?", async () => {
     const conn = Base.connection;
-    expect(await conn.isDataSourceExists("accounts")).toBe(true);
-    expect(await conn.isDataSourceExists("nonexistingtable")).toBe(false);
-    expect(await conn.isDataSourceExists("'")).toBe(false);
-    expect(await conn.isDataSourceExists(null as unknown as string)).toBe(false);
+    expect(await conn.dataSourceExists("accounts")).toBe(true);
+    expect(await conn.dataSourceExists("nonexistingtable")).toBe(false);
+    expect(await conn.dataSourceExists("'")).toBe(false);
+    expect(await conn.dataSourceExists(null as unknown as string)).toBe(false);
   });
 
   it("indexes", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -426,7 +426,7 @@ export interface AbstractAdapter {
   nativeDatabaseTypes(): Record<string, unknown>;
   typeToSql(type: ColumnType, options?: ColumnOptions): string;
   dataSources(): Promise<string[]>;
-  isDataSourceExists(name: string): Promise<boolean>;
+  dataSourceExists(name: string): Promise<boolean>;
   // --- DatabaseStatements ---
   /**
    * Reset the transaction manager, discarding any open transactions. With a

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -402,7 +402,7 @@ export interface AbstractAdapter {
     expression: string,
     options?: Record<string, unknown>,
   ): Promise<void>;
-  isCheckConstraintExists(
+  checkConstraintExists(
     tableName: string,
     options: { name?: string; expression?: string },
   ): Promise<boolean>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1693,7 +1693,7 @@ export class Table {
     }
   }
 
-  async isColumnExists(columnName: string, type?: ColumnType): Promise<boolean> {
+  async columnExists(columnName: string, type?: ColumnType): Promise<boolean> {
     return this._require("columnExists").call(this._schema, this._tableName, columnName, type);
   }
 
@@ -1705,7 +1705,7 @@ export class Table {
     return fn;
   }
 
-  async isIndexExists(
+  async indexExists(
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<boolean> {
@@ -1792,7 +1792,7 @@ export class Table {
     return this._require("removeForeignKey").call(this._schema, this._tableName, toTableOrOptions);
   }
 
-  async isForeignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {
+  async foreignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {
     return this._require("foreignKeyExists").call(this._schema, this._tableName, toTableOrOptions);
   }
 
@@ -1823,10 +1823,10 @@ export class Table {
     );
   }
 
-  async isCheckConstraintExists(
+  async checkConstraintExists(
     options: { name?: string; expression?: string } = {},
   ): Promise<boolean> {
-    return this._require("isCheckConstraintExists").call(this._schema, this._tableName, options);
+    return this._require("checkConstraintExists").call(this._schema, this._tableName, options);
   }
 
   async primaryKey(
@@ -1941,6 +1941,6 @@ export interface SchemaStatementsLike {
     expressionOrOptions?: string | Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<void>;
-  isCheckConstraintExists?(tableName: string, options?: Record<string, unknown>): Promise<boolean>;
+  checkConstraintExists?(tableName: string, options?: Record<string, unknown>): Promise<boolean>;
   primaryKey?(tableName: string): Promise<string | string[] | null>;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1566,7 +1566,7 @@ export class SchemaStatements {
     return [...new Set([...t, ...v])];
   }
 
-  async isDataSourceExists(name: string): Promise<boolean> {
+  async dataSourceExists(name: string): Promise<boolean> {
     if (!name) return false;
     if (await this.tableExists(name)) return true;
     return this.viewExists(name);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -907,7 +907,7 @@ export class SchemaStatements {
       name?: string;
       validate?: boolean;
     };
-    if (options.ifNotExists && (await this.isCheckConstraintExists(tableName, resolved))) return;
+    if (options.ifNotExists && (await this.checkConstraintExists(tableName, resolved))) return;
 
     const at = this.createAlterTable(tableName);
     at.addCheckConstraint(expression, resolved);
@@ -1773,7 +1773,7 @@ export class SchemaStatements {
     return dup;
   }
 
-  async isCheckConstraintExists(
+  async checkConstraintExists(
     tableName: string,
     options: { name?: string; expression?: string },
   ): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -324,6 +324,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
+    // Rails answers `data_source_exists?` through the base implementation,
+    // which is gated on `if name.present?`; this adapter-local override has to
+    // carry the same gate or a blank name reaches the catalog query.
+    if (!name) return false;
     const [schema, table] = this.pg.extractSchemaQualifiedName(name);
     if (schema) {
       const rows = await this.pg.schemaQuery(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1492,7 +1492,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     }
   }
 
-  static isDatabaseExists(config: { database?: string }): boolean {
+  static databaseExists(config: { database?: string }): boolean {
     if (!config.database || config.database === ":memory:") return true;
     try {
       return getFs().existsSync(config.database);
@@ -2096,6 +2096,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
+    // Rails answers `data_source_exists?` through the base implementation,
+    // which is gated on `if name.present?`; this adapter-local override has to
+    // carry the same gate or a blank name reaches the catalog query.
+    if (!name) return false;
     if (name.includes(".")) {
       // Schema-qualified name (e.g. "aux.widgets"). pragma_table_list returns
       // rows for every attached schema and exposes the schema name as a

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   schemaCreation,
   createSchemaDumper,
-  isVirtualTableExists,
+  virtualTableExists,
   _extractValueFromDefault,
   isColumnTheRowid,
   dataSourceSql,
@@ -30,24 +30,24 @@ describe("SQLite3::SchemaStatements", () => {
     });
   });
 
-  describe("isVirtualTableExists", () => {
+  describe("virtualTableExists", () => {
     it("returns true when a matching virtual table row is found", async () => {
       const fakeAdapter = {
         execute: vi.fn().mockResolvedValue([{ name: "virtual_tab" }]),
       } as any;
-      expect(await isVirtualTableExists(fakeAdapter, "virtual_tab")).toBe(true);
+      expect(await virtualTableExists(fakeAdapter, "virtual_tab")).toBe(true);
     });
 
     it("returns false when no matching row is found", async () => {
       const fakeAdapter = {
         execute: vi.fn().mockResolvedValue([]),
       } as any;
-      expect(await isVirtualTableExists(fakeAdapter, "no_such_table")).toBe(false);
+      expect(await virtualTableExists(fakeAdapter, "no_such_table")).toBe(false);
     });
 
     it("queries sqlite_temp_master for temp schema tables", async () => {
       const fakeAdapter = { execute: vi.fn().mockResolvedValue([]) } as any;
-      await isVirtualTableExists(fakeAdapter, "temp.my_vtab");
+      await virtualTableExists(fakeAdapter, "temp.my_vtab");
       expect(fakeAdapter.execute).toHaveBeenCalledWith(
         expect.stringContaining("sqlite_temp_master"),
         expect.anything(),

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -187,7 +187,7 @@ function resolveMasterTable(
   return { masterTable: `${adapter.quoteColumnName(schema)}.sqlite_master`, name };
 }
 
-export async function isVirtualTableExists(
+export async function virtualTableExists(
   adapter: DatabaseAdapter,
   tableName: string,
 ): Promise<boolean> {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1546,7 +1546,7 @@ describe("MigrationTest", () => {
 
   describe("IndexTest", () => {
     // Mirrors ActiveRecord::Migration::IndexTest — drives the Migration-class
-    // index twins (isIndexExists/removeIndex) so the `valid`/`ifExists` option
+    // index twins (indexExists/removeIndex) so the `valid`/`ifExists` option
     // widenings forward to the adapter. Rails' bespoke `testings(foo, bar)`
     // table is dropped in `finally` (Rails' `teardown`) so nothing leaks.
     async function withTestings(body: () => Promise<void>): Promise<void> {
@@ -1578,11 +1578,11 @@ describe("MigrationTest", () => {
         const mig = new (class extends Migration {})();
         await mig.addIndex("testings", ["foo"], { name: "foo" });
 
-        expect(await mig.isIndexExists("testings", "foo", { name: "foo" })).toBe(true);
+        expect(await mig.indexExists("testings", "foo", { name: "foo" })).toBe(true);
 
         await mig.removeIndex("testings", { name: "foo", ifExists: true });
 
-        expect(await mig.isIndexExists("testings", "foo", { name: "foo" })).toBe(false);
+        expect(await mig.indexExists("testings", "foo", { name: "foo" })).toBe(false);
       });
     });
 
@@ -1591,19 +1591,19 @@ describe("MigrationTest", () => {
         const mig = new (class extends Migration {})();
         await mig.addIndex("testings", ["foo"], { name: "foo" });
 
-        expect(await mig.isIndexExists("testings", "foo", { name: "foo" })).toBe(true);
+        expect(await mig.indexExists("testings", "foo", { name: "foo" })).toBe(true);
 
         await mig.removeIndex("testings", { column: ["foo", "bar"], ifExists: true });
 
-        expect(await mig.isIndexExists("testings", "foo", { name: "foo" })).toBe(true);
-        expect(await mig.isIndexExists("testings", ["foo", "bar"], { name: "foo" })).toBe(false);
+        expect(await mig.indexExists("testings", "foo", { name: "foo" })).toBe(true);
+        expect(await mig.indexExists("testings", ["foo", "bar"], { name: "foo" })).toBe(false);
       });
     });
   });
 
   describeIfPg("PostgresqlIndexTest", () => {
     // Mirrors PostgreSQLAdapterTest#test_invalid_index — a failed CONCURRENTLY
-    // unique index is left behind marked invalid; Migration#isIndexExists must
+    // unique index is left behind marked invalid; Migration#indexExists must
     // forward `valid` to distinguish it, matching the adapter twin.
     it("test_invalid_index", async () => {
       const conn = Base.connection;
@@ -1627,13 +1627,13 @@ describe("MigrationTest", () => {
         }
         expect(error).toBeInstanceOf(RecordNotUnique);
 
-        expect(await mig.isIndexExists("ex", "number", { name: "invalid_index" })).toBe(true);
-        expect(
-          await mig.isIndexExists("ex", "number", { name: "invalid_index", valid: true }),
-        ).toBe(false);
-        expect(
-          await mig.isIndexExists("ex", "number", { name: "invalid_index", valid: false }),
-        ).toBe(true);
+        expect(await mig.indexExists("ex", "number", { name: "invalid_index" })).toBe(true);
+        expect(await mig.indexExists("ex", "number", { name: "invalid_index", valid: true })).toBe(
+          false,
+        );
+        expect(await mig.indexExists("ex", "number", { name: "invalid_index", valid: false })).toBe(
+          true,
+        );
       } finally {
         await conn.dropTable("ex", { ifExists: true });
       }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1229,11 +1229,11 @@ export abstract class Migration {
     return this._recording && this._recorder.reverting;
   }
 
-  async isViewExists(viewName: string): Promise<boolean> {
+  async viewExists(viewName: string): Promise<boolean> {
     return this.schema.viewExists(viewName);
   }
 
-  async isIndexExists(
+  async indexExists(
     tableName: string,
     columnName: string | string[],
     options?: { unique?: boolean; name?: string; valid?: boolean },

--- a/packages/activerecord/src/migration/change-schema.test.ts
+++ b/packages/activerecord/src/migration/change-schema.test.ts
@@ -546,8 +546,8 @@ describe("Migration", () => {
         t.string("foo");
       });
       await connection.changeTable("testings", async (t) => {
-        expect(await t.isColumnExists("foo")).toBeTruthy();
-        expect(await t.isColumnExists("bar")).toBeFalsy();
+        expect(await t.columnExists("foo")).toBeTruthy();
+        expect(await t.columnExists("bar")).toBeFalsy();
       });
     });
 

--- a/packages/activerecord/src/migration/change-table.test.ts
+++ b/packages/activerecord/src/migration/change-table.test.ts
@@ -249,14 +249,14 @@ describe("Migration", () => {
     it("index exists", async () => {
       await withChangeTable(async (t, expect) => {
         expect("indexExists", null, ["delete_me", "bar"]);
-        await t.isIndexExists("bar");
+        await t.indexExists("bar");
       });
     });
 
     it("index exists with options", async () => {
       await withChangeTable(async (t, expect) => {
         expect("indexExists", null, ["delete_me", "bar", { unique: true }]);
-        await t.isIndexExists("bar", { unique: true });
+        await t.indexExists("bar", { unique: true });
       });
     });
 
@@ -349,8 +349,8 @@ describe("Migration", () => {
 
     it("check constraint exists", async () => {
       await withChangeTable(async (t, expect) => {
-        expect("isCheckConstraintExists", null, ["delete_me", { name: "price_check" }]);
-        vitestExpect(await t.isCheckConstraintExists({ name: "price_check" })).toBeFalsy();
+        expect("checkConstraintExists", null, ["delete_me", { name: "price_check" }]);
+        vitestExpect(await t.checkConstraintExists({ name: "price_check" })).toBeFalsy();
       });
     });
 

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -369,12 +369,12 @@ describeIfSupports("foreign_keys", "Migration", () => {
         await conn.changeTable("astronauts", async (t) => {
           await t.foreignKey("rockets", { column: "rocket_id", name: "fancy_named_fk" });
 
-          expect(await t.isForeignKeyExists({ column: "rocket_id" })).toBe(true);
-          expect(await t.isForeignKeyExists({ column: "star_id" })).toBe(false);
+          expect(await t.foreignKeyExists({ column: "rocket_id" })).toBe(true);
+          expect(await t.foreignKeyExists({ column: "star_id" })).toBe(false);
 
           if (unlessSqlite3Adapter) {
-            expect(await t.isForeignKeyExists({ name: "fancy_named_fk" })).toBe(true);
-            expect(await t.isForeignKeyExists({ name: "other_fancy_named_fk" })).toBe(false);
+            expect(await t.foreignKeyExists({ name: "fancy_named_fk" })).toBe(true);
+            expect(await t.foreignKeyExists({ name: "other_fancy_named_fk" })).toBe(false);
           }
         });
       });

--- a/packages/activerecord/src/support/fake-adapter.test.ts
+++ b/packages/activerecord/src/support/fake-adapter.test.ts
@@ -40,9 +40,9 @@ describe("FakeActiveRecordAdapter", () => {
     expect(adapter.columns("fake_nothing")).toEqual([]);
   });
 
-  it("data_source_exists? and active? are always true", () => {
+  it("data_source_exists? and active? are always true", async () => {
     const adapter = new FakeActiveRecordAdapter();
-    expect(adapter.dataSourceExists()).toBe(true);
+    expect(await adapter.dataSourceExists()).toBe(true);
     expect(adapter.active).toBe(true);
   });
 

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -49,8 +49,7 @@ export class FakeActiveRecordAdapter extends AbstractAdapter {
     return created;
   }
 
-  // @ts-expect-error -- synchronous in-memory lookup where the inherited one returns a promise
-  dataSourceExists(): boolean {
+  async dataSourceExists(): Promise<boolean> {
     return true;
   }
 

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -49,6 +49,7 @@ export class FakeActiveRecordAdapter extends AbstractAdapter {
     return created;
   }
 
+  // @ts-expect-error -- synchronous in-memory lookup where the inherited one returns a promise
   dataSourceExists(): boolean {
     return true;
   }

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -16,7 +16,7 @@ import { describeIfSupports, itIfSupports } from "./support/supports.js";
 import { dumpTableSchema } from "./support/schema-dumping-helper.js";
 
 // In Rails, AbstractAdapter includes SchemaStatements, so introspection
-// methods (views, viewExists, tableExists, isDataSourceExists) live directly
+// methods (views, viewExists, tableExists, dataSourceExists) live directly
 // on the connection object. Cast once here; all helpers pass through.
 function conn(): AbstractAdapter {
   return Base.connection as unknown as AbstractAdapter;
@@ -94,7 +94,7 @@ describeIfSupports("views", "ViewWithPrimaryKeyTest", () => {
   });
 
   itIfSupports("views", "views ara valid data sources", async () => {
-    expect(await conn().isDataSourceExists(Ebook._tableName)).toBe(true);
+    expect(await conn().dataSourceExists(Ebook._tableName)).toBe(true);
   });
 
   itIfSupports("views", "column definitions", async () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -170,13 +170,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "database_exists?",
-    "call": "exist?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "dbconsole",
     "call": "database_cli",
     "reason": "Rails reads the cli name only to pass it to `find_cmd_and_exec` (sqlite3_adapter.rb:51); that PTY exec is Ruby-only and unported, so our `dbconsole` returns the arg list and never needs the lookup."


### PR DESCRIPTION
`column_exists?` is one Rails method reachable two ways — on the connection
(`SchemaStatements#column_exists?`) and inside a `change_table` block
(`Table#column_exists?`) — but trails spelled it `columnExists` on the
connection and `isColumnExists` on the `Table` proxy, so the same method
resolved to a different TS name depending on the receiver (surfaced in #5558,
where `t.columnExists(...)` was "not a function").

The bare `<thing>Exists` form is the dominant convention (`tableExists`,
`columnExists`, `indexExists`, `foreignKeyExists`, `viewExists` on
`SchemaStatements` / `MigrationContext` / the adapter interface), so the
`is`-prefixed spellings are the outliers. This drops the prefix from every
`*_exists?` predicate that still carried it:

- `Table#isColumnExists` / `isIndexExists` / `isForeignKeyExists` /
  `isCheckConstraintExists`
- `SchemaStatements#isCheckConstraintExists` / `isDataSourceExists` (+ the
  adapter and `TableSchemaHost` interface members)
- `Migration#isViewExists` / `isIndexExists`
- `SQLite3Adapter.isDatabaseExists` (Rails `self.database_exists?`, already
  spelled `databaseExists` on mysql2) and the sqlite3
  `isVirtualTableExists` helper

## The `data_source_exists?` split was a live bug

`SchemaStatements` spelled it `isDataSourceExists` while every adapter
(sqlite3, postgresql, mysql2) spelled its override `dataSourceExists` — so
the adapter implementations never overrode the base one. Their catalog
queries were only reachable through an adapter-typed receiver; anything going
through the base (`SchemaCache`, `ModelSchema`) silently got the generic
`tableExists || viewExists` fallback. Converging the name makes the overrides
live, so the two that lacked Rails' `if name.present?` gate
(`schema_statements.rb:44`) now carry it — the mysql2 one already did. That
gap is what `AdapterTest#data source exists?` (which passes `null`) caught.

## Not converged: `AbstractAdapter#isDatabaseExists`

Renaming it collides with `PostgreSQLAdapter#databaseExists(name)`, a one-arg
async pg_database probe with no Rails counterpart (Rails PG has only
`self.database_exists?(config)` plus the inherited zero-arg instance
predicate). The clashing signature makes `PostgreSQLAdapter` unassignable to
`AbstractAdapter`. Reconciling that invention is its own change — registered
as story `database-exists-predicate-still-is-prefixed` under RFC 0051 rather
than folded in here.

## Verification

api:compare surface is unchanged: `rubyMethodToTs` returns both the
`is`-prefixed and bare candidates for a bare Ruby predicate, and a full
`pnpm api:compare` run left every manifest untouched (data layer 7723/7816,
overall 11788/17536, arity mismatches still 80).

`pnpm typecheck` clean; `adapter.test.ts`, `view.test.ts`, `migration.test.ts`,
`migration/change-schema.test.ts`, `migration/change-table.test.ts`,
`migration/foreign-key.test.ts`, `sqlite3-introspection.test.ts`,
`schema-cache.test.ts`, `model-schema-load.test.ts`,
`sqlite3/schema-statements.test.ts` and the sqlite3 virtual-table /
fake-adapter tests all green locally on the sqlite lane; pg and mysql lanes
rely on CI.

Closes-story: column-exists-has-two-ts-spellings-across-receivers
