### PR TITLE
refactor(migration): drop the invented _validateTargetVersion from Migrator

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2863,20 +2863,6 @@ export class Migrator {
     return !this._migrations.some((m) => m.version === key);
   }
 
-  private _validateTargetVersion(v: number | string): void {
-    if (typeof v === "string") {
-      if (!/^\d+$/.test(v)) {
-        throw new MigrationError(
-          `Invalid target version: ${v}. Must be a non-negative numeric value.`,
-        );
-      }
-    } else {
-      if (!Number.isInteger(v) || v < 0) {
-        throw new MigrationError(`Invalid target version: ${v}. Must be a non-negative integer.`);
-      }
-    }
-  }
-
   /**
    * Run exactly one migration (identified by `targetVersion`) in the given
    * direction. Used by the `db:migrate:up` / `db:migrate:down` CLI paths
@@ -2895,7 +2881,6 @@ export class Migrator {
   }
 
   private async _migrateUp(targetVersion: number | string | null): Promise<MigrationProxy[]> {
-    if (targetVersion !== null) this._validateTargetVersion(targetVersion);
     const target = targetVersion !== null ? BigInt(targetVersion) : null;
     const applied = await this._appliedVersions();
     const ran: MigrationProxy[] = [];
@@ -2913,7 +2898,6 @@ export class Migrator {
     // A null target means "revert everything" (Rails: a `:down` Migrator with no
     // target_version), which — unlike `down(0)` — also reverts a version-0
     // migration.
-    if (targetVersion !== null) this._validateTargetVersion(targetVersion);
     const target = targetVersion !== null ? BigInt(targetVersion) : null;
     const applied = await this._appliedVersions();
     const toRevert = this._migrations


### PR DESCRIPTION
Rails' `Migrator` validates a target version only through `invalid_target?`
(`vendor/rails/activerecord/lib/active_record/migration.rb:1524-1526`), checked
once in `migrate_without_lock` (:1503-1505), which raises
`UnknownMigrationVersionError`.

`Migrator._validateTargetVersion` was a trails invention raising
`MigrationError` (`Invalid target version: ...`). PR #5745 already established
it was unreachable from `migrate` and dropped that call site; the two remaining
ones in `_migrateUp` / `_migrateDown` are equally unreachable — both are private
and reached only via `migrateWithoutLock`, which rejects every bad target
(non-integer, negative, unknown, unparseable) through `isInvalidTarget()` before
dispatching. Deleted the method and both calls.

Pure dead-code removal: no observable behavior change. No test asserted the
`Invalid target version:` message, so nothing needed rewriting; the surviving
Rails behavior stays pinned by `migrator.test.ts` "migrator with missing version
numbers" (the port of `test_migrator_with_missing_version_numbers`, covering
targets 3, -1 and 0) and by `migrator.trails.test.ts` "up and down raise
UnknownMigrationVersionError for an unknown target".

`pnpm api:compare` shows no new extra-surface entry for `migration.rb`.

Closes-story: migrator-drop-validate-target-version
