### PR TITLE
fix(sqlite3): re-reflect the buffer in alter_table's second move_table

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -442,35 +442,24 @@ export class SchemaStatements {
       }
     }
 
-    await this._addPendingIndexes(name, td);
-  }
-
-  /**
-   * Rails inlines this loop at the tail of `create_table`
-   * (`abstract/schema_statements.rb:312-313`). It lives in its own method here
-   * so SQLite's `alter_table`, which renders the definition itself instead of
-   * routing the rebuilt table through `create_table`, can emit the same
-   * pending indexes.
-   * @internal
-   */
-  async _addPendingIndexes(name: string, td: TableDefinition): Promise<void> {
-    if (this.adapter.supportsIndexesInCreate?.()) return;
-    for (const idx of td.indexes) {
-      await this.addIndex(name, idx.columns, {
-        unique: idx.unique,
-        name: idx.name,
-        where: idx.where,
-        order: expandIndexOption(idx.orders, idx.columns),
-        using: idx.using,
-        type: idx.type,
-        comment: idx.comment,
-        length: expandIndexOption(idx.lengths, idx.columns),
-        opclass: expandIndexOption(idx.opclasses, idx.columns),
-        include: idx.include,
-        nullsNotDistinct: idx.nullsNotDistinct,
-        algorithm: idx.algorithm,
-        ifNotExists: idx.ifNotExists,
-      });
+    if (!this.adapter.supportsIndexesInCreate?.()) {
+      for (const idx of td.indexes) {
+        await this.addIndex(name, idx.columns, {
+          unique: idx.unique,
+          name: idx.name,
+          where: idx.where,
+          order: expandIndexOption(idx.orders, idx.columns),
+          using: idx.using,
+          type: idx.type,
+          comment: idx.comment,
+          length: expandIndexOption(idx.lengths, idx.columns),
+          opclass: expandIndexOption(idx.opclasses, idx.columns),
+          include: idx.include,
+          nullsNotDistinct: idx.nullsNotDistinct,
+          algorithm: idx.algorithm,
+          ifNotExists: idx.ifNotExists,
+        });
+      }
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2316,88 +2316,65 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   ): Promise<void> {
     await this.ensureConnected();
     const rename = options.rename ?? {};
-    const renamed = (name: string): string => rename[name] ?? name;
     const { bare: bareTable } = this._splitTableName(tableName);
-
-    // No explicit missing-table guard: `columns` reaches table_structure, which
-    // already raises StatementInvalid naming the table (foreign_key_test.rb:322).
-    const fromPrimaryKey = await this.primaryKey(tableName);
-    const sourceColumns = (await this.columns(tableName)) as Sqlite3Column[];
-    const definition = new SQLite3TableDefinition(tableName, {
-      id: false,
-      adapter: this,
-      ...(Array.isArray(fromPrimaryKey) ? { primaryKey: fromPrimaryKey.map(renamed) } : {}),
-    });
-    this.copyTableColumns(definition, fromPrimaryKey, sourceColumns, rename);
-
-    // Attached before the block runs, as in Rails' alter_table lambda
-    // (sqlite3_adapter.rb:566-583) — that ordering is what lets remove_column
-    // delete the FKs it orphans.
-    const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
-    const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
-    definition.foreignKeys.push(
-      ...fks.map((fk) => {
-        const column = typeof fk.column === "string" ? (rename[fk.column] ?? fk.column) : fk.column;
-        return column === fk.column
-          ? fk
-          : new ForeignKeyDefinition(
-              fk.fromTable,
-              fk.toTable,
-              column,
-              fk.primaryKey,
-              fk.name,
-              fk.onDelete,
-              fk.onUpdate,
-              fk.deferrable,
-              fk.storesValidate ? fk.validate : undefined,
-              fk.storedOptionKeys,
-            );
-      }),
-    );
-    definition.checkConstraints.push(...checks);
-
-    block?.(definition);
 
     // Rails: altered_table_name = "a#{table_name}" (sqlite3_adapter.rb:566).
     // Kept bare even for a schema-qualified table: the buffer is a TEMPORARY
     // table, which always lives in the `temp` schema, so a qualifier would be
     // rejected.
     const alteredTableName = `a${bareTable}`;
-    const colNames = definition.columns.map((c) => c.name);
 
-    const createTableSql = await this.schemaCreation.accept(definition);
+    // No explicit missing-table guard: `columns` reaches table_structure, which
+    // already raises StatementInvalid naming the table (foreign_key_test.rb:322).
+    // Rails reads the FK/check lists up front, before the first move drops the
+    // source table (sqlite3_adapter.rb:562-565 default args).
+    const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
+    const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
 
-    // Generated columns can't be inserted into — exclude them from the copy
-    // (Rails: columns_to_copy rejects columns with an :as option,
-    // sqlite3_adapter.rb:645).
-    const originalColNames = sourceColumns
-      .filter((c) => !c.isVirtual())
-      .map((c) => c.name)
-      .filter((n) => colNames.includes(renamed(n)));
+    // Rails' alter_table caller lambda (sqlite3_adapter.rb:568-583): the FKs and
+    // checks are layered on after copy_table has added the buffer's columns, and
+    // the block runs last — that ordering is what lets remove_column delete the
+    // FKs it orphans.
+    const caller = (definition: SQLite3TableDefinition): void => {
+      definition.foreignKeys.push(
+        ...fks.map((fk) => {
+          const column =
+            typeof fk.column === "string" ? (rename[fk.column] ?? fk.column) : fk.column;
+          return column === fk.column
+            ? fk
+            : new ForeignKeyDefinition(
+                fk.fromTable,
+                fk.toTable,
+                column,
+                fk.primaryKey,
+                fk.name,
+                fk.onDelete,
+                fk.onUpdate,
+                fk.deferrable,
+                fk.storesValidate ? fk.validate : undefined,
+                fk.storedOptionKeys,
+              );
+        }),
+      );
+      definition.checkConstraints.push(...checks);
+      block?.(definition);
+    };
 
     await this.transaction(async () => {
       await this.disableReferentialIntegrity(async () => {
         // Rails' alter_table is two move_table calls, each copy_table + drop_table
-        // (sqlite3_adapter.rb:585-596). The first move is Rails' verbatim: the
-        // throwaway "a"-prefixed buffer is built by copy_table off the source
-        // table's own reflection, so it carries the full column definitions
-        // rather than a hand-concatenated CREATE TABLE.
+        // (sqlite3_adapter.rb:585-596). `options` — and with it `:rename` — goes to
+        // the first move only; the second re-reflects the "a"-prefixed buffer and
+        // layers the caller's FKs / checks / `modify` on top of it.
         await this.moveTable(tableName, alteredTableName, { temporary: true, rename });
-        // The second move is copy_table + drop_table with the definition supplied
-        // by the caller above (fks/checks/`modify`) instead of re-derived from the
-        // buffer — that is where alter_table's whole point lives, and the buffer's
-        // reflection would have lost the pending changes.
-        await this.execCopyTable(createTableSql);
-        await this.schemaStatements()._addPendingIndexes(tableName, definition);
-        await this.copyTableIndexes(alteredTableName, tableName);
-        await this.copyTableContents(alteredTableName, tableName, originalColNames.map(renamed));
-        await this.execCopyTable(`DROP TABLE ${quoteTableName(alteredTableName)}`);
+        await this.moveTable(alteredTableName, tableName, {}, caller);
       });
     });
 
     this.schemaCache.clear();
-    // The rebuild issues its DDL via driver.exec (to manage savepoint nesting),
-    // bypassing the executeMutation path that dirtiesQueryCache wraps. Rails'
+    // The rebuild issues its index/drop/copy DDL via driver.exec (to manage
+    // savepoint nesting), bypassing the executeMutation path that
+    // dirtiesQueryCache wraps. Rails'
     // alter_table dirties the cache as a side effect of copy_table, which runs
     // create_table/drop_table through `execute` and copy_table_contents through
     // `internal_exec_query` — both in the dirties set — so clear it here to match.

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2324,17 +2324,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // rejected.
     const alteredTableName = `a${bareTable}`;
 
-    // No explicit missing-table guard: `columns` reaches table_structure, which
-    // already raises StatementInvalid naming the table (foreign_key_test.rb:322).
-    // Rails reads the FK/check lists up front, before the first move drops the
-    // source table (sqlite3_adapter.rb:562-565 default args).
+    // No explicit missing-table guard: the first move's `columns` reaches
+    // table_structure, which already raises StatementInvalid naming the table
+    // (foreign_key_test.rb:322).
     const fks = overrideForeignKeys ?? (await this.foreignKeys(tableName));
     const checks = overrideCheckConstraints ?? (await this.checkConstraints(tableName));
 
-    // Rails' alter_table caller lambda (sqlite3_adapter.rb:568-583): the FKs and
-    // checks are layered on after copy_table has added the buffer's columns, and
-    // the block runs last — that ordering is what lets remove_column delete the
-    // FKs it orphans.
+    // Rails' alter_table caller lambda (sqlite3_adapter.rb:568-583). The block
+    // running last is what lets remove_column delete the FKs it orphans.
     const caller = (definition: SQLite3TableDefinition): void => {
       definition.foreignKeys.push(
         ...fks.map((fk) => {
@@ -2372,12 +2369,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     });
 
     this.schemaCache.clear();
-    // The rebuild issues its index/drop/copy DDL via driver.exec (to manage
-    // savepoint nesting), bypassing the executeMutation path that
-    // dirtiesQueryCache wraps. Rails'
-    // alter_table dirties the cache as a side effect of copy_table, which runs
-    // create_table/drop_table through `execute` and copy_table_contents through
-    // `internal_exec_query` — both in the dirties set — so clear it here to match.
+    // The rebuild issues its index, DROP TABLE and content-copy DDL via
+    // driver.exec (to manage savepoint nesting), bypassing the executeMutation
+    // path that dirtiesQueryCache wraps. Rails' alter_table dirties the cache as
+    // a side effect of copy_table, which runs create_table/drop_table through
+    // `execute` and copy_table_contents through `internal_exec_query` — both in
+    // the dirties set — so clear it here to match.
     this.clearQueryCache();
   }
 


### PR DESCRIPTION
Converges SQLite's `alter_table` onto Rails' two-`move_table` shape.

Rails passes `options` — and with it `:rename` — to the **first** `move_table`
only; the second is `move_table(altered_table_name, table_name, &caller)` with
no options, so `copy_table` re-reflects the `"a"`-prefixed buffer table
(`primary_key(buffer)`, `columns(buffer)`) and the caller lambda layers the
foreign keys, check constraints and the `modify` block on top
(`sqlite3_adapter.rb:585-596`).

trails instead built the second definition from the **source** table's own
reflection with the rename map applied, hand-accepted its `CREATE TABLE` via
`schemaCreation.accept` + `execCopyTable`, and copied indexes/contents inline —
never reading the buffer back. This routes the second move through
`moveTable`/`copyTable` like the first, which:

- drops the `fromPrimaryKey.map(renamed)` stand-in for `primary_key(buffer)`
  (flagged in review on #5613),
- drops the inline `createTableSql` / `originalColNames` / index / contents
  duplication of `copyTable`, and
- turns the FK-rename + check-constraint + block assembly into the `caller`
  lambda Rails has.

The buffer round-trip turned out not to lose anything the old shape was
avoiding: the typeless (BLOB-affinity) column case, virtual columns and the
reflected defaults all survive both hops.

### `_addPendingIndexes` re-inlined

#5796 extracted `SchemaStatements#_addPendingIndexes` out of `createTable`
purely so `alterTable`, which rendered the rebuilt table's `CREATE TABLE`
itself, could emit the definition's pending indexes. The second `moveTable` now
reaches `createTable` through `copyTable`, so `createTable` is again the only
caller and Rails' inline `unless supports_indexes_in_create?` loop
(`abstract/schema_statements.rb:310-314`) is the faithful shape. Re-inlined in
place — same position in `createTable`, no behavior change — and #5796's
pending-index assertions in `copy-table.trails.test.ts` still pass.

## Testing

`adapters/sqlite3/`, `migration/`, `migration.test.ts`, `schema-dumper.test.ts`,
`schema-dumper.trails.test.ts`, `active-record-schema.test.ts` green locally on
SQLite (601 tests); `pnpm typecheck` and eslint clean.

Closes-story: sqlite-alter-table-second-move-does-not-reflect-the-buffer
