### PR TITLE
fix(api-compare): widen significantMissingCalls rubyCalls to readonly string[]

### DIFF
--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -259,7 +259,7 @@ export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES, partitionN
  */
 export function significantMissingCalls(
   rubyName: string,
-  rubyCalls: string[],
+  rubyCalls: readonly string[],
   tsCalls: Set<string>,
   isPortedWithArgs: (tsName: string) => boolean,
   mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,


### PR DESCRIPTION
`checkCalls` passes `rubyCalls` (`readonly string[]`, the return type of `dropWeakCalls`) into `significantMissingCalls`, whose parameter was still `string[]` — a TS2345 under `scripts/tsconfig.json`. The parameter only gets iterated, so widening it to `readonly string[]` is behavior-neutral.

`pnpm exec tsc --noEmit -p scripts/tsconfig.json` reports no source error in `scripts/api-compare/`; `compare.test.ts` passes (115 tests).

Closes-story: fix-significant-missing-calls-readonly-param