### PR TITLE
fix(sqlite3): emit the definition's pending indexes in alterTable

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
@@ -123,15 +123,8 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
 
   it("addColumn through the rebuild creates an index registered on the definition", async () => {
     await db.addIndex("customers", ["name"]);
-    // `null: false` with no default is an invalid ALTER TABLE ADD type, so this
-    // routes through alterTable's rebuild rather than a plain ADD COLUMN.
-    await db.addColumn("customers", "nickname", "string", {
-      null: false,
-      default: undefined,
-      index: true,
-    });
+    await db.addColumn("customers", "nickname", "string", { null: false, index: true });
     const names = ((await db.indexes("customers")) as Array<{ name: string }>).map((i) => i.name);
-    // The source index round-trips exactly once alongside the pending one.
     expect(names.filter((n) => n === "index_customers_on_name")).toHaveLength(1);
     expect(names).toContain("index_customers_on_nickname");
   });

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
@@ -121,6 +121,28 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
     expect(names).not.toContain("index_customers_on_name");
   });
 
+  it("addColumn through the rebuild creates an index registered on the definition", async () => {
+    await db.addIndex("customers", ["name"]);
+    // `null: false` with no default is an invalid ALTER TABLE ADD type, so this
+    // routes through alterTable's rebuild rather than a plain ADD COLUMN.
+    await db.addColumn("customers", "nickname", "string", {
+      null: false,
+      default: undefined,
+      index: true,
+    });
+    const names = ((await db.indexes("customers")) as Array<{ name: string }>).map((i) => i.name);
+    // The source index round-trips exactly once alongside the pending one.
+    expect(names.filter((n) => n === "index_customers_on_name")).toHaveLength(1);
+    expect(names).toContain("index_customers_on_nickname");
+  });
+
+  it("addColumn of a primary_key through the rebuild creates the definition's index", async () => {
+    await db.exec('CREATE TABLE "customers2" ("name" TEXT)');
+    await db.addColumn("customers2", "id", "primary_key", { index: true });
+    const names = ((await db.indexes("customers2")) as Array<{ name: string }>).map((i) => i.name);
+    expect(names).toContain("index_customers2_on_id");
+  });
+
   it("alterTable keeps the primary key of a lowercase integer-like declared type", async () => {
     await db.exec('CREATE TABLE "customers2" ("id" bigint PRIMARY KEY, "name" TEXT)');
     await db.removeColumn("customers2", "name");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -424,24 +424,35 @@ export class SchemaStatements {
       }
     }
 
-    if (!this.adapter.supportsIndexesInCreate?.()) {
-      for (const idx of td.indexes) {
-        await this.addIndex(name, idx.columns, {
-          unique: idx.unique,
-          name: idx.name,
-          where: idx.where,
-          order: expandIndexOption(idx.orders, idx.columns),
-          using: idx.using,
-          type: idx.type,
-          comment: idx.comment,
-          length: expandIndexOption(idx.lengths, idx.columns),
-          opclass: expandIndexOption(idx.opclasses, idx.columns),
-          include: idx.include,
-          nullsNotDistinct: idx.nullsNotDistinct,
-          algorithm: idx.algorithm,
-          ifNotExists: idx.ifNotExists,
-        });
-      }
+    await this._addPendingIndexes(name, td);
+  }
+
+  /**
+   * Rails inlines this loop at the tail of `create_table`
+   * (`abstract/schema_statements.rb:312-313`). It lives in its own method here
+   * so SQLite's `alter_table`, which renders the definition itself instead of
+   * routing the rebuilt table through `create_table`, can emit the same
+   * pending indexes.
+   * @internal
+   */
+  async _addPendingIndexes(name: string, td: TableDefinition): Promise<void> {
+    if (this.adapter.supportsIndexesInCreate?.()) return;
+    for (const idx of td.indexes) {
+      await this.addIndex(name, idx.columns, {
+        unique: idx.unique,
+        name: idx.name,
+        where: idx.where,
+        order: expandIndexOption(idx.orders, idx.columns),
+        using: idx.using,
+        type: idx.type,
+        comment: idx.comment,
+        length: expandIndexOption(idx.lengths, idx.columns),
+        opclass: expandIndexOption(idx.opclasses, idx.columns),
+        include: idx.include,
+        nullsNotDistinct: idx.nullsNotDistinct,
+        algorithm: idx.algorithm,
+        ifNotExists: idx.ifNotExists,
+      });
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2411,6 +2411,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         // buffer — that is where alter_table's whole point lives, and the buffer's
         // reflection would have lost the pending changes.
         await this.execCopyTable(createTableSql);
+        // Rails reaches the rebuilt table through create_table, which emits the
+        // definition's pending indexes after the CREATE
+        // (abstract/schema_statements.rb:312-313). Rendering the definition by
+        // hand skips that, so anything registered on the definition inside the
+        // alter_table block (e.g. add_column with `index: true`) would be lost.
+        await this.schemaStatements()._addPendingIndexes(tableName, definition);
         await this.copyTableIndexes(alteredTableName, tableName);
         await this.copyTableContents(alteredTableName, tableName, originalColNames.map(renamed));
         await this.execCopyTable(`DROP TABLE ${quoteTableName(alteredTableName)}`);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2411,11 +2411,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         // buffer — that is where alter_table's whole point lives, and the buffer's
         // reflection would have lost the pending changes.
         await this.execCopyTable(createTableSql);
-        // Rails reaches the rebuilt table through create_table, which emits the
-        // definition's pending indexes after the CREATE
-        // (abstract/schema_statements.rb:312-313). Rendering the definition by
-        // hand skips that, so anything registered on the definition inside the
-        // alter_table block (e.g. add_column with `index: true`) would be lost.
         await this.schemaStatements()._addPendingIndexes(tableName, definition);
         await this.copyTableIndexes(alteredTableName, tableName);
         await this.copyTableContents(alteredTableName, tableName, originalColNames.map(renamed));


### PR DESCRIPTION
Rails builds `alter_table`'s destination through `create_table`
(`sqlite3_adapter.rb:599`), whose tail emits the definition's pending indexes
(`abstract/schema_statements.rb:312-313`). trails renders the definition with
`schemaCreation.accept(definition)` and restores indexes only by reflecting
them off the buffer table, so an index registered on the definition *inside*
the `alterTable` block was silently dropped — reachable via
`addColumn(t, c, type, { index: true })` whenever `isInvalidAlterTableType`
routes the add through the rebuild.

- Extracted `create_table`'s `td.indexes` loop into `SchemaStatements#_addPendingIndexes`
  (`@internal`; same gate, same option mapping) and call it from `alterTable`
  right after the CREATE, before `copyTableIndexes` — matching Rails' ordering.
- Source-reflected indexes still round-trip exactly once (asserted).

Closes-story: sqlite-alter-table-drops-definition-indexes
