### PR TITLE
fix(scripts): clear the remaining 284 type errors in the scripts tsconfig program

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "vendor:fetch": "pnpm tsx vendor/fetch.ts"
   },
   "devDependencies": {
+    "@blazetrails/activerecord": "workspace:*",
     "@eslint/js": "^10.0.1",
     "@sinonjs/fake-timers": "^15.3.2",
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2458,9 +2458,10 @@ export class Base extends Model {
     cols: string[],
     tuples: unknown[][],
   ): Relation<InstanceType<T>>;
+  static where<T extends typeof Base>(this: T, node: Nodes.Node): Relation<InstanceType<T>>;
   static where<T extends typeof Base>(
     this: T,
-    conditionsOrSql: Record<string, unknown> | string | string[] | unknown[],
+    conditionsOrSql: Record<string, unknown> | string | string[] | unknown[] | Nodes.Node,
     ...rest: unknown[]
   ): Relation<InstanceType<T>> {
     if (typeof conditionsOrSql === "string") {
@@ -2491,6 +2492,10 @@ export class Base extends Model {
       // (query_methods.rb:1616-1618).
       return this.all().where(conditionsOrSql as unknown[]);
     }
+    // Arel nodes and hash conditions take the same runtime path; the split is
+    // only so each reaches its own `Relation#where` overload (a union argument
+    // matches neither).
+    if (conditionsOrSql instanceof Nodes.Node) return this.all().where(conditionsOrSql);
     return this.all().where(conditionsOrSql);
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2464,6 +2464,9 @@ export class Base extends Model {
     conditionsOrSql: Record<string, unknown> | string | string[] | unknown[] | Nodes.Node,
     ...rest: unknown[]
   ): Relation<InstanceType<T>> {
+    if (conditionsOrSql instanceof Nodes.Node) {
+      return this.all().where(conditionsOrSql);
+    }
     if (typeof conditionsOrSql === "string") {
       return this.all().where(conditionsOrSql, ...rest);
     }
@@ -2492,10 +2495,6 @@ export class Base extends Model {
       // (query_methods.rb:1616-1618).
       return this.all().where(conditionsOrSql as unknown[]);
     }
-    // Arel nodes and hash conditions take the same runtime path; the split is
-    // only so each reaches its own `Relation#where` overload (a union argument
-    // matches neither).
-    if (conditionsOrSql instanceof Nodes.Node) return this.all().where(conditionsOrSql);
     return this.all().where(conditionsOrSql);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -657,9 +657,9 @@ export class Relation<T extends Base> {
    * (query_methods.rb:88-92) — `@scope.joins!(association)` (unless the
    * association is already joined) then `self.not(pk => nil)`. Building the
    * join through JoinDependency means through / HABTM / composite-key shapes
-   * work for free; `skipJoinFor` carries WhereChain's already-joined guard.
+   * work for free.
    */
-  whereAssociated(assocNames: string[], skipJoinFor?: ReadonlySet<string>): Relation<T> {
+  whereAssociated(...assocNames: string[]): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
       const reflection = rel._whereChainReflection(assocName);
@@ -668,7 +668,11 @@ export class Relation<T extends Base> {
       // already present in joins_values / left_outer_joins_values. Routing the
       // join through JoinDependency (joins!) rather than a bespoke resolver is
       // what makes through / HABTM / composite-key shapes work for free.
-      if (!skipJoinFor?.has(assocName)) {
+      const reflectionName = reflection.name ?? assocName;
+      if (
+        !rel.joinsValues.includes(reflectionName) &&
+        !rel.leftOuterJoinsValues.includes(reflectionName)
+      ) {
         QueryMethodBangs.joinsBang.call(scope as any, assocName);
       }
       // Rails: `self.not(reflection.table_name => Array(pk).index_with(nil))`,

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -66,6 +66,11 @@ export class WhereChain<R = any> {
   }
 
   associated(...associationNames: string[]): R {
+    // The reflection is discarded on purpose: this call is here for Rails'
+    // fail-fast on an unknown association (`scope_association_reflection`
+    // raises, query_methods.rb:90), which happens before any join is built.
+    // `whereAssociated` re-derives it because it needs the *scope's* reflection
+    // as the scope advances. `missing` below has the same shape.
     for (const name of associationNames) this.scopeAssociationReflection(name);
     return this._scope.whereAssociated(...associationNames);
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -43,10 +43,8 @@ import { foreignKey } from "@blazetrails/activesupport";
  */
 export interface WhereChainScope<R> {
   whereNot(conditions: Record<string, unknown>): R;
-  whereAssociated(associationNames: string[], skipJoinFor?: ReadonlySet<string>): R;
+  whereAssociated(...associationNames: string[]): R;
   whereMissing(...associationNames: string[]): R;
-  joinsValues: unknown[];
-  leftOuterJoinsValues: unknown[];
   exists(conditions?: unknown): Promise<boolean>;
 }
 
@@ -68,21 +66,8 @@ export class WhereChain<R = any> {
   }
 
   associated(...associationNames: string[]): R {
-    // Mirror Rails' guard (query_methods.rb:91): skip the join for any
-    // association already present in joins_values / left_outer_joins_values,
-    // so an already-joined association does not get a duplicate join.
-    const skipJoinFor = new Set<string>();
-    for (const name of associationNames) {
-      const reflection = this.scopeAssociationReflection(name) as { name?: string } | undefined;
-      const reflectionName = reflection?.name ?? name;
-      if (
-        this._scope.joinsValues.includes(reflectionName) ||
-        this._scope.leftOuterJoinsValues.includes(reflectionName)
-      ) {
-        skipJoinFor.add(name);
-      }
-    }
-    return this._scope.whereAssociated(associationNames, skipJoinFor);
+    for (const name of associationNames) this.scopeAssociationReflection(name);
+    return this._scope.whereAssociated(...associationNames);
   }
 
   missing(...associationNames: string[]): R {

--- a/packages/arel/src/nodes/as.test.ts
+++ b/packages/arel/src/nodes/as.test.ts
@@ -33,11 +33,13 @@ describe("As", () => {
 
   describe("#to_cte", () => {
     it("returns a Cte node using the LHS's name and the RHS as the relation", () => {
-      const selectAst = users.project(users.get("id")).ast;
-      const asNode = new Nodes.As(selectAst, new Nodes.SqlLiteral("cte_name"));
-      const cte = asNode.toCte();
-      expect(cte).toBeInstanceOf(Nodes.Cte);
-      expect(cte.name).toBe("cte_name");
+      const table = new Table("users");
+      const asNode = new Nodes.As(table, "foo");
+      const cteNode = asNode.toCte();
+
+      expect(cteNode).toBeInstanceOf(Nodes.Cte);
+      expect(cteNode.name).toBe((asNode.left as Table).name);
+      expect(cteNode.relation).toBe(asNode.right);
     });
   });
 });

--- a/packages/arel/src/nodes/binary.test.ts
+++ b/packages/arel/src/nodes/binary.test.ts
@@ -13,13 +13,13 @@ describe("NodesTest", () => {
 
     it("Union supports as() from Binary", () => {
       const sm = new SelectManager(users);
-      const union = sm.union(new SelectManager(users)) as Nodes.Union;
+      const union = sm.union(new SelectManager(users));
       expect(union.as("u")).toBeInstanceOf(Nodes.As);
     });
 
     it("Union supports and() from Binary", () => {
       const sm = new SelectManager(users);
-      const union = sm.union(new SelectManager(users)) as Nodes.Union;
+      const union = sm.union(new SelectManager(users));
       const other = users.get("id").eq(1);
       expect(union.and(other)).toBeInstanceOf(Nodes.And);
     });

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -8,6 +8,7 @@ import { Or } from "./or.js";
 import { Not } from "./unary.js";
 import { Grouping } from "./grouping.js";
 import type { Cte } from "./cte.js";
+import type { SelectManager } from "../select-manager.js";
 
 // `ModelAttribute` is not an Arel node but occupies node slots in Rails:
 // `build_quoted` returns one unwrapped into the AST (casted.rb:50), and both
@@ -34,6 +35,12 @@ import type { Cte } from "./cte.js";
 export type NodeOrValue =
   | Node
   | ModelAttribute
+  // A SelectManager occupies node slots in Rails' own CTE idiom —
+  // `Arel::Nodes::As.new(cte_table, select_manager)` (select_manager.rb `#with`
+  // takes those As nodes, and Rails' arel tests build them that way) — and
+  // `visit_Arel_SelectManager` (to_sql.rb:358-361) is a real rendering visitor
+  // that wraps `o.ast` in parens, so nothing here can reach `unsupported`.
+  | SelectManager
   // Rails puts bare Strings in node slots structurally: `Cte#initialize` stores
   // the CTE name as `@left` (cte.rb:10-12), `TableAlias` the alias name as
   // `@right` (table_alias.rb), and Rails' own tests build
@@ -138,20 +145,21 @@ export class Assignment extends Binary {}
 // a hard cycle if `As.toCte` imported it directly. The package entrypoint
 // (`./index.ts`) calls `_registerCteFactory` at load, mirroring the
 // `registerBinaryInversions` / `registerNodeDeps` pattern used elsewhere.
-let cteFactory: ((name: string, relation: Node) => Cte) | null = null;
-export function _registerCteFactory(fn: (name: string, relation: Node) => Cte): void {
+let cteFactory: ((name: string | SqlLiteral, relation: Node) => Cte) | null = null;
+export function _registerCteFactory(fn: (name: string | SqlLiteral, relation: Node) => Cte): void {
   cteFactory = fn;
 }
 
 export class As extends Binary {
+  /** Mirrors: `Arel::Nodes::As#to_cte` (binary.rb:43-45) — `Cte.new(left.name, right)`. */
   toCte(): Cte {
-    const name = this.right instanceof SqlLiteral ? this.right.value : String(this.right);
     if (!cteFactory) {
       throw new Error(
         'As.toCte() requires the Cte factory registry. Import from "@blazetrails/arel" instead of deep-importing node classes.',
       );
     }
-    return cteFactory(name, this.left as Node);
+    const name = (this.left as { name: string | SqlLiteral }).name;
+    return cteFactory(name, this.right as Node);
   }
 }
 

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -11,6 +11,11 @@ import {
 } from "./index.js";
 import { testConnection, fakeRecordConnection } from "./test-helpers/connection.js";
 
+/** Minitest's `must_be_like`: compare SQL with runs of whitespace collapsed. */
+function mustBeLike(sql: string): string {
+  return sql.trim().replace(/\s+/g, " ");
+}
+
 describe("SelectManagerTest", () => {
   const users = new Table("users");
   const posts = new Table("posts");
@@ -350,25 +355,62 @@ describe("SelectManagerTest", () => {
 
   describe("with", () => {
     it("should support basic WITH", () => {
-      const cte = users.project(users.get("name")).where(users.get("age").gt(21));
-      const alias = new Nodes.TableAlias(cte.ast, "adults");
-      const cteAs = new Nodes.As(alias, cte.ast);
-      const main = new SelectManager();
-      main.with(cteAs);
-      main.from("adults");
-      main.project(sql("*"));
-      expect(main.toSql()).toContain("WITH");
+      const users = new Table("users");
+      const usersTop = new Table("users_top");
+      const comments = new Table("comments");
+
+      const top = users.project(users.get("id")).where(users.get("karma").gt(100));
+      const usersAs = new Nodes.As(usersTop, top);
+      const selectManager = comments
+        .project(star)
+        .with(usersAs)
+        .where(comments.get("author_id").in(usersTop.project(usersTop.get("id"))));
+
+      expect(mustBeLike(visitor.compile(selectManager.ast))).toBe(
+        mustBeLike(
+          `WITH "users_top" AS (SELECT "users"."id" FROM "users" WHERE "users"."karma" > 100) SELECT * FROM "comments" WHERE "comments"."author_id" IN (SELECT "users_top"."id" FROM "users_top")`,
+        ),
+      );
     });
 
     it("should support WITH RECURSIVE", () => {
-      const cte = users.project(star);
-      const alias = new Nodes.TableAlias(cte.ast, "tree");
-      const cteAs = new Nodes.As(alias, cte.ast);
-      const main = new SelectManager();
-      main.withRecursive(cteAs);
-      main.from("tree");
-      main.project(sql("*"));
-      expect(main.toSql()).toContain("WITH RECURSIVE");
+      const comments = new Table("comments");
+      const commentsId = comments.get("id");
+      const commentsParentId = comments.get("parent_id");
+
+      const replies = new Table("replies");
+      const repliesId = replies.get("id");
+
+      const nonRecursiveTerm = new SelectManager();
+      nonRecursiveTerm
+        .from(comments)
+        .project(commentsId, commentsParentId)
+        .where(commentsId.eq(42));
+
+      const recursiveTerm = new SelectManager();
+      recursiveTerm
+        .from(comments)
+        .project(commentsId, commentsParentId)
+        .join(replies)
+        .on(commentsParentId.eq(repliesId));
+
+      const union = nonRecursiveTerm.union(recursiveTerm);
+
+      const asStatement = new Nodes.As(replies, union);
+
+      const manager = new SelectManager();
+      manager.withRecursive(asStatement).from(replies).project(star);
+
+      expect(mustBeLike(visitor.compile(manager.ast))).toBe(
+        mustBeLike(`
+          WITH RECURSIVE "replies" AS (
+              SELECT "comments"."id", "comments"."parent_id" FROM "comments" WHERE "comments"."id" = 42
+            UNION
+              SELECT "comments"."id", "comments"."parent_id" FROM "comments" INNER JOIN "replies" ON "comments"."parent_id" = "replies"."id"
+          )
+          SELECT * FROM "replies"
+        `),
+      );
     });
   });
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -369,7 +369,7 @@ export class SelectManager extends TreeManager {
   /**
    * UNION with another manager.
    */
-  union(other: SelectManager | SelectStatement): Node {
+  union(other: SelectManager | SelectStatement): Union {
     const otherAst = other instanceof SelectManager ? other.ast : other;
     return new Union(this.ast, otherAst);
   }
@@ -377,7 +377,7 @@ export class SelectManager extends TreeManager {
   /**
    * INTERSECT with another manager.
    */
-  intersect(other: SelectManager | SelectStatement): Node {
+  intersect(other: SelectManager | SelectStatement): Intersect {
     const otherAst = other instanceof SelectManager ? other.ast : other;
     return new Intersect(this.ast, otherAst);
   }
@@ -385,13 +385,13 @@ export class SelectManager extends TreeManager {
   /**
    * EXCEPT with another manager.
    */
-  except(other: SelectManager | SelectStatement): Node {
+  except(other: SelectManager | SelectStatement): Except {
     const otherAst = other instanceof SelectManager ? other.ast : other;
     return new Except(this.ast, otherAst);
   }
 
   /** @internal */
-  minus(other: SelectManager | SelectStatement): Node {
+  minus(other: SelectManager | SelectStatement): Except {
     return this.except(other);
   }
 
@@ -512,7 +512,7 @@ export class SelectManager extends TreeManager {
   /**
    * UNION ALL with another manager.
    */
-  unionAll(other: SelectManager | SelectStatement): Node {
+  unionAll(other: SelectManager | SelectStatement): UnionAll {
     const otherAst = other instanceof SelectManager ? other.ast : other;
     return new UnionAll(this.ast, otherAst);
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -5,6 +5,7 @@ import { Composite } from "../collectors/composite.js";
 import { SubstituteBinds } from "../collectors/substitute-binds.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
+import { SelectManager } from "../select-manager.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
 import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
@@ -83,11 +84,11 @@ const DEFAULT_BIND_BLOCK: (index: number) => string = () => "?";
  */
 export function cteRelationSelfWraps(relation: Node): boolean {
   return (
-    // `Arel::Nodes::As.new(cte_table, select_manager)` is Rails' own CTE idiom,
+    // `Arel::Nodes::As.new(cte_table, select_manager)` is Rails' own CTE idiom
     // and `visit_Arel_SelectManager` (to_sql.rb:358-361) already emits the
-    // parens. Duck-typed rather than `instanceof`: select-manager.ts sits
-    // upstream of the visitors and importing it here would close a cycle.
-    (!(relation instanceof Node) && (relation as { ast?: unknown })?.ast instanceof Node) ||
+    // parens. A SelectManager is not a Node, so it reaches a CTE body slot as
+    // `NodeOrValue` rather than through the node hierarchy above.
+    (relation as unknown) instanceof SelectManager ||
     relation instanceof Nodes.Grouping ||
     relation instanceof Nodes.Union ||
     relation instanceof Nodes.UnionAll ||

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -77,12 +77,17 @@ const DEFAULT_BIND_BLOCK: (index: number) => string = () => "?";
 
 /**
  * True when a CTE body node renders its own surrounding parentheses (a
- * `Grouping` or a set-operation node), so `visit_Arel_Nodes_Cte` must not add
- * another pair. A bare `SelectStatement` / `SqlLiteral` returns false — those
- * need the explicit `AS (...)` wrap.
+ * `Grouping`, a set-operation node, or a `SelectManager`), so
+ * `visit_Arel_Nodes_Cte` must not add another pair. A bare `SelectStatement` /
+ * `SqlLiteral` returns false — those need the explicit `AS (...)` wrap.
  */
 export function cteRelationSelfWraps(relation: Node): boolean {
   return (
+    // `Arel::Nodes::As.new(cte_table, select_manager)` is Rails' own CTE idiom,
+    // and `visit_Arel_SelectManager` (to_sql.rb:358-361) already emits the
+    // parens. Duck-typed rather than `instanceof`: select-manager.ts sits
+    // upstream of the visitors and importing it here would close a cycle.
+    (!(relation instanceof Node) && (relation as { ast?: unknown })?.ast instanceof Node) ||
     relation instanceof Nodes.Grouping ||
     relation instanceof Nodes.Union ||
     relation instanceof Nodes.UnionAll ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@blazetrails/activerecord':
+        specifier: workspace:*
+        version: link:packages/activerecord
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3(jiti@2.6.1))

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
@@ -79,6 +79,27 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
+    "rubyName": "associated",
+    "call": "joins_values",
+    "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "associated",
+    "call": "left_outer_joins_values",
+    "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "associated",
+    "call": "include?",
+    "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
     "rubyName": "build_arel",
     "call": "annotate_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -259,7 +259,7 @@ export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES, partitionN
  */
 export function significantMissingCalls(
   rubyName: string,
-  rubyCalls: string[],
+  rubyCalls: readonly string[],
   tsCalls: Set<string>,
   isPortedWithArgs: (tsName: string) => boolean,
   mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -420,8 +420,8 @@ async function columnExists(
   column: string,
 ): Promise<boolean> {
   const quoted = `"${table.replace(/"/g, '""')}"`;
-  const cols = await adapter.execute(`PRAGMA table_info(${quoted})`);
-  return cols.some((c: { name: string }) => c.name === column);
+  const cols = (await adapter.execute(`PRAGMA table_info(${quoted})`)) as { name: string }[];
+  return cols.some((c) => c.name === column);
 }
 
 async function migrateDb(adapter: AbstractSQLite3Adapter) {
@@ -1465,7 +1465,7 @@ async function syncPrLinkedIssues() {
       let after: string | null = null;
       let hasNextPage = false;
       do {
-        const afterArg = after ? `, after:"${after}"` : "";
+        const afterArg: string = after ? `, after:"${after}"` : "";
         const resp = ghJson<{
           data: {
             repository: {
@@ -2138,12 +2138,10 @@ async function printSummary() {
     count("raw_job_logs"),
   ]);
 
-  const stateRows = await Base.adapter.execute(
+  const stateRows = (await Base.adapter.execute(
     `SELECT state, COUNT(*) as cnt FROM pull_requests GROUP BY state ORDER BY state`,
-  );
-  const stateParts = stateRows
-    .map((r: { cnt: number; state: string }) => `${r.cnt} ${r.state}`)
-    .join(", ");
+  )) as { cnt: number; state: string }[];
+  const stateParts = stateRows.map((r) => `${r.cnt} ${r.state}`).join(", ");
 
   console.log("\n=== Database Summary ===");
   console.log(`  PRs: ${prCount} (${stateParts})`);
@@ -2460,7 +2458,7 @@ async function main() {
       throw err;
     }
   } finally {
-    adapter.close();
+    await adapter.close();
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
     { "path": "packages/did-you-mean" },
     { "path": "packages/html-sanitizer" },
     { "path": "packages/nokogiri" },
-    { "path": "packages/activerecord-cli" }
+    { "path": "packages/activerecord-cli" },
+    { "path": "scripts" }
   ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Clears the 284 diagnostics `scripts/tsconfig.json` reported after the sibling
story cleared the file-local ones, then wires the project into the root
`tsconfig.json` so `pnpm typecheck` keeps it at zero.

Both deferred buckets had a single root cause each, and the 227 "AR
`declare`-model statics missing under plain `tsc`" errors turned out not to be
a tse-compiler question at all.

## Bucket A — `scripts/sync-stats/sync.ts` (262 → 0)

The repo root is not a workspace package, so `@blazetrails/activerecord` had no
`node_modules` link and did not resolve from `scripts/` — at type-check time
*or* at runtime (`node -e "import('@blazetrails/activerecord')"` fails on
`main`, so `pnpm stats:sync` is broken there too). Adding the workspace dep to
the root `package.json` fixes both and drops the bucket to 5: every missing
model static (`tableName`, `attribute`, `where`, `findBySql`, `upsertAll`,
`create`) was downstream of the unresolved import, and no `declare`-model
machinery is involved. Nothing is papered over with `as any`.

The residue: a do-while circularity (one annotation breaks the whole chain),
two raw-SQL row callbacks typed against `Record<string, unknown>`, and an
`adapter.close()` that is a floating promise now that the adapter has a real
type.

## Bucket B — `scripts/parity/fixtures/*/query.ts` (22 → 0)

Fixed in the AR/Arel signatures; the fixtures mirror their Ruby twins and are
untouched.

- `Base.where` gained the `Nodes.Node` overload `Relation#where` already has.
- `whereAssociated` is variadic like `whereMissing`, with Rails' already-joined
  guard (`query_methods.rb:89-91`) moved inline where Rails has it instead of
  precomputed into a `skipJoinFor` set by `WhereChain#associated`.
- `SelectManager#union` / `unionAll` / `intersect` / `except` / `minus` return
  their concrete node types rather than a widened `Node`.
- `NodeOrValue` admits a `SelectManager`, justified by
  `visit_Arel_SelectManager` (`to_sql.rb:358-361`).

## Two real bugs the types exposed

Both on the CTE path, both caught by the arel-53/54 parity fixtures, which were
emitting `WITH "[object Object]" AS ("cte_photos")`:

- `As#toCte` read the name off `right` and the relation off `left` — the
  reverse of Rails' `Cte.new(left.name, right)` (`binary.rb:43-45`).
- A `SelectManager` CTE body double-wrapped its parens because
  `cteRelationSelfWraps` did not know it self-wraps.

Neither was caught because all three relevant ported tests had watered-down
bodies. `as_test.rb`'s `#to_cte` was rewritten to assert the inversion, even
though its Rails-verbatim name already said "the LHS's name and the RHS as the
relation"; and `select_manager_test.rb`'s "should support basic WITH" /
"should support WITH RECURSIVE" built a `TableAlias` instead of Rails'
`Arel::Nodes::As.new(cte_table, query)` and asserted only
`toContain("WITH")` instead of the full SQL. All three are restored to their
Rails bodies. Reverting the two fixes makes all three fail, so this is real
regression cover in the unit lane, not only in the label-gated parity job.

Query parity goes 167 → 169 of 204.

## Verification

- `npx tsc --build tsconfig.json && npx tsc -p scripts/tsconfig.json` → 0.
- `pnpm typecheck` → 0, and probing with a deliberate error in a new
  `scripts/*.ts` file makes it fail, so the root reference really gates.
- `packages/arel` (1463 tests), `packages/activerecord/src/relation` (1138),
  `base.test.ts`, `where-chain*.test.ts` — all pass.
- `pnpm parity:query`: `ar-37`, `arel-53`, `arel-54` pass. The 8 remaining
  failures (`ar-13/18/32/38/79/102/131/182`) are pre-existing and unrelated —
  same set before and after, minus the two this fixes.

## One baseline entry added — please sanity-check it

`scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json`
gains three entries for `associated`: `joins_values`,
`left_outer_joins_values`, `include?`.

Flagging it explicitly because baselining can be a way to park unconverged
work, and I don't want this read that way. Moving Rails' already-joined guard
out of `WhereChain#associated` into `Relation#whereAssociated` took those three
calls with it, and the wide gate is lexical per-method. `joins!` and `not` were
already baselined for this same method, having moved to `whereAssociated` for
exactly the same reason — these three are the rest of Rails'
`associations.each` body following them. The guard still runs, per-iteration,
where `query_methods.rb:91` runs it. The reason field records that path rather
than reusing the RFC 0047 boilerplate.

## Known residual

`As#toCte` reads `left.name` off a cast; a `left` with no `name` yields
`undefined` where Rails raises `NoMethodError`. Left as-is rather than
inventing an error Rails does not have.

Closes-story: scripts-tsconfig-ar-declare-model-type-errors

