### PR TITLE
refactor(migration): memoize Migrator#migrated and reload it under the advisory lock

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1468,9 +1468,22 @@ describe("MigrationTest", () => {
     "advisory_locks",
     "with advisory lock raises the right error when it fails to release lock",
     async () => {
-      const lockAdapter = makeLockAdapter({ acquires: true, releases: false });
-      const migrator = new Migrator(lockAdapter, []);
-      const error = await migrator.withAdvisoryLock(async () => {}).catch((e) => e);
+      // Rails runs this against the real connection and provokes the release
+      // failure by releasing the lock from inside the block, so the migrator's
+      // own release finds nothing to release (migration_test.rb:1107-1124).
+      const realAdapter = Base.connection;
+      const proxy: MigrationProxy = {
+        version: "100",
+        name: "NoOp",
+        migration: () => anonymousMigration("NoOp", "100"),
+      };
+      const migrator = new Migrator(realAdapter, [proxy], { targetVersion: 100 });
+      const lockId = await migrator.generateMigratorAdvisoryLockId();
+      const error = await migrator
+        .withAdvisoryLock(async () => {
+          await realAdapter.releaseAdvisoryLock(lockId);
+        })
+        .catch((e) => e);
       expect(error).toBeInstanceOf(ConcurrentMigrationError);
       expect(error.message).toMatch(ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE);
     },

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -3121,18 +3121,25 @@ export class Migrator {
     return this._schemaMigration;
   }
 
+  /**
+   * Mirrors: ActiveRecord::MigrationContext#open (migration.rb:1278-1280).
+   *
+   * Returns a *fresh* Migrator, as Rails does. Callers that read
+   * {@link pendingMigrations} repeatedly (`CheckPending`) rely on this: the
+   * `migrated` memo lives on the per-run Migrator, so a new one is what makes
+   * each read see current schema_migrations.
+   */
   open(): Migrator {
-    return this;
+    return new Migrator(this._adapter, this._migrations, this._runOptions("up", null));
   }
 
   async needsMigration(): Promise<boolean> {
-    const pending = await this.pendingMigrations();
-    return pending.length > 0;
+    return (await this.pendingMigrationVersions()).length > 0;
   }
 
   async pendingMigrationVersions(): Promise<string[]> {
-    const pending = await this.pendingMigrations();
-    return pending.map((m) => m.version);
+    const applied = new Set(await this.getAllVersions());
+    return this._migrations.map((m) => m.version).filter((v) => !applied.has(v));
   }
 
   get currentEnvironment(): string {
@@ -3312,7 +3319,7 @@ export class CheckPending {
 
   async call(env: Record<string, unknown>): Promise<unknown> {
     if (this._migrator) {
-      const pending = await this._migrator.pendingMigrations();
+      const pending = await this._migrator.open().pendingMigrations();
       this._throwIfPending(pending.length);
     } else if (this._pendingConnection) {
       if (this._migrations.length === 0) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2152,7 +2152,6 @@ export class Migrator {
   private readonly _options: MigratorOptions;
   private readonly _direction: "up" | "down";
   private readonly _targetVersion: number | string | null;
-  /** Rails: `@migrated_versions` (migration.rb:1479-1485). */
   private _migratedVersions?: Set<string>;
 
   constructor(
@@ -2205,6 +2204,12 @@ export class Migrator {
    * Wrap a block with an advisory lock to prevent concurrent migrations.
    * If the adapter doesn't support advisory locks, runs without locking.
    *
+   * Once the lock is held, `loadMigrated` reloads schema_migrations to be sure
+   * it wasn't changed by another process while we blocked (migration.rb:1601).
+   * Rails' `Migrator` creates the bookkeeping tables in `initialize`; a
+   * constructor cannot await, so they are ensured here before the reload can
+   * query them.
+   *
    * Mirrors: ActiveRecord::Migrator#with_advisory_lock
    */
   private async _withAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -2226,10 +2231,6 @@ export class Migrator {
     if (!locked) {
       throw new ConcurrentMigrationError();
     }
-    // Reload schema_migrations to be sure it wasn't changed by another process
-    // before we got the lock (migration.rb:1601). Rails' Migrator creates the
-    // bookkeeping tables in `initialize`; we can't await in a constructor, so
-    // ensure them here before the reload can query them.
     await this._ensureSchemaTable();
     await this.loadMigrated();
     // Capture fn error so we can release the lock before re-throwing (no-unsafe-finally).
@@ -2960,18 +2961,9 @@ export class Migrator {
       loaded.connection = this._adapter;
       await this._ddlTransaction(loaded, async () => {
         await loaded.migrate(direction);
-        // Track our own writes in the `migrated` memo, as Rails'
-        // record_version_state_after_migrating does (migration.rb:1554-1562).
-        const migrated = await this.migrated();
-        if (direction === "up") {
-          migrated.add(proxy.version);
-          await this._schemaMigration.recordVersion(proxy.version);
-          if (this._internalMetadata.enabled) {
-            await this._internalMetadata.set("environment", this._environment);
-          }
-        } else {
-          migrated.delete(proxy.version);
-          await this._schemaMigration.deleteVersion(proxy.version);
+        await this.recordVersionStateAfterMigrating(proxy.version, direction);
+        if (direction === "up" && this._internalMetadata.enabled) {
+          await this._internalMetadata.set("environment", this._environment);
         }
       });
     } catch (e) {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2152,6 +2152,8 @@ export class Migrator {
   private readonly _options: MigratorOptions;
   private readonly _direction: "up" | "down";
   private readonly _targetVersion: number | string | null;
+  /** Rails: `@migrated_versions` (migration.rb:1479-1485). */
+  private _migratedVersions?: Set<string>;
 
   constructor(
     adapter: DatabaseAdapter,
@@ -2224,6 +2226,12 @@ export class Migrator {
     if (!locked) {
       throw new ConcurrentMigrationError();
     }
+    // Reload schema_migrations to be sure it wasn't changed by another process
+    // before we got the lock (migration.rb:1601). Rails' Migrator creates the
+    // bookkeeping tables in `initialize`; we can't await in a constructor, so
+    // ensure them here before the reload can query them.
+    await this._ensureSchemaTable();
+    await this.loadMigrated();
     // Capture fn error so we can release the lock before re-throwing (no-unsafe-finally).
     // Release errors are swallowed when fn itself failed so the migration error wins.
     const _sentinel = Symbol();
@@ -2288,6 +2296,17 @@ export class Migrator {
   }
 
   /**
+   * Rails builds a fresh `Migrator` for every `up` / `down` / `run`, so the
+   * caller's own `@migrated_versions` memo can never go stale. Our `Migrator`
+   * doubles as `MigrationContext` and is read again after delegating, so the
+   * memo has to be dropped once a per-run migrator has changed
+   * schema_migrations underneath it.
+   */
+  private _invalidateMigrated(): void {
+    this._migratedVersions = undefined;
+  }
+
+  /**
    * Run all pending migrations up to the target version (or all if no target).
    *
    * Mirrors: ActiveRecord::Migrator.up
@@ -2303,7 +2322,11 @@ export class Migrator {
       this._selectedMigrations(block),
       this._runOptions("up", targetVersion ?? null),
     );
-    return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
+    try {
+      return await migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
+    } finally {
+      this._invalidateMigrated();
+    }
   }
 
   /**
@@ -2322,7 +2345,11 @@ export class Migrator {
       this._selectedMigrations(block),
       this._runOptions("down", targetVersion ?? null),
     );
-    return migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
+    try {
+      return await migrator._withAdvisoryLock(() => migrator.migrateWithoutLock());
+    } finally {
+      this._invalidateMigrated();
+    }
   }
 
   /**
@@ -2337,7 +2364,7 @@ export class Migrator {
     let rolledBack: MigrationProxy[] = [];
     await this._withAdvisoryLock(async () => {
       await this._ensureSchemaTable();
-      const applied = await this._appliedVersions();
+      const applied = await this.migrated();
       const appliedMigrations = this._migrations.filter((m) => applied.has(m.version)).reverse();
       const toRollback = appliedMigrations.slice(0, steps);
 
@@ -2394,7 +2421,7 @@ export class Migrator {
     const proxy = this._migrations.find((m) => m.version === key);
     if (!proxy) throw new UnknownMigrationVersionError(targetVersion);
     await this.recordEnvironment();
-    const applied = await this._appliedVersions();
+    const applied = await this.migrated();
     if (this.isUp() && applied.has(key)) return undefined;
     if (this.isDown() && !applied.has(key)) return undefined;
     await this._runMigration(proxy, this._direction);
@@ -2434,7 +2461,7 @@ export class Migrator {
 
   /** @internal Mirrors: ActiveRecord::Migrator#ran? */
   async isRan(proxy: MigrationProxy): Promise<boolean> {
-    const applied = await this._appliedVersions();
+    const applied = await this.migrated();
     return applied.has(proxy.version);
   }
 
@@ -2457,9 +2484,12 @@ export class Migrator {
     version: string,
     direction: "up" | "down" = "up",
   ): Promise<void> {
+    const migrated = await this.migrated();
     if (direction === "up") {
+      migrated.add(version);
       await this._schemaMigration.recordVersion(version);
     } else {
+      migrated.delete(version);
       await this._schemaMigration.deleteVersion(version);
     }
   }
@@ -2599,7 +2629,7 @@ export class Migrator {
    */
   async pendingMigrations(): Promise<MigrationProxy[]> {
     await this._ensureSchemaTable();
-    const applied = await this._appliedVersions();
+    const applied = await this.migrated();
     return this._migrations.filter((m) => !applied.has(m.version));
   }
 
@@ -2882,12 +2912,16 @@ export class Migrator {
       this._migrations,
       this._runOptions(direction, targetVersion),
     );
-    return migrator._withAdvisoryLock(() => migrator.runWithoutLock());
+    try {
+      return await migrator._withAdvisoryLock(() => migrator.runWithoutLock());
+    } finally {
+      this._invalidateMigrated();
+    }
   }
 
   private async _migrateUp(targetVersion: number | string | null): Promise<MigrationProxy[]> {
     const target = targetVersion !== null ? BigInt(targetVersion) : null;
-    const applied = await this._appliedVersions();
+    const applied = await this.migrated();
     const ran: MigrationProxy[] = [];
 
     for (const proxy of this._migrations) {
@@ -2904,7 +2938,7 @@ export class Migrator {
     // target_version), which — unlike `down(0)` — also reverts a version-0
     // migration.
     const target = targetVersion !== null ? BigInt(targetVersion) : null;
-    const applied = await this._appliedVersions();
+    const applied = await this.migrated();
     const toRevert = this._migrations
       .filter((m) => applied.has(m.version) && (target === null || BigInt(m.version) > target))
       .reverse();
@@ -2926,12 +2960,17 @@ export class Migrator {
       loaded.connection = this._adapter;
       await this._ddlTransaction(loaded, async () => {
         await loaded.migrate(direction);
+        // Track our own writes in the `migrated` memo, as Rails'
+        // record_version_state_after_migrating does (migration.rb:1554-1562).
+        const migrated = await this.migrated();
         if (direction === "up") {
+          migrated.add(proxy.version);
           await this._schemaMigration.recordVersion(proxy.version);
           if (this._internalMetadata.enabled) {
             await this._internalMetadata.set("environment", this._environment);
           }
         } else {
+          migrated.delete(proxy.version);
           await this._schemaMigration.deleteVersion(proxy.version);
         }
       });
@@ -3157,11 +3196,11 @@ export class Migrator {
   }
 
   async migrated(): Promise<Set<string>> {
-    return this._appliedVersions();
+    return this._migratedVersions ?? this.loadMigrated();
   }
 
   async loadMigrated(): Promise<Set<string>> {
-    return this._appliedVersions();
+    return (this._migratedVersions = await this._appliedVersions());
   }
 
   static migrationsPaths: string[] = [];

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -479,6 +479,44 @@ describe("Migrator advisory lock wrapping", () => {
     const migrator = new Migrator(adapter, []);
     expect(migrator.isUseAdvisoryLock()).toBe(false);
   });
+
+  it("reloads the migrated versions after acquiring the advisory lock", async () => {
+    // Regression: `migrated` is memoized (Rails' `@migrated_versions`), so a
+    // migrator that computed its applied set before blocking on the lock would
+    // proceed on a stale view of schema_migrations unless `with_advisory_lock`
+    // reloads it once the lock is held (migration.rb:1601).
+    const adapter = Base.connection;
+    addAdvisoryLockSupport(adapter);
+    adapter.getAdvisoryLock = async () => true;
+    adapter.releaseAdvisoryLock = async () => true;
+    const schemaMigration = new SchemaMigration(adapter);
+    await schemaMigration.createTable();
+
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    expect(await migrator.migrated()).toEqual(new Set());
+
+    // Another process migrates version 1 while we wait for the lock.
+    await schemaMigration.recordVersion("1");
+    expect(await migrator.migrated()).toEqual(new Set());
+
+    let underLock: Set<string> | undefined;
+    await migrator.withAdvisoryLock(async () => {
+      underLock = await migrator.migrated();
+    });
+    expect(underLock).toEqual(new Set(["1"]));
+  });
+
+  it("record_version_state_after_migrating updates the migrated memo in place", async () => {
+    const adapter = Base.connection;
+    const migrator = new Migrator(adapter, [makeMigration("1", "M1")]);
+    await new SchemaMigration(adapter).createTable();
+
+    expect(await migrator.migrated()).toEqual(new Set());
+    await migrator.recordVersionStateAfterMigrating("1", "up");
+    expect(await migrator.migrated()).toEqual(new Set(["1"]));
+    await migrator.recordVersionStateAfterMigrating("1", "down");
+    expect(await migrator.migrated()).toEqual(new Set());
+  });
 });
 
 describe("Migrator drives migrations through Migration#migrate", () => {

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -517,6 +517,17 @@ describe("Migrator advisory lock wrapping", () => {
     await migrator.recordVersionStateAfterMigrating("1", "down");
     expect(await migrator.migrated()).toEqual(new Set());
   });
+
+  it("open returns a fresh Migrator so repeated pending checks are not memoized", async () => {
+    const adapter = Base.connection;
+    const schemaMigration = new SchemaMigration(adapter);
+    await schemaMigration.createTable();
+    const context = new Migrator(adapter, [makeMigration("1", "M1")]);
+
+    expect(await context.open().pendingMigrations()).toHaveLength(1);
+    await schemaMigration.recordVersion("1");
+    expect(await context.open().pendingMigrations()).toHaveLength(0);
+  });
 });
 
 describe("Migrator drives migrations through Migration#migrate", () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -143,13 +143,6 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "execute_migration_in_transaction",
-    "call": "record_version_state_after_migrating",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "execute_migration_in_transaction",
     "call": "use_transaction?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -311,13 +304,6 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "record_version_state_after_migrating",
-    "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "record_version_state_after_migrating",
     "call": "down?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -410,13 +396,6 @@
     "tsFile": "migration.ts",
     "rubyName": "validate",
     "call": "find",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "with_advisory_lock",
-    "call": "connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]


### PR DESCRIPTION
Rails' `Migrator` memoizes the applied-version set in `@migrated_versions` and
deliberately reloads it *after* acquiring the advisory lock, so a migrator that
blocked on the lock doesn't proceed on a stale view of `schema_migrations`
(`vendor/rails/activerecord/lib/active_record/migration.rb:1475-1485`,
`:1554-1562`, `:1601`).

trails had `migrated()` and `loadMigrated()` as two names for the same uncached
query, and `_withAdvisoryLock` never reloaded — the one call Rails makes purely
for correctness had no counterpart. Two migrators racing for the lock both
computed their applied set before blocking, and the loser ran on a stale view.

## Changes

- `Migrator` carries a `_migratedVersions` memo. `migrated()` returns it;
  `loadMigrated()` refreshes it (migration.rb:1480-1485).
- `_withAdvisoryLock` calls `loadMigrated()` once the lock is held, before the
  block runs (migration.rb:1601). It ensures the bookkeeping tables first, since
  Rails creates them in `Migrator#initialize` and a constructor cannot await.
- `recordVersionStateAfterMigrating` updates the memo in place
  (migration.rb:1554-1562). `_runMigration` now routes its version stamping
  through that method instead of duplicating the `schemaMigration` writes,
  matching `execute_migration_in_transaction` (migration.rb:1534-1537); the
  `internalMetadata` write stays alongside it.
- The `migrated`-reading consumers go through `migrated()`: `runWithoutLock`,
  `isRan`, `pendingMigrations`, `rollback`, `_migrateUp`, `_migrateDown`.
  The status/read-only surfaces (`getAllVersions`, `currentVersionReadOnly`,
  `pendingMigrationsReadOnly`, `migrationsStatus`) keep their fresh query,
  matching Rails' `integer_versions` reads.

### Keeping the memo from going stale

Our `Migrator` doubles as `MigrationContext`, so the same instance is read again
after it delegates to a per-run migrator. Two changes close that:

- `open()` now builds a *fresh* `Migrator` as Rails does
  (migration.rb:1278-1280) instead of returning `this`. That is exactly what
  keeps `CheckPending` — which reads pending migrations on every request — off a
  stale memo, so it goes through `open()` like Rails'
  `migration_context.open.pending_migrations` (migration.rb:763). `open()` had
  no other callers.
- `needsMigration()` / `pendingMigrationVersions()` compute from
  `getAllVersions()`, as `MigrationContext` does (migration.rb:1295-1301),
  rather than through the `Migrator`-role `pendingMigrations()`.
- `up` / `down` / `run` drop the outer instance's memo after delegating.

## Tests

- `reloads the migrated versions after acquiring the advisory lock` primes the
  memo empty, has another process record version 1, asserts the memo is still
  empty (**fails on baseline** — baseline re-queries and sees `{1}`), then
  asserts the set observed inside `withAdvisoryLock` includes it.
- `record_version_state_after_migrating updates the migrated memo in place`.
- `open returns a fresh Migrator so repeated pending checks are not memoized`.

Closes-story: migrator-migrated-versions-memo-and-reload-under-lock
