### PR TITLE
refactor(activerecord): store cross-klass merged join dependencies in joins_values

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1031,10 +1031,6 @@ export class AssociationScope {
     // cross-klass JoinDependencies (Merger#merge_joins / #merge_outer_joins).
     for (const jc of item._joinClauses ?? []) target._joinClauses.push(jc);
     for (const jv of item._joinValues ?? []) target._joinsValues.push(jv);
-    // Rails' Merger partitions Hash/Symbol/Array off as `associations`;
-    // everything else — notably a JoinDependency the item already accumulated
-    // from an earlier `.merge()` (a nested through-scope-of-a-through-scope) —
-    // is `others`, forwarded verbatim by `joins!(join_dependency, *others)`.
     const namedInner = (item._namedInnerJoins ?? []).filter((v) => !(v instanceof JoinDependency));
     const innerDeps = (item._namedInnerJoins ?? []).filter((v) => v instanceof JoinDependency);
     if (namedInner.length > 0) {

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -7,6 +7,7 @@ import { AliasTracker, aliasedArelTableForReflection } from "./alias-tracker.js"
 import { polymorphicName } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
+import { JoinDependency } from "./join-dependency.js";
 import { constructJoinDependency, structuralUnionEq } from "../relation/query-methods.js";
 
 /**
@@ -1010,8 +1011,6 @@ export class AssociationScope {
       _joinClauses?: unknown[];
       _namedInnerJoins?: unknown[];
       _leftOuterJoinsValues?: unknown[];
-      _namedInnerJoinDeps?: unknown[];
-      _leftOuterJoinDeps?: unknown[];
       _includesAssociations?: unknown[];
       _eagerLoadAssociations?: unknown[];
       _modelClass?: typeof Base;
@@ -1024,8 +1023,6 @@ export class AssociationScope {
       _joinClauses: unknown[];
       _namedInnerJoins: unknown[];
       _leftOuterJoinsValues: unknown[];
-      _namedInnerJoinDeps: unknown[];
-      _leftOuterJoinDeps: unknown[];
       _modelClass?: typeof Base;
     };
     const sameKlass = item._modelClass !== undefined && item._modelClass === target._modelClass;
@@ -1034,36 +1031,39 @@ export class AssociationScope {
     // cross-klass JoinDependencies (Merger#merge_joins / #merge_outer_joins).
     for (const jc of item._joinClauses ?? []) target._joinClauses.push(jc);
     for (const jv of item._joinValues ?? []) target._joinsValues.push(jv);
-    const namedInner = item._namedInnerJoins ?? [];
+    // Rails' Merger partitions Hash/Symbol/Array off as `associations`;
+    // everything else — notably a JoinDependency the item already accumulated
+    // from an earlier `.merge()` (a nested through-scope-of-a-through-scope) —
+    // is `others`, forwarded verbatim by `joins!(join_dependency, *others)`.
+    const namedInner = (item._namedInnerJoins ?? []).filter((v) => !(v instanceof JoinDependency));
+    const innerDeps = (item._namedInnerJoins ?? []).filter((v) => v instanceof JoinDependency);
     if (namedInner.length > 0) {
       if (sameKlass) {
         for (const v of namedInner)
           if (!target._namedInnerJoins.includes(v)) target._joinsValues.push(v);
       } else {
-        target._namedInnerJoinDeps.push(
+        target._joinsValues.push(
           constructJoinDependency.call(item as never, namedInner as never, Nodes.InnerJoin),
         );
       }
     }
-    const namedLeft = item._leftOuterJoinsValues ?? [];
+    target._joinsValues.push(...innerDeps);
+    const namedLeft = (item._leftOuterJoinsValues ?? []).filter(
+      (v) => !(v instanceof JoinDependency),
+    );
+    const leftDeps = (item._leftOuterJoinsValues ?? []).filter((v) => v instanceof JoinDependency);
     if (namedLeft.length > 0) {
       if (sameKlass) {
         for (const v of namedLeft)
           if (!target._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
             target._leftOuterJoinsValues.push(v);
       } else {
-        target._leftOuterJoinDeps.push(
+        target._leftOuterJoinsValues.push(
           constructJoinDependency.call(item as never, namedLeft as never, Nodes.OuterJoin),
         );
       }
     }
-    // Carry forward any cross-klass JoinDependencies the item already
-    // accumulated from an earlier `.merge()` (e.g. a nested through-scope-of-a-
-    // through-scope). Rails routes `merge! item.only(:joins, :left_outer_joins)`
-    // through the same Merger, whose merge_joins / merge_outer_joins forward
-    // `other._namedInnerJoinDeps` / `other._leftOuterJoinDeps` (merger.ts:127,149).
-    target._namedInnerJoinDeps.push(...(item._namedInnerJoinDeps ?? []));
-    target._leftOuterJoinDeps.push(...(item._leftOuterJoinDeps ?? []));
+    target._leftOuterJoinsValues.push(...leftDeps);
     // associations = eager_load_values | includes_values → OuterJoin. Rails'
     // `|` unions with dedup, so an association named in BOTH eager_load and
     // includes yields a single JoinDependency entry (not a double join).
@@ -1071,7 +1071,7 @@ export class AssociationScope {
       ...new Set([...(item._eagerLoadAssociations ?? []), ...(item._includesAssociations ?? [])]),
     ];
     if (associations.length > 0) {
-      target._leftOuterJoinDeps.push(
+      target._leftOuterJoinsValues.push(
         constructJoinDependency.call(item as never, associations as never, Nodes.OuterJoin),
       );
     }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -429,10 +429,17 @@ export class Relation<T extends Base> {
   // `_joinsValues` by this rule — the same rule `joins` uses at insert time. A
   // raw Symbol misrouted to `_joinValues` would reach the arel visitor and raise
   // "Unknown node type: Symbol", so Symbols must land in `_namedInnerJoins`.
+  //
+  // A `JoinDependency` (pushed by a cross-klass `merge`, Rails
+  // `joins!(join_dependency, *others)`) counts as named: Rails' build_join_buckets
+  // shifts only `Arel::Nodes::Join` values out of `joins_values` and hands the
+  // whole remainder — JoinDependency included — to `select_named_joins`, which
+  // stashes it (query_methods.rb:1856-1873, 1810-1822).
   private _isNamedJoinValue(v: unknown): boolean {
     return (
       _isPlainObject(v) ||
       typeof v === "symbol" ||
+      v instanceof JoinDependency ||
       (typeof v === "string" && this._isAssociationName(v))
     );
   }
@@ -449,14 +456,6 @@ export class Relation<T extends Base> {
   get _joinValues(): (string | Nodes.Join)[] {
     return this._joinsValues.filter((v) => !this._isNamedJoinValue(v)) as (string | Nodes.Join)[];
   }
-  // Pre-built InnerJoin JoinDependencies from a cross-klass `merge` (Rails
-  // merge_joins builds these against `other.klass` since the association names
-  // can't resolve on the receiver's model).
-  private _namedInnerJoinDeps: JoinDependency[] = [];
-  // Pre-built OuterJoin JoinDependencies from a cross-klass `merge` (Rails
-  // merge_outer_joins builds these against `other.klass` since the left-outer
-  // association names can't resolve on the receiver's model).
-  private _leftOuterJoinDeps: JoinDependency[] = [];
   private _includesAssociations: AssociationSpec[] = [];
   private _preloadAssociations: AssociationSpec[] = [];
   private _eagerLoadAssociations: AssociationSpec[] = [];
@@ -3289,9 +3288,7 @@ export class Relation<T extends Base> {
       manager.joinSourceCount > 0 ||
       this._eagerLoadAssociations.length > 0 ||
       this._leftOuterJoinsValues.length > 0 ||
-      this._namedInnerJoins.length > 0 ||
-      this._namedInnerJoinDeps.length > 0 ||
-      this._leftOuterJoinDeps.length > 0;
+      this._namedInnerJoins.length > 0;
     const leadingJoins: Nodes.Join[] = [];
     const joinNodes: Nodes.Join[] = [];
     for (const v of this._joinValues) {
@@ -3363,11 +3360,10 @@ export class Relation<T extends Base> {
     // it is a pure bucket-builder with neither an eager-JD parameter nor a live
     // manager — and are needed here because the short-circuit does NOT fold `eagerJd`
     // into the stash (it is pushed in the non-short-circuit branch below). Cross-klass
-    // merged JDs (`_namedInnerJoinDeps`/`_leftOuterJoinDeps`) are deliberately NOT
-    // checked: like Rails, they ride the SAME emission regardless of branch —
-    // emitJoinPlan emits them directly from `this`, not from the plan — so
-    // short-circuiting with them present yields identical SQL (verified against the
-    // subquery path for a cross-klass `.merge`).
+    // merged JDs live in `joinsValues` / `leftOuterJoinsValues` like any other join
+    // value, so `_namedInnerJoins` below already accounts for the inner ones — an
+    // inner merged JD blocks the short-circuit exactly as Rails' non-empty
+    // `joins_values` does.
     const pureLeftOuter =
       eagerJd === undefined &&
       manager.joinSourceCount === 0 &&
@@ -3683,6 +3679,9 @@ export class Relation<T extends Base> {
           ...this._leftOuterJoinsValues,
           ...joinableSpecs,
         ]) {
+          // A cross-klass merged JoinDependency is a stash, not a spec — it
+          // resolves against the merged-from model, not this one.
+          if (spec instanceof JoinDependency) continue;
           joinedJd.addAssociationSpec(spec);
         }
         for (const node of joinedJd.nodes) safeTables.add(node.tableName.toLowerCase());
@@ -4937,11 +4936,21 @@ export class Relation<T extends Base> {
    * eager-spec resolver, which rejects every non-string spec.
    */
   private _joinsReflectionsAreLimitable(): boolean {
+    // A cross-klass merged JoinDependency carries its own (already-built)
+    // reflections against another model; fold those in rather than re-resolving
+    // it as a spec on this relation's model.
     const specs = [...this._namedInnerJoins, ...this._leftOuterJoinsValues];
     if (specs.length === 0) return true;
     const jd = new JoinDependency(this._modelClass);
-    for (const spec of specs) jd.addAssociationSpec(spec);
-    return this.usingLimitableReflections(jd.reflections);
+    const mergedReflections: unknown[] = [];
+    for (const spec of specs) {
+      if (spec instanceof JoinDependency) {
+        mergedReflections.push(...spec.reflections);
+        continue;
+      }
+      jd.addAssociationSpec(spec);
+    }
+    return this.usingLimitableReflections([...jd.reflections, ...mergedReflections] as never);
   }
 
   /**
@@ -6960,8 +6969,6 @@ export class Relation<T extends Base> {
     this._joinClauses = [...source._joinClauses];
     this._joinsValues = [...source._joinsValues];
     this._leftOuterJoinsValues = [...source._leftOuterJoinsValues];
-    this._namedInnerJoinDeps = [...source._namedInnerJoinDeps];
-    this._leftOuterJoinDeps = [...source._leftOuterJoinDeps];
     this._includesAssociations = [...source._includesAssociations];
     this._preloadAssociations = [...source._preloadAssociations];
     this._eagerLoadAssociations = [...source._eagerLoadAssociations];

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3669,7 +3669,10 @@ export class Relation<T extends Base> {
           ...this._leftOuterJoinsValues,
           ...joinableSpecs,
         ]) {
-          if (spec instanceof JoinDependency) continue;
+          if (spec instanceof JoinDependency) {
+            for (const node of spec.nodes) safeTables.add(node.tableName.toLowerCase());
+            continue;
+          }
           joinedJd.addAssociationSpec(spec);
         }
         for (const node of joinedJd.nodes) safeTables.add(node.tableName.toLowerCase());

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -429,12 +429,6 @@ export class Relation<T extends Base> {
   // `_joinsValues` by this rule — the same rule `joins` uses at insert time. A
   // raw Symbol misrouted to `_joinValues` would reach the arel visitor and raise
   // "Unknown node type: Symbol", so Symbols must land in `_namedInnerJoins`.
-  //
-  // A `JoinDependency` (pushed by a cross-klass `merge`, Rails
-  // `joins!(join_dependency, *others)`) counts as named: Rails' build_join_buckets
-  // shifts only `Arel::Nodes::Join` values out of `joins_values` and hands the
-  // whole remainder — JoinDependency included — to `select_named_joins`, which
-  // stashes it (query_methods.rb:1856-1873, 1810-1822).
   private _isNamedJoinValue(v: unknown): boolean {
     return (
       _isPlainObject(v) ||
@@ -3360,10 +3354,6 @@ export class Relation<T extends Base> {
     // it is a pure bucket-builder with neither an eager-JD parameter nor a live
     // manager — and are needed here because the short-circuit does NOT fold `eagerJd`
     // into the stash (it is pushed in the non-short-circuit branch below). Cross-klass
-    // merged JDs live in `joinsValues` / `leftOuterJoinsValues` like any other join
-    // value, so `_namedInnerJoins` below already accounts for the inner ones — an
-    // inner merged JD blocks the short-circuit exactly as Rails' non-empty
-    // `joins_values` does.
     const pureLeftOuter =
       eagerJd === undefined &&
       manager.joinSourceCount === 0 &&
@@ -3679,8 +3669,6 @@ export class Relation<T extends Base> {
           ...this._leftOuterJoinsValues,
           ...joinableSpecs,
         ]) {
-          // A cross-klass merged JoinDependency is a stash, not a spec — it
-          // resolves against the merged-from model, not this one.
           if (spec instanceof JoinDependency) continue;
           joinedJd.addAssociationSpec(spec);
         }
@@ -4936,9 +4924,6 @@ export class Relation<T extends Base> {
    * eager-spec resolver, which rejects every non-string spec.
    */
   private _joinsReflectionsAreLimitable(): boolean {
-    // A cross-klass merged JoinDependency carries its own (already-built)
-    // reflections against another model; fold those in rather than re-resolving
-    // it as a spec on this relation's model.
     const specs = [...this._namedInnerJoins, ...this._leftOuterJoinsValues];
     if (specs.length === 0) return true;
     const jd = new JoinDependency(this._modelClass);

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -56,10 +56,10 @@ describe("build_joins from(subquery) dedup", () => {
 
   // Exercise the conditions the `pureLeftOuter` guard adds beyond a naive
   // "left-outer only" check: a cross-klass `.merge` pushes an OuterJoin
-  // JoinDependency into `_leftOuterJoinDeps` (merger.ts mergeOuterJoins). The
-  // guard does NOT gate on that array — emitJoinPlan emits merged deps directly
-  // from `this` regardless of branch — so the short-circuit must still emit BOTH
-  // the base left-outer join AND the merged one, identically to the subquery path.
+  // JoinDependency into `leftOuterJoinsValues` (merger.rb merge_outer_joins),
+  // where `selectNamedJoins` stashes it like any other. The short-circuit must
+  // still emit BOTH the base left-outer join AND the merged one, identically to
+  // the subquery path.
   it("emits cross-klass merged left_outer_joins on the live path like the from-subquery path", () => {
     const build = () => Post.leftOuterJoins("comments").merge(Comment.leftOuterJoins("post"));
     const liveSql = (build() as unknown as { toSql(): string }).toSql();

--- a/packages/activerecord/src/relation/merge-joins.ts
+++ b/packages/activerecord/src/relation/merge-joins.ts
@@ -4,16 +4,6 @@ import { JoinDependency } from "../associations/join-dependency.js";
 import type { AssociationSpec } from "./query-methods.js";
 import { constructJoinDependency, structuralUnionEq } from "./query-methods.js";
 
-// Join-folding passes for the single merge path (Merger#merge). Both `merge` and
-// `merge!` now funnel through Merger — `merge` is `spawn.merge!` and `merge!`
-// runs Merger#merge in place (spawn-methods.ts) — so there is one caller. Kept as
-// dedicated functions here (rather than inlined) so the dedup/branching logic
-// stays isolated and reviewable; Merger keeps thin mergeJoins/mergeOuterJoins
-// wrappers so api:compare still maps merger.rb's merge_joins/merge_outer_joins.
-
-// Minimal structural view of the join-related fields these helpers touch on a
-// Relation. Kept local (rather than `any`) so the shared module stays off the
-// no-explicit-any burndown allowlist (RFC 0037).
 interface JoinFoldRelation {
   model: unknown;
   _joinClauses: unknown[];
@@ -26,8 +16,12 @@ interface JoinFoldRelation {
   _isNamedJoinValue(v: unknown): boolean;
 }
 
-// Structural dedup for raw joins: an Arel node exposes `eql` and dedups by value
-// when same-constructor; everything else falls back to reference identity.
+function joinsUnionEq(v: unknown, existing: unknown): boolean {
+  return v instanceof JoinDependency || existing instanceof JoinDependency
+    ? v === existing
+    : rawJoinDup(v, existing) || structuralUnionEq(v, existing);
+}
+
 function rawJoinDup(v: unknown, existing: unknown): boolean {
   const node = v as { eql?: (o: unknown) => boolean; constructor?: unknown };
   if (
@@ -39,93 +33,71 @@ function rawJoinDup(v: unknown, existing: unknown): boolean {
   return v === existing;
 }
 
-// Rails merge_joins (merger.rb): joins_values and left_outer_joins_values are
-// separate arrays, so each merge helper unions its own array independently (no
-// interleaving in Rails). trails keeps explicit SQL joins in _joinClauses and
-// every `.joins` argument in the unified _joinsValues store; the source's
-// `joinsValues` is partitioned into raw join values vs named association joins
-// (the same split `build_joins` derives) and each is merged independently below,
-// writing back into _joinsValues.
-//
-// Rails `relation.joins_values |= other.joins_values` (merger.rb) is a single
-// ordered array union preserving `other`'s exact insertion order across the
-// named/raw boundary, so a source whose joins interleave (e.g.
-// `joins(:a, "RAW", :b)`) folds in as `[a, RAW, b]`, not `[RAW, a, b]`. We walk
-// `source.joinsValues` once, unioning each entry per its category:
-//   - raw joins union structurally (Arel node `eql`, else reference);
-//   - same-klass named specs dedup by `structuralUnionEq`.
-// Cross-klass named (Hash | Symbol/String | Array — every shape Rails treats as
-// an association) can't resolve on the receiver, so they're collected and built
-// into a single InnerJoin JoinDependency on `source` (whose AliasTracker handles
-// nested-through / HABTM) and pushed into _joinsValues, exactly as Rails'
-// `else` branch does with `joins!(join_dependency, *others)` — the `others`
-// (raw joins, and any JoinDependency the source already carries, which Rails'
-// `partition` also routes to `others`) still append in order. Arel::Nodes::InnerJoin is the type used for
-// same-model inner joins in Rails' cross-model merge path.
 export function foldMergeJoins(target: JoinFoldRelation, source: JoinFoldRelation): void {
   const clauses = source._joinClauses ?? [];
   if (clauses.length > 0) target._joinClauses.push(...clauses);
 
-  const sameKlass = source.model === target.model;
-  const crossKlassNamed: unknown[] = [];
-  for (const v of source.joinsValues ?? []) {
-    if (v instanceof JoinDependency) {
-      // Rails' `partition` matches only Hash/Symbol/Array, so a JoinDependency
-      // already in `other.joins_values` lands in `others` and rides through
-      // `joins!(join_dependency, *others)` untouched.
-      target._joinsValues.push(v);
-    } else if (!source._isNamedJoinValue(v)) {
-      if (!target._joinValues.some((existing) => rawJoinDup(v, existing)))
+  const joinsValues = source.joinsValues ?? [];
+  if (joinsValues.length === 0) return;
+  if (source.model === target.model) {
+    for (const v of joinsValues) {
+      if (!source._isNamedJoinValue(v)) {
+        if (!target._joinValues.some((existing) => rawJoinDup(v, existing)))
+          target._joinsValues.push(v);
+      } else if (!target._namedInnerJoins.some((seen) => structuralUnionEq(seen, v))) {
         target._joinsValues.push(v);
-    } else if (sameKlass) {
-      // joins_values |= dedups structurally-equal Hash specs (eql?/hash), so a
-      // same-klass merge folds an equal spec — not by JS reference identity.
-      if (!target._namedInnerJoins.some((seen) => structuralUnionEq(seen, v)))
-        target._joinsValues.push(v);
+      }
+    }
+    return;
+  }
+
+  const associations: unknown[] = [];
+  const others: unknown[] = [];
+  for (const v of joinsValues) {
+    if (!(v instanceof JoinDependency) && source._isNamedJoinValue(v)) {
+      associations.push(v);
     } else {
-      crossKlassNamed.push(v);
+      others.push(v);
     }
   }
-  if (crossKlassNamed.length > 0) {
-    target._joinsValues.push(
-      constructJoinDependency.call(
-        source as never,
-        crossKlassNamed as AssociationSpec[],
-        Nodes.InnerJoin,
-      ),
-    );
+  const joinDependency = constructJoinDependency.call(
+    source as never,
+    associations as AssociationSpec[],
+    Nodes.InnerJoin,
+  );
+  for (const v of [joinDependency, ...others]) {
+    if (!target._joinsValues.some((existing) => joinsUnionEq(v, existing)))
+      target._joinsValues.push(v);
   }
 }
 
-// Rails merge_outer_joins (merger.rb): when other.klass == relation.klass the
-// left_outer_joins association names union directly; otherwise Merger builds a
-// single OuterJoin JoinDependency against other.klass (the names can't resolve on
-// the receiver's model) and stashes it via left_outer_joins!.
 export function foldMergeOuterJoins(target: JoinFoldRelation, source: JoinFoldRelation): void {
-  // Read via the public leftOuterJoinsValues accessor (PR #4675 convergence),
-  // symmetric with foldMergeJoins reading source.joinsValues.
   const otherLeft = source.leftOuterJoinsValues ?? [];
-  const sameKlass = source.model === target.model;
-  if (sameKlass) {
+  if (otherLeft.length === 0) return;
+  if (source.model === target.model) {
     for (const v of otherLeft) {
       if (!target._leftOuterJoinsValues.some((seen) => structuralUnionEq(seen, v)))
         target._leftOuterJoinsValues.push(v);
     }
     return;
   }
-  // Rails partitions Hash/Symbol/Array off as `associations`; everything else —
-  // including a JoinDependency the source already carries — is `others`, forwarded
-  // verbatim by `left_outer_joins!(join_dependency, *others)`.
-  const associations = otherLeft.filter((v) => !(v instanceof JoinDependency));
-  const others = otherLeft.filter((v) => v instanceof JoinDependency);
-  if (associations.length > 0) {
-    target._leftOuterJoinsValues.push(
-      constructJoinDependency.call(
-        source as never,
-        associations as AssociationSpec[],
-        Nodes.OuterJoin,
-      ) as never,
-    );
+
+  const associations: unknown[] = [];
+  const others: unknown[] = [];
+  for (const v of otherLeft) {
+    if (!(v instanceof JoinDependency)) {
+      associations.push(v);
+    } else {
+      others.push(v);
+    }
   }
-  target._leftOuterJoinsValues.push(...(others as never[]));
+  const joinDependency = constructJoinDependency.call(
+    source as never,
+    associations as AssociationSpec[],
+    Nodes.OuterJoin,
+  );
+  for (const v of [joinDependency, ...others]) {
+    if (!target._leftOuterJoinsValues.some((seen) => joinsUnionEq(v, seen)))
+      target._leftOuterJoinsValues.push(v as never);
+  }
 }

--- a/packages/activerecord/src/relation/merge-joins.ts
+++ b/packages/activerecord/src/relation/merge-joins.ts
@@ -1,5 +1,6 @@
 import { Nodes } from "@blazetrails/arel";
 
+import { JoinDependency } from "../associations/join-dependency.js";
 import type { AssociationSpec } from "./query-methods.js";
 import { constructJoinDependency, structuralUnionEq } from "./query-methods.js";
 
@@ -19,9 +20,7 @@ interface JoinFoldRelation {
   _joinValues: unknown[];
   _joinsValues: unknown[];
   _namedInnerJoins: unknown[];
-  _namedInnerJoinDeps: unknown[];
   _leftOuterJoinsValues: unknown[];
-  _leftOuterJoinDeps: unknown[];
   joinsValues?: unknown[];
   leftOuterJoinsValues?: unknown[];
   _isNamedJoinValue(v: unknown): boolean;
@@ -58,9 +57,10 @@ function rawJoinDup(v: unknown, existing: unknown): boolean {
 // Cross-klass named (Hash | Symbol/String | Array — every shape Rails treats as
 // an association) can't resolve on the receiver, so they're collected and built
 // into a single InnerJoin JoinDependency on `source` (whose AliasTracker handles
-// nested-through / HABTM) rather than folded into _joinsValues; this mirrors
-// Rails' `else` branch where `others` (the raw joins) still append in order via
-// `joins!(join_dependency, *others)`. Arel::Nodes::InnerJoin is the type used for
+// nested-through / HABTM) and pushed into _joinsValues, exactly as Rails'
+// `else` branch does with `joins!(join_dependency, *others)` — the `others`
+// (raw joins, and any JoinDependency the source already carries, which Rails'
+// `partition` also routes to `others`) still append in order. Arel::Nodes::InnerJoin is the type used for
 // same-model inner joins in Rails' cross-model merge path.
 export function foldMergeJoins(target: JoinFoldRelation, source: JoinFoldRelation): void {
   const clauses = source._joinClauses ?? [];
@@ -69,7 +69,12 @@ export function foldMergeJoins(target: JoinFoldRelation, source: JoinFoldRelatio
   const sameKlass = source.model === target.model;
   const crossKlassNamed: unknown[] = [];
   for (const v of source.joinsValues ?? []) {
-    if (!source._isNamedJoinValue(v)) {
+    if (v instanceof JoinDependency) {
+      // Rails' `partition` matches only Hash/Symbol/Array, so a JoinDependency
+      // already in `other.joins_values` lands in `others` and rides through
+      // `joins!(join_dependency, *others)` untouched.
+      target._joinsValues.push(v);
+    } else if (!source._isNamedJoinValue(v)) {
       if (!target._joinValues.some((existing) => rawJoinDup(v, existing)))
         target._joinsValues.push(v);
     } else if (sameKlass) {
@@ -82,7 +87,7 @@ export function foldMergeJoins(target: JoinFoldRelation, source: JoinFoldRelatio
     }
   }
   if (crossKlassNamed.length > 0) {
-    target._namedInnerJoinDeps.push(
+    target._joinsValues.push(
       constructJoinDependency.call(
         source as never,
         crossKlassNamed as AssociationSpec[],
@@ -90,8 +95,6 @@ export function foldMergeJoins(target: JoinFoldRelation, source: JoinFoldRelatio
       ),
     );
   }
-  // Carry forward any cross-klass dependencies the source already accumulated.
-  target._namedInnerJoinDeps.push(...(source._namedInnerJoinDeps ?? []));
 }
 
 // Rails merge_outer_joins (merger.rb): when other.klass == relation.klass the
@@ -108,15 +111,21 @@ export function foldMergeOuterJoins(target: JoinFoldRelation, source: JoinFoldRe
       if (!target._leftOuterJoinsValues.some((seen) => structuralUnionEq(seen, v)))
         target._leftOuterJoinsValues.push(v);
     }
-  } else if (otherLeft.length > 0) {
-    target._leftOuterJoinDeps.push(
+    return;
+  }
+  // Rails partitions Hash/Symbol/Array off as `associations`; everything else —
+  // including a JoinDependency the source already carries — is `others`, forwarded
+  // verbatim by `left_outer_joins!(join_dependency, *others)`.
+  const associations = otherLeft.filter((v) => !(v instanceof JoinDependency));
+  const others = otherLeft.filter((v) => v instanceof JoinDependency);
+  if (associations.length > 0) {
+    target._leftOuterJoinsValues.push(
       constructJoinDependency.call(
         source as never,
-        otherLeft as AssociationSpec[],
+        associations as AssociationSpec[],
         Nodes.OuterJoin,
-      ),
+      ) as never,
     );
   }
-  // Carry forward any cross-klass dependencies the source already accumulated.
-  target._leftOuterJoinDeps.push(...(source._leftOuterJoinDeps ?? []));
+  target._leftOuterJoinsValues.push(...(others as never[]));
 }

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -289,9 +289,6 @@ describe("RelationMergingTest", () => {
     // into the receiver's joins_values (which would resolve them on the wrong
     // model). `merge` and `mergeBang` must agree here.
     const source = Post.joins("author");
-    // Rails pushes the built JoinDependency straight into the receiver's
-    // joins_values (`joins!(join_dependency, *others)`, merger.rb:131), where
-    // build_join_buckets' select_named_joins stashes it.
     const merged = Comment.all().merge(source);
     expect(merged.joinsValues.length).toBe(1);
     expect(merged.joinsValues[0]).toBeInstanceOf(JoinDependency);
@@ -309,8 +306,6 @@ describe("RelationMergingTest", () => {
     // than folding into the receiver's left_outer_joins_values. `merge` and
     // `mergeBang` must agree — mergeBang's old inline block skipped this split.
     const source = Post.leftOuterJoins("author");
-    // Rails pushes the built JoinDependency into left_outer_joins_values
-    // (`left_outer_joins!(join_dependency, *others)`, merger.rb:150).
     const merged = Comment.all().merge(source);
     expect(merged.leftOuterJoinsValues.length).toBe(1);
     expect(merged.leftOuterJoinsValues[0]).toBeInstanceOf(JoinDependency);

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -9,6 +9,7 @@ import { sql as arelSql } from "@blazetrails/arel";
 
 import { registerModel, Range } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
+import { JoinDependency } from "../associations/join-dependency.js";
 import { itIfSupports } from "../support/supports.js";
 import { assertQueriesCount, assertQueriesMatch } from "../testing/query-assertions.js";
 import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
@@ -288,14 +289,17 @@ describe("RelationMergingTest", () => {
     // into the receiver's joins_values (which would resolve them on the wrong
     // model). `merge` and `mergeBang` must agree here.
     const source = Post.joins("author");
+    // Rails pushes the built JoinDependency straight into the receiver's
+    // joins_values (`joins!(join_dependency, *others)`, merger.rb:131), where
+    // build_join_buckets' select_named_joins stashes it.
     const merged = Comment.all().merge(source);
-    expect(merged.joinsValues).toEqual([]);
-    expect((merged as any)._namedInnerJoinDeps.length).toBe(1);
+    expect(merged.joinsValues.length).toBe(1);
+    expect(merged.joinsValues[0]).toBeInstanceOf(JoinDependency);
 
     const banged = Comment.all();
     (banged as any).mergeBang(source);
-    expect(banged.joinsValues).toEqual([]);
-    expect((banged as any)._namedInnerJoinDeps.length).toBe(1);
+    expect(banged.joinsValues.length).toBe(1);
+    expect(banged.joinsValues[0]).toBeInstanceOf(JoinDependency);
   });
 
   it("relation merging with cross-klass left outer joins builds a join dependency", () => {
@@ -305,14 +309,16 @@ describe("RelationMergingTest", () => {
     // than folding into the receiver's left_outer_joins_values. `merge` and
     // `mergeBang` must agree — mergeBang's old inline block skipped this split.
     const source = Post.leftOuterJoins("author");
+    // Rails pushes the built JoinDependency into left_outer_joins_values
+    // (`left_outer_joins!(join_dependency, *others)`, merger.rb:150).
     const merged = Comment.all().merge(source);
-    expect((merged as any)._leftOuterJoinsValues).toEqual([]);
-    expect((merged as any)._leftOuterJoinDeps.length).toBe(1);
+    expect(merged.leftOuterJoinsValues.length).toBe(1);
+    expect(merged.leftOuterJoinsValues[0]).toBeInstanceOf(JoinDependency);
 
     const banged = Comment.all();
     (banged as any).mergeBang(source);
-    expect((banged as any)._leftOuterJoinsValues).toEqual([]);
-    expect((banged as any)._leftOuterJoinDeps.length).toBe(1);
+    expect(banged.leftOuterJoinsValues.length).toBe(1);
+    expect(banged.leftOuterJoinsValues[0]).toBeInstanceOf(JoinDependency);
   });
 
   it("relation merging with skip query cache", () => {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -206,8 +206,6 @@ interface QueryMethodsHost {
   // Public `left_outer_joins_values` value method (relation.ts getter); reads it
   // over the backing field so extractCalls credits the Rails value-method read.
   leftOuterJoinsValues: AssociationSpec[];
-  // Includes any cross-klass merged JoinDependency sitting in `joins_values`
-  // (Rails `joins!(join_dependency, *others)`), which `selectNamedJoins` stashes.
   readonly _namedInnerJoins: AssociationSpec[];
   _includesAssociations: AssociationSpec[];
   _preloadAssociations: AssociationSpec[];
@@ -1130,10 +1128,6 @@ function uniqArray(arr: unknown[]): unknown[] {
  * @internal
  */
 export function structuralUnionEq(a: unknown, b: unknown): boolean {
-  // A JoinDependency in joins_values / left_outer_joins_values is a stash, not a
-  // value spec: Ruby's `|=` dedups it through the default `eql?`/`hash`, i.e. by
-  // object identity. Walking its node graph structurally would be both wrong and
-  // unbounded (nodes reference their base klass and each other).
   if (a instanceof JoinDependency || b instanceof JoinDependency) return a === b;
   return deepEqual(a, b);
 }
@@ -2872,11 +2866,6 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
       // `_eagerLoadAssociations`, so both must be empty too — otherwise the
       // left-outer JD belongs in `stashed_join` (folded below), not `named_join`,
       // and the inner names would be dropped / double-emitted downstream.
-      //
-      // A cross-klass merged JoinDependency (from a `.merge` against a
-      // different-model relation) is an ordinary `joins_values` entry, so
-      // `namedInner` above already counts it — it blocks the short-circuit
-      // exactly as Rails' non-empty `joins_values` does.
       buckets.named_join.push(...namedLeft);
       buckets.stashed_join.push(...stashedLeft);
       return buckets;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -206,15 +206,9 @@ interface QueryMethodsHost {
   // Public `left_outer_joins_values` value method (relation.ts getter); reads it
   // over the backing field so extractCalls credits the Rails value-method read.
   leftOuterJoinsValues: AssociationSpec[];
+  // Includes any cross-klass merged JoinDependency sitting in `joins_values`
+  // (Rails `joins!(join_dependency, *others)`), which `selectNamedJoins` stashes.
   readonly _namedInnerJoins: AssociationSpec[];
-  // Pre-built InnerJoin JoinDependencies from a cross-klass merge (Rails
-  // merge_joins builds these against `other.klass`); emitted via joinConstraints
-  // and walked for klass lookups alongside _namedInnerJoins.
-  _namedInnerJoinDeps: JoinDependency[];
-  // Pre-built OuterJoin JoinDependencies from a cross-klass merge (Rails
-  // merge_outer_joins builds these against `other.klass`); emitted via
-  // joinConstraints with OuterJoin type.
-  _leftOuterJoinDeps: JoinDependency[];
   _includesAssociations: AssociationSpec[];
   _preloadAssociations: AssociationSpec[];
   _eagerLoadAssociations: AssociationSpec[];
@@ -1136,6 +1130,11 @@ function uniqArray(arr: unknown[]): unknown[] {
  * @internal
  */
 export function structuralUnionEq(a: unknown, b: unknown): boolean {
+  // A JoinDependency in joins_values / left_outer_joins_values is a stash, not a
+  // value spec: Ruby's `|=` dedups it through the default `eql?`/`hash`, i.e. by
+  // object identity. Walking its node graph structurally would be both wrong and
+  // unbounded (nodes reference their base klass and each other).
+  if (a instanceof JoinDependency || b instanceof JoinDependency) return a === b;
   return deepEqual(a, b);
 }
 
@@ -2694,10 +2693,6 @@ export function buildJoinDependencies(this: QueryMethodsHost): JoinDependency[] 
   const named = selectNamedJoins.call(this, joinNames, stashedJoins);
   const jd = constructJoinDependency.call(this, named as AssociationSpec[], null);
   stashedJoins.unshift(jd);
-  // Cross-klass merged dependencies carry their own nodes (built on the source
-  // relation's klass); include them so table-klass / cast-type lookups see them.
-  if (this._namedInnerJoinDeps.length > 0) stashedJoins.push(...this._namedInnerJoinDeps);
-  if (this._leftOuterJoinDeps.length > 0) stashedJoins.push(...this._leftOuterJoinDeps);
   return stashedJoins;
 }
 
@@ -2878,12 +2873,10 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
       // left-outer JD belongs in `stashed_join` (folded below), not `named_join`,
       // and the inner names would be dropped / double-emitted downstream.
       //
-      // Cross-klass merged JDs (`_namedInnerJoinDeps`/`_leftOuterJoinDeps`, from a
-      // `.merge` against a different-model relation) are intentionally NOT part of
-      // this guard: emitJoinPlan emits them directly from `this` (not via any
-      // bucket), so they are appended regardless of which branch runs here. A
-      // pure-left-outer `.merge` therefore still emits its merged joins after the
-      // short-circuit — none are dropped.
+      // A cross-klass merged JoinDependency (from a `.merge` against a
+      // different-model relation) is an ordinary `joins_values` entry, so
+      // `namedInner` above already counts it — it blocks the short-circuit
+      // exactly as Rails' non-empty `joins_values` does.
       buckets.named_join.push(...namedLeft);
       buckets.stashed_join.push(...stashedLeft);
       return buckets;
@@ -3078,19 +3071,6 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
       manager.appendJoinNode(node);
   }
 
-  // Cross-klass merged JoinDependencies (Rails merge_joins): emitted against the
-  // same shared tracker, so a join onto an already-joined table aliases at
-  // emit-time in makeConstraints (`authors_categorizations`).
-  for (const jd of this._namedInnerJoinDeps) {
-    for (const node of jd.joinConstraints([], sharedTracker())) manager.appendJoinNode(node);
-  }
-
-  // Cross-klass merged left-outer JoinDependencies (Rails merge_outer_joins):
-  // emitted against the same shared tracker.
-  for (const jd of this._leftOuterJoinDeps) {
-    for (const node of jd.joinConstraints([], sharedTracker())) manager.appendJoinNode(node);
-  }
-
   // Rails' single `buckets[:join_node]` array is populated raw joins_values Join
   // nodes FIRST (the `while joins.first.is_a?(Arel::Nodes::Join)` loop,
   // query_methods.rb:1856-1863), THEN CTE nodes appended by the select_named_joins
@@ -3128,11 +3108,7 @@ export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTra
   const hasNamedInner = joinsValues.some((v) => this._isNamedJoinValue(v));
   const hasRawJoins = joinsValues.some((v) => !this._isNamedJoinValue(v));
   const hasEagerAssocs =
-    this._eagerLoadAssociations.length > 0 ||
-    this.leftOuterJoinsValues.length > 0 ||
-    hasNamedInner ||
-    this._namedInnerJoinDeps.length > 0 ||
-    this._leftOuterJoinDeps.length > 0;
+    this._eagerLoadAssociations.length > 0 || this.leftOuterJoinsValues.length > 0 || hasNamedInner;
   if (this._joinClauses.length === 0 && !hasRawJoins && !hasEagerAssocs) return;
 
   // Subquery path: buckets fold eager into stashed_join. Delegate emission to


### PR DESCRIPTION
Step 1 of 3 in the ordered split of `converge-build-join-buckets-single-joins-store` (RFC 0083).

## What

Rails `merge_joins` / `merge_outer_joins`
(`vendor/rails/activerecord/lib/active_record/relation/merger.rb:117-152`) build a
cross-klass `JoinDependency` on the *other* relation's model and push it straight into
the receiver's stores — `relation.joins!(join_dependency, *others)` /
`relation.left_outer_joins!(join_dependency, *others)`. `build_join_buckets` then routes
it through `select_named_joins` → `select_association_list`
(`query_methods.rb:1810-1822`), which stashes it into `buckets[:stashed_join]`, so it
folds into the primary JD's `join_constraints` like any other stash.

trails instead parked those JDs in two side stores, `_namedInnerJoinDeps` and
`_leftOuterJoinDeps`, and `emitJoinPlan` appended their
`joinConstraints([], sharedTracker())` output *directly* to the manager, bypassing the
bucket routing entirely.

Both stores are gone. A `JoinDependency` is now an ordinary `joinsValues` /
`leftOuterJoinsValues` entry:

- `_isNamedJoinValue` counts a `JoinDependency` as *named*, mirroring
  `build_join_buckets`, which shifts only `Arel::Nodes::Join` values out of
  `joins_values` and hands the whole remainder — JoinDependency included — to
  `select_named_joins`. So `_namedInnerJoins` carries it and `_joinValues` does not.
- `foldMergeJoins` / `foldMergeOuterJoins` are restructured onto merger.rb's own shape:
  the `return if other.joins_values.empty?` guard, then the
  `if other.model == relation.model` union branch, then the `else` branch's
  `partition` into `associations` / `others` and the `|=` union of
  `[join_dependency, *others]`. The bespoke carry-forward lines that hand-copied the
  side stores are gone — `others` is what forwards them, as in Rails.
- `_mergeReferencedJoins` (association-scope) does the same partition.
- `emitJoinPlan`'s two direct-append loops are deleted; the JDs reach the emitter as
  `plan.stashedJoins` via `selectNamedJoins`, folded into the primary JD's single
  `joinConstraints(stashedJoins, sharedTracker(), references)` call.
- `structuralUnionEq` short-circuits to identity for a `JoinDependency` — Ruby's `|=`
  dedups a stash through the default `eql?`/`hash` (object identity), and deep-walking
  a JD's node graph would be both wrong and unbounded.

Alias-tracker sharing — the behaviour the direct-append path existed to guarantee — is
preserved because the stash rides the same shared tracker; `relation.test.ts`'s
`authors_categorizations` aliasing assertion is green unchanged.

No stubs, no placeholder surface: this deletes two stores and adds no new API.

## Not in scope

`buildJoinBuckets`' eager handling is untouched: `_eagerLoadAssociations` stays its own
store. Folding it back into `joins_values` (and with it the literal
`joins.last.base_klass == model` guard) is step 2,
`converge-apply-join-dependency-joins-bang`.

## Verification

- `pnpm api:compare` — exit 0, all ratchets pass, no manifest drift (`git status` clean
  after the run), so the delta is non-negative.
- `pnpm api:extra` — exit 0; the two deleted stores only shrink TS-only surface.
- `pnpm test:compare` — exit 0. No test added, removed, or renamed, and the two
  rewritten assertions keep their assertion counts, so the test delta is zero.
- `pnpm typecheck` clean; `relation/**`, `associations/**`, `relation.test.ts`,
  `relations.test.ts` — 3054 passed, 0 failed.

Closes-story: converge-merged-join-deps-into-joins-values
