### PR TITLE
refactor(migration): memoize Migrator schema-table creation and collapse call sites

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2334,7 +2334,6 @@ export class Migrator {
       throw new Error(`Invalid steps: ${steps}. Must be a non-negative integer.`);
     }
     await this._withAdvisoryLock(async () => {
-      await this._ensureSchemaTable();
       const pending = await this.pendingMigrations();
       const toRun = pending.slice(0, steps);
 
@@ -2404,7 +2403,6 @@ export class Migrator {
   async recordEnvironment(): Promise<void> {
     if (this.isDown()) return;
     if (this._internalMetadata.enabled) {
-      await this._ensureSchemaTable();
       await this._internalMetadata.set("environment", this._environment);
     }
   }
@@ -2493,7 +2491,6 @@ export class Migrator {
    * Mirrors: ActiveRecord::Migrator.current_version
    */
   async currentVersion(): Promise<number> {
-    await this._ensureSchemaTable();
     const versions = await this.getAllVersions();
     if (versions.length === 0) return 0;
     let max = BigInt(0);
@@ -2801,13 +2798,22 @@ export class Migrator {
     }
   }
 
-  private _schemaTableEnsured = false;
+  private _schemaTablesCreated?: Promise<void>;
 
-  private async _ensureSchemaTable(): Promise<void> {
-    if (this._schemaTableEnsured) return;
-    await this._schemaMigration.createTable();
-    await this._internalMetadata.createTable();
-    this._schemaTableEnsured = true;
+  /**
+   * Rails creates both bookkeeping tables as the last thing `Migrator#initialize`
+   * does (migration.rb:1429-1430), so every method downstream can assume they
+   * exist. `createTable` is async here and a constructor can't await, so the
+   * creation is memoized on the instance and awaited at the entry points
+   * instead. The memo is the deliberate stand-in for Rails' constructor-time
+   * creation: the tables are still created exactly once per Migrator, and a
+   * failure is cached the way a raise from `initialize` would be terminal.
+   */
+  private _ensureSchemaTable(): Promise<void> {
+    return (this._schemaTablesCreated ??= (async () => {
+      await this._schemaMigration.createTable();
+      await this._internalMetadata.createTable();
+    })());
   }
 
   private async _appliedVersions(): Promise<Set<string>> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2798,19 +2798,18 @@ export class Migrator {
     }
   }
 
-  private _schemaTablesCreated?: Promise<void>;
+  private _schemaTablesEnsured?: Promise<void>;
 
   /**
-   * Rails creates both bookkeeping tables as the last thing `Migrator#initialize`
-   * does (migration.rb:1429-1430), so every method downstream can assume they
-   * exist. `createTable` is async here and a constructor can't await, so the
-   * creation is memoized on the instance and awaited at the entry points
-   * instead. The memo is the deliberate stand-in for Rails' constructor-time
-   * creation: the tables are still created exactly once per Migrator, and a
-   * failure is cached the way a raise from `initialize` would be terminal.
+   * Deliberate stand-in for Rails' constructor-time creation: `initialize`
+   * creates both bookkeeping tables as its last act (migration.rb:1429-1430),
+   * so everything downstream may assume they exist. `createTable` is async and
+   * a constructor cannot await, so the creation is memoized here and awaited at
+   * the entry points instead — still exactly once per Migrator, and a failure
+   * stays terminal the way a raise from `initialize` would.
    */
   private _ensureSchemaTable(): Promise<void> {
-    return (this._schemaTablesCreated ??= (async () => {
+    return (this._schemaTablesEnsured ??= (async () => {
       await this._schemaMigration.createTable();
       await this._internalMetadata.createTable();
     })());

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -296,6 +296,13 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
+    "rubyName": "record_environment",
+    "call": "connection",
+    "reason": "Equivalent: Rails reads `connection.pool.db_config.env_name` at record time; trails resolves the same env name once in the constructor into `_environment` and stores that."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
     "rubyName": "record_version_state_after_migrating",
     "call": "create_version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Collapses the lazy `_ensureSchemaTable` scaffolding in `Migrator` toward Rails'
constructor-time table creation (`migration.rb:1429-1430`).

- `_schemaTableEnsured` (boolean flag + manual set) is replaced by a memoized
  promise, and the divergence is documented at the definition: Rails creates
  both bookkeeping tables at the end of `initialize`, our `createTable` is
  async and a constructor can't await, so the creation is memoized on the
  instance and awaited at the entry points instead. Tables are still created
  exactly once per Migrator, and a failure is cached the way a raise from
  `initialize` would be terminal.
- Redundant call sites removed: `currentVersion` (delegates to
  `getAllVersions`), `forward` (delegates to `pendingMigrations`), and
  `recordEnvironment` (both callers already ensure, and Rails'
  `record_environment` assumes the tables exist).

Remaining calls are the smallest set that still covers every externally
reachable entry point: `runWithoutLock`, `migrateWithoutLock`, `rollback`,
`getAllVersions`, `pendingMigrations`, `migrationsStatus`, `checkEnvironment`.

Migration/migrator/multi-db/schema/database-tasks/CLI suites pass; no test
renames.



One wide-call-ratchet baseline entry rides along: dropping the redundant
`_ensureSchemaTable()` from `recordEnvironment` shrank the body enough for the
wide gate to newly flag Rails' `connection` call there. Rails reads
`connection.pool.db_config.env_name` at record time (migration.rb:1516); trails
resolves the same env name once in the constructor into `_environment` and
stores that — equivalent by a different path, so it is baselined with that
reason rather than implemented.


Closes-story: migrator-defers-schema-table-creation-to-lazy-ensure
