### PR TITLE
refactor(actionview): drop the is prefix from templateExists

### DIFF
--- a/packages/actionview/src/view-paths.trails.test.ts
+++ b/packages/actionview/src/view-paths.trails.test.ts
@@ -9,9 +9,9 @@ import {
   detailsForLookup,
   formats,
   isAnyTemplates,
-  isTemplateExists,
   locale,
   lookupContext,
+  templateExists,
   type ViewPaths,
   type ViewPathsClass,
 } from "./view-paths.js";
@@ -35,7 +35,7 @@ class BaseController implements ViewPaths {
   detailsForLookup = detailsForLookup;
   formats = formats;
   locale = locale;
-  isTemplateExists = isTemplateExists;
+  templateExists = templateExists;
   appendViewPath = appendViewPath;
   isAnyTemplates = isAnyTemplates;
 }
@@ -91,7 +91,7 @@ describe("ViewPaths", () => {
     PostsController.viewPaths([]);
     const controller = new PostsController();
 
-    expect(controller.isTemplateExists("index", ["posts"])).toBe(false);
+    expect(controller.templateExists("index", ["posts"])).toBe(false);
     expect(controller.isAnyTemplates("index", ["posts"])).toBe(false);
   });
 
@@ -107,7 +107,7 @@ describe("ViewPaths", () => {
 
     controller.appendViewPath(resolver);
 
-    expect(controller.isTemplateExists("index", ["posts"])).toBe(true);
-    expect(controller.isTemplateExists("missing", ["posts"])).toBe(false);
+    expect(controller.templateExists("index", ["posts"])).toBe(true);
+    expect(controller.templateExists("missing", ["posts"])).toBe(false);
   });
 });

--- a/packages/actionview/src/view-paths.ts
+++ b/packages/actionview/src/view-paths.ts
@@ -120,7 +120,7 @@ export function prependViewPath(this: ViewPaths, path: ViewPathsInput): void {
     .prependViewPaths(ClassMethods._buildViewPaths.call(this.constructor, path).toArray());
 }
 
-export function isTemplateExists(
+export function templateExists(
   this: ViewPaths,
   name: string,
   prefixes: ReadonlyArray<string> = [],


### PR DESCRIPTION
Renames `isTemplateExists` → `templateExists` in `packages/actionview/src/view-paths.ts`, the last `*_exists?` predicate in the repo still carrying the `is` prefix (ports ActionView's `template_exists?`). Follows the sweep in #5736 / #5752.

Checked for a pre-existing bare `templateExists` in actionview: the only one is `AbstractRenderer#templateExists` (`renderer/abstract-renderer.ts:251`), which is not in the `ViewPaths` host hierarchy — it is an independent delegate to `lookupContext.isExists` with identical behaviour, so there is no dead override to reconcile.

api:compare surface unchanged.

Closes-story: actionview-template-exists-still-is-prefixed
