### PR TITLE
fix(migration): load the migration inside the all-later-migrations-canceled rescue

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1030,9 +1030,9 @@ describe("MigrationTest", () => {
     await adapter.dropTable("wtx_test", { ifExists: true });
   });
 
-  it("migration that fails to load is canceled with the later-migrations message", async () => {
+  it("migration that fails to load escapes the canceled message", async () => {
     const adapter = await freshAdapter();
-    const loadError = new Error("Unexpected token '}'");
+    const loadError = new Error("uninitialized constant MigThatFailsToLoad");
     const proxy: MigrationProxy = {
       version: "102",
       name: "MigThatFailsToLoad",
@@ -1045,12 +1045,12 @@ describe("MigrationTest", () => {
     } catch (e) {
       err = e as Error;
     }
-    expect(err).toBeInstanceOf(Error);
-    const useTx = adapter.supportsDdlTransactions?.() ?? false;
-    expect(err.message).toBe(
-      `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\nUnexpected token '}'`,
-    );
-    expect(err.cause).toBe(loadError);
+    // Rails' rescue calls use_transaction? -> MigrationProxy#disable_ddl_transaction,
+    // which re-runs the failed load and raises out of the rescue itself, so the
+    // "all later migrations canceled" wrapper never gets built.
+    expect(err).toBe(loadError);
+    const versions = await migrator.getAllVersions();
+    expect(versions).not.toContain("102");
   });
 
   it("internal metadata table name", async () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1030,6 +1030,29 @@ describe("MigrationTest", () => {
     await adapter.dropTable("wtx_test", { ifExists: true });
   });
 
+  it("migration that fails to load is canceled with the later-migrations message", async () => {
+    const adapter = await freshAdapter();
+    const loadError = new Error("Unexpected token '}'");
+    const proxy: MigrationProxy = {
+      version: "102",
+      name: "MigThatFailsToLoad",
+      migration: () => Promise.reject(loadError),
+    };
+    const migrator = new Migrator(adapter, [proxy]);
+    let err!: Error;
+    try {
+      await migrator.migrate();
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const useTx = adapter.supportsDdlTransactions?.() ?? false;
+    expect(err.message).toBe(
+      `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\nUnexpected token '}'`,
+    );
+    expect(err.cause).toBe(loadError);
+  });
+
   it("internal metadata table name", async () => {
     const { adapter } = await freshContext();
     const { InternalMetadata } = await import("./internal-metadata.js");

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2953,9 +2953,10 @@ export class Migrator {
       });
     } catch (e) {
       // Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction rescue block
-      const useTx = migration
-        ? this._useTransaction(migration)
-        : (this._adapter.supportsDdlTransactions?.() ?? false);
+      // Rails re-resolves the proxy here (`migration.rb:1540` → `use_transaction?`
+      // → `MigrationProxy#disable_ddl_transaction`), so a migration that failed to
+      // load raises again from inside the rescue and escapes unwrapped.
+      const useTx = this._useTransaction(migration ?? (await proxy.migration()));
       // Ruby's `#{e}` interpolates Exception#to_s — the bare message, without
       // the `Error: ` prefix JS String(e) would add.
       const msg = `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\n${e instanceof Error ? e.message : e}`;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2932,18 +2932,13 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    // Rails resolves the migration lazily inside `execute_migration_in_transaction`
-    // (`migration.rb:1528-1543`) — `MigrationProxy#migration` loads the file at the
-    // moment `migrate` is called, so a file that fails to load is caught by the same
-    // rescue and gets the "all later migrations canceled" framing.
     let migration: Migration | undefined;
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
     // atomically. Without this, a committed migration + failed stamp
     // would leave schema_migrations out of sync.
     try {
-      const loaded = await proxy.migration();
-      migration = loaded;
+      const loaded = (migration = await proxy.migration());
       loaded.connection = this._adapter;
       await this._ddlTransaction(loaded, async () => {
         await loaded.migrate(direction);
@@ -2958,9 +2953,6 @@ export class Migrator {
       });
     } catch (e) {
       // Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction rescue block
-      // A migration that failed to load has no `disable_ddl_transaction` to
-      // consult, so the decision falls to adapter support alone — the same
-      // answer Rails' `use_transaction?` gives for a nil opt-out.
       const useTx = migration
         ? this._useTransaction(migration)
         : (this._adapter.supportsDdlTransactions?.() ?? false);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2932,15 +2932,21 @@ export class Migrator {
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {
-    const migration = await proxy.migration();
-    migration.connection = this._adapter;
+    // Rails resolves the migration lazily inside `execute_migration_in_transaction`
+    // (`migration.rb:1528-1543`) — `MigrationProxy#migration` loads the file at the
+    // moment `migrate` is called, so a file that fails to load is caught by the same
+    // rescue and gets the "all later migrations canceled" framing.
+    let migration: Migration | undefined;
     // Rails wraps both the migration execution AND the version
     // stamping inside the same ddl_transaction so they commit/rollback
     // atomically. Without this, a committed migration + failed stamp
     // would leave schema_migrations out of sync.
     try {
-      await this._ddlTransaction(migration, async () => {
-        await migration.migrate(direction);
+      const loaded = await proxy.migration();
+      migration = loaded;
+      loaded.connection = this._adapter;
+      await this._ddlTransaction(loaded, async () => {
+        await loaded.migrate(direction);
         if (direction === "up") {
           await this._schemaMigration.recordVersion(proxy.version);
           if (this._internalMetadata.enabled) {
@@ -2952,7 +2958,12 @@ export class Migrator {
       });
     } catch (e) {
       // Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction rescue block
-      const useTx = this._useTransaction(migration);
+      // A migration that failed to load has no `disable_ddl_transaction` to
+      // consult, so the decision falls to adapter support alone — the same
+      // answer Rails' `use_transaction?` gives for a nil opt-out.
+      const useTx = migration
+        ? this._useTransaction(migration)
+        : (this._adapter.supportsDdlTransactions?.() ?? false);
       // Ruby's `#{e}` interpolates Exception#to_s — the bare message, without
       // the `Error: ` prefix JS String(e) would add.
       const msg = `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\n${e instanceof Error ? e.message : e}`;


### PR DESCRIPTION
`Migrator#_runMigration` loaded the migration before the `try` that produces
Rails' cancellation message. Rails loads it inside the protected region:
`execute_migration_in_transaction` (`migration.rb:1528-1543`) enters
`ddl_transaction(migration)` → `use_transaction?` → `MigrationProxy#disable_ddl_transaction`,
which is where `load_migration` actually fires.

**The story's premise — that Rails wraps a load failure in "all later migrations
canceled" — is wrong.** Traced against real Ruby:

- `MigrationProxy#migration` is `@migration ||= load_migration` (`migration.rb:1190-1192`),
  memoized only on success. A `StandardError` load failure (e.g. `name.constantize`
  raising `NameError`) is caught by the `rescue => e` at 1538; line 1540 then calls
  `use_transaction?(migration)` again, which re-runs `load_migration` and raises a
  second time — from inside the rescue, so it propagates **raw**, with Ruby's
  automatic `cause` chained to the first failure. The banner is never built.
- A genuine syntax error raises `SyntaxError`, a `ScriptError` and therefore not a
  `StandardError` — `rescue => e` never catches it at all. Raw on the first attempt.

So in no case does a load failure get the canceled framing. Rather than ratify the
nicer invented behavior, this converges on Rails: the load moves inside the `try`
(Rails' structure), and the rescue re-resolves the proxy exactly as `use_transaction?`
does, so a failed load raises back out unwrapped. The test pins that the raw load
error propagates and that no version is stamped.

Note for the reviewer: because the observable outcome for a load failure matches what
`main` already did (raw error either way), this test does not fail on `main` — it is a
pin against the wrapping behavior, not a regression test for a live bug. The behavioral
delta of this PR is structural fidelity to `migration.rb:1534-1541`.

Closes-story: migrator-loads-migration-outside-the-canceled-rescue
