### PR TITLE
fix(schema-statements): read createTable's table comment from the definition

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -914,4 +914,25 @@ describe("SchemaStatements#createTable statement ordering", () => {
 
     expect(sqls.some((sql) => sql.startsWith("CREATE INDEX IF NOT EXISTS"))).toBe(true);
   });
+
+  it("reads the table comment from the definition rather than the options hash", async () => {
+    const changeTableComment = vi.fn(async () => {});
+    const ss = makeStatements({
+      supportsComments: () => true,
+      supportsCommentsInCreate: () => false,
+      changeTableComment,
+    });
+
+    // Stands in for an adapter override / normalization that sets the comment on
+    // the definition without it appearing in the raw options hash.
+    const build = ss.buildCreateTableDefinition.bind(ss);
+    ss.buildCreateTableDefinition = ((name: string, options: Record<string, unknown>, fn: any) =>
+      build(name, { ...options, comment: "from the definition" }, fn)) as never;
+
+    await ss.createTable("things", { id: false }, (t) => {
+      t.column("name", "string");
+    });
+
+    expect(changeTableComment).toHaveBeenCalledWith("things", "from the definition");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -8,7 +8,10 @@ import { ForeignKeyDefinition, TableDefinition, type ColumnType } from "./schema
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { NotImplementedError } from "../../errors.js";
 
-function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
+function makeStatements(
+  adapterOverrides: Record<string, unknown> = {},
+  Statements: new (adapter: never) => SchemaStatements = SchemaStatements,
+) {
   const adapter: Record<string, unknown> = {
     adapterName: "sqlite" as const,
     quoteIdentifier: (n: string) => `"${n}"`,
@@ -33,7 +36,7 @@ function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
       binds,
       "SCHEMA",
     );
-  return new SchemaStatements(adapter as any);
+  return new Statements(adapter as never);
 }
 
 describe("SchemaStatements privates (PR 8)", () => {
@@ -916,18 +919,29 @@ describe("SchemaStatements#createTable statement ordering", () => {
   });
 
   it("reads the table comment from the definition rather than the options hash", async () => {
-    const changeTableComment = vi.fn(async () => {});
-    const ss = makeStatements({
-      supportsComments: () => true,
-      supportsCommentsInCreate: () => false,
-      changeTableComment,
-    });
+    class AdapterSettingTheCommentOnTheDefinition extends SchemaStatements {
+      override buildCreateTableDefinition(
+        tableName: string,
+        options: Parameters<SchemaStatements["buildCreateTableDefinition"]>[1] = {},
+        fn?: (td: TableDefinition) => void,
+      ): TableDefinition {
+        return super.buildCreateTableDefinition(
+          tableName,
+          { ...options, comment: "from the definition" },
+          fn,
+        );
+      }
+    }
 
-    // Stands in for an adapter override / normalization that sets the comment on
-    // the definition without it appearing in the raw options hash.
-    const build = ss.buildCreateTableDefinition.bind(ss);
-    ss.buildCreateTableDefinition = ((name: string, options: Record<string, unknown>, fn: any) =>
-      build(name, { ...options, comment: "from the definition" }, fn)) as never;
+    const changeTableComment = vi.fn(async () => {});
+    const ss = makeStatements(
+      {
+        supportsComments: () => true,
+        supportsCommentsInCreate: () => false,
+        changeTableComment,
+      },
+      AdapterSettingTheCommentOnTheDefinition,
+    );
 
     await ss.createTable("things", { id: false }, (t) => {
       t.column("name", "string");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -469,8 +469,6 @@ export class SchemaStatements {
     }
 
     if (this.adapter.supportsComments?.() && !this.adapter.supportsCommentsInCreate?.()) {
-      // Rails reads the comment off the definition, not the raw options hash —
-      // buildCreateTableDefinition and adapter overrides may set or normalize it.
       const tableComment = presence(td.comment);
       if (tableComment != null && typeof this.adapter.changeTableComment === "function") {
         await this.adapter.changeTableComment(name, tableComment);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -468,10 +468,10 @@ export class SchemaStatements {
       }
     }
 
-    // Rails: if supports_comments? && !supports_comments_in_create?
-    //   change_table_comment(table_name, comment) if options[:comment].present?
     if (this.adapter.supportsComments?.() && !this.adapter.supportsCommentsInCreate?.()) {
-      const tableComment = presence(options.comment);
+      // Rails reads the comment off the definition, not the raw options hash —
+      // buildCreateTableDefinition and adapter overrides may set or normalize it.
+      const tableComment = presence(td.comment);
       if (tableComment != null && typeof this.adapter.changeTableComment === "function") {
         await this.adapter.changeTableComment(name, tableComment);
       }


### PR DESCRIPTION
Rails reads the createTable table comment off the table definition, not the raw options hash:

```ruby
if table_comment = td.comment.presence
  change_table_comment(table_name, table_comment)
end
```

(`abstract/schema_statements.rb:316-318`)

trails read `presence(options.comment)`, which diverges whenever the definition's comment is set or normalized by `buildCreateTableDefinition` or an adapter override rather than by the literal option. The column arm already read `column.options?.comment` off the definition, so only the table-level read was out of step.

Adds a regression test covering a definition whose comment is not in the raw options hash (fails on baseline).

Closes-story: create-table-table-comment-read-from-options-not-td
