### PR TITLE
refactor(migration): port Rails' MigrationContext and give it to the pool

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1873,7 +1873,7 @@ export class AbstractAdapter implements Quoting {
   // (schema_dumper.rb#indexes: `... if !default_index_type?(index)`). PostgreSQL
   // and MySQL override to also treat `:btree` as the default; SQLite inherits
   // this nil-only check (so a non-nil `using` on sqlite still dumps). Surfaced
-  // here so `MigrationContext#addIndex` gates the stored `using` on the same
+  // here so `SchemaContext#addIndex` gates the stored `using` on the same
   // per-adapter predicate the dumper reads, rather than an adapter-name check.
   defaultIndexType(using?: string): boolean {
     return using == null;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -521,7 +521,11 @@ export class ConnectionPool implements ReapablePool {
   }
 
   get migrationsPaths(): string[] {
-    return (this.dbConfig as any).migrationsPaths ?? ["db/migrate"];
+    // `DatabaseConfig#migrationsPaths` answers a bare string for a single-path
+    // config; Rails wraps in `Array(migrations_paths)` before globbing
+    // (migration.rb:1369), and without that a string iterates per character.
+    const paths = (this.dbConfig as any).migrationsPaths ?? ["db/migrate"];
+    return Array.isArray(paths) ? paths : [paths];
   }
 
   get schemaMigration(): SchemaMigration {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -542,7 +542,11 @@ export class ConnectionPool implements ReapablePool {
 
   get migrationContext(): MigrationContext {
     if (!this._migrationContext) {
-      this._migrationContext = new MigrationContext(this._getAdapterProxy());
+      this._migrationContext = new MigrationContext(
+        this.migrationsPaths,
+        this.schemaMigration,
+        this.internalMetadata,
+      );
     }
     return this._migrationContext;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -287,7 +287,7 @@ export function validType(this: SchemaDumperMixinHost, type: string | null | und
  * schemaDefault, etc.) take effect. Mirrors the column-emission half of Rails'
  * `SchemaDumper#table`, whose `@connection.column_spec` is the adapter's
  * mixed-in method. Every dump reaches it — the single dumper class assigns this
- * onto its prototype, including the in-memory MigrationContext and mock-source
+ * onto its prototype, including the in-memory SchemaContext and mock-source
  * paths.
  *
  * Builds into a local buffer so a raise mid-table discards the partial

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `assume_migrated_upto_version` end to end against a REAL pool.
+ *
+ * The sibling `...-upto-version.trails.test.ts` pins the emitted SQL through a
+ * stubbed `pool.migrationContext`; nothing there proves the object a live pool
+ * hands back actually owns `getAllVersions` / `migrations`. These cases go
+ * through `Base.connectionPool()` untouched, so a pool wired to something
+ * without those members fails here.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Base } from "../../base.js";
+import { SchemaMigration } from "../../schema-migration.js";
+import { fixtures } from "../../test-fixtures.js";
+
+// `assumeMigratedUptoVersion` is mixed onto the adapter from SchemaStatements,
+// so it is not on the AbstractAdapter declaration.
+const assumeMigratedUptoVersion = (version: number) =>
+  (
+    Base.connection as unknown as {
+      assumeMigratedUptoVersion(v: number): Promise<void>;
+    }
+  ).assumeMigratedUptoVersion(version);
+
+// The `valid` fixture directory holds versions 1, 2 and 3.
+const VALID_MIGRATIONS = new URL("../../test-helpers/migrations/valid", import.meta.url).pathname;
+
+describe("SchemaStatements#assumeMigratedUptoVersion", () => {
+  fixtures({}, { useTransactionalTests: false });
+
+  let restorePaths: () => void;
+
+  beforeEach(async () => {
+    const pool = Base.connectionPool();
+    // `DatabaseConfig#migrationsPaths` is a reader over a frozen configuration
+    // hash, so shadow the reader itself rather than the hash behind it. The
+    // pool still builds its context the ordinary way.
+    const dbConfig = pool.dbConfig as unknown as object;
+    const previous = Object.getOwnPropertyDescriptor(dbConfig, "migrationsPaths");
+    Object.defineProperty(dbConfig, "migrationsPaths", {
+      configurable: true,
+      get: () => [VALID_MIGRATIONS],
+    });
+    // The context memoizes its paths the way Rails' constructor does, so drop
+    // the memo rather than mutating it in place.
+    delete (pool as unknown as { _migrationContext?: unknown })._migrationContext;
+    restorePaths = () => {
+      if (previous) Object.defineProperty(dbConfig, "migrationsPaths", previous);
+      else delete (dbConfig as Record<string, unknown>).migrationsPaths;
+      delete (pool as unknown as { _migrationContext?: unknown })._migrationContext;
+    };
+    await new SchemaMigration(Base.connection).dropTable();
+    await new SchemaMigration(Base.connection).createTable();
+  });
+
+  afterEach(() => {
+    restorePaths();
+  });
+
+  it("backfills every known version up to the target through the pool's migration context", async () => {
+    await assumeMigratedUptoVersion(3);
+    expect(await new SchemaMigration(Base.connection).integerVersions()).toEqual([1, 2, 3]);
+  });
+
+  it("does not re-insert a version the schema_migrations table already holds", async () => {
+    const schemaMigration = Base.connectionPool().schemaMigration;
+    await schemaMigration.createVersion("3");
+    await assumeMigratedUptoVersion(3);
+    expect(await schemaMigration.integerVersions()).toEqual([1, 2, 3]);
+  });
+
+  it("reads the migrations paths of the pool that built the context, not a global list", async () => {
+    const pool = Base.connectionPool();
+    expect(pool.migrationContext.migrationsPaths).toEqual([VALID_MIGRATIONS]);
+    expect(pool.migrationContext.migrations.map((m) => Number(m.version))).toEqual([1, 2, 3]);
+  });
+
+  it("reports the versions stored in the pool's schema_migrations table", async () => {
+    await Base.connectionPool().schemaMigration.createVersion("2");
+    expect(await Base.connectionPool().migrationContext.getAllVersions()).toEqual([2]);
+    expect(await Base.connectionPool().migrationContext.currentVersion()).toBe(2);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
@@ -3,17 +3,25 @@
  *
  * The sibling `...-upto-version.trails.test.ts` pins the emitted SQL through a
  * stubbed `pool.migrationContext`; nothing there proves the object a live pool
- * hands back actually owns `getAllVersions` / `migrations`. These cases go
- * through `Base.connectionPool()` untouched, so a pool wired to something
- * without those members fails here.
+ * hands back actually owns `getAllVersions` / `migrations`, nor that the paths
+ * it discovers migrations from are its own rather than `Migrator`'s global
+ * static. These cases go through `Base.connectionPool()` unstubbed.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../../base.js";
+import { Migrator } from "../../migration.js";
 import { SchemaMigration } from "../../schema-migration.js";
 import { fixtures } from "../../test-fixtures.js";
 
-// `assumeMigratedUptoVersion` is mixed onto the adapter from SchemaStatements,
-// so it is not on the AbstractAdapter declaration.
+const migrationsDir = (name: string) =>
+  new URL(`../../test-helpers/migrations/${name}`, import.meta.url).pathname;
+
+// versions 1, 2, 3
+const VALID = migrationsDir("valid");
+// versions 230, 231, 20210716122844, 20210716123013
+const OLD_AND_NEW_VERSIONS = migrationsDir("old_and_new_versions");
+
+/** `assumeMigratedUptoVersion` is mixed onto the adapter by `SchemaStatements`. */
 const assumeMigratedUptoVersion = (version: number) =>
   (
     Base.connection as unknown as {
@@ -21,39 +29,43 @@ const assumeMigratedUptoVersion = (version: number) =>
     }
   ).assumeMigratedUptoVersion(version);
 
-// The `valid` fixture directory holds versions 1, 2 and 3.
-const VALID_MIGRATIONS = new URL("../../test-helpers/migrations/valid", import.meta.url).pathname;
+/**
+ * `DatabaseConfig#migrationsPaths` is a reader over a frozen configuration
+ * hash, so shadow the reader and drop the pool's memoized context — which,
+ * like Rails, captures its paths at construction.
+ */
+function pointPoolAt(paths: string[]): () => void {
+  const pool = Base.connectionPool();
+  const dbConfig = pool.dbConfig as unknown as object;
+  const previous = Object.getOwnPropertyDescriptor(dbConfig, "migrationsPaths");
+  const dropMemo = () =>
+    delete (pool as unknown as { _migrationContext?: unknown })._migrationContext;
+  Object.defineProperty(dbConfig, "migrationsPaths", { configurable: true, get: () => paths });
+  dropMemo();
+  return () => {
+    if (previous) Object.defineProperty(dbConfig, "migrationsPaths", previous);
+    else delete (dbConfig as Record<string, unknown>).migrationsPaths;
+    dropMemo();
+  };
+}
 
 describe("SchemaStatements#assumeMigratedUptoVersion", () => {
   fixtures({}, { useTransactionalTests: false });
 
-  let restorePaths: () => void;
+  let restore: () => void;
+  let previousGlobalPaths: string[];
 
   beforeEach(async () => {
-    const pool = Base.connectionPool();
-    // `DatabaseConfig#migrationsPaths` is a reader over a frozen configuration
-    // hash, so shadow the reader itself rather than the hash behind it. The
-    // pool still builds its context the ordinary way.
-    const dbConfig = pool.dbConfig as unknown as object;
-    const previous = Object.getOwnPropertyDescriptor(dbConfig, "migrationsPaths");
-    Object.defineProperty(dbConfig, "migrationsPaths", {
-      configurable: true,
-      get: () => [VALID_MIGRATIONS],
-    });
-    // The context memoizes its paths the way Rails' constructor does, so drop
-    // the memo rather than mutating it in place.
-    delete (pool as unknown as { _migrationContext?: unknown })._migrationContext;
-    restorePaths = () => {
-      if (previous) Object.defineProperty(dbConfig, "migrationsPaths", previous);
-      else delete (dbConfig as Record<string, unknown>).migrationsPaths;
-      delete (pool as unknown as { _migrationContext?: unknown })._migrationContext;
-    };
+    restore = pointPoolAt([VALID]);
+    previousGlobalPaths = Migrator.migrationsPaths;
+    Migrator.migrationsPaths = [OLD_AND_NEW_VERSIONS];
     await new SchemaMigration(Base.connection).dropTable();
     await new SchemaMigration(Base.connection).createTable();
   });
 
   afterEach(() => {
-    restorePaths();
+    Migrator.migrationsPaths = previousGlobalPaths;
+    restore();
   });
 
   it("backfills every known version up to the target through the pool's migration context", async () => {
@@ -68,15 +80,21 @@ describe("SchemaStatements#assumeMigratedUptoVersion", () => {
     expect(await schemaMigration.integerVersions()).toEqual([1, 2, 3]);
   });
 
-  it("reads the migrations paths of the pool that built the context, not a global list", async () => {
-    const pool = Base.connectionPool();
-    expect(pool.migrationContext.migrationsPaths).toEqual([VALID_MIGRATIONS]);
-    expect(pool.migrationContext.migrations.map((m) => Number(m.version))).toEqual([1, 2, 3]);
+  it("discovers migrations from the paths its own pool was built with", async () => {
+    const context = Base.connectionPool().migrationContext;
+    expect(context.migrationsPaths).toEqual([VALID]);
+    expect(context.migrations.map((m) => Number(m.version))).toEqual([1, 2, 3]);
   });
 
   it("reports the versions stored in the pool's schema_migrations table", async () => {
     await Base.connectionPool().schemaMigration.createVersion("2");
     expect(await Base.connectionPool().migrationContext.getAllVersions()).toEqual([2]);
     expect(await Base.connectionPool().migrationContext.currentVersion()).toBe(2);
+  });
+
+  it("reports no applied versions when schema_migrations does not exist", async () => {
+    await new SchemaMigration(Base.connection).dropTable();
+    expect(await Base.connectionPool().migrationContext.getAllVersions()).toEqual([]);
+    expect(await Base.connectionPool().migrationContext.currentVersion()).toBe(0);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -275,11 +275,6 @@ function expandIndexOption<T>(opt: Record<string, T> | T, columns: string[]): Re
  * Versions are strings here where Rails' `MigrationContext#get_all_versions`
  * (`migration.rb:1282`) and `#migrations` (`:1303`) hand back integers, so
  * callers comparing against a numeric target coerce them.
- *
- * The class behind `migrationContext` is still trails' schema-DSL context
- * squatting the ported Rails name, with a parallel copy of these members on
- * `Migrator`; story `pool-migration-context-is-not-rails-migration-context`
- * re-layers the two.
  * @internal
  */
 interface SchemaMigrationPool {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -25,7 +25,7 @@ export type { AdapterName } from "./connection-adapters/abstract-adapter.js";
 export type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 export type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 export { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
-export { Migration, MigrationContext } from "./migration.js";
+export { Migration, MigrationContext, SchemaContext } from "./migration.js";
 export {
   TableDefinition,
   Table,

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { MigrationContext, Migrator } from "./index.js";
+import { SchemaContext, Migrator } from "./index.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migration, IllegalMigrationNameError } from "./migration.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
@@ -96,7 +96,7 @@ describe("MigrationTest", () => {
   });
 
   it("addIndex delegates the un-arrayified expression column to the adapter", async () => {
-    // Regression: MigrationContext#addIndex delegates the DDL to the adapter
+    // Regression: SchemaContext#addIndex delegates the DDL to the adapter
     // without pre-arrayifying an expression column. `indexNameOptions` only
     // reduces an expression column ("lower(email)" → "lower_email") when it sees
     // a bare String — a pre-arrayified `["lower(email)"]` fails its
@@ -114,20 +114,20 @@ describe("MigrationTest", () => {
         ss.indexName(t, o),
       indexNameOptions: (c: string | string[]) => ss.indexNameOptions(c),
     };
-    const ctx = new MigrationContext(stub as unknown as DatabaseAdapter);
+    const ctx = new SchemaContext(stub as unknown as DatabaseAdapter);
     await ctx.addIndex("users", "lower(email)");
     // The adapter (and thus the real DDL) receives the un-arrayified column.
     expect(ddlColumns[0]).toBe("lower(email)");
   });
 
   it("columnExists forwards type and columnOptionsKeys to the adapter", async () => {
-    // Regression: MigrationContext#columnExists is the live adapter-backed
+    // Regression: SchemaContext#columnExists is the live adapter-backed
     // introspection path, so it must expose Rails' full
     // `column_exists?(table, column, type = nil, **options)` surface and forward
     // `type` + the columnOptionsKeys (schema_statements.rb:132-141) rather than
     // matching on name alone. Ride the canonical `people` table
     // (`first_name` string, null: false — schema.rb:933).
-    const ctx = new MigrationContext(Base.connection);
+    const ctx = new SchemaContext(Base.connection);
     expect(await ctx.columnExists("people", "first_name")).toBe(true);
     expect(await ctx.columnExists("people", "first_name", "string")).toBe(true);
     expect(await ctx.columnExists("people", "first_name", "integer")).toBe(false);
@@ -136,7 +136,7 @@ describe("MigrationTest", () => {
   });
 
   it("dropTable delegates to the adapter drop_table, forwarding options", async () => {
-    // Regression: MigrationContext#dropTable routes through `this.connection`
+    // Regression: SchemaContext#dropTable routes through `this.connection`
     // (the adapter's own drop_table) rather than a bare SchemaStatements
     // instance, so the dialect overrides that emit `temporary:`/`force:
     // "cascade"` (e.g. MySQL's `DROP TEMPORARY TABLE ... CASCADE`) are reached.
@@ -147,7 +147,7 @@ describe("MigrationTest", () => {
         calls.push(args);
       },
     };
-    const ctx = new MigrationContext(stub as unknown as DatabaseAdapter);
+    const ctx = new SchemaContext(stub as unknown as DatabaseAdapter);
     await ctx.dropTable("widgets");
     await ctx.dropTable("a", "b", { ifExists: true, force: "cascade", temporary: true });
     expect(calls).toEqual([
@@ -157,11 +157,11 @@ describe("MigrationTest", () => {
   });
 
   it("renameTable delegates to the adapter rename_table, applying prefix/suffix", async () => {
-    // Regression: MigrationContext#renameTable routes through `this.connection`
+    // Regression: SchemaContext#renameTable routes through `this.connection`
     // (the adapter's own rename_table) so the dialect side effects — MySQL's
     // `RENAME TABLE` + rename_table_indexes, PostgreSQL's PK sequence/index
     // rename — are preserved, not the abstract `ALTER TABLE ... RENAME` fallback.
-    // MigrationContext still applies the tableNamePrefix/suffix the adapters do
+    // SchemaContext still applies the tableNamePrefix/suffix the adapters do
     // not.
     const calls: [string, string][] = [];
     const stub = {
@@ -169,7 +169,7 @@ describe("MigrationTest", () => {
         calls.push([from, to]);
       },
     };
-    const ctx = new MigrationContext(stub as unknown as DatabaseAdapter);
+    const ctx = new SchemaContext(stub as unknown as DatabaseAdapter);
     ctx.tableNamePrefix = "pre_";
     ctx.tableNameSuffix = "_suf";
     await ctx.renameTable("old", "new");

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -61,7 +61,7 @@ export {
   type Compatibility,
 } from "./migration/compatibility.js";
 
-import { ActiveRecordError } from "./errors.js";
+import { ActiveRecordError, NoDatabaseError } from "./errors.js";
 import { ActiveRecord } from "./ar-config.js";
 
 // Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
@@ -1676,7 +1676,7 @@ export abstract class Migration {
  * adapter-wrapping schema DSL object — `MigrationContext` is a migration-file
  * runner (`migration.rb:1211`) and the schema DSL lives on the connection.
  * This class is the `defineSchema(ctx)` receiver RFC 0059 is retiring; it held
- * the `MigrationContext` name until this story reclaimed it for the real port.
+ * the `MigrationContext` name until the real port took it back.
  */
 export class SchemaContext {
   private _tableNamePrefix: string | null = null;
@@ -2162,10 +2162,17 @@ export class MigrationContext {
     return [];
   }
 
-  /** @internal Mirrors: ActiveRecord::MigrationContext#current_version */
-  async currentVersion(): Promise<number> {
-    const versions = await this.getAllVersions();
-    return versions.length > 0 ? Math.max(...versions) : 0;
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#current_version
+   * (`migration.rb:1292-1295`), whose bare `rescue NoDatabaseError` returns nil.
+   */
+  async currentVersion(): Promise<number | undefined> {
+    try {
+      return (await this.getAllVersions()).reduce((max, v) => (v > max ? v : max), 0);
+    } catch (error) {
+      if (error instanceof NoDatabaseError) return undefined;
+      throw error;
+    }
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#needs_migration? */
@@ -2181,12 +2188,11 @@ export class MigrationContext {
 
   /**
    * @internal Mirrors: ActiveRecord::MigrationContext#migrations
-   *
-   * Discovery reads *this context's* `migrationsPaths` — Rails keeps them as
-   * per-instance constructor state (`attr_reader :migrations_paths`), so two
-   * contexts built for two different migration directories do not collide.
-   * The file-scan/parse half still lives on `Migrator`; moving it here is
-   * tracked by `move-migration-context-methods-off-migrator`.
+   * (`migration.rb:1303-1315`). Discovery reads *this context's*
+   * `migrationsPaths`, which Rails keeps as per-instance constructor state
+   * (`attr_reader :migrations_paths`), so two contexts built for two migration
+   * directories do not collide. The file-scan/parse half still lives on
+   * `Migrator`; `move-migration-context-methods-off-migrator` moves it here.
    */
   get migrations(): MigrationProxy[] {
     return Migrator.discoverMigrations(this.migrationsPaths);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2168,7 +2168,8 @@ export class MigrationContext {
    */
   async currentVersion(): Promise<number | undefined> {
     try {
-      return (await this.getAllVersions()).reduce((max, v) => (v > max ? v : max), 0);
+      const versions = await this.getAllVersions();
+      return versions.length > 0 ? Math.max(...versions) : 0;
     } catch (error) {
       if (error instanceof NoDatabaseError) return undefined;
       throw error;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1663,25 +1663,29 @@ export abstract class Migration {
 }
 
 /**
- * MigrationContext — wraps an adapter with schema-aware migration methods
+ * SchemaContext — wraps an adapter with schema-aware migration methods
  * and async schema inspection, for use in tests and programmatic migrations.
  *
  * The `columns()`/`indexes()`/`tables()`/`columnExists()`/`tableExists()`/
  * `indexExists()` readers delegate to the connection's real
  * `SchemaStatements` introspection (Rails' `new_column_from_field` et al.)
  * rather than any in-memory declared-schema bookkeeping, so a
- * MigrationContext reflects the live database exactly as the adapter does.
+ * SchemaContext reflects the live database exactly as the adapter does.
  *
- * Mirrors: ActiveRecord::MigrationContext
+ * @noRailsEquivalent CONVERGEABLE (RFC 0059 drop-defineschema-mirror-create-table). Rails has no
+ * adapter-wrapping schema DSL object — `MigrationContext` is a migration-file
+ * runner (`migration.rb:1211`) and the schema DSL lives on the connection.
+ * This class is the `defineSchema(ctx)` receiver RFC 0059 is retiring; it held
+ * the `MigrationContext` name until this story reclaimed it for the real port.
  */
-export class MigrationContext {
+export class SchemaContext {
   private _tableNamePrefix: string | null = null;
   private _tableNameSuffix: string | null = null;
 
   /**
    * Effective table-name prefix. Defaults to `Migration.tableNameOptions().tableNamePrefix`
    * (i.e. the configured `ActiveRecord::Base.table_name_prefix` value) when no explicit
-   * value has been assigned to this context. Mirrors Rails, where `MigrationContext`
+   * value has been assigned to this context. Mirrors Rails, where `SchemaContext`
    * does not carry its own prefix and reads from the active record config at use time.
    */
   get tableNamePrefix(): string {
@@ -1703,29 +1707,12 @@ export class MigrationContext {
 
   constructor(private connection: DatabaseAdapter) {}
 
-  /** Mirrors: ActiveRecord::MigrationContext#schema_migration */
-  get schemaMigration(): SchemaMigration {
-    return new SchemaMigration(this.connection);
-  }
-
-  /** Mirrors: ActiveRecord::MigrationContext#get_all_versions */
-  async getAllVersions(): Promise<number[]> {
-    const schemaMigration = this.schemaMigration;
-    if (await schemaMigration.tableExists()) return schemaMigration.integerVersions();
-    return [];
-  }
-
-  /** Mirrors: ActiveRecord::MigrationContext#migrations */
-  get migrations(): MigrationProxy[] {
-    return Migrator.discoverMigrations(Migrator.migrationsPaths);
-  }
-
   private _schema?: SchemaStatements;
   private _schemaConn?: DatabaseAdapter;
 
   /**
    * The connection's real `SchemaStatements` — the single Rails-faithful source
-   * of DDL/type generation. Mirrors {@link Migration.schema}; MigrationContext
+   * of DDL/type generation. Mirrors {@link Migration.schema}; SchemaContext
    * routes its schema-DSL methods through this instead of hand-rolling SQL so
    * there is one source of truth as in Rails.
    */
@@ -1991,7 +1978,7 @@ export class MigrationContext {
     // Warm the cached database version before issuing the index DDL. PostgreSQL's
     // `supportsIndexInclude` (≥ 11) and `supportsNullsNotDistinct` (≥ 15) *throw*
     // when the version is unset, and the adapter's addIndex reads them to emit
-    // `INCLUDE`/`NULLS NOT DISTINCT`. MigrationContext#addIndex runs on the
+    // `INCLUDE`/`NULLS NOT DISTINCT`. SchemaContext#addIndex runs on the
     // shared-worker schema-reconstruct path on a freshly-leased connection whose
     // version is still cold, so warm it here for every adapter.
     await this.connection.getDatabaseVersion?.();
@@ -2027,7 +2014,7 @@ export class MigrationContext {
     // renames the PK sequence/index after `ALTER TABLE`; SQLite emits
     // `ALTER TABLE ... RENAME TO`. Routing through `this.connection` (not a
     // bare SchemaStatements instance, whose abstract fallback misses those
-    // side effects) is what reaches those overrides. MigrationContext keeps the
+    // side effects) is what reaches those overrides. SchemaContext keeps the
     // prefix/suffix application the adapters do not perform.
     await this.connection.renameTable(fullFrom, fullTo);
   }
@@ -2058,7 +2045,7 @@ export class MigrationContext {
   // — the single Rails-faithful reflection path (`columns` →
   // `new_column_from_field` → `fetch_type_metadata`, so catalog types are
   // normalized through the adapter's type map; `indexes`, `data_source_exists?`
-  // …) — so a MigrationContext reflects the live database rather than any
+  // …) — so a SchemaContext reflects the live database rather than any
   // declared-schema bookkeeping.
 
   async tableExists(name: string): Promise<boolean> {
@@ -2138,6 +2125,72 @@ async function loadMigrationFrom(
     return new (exported as new (name?: string, version?: string) => Migration)(name, version);
   }
   throw new Error(`Migration ${name} must export a Migration class named "${name}"`);
+}
+
+/**
+ * = \Migration \Context
+ *
+ * MigrationContext sets the context in which a migration is run.
+ *
+ * A migration context requires the path to the migrations is set in the
+ * `migrationsPaths` parameter. Optionally a `schemaMigration` object can be
+ * provided. Multiple database applications will instantiate a
+ * `SchemaMigration` object per database.
+ *
+ * Mirrors: ActiveRecord::MigrationContext (migration.rb:1211)
+ */
+export class MigrationContext {
+  readonly migrationsPaths: string[];
+  readonly schemaMigration: SchemaMigration;
+  readonly internalMetadata: InternalMetadata;
+
+  constructor(
+    migrationsPaths: string[],
+    schemaMigration: SchemaMigration,
+    internalMetadata: InternalMetadata,
+  ) {
+    this.migrationsPaths = migrationsPaths;
+    this.schemaMigration = schemaMigration;
+    this.internalMetadata = internalMetadata;
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#get_all_versions */
+  async getAllVersions(): Promise<number[]> {
+    if (await this.schemaMigration.tableExists()) {
+      return this.schemaMigration.integerVersions();
+    }
+    return [];
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#current_version */
+  async currentVersion(): Promise<number> {
+    const versions = await this.getAllVersions();
+    return versions.length > 0 ? Math.max(...versions) : 0;
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#needs_migration? */
+  async needsMigration(): Promise<boolean> {
+    return (await this.pendingMigrationVersions()).length > 0;
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#pending_migration_versions */
+  async pendingMigrationVersions(): Promise<number[]> {
+    const applied = new Set(await this.getAllVersions());
+    return this.migrations.map((m) => Number(m.version)).filter((v) => !applied.has(v));
+  }
+
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#migrations
+   *
+   * Discovery reads *this context's* `migrationsPaths` — Rails keeps them as
+   * per-instance constructor state (`attr_reader :migrations_paths`), so two
+   * contexts built for two different migration directories do not collide.
+   * The file-scan/parse half still lives on `Migrator`; moving it here is
+   * tracked by `move-migration-context-methods-off-migrator`.
+   */
+  get migrations(): MigrationProxy[] {
+    return Migrator.discoverMigrations(this.migrationsPaths);
+  }
 }
 
 /**

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -154,7 +154,7 @@ function conciseOptions<T>(
 
 /**
  * Interface for sources that can provide schema information.
- * Both MigrationContext (sync/in-memory) and database adapters (async) can implement this.
+ * Both SchemaContext (sync/in-memory) and database adapters (async) can implement this.
  */
 export interface SchemaSource {
   /** @internal */

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -57,6 +57,20 @@ export class SchemaMigration {
     return "version";
   }
 
+  /**
+   * Rails' `SchemaMigration` holds a connection *pool* and reaches a connection
+   * through `@pool.with_connection` (schema_migration.rb:12-17); trails hands it
+   * an adapter, and the one a pool supplies is the pool's dispatch proxy, whose
+   * every member resolves through `withConnection` and so answers a Promise even
+   * for Rails' synchronous `to_sql`. Await it here so the pool-backed instance
+   * behind `pool.migrationContext` builds real SQL instead of feeding `execute`
+   * a Promise (which `tableExists` then swallows into a silent "no table").
+   * @internal
+   */
+  private async _toSql(manager: { toSql?: unknown }): Promise<string> {
+    return await (this._adapter.toSql(manager as never) as string | Promise<string>);
+  }
+
   // Rails: "#{Base.table_name_prefix}#{Base.schema_migrations_table_name}
   // #{Base.table_name_suffix}" (schema_migration.rb:50).
   get tableName(): string {
@@ -86,7 +100,7 @@ export class SchemaMigration {
   async createVersion(version: string): Promise<string> {
     const im = new InsertManager(this.arelTable);
     im.insert([[this.arelTable.get(this.primaryKey), version]]);
-    await this._adapter.execute(this._adapter.toSql(im));
+    await this._adapter.execute(await this._toSql(im));
     return version;
   }
 
@@ -94,7 +108,7 @@ export class SchemaMigration {
     const dm = new DeleteManager();
     dm.from(this.arelTable);
     dm.where(this.arelTable.get(this.primaryKey).eq(version));
-    await this._adapter.execute(this._adapter.toSql(dm));
+    await this._adapter.execute(await this._toSql(dm));
   }
 
   async deleteAllVersions(): Promise<void> {
@@ -108,7 +122,7 @@ export class SchemaMigration {
     const sm = new SelectManager(this.arelTable);
     sm.project(this.arelTable.get(this.primaryKey));
     sm.order(this.arelTable.get(this.primaryKey).asc());
-    const rows = await this._adapter.execute(this._adapter.toSql(sm));
+    const rows = await this._adapter.execute(await this._toSql(sm));
     return rows.map((row) => String(row[this.primaryKey]).trim());
   }
 
@@ -119,7 +133,7 @@ export class SchemaMigration {
   async count(): Promise<number> {
     const sm = new SelectManager(this.arelTable);
     sm.project(new Nodes.NamedFunction("COUNT", [star]).as("cnt"));
-    const rows = await this._adapter.execute(this._adapter.toSql(sm));
+    const rows = await this._adapter.execute(await this._toSql(sm));
     return Number(rows[0]?.cnt ?? 0);
   }
 
@@ -128,7 +142,7 @@ export class SchemaMigration {
       const sm = new SelectManager(this.arelTable);
       sm.project(new Nodes.Quoted(1));
       sm.take(1);
-      await this._adapter.execute(this._adapter.toSql(sm));
+      await this._adapter.execute(await this._toSql(sm));
       return true;
     } catch {
       return false;

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -58,14 +58,13 @@ export class SchemaMigration {
   }
 
   /**
-   * Rails' `SchemaMigration` holds a connection *pool* and reaches a connection
-   * through `@pool.with_connection` (schema_migration.rb:12-17); trails hands it
-   * an adapter, and the one a pool supplies is the pool's dispatch proxy, whose
-   * every member resolves through `withConnection` and so answers a Promise even
-   * for Rails' synchronous `to_sql`. Await it here so the pool-backed instance
-   * behind `pool.migrationContext` builds real SQL instead of feeding `execute`
-   * a Promise (which `tableExists` then swallows into a silent "no table").
-   * @internal
+   * @internal Rails' `SchemaMigration` holds a connection *pool* and reaches a
+   * connection through `@pool.with_connection` (schema_migration.rb:12-17);
+   * trails hands it an adapter, and the one a pool supplies is the pool's
+   * dispatch proxy, whose members all resolve through `withConnection` and so
+   * answer a Promise even for Rails' synchronous `to_sql`. Awaiting is what
+   * keeps a pool-backed instance from feeding `execute` a Promise — which
+   * `tableExists` swallowed into a silent "no table".
    */
   private async _toSql(manager: { toSql?: unknown }): Promise<string> {
     return await (this._adapter.toSql(manager as never) as string | Promise<string>);


### PR DESCRIPTION
`pool.migrationContext` handed back trails' schema-DSL context — a class
squatting the `MigrationContext` name whose methods are
`createTable`/`addColumn`/`addIndex`/`tableExists`, with neither
`getAllVersions` nor `migrations`, constructed from an adapter proxy rather
than from `migrationsPaths` the way Rails builds it
(`vendor/rails/activerecord/lib/active_record/migration.rb:1211-1215`).

PR #5800 bolted `schemaMigration`/`getAllVersions`/`migrations` onto that class
so `SchemaStatements#assumeMigratedUptoVersion` (mirroring
`schema_statements.rb:1364-1383`) would at least run, but `migrations` read
`Migrator.migrationsPaths` — a **global** static — where Rails keeps
`migrations_paths` as per-instance constructor state (`migration.rb:1214-1218`,
`attr_reader :migrations_paths`). Two contexts built for two migration
directories collided in trails where they would not in Rails.

## What changed

- The schema-DSL squatter is renamed `SchemaContext` and tagged
  `@noRailsEquivalent CONVERGEABLE` — Rails has no adapter-wrapping schema DSL
  object, and this is the `defineSchema(ctx)` receiver RFC 0059 is retiring.
  It is exported alongside the new class from `index.ts`.
- A real `MigrationContext` port lands in `migration.ts` at Rails' source
  position (after `MigrationProxy`, before `Migrator`), owning
  `migrationsPaths` / `schemaMigration` / `internalMetadata` constructor state
  plus `getAllVersions` (`migration.rb:1282-1288`), `currentVersion`,
  `migrations` (`:1303-1315`), `pendingMigrationVersions` and `needsMigration`.
- `ConnectionPool#migrationContext` constructs it the Rails way —
  `new MigrationContext(migrationsPaths, schemaMigration, internalMetadata)` —
  and `ConnectionPool#migrationsPaths` array-wraps, since `DatabaseConfig`
  answers a bare string for a single-path config and Rails globs
  `Array(migrations_paths)` (`migration.rb:1369`). Without the wrap a string
  config would have been iterated per character.
- `SchemaMigration` awaits `to_sql`. The adapter a pool supplies is the pool's
  dispatch proxy, whose every member resolves through `withConnection` and so
  answers a Promise even for Rails' synchronous `to_sql`; feeding that Promise
  to `execute` threw, and `tableExists` swallowed the throw into a silent
  "no table" — so `getAllVersions` reported nothing migrated against a real
  pool and `assumeMigratedUptoVersion` re-inserted an applied version. This is
  what makes the end-to-end path actually work.

## Coverage

New `schema-statements-assume-migrated-upto-version-pool.trails.test.ts` runs
through `Base.connectionPool()` with **no stub on `pool.migrationContext`**. It
points the pool's `migrationsPaths` at the `valid` fixture directory (1/2/3)
while pointing the *global* `Migrator.migrationsPaths` at
`old_and_new_versions` — so any read of the global static shows up as wrong
versions. It asserts the backfill lands in the real `schema_migrations` table,
that an already-stored version is not re-inserted (the case that raised
`UNIQUE constraint failed` before the `to_sql` fix), that the context discovers
from its own paths, that `getAllVersions`/`currentVersion` read the pool's
table, and that both answer empty/0 when the table is absent.

## Deferred

AC 5 — "`Migrator` keeps only what Rails' `Migrator` owns
(`migration.rb:1440+`)" — is not in this PR. Neither are the `MigrationContext`
methods that are **missing outright** rather than merely duplicated on
`Migrator`: `migrate` / `up` / `down` / `rollback` / `forward` / `run` / `open`
(`migration.rb:1220-1280`) and `migrations_status` (`:1317-1330`). Both groups
are now explicit acceptance criteria on the follow-up story, so nothing falls
through the gap between AC 1 and AC 5. `Migrator` still carries its
parallel `// --- MigrationContext-style methods ---` block and the static
discovery helpers `MigrationContext#migrations` still delegates to; unwinding
that touches every `Migrator.fromPath`/`fromDir` caller and does not fit under
the 500-LOC ceiling. Registered as
`0051-migration-schema-statements-fidelity/stories/move-migration-context-methods-off-migrator`
with the full member list and acceptance criteria.

Closes-story: pool-migration-context-is-not-rails-migration-context
