### PR TITLE
chore(migration): ratify the joinTableName inline copy of deriveJoinTableName

### DIFF
--- a/packages/activerecord/src/migration/join-table.test.ts
+++ b/packages/activerecord/src/migration/join-table.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { findJoinTableName, joinTableName } from "./join-table.js";
+import { deriveJoinTableName } from "../model-schema.js";
 
 describe("JoinTable#joinTableName", () => {
   it("sorts table names alphabetically", () => {
@@ -15,6 +16,22 @@ describe("JoinTable#joinTableName", () => {
 
   it("handles plain names without common prefix", () => {
     expect(joinTableName("users", "roles")).toBe("roles_users");
+  });
+});
+
+describe("JoinTable#joinTableName duplication guard", () => {
+  const cases: ReadonlyArray<readonly [string, string]> = [
+    ["assemblies", "parts"],
+    ["parts", "assemblies"],
+    ["catalog_categories", "catalog_products"],
+    ["users", "roles"],
+    ["music_artists", "music_records"],
+    ["music.artists", "music.records"],
+    ["public.users", "posts"],
+  ];
+
+  it.each(cases)("matches deriveJoinTableName for (%s, %s)", (table1, table2) => {
+    expect(joinTableName(table1, table2)).toBe(deriveJoinTableName(table1, table2));
   });
 });
 

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -16,13 +16,27 @@ export function findJoinTableName(
 /**
  * Rails' `join_table_name` delegates: `ModelSchema.derive_join_table_name(...)`
  * (join_table.rb:12). This port deliberately keeps its own copy of those three
- * lines instead. This module is a leaf — nothing else imports — and adding the
- * `model-schema.js` edge pulls that module's whole transitive graph in wherever
- * join-table is first imported, which reorders initialization enough that
- * `base.ts`'s top-level `extend(Base, { belongsTo: _Associations.belongsTo })`
- * runs against an uninitialized binding. `scripts/test-deps/adapter-graph-import-tdz.test.ts`
- * guards exactly that. `model-schema.ts#deriveJoinTableName` is the canonical
- * definition and stays byte-identical to this one.
+ * lines instead, and that duplication is ratified rather than pending.
+ *
+ * This module must stay import-leaf. It is imported from deep inside the model
+ * graph — `reflection.ts`, `associations.ts` and the abstract adapter's
+ * `schema-statements.ts` — so adding the `model-schema.js` edge pulls that
+ * module's transitive graph, including `connection-handling.js`, in ahead of
+ * `base.ts`. The delegation was re-attempted and re-measured on 2026-07-31:
+ * entering the graph through `SchemaStatements` then crashes at `base.ts`'s
+ * top-level `extend(Base, ConnectionHandling.ClassMethods)` with
+ * `TypeError: Cannot convert undefined or null to object`
+ * (activesupport `include.ts:209`), because the `ConnectionHandling` namespace
+ * is still mid-initialization. `scripts/test-deps/adapter-graph-import-tdz.test.ts`
+ * is the only thing that catches it — typecheck, lint and every AR suite pass
+ * while it is broken.
+ *
+ * The constraint is a property of `base.ts`'s eager module-level `extend()`
+ * wiring, not of this file; until that wiring stops running at module-evaluation
+ * time, nothing reaching the model graph can be imported here.
+ * `model-schema.ts#deriveJoinTableName` remains the canonical definition, and
+ * `join-table.test.ts` pins the two implementations to identical output so the
+ * copy cannot drift.
  *
  * @internal
  */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/join-table.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/join-table.json
@@ -4,6 +4,6 @@
     "tsFile": "migration/join-table.ts",
     "rubyName": "join_table_name",
     "call": "derive_join_table_name",
-    "reason": "Verified (RFC 0072 arity sweep): Rails delegates to ModelSchema.derive_join_table_name; this module must stay import-leaf — the model-schema.js edge reorders module init and trips scripts/test-deps/adapter-graph-import-tdz.test.ts — so it inlines the identical three lines. See the comment on joinTableName."
+    "reason": "Ratified permanent deviation (re-measured 2026-07-31, story migration-join-table-delegate-to-derive-join-table-name). Rails delegates to ModelSchema.derive_join_table_name; migration/join-table.ts must stay import-leaf because it is imported from deep inside the model graph (reflection.ts, associations.ts, connection-adapters/abstract/schema-statements.ts). Adding the model-schema.js edge pulls connection-handling.js in ahead of base.ts, so entering the graph via SchemaStatements crashes at base.ts's top-level `extend(Base, ConnectionHandling.ClassMethods)` with `TypeError: Cannot convert undefined or null to object` — caught only by scripts/test-deps/adapter-graph-import-tdz.test.ts. The blocker is base.ts's eager module-level extend() wiring; the delegation cannot land until that stops running at module-evaluation time. The inlined copy is pinned to deriveJoinTableName by a drift guard in migration/join-table.test.ts."
   }
 ]


### PR DESCRIPTION
## Summary

The story asked for `joinTableName` to delegate to `deriveJoinTableName`, **or** for
the duplication to be ratified with a written decision that the import-order
constraint is permanent. I re-attempted the delegation and it still fails, so this
PR takes the second branch.

## What was measured

Adding `import { deriveJoinTableName } from "../model-schema.js"` to
`packages/activerecord/src/migration/join-table.ts` makes
`scripts/test-deps/adapter-graph-import-tdz.test.ts` fail at collection time:

```
TypeError: Cannot convert undefined or null to object
 ❯ extend packages/activesupport/src/include.ts:209:14
 ❯ packages/activerecord/src/base.ts:4802:1
 ❯ packages/activerecord/src/schema-migration.ts:8:1
```

`base.ts:4802` is `extend(Base, ConnectionHandling.ClassMethods)`. `model-schema.ts`
imports `connection-handling.js`, and `join-table.ts` is imported from deep inside
the model graph (`reflection.ts`, `associations.ts`,
`connection-adapters/abstract/schema-statements.ts`), so the new edge pulls
`connection-handling.js` in ahead of `base.ts` and `base.ts`'s top-level `extend()`
reads a namespace that is still mid-initialization. Typecheck, lint and every AR
suite pass while this is broken — the TDZ test is the only guard.

The blocker is `base.ts`'s eager module-level `extend()` wiring, not this file. The
delegation cannot land until that wiring stops running at module-evaluation time,
which is a separate, much wider change.

## Changes

- `migration/join-table.ts` — the JSDoc on `joinTableName` now records the re-measurement,
  the exact failure, why the module must stay import-leaf, and the condition that
  would unblock the delegation.
- `call-mismatches-wide-exclude/.../join-table.json` — the reason is upgraded from
  "verified" to a ratified decision carrying the same detail.
- `migration/join-table.test.ts` — a drift guard asserting `joinTableName` and
  `deriveJoinTableName` agree across the Rails doc examples plus the schema-qualified
  cases, so the inlined copy cannot diverge from the canonical definition.

The wide call-set ratchet entry is retained, since the delegation did not land;
`pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts` is clean.

Closes-story: migration-join-table-delegate-to-derive-join-table-name
