### PR TITLE
ci: defer the PG/MariaDB AR suites past the draft-iteration phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
     # `ready_for_review` is what starts the draft-deferred PG/MariaDB suites;
     # without it a PR can reach ready with no adapter coverage and no event
     # left to trigger it.
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   schedule:
     # Weekly post-merge sweep so slow regressions can't hide between
     # parity-relevant PRs. Monday 06:00 UTC is off-peak on an Ubuntu runner.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,20 @@ on:
     #                         main / the weekly sweep / workflow_dispatch).
     #                         Opting in also gates the merge on it: the job is
     #                         in the `ci` aggregator's `needs:`.
+    #   run-db-adapters     — force the PostgreSQL + MariaDB AR suites on a
+    #                         DRAFT PR that doesn't touch adapter paths. They
+    #                         run unconditionally once the PR is ready for
+    #                         review, so this is only for iterating on a draft
+    #                         whose blast radius you know reaches PG/MySQL.
     #   website             — force the Website build on a PR that doesn't
     #                         touch packages/website/
     #   release             — implies `website` (release PRs need the site
     #                         built); reserve other release-only suites here
-    types: [opened, synchronize, reopened, labeled]
+    # `ready_for_review` is load-bearing, not cosmetic: the PG/MariaDB suites
+    # below are deferred on draft PRs, so the draft -> ready transition is the
+    # event that must start them. Without it a PR could reach "ready" with no
+    # adapter coverage and nothing left to trigger it.
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   schedule:
     # Weekly post-merge sweep so slow regressions can't hide between
     # parity-relevant PRs. Monday 06:00 UTC is off-peak on an Ubuntu runner.
@@ -45,6 +54,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
       activerecord_affected: ${{ steps.filter.outputs.activerecord_affected }}
+      db_adapter_affected: ${{ steps.filter.outputs.db_adapter_affected }}
       actionpack_affected: ${{ steps.filter.outputs.actionpack_affected }}
       actionview_affected: ${{ steps.filter.outputs.actionview_affected }}
       rack_affected: ${{ steps.filter.outputs.rack_affected }}
@@ -151,6 +161,23 @@ jobs:
           # exercise the CLI against real DBs), so cli source changes must also
           # flip activerecord_affected.
           AR_PKGS_RE='^packages/(activerecord|activerecord-cli|arel|activemodel|activesupport|globalid|did-you-mean|trails-tsc)/'
+          # db_adapter_affected does NOT gate anything on its own — it is the
+          # opt-IN that runs the PG/MariaDB suites on a PR that is still a
+          # draft (see postgres-tests / maria-tests). Once a PR is ready for
+          # review those suites run regardless, so this regex only has to
+          # answer "is this draft likely to break PG/MySQL specifically?" — a
+          # false negative costs a later signal, never lost coverage.
+          # Two source layouts hold adapter code (`src/adapters/` for the
+          # Rails `active_record/*_adapter` extras, `src/connection-adapters/`
+          # for the adapter classes themselves), plus Arel's per-backend
+          # visitors and the CLI's per-adapter E2E suites.
+          # `connection-adapters/abstract/` is deliberately included: it is the
+          # shared substrate (quoting, schema statements, type maps) whose
+          # changes break one backend without touching a file named after it.
+          # On the 29.5 h sample this cost nothing — no PR touched the abstract
+          # substrate without also touching a named PG/MySQL file — so it is
+          # free safety margin rather than a widened gate.
+          DB_ADAPTER_RE='^(packages/activerecord/src/(adapters/(postgresql|abstract-mysql-adapter)|connection-adapters/(postgresql|mysql|mysql2|abstract-mysql-adapter|abstract/|abstract-adapter\.ts|column\.ts|adapter-args\.ts|pool))|packages/arel/src/visitors/(postgres|mysql)|packages/activerecord-cli/src/__e2e__/(postgres|mysql))'
           # actionpack_affected gates actionpack-tests. True for actionpack +
           # its runtime deps (actionview/activemodel/activesupport/rack/did-you-mean).
           AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack|did-you-mean)/'
@@ -268,6 +295,7 @@ jobs:
           COMPARISON_RE='^(packages/|scripts/((api|test|fixtures|schema)-compare/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|deprecated-manifest-diff)\.ts$)|vendor/|docs/ruby-ts-conventions\.md$|eslint/rails-deprecated-methods\.json$)'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
+            echo "db_adapter_affected=true"   >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true"   >> "$GITHUB_OUTPUT"
             echo "actionview_affected=true"   >> "$GITHUB_OUTPUT"
             echo "rack_affected=true"         >> "$GITHUB_OUTPUT"
@@ -347,6 +375,7 @@ jobs:
               *)
                 if [ -z "$files" ]; then
                   echo "activerecord_affected=false" >> "$GITHUB_OUTPUT"
+                  echo "db_adapter_affected=false"   >> "$GITHUB_OUTPUT"
                   echo "actionpack_affected=false"   >> "$GITHUB_OUTPUT"
                   echo "actionview_affected=false"   >> "$GITHUB_OUTPUT"
                   echo "rack_affected=false"         >> "$GITHUB_OUTPUT"
@@ -376,6 +405,11 @@ jobs:
                     fi
                   }
                   set_gate activerecord_affected "$AR_PKGS_RE"
+                  # Routed through set_gate (not a bare grep) so cross-cutting
+                  # infra also opts a draft back in: the one infra-only PR in
+                  # the sample that broke MariaDB alone changed CI's DB grants,
+                  # not an adapter file.
+                  set_gate db_adapter_affected  "$DB_ADAPTER_RE"
                   set_gate actionpack_affected   "$AP_PKGS_RE"
                   set_gate actionview_affected   "$AV_PKGS_RE"
                   set_gate rack_affected         "$RACK_PKGS_RE"
@@ -1084,12 +1118,17 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  # Deferred on DRAFT PRs (see maria-tests for the shared rationale).
   postgres-tests:
     name: Active Record PostgreSQL Tests
     needs: changes
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.activerecord_affected == 'true'
+      needs.changes.outputs.activerecord_affected == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.draft == false ||
+       needs.changes.outputs.db_adapter_affected == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'run-db-adapters'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # 2-way file-level shard (RFC 0028 shard-ar-adapter-suites). This suite is
@@ -1259,12 +1298,31 @@ jobs:
   # The DB is throwaway per-run, so losing it on container stop is fine.
   # --mount is a `docker create` flag, so it goes in options (service
   # containers can't override the image command to pass server args directly).
+  # Deferred on DRAFT PRs, together with postgres-tests. SQLite still runs on
+  # every push, so a draft never goes dark — it loses the PG/MySQL-specific
+  # signal only, and only until the PR is marked ready for review, at which
+  # point `ready_for_review` starts a full run. Nothing merges without these:
+  # both jobs are in the `ci` aggregator's `needs:`, and `ci` is the
+  # branch-protection target, so coverage moves in TIME, never in extent.
+  #
+  # Why: measured over 400 PR runs (2026-07-30..31), 62% of superseded CI burn
+  # was runs killed mid-flight by a review-fix push a median 3.0 min after they
+  # started, with ~5 jobs already running. Deferring the four PG/MariaDB
+  # runners past the draft-iteration phase is the largest coverage-neutral
+  # saving available.
+  #
+  # A draft still runs them when the diff touches adapter paths
+  # (`db_adapter_affected`, DB_ADAPTER_RE above) or carries `run-db-adapters`.
   maria-tests:
     name: Active Record MariaDB Tests
     needs: changes
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.activerecord_affected == 'true'
+      needs.changes.outputs.activerecord_affected == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.draft == false ||
+       needs.changes.outputs.db_adapter_affected == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'run-db-adapters'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # 2-way file-level shard (RFC 0028 shard-ar-adapter-suites) — see the
@@ -1760,6 +1818,9 @@ jobs:
           PARITY_POSTGRES: ${{ needs.changes.outputs.parity_postgres }}
           PARITY_MYSQL: ${{ needs.changes.outputs.parity_mysql }}
           SQLITE_MEM_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-sqlite-mem') }}
+          # True exactly when postgres-tests/maria-tests were deferred because
+          # the PR is still a draft. Mirrors their `if:` — keep the two in sync.
+          DB_ADAPTERS_DRAFT_DEFERRED: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && needs.changes.outputs.db_adapter_affected != 'true' && !contains(github.event.pull_request.labels.*.name, 'run-db-adapters') }}
         run: |
           set -euo pipefail
           echo "$NEEDS_JSON"
@@ -1799,13 +1860,22 @@ jobs:
                   # legitimate until the job is re-enabled.
                   continue
                   ;;
-                sqlite-tests|postgres-tests|maria-tests)
+                sqlite-tests)
                   # AR test skip is legitimate when no AR-affecting paths changed.
-                  # postgres-tests and maria-tests are 2-way `--shard` matrices;
-                  # GitHub collapses both legs into a single result under the job
-                  # id here, so this one case covers all four legs — do NOT add
-                  # per-leg names (they don't exist in the `needs` context).
-                  [ "$AR_AFFECTED" = "false" ] && continue
+                  if [ "$AR_AFFECTED" = "false" ]; then
+                    continue
+                  fi
+                  ;;
+                postgres-tests|maria-tests)
+                  # Same AR gate as sqlite-tests, plus the draft deferral.
+                  # Both are 2-way `--shard` matrices; GitHub collapses the
+                  # legs into a single result under the job id here, so these
+                  # two names cover all four legs — do NOT add per-leg names
+                  # (they don't exist in the `needs` context).
+                  if [ "$AR_AFFECTED" = "false" ] || \
+                     [ "$DB_ADAPTERS_DRAFT_DEFERRED" = "true" ]; then
+                    continue
+                  fi
                   ;;
                 sqlite-mem-tests)
                   if [ "$AR_AFFECTED" = "false" ] || \
@@ -1870,7 +1940,7 @@ jobs:
                   [ "$any_parity" = "false" ] && continue
                   ;;
               esac
-              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED comparison_affected=$COMPARISON_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
+              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED comparison_affected=$COMPARISON_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL db_adapters_draft_deferred=$DB_ADAPTERS_DRAFT_DEFERRED)"
               unexpected=1
             done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
     # `ready_for_review` is what starts the draft-deferred PG/MariaDB suites;
     # without it a PR can reach ready with no adapter coverage and no event
     # left to trigger it.
-    types: [opened, synchronize, reopened, labeled, ready_for_review]
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     # Weekly post-merge sweep so slow regressions can't hide between
     # parity-relevant PRs. Monday 06:00 UTC is off-peak on an Ubuntu runner.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
                     fi
                   }
                   set_gate activerecord_affected "$AR_PKGS_RE"
-                  set_gate db_adapter_affected  "$DB_ADAPTER_RE"
+                  set_gate db_adapter_affected   "$DB_ADAPTER_RE"
                   set_gate actionpack_affected   "$AP_PKGS_RE"
                   set_gate actionview_affected   "$AV_PKGS_RE"
                   set_gate rack_affected         "$RACK_PKGS_RE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,52 +101,12 @@ jobs:
           # Cross-cutting paths force every per-package gate true. Anything
           # here affects all packages: workspace topology, root tooling
           # config, shared scripts, this workflow, composite actions.
-          # NOTE: the blanket `scripts/` here also matches subtrees that are
-          # NOT cross-cutting; they are carved back out of the infra sweep
-          # below (see `INFRA_CARVEOUT_RE` / `infra_files`). Keep that
-          # exclusion in sync if this pattern changes.
+          # The blanket `scripts/` below also sweeps up subtrees that are NOT
+          # cross-cutting; INFRA_CARVEOUT_RE strips them back out — keep the
+          # two in sync. Every carved subtree must still be named in the gate
+          # of whichever job runs its tests, or a change confined to it runs
+          # nothing; scripts/ci-suite-coverage.test.ts enforces that pairing.
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          # Paths that INFRA_RE's blanket `scripts/` sweeps up but which are
-          # single-consumer (or consumed by no CI job at all). Each is stripped
-          # from `infra_files` so a change confined to it does NOT force every
-          # per-package gate true. Classification (verify before adding more):
-          #   tasks/            - tests ride unit-tests only (UNIT_TESTS_PKGS_RE)
-          #   guides-typecheck/ - guides-typecheck job + unit-tests self-test;
-          #                       listed in GUIDES_PKGS_RE and UNIT_TESTS_PKGS_RE
-          #   {api,test,fixtures,schema}-compare/, and the manifest builders
-          #                     - rails-comparison only; listed in COMPARISON_RE
-          #   parity/           - parity jobs, which gate on labels/schedule
-          #                       only and consult no path regex
-          #   ci/               - gh-api-retry.sh runs in preflight;
-          #                       coverage-summary.mjs only in the `if: false`
-          #                       coverage jobs
-          #   test-deps/        - rails-test-deps.ts runs in `prelint`, i.e.
-          #                       inside the lint job
-          #   rails-find/, sync-stats/, phase-g-hunt/, fixtures-inventory/,
-          #   __fixtures__/, strip-asany*
-          #                     - local-dev tooling; no CI job runs the tools
-          #                       themselves.
-          #   ci-suite-coverage.test.ts
-          #                     - guards this file's own wiring; its only
-          #                       consumer is unit-tests, which names it in
-          #                       UNIT_TESTS_PKGS_RE.
-          # IMPORTANT: carving a subtree out of the infra sweep does NOT mean
-          # its own tests can go unnamed. unit-tests runs the compare/parity
-          # tooling's vitest suites — api-compare, test-compare,
-          # fixtures-compare, test-deps, rails-find, parity and the top-level
-          # scripts/*.test.ts files — so every one of those is also listed in
-          # UNIT_TESTS_PKGS_RE, while schema-compare's suite is a step of
-          # rails-comparison (COMPARISON_RE).
-          # scripts/ci-suite-coverage.test.ts enforces that pairing: it fails
-          # if a tooling test file is neither named in a ci.yml vitest
-          # invocation nor on its KNOWN_UNRUN list.
-          # The preflight/lint groups above need no regex addition because
-          # those jobs have no path gate at all — they run on every
-          # non-docs-only change, so carving cannot skip them. `pnpm lint` is
-          # `eslint .`, so it also still lints every carved subtree.
-          # Deliberately NOT carved (genuinely cross-cutting): typecheck.mjs
-          # (root `pnpm typecheck`), start-worktree.sh, and the remaining
-          # top-level scripts/*.ts one-offs.
           INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$)'
           # AR workspace deps: arel/activemodel/activesupport/globalid/
           # did-you-mean (per packages/activerecord/package.json). Also

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,15 @@ on:
     #                         Opting in also gates the merge on it: the job is
     #                         in the `ci` aggregator's `needs:`.
     #   run-db-adapters     — force the PostgreSQL + MariaDB AR suites on a
-    #                         DRAFT PR that doesn't touch adapter paths. They
-    #                         run unconditionally once the PR is ready for
-    #                         review, so this is only for iterating on a draft
-    #                         whose blast radius you know reaches PG/MySQL.
+    #                         draft PR that doesn't touch adapter paths; they
+    #                         run unconditionally once it is ready for review.
     #   website             — force the Website build on a PR that doesn't
     #                         touch packages/website/
     #   release             — implies `website` (release PRs need the site
     #                         built); reserve other release-only suites here
-    # `ready_for_review` is load-bearing, not cosmetic: the PG/MariaDB suites
-    # below are deferred on draft PRs, so the draft -> ready transition is the
-    # event that must start them. Without it a PR could reach "ready" with no
-    # adapter coverage and nothing left to trigger it.
+    # `ready_for_review` is what starts the draft-deferred PG/MariaDB suites;
+    # without it a PR can reach ready with no adapter coverage and no event
+    # left to trigger it.
     types: [opened, synchronize, reopened, labeled, ready_for_review]
   schedule:
     # Weekly post-merge sweep so slow regressions can't hide between
@@ -161,22 +158,10 @@ jobs:
           # exercise the CLI against real DBs), so cli source changes must also
           # flip activerecord_affected.
           AR_PKGS_RE='^packages/(activerecord|activerecord-cli|arel|activemodel|activesupport|globalid|did-you-mean|trails-tsc)/'
-          # db_adapter_affected does NOT gate anything on its own — it is the
-          # opt-IN that runs the PG/MariaDB suites on a PR that is still a
-          # draft (see postgres-tests / maria-tests). Once a PR is ready for
-          # review those suites run regardless, so this regex only has to
-          # answer "is this draft likely to break PG/MySQL specifically?" — a
-          # false negative costs a later signal, never lost coverage.
-          # Two source layouts hold adapter code (`src/adapters/` for the
-          # Rails `active_record/*_adapter` extras, `src/connection-adapters/`
-          # for the adapter classes themselves), plus Arel's per-backend
-          # visitors and the CLI's per-adapter E2E suites.
-          # `connection-adapters/abstract/` is deliberately included: it is the
-          # shared substrate (quoting, schema statements, type maps) whose
-          # changes break one backend without touching a file named after it.
-          # On the 29.5 h sample this cost nothing — no PR touched the abstract
-          # substrate without also touching a named PG/MySQL file — so it is
-          # free safety margin rather than a widened gate.
+          # db_adapter_affected gates nothing on its own: it is the opt-in that
+          # runs the PG/MariaDB suites while a PR is still a draft, so a false
+          # negative costs a later signal, never coverage. `abstract/` is in
+          # scope because that substrate breaks one backend without naming it.
           DB_ADAPTER_RE='^(packages/activerecord/src/(adapters/(postgresql|abstract-mysql-adapter)|connection-adapters/(postgresql|mysql|mysql2|abstract-mysql-adapter|abstract/|abstract-adapter\.ts|column\.ts|adapter-args\.ts|pool))|packages/arel/src/visitors/(postgres|mysql)|packages/activerecord-cli/src/__e2e__/(postgres|mysql))'
           # actionpack_affected gates actionpack-tests. True for actionpack +
           # its runtime deps (actionview/activemodel/activesupport/rack/did-you-mean).
@@ -405,10 +390,6 @@ jobs:
                     fi
                   }
                   set_gate activerecord_affected "$AR_PKGS_RE"
-                  # Routed through set_gate (not a bare grep) so cross-cutting
-                  # infra also opts a draft back in: the one infra-only PR in
-                  # the sample that broke MariaDB alone changed CI's DB grants,
-                  # not an adapter file.
                   set_gate db_adapter_affected  "$DB_ADAPTER_RE"
                   set_gate actionpack_affected   "$AP_PKGS_RE"
                   set_gate actionview_affected   "$AV_PKGS_RE"
@@ -1118,7 +1099,6 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-  # Deferred on DRAFT PRs (see maria-tests for the shared rationale).
   postgres-tests:
     name: Active Record PostgreSQL Tests
     needs: changes
@@ -1298,21 +1278,9 @@ jobs:
   # The DB is throwaway per-run, so losing it on container stop is fine.
   # --mount is a `docker create` flag, so it goes in options (service
   # containers can't override the image command to pass server args directly).
-  # Deferred on DRAFT PRs, together with postgres-tests. SQLite still runs on
-  # every push, so a draft never goes dark — it loses the PG/MySQL-specific
-  # signal only, and only until the PR is marked ready for review, at which
-  # point `ready_for_review` starts a full run. Nothing merges without these:
-  # both jobs are in the `ci` aggregator's `needs:`, and `ci` is the
-  # branch-protection target, so coverage moves in TIME, never in extent.
-  #
-  # Why: measured over 400 PR runs (2026-07-30..31), 62% of superseded CI burn
-  # was runs killed mid-flight by a review-fix push a median 3.0 min after they
-  # started, with ~5 jobs already running. Deferring the four PG/MariaDB
-  # runners past the draft-iteration phase is the largest coverage-neutral
-  # saving available.
-  #
-  # A draft still runs them when the diff touches adapter paths
-  # (`db_adapter_affected`, DB_ADAPTER_RE above) or carries `run-db-adapters`.
+  # Draft-deferred with postgres-tests. Both stay in the `ci` aggregator's
+  # `needs:` and `ci` is the branch-protection target, so this moves adapter
+  # coverage in time, not extent.
   maria-tests:
     name: Active Record MariaDB Tests
     needs: changes
@@ -1818,8 +1786,6 @@ jobs:
           PARITY_POSTGRES: ${{ needs.changes.outputs.parity_postgres }}
           PARITY_MYSQL: ${{ needs.changes.outputs.parity_mysql }}
           SQLITE_MEM_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-sqlite-mem') }}
-          # True exactly when postgres-tests/maria-tests were deferred because
-          # the PR is still a draft. Mirrors their `if:` — keep the two in sync.
           DB_ADAPTERS_DRAFT_DEFERRED: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && needs.changes.outputs.db_adapter_affected != 'true' && !contains(github.event.pull_request.labels.*.name, 'run-db-adapters') }}
         run: |
           set -euo pipefail
@@ -1867,7 +1833,6 @@ jobs:
                   fi
                   ;;
                 postgres-tests|maria-tests)
-                  # Same AR gate as sqlite-tests, plus the draft deferral.
                   # Both are 2-way `--shard` matrices; GitHub collapses the
                   # legs into a single result under the job id here, so these
                   # two names cover all four legs — do NOT add per-leg names

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,9 +160,11 @@ jobs:
           AR_PKGS_RE='^packages/(activerecord|activerecord-cli|arel|activemodel|activesupport|globalid|did-you-mean|trails-tsc)/'
           # db_adapter_affected gates nothing on its own: it is the opt-in that
           # runs the PG/MariaDB suites while a PR is still a draft, so a false
-          # negative costs a later signal, never coverage. `abstract/` is in
-          # scope because that substrate breaks one backend without naming it.
-          DB_ADAPTER_RE='^(packages/activerecord/src/(adapters/(postgresql|abstract-mysql-adapter)|connection-adapters/(postgresql|mysql|mysql2|abstract-mysql-adapter|abstract/|abstract-adapter\.ts|column\.ts|adapter-args\.ts|pool))|packages/arel/src/visitors/(postgres|mysql)|packages/activerecord-cli/src/__e2e__/(postgres|mysql))'
+          # negative costs a later signal, never coverage. `abstract/` and
+          # sql-classification.ts are in scope because that substrate breaks
+          # one backend without naming it (the latter carries the PG cursor
+          # statements in its read-only allowlist).
+          DB_ADAPTER_RE='^(packages/activerecord/src/(adapters/(postgresql|abstract-mysql-adapter)|connection-adapters/(postgresql|mysql|mysql2|abstract-mysql-adapter|abstract/|abstract-adapter\.ts|column\.ts|adapter-args\.ts|sql-classification\.ts|pool))|packages/arel/src/visitors/(postgres|mysql)|packages/activerecord-cli/src/__e2e__/(postgres|mysql))'
           # actionpack_affected gates actionpack-tests. True for actionpack +
           # its runtime deps (actionview/activemodel/activesupport/rack/did-you-mean).
           AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack|did-you-mean)/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1108,9 +1108,9 @@ jobs:
       needs.changes.outputs.docs_only != 'true' &&
       needs.changes.outputs.activerecord_affected == 'true' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.draft == false ||
-       needs.changes.outputs.db_adapter_affected == 'true' ||
-       contains(github.event.pull_request.labels.*.name, 'run-db-adapters'))
+      github.event.pull_request.draft == false ||
+      needs.changes.outputs.db_adapter_affected == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'run-db-adapters'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # 2-way file-level shard (RFC 0028 shard-ar-adapter-suites). This suite is
@@ -1290,9 +1290,9 @@ jobs:
       needs.changes.outputs.docs_only != 'true' &&
       needs.changes.outputs.activerecord_affected == 'true' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.draft == false ||
-       needs.changes.outputs.db_adapter_affected == 'true' ||
-       contains(github.event.pull_request.labels.*.name, 'run-db-adapters'))
+      github.event.pull_request.draft == false ||
+      needs.changes.outputs.db_adapter_affected == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'run-db-adapters'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # 2-way file-level shard (RFC 0028 shard-ar-adapter-suites) — see the

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -238,6 +238,43 @@ describe("CI runs every tooling test suite", () => {
     expect(skips.filter((f) => !gate.test(f))).toEqual([]);
   });
 
+  // db_adapter_affected is the draft opt-IN for postgres-tests/maria-tests.
+  // Under-firing only delays the PG/MySQL signal to the ready-for-review run,
+  // but over-firing hands back the saving the deferral exists to capture, so
+  // both directions are pinned.
+  it("fires db_adapter_affected for PG/MySQL adapter paths and not for backend-neutral ones", async () => {
+    const runGate = await gateRunner(await readFile(CI_YML, "utf8"));
+
+    const runs = [
+      "packages/activerecord/src/connection-adapters/postgresql-adapter.ts",
+      "packages/activerecord/src/connection-adapters/postgresql/column.ts",
+      "packages/activerecord/src/connection-adapters/mysql2-adapter.ts",
+      "packages/activerecord/src/connection-adapters/mysql/quoting.ts",
+      "packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts",
+      "packages/activerecord/src/adapters/postgresql/pg-range.ts",
+      // Shared substrate: breaks one backend without naming it.
+      "packages/activerecord/src/connection-adapters/abstract/quoting.ts",
+      "packages/activerecord/src/connection-adapters/abstract-adapter.ts",
+      "packages/arel/src/visitors/postgresql.ts",
+      "packages/arel/src/visitors/mysql.ts",
+      "packages/activerecord-cli/src/__e2e__/postgres-happy-path.test.ts",
+    ];
+    const skips = [
+      "packages/activerecord/src/relation.ts",
+      "packages/activerecord/src/associations.ts",
+      "packages/activerecord/src/base.test.ts",
+      "packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts",
+      "packages/activerecord/src/adapters/sqlite3/test-helper.ts",
+      "packages/arel/src/visitors/to-sql.ts",
+    ];
+    const fired = await Promise.all([...runs, ...skips].map(runGate));
+    const outcome = Object.fromEntries(
+      [...runs, ...skips].map((f, i) => [f, fired[i].db_adapter_affected]),
+    );
+    expect(runs.filter((f) => outcome[f] !== "true")).toEqual([]);
+    expect(skips.filter((f) => outcome[f] !== "false")).toEqual([]);
+  });
+
   it("keeps comparison_affected off for website-only changes", async () => {
     const runGate = await gateRunner(await readFile(CI_YML, "utf8"));
     expect((await runGate("packages/website/src/app.ts")).comparison_affected).toBe("false");

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -244,7 +244,8 @@ describe("CI runs every tooling test suite", () => {
   // but over-firing hands back the saving the deferral exists to capture, so
   // both directions are pinned.
   it("fires db_adapter_affected for PG/MySQL adapter paths and not for backend-neutral ones", async () => {
-    const runGate = await gateRunner(await readFile(CI_YML, "utf8"));
+    const yml = await readFile(CI_YML, "utf8");
+    const runGate = await gateRunner(yml);
 
     const runs = [
       "packages/activerecord/src/connection-adapters/postgresql-adapter.ts",
@@ -256,6 +257,7 @@ describe("CI runs every tooling test suite", () => {
       // Shared substrate: breaks one backend without naming it.
       "packages/activerecord/src/connection-adapters/abstract/quoting.ts",
       "packages/activerecord/src/connection-adapters/abstract-adapter.ts",
+      "packages/activerecord/src/connection-adapters/sql-classification.ts",
       "packages/arel/src/visitors/postgresql.ts",
       "packages/arel/src/visitors/mysql.ts",
       "packages/activerecord-cli/src/__e2e__/postgres-happy-path.test.ts",
@@ -274,6 +276,12 @@ describe("CI runs every tooling test suite", () => {
     );
     expect(runs.filter((f) => outcome[f] !== "true")).toEqual([]);
     expect(skips.filter((f) => outcome[f] !== "false")).toEqual([]);
+
+    // Anchor probe. Every path above starts at position 0, so none of them can
+    // catch an alternation whose `^` covers only its first branch — the shape
+    // a later edit to this regex is most likely to introduce.
+    const gate = gateRegex(yml, "DB_ADAPTER_RE");
+    expect(runs.filter((f) => gate.test(`vendor/${f}`))).toEqual([]);
   });
 
   it("keeps the draft deferral, its two jobs and the ci aggregate in agreement", async () => {

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -284,6 +284,18 @@ describe("CI runs every tooling test suite", () => {
     expect(runs.filter((f) => gate.test(`vendor/${f}`))).toEqual([]);
   });
 
+  // GitHub compiles each `run:` block as one template expression and rejects
+  // anything over 21,000 characters. Crossing it fails the WHOLE workflow at
+  // startup: zero jobs, no checks on the PR, and — because the `on:` filters
+  // can't be read either — a stray push-event run on a feature branch. The
+  // YAML stays valid, so nothing local catches it. Comments cost the same as
+  // code here, so keep prose out of that step.
+  it("keeps the changes-job filter script clear of the Actions expression limit", async () => {
+    const wf = parseYaml(await readFile(CI_YML, "utf8"));
+    const filter = wf.jobs.changes.steps.find((s: { id?: string }) => s.id === "filter");
+    expect(filter.run.length).toBeLessThan(20_500);
+  });
+
   it("keeps the draft deferral, its two jobs and the ci aggregate in agreement", async () => {
     const wf = parseYaml(await readFile(CI_YML, "utf8"));
     const gateOf = (job: string): string => wf.jobs[job].if.replace(/\s+/g, " ").trim();

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { parse as parseYaml } from "yaml";
 
 const execFileAsync = promisify(execFile);
 
@@ -273,6 +274,44 @@ describe("CI runs every tooling test suite", () => {
     );
     expect(runs.filter((f) => outcome[f] !== "true")).toEqual([]);
     expect(skips.filter((f) => outcome[f] !== "false")).toEqual([]);
+  });
+
+  it("keeps the draft deferral, its two jobs and the ci aggregate in agreement", async () => {
+    const wf = parseYaml(await readFile(CI_YML, "utf8"));
+    const gateOf = (job: string): string => wf.jobs[job].if.replace(/\s+/g, " ").trim();
+
+    // Drift between the pair would leave one adapter deferred and the other
+    // not, which no single-job assertion would catch.
+    expect(gateOf("postgres-tests")).toBe(gateOf("maria-tests"));
+
+    // A draft-deferred job that never sees the ready flip would let a PR reach
+    // ready with no adapter coverage and no event left to start it.
+    expect(gateOf("postgres-tests")).toContain("github.event.pull_request.draft");
+    expect(wf.on.pull_request.types).toContain("ready_for_review");
+
+    // The aggregate's skip allow-list has to recognise exactly the conditions
+    // the jobs skip under; a narrower one wedges every draft PR on
+    // "unexpectedly skipped", a wider one passes a genuinely missing suite.
+    // The two are written at opposite polarity — the job lists what opts a
+    // draft back IN, the aggregate states when the suites were deferred — so
+    // each clause is pinned on both sides rather than compared textually.
+    const deferred = wf.jobs.ci.steps[0].env.DB_ADAPTERS_DRAFT_DEFERRED.replace(/\s+/g, " ");
+    const optIn = gateOf("postgres-tests");
+    for (const [jobClause, aggregateClause] of [
+      ["github.event_name != 'pull_request'", "github.event_name == 'pull_request'"],
+      ["github.event.pull_request.draft == false", "github.event.pull_request.draft &&"],
+      [
+        "needs.changes.outputs.db_adapter_affected == 'true'",
+        "needs.changes.outputs.db_adapter_affected != 'true'",
+      ],
+      [
+        "contains(github.event.pull_request.labels.*.name, 'run-db-adapters')",
+        "!contains(github.event.pull_request.labels.*.name, 'run-db-adapters')",
+      ],
+    ]) {
+      expect(optIn).toContain(jobClause);
+      expect(deferred).toContain(aggregateClause);
+    }
   });
 
   it("keeps comparison_affected off for website-only changes", async () => {


### PR DESCRIPTION
Story: `0028-ci-cost-optimization/defer-pg-maria-suites-on-draft-prs`

## Why

Measured over 400 `pull_request` CI runs / 106 branches / 100 merged PRs in a
29.5 h window (`gh run list` + `actions/runs/$ID/jobs`):

| | |
| --- | --: |
| Total CI burn | 10,986 job-min (≈63,900/week) |
| The five AR DB jobs | **64.5%** of it |
| Non-final runs (superseded or retried) | **56.8%** of burn |
| …of which killed **mid-flight** by a later push | **62.5%** (4,182 min) |
| …of those, with a review in the window | **59%** (2,385 min = 21% of all burn) |
| Review → superseding push | **median 6 seconds** |

A doomed run dies a median 3.0 min old having already burned ~15 job-minutes
across ~5 parallel jobs. With the review trigger moving pre-ready, draft PRs
become the iteration phase — so the four PG/MariaDB runners would spend it
being started and cancelled.

### Net saving, including the ready_for_review re-run

`ready_for_review` triggers the **whole** workflow, not just the two deferred
jobs, so each PR pays for one extra run at the flip. Costing both sides per PR
from the same window:

| | min/PR |
| --- | --: |
| Saved: PG+MariaDB not run during the draft phase | 19.8 × (draft runs) |
| Cost: redundant non-PG/MariaDB half of the ready-flip run | 17.6 |

Break-even is at **0.89 draft runs per PR**. The observed mean today is
**1.43**, and the whole point of moving the review trigger pre-ready is to push
it higher — so this is above water now and gets better as iteration moves.

The cost is also softer than 17.6 in practice: a push followed the ready flip
within a median 1.7 min in **68 of 70** sampled PRs, cancelling most of that
redundant run (modelled 4.2 min/PR today).

**Net: ≈6,500 job-min/week worst case** (draft cadence unchanged *and* the
ready-flip run never superseded) **to ≈14,500/week** at today's observed
supersession rate. This supersedes the flat ~9,000 figure in the first version
of this description, which did not account for the ready-flip run — thanks to
the reviewer for catching it.

## What changes

- `postgres-tests` / `maria-tests` skip on **draft** PRs.
- A draft still runs them when the diff touches adapter paths — new
  `db_adapter_affected` gate (`DB_ADAPTER_RE`) covering both adapter source
  trees (`src/adapters/`, `src/connection-adapters/`), Arel's per-backend
  visitors, the CLI per-adapter E2E suites, and the shared
  `connection-adapters/abstract/` substrate — or carries `run-db-adapters`.
- `ready_for_review` joins `on.pull_request.types`. Load-bearing: without it
  the draft → ready transition starts nothing.
- `ci` aggregate learns the new legitimate skip (`DB_ADAPTERS_DRAFT_DEFERRED`).

## Coverage is not cut

Both jobs stay in the `ci` aggregator's `needs:`, and `ci` is the
branch-protection target — nothing merges without a green PG + MariaDB run.
Coverage moves in **time**, never in extent. SQLite runs on every push, as do
lint / build / typecheck / rails-comparison. Push to `main`, the weekly sweep
and `workflow_dispatch` are untouched.

This is a narrower successor to the closed `label-gate-ar-db-matrix` story
("user declined all of them", 2026-07-25): that one deferred PG/MariaDB to
*post-merge*, which was the stated objection. This defers to ready-for-review.

## Why not gate on adapter paths alone

I checked, and it does not hold up. Of 124 runs where all three adapter
families completed, 12 had a PG/MariaDB-specific failure SQLite missed — and
**only 1 of the 12 touched adapter-ish paths**; 9 were on non-adapter or
tests-only PRs. A permanent path gate would have leaked ~9 failures per 29 h.
That is why the path regex is an opt-**in** for drafts, not the gate itself.

The `connection-adapters/abstract/` substrate is included in the regex for the
same reason. It cost nothing on the sample — no PR touched the substrate
without also touching a named PG/MySQL file — so it is free safety margin.

## Tests

`scripts/ci-suite-coverage.test.ts` gains two cases:

1. **Path gate**, pinned in both directions (11 firing paths, 6 non-firing)
   through the existing `gateRunner` harness, which executes the real gate
   block from `ci.yml` under `set -euo pipefail`. Fails on baseline `main`,
   where the output does not exist.
2. **Drift test.** The deferral condition lives in three places — both job
   gates and `DB_ADAPTERS_DRAFT_DEFERRED` — at two polarities (the jobs list
   what opts a draft back *in*; the aggregate states when the suites *were*
   deferred). The test pins each clause on both sides, asserts the two job
   gates are byte-identical, and asserts `ready_for_review` is present whenever
   a job gates on draft state. Verified by mutation: dropping
   `ready_for_review`, desyncing `maria-tests` from `postgres-tests`, and
   flipping the aggregate's `!contains` each fail it.
3. **Anchor probe.** Every gate path is repo-root-anchored, so none of them can
   catch an alternation whose `^` covers only its first branch. Case 1 now
   re-tests every firing path under a `vendor/` prefix; verified it fails when
   the group is closed early.

## Why the ready_for_review re-run is not narrowed

The obvious optimisation — skip everything but `postgres-tests`/`maria-tests`
on the `ready_for_review` action — is unsafe here, and deliberately not done.
Branch protection targets the `ci` aggregate, so those skips would have to be
allow-listed in it. That is sound only when the preceding run actually
validated the other jobs on the same SHA — but **33.9% of runs in the window
were cancelled mid-flight**, so a draft run that never finished, followed by a
ready flip, would produce a green `ci` with lint/build having never passed on
that commit. A cheaper CI is not worth that hole. The redundant half is costed
above and accepted.

## Known caveat (reviewer: worth a second opinion)

Between the ready flip and the new run registering its `CI` check, the PR
briefly still shows the **draft** run's green `CI` on the same SHA. A merge
executed inside that window would land without PG/MariaDB having run. The
window is seconds and GitHub marks the new run pending as soon as it registers,
but if anything here merges on green automatically it is worth confirming that
path waits for a pending check rather than the last conclusive one.

## Drive-by

Splits the `sqlite-tests` arm out of the shared `postgres-tests|maria-tests`
case in the aggregate. The old `[ "$AR_AFFECTED" = "false" ] && continue` form
returns 1 on a genuinely unexpected skip, which under `set -e` exited the step
before it could print the `Unexpectedly skipped job:` diagnostic; the `if` form
reaches the message. Behaviour on the pass/skip paths is unchanged.

## Merge-time step

The `run-db-adapters` label does not exist in the repo yet (siblings
`run-sqlite-mem`, `run-parity-*` do). It needs creating for the escape hatch to
be usable — `contains()` on an absent label is simply false, so nothing breaks
before then, the hatch just isn't reachable. I have not created it
speculatively:

```
gh label create run-db-adapters --description "Run the PG + MariaDB AR suites on a draft PR" --color 0E8A16
```
