### PR TITLE
feat(migration): make Migrator#migrations/#runnable direction-aware

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2179,8 +2179,9 @@ export class Migrator {
     this._migrations = this._sortMigrations(normalized);
   }
 
+  /** @internal Mirrors: ActiveRecord::Migrator#migrations */
   get migrations(): MigrationProxy[] {
-    return [...this._migrations];
+    return this.isDown() ? [...this._migrations].reverse() : this._sortMigrations(this._migrations);
   }
 
   /**
@@ -2450,6 +2451,34 @@ export class Migrator {
     direction: "up" | "down" = "up",
   ): Promise<void> {
     await this._runMigration(proxy, direction);
+  }
+
+  /** @internal Mirrors: ActiveRecord::Migrator#target */
+  private target(): MigrationProxy | undefined {
+    if (this._targetVersion === null) return undefined;
+    let key: string;
+    try {
+      key = String(BigInt(this._targetVersion));
+    } catch {
+      return undefined;
+    }
+    return this.migrations.find((m) => m.version === key);
+  }
+
+  /** @internal Mirrors: ActiveRecord::Migrator#finish */
+  private finish(): number {
+    const migrations = this.migrations;
+    const target = this.target();
+    const index = target ? migrations.findIndex((m) => m.version === target.version) : -1;
+    return index === -1 ? migrations.length - 1 : index;
+  }
+
+  /** @internal Mirrors: ActiveRecord::Migrator#start */
+  private async start(): Promise<number> {
+    if (this.isUp()) return 0;
+    const current = await this.current();
+    const index = current ? this.migrations.findIndex((m) => m.version === current.version) : -1;
+    return index === -1 ? 0 : index;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#record_version_state_after_migrating */
@@ -3152,8 +3181,22 @@ export class Migrator {
     return this.currentMigration();
   }
 
+  /** @internal Mirrors: ActiveRecord::Migrator#runnable */
   async runnable(): Promise<MigrationProxy[]> {
-    return this.pendingMigrations();
+    const runnable = this.migrations.slice(await this.start(), this.finish() + 1);
+    const kept: MigrationProxy[] = [];
+    if (this.isUp()) {
+      for (const m of runnable) {
+        if (!(await this.isRan(m))) kept.push(m);
+      }
+      return kept;
+    }
+    // skip the last migration if we're headed down, but not ALL the way down
+    if (this.target()) runnable.pop();
+    for (const m of runnable) {
+      if (await this.isRan(m)) kept.push(m);
+    }
+    return kept;
   }
 
   async migrated(): Promise<Set<string>> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -3191,7 +3191,6 @@ export class Migrator {
       }
       return kept;
     }
-    // skip the last migration if we're headed down, but not ALL the way down
     if (this.target()) runnable.pop();
     for (const m of runnable) {
       if (await this.isRan(m)) kept.push(m);

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -593,7 +593,7 @@ describe("Migrator runnable direction awareness", () => {
     adapter = Base.connection;
   });
 
-  it("migrations is ascending going up and reversed going down", async () => {
+  it("migrations is ascending going up and reversed going down", () => {
     const migrations = three();
     const up = new Migrator(adapter, migrations);
     expect(up.migrations.map((m) => m.version)).toEqual(["1", "2", "3"]);
@@ -608,6 +608,17 @@ describe("Migrator runnable direction awareness", () => {
 
     const migrator = new Migrator(adapter, migrations, { direction: "up" });
     expect((await migrator.runnable()).map((m) => m.version)).toEqual(["3"]);
+  });
+
+  it("runnable going up stops at the target version", async () => {
+    const migrations = three();
+    await new Migrator(adapter, migrations).migrate(1);
+
+    const migrator = new Migrator(adapter, migrations, {
+      direction: "up",
+      targetVersion: 2,
+    });
+    expect((await migrator.runnable()).map((m) => m.version)).toEqual(["2"]);
   });
 
   it("runnable going down to a target skips the target migration", async () => {

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -576,3 +576,70 @@ describe("Migrator drives migrations through Migration#migrate", () => {
     }
   });
 });
+
+// Rails has no direct migrator_test.rb coverage for Migrator#runnable /
+// #migrations, so the direction-awareness ported from migration.rb:1466-1480
+// (and the start/finish/target helpers at 1538-1546) is exercised here.
+describe("Migrator runnable direction awareness", () => {
+  let adapter: DatabaseAdapter;
+
+  const three = (): MigrationProxy[] => [
+    makeMigration("1", "M1"),
+    makeMigration("2", "M2"),
+    makeMigration("3", "M3"),
+  ];
+
+  beforeEach(() => {
+    adapter = Base.connection;
+  });
+
+  it("migrations is ascending going up and reversed going down", async () => {
+    const migrations = three();
+    const up = new Migrator(adapter, migrations);
+    expect(up.migrations.map((m) => m.version)).toEqual(["1", "2", "3"]);
+
+    const down = new Migrator(adapter, migrations, { direction: "down" });
+    expect(down.migrations.map((m) => m.version)).toEqual(["3", "2", "1"]);
+  });
+
+  it("runnable going up returns only unapplied migrations", async () => {
+    const migrations = three();
+    await new Migrator(adapter, migrations).migrate(2);
+
+    const migrator = new Migrator(adapter, migrations, { direction: "up" });
+    expect((await migrator.runnable()).map((m) => m.version)).toEqual(["3"]);
+  });
+
+  it("runnable going down to a target skips the target migration", async () => {
+    const migrations = three();
+    await new Migrator(adapter, migrations).migrate();
+
+    const migrator = new Migrator(adapter, migrations, {
+      direction: "down",
+      targetVersion: 1,
+    });
+    expect((await migrator.runnable()).map((m) => m.version)).toEqual(["3", "2"]);
+  });
+
+  it("runnable going all the way down keeps every applied migration", async () => {
+    const migrations = three();
+    await new Migrator(adapter, migrations).migrate();
+
+    const migrator = new Migrator(adapter, migrations, {
+      direction: "down",
+      targetVersion: 0,
+    });
+    expect((await migrator.runnable()).map((m) => m.version)).toEqual(["3", "2", "1"]);
+  });
+
+  it("runnable going down ignores migrations that never ran", async () => {
+    const migrations = three();
+    await new Migrator(adapter, migrations).migrate(2);
+
+    const migrator = new Migrator(adapter, migrations, {
+      direction: "down",
+      targetVersion: 0,
+    });
+    expect((await migrator.runnable()).map((m) => m.version)).toEqual(["2", "1"]);
+  });
+});

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -366,20 +366,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "runnable",
-    "call": "ran?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "runnable",
-    "call": "up?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "up_only",
     "call": "execute_block",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Ports Rails' direction-aware `Migrator#runnable` / `#migrations` and the private
`start` / `finish` / `target` helpers.

Rails (`vendor/rails/activerecord/lib/active_record/migration.rb:1466-1480`, `1538-1546`):

```ruby
def runnable
  runnable = migrations[start..finish]
  if up?
    runnable.reject { |m| ran?(m) }
  else
    runnable.pop if target
    runnable.find_all { |m| ran?(m) }
  end
end

def migrations
  down? ? @migrations.reverse : @migrations.sort_by(&:version)
end
```

Before this change trails had neither shape:

- `get migrations()` returned `[...this._migrations]`, always ascending.
- `runnable()` was `return this.pendingMigrations()` — direction-blind, no
  `start..finish` slice, no `runnable.pop if target`, and on a down run it
  returned *unapplied* migrations where Rails returns *applied* ones. It was
  effectively wrong for every down run.
- `start` / `finish` / `target` did not exist.

`start` is async here because it reads `current()` (a DB round trip in trails);
`finish` / `target` stay sync as in Rails.

`runnable()` still has no caller inside `migration.ts` — `_migrateUp` /
`_migrateDown` keep their hand-rolled filtering — so this is a pure convergence
step that unblocks routing the migrate paths through Rails' real selection logic
later.

## Tests

Rails' `migrator_test.rb` has no case that exercises `runnable` directly (its
`test_target_version_zero_should_run_only_once` and
`test_migrator_going_down_due_to_version_target` are already ported in
`migrator.test.ts` and still pass), so the new coverage is trails-only and lands
in `migrator.trails.test.ts`: reversal on down, up returning only unapplied, down
with a target skipping the target migration, down all the way keeping every
applied one, and down ignoring migrations that never ran.

`pnpm api:compare` shows no new arity mismatch and no novel extra surface.

Closes-story: migrator-runnable-and-migrations-ignore-direction
