### PR TITLE
feat(migration): dispatch Migrator#migrate onto up/down

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2208,6 +2208,12 @@ export class Migrator {
    * Run all pending migrations up, or migrate to a specific version.
    *
    * Mirrors: ActiveRecord::Migrator#migrate
+   *
+   * Dispatches to {@link up} / {@link down}, which each build the per-run
+   * Migrator. A target equal to the current version goes to `up`, so an
+   * unapplied migration below an already-applied target still runs. The target
+   * is rejected up front because Ruby compares it against `current_version`
+   * directly, while it may reach us as a string.
    */
   async migrate(
     targetVersion?: number | string | null,
@@ -2215,12 +2221,9 @@ export class Migrator {
   ): Promise<MigrationProxy[]> {
     if (targetVersion === undefined || targetVersion === null) return this.up(null, block);
 
-    // Ruby compares `current_version > target_version` directly; the target may
-    // reach us as a string, so reject a non-version target before widening it.
     if (this._invalidTarget(targetVersion)) {
       throw new UnknownMigrationVersionError(targetVersion);
     }
-    this._validateTargetVersion(targetVersion);
 
     const target = BigInt(targetVersion);
     const current = BigInt(await this.currentVersion());

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2211,29 +2211,30 @@ export class Migrator {
    */
   async migrate(
     targetVersion?: number | string | null,
-    filter?: (m: MigrationProxy) => boolean,
+    block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
-    let ran: MigrationProxy[] = [];
-    await this._withAdvisoryLock(async () => {
-      await this._ensureSchemaTable();
+    if (targetVersion === undefined || targetVersion === null) return this.up(null, block);
 
-      if (targetVersion !== undefined && targetVersion !== null) {
-        if (this._invalidTarget(targetVersion)) {
-          throw new UnknownMigrationVersionError(targetVersion);
-        }
-        this._validateTargetVersion(targetVersion);
-        const target = BigInt(targetVersion);
-        const current = BigInt(await this.currentVersion());
-        if (target > current) {
-          ran = await this._migrateUp(targetVersion, filter);
-        } else if (target < current) {
-          ran = await this._migrateDown(targetVersion, filter);
-        }
-      } else {
-        ran = await this._migrateUp(null, filter);
-      }
-    });
-    return ran;
+    // Ruby compares `current_version > target_version` directly; the target may
+    // reach us as a string, so reject a non-version target before widening it.
+    if (this._invalidTarget(targetVersion)) {
+      throw new UnknownMigrationVersionError(targetVersion);
+    }
+    this._validateTargetVersion(targetVersion);
+
+    const target = BigInt(targetVersion);
+    const current = BigInt(await this.currentVersion());
+    if (current === BigInt(0) && target === BigInt(0)) return [];
+    if (current > target) return this.down(targetVersion, block);
+    return this.up(targetVersion, block);
+  }
+
+  /**
+   * The migration list handed to the per-run Migrator: Rails' `migrations` when
+   * no block is given, `migrations.select(&block)` when one is.
+   */
+  private _selectedMigrations(block?: (m: MigrationProxy) => boolean): MigrationProxy[] {
+    return block ? this._migrations.filter(block) : this._migrations;
   }
 
   /**
@@ -2243,10 +2244,13 @@ export class Migrator {
    *
    * @internal
    */
-  async up(targetVersion?: number | string | null): Promise<MigrationProxy[]> {
+  async up(
+    targetVersion?: number | string | null,
+    block?: (m: MigrationProxy) => boolean,
+  ): Promise<MigrationProxy[]> {
     const migrator = new Migrator(
       this._adapter,
-      this._migrations,
+      this._selectedMigrations(block),
       this._runOptions("up", targetVersion ?? null),
     );
     return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
@@ -2259,10 +2263,13 @@ export class Migrator {
    *
    * @internal
    */
-  async down(targetVersion?: number | string | null): Promise<MigrationProxy[]> {
+  async down(
+    targetVersion?: number | string | null,
+    block?: (m: MigrationProxy) => boolean,
+  ): Promise<MigrationProxy[]> {
     const migrator = new Migrator(
       this._adapter,
-      this._migrations,
+      this._selectedMigrations(block),
       this._runOptions("down", targetVersion ?? null),
     );
     return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
@@ -2837,10 +2844,7 @@ export class Migrator {
     return migrator._withAdvisoryLock(() => migrator.runWithoutLock());
   }
 
-  private async _migrateUp(
-    targetVersion: number | string | null,
-    filter?: (m: MigrationProxy) => boolean,
-  ): Promise<MigrationProxy[]> {
+  private async _migrateUp(targetVersion: number | string | null): Promise<MigrationProxy[]> {
     if (targetVersion !== null) this._validateTargetVersion(targetVersion);
     const target = targetVersion !== null ? BigInt(targetVersion) : null;
     const applied = await this._appliedVersions();
@@ -2849,17 +2853,13 @@ export class Migrator {
     for (const proxy of this._migrations) {
       if (applied.has(proxy.version)) continue;
       if (target !== null && BigInt(proxy.version) > target) break;
-      if (filter && !filter(proxy)) continue;
       await this._runMigration(proxy, "up");
       ran.push(proxy);
     }
     return ran;
   }
 
-  private async _migrateDown(
-    targetVersion: number | string | null,
-    filter?: (m: MigrationProxy) => boolean,
-  ): Promise<MigrationProxy[]> {
+  private async _migrateDown(targetVersion: number | string | null): Promise<MigrationProxy[]> {
     // A null target means "revert everything" (Rails: a `:down` Migrator with no
     // target_version), which — unlike `down(0)` — also reverts a version-0
     // migration.
@@ -2868,7 +2868,6 @@ export class Migrator {
     const applied = await this._appliedVersions();
     const toRevert = this._migrations
       .filter((m) => applied.has(m.version) && (target === null || BigInt(m.version) > target))
-      .filter((m) => !filter || filter(m))
       .reverse();
 
     for (const proxy of toRevert) {

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -84,6 +84,54 @@ describe("Migrator trails extensions", () => {
     await expect(new Migrator(adapter, list()).down(0)).resolves.toEqual([]);
   });
 
+  it("migrate to the current version runs an unapplied lower migration", async () => {
+    // Rails' `migrate` else-arm sends target == current_version to `up(target)`,
+    // whose runnable is `migrations[start..finish].reject { ran? }`
+    // (migration.rb:1233-1244) — an unapplied migration below an already-applied
+    // target still runs.
+    const ran: string[] = [];
+    const m1 = (): MigrationProxy =>
+      makeMigration("1", "M1", async () => {
+        ran.push("1");
+      });
+    const m2 = (): MigrationProxy =>
+      makeMigration("2", "M2", async () => {
+        ran.push("2");
+      });
+
+    await new Migrator(adapter, [m2()]).up();
+    expect(ran).toEqual(["2"]);
+
+    ran.length = 0;
+    await new Migrator(adapter, [m1(), m2()]).migrate(2);
+    expect(ran).toEqual(["1"]);
+  });
+
+  it("migrate returns [] when both the current and target version are 0", async () => {
+    const ran: string[] = [];
+    const migrator = new Migrator(adapter, [
+      makeMigration("0", "M0", async () => {
+        ran.push("0");
+      }),
+    ]);
+    await expect(migrator.migrate(0)).resolves.toEqual([]);
+    expect(ran).toEqual([]);
+  });
+
+  it("migrate applies its block by selecting the migrations handed to the per-run Migrator", async () => {
+    const ran: string[] = [];
+    const migrator = new Migrator(adapter, [
+      makeMigration("1", "M1", async () => {
+        ran.push("1");
+      }),
+      makeMigration("2", "M2", async () => {
+        ran.push("2");
+      }),
+    ]);
+    await migrator.migrate(null, (m) => m.version === "2");
+    expect(ran).toEqual(["2"]);
+  });
+
   it("down does not stamp the environment", async () => {
     // Rails' record_environment returns early when down? (migration.rb:1511).
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")], { environment: "test" });

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -128,6 +128,23 @@ describe("Migrator trails extensions", () => {
     expect(ran).toEqual(["2"]);
   });
 
+  it("migrate to a version below the current one reverts through down", async () => {
+    const reverted: string[] = [];
+    const migrations = (): MigrationProxy[] => [
+      makeMigration("1", "M1"),
+      makeMigration("2", "M2", undefined, async () => {
+        reverted.push("2");
+      }),
+      makeMigration("3", "M3", undefined, async () => {
+        reverted.push("3");
+      }),
+    ];
+
+    await new Migrator(adapter, migrations()).up();
+    await new Migrator(adapter, migrations()).migrate(1, (m) => m.version !== "3");
+    expect(reverted).toEqual(["2"]);
+  });
+
   it("down does not stamp the environment", async () => {
     // Rails' record_environment returns early when down? (migration.rb:1511).
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")], { environment: "test" });

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -85,10 +85,6 @@ describe("Migrator trails extensions", () => {
   });
 
   it("migrate to the current version runs an unapplied lower migration", async () => {
-    // Rails' `migrate` else-arm sends target == current_version to `up(target)`,
-    // whose runnable is `migrations[start..finish].reject { ran? }`
-    // (migration.rb:1233-1244) — an unapplied migration below an already-applied
-    // target still runs.
     const ran: string[] = [];
     const m1 = (): MigrationProxy =>
       makeMigration("1", "M1", async () => {


### PR DESCRIPTION
Converges `Migrator#migrate` onto Rails' `MigrationContext#migrate`
(`vendor/rails/activerecord/lib/active_record/migration.rb:1233-1244`), which
dispatches to `up` / `down` rather than deciding the direction inline.

Before, `migrate(target)` compared `target` to `currentVersion()` and called
`_migrateUp` / `_migrateDown` directly, doing **nothing** when they were equal.
Rails' `else` arm sends `target == current_version` to `up(target)`, whose
runnable rejects only already-ran migrations — so an unapplied migration below
an already-applied target still runs. Repro: versions `1` and `2` exist, only
`2` is applied; `migrate(2)` runs migration `1` in Rails and was a no-op here.

Also adds the `current_version == 0 && target_version == 0 → []` arm.

The `filter` callback is modelled as Rails' `&block`: `up` / `down` take it as
a trailing `block` param and apply it by selecting the migration list handed to
the per-run Migrator (`migrations.select(&block)`), so `_migrateUp` /
`_migrateDown` no longer carry a `filter`. `api:compare` reports **no** arity
mismatch for `migration.rb` (activerecord arity stays at 100%): the Ruby
`&block` param is matched by the trailing TS callback.

Two follow-on consequences, both Rails-faithful:

- The outer advisory lock in `migrate` is dropped — as in Rails, the per-run
  Migrator built by `up` / `down` takes it (nesting it would self-deadlock).
- A block that filters out the target version itself makes the per-run
  Migrator's `invalid_target?` fire, exactly as in Rails, where the same
  `Migrator.new(direction, migrations.select(&block), …, target_version)` is
  built. The one caller that passes both (`DatabaseTasks.migrate`) filters *to*
  the explicit version, so it is unaffected.

`_validateTargetVersion` is not called from `migrate` any more: every input it
rejected is already rejected by the preceding `_invalidTarget` check. It stays
on the `_migrateUp` / `_migrateDown` paths.

## Tests

`packages/activerecord/src/migrator.trails.test.ts` (trails-only — Rails'
`migrator_test.rb` has no `MigrationContext#migrate` case):

- `migrate to the current version runs an unapplied lower migration` — the
  regression; **fails on the pre-change baseline** (it ran nothing).
- `migrate returns [] when both the current and target version are 0`
- `migrate to a version below the current one reverts through down`
- `migrate applies its block by selecting the migrations handed to the per-run Migrator`

Also re-ran `migrator.test.ts`, `migration.test.ts`, `migration.trails.test.ts`,
`multi-db-migrator*.test.ts`, `tasks/`, and `trailties` `db.test.ts` — the
`migrate()` callers — all green.

Closes-story: converge-migrationcontext-migrate-dispatch-onto-up-down
