### PR TITLE
feat(api-compare): sample loose wide-gate resolution through delegation edges

### DIFF
--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -5,6 +5,7 @@ import {
   buildPackageIndex,
   candidateNames,
   classify,
+  crossesAdapterFamilies,
   classifyRow,
   includeGraphFiles,
   edgeKindOf,
@@ -235,6 +236,52 @@ describe("isCrossFile", () => {
         ...row,
         tsFile: "connection-adapters/postgresql-adapter.ts",
         rubyFile: "connection_adapters/postgresql_adapter.rb",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("crossesAdapterFamilies", () => {
+  const row = {
+    package: "activerecord",
+    tsName: "enableExtension",
+    rubyFile: "postgresql_adapter.rb",
+    call: "internal_exec_query → internalExecQuery",
+    bucket: "divergence" as const,
+    tsFile: "connection-adapters/postgresql-adapter.ts",
+  };
+
+  it("flags a PostgreSQL row credited to a MySQL body", () => {
+    expect(
+      crossesAdapterFamilies({
+        ...row,
+        resolutions: [
+          {
+            file: "connection-adapters/mysql/database-statements.ts",
+            edgeKind: "include",
+            methods: ["explain"],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag a row credited within its own family", () => {
+    expect(
+      crossesAdapterFamilies({
+        ...row,
+        resolutions: [
+          {
+            file: "connection-adapters/postgresql/schema-statements-class.ts",
+            edgeKind: "delegation",
+            methods: ["foreignKeys"],
+          },
+          {
+            file: "connection-adapters/abstract-adapter.ts",
+            edgeKind: "include",
+            methods: ["log"],
+          },
+        ],
       }),
     ).toBe(false);
   });

--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -4,22 +4,26 @@ import type { Entity, Mismatch } from "./audit-cross-file-calls.js";
 import {
   buildPackageIndex,
   candidateNames,
+  classify,
   classifyRow,
   includeGraphFiles,
   isCrossFile,
+  looseOnlyRows,
+  reachableFiles,
 } from "./audit-cross-file-calls.js";
 
 function entity(
   name: string,
   file: string,
   methods: { name: string; calls?: string[] }[],
-  edges: { includes?: string[]; extends?: string[] } = {},
+  edges: { includes?: string[]; extends?: string[]; delegatesTo?: string[] } = {},
 ): Entity {
   return {
     name,
     file,
     includes: edges.includes ?? [],
     extends: edges.extends ?? [],
+    ...(edges.delegatesTo ? { delegatesTo: edges.delegatesTo } : {}),
     instanceMethods: methods,
     classMethods: [],
   };
@@ -55,6 +59,59 @@ describe("includeGraphFiles", () => {
       entity("PgSchemaStatements", "pg/schema-statements-class.ts", []),
     ]);
     expect(includeGraphFiles("pg-adapter.ts", index).size).toBe(0);
+  });
+});
+
+describe("reachableFiles", () => {
+  const index = buildPackageIndex([
+    entity("Adapter", "pg-adapter.ts", [], {
+      includes: ["Quoting"],
+      delegatesTo: ["PgSchemaStatements"],
+    }),
+    entity("Quoting", "quoting.ts", []),
+    entity("PgSchemaStatements", "pg/schema-statements-class.ts", []),
+  ]);
+
+  it("ignores delegation edges unless asked to follow them", () => {
+    expect([...reachableFiles("pg-adapter.ts", index, false).keys()]).toEqual(["quoting.ts"]);
+  });
+
+  it("tags a file the delegation edge reaches", () => {
+    expect(Object.fromEntries(reachableFiles("pg-adapter.ts", index, true))).toEqual({
+      "quoting.ts": "include",
+      "pg/schema-statements-class.ts": "delegation",
+    });
+  });
+});
+
+describe("looseOnlyRows", () => {
+  const index = buildPackageIndex([
+    entity("Adapter", "pg-adapter.ts", [{ name: "indexes", calls: [] }], {
+      delegatesTo: ["PgSchemaStatements"],
+    }),
+    entity("PgSchemaStatements", "pg/schema-statements-class.ts", [
+      { name: "unrelated", calls: ["quotedScope"] },
+    ]),
+  ]);
+  const indexes = new Map([["activerecord", index]]);
+  const rows = classify(
+    [{ ...mismatch("pg-adapter.ts", "indexes"), missing: ["quoted_scope → quotedScope"] }],
+    indexes,
+  );
+
+  it("credits a row to an unrelated method in the delegation target's file", () => {
+    expect(looseOnlyRows(rows, indexes, true)).toEqual([
+      {
+        ...rows[0],
+        resolvedIn: "pg/schema-statements-class.ts",
+        edgeKind: "delegation",
+        resolvingMethods: ["unrelated"],
+      },
+    ]);
+  });
+
+  it("resolves nothing without the delegation edge", () => {
+    expect(looseOnlyRows(rows, indexes, false)).toEqual([]);
   });
 });
 

--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -7,6 +7,7 @@ import {
   classify,
   classifyRow,
   includeGraphFiles,
+  edgeKindOf,
   isCrossFile,
   looseOnlyRows,
   reachableFiles,
@@ -103,11 +104,51 @@ describe("looseOnlyRows", () => {
     expect(looseOnlyRows(rows, indexes, true)).toEqual([
       {
         ...rows[0],
-        resolvedIn: "pg/schema-statements-class.ts",
-        edgeKind: "delegation",
-        resolvingMethods: ["unrelated"],
+        resolutions: [
+          {
+            file: "pg/schema-statements-class.ts",
+            edgeKind: "delegation",
+            methods: ["unrelated"],
+          },
+        ],
       },
     ]);
+  });
+
+  it("reports every resolving file, in name order", () => {
+    const many = buildPackageIndex([
+      entity("Adapter", "pg-adapter.ts", [{ name: "indexes", calls: [] }], {
+        delegatesTo: ["Zeta", "Alpha"],
+      }),
+      entity("Zeta", "zeta.ts", [{ name: "unrelated", calls: ["quotedScope"] }]),
+      entity("Alpha", "alpha.ts", [{ name: "unrelated", calls: ["quotedScope"] }]),
+    ]);
+    const manyIndexes = new Map([["activerecord", many]]);
+    const manyRows = classify(
+      [{ ...mismatch("pg-adapter.ts", "indexes"), missing: ["quoted_scope → quotedScope"] }],
+      manyIndexes,
+    );
+    expect(looseOnlyRows(manyRows, manyIndexes, true)[0].resolutions.map((r) => r.file)).toEqual([
+      "alpha.ts",
+      "zeta.ts",
+    ]);
+  });
+
+  it("calls a row include-resolved when any reachable include edge also makes the call", () => {
+    const both = buildPackageIndex([
+      entity("Adapter", "pg-adapter.ts", [{ name: "indexes", calls: [] }], {
+        includes: ["Quoting"],
+        delegatesTo: ["Stmts"],
+      }),
+      entity("Quoting", "quoting.ts", [{ name: "other", calls: ["quotedScope"] }]),
+      entity("Stmts", "stmts.ts", [{ name: "unrelated", calls: ["quotedScope"] }]),
+    ]);
+    const bothIndexes = new Map([["activerecord", both]]);
+    const bothRows = classify(
+      [{ ...mismatch("pg-adapter.ts", "indexes"), missing: ["quoted_scope → quotedScope"] }],
+      bothIndexes,
+    );
+    expect(edgeKindOf(looseOnlyRows(bothRows, bothIndexes, true)[0])).toBe("include");
   });
 
   it("resolves nothing without the delegation edge", () => {

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -14,6 +14,7 @@ export type Entity = {
   file: string;
   includes: string[];
   extends: string[];
+  delegatesTo?: string[];
   instanceMethods: Method[];
   classMethods: Method[];
 };
@@ -48,12 +49,22 @@ export type Row = {
   resolvedIn?: string;
 };
 
-type Definition = { entity: string; file: string; calls: Set<string> };
+type Definition = { entity: string; file: string; calls: Set<string>; name?: string };
 
 export type PackageIndex = {
   entitiesByFile: Map<string, Entity[]>;
   entitiesByName: Map<string, Entity[]>;
   definitionsByName: Map<string, Definition[]>;
+  methodsByFile: Map<string, Definition[]>;
+};
+
+/** Which recorded edge kind carried the walk to a file. */
+export type EdgeKind = "include" | "delegation";
+
+export type LooseRow = Row & {
+  resolvedIn: string;
+  edgeKind: EdgeKind;
+  resolvingMethods: string[];
 };
 
 export function buildPackageIndex(
@@ -64,12 +75,17 @@ export function buildPackageIndex(
     entitiesByFile: new Map(),
     entitiesByName: new Map(),
     definitionsByName: new Map(),
+    methodsByFile: new Map(),
+  };
+  const record = (name: string, definition: Definition): void => {
+    push(index.definitionsByName, name, definition);
+    push(index.methodsByFile, definition.file, { ...definition, name });
   };
   for (const entity of entities) {
     push(index.entitiesByFile, entity.file, entity);
     push(index.entitiesByName, entity.name, entity);
     for (const method of [...entity.instanceMethods, ...entity.classMethods]) {
-      push(index.definitionsByName, method.name, {
+      record(method.name, {
         entity: entity.name,
         file: method.file ?? entity.file,
         calls: new Set(method.calls ?? []),
@@ -78,7 +94,7 @@ export function buildPackageIndex(
   }
   for (const [file, methods] of Object.entries(fileFunctions)) {
     for (const method of methods) {
-      push(index.definitionsByName, method.name, {
+      record(method.name, {
         entity: file,
         file: method.file ?? file,
         calls: new Set(method.calls ?? []),
@@ -95,21 +111,95 @@ function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
 }
 
 export function includeGraphFiles(tsFile: string, index: PackageIndex): Set<string> {
-  const files = new Set<string>();
+  return new Set(reachableFiles(tsFile, index, false).keys());
+}
+
+/**
+ * Files reachable from `tsFile`, each tagged with the edge kind that first
+ * reached it. `delegation` follows the `delegatesTo` edges recorded by
+ * `extract-ts-api.ts` (RFC 0083) in addition to `includes` / `extends`; a file
+ * reached both ways is tagged `include`, the narrower kind.
+ */
+export function reachableFiles(
+  tsFile: string,
+  index: PackageIndex,
+  delegation: boolean,
+): Map<string, EdgeKind> {
+  const files = new Map<string, EdgeKind>();
   const seen = new Set<string>();
-  const queue = [...(index.entitiesByFile.get(tsFile) ?? [])];
+  const queue = [...(index.entitiesByFile.get(tsFile) ?? [])].map(
+    (entity) => [entity, "include" as EdgeKind] as const,
+  );
   while (queue.length > 0) {
-    const entity = queue.pop()!;
-    for (const name of [...entity.includes, ...entity.extends]) {
-      if (seen.has(name)) continue;
-      seen.add(name);
+    const [entity, inherited] = queue.pop()!;
+    const edges: [string, EdgeKind][] = [
+      ...[...entity.includes, ...entity.extends].map(
+        (name) => [name, inherited] as [string, EdgeKind],
+      ),
+      ...(delegation ? (entity.delegatesTo ?? []) : []).map(
+        (name) => [name, "delegation"] as [string, EdgeKind],
+      ),
+    ];
+    for (const [name, kind] of edges) {
+      if (seen.has(`${kind}:${name}`)) continue;
+      seen.add(`${kind}:${name}`);
       for (const target of index.entitiesByName.get(name) ?? []) {
-        files.add(target.file);
-        queue.push(target);
+        if (files.get(target.file) !== "include") files.set(target.file, kind);
+        queue.push([target, kind]);
       }
     }
   }
   return files;
+}
+
+/**
+ * Rows the loose rule ("ANY method in a reachable file makes the call")
+ * resolves and the strict same-name rule does not — the population this
+ * story exists to classify.
+ */
+export function looseOnlyRows(
+  rows: Row[],
+  indexes: Map<string, PackageIndex>,
+  delegation: boolean,
+): LooseRow[] {
+  const loose: LooseRow[] = [];
+  for (const row of rows) {
+    if (row.bucket !== "divergence" && row.bucket !== "unported") continue;
+    const index = indexes.get(row.package);
+    if (!index) continue;
+    const candidates = candidateNames(row.call);
+    for (const [file, edgeKind] of reachableFiles(row.tsFile, index, delegation)) {
+      const makers = (index.methodsByFile.get(file) ?? []).filter((d) =>
+        candidates.some((c) => d.calls.has(c)),
+      );
+      if (makers.length === 0) continue;
+      loose.push({
+        ...row,
+        resolvedIn: file,
+        edgeKind,
+        resolvingMethods: [...new Set(makers.map((d) => d.name ?? "?"))].sort(),
+      });
+      break;
+    }
+  }
+  return loose;
+}
+
+/** Rows the strict same-name rule resolves through the graph, per edge policy. */
+export function sameNameGraphRows(
+  rows: Row[],
+  indexes: Map<string, PackageIndex>,
+  delegation: boolean,
+): Row[] {
+  return rows.filter((row) => {
+    const index = indexes.get(row.package);
+    if (!index) return false;
+    const candidates = candidateNames(row.call);
+    const reachable = reachableFiles(row.tsFile, index, delegation);
+    return (index.definitionsByName.get(row.tsName) ?? []).some(
+      (d) => reachable.has(d.file) && candidates.some((c) => d.calls.has(c)),
+    );
+  });
 }
 
 export function classifyRow(
@@ -175,37 +265,6 @@ function tsStem(tsFile: string): string {
   return tsFile.replace(/\.ts$/, "");
 }
 
-function countAnyMethodInGraph(rows: Row[], indexes: Map<string, PackageIndex>): number {
-  const callsByFile = new Map<string, Map<string, Set<string>>>();
-  for (const [pkg, index] of indexes) {
-    const perFile = new Map<string, Set<string>>();
-    for (const definitions of index.definitionsByName.values()) {
-      for (const definition of definitions) {
-        let set = perFile.get(definition.file);
-        if (!set) perFile.set(definition.file, (set = new Set()));
-        for (const call of definition.calls) set.add(call);
-      }
-    }
-    callsByFile.set(pkg, perFile);
-  }
-  let count = 0;
-  for (const row of rows) {
-    if (row.bucket !== "divergence" && row.bucket !== "unported") continue;
-    const index = indexes.get(row.package);
-    if (!index) continue;
-    const candidates = candidateNames(row.call);
-    const perFile = callsByFile.get(row.package)!;
-    for (const file of includeGraphFiles(row.tsFile, index)) {
-      const calls = perFile.get(file);
-      if (calls && candidates.some((c) => calls.has(c))) {
-        count++;
-        break;
-      }
-    }
-  }
-  return count;
-}
-
 function tally<T>(values: T[], key: (value: T) => string): [string, number][] {
   const counts = new Map<string, number>();
   for (const value of values) counts.set(key(value), (counts.get(key(value)) ?? 0) + 1);
@@ -232,11 +291,21 @@ async function main(): Promise<void> {
   const rows = classify(artifact.mismatches, indexes);
   const crossFile = rows.filter((r) => isCrossFile(r));
   const resolvable = rows.filter((r) => r.bucket !== "divergence" && r.bucket !== "unported");
+  const looseWithDelegation = looseOnlyRows(rows, indexes, true);
+
+  if (process.argv.includes("--loose-sample")) {
+    for (const row of looseWithDelegation) console.log(JSON.stringify(row));
+    return;
+  }
 
   const report = {
     totalRows: rows.length,
     crossFileRows: crossFile.length,
-    anyMethodInIncludeGraph: countAnyMethodInGraph(rows, indexes),
+    anyMethodInIncludeGraph: looseOnlyRows(rows, indexes, false).length,
+    anyMethodInDelegationGraph: looseWithDelegation.length,
+    sameNameInIncludeGraph: sameNameGraphRows(rows, indexes, false).length,
+    sameNameInDelegationGraph: sameNameGraphRows(rows, indexes, true).length,
+    anyMethodByEdgeKind: Object.fromEntries(tally(looseWithDelegation, (r) => r.edgeKind)),
     resolvableAnywhereByName: resolvable.length,
     resolvableForwardersAboveDelegationCap: resolvable.filter((r) =>
       (indexes.get(r.package)!.definitionsByName.get(r.tsName) ?? [])

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -49,7 +49,7 @@ export type Row = {
   resolvedIn?: string;
 };
 
-type Definition = { entity: string; file: string; calls: Set<string>; name?: string };
+type Definition = { name: string; entity: string; file: string; calls: Set<string> };
 
 export type PackageIndex = {
   entitiesByFile: Map<string, Entity[]>;
@@ -58,14 +58,11 @@ export type PackageIndex = {
   methodsByFile: Map<string, Definition[]>;
 };
 
-/** Which recorded edge kind carried the walk to a file. */
 export type EdgeKind = "include" | "delegation";
 
-export type LooseRow = Row & {
-  resolvedIn: string;
-  edgeKind: EdgeKind;
-  resolvingMethods: string[];
-};
+export type Resolution = { file: string; edgeKind: EdgeKind; methods: string[] };
+
+export type LooseRow = Row & { resolutions: Resolution[] };
 
 export function buildPackageIndex(
   entities: Entity[],
@@ -77,15 +74,16 @@ export function buildPackageIndex(
     definitionsByName: new Map(),
     methodsByFile: new Map(),
   };
-  const record = (name: string, definition: Definition): void => {
-    push(index.definitionsByName, name, definition);
-    push(index.methodsByFile, definition.file, { ...definition, name });
+  const record = (definition: Definition): void => {
+    push(index.definitionsByName, definition.name, definition);
+    push(index.methodsByFile, definition.file, definition);
   };
   for (const entity of entities) {
     push(index.entitiesByFile, entity.file, entity);
     push(index.entitiesByName, entity.name, entity);
     for (const method of [...entity.instanceMethods, ...entity.classMethods]) {
-      record(method.name, {
+      record({
+        name: method.name,
         entity: entity.name,
         file: method.file ?? entity.file,
         calls: new Set(method.calls ?? []),
@@ -94,7 +92,8 @@ export function buildPackageIndex(
   }
   for (const [file, methods] of Object.entries(fileFunctions)) {
     for (const method of methods) {
-      record(method.name, {
+      record({
+        name: method.name,
         entity: file,
         file: method.file ?? file,
         calls: new Set(method.calls ?? []),
@@ -114,12 +113,6 @@ export function includeGraphFiles(tsFile: string, index: PackageIndex): Set<stri
   return new Set(reachableFiles(tsFile, index, false).keys());
 }
 
-/**
- * Files reachable from `tsFile`, each tagged with the edge kind that first
- * reached it. `delegation` follows the `delegatesTo` edges recorded by
- * `extract-ts-api.ts` (RFC 0083) in addition to `includes` / `extends`; a file
- * reached both ways is tagged `include`, the narrower kind.
- */
 export function reachableFiles(
   tsFile: string,
   index: PackageIndex,
@@ -152,11 +145,6 @@ export function reachableFiles(
   return files;
 }
 
-/**
- * Rows the loose rule ("ANY method in a reachable file makes the call")
- * resolves and the strict same-name rule does not — the population this
- * story exists to classify.
- */
 export function looseOnlyRows(
   rows: Row[],
   indexes: Map<string, PackageIndex>,
@@ -168,24 +156,25 @@ export function looseOnlyRows(
     const index = indexes.get(row.package);
     if (!index) continue;
     const candidates = candidateNames(row.call);
+    const resolutions: Resolution[] = [];
     for (const [file, edgeKind] of reachableFiles(row.tsFile, index, delegation)) {
       const makers = (index.methodsByFile.get(file) ?? []).filter((d) =>
         candidates.some((c) => d.calls.has(c)),
       );
       if (makers.length === 0) continue;
-      loose.push({
-        ...row,
-        resolvedIn: file,
-        edgeKind,
-        resolvingMethods: [...new Set(makers.map((d) => d.name ?? "?"))].sort(),
-      });
-      break;
+      resolutions.push({ file, edgeKind, methods: [...new Set(makers.map((d) => d.name))].sort() });
     }
+    if (resolutions.length === 0) continue;
+    resolutions.sort((a, b) => a.file.localeCompare(b.file));
+    loose.push({ ...row, resolutions });
   }
   return loose;
 }
 
-/** Rows the strict same-name rule resolves through the graph, per edge policy. */
+export function edgeKindOf(row: LooseRow): EdgeKind {
+  return row.resolutions.some((r) => r.edgeKind === "include") ? "include" : "delegation";
+}
+
 export function sameNameGraphRows(
   rows: Row[],
   indexes: Map<string, PackageIndex>,
@@ -305,7 +294,13 @@ async function main(): Promise<void> {
     anyMethodInDelegationGraph: looseWithDelegation.length,
     sameNameInIncludeGraph: sameNameGraphRows(rows, indexes, false).length,
     sameNameInDelegationGraph: sameNameGraphRows(rows, indexes, true).length,
-    anyMethodByEdgeKind: Object.fromEntries(tally(looseWithDelegation, (r) => r.edgeKind)),
+    anyMethodByEdgeKind: Object.fromEntries(tally(looseWithDelegation, edgeKindOf)),
+    anyMethodResolvedOnlyInOwnFile: looseWithDelegation.filter((r) =>
+      r.resolutions.every((res) => res.file === r.tsFile),
+    ).length,
+    anyMethodWithSameNamedResolver: looseWithDelegation.filter((r) =>
+      r.resolutions.some((res) => res.methods.includes(r.tsName)),
+    ).length,
     resolvableAnywhereByName: resolvable.length,
     resolvableForwardersAboveDelegationCap: resolvable.filter((r) =>
       (indexes.get(r.package)!.definitionsByName.get(r.tsName) ?? [])

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -118,27 +118,32 @@ export function reachableFiles(
   index: PackageIndex,
   delegation: boolean,
 ): Map<string, EdgeKind> {
-  const files = new Map<string, EdgeKind>();
-  const seen = new Set<string>();
-  const queue = [...(index.entitiesByFile.get(tsFile) ?? [])].map(
-    (entity) => [entity, "include" as EdgeKind] as const,
+  const includeOnly = delegation ? walk(tsFile, index, false) : new Set<string>();
+  return new Map(
+    [...walk(tsFile, index, delegation)].map((file) => [
+      file,
+      delegation && !includeOnly.has(file) ? "delegation" : "include",
+    ]),
   );
+}
+
+function walk(tsFile: string, index: PackageIndex, delegation: boolean): Set<string> {
+  const files = new Set<string>();
+  const seen = new Set<string>();
+  const queue = [...(index.entitiesByFile.get(tsFile) ?? [])];
   while (queue.length > 0) {
-    const [entity, inherited] = queue.pop()!;
-    const edges: [string, EdgeKind][] = [
-      ...[...entity.includes, ...entity.extends].map(
-        (name) => [name, inherited] as [string, EdgeKind],
-      ),
-      ...(delegation ? (entity.delegatesTo ?? []) : []).map(
-        (name) => [name, "delegation"] as [string, EdgeKind],
-      ),
+    const entity = queue.pop()!;
+    const edges = [
+      ...entity.includes,
+      ...entity.extends,
+      ...(delegation ? (entity.delegatesTo ?? []) : []),
     ];
-    for (const [name, kind] of edges) {
-      if (seen.has(`${kind}:${name}`)) continue;
-      seen.add(`${kind}:${name}`);
+    for (const name of edges) {
+      if (seen.has(name)) continue;
+      seen.add(name);
       for (const target of index.entitiesByName.get(name) ?? []) {
-        if (files.get(target.file) !== "include") files.set(target.file, kind);
-        queue.push([target, kind]);
+        files.add(target.file);
+        queue.push(target);
       }
     }
   }
@@ -169,6 +174,21 @@ export function looseOnlyRows(
     loose.push({ ...row, resolutions });
   }
   return loose;
+}
+
+export function adapterFamily(file: string): string | undefined {
+  return [/postgresql/, /mysql|mariadb/, /sqlite/].find((re) => re.test(file))?.source;
+}
+
+export function crossesAdapterFamilies(row: LooseRow): boolean {
+  const own = adapterFamily(row.tsFile);
+  return (
+    own !== undefined &&
+    row.resolutions.some((r) => {
+      const other = adapterFamily(r.file);
+      return other !== undefined && other !== own;
+    })
+  );
 }
 
 export function edgeKindOf(row: LooseRow): EdgeKind {
@@ -298,6 +318,7 @@ async function main(): Promise<void> {
     anyMethodResolvedOnlyInOwnFile: looseWithDelegation.filter((r) =>
       r.resolutions.every((res) => res.file === r.tsFile),
     ).length,
+    anyMethodCrossingAdapterFamilies: looseWithDelegation.filter(crossesAdapterFamilies).length,
     anyMethodWithSameNamedResolver: looseWithDelegation.filter((r) =>
       r.resolutions.some((res) => res.methods.includes(r.tsName)),
     ).length,


### PR DESCRIPTION
## Summary

Evaluates the RFC 0083 proposal to relax wide-gate call resolution from "a
definition of the SAME method name in a reachable file makes the call" to "ANY
method in a reachable file makes the call", now that `extract-ts-api.ts` records
delegation edges (#5730).

**Verdict: reject.** No gate change, no baseline change, row delta 0.

The evaluation report is committed in the tasks repo alongside its sibling:
`rfcs/0083-wide-call-ratchet-noise-reduction/loose-resolution-evaluation.md`.

## What this PR changes

`scripts/api-compare/audit-cross-file-calls.ts` only — an audit script, not a gate:

- `reachableFiles(tsFile, index, delegation)` generalizes `includeGraphFiles`,
  optionally following the recorded `delegatesTo` edges and tagging each reached
  file with the edge kind that got there. `includeGraphFiles` is now a wrapper,
  so the existing classification is unchanged.
- `looseOnlyRows` / `sameNameGraphRows` measure the loose and strict rules under
  either edge policy. `--loose-sample` emits one JSON line per row carrying
  **every** resolution the loose rule admits (file, edge kind, and the names of
  the methods actually making the call), so the classification does not depend
  on traversal order.
- The summary gains the fields each figure below is read from, including
  `anyMethodCrossingAdapterFamilies`.

## Evidence

On the current tree (3251 artifact rows):

| metric                                        | include-graph only | + delegation edges |
| --------------------------------------------- | -----------------: | -----------------: |
| strict (same-named definition makes the call) |                 21 |                 21 |
| loose (ANY method in a reachable file)        |                252 |                458 |

Of those 458 loose rows: **0** have the paired method's own name among the
resolvers, 117 resolve nowhere but the paired file itself (already owned by
`wide-calls-same-file-transitive-call-set`), and **51 cross adapter families** —
`postgresql-adapter.ts#enableExtension` credited to `explain` in
`mysql/database-statements.ts`, `#getAdvisoryLock` credited to
`internalBeginTransaction` in `sqlite3/database-statements.ts`. That is the
per-adapter fidelity mask the cross-file audit warned about, and it arrives
through include edges the gate already has, before delegation is considered.

A deterministic every-9th-row sample of the 206 delegation-only rows (23 of 206)
was read in full: 23 of 23 are unrelated-method credits, dominated by generic
names (`first`, `size`, `connection`, `loaded?`) landing on whichever of the ~5
methods in a reachable file happens to use them.

`resolve-wide-candidates-through-include-graph` stays scoped to strict same-name
resolution — this story does not absorb it, and delegation edges do not change
its measured delta (21 either way).

Closes-story: evaluate-loose-any-method-wide-resolution
