### PR TITLE
test(ci): guard suite database names against the rails user's granted namespaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           # of whichever job runs its tests, or a change confined to it runs
           # nothing; scripts/ci-suite-coverage.test.ts enforces that pairing.
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$)'
+          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mysql-grant-namespaces)(\.test)?\.ts$)'
           # AR workspace deps: arel/activemodel/activesupport/globalid/
           # did-you-mean (per packages/activerecord/package.json). Also
           # consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
@@ -183,7 +183,7 @@ jobs:
           # eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
           # its byte set and the ESLint rule's, and scripts/ci/ is carved out
           # of the infra sweep (INFRA_CARVEOUT_RE).
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff)(\.test)?\.ts$|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mysql-grant-namespaces)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -696,6 +696,7 @@ jobs:
           scripts/rails-file-structure-mixins.test.ts
           scripts/deprecated-manifest-diff.test.ts
           scripts/ci-suite-coverage.test.ts
+          scripts/mysql-grant-namespaces.test.ts
           vendor/sources.test.ts
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -51,6 +51,11 @@ const GATE_INPUTS: Record<string, string[]> = {
     "vendor/sources.ts",
     "vendor/sources.lock.json",
     "scripts/api-compare/config.ts",
+    // Inputs scripts/mysql-grant-namespaces.test.ts asserts over: the grant
+    // file it derives the namespaces from, and the CLI E2E suites it reads the
+    // ar_cli_e2e database prefix out of.
+    "scripts/db-init/mysql/01-rails-user.sql",
+    "packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts",
   ],
 };
 

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -53,6 +53,7 @@ const GATE_INPUTS: Record<string, string[]> = {
     "scripts/api-compare/config.ts",
     "scripts/db-init/mysql/01-rails-user.sql",
     "packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts",
+    "packages/activerecord-cli/src/__e2e__/postgres-happy-path.test.ts",
   ],
 };
 

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -51,9 +51,6 @@ const GATE_INPUTS: Record<string, string[]> = {
     "vendor/sources.ts",
     "vendor/sources.lock.json",
     "scripts/api-compare/config.ts",
-    // Inputs scripts/mysql-grant-namespaces.test.ts asserts over: the grant
-    // file it derives the namespaces from, and the CLI E2E suites it reads the
-    // ar_cli_e2e database prefix out of.
     "scripts/db-init/mysql/01-rails-user.sql",
     "packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts",
   ],

--- a/scripts/mysql-grant-namespaces.test.ts
+++ b/scripts/mysql-grant-namespaces.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// scripts/db-init/mysql/01-rails-user.sql grants the `rails` test user a set of
+// database-name PATTERNS rather than *.*, which silently couples that file to
+// every database name the suites invent. The coupling broke during the review
+// of the PR that introduced it (#5646): the activerecord-cli E2E suites create
+// `ar_cli_e2e_<hrtime>` through `ar db:create` as the same user, no grant
+// covered it, and the failure surfaced only on the MySQL legs, only in CI, as
+// an exit code — a grep for `CREATE DATABASE` found nothing, because the
+// database is created through the CLI.
+//
+// This file derives the granted namespaces from that SQL and checks the known
+// database-name producers against them, so a name outside the grants fails here
+// instead of a CI round-trip later.
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const GRANT_FILE = "scripts/db-init/mysql/01-rails-user.sql";
+const E2E_FILES = [
+  "packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts",
+  "packages/activerecord-cli/src/__e2e__/postgres-happy-path.test.ts",
+];
+
+const readRepoFile = (relative: string): Promise<string> =>
+  readFile(path.join(REPO_ROOT, relative), "utf8");
+
+/** The database-name patterns `GRANT ALL PRIVILEGES ON <pattern>.*` names. */
+function grantedPatterns(sql: string): string[] {
+  const patterns = new Set<string>();
+  for (const match of sql.matchAll(/GRANT\s+[^;]*?\sON\s+(`(?:[^`]|``)+`|[^\s.`]+)\.\*/gi)) {
+    const raw = match[1];
+    patterns.add(raw.startsWith("`") ? raw.slice(1, -1).replace(/``/g, "`") : raw);
+  }
+  return [...patterns];
+}
+
+/**
+ * MySQL reads `_` and `%` in a database-level GRANT as LIKE wildcards unless
+ * they are backslash-escaped (dev.mysql.com/doc/en/grant.html), so
+ * `activerecord\_unittest%` matches `activerecord_unittest2` but not
+ * `activerecordXunittest_1`.
+ */
+function grantMatches(pattern: string, database: string): boolean {
+  let source = "";
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+    if (char === "\\" && i + 1 < pattern.length) {
+      source += escapeRegExp(pattern[++i]);
+    } else if (char === "_") {
+      source += ".";
+    } else if (char === "%") {
+      source += ".*";
+    } else {
+      source += escapeRegExp(char);
+    }
+  }
+  return new RegExp(`^${source}$`).test(database);
+}
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The `ar_cli_e2e_<hrtime>` prefix the CLI E2E suites hand to `ar db:create`,
+ * read out of the suites themselves so a rename fails here rather than on the
+ * MySQL legs.
+ */
+async function e2eDatabasePrefixes(): Promise<string[]> {
+  const prefixes: string[] = [];
+  for (const file of E2E_FILES) {
+    const source = await readRepoFile(file);
+    const match = /`([a-z0-9_]+_)\$\{process\.hrtime\.bigint\(\)\}`/.exec(source);
+    expect(
+      match,
+      `no <prefix>_\${process.hrtime.bigint()} database name in ${file}`,
+    ).not.toBeNull();
+    prefixes.push(match![1]);
+  }
+  return prefixes;
+}
+
+/**
+ * Every shape the harness names a MySQL database, from the base
+ * `activerecord_unittest` the CI services provision: the bare base (no run
+ * token stamped), the per-slot `<base>_<token>_<slot>` of `slotDatabaseName`
+ * (support/run-token.ts), and the arunit2 sibling `<base>2` plus its slot form
+ * (support/arunit2-config.ts).
+ */
+function harnessDatabases(base: string): string[] {
+  return [base, `${base}_rm1z9x4q7k_1`, `${base}2`, `${base}2_3`, `${base}_2`];
+}
+
+/**
+ * The base database names the MySQL/MariaDB CI jobs provision and connect to —
+ * read out of ci.yml so renaming the service database fails here too.
+ */
+async function ciMysqlBaseDatabases(): Promise<string[]> {
+  const yml = await readRepoFile(".github/workflows/ci.yml");
+  const bases = new Set<string>();
+  for (const match of yml.matchAll(/^\s*(?:MYSQL|MARIADB)_DATABASE:\s*(\S+)$/gm)) {
+    bases.add(match[1]);
+  }
+  for (const match of yml.matchAll(/^\s*MYSQL_TEST_URL:\s*mysql:\/\/[^/\s]+\/(\S+)$/gm)) {
+    bases.add(match[1]);
+  }
+  expect(bases.size, "no MySQL database names in ci.yml").toBeGreaterThan(0);
+  return [...bases];
+}
+
+describe("mysql grant namespaces", () => {
+  it("covers every database name the suites create", async () => {
+    const patterns = grantedPatterns(await readRepoFile(GRANT_FILE));
+    expect(patterns.length).toBeGreaterThan(0);
+
+    const databases = [
+      ...(await ciMysqlBaseDatabases()).flatMap(harnessDatabases),
+      ...(await e2eDatabasePrefixes()).map((prefix) => `${prefix}1234567890`),
+    ];
+
+    for (const database of databases) {
+      expect(
+        patterns.some((pattern) => grantMatches(pattern, database)),
+        `the rails test user cannot create \`${database}\`: no GRANT in ${GRANT_FILE} covers it. ` +
+          `Granted namespaces: ${patterns.join(", ")}. Add a grant there (both 'rails'@'%' and ` +
+          `'rails'@'localhost') or rename the database into an existing namespace.`,
+      ).toBe(true);
+    }
+  });
+
+  it("leaves the postgres-only temporary databases ungranted", async () => {
+    // connection-adapters/postgresql/schema-statements.test.ts creates these
+    // through the postgres role, which holds CREATEDB — not per-database. No
+    // MySQL grant covers them by design, so a guard that "fixed" that would be
+    // widening the grants for nothing.
+    const patterns = grantedPatterns(await readRepoFile(GRANT_FILE));
+    for (const database of ["trails_test_drop_db_tmp", "trails_test_recreate_tmp"]) {
+      expect(patterns.some((pattern) => grantMatches(pattern, database))).toBe(false);
+    }
+  });
+
+  it("reads unescaped underscore and percent as LIKE wildcards", () => {
+    expect(grantMatches("activerecord\\_unittest%", "activerecord_unittest2")).toBe(true);
+    expect(grantMatches("activerecord\\_unittest%", "activerecordXunittest_1")).toBe(false);
+    expect(
+      grantMatches("inexistent_activerecord_unittest", "inexistentXactiverecordXunittest"),
+    ).toBe(true);
+    expect(grantMatches("ar\\_cli\\_e2e%", "ar_cli_e2e_1234")).toBe(true);
+    expect(grantMatches("ar\\_cli\\_e2e%", "arXcliXe2e_1234")).toBe(false);
+    expect(grantMatches("activerecord\\_unittest%", "xactiverecord_unittest")).toBe(false);
+  });
+});

--- a/scripts/mysql-grant-namespaces.test.ts
+++ b/scripts/mysql-grant-namespaces.test.ts
@@ -3,30 +3,41 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// scripts/db-init/mysql/01-rails-user.sql grants the `rails` test user a set of
-// database-name PATTERNS rather than *.*, which silently couples that file to
-// every database name the suites invent. The coupling broke during the review
-// of the PR that introduced it (#5646): the activerecord-cli E2E suites create
-// `ar_cli_e2e_<hrtime>` through `ar db:create` as the same user, no grant
-// covered it, and the failure surfaced only on the MySQL legs, only in CI, as
-// an exit code — a grep for `CREATE DATABASE` found nothing, because the
-// database is created through the CLI.
-//
-// This file derives the granted namespaces from that SQL and checks the known
-// database-name producers against them, so a name outside the grants fails here
-// instead of a CI round-trip later.
-
+/**
+ * `scripts/db-init/mysql/01-rails-user.sql` grants the `rails` test user a set
+ * of database-name patterns rather than `*.*`, which couples that file to every
+ * database name the suites invent. The coupling broke during the review of the
+ * PR that introduced it (#5646): the activerecord-cli E2E suites create
+ * `ar_cli_e2e_<hrtime>` through `ar db:create` as the same user, no grant
+ * covered it, and the failure surfaced only on the MySQL legs, only in CI, as
+ * an exit code — a grep for `CREATE DATABASE` found nothing, because the
+ * database is created through the CLI. This suite derives the granted
+ * namespaces from that SQL and checks the known database-name producers against
+ * them.
+ */
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const GRANT_FILE = "scripts/db-init/mysql/01-rails-user.sql";
+const CI_WORKFLOW = ".github/workflows/ci.yml";
 const E2E_FILES = [
   "packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts",
   "packages/activerecord-cli/src/__e2e__/postgres-happy-path.test.ts",
 ];
 
+/**
+ * Temporary databases `connection-adapters/postgresql/schema-statements.test.ts`
+ * creates through the postgres role, whose `CREATEDB` is not per-database. No
+ * MySQL grant covers them by design.
+ */
+const POSTGRES_ONLY_DATABASES = ["trails_test_drop_db_tmp", "trails_test_recreate_tmp"];
+
 const readRepoFile = (relative: string): Promise<string> =>
   readFile(path.join(REPO_ROOT, relative), "utf8");
 
-/** The database-name patterns `GRANT ALL PRIVILEGES ON <pattern>.*` names. */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** The database-name patterns the file's `GRANT ... ON <pattern>.*` statements name. */
 function grantedPatterns(sql: string): string[] {
   const patterns = new Set<string>();
   for (const match of sql.matchAll(/GRANT\s+[^;]*?\sON\s+(`(?:[^`]|``)+`|[^\s.`]+)\.\*/gi)) {
@@ -37,9 +48,10 @@ function grantedPatterns(sql: string): string[] {
 }
 
 /**
- * MySQL reads `_` and `%` in a database-level GRANT as LIKE wildcards unless
- * they are backslash-escaped (dev.mysql.com/doc/en/grant.html), so
- * `activerecord\_unittest%` matches `activerecord_unittest2` but not
+ * Whether a database-level GRANT on `pattern` authorizes `database`. MySQL reads
+ * `_` and `%` in such a pattern as LIKE wildcards unless they are
+ * backslash-escaped (dev.mysql.com/doc/en/grant.html), so
+ * `activerecord\_unittest%` covers `activerecord_unittest2` but not
  * `activerecordXunittest_1`.
  */
 function grantMatches(pattern: string, database: string): boolean {
@@ -59,14 +71,10 @@ function grantMatches(pattern: string, database: string): boolean {
   return new RegExp(`^${source}$`).test(database);
 }
 
-function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /**
  * The `ar_cli_e2e_<hrtime>` prefix the CLI E2E suites hand to `ar db:create`,
- * read out of the suites themselves so a rename fails here rather than on the
- * MySQL legs.
+ * read out of the suites themselves so renaming it fails here rather than on
+ * the MySQL legs.
  */
 async function e2eDatabasePrefixes(): Promise<string[]> {
   const prefixes: string[] = [];
@@ -83,22 +91,19 @@ async function e2eDatabasePrefixes(): Promise<string[]> {
 }
 
 /**
- * Every shape the harness names a MySQL database, from the base
- * `activerecord_unittest` the CI services provision: the bare base (no run
- * token stamped), the per-slot `<base>_<token>_<slot>` of `slotDatabaseName`
- * (support/run-token.ts), and the arunit2 sibling `<base>2` plus its slot form
- * (support/arunit2-config.ts).
+ * Every shape the harness names a database of, given the base the CI services
+ * provision: the bare base (no run token stamped), `slotDatabaseName`'s
+ * `<base>_<token>_<slot>` and the un-tokened `<base>_<slot>`
+ * (support/run-token.ts, support/config.ts), and the arunit2 sibling `<base>2`
+ * with its own slot form (support/arunit2-config.ts).
  */
 function harnessDatabases(base: string): string[] {
-  return [base, `${base}_rm1z9x4q7k_1`, `${base}2`, `${base}2_3`, `${base}_2`];
+  return [base, `${base}_2`, `${base}_rm1z9x4q7k_1`, `${base}2`, `${base}2_3`];
 }
 
-/**
- * The base database names the MySQL/MariaDB CI jobs provision and connect to —
- * read out of ci.yml so renaming the service database fails here too.
- */
+/** The base database names the MySQL and MariaDB CI jobs provision and connect to. */
 async function ciMysqlBaseDatabases(): Promise<string[]> {
-  const yml = await readRepoFile(".github/workflows/ci.yml");
+  const yml = await readRepoFile(CI_WORKFLOW);
   const bases = new Set<string>();
   for (const match of yml.matchAll(/^\s*(?:MYSQL|MARIADB)_DATABASE:\s*(\S+)$/gm)) {
     bases.add(match[1]);
@@ -106,12 +111,12 @@ async function ciMysqlBaseDatabases(): Promise<string[]> {
   for (const match of yml.matchAll(/^\s*MYSQL_TEST_URL:\s*mysql:\/\/[^/\s]+\/(\S+)$/gm)) {
     bases.add(match[1]);
   }
-  expect(bases.size, "no MySQL database names in ci.yml").toBeGreaterThan(0);
+  expect(bases.size, `no MySQL database names in ${CI_WORKFLOW}`).toBeGreaterThan(0);
   return [...bases];
 }
 
 describe("mysql grant namespaces", () => {
-  it("covers every database name the suites create", async () => {
+  it("grants every database name the suites create", async () => {
     const patterns = grantedPatterns(await readRepoFile(GRANT_FILE));
     expect(patterns.length).toBeGreaterThan(0);
 
@@ -124,31 +129,35 @@ describe("mysql grant namespaces", () => {
       expect(
         patterns.some((pattern) => grantMatches(pattern, database)),
         `the rails test user cannot create \`${database}\`: no GRANT in ${GRANT_FILE} covers it. ` +
-          `Granted namespaces: ${patterns.join(", ")}. Add a grant there (both 'rails'@'%' and ` +
-          `'rails'@'localhost') or rename the database into an existing namespace.`,
+          `Granted namespaces: ${patterns.join(", ")}. Add a grant there (for both 'rails'@'%' ` +
+          `and 'rails'@'localhost') or rename the database into an existing namespace.`,
       ).toBe(true);
     }
   });
 
   it("leaves the postgres-only temporary databases ungranted", async () => {
-    // connection-adapters/postgresql/schema-statements.test.ts creates these
-    // through the postgres role, which holds CREATEDB — not per-database. No
-    // MySQL grant covers them by design, so a guard that "fixed" that would be
-    // widening the grants for nothing.
     const patterns = grantedPatterns(await readRepoFile(GRANT_FILE));
-    for (const database of ["trails_test_drop_db_tmp", "trails_test_recreate_tmp"]) {
+    for (const database of POSTGRES_ONLY_DATABASES) {
       expect(patterns.some((pattern) => grantMatches(pattern, database))).toBe(false);
     }
   });
 
   it("reads unescaped underscore and percent as LIKE wildcards", () => {
+    expect(grantMatches("activerecord\\_unittest%", "activerecord_unittest")).toBe(true);
     expect(grantMatches("activerecord\\_unittest%", "activerecord_unittest2")).toBe(true);
     expect(grantMatches("activerecord\\_unittest%", "activerecordXunittest_1")).toBe(false);
+    expect(grantMatches("activerecord\\_unittest%", "xactiverecord_unittest")).toBe(false);
     expect(
       grantMatches("inexistent_activerecord_unittest", "inexistentXactiverecordXunittest"),
     ).toBe(true);
     expect(grantMatches("ar\\_cli\\_e2e%", "ar_cli_e2e_1234")).toBe(true);
     expect(grantMatches("ar\\_cli\\_e2e%", "arXcliXe2e_1234")).toBe(false);
-    expect(grantMatches("activerecord\\_unittest%", "xactiverecord_unittest")).toBe(false);
+  });
+
+  it("parses backticked and bare grant patterns out of the grant file", async () => {
+    const patterns = grantedPatterns(await readRepoFile(GRANT_FILE));
+    expect(patterns).toContain("activerecord\\_unittest%");
+    expect(patterns).toContain("inexistent_activerecord_unittest");
+    expect(patterns).toContain("ar\\_cli\\_e2e%");
   });
 });


### PR DESCRIPTION
`scripts/db-init/mysql/01-rails-user.sql` grants the `rails` test user
per-namespace patterns rather than `*.*`, which implicitly couples that file to
every database name the suites invent — with nothing enforcing it. The coupling
broke during #5646's own review: the activerecord-cli E2E suites create
`ar_cli_e2e_<hrtime>` via `ar db:create` as the same user, the first revision
granted only `activerecord\_unittest%`, and it surfaced as an exit code on the
MySQL legs only, in CI only. A grep for `CREATE DATABASE` found nothing, because
the database is created through the CLI.

`scripts/mysql-grant-namespaces.test.ts` derives the granted namespaces from the
SQL file and checks the known producers against them:

- Grant patterns are parsed from the `GRANT ... ON <db>.*` statements, so the
  test follows the file as it changes.
- Matching models MySQL's LIKE semantics: `_` and `%` are wildcards unless
  backslash-escaped, so `activerecord\_unittest%` matches
  `activerecord_unittest2` but not `activerecordXunittest_1`.
- Producers are derived from source rather than hardcoded: the base database
  from ci.yml's MySQL/MariaDB service env + `MYSQL_TEST_URL`, expanded into the
  bare / `<base>_<token>_<slot>` / arunit2 shapes, and the `ar_cli_e2e_` prefix
  read out of both E2E suites (a rename there fails here).
- The Postgres-only temporaries (`trails_test_drop_db_tmp`,
  `trails_test_recreate_tmp`) are asserted to stay ungranted, so nobody "fixes"
  them by widening the MySQL grants.
- The failure message names the offending database, lists the granted
  namespaces, and points at the grant file.

Verified against the original defect: deleting the `ar\_cli\_e2e%` grants makes
the guard fail with
`the rails test user cannot create ar_cli_e2e_1234567890: no GRANT in scripts/db-init/mysql/01-rails-user.sql covers it`.

ci.yml registers the new suite in `unit-tests` and arms that job on changes to
the grant file and the E2E suites; `scripts/ci-suite-coverage.test.ts` records
those non-test inputs in `GATE_INPUTS`.

Closes-story: guard-suite-db-names-against-granted-namespaces
