### PR TITLE
fix(schema-statements): make the PostgreSQL indexNameExists override live

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -514,7 +514,7 @@ export class SchemaStatements {
       const present =
         colSpec != null
           ? await this.indexExists(tableName, colSpec, opts)
-          : opts.name != null && (await this.isIndexNameExists(tableName, opts.name));
+          : opts.name != null && (await this.indexNameExists(tableName, opts.name));
       if (!present) return;
     }
 
@@ -1708,7 +1708,7 @@ export class SchemaStatements {
     return new CreateIndexDefinition(idx, ifNotExists, algorithm);
   }
 
-  async isIndexNameExists(tableName: string, indexName: string): Promise<boolean> {
+  async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
     const idxs = await this.indexes(tableName);
     return idxs.some((idx) => idx.name === indexName);
   }


### PR DESCRIPTION
## Scope reduced after rebase

This PR originally carried three renames. Two landed independently in **#5757**
while it was in review, which is what produced the conflict:

| Original change | Status |
| --- | --- |
| `AbstractAdapter#isDatabaseExists` → `databaseExists` | superseded by #5757 (also converged the body onto `connect!` + `NoDatabaseError` and added the static `databaseExists(config)`) |
| PG `databaseExists(name)` → `databaseNameExists` | superseded by #5757, which **deleted** the one-arg `pg_database` probe outright |
| `isIndexNameExists` → `indexNameExists` | **still needed — this PR** |

Rebased onto `origin/main` taking main's side for the two superseded files. What
remains is a 2-line change that fixes a live bug.

## The bug

`PostgreSQLSchemaStatements#indexNameExists`
(`postgresql/schema-statements-class.ts:257`) never overrode the base
`isIndexNameExists`. They are different symbols, so TypeScript reports no
override error and api:compare accepts both spellings as valid ports of
`index_name_exists?`.

The consequence: every base-typed caller — including `removeIndex`'s `ifExists`
path at `abstract/schema-statements.ts:517` — silently used the generic
`indexes(table).some(...)` implementation on PostgreSQL, never PG's catalog
query.

Renaming the base makes the override live. That is the Rails behaviour, not a
change of intent: Rails PG overrides `index_name_exists?` with exactly this
catalog query (`postgresql/schema_statements.rb:66-82`) in place of the generic
`indexes(table_name).detect` base (`abstract/schema_statements.rb:1010-1014`),
and the trails body is already a faithful port of it.

This also removes the last `is`-prefixed `*_exists?` predicate in ActiveRecord,
finishing the sweep from #5736.

## Verification of the override activation

The only behavioural change, so it got the most scrutiny:

- **Blast radius is contained.** `PostgreSQLSchemaStatements` is the only
  subclass of `SchemaStatements` in the repo, and only PostgreSQL defines a bare
  `indexNameExists`. mysql2 and sqlite3 define none and keep inheriting the base,
  so no other dormant body goes live.
- **The body is a verbatim port**, including the `n.nspname = table[:schema]`
  predicate and the `> 0` count test.
- **The helper it depends on matches too.** The activation only behaves like
  Rails if `quotedScope` defaults the schema the way Rails does. It does:
  `postgresql-adapter.ts` returns `ANY (current_schemas(false))` for an
  unqualified name, identical to `schema_statements.rb:1141`.

## Verification

- `pnpm build` clean; no `isIndexNameExists` / `isDatabaseExists` remain anywhere
  in `packages/` (tests included).
- `pnpm vitest run packages/activerecord/src/connection-adapters/ migration.test.ts`
  — 1787 passed, 105 skipped, 0 failed, re-run after the rebase.
- No test titles changed; all pre-existing callers already used the bare spelling.
- PostgreSQL and MySQL lanes are CI's to confirm.

## Follow-ups

Registered earlier from this story's audit; two are now done:

- ~~`pg-port-static-database-exists-from-config`~~ — landed in #5757.
- ~~`abstract-database-exists-body-diverges-from-connect-rescue`~~ — landed in #5757.
- `actionview-template-exists-still-is-prefixed` — still open; `isTemplateExists`
  is now the last `is`-prefixed `*_exists?` predicate repo-wide.

Closes-story: database-exists-predicate-still-is-prefixed
