### PR TITLE
refactor(migration): drop the class-level version hook from Migration#version

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -72,10 +72,9 @@ describe("ActiveRecordSchemaTest", () => {
   it("schema version accessor", () => {
     // Migration instances have a version property
     class V1 extends Migration {
-      static version = "20230101000000";
       async change() {}
     }
-    const m = new V1();
+    const m = new V1(undefined, "20230101000000");
     expect(m.version).toBe("20230101000000");
   });
 
@@ -128,12 +127,11 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("normalize version", () => {
-    // Migration version is derived from static property or class name
+    // Migration version comes from the constructor (Rails: initialize(name, version)).
     class NormalMig extends Migration {
-      static version = "001";
       async change() {}
     }
-    expect(new NormalMig().version).toBe("001");
+    expect(new NormalMig(undefined, "001").version).toBe("001");
   });
 
   it("schema load with multiple indexes for column of different names", async () => {

--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -127,7 +127,6 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("normalize version", () => {
-    // Migration version comes from the constructor (Rails: initialize(name, version)).
     class NormalMig extends Migration {
       async change() {}
     }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1933,44 +1933,38 @@ describe("MigrationTest", () => {
   describe("CopyMigrationsTest", () => {
     it("copying migrations without timestamps", () => {
       class CM1 extends Migration {
-        static version = "001";
         async change() {}
       }
-      expect(new CM1().version).toBe("001");
+      expect(new CM1(undefined, "001").version).toBe("001");
     });
 
     it("copying migrations without timestamps from 2 sources", () => {
       class CM1 extends Migration {
-        static version = "001";
         async change() {}
       }
       class CM2 extends Migration {
-        static version = "002";
         async change() {}
       }
-      expect(new CM1().version).toBe("001");
-      expect(new CM2().version).toBe("002");
+      expect(new CM1(undefined, "001").version).toBe("001");
+      expect(new CM2(undefined, "002").version).toBe("002");
     });
 
     it("copying migrations with timestamps", () => {
       class CM1 extends Migration {
-        static version = "20230101120000";
         async change() {}
       }
-      expect(new CM1().version).toBe("20230101120000");
+      expect(new CM1(undefined, "20230101120000").version).toBe("20230101120000");
     });
 
     it("copying migrations with timestamps from 2 sources", () => {
       class CM1 extends Migration {
-        static version = "20230101120000";
         async change() {}
       }
       class CM2 extends Migration {
-        static version = "20230201120000";
         async change() {}
       }
-      expect(new CM1().version).toBe("20230101120000");
-      expect(new CM2().version).toBe("20230201120000");
+      expect(new CM1(undefined, "20230101120000").version).toBe("20230101120000");
+      expect(new CM2(undefined, "20230201120000").version).toBe("20230201120000");
     });
 
     it("copying migrations with timestamps to destination with timestamps in future", async () => {
@@ -2031,10 +2025,9 @@ describe("MigrationTest", () => {
 
     it("skipping migrations", () => {
       class CM1 extends Migration {
-        static version = "001";
         async change() {}
       }
-      expect(new CM1().version).toBe("001");
+      expect(new CM1(undefined, "001").version).toBe("001");
       expect(new CM1().name).toBe("CM1");
     });
 
@@ -2107,7 +2100,6 @@ describe("MigrationTest", () => {
     it("check pending with stdlib logger", async () => {
       const cpAdapter = await freshAdapter();
       class CPM1 extends Migration {
-        static version = "001";
         async change() {
           await this.createTable("pend_t", (t) => {
             t.string("x");
@@ -2115,7 +2107,7 @@ describe("MigrationTest", () => {
         }
       }
       const { MigrationRunner } = await import("./migrator.js");
-      const runner = new MigrationRunner(cpAdapter, [new CPM1()]);
+      const runner = new MigrationRunner(cpAdapter, [new CPM1(undefined, "001")]);
       const status = await runner.status();
       expect(status.length).toBe(1);
       expect(status[0].status).toBe("down");
@@ -2129,10 +2121,9 @@ describe("MigrationTest", () => {
       it("migration raises if timestamp greater than 14 digits", () => {
         // Version strings longer than 14 chars are still stored as-is
         class LongV extends Migration {
-          static version = "123456789012345";
           async change() {}
         }
-        expect(new LongV().version).toBe("123456789012345");
+        expect(new LongV(undefined, "123456789012345").version).toBe("123456789012345");
       });
 
       it("migration raises if timestamp is future date", () => {
@@ -2157,26 +2148,23 @@ describe("MigrationTest", () => {
         const now = Date.now();
         const ts = String(now);
         class FutureM extends Migration {
-          static version = ts;
           async change() {}
         }
-        expect(new FutureM().version).toBe(ts);
+        expect(new FutureM(undefined, ts).version).toBe(ts);
       });
 
       it("migration succeeds despite future timestamp if validate timestamps is false", () => {
         class FutureM2 extends Migration {
-          static version = "99991231235959";
           async change() {}
         }
-        expect(new FutureM2().version).toBe("99991231235959");
+        expect(new FutureM2(undefined, "99991231235959").version).toBe("99991231235959");
       });
 
       it("migration succeeds despite future timestamp if timestamped migrations is false", () => {
         class NoTs extends Migration {
-          static version = "99999999999999";
           async change() {}
         }
-        expect(new NoTs().version).toBe("99999999999999");
+        expect(new NoTs(undefined, "99999999999999").version).toBe("99999999999999");
       });
 
       it("copied migrations at timestamp boundary are valid", async () => {
@@ -2369,9 +2357,8 @@ describeIfMysqlAdapter("BulkAlterTableMigrationsTest", () => {
 function mockMigration(): { migration: Migration; sql: string[] } {
   const sql: string[] = [];
   const migration = new (class extends Migration {
-    static version = "20240101000000";
     async change() {}
-  })();
+  })(undefined, "20240101000000");
   (migration as any).adapter = {
     execute: async () => [],
     executeMutation: async (s: string) => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1270,11 +1270,10 @@ export abstract class Migration {
   /**
    * Get the migration version. Rails initializes `@version` to nil
    * (`migration.rb:799`) — only `@name` defaults to the class name — so an
-   * unversioned migration has no version. The static hook is the trails path
-   * for compatibility classes that declare one.
+   * unversioned migration has no version.
    */
   get version(): string | undefined {
-    return this._version ?? (this.constructor as any).version;
+    return this._version;
   }
 
   // --- Logging (Rails: Migration#write, #announce, #say, #say_with_time, #suppress_messages) ---

--- a/packages/trailties/src/generators/migration-generator.ts
+++ b/packages/trailties/src/generators/migration-generator.ts
@@ -235,8 +235,6 @@ export class MigrationGenerator extends GeneratorBase {
       `import { Migration } from "@blazetrails/activerecord";
 
 export class ${className} extends Migration {
-  static version = "${timestamp}";
-
   async change()${returnType} {
 ${body}
   }


### PR DESCRIPTION
Rails' `Migration#version` is a plain `attr_accessor` written only by `initialize(name = self.class.name, version = nil)` (`vendor/rails/activerecord/lib/active_record/migration.rb:797-803`); the value arrives from `MigrationProxy#load_migration` (`migration.rb:1195`) or stays nil. There is no class-level `version` hook.

Audit: no compatibility class in `migration/compatibility.ts` and no runtime caller set a static `version` — every `static version =` was in a test, plus one dead emission in the migration generator's template. So the hook and its `as any` cast are deleted; `#version` is `this._version` alone and stays `undefined` for an unversioned migration.

The tests now pass the version through the constructor, the way `load_migration` does. The generator no longer emits `static version`: the single instantiation path (`migration.ts:2095`) already passes the filename-derived version, and Rails' migration generator emits no version constant either.

Closes-story: migration-version-static-class-hook-has-no-rails-counterpart
