### PR TITLE
fix(activerecord): converge databaseExists on connect! + NoDatabaseError rescue

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -213,9 +213,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("database exists returns false when the database does not exist", async () => {
-      // Rails: `{ database: "non_extant_database", adapter: "postgresql" }`.
-      // trails has no configuration registry to inherit host/user from, so the
-      // suite URL carries them and only the database name is swapped.
       const url = new URL(PG_TEST_URL);
       url.pathname = "/non_extant_database";
       expect(await PostgreSQLAdapter.databaseExists(url.toString())).toBe(false);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -213,16 +213,16 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("database exists returns false when the database does not exist", async () => {
-      const exists = await adapter.databaseExists("nonexistent_db_xyz_12345");
-      expect(exists).toBe(false);
+      // Rails: `{ database: "non_extant_database", adapter: "postgresql" }`.
+      // trails has no configuration registry to inherit host/user from, so the
+      // suite URL carries them and only the database name is swapped.
+      const url = new URL(PG_TEST_URL);
+      url.pathname = "/non_extant_database";
+      expect(await PostgreSQLAdapter.databaseExists(url.toString())).toBe(false);
     });
 
     it("database exists returns true when the database exists", async () => {
-      const [{ current_database }] = await adapter.execute(
-        `SELECT current_database() AS current_database`,
-      );
-      const exists = await adapter.databaseExists(current_database as string);
-      expect(exists).toBe(true);
+      expect(await PostgreSQLAdapter.databaseExists(PG_TEST_URL)).toBe(true);
     });
 
     it("primary key", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -73,7 +73,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     const a = new BetterSQLite3Adapter(dbPath);
     try {
       expect(await BetterSQLite3Adapter.databaseExists({ database: dbPath })).toBe(true);
-      expect(await a.databaseExists()).toBe(true);
     } finally {
       await a.close();
       fs.rmSync(dbPath, { force: true });
@@ -82,9 +81,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
 
   it("database exists returns true for an in memory db", async () => {
     expect(await BetterSQLite3Adapter.databaseExists({ database: ":memory:" })).toBe(true);
-    const memAdapter = new BetterSQLite3Adapter(":memory:");
-    expect(await memAdapter.databaseExists()).toBe(true);
-    await memAdapter.close();
   });
 
   it("connect with url", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -56,18 +56,34 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     const dbPath = path.join(nested, "test.db");
     const a = new BetterSQLite3Adapter(dbPath);
     expect(a.isOpen).toBe(true);
+    expect(await BetterSQLite3Adapter.databaseExists({ database: dbPath })).toBe(true);
     await a.close();
     fs.rmSync(baseDir, { recursive: true, force: true });
   });
 
-  it("database exists returns true when database exists", () => {
-    // Our in-memory adapter is always "existing"
-    expect(adapter.isOpen).toBe(true);
+  it("database exists returns false when the database does not exist", async () => {
+    expect(await BetterSQLite3Adapter.databaseExists({ database: "non_extant_db" })).toBe(false);
+  });
+
+  it("database exists returns true when database exists", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const os = await import("os");
+    const dbPath = path.join(os.tmpdir(), `sqlite-exists-${Date.now()}.db`);
+    const a = new BetterSQLite3Adapter(dbPath);
+    try {
+      expect(await BetterSQLite3Adapter.databaseExists({ database: dbPath })).toBe(true);
+      expect(await a.databaseExists()).toBe(true);
+    } finally {
+      await a.close();
+      fs.rmSync(dbPath, { force: true });
+    }
   });
 
   it("database exists returns true for an in memory db", async () => {
+    expect(await BetterSQLite3Adapter.databaseExists({ database: ":memory:" })).toBe(true);
     const memAdapter = new BetterSQLite3Adapter(":memory:");
-    expect(memAdapter).toBeDefined();
+    expect(await memAdapter.databaseExists()).toBe(true);
     await memAdapter.close();
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -159,3 +159,27 @@ describe("SQLite3Adapter pragmas option", () => {
     expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"));
   });
 });
+
+describe("SQLite3 databaseExists", () => {
+  it("answers true for an in-memory adapter without connecting", async () => {
+    const a = new BetterSQLite3Adapter(":memory:");
+    expect(await a.databaseExists()).toBe(true);
+    await a.close();
+  });
+
+  it("answers from the file the driver opens, not a cached handle", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const os = await import("os");
+    const dbPath = path.join(os.tmpdir(), `sqlite-exists-instance-${Date.now()}.db`);
+    const a = new BetterSQLite3Adapter(dbPath);
+    try {
+      expect(await a.databaseExists()).toBe(true);
+      fs.rmSync(dbPath, { force: true });
+      expect(await a.databaseExists()).toBe(false);
+    } finally {
+      await a.close();
+      fs.rmSync(dbPath, { force: true });
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   ConnectionFailed,
   Deadlocked,
   LockWaitTimeout,
+  NoDatabaseError,
 } from "../errors.js";
 
 describe("AbstractAdapter connection lifecycle privates", () => {
@@ -83,5 +84,33 @@ describe("AbstractAdapter connection lifecycle privates", () => {
     a.checkVersion = () => void (called += 1);
     await a.configureConnection();
     expect(called).toBe(1);
+  });
+});
+
+describe("AbstractAdapter#databaseExists", () => {
+  it("proves the database by connecting, not by a cached handle", async () => {
+    const a = new AbstractAdapter();
+    // Never connected: Rails' `connect!` succeeds against a live database, so
+    // the answer is true even though `_connection` is still null.
+    expect((a as any)._connection).toBe(null);
+    expect(await a.databaseExists()).toBe(true);
+  });
+
+  it("returns false when connect! raises NoDatabaseError", async () => {
+    const a = new AbstractAdapter();
+    a.connectBang = async () => {
+      throw new NoDatabaseError("no such database");
+    };
+    // A stale cached handle must not make this answer true.
+    (a as any)._connection = {};
+    expect(await a.databaseExists()).toBe(false);
+  });
+
+  it("re-raises errors other than NoDatabaseError", async () => {
+    const a = new AbstractAdapter();
+    a.connectBang = async () => {
+      throw new ConnectionFailed("boom");
+    };
+    await expect(a.databaseExists()).rejects.toBeInstanceOf(ConnectionFailed);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
@@ -90,8 +90,6 @@ describe("AbstractAdapter connection lifecycle privates", () => {
 describe("AbstractAdapter#databaseExists", () => {
   it("proves the database by connecting, not by a cached handle", async () => {
     const a = new AbstractAdapter();
-    // Never connected: Rails' `connect!` succeeds against a live database, so
-    // the answer is true even though `_connection` is still null.
     expect((a as any)._connection).toBe(null);
     expect(await a.databaseExists()).toBe(true);
   });
@@ -101,7 +99,6 @@ describe("AbstractAdapter#databaseExists", () => {
     a.connectBang = async () => {
       throw new NoDatabaseError("no such database");
     };
-    // A stale cached handle must not make this answer true.
     (a as any)._connection = {};
     expect(await a.databaseExists()).toBe(false);
   });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -15,6 +15,7 @@ import {
   ConnectionNotEstablished,
   ConnectionNotDefined,
   ConnectionFailed,
+  NoDatabaseError,
   TransactionRollbackError,
   Deadlocked,
   LockWaitTimeout,
@@ -1969,8 +1970,41 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  isDatabaseExists(): boolean {
-    return this._connection !== null;
+  /**
+   * Does the database for this adapter exist? Mirrors Rails'
+   * `AbstractAdapter.database_exists?(config)` (abstract_adapter.rb:358):
+   * `new(config).database_exists?`.
+   *
+   * Deviation: the instance is disconnected before returning. Ruby lets the
+   * throw-away adapter's socket close when it is collected; JS has no such
+   * finalizer, so a probe that connected would leak the handle (and keep the
+   * event loop alive) forever. Mysql2Adapter's static already does this.
+   */
+  static async databaseExists(config: unknown): Promise<boolean> {
+    const ctor = this as unknown as new (config: unknown) => AbstractAdapter;
+    const adapter = new ctor(config);
+    try {
+      return await adapter.databaseExists();
+    } finally {
+      adapter.disconnectBang();
+    }
+  }
+
+  /**
+   * Mirrors Rails' `AbstractAdapter#database_exists?` (abstract_adapter.rb:362):
+   * prove the database is there by connecting to it, and read only
+   * `NoDatabaseError` as "it isn't". Reachability, not a cached handle — a
+   * never-connected adapter on a live database answers true, and a stale
+   * handle to a dropped database answers false.
+   */
+  async databaseExists(): Promise<boolean> {
+    try {
+      await this.connectBang();
+      return true;
+    } catch (error) {
+      if (error instanceof NoDatabaseError) return false;
+      throw error;
+    }
   }
 
   lockThread: boolean = false;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3766,10 +3766,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.reloadTypeMap();
   }
 
-  async databaseExists(name: string): Promise<boolean> {
-    return this.pgSchemaStatements().databaseExists(name);
-  }
-
   async indexes(tableName: string): Promise<IndexDefinition[]> {
     return this.pgSchemaStatements().indexes(tableName);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -569,14 +569,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // Database management
   // ---------------------------------------------------------------------------
 
-  async databaseExists(name: string): Promise<boolean> {
-    const rows = await this.pg.schemaQuery(
-      `SELECT COUNT(*) AS count FROM pg_database WHERE datname = $1`,
-      [name],
-    );
-    return Number(rows[0].count) > 0;
-  }
-
   async createDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
     const encoding = options.encoding ?? "utf8";
     let optionString = ` ENCODING = ${this.pg.quoteLiteral(encoding)}`;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1519,12 +1519,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * existence check has to ask about.
    */
   override async databaseExists(): Promise<boolean> {
-    if (this._memoryDatabase) return true;
-    try {
-      return await getFs().exists(this._filename);
-    } catch {
-      return false;
-    }
+    return this._memoryDatabase || (await getFs().exists(this._filename));
   }
 
   static newClient(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1493,10 +1493,35 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     }
   }
 
-  static databaseExists(config: { database?: string }): boolean {
+  /**
+   * Rails has no SQLite3-level `self.database_exists?` — the base's
+   * `new(config).database_exists?` suffices there because
+   * `SQLite3Adapter#initialize` does not open the file. trails' constructor
+   * connects eagerly (`this.connect()` above), which would CREATE the database
+   * it was asked about, so the class-level probe has to answer from the config
+   * instead of instantiating. The instance method below is the faithful port.
+   */
+  static override async databaseExists(config: { database?: string }): Promise<boolean> {
     if (!config.database || config.database === ":memory:") return true;
     try {
-      return getFs().existsSync(config.database);
+      return await getFs().exists(config.database);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Mirrors Rails' `SQLite3Adapter#database_exists?` (sqlite3_adapter.rb:135):
+   * `@config[:database] == ":memory:" || File.exist?(@config[:database].to_s)`.
+   * SQLite needs no connection to answer — the file either is there or isn't —
+   * so this overrides the base's `connect!` probe. `_filename` is the path the
+   * driver actually opens (the constructor expands it), which is what the
+   * existence check has to ask about.
+   */
+  override async databaseExists(): Promise<boolean> {
+    if (this._memoryDatabase) return true;
+    try {
+      return await getFs().exists(this._filename);
     } catch {
       return false;
     }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -149,6 +149,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "database_exists?",
+    "call": "exist?",
+    "reason": "Rails' File.exist? is spelled getFs().exists() in trails — same call, different name."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "dbconsole",
     "call": "database_cli",
     "reason": "Rails reads the cli name only to pass it to `find_cmd_and_exec` (sqlite3_adapter.rb:51); that PTY exec is Ruby-only and unported, so our `dbconsole` returns the arg list and never needs the lookup."


### PR DESCRIPTION
`AbstractAdapter#databaseExists` answered from a cached handle
(`this._connection !== null`), which is a different question than Rails asks: a
reachable database that has never been connected to answered `false`, and a
dropped database with a stale handle answered `true`.

## Changes

- `AbstractAdapter#databaseExists()` now ports Rails' body
  (`abstract_adapter.rb:362`): `connectBang()` → `true`, rescue
  `NoDatabaseError` → `false`, re-raise anything else. Signature is
  `Promise<boolean>` because `connect!`'s trails analogue is async; there were
  no callers of the old sync `isDatabaseExists`, so nothing rippled.
- `AbstractAdapter.databaseExists(config)` — the class-level probe
  (`abstract_adapter.rb:358`, `new(config).database_exists?`). It disconnects
  the throw-away instance before returning: Ruby closes the socket when the
  adapter is collected, JS has no such finalizer and would leak the handle.
  `Mysql2Adapter`'s existing static already did this.
- SQLite3 gains Rails' instance override (`sqlite3_adapter.rb:135`:
  `:memory:` or the file exists), on async fs. Its class-level probe stays
  config-based rather than inheriting the base: trails' SQLite3 constructor
  connects eagerly, so `new(config)` would **create** the database it was asked
  about. Documented at the call site.
- Dropped `PostgreSQLAdapter#databaseExists(name)` — a trails invention with no
  Rails counterpart, and incompatible with the base signature. The pg tests now
  go through the Rails-shaped class method, as
  `postgresql_adapter_test.rb:118-128` does.
- Dropped `PostgreSQLSchemaStatements#databaseExists(name)` with it: Rails'
  `postgresql/schema_statements.rb` has no `database_exists?`, and removing the
  adapter wrapper left it with no caller anywhere in the package.

## Tests

- `sqlite3-adapter.test.ts`: the two hollow `database exists ...` tests now
  actually call `databaseExists` (one assertion each, matching Rails' counts),
  plus the missing Rails case
  `database exists returns false when the database does not exist`, and the
  `SQLite3Adapter.database_exists?` assertion Rails makes in
  `database should get created when missing parent directories for database path`.
- `sqlite3-adapter.trails.test.ts`: TS-only coverage of the instance override —
  in-memory answers true without connecting, and a deleted file flips the answer
  to false while the handle is still open.
- `postgresql-adapter.test.ts`: both `database exists ...` tests use the class
  method with a config (host/user from the suite URL, since trails has no
  configuration registry to inherit them from).
- `abstract-adapter.lifecycle.test.ts`: never-connected → true, stale handle +
  `NoDatabaseError` → false, other errors re-raised. All three fail on the
  baseline body.

## Parity deltas

- `api:compare`: arity 7545/7625 → 7547/7627; every other total flat.
- `test:compare`: matched flat at 14876/22203, assertion-count-mismatch
  1988 → 1987.
- Wide call ratchet: one new entry, `database_exists?` → `exist?` on
  `sqlite3-adapter.ts` — Rails' `File.exist?` is spelled `getFs().exists()`
  here. Baselined with that reason; the unreviewed high-water mark is untouched.

Verified locally on all three lanes (sqlite3 + abstract in the default lane, pg
and mysql2 against an isolated compose stack).

Closes-story: abstract-database-exists-body-diverges-from-connect-rescue
