### PR TITLE
refactor(migration): type the validate-constraint delegations instead of casting to any

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -199,19 +199,16 @@ export type JoinTableOptions = {
  * signature drift on the adapter fails typecheck at the call site.
  */
 export interface ValidateConstraintStatements {
-  // Declared as function-typed properties, not methods: method syntax is checked
-  // bivariantly, which would let an adapter narrow a parameter (the `{ name?: string }`
-  // regression #5501 fixed) without failing `implements`.
-  validateConstraint: (tableName: string, constraintName: string) => Promise<void>;
-  validateCheckConstraint: (
+  validateConstraint(tableName: string, constraintName: string): Promise<void>;
+  validateCheckConstraint(
     tableName: string,
     nameOrOptions: string | { name: string },
-  ) => Promise<void>;
-  validateForeignKey: (
+  ): Promise<void>;
+  validateForeignKey(
     fromTable: string,
     toTable?: string,
     options?: Omit<ForeignKeyLookupOptions, "toTable">,
-  ) => Promise<void>;
+  ): Promise<void>;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -191,6 +191,29 @@ export type JoinTableOptions = {
   as?: string;
 };
 
+/**
+ * Constraint-validation statements that only adapters supporting
+ * `supportsValidateConstraints` (PostgreSQL) implement. Rails' `Migration`
+ * reaches them through `method_missing`, which is untyped in Ruby; declaring
+ * them here lets our delegations narrow to a real type instead of `any`, so
+ * signature drift on the adapter fails typecheck at the call site.
+ */
+export interface ValidateConstraintStatements {
+  // Declared as function-typed properties, not methods: method syntax is checked
+  // bivariantly, which would let an adapter narrow a parameter (the `{ name?: string }`
+  // regression #5501 fixed) without failing `implements`.
+  validateConstraint: (tableName: string, constraintName: string) => Promise<void>;
+  validateCheckConstraint: (
+    tableName: string,
+    nameOrOptions: string | { name: string },
+  ) => Promise<void>;
+  validateForeignKey: (
+    fromTable: string,
+    toTable?: string,
+    options?: Omit<ForeignKeyLookupOptions, "toTable">,
+  ) => Promise<void>;
+}
+
 /** @internal */
 function expandIndexOption<T>(opt: Record<string, T> | T, columns: string[]): Record<string, T> {
   if (typeof opt === "object" && opt !== null) return opt as Record<string, T>;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -74,7 +74,10 @@ import { AbstractAdapter, RAW_CONNECTION_DEPRECATION_MESSAGE } from "./abstract-
 import { deprecator } from "../deprecator.js";
 import { captureUnwrappedExecute, dirtiesQueryCache } from "./abstract/query-cache.js";
 import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class.js";
-import type { JoinTableOptions } from "./abstract/schema-statements.js";
+import type {
+  JoinTableOptions,
+  ValidateConstraintStatements,
+} from "./abstract/schema-statements.js";
 import { SchemaStatements } from "./abstract/schema-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
@@ -171,7 +174,10 @@ function toError(value: unknown): Error {
  * shape where driver params and adapter knobs share one hash.
  * Uses a connection pool internally for concurrent access.
  */
-export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapter {
+export class PostgreSQLAdapter
+  extends AbstractAdapter
+  implements DatabaseAdapter, ValidateConstraintStatements
+{
   override get adapterName(): AdapterName {
     return "postgres";
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -773,23 +773,13 @@ export abstract class Migration {
     tableName = this._pt(tableName);
     await this.schema.removeCheckConstraint(tableName, expressionOrOptions, options);
   }
-  // Rails forwards these to the connection through Migration#method_missing, which is
-  // untyped in Ruby. They only exist on adapters that support validating constraints
-  // (PostgreSQL), so the abstract adapter type genuinely lacks them — narrow to the
-  // interface that declares them rather than casting the call away.
-  /** @internal */
-  private _validateConstraintStatements(): DatabaseAdapter & ValidateConstraintStatements {
-    return this.connection as DatabaseAdapter & ValidateConstraintStatements;
-  }
 
   async validateCheckConstraint(
     tableName: string,
     nameOrOptions: string | { name: string },
   ): Promise<void> {
-    await this._validateConstraintStatements().validateCheckConstraint(
-      this._pt(tableName),
-      nameOrOptions,
-    );
+    const connection = this.connection as DatabaseAdapter & ValidateConstraintStatements;
+    await connection.validateCheckConstraint(this._pt(tableName), nameOrOptions);
   }
 
   async validateForeignKey(
@@ -799,11 +789,8 @@ export abstract class Migration {
   ): Promise<void> {
     const toTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
     const opts = typeof toTableOrOptions === "object" ? toTableOrOptions : (options ?? undefined);
-    await this._validateConstraintStatements().validateForeignKey(
-      this._pt(fromTable),
-      toTable,
-      opts,
-    );
+    const connection = this.connection as DatabaseAdapter & ValidateConstraintStatements;
+    await connection.validateForeignKey(this._pt(fromTable), toTable, opts);
   }
 
   async changeColumnComment(

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -26,6 +26,7 @@ import {
   SchemaStatements,
   assertSchemaAdapter,
   type JoinTableOptions,
+  type ValidateConstraintStatements,
 } from "./connection-adapters/abstract/schema-statements.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
 import { SchemaMigration } from "./schema-migration.js";
@@ -772,11 +773,23 @@ export abstract class Migration {
     tableName = this._pt(tableName);
     await this.schema.removeCheckConstraint(tableName, expressionOrOptions, options);
   }
+  // Rails forwards these to the connection through Migration#method_missing, which is
+  // untyped in Ruby. They only exist on adapters that support validating constraints
+  // (PostgreSQL), so the abstract adapter type genuinely lacks them — narrow to the
+  // interface that declares them rather than casting the call away.
+  /** @internal */
+  private _validateConstraintStatements(): DatabaseAdapter & ValidateConstraintStatements {
+    return this.connection as DatabaseAdapter & ValidateConstraintStatements;
+  }
+
   async validateCheckConstraint(
     tableName: string,
     nameOrOptions: string | { name: string },
   ): Promise<void> {
-    await (this.connection as any).validateCheckConstraint(this._pt(tableName), nameOrOptions);
+    await this._validateConstraintStatements().validateCheckConstraint(
+      this._pt(tableName),
+      nameOrOptions,
+    );
   }
 
   async validateForeignKey(
@@ -786,7 +799,11 @@ export abstract class Migration {
   ): Promise<void> {
     const toTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
     const opts = typeof toTableOrOptions === "object" ? toTableOrOptions : (options ?? undefined);
-    await (this.connection as any).validateForeignKey(this._pt(fromTable), toTable, opts);
+    await this._validateConstraintStatements().validateForeignKey(
+      this._pt(fromTable),
+      toTable,
+      opts,
+    );
   }
 
   async changeColumnComment(


### PR DESCRIPTION
`Migration#validateForeignKey` and `Migration#validateCheckConstraint` delegated
to the connection through `as any`, which defeated every check on the call. That
is how the `{ name?: string }` options shape on
`PostgreSQLAdapter#validateForeignKey` survived undetected until #5501 — no call
site ever typechecked against the real signature.

The delegation itself is real: `validate_foreign_key` is PostgreSQL-only
(`supports_validate_constraints?`, `postgresql_adapter.rb:232`), so
`this.connection`, typed as the abstract adapter, genuinely lacks the method.
Rails forwards it via `Migration#method_missing`
(`migration.rb:1044`), untyped in Ruby, so there is no fidelity reason for
the cast.

Changes:

- New `ValidateConstraintStatements` interface in
  `connection-adapters/abstract/schema-statements.ts` declaring the three
  constraint-validation statements with their real signatures.
- Both `Migration` delegations narrow the connection to
  `DatabaseAdapter & ValidateConstraintStatements` instead of `as any`, so the
  arguments and return type are checked against the real signature.
- `PostgreSQLAdapter` declares `implements ValidateConstraintStatements`, so
  dropping or renaming one of these, or drifting its return type, fails
  typecheck.

Note on the "reintroducing `{ name?: string }` must fail typecheck" criterion:
TypeScript compares class methods **bivariantly**, and `{ name?: string }` is
mutually assignable with `Omit<ForeignKeyLookupOptions, "toTable">` (all keys
optional), so a pure parameter *narrowing* cannot be caught by an interface at
all — I tried both `implements` and standalone assignability aliases and neither
fires. It is only caught by excess-property checking at a call site that passes
an object literal, which `migration/foreign-key.test.ts:522,540` already do
(verified: temporarily re-narrowing the adapter fails typecheck there).

Audit of the other adapter-specific delegations in `migration.ts`
(`changeColumnComment`, `changeTableComment`, `enableExtension`,
`disableExtension`, `createEnum`, `dropEnum`, `renameEnumValue`,
`addUniqueConstraint`, `removeUniqueConstraint`, plus the replay paths): they use
the same `as any` escape, but their migration-level option types are
`Record<string, unknown>` while the adapter declares real shapes
(`UniqueConstraintOptions`, `{ ifExists?: boolean }`, comment `{ from, to }`
hashes), so converging them is an option-type reconciliation rather than a cast
removal. Registered as
`0051-migration-schema-statements-fidelity/migration-remaining-as-any-adapter-delegations`.

Testing: `pnpm typecheck` clean; `migration.test.ts` and
`migration/foreign-key.test.ts` green locally (SQLite lane).
`adapters/postgresql/invertible-migration.test.ts` is PG-lane, covered by CI.

Closes-story: migration-validate-foreign-key-delegates-through-any
