### PR TITLE
refactor(schema-statements): drop the invented pool fallbacks in assumeMigratedUptoVersion

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version.trails.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { SchemaStatements } from "./schema-statements.js";
 
-function makeStatements(options: { migrated?: number[]; versions?: number[] } = {}) {
+function makeStatements(
+  options: { migrated?: Array<number | string>; versions?: Array<number | string> } = {},
+) {
   const executed: string[] = [];
   const adapter = {
     adapterName: "sqlite" as const,
@@ -101,6 +103,30 @@ describe("SchemaStatements#assumeMigratedUptoVersion", () => {
     const { ss, executed } = makeStatements({ migrated: [], versions: [1, 1, 3] });
     await expect(ss.assumeMigratedUptoVersion(3)).rejects.toThrow("Duplicate migration 1.");
     expect(executed).toEqual(['INSERT INTO "schema_migrations" (version) VALUES (3)']);
+  });
+
+  it("backfills string-typed migration versions below the target", async () => {
+    const { ss, executed } = makeStatements({ migrated: [], versions: ["1", "2", "3"] });
+    await ss.assumeMigratedUptoVersion(3);
+    expect(executed).toEqual([
+      'INSERT INTO "schema_migrations" (version) VALUES (3)',
+      'INSERT INTO "schema_migrations" (version) VALUES\n(2),\n(1);',
+    ]);
+  });
+
+  it("treats a string-typed migrated version as already migrated", async () => {
+    const { ss, executed } = makeStatements({ migrated: ["3"], versions: ["3"] });
+    await ss.assumeMigratedUptoVersion(3);
+    expect(executed).toEqual([]);
+  });
+
+  it("excludes string-typed migrated versions from the backfill", async () => {
+    const { ss, executed } = makeStatements({ migrated: ["1"], versions: ["1", "2", "3"] });
+    await ss.assumeMigratedUptoVersion(3);
+    expect(executed).toEqual([
+      'INSERT INTO "schema_migrations" (version) VALUES (3)',
+      'INSERT INTO "schema_migrations" (version) VALUES\n(2);',
+    ]);
   });
 
   it("ignores duplicates that are outside the backfill scope", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -266,10 +266,32 @@ function expandIndexOption<T>(opt: Record<string, T> | T, columns: string[]): Re
   return Object.fromEntries(columns.map((c) => [c, opt])) as Record<string, T>;
 }
 
+/**
+ * The pool surface the schema_migrations statements reach for. Rails calls
+ * `pool.schema_migration` / `pool.migration_context` unguarded
+ * (schema_statements.rb:1356-1370), so a mis-wired pool raises here rather
+ * than degrading to a bare `schema_migrations` literal. @internal
+ */
+interface SchemaMigrationPool {
+  schemaMigration: { tableName: string; versions(): Promise<Array<string | number>> };
+  migrationContext: {
+    getAllVersions(): Promise<Array<string | number>>;
+    migrations: ReadonlyArray<{ version: string | number }>;
+  };
+}
+
 export class SchemaStatements {
   private _schemaCreation?: SchemaCreation;
 
   constructor(protected readonly adapter: DatabaseAdapter & SchemaQuoter) {}
+
+  /**
+   * `AbstractAdapter#pool` is typed `unknown` (it holds a NullPool until a real
+   * ConnectionPool claims the connection); narrow it once here. @internal
+   */
+  private get _pool(): SchemaMigrationPool {
+    return this.adapter.pool as SchemaMigrationPool;
+  }
 
   protected get adapterName(): AdapterName {
     // Base AbstractAdapter#adapterName is typed `string` (Rails-faithful
@@ -1835,26 +1857,9 @@ export class SchemaStatements {
   }
 
   async dumpSchemaInformation(): Promise<string | null> {
-    const smTable = (this.adapter as any).pool?.schemaMigration;
-    if (!smTable) return null;
-    const versions: string[] =
-      typeof smTable.versions === "function" ? await smTable.versions() : (smTable.versions ?? []);
+    const versions = await this._pool.schemaMigration.versions();
     if (versions.length === 0) return null;
-    return this._insertVersionsSql(smTable.tableName ?? "schema_migrations", versions);
-  }
-
-  private _insertVersionsSql(
-    tableName: string,
-    versions: string | number | Array<string | number>,
-  ): string {
-    const smTable = this._qt(tableName);
-    if (Array.isArray(versions)) {
-      // Ruby's Array#reverse returns a new array; copy before reversing so we
-      // don't mutate the caller's array (e.g. pool.schemaMigration.versions).
-      const rows = [...versions].reverse().map((v) => `(${this.adapter.quote(v)})`);
-      return `INSERT INTO ${smTable} (version) VALUES\n${rows.join(",\n")};`;
-    }
-    return `INSERT INTO ${smTable} (version) VALUES (${this.adapter.quote(versions)});`;
+    return this.insertVersionsSql(versions);
   }
 
   internalStringOptionsForPrimaryKey(): Record<string, unknown> {
@@ -1865,19 +1870,14 @@ export class SchemaStatements {
     const leading = /^\s*([+-]?\d+(?:_\d+)*)/.exec(String(version));
     const verNum = leading ? parseInt(leading[1].replace(/_/g, ""), 10) : 0;
 
-    const pool = (this.adapter as any).pool;
-    const smTableName = pool?.schemaMigration?.tableName ?? "schema_migrations";
-    const smTable = this._qt(smTableName);
+    const pool = this._pool;
+    const smTable = this._qt(pool.schemaMigration.tableName);
 
-    const migrationContext = pool?.migrationContext;
-    const migrated: number[] = migrationContext
-      ? typeof migrationContext.getAllVersions === "function"
-        ? await migrationContext.getAllVersions()
-        : []
-      : [];
-    const allVersions: number[] = migrationContext
-      ? (migrationContext.migrations ?? []).map((m: { version: number }) => m.version)
-      : [];
+    const migrationContext = pool.migrationContext;
+    // Rails' Migrator.get_all_versions yields integers; our MigrationContext
+    // yields the raw string versions, so coerce before comparing to `verNum`.
+    const migrated = (await migrationContext.getAllVersions()).map(Number);
+    const allVersions = migrationContext.migrations.map((m) => Number(m.version));
 
     // Insert the target version if not already migrated. Rails passes the
     // numeric `version.to_i` to `quote`, emitting an unquoted numeric literal —
@@ -1897,7 +1897,7 @@ export class SchemaStatements {
           `Duplicate migration ${duplicate}. Please renumber your migrations to resolve the conflict.`,
         );
       }
-      await this.adapter.execute(this._insertVersionsSql(smTableName, inserting));
+      await this.adapter.execute(this.insertVersionsSql(inserting));
     }
   }
 
@@ -2694,10 +2694,16 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  insertVersionsSql(versions: string | string[]): string {
-    const smTableName =
-      (this.adapter as any).pool?.schemaMigration?.tableName ?? "schema_migrations";
-    return this._insertVersionsSql(smTableName, versions);
+  insertVersionsSql(versions: string | number | Array<string | number>): string {
+    const smTable = this._qt(this._pool.schemaMigration.tableName);
+
+    if (Array.isArray(versions)) {
+      // Ruby's Array#reverse returns a new array; copy before reversing so we
+      // don't mutate the caller's array (e.g. pool.schemaMigration.versions).
+      const rows = [...versions].reverse().map((v) => `(${this.adapter.quote(v)})`);
+      return `INSERT INTO ${smTable} (version) VALUES\n${rows.join(",\n")};`;
+    }
+    return `INSERT INTO ${smTable} (version) VALUES (${this.adapter.quote(versions)});`;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -272,9 +272,15 @@ function expandIndexOption<T>(opt: Record<string, T> | T, columns: string[]): Re
  * (schema_statements.rb:1356-1370), so a mis-wired pool raises here rather
  * than degrading to a bare `schema_migrations` literal.
  *
- * Versions are strings here where Rails' `Migrator.get_all_versions` and
- * `MigrationProxy#version` hand back integers, so callers comparing against a
- * numeric target coerce them. @internal
+ * Versions are strings here where Rails' `MigrationContext#get_all_versions`
+ * (`migration.rb:1282`) and `#migrations` (`:1303`) hand back integers, so
+ * callers comparing against a numeric target coerce them.
+ *
+ * `migrationContext` describes the Rails surface, not what the pool currently
+ * returns: trails' `MigrationContext` is a schema-DSL class, and carries
+ * `getAllVersions` / `migrations` over on `Migrator` instead.
+ * Story `pool-migration-context-is-not-rails-migration-context` re-layers it.
+ * @internal
  */
 interface SchemaMigrationPool {
   schemaMigration: { tableName: string; versions(): Promise<Array<string | number>> };

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -270,7 +270,11 @@ function expandIndexOption<T>(opt: Record<string, T> | T, columns: string[]): Re
  * The pool surface the schema_migrations statements reach for. Rails calls
  * `pool.schema_migration` / `pool.migration_context` unguarded
  * (schema_statements.rb:1356-1370), so a mis-wired pool raises here rather
- * than degrading to a bare `schema_migrations` literal. @internal
+ * than degrading to a bare `schema_migrations` literal.
+ *
+ * Versions are strings here where Rails' `Migrator.get_all_versions` and
+ * `MigrationProxy#version` hand back integers, so callers comparing against a
+ * numeric target coerce them. @internal
  */
 interface SchemaMigrationPool {
   schemaMigration: { tableName: string; versions(): Promise<Array<string | number>> };
@@ -1874,8 +1878,6 @@ export class SchemaStatements {
     const smTable = this._qt(pool.schemaMigration.tableName);
 
     const migrationContext = pool.migrationContext;
-    // Rails' Migrator.get_all_versions yields integers; our MigrationContext
-    // yields the raw string versions, so coerce before comparing to `verNum`.
     const migrated = (await migrationContext.getAllVersions()).map(Number);
     const allVersions = migrationContext.migrations.map((m) => Number(m.version));
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -276,10 +276,10 @@ function expandIndexOption<T>(opt: Record<string, T> | T, columns: string[]): Re
  * (`migration.rb:1282`) and `#migrations` (`:1303`) hand back integers, so
  * callers comparing against a numeric target coerce them.
  *
- * `migrationContext` describes the Rails surface, not what the pool currently
- * returns: trails' `MigrationContext` is a schema-DSL class, and carries
- * `getAllVersions` / `migrations` over on `Migrator` instead.
- * Story `pool-migration-context-is-not-rails-migration-context` re-layers it.
+ * The class behind `migrationContext` is still trails' schema-DSL context
+ * squatting the ported Rails name, with a parallel copy of these members on
+ * `Migrator`; story `pool-migration-context-is-not-rails-migration-context`
+ * re-layers the two.
  * @internal
  */
 interface SchemaMigrationPool {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1703,6 +1703,23 @@ export class MigrationContext {
 
   constructor(private connection: DatabaseAdapter) {}
 
+  /** Mirrors: ActiveRecord::MigrationContext#schema_migration */
+  get schemaMigration(): SchemaMigration {
+    return new SchemaMigration(this.connection);
+  }
+
+  /** Mirrors: ActiveRecord::MigrationContext#get_all_versions */
+  async getAllVersions(): Promise<number[]> {
+    const schemaMigration = this.schemaMigration;
+    if (await schemaMigration.tableExists()) return schemaMigration.integerVersions();
+    return [];
+  }
+
+  /** Mirrors: ActiveRecord::MigrationContext#migrations */
+  get migrations(): MigrationProxy[] {
+    return Migrator.discoverMigrations(Migrator.migrationsPaths);
+  }
+
   private _schema?: SchemaStatements;
   private _schemaConn?: DatabaseAdapter;
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "assume_migrated_upto_version",
-    "call": "insert_versions_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "bulk_change_table",
     "call": "partition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -95,13 +88,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "distinct_relation_for_primary_key",
     "call": "compile",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "dump_schema_information",
-    "call": "insert_versions_sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -170,13 +170,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "get_all_versions",
-    "call": "table_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "maintain_test_schema!",
     "call": "suppress_messages",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Drops the invented fallbacks in the schema_migrations statements so a
mis-wired pool fails loudly instead of emitting plausible SQL against a bare
table literal.

- `assumeMigratedUptoVersion` reads `pool.schemaMigration.tableName` and
  `pool.migrationContext` unguarded, matching
  `schema_statements.rb:1364-1383` — no `?? "schema_migrations"`, no
  `migrationContext ? ... : []` ternaries.
- Same for `dumpSchemaInformation` (`schema_statements.rb:1355-1358`), which
  now just awaits `pool.schemaMigration.versions()`.
- The `(this.adapter as any).pool` casts are replaced by a single typed
  private accessor (`AbstractAdapter#pool` is typed `unknown` because it holds
  a `NullPool` until a real pool claims the connection).
- Folds the private `_insertVersionsSql(tableName, versions)` helper into
  `insertVersionsSql(versions)`, which derives the table from the pool exactly
  as Rails' `insert_versions_sql` does — one method instead of two, and the
  third copy of the fallback goes with it.
- `MigrationContext` gains the three members Rails' `MigrationContext` owns
  and trails was missing: `schemaMigration`, `getAllVersions`
  (`migration.rb:1282-1288` — `integer_versions`, `[]` when the table is
  absent) and `migrations` (`:1303-1315`, delegating to the existing
  `Migrator.discoverMigrations` file scan). Without these the unguarded call
  threw `TypeError: getAllVersions is not a function` from `Schema.define`
  (`schema.ts:98`) — the ternaries had been masking a genuine structural gap,
  not just guarding a mis-wired pool.

One behavior change falls out of the typing: `MigrationProxy#version` is a
string in trails where Rails' `MigrationContext#migrations` does `version.to_i`
(`migration.rb:1310`), so versions are coerced before being compared to the
numeric target. Under the old `any`-typed read they flowed in as strings and
`migrated.includes(verNum)` could never match, re-inserting an already-migrated
version. The stubbed coverage used numbers, so this was invisible.

Deliberately **not** fixed here: `pool.migrationContext` still returns the
class at `migration.ts:1677`, which is a schema-DSL context
(`createTable`/`addColumn`/`addIndex`) squatting the ported Rails name, and it
is constructed from an adapter proxy rather than from `migrationsPaths`
(`migration.rb:1214`). Trails also keeps a parallel copy of the
`MigrationContext`-style methods on `Migrator` (`migration.ts:2184`, `:2615`).
Re-layering those two classes and freeing the name is a broad `migration.ts`
change well beyond this story, registered as
`0051-migration-schema-statements-fidelity/pool-migration-context-is-not-rails-migration-context`.
This PR adds only the members needed to make the Rails-faithful call site
work; the interface JSDoc points at that story.

Existing coverage in
`schema-statements-assume-migrated-upto-version.trails.test.ts` (11 tests),
`active-record-schema.test.ts` and `migration.test.ts` passes.

Closes-story: assume-migrated-upto-version-drops-pool-fallbacks
