### PR TITLE
refactor(activerecord): drop the invented numeric guard from assumeMigratedUptoVersion

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -834,6 +834,17 @@ describe("assumeMigratedUptoVersion", () => {
     ]);
   });
 
+  it("strips digit-separating underscores like String#to_i", async () => {
+    const { ss, execute } = makeStatementsWithMigrations([1, 2]);
+
+    await ss.assumeMigratedUptoVersion("1_000");
+
+    expect(execute.mock.calls.map((c) => c[0])).toEqual([
+      'INSERT INTO "schema_migrations" (version) VALUES (1000)',
+      'INSERT INTO "schema_migrations" (version) VALUES\n(2),\n(1);',
+    ]);
+  });
+
   it("takes the leading integer prefix of a partially numeric version", async () => {
     const { ss, execute } = makeStatementsWithMigrations([1, 2, 20]);
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -824,9 +824,6 @@ describe("assumeMigratedUptoVersion", () => {
     ]);
   });
 
-  // Rails' assume_migrated_upto_version does `version.to_i` with no validation
-  // (abstract/schema_statements.rb:1365), so a non-numeric version becomes 0:
-  // version 0 is inserted and nothing sorts below it.
   it("coerces a non-numeric version to 0 rather than raising", async () => {
     const { ss, execute } = makeStatementsWithMigrations([1, 2]);
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -795,3 +795,56 @@ describe("buildCreateTableDefinition hash-form id type fetch", () => {
     expect(td.columns.find((c) => c.options.primaryKey)?.type).toBe("primary_key");
   });
 });
+
+describe("assumeMigratedUptoVersion", () => {
+  function makeStatementsWithMigrations(migrations: number[], migrated: number[] = []) {
+    const execute = vi.fn().mockResolvedValue([]);
+    const ss = makeStatements({
+      execute,
+      quote: (v: unknown) => String(v),
+      pool: {
+        schemaMigration: { tableName: "schema_migrations" },
+        migrationContext: {
+          getAllVersions: async () => migrated,
+          migrations: migrations.map((version) => ({ version })),
+        },
+      },
+    });
+    return { ss, execute };
+  }
+
+  it("inserts the target version and every earlier known migration", async () => {
+    const { ss, execute } = makeStatementsWithMigrations([1, 2, 20], [1]);
+
+    await ss.assumeMigratedUptoVersion(10);
+
+    expect(execute.mock.calls.map((c) => c[0])).toEqual([
+      'INSERT INTO "schema_migrations" (version) VALUES (10)',
+      'INSERT INTO "schema_migrations" (version) VALUES\n(2);',
+    ]);
+  });
+
+  // Rails' assume_migrated_upto_version does `version.to_i` with no validation
+  // (abstract/schema_statements.rb:1365), so a non-numeric version becomes 0:
+  // version 0 is inserted and nothing sorts below it.
+  it("coerces a non-numeric version to 0 rather than raising", async () => {
+    const { ss, execute } = makeStatementsWithMigrations([1, 2]);
+
+    await ss.assumeMigratedUptoVersion("not_a_version");
+
+    expect(execute.mock.calls.map((c) => c[0])).toEqual([
+      'INSERT INTO "schema_migrations" (version) VALUES (0)',
+    ]);
+  });
+
+  it("takes the leading integer prefix of a partially numeric version", async () => {
+    const { ss, execute } = makeStatementsWithMigrations([1, 2, 20]);
+
+    await ss.assumeMigratedUptoVersion("10abc");
+
+    expect(execute.mock.calls.map((c) => c[0])).toEqual([
+      'INSERT INTO "schema_migrations" (version) VALUES (10)',
+      'INSERT INTO "schema_migrations" (version) VALUES\n(2),\n(1);',
+    ]);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1833,8 +1833,8 @@ export class SchemaStatements {
   }
 
   async assumeMigratedUptoVersion(version: number | string): Promise<void> {
-    const leading = /^\s*([+-]?\d+)/.exec(String(version));
-    const verNum = leading ? parseInt(leading[1], 10) : 0;
+    const leading = /^\s*([+-]?\d+(?:_\d+)*)/.exec(String(version));
+    const verNum = leading ? parseInt(leading[1].replace(/_/g, ""), 10) : 0;
 
     const pool = (this.adapter as any).pool;
     const smTableName = pool?.schemaMigration?.tableName ?? "schema_migrations";

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1833,10 +1833,6 @@ export class SchemaStatements {
   }
 
   async assumeMigratedUptoVersion(version: number | string): Promise<void> {
-    // Rails does `version = version.to_i` with no validation, so a non-numeric
-    // argument coerces to 0 rather than raising.
-    // Mirror Ruby String#to_i: leading signed-integer prefix, 0 when there is
-    // none ("abc" -> 0, "123abc" -> 123).
     const leading = /^\s*([+-]?\d+)/.exec(String(version));
     const verNum = leading ? parseInt(leading[1], 10) : 0;
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1833,11 +1833,12 @@ export class SchemaStatements {
   }
 
   async assumeMigratedUptoVersion(version: number | string): Promise<void> {
-    const ver = String(version);
-    if (!/^\d+$/.test(ver)) {
-      throw new Error(`Invalid migration version: ${version}`);
-    }
-    const verNum = parseInt(ver, 10);
+    // Rails does `version = version.to_i` with no validation, so a non-numeric
+    // argument coerces to 0 rather than raising.
+    // Mirror Ruby String#to_i: leading signed-integer prefix, 0 when there is
+    // none ("abc" -> 0, "123abc" -> 123).
+    const leading = /^\s*([+-]?\d+)/.exec(String(version));
+    const verNum = leading ? parseInt(leading[1], 10) : 0;
 
     const pool = (this.adapter as any).pool;
     const smTableName = pool?.schemaMigration?.tableName ?? "schema_migrations";


### PR DESCRIPTION
Rails' `assume_migrated_upto_version` (`abstract/schema_statements.rb:1365`) is
just `version = version.to_i` — no validation. trails opened with an invented
regex guard that raised `Invalid migration version: …` for any non-numeric
argument, which is observable to callers.

- Replace the guard with a `String#to_i` analogue: leading signed-integer
  prefix, `0` when there is none.
- Cover the coercion path: a non-numeric version targets `0` (inserted, nothing
  below it) instead of raising, and `"10abc"` targets `10`.

Closes-story: assume-migrated-upto-version-drop-invented-numeric-guard
