### PR TITLE
fix(migration): stamp the pool db_config env name in record_environment

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -63,6 +63,11 @@ async function freshAdapterWithPeople(): Promise<DatabaseAdapter> {
 // — the trails equivalent of Rails' anonymous `Class.new(Migration) { def
 // migrate(x); … end }` migrations that the people-migration tests feed to a
 // `Migrator`.
+/** Mirrors migration_test.rb:1165's private `env_name(pool)` helper. */
+function envName(adapter: DatabaseAdapter): string {
+  return (adapter.pool as { dbConfig: { envName: string } }).dbConfig.envName;
+}
+
 function migrateProxy(version: number, body: (m: Migration) => Promise<void>): MigrationProxy {
   return {
     version: String(version),
@@ -1094,13 +1099,13 @@ describe("MigrationTest", () => {
       name: "Failing",
       migration: () => new FailingMigration(),
     };
-    const migrator = new Migrator(adapter, [proxy], { environment: "test" });
+    const migrator = new Migrator(adapter, [proxy]);
     await migrator.up().catch(() => {});
     const env = await im.get("environment");
     // Rails stamps the environment in `record_environment` BEFORE running the
     // migrations, so a failing migration still leaves it recorded
     // (migration_test.rb:697-711).
-    expect(env).toBe("test");
+    expect(env).toBe(envName(adapter));
   });
 
   it("internal metadata stores environment when other data exists", async () => {
@@ -1115,9 +1120,9 @@ describe("MigrationTest", () => {
       name: "M1",
       migration: () => anonymousMigration("M1", "1"),
     };
-    const migrator = new Migrator(adapter, [proxy], { environment: "staging" });
+    const migrator = new Migrator(adapter, [proxy]);
     await migrator.up();
-    expect(await im.get("environment")).toBe("staging");
+    expect(await im.get("environment")).toBe(envName(adapter));
     expect(await im.get("custom_key")).toBe("custom_value");
   });
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2456,8 +2456,29 @@ export class Migrator {
   async recordEnvironment(): Promise<void> {
     if (this.isDown()) return;
     if (this._internalMetadata.enabled) {
-      await this._internalMetadata.set("environment", this._environment);
+      await this._internalMetadata.set("environment", this._recordedEnvironment());
     }
+  }
+
+  /**
+   * The env name stamped into `ar_internal_metadata`. Rails writes
+   * `connection.pool.db_config.env_name` straight through; a Migrator built on
+   * a bare adapter carries a NullPool, whose config answers nil for every key
+   * (Rails' `NullConfig#method_missing`), so fall back to the env name the
+   * Migrator resolved at construction rather than stamping undefined.
+   */
+  private _recordedEnvironment(): string {
+    const pool = this.connection.pool as { dbConfig?: { envName?: string } } | null;
+    return pool?.dbConfig?.envName ?? this._environment;
+  }
+
+  /**
+   * @internal Mirrors: ActiveRecord::Migrator#connection — Rails reaches for
+   * `DatabaseTasks.migration_connection`; trails takes the adapter as a
+   * constructor argument, so this exposes it under Rails' name.
+   */
+  private get connection(): DatabaseAdapter {
+    return this._adapter;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#ran? */
@@ -2963,7 +2984,7 @@ export class Migrator {
         await loaded.migrate(direction);
         await this.recordVersionStateAfterMigrating(proxy.version, direction);
         if (direction === "up" && this._internalMetadata.enabled) {
-          await this._internalMetadata.set("environment", this._environment);
+          await this._internalMetadata.set("environment", this._recordedEnvironment());
         }
       });
     } catch (e) {

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -28,7 +28,7 @@ import { fixtures } from "./test-fixtures.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 /** The env name `record_environment` stamps: `connection.pool.db_config.env_name`. */
-function poolEnvName(adapter: DatabaseAdapter): string {
+function envName(adapter: DatabaseAdapter): string {
   return (adapter.pool as { dbConfig: { envName: string } }).dbConfig.envName;
 }
 
@@ -74,7 +74,7 @@ describe("Migrator trails extensions", () => {
     });
     await migrator.up();
     const env = await migrator.internalMetadata.get("environment");
-    expect(env).toBe(poolEnvName(adapter));
+    expect(env).toBe(envName(adapter));
   });
 
   it("up and down raise UnknownMigrationVersionError for an unknown target", async () => {

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -27,6 +27,11 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import { fixtures } from "./test-fixtures.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
+/** The env name `record_environment` stamps: `connection.pool.db_config.env_name`. */
+function poolEnvName(adapter: DatabaseAdapter): string {
+  return (adapter.pool as { dbConfig: { envName: string } }).dbConfig.envName;
+}
+
 function makeMigration(
   version: string,
   name: string,
@@ -69,7 +74,7 @@ describe("Migrator trails extensions", () => {
     });
     await migrator.up();
     const env = await migrator.internalMetadata.get("environment");
-    expect(env).toBe("test");
+    expect(env).toBe(poolEnvName(adapter));
   });
 
   it("up and down raise UnknownMigrationVersionError for an unknown target", async () => {
@@ -162,6 +167,7 @@ describe("Migrator trails extensions", () => {
       environment: "production",
     });
     await migrator1.up();
+    await migrator1.internalMetadata.set("environment", "production");
 
     const migrator2 = new Migrator(adapter, [makeMigration("1", "M1")], {
       environment: "development",
@@ -174,6 +180,7 @@ describe("Migrator trails extensions", () => {
       environment: "development",
     });
     await migrator.up();
+    await migrator.internalMetadata.set("environment", "development");
     await expect(migrator.checkEnvironment()).resolves.toBeUndefined();
   });
 
@@ -182,6 +189,7 @@ describe("Migrator trails extensions", () => {
       environment: "production",
     });
     await migrator.up();
+    await migrator.internalMetadata.set("environment", "production");
     await expect(migrator.checkProtectedEnvironments()).rejects.toThrow(ProtectedEnvironmentError);
   });
 
@@ -202,6 +210,7 @@ describe("Migrator trails extensions", () => {
       environment: "development",
     });
     await migrator.up();
+    await migrator.internalMetadata.set("environment", "development");
     await expect(migrator.checkProtectedEnvironments()).resolves.toBeUndefined();
   });
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -289,13 +289,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "record_environment",
-    "call": "connection",
-    "reason": "Equivalent: Rails reads `connection.pool.db_config.env_name` at record time; trails resolves the same env name once in the constructor into `_environment` and stores that."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "record_version_state_after_migrating",
     "call": "create_version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `Migrator#record_environment` reads the env name off the connection at
record time (`migration.rb:1513-1517`):

```ruby
@internal_metadata[:environment] = connection.pool.db_config.env_name
```

trails resolved the name once in the `Migrator` constructor (from
`options.environment ?? TRAILS_ENV ?? NODE_ENV ?? defaultEnv`) and stamped that
snapshot, so a Migrator built against a pool whose config env differs from the
ambient process env stamped the wrong name.

`recordEnvironment` (and the version-stamp site that writes the same key) now
read `connection.pool.dbConfig.envName`. The constructor-resolved name survives
only as the fallback for an adapter carrying a `NullPool` — Rails' `NullConfig`
answers `nil` for every key there, and trails must not stamp `undefined`.
`_environment` still backs `checkEnvironment` / `checkProtectedEnvironments`,
which in Rails is a separate `DatabaseTasks` argument, not the stamped value.

Also adds `Migrator#connection` (Rails reaches for
`DatabaseTasks.migration_connection`; trails takes the adapter as a constructor
argument, so the getter just exposes it under Rails' name).

Tests: `migration.test.ts`'s two `internal_metadata_stores_environment_*` mirrors
now assert against the pool's env name via an `envName(...)` helper mirroring
Rails' private `env_name(pool)` (`migration_test.rb:1165`) — that is what Rails
asserts. The trails-only `migrator.trails.test.ts` env cases stamp their
mismatch/protected fixtures through `internalMetadata` directly instead of
relying on the constructor snapshot. No test renames.

Removes the `record_environment` / `connection` entry from
`call-mismatches-wide-exclude/activerecord/migration.json`; the wide ratchet is
green with it gone.

Closes-story: record-environment-reads-pool-db-config-env-name
