### PR TITLE
fix(mysql2): log the caller's binds in the sql.active_record payload

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -680,8 +680,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const payload: Record<string, unknown> = {
       sql: driverSql,
       name: name ?? "SQL",
-      binds: driverBinds,
-      type_casted_binds: this.typeCastedBinds(driverBinds) ?? [],
+      binds: binds ?? [],
+      type_casted_binds: this.typeCastedBinds(binds ?? []) ?? [],
       connection: this,
       row_count: 0,
       transaction: txPublicQuery.isOpen() ? txPublicQuery : null,


### PR DESCRIPTION
## Problem

`Mysql2Adapter#internalExecQuery` put `driverBinds` — the mysql2 wire form
produced by `mysqlBinds` (`valueForDatabase` unwrapped, Temporal stringified,
booleans as 1/0) — on the `sql.active_record` payload's `binds`, and derived
`type_casted_binds` from that same array.

Rails' `internal_exec_query` logs the caller's own binds and
`type_casted_binds(binds)` (`abstract/database_statements.rb:553-554`), so
subscribers get the `QueryAttribute` objects in `binds` and the driver
primitives in `type_casted_binds`. PostgreSQL's adapter here already follows
that shape.

The divergence failed `binds are logged`
(`packages/activerecord/src/bind-parameter.test.ts:321`) in the advisory
`maria-prepared-tests` lane — the test's identity check
(`payload.binds === binds`) found no matching event. Other lanes skip the test
under `!preparedStatements` or already pass the caller's array.

## Fix

Payload now carries `binds ?? []` and `typeCastedBinds(binds ?? [])`;
`driverBinds` stays on the driver call only.

## Verification

Isolated MariaDB stack, `bind-parameter` + `log-subscriber` (+ trails) +
`explain` + `explain-subscriber` + `instrumentation` (+ trails) +
`query-cache` + `statement-cache` + `type-casted-binds-payload`:

- `MYSQL_PREPARED_STATEMENTS=1`: 171 passed, 9 skipped
- `MYSQL_PREPARED_STATEMENTS=0`: 171 passed, 9 skipped

Baselined: with the diff reverted, `binds are logged` fails under
`MYSQL_PREPARED_STATEMENTS=1` on the same stack.

Closes-story: binds-missing-from-notification-under-prepared-default
