### PR TITLE
refactor(schema-statements): drop the bespoke adapter viewExists overrides

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
@@ -37,4 +37,10 @@ describe("SchemaStatements#viewExists", () => {
       expect(await conn().viewExists("no_such_view_anywhere")).toBe(false);
     });
   });
+
+  it("treats a blank name as absent, like Rails' present? guard", async () => {
+    expect(await conn().viewExists("")).toBe(false);
+    expect(await conn().viewExists("   ")).toBe(false);
+    expect(await conn().viewExists(null as unknown as string)).toBe(false);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
@@ -1,0 +1,40 @@
+/**
+ * trails-only regression coverage for SchemaStatements#viewExists.
+ *
+ * Rails runs the probe as `query_values(data_source_sql(...), "SCHEMA")`, so
+ * the query is named "SCHEMA" and query counting skips it. trails previously
+ * probed through `execute`, which names the query "SQL" and inflated
+ * `assertQueries` counts in any suite that straddled a view-existence check.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Base } from "../../index.js";
+import type { AbstractAdapter } from "../abstract-adapter.js";
+import { fixtures } from "../../test-fixtures.js";
+import { assertNoQueries } from "../../testing/query-assertions.js";
+
+describe("SchemaStatements#viewExists", () => {
+  fixtures({});
+
+  function conn(): AbstractAdapter {
+    return Base.connection as unknown as AbstractAdapter;
+  }
+
+  const viewName = "view_exists_probe_books";
+
+  beforeAll(async () => {
+    await conn().executeMutation(
+      `CREATE VIEW ${conn().quoteTableName(viewName)} AS SELECT * FROM books`,
+    );
+  });
+
+  afterAll(async () => {
+    await conn().executeMutation(`DROP VIEW ${conn().quoteTableName(viewName)}`);
+  });
+
+  it("issues its probe as a SCHEMA query", async () => {
+    await assertNoQueries(false, async () => {
+      expect(await conn().viewExists(viewName)).toBe(true);
+      expect(await conn().viewExists("no_such_view_anywhere")).toBe(false);
+    });
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1509,16 +1509,16 @@ export class SchemaStatements {
     //     views.include?(view_name.to_s)
     //
     // present? covers blank strings including whitespace-only.
-    // dataSourceSql dispatches through this.adapter so PG's override fires;
-    // MySQL/SQLite don't override → NotImplementedError → views() fallback.
-    if (!viewName || viewName.trim().length === 0) return false;
+    // The probe goes through schemaQuery (trails' internal_exec_query(..., "SCHEMA"))
+    // so query counting skips it, matching Rails' query_values(..., "SCHEMA").
+    if (!isPresent(viewName)) return false;
     try {
       const sql = this.adapter.dataSourceSql(viewName, { type: "VIEW" });
-      const rows = await this.adapter.execute(sql);
+      const rows = await this.adapter.schemaQuery(sql);
       return rows.length > 0;
     } catch (e) {
       if (e instanceof NotImplementedError) {
-        return (await this.views()).includes(viewName);
+        return (await this.views()).includes(String(viewName));
       }
       throw e;
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1509,8 +1509,8 @@ export class SchemaStatements {
     //     views.include?(view_name.to_s)
     //
     // present? covers blank strings including whitespace-only.
-    // The probe goes through schemaQuery (trails' internal_exec_query(..., "SCHEMA"))
-    // so query counting skips it, matching Rails' query_values(..., "SCHEMA").
+    // schemaQuery is trails' internal_exec_query(sql, "SCHEMA") — the "SCHEMA"
+    // name is what keeps the probe out of assertQueries counts.
     if (!isPresent(viewName)) return false;
     try {
       const sql = this.adapter.dataSourceSql(viewName, { type: "VIEW" });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1513,14 +1513,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return this.informationSchemaExists(name, "BASE TABLE");
   }
 
-  async viewExists(name: string): Promise<boolean> {
-    return this.informationSchemaExists(name, "VIEW");
-  }
-
-  private async informationSchemaExists(
-    name: string,
-    type: "BASE TABLE" | "VIEW",
-  ): Promise<boolean> {
+  private async informationSchemaExists(name: string, type: "BASE TABLE"): Promise<boolean> {
     // Rails' table_exists?(nil) / "" returns false; a null/empty name has no
     // schema to parse, so short-circuit before parseMysqlName (which trims).
     if (!name) return false;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1510,24 +1510,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   async tableExists(name: string): Promise<boolean> {
-    return this.informationSchemaExists(name, "BASE TABLE");
-  }
-
-  private async informationSchemaExists(name: string, type: "BASE TABLE"): Promise<boolean> {
     // Rails' table_exists?(nil) / "" returns false; a null/empty name has no
     // schema to parse, so short-circuit before parseMysqlName (which trims).
     if (!name) return false;
     const { schema, table } = this.parseMysqlName(name);
-    const schemaBind = schema ?? null;
     // Use `schema_placeholder OR database()` via COALESCE so the same
     // query shape serves qualified + unqualified callers.
     const rows = await this.schemaQuery(
       `SELECT 1 AS one FROM information_schema.tables
          WHERE table_schema = COALESCE(?, database())
          AND table_name = ?
-         AND table_type = ?
+         AND table_type = 'BASE TABLE'
          LIMIT 1`,
-      [schemaBind, table, type],
+      [schema ?? null, table],
     );
     return rows.length > 0;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4133,10 +4133,6 @@ export class PostgreSQLAdapter
     return this.pgSchemaStatements().tableExists(name);
   }
 
-  async viewExists(name: string): Promise<boolean> {
-    return this.pgSchemaStatements().viewExists(name);
-  }
-
   async addIndex(
     tableName: string,
     columns: string | string[],

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -338,17 +338,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   /**
-   * View-only existence check. Mirrors Rails'
-   * `SchemaStatements#view_exists?` which treats both views and
-   * materialized views as "view".
-   */
-  async viewExists(name: string): Promise<boolean> {
-    return this.relkindExists(name, ["v", "m"]);
-  }
-
-  /**
-   * Shared helper for table/view existence checks — lets both
-   * methods share Rails' pg_class-based predicate. Uses
+   * Shared helper for the table existence check — Rails' pg_class-based
+   * predicate. Uses
    * `SELECT 1 ... LIMIT 1` so the planner short-circuits instead of
    * counting every match.
    */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -338,9 +338,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   /**
-   * Shared helper for the table existence check — Rails' pg_class-based
-   * predicate. Uses
-   * `SELECT 1 ... LIMIT 1` so the planner short-circuits instead of
+   * Backs the table existence check with Rails' pg_class-based predicate.
+   * Uses `SELECT 1 ... LIMIT 1` so the planner short-circuits instead of
    * counting every match.
    */
   private async relkindExists(name: string, relkinds: string[]): Promise<boolean> {


### PR DESCRIPTION
Rails defines `view_exists?` only on `AbstractAdapter`'s `SchemaStatements`
(`schema_statements.rb:74`) — no concrete adapter overrides it. trails shadowed
it in two places:

- `mysql2-adapter.ts` → `informationSchemaExists(name, "VIEW")`, a bespoke
  bind-parameter `information_schema.tables` query with a `COALESCE` schema
  shape Rails never emits.
- `postgresql/schema-statements-class.ts` → `relkindExists(name, ["v", "m"])`,
  plus the `postgresql-adapter.ts` delegate.

Both are deleted. `include(AbstractAdapter, SchemaStatements)` already puts the
base body on every adapter's prototype chain, and all three adapters have a
faithful `dataSourceSql(..., { type: "VIEW" })` / `quotedScope`, so the callers
route through the converged base with no delegation stubs.
With `viewExists` gone, `informationSchemaExists` had a single caller and a
single `type`, so it is inlined into `tableExists` with the literal
`table_type = 'BASE TABLE'`.

The base probe also moves from `this.adapter.execute(sql)` (query named `"SQL"`)
to `this.adapter.schemaQuery(sql)` (named `"SCHEMA"`), matching Rails'
`query_values(data_source_sql(...), "SCHEMA")`. This has to land with the
deletion: query counting skips only `"SCHEMA"`, so removing the overrides —
which used `schemaQuery` — while the base still used `execute` would inflate
`assertQueries` counts across unrelated suites on all three lanes. Also
converged the blank-name guard onto `isPresent` and the fallback onto
`String(viewName)`, mirroring the sibling `dataSourceExists`.

Regression test asserts the probe runs under `assertNoQueries`; it fails on the
`execute` baseline (verified locally: `2 instead of 0 queries were executed`).

Local runs on sqlite: `view.test.ts`, `adapter.test.ts`,
`schema-statements-on-adapter.test.ts`,
`postgresql/schema-statements-class.trails.test.ts`, and the new regression
file all pass. pg/mysql lanes covered by CI.

Closes-story: remove-bespoke-adapter-view-exists-overrides
