### PR TITLE
refactor(migration): route MigrationContext schema-DSL callers onto the adapter

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from "vitest";
 import { Base, Migration, Schema, TableDefinition } from "./index.js";
-import { MigrationContext, Migrator } from "./migration.js";
+import { Migrator } from "./migration.js";
 import { SchemaMigration } from "./schema-migration.js";
 
 import { adapterType } from "./test-adapter.js";
@@ -31,8 +31,7 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   afterEach(async () => {
-    const ctx = new MigrationContext(adapter);
-    await ctx.dropTable(
+    await adapter.dropTable(
       "pk_test",
       "schema_test",
       "fruits",

--- a/packages/activerecord/src/cache-key.test.ts
+++ b/packages/activerecord/src/cache-key.test.ts
@@ -4,7 +4,6 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
 import { adapterType } from "./test-adapter.js";
-import { MigrationContext } from "./migration.js";
 import { fixtures } from "./test-fixtures.js";
 import { ActiveRecord } from "./ar-config.js";
 
@@ -34,16 +33,17 @@ describe("CacheKeyTest", () => {
   // bespoke tables per-test, so opt out of transactional fixtures — the per-test
   // DDL must commit, not roll back inside a wrapping (PG-poisoning) transaction.
   fixtures({}, { useTransactionalTests: false });
-  let ctx: MigrationContext;
 
   beforeEach(async () => {
-    ctx = new MigrationContext(Base.connection);
-    await ctx.createTable("cache_mes", { force: true }, (t: any) => t.timestamps());
-    await ctx.createTable("cache_me_with_versions", { force: true }, (t: any) => t.timestamps());
+    const adapter = Base.connection;
+    await adapter.createTable("cache_mes", { force: true }, (t: any) => t.timestamps());
+    await adapter.createTable("cache_me_with_versions", { force: true }, (t: any) =>
+      t.timestamps(),
+    );
   });
 
   afterEach(async () => {
-    await ctx.dropTable("cache_mes", "cache_me_with_versions", { ifExists: true });
+    await Base.connection.dropTable("cache_mes", "cache_me_with_versions", { ifExists: true });
   });
 
   function cacheMe() {

--- a/packages/activerecord/src/comment.test.ts
+++ b/packages/activerecord/src/comment.test.ts
@@ -5,7 +5,6 @@
 import { describe, beforeEach, afterEach, expect } from "vitest";
 import { Base } from "./index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import { MigrationContext } from "./migration.js";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-fixtures.js";
 import { itIfSupports } from "./support/supports.js";
@@ -19,20 +18,24 @@ describe("CommentTest", () => {
   // a wrapping (PG-poisoning) transaction.
   fixtures({}, { useTransactionalTests: false });
   let adapter: DatabaseAdapter;
-  let ctx: MigrationContext;
 
   beforeEach(async () => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
-    await ctx.createTable("commenteds", { comment: "A table with comment", force: true }, (t) => {
-      t.string("name", { comment: "Comment should help clarify the column purpose" });
-      t.boolean("obvious", { comment: "Question is: should you comment obviously named objects?" });
-      t.string("content");
-      t.index(["name"], {
-        comment: '"Very important" index that powers all the performance.\nAnd it\'s fun!',
-      });
-    });
-    await ctx.createTable("blank_comments", { comment: " ", force: true }, (t) => {
+    await adapter.createTable(
+      "commenteds",
+      { comment: "A table with comment", force: true },
+      (t) => {
+        t.string("name", { comment: "Comment should help clarify the column purpose" });
+        t.boolean("obvious", {
+          comment: "Question is: should you comment obviously named objects?",
+        });
+        t.string("content");
+        t.index(["name"], {
+          comment: '"Very important" index that powers all the performance.\nAnd it\'s fun!',
+        });
+      },
+    );
+    await adapter.createTable("blank_comments", { comment: " ", force: true }, (t) => {
       t.string("space_comment", { comment: " " });
       t.string("empty_comment", { comment: "" });
       t.string("nil_comment", { comment: null as any });
@@ -42,7 +45,7 @@ describe("CommentTest", () => {
       t.index(["nil_comment"], { comment: null as any });
       t.index(["absent_comment"]);
     });
-    await ctx.createTable(
+    await adapter.createTable(
       "pk_commenteds",
       { comment: "Table comment", id: false, force: true } as any,
       (t) => {
@@ -52,7 +55,7 @@ describe("CommentTest", () => {
   });
 
   afterEach(async () => {
-    await ctx.dropTable("commenteds", "blank_comments", "pk_commenteds", { ifExists: true });
+    await adapter.dropTable("commenteds", "blank_comments", "pk_commenteds", { ifExists: true });
   });
 
   itIfSupports("comments", "default primary key comment", async () => {
@@ -76,7 +79,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "add column with comment later", async () => {
-    await ctx.addColumn("commenteds", "rating", "integer", {
+    await adapter.addColumn("commenteds", "rating", "integer", {
       comment: "I am running out of imagination",
     });
     const cols = await (adapter as any).columns("commenteds");
@@ -86,7 +89,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "add index with comment later", async () => {
-    await ctx.addIndex("commenteds", "obvious", {
+    await adapter.addIndex("commenteds", "obvious", {
       name: "idx_obvious",
       comment: "We need to see obvious comments",
     });
@@ -103,7 +106,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "add comment to column", async () => {
-    await ctx.changeColumn("commenteds", "content", "string", {
+    await adapter.changeColumn("commenteds", "content", "string", {
       comment: "Whoa, content describes itself!",
     });
     const cols = await (adapter as any).columns("commenteds");
@@ -113,7 +116,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "remove comment from column", async () => {
-    await ctx.changeColumn("commenteds", "obvious", "string", { comment: null as any });
+    await adapter.changeColumn("commenteds", "obvious", "string", { comment: null as any });
     const cols = await (adapter as any).columns("commenteds");
     const col = cols.find((c: any) => c.name === "obvious")!;
     expect(col.type).toBe("string");
@@ -121,10 +124,10 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "rename column preserves comment", async () => {
-    await ctx.addColumn("commenteds", "rating", "string", {
+    await adapter.addColumn("commenteds", "rating", "string", {
       comment: "I am running out of imagination",
     });
-    await ctx.renameColumn("commenteds", "rating", "new_rating");
+    await adapter.renameColumn("commenteds", "rating", "new_rating");
     const cols = await (adapter as any).columns("commenteds");
     const col = cols.find((c: any) => c.name === "new_rating")!;
     expect(col.type).toBe("string");
@@ -139,13 +142,13 @@ describe("CommentTest", () => {
     "comments",
     "schema dump with comments",
     async () => {
-      await ctx.addColumn("commenteds", "rating", "integer", {
+      await adapter.addColumn("commenteds", "rating", "integer", {
         comment: "I am running out of imagination",
       });
-      await ctx.changeColumn("commenteds", "content", "string", {
+      await adapter.changeColumn("commenteds", "content", "string", {
         comment: "Whoa, content describes itself!",
       });
-      await ctx.changeColumn("commenteds", "obvious", "string", { comment: null as any });
+      await adapter.changeColumn("commenteds", "obvious", "string", { comment: null as any });
       // Scope to the table under assertion so the dump stays cheap on a cold
       // schema cache (the truncate-reset leaves the ~330 canonical tables in place).
       const output = await SchemaDumper.dumpTableSchema(adapter, "commenteds");
@@ -180,19 +183,19 @@ describe("CommentTest", () => {
   );
 
   itIfSupports("comments", "change table comment", async () => {
-    await (ctx as any).changeTableComment("commenteds", "Edited table comment");
+    await (adapter as any).changeTableComment("commenteds", "Edited table comment");
     const tableComment = await (adapter as any).tableComment("commenteds");
     expect(tableComment).toBe("Edited table comment");
   });
 
   itIfSupports("comments", "change table comment to nil", async () => {
-    await (ctx as any).changeTableComment("commenteds", null);
+    await (adapter as any).changeTableComment("commenteds", null);
     const tableComment = await (adapter as any).tableComment("commenteds");
     expect(tableComment).toBeNull();
   });
 
   itIfSupports("comments", "change column comment", async () => {
-    await (ctx as any).changeColumnComment("commenteds", "id", "Edited column comment");
+    await (adapter as any).changeColumnComment("commenteds", "id", "Edited column comment");
     const col = (await (adapter as any).columns("commenteds")).find((c: any) => c.name === "id")!;
     expect(col.comment).toBe("Edited column comment");
     if (adapterType === "mysql") {
@@ -201,7 +204,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "change column comment to nil", async () => {
-    await (ctx as any).changeColumnComment("commenteds", "name", null);
+    await (adapter as any).changeColumnComment("commenteds", "name", null);
     const col = (await (adapter as any).columns("commenteds")).find((c: any) => c.name === "name")!;
     expect(col.comment).toBeNull();
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -41,7 +41,7 @@ import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
-import { singularize, pluralize, getCrypto, isPresent } from "@blazetrails/activesupport";
+import { singularize, pluralize, getCrypto, isPresent, presence } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 import { rubyInspect } from "../../relation/ruby-inspect.js";
 import { Utils as PgUtils } from "../postgresql/utils.js";
@@ -396,12 +396,9 @@ export class SchemaStatements {
     // Rails: if supports_comments? && !supports_comments_in_create?
     //   change_table_comment(table_name, comment) if options[:comment].present?
     if (this.adapter.supportsComments?.() && !this.adapter.supportsCommentsInCreate?.()) {
-      if (
-        options.comment != null &&
-        options.comment.length > 0 &&
-        typeof this.adapter.changeTableComment === "function"
-      ) {
-        await this.adapter.changeTableComment(name, options.comment);
+      const tableComment = presence(options.comment);
+      if (tableComment != null && typeof this.adapter.changeTableComment === "function") {
+        await this.adapter.changeTableComment(name, tableComment);
       }
       // Mirrors Rails: adapters that can't inline column comments in CREATE
       // emit a COMMENT ON COLUMN per column so inline `comment:` options
@@ -416,8 +413,8 @@ export class SchemaStatements {
           name: string;
           options?: { comment?: string | null };
         }>) {
-          const columnComment = column.options?.comment;
-          if (columnComment != null && String(columnComment).length > 0) {
+          const columnComment = presence(column.options?.comment);
+          if (columnComment != null) {
             await commentAdapter.changeColumnComment(name, column.name, columnComment);
           }
         }

--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -5,7 +5,6 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { adapterType } from "./test-adapter.js";
-import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./schema-dumper.js";
 import { fixtures } from "./test-fixtures.js";
 import { itIfSupports } from "./support/supports.js";
@@ -24,7 +23,6 @@ describe("DateTimePrecisionTest", () => {
   // a wrapping (PG-poisoning) transaction.
   fixtures({}, { useTransactionalTests: false });
   let adapter: DatabaseAdapter;
-  let ctx: MigrationContext;
 
   // Rails: `foos` is not a schema.rb fixture table — each test builds it with
   // `create_table(:foos, force: true)` for the precision under test and the
@@ -32,10 +30,9 @@ describe("DateTimePrecisionTest", () => {
   // here rather than seeding a placeholder into the canonical schema.
   beforeEach(async () => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
   });
   afterEach(async () => {
-    await ctx.dropTable("foos", { ifExists: true });
+    await adapter.dropTable("foos", { ifExists: true });
   });
   function makeFoo() {
     class Foo extends Base {
@@ -46,9 +43,9 @@ describe("DateTimePrecisionTest", () => {
   }
 
   itIfSupports("datetime_with_precision", "datetime data type with precision", async () => {
-    await ctx.createTable("foos", { force: true }, () => {});
-    await ctx.addColumn("foos", "created_at", "datetime", { precision: 0 });
-    await ctx.addColumn("foos", "updated_at", "datetime", { precision: 5 });
+    await adapter.createTable("foos", { force: true }, () => {});
+    await adapter.addColumn("foos", "created_at", "datetime", { precision: 0 });
+    await adapter.addColumn("foos", "updated_at", "datetime", { precision: 5 });
     const Foo = makeFoo();
     await Foo.loadSchema();
     expect((Foo.columnsHash() as any)["created_at"].precision).toBe(0);
@@ -59,9 +56,9 @@ describe("DateTimePrecisionTest", () => {
     "datetime_with_precision",
     "datetime precision is truncated on assignment",
     async () => {
-      await ctx.createTable("foos", { force: true }, () => {});
-      await ctx.addColumn("foos", "created_at", "datetime", { precision: 0 });
-      await ctx.addColumn("foos", "updated_at", "datetime", { precision: 6 });
+      await adapter.createTable("foos", { force: true }, () => {});
+      await adapter.addColumn("foos", "created_at", "datetime", { precision: 0 });
+      await adapter.addColumn("foos", "updated_at", "datetime", { precision: 6 });
       const Foo = makeFoo();
       await Foo.loadSchema();
       const time = Temporal.Instant.from("2000-01-01T12:00:00.123456789Z");
@@ -79,7 +76,7 @@ describe("DateTimePrecisionTest", () => {
     "datetime_with_precision",
     "no datetime precision isnt truncated on assignment",
     async () => {
-      await ctx.createTable("foos", { force: true }, (t) => {
+      await adapter.createTable("foos", { force: true }, (t) => {
         t.datetime("happened_at");
       });
       const Foo = makeFoo();
@@ -92,7 +89,7 @@ describe("DateTimePrecisionTest", () => {
   );
 
   itIfSupports("datetime_with_precision", "timestamps helper with custom precision", async () => {
-    await ctx.createTable("foos", { force: true }, (t) => {
+    await adapter.createTable("foos", { force: true }, (t) => {
       t.timestamps({ precision: 4 });
     });
     const Foo = makeFoo();
@@ -105,7 +102,7 @@ describe("DateTimePrecisionTest", () => {
     "datetime_with_precision",
     "passing precision to datetime does not set limit",
     async () => {
-      await ctx.createTable("foos", { force: true }, (t) => {
+      await adapter.createTable("foos", { force: true }, (t) => {
         t.timestamps({ precision: 4 });
       });
       const Foo = makeFoo();
@@ -117,7 +114,7 @@ describe("DateTimePrecisionTest", () => {
 
   itIfSupports("datetime_with_precision", "invalid datetime precision raises error", async () => {
     await expect(
-      ctx.createTable("foos", { force: true }, (t) => {
+      adapter.createTable("foos", { force: true }, (t) => {
         t.timestamps({ precision: 7 });
       }),
     ).rejects.toThrow(ArgumentError);
@@ -127,9 +124,9 @@ describe("DateTimePrecisionTest", () => {
     "datetime_with_precision",
     "formatting datetime according to precision",
     async () => {
-      await ctx.createTable("foos", { force: true }, () => {});
-      await ctx.addColumn("foos", "created_at", "datetime", { precision: 0 });
-      await ctx.addColumn("foos", "updated_at", "datetime", { precision: 4 });
+      await adapter.createTable("foos", { force: true }, () => {});
+      await adapter.addColumn("foos", "created_at", "datetime", { precision: 0 });
+      await adapter.addColumn("foos", "updated_at", "datetime", { precision: 4 });
       const Foo = makeFoo();
       await Foo.loadSchema();
 
@@ -184,7 +181,7 @@ describe("DateTimePrecisionTest", () => {
   );
 
   itIfSupports("datetime_with_precision", "writing a blank attribute", async () => {
-    await ctx.createTable("foos", { force: true }, (t) => {
+    await adapter.createTable("foos", { force: true }, (t) => {
       t.datetime("happened_at");
     });
     const Foo = makeFoo();
@@ -196,7 +193,7 @@ describe("DateTimePrecisionTest", () => {
   });
 
   itIfSupports("datetime_with_precision", "writing a date attribute", async () => {
-    await ctx.createTable("foos", { force: true }, (t) => {
+    await adapter.createTable("foos", { force: true }, (t) => {
       t.datetime("happened_at");
     });
     const Foo = makeFoo();
@@ -236,7 +233,7 @@ describe("DateTimePrecisionTest", () => {
     "datetime_with_precision",
     "schema dump with default precision is not dumped",
     async () => {
-      await ctx.createTable("foos", { force: true }, (t) => {
+      await adapter.createTable("foos", { force: true }, (t) => {
         t.timestamps({ precision: 6 });
       });
       const output = await SchemaDumper.dumpTableSchema(adapter, "foos");
@@ -249,7 +246,7 @@ describe("DateTimePrecisionTest", () => {
     "datetime_with_precision",
     "schema dump with without precision has precision as nil",
     async () => {
-      await ctx.createTable("foos", { force: true }, (t) => {
+      await adapter.createTable("foos", { force: true }, (t) => {
         t.timestamps({ precision: null });
       });
       const output = await SchemaDumper.dumpTableSchema(adapter, "foos");

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -26,7 +26,6 @@ import { ValueType } from "@blazetrails/activemodel";
 import { TimeWithZone, getZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
-import { MigrationContext } from "./migration.js";
 import { itIfSupports } from "./support/supports.js";
 import { describeIfPg } from "./support/describe-if-pg.js";
 import { withTimezoneConfig } from "./test-helper.js";
@@ -811,15 +810,14 @@ describe("DirtyTest", () => {
     const Testings = class extends Base {
       static tableName = "testings";
     };
-    const ctx = new MigrationContext(Base.connection);
     try {
-      await ctx.createTable("testings", { force: true }, (t) => {
+      await Base.connection.createTable("testings", { force: true }, (t) => {
         t.string("field");
       });
       await Testings.loadSchema();
       expect(() => new Testings().attributes).not.toThrow();
     } finally {
-      await ctx.dropTable("testings", { ifExists: true });
+      await Base.connection.dropTable("testings", { ifExists: true });
     }
   });
 

--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { adapterType } from "./test-adapter.js";
-import { MigrationContext } from "./migration.js";
 import { PreparedStatementCacheExpired } from "./errors.js";
 import type { StatementPool } from "./connection-adapters/postgresql-adapter.js";
 import { fixtures } from "./test-fixtures.js";
@@ -57,8 +56,7 @@ describe("HotCompatibilityTest", () => {
     adapter: DatabaseAdapter;
   }> {
     const adapter = Base.connection;
-    const migration = new MigrationContext(adapter);
-    await migration.createTable("hot_compatibilities", { force: true }, (t) => {
+    await adapter.createTable("hot_compatibilities", { force: true }, (t) => {
       t.string("foo");
       t.string("bar");
     });
@@ -79,7 +77,7 @@ describe("HotCompatibilityTest", () => {
       expect(klass.columns().length).toBe(3);
 
       // remove one of them
-      await new MigrationContext(adapter).removeColumn("hot_compatibilities", "bar");
+      await adapter.removeColumn("hot_compatibilities", "bar");
 
       // we still have 3 columns in the cache
       expect(klass.columns().length).toBe(3);
@@ -90,7 +88,7 @@ describe("HotCompatibilityTest", () => {
       await record.reload();
       expect((record as unknown as { foo: string }).foo).toBe("foo");
     } finally {
-      await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
+      await adapter.dropTable("hot_compatibilities", { ifExists: true });
     }
   });
 
@@ -99,7 +97,7 @@ describe("HotCompatibilityTest", () => {
     try {
       const record = await klass.createBang({ foo: "foo" });
       expect(klass.columns().length).toBe(3);
-      await new MigrationContext(adapter).removeColumn("hot_compatibilities", "bar");
+      await adapter.removeColumn("hot_compatibilities", "bar");
       expect(klass.columns().length).toBe(3);
 
       await record.reload();
@@ -109,7 +107,7 @@ describe("HotCompatibilityTest", () => {
       await record.reload();
       expect((record as unknown as { foo: string }).foo).toBe("bar");
     } finally {
-      await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
+      await adapter.dropTable("hot_compatibilities", { ifExists: true });
     }
   });
 
@@ -123,7 +121,7 @@ describe("HotCompatibilityTest", () => {
     staleReload: (model: typeof Base, record: { reload(): Promise<unknown> }) => Promise<unknown>,
   ): Promise<void> {
     const adapter = Base.connection;
-    await new MigrationContext(adapter).createTable("hot_compatibilities", { force: true }, (t) => {
+    await adapter.createTable("hot_compatibilities", { force: true }, (t) => {
       t.string("foo");
       t.string("bar");
     });
@@ -142,7 +140,7 @@ describe("HotCompatibilityTest", () => {
       expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
 
       // add a new column on the second connection
-      await new MigrationContext(ddlConnection).addColumn("hot_compatibilities", "baz", "string");
+      await ddlConnection.addColumn("hot_compatibilities", "baz", "string");
 
       await expect(staleReload(HotCompatibility, record)).rejects.toBeInstanceOf(
         PreparedStatementCacheExpired,
@@ -150,7 +148,7 @@ describe("HotCompatibilityTest", () => {
 
       expect(preparedStatementCacheSize(adapter)).toBe(0);
     } finally {
-      await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
+      await adapter.dropTable("hot_compatibilities", { ifExists: true });
     }
   }
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeEach, afterAll, afterEach, vi } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { BigDecimal } from "@blazetrails/activesupport";
-import { Base, MigrationContext, Migrator, RecordNotUnique, StatementInvalid } from "./index.js";
+import { Base, Migrator, RecordNotUnique, StatementInvalid } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import { ConcurrentMigrationError } from "./migration.js";
@@ -42,12 +42,6 @@ import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
 import { leaseMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
-
-async function freshContext(): Promise<{ adapter: DatabaseAdapter; ctx: MigrationContext }> {
-  const adapter = Base.connection;
-  const ctx = new MigrationContext(adapter);
-  return { adapter, ctx };
-}
 
 // The migration-on-`people` tests (Rails runs `add_column/remove_column
 // "people", "last_name"` through a `Migrator`) need the canonical `people`
@@ -96,8 +90,8 @@ async function personColumnNames(adp: DatabaseAdapter): Promise<string[]> {
 // Rails runs every migration test on `ActiveRecord::Base.connection`; ride the
 // schema-loaded primary pool established by `fixtures()` rather than a
 // sidecar `_pool` lease (RFC 0059). Nothing clears tables between tests, so
-// this file owns the per-test cleanup of the bespoke tables its
-// `MigrationContext` sub-describes create — see the afterEach/afterAll below
+// this file owns the per-test cleanup of the bespoke tables its DDL
+// sub-describes create — see the afterEach/afterAll below
 // and each test's own `finally`.
 fixtures({}, { useTransactionalTests: false });
 
@@ -106,15 +100,9 @@ fixtures({}, { useTransactionalTests: false });
 // clears recorded versions — so sibling files see the pristine canonical shape.
 afterEach(async () => {
   const adapter = Base.connection;
-  const ctx = new MigrationContext(adapter);
   try {
-    // Gate the drop on the ADAPTER's live introspection, not `removeColumn`'s
-    // own `ifExists` short-circuit: the MigrationContext column cache may be
-    // empty for the freshly created `people` table, so an
-    // `ifExists` check would consult that empty cache, conclude last_name is
-    // absent, skip the drop, and leak the column into the next test.
     if (await (adapter as any).columnExists("people", "last_name")) {
-      await ctx.removeColumn("people", "last_name");
+      await adapter.removeColumn("people", "last_name");
     }
   } catch {
     /* column absent / adapter without the column — nothing to strip */
@@ -129,7 +117,7 @@ afterEach(async () => {
     // truncate-only reset never clears it; the InternalMetadata tests below
     // each build it fresh and assert on its rows/existence, so drop it between
     // tests (Rails' teardown does the same) to keep them independent.
-    await ctx.dropTable("ar_internal_metadata", { ifExists: true });
+    await adapter.dropTable("ar_internal_metadata", { ifExists: true });
   } catch {
     /* nothing to strip */
   }
@@ -143,37 +131,37 @@ afterEach(async () => {
 // `memberships`, `values`, …) are deliberately NOT in this list: dropping a
 // canonical table would corrupt siblings that ride it.
 afterAll(async () => {
-  const { ctx } = await freshContext();
+  const adapter = Base.connection;
   const o = { ifExists: true } as const;
-  await ctx.dropTable("big_numbers", o);
-  await ctx.dropTable("binary_testings", o);
-  await ctx.dropTable("bk1", o);
-  await ctx.dropTable("bk2", o);
-  await ctx.dropTable("bk3", o);
-  await ctx.dropTable("bk4", o);
-  await ctx.dropTable("bk5", o);
-  await ctx.dropTable("bk6", o);
-  await ctx.dropTable("bk7", o);
-  await ctx.dropTable("bk_idx", o);
-  await ctx.dropTable("nonexistent", o);
-  await ctx.dropTable("old_name", o);
-  await ctx.dropTable("pend_t", o);
-  await ctx.dropTable("people_src", o);
-  await ctx.dropTable("people_src2", o);
-  await ctx.dropTable("pre_new_suf", o);
-  await ctx.dropTable("pre_old_suf", o);
-  await ctx.dropTable("rv_bulk", o);
-  await ctx.dropTable("something", o);
-  await ctx.dropTable("table_from_query_testings", o);
-  await ctx.dropTable("table_from_query_testings2", o);
-  await ctx.dropTable("test_binary_limits", o);
-  await ctx.dropTable("test_integer_limits", o);
-  await ctx.dropTable("test_text_limits", o);
-  await ctx.dropTable("test_text_sizes", o);
-  await ctx.dropTable("testings", o);
-  await ctx.dropTable("things", o);
-  await ctx.dropTable("widgets", o);
-  await ctx.dropTable("wtx_test", o);
+  await adapter.dropTable("big_numbers", o);
+  await adapter.dropTable("binary_testings", o);
+  await adapter.dropTable("bk1", o);
+  await adapter.dropTable("bk2", o);
+  await adapter.dropTable("bk3", o);
+  await adapter.dropTable("bk4", o);
+  await adapter.dropTable("bk5", o);
+  await adapter.dropTable("bk6", o);
+  await adapter.dropTable("bk7", o);
+  await adapter.dropTable("bk_idx", o);
+  await adapter.dropTable("nonexistent", o);
+  await adapter.dropTable("old_name", o);
+  await adapter.dropTable("pend_t", o);
+  await adapter.dropTable("people_src", o);
+  await adapter.dropTable("people_src2", o);
+  await adapter.dropTable("pre_new_suf", o);
+  await adapter.dropTable("pre_old_suf", o);
+  await adapter.dropTable("rv_bulk", o);
+  await adapter.dropTable("something", o);
+  await adapter.dropTable("table_from_query_testings", o);
+  await adapter.dropTable("table_from_query_testings2", o);
+  await adapter.dropTable("test_binary_limits", o);
+  await adapter.dropTable("test_integer_limits", o);
+  await adapter.dropTable("test_text_limits", o);
+  await adapter.dropTable("test_text_sizes", o);
+  await adapter.dropTable("testings", o);
+  await adapter.dropTable("things", o);
+  await adapter.dropTable("widgets", o);
+  await adapter.dropTable("wtx_test", o);
 });
 
 function internalMetadataExistsSql(kind: typeof adapterType): string {
@@ -221,15 +209,18 @@ describe("MigrationTest", () => {
   });
 
   it("rename table with prefix and suffix", async () => {
-    const { adapter, ctx } = await freshContext();
-    ctx.tableNamePrefix = "pre_";
-    ctx.tableNameSuffix = "_suf";
+    const adapter = Base.connection;
+    const migration = anonymousMigration();
+    Base.tableNamePrefix = "pre_";
+    Base.tableNameSuffix = "_suf";
     // Own the scratch tables for the whole test: nothing clears tables between
     // tests, so a leaked `pre_old_suf`/`pre_new_suf` would break the
     // create/rename below, so clear any leak up front and drop in the finally.
-    await ctx.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
+    await adapter.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
     try {
-      await ctx.createTable("pre_old_suf", {}, (t) => {
+      // Dropped in the finally under its prefixed/suffixed name.
+      // eslint-disable-next-line blazetrails/require-table-teardown
+      await migration.createTable("old", {}, (t) => {
         t.string("content");
       });
       await adapter.executeMutation(
@@ -240,11 +231,13 @@ describe("MigrationTest", () => {
       );
       expect(before[0].content).toBe("hello world");
 
-      await ctx.renameTable("old", "new");
+      await migration.renameTable("old", "new");
       const after = await adapter.execute(`SELECT * FROM ${adapter.quoteTableName("pre_new_suf")}`);
       expect(after[0].content).toBe("hello world");
     } finally {
-      await ctx.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
+      Base.tableNamePrefix = "";
+      Base.tableNameSuffix = "";
+      await adapter.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
     }
   });
 
@@ -272,22 +265,21 @@ describe("MigrationTest", () => {
       };
       await adapter.createSchema("my_schema");
       try {
-        const ctx = new MigrationContext(adapter);
         // Torn down via dropSchema("my_schema") in the finally below (which
         // drops the schema and its tables); the lint rule only tracks dropTable.
         // eslint-disable-next-line blazetrails/require-table-teardown
-        await ctx.createTable("my_schema.values", { force: true }, (t) => {
+        await adapter.createTable("my_schema.values", { force: true }, (t) => {
           t.integer("value");
         });
 
         // Assert through the adapter's live `index_exists?` (Rails uses
-        // `connection.index_exists?`), not MigrationContext's in-memory
+        // `connection.index_exists?`), not any in-memory
         // bookkeeping, so a schema-qualified adapter bug can't slip past a
         // stale-but-correct cache.
-        await ctx.addIndex("my_schema.values", "value");
+        await adapter.addIndex("my_schema.values", "value");
         expect(await adapter.indexExists("my_schema.values", "value")).toBe(true);
 
-        await ctx.removeIndex("my_schema.values", { column: "value" });
+        await adapter.removeIndex("my_schema.values", { column: "value" });
         expect(await adapter.indexExists("my_schema.values", "value")).toBe(false);
       } finally {
         await adapter.dropSchema("my_schema");
@@ -310,7 +302,7 @@ async function freshAdapter(): Promise<DatabaseAdapter> {
 // ==========================================================================
 // D-1 partial conversion: columnsHash()-only tests drop their adapter assignment
 // (adapter-independent). The 3 DB-operation tests and the DDL sub-describes retain
-// freshAdapterWithPeople()/await freshContext() isolation.
+// freshAdapterWithPeople() isolation.
 describe("MigrationTest", () => {
   let adapter: DatabaseAdapter;
 
@@ -325,18 +317,18 @@ describe("MigrationTest", () => {
   });
 
   it("create table raises if already exists", async () => {
-    const { ctx } = await freshContext();
+    const adapter = Base.connection;
     try {
-      await ctx.createTable("testings", { force: true }, (t) => {
+      await adapter.createTable("testings", { force: true }, (t) => {
         t.string("foo");
       });
       await expect(
-        ctx.createTable("testings", {}, (t) => {
+        adapter.createTable("testings", {}, (t) => {
           t.string("foo");
         }),
       ).rejects.toThrow(StatementInvalid);
     } finally {
-      await ctx.dropTable("testings", { ifExists: true });
+      await adapter.dropTable("testings", { ifExists: true });
     }
   });
 
@@ -362,10 +354,10 @@ describe("MigrationTest", () => {
     // `big_numbers` with decimal columns carrying explicit precision/scale, then
     // a BigNumber row is persisted and read back to assert the per-adapter
     // value/type semantics (the part the old columnsHash() stub dropped).
-    const { adapter, ctx } = await freshContext();
-    await ctx.dropTable("big_numbers", { ifExists: true });
+    const adapter = Base.connection;
+    await adapter.dropTable("big_numbers", { ifExists: true });
     // GiveMeBigNumbers.up
-    await ctx.createTable("big_numbers", {}, (t) => {
+    await adapter.createTable("big_numbers", {}, (t) => {
       t.column("bank_balance", "decimal", { precision: 10, scale: 2 });
       t.column("big_bank_balance", "decimal", { precision: 15, scale: 2 });
       t.column("world_population", "decimal", { precision: 20 });
@@ -374,7 +366,7 @@ describe("MigrationTest", () => {
     });
 
     // The persisted column precision/scale survive the create_table path.
-    const cols = await ctx.columns("big_numbers");
+    const cols = await adapter.columns("big_numbers");
     const byName = (n: string) => cols.find((c) => c.name === n)!;
     expect(byName("bank_balance").precision).toBe(10);
     expect(byName("bank_balance").scale).toBe(2);
@@ -453,7 +445,7 @@ describe("MigrationTest", () => {
         expect(valueOfE).toBe(2);
       }
     } finally {
-      await ctx.dropTable("big_numbers", { ifExists: true });
+      await adapter.dropTable("big_numbers", { ifExists: true });
     }
   });
 
@@ -493,7 +485,7 @@ describe("MigrationTest", () => {
   });
 
   it("schema migrations table name", async () => {
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const schemaMigration = new SchemaMigration(adapter);
     const originalTableName = Base.schemaMigrationsTableName;
     const savedPrefix = Base.tableNamePrefix;
@@ -523,32 +515,31 @@ describe("MigrationTest", () => {
 
   it.skipIf(adapterType === "sqlite")("out of range integer limit should raise", async () => {
     const adapter = await freshAdapter();
-    const ctx = new MigrationContext(adapter);
-    const error = await ctx
+    const error = await adapter
       .createTable("test_integer_limits", { force: true }, (t) => {
         t.column("bigone", "integer", { limit: 10 });
       })
       .catch((e) => e);
     expect(error).toBeInstanceOf(ArgumentError);
     expect(error.message).toContain("No integer type has byte size 10");
-    await ctx.dropTable("test_integer_limits", { ifExists: true });
+    await adapter.dropTable("test_integer_limits", { ifExists: true });
   });
 
   it("create table with binary column", async () => {
     // Rails creates `binary_testings` with a `t.column "data", :binary,
     // null: false` and asserts the persisted column's default is nil. Drive the
     // live create_table path and introspect the column.
-    const { ctx } = await freshContext();
-    await ctx.dropTable("binary_testings", { ifExists: true });
-    await ctx.createTable("binary_testings", {}, (t) => {
+    const adapter = Base.connection;
+    await adapter.dropTable("binary_testings", { ifExists: true });
+    await adapter.createTable("binary_testings", {}, (t) => {
       t.column("data", "binary", { null: false });
     });
-    const cols = await ctx.columns("binary_testings");
+    const cols = await adapter.columns("binary_testings");
     const dataColumn = cols.find((c) => c.name === "data");
     expect(dataColumn).toBeDefined();
     expect(dataColumn!.type).toBe("binary");
     expect(dataColumn!.default ?? null).toBeNull();
-    await ctx.dropTable("binary_testings", { ifExists: true });
+    await adapter.dropTable("binary_testings", { ifExists: true });
   });
 
   it("proper table name on migration", () => {
@@ -766,65 +757,65 @@ describe("MigrationTest", () => {
   });
 
   it("create table with if not exists true", async () => {
-    const { ctx } = await freshContext();
+    const adapter = Base.connection;
     // Nothing clears tables between tests, so a leaked `things` from
     // a sibling file would make the first, non-ifNotExists create raise; clear
     // any leak up front and drop in the finally so DDL stays confined here.
-    await ctx.dropTable("things", { ifExists: true });
+    await adapter.dropTable("things", { ifExists: true });
     try {
-      await ctx.createTable("things", {}, (t) => {
+      await adapter.createTable("things", {}, (t) => {
         t.string("name");
       });
-      await ctx.createTable("things", { ifNotExists: true }, (t) => {
+      await adapter.createTable("things", { ifNotExists: true }, (t) => {
         t.string("name");
       });
-      expect(await ctx.tableExists("things")).toBe(true);
+      expect(await adapter.tableExists("things")).toBe(true);
     } finally {
-      await ctx.dropTable("things", { ifExists: true });
+      await adapter.dropTable("things", { ifExists: true });
     }
   });
 
   it("create table raises for long table names", async () => {
-    const { ctx } = await freshContext();
+    const adapter = Base.connection;
     const longName = "a".repeat(65);
-    await expect(ctx.createTable(longName, {})).rejects.toThrow(/too long/);
+    await expect(adapter.createTable(longName, {})).rejects.toThrow(/too long/);
   });
 
   it("create table with force and if not exists", async () => {
-    const { ctx } = await freshContext();
-    await expect(ctx.createTable("things", { force: true, ifNotExists: true })).rejects.toThrow(
+    const adapter = Base.connection;
+    await expect(adapter.createTable("things", { force: true, ifNotExists: true })).rejects.toThrow(
       /cannot be used simultaneously/i,
     );
   });
 
   it("create table with indexes and if not exists true", async () => {
-    const { ctx } = await freshContext();
+    const adapter = Base.connection;
     // Own the scratch table for the whole test: nothing clears tables between
     // tests, so a leaked `things`
     // would make the first, non-ifNotExists create raise. Clear any leak up
     // front and drop in the finally so DDL stays confined to this test.
-    await ctx.dropTable("things", { ifExists: true });
+    await adapter.dropTable("things", { ifExists: true });
     try {
-      await ctx.createTable("things", {}, (t) => {
+      await adapter.createTable("things", {}, (t) => {
         t.string("name");
       });
-      await ctx.addIndex("things", "name");
-      await ctx.createTable("things", { ifNotExists: true }, (t) => {
+      await adapter.addIndex("things", "name");
+      await adapter.createTable("things", { ifNotExists: true }, (t) => {
         t.string("name");
       });
-      expect(await ctx.tableExists("things")).toBe(true);
+      expect(await adapter.tableExists("things")).toBe(true);
     } finally {
-      await ctx.dropTable("things", { ifExists: true });
+      await adapter.dropTable("things", { ifExists: true });
     }
   });
 
   it("create table with force true does not drop nonexisting table", async () => {
-    const { ctx } = await freshContext();
-    expect(await ctx.tableExists("nonexistent")).toBe(false);
-    await ctx.createTable("nonexistent", { force: true }, (t) => {
+    const adapter = Base.connection;
+    expect(await adapter.tableExists("nonexistent")).toBe(false);
+    await adapter.createTable("nonexistent", { force: true }, (t) => {
       t.string("name");
     });
-    expect(await ctx.tableExists("nonexistent")).toBe(true);
+    expect(await adapter.tableExists("nonexistent")).toBe(true);
   });
 
   it("remove column with if exists set", async () => {
@@ -1054,7 +1045,7 @@ describe("MigrationTest", () => {
   });
 
   it("internal metadata table name", async () => {
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
     const internalMetadata = new InternalMetadata(adapter);
     const originalTableName = Base.internalMetadataTableName;
@@ -1078,7 +1069,7 @@ describe("MigrationTest", () => {
   });
 
   it("internal metadata stores environment when migration fails", async () => {
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
     const im = new InternalMetadata(adapter);
     await im.createTable();
@@ -1104,7 +1095,7 @@ describe("MigrationTest", () => {
   });
 
   it("internal metadata stores environment when other data exists", async () => {
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
     const im = new InternalMetadata(adapter);
     await im.createTable();
@@ -1122,7 +1113,7 @@ describe("MigrationTest", () => {
   });
 
   it("internal metadata not used when not enabled", async () => {
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
 
     const im = new InternalMetadata(adapter, { enabled: false });
@@ -1144,7 +1135,7 @@ describe("MigrationTest", () => {
   });
 
   it("inserting a new entry into internal metadata", async () => {
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
     const im = new InternalMetadata(adapter);
     await im.createTable();
@@ -1157,7 +1148,7 @@ describe("MigrationTest", () => {
   });
 
   it("updating an existing entry into internal metadata", async () => {
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
     const im = new InternalMetadata(adapter);
     await im.createTable();
@@ -1171,7 +1162,7 @@ describe("MigrationTest", () => {
     // invalidated after DDL rollback. Our tableExists() queries live (no cache),
     // so we verify the idempotent commit path instead — the underlying invariant
     // (no stale cache blocking re-creation) holds trivially in our implementation.
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
     const im = new InternalMetadata(adapter);
 
@@ -1206,7 +1197,7 @@ describe("MigrationTest", () => {
     // tableExists() queries live (no schema cache), so create_table is always
     // re-entrant across transactions. Verify that successive createTable() +
     // createVersion() pairs work correctly — the IF NOT EXISTS guard is idempotent.
-    const { adapter } = await freshContext();
+    const adapter = Base.connection;
     const sm = new SchemaMigration(adapter);
 
     // First transaction: create + write + commit
@@ -1301,35 +1292,33 @@ describe("MigrationTest", () => {
 
   it("create table with query", async () => {
     const adapter = await freshAdapter();
-    const ctx = new MigrationContext(adapter);
-    await ctx.createTable("people_src", {}, (t) => {
+    await adapter.createTable("people_src", {}, (t) => {
       t.integer("person_id");
     });
     // Unquoted lowercase identifiers parse identically on PG/SQLite/MySQL;
     // Rails-style `"…"` quoting is a string literal on MySQL.
     await adapter.executeMutation(`INSERT INTO people_src (person_id) VALUES (1)`);
 
-    await ctx.createTable("table_from_query_testings", {
+    await adapter.createTable("table_from_query_testings", {
       as: `SELECT person_id FROM people_src WHERE person_id = 1`,
     });
     const rows = await adapter.execute(`SELECT * FROM table_from_query_testings`);
     expect(rows).toHaveLength(1);
-    expect(await ctx.columnExists("table_from_query_testings", "person_id")).toBe(true);
+    expect(await adapter.columnExists("table_from_query_testings", "person_id")).toBe(true);
 
     // The CTAS column derivation reads back through the adapter's own
     // `columns()` (Rails `new_column_from_field`), so the persisted type is the
     // Rails-canonical name (not the raw catalog string).
-    const cols = await ctx.columns("table_from_query_testings");
+    const cols = await adapter.columns("table_from_query_testings");
     const pid = cols.find((c) => c.name === "person_id");
     expect(pid?.type).toBe("integer");
 
-    await ctx.dropTable("table_from_query_testings", "people_src");
+    await adapter.dropTable("table_from_query_testings", "people_src");
   });
 
   it("create table with query from relation", async () => {
     const adapter = await freshAdapter();
-    const ctx = new MigrationContext(adapter);
-    await ctx.createTable("people_src2", {}, (t) => {
+    await adapter.createTable("people_src2", {}, (t) => {
       t.integer("person_id");
     });
     await adapter.executeMutation(`INSERT INTO people_src2 (person_id) VALUES (1)`);
@@ -1339,29 +1328,28 @@ describe("MigrationTest", () => {
     const t = adapter.quoteTableName("people_src2");
     const c = `${t}.${adapter.quoteColumnName("person_id")}`;
     const sql = `SELECT ${c} FROM ${t} WHERE ${c} = 1`;
-    await ctx.createTable("table_from_query_testings2", { as: sql });
+    await adapter.createTable("table_from_query_testings2", { as: sql });
     const rows = await adapter.execute(`SELECT * FROM table_from_query_testings2`);
     expect(rows).toHaveLength(1);
 
-    await ctx.dropTable("table_from_query_testings2", "people_src2");
+    await adapter.dropTable("table_from_query_testings2", "people_src2");
   });
 
   it.skipIf(adapterType !== "sqlite")(
     "allows sqlite3 rollback on invalid column type",
     async () => {
       const adapter = await freshAdapter();
-      const ctx = new MigrationContext(adapter);
-      await ctx.createTable("something", { force: true }, (t) => {
+      await adapter.createTable("something", { force: true }, (t) => {
         t.integer("number");
         t.string("name");
         t.column("foo", "bar" as any);
       });
-      expect(await ctx.columnExists("something", "foo")).toBe(true);
-      await ctx.removeColumn("something", "foo");
-      expect(await ctx.columnExists("something", "foo")).toBe(false);
-      expect(await ctx.columnExists("something", "name")).toBe(true);
-      expect(await ctx.columnExists("something", "number")).toBe(true);
-      await ctx.dropTable("something");
+      expect(await adapter.columnExists("something", "foo")).toBe(true);
+      await adapter.removeColumn("something", "foo");
+      expect(await adapter.columnExists("something", "foo")).toBe(false);
+      expect(await adapter.columnExists("something", "name")).toBe(true);
+      expect(await adapter.columnExists("something", "number")).toBe(true);
+      await adapter.dropTable("something");
     },
   );
 
@@ -1491,34 +1479,31 @@ describe("MigrationTest", () => {
 
   it.skipIf(adapterType === "sqlite")("out of range text limit should raise", async () => {
     const adapter = await freshAdapter();
-    const ctx = new MigrationContext(adapter);
-    const error = await ctx
+    const error = await adapter
       .createTable("test_text_limits", { force: true }, (t) => {
         t.text("bigtext", { limit: 0xfffffffff });
       })
       .catch((e) => e);
     expect(error).toBeInstanceOf(ArgumentError);
     expect(error.message).toContain(`No text type has byte size ${0xfffffffff}`);
-    await ctx.dropTable("test_text_limits", { ifExists: true });
+    await adapter.dropTable("test_text_limits", { ifExists: true });
   });
 
   it.skipIf(adapterType === "sqlite")("out of range binary limit should raise", async () => {
     const adapter = await freshAdapter();
-    const ctx = new MigrationContext(adapter);
-    const error = await ctx
+    const error = await adapter
       .createTable("test_binary_limits", { force: true }, (t) => {
         t.binary("bigbinary", { limit: 0xfffffffff });
       })
       .catch((e) => e);
     expect(error).toBeInstanceOf(ArgumentError);
     expect(error.message).toContain(`No binary type has byte size ${0xfffffffff}`);
-    await ctx.dropTable("test_binary_limits", { ifExists: true });
+    await adapter.dropTable("test_binary_limits", { ifExists: true });
   });
 
   it.skipIf(adapterType !== "mysql")("invalid text size should raise", async () => {
     const adapter = await freshAdapter();
-    const ctx = new MigrationContext(adapter);
-    const error = await ctx
+    const error = await adapter
       .createTable("test_text_sizes", { force: true }, (t) => {
         t.text("bigtext", { size: 0xfffffffff } as any);
       })
@@ -1527,7 +1512,7 @@ describe("MigrationTest", () => {
     expect(error.message).toBe(
       `${0xfffffffff} is invalid :size value. Only :tiny, :medium, and :long are allowed.`,
     );
-    await ctx.dropTable("test_text_sizes", { ifExists: true });
+    await adapter.dropTable("test_text_sizes", { ifExists: true });
   });
   describe("ReservedWordsMigrationTest", () => {
     it("drop index from table named values", async () => {

--- a/packages/activerecord/src/schema-introspection.trails.test.ts
+++ b/packages/activerecord/src/schema-introspection.trails.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "./base.js";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-fixtures.js";
-import { MigrationContext } from "./migration.js";
 import {
   introspectTables,
   introspectColumns,
@@ -42,11 +41,10 @@ function withoutMethods<A extends object>(adapter: A, hidden: string[]): A {
 // sidecar test pool.
 fixtures({}, { useTransactionalTests: false });
 
-// The tables these tests create via MigrationContext leak into the shared
+// The tables these tests create leak into the shared
 // per-worker DB; drop them by name so they don't collide with sibling files.
 afterEach(async () => {
-  const ctx = new MigrationContext(Base.connection);
-  await ctx.dropTable("widgets", "more_testings", { ifExists: true });
+  await Base.connection.dropTable("widgets", "more_testings", { ifExists: true });
 });
 
 describe("introspectTables", () => {
@@ -67,9 +65,8 @@ describe("introspectTables", () => {
 
   it("falls back to SchemaStatements when the adapter doesn't implement tables()", async () => {
     const realAdapter = Base.connection;
-    const ctx = new MigrationContext(realAdapter);
-    await ctx.createTable("widgets", {}, () => {});
-    await ctx.createTable("more_testings", {}, () => {});
+    await realAdapter.createTable("widgets", {}, () => {});
+    await realAdapter.createTable("more_testings", {}, () => {});
 
     // Strip `tables()` so introspectTables routes through SchemaStatements.
     const stripped = withoutMethods(realAdapter, ["tables"]);
@@ -100,8 +97,7 @@ describe("introspectColumns", () => {
 
   it("falls back to SchemaStatements when the adapter doesn't implement columns()", async () => {
     const realAdapter = Base.connection;
-    const ctx = new MigrationContext(realAdapter);
-    await ctx.createTable("widgets", {}, (t) => {
+    await realAdapter.createTable("widgets", {}, (t) => {
       t.string("name");
       t.integer("age");
     });
@@ -135,11 +131,10 @@ describe("introspectIndexes", () => {
 
   it("falls back to SchemaStatements when the adapter doesn't implement indexes()", async () => {
     const realAdapter = Base.connection;
-    const ctx = new MigrationContext(realAdapter);
-    await ctx.createTable("widgets", {}, (t) => {
+    await realAdapter.createTable("widgets", {}, (t) => {
       t.string("name");
     });
-    await ctx.addIndex("widgets", ["name"], { name: "idx_widgets_name" });
+    await realAdapter.addIndex("widgets", ["name"], { name: "idx_widgets_name" });
 
     const stripped = withoutMethods(realAdapter, ["indexes"]);
 
@@ -154,12 +149,11 @@ describe("introspectIndexes", () => {
   it("surfaces where/orders carried by the fallback SchemaStatements.indexes()", async () => {
     const supportsPartial = adapterType === "sqlite" || adapterType === "postgres";
     const realAdapter = Base.connection;
-    const ctx = new MigrationContext(realAdapter);
-    await ctx.createTable("widgets", {}, (t) => {
+    await realAdapter.createTable("widgets", {}, (t) => {
       t.string("name");
       t.boolean("active");
     });
-    await ctx.addIndex("widgets", ["name"], {
+    await realAdapter.addIndex("widgets", ["name"], {
       name: "idx_widgets_name_partial",
       ...(supportsPartial ? { where: "active" } : {}),
       order: { name: "desc" },
@@ -196,11 +190,10 @@ describe("introspectIndexes", () => {
     "surfaces expression-index columns from the fallback SchemaStatements.indexes()",
     async () => {
       const realAdapter = Base.connection;
-      const ctx = new MigrationContext(realAdapter);
-      await ctx.createTable("widgets", {}, (t) => {
+      await realAdapter.createTable("widgets", {}, (t) => {
         t.string("name");
       });
-      await ctx.addIndex("widgets", "lower(name)", { name: "idx_widgets_lower_name" });
+      await realAdapter.addIndex("widgets", "lower(name)", { name: "idx_widgets_lower_name" });
 
       const stripped = withoutMethods(realAdapter, ["indexes"]);
 
@@ -250,8 +243,7 @@ describe("introspectPrimaryKey", () => {
 
   it("falls back to columns with primaryKey===true when adapter lacks primaryKey()", async () => {
     const realAdapter = Base.connection;
-    const ctx = new MigrationContext(realAdapter);
-    await ctx.createTable("widgets", {}, (t) => {
+    await realAdapter.createTable("widgets", {}, (t) => {
       t.string("name");
     });
 
@@ -312,8 +304,7 @@ describe("introspectForeignKeys", () => {
 
   it("returns [] from the SchemaStatements fallback when adapter lacks foreignKeys()", async () => {
     const realAdapter = Base.connection;
-    const ctx = new MigrationContext(realAdapter);
-    await ctx.createTable("widgets", {}, (t) => {
+    await realAdapter.createTable("widgets", {}, (t) => {
       t.string("name");
     });
 
@@ -329,8 +320,7 @@ describe("introspectForeignKeys", () => {
 
   it("returns [] for a real table with no foreign keys", async () => {
     const realAdapter = Base.connection;
-    const ctx = new MigrationContext(realAdapter);
-    await ctx.createTable("widgets", {}, (t) => {
+    await realAdapter.createTable("widgets", {}, (t) => {
       t.string("name");
     });
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -52,13 +52,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
-    "call": "presence",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
     "call": "validate_create_table_options!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Step 1 of 3 in freeing the `MigrationContext` name so trails' merged `Migrator`
can be split into Rails' `MigrationContext` + `Migrator` pair.

trails uses `MigrationContext` for a schema-DSL wrapper Rails has no counterpart
for — Rails' `MigrationContext` owns migration discovery and the migrate/up/down
entry points, and the schema DSL comes from `SchemaStatements` mixed into the
adapter (`connection.create_table`, `connection.add_index`, …). This PR points
callers at the adapter directly so the wrapper can be deleted in step 2.

Converted (purely mechanical, `ctx.<dsl>` → `adapter.<dsl>`):
`migration.test.ts`, `comment.test.ts`, `cache-key.test.ts`,
`date-time-precision.test.ts`, `dirty.test.ts`, `hot-compatibility.test.ts`,
`active-record-schema.test.ts`, `schema-introspection.trails.test.ts`.

Two spots that were not a pure rename:

- `rename table with prefix and suffix` — prefix/suffix application lives on
  `Migration` (`_pt` → `properTableName`), not on the adapter, exactly as in
  Rails, where the test sets `ActiveRecord::Base.table_name_prefix/suffix` and
  drives the rename through a migration. The test now sets
  `Base.tableNamePrefix/Suffix` and calls `Migration#renameTable`; the adapter
  still owns the fully-qualified drops in the `finally`.
- `migration.test.ts`'s `freshContext()` helper is gone; its callers take
  `Base.connection` directly (which is all `freshContext` ever returned).

Not in this PR, to stay under the 500-LOC ceiling — registered as
`route-remaining-migrationcontext-dsl-callers-onto-schema-statements`:
`schema-dumper.test.ts`, `defaults.test.ts`, `timestamp.test.ts`,
`schema-dumper.trails.test.ts`, `time-precision.test.ts`,
`bigint-roundtrip.test.ts`, the nine `associations/*.test.ts` callers,
`tasks/database-tasks.ts` and `pool.migrationContext`. `migration.trails.test.ts`'s
four cases are regression tests *of* the class itself and are expected to be
deleted with it in `delete-drained-migrationcontext-schema-dsl`.

One real divergence fell out of the conversion, fixed in the second commit:
`SchemaStatements#createTable` gated its post-CREATE comment statements on a
bare `length > 0`, so a whitespace-only `comment: " "` was written as a real
`COMMENT ON`. Rails gates on `td.comment.presence` / `column.comment.present?`
(abstract/schema_statements.rb:317-325), and MigrationContext's own copy
trimmed — so `CommentTest` only started failing once it ran through the
adapter. The adapter now uses `presence`, converging it with Rails.

443 LOC (adds + deletes). Touched suites green on sqlite, PostgreSQL and MySQL.

Closes-story: route-migrationcontext-dsl-callers-onto-schema-statements
