### PR TITLE
fix(schema-statements): emit createTable pending indexes before comments

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -887,13 +887,31 @@ describe("SchemaStatements#createTable statement ordering", () => {
       }),
     });
 
-    // Stub adapter — no database is touched, so there is nothing to tear down.
-    // eslint-disable-next-line blazetrails/require-table-teardown
+    // eslint-disable-next-line blazetrails/require-table-teardown -- stub adapter, no real database
     await ss.createTable("things", { id: false, comment: "a table" }, (t) => {
       t.column("name", "string", { comment: "a column" });
       t.index(["name"]);
     });
 
     expect(order).toEqual(["create", "index", "tableComment", "columnComment"]);
+  });
+
+  it("threads the table definition's ifNotExists into the pending addIndex calls", async () => {
+    const sqls: string[] = [];
+    const ss = makeStatements({
+      execute: vi.fn(async (sql: string) => {
+        sqls.push(sql);
+        return [];
+      }),
+      supportsIndexesInCreate: () => false,
+      quote: (v: unknown) => `'${String(v)}'`,
+    });
+
+    await ss.createTable("things", { id: false, ifNotExists: true }, (t) => {
+      t.column("name", "string");
+      t.index(["name"], { ifNotExists: false });
+    });
+
+    expect(sqls.some((sql) => sql.startsWith("CREATE INDEX IF NOT EXISTS"))).toBe(true);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -867,3 +867,33 @@ describe("assumeMigratedUptoVersion", () => {
     ]);
   });
 });
+
+describe("SchemaStatements#createTable statement ordering", () => {
+  it("emits pending indexes before the comment block", async () => {
+    const order: string[] = [];
+    const ss = makeStatements({
+      execute: vi.fn(async (sql: string) => {
+        order.push(sql.startsWith("CREATE INDEX") ? "index" : "create");
+        return [];
+      }),
+      supportsComments: () => true,
+      supportsCommentsInCreate: () => false,
+      supportsIndexesInCreate: () => false,
+      changeTableComment: vi.fn(async () => {
+        order.push("tableComment");
+      }),
+      changeColumnComment: vi.fn(async () => {
+        order.push("columnComment");
+      }),
+    });
+
+    // Stub adapter — no database is touched, so there is nothing to tear down.
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await ss.createTable("things", { id: false, comment: "a table" }, (t) => {
+      t.column("name", "string", { comment: "a column" });
+      t.index(["name"]);
+    });
+
+    expect(order).toEqual(["create", "index", "tableComment", "columnComment"]);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -446,6 +446,28 @@ export class SchemaStatements {
     await this.adapter.getDatabaseVersion?.();
     await this.adapter.execute(await this.schemaCreation.accept(td));
 
+    if (!this.adapter.supportsIndexesInCreate?.()) {
+      for (const idx of td.indexes) {
+        await this.addIndex(name, idx.columns, {
+          unique: idx.unique,
+          name: idx.name,
+          where: idx.where,
+          order: expandIndexOption(idx.orders, idx.columns),
+          using: idx.using,
+          type: idx.type,
+          comment: idx.comment,
+          length: expandIndexOption(idx.lengths, idx.columns),
+          opclass: expandIndexOption(idx.opclasses, idx.columns),
+          include: idx.include,
+          nullsNotDistinct: idx.nullsNotDistinct,
+          algorithm: idx.algorithm,
+          // Rails overrides any per-index `if_not_exists:` with the table
+          // definition's, since it splats `**index_options` first.
+          ifNotExists: td.ifNotExists,
+        });
+      }
+    }
+
     // Rails: if supports_comments? && !supports_comments_in_create?
     //   change_table_comment(table_name, comment) if options[:comment].present?
     if (this.adapter.supportsComments?.() && !this.adapter.supportsCommentsInCreate?.()) {
@@ -471,26 +493,6 @@ export class SchemaStatements {
             await commentAdapter.changeColumnComment(name, column.name, columnComment);
           }
         }
-      }
-    }
-
-    if (!this.adapter.supportsIndexesInCreate?.()) {
-      for (const idx of td.indexes) {
-        await this.addIndex(name, idx.columns, {
-          unique: idx.unique,
-          name: idx.name,
-          where: idx.where,
-          order: expandIndexOption(idx.orders, idx.columns),
-          using: idx.using,
-          type: idx.type,
-          comment: idx.comment,
-          length: expandIndexOption(idx.lengths, idx.columns),
-          opclass: expandIndexOption(idx.opclasses, idx.columns),
-          include: idx.include,
-          nullsNotDistinct: idx.nullsNotDistinct,
-          algorithm: idx.algorithm,
-          ifNotExists: idx.ifNotExists,
-        });
       }
     }
   }


### PR DESCRIPTION
Rails' `create_table` runs the pending-index loop **before** the comment block (`abstract/schema_statements.rb:308-320`); trails had them reversed, so on an adapter that supports comments but not indexes-in-create the emitted statement order diverged (`COMMENT ON` before `CREATE INDEX` in Rails, after in ours).

- Move the `supportsIndexesInCreate` loop above the comment block.
- Thread `td.ifNotExists` into each pending `addIndex`, matching Rails' `**index_options, if_not_exists: td.if_not_exists` (the explicit keyword wins over any per-index value).
- Regression test asserting the `create → index → tableComment → columnComment` order.

Closes-story: create-table-pending-indexes-emitted-after-comments