### PR TITLE
feat(api-compare): make @missingRailsCall suppress the wide call flag

### DIFF
--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -67,9 +67,10 @@ export class InsertManager extends TreeManager {
    * - values pass through raw — no `Quoted` wrap (Rails preserves them
    *   for the dialect-specific value visitor to quote)
    *
-   * @missingRailsCall first — Baseline (RFC 0047): wide call-set flag seeded
-   *   when the wide ratchet landed; bucket (b) equivalent or (c) noise pending
-   *   per-cluster burndown review.
+   * @missingRailsCall first — Rails reaches the first column with
+   *   `fields.first.first.relation`; JS indexes instead (`fields[0]?.[0]`),
+   *   which is the analogue of `Array#first` and the form the rest of arel
+   *   uses. There is no `first` to call.
    */
   insert(fields: string | [Attribute | Node, unknown][] | null | undefined): this {
     if (fields == null) return this;

--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -67,9 +67,6 @@ export class InsertManager extends TreeManager {
    * - values pass through raw — no `Quoted` wrap (Rails preserves them
    *   for the dialect-specific value visitor to quote)
    *
-   * @missingRailsCall each — Baseline (RFC 0047): wide call-set flag seeded when
-   *   the wide ratchet landed; bucket (b) equivalent or (c) noise pending
-   *   per-cluster burndown review.
    * @missingRailsCall first — Baseline (RFC 0047): wide call-set flag seeded
    *   when the wide ratchet landed; bucket (b) equivalent or (c) noise pending
    *   per-cluster burndown review.

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -102,8 +102,8 @@ const FILE = [
 describe("reconcileFileText", () => {
   it("reconciles: drops satisfied tags, adds tags, creates missing JSDoc", () => {
     const expectations = new Map([
-      ["bar", { rubyName: "bar", calls: new Set(["save"]) }],
-      ["baz", { rubyName: "baz", calls: new Set(["reload"]) }],
+      ["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }],
+      ["baz", { rubyNames: ["baz"], calls: new Set(["reload"]) }],
     ]);
     const { text, harvested } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(text).not.toBeNull();
@@ -119,8 +119,8 @@ describe("reconcileFileText", () => {
 
   it("is idempotent: a second run produces zero edits", () => {
     const expectations = new Map([
-      ["bar", { rubyName: "bar", calls: new Set(["save"]) }],
-      ["baz", { rubyName: "baz", calls: new Set(["reload"]) }],
+      ["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }],
+      ["baz", { rubyNames: ["baz"], calls: new Set(["reload"]) }],
     ]);
     const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
     const second = reconcileFileText("foo.ts", first, expectations, () => "why");
@@ -130,7 +130,7 @@ describe("reconcileFileText", () => {
   it("reconciles set accessors (extract-ts-api extracts them into the artifact)", () => {
     const src = ["export class Foo {", "  set name(v: string) {}", "}"].join("\n");
     const expectations = new Map([
-      ["name", { rubyName: "name=", calls: new Set(["write_attribute"]) }],
+      ["name", { rubyNames: ["name="], calls: new Set(["write_attribute"]) }],
     ]);
     const { text } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!).toContain("@missingRailsCall write_attribute — why");
@@ -142,7 +142,9 @@ describe("reconcileFileText", () => {
     const reason =
       "Per-entry verified (RFC 0032): Rails core.rb caches `klass.primary_key` into " +
       "@primary_key and calls `klass.define_attribute_methods`; neither call appears here.";
-    const expectations = new Map([["bar", { rubyName: "bar", calls: new Set(["primary_key"]) }]]);
+    const expectations = new Map([
+      ["bar", { rubyNames: ["bar"], calls: new Set(["primary_key"]) }],
+    ]);
     const first = reconcileFileText("foo.ts", src, expectations, () => reason).text!;
     const second = reconcileFileText("foo.ts", first, expectations, () => reason);
     expect(second.text).toBeNull();
@@ -154,8 +156,8 @@ describe("reconcileFileText", () => {
   it("tags constructors (Ruby initialize) and reports unmatched expectations", () => {
     const src = ["export class Foo {", "  constructor() {}", "}"].join("\n");
     const expectations = new Map([
-      ["constructor", { rubyName: "initialize", calls: new Set(["super"]) }],
-      ["prototypePatched", { rubyName: "patched", calls: new Set(["save"]) }],
+      ["constructor", { rubyNames: ["initialize"], calls: new Set(["super"]) }],
+      ["prototypePatched", { rubyNames: ["patched"], calls: new Set(["save"]) }],
     ]);
     const { text, unmatched } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!).toContain("@missingRailsCall super — why");
@@ -168,7 +170,7 @@ describe("reconcileFileText", () => {
       "export function f(a: number): void;",
       "export function f(a: unknown): void {}",
     ].join("\n");
-    const expectations = new Map([["f", { rubyName: "f", calls: new Set(["save"]) }]]);
+    const expectations = new Map([["f", { rubyNames: ["f"], calls: new Set(["save"]) }]]);
     const { text } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!.match(/@missingRailsCall save/g)).toHaveLength(1);
     expect(text!.indexOf("@missingRailsCall")).toBeGreaterThan(text!.indexOf("f(a: number)"));
@@ -207,8 +209,8 @@ describe("reconcileFileText", () => {
 describe("reconcileFileText baseline migration", () => {
   it("reports every justified (rubyName, call) so the baseline row can be dropped", () => {
     const expectations = new Map([
-      ["bar", { rubyName: "bar", calls: new Set(["save"]) }],
-      ["baz", { rubyName: "baz", calls: new Set(["reload"]) }],
+      ["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }],
+      ["baz", { rubyNames: ["baz"], calls: new Set(["reload"]) }],
     ]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(tagged).toEqual([
@@ -218,7 +220,7 @@ describe("reconcileFileText baseline migration", () => {
   });
 
   it("reports a KEPT tag too — an already-tagged call owes no baseline row", () => {
-    const expectations = new Map([["bar", { rubyName: "bar", calls: new Set(["save"]) }]]);
+    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
     const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
     const { tagged } = reconcileFileText("foo.ts", first, expectations, () => "why");
     expect(tagged).toEqual([{ rubyName: "bar", call: "save" }]);
@@ -262,8 +264,55 @@ describe("buildExpectations", () => {
   });
 
   it("leaves a placeholder-reasoned row in the baseline — it justifies nothing", () => {
-    const expectations = new Map([["bar", { rubyName: "bar", calls: new Set(["save"]) }]]);
+    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => DEFAULT_TAG_REASON);
     expect(tagged).toEqual([]);
+  });
+
+  it("records every Ruby name that lands on one TS method", () => {
+    const twoNames = {
+      packages: ["arel"],
+      mismatches: [
+        {
+          package: "arel",
+          tsFile: "insert-manager.ts",
+          rubyName: "insert",
+          tsName: "insert",
+          missing: ["each → forEach"],
+        },
+        {
+          package: "arel",
+          tsFile: "insert-manager.ts",
+          rubyName: "insert_all",
+          tsName: "insert",
+          missing: ["first → first"],
+        },
+      ],
+    };
+    const exp = buildExpectations(twoNames, "arel").get("insert-manager.ts")!.get("insert")!;
+    expect(exp.rubyNames).toEqual(["insert", "insert_all"]);
+  });
+});
+
+describe("reconcileFileText with two Ruby names on one TS method", () => {
+  it("drops the baseline row of each Ruby name a justified tag covers", () => {
+    const expectations = new Map([
+      ["bar", { rubyNames: ["bar", "bar_all"], calls: new Set(["save"]) }],
+    ]);
+    const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
+    expect(tagged).toEqual([
+      { rubyName: "bar", call: "save" },
+      { rubyName: "bar_all", call: "save" },
+    ]);
+  });
+
+  it("seeds a new tag from whichever Ruby name has curated prose", () => {
+    const expectations = new Map([
+      ["bar", { rubyNames: ["bar", "bar_all"], calls: new Set(["save"]) }],
+    ]);
+    const { text } = reconcileFileText("foo.ts", FILE, expectations, (rubyName) =>
+      rubyName === "bar_all" ? "curated" : DEFAULT_TAG_REASON,
+    );
+    expect(text!).toContain("@missingRailsCall save — curated");
   });
 });

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -202,3 +202,24 @@ describe("reconcileFileText", () => {
     );
   });
 });
+
+describe("reconcileFileText baseline migration", () => {
+  it("reports every tagged (rubyName, call) so the baseline row can be dropped", () => {
+    const expectations = new Map([
+      ["bar", { rubyName: "bar", calls: new Set(["save"]) }],
+      ["baz", { rubyName: "baz", calls: new Set(["reload"]) }],
+    ]);
+    const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
+    expect(tagged).toEqual([
+      { rubyName: "bar", call: "save" },
+      { rubyName: "baz", call: "reload" },
+    ]);
+  });
+
+  it("reports a KEPT tag too — an already-tagged call owes no baseline row", () => {
+    const expectations = new Map([["bar", { rubyName: "bar", calls: new Set(["save"]) }]]);
+    const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
+    const { tagged } = reconcileFileText("foo.ts", first, expectations, () => "why");
+    expect(tagged).toEqual([{ rubyName: "bar", call: "save" }]);
+  });
+});

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -5,6 +5,7 @@ import {
   reconcile,
   reconcileFileText,
   renderJsdoc,
+  buildExpectations,
 } from "./build.js";
 
 const reasonFor = () => DEFAULT_TAG_REASON;
@@ -204,7 +205,7 @@ describe("reconcileFileText", () => {
 });
 
 describe("reconcileFileText baseline migration", () => {
-  it("reports every tagged (rubyName, call) so the baseline row can be dropped", () => {
+  it("reports every justified (rubyName, call) so the baseline row can be dropped", () => {
     const expectations = new Map([
       ["bar", { rubyName: "bar", calls: new Set(["save"]) }],
       ["baz", { rubyName: "baz", calls: new Set(["reload"]) }],
@@ -221,5 +222,48 @@ describe("reconcileFileText baseline migration", () => {
     const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
     const { tagged } = reconcileFileText("foo.ts", first, expectations, () => "why");
     expect(tagged).toEqual([{ rubyName: "bar", call: "save" }]);
+  });
+});
+
+describe("buildExpectations", () => {
+  const artifact = {
+    packages: ["arel"],
+    mismatches: [
+      {
+        package: "arel",
+        tsFile: "insert-manager.ts",
+        rubyName: "insert",
+        tsName: "insert",
+        missing: ["each → forEach"],
+      },
+      { package: "other", tsFile: "x.ts", rubyName: "x", tsName: "x", missing: ["save → save"] },
+    ],
+    suppressed: [
+      {
+        package: "arel",
+        tsFile: "insert-manager.ts",
+        rubyName: "insert",
+        tsName: "insert",
+        call: "first",
+      },
+    ],
+  };
+
+  it("keeps a suppressed call expected, so the tag that earned it survives", () => {
+    const calls = buildExpectations(artifact, "arel")
+      .get("insert-manager.ts")!
+      .get("insert")!.calls;
+    expect([...calls].sort()).toEqual(["each", "first"]);
+  });
+
+  it("ignores other packages and honours the --file filter", () => {
+    expect(buildExpectations(artifact, "other").has("insert-manager.ts")).toBe(false);
+    expect(buildExpectations(artifact, "arel", "elsewhere.ts").size).toBe(0);
+  });
+
+  it("leaves a placeholder-reasoned row in the baseline — it justifies nothing", () => {
+    const expectations = new Map([["bar", { rubyName: "bar", calls: new Set(["save"]) }]]);
+    const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => DEFAULT_TAG_REASON);
+    expect(tagged).toEqual([]);
   });
 });

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -171,8 +171,27 @@ interface Edit {
 }
 
 export interface MethodExpectation {
-  rubyName: string;
+  /** Every Ruby method name matched onto this TS name, in artifact order. Two
+   *  Ruby names can land on one TS method, and each keys its own baseline rows
+   *  — reasons are looked up under all of them, and a justified tag drops the
+   *  row of each, so a second Ruby name's deviation is not attributed to the
+   *  first. */
+  rubyNames: string[];
   calls: Set<string>;
+}
+
+// The first curated reason any of `rubyNames` has for `call`, else the
+// placeholder. Only used to seed a NEW tag's prose.
+function firstCuratedReason(
+  rubyNames: string[],
+  call: string,
+  reasonFor: (rubyName: string, call: string) => string,
+): string {
+  for (const rubyName of rubyNames) {
+    const reason = reasonFor(rubyName, call);
+    if (reason !== DEFAULT_TAG_REASON) return reason;
+  }
+  return DEFAULT_TAG_REASON;
 }
 
 /** Reconcile every named function/method in one source file's text. Returns
@@ -248,11 +267,12 @@ export function reconcileFileText(
         );
         const expected = exp?.calls ?? new Set<string>();
         const r = reconcile(entries, expected, (c) =>
-          exp ? reasonFor(exp.rubyName, c) : DEFAULT_TAG_REASON,
+          exp ? firstCuratedReason(exp.rubyNames, c, reasonFor) : DEFAULT_TAG_REASON,
         );
         if (exp) {
           for (const e of [...r.kept, ...r.added]) {
-            if (justifies(e.reason)) tagged.push({ rubyName: exp.rubyName, call: e.call });
+            if (!justifies(e.reason)) continue;
+            for (const rubyName of exp.rubyNames) tagged.push({ rubyName, call: e.call });
           }
         }
         for (const d of r.dropped) {
@@ -301,7 +321,10 @@ export function buildExpectations(
   const byFile = new Map<string, Map<string, MethodExpectation>>();
   const expectationFor = (tsFile: string, tsName: string, rubyName: string) => {
     const fileMap = byFile.get(tsFile) ?? byFile.set(tsFile, new Map()).get(tsFile)!;
-    return fileMap.get(tsName) ?? fileMap.set(tsName, { rubyName, calls: new Set() }).get(tsName)!;
+    const exp =
+      fileMap.get(tsName) ?? fileMap.set(tsName, { rubyNames: [], calls: new Set() }).get(tsName)!;
+    if (!exp.rubyNames.includes(rubyName)) exp.rubyNames.push(rubyName);
+    return exp;
   };
   for (const m of artifact.mismatches) {
     if (m.package !== pkg) continue;

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -41,7 +41,13 @@ import {
   missingScope,
 } from "./lint-call-mismatches.js";
 import { loadSplitBaseline, writeSplitBaseline } from "./lint-call-mismatches-wide.js";
-import { TAG, type TagEntry, parseJsdoc } from "./missing-rails-call-tags.js";
+import {
+  DEFAULT_REASON,
+  TAG,
+  type TagEntry,
+  justifies,
+  parseJsdoc,
+} from "./missing-rails-call-tags.js";
 
 const ARTIFACT_PATH = path.join(OUTPUT_DIR, "call-mismatches-wide.json");
 const WIDE_BASELINE_DIR = path.join(
@@ -52,14 +58,12 @@ const WIDE_BASELINE_DIR = path.join(
 export { TAG, parseJsdoc } from "./missing-rails-call-tags.js";
 export type { JsdocOrigin, TagEntry } from "./missing-rails-call-tags.js";
 
-export const DEFAULT_TAG_REASON =
-  "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; " +
-  "bucket (b) equivalent or (c) noise pending per-cluster burndown review.";
+export const DEFAULT_TAG_REASON = DEFAULT_REASON;
 // Reasons treated as placeholders: dropping them on convergence needs no
 // harvest report.
 const PLACEHOLDER_REASONS = new Set([DEFAULT_TAG_REASON, "unported (api:build stub)"]);
 
-interface ArtifactMismatch {
+export interface ArtifactMismatch {
   package: string;
   tsFile: string;
   rubyName: string;
@@ -67,9 +71,21 @@ interface ArtifactMismatch {
   missing: string[];
 }
 
-interface WideArtifact {
+export interface SuppressedCall {
+  package: string;
+  tsFile: string;
+  rubyName: string;
+  tsName: string;
+  call: string;
+}
+
+export interface WideArtifact {
   packages?: string[];
   mismatches: ArtifactMismatch[];
+  /** Flags a `@missingRailsCall` tag already suppressed (compare.ts). They are
+   *  absent from `mismatches`, so reconciling against that list alone would
+   *  drop the very tags that suppressed them. */
+  suppressed?: SuppressedCall[];
 }
 
 export interface ReconcileResult {
@@ -154,7 +170,7 @@ interface Edit {
   text: string;
 }
 
-interface MethodExpectation {
+export interface MethodExpectation {
   rubyName: string;
   calls: Set<string>;
 }
@@ -169,9 +185,11 @@ export function reconcileFileText(
 ): {
   text: string | null;
   harvested: { tsName: string; entry: TagEntry }[];
-  /** Every (rubyName, call) the file now tags — kept and newly-added alike.
-   *  These are the baseline rows the tag supersedes, so `main` drops them from
-   *  the split baseline in the same operation (RFC 0083). */
+  /** Every (rubyName, call) the file now tags with a real justification — kept
+   *  and newly-added alike. These are the baseline rows the tag supersedes, so
+   *  `main` drops them from the split baseline in the same operation (RFC
+   *  0083). A tag still carrying the seeded placeholder justifies nothing and
+   *  keeps its row: it does not suppress either (see `justifies`). */
   tagged: { rubyName: string; call: string }[];
   /** Expectation names never seen on a body-bearing declaration (mixin
    *  host-class duplicates, prototype-patched methods, …) — reported, never
@@ -234,7 +252,7 @@ export function reconcileFileText(
         );
         if (exp) {
           for (const e of [...r.kept, ...r.added]) {
-            tagged.push({ rubyName: exp.rubyName, call: e.call });
+            if (justifies(e.reason)) tagged.push({ rubyName: exp.rubyName, call: e.call });
           }
         }
         for (const d of r.dropped) {
@@ -270,6 +288,35 @@ export function reconcileFileText(
   return { text: out, harvested, tagged, unmatched };
 }
 
+/** (tsFile → tsName → expectation) for one package: every call the artifact
+ *  still flags, PLUS every call a tag already suppressed. The second half is
+ *  what keeps this reconcile idempotent — a suppressed call is absent from
+ *  `mismatches`, so without it the tag that earned the suppression would be
+ *  dropped as satisfied and the flag would return to the ratchet. */
+export function buildExpectations(
+  artifact: WideArtifact,
+  pkg: string,
+  onlyFile?: string,
+): Map<string, Map<string, MethodExpectation>> {
+  const byFile = new Map<string, Map<string, MethodExpectation>>();
+  const expectationFor = (tsFile: string, tsName: string, rubyName: string) => {
+    const fileMap = byFile.get(tsFile) ?? byFile.set(tsFile, new Map()).get(tsFile)!;
+    return fileMap.get(tsName) ?? fileMap.set(tsName, { rubyName, calls: new Set() }).get(tsName)!;
+  };
+  for (const m of artifact.mismatches) {
+    if (m.package !== pkg) continue;
+    if (onlyFile && m.tsFile !== onlyFile) continue;
+    const exp = expectationFor(m.tsFile, m.tsName, m.rubyName);
+    for (const missing of m.missing) exp.calls.add(callOf(missing));
+  }
+  for (const c of artifact.suppressed ?? []) {
+    if (c.package !== pkg) continue;
+    if (onlyFile && c.tsFile !== onlyFile) continue;
+    expectationFor(c.tsFile, c.tsName, c.rubyName).calls.add(c.call);
+  }
+  return byFile;
+}
+
 async function main(argv: string[]): Promise<number> {
   const pkgIdx = argv.indexOf("--package");
   const pkg = pkgIdx !== -1 ? argv[pkgIdx + 1] : undefined;
@@ -299,21 +346,9 @@ async function main(argv: string[]): Promise<number> {
     reasons.set(keyOf(e), e.reason);
   }
 
-  // (package, tsFile) → tsName → expectation.
-  const byFile = new Map<string, Map<string, MethodExpectation>>();
-  for (const m of artifact.mismatches) {
-    if (m.package !== pkg) continue;
-    if (onlyFile && m.tsFile !== onlyFile) continue;
-    const fileMap = byFile.get(m.tsFile) ?? byFile.set(m.tsFile, new Map()).get(m.tsFile)!;
-    const exp =
-      fileMap.get(m.tsName) ??
-      fileMap.set(m.tsName, { rubyName: m.rubyName, calls: new Set() }).get(m.tsName)!;
-    for (const missing of m.missing) exp.calls.add(callOf(missing));
-  }
+  const byFile = buildExpectations(artifact, pkg, onlyFile);
 
   let changed = 0;
-  // Baseline keys now justified by a tag at the call site; dropped from the
-  // split baseline below so a deviation is recorded in exactly one place.
   const migrated = new Set<string>();
   const srcDir = packageSrcDir(pkg);
   for (const [tsFile, expectations] of [...byFile.entries()].sort()) {

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -40,7 +40,8 @@ import {
   loadBaseline as loadNarrowBaseline,
   missingScope,
 } from "./lint-call-mismatches.js";
-import { loadSplitBaseline } from "./lint-call-mismatches-wide.js";
+import { loadSplitBaseline, writeSplitBaseline } from "./lint-call-mismatches-wide.js";
+import { TAG, type TagEntry, parseJsdoc } from "./missing-rails-call-tags.js";
 
 const ARTIFACT_PATH = path.join(OUTPUT_DIR, "call-mismatches-wide.json");
 const WIDE_BASELINE_DIR = path.join(
@@ -48,7 +49,9 @@ const WIDE_BASELINE_DIR = path.join(
   "call-mismatches-wide-exclude",
 );
 
-export const TAG = "@missingRailsCall";
+export { TAG, parseJsdoc } from "./missing-rails-call-tags.js";
+export type { JsdocOrigin, TagEntry } from "./missing-rails-call-tags.js";
+
 export const DEFAULT_TAG_REASON =
   "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; " +
   "bucket (b) equivalent or (c) noise pending per-cluster burndown review.";
@@ -67,84 +70,6 @@ interface ArtifactMismatch {
 interface WideArtifact {
   packages?: string[];
   mismatches: ArtifactMismatch[];
-}
-
-/** One parsed `@missingRailsCall` tag: the Ruby call name plus its raw lines
- *  (kept verbatim for idempotency) and the flattened reason text. */
-export interface TagEntry {
-  call: string;
-  reason: string;
-  rawLines: string[];
-}
-
-const TAG_LINE = /^\s*\*?\s*@missingRailsCall\s+(\S+)(?:\s+—\s?(.*))?$/;
-// A line opening a NEW JSDoc tag: at most one space after the `*`. Curated
-// reasons can contain Ruby ivar names (`@primary_key`), and the wrapper's
-// hang indent (`*   `) can place one at line start — deeper-indented `@`
-// lines are continuations, not tag boundaries (found by the activerecord-wide
-// run: core.ts initInternals).
-const ANY_TAG_LINE = /^\s*\*?\s?@\S/;
-
-/** Where a JSDoc comment starts, so an empty-reason error can name a
- *  `file:line` the way `noRailsEquivalentReason` does. */
-export interface JsdocOrigin {
-  fileName: string;
-  /** 1-based line of the comment's first line in `fileName`. */
-  startLine: number;
-}
-
-/** Parse a JSDoc comment's text (including delimiters) into its non-tag lines
- *  and its `@missingRailsCall` entries. Continuation lines (not starting a new
- *  `@` tag) attach to the preceding entry.
- *
- *  An empty reason is a hard error, matching `@noRailsEquivalent` (RFC 0080):
- *  every tag in the tree is written with a reason — the generator always emits
- *  the curated baseline row's prose or a placeholder — so a bare tag is
- *  necessarily hand-authored, and backfilling it with a placeholder would turn
- *  an unjustified allowlist entry into a silently blessed one. The family's
- *  empty-reason contract is stated in
- *  docs/infrastructure/api-build-stub-generation-plan.md. */
-export function parseJsdoc(
-  comment: string,
-  origin?: JsdocOrigin,
-): { rest: string[]; entries: TagEntry[] } {
-  const lines = comment.split("\n");
-  const rest: string[] = [];
-  const entries: TagEntry[] = [];
-  const tagLineOf = new Map<TagEntry, number>();
-  let open: TagEntry | null = null;
-  for (const [index, line] of lines.entries()) {
-    const m = line.match(TAG_LINE);
-    if (m) {
-      // Trimmed at capture: `TAG_LINE` absorbs only one space after the
-      // em-dash, so trailing whitespace would otherwise read as a non-empty
-      // reason and slide past the empty-reason gate below. `rawLines` keeps
-      // the line verbatim, so idempotency is unaffected.
-      open = { call: m[1], reason: (m[2] ?? "").trim(), rawLines: [line] };
-      entries.push(open);
-      tagLineOf.set(open, index);
-      continue;
-    }
-    const closes = line.trim() === "*/" || line.trim().endsWith("*/");
-    if (open && !ANY_TAG_LINE.test(line) && !closes && line.trim() !== "*") {
-      open.rawLines.push(line);
-      open.reason = (open.reason + " " + line.replace(/^\s*\*\s?/, "").trim()).trim();
-      continue;
-    }
-    open = null;
-    rest.push(line);
-  }
-  for (const entry of entries) {
-    if (entry.reason !== "") continue;
-    const at = origin
-      ? ` ${origin.fileName}:${origin.startLine + (tagLineOf.get(entry) ?? 0)}`
-      : "";
-    throw new Error(
-      `${TAG} needs a reason:${at} — state why the Rails call ` +
-        `\`${entry.call}\` is not made here.`,
-    );
-  }
-  return { rest, entries };
 }
 
 export interface ReconcileResult {
@@ -244,6 +169,10 @@ export function reconcileFileText(
 ): {
   text: string | null;
   harvested: { tsName: string; entry: TagEntry }[];
+  /** Every (rubyName, call) the file now tags — kept and newly-added alike.
+   *  These are the baseline rows the tag supersedes, so `main` drops them from
+   *  the split baseline in the same operation (RFC 0083). */
+  tagged: { rubyName: string; call: string }[];
   /** Expectation names never seen on a body-bearing declaration (mixin
    *  host-class duplicates, prototype-patched methods, …) — reported, never
    *  silently dropped. */
@@ -252,6 +181,7 @@ export function reconcileFileText(
   const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
   const edits: Edit[] = [];
   const harvested: { tsName: string; entry: TagEntry }[] = [];
+  const tagged: { rubyName: string; call: string }[] = [];
   const seen = new Set<string>();
 
   const visit = (node: ts.Node): void => {
@@ -302,6 +232,11 @@ export function reconcileFileText(
         const r = reconcile(entries, expected, (c) =>
           exp ? reasonFor(exp.rubyName, c) : DEFAULT_TAG_REASON,
         );
+        if (exp) {
+          for (const e of [...r.kept, ...r.added]) {
+            tagged.push({ rubyName: exp.rubyName, call: e.call });
+          }
+        }
         for (const d of r.dropped) {
           if (!PLACEHOLDER_REASONS.has(d.reason)) harvested.push({ tsName: name, entry: d });
         }
@@ -327,12 +262,12 @@ export function reconcileFileText(
   visit(sf);
 
   const unmatched = [...expectations.keys()].filter((n) => !seen.has(n)).sort();
-  if (edits.length === 0) return { text: null, harvested, unmatched };
+  if (edits.length === 0) return { text: null, harvested, tagged, unmatched };
   let out = text;
   for (const e of edits.sort((a, b) => b.start - a.start)) {
     out = out.slice(0, e.start) + e.text + out.slice(e.end);
   }
-  return { text: out, harvested, unmatched };
+  return { text: out, harvested, tagged, unmatched };
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -377,6 +312,9 @@ async function main(argv: string[]): Promise<number> {
   }
 
   let changed = 0;
+  // Baseline keys now justified by a tag at the call site; dropped from the
+  // split baseline below so a deviation is recorded in exactly one place.
+  const migrated = new Set<string>();
   const srcDir = packageSrcDir(pkg);
   for (const [tsFile, expectations] of [...byFile.entries()].sort()) {
     const abs = path.join(srcDir, tsFile);
@@ -401,7 +339,8 @@ async function main(argv: string[]): Promise<number> {
       console.error(`api:build: ${err instanceof Error ? err.message : String(err)}`);
       return 1;
     }
-    const { text: next, harvested, unmatched } = reconciled;
+    const { text: next, harvested, tagged, unmatched } = reconciled;
+    for (const t of tagged) migrated.add(keyOf({ package: pkg, tsFile, ...t }));
     for (const h of harvested) {
       console.log(`harvested (${tsFile} ${h.tsName} ${h.entry.call}): ${h.entry.reason}`);
     }
@@ -414,6 +353,14 @@ async function main(argv: string[]): Promise<number> {
       else await fs.writeFile(abs, next);
     }
   }
+  const remaining = wideBaseline.filter((e) => !migrated.has(keyOf(e)));
+  const dropped = wideBaseline.length - remaining.length;
+  if (dropped > 0 && !dryRun) await writeSplitBaseline(remaining, WIDE_BASELINE_DIR);
+  console.log(
+    `api:build: ${dropped} baseline entr(ies) ${dryRun ? "would migrate" : "migrated"} to ` +
+      `@missingRailsCall tags and ${dryRun ? "would be" : "were"} dropped from ` +
+      `${path.relative(ROOT_DIR, WIDE_BASELINE_DIR)}/.`,
+  );
   console.log(`api:build: ${changed} file(s) ${dryRun ? "would change" : "updated"} (${pkg}).`);
   return 0;
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/insert-manager.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/insert-manager.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "arel",
-    "tsFile": "insert-manager.ts",
-    "rubyName": "insert",
-    "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -25,6 +25,9 @@ import {
   effectiveTsCalls,
   reachedSameFileMethods,
   narrowCallsApplies,
+  callTagKey,
+  staleCallTags,
+  suppressTaggedCalls,
 } from "./compare.js";
 import { rubyMethodToTs } from "./conventions.js";
 import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "./types.js";
@@ -1388,5 +1391,57 @@ describe("blazetrailsDepKeys", () => {
     // in package.json — without this, FakeAdapter's superclass resolves to
     // nothing.
     expect(blazetrailsDepKeys("activerecord-test-support")).toContain("activerecord");
+  });
+});
+
+describe("suppressTaggedCalls", () => {
+  it("drops a flagged call the declaration tags and records it as used", () => {
+    const used = new Set<string>();
+    const kept = suppressTaggedCalls(
+      ["synchronize → synchronize", "reload → reload"],
+      new Set(["synchronize"]),
+      used,
+    );
+    expect(kept).toEqual(["reload → reload"]);
+    expect([...used]).toEqual(["synchronize"]);
+  });
+
+  it("does not silence a call the tag does not name", () => {
+    const used = new Set<string>();
+    expect(suppressTaggedCalls(["reload → reload"], new Set(["synchronize"]), used)).toEqual([
+      "reload → reload",
+    ]);
+    expect([...used]).toEqual([]);
+  });
+});
+
+describe("staleCallTags", () => {
+  const tags = new Map([["relation.ts", new Map([["load", new Set(["synchronize", "reload"])]])]]);
+
+  it("reports a tag whose call no longer flags on a compared method", () => {
+    const used = new Map([[callTagKey("relation.ts", "load"), new Set(["synchronize"])]]);
+    expect(staleCallTags(tags, used)).toEqual([
+      { tsFile: "relation.ts", tsName: "load", call: "reload" },
+    ]);
+  });
+
+  it("reports nothing while every tag still suppresses", () => {
+    const used = new Map([[callTagKey("relation.ts", "load"), new Set(["synchronize", "reload"])]]);
+    expect(staleCallTags(tags, used)).toEqual([]);
+  });
+
+  it("stays silent about a method no matched pair compared", () => {
+    expect(staleCallTags(tags, new Map())).toEqual([]);
+  });
+
+  it("keys tags to their own file, so a same-named method elsewhere is untouched", () => {
+    const twoFiles = new Map([
+      ["relation.ts", new Map([["load", new Set(["synchronize"])]])],
+      ["core.ts", new Map([["load", new Set(["synchronize"])]])],
+    ]);
+    const used = new Map([[callTagKey("core.ts", "load"), new Set<string>()]]);
+    expect(staleCallTags(twoFiles, used)).toEqual([
+      { tsFile: "core.ts", tsName: "load", call: "synchronize" },
+    ]);
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -531,6 +531,19 @@ interface CallResult {
   mismatched: number;
   mismatches: CallMismatch[];
   staleTags: StaleCallTag[];
+  suppressed: SuppressedCall[];
+}
+
+/** A flag a `@missingRailsCall` tag suppressed. Reported in the artifact
+ *  because the mismatch list no longer carries it and `api:build` reconciles
+ *  tags against that list: without this, the next api:build run would read the
+ *  call as satisfied, drop the tag it just honoured, and hand the flag straight
+ *  back to the ratchet. */
+export interface SuppressedCall {
+  tsFile: string;
+  rubyName: string;
+  tsName: string;
+  call: string;
 }
 
 /** Identity of the declaration a `@missingRailsCall` tag is written on. Keyed
@@ -578,11 +591,11 @@ export function staleCallTags(
   );
 }
 
-// A `@missingRailsCall` tag (RFC 0083) on a COMPARED method whose call is no
-// longer flagged — the tag's only-shrink half, mirroring the baseline dir's
-// STALE entries: once the TS body makes the call, the justification must go.
-// Tags on methods no pair matched are NOT reported: nothing compared them, so
-// "no longer flagged" would be unknowable rather than true.
+/** A `@missingRailsCall` tag (RFC 0083) on a COMPARED method whose call is no
+ *  longer flagged — the tag's only-shrink half, mirroring the baseline dir's
+ *  STALE entries: once the TS body makes the call, the justification must go.
+ *  Tags on methods no pair matched are NOT reported: nothing compared them, so
+ *  "no longer flagged" would be unknowable rather than true. */
 export interface StaleCallTag {
   tsFile: string;
   tsName: string;
@@ -1328,11 +1341,6 @@ export function main() {
     const tsParamsByFileName = new Map<string, Map<string, ParamInfo[][]>>();
     // Body call-sets scoped per (file, name) for the advisory calls-parity check.
     const tsCallsByFileName = new Map<string, Map<string, string[][]>>();
-    // Calls suppressed by a `@missingRailsCall <call> — <reason>` tag on the TS
-    // declaration, scoped per (file, name) so a tag justifies the deviation for
-    // exactly the method that carries it (RFC 0083). This is what makes the tag
-    // load-bearing: a permanent, reasoned deviation leaves the wide baseline
-    // entirely and lives at the call site instead.
     const tsMissingCallTagsByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
     // scope tsParamsByName uses). Consulted ONLY by the delegation-transparency
@@ -1688,10 +1696,8 @@ export function main() {
     const literalMismatches: LiteralMismatch[] = [];
     let callsCompared = 0;
     const callMismatches: CallMismatch[] = [];
-    // (tsFile, tsName) → the tagged calls that actually suppressed a flag on a
-    // compared pair. A key's presence means the pair WAS compared, which is the
-    // precondition for calling any of its unused tags stale.
     const callTagsUsed = new Map<string, Set<string>>();
+    const suppressedCalls: SuppressedCall[] = [];
     const bodyHashRecords: BodyHashRecord[] = [];
     const fileResults: FileResult[] = [];
 
@@ -1865,6 +1871,10 @@ export function main() {
           const tagKey = callTagKey(tsFile, tsName);
           const used = callTagsUsed.get(tagKey) ?? callTagsUsed.set(tagKey, new Set()).get(tagKey)!;
           kept = suppressTaggedCalls(missing, tags, used);
+          for (const m of missing) {
+            const call = callOf(m);
+            if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, call });
+          }
         }
         if (kept.length === 0) return;
         callMismatches.push({ rubyFile, tsFile, rubyName, tsName, missing: kept });
@@ -2267,6 +2277,7 @@ export function main() {
         mismatched: callMismatches.length,
         mismatches: callMismatches,
         staleTags: staleCallTags(tsMissingCallTagsByFileName, callTagsUsed),
+        suppressed: suppressedCalls,
       },
       bodyHashes: bodyHashRecords,
     });
@@ -2377,6 +2388,9 @@ export function main() {
   const staleTagsFlat = results.flatMap((r) =>
     r.calls.staleTags.map((t) => ({ package: r.package, ...t })),
   );
+  const suppressedFlat = results.flatMap((r) =>
+    r.calls.suppressed.map((c) => ({ package: r.package, ...c })),
+  );
   fs.writeFileSync(
     callsPath,
     JSON.stringify(
@@ -2392,10 +2406,8 @@ export function main() {
         compared: results.reduce((n, r) => n + r.calls.compared, 0),
         mismatched: callsFlat.length,
         mismatches: callsFlat,
-        // `@missingRailsCall` tags whose call no longer flags (RFC 0083). The
-        // wide ratchet fails on these exactly as it does on a stale baseline
-        // entry — a justification only shrinks.
         staleTags: staleTagsFlat,
+        suppressed: suppressedFlat,
       },
       null,
       2,

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -98,6 +98,7 @@ import {
   parseArityExcludes,
 } from "./arity-exclude.js";
 import { matchOptionKeysAgainst } from "./options-keys.js";
+import { callOf } from "./lint-call-mismatches.js";
 import {
   compareDefaults,
   compareLiteral,
@@ -529,6 +530,63 @@ interface CallResult {
   compared: number;
   mismatched: number;
   mismatches: CallMismatch[];
+  staleTags: StaleCallTag[];
+}
+
+/** Identity of the declaration a `@missingRailsCall` tag is written on. Keyed
+ *  by (tsFile, tsName), so a tag justifies the deviation for exactly the method
+ *  that carries it and never for a same-named method in another file. */
+export function callTagKey(tsFile: string, tsName: string): string {
+  return `${tsFile}\u0000${tsName}`;
+}
+
+/** Drop the flagged calls a tag on this declaration justifies, recording each
+ *  one in `used` (a suppression is what makes a tag non-stale). A tag for one
+ *  call never silences another: `tags` is matched against each flag's own call
+ *  name. */
+export function suppressTaggedCalls(
+  missing: string[],
+  tags: ReadonlySet<string>,
+  used: Set<string>,
+): string[] {
+  return missing.filter((m) => {
+    const call = callOf(m);
+    if (!tags.has(call)) return true;
+    used.add(call);
+    return false;
+  });
+}
+
+/** Every tagged call on a COMPARED (tsFile, tsName) that never suppressed a
+ *  flag — the tag's stale half. Sorted for a deterministic artifact. */
+export function staleCallTags(
+  tagsByFileName: Map<string, Map<string, Set<string>>>,
+  used: Map<string, Set<string>>,
+): StaleCallTag[] {
+  const out: StaleCallTag[] = [];
+  for (const [tsFile, byName] of tagsByFileName) {
+    for (const [tsName, calls] of byName) {
+      const hit = used.get(callTagKey(tsFile, tsName));
+      if (hit === undefined) continue;
+      for (const call of calls) {
+        if (!hit.has(call)) out.push({ tsFile, tsName, call });
+      }
+    }
+  }
+  return out.sort((a, b) =>
+    `${a.tsFile} ${a.tsName} ${a.call}` < `${b.tsFile} ${b.tsName} ${b.call}` ? -1 : 1,
+  );
+}
+
+// A `@missingRailsCall` tag (RFC 0083) on a COMPARED method whose call is no
+// longer flagged — the tag's only-shrink half, mirroring the baseline dir's
+// STALE entries: once the TS body makes the call, the justification must go.
+// Tags on methods no pair matched are NOT reported: nothing compared them, so
+// "no longer flagged" would be unknowable rather than true.
+export interface StaleCallTag {
+  tsFile: string;
+  tsName: string;
+  call: string;
 }
 
 // Advisory signature comparison: for a name-matched (ruby, ts) pair whose
@@ -1270,6 +1328,12 @@ export function main() {
     const tsParamsByFileName = new Map<string, Map<string, ParamInfo[][]>>();
     // Body call-sets scoped per (file, name) for the advisory calls-parity check.
     const tsCallsByFileName = new Map<string, Map<string, string[][]>>();
+    // Calls suppressed by a `@missingRailsCall <call> — <reason>` tag on the TS
+    // declaration, scoped per (file, name) so a tag justifies the deviation for
+    // exactly the method that carries it (RFC 0083). This is what makes the tag
+    // load-bearing: a permanent, reasoned deviation leaves the wide baseline
+    // entirely and lives at the call site instead.
+    const tsMissingCallTagsByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
     // scope tsParamsByName uses). Consulted ONLY by the delegation-transparency
     // gate (see effectiveTsCalls), never as the primary population — the
@@ -1304,6 +1368,13 @@ export function main() {
         const byName = tsOptionKeysByFileName.get(file) ?? new Map<string, (string[] | null)[]>();
         byName.set(m.name, [...(byName.get(m.name) ?? []), m.optionKeys]);
         tsOptionKeysByFileName.set(file, byName);
+      }
+      if (m.missingRailsCalls !== undefined) {
+        const byName = tsMissingCallTagsByFileName.get(file) ?? new Map<string, Set<string>>();
+        const tagged = byName.get(m.name) ?? new Set<string>();
+        for (const c of m.missingRailsCalls) tagged.add(c);
+        byName.set(m.name, tagged);
+        tsMissingCallTagsByFileName.set(file, byName);
       }
       if (m.calls !== undefined) {
         const byName = tsCallsByFileName.get(file) ?? new Map<string, string[][]>();
@@ -1617,6 +1688,10 @@ export function main() {
     const literalMismatches: LiteralMismatch[] = [];
     let callsCompared = 0;
     const callMismatches: CallMismatch[] = [];
+    // (tsFile, tsName) → the tagged calls that actually suppressed a flag on a
+    // compared pair. A key's presence means the pair WAS compared, which is the
+    // precondition for calling any of its unused tags stale.
+    const callTagsUsed = new Map<string, Set<string>>();
     const bodyHashRecords: BodyHashRecord[] = [];
     const fileResults: FileResult[] = [];
 
@@ -1784,8 +1859,15 @@ export function main() {
           jsEnumerableAliases,
           negatedTsCalls,
         );
-        if (missing.length === 0) return;
-        callMismatches.push({ rubyFile, tsFile, rubyName, tsName, missing });
+        const tags = tsMissingCallTagsByFileName.get(tsFile)?.get(tsName);
+        let kept = missing;
+        if (tags !== undefined && tags.size > 0) {
+          const tagKey = callTagKey(tsFile, tsName);
+          const used = callTagsUsed.get(tagKey) ?? callTagsUsed.set(tagKey, new Set()).get(tagKey)!;
+          kept = suppressTaggedCalls(missing, tags, used);
+        }
+        if (kept.length === 0) return;
+        callMismatches.push({ rubyFile, tsFile, rubyName, tsName, missing: kept });
       };
 
       // Advisory arity check for one name-matched pair: flag when the Ruby and
@@ -2184,6 +2266,7 @@ export function main() {
         compared: callsCompared,
         mismatched: callMismatches.length,
         mismatches: callMismatches,
+        staleTags: staleCallTags(tsMissingCallTagsByFileName, callTagsUsed),
       },
       bodyHashes: bodyHashRecords,
     });
@@ -2291,6 +2374,9 @@ export function main() {
   const callsFlat = results.flatMap((r) =>
     r.calls.mismatches.map((m) => ({ package: r.package, ...m })),
   );
+  const staleTagsFlat = results.flatMap((r) =>
+    r.calls.staleTags.map((t) => ({ package: r.package, ...t })),
+  );
   fs.writeFileSync(
     callsPath,
     JSON.stringify(
@@ -2306,6 +2392,10 @@ export function main() {
         compared: results.reduce((n, r) => n + r.calls.compared, 0),
         mismatched: callsFlat.length,
         mismatches: callsFlat,
+        // `@missingRailsCall` tags whose call no longer flags (RFC 0083). The
+        // wide ratchet fails on these exactly as it does on a stale baseline
+        // entry — a justification only shrinks.
+        staleTags: staleTagsFlat,
       },
       null,
       2,

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2351,3 +2351,54 @@ describe("extractFromProgram — interface merged with a namespace of the same n
     expect(merged.isInterface).toBe(true);
   });
 });
+
+describe("@missingRailsCall extraction", () => {
+  it("records the tagged calls on a class method", () => {
+    const cls = extractFromSource(`
+      export class Foo {
+        /**
+         * Prose.
+         * @missingRailsCall synchronize — Ruby guards with Mutex#synchronize; trails is single-threaded.
+         */
+        bar(): void {}
+      }
+    `);
+    expect(cls.instanceMethods[0].missingRailsCalls).toEqual(["synchronize"]);
+  });
+
+  it("leaves an untagged method's missingRailsCalls undefined", () => {
+    const cls = extractFromSource(`
+      export class Foo {
+        /** Prose. */
+        bar(): void {}
+      }
+    `);
+    expect(cls.instanceMethods[0].missingRailsCalls).toBeUndefined();
+  });
+
+  it("does not leak a tag from the preceding method", () => {
+    const cls = extractFromSource(`
+      export class Foo {
+        /**
+         * @missingRailsCall synchronize — single-threaded.
+         */
+        bar(): void {}
+        baz(): void {}
+      }
+    `);
+    expect(cls.instanceMethods[1].missingRailsCalls).toBeUndefined();
+  });
+
+  it("throws on a bare tag (the empty-reason contract)", () => {
+    expect(() =>
+      extractFromSource(`
+      export class Foo {
+        /**
+         * @missingRailsCall synchronize
+         */
+        bar(): void {}
+      }
+    `),
+    ).toThrow(/needs a reason/);
+  });
+});

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2401,4 +2401,22 @@ describe("@missingRailsCall extraction", () => {
     `),
     ).toThrow(/needs a reason/);
   });
+
+  it("reads a renamed export's own tags instead of the declaration's", () => {
+    const info = extractFromFiles("/p", {
+      "registry.ts": `
+        /**
+         * @missingRailsCall each — declared spelling iterates with for-of.
+         */
+        function registerModelClass(): void {}
+
+        /**
+         * @missingRailsCall first — the alias indexes instead.
+         */
+        export { registerModelClass as registerModel };
+      `,
+    });
+    const fns = fileFunctionsOf(info, "registry.ts");
+    expect(fns.find((f) => f.name === "registerModel")!.missingRailsCalls).toEqual(["first"]);
+  });
 });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1463,8 +1463,16 @@ export function paramsOfCallableRef(
  * tag throws here too) and the continuation rules that keep a Ruby ivar in the
  * reason prose from re-parsing as a tag boundary.
  */
+const fileHasMissingRailsCallTag = new WeakMap<ts.SourceFile, boolean>();
+
 export function missingRailsCallTags(node: ts.Node): string[] | undefined {
   const sf = node.getSourceFile();
+  let present = fileHasMissingRailsCallTag.get(sf);
+  if (present === undefined) {
+    present = sf.text.includes(MISSING_RAILS_CALL_TAG);
+    fileHasMissingRailsCallTag.set(sf, present);
+  }
+  if (!present) return undefined;
   const ranges = ts.getLeadingCommentRanges(sf.text, node.getFullStart()) ?? [];
   const range = ranges.filter((r) => sf.text.slice(r.pos, r.pos + 3) === "/**").at(-1);
   if (!range) return undefined;

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -67,6 +67,7 @@ import {
 import { extractorSchemaToken } from "./extractor-schema.js";
 import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
 import { NEGATED_CALL_PREFIX } from "./enumerable-idioms.js";
+import { TAG as MISSING_RAILS_CALL_TAG, suppressedCallsIn } from "./missing-rails-call-tags.js";
 
 // Per-package cache: extracting all packages with the TS Compiler API
 // takes ~16s; only a handful of packages typically change between
@@ -633,6 +634,7 @@ export function extractFromProgram(
         const fnCalls = extractCalls(node.body);
         const internal = hasInternalJsDocTag(node);
         const noRailsEquivalent = noRailsEquivalentReason(node);
+        const fnMissingRailsCalls = missingRailsCallTags(node);
         fileFunctions.push({
           name: node.name.text,
           visibility: "public",
@@ -644,6 +646,7 @@ export function extractFromProgram(
           ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
           ...(fnOptionKeys !== undefined ? { optionKeys: fnOptionKeys } : {}),
           ...(fnCalls !== undefined ? { calls: fnCalls } : {}),
+          ...(fnMissingRailsCalls !== undefined ? { missingRailsCalls: fnMissingRailsCalls } : {}),
         });
       } else if (ts.isVariableStatement(node) && isExported(node)) {
         // Capture `export const X = { method() {...}, foo, bar: ... }`
@@ -1451,6 +1454,30 @@ export function paramsOfCallableRef(
 }
 
 /**
+ * The Ruby calls a declaration's leading JSDoc tags as deliberately not made
+ * (`@missingRailsCall <call> — <reason>`), or undefined when it carries none.
+ *
+ * Read from the RAW comment text through the shared `suppressedCallsIn` parser
+ * rather than `ts.getJSDocTags`, so the tag means exactly what api:build and
+ * api:reasons already mean by it — including the empty-reason contract (a bare
+ * tag throws here too) and the continuation rules that keep a Ruby ivar in the
+ * reason prose from re-parsing as a tag boundary.
+ */
+export function missingRailsCallTags(node: ts.Node): string[] | undefined {
+  const sf = node.getSourceFile();
+  const ranges = ts.getLeadingCommentRanges(sf.text, node.getFullStart()) ?? [];
+  const range = ranges.filter((r) => sf.text.slice(r.pos, r.pos + 3) === "/**").at(-1);
+  if (!range) return undefined;
+  const comment = sf.text.slice(range.pos, range.end);
+  if (!comment.includes(MISSING_RAILS_CALL_TAG)) return undefined;
+  const calls = suppressedCallsIn(comment, {
+    fileName: sf.fileName,
+    startLine: sf.getLineAndCharacterOfPosition(range.pos).line + 1,
+  });
+  return calls.length > 0 ? calls : undefined;
+}
+
+/**
  * True when a declaration's leading JSDoc carries an `@internal` tag. An
  * exported top-level function has no `private`/`protected` modifier to carry
  * the "wiring seam, not Rails-facing surface" signal (CONTRIBUTING.md), so
@@ -1642,6 +1669,7 @@ export function harvestObjectLiteralMethods(
     let calls: string[] | undefined;
     let internal = hasInternalJsDocTag(prop);
     let noRailsEquivalent = noRailsEquivalentReason(prop);
+    const propMissingRailsCalls = missingRailsCallTags(prop);
     if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
       mname = prop.name.text;
       params = extractParameters(prop.parameters);
@@ -1695,6 +1723,7 @@ export function harvestObjectLiteralMethods(
       ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
       ...(optionKeys !== undefined ? { optionKeys } : {}),
       ...(calls !== undefined ? { calls } : {}),
+      ...(propMissingRailsCalls !== undefined ? { missingRailsCalls: propMissingRailsCalls } : {}),
     });
   }
   return out;
@@ -1807,7 +1836,13 @@ export function extractClass(
     const visibility = memberVisibility(member);
     const internal = visibility !== "public";
     const noRailsEquivalent = noRailsEquivalentReason(member);
-    const tagged = noRailsEquivalent !== undefined ? { noRailsEquivalent } : {};
+    const memberMissingRailsCalls = missingRailsCallTags(member);
+    const tagged = {
+      ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
+      ...(memberMissingRailsCalls !== undefined
+        ? { missingRailsCalls: memberMissingRailsCalls }
+        : {}),
+    };
     const isStatic = hasModifier(member, ts.SyntaxKind.StaticKeyword);
     const line = member.getSourceFile().getLineAndCharacterOfPosition(member.getStart()).line + 1;
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -151,6 +151,8 @@ interface WorkerOutput {
   /** Absolute file names of every source file the program read. */
   inputs: string[];
 }
+const fileHasMissingRailsCallTag = new WeakMap<ts.SourceFile, boolean>();
+
 if (!isMainThread && parentPort) {
   const { package: pkgName, srcDir } = workerData as WorkerInput;
   const out: WorkerOutput = extractPackage(pkgName, srcDir);
@@ -1480,9 +1482,12 @@ export function paramsOfCallableRef(
  * the mixin pseudo-module's constructor) need no wiring: `checkCalls` skips a
  * pair with no TS call-set, so a call there is never flagged, never tagged by
  * api:build, and has nothing to suppress.
+ *
+ * `fileHasMissingRailsCallTag` is declared with the imports, not next to this
+ * function: a worker thread runs the whole extraction from the
+ * `!isMainThread` block during module evaluation, so a `const` declared
+ * further down the file is still in its temporal dead zone when this runs.
  */
-const fileHasMissingRailsCallTag = new WeakMap<ts.SourceFile, boolean>();
-
 export function missingRailsCallTags(node: ts.Node): string[] | undefined {
   const sf = node.getSourceFile();
   let present = fileHasMissingRailsCallTag.get(sf);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -849,6 +849,11 @@ export function extractFromProgram(
                 ? noRailsEquivalentReason(decl)
                 : (noRailsEquivalentReason(renamedSpecifier) ??
                   noRailsEquivalentReason(renamedSpecifier.parent.parent));
+            const exportedMissingRailsCalls =
+              renamedSpecifier === undefined
+                ? missingRailsCallTags(decl)
+                : (missingRailsCallTags(renamedSpecifier) ??
+                  missingRailsCallTags(renamedSpecifier.parent.parent));
             fileFunctions.push({
               name: sym.name,
               visibility: "public",
@@ -859,6 +864,9 @@ export function extractFromProgram(
               ...(internal ? { internal: true } : {}),
               ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
               ...(calls !== undefined ? { calls } : {}),
+              ...(exportedMissingRailsCalls !== undefined
+                ? { missingRailsCalls: exportedMissingRailsCalls }
+                : {}),
             });
           }
         }
@@ -1462,6 +1470,16 @@ export function paramsOfCallableRef(
  * api:reasons already mean by it — including the empty-reason contract (a bare
  * tag throws here too) and the continuation rules that keep a Ruby ivar in the
  * reason prose from re-parsing as a tag boundary.
+ *
+ * Called from every extraction path that records a `calls` array: class
+ * members (methods, constructor, accessors), object-literal members, top-level
+ * `export function` declarations, and the named-export-list path — where a
+ * RENAMED alias (`export { foo as bar }`) is its own surface entry and so
+ * reads a tag written on the specifier, exactly as `noRailsEquivalentReason`
+ * does. The paths that record no call-set (namespace and interface members,
+ * the mixin pseudo-module's constructor) need no wiring: `checkCalls` skips a
+ * pair with no TS call-set, so a call there is never flagged, never tagged by
+ * api:build, and has nothing to suppress.
  */
 const fileHasMissingRailsCallTag = new WeakMap<ts.SourceFile, boolean>();
 

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -78,6 +78,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "optionKeys",
   "declaredIn",
   "noRailsEquivalent",
+  "missingRailsCalls",
 ] as const;
 
 /**

--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -17,6 +17,7 @@ import {
   REGEN_SKIP_ENV,
   unreviewedCount,
   writeSplitBaseline,
+  renderStaleTags,
 } from "./lint-call-mismatches-wide.js";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 
@@ -365,5 +366,19 @@ describe("regenerateArtifact", () => {
     await expect(regenerateArtifact({ PATH: "" })).rejects.toThrow(
       /pnpm api:compare --wide-calls|spawn/,
     );
+  });
+});
+
+describe("renderStaleTags", () => {
+  it("returns null when no tag is stale", () => {
+    expect(renderStaleTags([])).toBeNull();
+  });
+
+  it("lists each stale tag with its package, file, method and call", () => {
+    const out = renderStaleTags([
+      { package: "activerecord", tsFile: "relation.ts", tsName: "load", call: "synchronize" },
+    ])!;
+    expect(out).toContain("1 STALE @missingRailsCall tag(s)");
+    expect(out).toContain("  - activerecord  relation.ts  load  synchronize");
   });
 });

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -16,6 +16,9 @@
  *
  *   - any NEW wide mismatch absent from the baseline (the ratchet);
  *   - any STALE baseline entry that no longer flags (only-shrink);
+ *   - any STALE `@missingRailsCall` tag whose call no longer flags (RFC 0083 —
+ *     the tag is the OTHER place a wide deviation can be justified, and it
+ *     shrinks by the same rule; see missing-rails-call-tags.ts);
  *   - more entries still carrying the seeded {@link DEFAULT_REASON} than the
  *     committed high-water mark in call-mismatches-wide-unreviewed.json
  *     (RFC 0083 — see unreviewed-ratchet.ts for why that is a second ratchet).
@@ -93,6 +96,7 @@ import {
   flattenArtifact,
   missingScope,
   reseed,
+  type StaleTag,
 } from "./lint-call-mismatches.js";
 import { reportNonCanonicalBaselines, serializeBaseline } from "./baseline-json.js";
 import {
@@ -107,6 +111,7 @@ import {
   writeMark,
 } from "./unreviewed-ratchet.js";
 import { rubyMethodToTsIgnoringSkip, snakeToCamel } from "./conventions.js";
+import { TAG } from "./missing-rails-call-tags.js";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 
 // The baseline is a directory of per-source-file JSON arrays (see header),
@@ -366,6 +371,20 @@ function section(title: string, rows: [string, number][], top?: number): string 
   ].join("\n");
 }
 
+/** The STALE-tag half of the only-shrink contract, rendered for the console;
+ *  null when every `@missingRailsCall` tag still suppresses a live flag. */
+export function renderStaleTags(staleTags: StaleTag[]): string | null {
+  if (staleTags.length === 0) return null;
+  return [
+    `\nwide call-mismatches ratchet: ${staleTags.length} STALE ${TAG} tag(s) whose call is ` +
+      "no longer flagged.",
+    "A justification only shrinks, exactly like a baseline entry: the TS body now makes " +
+      "the call, so delete the tag from its JSDoc block (or run `pnpm api:build --package " +
+      "<pkg>`, which drops it for you).\n",
+    ...staleTags.map((t) => `  - ${t.package}  ${t.tsFile}  ${t.tsName}  ${t.call}`),
+  ].join("\n");
+}
+
 export function unreviewedCount(entries: ExcludeEntry[]): number {
   return unreviewedEntries(entries, DEFAULT_REASON).length;
 }
@@ -472,13 +491,16 @@ async function main(write: boolean): Promise<number> {
   if (await reportNonCanonicalBaselines(files, "wide call-mismatches ratchet")) return 1;
 
   const { added, stale } = diffAgainstBaseline(current, baseline);
+  const staleTags = artifact.staleTags ?? [];
+  const staleTagReport = renderStaleTags(staleTags);
+  if (staleTagReport) console.error(staleTagReport);
 
   const unreviewed = unreviewedCount(baseline);
   const mark = await loadMark(MARK_PATH);
   const overMark = unreviewed > mark;
   if (overMark) console.error(renderExcess(unreviewed, mark, path.relative(ROOT_DIR, MARK_PATH)));
 
-  if (added.length === 0 && stale.length === 0) {
+  if (added.length === 0 && stale.length === 0 && staleTags.length === 0) {
     if (overMark) return 1;
     console.log(
       `wide call-mismatches ratchet: OK (${baseline.length} baselined, ` +

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -111,7 +111,7 @@ import {
   writeMark,
 } from "./unreviewed-ratchet.js";
 import { rubyMethodToTsIgnoringSkip, snakeToCamel } from "./conventions.js";
-import { TAG } from "./missing-rails-call-tags.js";
+import { DEFAULT_REASON, TAG } from "./missing-rails-call-tags.js";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 
 // The baseline is a directory of per-source-file JSON arrays (see header),
@@ -148,9 +148,7 @@ const MARK_PATH = path.join(
   "call-mismatches-wide-unreviewed.json",
 );
 
-export const DEFAULT_REASON =
-  "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; " +
-  "bucket (b) equivalent or (c) noise pending per-cluster burndown review.";
+export { DEFAULT_REASON } from "./missing-rails-call-tags.js";
 
 async function readJson<T>(file: string): Promise<T> {
   return JSON.parse(await fs.readFile(file, "utf-8")) as T;

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -112,6 +112,17 @@ export interface Artifact {
   // missingScope): a current compare.ts always emits it.
   packages?: string[];
   mismatches: ArtifactMismatch[];
+  /** `@missingRailsCall` tags on a compared method whose call no longer flags
+   *  (RFC 0083). Optional so an artifact predating the field still loads; the
+   *  wide gate fails on a non-empty list, the tag's only-shrink half. */
+  staleTags?: StaleTag[];
+}
+
+export interface StaleTag {
+  package: string;
+  tsFile: string;
+  tsName: string;
+  call: string;
 }
 
 // Packages that SHOULD have been compared but are absent from the artifact's

--- a/scripts/api-compare/missing-rails-call-tags.test.ts
+++ b/scripts/api-compare/missing-rails-call-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { suppressedCallsIn } from "./missing-rails-call-tags.js";
+import { DEFAULT_REASON, suppressedCallsIn } from "./missing-rails-call-tags.js";
 
 const block = (...lines: string[]): string =>
   ["/**", ...lines.map((l) => ` * ${l}`), " */"].join("\n");
@@ -56,5 +56,22 @@ describe("suppressedCallsIn", () => {
       "@primary_key is what the reader memoizes through.",
     );
     expect(suppressedCallsIn(comment)).toEqual(["reset"]);
+  });
+
+  it("does not treat the seeded placeholder as a justification", () => {
+    expect(suppressedCallsIn(block(`@missingRailsCall synchronize — ${DEFAULT_REASON}`))).toEqual(
+      [],
+    );
+  });
+
+  it("treats the placeholder as unjustified even when api:build wrapped it", () => {
+    const wrapped = [
+      "/**",
+      " * @missingRailsCall first — Baseline (RFC 0047): wide call-set flag seeded",
+      " *   when the wide ratchet landed; bucket (b) equivalent or (c) noise pending",
+      " *   per-cluster burndown review.",
+      " */",
+    ].join("\n");
+    expect(suppressedCallsIn(wrapped)).toEqual([]);
   });
 });

--- a/scripts/api-compare/missing-rails-call-tags.test.ts
+++ b/scripts/api-compare/missing-rails-call-tags.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { suppressedCallsIn } from "./missing-rails-call-tags.js";
+
+const block = (...lines: string[]): string =>
+  ["/**", ...lines.map((l) => ` * ${l}`), " */"].join("\n");
+
+describe("suppressedCallsIn", () => {
+  it("returns the tagged calls, sorted and deduplicated", () => {
+    const comment = block(
+      "Prose.",
+      "@missingRailsCall synchronize — Ruby guards with Mutex#synchronize; trails is single-threaded.",
+      "@missingRailsCall reload — satisfied by the caller.",
+    );
+    expect(suppressedCallsIn(comment)).toEqual(["reload", "synchronize"]);
+  });
+
+  it("returns nothing for a comment with no tag", () => {
+    expect(suppressedCallsIn(block("Just prose."))).toEqual([]);
+  });
+
+  it("throws on a bare tag (the empty-reason contract)", () => {
+    expect(() => suppressedCallsIn(block("@missingRailsCall synchronize"))).toThrow(
+      /needs a reason/,
+    );
+  });
+
+  it("throws on a whitespace-only reason", () => {
+    expect(() => suppressedCallsIn(block("@missingRailsCall synchronize —   "))).toThrow(
+      /needs a reason/,
+    );
+  });
+
+  it("names the file:line of the offending tag", () => {
+    const comment = block("Prose.", "@missingRailsCall synchronize");
+    expect(() => suppressedCallsIn(comment, { fileName: "a/b.ts", startLine: 10 })).toThrow(
+      /a\/b\.ts:12/,
+    );
+  });
+
+  it("keeps a deeper-indented Ruby ivar in the reason prose out of the call set", () => {
+    // project_bare_jsdoc_tag_in_reason_prose_drops_surface: a line-leading `@`
+    // inside a reason has bitten this tag family before. The hang indent the
+    // generator writes keeps it a continuation, not a second tag.
+    const comment = [
+      "/**",
+      " * @missingRailsCall reset — the reader memoizes through",
+      " *   @primary_key instead, so Rails' reset has no counterpart.",
+      " */",
+    ].join("\n");
+    expect(suppressedCallsIn(comment)).toEqual(["reset"]);
+  });
+
+  it("never mints a suppression from a line-leading prose tag in a reason", () => {
+    const comment = block(
+      "@missingRailsCall reset — see below.",
+      "@primary_key is what the reader memoizes through.",
+    );
+    expect(suppressedCallsIn(comment)).toEqual(["reset"]);
+  });
+});

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -1,0 +1,105 @@
+/**
+ * The `@missingRailsCall <ruby_call> — <reason>` JSDoc tag: its parser and the
+ * empty-reason contract, in one module so every consumer shares ONE
+ * implementation (RFC 0083).
+ *
+ * Consumers:
+ *   - api:build (build.ts) — reconciles tags against the wide artifact;
+ *   - api:reasons (lint-missing-rails-call-reasons.ts) — gates the contract;
+ *   - the TS extractor (extract-ts-api.ts) — records the tagged calls so
+ *     compare.ts's `checkCalls` can suppress them, which is what makes the tag
+ *     load-bearing rather than documentation.
+ *
+ * Hard rules: no node:* imports, no process.* references, async fs.
+ */
+
+export const TAG = "@missingRailsCall";
+
+/** One parsed `@missingRailsCall` tag: the Ruby call name plus its raw lines
+ *  (kept verbatim for idempotency) and the flattened reason text. */
+export interface TagEntry {
+  call: string;
+  reason: string;
+  rawLines: string[];
+}
+
+/** Where a JSDoc comment starts, so an empty-reason error can name a
+ *  `file:line` the way `noRailsEquivalentReason` does. */
+export interface JsdocOrigin {
+  fileName: string;
+  /** 1-based line of the comment's first line in `fileName`. */
+  startLine: number;
+}
+
+const TAG_LINE = /^\s*\*?\s*@missingRailsCall\s+(\S+)(?:\s+—\s?(.*))?$/;
+// A line opening a NEW JSDoc tag: at most one space after the `*`. Curated
+// reasons can contain Ruby ivar names (`@primary_key`), and the wrapper's
+// hang indent (`*   `) can place one at line start — deeper-indented `@`
+// lines are continuations, not tag boundaries (found by the activerecord-wide
+// run: core.ts initInternals).
+const ANY_TAG_LINE = /^\s*\*?\s?@\S/;
+
+/** Parse a JSDoc comment's text (including delimiters) into its non-tag lines
+ *  and its `@missingRailsCall` entries. Continuation lines (not starting a new
+ *  `@` tag) attach to the preceding entry.
+ *
+ *  An empty reason is a hard error, matching `@noRailsEquivalent` (RFC 0080):
+ *  every tag in the tree is written with a reason — the generator always emits
+ *  the curated baseline row's prose or a placeholder — so a bare tag is
+ *  necessarily hand-authored, and backfilling it with a placeholder would turn
+ *  an unjustified allowlist entry into a silently blessed one. The family's
+ *  empty-reason contract is stated in
+ *  docs/infrastructure/api-build-stub-generation-plan.md. */
+export function parseJsdoc(
+  comment: string,
+  origin?: JsdocOrigin,
+): { rest: string[]; entries: TagEntry[] } {
+  const lines = comment.split("\n");
+  const rest: string[] = [];
+  const entries: TagEntry[] = [];
+  const tagLineOf = new Map<TagEntry, number>();
+  let open: TagEntry | null = null;
+  for (const [index, line] of lines.entries()) {
+    const m = line.match(TAG_LINE);
+    if (m) {
+      // Trimmed at capture: `TAG_LINE` absorbs only one space after the
+      // em-dash, so trailing whitespace would otherwise read as a non-empty
+      // reason and slide past the empty-reason gate below. `rawLines` keeps
+      // the line verbatim, so idempotency is unaffected.
+      open = { call: m[1], reason: (m[2] ?? "").trim(), rawLines: [line] };
+      entries.push(open);
+      tagLineOf.set(open, index);
+      continue;
+    }
+    const closes = line.trim() === "*/" || line.trim().endsWith("*/");
+    if (open && !ANY_TAG_LINE.test(line) && !closes && line.trim() !== "*") {
+      open.rawLines.push(line);
+      open.reason = (open.reason + " " + line.replace(/^\s*\*\s?/, "").trim()).trim();
+      continue;
+    }
+    open = null;
+    rest.push(line);
+  }
+  for (const entry of entries) {
+    if (entry.reason !== "") continue;
+    const at = origin
+      ? ` ${origin.fileName}:${origin.startLine + (tagLineOf.get(entry) ?? 0)}`
+      : "";
+    throw new Error(
+      `${TAG} needs a reason:${at} — state why the Rails call ` +
+        `\`${entry.call}\` is not made here.`,
+    );
+  }
+  return { rest, entries };
+}
+
+/** The Ruby call names one JSDoc comment tags as deliberately not made, sorted
+ *  and deduplicated. Throws on a bare or whitespace-only tag (the empty-reason
+ *  contract): a call is only suppressed when its deviation is justified in
+ *  prose at the call site. A line-leading prose `@tag` inside a reason ends
+ *  that reason at `parseJsdoc`'s boundary rule, so it can never mint a
+ *  suppression for a call nobody tagged. */
+export function suppressedCallsIn(comment: string, origin?: JsdocOrigin): string[] {
+  const { entries } = parseJsdoc(comment, origin);
+  return [...new Set(entries.filter((e) => e.reason !== "").map((e) => e.call))].sort();
+}

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -15,6 +15,22 @@
 
 export const TAG = "@missingRailsCall";
 
+/**
+ * The reason `api:build` stamps on a tag it mints with nothing curated to
+ * migrate — the RFC 0047 seed prose, shared with the wide baseline's
+ * `DEFAULT_REASON` (an entry carrying it is what the unreviewed high-water
+ * mark counts).
+ *
+ * A tag carrying it is deliberately NOT a justification: `api:build` mints one
+ * per still-missing call, so if the placeholder suppressed, a single
+ * `api:build --package <pkg>` run would move the whole baseline into inert
+ * tags and zero the wide gate. It has to be replaced with real per-entry prose
+ * before the call leaves the population.
+ */
+export const DEFAULT_REASON =
+  "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; " +
+  "bucket (b) equivalent or (c) noise pending per-cluster burndown review.";
+
 /** One parsed `@missingRailsCall` tag: the Ruby call name plus its raw lines
  *  (kept verbatim for idempotency) and the flattened reason text. */
 export interface TagEntry {
@@ -93,13 +109,23 @@ export function parseJsdoc(
   return { rest, entries };
 }
 
-/** The Ruby call names one JSDoc comment tags as deliberately not made, sorted
- *  and deduplicated. Throws on a bare or whitespace-only tag (the empty-reason
- *  contract): a call is only suppressed when its deviation is justified in
- *  prose at the call site. A line-leading prose `@tag` inside a reason ends
- *  that reason at `parseJsdoc`'s boundary rule, so it can never mint a
- *  suppression for a call nobody tagged. */
+/** True when a tag's reason argues the deviation, rather than standing in for
+ *  one: real per-entry prose, not the {@link DEFAULT_REASON} seed. The single
+ *  predicate behind both halves of the contract — a tag suppresses its flag if
+ *  and only if its baseline row may be dropped. */
+export function justifies(reason: string): boolean {
+  return reason !== "" && reason !== DEFAULT_REASON;
+}
+
+/** The Ruby call names one JSDoc comment JUSTIFIES as deliberately not made,
+ *  sorted and deduplicated. Throws on a bare or whitespace-only tag (the
+ *  empty-reason contract), and skips a tag still carrying
+ *  {@link DEFAULT_REASON}: a call only leaves the population when its deviation
+ *  is argued in prose at the call site. A line-leading prose `@tag` inside a
+ *  reason ends that reason at `parseJsdoc`'s boundary rule, so it can never
+ *  mint a suppression for a call nobody tagged. */
 export function suppressedCallsIn(comment: string, origin?: JsdocOrigin): string[] {
   const { entries } = parseJsdoc(comment, origin);
-  return [...new Set(entries.filter((e) => e.reason !== "").map((e) => e.call))].sort();
+  const justified = entries.filter((e) => justifies(e.reason));
+  return [...new Set(justified.map((e) => e.call))].sort();
 }

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -46,6 +46,14 @@ export interface MethodInfo {
    */
   weakCalls?: string[];
   /**
+   * TS-side only (RFC 0083): the Ruby call names this declaration's JSDoc tags
+   * as deliberately not made, via `@missingRailsCall <call> — <reason>`.
+   * compare.ts's `checkCalls` drops these from the wide call-mismatch
+   * population, which is what makes the tag load-bearing instead of
+   * documentation — see missing-rails-call-tags.ts.
+   */
+  missingRailsCalls?: string[];
+  /**
    * Normalized digest of the Ruby method BODY (source-hash pinning, RFC 0025).
    * Whitespace/comment-insensitive, body-only; changes when the ported code
    * changes upstream. Ruby-side only (the TS extractor does not emit it); used


### PR DESCRIPTION
Makes `@missingRailsCall` load-bearing (RFC 0083), so a permanent, verified
deviation lives at the call site instead of sitting in the wide JSON baseline
forever. Until now `api:build` wrote the tag and `api:reasons` gated its
reason, but neither `compare.ts` nor the wide ratchet read it — annotating a
call did not remove its baseline entry.

> **LOC waiver requested — 790+/132- against the 500 ceiling.** Deliberate, not
> an oversight. ~105 additions and ~100 deletions are the verbatim move of
> `parseJsdoc`/`TAG`/`DEFAULT_REASON` out of `build.ts` into the new shared
> module, and ~430 of the remainder is tests across five files. The production
> change is ~250 LOC and is not separable: the extractor field, the
> `checkCalls` suppression, the stale-tag gate and the `api:build` round-trip
> are one contract — ship any subset and the tag is either still inert, or
> `api:build` drops baseline rows nothing honours. Splitting would mean landing
> a half-wired gate on `main` between PRs. Happy to trim test coverage instead
> if that is preferred, but I would rather not.

## The contract

A tag suppresses its wide flag **if and only if** its baseline row may be
dropped, and one predicate (`justifies`) decides both. A reason qualifies when
it is real per-entry prose: a bare or whitespace-only tag still throws (the
existing empty-reason contract, unchanged), and a tag still carrying the seeded
RFC 0047 placeholder justifies nothing. That second half matters — `api:build`
mints a placeholder tag per still-missing call, so if the placeholder counted,
a single `api:build --package activerecord` run would move the whole baseline
into inert tags and silently zero the gate.

## What changed

- **`missing-rails-call-tags.ts` (new)** — `TAG`, `DEFAULT_REASON`,
  `parseJsdoc` and the empty-reason contract, moved verbatim out of `build.ts`
  (which re-exports them, so `api:build` / `api:reasons` are untouched). One
  implementation shared by all consumers — the contract is reused, not
  reimplemented. `DEFAULT_REASON` was duplicated between `build.ts` and the
  wide ratchet; both now import the one declaration.
- **Extractor** — records `MethodInfo.missingRailsCalls` on functions, class
  members and object-literal members, read from the RAW comment through that
  same parser (memoized per source file). Schema token bumped.
- **`checkCalls`** — drops a flagged call the matched TS method justifies.
  Keyed to the `(tsFile, tsName, ruby_call)` triple: the tag index is per-file
  and each flag is matched against its own call name, so one tag never silences
  another call, or the same-named method in another file.
- **Stale tags** — a tag on a *compared* method whose call no longer flags is
  written to the artifact (`staleTags`) and fails the wide ratchet, the same
  only-shrink rule the baseline dir has. Tags on methods no pair compared are
  not reported: nothing measured them, so "no longer flagged" would be
  unknowable rather than true.
- **Round-trip** — the artifact also reports the flags a tag suppressed, and
  `buildExpectations` folds them back in. Without that, `api:build` would read
  a suppressed call as satisfied, drop the tag that earned the suppression, and
  hand the flag back to the ratchet on the next run.
- **`api:build`** — drops the baseline rows its justified tags supersede in the
  same run, so a deviation is recorded in exactly one place.

## Applied to the tree

The two existing tags on `arel/insert-manager.ts`: the `each` tag is deleted
(its call no longer flags), and `first` trades the placeholder for a real
reason — Rails reaches the first column with `fields.first.first.relation`,
the port indexes (`fields[0]?.[0]`) — so its baseline row migrates to the tag
and `call-mismatches-wide-exclude/arel/insert-manager.json` is removed.

Verified end-to-end against a forced `api:compare --wide-calls` on a fresh
build: `staleTags` empty, `suppressed` exactly that one call, wide ratchet
green (3088 baselined, 2846 unreviewed ≤ mark 2849), `api:reasons` green, and
`api:build --package arel --dry-run` migrates 0 rows (every other arel tag is
still a placeholder).

## Review round 2

- **Renamed exports read their own tag.** The named-export-list path never
  called `missingRailsCallTags`, so a tag on `export { foo as bar }` — its own
  surface entry — was gated by `api:reasons` but invisible to `compare.ts`. It
  now reads the specifier's tag, mirroring `noRailsEquivalentReason`. The other
  paths the reviewer listed (namespace and interface members, the mixin
  pseudo-module's constructor) record no `calls` array at all, so `checkCalls`
  never compares them, nothing is ever flagged there and `api:build` never
  tags them — documented on `missingRailsCallTags` rather than wired.
- **Two Ruby names on one TS method.** `MethodExpectation` now carries every
  matched `rubyName`; a justified tag drops the baseline row of each, and a new
  tag's prose is seeded from whichever name has curated prose. Previously only
  the first name seen was used, which could have dropped the wrong row.

## Notes

- `project_bare_jsdoc_tag_in_reason_prose_drops_surface` is covered by two
  tests: a hang-indented `@primary_key` inside a reason stays a continuation,
  and a line-leading prose `@tag` never mints a suppression for a call nobody
  tagged.
- LOC waiver is requested at the top of this description.

Closes-story: missing-rails-call-tag-suppresses-wide-flag
