### PR TITLE
refactor(migration): route remaining MigrationContext DSL callers onto the adapter

### DIFF
--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
@@ -20,13 +20,9 @@
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, MigrationContext, association, registerModel } from "../index.js";
+import { Base, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { fixtures } from "../test-fixtures.js";
-
-function migrationCtx() {
-  return new MigrationContext(Base.connection);
-}
 
 describe("CollectionProxy#count — disable_joins through", () => {
   fixtures([]);
@@ -53,18 +49,18 @@ describe("CollectionProxy#count — disable_joins through", () => {
   }
 
   beforeAll(async () => {
-    await migrationCtx().createTable("cd_authors", { force: true }, (t: any) => {
+    await Base.connection.createTable("cd_authors", { force: true }, (t: any) => {
       t.string("name");
     });
-    await migrationCtx().createTable("cd_posts", { force: true }, (t: any) => {
+    await Base.connection.createTable("cd_posts", { force: true }, (t: any) => {
       t.integer("cd_author_id");
       t.string("title");
     });
-    await migrationCtx().createTable("cd_comments", { force: true }, (t: any) => {
+    await Base.connection.createTable("cd_comments", { force: true }, (t: any) => {
       t.integer("cd_post_id");
       t.string("body");
     });
-    await migrationCtx().createTable("cd_ratings", { force: true }, (t: any) => {
+    await Base.connection.createTable("cd_ratings", { force: true }, (t: any) => {
       t.integer("cd_comment_id");
       t.integer("value");
     });
@@ -95,7 +91,7 @@ describe("CollectionProxy#count — disable_joins through", () => {
   });
 
   afterAll(async () => {
-    await migrationCtx().dropTable("cd_ratings", "cd_comments", "cd_posts", "cd_authors", {
+    await Base.connection.dropTable("cd_ratings", "cd_comments", "cd_posts", "cd_authors", {
       ifExists: true,
     });
   });

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -1,15 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, MigrationContext, registerModel } from "../index.js";
+import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { findTarget } from "./has-many-association.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { fixtures } from "../test-fixtures.js";
-
-function migrationCtx() {
-  return new MigrationContext(Base.connection);
-}
 
 describe("DisableJoinsAssociationScope", () => {
   fixtures([]);
@@ -36,14 +32,14 @@ describe("DisableJoinsAssociationScope", () => {
   }
 
   beforeAll(async () => {
-    await migrationCtx().createTable("djs_authors", { force: true }, (t: any) => {
+    await Base.connection.createTable("djs_authors", { force: true }, (t: any) => {
       t.string("name");
     });
-    await migrationCtx().createTable("djs_posts", { force: true }, (t: any) => {
+    await Base.connection.createTable("djs_posts", { force: true }, (t: any) => {
       t.integer("djs_author_id");
       t.string("title");
     });
-    await migrationCtx().createTable("djs_comments", { force: true }, (t: any) => {
+    await Base.connection.createTable("djs_comments", { force: true }, (t: any) => {
       t.integer("djs_post_id");
       t.string("body");
     });
@@ -81,7 +77,7 @@ describe("DisableJoinsAssociationScope", () => {
   });
 
   afterAll(async () => {
-    await migrationCtx().dropTable("djs_comments", "djs_posts", "djs_authors", {
+    await Base.connection.dropTable("djs_comments", "djs_posts", "djs_authors", {
       ifExists: true,
     });
   });

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -16,15 +16,11 @@
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, MigrationContext, registerModel } from "../index.js";
+import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { findTarget } from "./has-many-association.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { fixtures } from "../test-fixtures.js";
-
-function migrationCtx() {
-  return new MigrationContext(Base.connection);
-}
 
 describe("DJAS — composite key support", () => {
   fixtures([]);
@@ -54,10 +50,10 @@ describe("DJAS — composite key support", () => {
   }
 
   beforeAll(async () => {
-    await migrationCtx().createTable("ck_shops", { force: true }, (t: any) => {
+    await Base.connection.createTable("ck_shops", { force: true }, (t: any) => {
       t.string("name");
     });
-    await migrationCtx().createTable(
+    await Base.connection.createTable(
       "ck_orders",
       { primaryKey: ["shop_id", "order_number"], force: true },
       (t: any) => {
@@ -66,7 +62,7 @@ describe("DJAS — composite key support", () => {
         t.string("name");
       },
     );
-    await migrationCtx().createTable("ck_line_items", { force: true }, (t: any) => {
+    await Base.connection.createTable("ck_line_items", { force: true }, (t: any) => {
       t.integer("ck_order_shop_id");
       t.integer("ck_order_number");
       t.string("sku");
@@ -95,7 +91,7 @@ describe("DJAS — composite key support", () => {
   });
 
   afterAll(async () => {
-    await migrationCtx().dropTable("ck_line_items", "ck_orders", "ck_shops", { ifExists: true });
+    await Base.connection.dropTable("ck_line_items", "ck_orders", "ck_shops", { ifExists: true });
   });
 
   afterEach(() => {

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -30,14 +30,10 @@
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, MigrationContext, registerModel } from "../index.js";
+import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-fixtures.js";
-
-function migrationCtx() {
-  return new MigrationContext(Base.connection);
-}
 
 describe("DJAS composite-key + nested-through", () => {
   fixtures([]);
@@ -74,10 +70,10 @@ describe("DJAS composite-key + nested-through", () => {
   }
 
   beforeAll(async () => {
-    await migrationCtx().createTable("ckn_shops", { force: true }, (t: any) => {
+    await Base.connection.createTable("ckn_shops", { force: true }, (t: any) => {
       t.string("name");
     });
-    await migrationCtx().createTable(
+    await Base.connection.createTable(
       "ckn_orders",
       { primaryKey: ["shop_id", "order_number"], force: true },
       (t: any) => {
@@ -86,12 +82,12 @@ describe("DJAS composite-key + nested-through", () => {
         t.string("label");
       },
     );
-    await migrationCtx().createTable("ckn_line_items", { force: true }, (t: any) => {
+    await Base.connection.createTable("ckn_line_items", { force: true }, (t: any) => {
       t.integer("ckn_order_shop_id");
       t.integer("ckn_order_number");
       t.string("sku");
     });
-    await migrationCtx().createTable("ckn_tags", { force: true }, (t: any) => {
+    await Base.connection.createTable("ckn_tags", { force: true }, (t: any) => {
       t.integer("ckn_line_item_id");
       t.string("value");
     });
@@ -133,7 +129,7 @@ describe("DJAS composite-key + nested-through", () => {
   });
 
   afterAll(async () => {
-    await migrationCtx().dropTable("ckn_tags", "ckn_line_items", "ckn_orders", "ckn_shops", {
+    await Base.connection.dropTable("ckn_tags", "ckn_line_items", "ckn_orders", "ckn_shops", {
       ifExists: true,
     });
   });

--- a/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
@@ -21,14 +21,10 @@
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, MigrationContext, registerModel } from "../index.js";
+import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-fixtures.js";
-
-function migrationCtx() {
-  return new MigrationContext(Base.connection);
-}
 
 describe("DJAS routing widening — nested-through", () => {
   fixtures([]);
@@ -62,18 +58,18 @@ describe("DJAS routing widening — nested-through", () => {
   }
 
   beforeAll(async () => {
-    await migrationCtx().createTable("nt_authors", { force: true }, (t: any) => {
+    await Base.connection.createTable("nt_authors", { force: true }, (t: any) => {
       t.string("name");
     });
-    await migrationCtx().createTable("nt_posts", { force: true }, (t: any) => {
+    await Base.connection.createTable("nt_posts", { force: true }, (t: any) => {
       t.integer("nt_author_id");
       t.string("title");
     });
-    await migrationCtx().createTable("nt_comments", { force: true }, (t: any) => {
+    await Base.connection.createTable("nt_comments", { force: true }, (t: any) => {
       t.integer("nt_post_id");
       t.string("body");
     });
-    await migrationCtx().createTable("nt_ratings", { force: true }, (t: any) => {
+    await Base.connection.createTable("nt_ratings", { force: true }, (t: any) => {
       t.integer("nt_comment_id");
       t.integer("value");
     });
@@ -111,7 +107,7 @@ describe("DJAS routing widening — nested-through", () => {
   });
 
   afterAll(async () => {
-    await migrationCtx().dropTable("nt_ratings", "nt_comments", "nt_posts", "nt_authors", {
+    await Base.connection.dropTable("nt_ratings", "nt_comments", "nt_posts", "nt_authors", {
       ifExists: true,
     });
   });

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -20,14 +20,10 @@
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, MigrationContext, registerModel } from "../index.js";
+import { Base, registerModel } from "../index.js";
 import { Associations, association } from "../associations.js";
 import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-fixtures.js";
-
-function migrationCtx() {
-  return new MigrationContext(Base.connection);
-}
 
 describe("DJAS routing widening — sourceType + polymorphic source", () => {
   fixtures([]);
@@ -60,18 +56,18 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
   }
 
   beforeAll(async () => {
-    await migrationCtx().createTable("rw_authors", { force: true }, (t: any) => {
+    await Base.connection.createTable("rw_authors", { force: true }, (t: any) => {
       t.string("name");
     });
-    await migrationCtx().createTable("rw_comments", { force: true }, (t: any) => {
+    await Base.connection.createTable("rw_comments", { force: true }, (t: any) => {
       t.integer("rw_author_id");
       t.integer("origin_id");
       t.string("origin_type");
     });
-    await migrationCtx().createTable("rw_members", { force: true }, (t: any) => {
+    await Base.connection.createTable("rw_members", { force: true }, (t: any) => {
       t.string("name");
     });
-    await migrationCtx().createTable("rw_other_origins", { force: true }, (t: any) => {
+    await Base.connection.createTable("rw_other_origins", { force: true }, (t: any) => {
       t.string("label");
     });
     registerModel("RwAuthor", RwAuthor);
@@ -111,7 +107,7 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
   });
 
   afterAll(async () => {
-    await migrationCtx().dropTable("rw_other_origins", "rw_members", "rw_comments", "rw_authors", {
+    await Base.connection.dropTable("rw_other_origins", "rw_members", "rw_comments", "rw_authors", {
       ifExists: true,
     });
   });

--- a/packages/activerecord/src/associations/eager-singularization.test.ts
+++ b/packages/activerecord/src/associations/eager-singularization.test.ts
@@ -6,63 +6,59 @@
  * (viri/octopi/passes/buses/crises_messes/messes/crises/successes/analyses/
  * dresses/compresses) are deliberately irregular plurals with no schema.rb
  * analog; Rails creates them dynamically in setup and drops them in teardown.
- * We mirror that with MigrationContext createTable/dropTable — the model table
+ * We mirror that with the adapter's createTable/dropTable — the model table
  * names derive from the inflector exactly as in Rails (no _tableName hacks).
  */
 import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import { Base, registerModel } from "../index.js";
-import { MigrationContext } from "../migration.js";
 import { fixtures } from "../test-fixtures.js";
 
 describe("EagerSingularizationTest", () => {
   fixtures([]);
 
-  let ctx: MigrationContext;
-
   beforeAll(async () => {
-    ctx = new MigrationContext(Base.connection);
-    await ctx.createTable("viri", { force: true }, (t) => {
+    await Base.connection.createTable("viri", { force: true }, (t) => {
       t.integer("octopus_id");
       t.string("species");
     });
-    await ctx.createTable("octopi", { force: true }, (t) => {
+    await Base.connection.createTable("octopi", { force: true }, (t) => {
       t.string("species");
     });
-    await ctx.createTable("passes", { force: true }, (t) => {
+    await Base.connection.createTable("passes", { force: true }, (t) => {
       t.integer("bus_id");
       t.integer("rides");
     });
-    await ctx.createTable("buses", { force: true }, (t) => {
+    await Base.connection.createTable("buses", { force: true }, (t) => {
       t.string("name");
     });
-    await ctx.createTable("crises_messes", { id: false, force: true }, (t) => {
+    await Base.connection.createTable("crises_messes", { id: false, force: true }, (t) => {
       t.integer("crisis_id");
       t.integer("mess_id");
     });
-    await ctx.createTable("messes", { force: true }, (t) => {
+    await Base.connection.createTable("messes", { force: true }, (t) => {
       t.string("name");
     });
-    await ctx.createTable("crises", { force: true }, (t) => {
+    await Base.connection.createTable("crises", { force: true }, (t) => {
       t.string("name");
     });
-    await ctx.createTable("successes", { force: true }, (t) => {
+    await Base.connection.createTable("successes", { force: true }, (t) => {
       t.string("name");
     });
-    await ctx.createTable("analyses", { force: true }, (t) => {
+    await Base.connection.createTable("analyses", { force: true }, (t) => {
       t.integer("crisis_id");
       t.integer("success_id");
     });
-    await ctx.createTable("dresses", { force: true }, (t) => {
+    await Base.connection.createTable("dresses", { force: true }, (t) => {
       t.integer("crisis_id");
     });
-    await ctx.createTable("compresses", { force: true }, (t) => {
+    await Base.connection.createTable("compresses", { force: true }, (t) => {
       t.integer("dress_id");
     });
   });
 
   afterAll(async () => {
-    await ctx.dropTable(
+    await Base.connection.dropTable(
       "viri",
       "octopi",
       "passes",

--- a/packages/activerecord/src/associations/loader-methods.test.ts
+++ b/packages/activerecord/src/associations/loader-methods.test.ts
@@ -11,7 +11,6 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, registerModel, AssociationNotFoundError } from "../index.js";
-import { MigrationContext } from "../migration.js";
 import { fixtures } from "../test-fixtures.js";
 
 describe("Base#loadBelongsTo / Base#loadHasOne", () => {
@@ -19,10 +18,9 @@ describe("Base#loadBelongsTo / Base#loadHasOne", () => {
   // `_pool` lease. `fixtures({})` establishes the handler and per-test
   // transactional rollback (no seed rows). The `lo_*` tables are genuinely
   // bespoke (no canonical equivalent), so they're still laid via
-  // MigrationContext and dropped in afterAll — but on the primary boot
+  // the adapter and dropped in afterAll — but on the primary boot
   // connection.
   fixtures({});
-  let ctx: MigrationContext;
 
   class LoAuthor extends Base {
     declare name: string;
@@ -54,15 +52,14 @@ describe("Base#loadBelongsTo / Base#loadHasOne", () => {
   LoPost.belongsTo("loAuthor", { className: "LoAuthor" });
 
   beforeAll(async () => {
-    ctx = new MigrationContext(Base.connection);
-    await ctx.createTable("lo_authors", { force: true }, (t) => {
+    await Base.connection.createTable("lo_authors", { force: true }, (t) => {
       t.string("name");
     });
-    await ctx.createTable("lo_posts", { force: true }, (t) => {
+    await Base.connection.createTable("lo_posts", { force: true }, (t) => {
       t.string("title");
       t.integer("lo_author_id");
     });
-    await ctx.createTable("lo_profiles", { force: true }, (t) => {
+    await Base.connection.createTable("lo_profiles", { force: true }, (t) => {
       t.string("bio");
       t.integer("lo_author_id");
     });
@@ -71,7 +68,7 @@ describe("Base#loadBelongsTo / Base#loadHasOne", () => {
     registerModel(LoProfile);
   });
   afterAll(async () => {
-    await ctx.dropTable("lo_profiles", "lo_posts", "lo_authors", { ifExists: true });
+    await Base.connection.dropTable("lo_profiles", "lo_posts", "lo_authors", { ifExists: true });
   });
   it("loadBelongsTo returns the associated record", async () => {
     const author = new LoAuthor({ name: "dean" });

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -5,22 +5,19 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { MigrationContext } from "../migration.js";
 import { fixtures } from "../test-fixtures.js";
 import { rebuildCanonicalTables } from "../support/canonical-table-rebuild.js";
 
 describe("RequiredAssociationsTest", () => {
   fixtures([]);
-  let ctx: MigrationContext;
   beforeAll(async () => {
-    ctx = new MigrationContext(Base.connection);
-    await ctx.createTable("parents", { force: true }, () => {});
-    await ctx.createTable("children", { force: true }, (t) => {
+    await Base.connection.createTable("parents", { force: true }, () => {});
+    await Base.connection.createTable("children", { force: true }, (t) => {
       t.integer("parent_id");
     });
   });
   afterAll(async () => {
-    await ctx.dropTable("children", "parents", { ifExists: true });
+    await Base.connection.dropTable("children", "parents", { ifExists: true });
     await rebuildCanonicalTables(Base.connection, ["children"]);
   });
 

--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -7,7 +7,6 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "./index.js";
-import { MigrationContext } from "./migration.js";
 import { fixtures } from "./test-fixtures.js";
 
 const BIG = 2n ** 62n; // 4611686018427387904 — above Number.MAX_SAFE_INTEGER
@@ -16,17 +15,14 @@ fixtures([]);
 // `metrics` is a trails-only scratch table (no Rails counterpart). Build it via
 // the migration API and drop it afterward rather than seeding it into the
 // canonical schema, which mirrors only Rails' schema.rb fixture tables.
-function migrationCtx(): MigrationContext {
-  return new MigrationContext(Base.connection);
-}
 beforeAll(async () => {
-  await migrationCtx().createTable("metrics", { force: true }, (t) => {
+  await Base.connection.createTable("metrics", { force: true }, (t) => {
     t.bigint("score");
     t.string("label");
   });
 });
 afterAll(async () => {
-  await migrationCtx().dropTable("metrics", { ifExists: true });
+  await Base.connection.dropTable("metrics", { ifExists: true });
 });
 describe("bigint model round-trip (all adapters)", () => {
   function makeModel() {

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -10,7 +10,6 @@ import { SchemaDumper } from "./schema-dumper.js";
 import type { SchemaSource } from "./schema-dumper.js";
 import { NotNullViolation } from "./errors.js";
 import { adapterType } from "./test-adapter.js";
-import { MigrationContext } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
@@ -93,8 +92,7 @@ describe("DefaultNumbersTest", () => {
 
   beforeEach(async () => {
     adapter = Base.connection;
-    const ctx = new MigrationContext(adapter);
-    await ctx.createTable("default_numbers", { force: true }, (t: any) => {
+    await adapter.createTable("default_numbers", { force: true }, (t: any) => {
       t.integer("positive_integer", { default: 7 });
       t.integer("negative_integer", { default: -5 });
       t.decimal("decimal_number", { default: "2.78", precision: 5, scale: 2 });
@@ -108,7 +106,7 @@ describe("DefaultNumbersTest", () => {
   });
 
   afterEach(async () => {
-    await new MigrationContext(adapter).dropTable("default_numbers", { ifExists: true });
+    await adapter.dropTable("default_numbers", { ifExists: true });
   });
 
   it("default positive integer", () => {
@@ -136,8 +134,7 @@ describe("DefaultStringsTest", () => {
 
   beforeEach(async () => {
     adapter = Base.connection;
-    const ctx = new MigrationContext(adapter);
-    await ctx.createTable("default_strings", { force: true }, (t: any) => {
+    await adapter.createTable("default_strings", { force: true }, (t: any) => {
       t.string("string_col", { default: "Smith" });
       t.string("string_col_with_quotes", { default: "O'Connor" });
     });
@@ -150,7 +147,7 @@ describe("DefaultStringsTest", () => {
   });
 
   afterEach(async () => {
-    await new MigrationContext(adapter).dropTable("default_strings", { ifExists: true });
+    await adapter.dropTable("default_strings", { ifExists: true });
   });
 
   it("default strings", () => {
@@ -169,8 +166,7 @@ describe.skipIf(adapterType === "mysql")("DefaultBinaryTest", () => {
 
   beforeEach(async () => {
     adapter = Base.connection;
-    const ctx = new MigrationContext(adapter);
-    await ctx.createTable("default_binaries", { force: true }, (t: any) => {
+    await adapter.createTable("default_binaries", { force: true }, (t: any) => {
       t.binary("varbinary_col", { null: false, limit: 64, default: "varbinary_default" });
       t.binary("varbinary_col_hex_looking", { null: false, limit: 64, default: "0xDEADBEEF" });
     });
@@ -183,7 +179,7 @@ describe.skipIf(adapterType === "mysql")("DefaultBinaryTest", () => {
   });
 
   afterEach(async () => {
-    await new MigrationContext(adapter).dropTable("default_binaries", { ifExists: true });
+    await adapter.dropTable("default_binaries", { ifExists: true });
   });
 
   // Rails asserts string equality; a binary column deserializes to bytes in
@@ -223,8 +219,7 @@ describeIfSupports("text_column_with_default", "DefaultTextTest", () => {
 
   beforeEach(async () => {
     adapter = Base.connection;
-    const ctx = new MigrationContext(adapter);
-    await ctx.createTable("default_texts", { force: true }, (t: any) => {
+    await adapter.createTable("default_texts", { force: true }, (t: any) => {
       t.text("text_col", { default: "Smith" });
       t.text("text_col_with_quotes", { default: "O'Connor" });
     });
@@ -237,7 +232,7 @@ describeIfSupports("text_column_with_default", "DefaultTextTest", () => {
   });
 
   afterEach(async () => {
-    await new MigrationContext(adapter).dropTable("default_texts", { ifExists: true });
+    await adapter.dropTable("default_texts", { ifExists: true });
   });
 
   it("default texts", () => {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -365,12 +365,10 @@ describe("SchemaDumperTest", () => {
 // adapter tables / reflection fixes — tracked as follow-up stories under RFC 0048.
 // Nothing drops their bespoke tables between tests, so each case that would
 // collide clears its own up front and the file-level `afterAll` below drops the
-// rest.
-// Each case builds its own bespoke tables and dumps only those —
-// `SchemaDumper.dumpTableSchema(adapter, name)` introspects only the named
-// table (no `tables()` enumeration of the ~330 canonical tables the
-// truncate-reset preserves). So none of them enter the dump's output/timing:
-// no empty-DB precondition (and no drop-all crutch) needed.
+// rest. Each dumps only its own tables — `SchemaDumper.dumpTableSchema(adapter,
+// name)` introspects only the named table (no `tables()` enumeration of the
+// ~330 canonical tables the truncate-reset preserves) — so no empty-DB
+// precondition (and no drop-all crutch) is needed.
 describe("SchemaDumperTest", () => {
   afterEach(() => {
     SchemaDumper.ignoreTables = [];

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll } from "vitest";
 import { Base } from "./base.js";
-import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 import type { SchemaSource } from "./schema-dumper.js";
 import { adapterType } from "./test-adapter.js";
@@ -367,17 +366,12 @@ describe("SchemaDumperTest", () => {
 // Nothing drops their bespoke tables between tests, so each case that would
 // collide clears its own up front and the file-level `afterAll` below drops the
 // rest.
+// Each case builds its own bespoke tables and dumps only those —
+// `SchemaDumper.dumpTableSchema(adapter, name)` introspects only the named
+// table (no `tables()` enumeration of the ~330 canonical tables the
+// truncate-reset preserves). So none of them enter the dump's output/timing:
+// no empty-DB precondition (and no drop-all crutch) needed.
 describe("SchemaDumperTest", () => {
-  let ctx: MigrationContext;
-  beforeEach(() => {
-    // Each case builds its own bespoke tables and dumps only those — `ctx`
-    // dumps use MigrationContext's in-memory table set, and adapter dumps go
-    // through `SchemaDumper.dumpTableSchema(adapter, name)`, which introspects
-    // only the named table (no `tables()` enumeration of the ~330 canonical
-    // tables the truncate-reset preserves). So none of them enter the dump's
-    // output/timing: no empty-DB precondition (and no drop-all crutch) needed.
-    ctx = new MigrationContext(Base.connection);
-  });
   afterEach(() => {
     SchemaDumper.ignoreTables = [];
     SchemaDumper.fkIgnorePattern = /^fk_rails_[0-9a-f]{10}$/;
@@ -444,10 +438,10 @@ describe("SchemaDumperTest", () => {
   // column is `key` (not `id`), which keeps the explicit `id: false` in the dump
   // on every adapter. Tracked as an RFC 0048 follow-up story.
   it("schema dump keeps id false when id is false and unique not null column added", async () => {
-    await ctx.createTable("string_key_objects", { id: false, force: true }, (t) => {
+    await Base.connection.createTable("string_key_objects", { id: false, force: true }, (t) => {
       t.string("key", { null: false });
     });
-    await ctx.addIndex("string_key_objects", "key", { unique: true });
+    await Base.connection.addIndex("string_key_objects", "key", { unique: true });
     const output = await SchemaDumper.dumpTableSchema(Base.connection, "string_key_objects");
     expect(output).toMatch(/createTable\("string_key_objects",\s*\{[^}]*id:\s*false/);
   });
@@ -456,8 +450,7 @@ describe("SchemaDumperTest", () => {
     const { SchemaStatements } =
       await import("./connection-adapters/abstract/schema-statements.js");
     const testAdapter = Base.connection;
-    const testCtx = new MigrationContext(testAdapter);
-    await testCtx.createTable("products", { force: true }, (t) => {
+    await testAdapter.createTable("products", { force: true }, (t) => {
       t.decimal("price");
       t.decimal("discounted_price");
     });
@@ -471,8 +464,7 @@ describe("SchemaDumperTest", () => {
   });
   itIfSupports("exclusion_constraints", "schema dumps exclusion constraints", async () => {
     const testAdapter = Base.connection;
-    const testCtx = new MigrationContext(testAdapter);
-    await testCtx.createTable("test_schema_exclusion", { id: false }, (t) => {
+    await testAdapter.createTable("test_schema_exclusion", { id: false }, (t) => {
       t.date("start_date");
       t.date("end_date");
     });
@@ -488,8 +480,7 @@ describe("SchemaDumperTest", () => {
   });
   itIfSupports("unique_constraints", "schema dumps unique constraints", async () => {
     const testAdapter = Base.connection;
-    const testCtx = new MigrationContext(testAdapter);
-    await testCtx.createTable("test_schema_unique", {}, (t) => {
+    await testAdapter.createTable("test_schema_unique", {}, (t) => {
       t.integer("position_1");
       t.integer("position_2");
     });
@@ -511,8 +502,7 @@ describe("SchemaDumperTest", () => {
     "schema does not dump unique constraints as indexes",
     async () => {
       const testAdapter = Base.connection;
-      const testCtx = new MigrationContext(testAdapter);
-      await testCtx.createTable("test_uc_no_idx", {}, (t) => {
+      await testAdapter.createTable("test_uc_no_idx", {}, (t) => {
         t.integer("position");
       });
       await (testAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
@@ -556,8 +546,7 @@ describe("SchemaDumperTest", () => {
     "schema does not include limit for emulated mysql boolean fields",
     async () => {
       const adapter = Base.connection;
-      const testCtx = new MigrationContext(adapter);
-      await testCtx.createTable("booleans", { force: true }, (t) => {
+      await adapter.createTable("booleans", { force: true }, (t) => {
         t.boolean("has_fun", { default: false });
       });
       const output = await SchemaDumper.dumpTableSchema(adapter, "booleans");
@@ -613,7 +602,7 @@ describe("SchemaDumperTest", () => {
     // dump. Dump a single throwaway table via `dumpTableSchema` (which does
     // NOT enumerate the ~330 canonical tables the truncate-reset preserves)
     // rather than a full dump, so the header stays cheap under CI fork load.
-    await new MigrationContext(adapter).createTable("schema_dump_probe", { force: true }, (t) => {
+    await adapter.createTable("schema_dump_probe", { force: true }, (t) => {
       t.integer("x");
     });
     try {
@@ -635,7 +624,7 @@ describe("SchemaDumperTest", () => {
     async () => {
       const adapter = Base.connection;
       const original = (adapter as any).extensions;
-      await new MigrationContext(adapter).createTable("schema_dump_probe", { force: true }, (t) => {
+      await adapter.createTable("schema_dump_probe", { force: true }, (t) => {
         t.integer("x");
       });
       try {
@@ -650,8 +639,7 @@ describe("SchemaDumperTest", () => {
   );
   it.skipIf(adapterType !== "postgres")("schema dump include limit for float4 field", async () => {
     const adapter = Base.connection;
-    const testCtx = new MigrationContext(adapter);
-    await testCtx.createTable("numeric_data", { force: true }, (t) => {
+    await adapter.createTable("numeric_data", { force: true }, (t) => {
       t.float("temperature_with_limit", { limit: 24 });
     });
     const output = await SchemaDumper.dumpTableSchema(adapter, "numeric_data");
@@ -664,7 +652,7 @@ describe("SchemaDumperTest", () => {
       await (adapter as any).createEnum("enum_with_comma", ["value1", "value,2", "value3"]);
       // Dump a throwaway table (not a full dump) so the enum-type header is
       // emitted without introspecting the ~330 canonical tables.
-      await new MigrationContext(adapter).createTable("schema_dump_probe", { force: true }, (t) => {
+      await adapter.createTable("schema_dump_probe", { force: true }, (t) => {
         t.integer("x");
       });
       try {
@@ -789,7 +777,7 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump with correct timestamp types via create table and t column",
     async () => {
-      await ctx.createTable("posts", { force: true }, (t) => {
+      await Base.connection.createTable("posts", { force: true }, (t) => {
         t.string("title");
         t.timestamps();
       });
@@ -804,7 +792,7 @@ describe("SchemaDumperTest", () => {
     "schema dump with timestamptz datetime format",
     async () => {
       await withPostgresqlDatetimeType("timestamptz", async () => {
-        await ctx.createTable("timestamps", { force: true }, (t) => {
+        await Base.connection.createTable("timestamps", { force: true }, (t) => {
           t.datetime("this_should_remain_datetime");
           (t as any).timestamptz("this_is_an_alias_of_datetime");
           t.column("without_time_zone", "timestamp");
@@ -834,7 +822,7 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump when changing datetime type for an existing app",
     async () => {
-      await ctx.createTable("timestamps", { force: true }, (t) => {
+      await Base.connection.createTable("timestamps", { force: true }, (t) => {
         t.datetime("default_format");
         t.column("without_time_zone", "timestamp");
         t.column("with_time_zone", "timestamptz");
@@ -856,7 +844,7 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump with correct timestamp types via create table and t timestamptz",
     async () => {
-      await ctx.createTable("timestamps", { force: true }, (t) => {
+      await Base.connection.createTable("timestamps", { force: true }, (t) => {
         t.datetime("default_format");
         t.datetime("without_time_zone");
         t.timestamp("also_without_time_zone");
@@ -873,10 +861,10 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump with correct timestamp types via add column",
     async () => {
-      await ctx.createTable("posts", { force: true }, (t) => {
+      await Base.connection.createTable("posts", { force: true }, (t) => {
         t.string("title");
       });
-      await ctx.addColumn("posts", "created_at", "datetime");
+      await Base.connection.addColumn("posts", "created_at", "datetime");
       const output = await SchemaDumper.dumpTableSchema(Base.connection, "posts");
       expect(output).toContain("datetime");
       expect(output).toContain("created_at");
@@ -903,10 +891,10 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump with correct timestamp types via add column with type as string",
     async () => {
-      await ctx.createTable("posts", { force: true }, (t) => {
+      await Base.connection.createTable("posts", { force: true }, (t) => {
         t.string("title");
       });
-      await ctx.addColumn("posts", "posted_at", "datetime");
+      await Base.connection.addColumn("posts", "posted_at", "datetime");
       const output = await SchemaDumper.dumpTableSchema(Base.connection, "posts");
       expect(output).toContain("datetime");
       expect(output).toContain("posted_at");
@@ -915,18 +903,15 @@ describe("SchemaDumperTest", () => {
 });
 
 describe("SchemaDumperDefaultsTest", () => {
-  let ctx: MigrationContext;
   let adapter: TestDatabaseAdapter;
   beforeEach(() => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
-    // See SchemaDumperTest beforeEach: `ctx` dumps are scoped to the in-memory
-    // table set and the adapter case uses `dumpTableSchema`, so no empty-DB
-    // precondition is needed.
+    // See SchemaDumperTest above: dumps go through `dumpTableSchema` on the
+    // named table only, so no empty-DB precondition is needed.
   });
 
   it("schema dump defaults with universally supported types", async () => {
-    await ctx.createTable("dump_defaults", { force: true }, (t) => {
+    await adapter.createTable("dump_defaults", { force: true }, (t) => {
       t.string("string_with_default", { default: "Hello!" });
       t.date("date_with_default", { default: "2014-06-05" });
       t.datetime("datetime_with_default", { default: "2014-06-05 07:17:04" });
@@ -941,7 +926,7 @@ describe("SchemaDumperDefaultsTest", () => {
 
   // MySQL 8 strict mode forbids TEXT column defaults; MariaDB allowed them.
   itIfSupports("text_column_with_default", "schema dump with text column", async () => {
-    await ctx.createTable("dump_defaults", { force: true }, (t) => {
+    await adapter.createTable("dump_defaults", { force: true }, (t) => {
       t.text("text_with_default", { default: "John" });
     });
     const output = await SchemaDumper.dumpTableSchema(Base.connection, "dump_defaults");
@@ -949,7 +934,7 @@ describe("SchemaDumperDefaultsTest", () => {
   });
 
   it.skipIf(adapterType !== "postgres")("schema dump with column infinity default", async () => {
-    await ctx.createTable("infinity_defaults", {}, (t) => {
+    await adapter.createTable("infinity_defaults", {}, (t) => {
       t.float("float_with_inf_default", { default: Infinity });
       t.float("float_with_nan_default", { default: NaN });
       t.datetime("beginning_of_time", { default: "-infinity" });
@@ -969,7 +954,7 @@ describe("SchemaDumperDefaultsTest", () => {
 });
 
 // The deferred bespoke cases in the second `SchemaDumperTest` describe build
-// real ad-hoc tables via MigrationContext on the shared per-worker DB; drop
+// real ad-hoc tables via the adapter DSL on the shared per-worker DB; drop
 // every one they create, by name, so the leaked tables don't collide with
 // sibling files under parallel forks. The canonical tables the first describe
 // *rides* (accounts/authors/binaries/movies/…) are shielded by `fixtures({})`
@@ -978,28 +963,27 @@ describe("SchemaDumperDefaultsTest", () => {
 // some adapters; the rebuildCanonicalTables call below restores their canonical
 // shape.
 afterAll(async () => {
-  const ctx = new MigrationContext(Base.connection);
   const o = { ifExists: true } as const;
-  await ctx.dropTable("booleans", o);
-  await ctx.dropTable("companies", o);
-  await ctx.dropTable("dump_defaults", o);
-  await ctx.dropTable("indexed", o);
-  await ctx.dropTable("infinity_defaults", o);
-  await ctx.dropTable("limits", o);
-  await ctx.dropTable("myapp_posts", o);
-  await ctx.dropTable("myapp_users", o);
-  await ctx.dropTable("myapp_users_v1", o);
-  await ctx.dropTable("numeric_data", o);
-  await ctx.dropTable("posts", o);
-  await ctx.dropTable("schema_dump_probe", o);
-  await ctx.dropTable("products", o);
-  await ctx.dropTable("string_key_objects", o);
-  await ctx.dropTable("temp_cache", o);
-  await ctx.dropTable("test_schema_exclusion", o);
-  await ctx.dropTable("test_schema_unique", o);
-  await ctx.dropTable("test_uc_no_idx", o);
-  await ctx.dropTable("timestamps", o);
-  await ctx.dropTable("users", o);
+  await Base.connection.dropTable("booleans", o);
+  await Base.connection.dropTable("companies", o);
+  await Base.connection.dropTable("dump_defaults", o);
+  await Base.connection.dropTable("indexed", o);
+  await Base.connection.dropTable("infinity_defaults", o);
+  await Base.connection.dropTable("limits", o);
+  await Base.connection.dropTable("myapp_posts", o);
+  await Base.connection.dropTable("myapp_users", o);
+  await Base.connection.dropTable("myapp_users_v1", o);
+  await Base.connection.dropTable("numeric_data", o);
+  await Base.connection.dropTable("posts", o);
+  await Base.connection.dropTable("schema_dump_probe", o);
+  await Base.connection.dropTable("products", o);
+  await Base.connection.dropTable("string_key_objects", o);
+  await Base.connection.dropTable("temp_cache", o);
+  await Base.connection.dropTable("test_schema_exclusion", o);
+  await Base.connection.dropTable("test_schema_unique", o);
+  await Base.connection.dropTable("test_uc_no_idx", o);
+  await Base.connection.dropTable("timestamps", o);
+  await Base.connection.dropTable("users", o);
   // The drops above include canonical tables the deferred cases `force`-recreate
   // in a bespoke shape; restore the canonical ones here instead of leaving the
   // shared worker DB drifted for the next file.

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -5,7 +5,6 @@
 // round-trips. Kept out of the Rails-mirrored schema-dumper.test.ts so
 // test:compare maps cleanly.
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-fixtures.js";
@@ -208,16 +207,14 @@ describe("SchemaDumperAdapterTest", () => {
   fixtures({}, { useTransactionalTests: false });
 
   let adapter: DatabaseAdapter;
-  let ctx: MigrationContext;
 
   beforeEach(() => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
   });
 
   it("dumps schema from adapter introspection", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
-    await ctx.createTable("horses", {}, (t) => {
+    await adapter.createTable("horses", {}, (t) => {
       t.string("title", { null: false });
       t.text("body");
     });
@@ -229,10 +226,10 @@ describe("SchemaDumperAdapterTest", () => {
 
   it("dumps schema with indexes from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
-    await ctx.createTable("testings", {}, (t) => {
+    await adapter.createTable("testings", {}, (t) => {
       t.integer("post_id");
     });
-    await ctx.addIndex("testings", "post_id", { name: "index_testings_on_post_id" });
+    await adapter.addIndex("testings", "post_id", { name: "index_testings_on_post_id" });
     const result = await TopLevelDumper.dumpTableSchema(adapter, "testings");
     expect(result).toContain("addIndex");
     expect(result).toContain("index_testings_on_post_id");
@@ -240,7 +237,7 @@ describe("SchemaDumperAdapterTest", () => {
 
   it("adapter-backed dump emits precision: null for datetime column without precision", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
-    await ctx.createTable("octopi", {}, (t) => {
+    await adapter.createTable("octopi", {}, (t) => {
       t.datetime("happened_at", { precision: null });
     });
     const result = await TopLevelDumper.dumpTableSchema(adapter, "octopi");
@@ -251,9 +248,9 @@ describe("SchemaDumperAdapterTest", () => {
     // Guards the U2 type/sqlType split: emitTable resolves the limit from the
     // dsl/raw type carried by AdapterSchemaSource. A live introspected column's
     // limit must survive the round-trip on the adapter path (not just the
-    // in-memory MigrationContext path).
+    // in-memory schema-statements path).
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
-    await ctx.createTable("barcodes", {}, (t) => {
+    await adapter.createTable("barcodes", {}, (t) => {
       t.string("code", { limit: 10 });
     });
     const result = await TopLevelDumper.dumpTableSchema(adapter, "barcodes");
@@ -266,7 +263,7 @@ describe("SchemaDumperAdapterTest", () => {
     const { InternalMetadata } = await import("./internal-metadata.js");
     await new SchemaMigration(adapter).createTable();
     await new InternalMetadata(adapter).createTable();
-    await ctx.createTable("reminders", {}, (t) => {
+    await adapter.createTable("reminders", {}, (t) => {
       t.string("name");
     });
     const result = await TopLevelDumper.dump(adapter);
@@ -366,13 +363,12 @@ describe("SchemaDumperAdapterTest", () => {
   // Nothing drops them between tests, so drop them per test (not just in
   // afterAll) to keep the shared-DB exposure window one test wide.
   afterEach(async () => {
-    const cleanupCtx = new MigrationContext(Base.connection);
     const o = { ifExists: true } as const;
-    await cleanupCtx.dropTable("barcodes", o);
-    await cleanupCtx.dropTable("horses", o);
-    await cleanupCtx.dropTable("octopi", o);
-    await cleanupCtx.dropTable("reminders", o);
-    await cleanupCtx.dropTable("testings", o);
+    await Base.connection.dropTable("barcodes", o);
+    await Base.connection.dropTable("horses", o);
+    await Base.connection.dropTable("octopi", o);
+    await Base.connection.dropTable("reminders", o);
+    await Base.connection.dropTable("testings", o);
   });
 });
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -154,7 +154,7 @@ function conciseOptions<T>(
 
 /**
  * Interface for sources that can provide schema information.
- * Both MigrationContext (sync/in-memory) and database adapters (async) can implement this.
+ * Database adapters implement this; in-memory/mock sources in tests do too.
  */
 export interface SchemaSource {
   /** @internal */
@@ -179,7 +179,7 @@ export interface SchemaDumperOptions {
  * or adapter-specific subclasses (e.g. PG range helpers in
  * connection-adapters/postgresql/schema-definitions.ts). Types mapped
  * to names outside this set are emitted as `t.column(name, sqlType,
- * options)` so the dumped schema loads through MigrationContext
+ * options)` so the dumped schema loads through the adapter DSL
  * without a ReferenceError.
  */
 const DSL_HELPER_METHODS = new Set([
@@ -653,11 +653,11 @@ export class SchemaDumper {
     if (params) lines.push(`// ${params}`);
     lines.push("");
     if (this._language === "ts") {
-      lines.push(`import type { MigrationContext } from "@blazetrails/activerecord";`);
+      lines.push(`import type { DatabaseAdapter } from "@blazetrails/activerecord";`);
       lines.push("");
-      lines.push("export default async function defineSchema(ctx: MigrationContext) {");
+      lines.push("export default async function defineSchema(ctx: DatabaseAdapter) {");
     } else {
-      lines.push("/** @param {import('@blazetrails/activerecord').MigrationContext} ctx */");
+      lines.push("/** @param {import('@blazetrails/activerecord').DatabaseAdapter} ctx */");
       lines.push("export default async function defineSchema(ctx) {");
     }
   }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -154,7 +154,7 @@ function conciseOptions<T>(
 
 /**
  * Interface for sources that can provide schema information.
- * Database adapters implement this; in-memory/mock sources in tests do too.
+ * Both MigrationContext (sync/in-memory) and database adapters (async) can implement this.
  */
 export interface SchemaSource {
   /** @internal */

--- a/packages/activerecord/src/support/schema-file-generator.test.ts
+++ b/packages/activerecord/src/support/schema-file-generator.test.ts
@@ -72,9 +72,9 @@ describe("generateSchemaFile", () => {
     expect(await fs.exists(filePath)).toBe(true);
   });
 
-  it("exports a default async function accepting MigrationContext", () => {
+  it("exports a default async function accepting DatabaseAdapter", () => {
     expect(content).toContain("export default async function defineSchema");
-    expect(content).toContain("MigrationContext");
+    expect(content).toContain("DatabaseAdapter");
   });
 
   it("emits createTable for every table in the schema", () => {

--- a/packages/activerecord/src/support/schema-file-generator.ts
+++ b/packages/activerecord/src/support/schema-file-generator.ts
@@ -1,7 +1,7 @@
 /**
  * Generates a loadable schema-file module from `TEST_SCHEMA` at runtime,
  * once per Vitest worker. The generated file exports a default function
- * `(ctx: MigrationContext) => Promise<void>` that drives
+ * `(ctx: DatabaseAdapter) => Promise<void>` that drives
  * `DatabaseTasks.loadSchema`, giving that path the same coverage it gets
  * in a Rails `db:test:prepare` flow without requiring a checked-in artifact.
  *
@@ -121,9 +121,9 @@ function generateCode(
   supportsExpressionIndex?: boolean,
 ): string {
   const lines: string[] = [
-    `import type { MigrationContext } from "@blazetrails/activerecord";`,
+    `import type { DatabaseAdapter } from "@blazetrails/activerecord";`,
     ``,
-    `export default async function defineSchema(ctx: MigrationContext): Promise<void> {`,
+    `export default async function defineSchema(ctx: DatabaseAdapter): Promise<void> {`,
   ];
 
   // PG/MySQL: loadSchema runs on a shared database that other workers may already

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -964,9 +964,7 @@ export class DatabaseTasks {
         throw new Error(`Schema file must export a default function (got ${typeof defineSchema})`);
       }
       const adapter = await this._migrationAdapter();
-      const { MigrationContext } = await import("../migration.js");
-      const ctx = new MigrationContext(adapter);
-      await defineSchema(ctx);
+      await defineSchema(adapter);
       // Stamp using the resolved absolute path — `filename` may be
       // relative and `_schemaSha1` reads the file via getFs(), so the
       // path must match what was actually imported.

--- a/packages/activerecord/src/time-precision.test.ts
+++ b/packages/activerecord/src/time-precision.test.ts
@@ -4,7 +4,6 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { adapterType } from "./test-adapter.js";
-import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./schema-dumper.js";
 import { fixtures } from "./test-fixtures.js";
 import { itIfSupports } from "./support/supports.js";
@@ -21,7 +20,6 @@ describe("TimePrecisionTest", () => {
   // a wrapping (PG-poisoning) transaction.
   fixtures({}, { useTransactionalTests: false });
   let adapter: DatabaseAdapter;
-  let ctx: MigrationContext;
 
   // Rails: `foos` is not a schema.rb fixture table — each test builds it with
   // `create_table(:foos, force: true)` for the precision under test and the
@@ -29,10 +27,9 @@ describe("TimePrecisionTest", () => {
   // here rather than seeding a placeholder into the canonical schema.
   beforeEach(async () => {
     adapter = Base.connection;
-    ctx = new MigrationContext(adapter);
   });
   afterEach(async () => {
-    await ctx.dropTable("foos", { ifExists: true });
+    await adapter.dropTable("foos", { ifExists: true });
   });
   function makeFoo() {
     class Foo extends Base {
@@ -43,9 +40,9 @@ describe("TimePrecisionTest", () => {
   }
 
   itIfSupports("datetime_with_precision", "time data type with precision", async () => {
-    await ctx.createTable("foos", { force: true }, () => {});
-    await ctx.addColumn("foos", "start", "time", { precision: 3 });
-    await ctx.addColumn("foos", "finish", "time", { precision: 6 });
+    await adapter.createTable("foos", { force: true }, () => {});
+    await adapter.addColumn("foos", "start", "time", { precision: 3 });
+    await adapter.addColumn("foos", "finish", "time", { precision: 6 });
     const Foo = makeFoo();
     await Foo.loadSchema();
     expect((Foo.columnsHash() as any)["start"].precision).toBe(3);
@@ -53,9 +50,9 @@ describe("TimePrecisionTest", () => {
   });
 
   itIfSupports("datetime_with_precision", "time precision is truncated on assignment", async () => {
-    await ctx.createTable("foos", { force: true }, () => {});
-    await ctx.addColumn("foos", "start", "time", { precision: 0 });
-    await ctx.addColumn("foos", "finish", "time", { precision: 6 });
+    await adapter.createTable("foos", { force: true }, () => {});
+    await adapter.addColumn("foos", "start", "time", { precision: 0 });
+    await adapter.addColumn("foos", "finish", "time", { precision: 6 });
     const Foo = makeFoo();
     await Foo.loadSchema();
     const time = Temporal.PlainTime.from({
@@ -82,9 +79,9 @@ describe("TimePrecisionTest", () => {
     "datetime_with_precision",
     "no time precision isnt truncated on assignment",
     async () => {
-      await ctx.createTable("foos", { force: true }, () => {});
-      await ctx.addColumn("foos", "start", "time");
-      await ctx.addColumn("foos", "finish", "time", { precision: 6 });
+      await adapter.createTable("foos", { force: true }, () => {});
+      await adapter.addColumn("foos", "start", "time");
+      await adapter.addColumn("foos", "finish", "time", { precision: 6 });
       const Foo = makeFoo();
       await Foo.loadSchema();
       const time = Temporal.PlainTime.from({
@@ -109,7 +106,7 @@ describe("TimePrecisionTest", () => {
     "datetime_with_precision",
     "passing precision to time does not set limit",
     async () => {
-      await ctx.createTable("foos", { force: true }, (t) => {
+      await adapter.createTable("foos", { force: true }, (t) => {
         t.time("start", { precision: 3 });
         t.time("finish", { precision: 6 });
       });
@@ -122,7 +119,7 @@ describe("TimePrecisionTest", () => {
 
   itIfSupports("datetime_with_precision", "invalid time precision raises error", async () => {
     await expect(
-      ctx.createTable("foos", { force: true }, (t) => {
+      adapter.createTable("foos", { force: true }, (t) => {
         t.time("start", { precision: 7 });
         t.time("finish", { precision: 7 });
       }),
@@ -135,7 +132,7 @@ describe("TimePrecisionTest", () => {
   });
 
   itIfSupports("datetime_with_precision", "schema dump includes time precision", async () => {
-    await ctx.createTable("foos", { force: true }, (t) => {
+    await adapter.createTable("foos", { force: true }, (t) => {
       t.time("start", { precision: 4 });
       t.time("finish", { precision: 6 });
     });

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { travel, travelBack } from "@blazetrails/activesupport";
-import { Base, MigrationContext, registerModel } from "./index.js";
+import { Base, registerModel } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import {
   Developer,
@@ -527,13 +527,11 @@ describe("TimestampsWithoutTransactionTest", () => {
   fixtures({}, { useTransactionalTests: false });
 
   afterEach(async () => {
-    const ctx = new MigrationContext(Base.connection);
-    await ctx.dropTable("timestamp_attribute_posts", "foos", { ifExists: true });
+    await Base.connection.dropTable("timestamp_attribute_posts", "foos", { ifExists: true });
   });
 
   it("do not write timestamps on save if they are not attributes", async () => {
-    const ctx = new MigrationContext(Base.connection);
-    await ctx.createTable("timestamp_attribute_posts", { force: true }, (t) => {
+    await Base.connection.createTable("timestamp_attribute_posts", { force: true }, (t) => {
       // Only id column — no created_at / updated_at
     });
 
@@ -559,15 +557,16 @@ describe("TimestampsWithoutTransactionTest", () => {
   });
 
   it("index is created for both timestamps", async () => {
-    const ctx = new MigrationContext(Base.connection);
-    await ctx.createTable("foos", { force: true }, (t) => {
+    await Base.connection.createTable("foos", { force: true }, (t) => {
       t.timestamps({ null: true, index: true });
     });
 
-    const indexes = await ctx.indexes("foos");
+    // AbstractAdapter#indexes is declared `Promise<unknown[]>` (the concrete
+    // IndexDefinition shape lives on the dialect adapters).
+    const indexes = (await Base.connection.indexes("foos")) as { columns: string[] }[];
     const columns = indexes.flatMap((i) => i.columns).sort();
     expect(columns).toEqual(["created_at", "updated_at"]);
 
-    await ctx.dropTable("foos");
+    await Base.connection.dropTable("foos");
   });
 });

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -561,8 +561,6 @@ describe("TimestampsWithoutTransactionTest", () => {
       t.timestamps({ null: true, index: true });
     });
 
-    // AbstractAdapter#indexes is declared `Promise<unknown[]>` (the concrete
-    // IndexDefinition shape lives on the dialect adapters).
     const indexes = (await Base.connection.indexes("foos")) as { columns: string[] }[];
     const columns = indexes.flatMap((i) => i.columns).sort();
     expect(columns).toEqual(["created_at", "updated_at"]);

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -859,7 +859,7 @@ export class CreatePosts extends Migration {
 
 describe("schema dump and load", () => {
   it("dumps schema from SQLite and loads it into a fresh database", async () => {
-    const { SchemaDumper, MigrationContext } = await import("@blazetrails/activerecord");
+    const { SchemaDumper } = await import("@blazetrails/activerecord");
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
     const { AdapterSchemaSource } = await import("../schema-source.js");
@@ -868,8 +868,7 @@ describe("schema dump and load", () => {
     const targetAdapter = new BetterSQLite3Adapter(":memory:");
     try {
       // Create a database with a table
-      const ctx = new MigrationContext(sourceAdapter);
-      await ctx.createTable("users", {}, (t) => {
+      await sourceAdapter.createTable("users", {}, (t) => {
         t.string("name");
         t.integer("age");
       });
@@ -883,7 +882,6 @@ describe("schema dump and load", () => {
       expect(schema).toContain("createTable");
 
       // Load into a fresh database
-      const targetCtx = new MigrationContext(targetAdapter);
       const defineSchema = new Function(
         "ctx",
         schema
@@ -898,7 +896,7 @@ describe("schema dump and load", () => {
           )
           .replace(/}$/, "})();"),
       );
-      await defineSchema(targetCtx);
+      await defineSchema(targetAdapter);
 
       // Verify table exists in target
       const tables = await targetAdapter.execute(

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 import { mkdirSync, readdirSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
-import { Base, MigrationContext } from "@blazetrails/activerecord";
+import { Base } from "@blazetrails/activerecord";
 import type { AbstractSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js";
 import { parseTestCompareFromLogs } from "./parse-test-compare.js";
@@ -403,7 +403,7 @@ class SyncLog extends Base {
 }
 
 // ---------------------------------------------------------------------------
-// Schema setup via MigrationContext
+// Schema setup via the adapter schema DSL
 // ---------------------------------------------------------------------------
 
 async function tableExists(adapter: AbstractSQLite3Adapter, name: string): Promise<boolean> {
@@ -425,13 +425,11 @@ async function columnExists(
 }
 
 async function migrateDb(adapter: AbstractSQLite3Adapter) {
-  const ctx = new MigrationContext(adapter);
-
   const hasExistingSchema = await tableExists(adapter, "sync_log");
 
   if (hasExistingSchema) {
     if (!(await tableExists(adapter, "compare_logs"))) {
-      await ctx.createTable("compare_logs", {}, (t) => {
+      await adapter.createTable("compare_logs", {}, (t) => {
         t.string("merge_commit_sha");
         t.integer("pr_number");
         t.string("step_name");
@@ -476,7 +474,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
         );
       }
     } else {
-      await ctx.createTable("raw_job_logs", { id: false }, (t) => {
+      await adapter.createTable("raw_job_logs", { id: false }, (t) => {
         t.integer("job_id", { primaryKey: true });
         t.integer("run_id");
         t.string("job_name");
@@ -542,7 +540,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
     }
 
     if (!(await tableExists(adapter, "pr_requested_reviewers"))) {
-      await ctx.createTable("pr_requested_reviewers", {}, (t) => {
+      await adapter.createTable("pr_requested_reviewers", {}, (t) => {
         t.integer("pr_number");
         t.string("reviewer");
         t.string("reviewer_type");
@@ -551,7 +549,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
     }
 
     if (!(await tableExists(adapter, "pr_linked_issues"))) {
-      await ctx.createTable("pr_linked_issues", {}, (t) => {
+      await adapter.createTable("pr_linked_issues", {}, (t) => {
         t.integer("pr_number");
         t.integer("issue_number");
         t.string("issue_title");
@@ -561,7 +559,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
     }
 
     if (!(await tableExists(adapter, "pr_timeline_events"))) {
-      await ctx.createTable("pr_timeline_events", {}, (t) => {
+      await adapter.createTable("pr_timeline_events", {}, (t) => {
         t.integer("pr_number");
         t.string("event_type");
         t.string("actor");
@@ -573,7 +571,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
     }
 
     if (!(await tableExists(adapter, "pr_reactions"))) {
-      await ctx.createTable("pr_reactions", { id: false }, (t) => {
+      await adapter.createTable("pr_reactions", { id: false }, (t) => {
         t.integer("reaction_id", { primaryKey: true });
         t.integer("pr_number");
         t.string("user");
@@ -585,7 +583,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
     }
 
     if (!(await tableExists(adapter, "check_annotations"))) {
-      await ctx.createTable("check_annotations", {}, (t) => {
+      await adapter.createTable("check_annotations", {}, (t) => {
         t.integer("run_id");
         t.integer("job_id");
         t.string("path");
@@ -600,7 +598,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
     }
 
     if (!(await tableExists(adapter, "workflow_steps"))) {
-      await ctx.createTable("workflow_steps", {}, (t) => {
+      await adapter.createTable("workflow_steps", {}, (t) => {
         t.integer("job_id");
         t.string("name");
         t.string("status");
@@ -614,7 +612,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
     }
 
     if (!(await tableExists(adapter, "api_compare_privates_stats"))) {
-      await ctx.createTable("api_compare_privates_stats", {}, (t) => {
+      await adapter.createTable("api_compare_privates_stats", {}, (t) => {
         t.string("merge_commit_sha");
         t.integer("pr_number");
         t.string("package");
@@ -631,7 +629,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
 
   await adapter.beginTransaction();
   try {
-    await ctx.createTable("pull_requests", { id: false }, (t) => {
+    await adapter.createTable("pull_requests", { id: false }, (t) => {
       t.integer("number", { primaryKey: true });
       t.string("title");
       t.string("author");
@@ -659,7 +657,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.integer("reactions_synced", { default: 0 });
     });
 
-    await ctx.createTable("pr_files", {}, (t) => {
+    await adapter.createTable("pr_files", {}, (t) => {
       t.integer("pr_number");
       t.string("filename");
       t.string("status");
@@ -670,7 +668,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["pr_number", "filename"], { unique: true });
     });
 
-    await ctx.createTable("pr_commits", {}, (t) => {
+    await adapter.createTable("pr_commits", {}, (t) => {
       t.integer("pr_number");
       t.string("sha");
       t.text("message");
@@ -679,7 +677,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["pr_number", "sha"], { unique: true });
     });
 
-    await ctx.createTable("pr_comments", { id: false }, (t) => {
+    await adapter.createTable("pr_comments", { id: false }, (t) => {
       t.integer("id", { primaryKey: true });
       t.integer("pr_number");
       t.string("author");
@@ -693,7 +691,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["pr_number"]);
     });
 
-    await ctx.createTable("pr_reviews", { id: false }, (t) => {
+    await adapter.createTable("pr_reviews", { id: false }, (t) => {
       t.integer("id", { primaryKey: true });
       t.integer("pr_number");
       t.string("author");
@@ -706,14 +704,14 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["source_path"], { unique: true });
     });
 
-    await ctx.createTable("pr_requested_reviewers", {}, (t) => {
+    await adapter.createTable("pr_requested_reviewers", {}, (t) => {
       t.integer("pr_number");
       t.string("reviewer");
       t.string("reviewer_type");
       t.index(["pr_number", "reviewer", "reviewer_type"], { unique: true });
     });
 
-    await ctx.createTable("pr_linked_issues", {}, (t) => {
+    await adapter.createTable("pr_linked_issues", {}, (t) => {
       t.integer("pr_number");
       t.integer("issue_number");
       t.string("issue_title");
@@ -721,7 +719,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["pr_number", "issue_number"], { unique: true });
     });
 
-    await ctx.createTable("pr_timeline_events", {}, (t) => {
+    await adapter.createTable("pr_timeline_events", {}, (t) => {
       t.integer("pr_number");
       t.string("event_type");
       t.string("actor");
@@ -731,7 +729,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["pr_number"]);
     });
 
-    await ctx.createTable("pr_reactions", { id: false }, (t) => {
+    await adapter.createTable("pr_reactions", { id: false }, (t) => {
       t.integer("reaction_id", { primaryKey: true });
       t.integer("pr_number");
       t.string("user");
@@ -741,7 +739,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["pr_number"]);
     });
 
-    await ctx.createTable("workflow_runs", { id: false }, (t) => {
+    await adapter.createTable("workflow_runs", { id: false }, (t) => {
       t.integer("id", { primaryKey: true });
       t.string("head_sha");
       t.integer("pr_number");
@@ -757,7 +755,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["head_sha"]);
     });
 
-    await ctx.createTable("workflow_jobs", { id: false }, (t) => {
+    await adapter.createTable("workflow_jobs", { id: false }, (t) => {
       t.integer("id", { primaryKey: true });
       t.integer("run_id");
       t.string("name");
@@ -769,7 +767,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["run_id", "name"]);
     });
 
-    await ctx.createTable("workflow_steps", {}, (t) => {
+    await adapter.createTable("workflow_steps", {}, (t) => {
       t.integer("job_id");
       t.string("name");
       t.string("status");
@@ -781,7 +779,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["job_id", "number"], { unique: true });
     });
 
-    await ctx.createTable("check_annotations", {}, (t) => {
+    await adapter.createTable("check_annotations", {}, (t) => {
       t.integer("run_id");
       t.integer("job_id");
       t.string("path");
@@ -794,7 +792,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["job_id"]);
     });
 
-    await ctx.createTable("test_compare_stats", {}, (t) => {
+    await adapter.createTable("test_compare_stats", {}, (t) => {
       t.string("merge_commit_sha");
       t.integer("pr_number");
       t.string("package");
@@ -808,7 +806,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["merge_commit_sha", "package"], { unique: true });
     });
 
-    await ctx.createTable("api_compare_stats", {}, (t) => {
+    await adapter.createTable("api_compare_stats", {}, (t) => {
       t.string("merge_commit_sha");
       t.integer("pr_number");
       t.string("package");
@@ -820,7 +818,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["merge_commit_sha", "package"], { unique: true });
     });
 
-    await ctx.createTable("api_compare_privates_stats", {}, (t) => {
+    await adapter.createTable("api_compare_privates_stats", {}, (t) => {
       t.string("merge_commit_sha");
       t.integer("pr_number");
       t.string("package");
@@ -831,7 +829,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["merge_commit_sha", "package"], { unique: true });
     });
 
-    await ctx.createTable("compare_logs", {}, (t) => {
+    await adapter.createTable("compare_logs", {}, (t) => {
       t.string("merge_commit_sha");
       t.integer("pr_number");
       t.string("step_name");
@@ -839,7 +837,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["merge_commit_sha", "step_name"], { unique: true });
     });
 
-    await ctx.createTable("raw_job_logs", { id: false }, (t) => {
+    await adapter.createTable("raw_job_logs", { id: false }, (t) => {
       t.integer("job_id", { primaryKey: true });
       t.integer("run_id");
       t.string("job_name");
@@ -850,7 +848,7 @@ async function migrateDb(adapter: AbstractSQLite3Adapter) {
       t.index(["run_id"]);
     });
 
-    await ctx.createTable("sync_log", {}, (t) => {
+    await adapter.createTable("sync_log", {}, (t) => {
       t.string("synced_at");
       t.integer("prs_synced", { default: 0 });
       t.integer("runs_synced", { default: 0 });


### PR DESCRIPTION
Follow-up to `route-migrationcontext-dsl-callers-onto-schema-statements`, which
hit the LOC ceiling after its ten files. This converts every remaining
`new MigrationContext(...)` schema-DSL caller outside `migration.ts` to call the
adapter's `SchemaStatements` methods directly — `connection.create_table(...)` in
Rails terms — which is what `MigrationContext` already delegated to.

## What changed

- Tests: `schema-dumper.test.ts`, `schema-dumper.trails.test.ts`,
  `defaults.test.ts`, `timestamp.test.ts`, `time-precision.test.ts`,
  `bigint-roundtrip.test.ts`, the nine `associations/*` files, and
  `trailties/src/commands/db.test.ts`.
- `scripts/sync-stats/sync.ts` schema setup.
- `DatabaseTasks#loadSchema` now passes the adapter straight into the loaded
  schema function.
- The generated `defineSchema` preamble (`schema-dumper.ts`,
  `support/schema-file-generator.ts`) is now `ctx: DatabaseAdapter` instead of
  `ctx: MigrationContext`, so generated schema files keep compiling once the
  class is deleted.

No test renames, no new surface, no behavior change. The only non-mechanical
bit is `timestamp.test.ts`'s `indexes("foos")` call: `AbstractAdapter#indexes`
is declared `Promise<unknown[]>` (the concrete `IndexDefinition` shape lives on
the dialect adapters), so the call site casts.

## Deliberately left alone

- `migration.trails.test.ts` (4 callers) — regression tests *of* the class,
  deferred to `delete-drained-migrationcontext-schema-dsl` per the story.
- `ConnectionPool#migrationContext` — this mirrors Rails'
  `ActiveRecord::ConnectionAdapters::ConnectionPool#migration_context`
  (`connection_pool.rb:294`) and is consumed for version bookkeeping
  (`getAllVersions` / `migrations`), not the schema DSL. Converting it would be
  a fidelity regression; it belongs to
  `rename-merged-migrator-into-migrationcontext-and-migrator`.
- The files in flight on the parent PR #5792 (`migration.test.ts`,
  `comment.test.ts`, `cache-key.test.ts`, `date-time-precision.test.ts`,
  `dirty.test.ts`, `hot-compatibility.test.ts`, `active-record-schema.test.ts`,
  `schema-introspection.trails.test.ts`) — non-overlapping by design.

## Verification

- `pnpm api:compare` — Overall 11788/17536 (67.2%), Data layer 7723/7816,
  identical to baseline.
- `pnpm test:compare` — Overall 14876/22203 (67%), 763/1044 files, identical to
  baseline.
- `tsc -b` and `eslint` clean; all touched suites green on the sqlite lane
  (PG/MySQL via CI).

Closes-story: route-remaining-migrationcontext-dsl-callers-onto-schema-statements
