### PR TITLE
fix(migration): render formatArguments with Ruby inspect semantics

### DIFF
--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -357,8 +357,6 @@ describe("Migration#createTable id option type", () => {
     });
 
     it("announces a non-Hash object last argument through inspect", async () => {
-      // A Temporal value is an object but not a Hash, so Ruby takes the
-      // `inspect` branch; the options-filtering branch would drop it entirely.
       expect(await announce("execute", "SELECT 1", Temporal.PlainDate.from("2024-01-01"))).toBe(
         '-- execute("SELECT 1", 2024-01-01)',
       );

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -9,6 +9,7 @@
  * Rails 1:1 while the invariants stay covered.
  */
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { MigrationContext, Migrator } from "./index.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migration, IllegalMigrationNameError } from "./migration.js";
@@ -335,8 +336,41 @@ describe("Migration#createTable id option type", () => {
       } finally {
         Migration.verbose = verboseWas;
       }
-      expect(migration.lines[0]).toBe('-- createTable("widgets", {"id":false})');
+      expect(migration.lines[0]).toBe('-- createTable("widgets", {id: false})');
       expect(migration.lines[1]).toMatch(/^ {3}-> \d+\.\d{4}s$/);
+    });
+
+    const announce = async (name: string, ...args: unknown[]): Promise<string> => {
+      const migration = new RecordingMigration();
+      const verboseWas = Migration.verbose;
+      Migration.verbose = true;
+      try {
+        await migration.methodMissing(name, ...args);
+      } finally {
+        Migration.verbose = verboseWas;
+      }
+      return migration.lines[0];
+    };
+
+    it("announces a no-argument call with Ruby's nil last argument", async () => {
+      expect(await announce("createTable")).toBe("-- createTable(nil)");
+    });
+
+    it("announces a non-Hash object last argument through inspect", async () => {
+      // A Temporal value is an object but not a Hash, so Ruby takes the
+      // `inspect` branch; the options-filtering branch would drop it entirely.
+      expect(await announce("execute", "SELECT 1", Temporal.PlainDate.from("2024-01-01"))).toBe(
+        '-- execute("SELECT 1", 2024-01-01)',
+      );
+    });
+
+    it("drops internal options and renders the rest Ruby-inspect style", async () => {
+      expect(await announce("createTable", "widgets", { _uses_legacy_table_name: true })).toBe(
+        '-- createTable("widgets")',
+      );
+      expect(await announce("createTable", "widgets", { id: false, force: "cascade" })).toBe(
+        '-- createTable("widgets", {id: false, force: "cascade"})',
+      );
     });
 
     it("rewrites the first argument through properTableName", async () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -9,6 +9,7 @@ import {
   stdout,
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
+import { rubyInspect } from "./relation/ruby-inspect.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
@@ -1607,17 +1608,17 @@ export abstract class Migration {
 
   /** @internal */
   formatArguments(args: unknown[]): string {
-    const safeJson = (v: unknown) =>
-      JSON.stringify(v, (_k, val) => (typeof val === "bigint" ? `${val}n` : val));
-    const argList = args.slice(0, -1).map((a) => safeJson(a));
+    const argList = args.slice(0, -1).map((a) => rubyInspect(a));
+    // Ruby's `arguments.last` on an empty argument list is `nil`, so the
+    // else branch still pushes `"nil"` — `create_table(nil)`, not `create_table()`.
     const last = args[args.length - 1];
-    if (last !== null && typeof last === "object" && !Array.isArray(last)) {
+    if (isPlainObject(last)) {
       const filtered = Object.fromEntries(
-        Object.entries(last as Record<string, unknown>).filter(([k]) => !this.isInternalOption(k)),
+        Object.entries(last).filter(([k]) => !this.isInternalOption(k)),
       );
-      if (Object.keys(filtered).length > 0) argList.push(safeJson(filtered));
-    } else if (last !== undefined) {
-      argList.push(safeJson(last));
+      if (Object.keys(filtered).length > 0) argList.push(rubyInspect(filtered));
+    } else {
+      argList.push(rubyInspect(last));
     }
     return argList.join(", ");
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1606,11 +1606,17 @@ export abstract class Migration {
     return fn();
   }
 
-  /** @internal */
+  /**
+   * Render a dispatched statement's arguments the way Ruby's
+   * `format_arguments` does: every argument through `inspect`, with a
+   * trailing options Hash stripped of internal (`_`-prefixed) keys and
+   * omitted when nothing survives. An empty argument list still yields
+   * `"nil"`, matching Ruby's `arguments.last` on an empty array.
+   *
+   * @internal
+   */
   formatArguments(args: unknown[]): string {
     const argList = args.slice(0, -1).map((a) => rubyInspect(a));
-    // Ruby's `arguments.last` on an empty argument list is `nil`, so the
-    // else branch still pushes `"nil"` — `create_table(nil)`, not `create_table()`.
     const last = args[args.length - 1];
     if (isPlainObject(last)) {
       const filtered = Object.fromEntries(


### PR DESCRIPTION
Converges `Migration#formatArguments` on Ruby's `format_arguments`
(`vendor/rails/activerecord/lib/active_record/migration.rb:1154-1164`), now
user-visible via the `methodMissing` → `sayWithTime` label added in #5769.

Three divergences fixed:

- Arguments render through `rubyInspect` (the existing
  `relation/ruby-inspect.ts` helper) instead of `JSON.stringify`, so a Hash
  reads `{id: false}` rather than `{"id":false}`.
- A no-argument call now pushes `nil` like Ruby's `arguments.last`, giving
  `createTable(nil)` instead of `createTable()`.
- The Hash branch is gated on `isPlainObject` rather than any non-array
  `object`, so a Temporal value or model instance takes the `inspect` branch
  instead of being filtered as options (and silently dropped).

Tests cover all three shapes through the `methodMissing` announce path.

Closes-story: migration-format-arguments-ruby-inspect-fidelity
