### PR TITLE
refactor(activerecord): take base.ts out of its import cycle so mixin wiring is entry-order independent

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -40,6 +40,12 @@ import { Table, UpdateManager, DeleteManager, Nodes, sql as arelSql } from "@bla
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { Relation } from "./relation.js";
+import { wrapWithScopeProxy, relationClassFor } from "./relation/delegation.js";
+import { _registerBase as _registerBaseWithSchemaMigration } from "./schema-migration.js";
+import { _registerBase as _registerBaseWithInternalMetadata } from "./internal-metadata.js";
+import { _registerBase as _registerBaseWithSchemaDumper } from "./schema-dumper.js";
+import { _registerBase as _registerBaseWithNamedScoping } from "./scoping/named.js";
+import { _registerQuoteSqlValue } from "./insert-all.js";
 import {
   discriminateClassForRecord,
   stiName,
@@ -401,51 +407,21 @@ export type PrimaryKeyScalar = string | number | bigint | null | undefined;
  */
 export type PrimaryKeyValue = PrimaryKeyScalar | PrimaryKeyScalar[];
 
-// Late-bound Relation constructor to break circular dependency.
-// Set by relation.ts when it loads.
-//
-// `var` (rather than `let`) with no initializer is deliberate: these are
-// assigned from other modules' top-level code (relation.ts's
-// `_setRelationCtor(Relation)` call runs during module init). With
-// `extends Relation` chains, base.ts's own imports can trigger that
-// call before base.ts reaches this line. `let` would throw TDZ; `var
-// x = null` would hoist then RESET the value back to null; `var x;`
-// hoists as `undefined` without clobbering a later-set value.
-// eslint-disable-next-line no-var
-var _RelationCtor: (new (modelClass: typeof Base, table?: any) => any) | undefined;
-// eslint-disable-next-line no-var
-var _wrapWithScopeProxy: ((rel: any) => any) | undefined;
-// eslint-disable-next-line no-var
-var _relationClassResolver:
-  | ((model: typeof Base) => new (model: typeof Base, table?: any) => any)
-  | undefined;
-
-/** @internal Called by relation.ts to register itself. */
-export function _setRelationCtor(ctor: new (modelClass: typeof Base) => any): void {
-  _RelationCtor = ctor;
-}
-
-/** @internal Called by relation.ts to register the scope proxy wrapper. */
-export function _setScopeProxyWrapper(wrapper: (rel: any) => any): void {
-  _wrapWithScopeProxy = wrapper;
-}
+// relation.ts used to push `Relation`, `wrapWithScopeProxy` and
+// `relationClassFor` into base.ts from its own module body, which meant
+// relation.ts imported base.js for its value and so formed an import cycle with
+// it — leaving base.ts's mixin wiring below dependent on which module the graph
+// happened to be entered through. base.ts imports them directly now; relation.ts
+// no longer imports base.js for its value, so relation.ts is guaranteed to have
+// finished evaluating by the time this module body runs.
 
 /**
- * @internal Called by relation.ts to register the per-model `Relation`
- * subclass resolver (`relationClassFor`). Base relations are constructed from
- * the returned per-model subclass so generated relation methods resolve as real
- * methods via its prototype carrier (Rails' `relation_class_for`). Falls back to
- * the shared `Relation` ctor until registered.
+ * @internal The per-model `Relation` subclass ctor (Rails' `relation_class_for`).
+ * Base relations are constructed from the per-model subclass so generated
+ * relation methods resolve as real methods via its prototype carrier.
  */
-export function _setRelationClassResolver(
-  resolver: (model: typeof Base) => new (model: typeof Base, table?: any) => any,
-): void {
-  _relationClassResolver = resolver;
-}
-
-/** @internal The per-model `Relation` subclass ctor, or the shared ctor. */
 function _relationCtorFor(this: void, model: typeof Base): new (m: typeof Base, t?: any) => any {
-  return _relationClassResolver ? _relationClassResolver(model) : _RelationCtor!;
+  return relationClassFor(model) as new (m: typeof Base, t?: any) => any;
 }
 
 /**
@@ -2199,9 +2175,6 @@ export class Base extends Model {
    *  classes, so callers like `AssociationScope` get a type-filtered base
    *  without re-adding the condition themselves. */
   static _buildUnscopedRelation(table?: any): any {
-    if (!_RelationCtor) {
-      throw new Error("Relation not loaded. Import relation.ts first.");
-    }
     // `table` lets callers build the relation against a specific Arel table
     // (e.g. an association-scope chain entry's aliased table). Passing it to
     // the ctor means the STI `type_condition` that `_applyStiTypeCondition`
@@ -2209,7 +2182,7 @@ export class Base extends Model {
     // through doesn't end up with the STI predicate on the FROM table and
     // the source-type predicate on the alias.
     const rel = new (_relationCtorFor(this))(this, table);
-    return this._applyStiTypeCondition(_wrapWithScopeProxy ? _wrapWithScopeProxy(rel) : rel);
+    return this._applyStiTypeCondition(wrapWithScopeProxy(rel));
   }
 
   /** @internal Bare relation against an optional Arel table — no default
@@ -2218,11 +2191,8 @@ export class Base extends Model {
    *  later by `join_scope` (qualified by the join's, possibly aliased, table)
    *  rather than baked into the base relation. */
   static _buildBareRelation(table?: any): any {
-    if (!_RelationCtor) {
-      throw new Error("Relation not loaded. Import relation.ts first.");
-    }
     const rel = new (_relationCtorFor(this))(this, table);
-    return _wrapWithScopeProxy ? _wrapWithScopeProxy(rel) : rel;
+    return wrapWithScopeProxy(rel);
   }
 
   /** @internal Re-apply the STI `type_condition` WHERE for subclasses.
@@ -2246,12 +2216,9 @@ export class Base extends Model {
   }
 
   private static _buildDefaultRelation(allQueries?: boolean | null): any {
-    if (!_RelationCtor) {
-      throw new Error("Relation not loaded. Import relation.ts first.");
-    }
     const buildBase = () => {
       const r = new (_relationCtorFor(this))(this);
-      return _wrapWithScopeProxy ? _wrapWithScopeProxy(r) : r;
+      return wrapWithScopeProxy(r);
     };
     const rel = DefaultScoping.buildDefaultScope(this, buildBase, allQueries) ?? buildBase();
     return this._applyStiTypeCondition(rel);
@@ -5284,3 +5251,21 @@ Table.engine = {
     return pool.activeConnection ?? pool.leaseConnectionSync();
   },
 };
+
+// ---------------------------------------------------------------------------
+// Late-bound registrations.
+//
+// Rails resolves `ActiveRecord::Base` at call time through autoload, so none of
+// these modules `require` base.rb. In ESM a value import is a load-time edge,
+// and an edge back into base.ts makes base.ts a cycle member — which decides,
+// purely by which module the graph is entered through, whether the mixin wiring
+// above reads initialized bindings or hits a TDZ ReferenceError. Every consumer
+// that only needs `Base` at call time therefore takes it from here instead, and
+// base.ts (which by construction evaluates after everything it imports) pushes.
+// ---------------------------------------------------------------------------
+
+_registerBaseWithSchemaMigration(Base);
+_registerBaseWithInternalMetadata(Base);
+_registerBaseWithSchemaDumper(Base);
+_registerBaseWithNamedScoping(Base);
+_registerQuoteSqlValue(quoteSqlValue);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -40,6 +40,10 @@ import { Table, UpdateManager, DeleteManager, Nodes, sql as arelSql } from "@bla
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { Relation } from "./relation.js";
+// Side-effect import: relation.ts registers the `Relation` family slot that
+// `relationClassFor` builds every per-model relation subclass from. relation.ts
+// no longer imports base.js for its value, so this edge is one-way.
+import "./relation.js";
 import { wrapWithScopeProxy, relationClassFor } from "./relation/delegation.js";
 import { _registerBase as _registerBaseWithSchemaMigration } from "./schema-migration.js";
 import { _registerBase as _registerBaseWithInternalMetadata } from "./internal-metadata.js";

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -407,14 +407,6 @@ export type PrimaryKeyScalar = string | number | bigint | null | undefined;
  */
 export type PrimaryKeyValue = PrimaryKeyScalar | PrimaryKeyScalar[];
 
-// relation.ts used to push `Relation`, `wrapWithScopeProxy` and
-// `relationClassFor` into base.ts from its own module body, which meant
-// relation.ts imported base.js for its value and so formed an import cycle with
-// it — leaving base.ts's mixin wiring below dependent on which module the graph
-// happened to be entered through. base.ts imports them directly now; relation.ts
-// no longer imports base.js for its value, so relation.ts is guaranteed to have
-// finished evaluating by the time this module body runs.
-
 /**
  * @internal The per-model `Relation` subclass ctor (Rails' `relation_class_for`).
  * Base relations are constructed from the per-model subclass so generated
@@ -5252,17 +5244,12 @@ Table.engine = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// Late-bound registrations.
-//
 // Rails resolves `ActiveRecord::Base` at call time through autoload, so none of
 // these modules `require` base.rb. In ESM a value import is a load-time edge,
-// and an edge back into base.ts makes base.ts a cycle member — which decides,
-// purely by which module the graph is entered through, whether the mixin wiring
-// above reads initialized bindings or hits a TDZ ReferenceError. Every consumer
-// that only needs `Base` at call time therefore takes it from here instead, and
-// base.ts (which by construction evaluates after everything it imports) pushes.
-// ---------------------------------------------------------------------------
+// and an edge back into base.ts would make base.ts a cycle member — deciding,
+// purely by the graph's entry point, whether the mixin wiring above reads
+// initialized bindings or hits a TDZ ReferenceError. Consumers that only need
+// `Base` at call time take it from here instead.
 
 _registerBaseWithSchemaMigration(Base);
 _registerBaseWithInternalMetadata(Base);

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -5,7 +5,17 @@ import { IndexDefinition } from "./connection-adapters/abstract/schema-definitio
 import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
-import { quoteSqlValue } from "./base.js";
+
+// `quoteSqlValue` lives in base.ts, but importing it for its value would put a
+// load-time edge back into `base.ts` — and base.ts's own mixin wiring then
+// depends on which module the import graph is entered through. base.ts pushes
+// the helper in at the end of its module body instead.
+let _quoteSqlValue: ((v: unknown, dialect?: AdapterName) => string) | undefined;
+
+/** @internal Called from base.ts at module init. */
+export function _registerQuoteSqlValue(fn: (v: unknown, dialect?: AdapterName) => string): void {
+  _quoteSqlValue = fn;
+}
 import { stiName, isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
@@ -722,7 +732,7 @@ export class Builder implements InsertBuilder {
       if (arrayCols.has(key)) {
         return new Nodes.SqlLiteral(this._insertAll.connection.quote(value));
       }
-      return new Nodes.SqlLiteral(quoteSqlValue(value, this._dialect));
+      return new Nodes.SqlLiteral(_quoteSqlValue!(value, this._dialect));
     });
     return new Nodes.ValuesList(rows);
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -3,8 +3,14 @@ import { Nodes, Visitors } from "@blazetrails/arel";
 import { ArgumentError, SerializeCastValue } from "@blazetrails/activemodel";
 import { IndexDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 import { realPool } from "./connection-adapters/abstract/connection-pool.js";
-import { UnknownAttributeError } from "./errors.js";
+import { ActiveRecordError, UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
+
+import { stiName, isFinderNeedsTypeCondition } from "./inheritance.js";
+import type { Relation } from "./relation.js";
+import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
+import { Result } from "./result.js";
+import { withPooledOrDirectConnection } from "./connection-handling.js";
 
 let _quoteSqlValue: ((v: unknown, dialect?: AdapterName) => string) | undefined;
 
@@ -17,11 +23,11 @@ let _quoteSqlValue: ((v: unknown, dialect?: AdapterName) => string) | undefined;
 export function _registerQuoteSqlValue(fn: (v: unknown, dialect?: AdapterName) => string): void {
   _quoteSqlValue = fn;
 }
-import { stiName, isFinderNeedsTypeCondition } from "./inheritance.js";
-import type { Relation } from "./relation.js";
-import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
-import { Result } from "./result.js";
-import { withPooledOrDirectConnection } from "./connection-handling.js";
+
+function quoteSqlValue(v: unknown, dialect?: AdapterName): string {
+  if (!_quoteSqlValue) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _quoteSqlValue(v, dialect);
+}
 
 type ModelClass = typeof Base;
 type AdapterDialect = AdapterName;
@@ -733,7 +739,7 @@ export class Builder implements InsertBuilder {
       if (arrayCols.has(key)) {
         return new Nodes.SqlLiteral(this._insertAll.connection.quote(value));
       }
-      return new Nodes.SqlLiteral(_quoteSqlValue!(value, this._dialect));
+      return new Nodes.SqlLiteral(quoteSqlValue(value, this._dialect));
     });
     return new Nodes.ValuesList(rows);
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -6,13 +6,14 @@ import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
 
-// `quoteSqlValue` lives in base.ts, but importing it for its value would put a
-// load-time edge back into `base.ts` — and base.ts's own mixin wiring then
-// depends on which module the import graph is entered through. base.ts pushes
-// the helper in at the end of its module body instead.
 let _quoteSqlValue: ((v: unknown, dialect?: AdapterName) => string) | undefined;
 
-/** @internal Called from base.ts at module init. */
+/**
+ * @internal Receives base.ts's `quoteSqlValue` at module init. Importing it for
+ * its value would be a load-time edge putting base.ts in an import cycle,
+ * leaving its own module-evaluation-time mixin wiring dependent on the graph's
+ * entry order.
+ */
 export function _registerQuoteSqlValue(fn: (v: unknown, dialect?: AdapterName) => string): void {
   _quoteSqlValue = fn;
 }

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -6,8 +6,9 @@
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import { Base } from "./base.js";
+import type { Base } from "./base.js";
 import { EnvironmentStorageError } from "./migration.js";
+import { ActiveRecordError } from "./errors.js";
 import {
   Table,
   SelectManager,
@@ -17,6 +18,24 @@ import {
   Nodes,
   star,
 } from "@blazetrails/arel";
+
+// `base.js` is deliberately NOT imported for its value here. Rails resolves
+// `ActiveRecord::Base` at call time via autoload (internal_metadata.rb:32), so an
+// import edge would be a trails invention — and a load-time edge back into
+// `base.ts` puts it in an import cycle whose evaluation order then decides
+// whether base.ts's own mixin wiring reads initialized bindings. base.ts
+// pushes itself in at the end of its module body instead.
+let _base: typeof Base | undefined;
+
+/** @internal Called from base.ts at module init. */
+export function _registerBase(base: typeof Base): void {
+  _base = base;
+}
+
+function baseClass(): typeof Base {
+  if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _base;
+}
 
 /**
  * Stand-in for InternalMetadata when metadata storage is disabled
@@ -63,7 +82,8 @@ export class InternalMetadata {
   // Rails: "#{Base.table_name_prefix}#{Base.internal_metadata_table_name}
   // #{Base.table_name_suffix}" (internal_metadata.rb:32).
   get tableName(): string {
-    return `${Base.tableNamePrefix}${Base.internalMetadataTableName}${Base.tableNameSuffix}`;
+    const base = baseClass();
+    return `${base.tableNamePrefix}${base.internalMetadataTableName}${base.tableNameSuffix}`;
   }
 
   private _enabled: boolean;

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -19,15 +19,15 @@ import {
   star,
 } from "@blazetrails/arel";
 
-// `base.js` is deliberately NOT imported for its value here. Rails resolves
-// `ActiveRecord::Base` at call time via autoload (internal_metadata.rb:32), so an
-// import edge would be a trails invention — and a load-time edge back into
-// `base.ts` puts it in an import cycle whose evaluation order then decides
-// whether base.ts's own mixin wiring reads initialized bindings. base.ts
-// pushes itself in at the end of its module body instead.
 let _base: typeof Base | undefined;
 
-/** @internal Called from base.ts at module init. */
+/**
+ * @internal Receives `ActiveRecord::Base` from base.ts at module init. Rails
+ * resolves the constant at call time via autoload (internal_metadata.rb:32), so base.rb
+ * is not required here; in ESM a value import of `base.js` would instead be a
+ * load-time edge putting base.ts in an import cycle, leaving its own
+ * module-evaluation-time mixin wiring dependent on the graph's entry order.
+ */
 export function _registerBase(base: typeof Base): void {
   _base = base;
 }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -11,7 +11,6 @@ import {
 import type { Base } from "./base.js";
 import { withQueryConnection, threadedConnectionFor } from "./connection-handling.js";
 import { exceedsBindParamsLimit } from "./connection-adapters/abstract/database-limits.js";
-import { _setRelationCtor, _setScopeProxyWrapper, _setRelationClassResolver } from "./base.js";
 import {
   ActiveRecordError,
   ConnectionNotEstablished,
@@ -7746,11 +7745,6 @@ include(Relation, DelegationMethods);
 
 // Thenable: make Relation directly awaitable (delegates to toArray).
 applyThenable(Relation.prototype);
-
-// Register Relation with Base to break the circular dependency.
-_setRelationCtor(Relation as any);
-_setScopeProxyWrapper(wrapWithScopeProxy);
-_setRelationClassResolver(relationClassFor);
 
 /** @internal */
 async function computeCacheKey(

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -32,15 +32,15 @@ import { SchemaMigration } from "./schema-migration.js";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
 
-// `base.js` is deliberately NOT imported for its value here. Rails resolves
-// `ActiveRecord::Base` at call time via autoload (schema_dumper.rb:78-80), so an
-// import edge would be a trails invention — and a load-time edge back into
-// `base.ts` puts it in an import cycle whose evaluation order then decides
-// whether base.ts's own mixin wiring reads initialized bindings. base.ts
-// pushes itself in at the end of its module body instead.
 let _base: typeof Base | undefined;
 
-/** @internal Called from base.ts at module init. */
+/**
+ * @internal Receives `ActiveRecord::Base` from base.ts at module init. Rails
+ * resolves the constant at call time via autoload (schema_dumper.rb:78-80), so base.rb
+ * is not required here; in ESM a value import of `base.js` would instead be a
+ * load-time edge putting base.ts in an import cycle, leaving its own
+ * module-evaluation-time mixin wiring dependent on the graph's entry order.
+ */
 export function _registerBase(base: typeof Base): void {
   _base = base;
 }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -29,7 +29,26 @@ import type {
   Column,
 } from "./connection-adapters/abstract/schema-dumper.js";
 import { SchemaMigration } from "./schema-migration.js";
-import { Base } from "./base.js";
+import { ActiveRecordError } from "./errors.js";
+import type { Base } from "./base.js";
+
+// `base.js` is deliberately NOT imported for its value here. Rails resolves
+// `ActiveRecord::Base` at call time via autoload (schema_dumper.rb:78-80), so an
+// import edge would be a trails invention — and a load-time edge back into
+// `base.ts` puts it in an import cycle whose evaluation order then decides
+// whether base.ts's own mixin wiring reads initialized bindings. base.ts
+// pushes itself in at the end of its module body instead.
+let _base: typeof Base | undefined;
+
+/** @internal Called from base.ts at module init. */
+export function _registerBase(base: typeof Base): void {
+  _base = base;
+}
+
+function baseClass(): typeof Base {
+  if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _base;
+}
 
 // Lazy-load schema-introspection to break the static cycle
 // (schema-dumper -> schema-introspection -> schema-statements ->
@@ -394,9 +413,10 @@ export class SchemaDumper {
     // Rails seeds @ignore_tables from the configurable bookkeeping table names
     // (schema_dumper.rb:78-80) so a renamed schema_migrations/ar_internal_metadata
     // table is still excluded from the dump.
+    const base = baseClass();
     this._ignoreTables = [
-      Base.schemaMigrationsTableName,
-      Base.internalMetadataTableName,
+      base.schemaMigrationsTableName,
+      base.internalMetadataTableName,
       ...subclassIgnore,
     ];
   }

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -9,15 +9,15 @@ import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
 import { Table, SelectManager, InsertManager, DeleteManager, Nodes, star } from "@blazetrails/arel";
 
-// `base.js` is deliberately NOT imported for its value here. Rails resolves
-// `ActiveRecord::Base` at call time via autoload (schema_migration.rb:50), so an
-// import edge would be a trails invention — and a load-time edge back into
-// `base.ts` puts it in an import cycle whose evaluation order then decides
-// whether base.ts's own mixin wiring reads initialized bindings. base.ts
-// pushes itself in at the end of its module body instead.
 let _base: typeof Base | undefined;
 
-/** @internal Called from base.ts at module init. */
+/**
+ * @internal Receives `ActiveRecord::Base` from base.ts at module init. Rails
+ * resolves the constant at call time via autoload (schema_migration.rb:50), so base.rb
+ * is not required here; in ESM a value import of `base.js` would instead be a
+ * load-time edge putting base.ts in an import cycle, leaving its own
+ * module-evaluation-time mixin wiring dependent on the graph's entry order.
+ */
 export function _registerBase(base: typeof Base): void {
   _base = base;
 }

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -5,8 +5,27 @@
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import { Base } from "./base.js";
+import { ActiveRecordError } from "./errors.js";
+import type { Base } from "./base.js";
 import { Table, SelectManager, InsertManager, DeleteManager, Nodes, star } from "@blazetrails/arel";
+
+// `base.js` is deliberately NOT imported for its value here. Rails resolves
+// `ActiveRecord::Base` at call time via autoload (schema_migration.rb:50), so an
+// import edge would be a trails invention — and a load-time edge back into
+// `base.ts` puts it in an import cycle whose evaluation order then decides
+// whether base.ts's own mixin wiring reads initialized bindings. base.ts
+// pushes itself in at the end of its module body instead.
+let _base: typeof Base | undefined;
+
+/** @internal Called from base.ts at module init. */
+export function _registerBase(base: typeof Base): void {
+  _base = base;
+}
+
+function baseClass(): typeof Base {
+  if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _base;
+}
 
 export class NullSchemaMigration {
   async createTable(): Promise<void> {}
@@ -41,7 +60,8 @@ export class SchemaMigration {
   // Rails: "#{Base.table_name_prefix}#{Base.schema_migrations_table_name}
   // #{Base.table_name_suffix}" (schema_migration.rb:50).
   get tableName(): string {
-    return `${Base.tableNamePrefix}${Base.schemaMigrationsTableName}${Base.tableNameSuffix}`;
+    const base = baseClass();
+    return `${base.tableNamePrefix}${base.schemaMigrationsTableName}${base.tableNameSuffix}`;
   }
 
   // Rails: create_table(table_name, id: false) { |t| t.string :version,

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -1,5 +1,25 @@
 import { ArgumentError } from "@blazetrails/activemodel";
-import { Base } from "../base.js";
+import { ActiveRecordError } from "../errors.js";
+import type { Base } from "../base.js";
+
+// `base.js` is deliberately NOT imported for its value here. Rails resolves
+// `ActiveRecord::Base` at call time via autoload (attribute_methods.rb:88), so an
+// import edge would be a trails invention — and a load-time edge back into
+// `base.ts` puts it in an import cycle whose evaluation order then decides
+// whether base.ts's own mixin wiring reads initialized bindings. base.ts
+// pushes itself in at the end of its module body instead.
+let _base: typeof Base | undefined;
+
+/** @internal Called from base.ts at module init. */
+export function _registerBase(base: typeof Base): void {
+  _base = base;
+}
+
+function baseClass(): typeof Base {
+  if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _base;
+}
+
 import { Relation } from "../relation.js";
 import { Default } from "./default.js";
 
@@ -36,7 +56,7 @@ const INTRINSIC_FUNCTION_PROPS = new Set(["length", "name", "prototype"]);
 export function isDangerousClassMethod(name: string): boolean {
   if (RESTRICTED_CLASS_METHODS.has(name)) return true;
   if (INTRINSIC_FUNCTION_PROPS.has(name)) return false;
-  let klass: any = Base;
+  let klass: any = baseClass();
   while (klass && klass !== Function.prototype && klass !== Object.prototype) {
     if (Object.prototype.hasOwnProperty.call(klass, name)) return true;
     klass = Object.getPrototypeOf(klass);

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -2,15 +2,15 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "../errors.js";
 import type { Base } from "../base.js";
 
-// `base.js` is deliberately NOT imported for its value here. Rails resolves
-// `ActiveRecord::Base` at call time via autoload (attribute_methods.rb:88), so an
-// import edge would be a trails invention — and a load-time edge back into
-// `base.ts` puts it in an import cycle whose evaluation order then decides
-// whether base.ts's own mixin wiring reads initialized bindings. base.ts
-// pushes itself in at the end of its module body instead.
 let _base: typeof Base | undefined;
 
-/** @internal Called from base.ts at module init. */
+/**
+ * @internal Receives `ActiveRecord::Base` from base.ts at module init. Rails
+ * resolves the constant at call time via autoload (attribute_methods.rb:88), so base.rb
+ * is not required here; in ESM a value import of `base.js` would instead be a
+ * load-time edge putting base.ts in an import cycle, leaving its own
+ * module-evaluation-time mixin wiring dependent on the graph's entry order.
+ */
 export function _registerBase(base: typeof Base): void {
   _base = base;
 }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -20,12 +20,6 @@ import {
 import { ActiveRecordError, ConnectionNotDefined } from "../errors.js";
 import type { Base } from "../base.js";
 
-// `base.js` is deliberately NOT imported for its value here. Rails resolves
-// `ActiveRecord::Base` at call time via autoload (database_statements.rb:222-223), so an
-// import edge would be a trails invention — and a load-time edge back into
-// `base.ts` puts it in an import cycle whose evaluation order then decides
-// whether base.ts's own mixin wiring reads initialized bindings. base.ts
-// pushes itself in at the end of its module body instead.
 let _base: typeof Base | undefined;
 
 function setModuleBase(base: typeof Base): void {
@@ -1250,7 +1244,14 @@ export class DatabaseTasks {
     return Base;
   }
 
-  /** @internal Called from base.ts at module init so migrationConnection() works before any async method runs. */
+  /**
+   * @internal Receives `ActiveRecord::Base` from base.ts at module init. Rails
+   * resolves the constant at call time via autoload
+   * (database_statements.rb:222-223), so base.rb is not required here; in ESM a
+   * value import of `base.js` would instead be a load-time edge putting base.ts
+   * in an import cycle, leaving its own module-evaluation-time mixin wiring
+   * dependent on the graph's entry order.
+   */
   static _registerBase(base: typeof import("../base.js").Base): void {
     this._baseClass = base;
     setModuleBase(base);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -17,8 +17,25 @@ import {
   stdout,
   stderr,
 } from "@blazetrails/activesupport";
-import { ConnectionNotDefined } from "../errors.js";
-import { Base } from "../base.js";
+import { ActiveRecordError, ConnectionNotDefined } from "../errors.js";
+import type { Base } from "../base.js";
+
+// `base.js` is deliberately NOT imported for its value here. Rails resolves
+// `ActiveRecord::Base` at call time via autoload (database_statements.rb:222-223), so an
+// import edge would be a trails invention — and a load-time edge back into
+// `base.ts` puts it in an import cycle whose evaluation order then decides
+// whether base.ts's own mixin wiring reads initialized bindings. base.ts
+// pushes itself in at the end of its module body instead.
+let _base: typeof Base | undefined;
+
+function setModuleBase(base: typeof Base): void {
+  _base = base;
+}
+
+function baseClass(): typeof Base {
+  if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _base;
+}
 
 /**
  * Raised when a database task is invoked against an adapter that
@@ -1236,6 +1253,7 @@ export class DatabaseTasks {
   /** @internal Called from base.ts at module init so migrationConnection() works before any async method runs. */
   static _registerBase(base: typeof import("../base.js").Base): void {
     this._baseClass = base;
+    setModuleBase(base);
   }
 
   static migrationConnection():
@@ -1470,11 +1488,12 @@ export function isVerbose(): boolean {
  * internal_metadata.rb:31-32).
  */
 export function metadataTableNames(): Set<string> {
-  const prefix = Base.tableNamePrefix;
-  const suffix = Base.tableNameSuffix;
+  const base = baseClass();
+  const prefix = base.tableNamePrefix;
+  const suffix = base.tableNameSuffix;
   return new Set([
-    `${prefix}${Base.schemaMigrationsTableName}${suffix}`,
-    `${prefix}${Base.internalMetadataTableName}${suffix}`,
+    `${prefix}${base.schemaMigrationsTableName}${suffix}`,
+    `${prefix}${base.internalMetadataTableName}${suffix}`,
   ]);
 }
 

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -32,10 +32,6 @@ import { connect } from "./support/connection.js";
 import { getEnv } from "@blazetrails/activesupport";
 import { Base } from "./base.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
-// Registers _RelationCtor so Model.first()/.all()/.where() etc. work in
-// test files that import base.js directly rather than index.js (which
-// re-exports relation.js as a side effect).
-import "./relation.js";
 
 const { adapter, envConfig } = await connect();
 

--- a/scripts/test-deps/base-import-cycle.test.ts
+++ b/scripts/test-deps/base-import-cycle.test.ts
@@ -1,0 +1,85 @@
+// Regression guard: `base.ts` must not be a member of any import cycle.
+//
+// base.ts wires its Ruby-style mixins (`extend(Base, ConnectionHandling.ClassMethods)`,
+// …) in ~40 statements at module-evaluation time. ESM evaluates a cycle
+// member's body BEFORE its still-in-progress dependencies' bodies, so as long
+// as base.ts sits inside a cycle, whether those statements read initialized
+// bindings or hit a temporal dead zone depends entirely on which module the
+// import graph happens to be entered through. Adding one unrelated import edge
+// elsewhere is enough to flip the entry order and crash the whole package with
+// `ReferenceError: Cannot access 'ClassMethods' before initialization`.
+//
+// Rails has no such hazard: base.rb `extend`s inside the class body and Ruby
+// autoload resolves each constant on first reference, so none of these modules
+// `require` base.rb. The fix is the same shape — consumers that only need
+// `Base` at call time take it from a registration base.ts pushes at the end of
+// its own module body, rather than importing base.js for its value.
+//
+// This test walks the *source* import graph (value imports only — `import type`
+// is erased and carries no load-time edge) and asserts nothing base.ts can
+// reach imports base.ts back.
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const SRC = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../packages/activerecord/src",
+);
+
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)\s+([\s\S]*?)\s*from\s*["']([^"']+)["']/g;
+
+async function tsFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "test-helpers") continue;
+      out.push(...(await tsFiles(full)));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(path.relative(SRC, full));
+    }
+  }
+  return out;
+}
+
+/** Value-import edges (relative, within the package) keyed by source file. */
+async function importGraph(): Promise<Map<string, string[]>> {
+  const files = await tsFiles(SRC);
+  const known = new Set(files);
+  const graph = new Map<string, string[]>();
+  for (const file of files) {
+    const source = await readFile(path.join(SRC, file), "utf8");
+    const targets = new Set<string>();
+    for (const [, clause, specifier] of source.matchAll(IMPORT_RE)) {
+      if (!specifier.startsWith(".")) continue;
+      // `import type { X } from` is erased by tsc — no runtime edge.
+      if (/^\s*type\b/.test(clause)) continue;
+      const target = path
+        .normalize(path.join(path.dirname(file), specifier))
+        .replace(/\.js$/, ".ts");
+      if (known.has(target)) targets.add(target);
+    }
+    graph.set(file, [...targets]);
+  }
+  return graph;
+}
+
+describe("base.ts import cycle", () => {
+  it("is not reachable from anything base.ts imports", async () => {
+    const graph = await importGraph();
+    const seen = new Set<string>();
+    const offenders: string[] = [];
+    const stack = [...(graph.get("base.ts") ?? [])];
+    while (stack.length > 0) {
+      const file = stack.pop()!;
+      if (seen.has(file)) continue;
+      seen.add(file);
+      const targets = graph.get(file) ?? [];
+      if (targets.includes("base.ts")) offenders.push(file);
+      stack.push(...targets.filter((t) => t !== "base.ts"));
+    }
+    expect(offenders.sort()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes the load-order hazard in `base.ts`'s mixin wiring.

## Problem

`base.ts` applies its Ruby-style mixin wiring in ~40 statements at
module-evaluation time (`extend(Base, ConnectionHandling.ClassMethods)`, …).
Every one reads a binding from a module that was in an import cycle with
`base.ts`. ESM evaluates a cycle member's body *before* its in-progress
dependencies' bodies, so whether those reads saw initialized bindings depended
entirely on which module the graph was entered through — it worked by luck of
entry order, not by construction. Adding one unrelated import edge
(`migration/join-table.ts` → `model-schema.js`) was enough to flip the order and
kill the package with `ReferenceError: Cannot access 'ClassMethods' before
initialization`.

Rails has no such hazard: `base.rb` does `extend ConnectionHandling` inside the
class body and autoload resolves each constant on first reference, so none of
these files `require` base.rb. Our load-time edges into `base.ts` were pure
inventions — e.g. `schema_migration.rb` has zero `require`s, yet
`schema-migration.ts` statically imported `base.js` just to read
`Base.tableNamePrefix` inside the `tableName` getter.

## Change

Removed all seven value-import edges back into `base.ts`:

| module | needed `Base` for | now |
| --- | --- | --- |
| `schema-migration.ts` | `tableName` getter | `_registerBase` push |
| `internal-metadata.ts` | `tableName` getter | `_registerBase` push |
| `schema-dumper.ts` | seeding `_ignoreTables` | `_registerBase` push |
| `scoping/named.ts` | `isDangerousClassMethod` walk | `_registerBase` push |
| `tasks/database-tasks.ts` | `metadataTableNames()` | existing `DatabaseTasks._registerBase` |
| `insert-all.ts` | `quoteSqlValue` | `_registerQuoteSqlValue` push |
| `relation.ts` | `_setRelationCtor` self-registration | inverted — `base.ts` imports `Relation` directly |

`base.ts` pushes each of these at the end of its own module body, mirroring
Rails' call-time constant resolution. Because `base.ts` is now in **no cycle at
all**, it is guaranteed by construction to evaluate after every module its
wiring reads — and the `Relation`/`wrapWithScopeProxy`/`relationClassFor`
late-binding holders and their three `if (!_RelationCtor) throw` guards could go
away entirely, since those are ordinary static imports now.

## Verification

- `scripts/test-deps/base-import-cycle.test.ts` (new) walks the source import
  graph and asserts nothing reachable from `base.ts` imports `base.ts` back.
  Verified it fails on baseline (re-adding a `base.js` value import to
  `relation.ts` reports `[ 'relation.ts' ]`).
- `scripts/test-deps/adapter-graph-import-tdz.test.ts` passes, entered through
  `SchemaStatements` as today.
- **Acceptance probe:** with
  `import { deriveJoinTableName } from "../model-schema.js"` added to
  `migration/join-table.ts`, both the TDZ guard and
  `node -e 'await import("./dist/connection-adapters/abstract/schema-statements.js")'`
  pass. That import is not shipped here.
- `pnpm typecheck`, targeted eslint, and the AR suites covering the touched
  modules (base, relations, scoping, insert-all, schema-dumper,
  schema-migration, internal-metadata, tasks, associations, inheritance,
  migrator) pass locally.

Unblocks `migration-join-table-delegate-to-derive-join-table-name` and removes
the standing reason `migration/join-table.ts` must stay import-leaf.

Closes-story: base-mixin-wiring-order-independent-module-init