### PR TITLE
feat(prism-codegen): drive await insertion from a whole-program async manifest

### DIFF
--- a/docs/infrastructure/prism-codegen-spike.md
+++ b/docs/infrastructure/prism-codegen-spike.md
@@ -315,9 +315,13 @@ computes at runtime:
    the method names the Rails file itself `def`s, so generic Relation async
    names the file merely _calls_ on other receivers (`Array#first`, `#one?`) are
    not swept in (the `await` rule is receiver-blind, so an unscoped union would
-   await unrelated same-named calls). Remaining limits: (a) files with no port
-   yet fall back to sync, and (b) `await` placement is file-local — a call to an
-   async method defined in a _different_ file is not awaited.
+   await unrelated same-named calls). Beyond the twin file, a whole-program
+   async manifest over `packages/activerecord/src` (`buildAsyncManifest`) carries
+   `await` across file boundaries: a name that exactly one other port file
+   defines async, and that Rails `def`s somewhere in the target set, is awaited
+   too — the same unambiguous-global-hit rule the scorer's cross-file fallback
+   uses, so a name async in several port files is declined rather than guessed.
+   Remaining limit: files with no port yet fall back to sync.
 4. **Ruby stdlib idioms pass through untranslated.** `attributes.collect { }`,
    `arr.first`, `Array(x)`, `raise` — emitted verbatim; no runtime shim.
 5. **Metaprogramming is opaque.** `define_method`, `method_missing`, `send`,

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -1,9 +1,8 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import * as path from "node:path";
 import { rubyFileToTs, methodName } from "./naming.js";
-import { TARGET_FILES, rubyAbsPath } from "./files.js";
+import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath, type PortFile } from "./files.js";
 import { resolvePath } from "../../vendor/sources.js";
-const TRAILS_AR_SRC = "packages/activerecord/src";
 const AR_ROOT = resolvePath("activerecord");
 const AR_LIB = path.dirname(AR_ROOT);
 const RUBY_DEF = /^\s*def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)/gm;
@@ -60,7 +59,7 @@ function readFileOr(tsPath: string): string {
 export interface AsyncManifest {
   byName: Map<string, Set<string>>;
 }
-export function buildAsyncManifest(files: { path: string; source: string }[]): AsyncManifest {
+export function buildAsyncManifest(files: PortFile[]): AsyncManifest {
   const byName = new Map<string, Set<string>>();
   for (const { path: file, source } of files) {
     for (const name of extractAsyncNames(source)) {
@@ -82,10 +81,9 @@ export function crossFileAsyncNames(
   opts: { twinTsPath: string; railsDefs: ReadonlySet<string> },
 ): Set<string> {
   const names = new Set<string>();
-  for (const [name, files] of manifest.byName) {
-    if (files.size !== 1) continue;
-    if (files.has(opts.twinTsPath)) continue;
-    if (!opts.railsDefs.has(name)) continue;
+  for (const name of opts.railsDefs) {
+    const files = manifest.byName.get(name);
+    if (!files || files.size !== 1 || files.has(opts.twinTsPath)) continue;
     names.add(name);
   }
   return names;
@@ -104,25 +102,6 @@ export function resolveAsyncNames(opts: {
   }
   for (const n of opts.crossFile ?? []) names.add(n);
   return names;
-}
-function portTreeFiles(): { path: string; source: string }[] {
-  const out: { path: string; source: string }[] = [];
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir)) {
-      const full = path.join(dir, entry);
-      if (statSync(full).isDirectory()) {
-        if (entry === "test-helpers" || entry === "support") continue;
-        walk(full);
-      } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
-        out.push({
-          path: path.relative(TRAILS_AR_SRC, full),
-          source: readFileSync(full, "utf8"),
-        });
-      }
-    }
-  };
-  walk(TRAILS_AR_SRC);
-  return out;
 }
 let manifestCache: AsyncManifest | undefined;
 export function defaultAsyncManifest(): AsyncManifest {

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import * as path from "node:path";
 import { rubyFileToTs, methodName } from "./naming.js";
+import { TARGET_FILES, rubyAbsPath } from "./files.js";
 import { resolvePath } from "../../vendor/sources.js";
 const TRAILS_AR_SRC = "packages/activerecord/src";
 const AR_ROOT = resolvePath("activerecord");
@@ -50,10 +51,50 @@ export function extractAsyncNames(src: string): Set<string> {
 function readFileOr(tsPath: string): string {
   return existsSync(tsPath) ? readFileSync(tsPath, "utf8") : "";
 }
+/**
+ * Whole-program view of which method names are async somewhere in the port
+ * tree, and in how many files — the same shape the scorer's global fallback
+ * indexes by, so an await decision can be taken on an unambiguous cross-file
+ * hit rather than only on the one twin file.
+ */
+export interface AsyncManifest {
+  byName: Map<string, Set<string>>;
+}
+export function buildAsyncManifest(files: { path: string; source: string }[]): AsyncManifest {
+  const byName = new Map<string, Set<string>>();
+  for (const { path: file, source } of files) {
+    for (const name of extractAsyncNames(source)) {
+      const seen = byName.get(name) ?? new Set<string>();
+      seen.add(file);
+      byName.set(name, seen);
+    }
+  }
+  return { byName };
+}
+/**
+ * Names the manifest resolves to exactly one async definition outside the twin
+ * file. Ambiguous names (async in several port files) are declined: the await
+ * rule is receiver-blind, so a name that could be two different methods must
+ * not drag an await onto the wrong call.
+ */
+export function crossFileAsyncNames(
+  manifest: AsyncManifest,
+  opts: { twinTsPath: string; railsDefs: ReadonlySet<string> },
+): Set<string> {
+  const names = new Set<string>();
+  for (const [name, files] of manifest.byName) {
+    if (files.size !== 1) continue;
+    if (files.has(opts.twinTsPath)) continue;
+    if (!opts.railsDefs.has(name)) continue;
+    names.add(name);
+  }
+  return names;
+}
 export function resolveAsyncNames(opts: {
   twinTs: string;
   relationTs?: string;
   ownRubyDefs?: ReadonlySet<string>;
+  crossFile?: ReadonlySet<string>;
 }): Set<string> {
   const names = extractAsyncNames(opts.twinTs);
   if (opts.relationTs && opts.ownRubyDefs) {
@@ -61,15 +102,64 @@ export function resolveAsyncNames(opts: {
       if (opts.ownRubyDefs.has(n)) names.add(n);
     }
   }
+  for (const n of opts.crossFile ?? []) names.add(n);
   return names;
 }
-export function asyncMethodsForRailsFile(railsRelPath: string): Set<string> {
+function portTreeFiles(): { path: string; source: string }[] {
+  const out: { path: string; source: string }[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === "test-helpers" || entry === "support") continue;
+        walk(full);
+      } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+        out.push({
+          path: path.relative(TRAILS_AR_SRC, full),
+          source: readFileSync(full, "utf8"),
+        });
+      }
+    }
+  };
+  walk(TRAILS_AR_SRC);
+  return out;
+}
+let manifestCache: AsyncManifest | undefined;
+export function defaultAsyncManifest(): AsyncManifest {
+  manifestCache ??= buildAsyncManifest(portTreeFiles());
+  return manifestCache;
+}
+let railsCorpusDefsCache: Set<string> | undefined;
+/**
+ * Every method Rails defines across the codegen target set. A cross-file async
+ * name only earns an await when it is also a Rails method — that keeps
+ * incidental TS-only helpers (and same-named library calls) out of the
+ * receiver-blind await rule, the same intersect-with-Rails-defs guard the
+ * relation.ts supplement has always used.
+ */
+function railsCorpusDefs(): Set<string> {
+  if (railsCorpusDefsCache) return railsCorpusDefsCache;
+  const defs = new Set<string>();
+  for (const f of TARGET_FILES) {
+    const abs = rubyAbsPath(f);
+    if (!existsSync(abs)) continue;
+    for (const n of rubyDefinedMethods(readFileSync(abs, "utf8"))) defs.add(n);
+  }
+  railsCorpusDefsCache = defs;
+  return defs;
+}
+export function asyncMethodsForRailsFile(
+  railsRelPath: string,
+  manifest: AsyncManifest = defaultAsyncManifest(),
+): Set<string> {
   const short = railsRelPath.replace(/^active_record\//, "");
-  const twinTs = readFileOr(path.join(TRAILS_AR_SRC, rubyFileToTs(short)));
+  const twinTsPath = rubyFileToTs(short);
+  const twinTs = readFileOr(path.join(TRAILS_AR_SRC, twinTsPath));
   const relationFamily = short.startsWith("relation/") || short === "relation.rb";
   return resolveAsyncNames({
     twinTs,
     relationTs: relationFamily ? readFileOr(path.join(TRAILS_AR_SRC, "relation.ts")) : undefined,
     ownRubyDefs: relationFamily ? railsDefinedMethods(railsRelPath) : undefined,
+    crossFile: crossFileAsyncNames(manifest, { twinTsPath, railsDefs: railsCorpusDefs() }),
   });
 }

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -4,7 +4,13 @@ import { generateFromSource } from "./index.js";
 import { summarizeCoverage, mergeCoverages } from "./coverage.js";
 import { Registry } from "./registry.js";
 import { tsToRubyFile } from "./naming.js";
-import { extractAsyncNames, resolveAsyncNames, rubyDefinedMethods } from "./async-source.js";
+import {
+  buildAsyncManifest,
+  crossFileAsyncNames,
+  extractAsyncNames,
+  resolveAsyncNames,
+  rubyDefinedMethods,
+} from "./async-source.js";
 import type { Coverage } from "./types.js";
 describe("prism-codegen", () => {
   it("translates class/def shape and method-name conventions", async () => {
@@ -349,6 +355,46 @@ describe("prism-codegen", () => {
     expect(names.has("ids")).toBe(true);
     expect(names.has("first")).toBe(false);
     expect(names.has("isOne")).toBe(false);
+  });
+  it("awaits calls into async methods defined in another port file", async () => {
+    const manifest = buildAsyncManifest([
+      { path: "persistence.ts", source: `export async function performSave() {}` },
+      { path: "relation/finder-methods.ts", source: `export async function findBy() {}` },
+    ]);
+    const crossFile = crossFileAsyncNames(manifest, {
+      twinTsPath: "persistence.ts",
+      railsDefs: rubyDefinedMethods(`def find_by; end\ndef perform_save; end`),
+    });
+    expect(crossFile.has("findBy")).toBe(true);
+    expect(crossFile.has("performSave")).toBe(false);
+    const { code } = await generateFromSource(
+      `module M
+        def reload; self.find_by(1); end
+      end`,
+      resolveAsyncNames({ twinTs: `export async function reload() {}`, crossFile }),
+    );
+    expect(code).toContain("await this.findBy(1)");
+  });
+  it("declines the await when a name is async in more than one port file", () => {
+    const manifest = buildAsyncManifest([
+      { path: "relation.ts", source: `class R { async reset() {} }` },
+      { path: "connection-adapters/pool.ts", source: `class P { async reset() {} }` },
+      { path: "persistence.ts", source: `export async function touch() {}` },
+    ]);
+    const railsDefs = rubyDefinedMethods(`def reset; end\ndef touch; end`);
+    const crossFile = crossFileAsyncNames(manifest, { twinTsPath: "core.ts", railsDefs });
+    expect(crossFile.has("reset")).toBe(false);
+    expect(crossFile.has("touch")).toBe(true);
+  });
+  it("keeps cross-file async names out unless Rails defines the method", () => {
+    const manifest = buildAsyncManifest([
+      { path: "relation.ts", source: `class R { async then() {} }` },
+    ]);
+    const crossFile = crossFileAsyncNames(manifest, {
+      twinTsPath: "core.ts",
+      railsDefs: rubyDefinedMethods(`def save; end`),
+    });
+    expect(crossFile.has("then")).toBe(false);
   });
   it("omits the relation supplement when no defs are provided (Model-side files)", () => {
     const names = resolveAsyncNames({ twinTs: `export async function save() {}` });

--- a/scripts/prism-codegen/files.ts
+++ b/scripts/prism-codegen/files.ts
@@ -1,3 +1,4 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import * as path from "node:path";
 import { resolvePath } from "../../vendor/sources.js";
 export interface TargetFile {
@@ -80,4 +81,30 @@ export function rubyAbsPath(f: TargetFile): string {
 }
 export function railsLibRelPaths(): string[] {
   return TARGET_FILES.map((f) => f.ruby);
+}
+export const TRAILS_AR_SRC = "packages/activerecord/src";
+export interface PortFile {
+  path: string;
+  source: string;
+}
+/**
+ * Every hand-written port source under `packages/activerecord/src`, keyed by
+ * its path relative to that root. Test helpers and support scaffolding are not
+ * port surface, so they stay out.
+ */
+export function portTreeFiles(): PortFile[] {
+  const out: PortFile[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === "test-helpers" || entry === "support") continue;
+        walk(full);
+      } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+        out.push({ path: path.relative(TRAILS_AR_SRC, full), source: readFileSync(full, "utf8") });
+      }
+    }
+  };
+  walk(TRAILS_AR_SRC);
+  return out;
 }

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -1,11 +1,11 @@
 import * as fs from "fs/promises";
-import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
-import { TARGET_FILES, rubyAbsPath } from "./files.js";
+import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath } from "./files.js";
 import { rubyFileToTs } from "./naming.js";
 import { scoreFile, indexPortTree, type ScoreEntry } from "./score.js";
 import {
@@ -30,28 +30,10 @@ import {
   staleSignOffs,
 } from "./signoff.js";
 
-const TRAILS_AR_SRC = "packages/activerecord/src";
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const API_COMPARE = path.join(HERE, "..", "api-compare");
 const BASELINE_PATH = path.join(HERE, "convergence-baseline.json");
 const SIGNOFF_PATH = path.join(HERE, "convergence-signoff.json");
-
-function portTreeFiles(): { path: string; source: string }[] {
-  const out: { path: string; source: string }[] = [];
-  const walk = (dir: string) => {
-    for (const e of readdirSync(dir)) {
-      const full = path.join(dir, e);
-      if (statSync(full).isDirectory()) {
-        if (e === "test-helpers" || e === "support") continue;
-        walk(full);
-      } else if (e.endsWith(".ts") && !e.endsWith(".test.ts")) {
-        out.push({ path: path.relative(TRAILS_AR_SRC, full), source: readFileSync(full, "utf8") });
-      }
-    }
-  };
-  walk(TRAILS_AR_SRC);
-  return out;
-}
 
 async function listJsonFiles(dir: string): Promise<string[]> {
   const out: string[] = [];

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -3,7 +3,7 @@ import { readFileSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { generateFromSource } from "./index.js";
-import { asyncMethodsForRailsFile } from "./async-source.js";
+import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
 import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath } from "./files.js";
 import { rubyFileToTs } from "./naming.js";
@@ -92,7 +92,9 @@ async function main() {
   const verbose = process.argv.includes("--verbose");
   const write = process.argv.includes("--write");
   const guard = process.argv.includes("--guard") || write;
-  const globalIndex = indexPortTree(portTreeFiles());
+  const portFiles = portTreeFiles();
+  const globalIndex = indexPortTree(portFiles);
+  const asyncManifest = buildAsyncManifest(portFiles);
   const catalog = buildCatalog(await loadExcludes(), "activerecord");
   let totMatched = 0;
   let totReordered = 0;
@@ -120,7 +122,7 @@ async function main() {
     }
     const { code, perDef } = await generateFromSource(
       readFileSync(rubyAbsPath(f), "utf8"),
-      asyncMethodsForRailsFile(f.ruby),
+      asyncMethodsForRailsFile(f.ruby, asyncManifest),
     );
     const cleanDefs = new Set(
       [...perDef].filter(([n, d]) => n !== TOPLEVEL && d.passthrough === 0).map(([n]) => n),


### PR DESCRIPTION
RFC 0065 roadmap item 2: `await` placement was file-local, so a call into an
async method whose port lives in a *different* file was never awaited — the
same cross-file population the scorer already reports (27 defs resolve in a
different port file than their Rails twin).

`async-source.ts` now builds a whole-program async manifest over
`packages/activerecord/src` (`buildAsyncManifest`) and feeds it into
`resolveAsyncNames` alongside the twin file and the existing `relation.ts`
supplement.

Two guards keep the receiver-blind await rule safe, mirroring the scorer's
global fallback:

- a name async in more than one port file is ambiguous and is declined —
  only an unambiguous global hit earns an `await`;
- a cross-file name must also be a Rails-defined method. This is the existing
  intersect-with-Rails-defs guard, widened from the one file's own `def`s to
  the codegen target corpus, since a cross-file call is by definition often
  into a method Rails defines elsewhere. TS-only helpers and same-named
  library calls stay out.

Also folds `score-cli.ts`'s port-tree walk into a shared `portTreeFiles()` in
`files.ts` (the manifest needs the same walk), and updates the spike doc's
Honest limits #3, which recorded this hole.

`pnpm codegen:score` TOTAL is unchanged (matched 33, divergent 297, missing 73);
`pnpm codegen:generate` still emits 0 parse errors with the new awaits in place.

Tests cover a cross-file async call being awaited, an ambiguous-name decline,
and a non-Rails-name decline.

Closes-story: codegen-async-cross-file-propagation
