### PR TITLE
refactor(adapters): delete the bespoke dataSourceExists overrides

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -9,7 +9,7 @@ import { AbstractAdapter } from "../abstract-adapter.js";
 import { NotImplementedError } from "../../errors.js";
 
 function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
-  return new SchemaStatements({
+  const adapter: Record<string, unknown> = {
     adapterName: "sqlite" as const,
     quoteIdentifier: (n: string) => `"${n}"`,
     quoteTableName: (n: string) => `"${n}"`,
@@ -22,7 +22,18 @@ function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
     lookupCastType: (sqlType: string | null) => AbstractAdapter.TYPE_MAP.lookup(sqlType),
     config: {},
     ...adapterOverrides,
-  } as any);
+  };
+  // Real hosts inherit AbstractAdapter#schemaQuery, which is `execute` tagged
+  // with the "SCHEMA" query name (Rails' `internal_exec_query(sql, "SCHEMA")`).
+  // Route the stub's through whichever `execute` this call installed so
+  // reflection probes stay visible to per-test `execute` spies.
+  adapter["schemaQuery"] ??= (sql: string, binds: unknown[] = []) =>
+    (adapter["execute"] as (s: string, b?: unknown[], n?: string) => Promise<unknown>)(
+      sql,
+      binds,
+      "SCHEMA",
+    );
+  return new SchemaStatements(adapter as any);
 }
 
 describe("SchemaStatements privates (PR 8)", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1639,7 +1639,7 @@ export class SchemaStatements {
     if (!isPresent(name)) return false;
     try {
       const sql = this.adapter.dataSourceSql(name);
-      const rows = await this.adapter.execute(sql);
+      const rows = await this.adapter.schemaQuery(sql);
       return rows.length > 0;
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1518,12 +1518,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
-    return this.informationSchemaExists(name, null);
+    return this.schemaStatements().dataSourceExists(name);
   }
 
   private async informationSchemaExists(
     name: string,
-    type: "BASE TABLE" | "VIEW" | null,
+    type: "BASE TABLE" | "VIEW",
   ): Promise<boolean> {
     // Rails' table_exists?(nil) / "" returns false; a null/empty name has no
     // schema to parse, so short-circuit before parseMysqlName (which trims).
@@ -1532,16 +1532,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const schemaBind = schema ?? null;
     // Use `schema_placeholder OR database()` via COALESCE so the same
     // query shape serves qualified + unqualified callers.
-    const typeClause = type ? "AND table_type = ?" : "";
-    const params: unknown[] = [schemaBind, table];
-    if (type) params.push(type);
     const rows = await this.schemaQuery(
       `SELECT 1 AS one FROM information_schema.tables
          WHERE table_schema = COALESCE(?, database())
          AND table_name = ?
-         ${typeClause}
+         AND table_type = ?
          LIMIT 1`,
-      params,
+      [schemaBind, table, type],
     );
     return rows.length > 0;
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1517,10 +1517,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return this.informationSchemaExists(name, "VIEW");
   }
 
-  async dataSourceExists(name: string): Promise<boolean> {
-    return this.schemaStatements().dataSourceExists(name);
-  }
-
   private async informationSchemaExists(
     name: string,
     type: "BASE TABLE" | "VIEW",

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3509,10 +3509,6 @@ export class PostgreSQLAdapter
     return this.pgSchemaStatements().currentSchema();
   }
 
-  async dataSourceExists(name: string): Promise<boolean> {
-    return this.schemaStatements().dataSourceExists(name);
-  }
-
   quoteColumnName(name: string): string {
     return pgQuoteColumnName(name);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3510,7 +3510,7 @@ export class PostgreSQLAdapter
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
-    return this.pgSchemaStatements().dataSourceExists(name);
+    return this.schemaStatements().dataSourceExists(name);
   }
 
   quoteColumnName(name: string): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -323,23 +323,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     return Array.from(new Set([...tables, ...views]));
   }
 
-  async dataSourceExists(name: string): Promise<boolean> {
-    // Rails answers `data_source_exists?` through the base implementation,
-    // which is gated on `if name.present?`; this adapter-local override has to
-    // carry the same gate or a blank name reaches the catalog query.
-    if (!name) return false;
-    const [schema, table] = this.pg.extractSchemaQualifiedName(name);
-    if (schema) {
-      const rows = await this.pg.schemaQuery(
-        `SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2`,
-        [schema, table],
-      );
-      return Number(rows[0].count) > 0;
-    }
-    const rows = await this.pg.schemaQuery(`SELECT to_regclass($1) AS oid`, [name]);
-    return rows[0].oid != null;
-  }
-
   /**
    * Table-only existence check (no views). Mirrors Rails'
    * `table_exists?` vs `data_source_exists?` distinction: a table is a

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2117,26 +2117,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
-    // Rails answers `data_source_exists?` through the base implementation,
-    // which is gated on `if name.present?`; this adapter-local override has to
-    // carry the same gate or a blank name reaches the catalog query.
-    if (!name) return false;
-    if (name.includes(".")) {
-      // Schema-qualified name (e.g. "aux.widgets"). pragma_table_list returns
-      // rows for every attached schema and exposes the schema name as a
-      // column, so we can scope by it directly — keeping the qualified and
-      // bare-name branches on the same exclusion semantics (no virtuals,
-      // no FTS shadow tables).
-      const { schema, bare } = this._splitTableName(name);
-      const rows = (await this.schemaQuery(
-        `SELECT name FROM pragma_table_list WHERE schema = ${sqliteQuoteStringLiteral(schema)} COLLATE NOCASE AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(bare)} AND type IN ('table','view')`,
-      )) as Array<{ name: string }>;
-      return rows.length > 0;
-    }
-    const rows = (await this.schemaQuery(
-      `SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(name)} AND type IN ('table','view')`,
-    )) as Array<{ name: string }>;
-    return rows.length > 0;
+    return this.schemaStatements().dataSourceExists(name);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2116,10 +2116,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return rows.length > 0;
   }
 
-  async dataSourceExists(name: string): Promise<boolean> {
-    return this.schemaStatements().dataSourceExists(name);
-  }
-
   /**
    * Return the primary key for the named table: a single string for
    * scalar PKs, an array for composite PKs, or null for rowid-only

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -263,11 +263,6 @@ describe("SQLite3Adapter schema introspection", () => {
 
     expect(await adapter.tableExists("aux.widgets")).toBe(true);
     expect(await adapter.tableExists("aux.missing")).toBe(false);
-
-    // `data_source_exists?` runs Rails' SQLite3 `data_source_sql`, which
-    // matches `pragma_table_list.name` — an unqualified name, listed for
-    // every attached schema. So the bare name resolves against aux while the
-    // qualified spelling never matches any row.
     expect(await adapter.dataSourceExists("widgets")).toBe(true);
     expect(await adapter.dataSourceExists("widget_view")).toBe(true);
     expect(await adapter.dataSourceExists("aux.widgets")).toBe(false);

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -262,8 +262,14 @@ describe("SQLite3Adapter schema introspection", () => {
     await adapter.executeMutation("CREATE VIEW aux.widget_view AS SELECT id FROM aux.widgets");
 
     expect(await adapter.tableExists("aux.widgets")).toBe(true);
-    expect(await adapter.dataSourceExists("aux.widgets")).toBe(true);
-    expect(await adapter.dataSourceExists("aux.widget_view")).toBe(true);
     expect(await adapter.tableExists("aux.missing")).toBe(false);
+
+    // `data_source_exists?` runs Rails' SQLite3 `data_source_sql`, which
+    // matches `pragma_table_list.name` — an unqualified name, listed for
+    // every attached schema. So the bare name resolves against aux while the
+    // qualified spelling never matches any row.
+    expect(await adapter.dataSourceExists("widgets")).toBe(true);
+    expect(await adapter.dataSourceExists("widget_view")).toBe(true);
+    expect(await adapter.dataSourceExists("aux.widgets")).toBe(false);
   });
 });


### PR DESCRIPTION
Rails answers `data_source_exists?` from the abstract `SchemaStatements` body on
every adapter — only `data_source_sql` / `quoted_scope` are overridden. PR #5746
converged our base body onto that shape, but all three concrete adapters still
shadowed it with bespoke catalog queries that Rails does not have.

`ensureAbstractAdapterMixinsApplied()` already does `include(AbstractAdapter,
SchemaStatements)`, so the base body is on every adapter's prototype chain, and
`this.adapter.dataSourceSql` dispatches to each adapter's own override. The
shadowing methods are therefore **deleted outright** rather than replaced with
delegation stubs — matching Rails, where the concrete adapters define no
`data_source_exists?` at all.

- `sqlite3-adapter.ts` — dropped the hand-written `pragma_table_list` query
  (both branches). `tableExists` and its `<schema>.sqlite_master` routing are
  untouched.
- `mysql2-adapter.ts` — dropped `informationSchemaExists(name, null)`. The
  `null` type arm is now unreachable, so the private helper's signature tightens
  to `"BASE TABLE" | "VIEW"` and its conditional `typeClause` collapses.
- `postgresql-adapter.ts` — dropped the `pgSchemaStatements()` hop, plus the
  now-dead `to_regclass` / `information_schema.tables` override in
  `postgresql/schema-statements-class.ts`.

## Behaviour delta

One deliberate convergence, on sqlite3 only. The removed override had a
schema-qualified branch that scoped `pragma_table_list.schema`, so
`data_source_exists?("aux.widgets")` was true. Rails' `data_source_sql` matches
`pragma_table_list.name`, which is the *unqualified* name — listed once per
attached schema. So under Rails the bare name resolves against `aux` and the
qualified spelling never matches a row. The trails-only assertions in
`sqlite3-introspection.test.ts` are updated to the Rails results.

PG and MySQL are assertion-for-assertion equivalent: the ported `data source
exists?` / `... wrong schema` / `... on schema search path` tests exercise
exactly what `quotedScope` + `dataSourceSql` produce, and all three
`dataSourceSql` overrides were verified line-by-line against
`{sqlite3,mysql,postgresql}/schema_statements.rb`.

Verified locally on sqlite: `sqlite3-introspection`, `adapter`, `view`,
`schema-cache` suites, plus `pnpm typecheck` and `pnpm api:compare` (no manifest
churn). PG/MySQL lanes ride on CI.

## Base-body fix (found by CI)

Removing the overrides surfaced a latent bug in the base body. Rails runs the
probe as `query_values(data_source_sql(name), "SCHEMA")` — the `"SCHEMA"`
name is what `assert_queries` uses to ignore reflection traffic. Our base body
used `this.adapter.execute(sql)`, which names the query `"SQL"`, so the probe
was counted; `testing/query-assertions.ts:48` only skips `name === "SCHEMA"`.

The bespoke overrides all used `schemaQuery` (correctly named), which is why
this never showed until they were deleted. `UniquenessValidationWithIndexTest`
failed on all three lanes with `N instead of N-1 queries were executed`.

Fixed by routing the probe through `this.adapter.schemaQuery(sql)` — trails'
stand-in for `internal_exec_query(sql, "SCHEMA")` (`abstract-adapter.ts:980`).

`viewExists` has the identical bug one method up and is currently green only by
luck of test placement. Left out to keep this PR scoped; registered as story
`view-exists-probe-must-be-schema-named` on RFC 0051.

Closes-story: remove-bespoke-adapter-data-source-exists-overrides

