### PR TITLE
fix(migration): filter the direction-aware migrations reader in pendingMigrations

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2687,7 +2687,7 @@ export class Migrator {
     const applied = (await this._schemaMigration.tableExists())
       ? await this._appliedVersions()
       : new Set<string>();
-    return this._migrations.filter((m) => !applied.has(m.version));
+    return this.migrations.filter((m) => !applied.has(m.version));
   }
 
   /**
@@ -2698,7 +2698,7 @@ export class Migrator {
   async pendingMigrations(): Promise<MigrationProxy[]> {
     await this._ensureSchemaTable();
     const applied = await this.migrated();
-    return this._migrations.filter((m) => !applied.has(m.version));
+    return this.migrations.filter((m) => !applied.has(m.version));
   }
 
   /**

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -108,6 +108,23 @@ describe("Migrator trails extensions", () => {
     expect(ran).toEqual(["1"]);
   });
 
+  it("pending_migrations on a down migrator returns migrations in reverse order", async () => {
+    const migrator = new Migrator(
+      adapter,
+      [makeMigration("1", "M1"), makeMigration("2", "M2"), makeMigration("3", "M3")],
+      { direction: "down" },
+    );
+    const schemaMigration = new SchemaMigration(Base.connection);
+    await schemaMigration.createTable();
+    await schemaMigration.createVersion("2");
+
+    const pending = await migrator.pendingMigrations();
+    expect(pending.map((m) => m.version)).toEqual(["3", "1"]);
+
+    const pendingReadOnly = await migrator.pendingMigrationsReadOnly();
+    expect(pendingReadOnly.map((m) => m.version)).toEqual(["3", "1"]);
+  });
+
   it("migrate returns [] when both the current and target version are 0", async () => {
     const ran: string[] = [];
     const migrator = new Migrator(adapter, [

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -108,13 +108,13 @@ describe("Migrator trails extensions", () => {
     expect(ran).toEqual(["1"]);
   });
 
-  it("pending_migrations on a down migrator returns migrations in reverse order", async () => {
+  it("pendingMigrations on a down migrator returns migrations in reverse order", async () => {
     const migrator = new Migrator(
       adapter,
       [makeMigration("1", "M1"), makeMigration("2", "M2"), makeMigration("3", "M3")],
       { direction: "down" },
     );
-    const schemaMigration = new SchemaMigration(Base.connection);
+    const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.createTable();
     await schemaMigration.createVersion("2");
 


### PR DESCRIPTION
Rails' `Migrator#pending_migrations` rejects already-applied versions from the
direction-aware `migrations` reader
(`vendor/rails/activerecord/lib/active_record/migration.rb:1478-1481`), not the
raw ivar. trails reached past the getter into `_migrations`, which was invisible
until #5784 made `get migrations()` reverse for down-direction migrators — since
then a `direction: "down"` Migrator returned ascending order where Rails returns
descending.

- `pendingMigrations` now filters `this.migrations`.
- `pendingMigrationsReadOnly` (trails-only read-only variant) is converged the
  same way rather than left divergent.
- Callers checked: `forward`, `CheckPending`, schema-statements, the trailties
  `db` commands, `activerecord-cli`, and the website CLI frontier all construct
  up-direction Migrators, so their behavior is unchanged.

Test: a trails-only case in `migrator.trails.test.ts` (Rails'
`migrator_test.rb:141` `test_finds_pending_migrations` is up-only). It fails on
baseline (`["1","3"]`) and passes with the fix.

Closes-story: pending-migrations-should-filter-the-direction-aware-migrations-reader
