### PR TITLE
fix(tasks): build checkProtectedEnvironments' migrator from its dbConfig

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { DatabaseTasks } from "./database-tasks.js";
+import { DatabaseConfigurations } from "../database-configurations.js";
+import { Base } from "../base.js";
+import { ProtectedEnvironmentError } from "../migration.js";
+import { adapterType } from "../test-adapter.js";
+import { inMemoryDb } from "../support/adapter-helper.js";
+
+// TS-only coverage for the migrator built inside
+// `checkProtectedEnvironments!`: Rails compares the stored stamp against
+// `migration_context.current_environment` (the config's own env), so the
+// migrator has to be built with `environment: dbConfig.envName`. Without it
+// the migrator's current environment falls back to TRAILS_ENV / NODE_ENV and
+// a config living under a different env name mismatches against itself.
+describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => {
+  const dirs: string[] = [];
+  const env = "storyenv";
+
+  afterEach(async () => {
+    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.clearRegisteredTasks();
+    for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true });
+  });
+
+  async function stampedConfig(): Promise<void> {
+    const dir = await mkdtemp(join(tmpdir(), "trails-protected-env-"));
+    dirs.push(dir);
+    const dbFile = join(dir, "primary.sqlite3");
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      [env]: { primary: { adapter: "sqlite3", database: dbFile, pool: 1 } },
+    });
+    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+
+    const { BetterSQLite3Adapter } =
+      await import("../connection-adapters/better-sqlite3-adapter.js");
+    const adapter = new BetterSQLite3Adapter(dbFile);
+    try {
+      // Per-test tmpdir database, dropped with the directory in afterEach.
+      await adapter.executeMutation(
+        // eslint-disable-next-line blazetrails/require-table-teardown
+        "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR(255) PRIMARY KEY NOT NULL)",
+      );
+      await adapter.executeMutation("INSERT INTO schema_migrations (version) VALUES ('1')");
+      // Per-test tmpdir database, dropped with the directory in afterEach.
+      await adapter.executeMutation(
+        // eslint-disable-next-line blazetrails/require-table-teardown
+        "CREATE TABLE IF NOT EXISTS ar_internal_metadata (key VARCHAR PRIMARY KEY NOT NULL, value VARCHAR, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)",
+      );
+      await adapter.executeMutation(
+        `INSERT INTO ar_internal_metadata (key, value, created_at, updated_at) VALUES ('environment', '${env}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      );
+    } finally {
+      await adapter.close();
+    }
+  }
+
+  it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
+    "compares the stored environment against the config's own environment",
+    async () => {
+      expect(DatabaseTasks.env).not.toBe(env);
+      await stampedConfig();
+      await DatabaseTasks.checkProtectedEnvironmentsBang(env);
+    },
+  );
+
+  it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
+    "raises when the config's own environment is protected",
+    async () => {
+      const protectedEnvironments = Base.protectedEnvironments;
+      await stampedConfig();
+      Base.protectedEnvironments = [env];
+      try {
+        await expect(DatabaseTasks.checkProtectedEnvironmentsBang(env)).rejects.toThrow(
+          ProtectedEnvironmentError,
+        );
+      } finally {
+        Base.protectedEnvironments = protectedEnvironments;
+      }
+    },
+  );
+});

--- a/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
@@ -5,16 +5,10 @@ import { join } from "path";
 import { DatabaseTasks } from "./database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
-import { ProtectedEnvironmentError } from "../migration.js";
+import { EnvironmentMismatchError, ProtectedEnvironmentError } from "../migration.js";
 import { adapterType } from "../test-adapter.js";
 import { inMemoryDb } from "../support/adapter-helper.js";
 
-// TS-only coverage for the migrator built inside
-// `checkProtectedEnvironments!`: Rails compares the stored stamp against
-// `migration_context.current_environment` (the config's own env), so the
-// migrator has to be built with `environment: dbConfig.envName`. Without it
-// the migrator's current environment falls back to TRAILS_ENV / NODE_ENV and
-// a config living under a different env name mismatches against itself.
 describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => {
   const dirs: string[] = [];
   const env = "storyenv";
@@ -25,7 +19,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
     for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true });
   });
 
-  async function stampedConfig(): Promise<void> {
+  async function stampedConfig(storedEnv: string = env): Promise<void> {
     const dir = await mkdtemp(join(tmpdir(), "trails-protected-env-"));
     dirs.push(dir);
     const dbFile = join(dir, "primary.sqlite3");
@@ -38,19 +32,17 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
       await import("../connection-adapters/better-sqlite3-adapter.js");
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
-      // Per-test tmpdir database, dropped with the directory in afterEach.
       await adapter.executeMutation(
         // eslint-disable-next-line blazetrails/require-table-teardown
         "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR(255) PRIMARY KEY NOT NULL)",
       );
       await adapter.executeMutation("INSERT INTO schema_migrations (version) VALUES ('1')");
-      // Per-test tmpdir database, dropped with the directory in afterEach.
       await adapter.executeMutation(
         // eslint-disable-next-line blazetrails/require-table-teardown
         "CREATE TABLE IF NOT EXISTS ar_internal_metadata (key VARCHAR PRIMARY KEY NOT NULL, value VARCHAR, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)",
       );
       await adapter.executeMutation(
-        `INSERT INTO ar_internal_metadata (key, value, created_at, updated_at) VALUES ('environment', '${env}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        `INSERT INTO ar_internal_metadata (key, value, created_at, updated_at) VALUES ('environment', '${storedEnv}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
       );
     } finally {
       await adapter.close();
@@ -63,6 +55,20 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
       expect(DatabaseTasks.env).not.toBe(env);
       await stampedConfig();
       await DatabaseTasks.checkProtectedEnvironmentsBang(env);
+    },
+  );
+
+  it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
+    "reports the config's own environment as current on a mismatch",
+    async () => {
+      await stampedConfig("otherenv");
+      const error = await DatabaseTasks.checkProtectedEnvironmentsBang(env).catch(
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(EnvironmentMismatchError);
+      expect((error as Error).message).toMatch(
+        new RegExp(`last run in \`otherenv\`[\\s\\S]*running in \`${env}\``),
+      );
     },
   );
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -604,9 +604,6 @@ export class DatabaseTasks {
       try {
         await this.withTemporaryConnection(config, async (adapter) => {
           const migrator = await this._migratorFor(adapter, config);
-          // Rails compares against `migration_context.current_environment`
-          // (the pool's config env), not the method's `environment`
-          // argument.
           const current = migrator.currentEnvironment;
           const stored = await migrator.lastStoredEnvironment();
           if (await migrator.protectedEnvironment()) {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -598,20 +598,22 @@ export class DatabaseTasks {
     }
 
     const { NoDatabaseError } = await import("../errors.js");
-    const { Migrator, EnvironmentMismatchError } = await import("../migration.js");
+    const { EnvironmentMismatchError } = await import("../migration.js");
 
     for (const config of configs) {
       try {
         await this.withTemporaryConnection(config, async (adapter) => {
-          const migrator = new Migrator(adapter, [], {
-            internalMetadataEnabled: config.useMetadataTable,
-          });
+          const migrator = await this._migratorFor(adapter, config);
+          // Rails compares against `migration_context.current_environment`
+          // (the pool's config env), not the method's `environment`
+          // argument.
+          const current = migrator.currentEnvironment;
           const stored = await migrator.lastStoredEnvironment();
-          if (stored && protectedEnvs.includes(stored)) {
-            throw new ProtectedEnvironmentError(stored);
+          if (await migrator.protectedEnvironment()) {
+            throw new ProtectedEnvironmentError(stored ?? current);
           }
-          if (stored && stored !== envName) {
-            throw new EnvironmentMismatchError(envName, stored);
+          if (stored && stored !== current) {
+            throw new EnvironmentMismatchError(current, stored);
           }
         });
       } catch (error) {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -606,8 +606,8 @@ export class DatabaseTasks {
           const migrator = await this._migratorFor(adapter, config);
           const current = migrator.currentEnvironment;
           const stored = await migrator.lastStoredEnvironment();
-          if (await migrator.protectedEnvironment()) {
-            throw new ProtectedEnvironmentError(stored ?? current);
+          if (stored && (await migrator.protectedEnvironment())) {
+            throw new ProtectedEnvironmentError(stored);
           }
           if (stored && stored !== current) {
             throw new EnvironmentMismatchError(current, stored);


### PR DESCRIPTION
`checkProtectedEnvironments!` was the one `DatabaseTasks` migrator left
hand-built after #5759. It now goes through `_migratorFor(adapter, config)`,
so it carries `environment: dbConfig.envName` like the other six sites, and
the checks follow Rails' `check_current_protected_environment!`
(`vendor/rails/activerecord/lib/active_record/tasks/database_tasks.rb:635-650`):

- `stored` is compared against `migrator.currentEnvironment`, not the
  method's `environment` argument.
- the protected check goes through `migrator.protectedEnvironment()`
  (the `protected_environment?` equivalent) instead of a local
  `protectedEnvs.includes(stored)` membership test. The local list is still
  used for the no-configs fallback, which has no migrator.

### Coverage

`DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest` (trails-only)
stamps a sqlite config under an env name that is not `TRAILS_ENV` / `NODE_ENV`
and asserts it is checked against its own env: the matching stamp passes, a
`otherenv` stamp raises `EnvironmentMismatchError` naming the config's env as
current, and the config's env being protected raises
`ProtectedEnvironmentError`.

Being straight about it: these tests do **not** fail on `main`. The old code
compared `stored` against the `environment` argument, and
`configsFor({ envName })` only ever returns configs whose `envName` equals
that argument — so the two values coincided and the divergence was latent,
not observable. The tests do fail if `environment: dbConfig.envName` is
dropped from `_migratorFor` (verified by mutation), which is what the
now-live `currentEnvironment` read depends on.

Closes-story: check-protected-environments-migrator-from-db-config
