### PR TITLE
refactor(activerecord): converge ExecutionStrategy onto Rails' method_missing delegator shape

### DIFF
--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -351,7 +351,8 @@ export const ActiveRecord = {
 
   /**
    * The execution strategy migrations run through. Defaults to
-   * {@link DefaultStrategy}, which runs the migration's `up`/`down` directly.
+   * {@link DefaultStrategy}, which forwards the calls a migration doesn't
+   * implement itself to the connection adapter.
    * Mirrors `ActiveRecord.migration_strategy` (active_record.rb:398-401, default
    * `Migration::DefaultStrategy`).
    */

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from "vitest";
 import { MigrationContext, Migrator } from "./index.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migration, IllegalMigrationNameError } from "./migration.js";
+import { DefaultStrategy } from "./migration/default-strategy.js";
 import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { newRawTestAdapter } from "./test-adapter.js";
@@ -259,5 +260,33 @@ describe("Migration#createTable id option type", () => {
       "uuid",
       { type: "string", limit: 36 },
     ]);
+  });
+
+  // Rails routes Migration#method_missing through execution_strategy, whose
+  // method_missing forwards to migration.connection. JS has no implicit
+  // method_missing, so the forwarding pair is called explicitly.
+  describe("execution strategy", () => {
+    class StrategyMigration extends Migration {
+      override get connection(): DatabaseAdapter {
+        return { createTable: () => "hi mom!" } as unknown as DatabaseAdapter;
+      }
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    it("memoizes the configured strategy, constructed with the migration", () => {
+      const migration = new StrategyMigration();
+      expect(migration.executionStrategy).toBeInstanceOf(DefaultStrategy);
+      expect(migration.executionStrategy).toBe(migration.executionStrategy);
+    });
+
+    it("forwards unknown calls through the strategy to the connection", () => {
+      const migration = new StrategyMigration();
+      const strategy = migration.executionStrategy as DefaultStrategy;
+      expect(strategy.respondToMissing("createTable")).toBe(true);
+      expect(strategy.respondToMissing("nopeNotHere")).toBe(false);
+      expect(strategy.methodMissing("createTable")).toBe("hi mom!");
+      expect(() => migration.methodMissing("nopeNotHere")).toThrow(TypeError);
+    });
   });
 });

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -262,9 +262,6 @@ describe("Migration#createTable id option type", () => {
     ]);
   });
 
-  // Rails routes Migration#method_missing through execution_strategy, whose
-  // method_missing forwards to migration.connection. JS has no implicit
-  // method_missing, so the forwarding pair is called explicitly.
   describe("execution strategy", () => {
     class StrategyMigration extends Migration {
       override get connection(): DatabaseAdapter {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -32,7 +32,6 @@ import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { migrationArConfig } from "./migration/ar-config-source.js";
-import { DefaultStrategy } from "./migration/default-strategy.js";
 import type { ExecutionStrategy } from "./migration/execution-strategy.js";
 import type { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
 import { registerVersion, findVersion, CURRENT_VERSION } from "./migration/compatibility.js";
@@ -279,6 +278,8 @@ export abstract class Migration {
   protected _connectionOverride?: DatabaseAdapter;
   /** @internal Per-migration pool override — mirrors Rails' @pool ivar. */
   protected _poolOverride?: ConnectionPool;
+  /** @internal Memoized strategy — mirrors Rails' @execution_strategy ivar. */
+  private _executionStrategy?: ExecutionStrategy;
   private _recording = false;
   private _recorder = new CommandRecorder();
   private _name?: string;
@@ -1346,11 +1347,15 @@ export abstract class Migration {
       }
     } finally {
       this._connectionOverride = undefined;
+      this._executionStrategy = undefined;
     }
   }
 
   get executionStrategy(): ExecutionStrategy {
-    return new DefaultStrategy();
+    this._executionStrategy ??= new (ActiveRecord.migrationStrategy as new (
+      migration: Migration,
+    ) => ExecutionStrategy)(this);
+    return this._executionStrategy;
   }
 
   get disableDdlTransaction(): boolean {
@@ -1570,12 +1575,16 @@ export abstract class Migration {
 
   /** @internal */
   methodMissing(name: string, ...args: unknown[]): unknown {
-    const conn = this.connection as unknown as Record<string, unknown>;
-    if (typeof conn[name] !== "function") {
-      // JS has no NoMethodError; TypeError is the closest stdlib equivalent.
+    const strategy = this.executionStrategy as {
+      respondToMissing?: (name: string) => boolean;
+      methodMissing?: (name: string, ...args: unknown[]) => unknown;
+    };
+    if (strategy.respondToMissing?.(name) !== true) {
+      // Rails falls through to `super`, which raises NoMethodError. JS has no
+      // NoMethodError; TypeError is the closest stdlib equivalent.
       throw new TypeError(`undefined method '${name}' for ${this.connection.constructor.name}`);
     }
-    return (conn[name] as (...a: unknown[]) => unknown).apply(conn, args);
+    return strategy.methodMissing?.(name, ...args);
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -278,7 +278,6 @@ export abstract class Migration {
   protected _connectionOverride?: DatabaseAdapter;
   /** @internal Per-migration pool override — mirrors Rails' @pool ivar. */
   protected _poolOverride?: ConnectionPool;
-  /** @internal Memoized strategy — mirrors Rails' @execution_strategy ivar. */
   private _executionStrategy?: ExecutionStrategy;
   private _recording = false;
   private _recorder = new CommandRecorder();
@@ -1580,8 +1579,6 @@ export abstract class Migration {
       methodMissing?: (name: string, ...args: unknown[]) => unknown;
     };
     if (strategy.respondToMissing?.(name) !== true) {
-      // Rails falls through to `super`, which raises NoMethodError. JS has no
-      // NoMethodError; TypeError is the closest stdlib equivalent.
       throw new TypeError(`undefined method '${name}' for ${this.connection.constructor.name}`);
     }
     return strategy.methodMissing?.(name, ...args);

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -1,41 +1,27 @@
 /**
- * Default migration execution strategy — runs migrations directly.
+ * The default strategy for executing migrations. Delegates method calls
+ * to the connection adapter.
  *
  * Mirrors: ActiveRecord::Migration::DefaultStrategy
- *
- * Simply calls the migration's up/down method. A custom strategy could
- * wrap this with advisory locks to prevent concurrent migrations.
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
-import type { Migration } from "../migration.js";
 import { ExecutionStrategy } from "./execution-strategy.js";
 
 export class DefaultStrategy extends ExecutionStrategy {
-  private _adapter: DatabaseAdapter | null = null;
-
-  async exec(
-    direction: "up" | "down",
-    migration: Migration,
-    adapter: DatabaseAdapter,
-  ): Promise<void> {
-    this.migration = migration;
-    this._adapter = adapter;
-    migration.connection = adapter;
-    if (direction === "up") {
-      await migration.up();
-    } else {
-      await migration.down();
-    }
+  /** @internal JS has no implicit method_missing, so Migration calls this explicitly. */
+  methodMissing(method: string, ...args: unknown[]): unknown {
+    const conn = this.connection as unknown as Record<string, unknown>;
+    return (conn[method] as (...a: unknown[]) => unknown).apply(conn, args);
   }
 
   /** @internal */
-  connection(): DatabaseAdapter {
-    // Mirrors Rails: DefaultStrategy#connection → migration.connection.
-    // _adapter is our exec()-time fallback; per-migration connection wins.
-    const conn = (this.migration as Migration | null)?.connection ?? this._adapter;
-    if (!conn)
-      throw new Error("DefaultStrategy: no adapter available (exec() has not been called)");
-    return conn;
+  respondToMissing(method: string): boolean {
+    const conn = this.connection as unknown as Record<string, unknown>;
+    return typeof conn[method] === "function";
+  }
+
+  protected get connection(): DatabaseAdapter {
+    return this.migration.connection;
   }
 }

--- a/packages/activerecord/src/migration/default-strategy.ts
+++ b/packages/activerecord/src/migration/default-strategy.ts
@@ -9,7 +9,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/
 import { ExecutionStrategy } from "./execution-strategy.js";
 
 export class DefaultStrategy extends ExecutionStrategy {
-  /** @internal JS has no implicit method_missing, so Migration calls this explicitly. */
+  /** @internal */
   methodMissing(method: string, ...args: unknown[]): unknown {
     const conn = this.connection as unknown as Record<string, unknown>;
     return (conn[method] as (...a: unknown[]) => unknown).apply(conn, args);

--- a/packages/activerecord/src/migration/execution-strategy.ts
+++ b/packages/activerecord/src/migration/execution-strategy.ts
@@ -1,25 +1,23 @@
 /**
- * Migration execution strategy — controls how migration methods are invoked.
+ * ExecutionStrategy is used by the migration to respond to any method calls
+ * that the migration class does not implement directly. This is the base
+ * strategy. All strategies should inherit from this class.
+ *
+ * The ExecutionStrategy receives the current `migration` when initialized.
  *
  * Mirrors: ActiveRecord::Migration::ExecutionStrategy
- *
- * Subclasses can wrap execution with advisory locks, logging, or
- * other cross-cutting concerns.
  */
 
-import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { Migration } from "../migration.js";
 
-export abstract class ExecutionStrategy {
-  protected migration: unknown;
+export class ExecutionStrategy {
+  readonly #migration: Migration;
 
-  constructor(migration?: unknown) {
-    this.migration = migration ?? null;
+  constructor(migration: Migration) {
+    this.#migration = migration;
   }
 
-  abstract exec(
-    direction: "up" | "down",
-    migration: Migration,
-    adapter: DatabaseAdapter,
-  ): Promise<void>;
+  protected get migration(): Migration {
+    return this.#migration;
+  }
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -52,6 +52,13 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "copy",
+    "call": "call",
+    "reason": "Ruby's `options[:on_skip].call(scope, migration)` is a Proc invocation; TS calls the callback directly as `options.onSkip(scope, source)`, which has no `.call` token."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "copy",
     "call": "exist?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Converges `ExecutionStrategy` / `DefaultStrategy` onto Rails'
`method_missing` delegator shape.

- `ExecutionStrategy` is now a plain class constructed with the migration
  (`initialize(migration)` / private `attr_reader :migration`); the invented
  `abstract exec(direction, migration, adapter)` is gone (its last caller went
  away in #5596).
- `DefaultStrategy` forwards unknown calls to `migration.connection` via the JS
  analogues of `method_missing` / `respond_to_missing?`, with a private
  `connection` getter, matching `default_strategy.rb`.
- `Migration#executionStrategy` memoizes `ActiveRecord.migrationStrategy.new(this)`
  (migration.rb:808) and is cleared in `execMigration`'s ensure block
  (migration.rb:998); `Migration#methodMissing` now dispatches through the
  strategy, falling back to a `TypeError` where Rails calls `super`
  (migration.rb:1055-1056).
- No caller passes a strategy to `Migrator`; that option stays removed.

Closes-story: converge-execution-strategy-onto-rails-method-missing-shape
