### PR TITLE
refactor(migration): drop pre-built instance exports from migration fixtures

### DIFF
--- a/packages/activerecord-cli/src/__e2e__/helpers.ts
+++ b/packages/activerecord-cli/src/__e2e__/helpers.ts
@@ -6,7 +6,7 @@ import { join } from "path";
 export const MIGRATION_BODY = `\
 import { Migration } from "@blazetrails/activerecord";
 
-export default class CreateUsers extends Migration {
+export class AddUsersTable extends Migration {
   async up() {
     await this.connection.createTable("users", (t) => {
       t.string("name");

--- a/packages/activerecord-cli/src/generate-migration.test.ts
+++ b/packages/activerecord-cli/src/generate-migration.test.ts
@@ -28,7 +28,7 @@ describe("ArGenerateMigrationTest", () => {
 
   it("renders add_*_to_* migration with addColumn calls; tableizes singular table segment", () => {
     const src = renderMigration("add_name_to_user", [{ name: "name", type: "string" }]);
-    expect(src).toContain("export default class AddNameToUser extends Migration");
+    expect(src).toContain("export class AddNameToUser extends Migration");
     // table segment "user" → tableize → "users"
     expect(src).toContain('this.addColumn("users", "name", "string")');
   });

--- a/packages/activerecord-cli/src/generate-migration.ts
+++ b/packages/activerecord-cli/src/generate-migration.ts
@@ -142,7 +142,7 @@ export function renderMigration(snakeName: string, fields: FieldSpec[]): string 
   const className = camelize(snakeName);
   return (
     `import { Migration } from "@blazetrails/activerecord";\n\n` +
-    `export default class ${className} extends Migration {\n` +
+    `export class ${className} extends Migration {\n` +
     `  async change(): Promise<void> {\n` +
     `${renderBody(snakeName, fields)}\n` +
     `  }\n` +

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2062,16 +2062,16 @@ export interface MigrationProxy {
 
 /**
  * Mirrors: ActiveRecord::MigrationProxy#load_migration (`migration.rb:1195`) —
- * `name.constantize.new(name, version)`. The module's named export is the
- * migration class; the legacy `default` export is a pre-built instance that
- * cannot carry the proxy's identity, so it is only the fallback.
+ * `name.constantize.new(name, version)`. The module's export named after the
+ * migration is the class; the instance is always constructed here so it
+ * carries the proxy's name and version.
  */
 async function loadMigrationFrom(
   mod: Record<string, unknown>,
   name: string,
   version: string,
 ): Promise<Migration> {
-  const exported = mod[name] ?? mod.default;
+  const exported = mod[name];
   if (typeof exported === "function") {
     return new (exported as new (name?: string, version?: string) => Migration)(name, version);
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2075,11 +2075,7 @@ async function loadMigrationFrom(
   if (typeof exported === "function") {
     return new (exported as new (name?: string, version?: string) => Migration)(name, version);
   }
-  if (exported instanceof Migration) return exported;
-  throw new Error(
-    `Migration ${name} must export a Migration class named "${name}" ` +
-      `(or a Migration instance as the default export)`,
-  );
+  throw new Error(`Migration ${name} must export a Migration class named "${name}"`);
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/migrations/10_urban/9_add_expressions.ts
+++ b/packages/activerecord/src/test-helpers/migrations/10_urban/9_add_expressions.ts
@@ -12,5 +12,3 @@ export class AddExpressions extends Migration {
     await this.dropTable("expressions");
   }
 }
-
-export default new AddExpressions();

--- a/packages/activerecord/src/test-helpers/migrations/future_timestamp/99991231235959_future_timestamp_migration.ts
+++ b/packages/activerecord/src/test-helpers/migrations/future_timestamp/99991231235959_future_timestamp_migration.ts
@@ -5,5 +5,3 @@ export class FutureTimestampMigration extends Migration {
 
   async down(): Promise<void> {}
 }
-
-export default new FutureTimestampMigration();

--- a/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/20210716122844_add_people_description.ts
+++ b/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/20210716122844_add_people_description.ts
@@ -10,5 +10,3 @@ export class AddPeopleDescription extends Migration {
     await this.removeColumn("people", "description");
   }
 }
-
-export default new AddPeopleDescription();

--- a/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/20210716123013_add_people_number_of_legs.ts
+++ b/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/20210716123013_add_people_number_of_legs.ts
@@ -10,5 +10,3 @@ export class AddPeopleNumberOfLegs extends Migration {
     await this.removeColumn("people", "number_of_legs");
   }
 }
-
-export default new AddPeopleNumberOfLegs();

--- a/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/230_add_people_hobby.ts
+++ b/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/230_add_people_hobby.ts
@@ -10,5 +10,3 @@ export class AddPeopleHobby extends Migration {
     await this.removeColumn("people", "hobby");
   }
 }
-
-export default new AddPeopleHobby();

--- a/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/231_add_people_last_name.ts
+++ b/packages/activerecord/src/test-helpers/migrations/old_and_new_versions/231_add_people_last_name.ts
@@ -10,5 +10,3 @@ export class AddPeopleLastName extends Migration {
     await this.removeColumn("people", "last_name");
   }
 }
-
-export default new AddPeopleLastName();

--- a/packages/activerecord/src/test-helpers/migrations/to_copy_with_timestamps/20090101010101_people_have_hobbies.ts
+++ b/packages/activerecord/src/test-helpers/migrations/to_copy_with_timestamps/20090101010101_people_have_hobbies.ts
@@ -10,5 +10,3 @@ export class PeopleHaveHobbies extends Migration {
     await this.removeColumn("people", "hobbies");
   }
 }
-
-export default new PeopleHaveHobbies();

--- a/packages/activerecord/src/test-helpers/migrations/to_copy_with_timestamps/20090101010202_people_have_descriptions.ts
+++ b/packages/activerecord/src/test-helpers/migrations/to_copy_with_timestamps/20090101010202_people_have_descriptions.ts
@@ -10,5 +10,3 @@ export class PeopleHaveDescriptions extends Migration {
     await this.removeColumn("people", "description");
   }
 }
-
-export default new PeopleHaveDescriptions();

--- a/packages/activerecord/src/test-helpers/migrations/valid/1_valid_people_have_last_names.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid/1_valid_people_have_last_names.ts
@@ -10,5 +10,3 @@ export class ValidPeopleHaveLastNames extends Migration {
     await this.removeColumn("people", "last_name");
   }
 }
-
-export default new ValidPeopleHaveLastNames();

--- a/packages/activerecord/src/test-helpers/migrations/valid/2_we_need_reminders.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid/2_we_need_reminders.ts
@@ -13,5 +13,3 @@ export class WeNeedReminders extends Migration {
     await this.dropTable("reminders");
   }
 }
-
-export default new WeNeedReminders();

--- a/packages/activerecord/src/test-helpers/migrations/valid/3_innocent_jointable.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid/3_innocent_jointable.ts
@@ -13,5 +13,3 @@ export class InnocentJointable extends Migration {
     await this.dropTable("people_reminders");
   }
 }
-
-export default new InnocentJointable();

--- a/packages/activerecord/src/test-helpers/migrations/valid_with_subdirectories/1_valid_people_have_last_names.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid_with_subdirectories/1_valid_people_have_last_names.ts
@@ -10,5 +10,3 @@ export class ValidPeopleHaveLastNames extends Migration {
     await this.removeColumn("people", "last_name");
   }
 }
-
-export default new ValidPeopleHaveLastNames();

--- a/packages/activerecord/src/test-helpers/migrations/valid_with_subdirectories/sub/2_we_need_reminders.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid_with_subdirectories/sub/2_we_need_reminders.ts
@@ -13,5 +13,3 @@ export class WeNeedReminders extends Migration {
     await this.dropTable("reminders");
   }
 }
-
-export default new WeNeedReminders();

--- a/packages/activerecord/src/test-helpers/migrations/valid_with_subdirectories/sub1/3_innocent_jointable.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid_with_subdirectories/sub1/3_innocent_jointable.ts
@@ -13,5 +13,3 @@ export class InnocentJointable extends Migration {
     await this.dropTable("people_reminders");
   }
 }
-
-export default new InnocentJointable();

--- a/packages/activerecord/src/test-helpers/migrations/valid_with_timestamps/20100101010101_valid_with_timestamps_people_have_last_names.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid_with_timestamps/20100101010101_valid_with_timestamps_people_have_last_names.ts
@@ -10,5 +10,3 @@ export class ValidWithTimestampsPeopleHaveLastNames extends Migration {
     await this.removeColumn("people", "last_name");
   }
 }
-
-export default new ValidWithTimestampsPeopleHaveLastNames();

--- a/packages/activerecord/src/test-helpers/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.ts
@@ -13,5 +13,3 @@ export class ValidWithTimestampsWeNeedReminders extends Migration {
     await this.dropTable("reminders");
   }
 }
-
-export default new ValidWithTimestampsWeNeedReminders();

--- a/packages/activerecord/src/test-helpers/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.ts
+++ b/packages/activerecord/src/test-helpers/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.ts
@@ -13,5 +13,3 @@ export class ValidWithTimestampsInnocentJointable extends Migration {
     await this.dropTable("people_reminders");
   }
 }
-
-export default new ValidWithTimestampsInnocentJointable();


### PR DESCRIPTION
Rails' migration files define only the class; `MigrationProxy#load_migration`
(`vendor/rails/activerecord/lib/active_record/migration.rb:1195-1199`) does
`load(...)` then `name.constantize.new(name, version)` — the instance is built
by the proxy, carrying the proxy's name/version, never by the file.

- Removed `export default new Foo();` from the 17 migration fixtures under
  `test-helpers/migrations/`, leaving only the class export.
- `loadMigrationFrom` no longer accepts a pre-built `Migration` instance, and
  resolves the class by name only (Rails' `constantize`) rather than falling
  back to the `default` export; it always constructs `new Klass(name, version)`.

- `activerecord-cli`'s `generate:migration` template emitted `export default
  class Foo` and its E2E fixture body a `CreateUsers` class written into a
  `..._add_users_table.ts` file; both now use a named export whose class name
  matches the migration name, which is what `constantize` resolves. (Caught by
  CI: the CLI E2E `db:migrate` step was the only remaining `default` consumer.)

`migrator.test.ts`, `migration.test.ts` and `multi-db-migrator.test.ts` pass
unchanged, as does `schema-file-generator.test.ts` (the other user of default
exports, which is unrelated).

Closes-story: migration-fixtures-export-prebuilt-instance-not-class
