### PR TITLE
refactor(activerecord): pop the eager stash off joins_values in build_join_buckets

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -7304,7 +7304,10 @@ export class Relation<T extends Base> {
   }
 
   /** @internal */
-  private buildJoinBuckets(): Record<string, unknown[]> {
+  private buildJoinBuckets(): [
+    Record<string, unknown[]>,
+    typeof Nodes.InnerJoin | typeof Nodes.OuterJoin,
+  ] {
     return _qm.buildJoinBuckets.call(this as any);
   }
 

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -86,4 +86,17 @@ describe("build_joins from(subquery) dedup", () => {
       new RegExp(`FROM ${q("posts")} CROSS JOIN categories INNER JOIN ${q("comments")}`),
     );
   });
+
+  // Rails only shifts the LEADING run of Arel Join nodes out of `joins`
+  // (query_methods.rb:1855-1862); a Join node sitting BEHIND a named join falls
+  // through to the `select_named_joins` block, which buckets it as a join_node
+  // unconditionally (query_methods.rb:1866-1867) — so it is appended after the
+  // association joins even when the leading-loop guard is off.
+  it("appends a raw join that trails a named join instead of leading with it", () => {
+    const rel = Post.joins("comments").joins("CROSS JOIN categories");
+    const sql = (Post.from(rel, "posts") as unknown as { toSql(): string }).toSql();
+    const q = (name: string) => escapeRegExp(quoteTableName(name));
+    expect(sql).toMatch(new RegExp(`FROM ${q("posts")} INNER JOIN ${q("comments")}`));
+    expect(sql).toMatch(new RegExp(`INNER JOIN ${q("comments")}[^)]*CROSS JOIN categories`));
+  });
 });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2806,12 +2806,14 @@ export function assertValidLeftOuterJoinsBang(values: unknown[]): void {
 }
 
 /**
- * Rails' inner `select_named_joins` block (query_methods.rb:1865-1873): a
- * CTEJoin — a `joins()` symbol matching a `with(...)` CTE name — becomes an
- * InnerJoin join_node, and anything else raises a plain RuntimeError
- * `"unknown class: <ClassName>"` (NOT the left-outer bucket's ArgumentError,
- * query_methods.rb:1834). Shared by `buildJoinBuckets` and the live path's
- * `emitJoinPlan`, which partition the same joins_values the same way.
+ * Rails' inner `select_named_joins` block (query_methods.rb:1865-1873): an Arel
+ * Join node that survived the leading-join loop becomes a join_node
+ * unconditionally, a CTEJoin — a `joins()` symbol matching a `with(...)` CTE
+ * name — becomes an InnerJoin join_node, and anything else raises a plain
+ * RuntimeError `"unknown class: <ClassName>"` (NOT the left-outer bucket's
+ * ArgumentError, query_methods.rb:1834). Shared by `buildJoinBuckets` and the
+ * live path's `emitJoinPlan`, which partition the same joins_values the same
+ * way.
  *
  * @internal
  */
@@ -2819,11 +2821,13 @@ function selectInnerNamedJoins(
   this: QueryMethodsHost,
   values: unknown[],
   stashedJoins: unknown[],
-  cteJoinNodes: Nodes.Join[],
+  joinNodes: Nodes.Join[],
 ): AssociationSpec[] {
   return selectNamedJoins.call(this, values, stashedJoins, (join) => {
-    if (join instanceof CTEJoin) {
-      cteJoinNodes.push(buildWithJoinNode.call(this, join.name, Nodes.InnerJoin) as Nodes.Join);
+    if (join instanceof Nodes.Join) {
+      joinNodes.push(join);
+    } else if (join instanceof CTEJoin) {
+      joinNodes.push(buildWithJoinNode.call(this, join.name, Nodes.InnerJoin) as Nodes.Join);
     } else {
       throw new Error(
         `unknown class: ${(join as { constructor?: { name?: string } })?.constructor?.name}`,
@@ -2895,27 +2899,34 @@ export function buildJoinBuckets(
   // query_methods.rb:1856-1862: `stashed_eager_load || stashed_left_joins`.
   const hasStashed = Boolean(stashedEagerLoad) || stashedLeft.length > 0;
 
-  for (const v of joins.filter((j) => !this._isNamedJoinValue(j)) as (string | Nodes.Join)[]) {
-    const node: Nodes.Join =
-      typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v;
-    if (!(node instanceof Nodes.LeadingJoin) && hasStashed) {
-      buckets.join_node.push(node);
-    } else {
-      buckets.leading_join.push(node);
+  // query_methods.rb:1851-1853. Rails wraps every String; trails collapses
+  // Ruby's Symbol and String into one type, so an association-name string
+  // stays a named join value instead of becoming a raw SQL fragment.
+  for (const [i, v] of joins.entries()) {
+    if (typeof v === "string" && !this._isNamedJoinValue(v)) {
+      joins[i] = new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join;
     }
   }
 
-  // query_methods.rb:1865-1873.
-  const cteInnerJoinNodes: Nodes.Join[] = [];
+  // query_methods.rb:1855-1862: only the LEADING run of Join nodes is shifted
+  // off and routed by `hasStashed`; a Join node sitting behind a named join
+  // falls through to the `select_named_joins` block below, which buckets it as
+  // a join_node unconditionally.
+  while (joins[0] instanceof Nodes.Join) {
+    const joinNode = joins.shift() as Nodes.Join;
+    if (!(joinNode instanceof Nodes.LeadingJoin) && hasStashed) {
+      buckets.join_node.push(joinNode);
+    } else {
+      buckets.leading_join.push(joinNode);
+    }
+  }
+
+  // query_methods.rb:1864-1873.
+  const innerJoinNodes: Nodes.Join[] = [];
   buckets.named_join.push(
-    ...selectInnerNamedJoins.call(
-      this,
-      joins.filter((j) => this._isNamedJoinValue(j)),
-      buckets.stashed_join,
-      cteInnerJoinNodes,
-    ),
+    ...selectInnerNamedJoins.call(this, joins, buckets.stashed_join, innerJoinNodes),
   );
-  buckets.join_node.push(...cteInnerJoinNodes);
+  buckets.join_node.push(...innerJoinNodes);
 
   // query_methods.rb:1875-1876 — the eager stash goes in LAST.
   buckets.stashed_join.push(...stashedLeft);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2806,7 +2806,9 @@ export function assertValidLeftOuterJoinsBang(values: unknown[]): void {
 }
 
 /** @internal */
-export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
+export function buildJoinBuckets(
+  this: QueryMethodsHost,
+): [Record<string, unknown[]>, typeof Nodes.InnerJoin | typeof Nodes.OuterJoin] {
   const buckets: Record<string, unknown[]> = {
     leading_join: [],
     join_node: [],
@@ -2830,8 +2832,8 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
   // early with OuterJoin type and named_join populated. Otherwise the left-outer
   // JoinDependency is prepended to stashed_left_joins.
   const leftOuterJoinsValues = this.leftOuterJoinsValues;
+  const stashedLeft: JoinDependency[] = [];
   if (leftOuterJoinsValues.length > 0) {
-    const stashedLeft: JoinDependency[] = [];
     assertValidLeftOuterJoinsBang(leftOuterJoinsValues);
     // Mirror Rails' block (query_methods.rb:1830-1836): a CTEJoin becomes an
     // OuterJoin join_node; any other non-association value raises.
@@ -2847,7 +2849,7 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
       // query_methods.rb:1838-1842: `if joins_values.empty?`.
       buckets.named_join.push(...namedLeft);
       buckets.stashed_join.push(...stashedLeft);
-      return buckets;
+      return [buckets, Nodes.OuterJoin];
     }
 
     const leftJd = constructJoinDependency.call(
@@ -2856,19 +2858,26 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
       Nodes.OuterJoin,
     );
     stashedLeft.unshift(leftJd);
-    buckets.stashed_join.push(...stashedLeft);
   }
 
-  // Rails' `stashed_eager_load || stashed_left_joins` (query_methods.rb:1857).
-  // `stashed_eager_load` is the trailing `joins_values` JoinDependency built on
-  // this relation's own model (query_methods.rb:1843-1845) — a cross-klass
-  // merged JoinDependency is NOT it and does not arm this guard.
-  const lastJoinValue = joinsValues[joinsValues.length - 1];
-  const stashedEagerLoad =
-    lastJoinValue instanceof JoinDependency && lastJoinValue.baseKlass === this.model;
-  const hasStashed = buckets.stashed_join.length > 0 || stashedEagerLoad;
+  // query_methods.rb:1847-1850: dup `joins_values` and pop a TRAILING
+  // JoinDependency built on this relation's own model — the eager stash pushed
+  // in by `apply_join_dependency`. A cross-klass merged JoinDependency fails
+  // `base_klass == model` and stays in the stream for `select_named_joins`.
+  const joins = [...joinsValues];
+  const lastJoinValue = joins[joins.length - 1];
+  let stashedEagerLoad: JoinDependency | undefined;
+  if (lastJoinValue instanceof JoinDependency) {
+    if (lastJoinValue.baseKlass === this.model) {
+      joins.pop();
+      stashedEagerLoad = lastJoinValue;
+    }
+  }
 
-  for (const v of rawJoinValues) {
+  // query_methods.rb:1856-1862: `stashed_eager_load || stashed_left_joins`.
+  const hasStashed = Boolean(stashedEagerLoad) || stashedLeft.length > 0;
+
+  for (const v of joins.filter((j) => !this._isNamedJoinValue(j)) as (string | Nodes.Join)[]) {
     const node: Nodes.Join =
       typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v;
     if (!(node instanceof Nodes.LeadingJoin) && hasStashed) {
@@ -2878,7 +2887,35 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
     }
   }
 
-  return buckets;
+  // query_methods.rb:1865-1873: the remaining (post-pop) joins_values run
+  // through `select_named_joins`, which stashes merged JoinDependencies into
+  // `stashed_join` and routes a CTE name to an InnerJoin join_node.
+  buckets.named_join.push(
+    ...selectNamedJoins.call(
+      this,
+      joins.filter((j) => this._isNamedJoinValue(j)),
+      buckets.stashed_join,
+      (join) => {
+        if (join instanceof CTEJoin) {
+          buckets.join_node.push(buildWithJoinNode.call(this, join.name, Nodes.InnerJoin));
+        } else {
+          // Rails' inner joins_values fallback raises a plain RuntimeError
+          // `"unknown class: <ClassName>"` (query_methods.rb:1870-1872) — NOT the
+          // left-outer bucket's ArgumentError (query_methods.rb:1834).
+          throw new Error(
+            `unknown class: ${(join as { constructor?: { name?: string } })?.constructor?.name}`,
+          );
+        }
+      },
+    ),
+  );
+
+  // query_methods.rb:1875-1876 — the eager stash goes in LAST, after the
+  // left-outer stash.
+  buckets.stashed_join.push(...stashedLeft);
+  if (stashedEagerLoad) buckets.stashed_join.push(stashedEagerLoad);
+
+  return [buckets, Nodes.InnerJoin];
 }
 
 /**
@@ -2905,8 +2942,20 @@ export interface JoinEmissionPlan {
    * When no named/left-outer association join exists, the first is the primary.
    */
   stashedJoins: JoinDependency[];
-  /** Pure left-outer-only association names (no joins_values): emitted as OuterJoin. */
+  /**
+   * `buckets[:named_join]`. On the live path (which does not go through
+   * `buildJoinBuckets`) this carries only the pure left-outer-only association
+   * names and `joinType` is absent, so the named inner joins are partitioned
+   * out of `_namedInnerJoins` here instead.
+   */
   namedJoins: AssociationSpec[];
+  /**
+   * The join type `build_join_buckets` returned alongside the buckets
+   * (query_methods.rb:1841/1878). Present only when the caller ran
+   * `buildJoinBuckets`, in which case `namedJoins` is already the partitioned
+   * `buckets[:named_join]` and must not be re-derived.
+   */
+  joinType?: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin;
   /** Tracker threaded in from `build_from`; absent on the live path. */
   aliases?: AliasTracker;
   /**
@@ -2997,7 +3046,7 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // "Unknown node type: Symbol".
   const cteInnerJoinNodes: Nodes.Join[] = [];
   const innerNamed =
-    this._namedInnerJoins.length > 0
+    plan.joinType === undefined && this._namedInnerJoins.length > 0
       ? (selectNamedJoins.call(this, this._namedInnerJoins, plan.stashedJoins, (join) => {
           if (join instanceof CTEJoin) {
             cteInnerJoinNodes.push(
@@ -3016,11 +3065,13 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
         }) as AssociationSpec[])
       : ([] as AssociationSpec[]);
   const [namedJoins, joinType] =
-    innerNamed.length > 0
-      ? ([innerNamed, Nodes.InnerJoin] as const)
-      : plan.namedJoins.length > 0
-        ? ([plan.namedJoins, Nodes.OuterJoin] as const)
-        : ([[] as AssociationSpec[], Nodes.InnerJoin] as const);
+    plan.joinType !== undefined
+      ? ([plan.namedJoins, plan.joinType] as const)
+      : innerNamed.length > 0
+        ? ([innerNamed, Nodes.InnerJoin] as const)
+        : plan.namedJoins.length > 0
+          ? ([plan.namedJoins, Nodes.OuterJoin] as const)
+          : ([[] as AssociationSpec[], Nodes.InnerJoin] as const);
   if (namedJoins.length > 0 || plan.stashedJoins.length > 0) {
     const jd = constructJoinDependency.call(this, namedJoins, joinType);
     for (const node of jd.joinConstraints(plan.stashedJoins, sharedTracker(), references))
@@ -3069,7 +3120,7 @@ export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTra
 
   // Subquery path: buckets fold eager into stashed_join. Delegate emission to
   // the shared `build_joins` port.
-  const buckets = buildJoinBuckets.call(this);
+  const [buckets, joinType] = buildJoinBuckets.call(this);
   const leadingJoins = buckets.leading_join as Nodes.Join[];
   const joinNodes = buckets.join_node as Nodes.Join[];
   // Rails: `alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)`
@@ -3091,6 +3142,7 @@ export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTra
     joinNodes,
     stashedJoins: buckets.stashed_join as JoinDependency[],
     namedJoins: buckets.named_join as AssociationSpec[],
+    joinType,
     aliases,
     tracker,
   });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2805,6 +2805,33 @@ export function assertValidLeftOuterJoinsBang(values: unknown[]): void {
   }
 }
 
+/**
+ * Rails' inner `select_named_joins` block (query_methods.rb:1865-1873): a
+ * CTEJoin — a `joins()` symbol matching a `with(...)` CTE name — becomes an
+ * InnerJoin join_node, and anything else raises a plain RuntimeError
+ * `"unknown class: <ClassName>"` (NOT the left-outer bucket's ArgumentError,
+ * query_methods.rb:1834). Shared by `buildJoinBuckets` and the live path's
+ * `emitJoinPlan`, which partition the same joins_values the same way.
+ *
+ * @internal
+ */
+function selectInnerNamedJoins(
+  this: QueryMethodsHost,
+  values: unknown[],
+  stashedJoins: unknown[],
+  cteJoinNodes: Nodes.Join[],
+): AssociationSpec[] {
+  return selectNamedJoins.call(this, values, stashedJoins, (join) => {
+    if (join instanceof CTEJoin) {
+      cteJoinNodes.push(buildWithJoinNode.call(this, join.name, Nodes.InnerJoin) as Nodes.Join);
+    } else {
+      throw new Error(
+        `unknown class: ${(join as { constructor?: { name?: string } })?.constructor?.name}`,
+      );
+    }
+  }) as AssociationSpec[];
+}
+
 /** @internal */
 export function buildJoinBuckets(
   this: QueryMethodsHost,
@@ -2816,15 +2843,7 @@ export function buildJoinBuckets(
     named_join: [],
   };
 
-  // Named association joins vs raw join values, both derived from the unified
-  // `joins_values` store (Rails reads `joins_values` here and partitions with
-  // `select_named_joins`).
   const joinsValues = this.joinsValues;
-  const namedInner = joinsValues.filter((v) => this._isNamedJoinValue(v)) as AssociationSpec[];
-  const rawJoinValues = joinsValues.filter((v) => !this._isNamedJoinValue(v)) as (
-    | string
-    | Nodes.Join
-  )[];
 
   // Mirror Rails build_join_buckets (query_methods.rb:1828–1876):
   // When left_outer_joins_values is non-empty, Rails runs select_named_joins on
@@ -2845,7 +2864,7 @@ export function buildJoinBuckets(
       }
     });
 
-    if (namedInner.length === 0 && rawJoinValues.length === 0 && this._joinClauses.length === 0) {
+    if (joinsValues.length === 0 && this._joinClauses.length === 0) {
       // query_methods.rb:1838-1842: `if joins_values.empty?`.
       buckets.named_join.push(...namedLeft);
       buckets.stashed_join.push(...stashedLeft);
@@ -2860,9 +2879,8 @@ export function buildJoinBuckets(
     stashedLeft.unshift(leftJd);
   }
 
-  // query_methods.rb:1847-1850: dup `joins_values` and pop a TRAILING
-  // JoinDependency built on this relation's own model — the eager stash pushed
-  // in by `apply_join_dependency`. A cross-klass merged JoinDependency fails
+  // query_methods.rb:1847-1850. The popped JoinDependency is the eager stash
+  // `apply_join_dependency` pushed in; a cross-klass merged one fails
   // `base_klass == model` and stays in the stream for `select_named_joins`.
   const joins = [...joinsValues];
   const lastJoinValue = joins[joins.length - 1];
@@ -2887,31 +2905,19 @@ export function buildJoinBuckets(
     }
   }
 
-  // query_methods.rb:1865-1873: the remaining (post-pop) joins_values run
-  // through `select_named_joins`, which stashes merged JoinDependencies into
-  // `stashed_join` and routes a CTE name to an InnerJoin join_node.
+  // query_methods.rb:1865-1873.
+  const cteInnerJoinNodes: Nodes.Join[] = [];
   buckets.named_join.push(
-    ...selectNamedJoins.call(
+    ...selectInnerNamedJoins.call(
       this,
       joins.filter((j) => this._isNamedJoinValue(j)),
       buckets.stashed_join,
-      (join) => {
-        if (join instanceof CTEJoin) {
-          buckets.join_node.push(buildWithJoinNode.call(this, join.name, Nodes.InnerJoin));
-        } else {
-          // Rails' inner joins_values fallback raises a plain RuntimeError
-          // `"unknown class: <ClassName>"` (query_methods.rb:1870-1872) — NOT the
-          // left-outer bucket's ArgumentError (query_methods.rb:1834).
-          throw new Error(
-            `unknown class: ${(join as { constructor?: { name?: string } })?.constructor?.name}`,
-          );
-        }
-      },
+      cteInnerJoinNodes,
     ),
   );
+  buckets.join_node.push(...cteInnerJoinNodes);
 
-  // query_methods.rb:1875-1876 — the eager stash goes in LAST, after the
-  // left-outer stash.
+  // query_methods.rb:1875-1876 — the eager stash goes in LAST.
   buckets.stashed_join.push(...stashedLeft);
   if (stashedEagerLoad) buckets.stashed_join.push(stashedEagerLoad);
 
@@ -3047,22 +3053,12 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   const cteInnerJoinNodes: Nodes.Join[] = [];
   const innerNamed =
     plan.joinType === undefined && this._namedInnerJoins.length > 0
-      ? (selectNamedJoins.call(this, this._namedInnerJoins, plan.stashedJoins, (join) => {
-          if (join instanceof CTEJoin) {
-            cteInnerJoinNodes.push(
-              buildWithJoinNode.call(this, join.name, Nodes.InnerJoin) as Nodes.Join,
-            );
-          } else {
-            // Rails' inner joins_values fallback raises a plain RuntimeError
-            // `"unknown class: <ClassName>"` (query_methods.rb:1870-1872) — NOT
-            // the left-outer bucket's `ArgumentError` "only Hash, Symbol and
-            // Array are allowed" (query_methods.rb:1834). The two buckets diverge
-            // here, so mirror that divergence.
-            throw new Error(
-              `unknown class: ${(join as { constructor?: { name?: string } })?.constructor?.name}`,
-            );
-          }
-        }) as AssociationSpec[])
+      ? selectInnerNamedJoins.call(
+          this,
+          this._namedInnerJoins,
+          plan.stashedJoins,
+          cteInnerJoinNodes,
+        )
       : ([] as AssociationSpec[]);
   const [namedJoins, joinType] =
     plan.joinType !== undefined

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
@@ -25,7 +25,7 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_joins",
     "call": "joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0083 step 3): Rails merger.rb:117-134/136-152 ends the cross-model branch with `relation.joins!(join_dependency, *others)` / `relation.left_outer_joins!(...)`; trails merger.ts#mergeJoins/#mergeOuterJoins are thin wrappers over foldMergeJoins/foldMergeOuterJoins (relation/merge-joins.ts), which append to `_joinsValues` / `_leftOuterJoinsValues` with the same structural union `joins!` performs. The wide gate does not follow into the helper, so the entry stays until the helper split itself is converged (`converge-merge-joins-helper-onto-joins-bang`)."
   },
   {
     "package": "activerecord",
@@ -102,7 +102,7 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_outer_joins",
     "call": "left_outer_joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0083 step 3): Rails merger.rb:117-134/136-152 ends the cross-model branch with `relation.joins!(join_dependency, *others)` / `relation.left_outer_joins!(...)`; trails merger.ts#mergeJoins/#mergeOuterJoins are thin wrappers over foldMergeJoins/foldMergeOuterJoins (relation/merge-joins.ts), which append to `_joinsValues` / `_leftOuterJoinsValues` with the same structural union `joins!` performs. The wide gate does not follow into the helper, so the entry stays until the helper split itself is converged (`converge-merge-joins-helper-onto-joins-bang`)."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Step 3 of 3 — the payload — in the ordered split of
`converge-build-join-buckets-single-joins-store` (RFC 0083), following #5737 and
#5747.

## What

Rails `build_join_buckets` (`query_methods.rb:1847-1850`):

```ruby
joins = joins_values.dup
if joins.last.is_a?(ActiveRecord::Associations::JoinDependency)
  stashed_eager_load = joins.pop if joins.last.base_klass == model
end
```

Now that `joins_values` is the single store holding both cross-klass merged
JoinDependencies and the eager stash, that discriminator is meaningful, so
`buildJoinBuckets` ports it literally:

- dup `joinsValues`, test the last element for `instanceof JoinDependency`, and
  pop it into a local `stashedEagerLoad` only when `baseKlass === model`
  (previously this was computed as a bare boolean and the JD was left in the
  stream).
- `hasStashed` is `stashedEagerLoad || stashedLeftJoins`
  (`query_methods.rb:1856-1862`), and the raw-node routing loop runs over the
  post-pop values.
- The post-pop values run through `select_named_joins`
  (`query_methods.rb:1865-1873`) here, where Rails has it — filling
  `buckets[:named_join]`, stashing merged JDs into `buckets[:stashed_join]`, and
  routing a CTE name to an InnerJoin `join_node`.
- `buckets[:stashed_join]` gets the left-outer stash and then the eager stash
  LAST (`query_methods.rb:1875-1876`); previously the left-outer stash was
  pushed early and the eager JD arrived incidentally, via `emitJoinPlan`'s walk
  of `_namedInnerJoins`.
- The inner `select_named_joins` block is extracted to a shared
  `selectInnerNamedJoins` helper, so `buildJoinBuckets` and the live path's
  `emitJoinPlan` partition joins_values through one implementation instead of
  two copies.
- `buildJoinBuckets` returns `[buckets, joinType]`, as Rails does
  (`query_methods.rb:1841`/`1878`). `emitJoinPlan` uses the caller-supplied
  `joinType` when present and skips re-deriving the named inner joins; the live
  path (`_applyJoinsToManager`), which does not go through `buildJoinBuckets`,
  is unchanged and still partitions `_namedInnerJoins` itself.

## Review finding: the leading-join loop (fixed here)

The first review flagged that the leading/join_node split scanned the whole
array rather than the leading prefix. Confirmed live, and fixed in this PR
rather than deferred, since it is inside the method being ported.

Rails' `while joins.first.is_a?(Arel::Nodes::Join)` (`query_methods.rb:1855-1862`)
shifts only the LEADING run of Join nodes and routes them by `stashed_eager_load
|| stashed_left_joins`; a Join node behind a named join stays in the array and
reaches the `select_named_joins` block, which buckets it as a join_node
**unconditionally** (`query_methods.rb:1866-1867`). `buildJoinBuckets` filtered
every raw join value out regardless of position and ran the `hasStashed`-gated
branch over all of them.

Observable on the subquery path:
`Post.from(Post.joins("comments").joins("CROSS JOIN categories"))` emitted
`FROM posts CROSS JOIN categories INNER JOIN comments` — the CROSS JOIN ahead of
the association join, where Rails appends it after. Now ported literally: the
String wrap (`:1851-1853`), the leading-prefix shift, and the block's
`Arel::Nodes::Join` branch. The live path is unaffected — its `hasStashed` also
counts named inner joins, so it already appended (verified: same relation on the
live path emits `authors` then `comments` both before and after).

Covered by a new case in `build-joins-from-subquery-dedup.test.ts`, verified to
fail on the pre-fix implementation and pass after.

## Deviation from the story: the two `merger.json` wide-exclude entries

The story asked to DELETE three `joins!` / `left_outer_joins!` wide-exclude
entries on the premise that steps 1 and 2 made those calls real. That holds for
only one of them — `relation.json` `apply_join_dependency` / `joins!`, already
deleted by #5747.

The other two are not real. Rails ends the cross-model branch of `merge_joins` /
`merge_outer_joins` with `relation.joins!(join_dependency, *others)`
(`merger.rb:117-152`), but trails' `Merger#mergeJoins` / `#mergeOuterJoins` are
thin wrappers over `foldMergeJoins` / `foldMergeOuterJoins`
(`relation/merge-joins.ts`), which push straight onto `_joinsValues` /
`_leftOuterJoinsValues` with their own structural-union dedup. Deleting the
entries was tried and reverted: `pnpm api:calls:wide` reports both as NEW
mismatches, because the wide gate does not follow `merger.ts` into
`merge-joins.ts`.

So instead of deleting them, their stale RFC 0047 baseline reasons are rewritten
to record that real state, and the convergence is registered as
`0083-wide-call-ratchet-noise-reduction/converge-merge-joins-helper-onto-joins-bang`
rather than half-shipped here.

## Testing

`packages/activerecord/src/relation/**` (51 files), `associations/eager.test.ts`,
`relation.trails.test.ts`, `cascaded-eager-loading`, `inner-join-association`,
`left-outer-join-association`, `relations`, `calculations`, `finder` — 1925
passed, 37 skipped, no test renames. Earlier
runs also covered `cascaded-eager-loading`, `inner-join-association`,
`left-outer-join-association`, `relations`, `calculations`, `finder` — all green.
`pnpm api:compare` exits 0 with Overall unchanged at 11788/17536, and
`pnpm api:calls:wide` is clean (`OK (3085 baselined, 2840 unreviewed <= mark
2845)`). `pnpm test:compare` Overall is unchanged at 14876/22203 — this PR
touches no tests, so both deltas are 0; no ratchet or allowlist churn,
so the unreviewed mark is left alone.

Closes-story: port-build-join-buckets-eager-stash-pop
