### PR TITLE
refactor(migration): type the remaining adapter-specific delegations instead of casting to any

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2036,7 +2036,11 @@ export class AbstractAdapter implements Quoting {
   // Keep the TS signature permissive to match.
   async renameEnumValue(..._args: unknown[]): Promise<void> {}
 
-  async createVirtualTable(_name: string, _options?: unknown): Promise<void> {}
+  async createVirtualTable(
+    _name: string,
+    _optionsOrModuleName?: unknown,
+    _values?: unknown,
+  ): Promise<void> {}
 
   async dropVirtualTable(_name: string): Promise<void> {}
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -34,6 +34,7 @@ import {
   type ForeignKeyLookupOptions,
   type RemoveForeignKeyOptions,
 } from "./schema-definitions.js";
+import type { UniqueConstraintOptions } from "../postgresql/schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { maxIdentifierLength } from "./database-limits.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
@@ -209,6 +210,54 @@ export interface ValidateConstraintStatements {
     toTable?: string,
     options?: Omit<ForeignKeyLookupOptions, "toTable">,
   ): Promise<void>;
+}
+
+/** A comment argument: either the new value, or Rails' `{ from:, to: }` change hash. */
+export type CommentOrChanges = string | null | { from?: string | null; to?: string | null };
+
+/**
+ * Comment DDL that only adapters supporting `supportsComments` implement.
+ * Reached from `Migration` the same way as {@link ValidateConstraintStatements}.
+ */
+export interface CommentStatements {
+  changeTableComment(tableName: string, commentOrChanges: CommentOrChanges): Promise<void>;
+  changeColumnComment(
+    tableName: string,
+    columnName: string,
+    commentOrChanges: CommentOrChanges,
+  ): Promise<void>;
+}
+
+/** Extension DDL — PostgreSQL only. */
+export interface ExtensionStatements {
+  enableExtension(name: string, options?: Record<string, unknown>): Promise<void>;
+  disableExtension(name: string, options?: { force?: "cascade"; schema?: string }): Promise<void>;
+}
+
+/** Enum type DDL — PostgreSQL only. */
+export interface EnumStatements {
+  createEnum(name: string, values: string[], options?: Record<string, unknown>): Promise<void>;
+  dropEnum(name: string, options?: { ifExists?: boolean }): Promise<void>;
+  renameEnumValue(name: string, options: { from: string; to: string }): Promise<void>;
+}
+
+/** Unique-constraint DDL — PostgreSQL only. */
+export interface UniqueConstraintStatements {
+  addUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[] | null,
+    options?: UniqueConstraintOptions,
+  ): Promise<void>;
+  removeUniqueConstraint(
+    tableName: string,
+    columnNameOrOptions?: string | string[] | UniqueConstraintOptions | null,
+    options?: UniqueConstraintOptions,
+  ): Promise<void>;
+}
+
+/** Schema (namespace) DDL — PostgreSQL only. */
+export interface SchemaNamespaceStatements {
+  createSchema(name: string, options?: { force?: boolean; ifNotExists?: boolean }): Promise<void>;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -77,6 +77,11 @@ import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class
 import type {
   JoinTableOptions,
   ValidateConstraintStatements,
+  CommentStatements,
+  ExtensionStatements,
+  EnumStatements,
+  UniqueConstraintStatements,
+  SchemaNamespaceStatements,
 } from "./abstract/schema-statements.js";
 import { SchemaStatements } from "./abstract/schema-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
@@ -176,7 +181,14 @@ function toError(value: unknown): Error {
  */
 export class PostgreSQLAdapter
   extends AbstractAdapter
-  implements DatabaseAdapter, ValidateConstraintStatements
+  implements
+    DatabaseAdapter,
+    ValidateConstraintStatements,
+    CommentStatements,
+    ExtensionStatements,
+    EnumStatements,
+    UniqueConstraintStatements,
+    SchemaNamespaceStatements
 {
   override get adapterName(): AdapterName {
     return "postgres";

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -66,9 +66,7 @@ import { ActiveRecord } from "./ar-config.js";
 // Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
 // For {from,to} hashes, returns `to` (which may be null to clear a comment).
 // `to: undefined` is rejected — a missing value cannot be forwarded to SQL.
-function _extractNewCommentValue(
-  v: string | null | { from?: unknown; to?: unknown },
-): string | null {
+function _extractNewCommentValue(v: CommentOrChanges): string | null {
   if (v !== null && typeof v === "object") {
     if (!("to" in v) || (v as { to: unknown }).to === undefined) {
       throw new ArgumentError("change_column_comment / change_table_comment requires a :to value");

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1878,7 +1878,6 @@ export class MigrationContext {
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#create_virtual_table
   async createVirtualTable(name: string, moduleName: string, args: string[]): Promise<void> {
-    // Non-SQLite adapters inherit AbstractAdapter#createVirtualTable, a no-op.
     await this.connection.createVirtualTable(name, moduleName, args);
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -28,7 +28,14 @@ import {
   assertSchemaAdapter,
   type JoinTableOptions,
   type ValidateConstraintStatements,
+  type CommentOrChanges,
+  type CommentStatements,
+  type EnumStatements,
+  type ExtensionStatements,
+  type SchemaNamespaceStatements,
+  type UniqueConstraintStatements,
 } from "./connection-adapters/abstract/schema-statements.js";
+import type { UniqueConstraintOptions } from "./connection-adapters/postgresql/schema-definitions.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
@@ -797,7 +804,7 @@ export abstract class Migration {
   async changeColumnComment(
     tableName: string,
     columnName: string,
-    commentOrChanges: string | null | { from?: unknown; to?: unknown },
+    commentOrChanges: CommentOrChanges,
   ): Promise<void> {
     if (this._recording) {
       this._recorder.record("changeColumnComment", [tableName, columnName, commentOrChanges]);
@@ -805,20 +812,19 @@ export abstract class Migration {
     }
     tableName = this._pt(tableName);
     const resolved = _extractNewCommentValue(commentOrChanges);
-    await (this.connection as any).changeColumnComment(tableName, columnName, resolved);
+    const connection = this.connection as DatabaseAdapter & CommentStatements;
+    await connection.changeColumnComment(tableName, columnName, resolved);
   }
 
-  async changeTableComment(
-    tableName: string,
-    commentOrChanges: string | null | { from?: unknown; to?: unknown },
-  ): Promise<void> {
+  async changeTableComment(tableName: string, commentOrChanges: CommentOrChanges): Promise<void> {
     if (this._recording) {
       this._recorder.record("changeTableComment", [tableName, commentOrChanges]);
       return;
     }
     tableName = this._pt(tableName);
     const resolved = _extractNewCommentValue(commentOrChanges);
-    await (this.connection as any).changeTableComment(tableName, resolved);
+    const connection = this.connection as DatabaseAdapter & CommentStatements;
+    await connection.changeTableComment(tableName, resolved);
   }
 
   async enableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
@@ -826,15 +832,20 @@ export abstract class Migration {
       this._recorder.record("enableExtension", [name, options]);
       return;
     }
-    await (this.connection as any).enableExtension(name, options);
+    const connection = this.connection as DatabaseAdapter & ExtensionStatements;
+    await connection.enableExtension(name, options);
   }
 
-  async disableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
+  async disableExtension(
+    name: string,
+    options?: { force?: "cascade"; schema?: string },
+  ): Promise<void> {
     if (this._recording) {
       this._recorder.record("disableExtension", [name, options]);
       return;
     }
-    await (this.connection as any).disableExtension(name, options);
+    const connection = this.connection as DatabaseAdapter & ExtensionStatements;
+    await connection.disableExtension(name, options);
   }
 
   async createEnum(
@@ -846,13 +857,14 @@ export abstract class Migration {
       this._recorder.record("createEnum", [name, values, options]);
       return;
     }
-    await (this.connection as any).createEnum(name, values, options);
+    const connection = this.connection as DatabaseAdapter & EnumStatements;
+    await connection.createEnum(name, values, options);
   }
 
   async dropEnum(
     name: string,
-    valuesOrOptions?: string[] | Record<string, unknown>,
-    options?: Record<string, unknown>,
+    valuesOrOptions?: string[] | { ifExists?: boolean },
+    options?: { ifExists?: boolean },
   ): Promise<void> {
     // Normalize: if second arg is a plain object it is the options hash (no values).
     // Mirrors Rails drop_enum(name, values = nil, **options) which allows options-only calls.
@@ -868,7 +880,8 @@ export abstract class Migration {
     }
     // values is only captured for recording (so dropEnum can be inverted to createEnum);
     // the adapter's dropEnum(name, options?) doesn't need values for SQL execution.
-    await (this.connection as any).dropEnum(name, opts ?? {});
+    const connection = this.connection as DatabaseAdapter & EnumStatements;
+    await connection.dropEnum(name, opts ?? {});
   }
 
   async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {
@@ -876,26 +889,28 @@ export abstract class Migration {
       this._recorder.record("renameEnumValue", [name, options]);
       return;
     }
-    await (this.connection as any).renameEnumValue(name, options);
+    const connection = this.connection as DatabaseAdapter & EnumStatements;
+    await connection.renameEnumValue(name, options);
   }
 
   async addUniqueConstraint(
     tableName: string,
     columnName?: string | string[],
-    options?: Record<string, unknown>,
+    options?: UniqueConstraintOptions,
   ): Promise<void> {
     if (this._recording) {
       this._recorder.record("addUniqueConstraint", [tableName, columnName, options]);
       return;
     }
     tableName = this._pt(tableName);
-    await (this.connection as any).addUniqueConstraint(tableName, columnName, options);
+    const connection = this.connection as DatabaseAdapter & UniqueConstraintStatements;
+    await connection.addUniqueConstraint(tableName, columnName, options);
   }
 
   async removeUniqueConstraint(
     tableName: string,
-    columnNameOrOptions?: string | string[] | Record<string, unknown>,
-    options?: Record<string, unknown>,
+    columnNameOrOptions?: string | string[] | UniqueConstraintOptions,
+    options?: UniqueConstraintOptions,
   ): Promise<void> {
     // Normalize: if second arg is a plain object it is the options hash (no column).
     // Mirrors Rails extract_options! semantics for remove_unique_constraint(table, **opts).
@@ -910,7 +925,8 @@ export abstract class Migration {
       return;
     }
     tableName = this._pt(tableName);
-    await (this.connection as any).removeUniqueConstraint(tableName, columnName, opts);
+    const connection = this.connection as DatabaseAdapter & UniqueConstraintStatements;
+    await connection.removeUniqueConstraint(tableName, columnName, opts);
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
@@ -1839,7 +1855,8 @@ export class MigrationContext {
   }
 
   async enableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
-    await (this.connection as any).enableExtension?.(name, options);
+    const connection = this.connection as DatabaseAdapter & Partial<ExtensionStatements>;
+    await connection.enableExtension?.(name, options);
   }
 
   async createEnum(
@@ -1847,19 +1864,22 @@ export class MigrationContext {
     values: string[],
     options?: Record<string, unknown>,
   ): Promise<void> {
-    await (this.connection as any).createEnum?.(name, values, options);
+    const connection = this.connection as DatabaseAdapter & Partial<EnumStatements>;
+    await connection.createEnum?.(name, values, options);
   }
 
-  async createSchema(name: string, options?: Record<string, unknown>): Promise<void> {
-    await (this.connection as any).createSchema?.(name, options);
+  async createSchema(
+    name: string,
+    options?: { force?: boolean; ifNotExists?: boolean },
+  ): Promise<void> {
+    const connection = this.connection as DatabaseAdapter & Partial<SchemaNamespaceStatements>;
+    await connection.createSchema?.(name, options);
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#create_virtual_table
   async createVirtualTable(name: string, moduleName: string, args: string[]): Promise<void> {
-    if (typeof (this.connection as any).createVirtualTable === "function") {
-      await (this.connection as any).createVirtualTable(name, moduleName, args);
-    }
-    // Non-SQLite adapters: no-op; virtual tables are SQLite-specific.
+    // Non-SQLite adapters inherit AbstractAdapter#createVirtualTable, a no-op.
+    await this.connection.createVirtualTable(name, moduleName, args);
   }
 
   async addColumn(
@@ -1922,11 +1942,13 @@ export class MigrationContext {
   }
 
   async changeTableComment(name: string, comment: string | null): Promise<void> {
-    await (this.connection as any).changeTableComment(name, comment);
+    const connection = this.connection as DatabaseAdapter & CommentStatements;
+    await connection.changeTableComment(name, comment);
   }
 
   async changeColumnComment(table: string, col: string, comment: string | null): Promise<void> {
-    await (this.connection as any).changeColumnComment(table, col, comment);
+    const connection = this.connection as DatabaseAdapter & CommentStatements;
+    await connection.changeColumnComment(table, col, comment);
   }
 
   async addIndex(


### PR DESCRIPTION
Removes the remaining `as any` adapter delegations from `Migration` (and the
`DefaultStrategy` replay paths), following the pattern established by
`ValidateConstraintStatements`.

New adapter-specific interfaces in `connection-adapters/abstract/schema-statements.ts`:
`CommentStatements`, `ExtensionStatements`, `EnumStatements`,
`UniqueConstraintStatements`, `SchemaNamespaceStatements` — all declared in
`PostgreSQLAdapter`'s `implements` clause.

Migration-level option types are reconciled with the PG shapes rather than
widened on the adapter side: `disableExtension` takes
`{ force?: "cascade"; schema?: string }`, `dropEnum` takes `{ ifExists?: boolean }`,
the unique-constraint pair takes `UniqueConstraintOptions`, and the comment
methods take the shared `CommentOrChanges` (`{ from?, to? }` typed as
`string | null` rather than `unknown`).

`AbstractAdapter#createVirtualTable` gains the third parameter the SQLite
override already declares, so the replay path can call it directly instead of
a `typeof === "function"` probe against `any` (the base is a no-op, which is
the intended non-SQLite behavior).

`pnpm typecheck` clean; migration/invertible-migration/trails migration suites
green locally (comment + unique-constraint suites are PG-gated and covered in CI).

Closes-story: migration-remaining-as-any-adapter-delegations
