### PR TITLE
refactor(api-compare): align the cross-file audit with the shipped per-entity resolution

### DIFF
--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -222,6 +222,29 @@ describe("classifyRow", () => {
     ).toEqual({ bucket: "collaborator", resolvedIn: "other.ts" });
   });
 
+  it("keeps a sibling reached only through a barrel out of the include graph", () => {
+    const stores = buildPackageIndex([
+      entity("FileStore", "cache/file-store.ts", [{ name: "deleteMatched", calls: [] }], {
+        extends: ["Store"],
+      }),
+      entity("Store", "cache/store.ts", []),
+      entity("MemoryStore", "cache/memory-store.ts", [
+        { name: "deleteMatched", calls: ["quotedScope"] },
+      ]),
+      entity("Store", "cache/index.ts", [], { reExportedFrom: "cache/store.ts:Store" }),
+      entity("MemoryStore", "cache/index.ts", [{ name: "deleteMatched", calls: ["quotedScope"] }], {
+        reExportedFrom: "cache/memory-store.ts:MemoryStore",
+      }),
+    ]);
+    expect(
+      classifyRow(
+        mismatch("cache/file-store.ts", "deleteMatched"),
+        "quoted_scope → quotedScope",
+        stores,
+      ),
+    ).toEqual({ bucket: "collaborator", resolvedIn: "cache/memory-store.ts" });
+  });
+
   it("keeps a call no definition makes as a real divergence", () => {
     expect(
       classifyRow(mismatch("adapter.ts", "indexes"), "presence → presence", index).bucket,

--- a/scripts/api-compare/audit-cross-file-calls.test.ts
+++ b/scripts/api-compare/audit-cross-file-calls.test.ts
@@ -7,22 +7,28 @@ import {
   classify,
   crossesAdapterFamilies,
   classifyRow,
-  includeGraphFiles,
+  includeGraphOwners,
   edgeKindOf,
   isCrossFile,
   looseOnlyRows,
-  reachableFiles,
+  reachableEntities,
 } from "./audit-cross-file-calls.js";
 
 function entity(
   name: string,
   file: string,
   methods: { name: string; calls?: string[] }[],
-  edges: { includes?: string[]; extends?: string[]; delegatesTo?: string[] } = {},
+  edges: {
+    includes?: string[];
+    extends?: string[];
+    delegatesTo?: string[];
+    reExportedFrom?: string;
+  } = {},
 ): Entity {
   return {
     name,
     file,
+    ...(edges.reExportedFrom ? { reExportedFrom: edges.reExportedFrom } : {}),
     includes: edges.includes ?? [],
     extends: edges.extends ?? [],
     ...(edges.delegatesTo ? { delegatesTo: edges.delegatesTo } : {}),
@@ -45,14 +51,19 @@ describe("candidateNames", () => {
   });
 });
 
-describe("includeGraphFiles", () => {
+describe("includeGraphOwners", () => {
   it("walks includes and extends transitively", () => {
     const index = buildPackageIndex([
       entity("Adapter", "adapter.ts", [], { includes: ["Quoting"] }),
       entity("Quoting", "quoting.ts", [], { extends: ["Base"] }),
       entity("Base", "base.ts", []),
     ]);
-    expect([...includeGraphFiles("adapter.ts", index)].sort()).toEqual(["base.ts", "quoting.ts"]);
+    expect([...includeGraphOwners("adapter.ts", index)].sort()).toEqual([
+      "base.ts:Base",
+      "fn:base.ts",
+      "fn:quoting.ts",
+      "quoting.ts:Quoting",
+    ]);
   });
 
   it("does not reach a collaborator that no recorded edge names", () => {
@@ -60,11 +71,36 @@ describe("includeGraphFiles", () => {
       entity("Adapter", "pg-adapter.ts", []),
       entity("PgSchemaStatements", "pg/schema-statements-class.ts", []),
     ]);
-    expect(includeGraphFiles("pg-adapter.ts", index).size).toBe(0);
+    expect(includeGraphOwners("pg-adapter.ts", index).size).toBe(0);
+  });
+
+  it("drops an edge name more than one entity answers to", () => {
+    const index = buildPackageIndex([
+      entity("Sqlite3Adapter", "sqlite3-adapter.ts", [], { includes: ["DatabaseStatements"] }),
+      entity("DatabaseStatements", "sqlite3/database-statements.ts", []),
+      entity("DatabaseStatements", "mysql/database-statements.ts", []),
+    ]);
+    expect(includeGraphOwners("sqlite3-adapter.ts", index).size).toBe(0);
+  });
+
+  it("credits only the reached entity, not every entity a barrel re-exports", () => {
+    const index = buildPackageIndex([
+      entity("FileStore", "cache/file-store.ts", [], { extends: ["Store"] }),
+      entity("Store", "cache/store.ts", []),
+      entity("MemoryStore", "cache/memory-store.ts", []),
+      entity("Store", "cache/index.ts", [], { reExportedFrom: "cache/store.ts:Store" }),
+      entity("MemoryStore", "cache/index.ts", [], {
+        reExportedFrom: "cache/memory-store.ts:MemoryStore",
+      }),
+    ]);
+    expect([...includeGraphOwners("cache/file-store.ts", index)].sort()).toEqual([
+      "cache/store.ts:Store",
+      "fn:cache/store.ts",
+    ]);
   });
 });
 
-describe("reachableFiles", () => {
+describe("reachableEntities", () => {
   const index = buildPackageIndex([
     entity("Adapter", "pg-adapter.ts", [], {
       includes: ["Quoting"],
@@ -75,11 +111,17 @@ describe("reachableFiles", () => {
   ]);
 
   it("ignores delegation edges unless asked to follow them", () => {
-    expect([...reachableFiles("pg-adapter.ts", index, false).keys()]).toEqual(["quoting.ts"]);
+    expect(reachableEntities("pg-adapter.ts", index, false).map(([e]) => e.file)).toEqual([
+      "quoting.ts",
+    ]);
   });
 
-  it("tags a file the delegation edge reaches", () => {
-    expect(Object.fromEntries(reachableFiles("pg-adapter.ts", index, true))).toEqual({
+  it("tags an entity the delegation edge reaches", () => {
+    expect(
+      Object.fromEntries(
+        reachableEntities("pg-adapter.ts", index, true).map(([e, k]) => [e.file, k]),
+      ),
+    ).toEqual({
       "quoting.ts": "include",
       "pg/schema-statements-class.ts": "delegation",
     });
@@ -107,6 +149,7 @@ describe("looseOnlyRows", () => {
         ...rows[0],
         resolutions: [
           {
+            entity: "PgSchemaStatements",
             file: "pg/schema-statements-class.ts",
             edgeKind: "delegation",
             methods: ["unrelated"],
@@ -257,6 +300,7 @@ describe("crossesAdapterFamilies", () => {
         ...row,
         resolutions: [
           {
+            entity: "DatabaseStatements",
             file: "connection-adapters/mysql/database-statements.ts",
             edgeKind: "include",
             methods: ["explain"],
@@ -272,11 +316,13 @@ describe("crossesAdapterFamilies", () => {
         ...row,
         resolutions: [
           {
+            entity: "PostgreSQLSchemaStatements",
             file: "connection-adapters/postgresql/schema-statements-class.ts",
             edgeKind: "delegation",
             methods: ["foreignKeys"],
           },
           {
+            entity: "AbstractAdapter",
             file: "connection-adapters/abstract-adapter.ts",
             edgeKind: "include",
             methods: ["log"],

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -3,7 +3,12 @@ import * as path from "path";
 
 import { OUTPUT_DIR } from "./config.js";
 import { jsEnumerableAliases } from "./enumerable-idioms.js";
-import { buildIncludeGraph, includeGraphEntities, type IncludeGraph } from "./include-graph.js";
+import {
+  buildIncludeGraph,
+  includeGraphEntities,
+  type GraphEntity,
+  type IncludeGraph,
+} from "./include-graph.js";
 
 // Mirrors the gate's own, unexported DELEGATION_MAX_CALLS (compare.ts:295) —
 // keep in step if that threshold ever moves.
@@ -79,8 +84,12 @@ export type LooseRow = Row & { resolutions: Resolution[] };
  * letting `MemoryStore#deleteMatched` discharge a call missing from
  * `FileStore#deleteMatched`.
  */
-function ownersOf(entity: Entity): string[] {
-  return [`${entity.file}:${entity.name}`, `fn:${entity.file}`];
+function ownersOf(entity: GraphEntity): string[] {
+  return [entityKey(entity), `fn:${entity.file}`];
+}
+
+function entityKey(entity: GraphEntity): string {
+  return `${entity.file}:${entity.name}`;
 }
 
 export function buildPackageIndex(
@@ -140,18 +149,17 @@ export function reachableEntities(
   tsFile: string,
   index: PackageIndex,
   delegation: boolean,
-): [Entity, EdgeKind][] {
-  const key = (entity: Entity): string => `${entity.file}:${entity.name}`;
+): [GraphEntity, EdgeKind][] {
   const includeOnly = delegation
-    ? new Set(includeGraphEntities(tsFile, index.graph).map((e) => key(e as Entity)))
+    ? new Set(includeGraphEntities(tsFile, index.graph).map(entityKey))
     : new Set<string>();
-  return includeGraphEntities(tsFile, index.graph, { delegation }).map((reached) => {
-    const entity = reached as Entity;
-    return [entity, delegation && !includeOnly.has(key(entity)) ? "delegation" : "include"];
-  });
+  return includeGraphEntities(tsFile, index.graph, { delegation }).map((entity) => [
+    entity,
+    delegation && !includeOnly.has(entityKey(entity)) ? "delegation" : "include",
+  ]);
 }
 
-function definitionsOf(entity: Entity, index: PackageIndex): Definition[] {
+function definitionsOf(entity: GraphEntity, index: PackageIndex): Definition[] {
   return ownersOf(entity).flatMap((owner) => index.definitionsByOwner.get(owner) ?? []);
 }
 
@@ -174,7 +182,7 @@ export function looseOnlyRows(
       if (makers.length === 0) continue;
       resolutions.push({
         entity: entity.name,
-        file: entity.file,
+        file: entity.file ?? "",
         edgeKind,
         methods: [...new Set(makers.map((d) => d.name))].sort(),
       });

--- a/scripts/api-compare/audit-cross-file-calls.ts
+++ b/scripts/api-compare/audit-cross-file-calls.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 import { OUTPUT_DIR } from "./config.js";
 import { jsEnumerableAliases } from "./enumerable-idioms.js";
+import { buildIncludeGraph, includeGraphEntities, type IncludeGraph } from "./include-graph.js";
 
 // Mirrors the gate's own, unexported DELEGATION_MAX_CALLS (compare.ts:295) —
 // keep in step if that threshold ever moves.
@@ -12,6 +13,7 @@ export type Method = { name: string; file?: string; calls?: string[] };
 export type Entity = {
   name: string;
   file: string;
+  reExportedFrom?: string;
   includes: string[];
   extends: string[];
   delegatesTo?: string[];
@@ -49,42 +51,56 @@ export type Row = {
   resolvedIn?: string;
 };
 
-type Definition = { name: string; entity: string; file: string; calls: Set<string> };
+type Definition = { name: string; owner: string; file: string; calls: Set<string> };
 
 export type PackageIndex = {
-  entitiesByFile: Map<string, Entity[]>;
-  entitiesByName: Map<string, Entity[]>;
+  graph: IncludeGraph;
   definitionsByName: Map<string, Definition[]>;
-  methodsByFile: Map<string, Definition[]>;
+  definitionsByOwner: Map<string, Definition[]>;
 };
 
 export type EdgeKind = "include" | "delegation";
 
-export type Resolution = { file: string; edgeKind: EdgeKind; methods: string[] };
+export type Resolution = {
+  entity: string;
+  file: string;
+  edgeKind: EdgeKind;
+  methods: string[];
+};
 
 export type LooseRow = Row & { resolutions: Resolution[] };
+
+/**
+ * An entity's own methods sit under `<file>:<name>`; a file's mixed-in
+ * `this`-typed functions sit under `fn:<file>` and are credited to every entity
+ * declared in that file — the same two sources `includeGraphCallSets` unions,
+ * and no wider. Keying by ENTITY rather than by file is what keeps a barrel
+ * (`cache/index.ts`, which holds a re-exported entry for every store) from
+ * letting `MemoryStore#deleteMatched` discharge a call missing from
+ * `FileStore#deleteMatched`.
+ */
+function ownersOf(entity: Entity): string[] {
+  return [`${entity.file}:${entity.name}`, `fn:${entity.file}`];
+}
 
 export function buildPackageIndex(
   entities: Entity[],
   fileFunctions: Record<string, Method[]> = {},
 ): PackageIndex {
   const index: PackageIndex = {
-    entitiesByFile: new Map(),
-    entitiesByName: new Map(),
+    graph: buildIncludeGraph(entities, fileFunctions),
     definitionsByName: new Map(),
-    methodsByFile: new Map(),
+    definitionsByOwner: new Map(),
   };
   const record = (definition: Definition): void => {
     push(index.definitionsByName, definition.name, definition);
-    push(index.methodsByFile, definition.file, definition);
+    push(index.definitionsByOwner, definition.owner, definition);
   };
   for (const entity of entities) {
-    push(index.entitiesByFile, entity.file, entity);
-    push(index.entitiesByName, entity.name, entity);
     for (const method of [...entity.instanceMethods, ...entity.classMethods]) {
       record({
         name: method.name,
-        entity: entity.name,
+        owner: `${entity.file}:${entity.name}`,
         file: method.file ?? entity.file,
         calls: new Set(method.calls ?? []),
       });
@@ -94,7 +110,7 @@ export function buildPackageIndex(
     for (const method of methods) {
       record({
         name: method.name,
-        entity: file,
+        owner: `fn:${file}`,
         file: method.file ?? file,
         calls: new Set(method.calls ?? []),
       });
@@ -109,45 +125,34 @@ function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   else map.set(key, [value]);
 }
 
-export function includeGraphFiles(tsFile: string, index: PackageIndex): Set<string> {
-  return new Set(reachableFiles(tsFile, index, false).keys());
+export function includeGraphOwners(tsFile: string, index: PackageIndex): Set<string> {
+  return new Set(reachableEntities(tsFile, index, false).flatMap(([e]) => ownersOf(e)));
 }
 
-export function reachableFiles(
+/**
+ * The entities `tsFile` reaches, through the SHIPPED gate walk
+ * (`includeGraphEntities`): per-entity, and dropping an edge name that resolves
+ * to more than one entity. The audit measured a file-level, ambiguity-blind
+ * variant of this walk first; PR #5755 showed both readings over-resolve, so the
+ * audit now reports what the gate actually credits.
+ */
+export function reachableEntities(
   tsFile: string,
   index: PackageIndex,
   delegation: boolean,
-): Map<string, EdgeKind> {
-  const includeOnly = delegation ? walk(tsFile, index, false) : new Set<string>();
-  return new Map(
-    [...walk(tsFile, index, delegation)].map((file) => [
-      file,
-      delegation && !includeOnly.has(file) ? "delegation" : "include",
-    ]),
-  );
+): [Entity, EdgeKind][] {
+  const key = (entity: Entity): string => `${entity.file}:${entity.name}`;
+  const includeOnly = delegation
+    ? new Set(includeGraphEntities(tsFile, index.graph).map((e) => key(e as Entity)))
+    : new Set<string>();
+  return includeGraphEntities(tsFile, index.graph, { delegation }).map((reached) => {
+    const entity = reached as Entity;
+    return [entity, delegation && !includeOnly.has(key(entity)) ? "delegation" : "include"];
+  });
 }
 
-function walk(tsFile: string, index: PackageIndex, delegation: boolean): Set<string> {
-  const files = new Set<string>();
-  const seen = new Set<string>();
-  const queue = [...(index.entitiesByFile.get(tsFile) ?? [])];
-  while (queue.length > 0) {
-    const entity = queue.pop()!;
-    const edges = [
-      ...entity.includes,
-      ...entity.extends,
-      ...(delegation ? (entity.delegatesTo ?? []) : []),
-    ];
-    for (const name of edges) {
-      if (seen.has(name)) continue;
-      seen.add(name);
-      for (const target of index.entitiesByName.get(name) ?? []) {
-        files.add(target.file);
-        queue.push(target);
-      }
-    }
-  }
-  return files;
+function definitionsOf(entity: Entity, index: PackageIndex): Definition[] {
+  return ownersOf(entity).flatMap((owner) => index.definitionsByOwner.get(owner) ?? []);
 }
 
 export function looseOnlyRows(
@@ -162,15 +167,20 @@ export function looseOnlyRows(
     if (!index) continue;
     const candidates = candidateNames(row.call);
     const resolutions: Resolution[] = [];
-    for (const [file, edgeKind] of reachableFiles(row.tsFile, index, delegation)) {
-      const makers = (index.methodsByFile.get(file) ?? []).filter((d) =>
+    for (const [entity, edgeKind] of reachableEntities(row.tsFile, index, delegation)) {
+      const makers = definitionsOf(entity, index).filter((d) =>
         candidates.some((c) => d.calls.has(c)),
       );
       if (makers.length === 0) continue;
-      resolutions.push({ file, edgeKind, methods: [...new Set(makers.map((d) => d.name))].sort() });
+      resolutions.push({
+        entity: entity.name,
+        file: entity.file,
+        edgeKind,
+        methods: [...new Set(makers.map((d) => d.name))].sort(),
+      });
     }
     if (resolutions.length === 0) continue;
-    resolutions.sort((a, b) => a.file.localeCompare(b.file));
+    resolutions.sort((a, b) => a.file.localeCompare(b.file) || a.entity.localeCompare(b.entity));
     loose.push({ ...row, resolutions });
   }
   return loose;
@@ -204,9 +214,11 @@ export function sameNameGraphRows(
     const index = indexes.get(row.package);
     if (!index) return false;
     const candidates = candidateNames(row.call);
-    const reachable = reachableFiles(row.tsFile, index, delegation);
+    const owners = new Set(
+      reachableEntities(row.tsFile, index, delegation).flatMap(([e]) => ownersOf(e)),
+    );
     return (index.definitionsByName.get(row.tsName) ?? []).some(
-      (d) => reachable.has(d.file) && candidates.some((c) => d.calls.has(c)),
+      (d) => owners.has(d.owner) && candidates.some((c) => d.calls.has(c)),
     );
   });
 }
@@ -224,8 +236,8 @@ export function classifyRow(
     const hollow = own.length === definitions.length && own.every((d) => d.calls.size === 0);
     return { bucket: own.length > 0 && hollow ? "unported" : "divergence" };
   }
-  const reachable = includeGraphFiles(mismatch.tsFile, index);
-  const viaGraph = makesCall.find((d) => reachable.has(d.file));
+  const owners = includeGraphOwners(mismatch.tsFile, index);
+  const viaGraph = makesCall.find((d) => owners.has(d.owner));
   if (viaGraph) return { bucket: "include-graph", resolvedIn: viaGraph.file };
   return { bucket: "collaborator", resolvedIn: makesCall[0].file };
 }
@@ -315,9 +327,6 @@ async function main(): Promise<void> {
     sameNameInIncludeGraph: sameNameGraphRows(rows, indexes, false).length,
     sameNameInDelegationGraph: sameNameGraphRows(rows, indexes, true).length,
     anyMethodByEdgeKind: Object.fromEntries(tally(looseWithDelegation, edgeKindOf)),
-    anyMethodResolvedOnlyInOwnFile: looseWithDelegation.filter((r) =>
-      r.resolutions.every((res) => res.file === r.tsFile),
-    ).length,
     anyMethodCrossingAdapterFamilies: looseWithDelegation.filter(crossesAdapterFamilies).length,
     anyMethodWithSameNamedResolver: looseWithDelegation.filter((r) =>
       r.resolutions.some((res) => res.methods.includes(r.tsName)),
@@ -329,7 +338,7 @@ async function main(): Promise<void> {
         .some((d) => d.calls.has(r.tsName) && d.calls.size > DELEGATION_MAX_CALLS),
     ).length,
     rowsWithNoGraphEdge: rows.filter(
-      (r) => includeGraphFiles(r.tsFile, indexes.get(r.package)!).size === 0,
+      (r) => includeGraphOwners(r.tsFile, indexes.get(r.package)!).size === 0,
     ).length,
     rowsWithNoDefinition: rows.filter(
       (r) => (indexes.get(r.package)!.definitionsByName.get(r.tsName) ?? []).length === 0,

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -106,7 +106,12 @@ import {
   displayLiteral,
 } from "./literals.js";
 import { isSourceUnported } from "./unported-files.js";
-import { buildIncludeGraph, includeGraphCallSets, includeGraphEntities } from "./include-graph.js";
+import {
+  buildIncludeGraph,
+  includeGraphCallSets,
+  includeGraphEntities,
+  type GraphEntity,
+} from "./include-graph.js";
 import {
   JS_ENUMERABLE_ALIASES,
   jsEnumerableAliases,
@@ -1396,7 +1401,7 @@ export function main() {
       tsPkg ? [...Object.values(tsPkg.classes), ...Object.values(tsPkg.modules)] : [],
       tsPkg?.fileFunctions ?? {},
     );
-    const graphEntities = new Map<string, ClassInfo[]>();
+    const graphEntities = new Map<string, GraphEntity[]>();
     const includeGraphCalls = (tsFile: string, tsName: string): PartitionedCalls => {
       let entities = graphEntities.get(tsFile);
       if (!entities) {

--- a/scripts/api-compare/include-graph.test.ts
+++ b/scripts/api-compare/include-graph.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { buildIncludeGraph, includeGraphCallSets, includeGraphEntities } from "./include-graph.js";
+import {
+  buildIncludeGraph,
+  includeGraphCallSets,
+  includeGraphEntities,
+  type GraphEntity,
+} from "./include-graph.js";
 import type { ClassInfo, MethodInfo } from "./types.js";
 
 function method(name: string, calls?: string[]): MethodInfo {
@@ -22,7 +27,7 @@ function entity(
   };
 }
 
-const names = (entities: ClassInfo[]) => entities.map((e) => e.name).sort();
+const names = (entities: GraphEntity[]) => entities.map((e) => e.name).sort();
 
 describe("includeGraphEntities", () => {
   it("reaches an entity through a recorded includes edge", () => {

--- a/scripts/api-compare/include-graph.ts
+++ b/scripts/api-compare/include-graph.ts
@@ -1,5 +1,26 @@
 import { partitionNegatedCalls } from "./enumerable-idioms.js";
-import type { ClassInfo, MethodInfo } from "./types.js";
+
+/**
+ * The structural minimum this walk reads off an entity. Stated structurally
+ * rather than as `ClassInfo` so the cross-file audit
+ * (`audit-cross-file-calls.ts`) can resolve through the very same walk the gate
+ * uses, instead of keeping a second, looser copy of it.
+ */
+export interface GraphMethod {
+  name: string;
+  calls?: string[];
+}
+
+export interface GraphEntity {
+  name: string;
+  file?: string;
+  reExportedFrom?: string;
+  includes: string[];
+  extends: string[];
+  delegatesTo?: string[];
+  instanceMethods: GraphMethod[];
+  classMethods: GraphMethod[];
+}
 
 /**
  * The include/extends graph the wide calls-parity gate resolves candidates
@@ -25,9 +46,9 @@ import type { ClassInfo, MethodInfo } from "./types.js";
  * match.
  */
 export interface IncludeGraph {
-  entitiesByFile: Map<string, ClassInfo[]>;
-  entitiesByName: Map<string, ClassInfo[]>;
-  fileFunctions: Record<string, MethodInfo[]>;
+  entitiesByFile: Map<string, GraphEntity[]>;
+  entitiesByName: Map<string, GraphEntity[]>;
+  fileFunctions: Record<string, GraphMethod[]>;
 }
 
 /**
@@ -41,13 +62,13 @@ export interface IncludeGraph {
  * still resolves the alias it re-exports.
  */
 export function buildIncludeGraph(
-  entities: Iterable<ClassInfo>,
-  fileFunctions: Record<string, MethodInfo[]> = {},
+  entities: Iterable<GraphEntity>,
+  fileFunctions: Record<string, GraphMethod[]> = {},
 ): IncludeGraph {
   const all = [...entities].filter((e) => (e.file ?? "") !== "");
-  const byKey = new Map<string, ClassInfo>();
+  const byKey = new Map<string, GraphEntity>();
   for (const entity of all) byKey.set(`${entity.file}:${entity.name}`, entity);
-  const origin = (entity: ClassInfo): ClassInfo => {
+  const origin = (entity: GraphEntity): GraphEntity => {
     const seen = new Set<string>();
     let current = entity;
     while (current.reExportedFrom !== undefined && !seen.has(current.reExportedFrom)) {
@@ -59,8 +80,8 @@ export function buildIncludeGraph(
     return current;
   };
 
-  const entitiesByFile = new Map<string, ClassInfo[]>();
-  const entitiesByName = new Map<string, ClassInfo[]>();
+  const entitiesByFile = new Map<string, GraphEntity[]>();
+  const entitiesByName = new Map<string, GraphEntity[]>();
   const namedKeys = new Map<string, Set<string>>();
   for (const entity of all) {
     push(entitiesByFile, entity.file!, entity);
@@ -92,14 +113,27 @@ function push<V>(map: Map<string, V[]>, key: string, value: V): void {
  * `mysql/`, `postgresql/` and `sqlite3/`, so following every candidate credits
  * one adapter with another adapter's calls, and picking one by path proximity is
  * the filename heuristic this resolution must not use.
+ *
+ * `delegation` additionally follows recorded `delegatesTo` edges. The gate never
+ * passes it — it exists so the cross-file audit can measure what a
+ * delegation-following rule WOULD resolve without re-implementing the walk.
  */
-export function includeGraphEntities(tsFile: string, graph: IncludeGraph): ClassInfo[] {
-  const reached: ClassInfo[] = [];
+export function includeGraphEntities(
+  tsFile: string,
+  graph: IncludeGraph,
+  { delegation = false }: { delegation?: boolean } = {},
+): GraphEntity[] {
+  const reached: GraphEntity[] = [];
   const seenEdges = new Set<string>();
   const queue = [...(graph.entitiesByFile.get(tsFile) ?? [])];
   while (queue.length > 0) {
     const entity = queue.pop()!;
-    for (const name of [...entity.includes, ...entity.extends]) {
+    const edges = [
+      ...entity.includes,
+      ...entity.extends,
+      ...(delegation ? (entity.delegatesTo ?? []) : []),
+    ];
+    for (const name of edges) {
       if (seenEdges.has(name)) continue;
       seenEdges.add(name);
       const targets = graph.entitiesByName.get(name) ?? [];
@@ -126,7 +160,7 @@ export function includeGraphEntities(tsFile: string, graph: IncludeGraph): Class
  * the real body lives there and nowhere else.
  */
 export function includeGraphCallSets(
-  entities: readonly ClassInfo[],
+  entities: readonly GraphEntity[],
   tsName: string,
   graph: IncludeGraph,
 ): { calls: Set<string>; negated: Set<string> } {


### PR DESCRIPTION
`scripts/api-compare/audit-cross-file-calls.ts` classified wide-ratchet rows
with a FILE-level, ambiguity-blind walk of its own. Implementing the audit's
recommended rule literally in the gate (#5755) showed both readings
over-resolve:

- a barrel (`cache/index.ts` holds a re-exported entry for every store) let
  `MemoryStore#deleteMatched` discharge calls missing from
  `FileStore#deleteMatched`;
- an ambiguous edge name (`DatabaseStatements` exists under `abstract/`,
  `mysql/`, `postgresql/`, `sqlite3/`) credited `sqlite3-adapter.ts#explain`
  with calls made in `mysql/database-statements.ts`.

The shipped gate resolves per entity and drops ambiguous edge names, so the
audit now reuses `include-graph.ts` — the gate's own walk — instead of keeping
a second, looser copy. `include-graph.ts` states its input structurally
(`GraphEntity` / `GraphMethod`, which `ClassInfo` / `MethodInfo` satisfy) so
the audit's leaner shapes fit, and takes an audit-only `delegation` option so
the delegation measurement is the same walk too.

Re-measured on the current wide artifact (3243 rows), same artifact both ways:

| Figure                       | file-level | per-entity |
| ---------------------------- | ---------: | ---------: |
| `include-graph`              |         16 |          0 |
| `collaborator`               |        191 |        207 |
| `divergence`                 |       3035 |       3035 |
| `anyMethodInIncludeGraph`    |        250 |        159 |
| `anyMethodCrossingAdapterFam`|         51 |          0 |

The 16 rows lost from `include-graph` are the cross-credits the gate refuses;
they land in `collaborator`, the bucket the audit says must not be resolved.
`rfcs/0083-.../cross-file-audit.md` (tasks repo) records the corrected figures
and flags the earlier ones as the tooling artifact they were.
`anyMethodResolvedOnlyInOwnFile` is dropped — the shipped walk never returns an
entity in the row's own file, so it is 0 by construction.

Audit tooling only: no gate change, no baseline change, wide-row delta 0.

Closes-story: align-cross-file-audit-with-shipped-resolution
