### PR TITLE
refactor(activerecord): route the eager JoinDependency through joins_values

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2756,7 +2756,7 @@ export class Relation<T extends Base> {
     // Populate the JoinDependency tree only. Alias resolution and `references`
     // re-aliasing (`authors AS author`) are deferred to emit-time: the eager JD
     // is folded into the single `build_joins` `emitJoinPlan` call (via
-    // `_applyJoinsToManager(manager, jd)`), whose one shared `AliasTracker` and
+    // `_applyJoinsToManager`), whose one shared `AliasTracker` and
     // `walk` fold handle collisions against the manual joins — there is no
     // separate construction tracker to seed and no skip filter to compute.
     const fallbackAssocs: AssociationSpec[] = [];
@@ -3253,32 +3253,41 @@ export class Relation<T extends Base> {
     for (const spec of specs) jd.validateEagerLoadSpec(spec);
   }
 
-  private _applyJoinsToManager(
-    manager: SelectManager,
-    eagerJd?: JoinDependency,
-    aliases?: AliasTracker,
-  ): void {
+  /**
+   * Rails `apply_join_dependency` hands the eager JoinDependency to the query
+   * builder by pushing it into `joins_values`
+   * (`joins!(construct_join_dependency(...))`, finder_methods.rb:457-461) — not
+   * as a side-channel argument. Mirror that for the eager SELECT/calculation
+   * paths, which construct their JoinDependency locally: spawn a relation whose
+   * `joins_values` carries the JD, so `build_joins` picks it up through the same
+   * `select_named_joins` partition that stashes any other JoinDependency in
+   * `joins_values`.
+   * @internal
+   */
+  _withEagerJoinDependency(jd?: JoinDependency): Relation<T> {
+    if (jd === undefined) return this;
+    const rel = this._clone();
+    QueryMethodBangs.joinsBang.call(rel as any, jd as any);
+    return rel;
+  }
+
+  private _applyJoinsToManager(manager: SelectManager, aliases?: AliasTracker): void {
     // Live SQL path: assemble a JoinEmissionPlan and hand it to the shared
     // `build_joins` port (`emitJoinPlan`), which `buildJoins` (the
-    // `from(relation)` subquery path) also delegates to. When `eagerJd` is
-    // supplied (the eager SELECT path, `_buildEagerJoinManager` /
-    // `_buildEagerIdSubquery`) it is folded into `stashedJoins` exactly as Rails
-    // `apply_join_dependency` folds the eager JoinDependency into `joins_values`,
-    // so the manual joins AND the eager JD emit through ONE `build_joins` call
-    // with ONE shared `AliasTracker` and dedup via the JD `walk` fold — no
-    // separate eager tracker, no table-name skip filter. The shared emitter
-    // handles raw join clauses, the shared AliasTracker, and the
-    // left_outer/joins/eager dedup fold.
+    // `from(relation)` subquery path) also delegates to. An eager JoinDependency
+    // rides in `joins_values` (see `_withEagerJoinDependency`) exactly as Rails
+    // `apply_join_dependency` puts it there, so `emitJoinPlan`'s
+    // `select_named_joins` partition folds it into `stashedJoins`: the manual
+    // joins AND the eager JD emit through ONE `build_joins` call with ONE shared
+    // `AliasTracker` and dedup via the JD `walk` fold — no separate eager
+    // tracker, no table-name skip filter. The shared emitter handles raw join
+    // clauses, the shared AliasTracker, and the left_outer/joins/eager dedup fold.
     //
     // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
     // when stashed joins exist, non-LeadingJoin nodes go to join_node (appended
     // after), LeadingJoin goes to leading_join (prepended before). Without
-    // stashed joins all nodes go to leading_join (Rails' else branch). A passed
-    // `eagerJd` IS Rails' `stashed_eager_load`, so it counts toward the
-    // `stashed_eager_load || stashed_left_joins` guard even when the eager load
-    // came from promoted `includes(...).references(...)` (no `_eagerLoadAssociations`).
+    // stashed joins all nodes go to leading_join (Rails' else branch).
     const hasStashed =
-      eagerJd !== undefined ||
       manager.joinSourceCount > 0 ||
       this._eagerLoadAssociations.length > 0 ||
       this._leftOuterJoinsValues.length > 0 ||
@@ -3350,12 +3359,9 @@ export class Relation<T extends Base> {
     // to the subquery `from(relation)` path.
     //
     // The four emptiness checks below mirror buildJoinBuckets exactly. The extra
-    // `eagerJd`/`manager.joinSourceCount` guards have no buildJoinBuckets analog —
-    // it is a pure bucket-builder with neither an eager-JD parameter nor a live
-    // manager — and are needed here because the short-circuit does NOT fold `eagerJd`
-    // into the stash (it is pushed in the non-short-circuit branch below). Cross-klass
+    // `manager.joinSourceCount` guard has no buildJoinBuckets analog — it is a
+    // pure bucket-builder with no live manager.
     const pureLeftOuter =
-      eagerJd === undefined &&
       manager.joinSourceCount === 0 &&
       this._eagerLoadAssociations.length === 0 &&
       this._namedInnerJoins.length === 0 &&
@@ -3405,11 +3411,6 @@ export class Relation<T extends Base> {
         : null;
     if (leftOuterJd) leftStashed.unshift(leftOuterJd);
     const stashedJoins: JoinDependency[] = [...leftStashed];
-    // Fold the eager JoinDependency in last, mirroring Rails' `joins_values`
-    // ordering (left-outer stash unshifted ahead of the eager stash in
-    // `build_join_buckets`). `walk` dedups any eager node coinciding with a
-    // manual INNER / left-outer join against the single shared tracker.
-    if (eagerJd) stashedJoins.push(eagerJd);
     _qm.emitJoinPlan.call(this as any, manager, {
       leadingJoins,
       joinNodes,
@@ -5215,7 +5216,7 @@ export class Relation<T extends Base> {
     // in place, so the column-alias projection below reads their resolved tables
     // (a deduped node now points at the manual join's un-aliased table).
     const manager = table.project();
-    this._applyJoinsToManager(manager, jd);
+    this._withEagerJoinDependency(jd)._applyJoinsToManager(manager);
 
     // Mirrors Rails' apply_column_aliases + `_select!(-> { aliases.columns })`:
     // an explicit `select` keeps its own projection and the JoinDependency only
@@ -5296,7 +5297,7 @@ export class Relation<T extends Base> {
     // shared `AliasTracker` spanning the eager JoinDependency and the manual
     // joins, deduping coinciding nodes via `walk` — same threading as
     // `_buildEagerJoinManager`.
-    this._applyJoinsToManager(idSubquery, jd);
+    this._withEagerJoinDependency(jd)._applyJoinsToManager(idSubquery);
     this._applyWheresToManager(idSubquery, table);
     this._applyOrderToManager(idSubquery, table);
     if (this._limitValue !== null) idSubquery.take(this._limitValue);
@@ -5436,7 +5437,7 @@ export class Relation<T extends Base> {
             return m;
           })(new SelectManager(table as any));
 
-    this._applyJoinsToManager(manager, undefined, aliases);
+    this._applyJoinsToManager(manager, aliases);
 
     this._applyWheresToManager(manager, table);
     this._applyOrderToManager(manager, table);

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -98,7 +98,9 @@ interface CalculationRelation {
   /** Mirrors `Relation#select_values`; folded into a grouped projection when HAVING is present. */
   selectValues: (string | symbol | Nodes.Node)[];
   _ctes: Array<{ name: string; expression: Nodes.Node; recursive: boolean }>;
-  _applyJoinsToManager(manager: any, eagerJd?: JoinDependency): void;
+  _applyJoinsToManager(manager: any): void;
+  /** @internal Rails `apply_join_dependency`'s `joins!(jd)`; see Relation. */
+  _withEagerJoinDependency(jd?: JoinDependency): CalculationRelation;
   _applyWheresToManager(manager: any, table: any): void;
   _applyOrderToManager(manager: any, table: any): void;
   _buildFromNode(): Nodes.Node | string | undefined;
@@ -441,7 +443,7 @@ async function singleAggregate(
   // has_include? — includes().references() promotes to a LEFT OUTER JOIN here.
   const allEagerSa = collectEagerSpecs(rel);
   // Fold the eager JoinDependency into the shared `build_joins` port
-  // (`_applyJoinsToManager(manager, eagerJd)`) exactly as Rails
+  // (`_applyJoinsToManager`) exactly as Rails
   // `apply_join_dependency` folds it into `joins_values` — one shared
   // `AliasTracker` spans the manual joins AND the eager JD, and `walk` dedups a
   // coinciding association, so no parallel eager tracker is built.
@@ -449,7 +451,7 @@ async function singleAggregate(
     allEagerSa.length > 0
       ? QueryMethodBangs.constructJoinDependency.call(rel as any, allEagerSa, Nodes.OuterJoin)
       : undefined;
-  rel._applyJoinsToManager(manager, eagerJd);
+  rel._withEagerJoinDependency(eagerJd)._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   // `execute_simple_calculation` runs the relation's own arel too, and
@@ -549,7 +551,7 @@ async function groupedAggregate(
     allEagerGa.length > 0
       ? QueryMethodBangs.constructJoinDependency.call(rel as any, allEagerGa, Nodes.OuterJoin)
       : undefined;
-  rel._applyJoinsToManager(manager, eagerJdGa);
+  rel._withEagerJoinDependency(eagerJdGa)._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   for (const n of groupNodes) manager.group(n);
@@ -693,7 +695,7 @@ async function groupedCompositeAssoc(
     allEagerCa.length > 0
       ? QueryMethodBangs.constructJoinDependency.call(rel as any, allEagerCa, Nodes.OuterJoin)
       : undefined;
-  rel._applyJoinsToManager(manager, eagerJdCa);
+  rel._withEagerJoinDependency(eagerJdCa)._applyJoinsToManager(manager);
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   for (const n of groupNodes) manager.group(n);
@@ -822,7 +824,7 @@ export async function performCount(
       const pk = this._modelClass.primaryKey;
       if (!Array.isArray(pk)) {
         // Fold the eager JoinDependency into the shared `build_joins` port
-        // (`_applyJoinsToManager(manager, eagerJd)`) as Rails
+        // (`_applyJoinsToManager`) as Rails
         // `apply_join_dependency` folds it into `joins_values`. One shared
         // `AliasTracker` spans the manual joins AND the eager JD, so an eager
         // association coinciding with an explicit join re-aliases at emit-time
@@ -845,7 +847,7 @@ export async function performCount(
           // 'LIMIT & IN/ALL/ANY/SOME subquery'" restriction.
           const idSubquery = table.project(table.get(pk));
           idSubquery.distinct();
-          this._applyJoinsToManager(idSubquery, makeEagerJd());
+          this._withEagerJoinDependency(makeEagerJd())._applyJoinsToManager(idSubquery);
           this._applyWheresToManager(idSubquery, table);
           // Mirror Rails `distinct_relation_for_primary_key`
           // (schema_statements.rb:1429-1452): the limited id subquery retains
@@ -885,7 +887,7 @@ export async function performCount(
           const countManager = table.project(
             (aggregateColumn(this, colForCount) as any).count(true).as("count"),
           );
-          this._applyJoinsToManager(countManager, makeEagerJd());
+          this._withEagerJoinDependency(makeEagerJd())._applyJoinsToManager(countManager);
           // Rails `where!(pk => limited_ids)` adds the id filter to the relation that
           // STILL carries the original where + from, only nulling limit/offset. Re-apply
           // them so a collection-level predicate (e.g. `comments.body = 'x'`) keeps
@@ -910,7 +912,7 @@ export async function performCount(
         const manager = table.project(
           (aggregateColumn(this, colForCount) as any).count(true).as("count"),
         );
-        this._applyJoinsToManager(manager, makeEagerJd());
+        this._withEagerJoinDependency(makeEagerJd())._applyJoinsToManager(manager);
         this._applyWheresToManager(manager, table);
         applyFromToManager(this, manager);
         applyHavingToManager(this, manager);
@@ -948,7 +950,7 @@ export async function performCount(
             // truncate distinct values instead of rows.
             const idSubquery = table.project(...pk.map((c: string) => table.get(c)));
             idSubquery.distinct();
-            this._applyJoinsToManager(idSubquery, makeEagerJd());
+            this._withEagerJoinDependency(makeEagerJd())._applyJoinsToManager(idSubquery);
             this._applyWheresToManager(idSubquery, table);
             this._applyOrderToManager(idSubquery, table);
             // Rails `distinct_relation_for_primary_key` builds the DISTINCT
@@ -986,7 +988,7 @@ export async function performCount(
             const countManager = table.project(
               (aggregateColumn(this, column) as any).count(true).as("count"),
             );
-            this._applyJoinsToManager(countManager, makeEagerJd());
+            this._withEagerJoinDependency(makeEagerJd())._applyJoinsToManager(countManager);
             this._applyWheresToManager(countManager, table);
             applyFromToManager(this, countManager);
             applyHavingToManager(this, countManager);
@@ -1008,7 +1010,7 @@ export async function performCount(
           const manager = table.project(
             (aggregateColumn(this, column) as any).count(true).as("count"),
           );
-          this._applyJoinsToManager(manager, makeEagerJd());
+          this._withEagerJoinDependency(makeEagerJd())._applyJoinsToManager(manager);
           this._applyWheresToManager(manager, table);
           applyFromToManager(this, manager);
           applyHavingToManager(this, manager);
@@ -1023,7 +1025,7 @@ export async function performCount(
         }
         const innerManager = table.project(...pk.map((c: string) => table.get(c)));
         innerManager.distinct();
-        this._applyJoinsToManager(innerManager, makeEagerJd());
+        this._withEagerJoinDependency(makeEagerJd())._applyJoinsToManager(innerManager);
         this._applyWheresToManager(innerManager, table);
         applyFromToManager(this, innerManager);
         applyHavingToManager(this, innerManager);


### PR DESCRIPTION
Rails `apply_join_dependency` hands the eager JoinDependency to the query builder by pushing it into `joins_values` (`joins!(construct_join_dependency(...))`, `finder_methods.rb:457-461`). trails instead passed it to `_applyJoinsToManager` as a side-channel parameter, which drove three clauses with no `build_join_buckets` analogue.

This drops the parameter:

- New `Relation#_withEagerJoinDependency(jd)` spawns a clone with the JD in `joins_values` (via `joinsBang`). `emitJoinPlan` already routes `_namedInnerJoins` through `select_named_joins`, which stashes any `JoinDependency` — so the JD lands in `stashedJoins` at the same position (after the left-outer stash) it was folded in at before.
- The `hasStashed` `eagerJd !== undefined` term and the `pureLeftOuter` `eagerJd === undefined` term are subsumed by the existing `_namedInnerJoins` terms, since the JD is now a named join value.
- All eager call sites in `relation.ts` and `relation/calculations.ts` (plus the host-interface declaration) move together, so the arity change is not silent.

Tests: `relation/update-all.test.ts`, `calculations.test.ts`, `associations/eager.test.ts`, `relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts` and the whole `relation/` directory pass unchanged.

Closes-story: converge-apply-joins-to-manager-drop-eager-jd-param
