### PR TITLE
refactor(activerecord): route non-through collection push onto concatRecords

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -412,6 +412,13 @@ export class Association {
     const inverse = this.inverseAssociationFor(record);
     if (inverse) {
       inverse.inversedFrom(this.owner);
+      // `_explicitTarget` is the trails flag `_loadedSingularTarget` consults
+      // before the inner belongs_to/has_one loaders query (RFC 0022). Rails has
+      // no analog — `inversed_from` alone is the whole of `set_inverse_instance`
+      // — so it has to be raised here, as `_cacheSingularTarget` does on the
+      // other seeding path, or an inverse wired through this method reads back
+      // as an unset target and re-queries.
+      if (!inverse.isCollection()) inverse._explicitTarget = true;
     }
     return record;
   }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -116,6 +116,9 @@ export class Association {
    */
   _loaderWritebackSuppressed = 0;
 
+  /** @internal Rails' `@skip_strict_loading`, raised by `skipStrictLoading`. */
+  protected _skipStrictLoading = false;
+
   private _staleState: unknown = undefined;
   private _staleStateSnapshotted = false;
   /**
@@ -864,19 +867,36 @@ export class Association {
     return this.doAsyncFindTarget();
   }
 
-  private skipStrictLoading<T>(block: () => T): T {
-    const prev = (this as any)._skipStrictLoading;
-    (this as any)._skipStrictLoading = true;
+  /**
+   * Rails' `Association#skip_strict_loading` (association.rb). A
+   * promise-returning block keeps the flag raised until it settles — Ruby's
+   * `ensure` fires after the block has fully run, and restoring at the first
+   * `await` would let the query it guards raise `StrictLoadingViolationError`.
+   * @internal
+   */
+  protected skipStrictLoading<T>(block: () => T): T {
+    const prev = this._skipStrictLoading;
+    this._skipStrictLoading = true;
+    const restore = (): void => {
+      this._skipStrictLoading = prev;
+    };
+    let result: T;
     try {
-      return block();
-    } finally {
-      (this as any)._skipStrictLoading = prev;
+      result = block();
+    } catch (error) {
+      restore();
+      throw error;
     }
+    if (result instanceof Promise) {
+      return result.finally(restore) as T;
+    }
+    restore();
+    return result;
   }
 
   private isViolatesStrictLoading(): boolean {
     const ownerAny = this.owner as any;
-    if ((this as any)._skipStrictLoading) return false;
+    if (this._skipStrictLoading) return false;
     return !!(
       ownerAny._strictLoading && !ownerAny._strictLoadingWhitelist?.includes(this.reflection.name)
     );

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -407,17 +407,18 @@ export class Association {
   /**
    * Set the inverse association on the given record, so that
    * `record.association(inverse_name).target` points back to owner.
+   *
+   * `_explicitTarget` has no Rails analog — `inversed_from` alone is the whole
+   * of `set_inverse_instance` there. It is the trails flag (RFC 0022) that
+   * `_loadedSingularTarget` consults before the inner belongs_to/has_one
+   * loaders query, so it is raised here exactly as `_cacheSingularTarget` does
+   * on the other seeding path; without it an inverse wired through this method
+   * reads back as an unset target and re-queries.
    */
   setInverseInstance(record: Base): Base {
     const inverse = this.inverseAssociationFor(record);
     if (inverse) {
       inverse.inversedFrom(this.owner);
-      // `_explicitTarget` is the trails flag `_loadedSingularTarget` consults
-      // before the inner belongs_to/has_one loaders query (RFC 0022). Rails has
-      // no analog — `inversed_from` alone is the whole of `set_inverse_instance`
-      // — so it has to be raised here, as `_cacheSingularTarget` does on the
-      // other seeding path, or an inverse wired through this method reads back
-      // as an unset target and re-queries.
       if (!inverse.isCollection()) inverse._explicitTarget = true;
     }
     return record;

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -763,9 +763,9 @@ export class CollectionAssociation extends Association {
    *
    * Rails passes `replace: replace || association_scope.distinct_value`, so a
    * `distinct` association scope dedups in place on append rather than
-   * appending the same record twice. The scope build is guarded because
-   * `add_to_target` is not where trails surfaces an unresolvable target class
-   * or foreign key — those are deferred to the load chokepoint.
+   * appending the same record twice. As in Rails the scope build is unguarded:
+   * `association_scope` raising here is a real failure, not something
+   * `add_to_target` absorbs into a `false`.
    */
   addToTarget(record: Base, options?: { skipCallbacks?: boolean; replace?: boolean }): Base | null;
   addToTarget(
@@ -779,13 +779,8 @@ export class CollectionAssociation extends Association {
     save?: () => Promise<void>,
   ): Base | null | Promise<Base | null> {
     const { skipCallbacks = false, replace = false } = options;
-    let distinctValue = false;
-    try {
-      distinctValue = !!(this.associationScope() as { distinctValue?: boolean } | undefined)
-        ?.distinctValue;
-    } catch {
-      distinctValue = false;
-    }
+    const distinctValue = !!(this.associationScope() as { distinctValue?: boolean } | undefined)
+      ?.distinctValue;
     const shouldReplace = replace || distinctValue;
     if (save) return replaceOnTargetAsync(this, record, skipCallbacks, shouldReplace, save);
     return replaceOnTarget(this, record, skipCallbacks, shouldReplace);

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -396,7 +396,7 @@ export class CollectionAssociation extends Association {
   async concat(...records: Base[]): Promise<Base[] | undefined> {
     const flattened = records.flat();
     if (this.owner.isNewRecord()) {
-      await this.loadTarget();
+      await this.skipStrictLoading(() => this.loadTarget());
       return this.concatRecords(flattened);
     }
     return this.transaction(() => this.concatRecords(flattened));

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -760,6 +760,12 @@ export class CollectionAssociation extends Association {
    * relies on the surrounding `raise Rollback` to undo a failed insert), keeping
    * the OO path's membership behavior unchanged. Sync callers (build/replace,
    * no `save`) get the synchronous return.
+   *
+   * Rails passes `replace: replace || association_scope.distinct_value`, so a
+   * `distinct` association scope dedups in place on append rather than
+   * appending the same record twice. The scope build is guarded because
+   * `add_to_target` is not where trails surfaces an unresolvable target class
+   * or foreign key — those are deferred to the load chokepoint.
    */
   addToTarget(record: Base, options?: { skipCallbacks?: boolean; replace?: boolean }): Base | null;
   addToTarget(
@@ -773,27 +779,16 @@ export class CollectionAssociation extends Association {
     save?: () => Promise<void>,
   ): Base | null | Promise<Base | null> {
     const { skipCallbacks = false, replace = false } = options;
-    // Rails: `replace: replace || association_scope.distinct_value`
-    // (collection_association.rb:283) — a `distinct` association scope dedups
-    // in place on append rather than appending the same record twice.
-    const shouldReplace = replace || this.associationScopeDistinctValue();
+    let distinctValue = false;
+    try {
+      distinctValue = !!(this.associationScope() as { distinctValue?: boolean } | undefined)
+        ?.distinctValue;
+    } catch {
+      distinctValue = false;
+    }
+    const shouldReplace = replace || distinctValue;
     if (save) return replaceOnTargetAsync(this, record, skipCallbacks, shouldReplace, save);
     return replaceOnTarget(this, record, skipCallbacks, shouldReplace);
-  }
-
-  /**
-   * `association_scope.distinct_value`, resolved defensively: the memoized
-   * association scope is unavailable for an owner whose target class or FK
-   * cannot be resolved yet, and Rails' `add_to_target` is not the place that
-   * surfaces such a failure.
-   * @internal
-   */
-  private associationScopeDistinctValue(): boolean {
-    try {
-      return !!(this.associationScope() as { distinctValue?: boolean } | undefined)?.distinctValue;
-    } catch {
-      return false;
-    }
   }
 
   /**
@@ -930,17 +925,20 @@ export class CollectionAssociation extends Association {
 
   // --- Protected helpers ---
 
+  /**
+   * Mirrors `ForeignAssociation#set_owner_attributes` (foreign_association.rb:22),
+   * which zips `Array(reflection.join_primary_key)` — the child FK columns —
+   * against `Array(reflection.join_foreign_key)`. For a has_many the latter is
+   * `active_record_primary_key`, not the owner's bare `primary_key`: a composite
+   * FK derived from the owner's `query_constraints` (`Sharded::BlogPost`
+   * `[blog_id, id]`) only pairs correctly through that resolver, and
+   * `ctor.primaryKey` would collapse both FK columns onto `id`.
+   */
   protected setOwnerAttributes(record: Base): void {
     if (this.reflection.options.through) return;
 
     const ctor = this.owner.constructor as any;
     const fks = this.foreignKeyColumns();
-    // Rails zips `Array(reflection.join_primary_key)` (the child FK columns)
-    // against `Array(reflection.join_foreign_key)` — for a has_many the latter
-    // is `active_record_primary_key`, NOT the owner's bare `primary_key`. A
-    // composite FK derived from the owner's `query_constraints` (Sharded::BlogPost
-    // `[blog_id, id]`) only pairs correctly through that resolver; falling back
-    // to `ctor.primaryKey` collapses both FK columns onto `id`.
     const richPk = (
       ctor._reflectOnAssociation?.(this.reflection.name) as
         | { activeRecordPrimaryKey?: string | string[] }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -772,9 +772,28 @@ export class CollectionAssociation extends Association {
     options: { skipCallbacks?: boolean; replace?: boolean } = {},
     save?: () => Promise<void>,
   ): Base | null | Promise<Base | null> {
-    const { skipCallbacks = false, replace: shouldReplace = false } = options;
+    const { skipCallbacks = false, replace = false } = options;
+    // Rails: `replace: replace || association_scope.distinct_value`
+    // (collection_association.rb:283) — a `distinct` association scope dedups
+    // in place on append rather than appending the same record twice.
+    const shouldReplace = replace || this.associationScopeDistinctValue();
     if (save) return replaceOnTargetAsync(this, record, skipCallbacks, shouldReplace, save);
     return replaceOnTarget(this, record, skipCallbacks, shouldReplace);
+  }
+
+  /**
+   * `association_scope.distinct_value`, resolved defensively: the memoized
+   * association scope is unavailable for an owner whose target class or FK
+   * cannot be resolved yet, and Rails' `add_to_target` is not the place that
+   * surfaces such a failure.
+   * @internal
+   */
+  private associationScopeDistinctValue(): boolean {
+    try {
+      return !!(this.associationScope() as { distinctValue?: boolean } | undefined)?.distinctValue;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -915,9 +934,20 @@ export class CollectionAssociation extends Association {
     if (this.reflection.options.through) return;
 
     const ctor = this.owner.constructor as any;
-    const configuredPk = this.reflection.options.primaryKey ?? ctor.primaryKey ?? "id";
-    const pks = Array.isArray(configuredPk) ? configuredPk : [configuredPk];
     const fks = this.foreignKeyColumns();
+    // Rails zips `Array(reflection.join_primary_key)` (the child FK columns)
+    // against `Array(reflection.join_foreign_key)` — for a has_many the latter
+    // is `active_record_primary_key`, NOT the owner's bare `primary_key`. A
+    // composite FK derived from the owner's `query_constraints` (Sharded::BlogPost
+    // `[blog_id, id]`) only pairs correctly through that resolver; falling back
+    // to `ctor.primaryKey` collapses both FK columns onto `id`.
+    const richPk = (
+      ctor._reflectOnAssociation?.(this.reflection.name) as
+        | { activeRecordPrimaryKey?: string | string[] }
+        | undefined
+    )?.activeRecordPrimaryKey;
+    const configuredPk = this.reflection.options.primaryKey ?? richPk ?? ctor.primaryKey ?? "id";
+    const pks = Array.isArray(configuredPk) ? configuredPk : [configuredPk];
 
     for (let i = 0; i < fks.length; i++) {
       const pkCol = pks[i] ?? pks[0];

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3,7 +3,6 @@ import { Relation } from "../relation.js";
 import {
   CollectionAssociation,
   callback as assocCallback,
-  concatRecordsLoop,
   type CallbackHost,
 } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
@@ -2097,115 +2096,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return stripThenable(this._proxySelf ?? this);
     }
 
-    // Mirror Rails CollectionAssociation#concat: a new-record owner loads the
-    // target up front. Rails' `load_target` skips the query entirely for a
-    // new-record owner (`find_target?` is false) and just runs `loaded!`, so we
-    // mark the association loaded over its current in-memory target rather than
-    // routing through the full load path — which would also raise the
-    // strict-loading check that Rails never reaches for a new record.
-    if (this._record.isNewRecord() && !this._targetLoaded) {
-      this._targetLoaded = true;
-    }
-
-    const ctor = this._record.constructor as typeof Base;
-    const asName = this._assocDef.options.as;
-    let primaryKey = this._assocDef.options.primaryKey ?? ctor.primaryKey;
-    const foreignKey = asName
-      ? (this._assocDef.options.foreignKey ??
-        this._reflectionForeignKey() ??
-        `${underscore(asName)}_id`)
-      : (this._assocDef.options.foreignKey ??
-        this._reflectionForeignKey() ??
-        this._assocDef.options.queryConstraints ??
-        (Array.isArray(primaryKey)
-          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
-          : `${underscore(ctor.name)}_id`));
-    // A composite FK derived from the owner's query_constraints (e.g.
-    // Sharded::BlogPost `[blog_id, id]`) pairs each FK column with the owner's
-    // query-constraint key, not its scalar `id`. Defer to the reflection's
-    // `activeRecordPrimaryKey` — the single resolver the join/preload paths
-    // already use (Rails `reflection.active_record_primary_key`).
-    if (!asName && Array.isArray(foreignKey) && !Array.isArray(primaryKey)) {
-      const reflection = (ctor as any)._reflectOnAssociation?.(this._assocName);
-      if (Array.isArray(reflection?.activeRecordPrimaryKey)) {
-        primaryKey = reflection.activeRecordPrimaryKey;
-      }
-    }
-    const typeCol = asName
-      ? (this._assocDef.options.foreignType ?? `${underscore(asName)}_type`)
-      : null;
-    // insert_record: assign the owner's FK/type onto the record, then save.
-    // Mirrors Rails' `CollectionAssociation#insert_record` →
-    // `set_owner_attributes` + `record.save`.
-    const insertRecord = (record: T): Promise<boolean | undefined> => {
-      if (Array.isArray(foreignKey)) {
-        if (!Array.isArray(primaryKey) || primaryKey.length !== foreignKey.length) {
-          throw new Error(
-            `Composite foreignKey on "${this._assocName}" requires primaryKey to be an array of the same length`,
-          );
-        }
-        for (let i = 0; i < foreignKey.length; i++) {
-          record._writeAttribute(foreignKey[i], this._record._readAttribute(primaryKey[i]));
-        }
-      } else {
-        if (Array.isArray(primaryKey)) {
-          throw new Error(
-            `Association "${this._assocName}" with composite primaryKey requires a composite foreignKey array`,
-          );
-        }
-        const pkValue = this._record._readAttribute(primaryKey);
-        record._writeAttribute(foreignKey, pkValue);
-      }
-      if (typeCol) record._writeAttribute(typeCol, polymorphicName(ctor));
-
-      return record.save();
+    // Rails has no proxy-local insert: `CollectionProxy#<<` is
+    // `proxy_association.concat(records)` (collection_proxy.rb:1053), and the
+    // owner FK / composite PK pairing / polymorphic `<as>_type` derivation lives
+    // on `CollectionAssociation#insert_record` → `set_owner_attributes`
+    // (collection_association.rb:439-446). The proxy and the association object
+    // share ONE in-memory target (`_sharedTarget`), so the appended records,
+    // loaded-ness, `@replaced_or_added_targets` dedup, and before/after_add
+    // callbacks all land on this proxy too. `concat` owns both halves Rails puts
+    // there: the new-record-owner `load_target` and the persisted-owner
+    // `transaction { concat_records }` whose swallowed `Rollback` yields the
+    // `nil` that makes `<<` falsy.
+    const assoc = this._record.association(this._assocName) as unknown as {
+      concat: (...records: Base[]) => Promise<Base[] | undefined>;
     };
-    // Shared `concatRecordsLoop` owns the `result &&= insert_record(...)` /
-    // `raise ActiveRecord::Rollback unless result` accumulation
-    // (collection_association.rb:438-452) so this runtime path and the OO
-    // `CollectionAssociation#concatRecords` parity surface stay in lock-step.
-    // A record whose `save` merely *returns false* (a validation/callback abort
-    // that doesn't raise) still rolls back the records already inserted.
-    const concatRecords = async (): Promise<T[]> => {
-      await concatRecordsLoop(records, async (record, resultStillTrue) => {
-        // Route through replace_on_target (via _addToTarget) so set_inverse_instance
-        // and @replaced_or_added_targets dedup tracking run on push/<<, mirroring
-        // Rails' concat_records → add_to_target(record) { insert_record }. A record
-        // already wired into the loaded target by inverse-of setting is replaced in
-        // place rather than appended twice.
-        // Rails' add_to_target computes `replace: replace || association_scope.distinct_value`
-        // so a `distinct` association scope dedups in place on append rather than appending twice.
-        //
-        // Rails' `concat_records` runs `insert_record` inside the per-record
-        // `add_to_target` block, guarded by `unless owner.new_record?`
-        // (collection_association.rb:444). For a new-record owner the child is
-        // added to the in-memory target and saved later via autosave; skipping
-        // the insert also avoids writing a child row with a null owner FK. The
-        // check is evaluated per record at save time (after `before_add` fires),
-        // so a callback that persists the owner mid-loop flips the remaining
-        // records onto the insert path — matching Rails' control flow.
-        let saved = true;
-        await this._addToTarget(record as T, { replace: this.distinctValue }, async () => {
-          // Skip the insert for a new-record owner (deferred to autosave) or once
-          // a prior record failed — Rails' `result &&= insert_record` short-circuits
-          // but still buffers this record into the target above.
-          if (this._record.isNewRecord() || !resultStillTrue) return true;
-          saved = (await insertRecord(record as T)) ?? false;
-          return saved;
-        });
-        return saved;
-      });
-      return records;
-    };
-    // Rails' `CollectionAssociation#concat` wraps the inserts in a transaction
-    // for a persisted owner (`transaction { concat_records(records) }`,
-    // collection_association.rb:133) so a mid-batch save failure rolls back the
-    // records already inserted. A new-record owner skips the transaction — the
-    // inserts are deferred to autosave, so no DB write happens here (and a
-    // BEGIN would violate the "push does not query" invariant).
-    const concatResult = this._record.isNewRecord()
-      ? await concatRecords()
-      : await this.transaction(concatRecords);
+    const concatResult = await assoc.concat(...(records as unknown as Base[]));
     if (!concatResult) return false;
     return stripThenable(this._proxySelf ?? this);
   }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2086,6 +2086,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * unwrapped by promise adoption — otherwise `return this` would call the
    * proxy's `then` and load the target, breaking Rails' "push does not load
    * target" invariant.
+   *
+   * The non-through branch is that one delegation: the owner FK / composite
+   * primary-key pairing / polymorphic `<as>_type` derivation lives on
+   * `CollectionAssociation#insert_record` → `set_owner_attributes`
+   * (collection_association.rb:439-446), and `concat` owns both halves Rails
+   * puts there — the new-record-owner `load_target` and the persisted-owner
+   * `transaction { concat_records }`. The proxy and the association object
+   * share ONE in-memory target (`_sharedTarget`), so the appended records,
+   * loaded-ness, `@replaced_or_added_targets` dedup and before/after_add
+   * callbacks all land on this proxy too.
    */
   async push(...records: T[]): Promise<Omit<this, "then"> | false> {
     this._ensureThroughWritable();
@@ -2096,17 +2106,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return stripThenable(this._proxySelf ?? this);
     }
 
-    // Rails has no proxy-local insert: `CollectionProxy#<<` is
-    // `proxy_association.concat(records)` (collection_proxy.rb:1053), and the
-    // owner FK / composite PK pairing / polymorphic `<as>_type` derivation lives
-    // on `CollectionAssociation#insert_record` → `set_owner_attributes`
-    // (collection_association.rb:439-446). The proxy and the association object
-    // share ONE in-memory target (`_sharedTarget`), so the appended records,
-    // loaded-ness, `@replaced_or_added_targets` dedup, and before/after_add
-    // callbacks all land on this proxy too. `concat` owns both halves Rails puts
-    // there: the new-record-owner `load_target` and the persisted-owner
-    // `transaction { concat_records }` whose swallowed `Rollback` yields the
-    // `nil` that makes `<<` falsy.
     const assoc = this._record.association(this._assocName) as unknown as {
       concat: (...records: Base[]) => Promise<Base[] | undefined>;
     };

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -166,7 +166,13 @@ export class HasManyAssociation extends CollectionAssociation {
     // flight. See `_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;
     try {
-      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
+      return await findTarget(
+        this.owner,
+        this.reflection.name,
+        this.reflection.options,
+        undefined,
+        this._skipStrictLoading,
+      );
     } finally {
       this._loaderWritebackSuppressed--;
     }
@@ -501,6 +507,10 @@ export function setIntersection(a: Base[], b: Base[]): Base[] {
  * through-association loaders reach the loader without one; that triple shape
  * is a trails-only calling convention, not Rails surface.
  *
+ * `skipStrictLoading` carries the association's `@skip_strict_loading`
+ * (association.rb) into this loader, since the strict-loading check Rails runs
+ * inside `find_target` lives here rather than on the association instance.
+ *
  * @internal
  */
 export async function findTarget(
@@ -508,6 +518,7 @@ export async function findTarget(
   assocName: string,
   options: AssociationOptions,
   queryExecutor?: () => Promise<Base[]>,
+  skipStrictLoading = false,
 ): Promise<Base[]> {
   if (options.through) {
     validateThroughReflection(record.constructor as typeof Base, assocName);
@@ -539,6 +550,7 @@ export async function findTarget(
   // Strict loading check. Gated by `find_target?`: a new-record owner without
   // the FK present never reaches `find_target` and so never raises.
   if (
+    !skipStrictLoading &&
     _violatesStrictLoading(record, options) &&
     _findTargetReachable(record, assocName, options, "foreign")
   ) {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "concat",
-    "call": "skip_strict_loading",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "concat_records",
     "call": "loaded?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Follow-up to #5751 (which collapsed the *through* half of the proxy's write
path). The non-through half of `CollectionProxy#push` was still a proxy-local
reimplementation: it derived the foreign key, the composite
`activeRecordPrimaryKey` pairing and the polymorphic `<as>_type` column itself,
then defined a local `insertRecord` closure that wrote those attributes and
called `record.save()`.

Rails has none of that. `CollectionProxy#<<` is `proxy_association.concat(records)`
(`collection_proxy.rb:1053`) and the FK assignment is
`CollectionAssociation#insert_record` → `set_owner_attributes(record)` +
`record.save` (`collection_association.rb:439-446`).

## What changed

- `CollectionProxy#push`'s non-through branch is now
  `await assoc.concat(...records)`. The proxy-local FK / PK / polymorphic-type
  derivation and the `insertRecord` closure are deleted, along with the local
  new-record `load_target` and persisted-owner `transaction` wrapping — `concat`
  owns both (`collection_association.rb:127-135`). Proxy and association share
  one in-memory target, so membership, loaded-ness,
  `@replaced_or_added_targets` dedup and before/after_add all still land on the
  proxy.

Three convergence fixes fall out of routing through the OO path — each one was
previously done *only* on the proxy side:

- `CollectionAssociation#addToTarget` now ORs `association_scope.distinct_value`
  into `replace`, as Rails' `add_to_target` does
  (`collection_association.rb:283`). The proxy used to pass `this.distinctValue`
  at every call site.
- `setOwnerAttributes` pairs the child FK columns against the reflection's
  `activeRecordPrimaryKey` — Rails' `join_foreign_key`
  (`foreign_association.rb:25-33`) — rather than the owner's bare `primaryKey`.
  Without it a composite FK derived from `query_constraints`
  (`Sharded::BlogPost` `[blog_id, id]`) collapses both columns onto `id`.
- `Association#setInverseInstance` raises `_explicitTarget` on a singular
  inverse, as the proxy's `_cacheSingularTarget` seeding path already did.
  `_explicitTarget` is the trails flag `_loadedSingularTarget` consults before
  the inner belongs_to/has_one loaders query (RFC 0022); Rails has no analog, so
  an inverse wired through `setInverseInstance` otherwise read back as unset and
  re-queried.

- `concat` wraps the new-record-owner `load_target` in `skip_strict_loading`
  (`collection_association.rb:128`), which trails had never carried; the deleted
  proxy code side-stepped it by faking the load. `Association#skipStrictLoading`
  is widened to `protected` and made promise-aware (Ruby's `ensure` fires after
  the block completes; restoring at the first `await` would leave the query it
  guards unprotected), and the flag is threaded into the functional has_many
  loader, where the `find_target` strict-loading check actually lives.

`appendBang`'s post-push `RecordInvalid` re-check is unaffected: `push` still
returns `false` on the swallowed `Rollback` and the proxy otherwise.

## Verification

- `packages/activerecord/src/associations/` + `associations.test.ts` +
  `autosave-association.test.ts` — 91 files, 2317 passed
- also green: `counter-cache*`, `nested-attributes*`, `base.test.ts`,
  `persistence.test.ts`, `relations.test.ts`, `transactions.test.ts`,
  `dirty.test.ts`
- `pnpm api:compare` — clean (exit 0, no ratchet movement)
- `pnpm test:compare` — clean; no test files touched, so the delta is zero

Net −33 LOC, no new API surface.

Closes-story: route-non-through-collection-push-onto-concat-records
