### PR TITLE
refactor(activerecord): converge data_source_exists? on the untyped data_source_sql query

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -358,6 +358,8 @@ export interface AbstractAdapter {
   tables(): Promise<string[]>;
   views(): Promise<string[]>;
   viewExists(viewName: string): Promise<boolean>;
+  /** @internal */
+  dataSourceSql(name?: string | null, options?: { type?: string }): string;
   columns(tableName: string): Promise<Column[]>;
   primaryKey(tableName: string): Promise<string | string[] | null>;
   indexes(tableName: string): Promise<unknown[]>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./schema-statements.js";
 import { ForeignKeyDefinition, TableDefinition, type ColumnType } from "./schema-definitions.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
+import { NotImplementedError } from "../../errors.js";
 
 function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
   return new SchemaStatements({
@@ -606,6 +607,52 @@ describe("tableExists NotImplementedError fallback", () => {
     });
 
     await expect(ss.tableExists("posts")).rejects.toThrow("connection lost");
+  });
+});
+
+describe("dataSourceExists NotImplementedError fallback", () => {
+  it("returns false for a blank data source name without querying", async () => {
+    const execute = vi.fn().mockResolvedValue([]);
+    const ss = makeStatements({
+      execute,
+      dataSourceSql: (n: string) => `SELECT 1 WHERE name = '${n}'`,
+    });
+
+    expect(await ss.dataSourceExists("")).toBe(false);
+    expect(await ss.dataSourceExists("   ")).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("issues one untyped data_source_sql query for tables and views alike", async () => {
+    const execute = vi.fn().mockResolvedValue([{ one: 1 }]);
+    const dataSourceSql = vi.fn((n: string) => `SELECT 1 WHERE name = '${n}'`);
+    const ss = makeStatements({ execute, dataSourceSql });
+
+    expect(await ss.dataSourceExists("posts")).toBe(true);
+    expect(dataSourceSql).toHaveBeenCalledTimes(1);
+    expect(dataSourceSql).toHaveBeenCalledWith("posts");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to data_sources.include? when the data-source path is not implemented", async () => {
+    const ss = makeStatements({
+      dataSourceSql: () => {
+        throw new NotImplementedError("#data_source_sql is not implemented");
+      },
+    });
+    vi.spyOn(ss, "dataSources").mockResolvedValue(["posts", "comments"]);
+
+    expect(await ss.dataSourceExists("posts")).toBe(true);
+    expect(await ss.dataSourceExists("widgets")).toBe(false);
+  });
+
+  it("propagates errors other than NotImplementedError", async () => {
+    const ss = makeStatements({
+      dataSourceSql: (n: string) => `SELECT 1 WHERE name = '${n}'`,
+      execute: vi.fn().mockRejectedValue(new Error("connection lost")),
+    });
+
+    await expect(ss.dataSourceExists("posts")).rejects.toThrow("connection lost");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1567,9 +1567,19 @@ export class SchemaStatements {
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
-    if (!name) return false;
-    if (await this.tableExists(name)) return true;
-    return this.viewExists(name);
+    // Rails passes no `type:`, so one untyped data_source_sql query matches any
+    // relation kind (table or view) in a single round trip. dataSourceSql
+    // dispatches through this.adapter so each adapter's override fires; an
+    // adapter without one raises NotImplementedError → dataSources() fallback.
+    if (!isPresent(name)) return false;
+    try {
+      const sql = (this.adapter as unknown as SchemaStatements).dataSourceSql(name);
+      const rows = await this.adapter.execute(sql);
+      return rows.length > 0;
+    } catch (error) {
+      if (!(error instanceof NotImplementedError)) throw error;
+      return (await this.dataSources()).includes(String(name));
+    }
   }
 
   buildCreateTableDefinition(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1458,7 +1458,7 @@ export class SchemaStatements {
     // MySQL/SQLite don't override → NotImplementedError → views() fallback.
     if (!viewName || viewName.trim().length === 0) return false;
     try {
-      const sql = (this.adapter as any).dataSourceSql(viewName, { type: "VIEW" });
+      const sql = this.adapter.dataSourceSql(viewName, { type: "VIEW" });
       const rows = await this.adapter.execute(sql);
       return rows.length > 0;
     } catch (e) {
@@ -1569,7 +1569,7 @@ export class SchemaStatements {
   async dataSourceExists(name: string): Promise<boolean> {
     if (!isPresent(name)) return false;
     try {
-      const sql = (this.adapter as unknown as SchemaStatements).dataSourceSql(name);
+      const sql = this.adapter.dataSourceSql(name);
       const rows = await this.adapter.execute(sql);
       return rows.length > 0;
     } catch (error) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1567,10 +1567,6 @@ export class SchemaStatements {
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
-    // Rails passes no `type:`, so one untyped data_source_sql query matches any
-    // relation kind (table or view) in a single round trip. dataSourceSql
-    // dispatches through this.adapter so each adapter's override fires; an
-    // adapter without one raises NotImplementedError → dataSources() fallback.
     if (!isPresent(name)) return false;
     try {
       const sql = (this.adapter as unknown as SchemaStatements).dataSourceSql(name);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -80,13 +80,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "data_source_exists?",
-    "call": "data_sources",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "data_source_exists?",
     "call": "query_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Converges `data_source_exists?` (`vendor/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:44-48`).

Base `SchemaStatements#dataSourceExists` diverged three ways: it ORed `tableExists(name) || viewExists(name)` (two typed round trips) instead of one untyped `data_source_sql(name)` query, it had no `rescue NotImplementedError` arm degrading to `data_sources.include?`, and it guarded with a bare falsy check rather than `present?`.

Also retires the now-converged `data_source_exists?` / `data_sources` wide-exclude entry.

Verified: `API_COMPARE_FORCE=1 pnpm api:compare --wide-calls` + `pnpm api:calls:wide` (OK, 3088 baselined) and `pnpm api:compare` + `pnpm api:calls` (OK, 14 baselined). New tests fail on baseline.

Closes-story: data-source-exists-notimplementederror-fallback
