### PR TITLE
fix(tasks): build every DatabaseTasks Migrator from its dbConfig

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
@@ -8,10 +8,6 @@ import { Base } from "../base.js";
 import type { MigrationProxy } from "../migration.js";
 import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
 
-// Rails builds every migrator from the pool (`migration_connection_pool.migration_context`),
-// so `use_metadata_table: false` suppresses the `ar_internal_metadata` stamp no matter which
-// task drove the migration. The fan-out tasks (`migrate_all` / `prepare_all`) used to build
-// their migrators bare, which stamped the table anyway.
 describe("DatabaseTasksMigrateAllMetadataTest", () => {
   const dirs: string[] = [];
 

--- a/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { DatabaseTasks } from "./database-tasks.js";
+import { DatabaseConfigurations } from "../database-configurations.js";
+import { Base } from "../base.js";
+import type { MigrationProxy } from "../migration.js";
+import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
+
+// Rails builds every migrator from the pool (`migration_connection_pool.migration_context`),
+// so `use_metadata_table: false` suppresses the `ar_internal_metadata` stamp no matter which
+// task drove the migration. The fan-out tasks (`migrate_all` / `prepare_all`) used to build
+// their migrators bare, which stamped the table anyway.
+describe("DatabaseTasksMigrateAllMetadataTest", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    DatabaseTasks.registerMigrations([]);
+    DatabaseTasks.databaseConfiguration = null;
+    try {
+      Base.removeConnection();
+    } catch {
+      void 0;
+    }
+    for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true });
+  });
+
+  const migration = (version: string, name: string): MigrationProxy => ({
+    version,
+    name,
+    migration: () =>
+      anonymousMigration(
+        name,
+        version,
+        async () => {},
+        async () => {},
+      ),
+  });
+
+  async function setupConfigs(): Promise<void> {
+    const dir = await mkdtemp(join(tmpdir(), "trails-migrate-all-meta-"));
+    dirs.push(dir);
+    const env = DatabaseTasks.env;
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      [env]: {
+        primary: {
+          adapter: "sqlite3",
+          database: join(dir, "primary.sqlite3"),
+          pool: 1,
+          useMetadataTable: false,
+        },
+        animals: {
+          adapter: "sqlite3",
+          database: join(dir, "animals.sqlite3"),
+          pool: 1,
+          useMetadataTable: false,
+        },
+      },
+    });
+    DatabaseTasks.registerMigrations([migration("1", "CreateNothing")]);
+  }
+
+  async function metadataTablesExist(): Promise<boolean[]> {
+    const results: boolean[] = [];
+    for (const config of DatabaseTasks.configsFor(DatabaseTasks.env)) {
+      await DatabaseTasks.withTemporaryConnection(config, async (adapter) => {
+        results.push(await adapter.tableExists("ar_internal_metadata"));
+      });
+    }
+    return results;
+  }
+
+  it("migrate_all does not create ar_internal_metadata when use_metadata_table is false", async () => {
+    await setupConfigs();
+    await DatabaseTasks.migrateAll();
+    expect(await metadataTablesExist()).toEqual([false, false]);
+  });
+
+  it("prepare_all does not create ar_internal_metadata when use_metadata_table is false", async () => {
+    await setupConfigs();
+    const dumpWas = DatabaseTasks.dumpSchemaAfterMigration;
+    DatabaseTasks.dumpSchemaAfterMigration = false;
+    try {
+      await DatabaseTasks.prepareAll();
+    } finally {
+      DatabaseTasks.dumpSchemaAfterMigration = dumpWas;
+    }
+    expect(await metadataTablesExist()).toEqual([false, false]);
+  });
+});

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -326,12 +326,6 @@ export class DatabaseTasks {
     return this._migrationsByConfig.get(this._migrationsKey(dbConfig)) ?? this._migrations;
   }
 
-  // Rails never builds a migrator by hand: it goes through
-  // `migration_connection_pool.migration_context` (`connection_pool.rb:294-296`),
-  // so the pool's db_config always governs — `InternalMetadata#enabled?` reads
-  // `pool.db_config.use_metadata_table` and the environment stamp comes from the
-  // config, not from the process env. Building every migrator here keeps that
-  // invariant instead of letting Migrator fall back to TRAILS_ENV / NODE_ENV.
   private static async _migratorFor(
     adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
     dbConfig: DatabaseConfig,

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -326,6 +326,23 @@ export class DatabaseTasks {
     return this._migrationsByConfig.get(this._migrationsKey(dbConfig)) ?? this._migrations;
   }
 
+  // Rails never builds a migrator by hand: it goes through
+  // `migration_connection_pool.migration_context` (`connection_pool.rb:294-296`),
+  // so the pool's db_config always governs — `InternalMetadata#enabled?` reads
+  // `pool.db_config.use_metadata_table` and the environment stamp comes from the
+  // config, not from the process env. Building every migrator here keeps that
+  // invariant instead of letting Migrator fall back to TRAILS_ENV / NODE_ENV.
+  private static async _migratorFor(
+    adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
+    dbConfig: DatabaseConfig,
+  ): Promise<import("../migration.js").Migrator> {
+    const { Migrator } = await import("../migration.js");
+    return new Migrator(adapter, this._migrationsFor(dbConfig), {
+      environment: dbConfig.envName,
+      internalMetadataEnabled: dbConfig.useMetadataTable,
+    });
+  }
+
   static async migrate(
     version?: number | string,
     { skipInitialize = false }: { skipInitialize?: boolean } = {},
@@ -334,7 +351,7 @@ export class DatabaseTasks {
     const effectiveVersion = typeof raw === "string" ? raw.trim() || null : raw;
     this.checkTargetVersion(effectiveVersion ?? undefined);
 
-    const { Migration, Migrator } = await import("../migration.js");
+    const { Migration } = await import("../migration.js");
     const scope = getEnv("SCOPE");
     // Rails: `verbose_was, Migration.verbose = Migration.verbose, verbose?`
     // (`database_tasks.rb:264`), restored in the ensure block at `:282`.
@@ -348,10 +365,7 @@ export class DatabaseTasks {
       // Rails builds the migrator from `migration_connection_pool.migration_context`
       // (`connection_pool.rb:294-299`), i.e. from the pool's own
       // `db_config.migrations_paths` — not from a process-global list.
-      const migrator = new Migrator(adapter, this._migrationsFor(dbConfig), {
-        environment: dbConfig.envName,
-        internalMetadataEnabled: dbConfig.useMetadataTable,
-      });
+      const migrator = await this._migratorFor(adapter, dbConfig);
       // Rails block: `version.blank? ? (scope.blank? || scope == m.scope) : m.version == version`
       // `version` is the *method parameter* (explicit arg), NOT ENV["VERSION"].
       // The rake task always calls migrate() with no arg, so version is nil → scope filter only.
@@ -411,14 +425,10 @@ export class DatabaseTasks {
     direction: "rollback" | "forward",
     steps: number,
   ): Promise<void> {
-    const { Migrator } = await import("../migration.js");
     const pool = await this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
     const dbConfig = pool.dbConfig;
-    const migrator = new Migrator(adapter, this._migrationsFor(dbConfig), {
-      environment: dbConfig.envName,
-      internalMetadataEnabled: dbConfig.useMetadataTable,
-    });
+    const migrator = await this._migratorFor(adapter, dbConfig);
     await migrator[direction](steps);
     adapter.schemaCache?.clear();
   }
@@ -1013,8 +1023,7 @@ export class DatabaseTasks {
     this._baseClass = Base;
     const pool = Base.connectionPool();
     const adapter = await pool.leaseConnection();
-    const { Migrator } = await import("../migration.js");
-    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
+    const migrator = await this._migratorFor(adapter, pool.dbConfig);
     // Mirrors database_tasks.rb:302-305: abort unless schema_migrations exists.
     if (!(await migrator.schemaMigrationTableExists())) {
       throw new Error("Schema migrations table does not exist yet.");
@@ -1046,8 +1055,7 @@ export class DatabaseTasks {
   static async currentVersion(): Promise<number> {
     const pool = await this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
-    const { Migrator } = await import("../migration.js");
-    const migrator = new Migrator(adapter, this._migrationsFor(pool.dbConfig));
+    const migrator = await this._migratorFor(adapter, pool.dbConfig);
     return migrator.currentVersionReadOnly();
   }
 
@@ -1077,8 +1085,7 @@ export class DatabaseTasks {
     for (const [version, dbConfigs] of sorted) {
       for (const dbConfig of dbConfigs) {
         await this.withTemporaryConnection(dbConfig, async (adapter) => {
-          const { Migrator } = await import("../migration.js");
-          const migrator = new Migrator(adapter, this._migrationsFor(dbConfig));
+          const migrator = await this._migratorFor(adapter, dbConfig);
           await migrator.migrate(version ?? null);
           adapter.schemaCache?.clear();
         });
@@ -1109,11 +1116,7 @@ export class DatabaseTasks {
         for (const dbConfig of dbConfigs) {
           if (!dumpDbConfigs.includes(dbConfig)) dumpDbConfigs.push(dbConfig);
           await this.withTemporaryPool(dbConfig, async (pool) => {
-            const { Migrator } = await import("../migration.js");
-            const migrator = new Migrator(
-              await pool.leaseConnection(),
-              this._migrationsFor(dbConfig),
-            );
+            const migrator = await this._migratorFor(await pool.leaseConnection(), dbConfig);
             await migrator.migrate(version ?? null);
           });
         }
@@ -1137,10 +1140,9 @@ export class DatabaseTasks {
     const dbConfigsWithVersions = new Map<string | number, DatabaseConfig[]>();
     const env = this._normalizeEnv(environment);
     const targetVersion = this.targetVersion();
-    const { Migrator } = await import("../migration.js");
     for (const config of this.configsFor(env)) {
       await this.withTemporaryPool(config, async (pool) => {
-        const migrator = new Migrator(await pool.leaseConnection(), this._migrationsFor(config));
+        const migrator = await this._migratorFor(await pool.leaseConnection(), config);
         const versionsToRun = await migrator.pendingMigrationVersions();
         for (const version of versionsToRun) {
           if (targetVersion !== null && targetVersion !== Number(version)) continue;


### PR DESCRIPTION
`DatabaseTasks` built its `Migrator` instances by hand and most call sites passed no
options, silently dropping the config's `useMetadataTable` and stamping
`ar_internal_metadata.environment` from `TRAILS_ENV` / `NODE_ENV` instead of the
config's own env. Rails never has this gap: the migrator always comes from
`migration_connection_pool.migration_context` (`connection_pool.rb:294-296`), and
`InternalMetadata#enabled?` reads `pool.db_config.use_metadata_table`, so the config
always governs.

PR #5616 converged `migrate` and `_stepMigrations`. The remaining six sites are here.

## Changes

- New private `_migratorFor(adapter, dbConfig)` helper that builds every migrator with
  `environment: dbConfig.envName` / `internalMetadataEnabled: dbConfig.useMetadataTable`.
- All sites routed through it: the two writing ones (`migrateAll`, `prepareAll`) and the
  read-only ones (`migrateStatus`, `currentVersion`, `dbConfigsWithVersions`' pending
  scan), so the invariant holds uniformly rather than by case analysis.
- The `migrate` / `_stepMigrations` sites #5616 converged now share the helper too.

## Regression coverage

`database-tasks-migrate-all-metadata.trails.test.ts`: a two-database config with
`useMetadataTable: false`, migrated through `migrateAll` and through `prepareAll`,
leaves no `ar_internal_metadata` table. Both tests fail on baseline (the table is
created) and pass with the fix.

Closes-story: database-tasks-migrator-options-from-db-config
