### PR TITLE
feat(test-compare): ratchet assertion-level mismatches so the debt only shrinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1493,6 +1493,13 @@ jobs:
         # fails the step if activerecord's gate-mismatch count is non-zero
         # (hard zero, no baseline — RFC 0032 ar-gate-fidelity-burndown).
         run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts --gates --check
+      - name: Assertion-mismatch ratchet
+        # Only-shrink gate on the assertion-count / kind / value totals inside
+        # name-matched tests (RFC 0025). Reads output/convention-comparison.json
+        # written by the step above — --no-regen because CI must not pay for the
+        # extraction twice. Reseed after convergence with
+        # `pnpm test:assertions:ratchet:reseed`.
+        run: pnpm exec tsx scripts/test-compare/lint-assertion-mismatches.ts --no-regen
       - name: Fixtures comparison
         run: pnpm exec tsx scripts/fixtures-compare/compare.ts --package activerecord --ci
       - name: Models comparison

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,47 @@ and the two ratchets gate different artifacts against different baselines; a
 combined `api:gates` wrapper was considered and declined as premature — the doc
 pointer above is the intended fix.
 
+### Assertion-mismatch ratchet
+
+`pnpm test:compare` measures three assertion-level divergences _inside_
+name-matched tests — the pair asserts a different **number** of things
+(`totalAssertionMismatch`), the same number but different **kinds**
+(`totalKindMismatch`), or the same kinds with different literal **expected
+values** (`totalValueMismatch`). Without a gate, a newly ported test can assert
+less than its Rails counterpart and still count as matched, so those totals are
+pinned by an only-shrink ratchet (RFC 0025):
+
+```sh
+pnpm test:assertions:ratchet          # gate
+pnpm test:assertions:ratchet:reseed   # lower the mark after convergence
+```
+
+The high-water mark is `scripts/test-compare/assertion-mismatch-mark.json`: one
+entry per package, three counters each. CI runs the gate in the
+`rails-comparison` job ("Assertion-mismatch ratchet"). Like the wide-call
+unreviewed counter, the arm is **aggregate** — the guarantee is "assertion-level
+debt never grows", not that every remaining mismatch has been reviewed.
+Converging one test while porting another that asserts less is a neutral trade
+the gate lets through; the reviewer of the diff enforces the stronger rule.
+Shrinkage is auto-acknowledged: `--write` (the `:reseed` script) lowers each
+counter to its current value and never raises one, so a run that grew a counter
+cannot buy headroom by reseeding.
+
+**The stale-artifact trap**: the counts are read from
+`scripts/test-compare/output/convention-comparison.json` — no second extractor.
+Gating a file written before a sibling PR's tests landed reports movement that
+never happened, and reseeding would commit that fiction as the new mark. So a
+plain local run regenerates the artifact itself (`pnpm test:compare --json`)
+before gating. `--no-regen` (what CI uses, since it writes the artifact in the
+preceding step) gates whatever is on disk. A partial-scope run is caught
+separately: if a package in the mark is missing from the artifact — a
+`--package` filter, an unfetched vendor source — the lint fails rather than
+letting the reseed drop that package's mark.
+
+Once the counters are pinned their burn rate is measurable, which is what the
+ActiveRecord release estimate needs to price promoting this from a ratchet to a
+hard release gate (the path `gates.ts` already took: advisory → ratchet → zero).
+
 The advisory **arity** check has its own reasoned suppression file,
 `scripts/api-compare/arity-exclude.json` (RFC 0072), keyed by
 `package + rubyFile + rubyName` with a mandatory `reason` per entry. `pnpm

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "api:conventions": "pnpm tsx scripts/api-compare/conventions-doc.ts",
     "lint:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "test:compare": "bash scripts/test-compare/run.sh",
+    "test:assertions:ratchet": "pnpm tsx scripts/test-compare/lint-assertion-mismatches.ts",
+    "test:assertions:ratchet:reseed": "pnpm tsx scripts/test-compare/lint-assertion-mismatches.ts --write",
     "rails:find": "bash scripts/rails-find/run.sh",
     "test:deps": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/test-deps/rails-test-deps.ts",
     "fixture-baseline:refresh": "pnpm test:deps >/dev/null && pnpm tsx scripts/test-deps/build-fixture-baseline.ts",

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -1,0 +1,64 @@
+{
+  "packages": {
+    "abstractcontroller": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "actioncontroller": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "actiondispatch": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "actionview": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "activemodel": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "activerecord": {
+      "assertionCount": 1987,
+      "kind": 4069,
+      "value": 54
+    },
+    "activesupport": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "arel": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "did-you-mean": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "globalid": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "rack": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
+    "trailties": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    }
+  }
+}

--- a/scripts/test-compare/assertion-ratchet.test.ts
+++ b/scripts/test-compare/assertion-ratchet.test.ts
@@ -1,23 +1,8 @@
 import { describe, expect, it } from "vitest";
-import {
-  type AssertionMark,
-  countsFromArtifact,
-  missingFromArtifact,
-  nextMark,
-  parseMark,
-  renderExceeded,
-  shrunk,
-  violations,
-} from "./assertion-ratchet.js";
-import { NO_REGEN_FLAG, REGEN_SKIP_ENV, shouldRegenerate } from "./lint-assertion-mismatches.js";
+import { countsFromArtifact, parseMark } from "./assertion-ratchet.js";
 
-const mark: AssertionMark = {
-  packages: {
-    activerecord: { assertionCount: 10, kind: 20, value: 3 },
-    arel: { assertionCount: 0, kind: 0, value: 0 },
-  },
-};
-
+// The gate arms (violations / nextMark / missingFromArtifact / the renderers)
+// are exercised end-to-end through `main` in lint-assertion-mismatches.test.ts.
 describe("countsFromArtifact", () => {
   it("reads the three per-package totals", () => {
     expect(
@@ -56,116 +41,5 @@ describe("parseMark", () => {
 
   it("rejects a mark without a packages object", () => {
     expect(() => parseMark("{}")).toThrow(/expected/);
-  });
-});
-
-describe("violations", () => {
-  it("flags each counter that exceeds its mark", () => {
-    const { exceeded, unmarked } = violations(
-      {
-        activerecord: { assertionCount: 11, kind: 20, value: 4 },
-        arel: { assertionCount: 0, kind: 0, value: 0 },
-      },
-      mark,
-    );
-    expect(unmarked).toEqual([]);
-    expect(exceeded).toEqual([
-      { package: "activerecord", counter: "assertionCount", current: 11, mark: 10 },
-      { package: "activerecord", counter: "value", current: 4, mark: 3 },
-    ]);
-  });
-
-  it("treats a package absent from the mark as an error, not an implicit zero", () => {
-    const { exceeded, unmarked } = violations(
-      { activemodel: { assertionCount: 9, kind: 0, value: 0 } },
-      mark,
-    );
-    expect(exceeded).toEqual([]);
-    expect(unmarked).toEqual(["activemodel"]);
-  });
-
-  it("passes when every counter sits at or under its mark", () => {
-    const { exceeded, unmarked } = violations(
-      {
-        activerecord: { assertionCount: 10, kind: 19, value: 0 },
-        arel: { assertionCount: 0, kind: 0, value: 0 },
-      },
-      mark,
-    );
-    expect(exceeded).toEqual([]);
-    expect(unmarked).toEqual([]);
-  });
-});
-
-describe("nextMark", () => {
-  it("lowers a counter that shrank and never raises one that grew", () => {
-    expect(
-      nextMark(
-        {
-          activerecord: { assertionCount: 4, kind: 99, value: 3 },
-          arel: { assertionCount: 0, kind: 0, value: 0 },
-        },
-        mark,
-      ),
-    ).toEqual({
-      packages: {
-        activerecord: { assertionCount: 4, kind: 20, value: 3 },
-        arel: { assertionCount: 0, kind: 0, value: 0 },
-      },
-    });
-  });
-
-  it("seeds a package the mark does not cover at its current counts", () => {
-    expect(nextMark({ activemodel: { assertionCount: 2, kind: 1, value: 0 } }, mark)).toEqual({
-      packages: { activemodel: { assertionCount: 2, kind: 1, value: 0 } },
-    });
-  });
-});
-
-describe("missingFromArtifact", () => {
-  it("reports marked packages the artifact does not cover", () => {
-    expect(
-      missingFromArtifact({ activerecord: { assertionCount: 1, kind: 1, value: 1 } }, mark),
-    ).toEqual(["arel"]);
-  });
-});
-
-describe("shrunk", () => {
-  it("reports counters that came in under the mark", () => {
-    expect(
-      shrunk(
-        {
-          activerecord: { assertionCount: 10, kind: 18, value: 3 },
-          arel: { assertionCount: 0, kind: 0, value: 0 },
-        },
-        mark,
-      ),
-    ).toEqual([{ package: "activerecord", counter: "kind", current: 18, mark: 20 }]);
-  });
-});
-
-describe("renderExceeded", () => {
-  it("names the counter, the excess, and the only-shrink rule", () => {
-    const text = renderExceeded(
-      [{ package: "activerecord", counter: "kind", current: 25, mark: 20 }],
-      "scripts/test-compare/assertion-mismatch-mark.json",
-    );
-    expect(text).toContain("assertion-kind-mismatch: 25 (mark 20, +5)");
-    expect(text).toContain("only shrinks");
-  });
-});
-
-describe("shouldRegenerate", () => {
-  it("regenerates the artifact for a plain local run", () => {
-    expect(shouldRegenerate([], {})).toBe(true);
-  });
-
-  it("does not regenerate under CI, which writes the artifact in its own step", () => {
-    expect(shouldRegenerate([], { CI: "true" })).toBe(false);
-  });
-
-  it("does not regenerate under --no-regen or the skip env", () => {
-    expect(shouldRegenerate([NO_REGEN_FLAG], {})).toBe(false);
-    expect(shouldRegenerate([], { [REGEN_SKIP_ENV]: "1" })).toBe(false);
   });
 });

--- a/scripts/test-compare/assertion-ratchet.test.ts
+++ b/scripts/test-compare/assertion-ratchet.test.ts
@@ -9,6 +9,7 @@ import {
   shrunk,
   violations,
 } from "./assertion-ratchet.js";
+import { NO_REGEN_FLAG, REGEN_SKIP_ENV, shouldRegenerate } from "./lint-assertion-mismatches.js";
 
 const mark: AssertionMark = {
   packages: {
@@ -151,5 +152,20 @@ describe("renderExceeded", () => {
     );
     expect(text).toContain("assertion-kind-mismatch: 25 (mark 20, +5)");
     expect(text).toContain("only shrinks");
+  });
+});
+
+describe("shouldRegenerate", () => {
+  it("regenerates the artifact for a plain local run", () => {
+    expect(shouldRegenerate([], {})).toBe(true);
+  });
+
+  it("does not regenerate under CI, which writes the artifact in its own step", () => {
+    expect(shouldRegenerate([], { CI: "true" })).toBe(false);
+  });
+
+  it("does not regenerate under --no-regen or the skip env", () => {
+    expect(shouldRegenerate([NO_REGEN_FLAG], {})).toBe(false);
+    expect(shouldRegenerate([], { [REGEN_SKIP_ENV]: "1" })).toBe(false);
   });
 });

--- a/scripts/test-compare/assertion-ratchet.test.ts
+++ b/scripts/test-compare/assertion-ratchet.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AssertionMark,
+  countsFromArtifact,
+  missingFromArtifact,
+  nextMark,
+  parseMark,
+  renderExceeded,
+  shrunk,
+  violations,
+} from "./assertion-ratchet.js";
+
+const mark: AssertionMark = {
+  packages: {
+    activerecord: { assertionCount: 10, kind: 20, value: 3 },
+    arel: { assertionCount: 0, kind: 0, value: 0 },
+  },
+};
+
+describe("countsFromArtifact", () => {
+  it("reads the three per-package totals", () => {
+    expect(
+      countsFromArtifact({
+        results: [
+          {
+            package: "activerecord",
+            totalAssertionMismatch: 5,
+            totalKindMismatch: 7,
+            totalValueMismatch: 1,
+          },
+        ],
+      }),
+    ).toEqual({ activerecord: { assertionCount: 5, kind: 7, value: 1 } });
+  });
+
+  it("keeps a converged package at zero rather than dropping it", () => {
+    expect(countsFromArtifact({ results: [{ package: "arel" }] })).toEqual({
+      arel: { assertionCount: 0, kind: 0, value: 0 },
+    });
+  });
+});
+
+describe("parseMark", () => {
+  it("rejects a non-integer counter", () => {
+    expect(() =>
+      parseMark('{"packages":{"arel":{"assertionCount":1.5,"kind":0,"value":0}}}'),
+    ).toThrow(/arel\.assertionCount/);
+  });
+
+  it("rejects a missing counter", () => {
+    expect(() => parseMark('{"packages":{"arel":{"assertionCount":0,"kind":0}}}')).toThrow(
+      /arel\.value/,
+    );
+  });
+
+  it("rejects a mark without a packages object", () => {
+    expect(() => parseMark("{}")).toThrow(/expected/);
+  });
+});
+
+describe("violations", () => {
+  it("flags each counter that exceeds its mark", () => {
+    const { exceeded, unmarked } = violations(
+      {
+        activerecord: { assertionCount: 11, kind: 20, value: 4 },
+        arel: { assertionCount: 0, kind: 0, value: 0 },
+      },
+      mark,
+    );
+    expect(unmarked).toEqual([]);
+    expect(exceeded).toEqual([
+      { package: "activerecord", counter: "assertionCount", current: 11, mark: 10 },
+      { package: "activerecord", counter: "value", current: 4, mark: 3 },
+    ]);
+  });
+
+  it("treats a package absent from the mark as an error, not an implicit zero", () => {
+    const { exceeded, unmarked } = violations(
+      { activemodel: { assertionCount: 9, kind: 0, value: 0 } },
+      mark,
+    );
+    expect(exceeded).toEqual([]);
+    expect(unmarked).toEqual(["activemodel"]);
+  });
+
+  it("passes when every counter sits at or under its mark", () => {
+    const { exceeded, unmarked } = violations(
+      {
+        activerecord: { assertionCount: 10, kind: 19, value: 0 },
+        arel: { assertionCount: 0, kind: 0, value: 0 },
+      },
+      mark,
+    );
+    expect(exceeded).toEqual([]);
+    expect(unmarked).toEqual([]);
+  });
+});
+
+describe("nextMark", () => {
+  it("lowers a counter that shrank and never raises one that grew", () => {
+    expect(
+      nextMark(
+        {
+          activerecord: { assertionCount: 4, kind: 99, value: 3 },
+          arel: { assertionCount: 0, kind: 0, value: 0 },
+        },
+        mark,
+      ),
+    ).toEqual({
+      packages: {
+        activerecord: { assertionCount: 4, kind: 20, value: 3 },
+        arel: { assertionCount: 0, kind: 0, value: 0 },
+      },
+    });
+  });
+
+  it("seeds a package the mark does not cover at its current counts", () => {
+    expect(nextMark({ activemodel: { assertionCount: 2, kind: 1, value: 0 } }, mark)).toEqual({
+      packages: { activemodel: { assertionCount: 2, kind: 1, value: 0 } },
+    });
+  });
+});
+
+describe("missingFromArtifact", () => {
+  it("reports marked packages the artifact does not cover", () => {
+    expect(
+      missingFromArtifact({ activerecord: { assertionCount: 1, kind: 1, value: 1 } }, mark),
+    ).toEqual(["arel"]);
+  });
+});
+
+describe("shrunk", () => {
+  it("reports counters that came in under the mark", () => {
+    expect(
+      shrunk(
+        {
+          activerecord: { assertionCount: 10, kind: 18, value: 3 },
+          arel: { assertionCount: 0, kind: 0, value: 0 },
+        },
+        mark,
+      ),
+    ).toEqual([{ package: "activerecord", counter: "kind", current: 18, mark: 20 }]);
+  });
+});
+
+describe("renderExceeded", () => {
+  it("names the counter, the excess, and the only-shrink rule", () => {
+    const text = renderExceeded(
+      [{ package: "activerecord", counter: "kind", current: 25, mark: 20 }],
+      "scripts/test-compare/assertion-mismatch-mark.json",
+    );
+    expect(text).toContain("assertion-kind-mismatch: 25 (mark 20, +5)");
+    expect(text).toContain("only shrinks");
+  });
+});

--- a/scripts/test-compare/assertion-ratchet.ts
+++ b/scripts/test-compare/assertion-ratchet.ts
@@ -104,14 +104,17 @@ export function parseMark(text: string): AssertionMark {
   return { packages: out };
 }
 
+/**
+ * Read the committed mark. A missing file is reported as the disarmed ratchet
+ * it is — deleting it is how the gate would be silently switched off — rather
+ * than as a bare ENOENT.
+ */
 export async function loadMark(file: string): Promise<AssertionMark> {
   let text: string;
   try {
     text = await fs.readFile(file, "utf-8");
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
-    // Deleting the mark is how this ratchet would be silently disarmed, so name
-    // it rather than surfacing a bare ENOENT.
     throw new Error(
       `assertion high-water mark: ${file} is missing. It is a committed ratchet file; ` +
         "restore it from git rather than regenerating, or the mark is lost.",

--- a/scripts/test-compare/assertion-ratchet.ts
+++ b/scripts/test-compare/assertion-ratchet.ts
@@ -1,0 +1,265 @@
+/**
+ * Only-shrink ratchet for the ASSERTION-LEVEL fidelity counters (RFC 0025).
+ *
+ * `pnpm test:compare` already measures three divergences inside name-MATCHED
+ * tests and writes them to output/convention-comparison.json as per-package
+ * totals: `totalAssertionMismatch` (the pair makes a different NUMBER of
+ * assertions), `totalKindMismatch` (same count, divergent KINDS — Rails
+ * `assert_equal` vs a trails `toBeTruthy`), `totalValueMismatch` (same kinds,
+ * divergent literal EXPECTED VALUES).
+ *
+ * Those numbers were advisory: nothing failed when they grew, so a newly ported
+ * test could assert less than its Rails counterpart and still count as matched.
+ * This module pins them, mirroring the wide call-mismatch ratchet's AGGREGATE
+ * contract (RFC 0083): a committed high-water mark per package per counter,
+ * which `--write` lowers and never raises. The guarantee is "assertion-level
+ * debt never grows", NOT "every remaining mismatch has been reviewed" —
+ * committing the per-pair population instead would mirror data
+ * convention-comparison.json already carries and churn on every test rename.
+ *
+ * There is no second extractor; the mark is compared against that artifact's
+ * totals. A STALE artifact is the trap (see lint-assertion-mismatches.ts, which
+ * regenerates it first). A package present in the artifact but absent from the
+ * mark is an ERROR, not an implicit zero: admitting one silently would let its
+ * whole assertion debt in unmeasured. Seed it with `--write`.
+ *
+ * Hard rules: no node:* imports, no process.*, async fs.
+ */
+import * as fs from "fs/promises";
+
+/** The three assertion-level counters, in report order. */
+export const COUNTERS = ["assertionCount", "kind", "value"] as const;
+
+export type Counter = (typeof COUNTERS)[number];
+
+/** Human label per counter, matching the `test:compare` summary tokens. */
+export const COUNTER_LABELS: Record<Counter, string> = {
+  assertionCount: "assertion-count-mismatch",
+  kind: "assertion-kind-mismatch",
+  value: "assertion-value-mismatch",
+};
+
+export type Counts = Record<Counter, number>;
+
+/** The committed high-water mark: per package, one number per counter. */
+export interface AssertionMark {
+  packages: Record<string, Counts>;
+}
+
+/** The slice of convention-comparison.json this gate reads. */
+export interface ComparisonArtifact {
+  results?: {
+    package: string;
+    totalAssertionMismatch?: number;
+    totalKindMismatch?: number;
+    totalValueMismatch?: number;
+  }[];
+}
+
+/**
+ * Per-package current counts, read from the test-compare artifact.
+ *
+ * Packages whose three counters are all zero are kept: dropping them would make
+ * a converged package look "new" on the next run and re-admit its debt.
+ */
+export function countsFromArtifact(artifact: ComparisonArtifact): Record<string, Counts> {
+  const out: Record<string, Counts> = {};
+  for (const r of artifact.results ?? []) {
+    out[r.package] = {
+      assertionCount: r.totalAssertionMismatch ?? 0,
+      kind: r.totalKindMismatch ?? 0,
+      value: r.totalValueMismatch ?? 0,
+    };
+  }
+  return out;
+}
+
+function parseCounts(pkg: string, raw: unknown): Counts {
+  const counts = {} as Counts;
+  for (const counter of COUNTERS) {
+    const value = (raw as Partial<Record<Counter, unknown>> | null)?.[counter];
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+      throw new Error(
+        `assertion high-water mark: ${pkg}.${counter} must be a non-negative integer, got ` +
+          `${JSON.stringify(value)}`,
+      );
+    }
+    counts[counter] = value;
+  }
+  return counts;
+}
+
+export function parseMark(text: string): AssertionMark {
+  const parsed = JSON.parse(text) as { packages?: unknown } | null;
+  const packages = parsed?.packages;
+  if (typeof packages !== "object" || packages === null || Array.isArray(packages)) {
+    throw new Error(
+      `assertion high-water mark: expected {"packages": {<pkg>: {…}}}, got ${text.trim()}`,
+    );
+  }
+  const out: Record<string, Counts> = {};
+  for (const [pkg, raw] of Object.entries(packages as Record<string, unknown>)) {
+    out[pkg] = parseCounts(pkg, raw);
+  }
+  return { packages: out };
+}
+
+export async function loadMark(file: string): Promise<AssertionMark> {
+  let text: string;
+  try {
+    text = await fs.readFile(file, "utf-8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    // Deleting the mark is how this ratchet would be silently disarmed, so name
+    // it rather than surfacing a bare ENOENT.
+    throw new Error(
+      `assertion high-water mark: ${file} is missing. It is a committed ratchet file; ` +
+        "restore it from git rather than regenerating, or the mark is lost.",
+      { cause: e },
+    );
+  }
+  return parseMark(text);
+}
+
+export async function writeMark(file: string, mark: AssertionMark): Promise<void> {
+  const packages: Record<string, Counts> = {};
+  for (const pkg of Object.keys(mark.packages).sort()) packages[pkg] = mark.packages[pkg];
+  await fs.writeFile(file, `${JSON.stringify({ packages }, null, 2)}\n`);
+}
+
+/** Only-shrink: each counter takes the lower of current and mark. */
+export function nextMark(current: Record<string, Counts>, mark: AssertionMark): AssertionMark {
+  const packages: Record<string, Counts> = {};
+  for (const [pkg, counts] of Object.entries(current)) {
+    const prior = mark.packages[pkg];
+    const next = {} as Counts;
+    for (const counter of COUNTERS) {
+      next[counter] = prior ? Math.min(counts[counter], prior[counter]) : counts[counter];
+    }
+    packages[pkg] = next;
+  }
+  return { packages };
+}
+
+export interface Violation {
+  package: string;
+  counter: Counter;
+  current: number;
+  mark: number;
+}
+
+/** Counters that exceed their mark, plus packages the mark does not cover. */
+export function violations(
+  current: Record<string, Counts>,
+  mark: AssertionMark,
+): { exceeded: Violation[]; unmarked: string[] } {
+  const exceeded: Violation[] = [];
+  const unmarked: string[] = [];
+  for (const pkg of Object.keys(current).sort()) {
+    const prior = mark.packages[pkg];
+    if (!prior) {
+      unmarked.push(pkg);
+      continue;
+    }
+    for (const counter of COUNTERS) {
+      if (current[pkg][counter] > prior[counter]) {
+        exceeded.push({
+          package: pkg,
+          counter,
+          current: current[pkg][counter],
+          mark: prior[counter],
+        });
+      }
+    }
+  }
+  return { exceeded, unmarked };
+}
+
+/** Marked packages that vanished from the artifact — a stale or misscoped run. */
+export function missingFromArtifact(
+  current: Record<string, Counts>,
+  mark: AssertionMark,
+): string[] {
+  return Object.keys(mark.packages)
+    .filter((pkg) => !(pkg in current))
+    .sort();
+}
+
+/** Counters that came in UNDER the mark, i.e. real convergence to acknowledge. */
+export function shrunk(current: Record<string, Counts>, mark: AssertionMark): Violation[] {
+  const out: Violation[] = [];
+  for (const pkg of Object.keys(current).sort()) {
+    const prior = mark.packages[pkg];
+    if (!prior) continue;
+    for (const counter of COUNTERS) {
+      if (current[pkg][counter] < prior[counter]) {
+        out.push({ package: pkg, counter, current: current[pkg][counter], mark: prior[counter] });
+      }
+    }
+  }
+  return out;
+}
+
+export function renderExceeded(exceeded: Violation[], markPath: string): string {
+  return [
+    "",
+    "assertion-mismatch ratchet: assertion-level debt GREW inside name-matched tests.",
+    "",
+    ...exceeded.map(
+      (v) =>
+        `  ${v.package}  ${COUNTER_LABELS[v.counter]}: ${v.current} (mark ${v.mark}, ` +
+        `+${v.current - v.mark})`,
+    ),
+    "",
+    "A matched test now asserts a different number of things, different kinds of things, or",
+    "different literal values than its Rails counterpart. Read the Rails test and converge the",
+    "port's assertions — `pnpm test:compare --assertions` has the per-test breakdown.",
+    `The mark in ${markPath} only shrinks; it is never raised to admit new debt.`,
+  ].join("\n");
+}
+
+export function renderUnmarked(unmarked: string[], markPath: string): string {
+  return [
+    "",
+    `assertion-mismatch ratchet: ${unmarked.length} package(s) are absent from ${markPath}:`,
+    ...unmarked.map((p) => `  ${p}`),
+    "An unmarked package would let its whole assertion debt in unmeasured. Seed it with",
+    "`pnpm test:assertions:ratchet:reseed`.",
+  ].join("\n");
+}
+
+export function renderMissing(missing: string[], markPath: string): string {
+  return [
+    "",
+    `assertion-mismatch ratchet: ${missing.length} marked package(s) are absent from the artifact:`,
+    ...missing.map((p) => `  ${p}`),
+    "That is a partial-scope run (a `--package` filter, an unfetched vendor source), not",
+    `convergence. Re-run the full comparison before trusting ${markPath}.`,
+  ].join("\n");
+}
+
+export function renderShrunk(rows: Violation[], markPath: string): string {
+  return [
+    "",
+    `${rows.length} counter(s) came in under the mark:`,
+    ...rows.map(
+      (v) =>
+        `  ${v.package}  ${COUNTER_LABELS[v.counter]}: ${v.current} (was ${v.mark}, ` +
+        `\u2212${v.mark - v.current})`,
+    ),
+    `Run \`pnpm test:assertions:ratchet:reseed\` to lower ${markPath}.`,
+  ].join("\n");
+}
+
+export function renderWriteSummary(mark: AssertionMark, markPath: string): string {
+  return [
+    `Wrote ${markPath}:`,
+    ...Object.keys(mark.packages)
+      .sort()
+      .map(
+        (pkg) =>
+          `  ${pkg}  ` +
+          COUNTERS.map((c) => `${COUNTER_LABELS[c]}=${mark.packages[pkg][c]}`).join("  "),
+      ),
+  ].join("\n");
+}

--- a/scripts/test-compare/assertion-ratchet.ts
+++ b/scripts/test-compare/assertion-ratchet.ts
@@ -1,27 +1,19 @@
 /**
  * Only-shrink ratchet for the ASSERTION-LEVEL fidelity counters (RFC 0025).
  *
- * `pnpm test:compare` already measures three divergences inside name-MATCHED
- * tests and writes them to output/convention-comparison.json as per-package
- * totals: `totalAssertionMismatch` (the pair makes a different NUMBER of
- * assertions), `totalKindMismatch` (same count, divergent KINDS — Rails
- * `assert_equal` vs a trails `toBeTruthy`), `totalValueMismatch` (same kinds,
- * divergent literal EXPECTED VALUES).
+ * `pnpm test:compare` measures three divergences inside name-MATCHED tests and
+ * writes them to output/convention-comparison.json as per-package totals:
+ * `totalAssertionMismatch` (different NUMBER of assertions), `totalKindMismatch`
+ * (same count, divergent KINDS), `totalValueMismatch` (same kinds, divergent
+ * literal EXPECTED VALUES). They were advisory, so a newly ported test could
+ * assert less than its Rails counterpart and still count as matched.
  *
- * Those numbers were advisory: nothing failed when they grew, so a newly ported
- * test could assert less than its Rails counterpart and still count as matched.
- * This module pins them, mirroring the wide call-mismatch ratchet's AGGREGATE
- * contract (RFC 0083): a committed high-water mark per package per counter,
- * which `--write` lowers and never raises. The guarantee is "assertion-level
- * debt never grows", NOT "every remaining mismatch has been reviewed" —
- * committing the per-pair population instead would mirror data
- * convention-comparison.json already carries and churn on every test rename.
- *
- * There is no second extractor; the mark is compared against that artifact's
- * totals. A STALE artifact is the trap (see lint-assertion-mismatches.ts, which
- * regenerates it first). A package present in the artifact but absent from the
- * mark is an ERROR, not an implicit zero: admitting one silently would let its
- * whole assertion debt in unmeasured. Seed it with `--write`.
+ * This pins them the way the wide call-mismatch ratchet pins its unreviewed
+ * count (RFC 0083): a committed high-water mark per package per counter, which
+ * `--write` lowers and never raises. The arm is AGGREGATE — the guarantee is
+ * "assertion-level debt never grows", not "every remaining mismatch was
+ * reviewed". See CONTRIBUTING.md "Measuring progress" for the full contract and
+ * the stale-artifact trap.
  *
  * Hard rules: no node:* imports, no process.*, async fs.
  */
@@ -188,21 +180,6 @@ export function missingFromArtifact(
     .sort();
 }
 
-/** Counters that came in UNDER the mark, i.e. real convergence to acknowledge. */
-export function shrunk(current: Record<string, Counts>, mark: AssertionMark): Violation[] {
-  const out: Violation[] = [];
-  for (const pkg of Object.keys(current).sort()) {
-    const prior = mark.packages[pkg];
-    if (!prior) continue;
-    for (const counter of COUNTERS) {
-      if (current[pkg][counter] < prior[counter]) {
-        out.push({ package: pkg, counter, current: current[pkg][counter], mark: prior[counter] });
-      }
-    }
-  }
-  return out;
-}
-
 export function renderExceeded(exceeded: Violation[], markPath: string): string {
   return [
     "",
@@ -238,19 +215,6 @@ export function renderMissing(missing: string[], markPath: string): string {
     ...missing.map((p) => `  ${p}`),
     "That is a partial-scope run (a `--package` filter, an unfetched vendor source), not",
     `convergence. Re-run the full comparison before trusting ${markPath}.`,
-  ].join("\n");
-}
-
-export function renderShrunk(rows: Violation[], markPath: string): string {
-  return [
-    "",
-    `${rows.length} counter(s) came in under the mark:`,
-    ...rows.map(
-      (v) =>
-        `  ${v.package}  ${COUNTER_LABELS[v.counter]}: ${v.current} (was ${v.mark}, ` +
-        `\u2212${v.mark - v.current})`,
-    ),
-    `Run \`pnpm test:assertions:ratchet:reseed\` to lower ${markPath}.`,
   ].join("\n");
 }
 

--- a/scripts/test-compare/lint-assertion-mismatches.test.ts
+++ b/scripts/test-compare/lint-assertion-mismatches.test.ts
@@ -1,0 +1,120 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Counts } from "./assertion-ratchet.js";
+import {
+  main,
+  NO_REGEN_FLAG,
+  REGEN_SKIP_ENV,
+  shouldRegenerate,
+} from "./lint-assertion-mismatches.js";
+
+let dir: string;
+let paths: { artifact: string; mark: string };
+
+async function writeFixtures(
+  artifact: Record<string, [number, number, number]>,
+  mark: Record<string, [number, number, number]>,
+): Promise<void> {
+  await fs.writeFile(
+    paths.artifact,
+    JSON.stringify({
+      results: Object.entries(artifact).map(([pkg, [count, kind, value]]) => ({
+        package: pkg,
+        totalAssertionMismatch: count,
+        totalKindMismatch: kind,
+        totalValueMismatch: value,
+      })),
+    }),
+  );
+  await fs.writeFile(
+    paths.mark,
+    JSON.stringify({
+      packages: Object.fromEntries(
+        Object.entries(mark).map(([pkg, [assertionCount, kind, value]]) => [
+          pkg,
+          { assertionCount, kind, value },
+        ]),
+      ),
+    }),
+  );
+}
+
+async function readMark(): Promise<Record<string, Counts>> {
+  return (
+    JSON.parse(await fs.readFile(paths.mark, "utf-8")) as { packages: Record<string, Counts> }
+  ).packages;
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "assertion-ratchet-"));
+  paths = { artifact: path.join(dir, "artifact.json"), mark: path.join(dir, "mark.json") };
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe("main", () => {
+  it("passes when every counter sits at or under its mark", async () => {
+    await writeFixtures({ activerecord: [9, 20, 3] }, { activerecord: [10, 20, 3] });
+    expect(await main(false, paths)).toBe(0);
+  });
+
+  it("fails when a counter grew past its mark", async () => {
+    await writeFixtures({ activerecord: [10, 23, 3] }, { activerecord: [10, 20, 3] });
+    expect(await main(false, paths)).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.join("\n")).toContain(
+      "assertion-kind-mismatch: 23 (mark 20, +3)",
+    );
+  });
+
+  it("fails when the artifact carries a package the mark does not", async () => {
+    await writeFixtures({ activerecord: [1, 1, 1], arel: [0, 0, 0] }, { activerecord: [1, 1, 1] });
+    expect(await main(false, paths)).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.join("\n")).toContain("absent from");
+  });
+
+  it("lowers the mark to the shrunken counters under --write", async () => {
+    await writeFixtures({ activerecord: [4, 20, 0] }, { activerecord: [10, 20, 3] });
+    expect(await main(true, paths)).toBe(0);
+    expect(await readMark()).toEqual({ activerecord: { assertionCount: 4, kind: 20, value: 0 } });
+  });
+
+  it("never raises the mark under --write", async () => {
+    await writeFixtures({ activerecord: [99, 99, 99] }, { activerecord: [10, 20, 3] });
+    expect(await main(true, paths)).toBe(0);
+    expect(await readMark()).toEqual({ activerecord: { assertionCount: 10, kind: 20, value: 3 } });
+  });
+
+  it("refuses a partial-scope run rather than dropping a marked package", async () => {
+    await writeFixtures({ activerecord: [1, 1, 1] }, { activerecord: [1, 1, 1], arel: [0, 0, 0] });
+    expect(await main(true, paths)).toBe(1);
+    expect(await readMark()).toHaveProperty("arel");
+  });
+
+  it("names the missing artifact rather than surfacing a bare ENOENT", async () => {
+    await writeFixtures({}, {});
+    await fs.rm(paths.artifact);
+    await expect(main(false, paths)).rejects.toThrow(/pnpm test:compare --json/);
+  });
+});
+
+describe("shouldRegenerate", () => {
+  it("regenerates the artifact for a plain local run", () => {
+    expect(shouldRegenerate([], {})).toBe(true);
+  });
+
+  it("does not regenerate under CI, which writes the artifact in its own step", () => {
+    expect(shouldRegenerate([], { CI: "true" })).toBe(false);
+  });
+
+  it("does not regenerate under --no-regen or the skip env", () => {
+    expect(shouldRegenerate([NO_REGEN_FLAG], {})).toBe(false);
+    expect(shouldRegenerate([], { [REGEN_SKIP_ENV]: "1" })).toBe(false);
+  });
+});

--- a/scripts/test-compare/lint-assertion-mismatches.ts
+++ b/scripts/test-compare/lint-assertion-mismatches.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env npx tsx
+/**
+ * CLI for the assertion-level only-shrink ratchet (RFC 0025).
+ *
+ * Reads the per-package assertion-count / kind / value mismatch totals out of
+ * output/convention-comparison.json and gates them against the committed
+ * high-water mark in assertion-mismatch-mark.json. See assertion-ratchet.ts for
+ * the contract (aggregate, only-shrink, no second extractor).
+ *
+ * Usage:
+ *   pnpm test:assertions:ratchet            # gate (regenerates the artifact first)
+ *   pnpm test:assertions:ratchet:reseed     # lower the mark after convergence
+ *   pnpm tsx scripts/test-compare/lint-assertion-mismatches.ts --no-regen
+ *
+ * A plain run regenerates the artifact itself by shelling out to
+ * `pnpm test:compare --json` — gating a STALE convention-comparison.json is the
+ * trap this mirrors from `api:calls:wide`: a file written before a sibling PR's
+ * tests landed reports movement that never happened, and `--write` would commit
+ * that fiction as the new mark. Opt out with `--no-regen`,
+ * TEST_COMPARE_SKIP_REGEN=1, or any CI value — CI writes the artifact in its own
+ * test-comparison step and must not pay for the extraction twice.
+ *
+ * Hard rules: no node:* imports, no process.* outside the CLI entry guard,
+ * async fs.
+ */
+import { spawn } from "child_process";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import {
+  type ComparisonArtifact,
+  countsFromArtifact,
+  loadMark,
+  missingFromArtifact,
+  nextMark,
+  renderExceeded,
+  renderMissing,
+  renderShrunk,
+  renderUnmarked,
+  renderWriteSummary,
+  shrunk,
+  violations,
+  writeMark,
+} from "./assertion-ratchet.js";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(SCRIPT_DIR, "../..");
+const ARTIFACT_PATH = path.join(SCRIPT_DIR, "output", "convention-comparison.json");
+const MARK_PATH = path.join(SCRIPT_DIR, "assertion-mismatch-mark.json");
+const MARK_REL = path.relative(ROOT_DIR, MARK_PATH);
+
+export const NO_REGEN_FLAG = "--no-regen";
+export const REGEN_SKIP_ENV = "TEST_COMPARE_SKIP_REGEN";
+
+export function shouldRegenerate(argv: string[], env: Record<string, string | undefined>): boolean {
+  if (argv.includes(NO_REGEN_FLAG)) return false;
+  return !env.CI && env[REGEN_SKIP_ENV] !== "1";
+}
+
+export function regenerateArtifact(env: Record<string, string | undefined>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", ["test:compare", "--json"], {
+      cwd: ROOT_DIR,
+      env,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`\`pnpm test:compare --json\` exited with ${signal ?? code}`));
+    });
+  });
+}
+
+async function loadArtifact(): Promise<ComparisonArtifact> {
+  let text: string;
+  try {
+    text = await fs.readFile(ARTIFACT_PATH, "utf-8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    throw new Error(
+      `Missing ${path.relative(ROOT_DIR, ARTIFACT_PATH)} — run \`pnpm test:compare --json\` ` +
+        "first to write it.",
+      { cause: e },
+    );
+  }
+  return JSON.parse(text) as ComparisonArtifact;
+}
+
+export async function main(write: boolean): Promise<number> {
+  const current = countsFromArtifact(await loadArtifact());
+  const mark = await loadMark(MARK_PATH);
+
+  // A marked package that vanished means the artifact was written by a
+  // partial-scope run; reseeding from it would drop that package's mark
+  // entirely. Fail before either arm touches the file.
+  const missing = missingFromArtifact(current, mark);
+  if (missing.length > 0) {
+    console.error(renderMissing(missing, MARK_REL));
+    return 1;
+  }
+
+  if (write) {
+    const next = nextMark(current, mark);
+    await writeMark(MARK_PATH, next);
+    console.log(renderWriteSummary(next, MARK_REL));
+    return 0;
+  }
+
+  const { exceeded, unmarked } = violations(current, mark);
+  if (unmarked.length > 0) console.error(renderUnmarked(unmarked, MARK_REL));
+  if (exceeded.length > 0) console.error(renderExceeded(exceeded, MARK_REL));
+  if (exceeded.length > 0 || unmarked.length > 0) return 1;
+
+  const under = shrunk(current, mark);
+  if (under.length > 0) console.log(renderShrunk(under, MARK_REL));
+  console.log("assertion-mismatch ratchet: OK (no counter exceeds its high-water mark).");
+  return 0;
+}
+
+async function runAsScript(): Promise<void> {
+  const self = fileURLToPath(import.meta.url);
+  const invoked = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  if (path.resolve(self) !== invoked) return;
+  const argv = process.argv.slice(2);
+  if (shouldRegenerate(argv, process.env)) {
+    console.log("Regenerating output/convention-comparison.json (test:compare --json)…");
+    try {
+      await regenerateArtifact(process.env);
+    } catch (e) {
+      console.error(
+        `\nassertion-mismatch ratchet: could not regenerate the artifact: ${(e as Error).message}\n` +
+          `Re-run with ${NO_REGEN_FLAG} to gate against the artifact already on disk.\n`,
+      );
+      process.exit(2);
+    }
+  }
+  try {
+    process.exit(await main(argv.includes("--write")));
+  } catch (e) {
+    console.error(`\nassertion-mismatch ratchet: ${(e as Error).message}\n`);
+    process.exit(2);
+  }
+}
+
+void runAsScript();

--- a/scripts/test-compare/lint-assertion-mismatches.ts
+++ b/scripts/test-compare/lint-assertion-mismatches.ts
@@ -1,24 +1,20 @@
 #!/usr/bin/env npx tsx
 /**
- * CLI for the assertion-level only-shrink ratchet (RFC 0025).
- *
- * Reads the per-package assertion-count / kind / value mismatch totals out of
- * output/convention-comparison.json and gates them against the committed
- * high-water mark in assertion-mismatch-mark.json. See assertion-ratchet.ts for
- * the contract (aggregate, only-shrink, no second extractor).
+ * CLI for the assertion-level only-shrink ratchet (RFC 0025). Reads the
+ * per-package assertion-count / kind / value totals out of
+ * output/convention-comparison.json and gates them against the mark in
+ * assertion-mismatch-mark.json; see assertion-ratchet.ts for the contract.
  *
  * Usage:
  *   pnpm test:assertions:ratchet            # gate (regenerates the artifact first)
  *   pnpm test:assertions:ratchet:reseed     # lower the mark after convergence
  *   pnpm tsx scripts/test-compare/lint-assertion-mismatches.ts --no-regen
  *
- * A plain run regenerates the artifact itself by shelling out to
- * `pnpm test:compare --json` — gating a STALE convention-comparison.json is the
- * trap this mirrors from `api:calls:wide`: a file written before a sibling PR's
- * tests landed reports movement that never happened, and `--write` would commit
- * that fiction as the new mark. Opt out with `--no-regen`,
- * TEST_COMPARE_SKIP_REGEN=1, or any CI value — CI writes the artifact in its own
- * test-comparison step and must not pay for the extraction twice.
+ * A plain run regenerates the artifact via `pnpm test:compare --json`: gating a
+ * STALE convention-comparison.json reports movement that never happened, and
+ * `--write` would commit that fiction as the new mark. Opt out with
+ * `--no-regen`, TEST_COMPARE_SKIP_REGEN=1, or any CI value — CI writes the
+ * artifact in its own test-comparison step and must not pay for it twice.
  *
  * Hard rules: no node:* imports, no process.* outside the CLI entry guard,
  * async fs.
@@ -35,10 +31,8 @@ import {
   nextMark,
   renderExceeded,
   renderMissing,
-  renderShrunk,
   renderUnmarked,
   renderWriteSummary,
-  shrunk,
   violations,
   writeMark,
 } from "./assertion-ratchet.js";
@@ -47,7 +41,6 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "../..");
 const ARTIFACT_PATH = path.join(SCRIPT_DIR, "output", "convention-comparison.json");
 const MARK_PATH = path.join(SCRIPT_DIR, "assertion-mismatch-mark.json");
-const MARK_REL = path.relative(ROOT_DIR, MARK_PATH);
 
 export const NO_REGEN_FLAG = "--no-regen";
 export const REGEN_SKIP_ENV = "TEST_COMPARE_SKIP_REGEN";
@@ -72,20 +65,28 @@ export function regenerateArtifact(env: Record<string, string | undefined>): Pro
   });
 }
 
-async function loadArtifact(): Promise<ComparisonArtifact> {
+async function loadArtifact(file: string): Promise<ComparisonArtifact> {
   let text: string;
   try {
-    text = await fs.readFile(ARTIFACT_PATH, "utf-8");
+    text = await fs.readFile(file, "utf-8");
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
     throw new Error(
-      `Missing ${path.relative(ROOT_DIR, ARTIFACT_PATH)} — run \`pnpm test:compare --json\` ` +
-        "first to write it.",
+      `Missing ${path.relative(ROOT_DIR, file)} — run \`pnpm test:compare --json\` first to ` +
+        "write it.",
       { cause: e },
     );
   }
   return JSON.parse(text) as ComparisonArtifact;
 }
+
+/** File pair the gate reads/writes; overridable so tests can drive `main`. */
+export interface Paths {
+  artifact: string;
+  mark: string;
+}
+
+export const DEFAULT_PATHS: Paths = { artifact: ARTIFACT_PATH, mark: MARK_PATH };
 
 /**
  * Gate (or, under `write`, reseed) the mark against the artifact on disk.
@@ -95,30 +96,29 @@ async function loadArtifact(): Promise<ComparisonArtifact> {
  * reseeding from one would drop that package's mark entirely — so both arms
  * bail on it before either touches the file.
  */
-export async function main(write: boolean): Promise<number> {
-  const current = countsFromArtifact(await loadArtifact());
-  const mark = await loadMark(MARK_PATH);
+export async function main(write: boolean, paths: Paths = DEFAULT_PATHS): Promise<number> {
+  const markRel = path.relative(ROOT_DIR, paths.mark);
+  const current = countsFromArtifact(await loadArtifact(paths.artifact));
+  const mark = await loadMark(paths.mark);
 
   const missing = missingFromArtifact(current, mark);
   if (missing.length > 0) {
-    console.error(renderMissing(missing, MARK_REL));
+    console.error(renderMissing(missing, markRel));
     return 1;
   }
 
   if (write) {
     const next = nextMark(current, mark);
-    await writeMark(MARK_PATH, next);
-    console.log(renderWriteSummary(next, MARK_REL));
+    await writeMark(paths.mark, next);
+    console.log(renderWriteSummary(next, markRel));
     return 0;
   }
 
   const { exceeded, unmarked } = violations(current, mark);
-  if (unmarked.length > 0) console.error(renderUnmarked(unmarked, MARK_REL));
-  if (exceeded.length > 0) console.error(renderExceeded(exceeded, MARK_REL));
+  if (unmarked.length > 0) console.error(renderUnmarked(unmarked, markRel));
+  if (exceeded.length > 0) console.error(renderExceeded(exceeded, markRel));
   if (exceeded.length > 0 || unmarked.length > 0) return 1;
 
-  const under = shrunk(current, mark);
-  if (under.length > 0) console.log(renderShrunk(under, MARK_REL));
   console.log("assertion-mismatch ratchet: OK (no counter exceeds its high-water mark).");
   return 0;
 }

--- a/scripts/test-compare/lint-assertion-mismatches.ts
+++ b/scripts/test-compare/lint-assertion-mismatches.ts
@@ -87,13 +87,18 @@ async function loadArtifact(): Promise<ComparisonArtifact> {
   return JSON.parse(text) as ComparisonArtifact;
 }
 
+/**
+ * Gate (or, under `write`, reseed) the mark against the artifact on disk.
+ * Returns the exit code.
+ *
+ * A marked package missing from the artifact means a partial-scope run, and
+ * reseeding from one would drop that package's mark entirely — so both arms
+ * bail on it before either touches the file.
+ */
 export async function main(write: boolean): Promise<number> {
   const current = countsFromArtifact(await loadArtifact());
   const mark = await loadMark(MARK_PATH);
 
-  // A marked package that vanished means the artifact was written by a
-  // partial-scope run; reseeding from it would drop that package's mark
-  // entirely. Fail before either arm touches the file.
   const missing = missingFromArtifact(current, mark);
   if (missing.length > 0) {
     console.error(renderMissing(missing, MARK_REL));


### PR DESCRIPTION
`pnpm test:compare` already measures three assertion-level divergences *inside*
name-matched tests — different assertion **count**, same count but different
**kinds**, same kinds but different literal **values** — and reports them in
`output/convention-comparison.json`. They were advisory only: nothing failed
when they grew, so a newly ported test could assert less (or differently) than
its Rails counterpart and still count as matched. At 1,987 / 4,069 / 54 for
activerecord that was the largest unguarded fidelity surface in the release
scope, with no measurable burn rate.

This pins them with an only-shrink ratchet, mirroring the wide call-mismatch
ratchet's aggregate contract (RFC 0083):

- `scripts/test-compare/assertion-mismatch-mark.json` — committed high-water
  mark, one entry per package, three counters each, seeded at today's values.
- `pnpm test:assertions:ratchet` gates; `pnpm test:assertions:ratchet:reseed`
  lowers the mark (never raises it), so shrinkage is auto-acknowledged and a run
  that grew a counter can't buy headroom by reseeding.
- CI runs it in `rails-comparison` right after the test-comparison step.

Design notes:

- **Aggregate, not per-entry.** The guarantee is "assertion-level debt never
  grows", not "every remaining mismatch was reviewed". Committing the per-pair
  population would mirror data the artifact already carries and churn on every
  unrelated test rename.
- **No second extractor.** The counts come straight from
  `convention-comparison.json`. Gating a stale artifact is the trap (a file
  written before a sibling PR's tests landed reports movement that never
  happened, and `--write` would commit that fiction), so a local run regenerates
  it first via `pnpm test:compare --json`; CI passes `--no-regen` because it
  writes the artifact in the preceding step.
- A package in the artifact but absent from the mark is an error, not an
  implicit zero. A marked package missing from the artifact fails as a
  partial-scope run, so a `--package`-filtered reseed can't drop a mark.
- CONTRIBUTING.md "Measuring progress" documents the ratchet next to the
  wide-call one, including the stale-artifact trap and the note that the burn
  rate is now measurable — which is what the release estimate needs to price
  promoting this to a hard gate.

Verification: `scripts/test-compare/lint-assertion-mismatches.test.ts` drives
`main()` over temp-dir fixtures — pass under the mark, fail with the rendered
`+3` excess when a counter grows, fail on a package the mark does not carry,
`--write` lowering a shrunken counter, `--write` refusing to raise a grown one,
a partial-scope reseed refusing to drop a marked package, and the named
missing-artifact error. `assertion-ratchet.test.ts` keeps the pure parser/reader
cases. Plus a live run: the real artifact passes, and bumping a counter in it by
3 turns the gate red with `assertion-kind-mismatch: 4072 (mark 4069, +3)`.

Seed values: the mark holds 1,987 / 4,069 / 54 for activerecord, one off the
1,988 / 4,068 / 55 in the story context. That is a day of drift between the
2026-07-31 audit and the seeding run, not a seeding error — the mark is whatever
`test:compare` reported at the moment it was written, which is the only value
the gate can be consistent with.

Size: 621 non-doc LOC against the 500 ceiling — gate code 383, tests 165,
generated mark file 64, CI/package wiring 9. Trimmed ~85 from the first push by
cutting test duplication, prose, and a shrinkage-report helper. The remainder is
indivisible: a mark without its lint gates nothing, and an untested lint is the
defect the review flagged. **Overage explicitly signed off by the repo owner**
rather than claimed under an exemption — CLAUDE.md's "tests and fixtures count"
is not being reinterpreted here.

Closes-story: assertion-mismatch-ratchet
