### PR TITLE
feat(migration): wrap methodMissing in sayWithTime with properTableName rewriting

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -886,7 +886,7 @@ describe("MigrationTest", () => {
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
 
-  it("method missing delegates to connection", () => {
+  it("method missing delegates to connection", async () => {
     class M extends Migration {
       override get connection(): DatabaseAdapter {
         return { createTable: () => "hi mom!" } as unknown as DatabaseAdapter;
@@ -895,7 +895,7 @@ describe("MigrationTest", () => {
       async down() {}
     }
     const migration = new M();
-    expect(migration.methodMissing("createTable")).toBe("hi mom!");
+    expect(await migration.methodMissing("createTable")).toBe("hi mom!");
   });
 
   it("filtering migrations", async () => {

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -277,13 +277,112 @@ describe("Migration#createTable id option type", () => {
       expect(migration.executionStrategy).toBe(migration.executionStrategy);
     });
 
-    it("forwards unknown calls through the strategy to the connection", () => {
+    it("forwards unknown calls through the strategy to the connection", async () => {
       const migration = new StrategyMigration();
       const strategy = migration.executionStrategy as DefaultStrategy;
       expect(strategy.respondToMissing("createTable")).toBe(true);
       expect(strategy.respondToMissing("nopeNotHere")).toBe(false);
       expect(strategy.methodMissing("createTable")).toBe("hi mom!");
-      expect(() => migration.methodMissing("nopeNotHere")).toThrow(TypeError);
+      await expect(migration.methodMissing("nopeNotHere")).rejects.toThrow(TypeError);
+    });
+
+    // `Migration#methodMissing` mirrors `migration.rb:1044-1058`: the dispatch
+    // is wrapped in `sayWithTime` and the leading table-name arguments are
+    // rewritten through `properTableName`.
+    class RecordingMigration extends Migration {
+      calls: [string, unknown[]][] = [];
+      lines: string[] = [];
+      revertable = false;
+      override get connection(): DatabaseAdapter {
+        const record =
+          (name: string) =>
+          (...args: unknown[]) => {
+            this.calls.push([name, args]);
+            return name;
+          };
+        const conn: Record<string, unknown> = {
+          createTable: record("createTable"),
+          renameTable: record("renameTable"),
+          removeForeignKey: record("removeForeignKey"),
+          execute: record("execute"),
+        };
+        if (this.revertable) conn["revert"] = () => undefined;
+        return conn as unknown as DatabaseAdapter;
+      }
+      override write(text = ""): void {
+        this.lines.push(text);
+      }
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    const withTableNameAffixes = async (fn: () => Promise<void>): Promise<void> => {
+      const savedPrefix = Base.tableNamePrefix;
+      const savedSuffix = Base.tableNameSuffix;
+      Base.tableNamePrefix = "p_";
+      Base.tableNameSuffix = "_s";
+      try {
+        await fn();
+      } finally {
+        Base.tableNamePrefix = savedPrefix;
+        Base.tableNameSuffix = savedSuffix;
+      }
+    };
+
+    it("announces and times the dispatched statement", async () => {
+      const migration = new RecordingMigration();
+      const verboseWas = Migration.verbose;
+      Migration.verbose = true;
+      try {
+        await migration.methodMissing("createTable", "widgets", { id: false });
+      } finally {
+        Migration.verbose = verboseWas;
+      }
+      expect(migration.lines[0]).toBe('-- createTable("widgets", {"id":false})');
+      expect(migration.lines[1]).toMatch(/^ {3}-> \d+\.\d{4}s$/);
+    });
+
+    it("rewrites the first argument through properTableName", async () => {
+      await withTableNameAffixes(async () => {
+        const migration = new RecordingMigration();
+        await migration.methodMissing("createTable", "widgets", { id: false });
+        expect(migration.calls).toEqual([["createTable", ["p_widgets_s", { id: false }]]]);
+      });
+    });
+
+    it("rewrites the second argument for renameTable and non-Hash removeForeignKey", async () => {
+      await withTableNameAffixes(async () => {
+        const migration = new RecordingMigration();
+        await migration.methodMissing("renameTable", "widgets", "gadgets");
+        await migration.methodMissing("removeForeignKey", "widgets", "gadgets");
+        await migration.methodMissing("removeForeignKey", "widgets", { column: "gadget_id" });
+        expect(migration.calls).toEqual([
+          ["renameTable", ["p_widgets_s", "p_gadgets_s"]],
+          ["removeForeignKey", ["p_widgets_s", "p_gadgets_s"]],
+          ["removeForeignKey", ["p_widgets_s", { column: "gadget_id" }]],
+        ]);
+      });
+    });
+
+    it("leaves execute and no-argument calls untouched", async () => {
+      await withTableNameAffixes(async () => {
+        const migration = new RecordingMigration();
+        await migration.methodMissing("execute", "SELECT 1");
+        await migration.methodMissing("createTable");
+        expect(migration.calls).toEqual([
+          ["execute", ["SELECT 1"]],
+          ["createTable", []],
+        ]);
+      });
+    });
+
+    it("skips the rewriting when the connection responds to revert", async () => {
+      await withTableNameAffixes(async () => {
+        const migration = new RecordingMigration();
+        migration.revertable = true;
+        await migration.methodMissing("createTable", "widgets");
+        expect(migration.calls).toEqual([["createTable", ["widgets"]]]);
+      });
     });
   });
 });

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -286,9 +286,6 @@ describe("Migration#createTable id option type", () => {
       await expect(migration.methodMissing("nopeNotHere")).rejects.toThrow(TypeError);
     });
 
-    // `Migration#methodMissing` mirrors `migration.rb:1044-1058`: the dispatch
-    // is wrapped in `sayWithTime` and the leading table-name arguments are
-    // rewritten through `properTableName`.
     class RecordingMigration extends Migration {
       calls: [string, unknown[]][] = [];
       lines: string[] = [];

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -5,6 +5,7 @@ import {
   camelize,
   underscore,
   humanize,
+  isPlainObject,
   stdout,
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -1573,15 +1574,32 @@ export abstract class Migration {
   }
 
   /** @internal */
-  methodMissing(name: string, ...args: unknown[]): unknown {
-    const strategy = this.executionStrategy as {
-      respondToMissing?: (name: string) => boolean;
-      methodMissing?: (name: string, ...args: unknown[]) => unknown;
-    };
-    if (strategy.respondToMissing?.(name) !== true) {
-      throw new TypeError(`undefined method '${name}' for ${this.connection.constructor.name}`);
-    }
-    return strategy.methodMissing?.(name, ...args);
+  async methodMissing(name: string, ...args: unknown[]): Promise<unknown> {
+    return await this.sayWithTime(`${name}(${this.formatArguments(args)})`, async () => {
+      const conn = this.connection as unknown as Record<string, unknown>;
+      if (typeof conn["revert"] !== "function") {
+        if (args.length > 0 && !["execute", "enableExtension", "disableExtension"].includes(name)) {
+          args[0] = Migration.properTableName(
+            args[0] as string | { tableName?: unknown },
+            Migration.tableNameOptions(),
+          );
+          if (name === "renameTable" || (name === "removeForeignKey" && !isPlainObject(args[1]))) {
+            args[1] = Migration.properTableName(
+              args[1] as string | { tableName?: unknown },
+              Migration.tableNameOptions(),
+            );
+          }
+        }
+      }
+      const strategy = this.executionStrategy as {
+        respondToMissing?: (name: string) => boolean;
+        methodMissing?: (name: string, ...args: unknown[]) => unknown;
+      };
+      if (strategy.respondToMissing?.(name) !== true) {
+        throw new TypeError(`undefined method '${name}' for ${this.connection.constructor.name}`);
+      }
+      return await strategy.methodMissing?.(name, ...args);
+    });
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1580,9 +1580,12 @@ export abstract class Migration {
       if (typeof conn["revert"] !== "function") {
         if (args.length > 0 && !["execute", "enableExtension", "disableExtension"].includes(name)) {
           const options = Migration.tableNameOptions();
-          args[0] = Migration.properTableName(args[0] as string, options);
+          args[0] = Migration.properTableName(args[0] as string | { tableName?: unknown }, options);
           if (name === "renameTable" || (name === "removeForeignKey" && !isPlainObject(args[1]))) {
-            args[1] = Migration.properTableName(args[1] as string, options);
+            args[1] = Migration.properTableName(
+              args[1] as string | { tableName?: unknown },
+              options,
+            );
           }
         }
       }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1579,15 +1579,10 @@ export abstract class Migration {
       const conn = this.connection as unknown as Record<string, unknown>;
       if (typeof conn["revert"] !== "function") {
         if (args.length > 0 && !["execute", "enableExtension", "disableExtension"].includes(name)) {
-          args[0] = Migration.properTableName(
-            args[0] as string | { tableName?: unknown },
-            Migration.tableNameOptions(),
-          );
+          const options = Migration.tableNameOptions();
+          args[0] = Migration.properTableName(args[0] as string, options);
           if (name === "renameTable" || (name === "removeForeignKey" && !isPlainObject(args[1]))) {
-            args[1] = Migration.properTableName(
-              args[1] as string | { tableName?: unknown },
-              Migration.tableNameOptions(),
-            );
+            args[1] = Migration.properTableName(args[1] as string, options);
           }
         }
       }


### PR DESCRIPTION
Ports the remaining body of Rails' `Migration#method_missing`
(`vendor/rails/activerecord/lib/active_record/migration.rb:1044-1058`). The
strategy dispatch added by #5743 was bare; it now:

- wraps the call in `sayWithTime` with Rails' `"#{method}(#{formatArguments(arguments)})"` label, so schema statements dispatched this way announce and time themselves;
- rewrites `arguments[0]` via `properTableName(..., tableNameOptions())` unless the connection responds to `revert`, the arguments are empty, or the method is `execute` / `enableExtension` / `disableExtension`;
- rewrites `arguments[1]` too for `renameTable` and for `removeForeignKey` with a non-Hash second argument.

`methodMissing` becomes async because `sayWithTime` is (trails' sync/async
split); the two existing tests that call it were updated to await.

Tests: announce/timing output, first-argument rewriting, the second-argument
rewrite for `renameTable` / non-Hash `removeForeignKey`, the `execute` and
empty-argument exemptions, and the `revert` escape.

Closes-story: migration-method-missing-say-with-time-and-proper-table-name