### PR TITLE
refactor(adapters): drop bespoke dataSources overrides in favour of the base

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1493,22 +1493,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return rows.map((r) => (r.name ?? r.NAME ?? r.TABLE_NAME) as string);
   }
 
-  /**
-   * Tables + views, deduped. Matches Rails'
-   * `AbstractAdapter#data_sources` — the name SchemaCache.addAll calls
-   * through. information_schema.tables already returns distinct rows
-   * within a schema, but the Set pass is defensive + keeps the
-   * contract explicit for future callers.
-   */
-  async dataSources(): Promise<string[]> {
-    const rows = await this.schemaQuery(
-      `SELECT table_name AS name FROM information_schema.tables
-         WHERE table_schema = database()
-         ORDER BY table_name`,
-    );
-    return [...new Set(rows.map((r) => (r.name ?? r.NAME ?? r.TABLE_NAME) as string))];
-  }
-
   async tableExists(name: string): Promise<boolean> {
     return this.informationSchemaExists(name, "BASE TABLE");
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4125,10 +4125,6 @@ export class PostgreSQLAdapter
     return this.pgSchemaStatements().views();
   }
 
-  async dataSources(): Promise<string[]> {
-    return this.pgSchemaStatements().dataSources();
-  }
-
   async tableExists(name: string): Promise<boolean> {
     return this.pgSchemaStatements().tableExists(name);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -313,17 +313,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   /**
-   * Tables + views, deduped. Mirrors AbstractAdapter#data_sources. The
-   * name is what SchemaCache.addAll queries to build the initial
-   * dump — without this method the PG adapter is rejected by
-   * DatabaseTasks.dumpSchemaCache's capability check.
-   */
-  async dataSources(): Promise<string[]> {
-    const [tables, views] = await Promise.all([this.tables(), this.views()]);
-    return Array.from(new Set([...tables, ...views]));
-  }
-
-  /**
    * Table-only existence check (no views). Mirrors Rails'
    * `table_exists?` vs `data_source_exists?` distinction: a table is a
    * data source but a data source isn't always a table. SchemaCache

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2077,13 +2077,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   /**
-   * Tables + views, deduped. Mirrors AbstractAdapter#data_sources.
-   */
-  async dataSources(): Promise<string[]> {
-    return [...new Set([...(await this.tables()), ...(await this.views())])];
-  }
-
-  /**
    * Resolve the sqlite_master reference for a possibly-schema-qualified
    * name. SQLite stores each attached DB's schema in its own
    * `<schema>.sqlite_master`; `aux.widgets` is row `name='widgets'` in


### PR DESCRIPTION
Rails defines `data_sources` only on `AbstractAdapter::SchemaStatements` (`tables | views`); no concrete adapter overrides it. `include(AbstractAdapter, SchemaStatements)` already puts that body on every adapter prototype, so the three trails shadows are deleted outright.

- **sqlite3** — faithful reimplementation, pure duplication.
- **mysql2** — a real deviation: one `information_schema.tables` catalog scan with an `ORDER BY` Rails does not impose, instead of `tables | views`. Removed, no caller depends on the ordering.
- **postgresql** — the comment claimed `DatabaseTasks.dumpSchemaCache`s capability check requires the method on the adapter. It does not: the check is a `typeof connection[m] === "function"` lookup, which an inherited prototype method satisfies. `DatabaseTasksDumpSchemaCacheTest` passes with the shadow gone, so the shadow was retired rather than the check changed. The `postgresql-adapter.ts` delegation to `pgSchemaStatements()` goes with it.

Tests: `schema-cache`, `adapter`, `database-tasks`, `schema-statements-privates` pass on sqlite; pg/mysql lanes covered by CI.

Closes-story: remove-bespoke-adapter-data-sources-overrides