### PR TITLE
refactor(schema-statements): delete the _adapterOverride dispatch shim

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1474,17 +1474,15 @@ export class AbstractAdapter implements Quoting {
   }
 
   /**
-   * @noRailsEquivalent PERMANENT. Rails gains these bodies with `include SchemaStatements` on the
-   *   adapter, so there is no accessor to mirror. Permanent because TypeScript has no `include`:
-   *   the repo's substitute is a `this`-typed function assigned per method, and
-   *   abstract/schema_statements.rb defines 76 of them — that many hand-assigned statics is not a
-   *   readable class, and no future port removes the limitation. trails therefore declares the
-   *   module as a class and mixes it in with `include(AbstractAdapter, SchemaStatements)` below;
-   *   this accessor is only the typed handle onto those mixed-in bodies, so it returns the host
-   *   adapter itself. Dispatch is then plain prototype lookup + `super`, exactly as in Ruby.
+   * @noRailsEquivalent CONVERGEABLE. Rails gains these bodies with `include SchemaStatements` on
+   *   the adapter, so there is no accessor to mirror; `include(AbstractAdapter, SchemaStatements)`
+   *   below is trails' equivalent and dispatch is plain prototype lookup + `super`, exactly as in
+   *   Ruby. That leaves this an identity function whose remaining job is typing the mixed-in
+   *   bodies at the call site. Story `delete-the-schema-statements-accessor` retires it and points
+   *   every caller at the adapter member directly.
    */
-  schemaStatements(host?: AbstractAdapter): SchemaStatements {
-    return (host ?? this) as unknown as SchemaStatements;
+  schemaStatements(): SchemaStatements {
+    return this as unknown as SchemaStatements;
   }
 
   get schemaCache(): SchemaCache {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1478,13 +1478,13 @@ export class AbstractAdapter implements Quoting {
    *   adapter, so there is no accessor to mirror. Permanent because TypeScript has no `include`:
    *   the repo's substitute is a `this`-typed function assigned per method, and
    *   abstract/schema_statements.rb defines 76 of them — that many hand-assigned statics is not a
-   *   readable class, and no future port removes the limitation. trails therefore keeps the module
-   *   as a companion class and `schemaStatements(host?)` returns it bound to a host adapter. It is
-   *   the TS stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to
-   *   return the MySQL companion the same way Rails includes `MySQL::SchemaStatements`.
+   *   readable class, and no future port removes the limitation. trails therefore declares the
+   *   module as a class and mixes it in with `include(AbstractAdapter, SchemaStatements)` below;
+   *   this accessor is only the typed handle onto those mixed-in bodies, so it returns the host
+   *   adapter itself. Dispatch is then plain prototype lookup + `super`, exactly as in Ruby.
    */
   schemaStatements(host?: AbstractAdapter): SchemaStatements {
-    return new SchemaStatements((host ?? this) as unknown as AbstractAdapter);
+    return (host ?? this) as unknown as SchemaStatements;
   }
 
   get schemaCache(): SchemaCache {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -339,6 +339,25 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(stub.allSql.at(-1)).toMatch(/CHECK \(price > 0\)/);
   });
 
+  it("schemaStatements() is the adapter itself, so Migration#schema reaches adapter overrides", async () => {
+    // Rails has no `schema_statements` accessor: `include SchemaStatements` puts
+    // the bodies on the adapter, and Migration#method_missing hands work to the
+    // connection. trails' accessor is only a typed handle onto the same object,
+    // so an adapter override is what a `schema` handle dispatches to — no
+    // companion instance re-implementing the lookup.
+    class OverridingAdapter extends SqliteCapturingAdapter {
+      renameColumnCalls = 0;
+      async renameColumn(tableName: string, oldName: string, newName: string) {
+        this.renameColumnCalls += 1;
+        return super.renameColumn(tableName, oldName, newName);
+      }
+    }
+    const stub = new OverridingAdapter();
+    expect(stub.schemaStatements()).toBe(stub);
+    await stub.schemaStatements().renameColumn("widgets", "title", "name");
+    expect(stub.renameColumnCalls).toBe(1);
+  });
+
   it("removeForeignKey ifExists probe matches on to_table only, not name (Rails)", async () => {
     // Rails' remove_foreign_key checks existence with only the positional
     // to_table, then resolves the exact constraint (with column/name) via

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -299,15 +299,15 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       }
     }
     const stub = new FkStub();
-    // foreignKeys base path returns [] when adapter has no override
-    const fks = await stub.foreignKeys("any_table");
-    expect(fks).toEqual([]);
+    // foreignKeys base path raises NotImplementedError (Rails) rather than
+    // recursing when the adapter has no override.
+    await expect(stub.foreignKeys("any_table")).rejects.toThrow(/foreign_keys is not implemented/);
     // removeForeignKey base path resolves the real constraint via
-    // foreign_key_for! (Rails-faithful); against a stub with no foreign keys it
-    // raises ArgumentError promptly rather than recursing into a stack overflow.
+    // foreign_key_for! (Rails-faithful), so it surfaces foreignKeys' own
+    // NotImplementedError promptly rather than recursing into a stack overflow.
     await expect(
       stub.removeForeignKey("products", { name: "fk_products_user_id" }),
-    ).rejects.toThrow(/no foreign key/i);
+    ).rejects.toThrow(/foreign_keys is not implemented/);
   });
 
   it("adapter overrides that call super reach the base body without self-dispatching", async () => {
@@ -340,11 +340,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
   });
 
   it("schemaStatements() is the adapter itself, so Migration#schema reaches adapter overrides", async () => {
-    // Rails has no `schema_statements` accessor: `include SchemaStatements` puts
-    // the bodies on the adapter, and Migration#method_missing hands work to the
-    // connection. trails' accessor is only a typed handle onto the same object,
-    // so an adapter override is what a `schema` handle dispatches to — no
-    // companion instance re-implementing the lookup.
     class OverridingAdapter extends SqliteCapturingAdapter {
       renameColumnCalls = 0;
       async renameColumn(tableName: string, oldName: string, newName: string) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -299,15 +299,15 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       }
     }
     const stub = new FkStub();
-    // foreignKeys base path raises NotImplementedError (Rails) rather than
-    // recursing when the adapter has no override.
-    await expect(stub.foreignKeys("any_table")).rejects.toThrow(/foreign_keys is not implemented/);
+    // foreignKeys base path returns [] when adapter has no override
+    const fks = await stub.foreignKeys("any_table");
+    expect(fks).toEqual([]);
     // removeForeignKey base path resolves the real constraint via
-    // foreign_key_for! (Rails-faithful), so it surfaces foreignKeys' own
-    // NotImplementedError promptly rather than recursing into a stack overflow.
+    // foreign_key_for! (Rails-faithful); against a stub with no foreign keys it
+    // raises ArgumentError promptly rather than recursing into a stack overflow.
     await expect(
       stub.removeForeignKey("products", { name: "fk_products_user_id" }),
-    ).rejects.toThrow(/foreign_keys is not implemented/);
+    ).rejects.toThrow(/no foreign key/i);
   });
 
   it("adapter overrides that call super reach the base body without self-dispatching", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1373,9 +1373,11 @@ export class SchemaStatements {
     }
   }
 
+  // Rails raises `NotImplementedError, "foreign_keys is not implemented"` here
+  // (schema_statements.rb:1103). trails' `introspectForeignKeys` is built on the
+  // `[]`; story `converge-schema-statements-not-implemented-bodies` retires it.
   async foreignKeys(_tableName: string): Promise<ForeignKeyDefinition[]> {
-    // @nie disposition=TODO
-    throw new NotImplementedError("foreign_keys is not implemented");
+    return [];
   }
 
   async tables(): Promise<string[]> {
@@ -1468,18 +1470,21 @@ export class SchemaStatements {
   async indexExists(
     tableName: string,
     columnName: string | string[] | null | undefined,
-    options?: { unique?: boolean; name?: string; valid?: boolean },
+    options?: { unique?: boolean; name?: string; valid?: boolean; column?: string | string[] },
   ): Promise<boolean> {
     const allIndexes = await this.adapterIndexes(tableName);
-    // Rails `defined_for?`: the column check only applies when columns are
-    // present (`columns.blank?` — nil, "", and [] are all absent), so
-    // `index_exists?(:t, nil, name: ...)` matches on name alone (used to
-    // reverse a named expression index).
-    const hasColumn =
-      columnName != null &&
-      columnName !== "" &&
-      !(Array.isArray(columnName) && columnName.length === 0);
-    const targetCols = hasColumn ? (Array.isArray(columnName) ? columnName : [columnName]) : null;
+    // Rails `defined_for?`: `columns = options[:column] if columns.blank?`, then
+    // the column check only applies when columns are present (`columns.blank?` —
+    // nil, "", and [] are all absent), so `index_exists?(:t, nil, name: ...)`
+    // matches on name alone (used to reverse a named expression index).
+    const isBlank = (c: string | string[] | null | undefined): boolean =>
+      c == null || c === "" || (Array.isArray(c) && c.length === 0);
+    const columns = isBlank(columnName) ? options?.column : columnName;
+    const targetCols = isBlank(columns)
+      ? null
+      : Array.isArray(columns)
+        ? columns
+        : [columns as string];
 
     return allIndexes.some((idx) => {
       if (options?.name && idx.name !== options.name) return false;
@@ -1745,8 +1750,7 @@ export class SchemaStatements {
   }
 
   async checkConstraints(_tableName: string): Promise<CheckConstraintDefinition[]> {
-    // @nie disposition=TODO
-    throw new NotImplementedError();
+    throw new Error("NotImplementedError: checkConstraints is not implemented");
   }
 
   checkConstraintOptions(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1373,8 +1373,9 @@ export class SchemaStatements {
     }
   }
 
-  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    return [];
+  async foreignKeys(_tableName: string): Promise<ForeignKeyDefinition[]> {
+    // @nie disposition=TODO
+    throw new NotImplementedError("foreign_keys is not implemented");
   }
 
   async tables(): Promise<string[]> {
@@ -1743,8 +1744,9 @@ export class SchemaStatements {
     return result;
   }
 
-  async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
-    throw new Error("NotImplementedError: checkConstraints is not implemented");
+  async checkConstraints(_tableName: string): Promise<CheckConstraintDefinition[]> {
+    // @nie disposition=TODO
+    throw new NotImplementedError();
   }
 
   checkConstraintOptions(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1750,7 +1750,8 @@ export class SchemaStatements {
   }
 
   async checkConstraints(_tableName: string): Promise<CheckConstraintDefinition[]> {
-    throw new Error("NotImplementedError: checkConstraints is not implemented");
+    // @nie disposition=TODO
+    throw new NotImplementedError();
   }
 
   checkConstraintOptions(
@@ -1781,7 +1782,7 @@ export class SchemaStatements {
         return false;
       });
     } catch (e) {
-      if (e instanceof Error && e.message.startsWith("NotImplementedError")) return false;
+      if (e instanceof NotImplementedError) return false;
       throw e;
     }
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -286,8 +286,6 @@ interface SchemaMigrationPool {
 }
 
 export class SchemaStatements {
-  private _schemaCreation?: SchemaCreation;
-
   constructor(protected readonly adapter: DatabaseAdapter & SchemaQuoter) {}
 
   /**
@@ -304,36 +302,9 @@ export class SchemaStatements {
     return this.adapter.adapterName as AdapterName;
   }
 
+  /** Mirrors: SchemaStatements#schema_creation — `SchemaCreation.new(self)`. */
   get schemaCreation(): SchemaCreation {
-    if (!this._schemaCreation) {
-      const adapterSC =
-        (this.adapter as unknown) === (this as unknown)
-          ? undefined
-          : (this.adapter as unknown as { schemaCreation?: unknown }).schemaCreation;
-      this._schemaCreation =
-        adapterSC instanceof SchemaCreation
-          ? adapterSC
-          : new SchemaCreation(this.adapterName, this.adapter);
-    }
-    return this._schemaCreation;
-  }
-
-  /**
-   * The adapter's own override of `name`, or `undefined` when the base body
-   * should run. Dispatch is one-way: mixed into an adapter
-   * (`include(AbstractAdapter, SchemaStatements)`) `this.adapter` is `this`, so
-   * an override reaching this body through `super` must not be sent back to
-   * itself.
-   */
-  protected _adapterOverride<K extends keyof SchemaStatements>(
-    name: K,
-  ): Extract<SchemaStatements[K], (...args: never[]) => unknown> | undefined {
-    const adapter = this.adapter as unknown as Record<PropertyKey, unknown>;
-    if ((adapter as unknown) === (this as unknown)) return undefined;
-    const fn = adapter[name];
-    const base = (SchemaStatements.prototype as unknown as Record<PropertyKey, unknown>)[name];
-    if (typeof fn !== "function" || fn === base) return undefined;
-    return fn.bind(adapter) as Extract<SchemaStatements[K], (...args: never[]) => unknown>;
+    return new SchemaCreation(this.adapterName, this.adapter);
   }
 
   protected _qi(name: string): string {
@@ -546,11 +517,6 @@ export class SchemaStatements {
     if (options.ifExists && !(await this.columnExists(tableName, columnName))) {
       return;
     }
-    // SQLite rebuilds the table (alter_table) to drop a column so indexes that
-    // reference it are dropped instead of left dangling; delegate when the
-    // adapter supplies its own removeColumn (mirrors renameColumn's gate).
-    const override = this._adapterOverride("removeColumn");
-    if (override) return override(tableName, columnName, _type, options);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} DROP COLUMN ${this._qi(columnName)}`,
@@ -558,12 +524,6 @@ export class SchemaStatements {
   }
 
   async renameColumn(tableName: string, oldName: string, newName: string): Promise<void> {
-    // MySQL/MariaDB need the RENAME-COLUMN/CHANGE branch plus index fixups in
-    // AbstractMysqlAdapter#renameColumn; delegate when the adapter supplies its
-    // own implementation. The gate prevents self-recursion now that
-    // SchemaStatements is mixed into AbstractAdapter (see changeColumn).
-    const override = this._adapterOverride("renameColumn");
-    if (override) return override(tableName, oldName, newName);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} RENAME COLUMN ${this._qi(oldName)} TO ${this._qi(newName)}`,
@@ -642,12 +602,6 @@ export class SchemaStatements {
     type: ColumnType,
     options: ColumnOptions = {},
   ): Promise<void> {
-    // Adapters that cannot run `ALTER COLUMN ... TYPE` (SQLite) override
-    // changeColumn with a table-rebuild path. Delegate when the adapter supplies
-    // its own implementation; the gate prevents self-recursion now that
-    // SchemaStatements is mixed into AbstractAdapter (see changeColumnDefault).
-    const override = this._adapterOverride("changeColumn");
-    if (override) return override(tableName, columnName, type, options);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const sqlType = this.schemaCreation.typeToSql(type, options);
     const table = this._qi(tableName);
@@ -770,12 +724,6 @@ export class SchemaStatements {
     columnName: string,
     options: { from?: unknown; to: unknown } | unknown,
   ): Promise<void> {
-    // Adapters that cannot run `ALTER COLUMN ... SET DEFAULT` (SQLite) override
-    // changeColumnDefault with a table-rebuild path. Delegate when the adapter
-    // supplies its own implementation; the gate prevents self-recursion now
-    // that SchemaStatements is mixed into AbstractAdapter (see addForeignKey).
-    const override = this._adapterOverride("changeColumnDefault");
-    if (override) return override(tableName, columnName, options);
     // Rails unwraps a Hash to its :to only when it carries BOTH :from and :to
     // (extract_new_default_value, schema_statements.rb:1820); a bare structured
     // default like `{ to: 1 }` without :from is the literal default.
@@ -874,13 +822,6 @@ export class SchemaStatements {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
-    // SQLite can't ALTER TABLE ADD CONSTRAINT, so it rebuilds the table in its
-    // own addForeignKey override. When invoked through a SchemaStatements
-    // wrapper (this !== the adapter), delegate to that override. The
-    // `this !== adapter` guard keeps adapters that call `super` (e.g. PostgreSQL)
-    // from re-entering this gate and recursing.
-    const override = this._adapterOverride("addForeignKey");
-    if (override) return override(fromTable, toTable, options);
     // Rails: return unless use_foreign_keys?
     if (!this.isUseForeignKeys()) return;
     // Mirrors Rails' add_foreign_key short-circuit:
@@ -921,8 +862,6 @@ export class SchemaStatements {
     toTableOrOptions?: string | RemoveForeignKeyOptions,
     options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
-    const override = this._adapterOverride("removeForeignKey");
-    if (override) return override(fromTable, toTableOrOptions, options);
     // Rails: return unless use_foreign_keys?
     if (!this.isUseForeignKeys()) return;
     // Mirrors Rails remove_foreign_key(from_table, to_table = nil, **options):
@@ -966,8 +905,6 @@ export class SchemaStatements {
       [key: string]: unknown;
     } = {},
   ): Promise<void> {
-    const override = this._adapterOverride("addCheckConstraint");
-    if (override) return override(tableName, expression, options);
     const support = this.adapter as { supportsCheckConstraints?: () => boolean };
     if (
       typeof support.supportsCheckConstraints === "function" &&
@@ -991,8 +928,6 @@ export class SchemaStatements {
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
     options: { name?: string; ifExists?: boolean } = {},
   ): Promise<void> {
-    const override = this._adapterOverride("removeCheckConstraint");
-    if (override) return override(tableName, expressionOrOptions, options);
     // Mirrors Rails remove_check_constraint(table, expression = nil, **options):
     // resolve the live constraint via check_constraint_for! (by :name, else the
     // hash of the expression) and drop it by its real name — mirroring how
@@ -1027,8 +962,6 @@ export class SchemaStatements {
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
-    const override = this._adapterOverride("addTimestamps");
-    if (override) return override(tableName, options);
     const fragments = await this.addTimestampsForAlter(tableName, options);
     await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
   }
@@ -1142,10 +1075,6 @@ export class SchemaStatements {
         "You must specify at least one column name. Example: remove_columns(:people, :first_name)",
       );
     }
-    const override = this._adapterOverride("removeColumns") as
-      | ((tableName: string, ...columns: string[]) => Promise<void>)
-      | undefined;
-    if (override) return override(tableName, ...columns);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const fragments = this.removeColumnsForAlter(tableName, columns, { ...opts } as Record<
       string,
@@ -1445,8 +1374,6 @@ export class SchemaStatements {
   }
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    const override = this._adapterOverride("foreignKeys");
-    if (override) return override(tableName);
     return [];
   }
 
@@ -1817,8 +1744,6 @@ export class SchemaStatements {
   }
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
-    const override = this._adapterOverride("checkConstraints");
-    if (override) return override(tableName);
     throw new Error("NotImplementedError: checkConstraints is not implemented");
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -20,7 +20,6 @@ import {
   foreignKeys,
   indexes,
   parseMysqlName,
-  MysqlSchemaStatements,
 } from "./schema-statements.js";
 import { quote } from "./quoting.js";
 
@@ -556,29 +555,6 @@ describe("MySQL::SchemaStatements", () => {
       "pages",
     );
     expect(idx[0].columns).toBe("(lower(`title`)), `position`(4)");
-  });
-});
-
-describe("MysqlSchemaStatements#renameColumn delegation", () => {
-  // Migration#renameColumn dispatches through this.schema.renameColumn — i.e.
-  // MysqlSchemaStatements, which inherits the generic base. The base must
-  // delegate to AbstractMysqlAdapter#renameColumn so the RENAME-COLUMN/CHANGE
-  // branch and index fixups run; otherwise the MySQL path is silently skipped.
-  it("inherited renameColumn delegates to the adapter's renameColumn", async () => {
-    const calls: unknown[][] = [];
-    const adapter = {
-      renameColumn: async (...args: unknown[]) => {
-        calls.push(args);
-      },
-      executeMutation: async () => {
-        throw new Error("base RENAME COLUMN path should not run when adapter overrides");
-      },
-      schemaCache: null,
-      pool: {},
-    };
-    const ss = new MysqlSchemaStatements(adapter as never);
-    await ss.renameColumn("users", "old_name", "new_name");
-    expect(calls).toEqual([["users", "old_name", "new_name"]]);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -22,7 +22,8 @@ import type { AddIndexOptions, SchemaStatementsLike } from "../abstract/schema-d
  * the `temporary: true` option, which emits `DROP TEMPORARY TABLE` — a MySQL/MariaDB
  * extension required to drop temporary tables without affecting base tables.
  *
- * Returned by `Mysql2Adapter#schemaStatements()` so Migration#schema picks it up.
+ * Mixed into AbstractMysqlAdapter at the bottom of `abstract-mysql-adapter.ts`,
+ * mirroring `include MySQL::SchemaStatements`.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (partial)
  */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -56,7 +56,6 @@ import { abandonRawSocket } from "./abandon-raw-socket.js";
 import {
   indexes as mysqlIndexes,
   parseMysqlName as mysqlParseName,
-  MysqlSchemaStatements,
 } from "./mysql/schema-statements.js";
 
 /**
@@ -1424,10 +1423,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const dumper = new MysqlSchemaDumper(source, options);
     dumper.connection = this;
     return dumper;
-  }
-
-  override schemaStatements(host?: DatabaseAdapter): MysqlSchemaStatements {
-    return new MysqlSchemaStatements(host ?? this);
   }
 
   // ── Schema DDL ──

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4542,21 +4542,14 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * @noRailsEquivalent PERMANENT. Rails gains these bodies with `include SchemaStatements` on the
-   *   adapter, so there is no accessor to mirror. Permanent because TypeScript has no `include`:
-   *   the repo's substitute is a `this`-typed function assigned per method, and
-   *   abstract/schema_statements.rb defines 76 of them — that many hand-assigned statics is not a
-   *   readable class, and no future port removes the limitation. trails therefore keeps the module
-   *   as a companion class and `schemaStatements(host?)` returns it bound to a host adapter. It is
-   *   the TS stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to
-   *   return the MySQL companion the same way Rails includes `MySQL::SchemaStatements`.
+   * The PostgreSQL-specific half of `PostgreSQL::SchemaStatements`, still a companion class
+   * rather than a mixin: every method below delegates into it. Story
+   * `dissolve-the-postgresql-schema-statements-companion` folds it onto the adapter the way
+   * MySQL's is folded on, at which point this accessor goes away.
+   * @internal
    */
-  override schemaStatements(host?: DatabaseAdapter): SchemaStatements {
-    return new PostgreSQLSchemaStatements((host ?? this) as unknown as DatabaseAdapter);
-  }
-
   private pgSchemaStatements(): PostgreSQLSchemaStatements {
-    return this.schemaStatements() as PostgreSQLSchemaStatements;
+    return new PostgreSQLSchemaStatements(this as unknown as DatabaseAdapter);
   }
 
   async dropTable(
@@ -4568,7 +4561,7 @@ export class PostgreSQLAdapter
     // solely from the included `PostgreSQL::SchemaStatements` module. Delegate
     // here so schema-cache eviction + single-statement CASCADE behavior lives
     // in one place (PostgreSQLSchemaStatements#dropTable).
-    await this.schemaStatements().dropTable(...args);
+    await this.pgSchemaStatements().dropTable(...args);
   }
 
   async currentDatabase(): Promise<string> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -83,7 +83,6 @@ import type {
   UniqueConstraintStatements,
   SchemaNamespaceStatements,
 } from "./abstract/schema-statements.js";
-import { SchemaStatements } from "./abstract/schema-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
   transactionIsolationLevels,
@@ -4241,7 +4240,7 @@ export class PostgreSQLAdapter
     // Rails: PostgreSQL::SchemaStatements#add_foreign_key is just
     //   assert_valid_deferrable(options[:deferrable]); super
     this.assertValidDeferrable(options.deferrable);
-    await SchemaStatements.prototype.addForeignKey.call(this, fromTable, toTable, options);
+    await super.addForeignKey(fromTable, toTable, options);
   }
 
   async foreignKeyExists(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -2,6 +2,7 @@ import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaStatements } from "../abstract/schema-statements.js";
+import { SchemaCreation as PgSchemaCreation } from "./schema-creation.js";
 import {
   AlterTable,
   ChangeColumnDefinition,
@@ -99,6 +100,11 @@ interface PgSchemaAdapter {
 export class PostgreSQLSchemaStatements extends SchemaStatements {
   private get pg(): PgSchemaAdapter {
     return this.adapter as unknown as PgSchemaAdapter;
+  }
+
+  /** Mirrors: PostgreSQL::SchemaStatements#schema_creation */
+  override get schemaCreation(): PgSchemaCreation {
+    return new PgSchemaCreation(this.adapter);
   }
 
   /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -445,15 +445,12 @@ describe("SchemaDumperTest", () => {
   });
 
   itIfSupports("check_constraints", "schema dumps check constraints", async () => {
-    const { SchemaStatements } =
-      await import("./connection-adapters/abstract/schema-statements.js");
     const testAdapter = Base.connection;
     await testAdapter.createTable("products", { force: true }, (t) => {
       t.decimal("price");
       t.decimal("discounted_price");
     });
-    const ss = new SchemaStatements(testAdapter as any);
-    await ss.addCheckConstraint("products", "price > discounted_price", {
+    await testAdapter.addCheckConstraint("products", "price > discounted_price", {
       name: "products_price_check",
     });
     const output = await SchemaDumper.dumpTableSchema(testAdapter, "products");

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -1,7 +1,7 @@
 import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
-import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
-import type { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 import { Column } from "../connection-adapters/column.js";
+import type { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
+import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
 import { register } from "../connection-adapters.js";
 
 export interface MergeColumnOptions {
@@ -58,10 +58,13 @@ export class FakeActiveRecordAdapter extends AbstractAdapter {
     return true;
   }
 
-  // Rails' FakeAdapter gets `fetch_type_metadata` from `include SchemaStatements`.
-  // Here the base body is reached through the module prototype rather than
-  // `super`, because PostgreSQLAdapter redeclares the name with a four-argument
-  // signature, so AbstractAdapter cannot carry this one in its mixin interface.
+  /**
+   * Rails' FakeAdapter gets this from `include SchemaStatements`. Here it is
+   * reached through the module prototype: PostgreSQLAdapter redeclares the name
+   * with a four-argument signature, so AbstractAdapter cannot carry it in the
+   * mixin interface, and this class's deliberate `columns` divergence rules out
+   * declaration merging.
+   */
   private fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
     return SchemaStatements.prototype.fetchTypeMetadata.call(
       this as unknown as SchemaStatements,

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -1,6 +1,7 @@
 import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
-import { Column } from "../connection-adapters/column.js";
+import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
 import type { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
+import { Column } from "../connection-adapters/column.js";
 import { register } from "../connection-adapters.js";
 
 export interface MergeColumnOptions {
@@ -57,8 +58,15 @@ export class FakeActiveRecordAdapter extends AbstractAdapter {
     return true;
   }
 
+  // Rails' FakeAdapter gets `fetch_type_metadata` from `include SchemaStatements`.
+  // Here the base body is reached through the module prototype rather than
+  // `super`, because PostgreSQLAdapter redeclares the name with a four-argument
+  // signature, so AbstractAdapter cannot carry this one in its mixin interface.
   private fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
-    return this.schemaStatements().fetchTypeMetadata(sqlType);
+    return SchemaStatements.prototype.fetchTypeMetadata.call(
+      this as unknown as SchemaStatements,
+      sqlType,
+    );
   }
 }
 

--- a/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
@@ -116,7 +116,12 @@ describe("load_schema arm-probe guard", () => {
 
     const probe = new Probe(":memory:");
     try {
-      await expect(loadSchema(probe as unknown as AbstractAdapter)).resolves.toBeUndefined();
+      // The override really does take effect on the lay path — `schemaStatements()`
+      // hands back the adapter itself — so the lay dies downstream on the empty
+      // table. What this pins is that it is NOT `assertNotStubbed` that stops it.
+      const err = await loadSchema(probe as unknown as AbstractAdapter).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect(String(err)).not.toMatch(/is stubbed/);
     } finally {
       await probe.close();
     }

--- a/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
@@ -116,9 +116,6 @@ describe("load_schema arm-probe guard", () => {
 
     const probe = new Probe(":memory:");
     try {
-      // The override really does take effect on the lay path — `schemaStatements()`
-      // hands back the adapter itself — so the lay dies downstream on the empty
-      // table. What this pins is that it is NOT `assertNotStubbed` that stops it.
       const err = await loadSchema(probe as unknown as AbstractAdapter).catch((e: unknown) => e);
       expect(err).toBeInstanceOf(Error);
       expect(String(err)).not.toMatch(/is stubbed/);

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -3,6 +3,7 @@ import "../sqlite/better-sqlite3.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
+import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
 import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
 
 /**
@@ -37,28 +38,33 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
     "createTableDefinition",
     "definition factory — a stub returns no TableDefinition and dies at once, so it cannot silently lay nothing",
   ],
+  ["_config", "config read behind supportsForeignKeys/foreign_keys, not a DDL emitter"],
+  ["supportsForeignKeys", "capability read — decides whether an FK clause rides inline"],
+  ["nativeDatabaseTypes", "renderer input — the type map typeToSql resolves a column type against"],
+  ["quoteIdentifier", "renderer input — quotes a column name into the DDL string"],
+  ["quoteTableName", "renderer input — quotes a table name into the DDL string"],
+  ["quoteDefaultExpression", "renderer input — quotes a column default into the DDL string"],
+  ["quotedColumnsForIndex", "renderer input — builds the column list of a CREATE INDEX"],
 ]);
 
 /**
  * Lay the canonical schema through a proxy that records every adapter member
  * the loader reaches for.
  *
- * `schemaStatements(host)` is re-bound to the proxy deliberately: the companion
- * is where the lay path's adapter calls actually come from, and letting the real
- * adapter hand back a companion bound to itself would record none of them.
- * Every other member is handed back bound to the *real* adapter, so calls the
- * adapter makes to itself internally stay unrecorded — the boundary being
- * pinned is the one a cover can intercept.
+ * `schemaStatements()` is answered with a `SchemaStatements` bound to the proxy.
+ * That is instrumentation, not the production shape — in production the accessor
+ * returns the adapter itself and the module bodies are the adapter's own. Binding
+ * a module view to the proxy is what pins the *adapter* boundary specifically:
+ * every `this.adapter.<member>` a module body makes is recorded one hop deep,
+ * while the calls the real adapter then makes to itself stay unrecorded. That
+ * boundary — the one a cover can intercept — is the whole scope of this guard.
  *
- * That boundary is the whole scope, and the `schemaCreation` hop shows where it
- * stops: the getter hands back the *real* adapter's SchemaCreation instance, so
- * every quoting/type call it makes while rendering DDL (`quoteColumnName`,
- * `quoteDefaultExpression`, `lookupCastType`, …) resolves against the real
- * adapter and is invisible here. The `schemaCreation` access is recorded; what
- * happens downstream of it is not. That is deliberate — a cover intercepts an
- * adapter member, and nothing downstream of `schemaCreation` is reachable that
- * way — but it means the floor assertions below pin the boundary, not the full
- * DDL-rendering call graph.
+ * `schemaCreation` is the one member the device cannot see: a module view builds
+ * its own SchemaCreation (Rails' `SchemaCreation.new(self)`), where in production
+ * the adapter's own getter is what the mixed-in bodies hit. It stays in the
+ * guarded set for that reason. The renderer's own quoting/type reads
+ * (`quoteIdentifier`, `quoteDefaultExpression`, `nativeDatabaseTypes`, …) do come
+ * back through the proxy and are exempted below as renderer inputs.
  */
 async function recordLayPath(): Promise<Set<string>> {
   const real = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
@@ -68,7 +74,7 @@ async function recordLayPath(): Promise<Set<string>> {
       if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
       touched.add(prop);
       if (prop === "schemaStatements") {
-        return (host?: AbstractAdapter) => target.schemaStatements(host ?? proxy);
+        return () => new SchemaStatements(proxy as never);
       }
       const value = Reflect.get(target, prop, target) as unknown;
       return typeof value === "function"
@@ -110,7 +116,7 @@ describe("STUBBED_DDL_METHODS", () => {
     // vacuously.
     expect(touched.has("execute")).toBe(true);
     expect(touched.has("schemaStatements")).toBe(true);
-    expect(touched.has("schemaCreation")).toBe(true);
+    expect(touched.has("createTableDefinition")).toBe(true);
 
     const unaccounted = [...touched]
       .filter((name) => !STUBBED_DDL_METHODS.includes(name) && !NON_EMITTING.has(name))

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -74,7 +74,10 @@ async function recordLayPath(): Promise<Set<string>> {
       if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
       touched.add(prop);
       if (prop === "schemaStatements") {
-        return () => new SchemaStatements(proxy as never);
+        return () =>
+          new SchemaStatements(
+            proxy as unknown as ConstructorParameters<typeof SchemaStatements>[0],
+          );
       }
       const value = Reflect.get(target, prop, target) as unknown;
       return typeof value === "function"


### PR DESCRIPTION
`SchemaStatements` was dual-purpose: a standalone companion class handed out by
`schemaStatements()` **and** a mixin applied with
`include(AbstractAdapter, SchemaStatements)`. In the mixed-in case
`this.adapter === this`, which is the only reason `_adapterOverride` (PR #5794)
existed — 12 methods plus the `schemaCreation` getter re-implemented Ruby's
method lookup by hand. Rails has no equivalent: `SchemaStatements` is a plain
module and `super` handles adapter overrides natively.

This resolves the duality in favour of the mixin.

- `AbstractAdapter#schemaStatements()` returns the adapter itself, so the
  accessor is only a typed handle onto the mixed-in bodies. Its unused `host`
  parameter — which existed to bind a companion to a different adapter — goes
  with it. MySQL was already converged: `include(AbstractMysqlAdapter,
  MysqlSchemaStatements)` (`abstract-mysql-adapter.ts`) mirrors
  `include MySQL::SchemaStatements`, so `Mysql2Adapter#schemaStatements` just
  disappears.
- `_adapterOverride` and all 12 call sites are deleted. `removeColumn`,
  `renameColumn`, `changeColumn`, `changeColumnDefault`, `addForeignKey`,
  `removeForeignKey`, `addCheckConstraint`, `removeCheckConstraint`,
  `addTimestamps`, `removeColumns`, `foreignKeys` and `checkConstraints` reach
  their adapter overrides through plain prototype dispatch, and the overrides
  reach the base bodies through `super` —
  `PostgreSQLAdapter#addForeignKey`'s `SchemaStatements.prototype.…call(this)`
  becomes a real `super.addForeignKey(...)`.
- `schemaCreation` becomes Rails' `SchemaCreation.new(self)` — no identity
  check, no memo. Every adapter already defines its own getter, which shadows
  this one; `PostgreSQLSchemaStatements` gains the
  `PostgreSQL::SchemaCreation.new` override Rails has.

One real bug surfaces once dispatch is honest, and is fixed here.
`indexExists` never consulted `options.column`, so a spec arriving in the
options hash rather than positionally matched nothing. Rails'
`Index#defined_for?` opens with `columns = options[:column] if columns.blank?`
(`schema_definitions.rb:55`), which is what makes
`remove_index(:testings, column: %w[foo bar], if_exists: true)` a no-op instead
of a raise. The base `removeIndex` papered over the gap locally
(`columnName ?? opts.column`), so it stayed hidden until PostgreSQL's
`remove_index` override became the one `Migration` reaches — that override
delegates straight to `index_exists?` the way Rails does
(`postgresql/schema_statements.rb:557`). `test_remove_index_with_column_array_which_does_not_exist_doesnt_raise_with_option`
is the Rails-paired test that failed on the PG lane and now passes.

The `super`-reaching test from PR #5794
(`schema-statements-on-adapter.test.ts`) passes unchanged; a new case there
pins `schemaStatements() === adapter` and that an adapter override is what a
`schema` handle dispatches to.

### Scoped out

- **PostgreSQL's companion.** `PostgreSQLSchemaStatements` is ~2000 lines with
  ~100 methods, each fronted by a thin delegator on the adapter; it is now a
  private implementation detail behind `pgSchemaStatements()` rather than
  something `schemaStatements()` hands out. Folding it onto the adapter is well
  past the 500-LOC ceiling and lands as
  `dissolve-the-postgresql-schema-statements-companion` (RFC 0051). Deleting the
  guard is safe for it today: for each of the 12 methods either the companion
  overrides it too, or neither the companion nor the adapter does.
- **`foreignKeys`' `[]`.** An earlier revision of this branch converged it to
  Rails' `NotImplementedError` (`schema_statements.rb:1103`) and had to back it
  out: the trails-only `introspectForeignKeys` (`schema-introspection.ts`) is
  built on the `[]` and documents it, and the SQLite, MariaDB and PostgreSQL
  lanes all failed on the test that pins it. That helper has no Rails
  counterpart, so the convergence is really a question about it —
  `converge-schema-statements-not-implemented-bodies` (RFC 0051) carries it.
- **`checkConstraintExists`' invented rescue.** Rails never rescues
  `NotImplementedError` here: `check_constraint_for`
  (`schema_statements.rb:1797`) opens with
  `return unless supports_check_constraints?`, so an unsupported adapter never
  reaches the raise. trails has no `checkConstraintFor` seam at all and wraps
  `checkConstraints` in a try/catch instead. `checkConstraints` now raises a real
  `NotImplementedError` (matching `:1274` — no message, like every other stub in
  the file) and the catch tests `instanceof` rather than sniffing the message
  prefix, which could never have matched a real messageless instance. Retiring
  the rescue in favour of the `supports_check_constraints?` guard is
  `converge-check-constraint-exists-on-the-supports-guard` (RFC 0051).
- **The accessor itself.** `schemaStatements()` is now an identity function that
  Rails has no counterpart for; its `@noRailsEquivalent` is reclassified
  PERMANENT → CONVERGEABLE and `delete-the-schema-statements-accessor`
  (RFC 0051) retires it across ~40 call sites.

### Test-shape changes

- `MysqlSchemaStatements#renameColumn delegation` asserted the shim's forwarding
  through a companion; that behaviour is now structural, so the case is removed
  rather than reworded.
- `stubbed-ddl-methods.test.ts` binds a `SchemaStatements` view to its recording
  proxy as instrumentation — with `schemaStatements()` returning the adapter
  there is no companion whose `this.adapter` could be swapped. The renderer's
  quoting/type reads become visible through that view and are exempted in
  `NON_EMITTING` as renderer inputs.
- The arm guard's class-body-override case pins that `assertNotStubbed` is not
  what stops the lay (the override really does take effect now), instead of
  pinning a clean resolve.

Verified locally on both SQLite and PostgreSQL: `connection-adapters/`,
`migration/`, `migration.test.ts`, `schema-introspection.trails.test.ts`,
`schema-dumper.test.ts`, `support/`, `adapters/sqlite3/`,
`adapters/postgresql/`. The three `SchemaDumperTest` dump-timeout failures seen
on the PG lane are the known `schema_migrations` flake and pass in isolation.
MySQL runs in CI.

Closes-story: remove-schema-statements-dispatch-shim-companion-mixin-duality
