### PR TITLE
refactor(activerecord): drop the joinSourceCount routing guard from _applyJoinsToManager

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3292,7 +3292,6 @@ export class Relation<T extends Base> {
     // after), LeadingJoin goes to leading_join (prepended before). Without
     // stashed joins all nodes go to leading_join (Rails' else branch).
     const hasStashed =
-      manager.joinSourceCount > 0 ||
       this._eagerLoadAssociations.length > 0 ||
       this._leftOuterJoinsValues.length > 0 ||
       this._namedInnerJoins.length > 0;
@@ -3362,11 +3361,8 @@ export class Relation<T extends Base> {
     // left-outer JD and folding it into the stash. This keeps the shape identical
     // to the subquery `from(relation)` path.
     //
-    // The four emptiness checks below mirror buildJoinBuckets exactly. The extra
-    // `manager.joinSourceCount` guard has no buildJoinBuckets analog — it is a
-    // pure bucket-builder with no live manager.
+    // The four emptiness checks below mirror buildJoinBuckets exactly.
     const pureLeftOuter =
-      manager.joinSourceCount === 0 &&
       this._eagerLoadAssociations.length === 0 &&
       this._namedInnerJoins.length === 0 &&
       this._joinValues.length === 0 &&

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -517,10 +517,6 @@ export class SelectManager extends TreeManager {
     return new UnionAll(this.ast, otherAst);
   }
 
-  get joinSourceCount(): number {
-    return this.core.source.right.length;
-  }
-
   /**
    * Create an InsertManager from a SELECT.
    *


### PR DESCRIPTION
Drops the trails-only `manager.joinSourceCount` routing guard from
`_applyJoinsToManager` (`packages/activerecord/src/relation.ts`), the last
non-Rails term left in its two routing guards after #5748.

Every caller reaches `_applyJoinsToManager` with a freshly projected manager —
`table.project(...)` in `_buildEagerJoinManager`, the eager id-subquery builder,
and all of `relation/calculations.ts`, or `new SelectManager(alias)` in
`toArel` — so `manager.joinSourceCount` is always `0` and neither term
(`> 0` in `hasStashed`, `=== 0` in `pureLeftOuter`) could ever fire. With them
gone, both guards read only relation state (`_eagerLoadAssociations`,
`_leftOuterJoinsValues`, `_namedInnerJoins`, `_joinValues`, `_joinClauses`),
matching Rails' `build_join_buckets`
(`vendor/rails/activerecord/lib/active_record/relation/query_methods.rb:1824-1876`),
a pure bucket-builder that never inspects a live manager.

The now-unused `SelectManager#joinSourceCount` accessor in
`packages/arel/src/select-manager.ts` — a trails-only addition with no Arel
analogue — is removed with it.

Verified: `relation/` suite, `relation.trails.test.ts`,
`relation/calculations.test.ts`, `associations/eager.test.ts` — 1344 passed,
no test renames.

Closes-story: drop-apply-joins-manager-join-source-count-guard
