### PR TITLE
refactor(migration): route migrateWithoutLock through runnable

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2455,11 +2455,9 @@ export class Migrator {
     }
     await this._ensureSchemaTable();
     await this.recordEnvironment();
-    // Rails returns `runnable.each(...)`, i.e. the runnable list; trails callers
-    // assert on its length, so return the same array we ran.
     const runnable = await this.runnable();
     for (const proxy of runnable) {
-      await this.executeMigrationInTransaction(proxy, this._direction);
+      await this.executeMigrationInTransaction(proxy);
     }
     return runnable;
   }
@@ -2516,11 +2514,8 @@ export class Migrator {
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction */
-  async executeMigrationInTransaction(
-    proxy: MigrationProxy,
-    direction: "up" | "down" = "up",
-  ): Promise<void> {
-    await this._runMigration(proxy, direction);
+  async executeMigrationInTransaction(proxy: MigrationProxy): Promise<void> {
+    await this._runMigration(proxy, this._direction);
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#target */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2455,9 +2455,13 @@ export class Migrator {
     }
     await this._ensureSchemaTable();
     await this.recordEnvironment();
-    return this.isDown()
-      ? this._migrateDown(this._targetVersion)
-      : this._migrateUp(this._targetVersion);
+    // Rails returns `runnable.each(...)`, i.e. the runnable list; trails callers
+    // assert on its length, so return the same array we ran.
+    const runnable = await this.runnable();
+    for (const proxy of runnable) {
+      await this.executeMigrationInTransaction(proxy, this._direction);
+    }
+    return runnable;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#up? */
@@ -2985,36 +2989,6 @@ export class Migrator {
     } finally {
       this._invalidateMigrated();
     }
-  }
-
-  private async _migrateUp(targetVersion: number | string | null): Promise<MigrationProxy[]> {
-    const target = targetVersion !== null ? BigInt(targetVersion) : null;
-    const applied = await this.migrated();
-    const ran: MigrationProxy[] = [];
-
-    for (const proxy of this._migrations) {
-      if (applied.has(proxy.version)) continue;
-      if (target !== null && BigInt(proxy.version) > target) break;
-      await this._runMigration(proxy, "up");
-      ran.push(proxy);
-    }
-    return ran;
-  }
-
-  private async _migrateDown(targetVersion: number | string | null): Promise<MigrationProxy[]> {
-    // A null target means "revert everything" (Rails: a `:down` Migrator with no
-    // target_version), which — unlike `down(0)` — also reverts a version-0
-    // migration.
-    const target = targetVersion !== null ? BigInt(targetVersion) : null;
-    const applied = await this.migrated();
-    const toRevert = this._migrations
-      .filter((m) => applied.has(m.version) && (target === null || BigInt(m.version) > target))
-      .reverse();
-
-    for (const proxy of toRevert) {
-      await this._runMigration(proxy, "down");
-    }
-    return toRevert;
   }
 
   private async _runMigration(proxy: MigrationProxy, direction: "up" | "down"): Promise<void> {


### PR DESCRIPTION
Rails' `migrate_without_lock` drives the whole multi-migration run through
`runnable` (`migration.rb:1500-1507`). #5784 ported `Migrator#runnable` (plus
`start` / `finish` / `target`) faithfully but nothing called it: `migrateWithoutLock`
still branched to the invented `_migrateUp` / `_migrateDown`, which hand-rolled
the same selection logic inline. Two implementations of one rule, one of them
unused.

This routes `migrateWithoutLock` through `runnable()` + `executeMigrationInTransaction`
and deletes `_migrateUp` / `_migrateDown` entirely — nothing in them lacked a
Rails counterpart.

The trails return contract is kept: `migrateWithoutLock` still resolves to the
`MigrationProxy[]` that ran (Rails' `runnable.each` also returns the runnable
list), so `migrate` / `rollback` / `forward` and the length assertions in
`migrator.test.ts` are unchanged.

`runnable()` reads `migrated()` per migration via `isRan`, which stays memoized
(#5782) — the memo is only cleared in `loadMigrated` under the advisory lock.

Migrator/migration/multi-db-migrator/invertible + tasks suites pass unchanged;
`tsc -b` clean.

Closes-story: route-migrate-without-lock-through-runnable
