### PR TITLE
docs(api-compare): cite the measured fixed point in SAME_FILE_CLOSURE_DEPTH

### DIFF
--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -352,21 +352,24 @@ export function isDelegatingWrapper(tsName: string, tsCalls: Set<string>): boole
  *
  * Three is deliberate, not the largest defensible value. Sweeping this constant
  * over the whole wide artifact (RFC 0083) shows the closure saturating at depth
- * 8 — 0 → 3693 rows, 1 → 3332, 2 → 3276, 3 → 3251, 4 → 3243, 5 → 3236, 6 → 3236,
- * 8 → 3230, and 12 and 40 identical to 8. The mean effective call-set per body
- * follows the same schedule: 2.35 (depth 0) → 6.77 (depth 3) → 9.00 (depth 8) →
- * 9.05 (depth 12 = depth 40).
+ * 8: 3693 rows at 0, 3332 at 1, 3276 at 2, 3251 at 3, 3243 at 4, 3236 at 5 and
+ * 6, 3230 at 8, and 12 and 40 identical to 8. The mean effective call-set per
+ * body saturates on the same schedule — 2.35 (depth 0) → 6.77 (depth 3) → 9.00
+ * (depth 8) → 9.05 (depth 12 = depth 40). Absolute row counts drift with the
+ * ported surface; the fixed point does not.
  *
  * Moving 3 → 8 was evaluated and REJECTED. It is sound in the way the
- * DELEGATION_MAX_CALLS cap is not (the closure never leaves the file, so it
- * cannot credit a sibling adapter), but it buys only ~0.6% fewer rows, and
- * every row it silences is one worth keeping: all of the ~15 dropped keys are
- * genuine omissions in the 420-row `relation.ts`, discharged by a helper
- * several hops away — `#toSql` and `#execMainQuery` missing
- * `apply_join_dependency`, `#updateAll` / `#deleteAll` / `#ids` missing
- * `arel_columns`, `#execQueries` missing `preload_associations`. Depth 3 is the
- * point where extraction-shaped false positives are gone but a body is still
- * held to the calls it actually makes.
+ * DELEGATION_MAX_CALLS cap is not — the closure never leaves the file, so it
+ * cannot credit a sibling adapter with a delegate's work — but it silences
+ * about 15 keys (~0.5%) and adds none, and most of those are omissions worth
+ * keeping: `relation.ts`'s `to_sql` and `exec_main_query` missing
+ * `apply_join_dependency`, its `update_all` / `delete_all` / `ids` missing
+ * `arel_columns`, its `exec_queries` missing `preload_associations`, plus
+ * `migration.ts#migrate` missing `with_connection`. Those sit in files large
+ * enough (`relation.ts` alone carries ~420 rows) that a helper several hops
+ * away discharging the call is precisely the case the cap exists to catch.
+ * Depth 3 is where extraction-shaped false positives are already gone but a
+ * body is still held to the calls it makes.
  */
 export const SAME_FILE_CLOSURE_DEPTH = 3;
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -349,6 +349,24 @@ export function isDelegatingWrapper(tsName: string, tsCalls: Set<string>): boole
  * unioned in (they are its call-set), they are just not walked through. Depth 3
  * therefore admits `indexRowToDefinition`'s `columnNamesFromColumnNumbers`, and
  * stops before that leaf's callees.
+ *
+ * Three is deliberate, not the largest defensible value. Sweeping this constant
+ * over the whole wide artifact (RFC 0083) shows the closure saturating at depth
+ * 8 — 0 → 3693 rows, 1 → 3332, 2 → 3276, 3 → 3251, 4 → 3243, 5 → 3236, 6 → 3236,
+ * 8 → 3230, and 12 and 40 identical to 8. The mean effective call-set per body
+ * follows the same schedule: 2.35 (depth 0) → 6.77 (depth 3) → 9.00 (depth 8) →
+ * 9.05 (depth 12 = depth 40).
+ *
+ * Moving 3 → 8 was evaluated and REJECTED. It is sound in the way the
+ * DELEGATION_MAX_CALLS cap is not (the closure never leaves the file, so it
+ * cannot credit a sibling adapter), but it buys only ~0.6% fewer rows, and
+ * every row it silences is one worth keeping: all of the ~15 dropped keys are
+ * genuine omissions in the 420-row `relation.ts`, discharged by a helper
+ * several hops away — `#toSql` and `#execMainQuery` missing
+ * `apply_join_dependency`, `#updateAll` / `#deleteAll` / `#ids` missing
+ * `arel_columns`, `#execQueries` missing `preload_associations`. Depth 3 is the
+ * point where extraction-shaped false positives are gone but a body is still
+ * held to the calls it actually makes.
  */
 export const SAME_FILE_CLOSURE_DEPTH = 3;
 


### PR DESCRIPTION
Decision on RFC 0083's open question: should `SAME_FILE_CLOSURE_DEPTH` move
from 3 to its measured fixed point (8)?

**Rejected.** No behavior change — this PR records the measurement and the
rejection in the docstring, replacing the purely qualitative rationale.

## Evidence

Re-measured on this branch by overriding the constant and regenerating
`output/call-mismatches-wide.json` at each value. The closure saturates at 8:

| depth | rows |
| ----- | ---: |
| 0 | 3693 |
| 1 | 3332 |
| 2 | 3276 |
| 3 (today) | 3251 |
| 4 | 3243 |
| 5 | 3236 |
| 6 | 3236 |
| 8 | 3230 |
| 12, 40 | 3230 |

Mean effective call-set per body: 2.35 (depth 0) → 6.77 (depth 3) → 9.00
(depth 8) → 9.05 (depth 12 = depth 40).

Diffing unique keys at depth 3 vs depth 8 on this checkout: **15 dropped, 0
added.** Raising the depth is sound (unlike the `DELEGATION_MAX_CALLS` cap it
never leaves the file, so it cannot credit a sibling adapter) — but it buys
0.5% fewer rows, and the keys it silences are ones a reviewer wants:

- `relation.ts#to_sql`, `#exec_main_query` missing `apply_join_dependency`
- `relation.ts#update_all` / `#delete_all` / `#ids` missing `arel_columns`
- `relation.ts#exec_queries` missing `preload_associations`
- `relation.ts#in_order_of` missing `order!`, `#only` missing `values`
- `migration.ts#migrate` missing `with_connection`
- `join-dependency.ts#walk`, `routing/mapper.ts#draw` missing `map`

Twelve of the fifteen are inside the ~420-row `relation.ts`, discharged by a helper
several hops away — exactly the large-file case depth 3 exists to protect.
No reseed, so no `droppedReviewed` output.

`DELEGATION_MAX_CALLS` was out of scope and is untouched.

Closes-story: decide-same-file-closure-depth-fixed-point
