### PR TITLE
refactor(tasks): drop the databaseConfiguration gate from DatabaseTasks.rollback

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -58,4 +58,34 @@ describe("DatabaseTasksRollbackTest", () => {
     expect(reverted).toEqual(["PrimaryOnly"]);
     expect(await schemaMigration.versions()).toEqual([]);
   });
+
+  it("rolls back off the ambient pool when no configurations are loaded", async () => {
+    const reverted: string[] = [];
+    DatabaseTasks.registerMigrations([
+      {
+        version: "1",
+        name: "Ambient",
+        migration: () =>
+          anonymousMigration(
+            "Ambient",
+            "1",
+            async () => {},
+            async () => {
+              reverted.push("Ambient");
+            },
+          ),
+      },
+    ]);
+
+    DatabaseTasks.databaseConfiguration = null;
+    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    const schemaMigration = new SchemaMigration(await Base.connectionPool().leaseConnection());
+    await schemaMigration.createTable();
+    await schemaMigration.createVersion("1");
+
+    await DatabaseTasks.rollback();
+
+    expect(reverted).toEqual(["Ambient"]);
+    expect(await schemaMigration.versions()).toEqual([]);
+  });
 });

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -389,11 +389,19 @@ export class DatabaseTasks {
     }
   }
 
-  /** Roll back the last N migrations (default 1). Mirrors `db:rollback`. */
+  /**
+   * @internal Rails has no `DatabaseTasks.rollback`; `rake db:rollback`
+   * (`railties/databases.rake`) inlines
+   * `Base.connection_pool.migration_context.rollback(step)`. We keep the body
+   * here rather than in the CLI because `MigrationContext` is not ported — the
+   * migrator is built from the pool directly. Like the rake task it takes the
+   * ambient pool with no `configurations` lookup and no early return.
+   */
   static async rollback(steps: number = 1): Promise<void> {
     await this._stepMigrations("rollback", steps);
   }
 
+  /** @internal Same deviation as {@link rollback}, for `rake db:forward`. */
   static async forward(steps: number = 1): Promise<void> {
     await this._stepMigrations("forward", steps);
   }
@@ -402,8 +410,6 @@ export class DatabaseTasks {
     direction: "rollback" | "forward",
     steps: number,
   ): Promise<void> {
-    if (!this.databaseConfiguration) return;
-    if (this.configsFor(this._normalizeEnv()).length === 0) return;
     const { Migrator } = await import("../migration.js");
     const pool = await this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -391,17 +391,18 @@ export class DatabaseTasks {
 
   /**
    * @internal Rails has no `DatabaseTasks.rollback`; `rake db:rollback`
-   * (`railties/databases.rake`) inlines
-   * `Base.connection_pool.migration_context.rollback(step)`. We keep the body
-   * here rather than in the CLI because `MigrationContext` is not ported — the
-   * migrator is built from the pool directly. Like the rake task it takes the
-   * ambient pool with no `configurations` lookup and no early return.
+   * (`railties/databases.rake:269`) inlines
+   * `DatabaseTasks.migration_connection_pool.migration_context.rollback(step)`.
+   * The body lives here rather than in the CLI because `MigrationContext` is
+   * not ported, so the migrator is built from the pool directly — otherwise
+   * this is the rake task: the pool it is handed, no `configurations` lookup
+   * and no early return.
    */
   static async rollback(steps: number = 1): Promise<void> {
     await this._stepMigrations("rollback", steps);
   }
 
-  /** @internal Same deviation as {@link rollback}, for `rake db:forward`. */
+  /** @internal Same deviation as {@link rollback}, for `db:forward` (`databases.rake:279`). */
   static async forward(steps: number = 1): Promise<void> {
     await this._stepMigrations("forward", steps);
   }


### PR DESCRIPTION
`rake db:rollback` (`vendor/rails/activerecord/lib/active_record/railties/databases.rake:269`) is:

```ruby
ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.migration_context.rollback(step)
```

— straight off the migration pool, no `configurations` lookup and no early return, the same conclusion #5473 reached for `migrate`. `db:forward` (`:279`) is the same line with `forward`.

`DatabaseTasks._stepMigrations` (backing `rollback` and `forward`) already resolved its pool through `migrationConnectionPool()`, so the `if (!this.databaseConfiguration) return` / `configsFor(env).length === 0` guards were pure downside: with a live connection but no loaded `configurations`, `rollback` silently no-op'd. Both are gone.

`rollback`/`forward` stay on `DatabaseTasks` rather than moving into the CLI because `MigrationContext` isn't ported — the migrator is built from the pool here. That's recorded as an `@internal` deviation note on both methods, cited against `databases.rake`. `ar db:rollback` (`db-tasks.ts:123-141`) already wraps the call in `withEnvironmentConnection`, i.e. the same ambient-pool treatment `dbMigrate` got; no change needed there.

Tests: `db-migrate.test.ts`'s `db:rollback` cases pass unchanged; added an ambient-pool case to `database-tasks-rollback.trails.test.ts` that fails on baseline (rollback returns without reverting) and passes here.

Closes-story: database-tasks-rollback-drops-database-configuration-gate
