### PR TITLE
test(sqlite3): pin composite fk survival across removeColumn

### DIFF
--- a/packages/activerecord/src/migration/foreign-key.trails.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.trails.test.ts
@@ -2,12 +2,19 @@
  * TS-only regression coverage for `remove_foreign_key`. Rails has no test that
  * pins the generic-option narrowing of `foreign_key_for!` / `defined_for?`
  * (`schema_statements.rb:1214-1224`, `schema_definitions.rb:161-167`), so this
- * lives outside the ported foreign-key.test.ts.
+ * lives outside the ported foreign-key.test.ts. Same for the SQLite3
+ * `remove_column` composite-fk case at the bottom (`sqlite3_adapter.rb:349-363`).
  */
 import { describe, it, expect } from "vitest";
+import { StatementInvalid } from "../errors.js";
 import { fixtures } from "../test-fixtures.js";
-import { ambientConnection, withRocketTables } from "../support/rocket-tables.js";
+import {
+  ambientConnection,
+  withCompositeRocketTables,
+  withRocketTables,
+} from "../support/rocket-tables.js";
 import { Base } from "../base.js";
+import { adapterType } from "../test-adapter.js";
 
 describe("removeForeignKey option narrowing", () => {
   fixtures([], { useTransactionalTests: false });
@@ -71,5 +78,40 @@ describe("renameColumn under a table_name_prefix", () => {
       await conn.dropTable("p_astronauts", "p_rockets", { ifExists: true });
       Base.tableNamePrefix = "";
     }
+  });
+});
+
+// SQLite3-only: `remove_column` there rebuilds the table from a reflected
+// definition, so the FK list is filtered in Ruby (`sqlite3_adapter.rb:349-363`)
+// rather than by the server. On PostgreSQL/MySQL the server drops any FK that
+// covers a dropped column, so there is no whole-value comparison to pin.
+describe.skipIf(adapterType !== "sqlite")("removeColumn against a composite foreign key", () => {
+  fixtures([], { useTransactionalTests: false });
+
+  it("keeps the composite foreign key when a member column is removed", async () => {
+    const conn = await ambientConnection();
+    await withCompositeRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", { primaryKey: ["tenant_id", "id"] });
+
+      // `delete_if { |fk| fk.column == column_name.to_s }` compares the whole
+      // value, and a composite fk's `column` is an Array — so the member name
+      // never matches and the fk is carried into the rebuilt definition. SQLite
+      // then rejects the CREATE TABLE because the child column is gone: the
+      // error is the observable proof that the fk was preserved rather than
+      // dropped, and is exactly what Rails does here too.
+      const error = await conn.removeColumn("astronauts", "rocket_tenant_id").then(
+        () => undefined,
+        (err: unknown) => err,
+      );
+
+      expect(error).toBeInstanceOf(StatementInvalid);
+      expect((error as Error).message).toMatch(
+        /unknown column "rocket_tenant_id" in foreign key definition/,
+      );
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(1);
+      expect(foreignKeys[0].column).toEqual(["rocket_tenant_id", "rocket_id"]);
+    });
   });
 });

--- a/packages/activerecord/src/migration/foreign-key.trails.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.trails.test.ts
@@ -2,8 +2,16 @@
  * TS-only regression coverage for `remove_foreign_key`. Rails has no test that
  * pins the generic-option narrowing of `foreign_key_for!` / `defined_for?`
  * (`schema_statements.rb:1214-1224`, `schema_definitions.rb:161-167`), so this
- * lives outside the ported foreign-key.test.ts. Same for the SQLite3
- * `remove_column` composite-fk case at the bottom (`sqlite3_adapter.rb:349-363`).
+ * lives outside the ported foreign-key.test.ts.
+ *
+ * The same goes for the SQLite3 `remove_column` composite-fk case at the
+ * bottom: `definition.foreign_keys.delete_if { |fk| fk.column == column_name }`
+ * (`sqlite3_adapter.rb:349-363`) compares the whole value, and a composite fk's
+ * `column` is an Array, so a member name never matches and the fk is carried
+ * into the rebuilt table — SQLite then rejects the CREATE TABLE because the
+ * child column is gone, which is the observable proof the fk was preserved.
+ * SQLite3-only: PostgreSQL and MySQL drop any fk covering a dropped column
+ * server-side, so there is no Ruby-side comparison to pin.
  */
 import { describe, it, expect } from "vitest";
 import { StatementInvalid } from "../errors.js";
@@ -81,10 +89,6 @@ describe("renameColumn under a table_name_prefix", () => {
   });
 });
 
-// SQLite3-only: `remove_column` there rebuilds the table from a reflected
-// definition, so the FK list is filtered in Ruby (`sqlite3_adapter.rb:349-363`)
-// rather than by the server. On PostgreSQL/MySQL the server drops any FK that
-// covers a dropped column, so there is no whole-value comparison to pin.
 describe.skipIf(adapterType !== "sqlite")("removeColumn against a composite foreign key", () => {
   fixtures([], { useTransactionalTests: false });
 
@@ -93,12 +97,6 @@ describe.skipIf(adapterType !== "sqlite")("removeColumn against a composite fore
     await withCompositeRocketTables(conn, async () => {
       await conn.addForeignKey("astronauts", "rockets", { primaryKey: ["tenant_id", "id"] });
 
-      // `delete_if { |fk| fk.column == column_name.to_s }` compares the whole
-      // value, and a composite fk's `column` is an Array — so the member name
-      // never matches and the fk is carried into the rebuilt definition. SQLite
-      // then rejects the CREATE TABLE because the child column is gone: the
-      // error is the observable proof that the fk was preserved rather than
-      // dropped, and is exactly what Rails does here too.
       const error = await conn.removeColumn("astronauts", "rocket_tenant_id").then(
         () => undefined,
         (err: unknown) => err,


### PR DESCRIPTION
`removeColumn` / `removeColumns` on SQLite3 drop the foreign keys they orphan
via `deleteForeignKeysForColumns`, mirroring Rails'
`definition.foreign_keys.delete_if` (`sqlite3_adapter.rb:349-363`). Rails
compares the *whole* value (`fk.column == column_name.to_s`), and a composite
FK reflects `column` as an Array — so a composite FK never matches and is
carried into the rebuilt table. That was corrected during #5528 review but
nothing asserted it.

This adds the missing pin. Rails has no test for it (checked
`test/cases/migration/foreign_key_test.rb`, including `CompositeForeignKeyTest`),
so it lands in the `.trails.test.ts` sibling, reusing the existing
`withCompositeRocketTables` helper — no bespoke schema.

Removing a member column leaves the FK in the definition, and SQLite then
rejects the rebuild with `unknown column "rocket_tenant_id" in foreign key
definition`. That error *is* the observable proof the FK was preserved rather
than dropped; the surviving array-valued FK is asserted afterwards. Gated to
SQLite3: on PostgreSQL/MySQL the server drops any FK covering a dropped column,
so there is no Ruby-side whole-value comparison to pin.

Verified the test fails against a helper revision that matches FK members
individually, and passes on the converged one.

Closes-story: sqlite-composite-fk-survives-remove-column-untested
