### PR TITLE
fix(sqlite3): route alter_table's rebuilt FKs through definition.foreignKey

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -15,14 +15,13 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
     });
     await adapter.createTable("p_astronauts_s", { force: true }, (t) => {
       t.integer("rocket_id");
-      t.string("nickname");
     });
   });
 
   afterEach(async () => {
     Base.tableNamePrefix = "";
     Base.tableNameSuffix = "";
-    await adapter.dropTable("p_astronauts_s", "p_rockets_s", "rockets", { ifExists: true });
+    await adapter.dropTable("p_astronauts_s", "p_rockets_s", { ifExists: true });
     await adapter.close();
   });
 
@@ -41,8 +40,35 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
     expect(foreignKeys.length).toBe(1);
     expect(foreignKeys[0].toTable).toBe("p_rockets_s");
   });
+});
 
-  it("keeps the foreign key pointing at the prefixed table across a table rebuild", async () => {
+describe("SQLite3Adapter alterTable under a table name prefix/suffix", () => {
+  let adapter: AbstractSQLite3Adapter;
+
+  beforeEach(async () => {
+    adapter = new BetterSQLite3Adapter(":memory:");
+    Base.tableNamePrefix = "p_";
+    Base.tableNameSuffix = "_s";
+    await adapter.createTable("p_rockets_s", { force: true }, (t) => {
+      t.string("name");
+    });
+    await adapter.createTable("rockets", { force: true }, (t) => {
+      t.string("name");
+    });
+  });
+
+  afterEach(async () => {
+    Base.tableNamePrefix = "";
+    Base.tableNameSuffix = "";
+    await adapter.dropTable("p_astronauts_s", "p_rockets_s", "rockets", { ifExists: true });
+    await adapter.close();
+  });
+
+  it("keeps a rebuilt foreign key pointing at the affixed table", async () => {
+    await adapter.createTable("p_astronauts_s", { force: true }, (t) => {
+      t.integer("rocket_id");
+      t.string("nickname");
+    });
     await adapter.addForeignKey("p_astronauts_s", "p_rockets_s", { column: "rocket_id" });
 
     await adapter.removeColumn("p_astronauts_s", "nickname");
@@ -51,15 +77,10 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
     expect(foreignKeys.length).toBe(1);
     expect(foreignKeys[0].toTable).toBe("p_rockets_s");
     expect(foreignKeys[0].column).toBe("rocket_id");
+    expect(foreignKeys[0].name).toBe("fk_rails_69fb0920bf");
   });
 
-  it("re-applies the affixes to an unaffixed toTable across a table rebuild", async () => {
-    await adapter.createTable("rockets", { force: true }, (t) => {
-      t.string("name");
-    });
-    // addForeignKey already strips and re-applies the affixes, so the unaffixed
-    // to_table only reaches the rebuild via DDL trails did not author.
-    await adapter.dropTable("p_astronauts_s");
+  it("re-applies the affixes to a rebuilt foreign key whose toTable is unaffixed", async () => {
     await adapter.execute(
       `CREATE TABLE "p_astronauts_s" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, ` +
         `"rocket_id" integer, "nickname" varchar, ` +
@@ -68,12 +89,9 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
 
     await adapter.removeColumn("p_astronauts_s", "nickname");
 
-    // Rails' alter_table caller strips the affixes off the reflected to_table and
-    // routes back through definition.foreign_key, which re-applies them
-    // (sqlite3_adapter.rb:573-575). strip_table_name_prefix_and_suffix leaves an
-    // unaffixed name alone, so the rebuild retargets "rockets" at "p_rockets_s".
     const foreignKeys = await adapter.foreignKeys("p_astronauts_s");
     expect(foreignKeys.length).toBe(1);
     expect(foreignKeys[0].toTable).toBe("p_rockets_s");
+    expect(foreignKeys[0].name).toBe("fk_rockets");
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -15,13 +15,14 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
     });
     await adapter.createTable("p_astronauts_s", { force: true }, (t) => {
       t.integer("rocket_id");
+      t.string("nickname");
     });
   });
 
   afterEach(async () => {
     Base.tableNamePrefix = "";
     Base.tableNameSuffix = "";
-    await adapter.dropTable("p_astronauts_s", "p_rockets_s", { ifExists: true });
+    await adapter.dropTable("p_astronauts_s", "p_rockets_s", "rockets", { ifExists: true });
     await adapter.close();
   });
 
@@ -36,6 +37,41 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
   it("reflects the singly prefixed table for a schema qualified toTable", async () => {
     await adapter.addForeignKey("p_astronauts_s", "main.p_rockets_s", { column: "rocket_id" });
 
+    const foreignKeys = await adapter.foreignKeys("p_astronauts_s");
+    expect(foreignKeys.length).toBe(1);
+    expect(foreignKeys[0].toTable).toBe("p_rockets_s");
+  });
+
+  it("keeps the foreign key pointing at the prefixed table across a table rebuild", async () => {
+    await adapter.addForeignKey("p_astronauts_s", "p_rockets_s", { column: "rocket_id" });
+
+    await adapter.removeColumn("p_astronauts_s", "nickname");
+
+    const foreignKeys = await adapter.foreignKeys("p_astronauts_s");
+    expect(foreignKeys.length).toBe(1);
+    expect(foreignKeys[0].toTable).toBe("p_rockets_s");
+    expect(foreignKeys[0].column).toBe("rocket_id");
+  });
+
+  it("re-applies the affixes to an unaffixed toTable across a table rebuild", async () => {
+    await adapter.createTable("rockets", { force: true }, (t) => {
+      t.string("name");
+    });
+    // addForeignKey already strips and re-applies the affixes, so the unaffixed
+    // to_table only reaches the rebuild via DDL trails did not author.
+    await adapter.dropTable("p_astronauts_s");
+    await adapter.execute(
+      `CREATE TABLE "p_astronauts_s" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, ` +
+        `"rocket_id" integer, "nickname" varchar, ` +
+        `CONSTRAINT "fk_rockets" FOREIGN KEY ("rocket_id") REFERENCES "rockets" ("id"))`,
+    );
+
+    await adapter.removeColumn("p_astronauts_s", "nickname");
+
+    // Rails' alter_table caller strips the affixes off the reflected to_table and
+    // routes back through definition.foreign_key, which re-applies them
+    // (sqlite3_adapter.rb:573-575). strip_table_name_prefix_and_suffix leaves an
+    // unaffixed name alone, so the rebuild retargets "rockets" at "p_rockets_s".
     const foreignKeys = await adapter.foreignKeys("p_astronauts_s");
     expect(foreignKeys.length).toBe(1);
     expect(foreignKeys[0].toTable).toBe("p_rockets_s");

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -92,6 +92,6 @@ describe("SQLite3Adapter alterTable under a table name prefix/suffix", () => {
     const foreignKeys = await adapter.foreignKeys("p_astronauts_s");
     expect(foreignKeys.length).toBe(1);
     expect(foreignKeys[0].toTable).toBe("p_rockets_s");
-    expect(foreignKeys[0].name).toBe("fk_rockets");
+    expect(foreignKeys[0].name).toBe("fk_rails_69fb0920bf");
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2332,7 +2332,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         definition.foreignKey(toTable, {
           column,
           primaryKey: fk.primaryKey,
-          name: fk.name,
           onDelete: fk.onDelete,
           onUpdate: fk.onUpdate,
           deferrable: fk.deferrable,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2326,26 +2326,22 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // Rails' alter_table caller lambda (sqlite3_adapter.rb:568-583). The block
     // running last is what lets remove_column delete the FKs it orphans.
     const caller = (definition: SQLite3TableDefinition): void => {
-      definition.foreignKeys.push(
-        ...fks.map((fk) => {
-          const column =
-            typeof fk.column === "string" ? (rename[fk.column] ?? fk.column) : fk.column;
-          return column === fk.column
-            ? fk
-            : new ForeignKeyDefinition(
-                fk.fromTable,
-                fk.toTable,
-                column,
-                fk.primaryKey,
-                fk.name,
-                fk.onDelete,
-                fk.onUpdate,
-                fk.deferrable,
-                fk.storesValidate ? fk.validate : undefined,
-                fk.storedOptionKeys,
-              );
-        }),
-      );
+      for (const fk of fks) {
+        const column = typeof fk.column === "string" ? (rename[fk.column] ?? fk.column) : fk.column;
+        // Rails strips the affixes off the reflected (physical) to_table so
+        // that new_foreign_key_definition can re-apply them
+        // (sqlite3_adapter.rb:573-575).
+        const toTable = this.schemaStatements().stripTableNamePrefixAndSuffix(fk.toTable);
+        definition.foreignKey(toTable, {
+          column,
+          primaryKey: fk.primaryKey,
+          name: fk.name,
+          onDelete: fk.onDelete,
+          onUpdate: fk.onUpdate,
+          deferrable: fk.deferrable,
+          validate: fk.storesValidate ? fk.validate : undefined,
+        });
+      }
       definition.checkConstraints.push(...checks);
       block?.(definition);
     };

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2328,9 +2328,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const caller = (definition: SQLite3TableDefinition): void => {
       for (const fk of fks) {
         const column = typeof fk.column === "string" ? (rename[fk.column] ?? fk.column) : fk.column;
-        // Rails strips the affixes off the reflected (physical) to_table so
-        // that new_foreign_key_definition can re-apply them
-        // (sqlite3_adapter.rb:573-575).
         const toTable = this.schemaStatements().stripTableNamePrefixAndSuffix(fk.toTable);
         definition.foreignKey(toTable, {
           column,

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "alter_table",
-    "call": "strip_table_name_prefix_and_suffix",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "begin_db_transaction",
     "call": "internal_begin_transaction",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `alter_table` caller lambda strips the configured table-name
prefix/suffix off each reflected `to_table` and routes through the
definition's own builder (`sqlite3_adapter.rb:573-575`):

```ruby
to_table = strip_table_name_prefix_and_suffix(fk.to_table)
definition.foreign_key(to_table, **fk.options)
```

trails pushed the reflected `ForeignKeyDefinition` objects straight onto
`definition.foreignKeys`, so both the affix round-trip and whatever
`TableDefinition#foreignKey` defaults were skipped on the rebuild path.
`addForeignKey` already stripped here; the rebuild was missed.

Tests (new `SQLite3Adapter alterTable under a table name prefix/suffix`
describe): a rebuild (`removeColumn`) under a configured `tableNamePrefix` /
`tableNameSuffix` keeps an affixed FK pointing at the right table, and an
unaffixed `to_table` that reached the table via foreign DDL is re-affixed the
way Rails' unanchored `strip_table_name_prefix_and_suffix` plus
`new_foreign_key_definition` does. The second case fails on baseline.

Closes-story: sqlite-alter-table-caller-bypasses-definition-foreign-key
