### PR TITLE
refactor(schema-statements): try data_source_sql before the tables|views arm in dataSources

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -621,6 +621,43 @@ describe("tableExists NotImplementedError fallback", () => {
   });
 });
 
+describe("dataSources NotImplementedError fallback", () => {
+  it("answers from one data_source_sql query when the adapter implements it", async () => {
+    const execute = vi.fn().mockResolvedValue([{ name: "posts" }, { name: "comments" }]);
+    const dataSourceSql = vi.fn(() => "SELECT name FROM catalog");
+    const ss = makeStatements({ execute, dataSourceSql });
+    const tables = vi.spyOn(ss, "tables");
+    const views = vi.spyOn(ss, "views");
+
+    expect(await ss.dataSources()).toEqual(["posts", "comments"]);
+    expect(dataSourceSql).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(tables).not.toHaveBeenCalled();
+    expect(views).not.toHaveBeenCalled();
+  });
+
+  it("falls back to tables | views when the data-source path is not implemented", async () => {
+    const ss = makeStatements({
+      dataSourceSql: () => {
+        throw new NotImplementedError("#data_source_sql is not implemented");
+      },
+    });
+    vi.spyOn(ss, "tables").mockResolvedValue(["posts", "comments"]);
+    vi.spyOn(ss, "views").mockResolvedValue(["comments", "recent_posts"]);
+
+    expect(await ss.dataSources()).toEqual(["posts", "comments", "recent_posts"]);
+  });
+
+  it("propagates errors other than NotImplementedError", async () => {
+    const ss = makeStatements({
+      dataSourceSql: () => "SELECT name FROM catalog",
+      execute: vi.fn().mockRejectedValue(new Error("connection lost")),
+    });
+
+    await expect(ss.dataSources()).rejects.toThrow("connection lost");
+  });
+});
+
 describe("dataSourceExists NotImplementedError fallback", () => {
   it("returns false for a blank data source name without querying", async () => {
     const execute = vi.fn().mockResolvedValue([]);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1616,9 +1616,19 @@ export class SchemaStatements {
   }
 
   async dataSources(): Promise<string[]> {
-    const t = await this.tables();
-    const v = await this.views();
-    return [...new Set([...t, ...v])];
+    try {
+      const sql = this.adapter.dataSourceSql();
+      const rows = await this.adapter.schemaQuery(sql);
+      // query_values projects the first column of each row.
+      return rows.map((row) => String(Object.values(row)[0]));
+    } catch (error) {
+      if (!(error instanceof NotImplementedError)) throw error;
+      // Rails' rescue arm is `tables | views` — Ruby array union, which dedupes
+      // while preserving first-seen order.
+      const t = await this.tables();
+      const v = await this.views();
+      return [...new Set([...t, ...v])];
+    }
   }
 
   async dataSourceExists(name: string): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1619,12 +1619,9 @@ export class SchemaStatements {
     try {
       const sql = this.adapter.dataSourceSql();
       const rows = await this.adapter.schemaQuery(sql);
-      // query_values projects the first column of each row.
       return rows.map((row) => String(Object.values(row)[0]));
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
-      // Rails' rescue arm is `tables | views` — Ruby array union, which dedupes
-      // while preserving first-seen order.
       const t = await this.tables();
       const v = await this.views();
       return [...new Set([...t, ...v])];

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -73,13 +73,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "data_sources",
-    "call": "data_source_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "data_sources",
     "call": "query_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Rails `SchemaStatements#data_sources` attempts `query_values(data_source_sql, "SCHEMA")` and only falls back to `tables | views` on `NotImplementedError` (`schema_statements.rb:33-38`). trails skipped the first arm entirely and always issued two round-trips, even on adapters that implement `dataSourceSql`.

- `dataSources` now tries `this.adapter.dataSourceSql()` via `schemaQuery`, projecting the first column of each row (Rails' `query_values`), mirroring the sibling `dataSourceExists` shape in the same file.
- On `NotImplementedError` it falls back to `tables | views` (Set-spread dedupe preserves first-seen order, matching Ruby array union).
- Any other error propagates.

Tests: three cases in `schema-statements-privates.test.ts` covering the query-values arm, the fallback arm, and error propagation.

Closes-story: converge-data-sources-query-values-first-arm
