### PR TITLE
test(activerecord): use the canonical Bird model in base-prevent-writes

### DIFF
--- a/packages/activerecord/src/base-prevent-writes.test.ts
+++ b/packages/activerecord/src/base-prevent-writes.test.ts
@@ -4,16 +4,11 @@ import { Base } from "./index.js";
 import { ReadOnlyError } from "./errors.js";
 import { fixtures } from "./test-fixtures.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
+import { Bird } from "./test-helpers/models/bird.js";
 import { Professor } from "./test-helpers/models/professor.js";
 
 describe("BasePreventWritesTest", () => {
   fixtures([]);
-
-  class Bird extends Base {
-    static {
-      this.attribute("name", "string");
-    }
-  }
 
   it("creating a record raises if preventing writes", async () => {
     const error = await Base.whilePreventingWrites(async () => {

--- a/packages/activerecord/src/base-prevent-writes.test.ts
+++ b/packages/activerecord/src/base-prevent-writes.test.ts
@@ -62,7 +62,9 @@ describe("BasePreventWritesTest", () => {
 
   it("an empty transaction does not raise if preventing writes", async () => {
     await Base.whilePreventingWrites(async () => {
-      await Bird.transaction(async () => {});
+      await Bird.transaction(async () => {
+        await (await Base.leaseConnection()).materializeTransactions();
+      });
     });
   });
 


### PR DESCRIPTION
Deletes the inline `Bird` class in `base-prevent-writes.test.ts` and imports the canonical `test-helpers/models/bird.js` instead, matching Rails' `require "models/bird"` (`base_prevent_writes_test.rb:4`). The `birds` table comes from the canonical schema via the existing `fixtures([])` call; its columns match `schema.rb:120`.

The bespoke class declared a `name` attribute, which suppressed DB reflection, so the tests were not running against the canonical column set.

Also fixes the "an empty transaction does not raise if preventing writes" body: Rails (`base_prevent_writes_test.rb:58-66`) calls `ActiveRecord::Base.lease_connection.materialize_transactions` *inside* the transaction block — that explicit call is what the `assert_queries_count(2, include_schema: true)` measures. The trails port had an empty block, so it asserted nothing about materialization. It now makes the same call.

An earlier version of this description credited canonical `Bird`'s `before_save` materialize hook for that test — that was wrong: the block never saves a record, so the hook never fires there. The hook still matters for the create/update tests.

Note: Rails guards the whole class with `if !in_memory_db?`; this trails file has never had that guard. Pre-existing, not touched here.

All eight tests pass on sqlite locally; CI covers postgresql and mysql2.

Closes-story: base-prevent-writes-declares-bespoke-bird-model
