### PR TITLE
feat(prism-codegen): resolve accessor and const-arrow ports in the scorer

### DIFF
--- a/scripts/prism-codegen/score.test.ts
+++ b/scripts/prism-codegen/score.test.ts
@@ -181,6 +181,78 @@ describe("prism-codegen scorer", () => {
     ]);
   });
 
+  it("indexes object-literal getters and setters as ports", () => {
+    const idx = indexPortFile(`
+      export const AttributeMethods = {
+        get readonly(): boolean {
+          return this._readonly;
+        },
+        set readonly(value: boolean) {
+          this._readonly = value;
+        },
+        get name(): string { return this._name; },
+      };
+    `);
+    expect(idx.byName.has("readonly")).toBe(true);
+    expect(idx.byName.has("name")).toBe(true);
+    // The getter (arity 0) owns the shared name, not the setter.
+    expect(idx.byName.get("readonly")!.parameters.length).toBe(0);
+  });
+
+  it("indexes const arrow ports, including through mixin indirection", () => {
+    const idx = indexPortFile(`
+      export const performFindBy = async (this: R, c: unknown): Promise<any> => {
+        return this.where(c).limit(1).toArray();
+      };
+      export const FinderMethods = { findBy: performFindBy };
+    `);
+    expect(idx.byName.has("performFindBy")).toBe(true);
+    expect(idx.byName.get("findBy")).toBe(idx.byName.get("performFindBy"));
+  });
+
+  it("matches a generated body against a const arrow port", async () => {
+    const score = await scoreRuby(
+      `def take_one(list)
+         if list.empty?
+           raise ArgumentError.new("empty")
+         end
+         list.first
+       end`,
+      `export const takeOne = (list: unknown[]): unknown => {
+         if (list.empty()) {
+           throw new ArgumentError("empty");
+         }
+         return list.first;
+       };`,
+    );
+    expect(score.entries).toEqual([
+      expect.objectContaining({ name: "takeOne", status: "matched" }),
+    ]);
+  });
+
+  it("keeps a predicate fallback off an accessor of a different arity", () => {
+    const port = `
+      export const AttributeMethods = {
+        get readonly(): boolean { return this._readonly; },
+      };
+    `;
+    const missing = scoreFile(
+      `function isReadonly(value) { return value; }`,
+      port,
+      new Set(["isReadonly"]),
+    );
+    expect(missing.entries).toEqual([{ name: "isReadonly", status: "missing" }]);
+
+    const hit = scoreFile(
+      `function isReadonly() { return this._readonly; }`,
+      port,
+      new Set(["isReadonly"]),
+    );
+    expect(hit.entries).toEqual([
+      expect.objectContaining({ name: "isReadonly", status: "matched" }),
+    ]);
+  });
+
   it("only scores clean defs — tainted ones stay out of the denominator", async () => {
     const score = await scoreRuby(
       `def tainted(a); a <=> 1; end`,

--- a/scripts/prism-codegen/score.test.ts
+++ b/scripts/prism-codegen/score.test.ts
@@ -184,18 +184,16 @@ describe("prism-codegen scorer", () => {
   it("indexes object-literal getters and setters as ports", () => {
     const idx = indexPortFile(`
       export const AttributeMethods = {
-        get readonly(): boolean {
-          return this._readonly;
-        },
         set readonly(value: boolean) {
           this._readonly = value;
+        },
+        get readonly(): boolean {
+          return this._readonly;
         },
         get name(): string { return this._name; },
       };
     `);
-    expect(idx.byName.has("readonly")).toBe(true);
     expect(idx.byName.has("name")).toBe(true);
-    // The getter (arity 0) owns the shared name, not the setter.
     expect(idx.byName.get("readonly")!.parameters.length).toBe(0);
   });
 

--- a/scripts/prism-codegen/score.test.ts
+++ b/scripts/prism-codegen/score.test.ts
@@ -208,6 +208,17 @@ describe("prism-codegen scorer", () => {
     expect(idx.byName.get("findBy")).toBe(idx.byName.get("performFindBy"));
   });
 
+  it("ignores local helper arrows declared inside a function body", () => {
+    const idx = indexPortFile(`
+      export function loadTarget(this: R): unknown {
+        const findBy = (c: unknown) => this.scope(c);
+        return findBy(1);
+      }
+    `);
+    expect(idx.byName.has("loadTarget")).toBe(true);
+    expect(idx.byName.has("findBy")).toBe(false);
+  });
+
   it("matches a generated body against a const arrow port", async () => {
     const score = await scoreRuby(
       `def take_one(list)

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -25,6 +25,20 @@ interface PortIndex {
   byName: Map<string, ts.FunctionLikeDeclaration>;
 }
 
+/**
+ * True when a variable declaration sits directly in the module body — a local
+ * helper arrow inside some unrelated function is not a port symbol and must not
+ * shadow one.
+ */
+function isTopLevelDeclaration(node: ts.VariableDeclaration): boolean {
+  const statement = node.parent?.parent;
+  return (
+    !!statement &&
+    ts.isVariableStatement(statement) &&
+    (ts.isSourceFile(statement.parent) || ts.isModuleBlock(statement.parent))
+  );
+}
+
 export function indexPortFile(source: string): PortIndex {
   const sf = ts.createSourceFile("port.ts", source, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS);
   const fns = new Map<string, ts.FunctionLikeDeclaration>();
@@ -52,7 +66,8 @@ export function indexPortFile(source: string): PortIndex {
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
       node.initializer &&
-      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)) &&
+      isTopLevelDeclaration(node)
     ) {
       fns.set(node.name.text, node.initializer);
       if (!byName.has(node.name.text)) byName.set(node.name.text, node.initializer);

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -38,22 +38,21 @@ export function indexPortFile(source: string): PortIndex {
     if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name) && node.body) {
       if (!byName.has(node.name.text)) byName.set(node.name.text, node);
     }
-    // Ruby attr-style ports land as accessors. A getter and setter share one
-    // name, so the getter (the reader, arity 0) wins and the setter only fills
-    // an empty slot — resolvePortFn's arity guard sorts out the rest.
-    if (ts.isGetAccessorDeclaration(node) && ts.isIdentifier(node.name) && node.body) {
+    if (
+      (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) &&
+      ts.isIdentifier(node.name) &&
+      node.body
+    ) {
       const existing = byName.get(node.name.text);
-      if (!existing || ts.isSetAccessorDeclaration(existing)) byName.set(node.name.text, node);
-    }
-    if (ts.isSetAccessorDeclaration(node) && ts.isIdentifier(node.name) && node.body) {
-      if (!byName.has(node.name.text)) byName.set(node.name.text, node);
+      const getterOverSetter =
+        !!existing && ts.isSetAccessorDeclaration(existing) && ts.isGetAccessorDeclaration(node);
+      if (!existing || getterOverSetter) byName.set(node.name.text, node);
     }
     if (
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
       node.initializer &&
-      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)) &&
-      node.initializer.body
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
     ) {
       fns.set(node.name.text, node.initializer);
       if (!byName.has(node.name.text)) byName.set(node.name.text, node.initializer);

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -38,6 +38,26 @@ export function indexPortFile(source: string): PortIndex {
     if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name) && node.body) {
       if (!byName.has(node.name.text)) byName.set(node.name.text, node);
     }
+    // Ruby attr-style ports land as accessors. A getter and setter share one
+    // name, so the getter (the reader, arity 0) wins and the setter only fills
+    // an empty slot — resolvePortFn's arity guard sorts out the rest.
+    if (ts.isGetAccessorDeclaration(node) && ts.isIdentifier(node.name) && node.body) {
+      const existing = byName.get(node.name.text);
+      if (!existing || ts.isSetAccessorDeclaration(existing)) byName.set(node.name.text, node);
+    }
+    if (ts.isSetAccessorDeclaration(node) && ts.isIdentifier(node.name) && node.body) {
+      if (!byName.has(node.name.text)) byName.set(node.name.text, node);
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)) &&
+      node.initializer.body
+    ) {
+      fns.set(node.name.text, node.initializer);
+      if (!byName.has(node.name.text)) byName.set(node.name.text, node.initializer);
+    }
     ts.forEachChild(node, visit);
   };
   visit(sf);


### PR DESCRIPTION
`indexPortFile` saw function declarations, method declarations, and mixin-map
indirection, but not ports written as object-literal getters/setters or
`export const foo = (...) => ...`. Those scored as `missing`.

- Index `GetAccessor`/`SetAccessor` declarations. Within the accessor pair a
  getter displaces a setter (the reader, arity 0, is the better representative);
  otherwise the file-wide rule is unchanged first-wins, same as the pre-existing
  method indexing.
- Index arrow/function-expression initializers of **top-level** variable
  declarations, both directly and as mixin-map targets
  (`FinderMethods = { findBy: performFindBy }` where `performFindBy` is a const
  arrow). Local helper arrows inside a function body are skipped so they cannot
  shadow a real port symbol.
- Arity discipline is unchanged: `resolvePortFn` still requires arity agreement
  before accepting a predicate fallback (`isReadonly` → `readonly`), so a
  0-param getter does not absorb a 1-param generated predicate.

`pnpm codegen:score` totals, before → after: matched 32 → 33, divergent 292 →
297, missing 79 → 73. Nothing moved out of present.

Closes-story: scorer-getter-and-arrow-resolution
