### PR TITLE
fix(schema-statements): guard every adapter-dispatch shim site against self-dispatch

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -310,6 +310,41 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     ).rejects.toThrow(/no foreign key/i);
   });
 
+  it("adapter overrides that call super reach the base body without self-dispatching", async () => {
+    // Regression guard for the whole dispatch shim, not just removeForeignKey:
+    // when SchemaStatements is mixed into AbstractAdapter, `this.adapter` is the
+    // adapter itself, so an override reaching the base body through `super` used
+    // to be dispatched straight back into the override and spin forever. Every
+    // shim site now carries the `adapter !== this` guard, so `super` lands in the
+    // base body.
+    class SuperCallingAdapter extends SqliteCapturingAdapter {
+      changeColumnDefaultCalls = 0;
+      addCheckConstraintCalls = 0;
+      supportsCheckConstraints() {
+        return true;
+      }
+      quoteColumnName(name: string) {
+        return `"${name}"`;
+      }
+      async changeColumnDefault(tableName: string, columnName: string, options: any) {
+        this.changeColumnDefaultCalls += 1;
+        return super.changeColumnDefault(tableName, columnName, options);
+      }
+      async addCheckConstraint(tableName: string, expression: string, options: any = {}) {
+        this.addCheckConstraintCalls += 1;
+        return super.addCheckConstraint(tableName, expression, options);
+      }
+    }
+    const stub = new SuperCallingAdapter();
+    await stub.changeColumnDefault("widgets", "title", { from: null, to: "hi" });
+    expect(stub.changeColumnDefaultCalls).toBe(1);
+    expect(stub.allSql.at(-1)).toMatch(/ALTER TABLE "widgets" ALTER COLUMN "title" SET DEFAULT/);
+
+    await stub.addCheckConstraint("widgets", "price > 0", { name: "price_check" });
+    expect(stub.addCheckConstraintCalls).toBe(1);
+    expect(stub.allSql.at(-1)).toMatch(/CHECK \(price > 0\)/);
+  });
+
   it("removeForeignKey ifExists probe matches on to_table only, not name (Rails)", async () => {
     // Rails' remove_foreign_key checks existence with only the positional
     // to_table, then resolves the exact constraint (with column/name) via

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -311,12 +311,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
   });
 
   it("adapter overrides that call super reach the base body without self-dispatching", async () => {
-    // Regression guard for the whole dispatch shim, not just removeForeignKey:
-    // when SchemaStatements is mixed into AbstractAdapter, `this.adapter` is the
-    // adapter itself, so an override reaching the base body through `super` used
-    // to be dispatched straight back into the override and spin forever. Every
-    // shim site now carries the `adapter !== this` guard, so `super` lands in the
-    // base body.
     class SuperCallingAdapter extends SqliteCapturingAdapter {
       changeColumnDefaultCalls = 0;
       addCheckConstraintCalls = 0;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -279,9 +279,6 @@ export class SchemaStatements {
 
   get schemaCreation(): SchemaCreation {
     if (!this._schemaCreation) {
-      // Same one-way dispatch as the method shims below: mixed into an adapter
-      // `this.adapter` is `this`, so reading `.schemaCreation` off it would
-      // re-enter this getter forever.
       const adapterSC =
         (this.adapter as unknown) === (this as unknown)
           ? undefined
@@ -292,6 +289,24 @@ export class SchemaStatements {
           : new SchemaCreation(this.adapterName, this.adapter);
     }
     return this._schemaCreation;
+  }
+
+  /**
+   * The adapter's own override of `name`, or `undefined` when the base body
+   * should run. Dispatch is one-way: mixed into an adapter
+   * (`include(AbstractAdapter, SchemaStatements)`) `this.adapter` is `this`, so
+   * an override reaching this body through `super` must not be sent back to
+   * itself.
+   */
+  protected _adapterOverride<K extends keyof SchemaStatements>(
+    name: K,
+  ): Extract<SchemaStatements[K], (...args: never[]) => unknown> | undefined {
+    const adapter = this.adapter as unknown as Record<PropertyKey, unknown>;
+    if ((adapter as unknown) === (this as unknown)) return undefined;
+    const fn = adapter[name];
+    const base = (SchemaStatements.prototype as unknown as Record<PropertyKey, unknown>)[name];
+    if (typeof fn !== "function" || fn === base) return undefined;
+    return fn.bind(adapter) as Extract<SchemaStatements[K], (...args: never[]) => unknown>;
   }
 
   protected _qi(name: string): string {
@@ -510,14 +525,8 @@ export class SchemaStatements {
     // SQLite rebuilds the table (alter_table) to drop a column so indexes that
     // reference it are dropped instead of left dangling; delegate when the
     // adapter supplies its own removeColumn (mirrors renameColumn's gate).
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.removeColumn === "function" &&
-      adapter.removeColumn !== SchemaStatements.prototype.removeColumn
-    ) {
-      return adapter.removeColumn(tableName, columnName, _type, options);
-    }
+    const override = this._adapterOverride("removeColumn");
+    if (override) return override(tableName, columnName, _type, options);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} DROP COLUMN ${this._qi(columnName)}`,
@@ -529,14 +538,8 @@ export class SchemaStatements {
     // AbstractMysqlAdapter#renameColumn; delegate when the adapter supplies its
     // own implementation. The gate prevents self-recursion now that
     // SchemaStatements is mixed into AbstractAdapter (see changeColumn).
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.renameColumn === "function" &&
-      adapter.renameColumn !== SchemaStatements.prototype.renameColumn
-    ) {
-      return adapter.renameColumn(tableName, oldName, newName);
-    }
+    const override = this._adapterOverride("renameColumn");
+    if (override) return override(tableName, oldName, newName);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} RENAME COLUMN ${this._qi(oldName)} TO ${this._qi(newName)}`,
@@ -619,14 +622,8 @@ export class SchemaStatements {
     // changeColumn with a table-rebuild path. Delegate when the adapter supplies
     // its own implementation; the gate prevents self-recursion now that
     // SchemaStatements is mixed into AbstractAdapter (see changeColumnDefault).
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.changeColumn === "function" &&
-      adapter.changeColumn !== SchemaStatements.prototype.changeColumn
-    ) {
-      return adapter.changeColumn(tableName, columnName, type, options);
-    }
+    const override = this._adapterOverride("changeColumn");
+    if (override) return override(tableName, columnName, type, options);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const sqlType = this.schemaCreation.typeToSql(type, options);
     const table = this._qi(tableName);
@@ -753,14 +750,8 @@ export class SchemaStatements {
     // changeColumnDefault with a table-rebuild path. Delegate when the adapter
     // supplies its own implementation; the gate prevents self-recursion now
     // that SchemaStatements is mixed into AbstractAdapter (see addForeignKey).
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.changeColumnDefault === "function" &&
-      adapter.changeColumnDefault !== SchemaStatements.prototype.changeColumnDefault
-    ) {
-      return adapter.changeColumnDefault(tableName, columnName, options);
-    }
+    const override = this._adapterOverride("changeColumnDefault");
+    if (override) return override(tableName, columnName, options);
     // Rails unwraps a Hash to its :to only when it carries BOTH :from and :to
     // (extract_new_default_value, schema_statements.rb:1820); a bare structured
     // default like `{ to: 1 }` without :from is the literal default.
@@ -864,14 +855,8 @@ export class SchemaStatements {
     // wrapper (this !== the adapter), delegate to that override. The
     // `this !== adapter` guard keeps adapters that call `super` (e.g. PostgreSQL)
     // from re-entering this gate and recursing.
-    const fkAdapter = this.adapter as any;
-    if (
-      this !== fkAdapter &&
-      typeof fkAdapter.addForeignKey === "function" &&
-      fkAdapter.addForeignKey !== SchemaStatements.prototype.addForeignKey
-    ) {
-      return fkAdapter.addForeignKey(fromTable, toTable, options);
-    }
+    const override = this._adapterOverride("addForeignKey");
+    if (override) return override(fromTable, toTable, options);
     // Rails: return unless use_foreign_keys?
     if (!this.isUseForeignKeys()) return;
     // Mirrors Rails' add_foreign_key short-circuit:
@@ -912,19 +897,8 @@ export class SchemaStatements {
     toTableOrOptions?: string | RemoveForeignKeyOptions,
     options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
-    const adapter = this.adapter as any;
-    // `adapter !== this` keeps the dispatch one-way. When these methods run
-    // mixed into an adapter (`include(AbstractAdapter, SchemaStatements)`),
-    // `this.adapter` is the adapter itself, so an adapter override reaching the
-    // base body through `super` would otherwise be dispatched straight back to
-    // itself.
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.removeForeignKey === "function" &&
-      adapter.removeForeignKey !== SchemaStatements.prototype.removeForeignKey
-    ) {
-      return adapter.removeForeignKey(fromTable, toTableOrOptions, options);
-    }
+    const override = this._adapterOverride("removeForeignKey");
+    if (override) return override(fromTable, toTableOrOptions, options);
     // Rails: return unless use_foreign_keys?
     if (!this.isUseForeignKeys()) return;
     // Mirrors Rails remove_foreign_key(from_table, to_table = nil, **options):
@@ -968,17 +942,12 @@ export class SchemaStatements {
       [key: string]: unknown;
     } = {},
   ): Promise<void> {
-    const adapter = this.adapter as any;
+    const override = this._adapterOverride("addCheckConstraint");
+    if (override) return override(tableName, expression, options);
+    const support = this.adapter as { supportsCheckConstraints?: () => boolean };
     if (
-      adapter !== (this as unknown) &&
-      typeof adapter.addCheckConstraint === "function" &&
-      adapter.addCheckConstraint !== SchemaStatements.prototype.addCheckConstraint
-    ) {
-      return adapter.addCheckConstraint(tableName, expression, options);
-    }
-    if (
-      typeof adapter.supportsCheckConstraints === "function" &&
-      !adapter.supportsCheckConstraints()
+      typeof support.supportsCheckConstraints === "function" &&
+      !support.supportsCheckConstraints()
     )
       return;
 
@@ -998,14 +967,8 @@ export class SchemaStatements {
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
     options: { name?: string; ifExists?: boolean } = {},
   ): Promise<void> {
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.removeCheckConstraint === "function" &&
-      adapter.removeCheckConstraint !== SchemaStatements.prototype.removeCheckConstraint
-    ) {
-      return adapter.removeCheckConstraint(tableName, expressionOrOptions, options);
-    }
+    const override = this._adapterOverride("removeCheckConstraint");
+    if (override) return override(tableName, expressionOrOptions, options);
     // Mirrors Rails remove_check_constraint(table, expression = nil, **options):
     // resolve the live constraint via check_constraint_for! (by :name, else the
     // hash of the expression) and drop it by its real name — mirroring how
@@ -1040,14 +1003,8 @@ export class SchemaStatements {
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.addTimestamps === "function" &&
-      adapter.addTimestamps !== SchemaStatements.prototype.addTimestamps
-    ) {
-      return adapter.addTimestamps(tableName, options);
-    }
+    const override = this._adapterOverride("addTimestamps");
+    if (override) return override(tableName, options);
     const fragments = await this.addTimestampsForAlter(tableName, options);
     await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
   }
@@ -1161,14 +1118,10 @@ export class SchemaStatements {
         "You must specify at least one column name. Example: remove_columns(:people, :first_name)",
       );
     }
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.removeColumns === "function" &&
-      adapter.removeColumns !== SchemaStatements.prototype.removeColumns
-    ) {
-      return adapter.removeColumns(tableName, ...columns);
-    }
+    const override = this._adapterOverride("removeColumns") as
+      | ((tableName: string, ...columns: string[]) => Promise<void>)
+      | undefined;
+    if (override) return override(tableName, ...columns);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const fragments = this.removeColumnsForAlter(tableName, columns, { ...opts } as Record<
       string,
@@ -1464,16 +1417,8 @@ export class SchemaStatements {
   }
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    const adapter = this.adapter as {
-      foreignKeys?: (t: string) => Promise<ForeignKeyDefinition[]>;
-    };
-    if (
-      (adapter as unknown) !== (this as unknown) &&
-      typeof adapter.foreignKeys === "function" &&
-      (adapter.foreignKeys as unknown) !== SchemaStatements.prototype.foreignKeys
-    ) {
-      return adapter.foreignKeys(tableName);
-    }
+    const override = this._adapterOverride("foreignKeys");
+    if (override) return override(tableName);
     return [];
   }
 
@@ -1837,14 +1782,8 @@ export class SchemaStatements {
   }
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
-    const adapter = this.adapter as any;
-    if (
-      adapter !== (this as unknown) &&
-      typeof adapter.checkConstraints === "function" &&
-      adapter.checkConstraints !== SchemaStatements.prototype.checkConstraints
-    ) {
-      return adapter.checkConstraints(tableName);
-    }
+    const override = this._adapterOverride("checkConstraints");
+    if (override) return override(tableName);
     throw new Error("NotImplementedError: checkConstraints is not implemented");
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -279,7 +279,13 @@ export class SchemaStatements {
 
   get schemaCreation(): SchemaCreation {
     if (!this._schemaCreation) {
-      const adapterSC = (this.adapter as unknown as { schemaCreation?: unknown }).schemaCreation;
+      // Same one-way dispatch as the method shims below: mixed into an adapter
+      // `this.adapter` is `this`, so reading `.schemaCreation` off it would
+      // re-enter this getter forever.
+      const adapterSC =
+        (this.adapter as unknown) === (this as unknown)
+          ? undefined
+          : (this.adapter as unknown as { schemaCreation?: unknown }).schemaCreation;
       this._schemaCreation =
         adapterSC instanceof SchemaCreation
           ? adapterSC
@@ -525,6 +531,7 @@ export class SchemaStatements {
     // SchemaStatements is mixed into AbstractAdapter (see changeColumn).
     const adapter = this.adapter as any;
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.renameColumn === "function" &&
       adapter.renameColumn !== SchemaStatements.prototype.renameColumn
     ) {
@@ -614,6 +621,7 @@ export class SchemaStatements {
     // SchemaStatements is mixed into AbstractAdapter (see changeColumnDefault).
     const adapter = this.adapter as any;
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.changeColumn === "function" &&
       adapter.changeColumn !== SchemaStatements.prototype.changeColumn
     ) {
@@ -747,6 +755,7 @@ export class SchemaStatements {
     // that SchemaStatements is mixed into AbstractAdapter (see addForeignKey).
     const adapter = this.adapter as any;
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.changeColumnDefault === "function" &&
       adapter.changeColumnDefault !== SchemaStatements.prototype.changeColumnDefault
     ) {
@@ -961,6 +970,7 @@ export class SchemaStatements {
   ): Promise<void> {
     const adapter = this.adapter as any;
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.addCheckConstraint === "function" &&
       adapter.addCheckConstraint !== SchemaStatements.prototype.addCheckConstraint
     ) {
@@ -990,6 +1000,7 @@ export class SchemaStatements {
   ): Promise<void> {
     const adapter = this.adapter as any;
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.removeCheckConstraint === "function" &&
       adapter.removeCheckConstraint !== SchemaStatements.prototype.removeCheckConstraint
     ) {
@@ -1457,6 +1468,7 @@ export class SchemaStatements {
       foreignKeys?: (t: string) => Promise<ForeignKeyDefinition[]>;
     };
     if (
+      (adapter as unknown) !== (this as unknown) &&
       typeof adapter.foreignKeys === "function" &&
       (adapter.foreignKeys as unknown) !== SchemaStatements.prototype.foreignKeys
     ) {
@@ -1827,6 +1839,7 @@ export class SchemaStatements {
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
     const adapter = this.adapter as any;
     if (
+      adapter !== (this as unknown) &&
       typeof adapter.checkConstraints === "function" &&
       adapter.checkConstraints !== SchemaStatements.prototype.checkConstraints
     ) {


### PR DESCRIPTION
## What

`abstract/schema-statements.ts` routed 12 methods through hand-copied
"did the adapter override this?" gates. Rails has no such shim — `SchemaStatements`
is a plain module and Ruby's method lookup handles it. Ours needs one because
`SchemaStatements` is both a standalone companion (`schemaStatements()`) and a
mixin (`include(AbstractAdapter, SchemaStatements)`).

In the mixed-in case `this.adapter === this`, so an adapter override reaching the
base body through `super` was dispatched straight back into itself and looped
forever. PR #5476 added the `adapter !== this` guard to `removeForeignKey` only;
the other sites still carried the trap.

All 12 gates now go through a single `_adapterOverride(name)` helper that owns the
`adapter !== this` check, so the guard cannot be forgotten at a new site. Sites
converted: `removeColumn`, `renameColumn`, `changeColumn`, `changeColumnDefault`,
`addForeignKey`, `removeForeignKey`, `addCheckConstraint`, `removeCheckConstraint`,
`addTimestamps`, `removeColumns`, `foreignKeys`, `checkConstraints`.

The `schemaCreation` getter had the same bug — it read `this.adapter.schemaCreation`
and re-entered itself when mixed in — and gets the same one-way check.

Net −19 LOC. Behavior is unchanged for the companion path (`adapter !== this`
there already) and for the existing SQLite/MySQL/PG overrides, which reach their
bodies via plain prototype dispatch and never through the shim.

The full convergence — deleting the shim by dissolving the companion/mixin
duality — is out of scope here; this closes the loop-forever trap at every site.

## Test

`schema-statements-on-adapter.test.ts` gains a case where an adapter overrides
`changeColumnDefault` and `addCheckConstraint` and calls `super` for both. On the
pre-fix baseline it fails with a stack overflow at `changeColumnDefault`; with the
fix `super` lands in the base body and emits the expected SQL.

Green locally on SQLite: the schema-statements, migration column, foreign-key,
references-foreign-key, change-table, invertible-migration, schema-dumper, and
sqlite3 copy-table suites, plus `pnpm typecheck`, `pnpm lint`, and `pnpm api:compare`.

Closes-story: schema-statements-adapter-dispatch-shim-self-dispatch
