### PR TITLE
test(bind-parameter): mirror Rails' MySQL string-cast branch in bind_params_to_sql

### DIFF
--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -438,10 +438,8 @@ describe("BindParameterTest", () => {
     // separately as story `array-where-integer-range-exclusion`.
 
     // Rails (bind_parameter_test.rb:240-246): "With MySQL integers are casted as
-    // string for security" — `mysql/quoting.rb#cast_bound_value` stringifies every
-    // Numeric, and `visit_Arel_Nodes_BoundSqlLiteral` runs each array element
-    // through it, so the MySQL IN-list is `'1', '2', '3'`. Every other adapter's
-    // `cast_bound_value` is the identity and renders `1, 2, 3`.
+    // string for security" — `mysql/quoting.rb#cast_bound_value`, which
+    // `visit_Arel_Nodes_BoundSqlLiteral` applies to every array element.
     const params = currentAdapter("Mysql2Adapter", "TrilogyAdapter")
       ? bindParams(conn, ["1", "2", "3"])
       : bindParams(conn, [1, 2, 3]);

--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -14,6 +14,7 @@ import { Base, RecordNotFound } from "./index.js";
 import { registerModel } from "./associations.js";
 import { fixtures } from "./test-fixtures.js";
 import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
+import { currentAdapter } from "./support/adapter-helper.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Author } from "./test-helpers/models/author.js";
 import { Post } from "./test-helpers/models/post.js";
@@ -410,9 +411,9 @@ describe("BindParameterTest", () => {
   // Deliberate deviation: trails' `to_sql` always inlines bind values (it mirrors
   // Rails' *unprepared* `to_sql` even when prepared_statements is on — see
   // database-statements.ts), so we drive an inlining SubstituteBinds collector
-  // here regardless of mode. That renders the IN-list the same way `to_sql` does
-  // (`1, 2, 3`) so the expected SQL matches on every adapter.
-  function bindParams(conn: any, ids: number[]): string {
+  // here regardless of mode. That renders the IN-list the same way `to_sql` does,
+  // on every adapter and in both modes.
+  function bindParams(conn: any, ids: (number | string)[]): string {
     const collector = new Collectors.SubstituteBinds(conn, new Collectors.SQLString());
     return conn.visitor.compile(
       ids.map((i) => new Nodes.BindParam(i)),
@@ -436,7 +437,15 @@ describe("BindParameterTest", () => {
     // a distinct gap from this story's bind_params_to_sql collector, tracked
     // separately as story `array-where-integer-range-exclusion`.
 
-    sql = `SELECT ${table}.* FROM ${table} WHERE ${pk} IN (${bindParams(conn, [1, 2, 3])})`;
+    // Rails (bind_parameter_test.rb:240-246): "With MySQL integers are casted as
+    // string for security" — `mysql/quoting.rb#cast_bound_value` stringifies every
+    // Numeric, and `visit_Arel_Nodes_BoundSqlLiteral` runs each array element
+    // through it, so the MySQL IN-list is `'1', '2', '3'`. Every other adapter's
+    // `cast_bound_value` is the identity and renders `1, 2, 3`.
+    const params = currentAdapter("Mysql2Adapter", "TrilogyAdapter")
+      ? bindParams(conn, ["1", "2", "3"])
+      : bindParams(conn, [1, 2, 3]);
+    sql = `SELECT ${table}.* FROM ${table} WHERE ${pk} IN (${params})`;
     const arelNode = new Nodes.BoundSqlLiteral(
       `SELECT ${table}.* FROM ${table} WHERE ${pk} IN (?)`,
       [[1, 2, 3]],


### PR DESCRIPTION
`bind_parameter_test.rb`'s `assert_bind_params_to_sql` builds its third expected
IN-list adapter-conditionally (bind_parameter_test.rb:240-246):

```ruby
params = if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
  # With MySQL integers are casted as string for security.
  bind_params((1..3).map(&:to_s))
else
  bind_params(1..3)
end
```

trails' port hardcoded the non-MySQL branch, so the assertion expected
``IN (1, 2, 3)`` on every adapter. That is only reachable off MySQL: the
assertion drives a `BoundSqlLiteral` whose single bind is the array `[1, 2, 3]`,
and `visit_Arel_Nodes_BoundSqlLiteral` runs every array element through
`@connection.cast_bound_value` (to_sql.rb:782), which `mysql/quoting.rb:55-67`
implements as `Numeric#to_s`. The `SubstituteBinds` collector then quotes those
strings, giving ``IN ('1', '2', '3')`` — exactly what Rails expects on MySQL.

Rails never sees the failure because `BindParameterTest` is wrapped in
`if prepared_statements` and MySQL defaults it off; trails' `maria-prepared-tests`
lane (`ARCONN=mysql2` + `MYSQL_PREPARED_STATEMENTS=1`) turns the class-level gate
on and exposes the divergence in both the prepared and unprepared variants (the
per-test toggle is fine — `to_sql` inlines binds in both modes, and
`cast_bound_value` applies in both).

Fix is the missing Rails branch, restoring the adapter conditional. No production
code changes: `castBoundValue` already matches Rails.

Verified locally against an isolated compose stack:

- `ARCONN=mysql2 MYSQL_PREPARED_STATEMENTS=1` — both tests now pass (they fail on
  `origin/main` at the same commit).
- `ARCONN=mysql2` (plain), `ARCONN=postgresql`, sqlite3 — all still green.

Pre-existing and out of scope: `binds are logged` also fails on the prepared
MariaDB lane, on `origin/main` as well as this branch.

Closes-story: array-bind-elements-quoted-under-prepared-default
