### PR TITLE
refactor(activerecord): push the eager join dependency into joins_values via joins!

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4865,7 +4865,10 @@ export class Relation<T extends Base> {
     // claim parity we reject this combination explicitly. Tracked by the
     // `relation-handler-distinct-pk-materialization` continuation story.
     const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-    if (eagerLoading && hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
+    const isLimitable =
+      this.usingLimitableReflections(joinDependency.reflections as never) &&
+      this._joinsReflectionsAreLimitable();
+    if (eagerLoading && hasLimitOrOffset && !isLimitable) {
       // @nie disposition=TODO
       throw new NotImplementedError(
         "Using an eager-loaded relation with a limit/offset over a collection " +

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3353,7 +3353,7 @@ export class Relation<T extends Base> {
     // `eagerJd`/`manager.joinSourceCount` guards have no buildJoinBuckets analog —
     // it is a pure bucket-builder with neither an eager-JD parameter nor a live
     // manager — and are needed here because the short-circuit does NOT fold `eagerJd`
-    // into the stash (it is pushed in the non-short-circuit branch below). Cross-klass
+    // into the stash (it is pushed in the non-short-circuit branch below).
     const pureLeftOuter =
       eagerJd === undefined &&
       manager.joinSourceCount === 0 &&
@@ -4822,19 +4822,11 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirror Rails `apply_join_dependency` for subquery embedding: convert the
-   * eager_load/includes associations into LEFT OUTER joins and clear the eager
-   * values, so `arel()` carries the join (with a normal projection) instead of
-   * dropping it. A no-op when the relation is not eager-loading.
-   *
-   * Rails `RelationHandler#call` does `value = value.apply_join_dependency`
-   * before selecting the primary key and reading `value.arel`
-   * (predicate_builder/relation_handler.rb:7); `apply_join_dependency` builds a
-   * JoinDependency over `eager_load_values | includes_values` and returns
-   * `except(:includes, :eager_load, :preload).joins!(join_dependency)`
-   * (finder_methods.rb:457). trails models the same outcome with
-   * `leftOuterJoins` (rendered as OUTER joins by `_applyJoinsToManager`) over
-   * the cleared eager specs.
+   * Mirror Rails `apply_join_dependency` (finder_methods.rb:457-461): build a
+   * JoinDependency over `eager_load_values | includes_values` with an OuterJoin
+   * join type and push it into `joins_values` via `joins!`, on a relation that
+   * has dropped `:includes`, `:eager_load` and `:preload`. A no-op when the
+   * relation is not eager-loading.
    *
    * `eagerLoading` mirrors Rails `apply_join_dependency(eager_loading:
    * group_values.empty?)` (finder_methods.rb:457): when `false` (a grouped
@@ -4848,6 +4840,16 @@ export class Relation<T extends Base> {
     const eagerSpecs = [
       ...new Set([...this._eagerLoadAssociations, ...this._includesAssociations]),
     ];
+    const joinDependency = QueryMethodBangs.constructJoinDependency.call(
+      this as any,
+      eagerSpecs as any,
+      Nodes.OuterJoin,
+    );
+    const rel = this._clone();
+    rel._eagerLoadAssociations = [];
+    rel._includesAssociations = [];
+    rel._preloadAssociations = [];
+    QueryMethodBangs.joinsBang.call(rel as any, joinDependency as any);
 
     // Rails `apply_join_dependency`, for a limit/offset over non-limitable
     // (collection) reflections, replaces the relation with
@@ -4875,10 +4877,7 @@ export class Relation<T extends Base> {
       );
     }
 
-    const rel = this._clone();
-    rel._eagerLoadAssociations = [];
-    rel._includesAssociations = [];
-    return rel.leftOuterJoins(eagerSpecs);
+    return rel;
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3353,7 +3353,7 @@ export class Relation<T extends Base> {
     // `eagerJd`/`manager.joinSourceCount` guards have no buildJoinBuckets analog —
     // it is a pure bucket-builder with neither an eager-JD parameter nor a live
     // manager — and are needed here because the short-circuit does NOT fold `eagerJd`
-    // into the stash (it is pushed in the non-short-circuit branch below).
+    // into the stash (it is pushed in the non-short-circuit branch below). Cross-klass
     const pureLeftOuter =
       eagerJd === undefined &&
       manager.joinSourceCount === 0 &&

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -69,4 +69,17 @@ describe("build_joins from(subquery) dedup", () => {
     // The whole FROM…joins structure of the live path is the subquery's inner query.
     expect(subSql).toContain(liveSql.slice(liveSql.indexOf('FROM "posts"')));
   });
+
+  // Rails arms build_join_buckets' raw-join routing on `stashed_eager_load ||
+  // stashed_left_joins` (query_methods.rb:1857), and `stashed_eager_load` is only
+  // the trailing joins_values JoinDependency whose `base_klass == model`
+  // (query_methods.rb:1843-1845). A cross-klass merged JoinDependency (base_klass
+  // Comment, not Post) is not it, so with no left-outer values the guard stays
+  // off and a raw join node goes to `leading_join` — emitted BEFORE the
+  // association joins, not appended after them.
+  it("keeps a raw join leading when the only joins_values JoinDependency is cross-klass", () => {
+    const rel = Post.joins("CROSS JOIN categories").joins("comments").merge(Comment.joins("post"));
+    const sql = (Post.from(rel, "posts") as unknown as { toSql(): string }).toSql();
+    expect(sql).toContain('FROM "posts" CROSS JOIN categories INNER JOIN "comments"');
+  });
 });

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -22,6 +22,7 @@ import { fixtures } from "../test-fixtures.js";
 import "../support/canonical-model-index.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
+import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 
 describe("build_joins from(subquery) dedup", () => {
   fixtures([]);
@@ -80,6 +81,9 @@ describe("build_joins from(subquery) dedup", () => {
   it("keeps a raw join leading when the only joins_values JoinDependency is cross-klass", () => {
     const rel = Post.joins("CROSS JOIN categories").joins("comments").merge(Comment.joins("post"));
     const sql = (Post.from(rel, "posts") as unknown as { toSql(): string }).toSql();
-    expect(sql).toContain('FROM "posts" CROSS JOIN categories INNER JOIN "comments"');
+    const q = (name: string) => escapeRegExp(quoteTableName(name));
+    expect(sql).toMatch(
+      new RegExp(`FROM ${q("posts")} CROSS JOIN categories INNER JOIN ${q("comments")}`),
+    );
   });
 });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2870,8 +2870,13 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
   }
 
   // Rails' `stashed_eager_load || stashed_left_joins` (query_methods.rb:1857).
-  const hasStashed =
-    buckets.stashed_join.length > 0 || namedInner.some((v) => v instanceof JoinDependency);
+  // `stashed_eager_load` is the trailing `joins_values` JoinDependency built on
+  // this relation's own model (query_methods.rb:1843-1845) — a cross-klass
+  // merged JoinDependency is NOT it and does not arm this guard.
+  const lastJoinValue = joinsValues[joinsValues.length - 1];
+  const stashedEagerLoad =
+    lastJoinValue instanceof JoinDependency && lastJoinValue.baseKlass === this.model;
+  const hasStashed = buckets.stashed_join.length > 0 || stashedEagerLoad;
 
   for (const v of rawJoinValues) {
     const node: Nodes.Join =

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2854,10 +2854,7 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
     });
 
     if (namedInner.length === 0 && rawJoinValues.length === 0 && this._joinClauses.length === 0) {
-      // Only left outer joins, no inner/explicit joins — short-circuit
-      // (query_methods.rb:1838-1842: `if joins_values.empty?`). The eager
-      // JoinDependency arrives in `joins_values` via `applyJoinDependency`'s
-      // `joins!` (finder_methods.rb:461), so `namedInner` already covers it.
+      // query_methods.rb:1838-1842: `if joins_values.empty?`.
       buckets.named_join.push(...namedLeft);
       buckets.stashed_join.push(...stashedLeft);
       return buckets;
@@ -2872,11 +2869,7 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
     buckets.stashed_join.push(...stashedLeft);
   }
 
-  // Rails routes raw join nodes on `stashed_eager_load || stashed_left_joins`
-  // (query_methods.rb:1857). `stashed_left_joins` is `buckets.stashed_join` here;
-  // the eager JoinDependency `applyJoinDependency` pushed into `joins_values` is
-  // still in `namedInner` (the `joins.pop` discriminator is a separate story), so
-  // detect it there rather than in the stash.
+  // Rails' `stashed_eager_load || stashed_left_joins` (query_methods.rb:1857).
   const hasStashed =
     buckets.stashed_join.length > 0 || namedInner.some((v) => v instanceof JoinDependency);
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2853,19 +2853,11 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
       }
     });
 
-    if (
-      namedInner.length === 0 &&
-      rawJoinValues.length === 0 &&
-      this._joinClauses.length === 0 &&
-      this._eagerLoadAssociations.length === 0
-    ) {
-      // Only left outer joins, no inner/explicit joins or eager stash —
-      // short-circuit (query_methods.rb:1838-1842: `if joins_values.empty?`). In
-      // Rails `joins_values` holds both inner association names AND the eager
-      // stash; trails splits those into `_namedInnerJoins` and
-      // `_eagerLoadAssociations`, so both must be empty too — otherwise the
-      // left-outer JD belongs in `stashed_join` (folded below), not `named_join`,
-      // and the inner names would be dropped / double-emitted downstream.
+    if (namedInner.length === 0 && rawJoinValues.length === 0 && this._joinClauses.length === 0) {
+      // Only left outer joins, no inner/explicit joins — short-circuit
+      // (query_methods.rb:1838-1842: `if joins_values.empty?`). The eager
+      // JoinDependency arrives in `joins_values` via `applyJoinDependency`'s
+      // `joins!` (finder_methods.rb:461), so `namedInner` already covers it.
       buckets.named_join.push(...namedLeft);
       buckets.stashed_join.push(...stashedLeft);
       return buckets;
@@ -2880,26 +2872,13 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
     buckets.stashed_join.push(...stashedLeft);
   }
 
-  // Stashed eager signal: _eagerLoadAssociations (stashed_eager_load equivalent).
-  // _leftOuterJoinsValues is already handled above, so only eager is added here
-  // to avoid double-inclusion. Only push a primary JD when namedEager has at least
-  // one string association — non-string specs (hashes/nested) skip constructJoinDependency
-  // and would produce an empty JD that still sets hasStashed, incorrectly changing routing.
-  if (this._eagerLoadAssociations.length > 0) {
-    const eagerStash: JoinDependency[] = [];
-    const namedEager = selectNamedJoins.call(
-      this,
-      this._eagerLoadAssociations as string[],
-      eagerStash,
-    );
-    const hasJoinableEager = (namedEager as AssociationSpec[]).some((a) => typeof a === "string");
-    if (hasJoinableEager) {
-      const eagerJd = constructJoinDependency.call(this, namedEager as AssociationSpec[], null);
-      eagerStash.unshift(eagerJd);
-    }
-    if (eagerStash.length > 0) buckets.stashed_join.push(...eagerStash);
-  }
-  const hasStashed = buckets.stashed_join.length > 0;
+  // Rails routes raw join nodes on `stashed_eager_load || stashed_left_joins`
+  // (query_methods.rb:1857). `stashed_left_joins` is `buckets.stashed_join` here;
+  // the eager JoinDependency `applyJoinDependency` pushed into `joins_values` is
+  // still in `namedInner` (the `joins.pop` discriminator is a separate story), so
+  // detect it there rather than in the stash.
+  const hasStashed =
+    buckets.stashed_join.length > 0 || namedInner.some((v) => v instanceof JoinDependency);
 
   for (const v of rawJoinValues) {
     const node: Nodes.Join =

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -59,13 +59,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
-    "call": "construct_join_dependency",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "apply_join_dependency",
     "call": "eager_load_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -81,13 +74,6 @@
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "includes_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "joins!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Step 2 of the ordered split of `converge-build-join-buckets-single-joins-store`
(RFC 0083), following #5737.

## What

Rails `apply_join_dependency`
(`finder_methods.rb:457-461`) builds the eager JoinDependency and pushes it into
`joins_values`:

```ruby
join_dependency = construct_join_dependency(
  eager_load_values | includes_values, Arel::Nodes::OuterJoin
)
relation = except(:includes, :eager_load, :preload).joins!(join_dependency)
```

trails' `applyJoinDependency` instead cleared the eager stores and returned
`rel.leftOuterJoins(eagerSpecs)`, so no JoinDependency ever landed in
`joinsValues`. `buildJoinBuckets` compensated by constructing the eager JD
inline from `_eagerLoadAssociations` at bucket-build time, and its
`joins_values.empty?` short-circuit carried an extra
`_eagerLoadAssociations.length === 0` clause whose comment documented exactly
that divergence.

This PR:

- `applyJoinDependency` now `joins!`es a `constructJoinDependency(eagerLoad |
  includes, OuterJoin)` onto a relation that has dropped `:includes`,
  `:eager_load` and `:preload` — Rails' shape.
- `buildJoinBuckets` drops the inline eager-JD construction; the eager stash
  arrives through `joins_values` and is partitioned into `stashed_join` by
  `select_named_joins` like every other named join value.
- The short-circuit drops its `_eagerLoadAssociations` clause. Its
  `stashed_eager_load || stashed_left_joins` raw-node routing now detects the
  eager JD in `joins_values` using Rails' own discriminator — the TRAILING
  `joins_values` JoinDependency whose `base_klass == model`
  (`query_methods.rb:1843-1845`), so a cross-klass merged JD does not arm it.
  The `joins.pop` itself (which also moves the eager JD to the END of
  `stashed_join`) is step 3 of the split, not this PR.

- The limit/offset guard now reads
  `usingLimitableReflections(joinDependency.reflections)` off the
  JoinDependency it just built, as Rails does (`finder_methods.rb:464-470`),
  instead of reconstructing a second one from the eager specs.

The `distinct_relation_for_primary_key` materialization guard itself and its
`NotImplementedError` deviation are untouched, per the story.

## Not done here

The story's scope also named retiring `_buildEagerJoinManager`'s eager
pre-emission — the `eagerJd` side-channel parameter on `_applyJoinsToManager`.
That parameter has ~10 further call sites in `relation/calculations.ts` plus a
host-interface declaration, and an attempt to route it through a
`joins!`-carrying clone broke `UpdateAllTest > update all with includes` (the
silent arity change fed `makeEagerJd()` in as `aliases`). It needs all call
sites moved together, so it is registered as
`0083-wide-call-ratchet-noise-reduction/converge-apply-joins-to-manager-drop-eager-jd-param`
rather than half-shipped here.

## Note on the `Cross-klass` comment fragment (relation.ts:3356)

That dangling fragment is pre-existing on `main` (introduced by #4647,
`78768a4ee`) and does **not** appear in this PR's net diff — the line is
byte-identical to `main`. Commit `68d18173a` shows it as an addition only
because it reverts a drive-by cleanup from `eb05b172f`; the net across the
branch is zero.

It is left alone deliberately: that one line was the sole merge conflict
against #5748, which deletes the whole comment block anyway. Restoring `main`'s
wording brings the two PRs to zero shared lines (`git merge-tree` reports 0
conflicts).

## Testing

`relation/**` (55 files), `associations/eager.test.ts`,
`cascaded-eager-loading`, `inner-join-association`,
`left-outer-join-association`, `relations`, `calculations`, `finder`,
`querying`, `strict-loading` — 1945 passed, no test renames.
`pnpm api:compare` and `pnpm test:compare` both exit 0 with no ratchet,
allowlist, or manifest churn; `test:compare` Overall is byte-identical before
and after (the one added test is trails-only, in a file already outside the
Rails-matched population), so both deltas are 0.

Closes-story: converge-apply-join-dependency-joins-bang
