### PR TITLE
feat(prism-codegen): resolve delegate macro calls through their receiver

### DIFF
--- a/scripts/prism-codegen/__snapshots__/associations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/associations.js.snap
@@ -77,7 +77,7 @@ export function hasOne(name, scope = null, { ...options } = {}) {
     reflection = Builder.HasOne.build(this, name, scope, options);
     return Reflection.addReflection(this, name, reflection);
 }
-export function belongsTo(name, scope = null, { ...options } = {}) {
+export async function belongsTo(name, scope = null, { ...options } = {}) {
     let reflection;
     reflection = Builder.BelongsTo.build(this, name, scope, options);
     return Reflection.addReflection(this, name, reflection);

--- a/scripts/prism-codegen/__snapshots__/core.js.snap
+++ b/scripts/prism-codegen/__snapshots__/core.js.snap
@@ -178,7 +178,7 @@ export async function find(...ids, block) {
     }
     return await this.cachedFindBy([this.primaryKey], [id]) || (() => { throw new RecordNotFound(`Couldn't find ${this.name} with '${this.primaryKey}'=${id}`, this.name, this.primaryKey, id); })();
 }
-export function findBy(...args) {
+export async function findBy(...args) {
     let hash;
     if (this.isScopeAttributes) {
         return __PRISM_TODO("ForwardingSuperNode");
@@ -188,10 +188,10 @@ export function findBy(...args) {
         return __PRISM_TODO("ForwardingSuperNode");
     }
     hash = __PRISM_TODO("CallNode");
-    return this.cachedFindBy(hash.keys(), hash.values());
+    return await this.cachedFindBy(hash.keys(), hash.values());
 }
-export function findByBang(...args) {
-    return this.findBy(...args) || this.where(...args).raiseRecordNotFoundExceptionBang();
+export async function findByBang(...args) {
+    return await this.findBy(...args) || this.where(...args).raiseRecordNotFoundExceptionBang();
 }
 export function initializeGeneratedModules() {
     return this.generatedAssociationMethods;
@@ -219,7 +219,7 @@ export function inspectionFilter() {
         return this.inspection_filter ||= __PRISM_TODO("BeginNode");
     }
 }
-export function inspect() {
+export async function inspect() {
     let attr_list;
     if (this === Base || this.isSingletonClass) {
         return __PRISM_TODO("ForwardingSuperNode");
@@ -253,7 +253,7 @@ export function cachedFindByStatement(connection, key, block) {
     return cache.computeIfAbsent(key, () => StatementCache.create(connection, block));
 }
 __PRISM_TODO("CallNode");
-export function inherited(subclass) {
+export async function inherited(subclass) {
     let klass;
     subclass.initializeFindByCache();
     if (!subclass.isBaseClass()) {
@@ -359,7 +359,7 @@ export function encodeWith(coder) {
 }
 __PRISM_TODO("DefNode");
 __PRISM_TODO("AliasMethodNode");
-export function hash() {
+export async function hash() {
     let id;
     id = this.id();
     if (this.isPrimaryKeyValuesPresent) {
@@ -377,7 +377,7 @@ export function isFrozen() {
     return this.attributes.isFrozen();
 }
 __PRISM_TODO("DefNode");
-export function isPresent() {
+export async function isPresent() {
     return true;
 }
 export function isBlank() {
@@ -409,7 +409,7 @@ export function readonlyBang() {
 export function connectionHandler() {
     return this.class().connectionHandler();
 }
-export function inspect() {
+export async function inspect() {
     return this.inspectWithAttributes(this.attributesForInspect);
 }
 export function fullInspect() {
@@ -422,11 +422,11 @@ export async function prettyPrint(pp) {
     }
     return pp.objectAddressGroup(this, () => {
         if (this.attributes) {
-            attr_names = this.attributesForInspect.select(name => this.is_hasAttribute(name.toString()));
+            attr_names = await this.attributesForInspect.select(name => this.is_hasAttribute(name.toString()));
             return pp.seplist(attr_names, this.proc(() => pp.text(",")), attr_name => {
                 attr_name = attr_name.toString();
                 pp.breakable(" ");
-                return pp.group(1, () => {
+                return await pp.group(1, () => {
                     pp.text(attr_name);
                     pp.text(":");
                     pp.breakable();

--- a/scripts/prism-codegen/__snapshots__/inheritance.js.snap
+++ b/scripts/prism-codegen/__snapshots__/inheritance.js.snap
@@ -99,7 +99,7 @@ export function polymorphicClassFor(name) {
         return this.computeType(name);
     }
 }
-export function dup() {
+export async function dup() {
     let other;
     other = __PRISM_TODO("ForwardingSuperNode");
     other.setBaseClass();
@@ -136,7 +136,7 @@ export function setBaseClass() {
     return this.base_class = __PRISM_TODO("IfNode");
 }
 __PRISM_TODO("CallNode");
-export function inherited(subclass) {
+export async function inherited(subclass) {
     subclass.setBaseClass();
     subclass.instanceVariableSet("@_type_candidates_cache", new Concurrent.Map());
     return subclass.classEval(() => this.finder_needs_type_condition = null);

--- a/scripts/prism-codegen/__snapshots__/model-schema.js.snap
+++ b/scripts/prism-codegen/__snapshots__/model-schema.js.snap
@@ -114,7 +114,7 @@ export function isTableExists() {
 export function attributesBuilder() {
     return this.attributes_builder ||= __PRISM_TODO("BeginNode");
 }
-export function columnsHash() {
+export async function columnsHash() {
     if (!this.columns_hash) {
         this.loadSchema;
     }
@@ -129,7 +129,7 @@ export function _returningColumnsForInsert(connection) {
 export function yamlEncoder() {
     return this.yaml_encoder ||= new ActiveModel.AttributeSet.YAMLEncoder(this.attributeTypes);
 }
-export function columnForAttribute(name) {
+export async function columnForAttribute(name) {
     name = name.toString();
     return this.columnsHash.fetch(name, () => new ConnectionAdapters.NullColumn(name));
 }
@@ -194,7 +194,7 @@ export function reloadSchemaFromCache(recursive = true) {
     }
 }
 __PRISM_TODO("CallNode");
-export function inherited(child_class) {
+export async function inherited(child_class) {
     child_class.initializeLoadSchemaMonitor();
     child_class.reloadSchemaFromCache(false);
     return child_class.classEval(() => this.ignored_columns = null);

--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -45,7 +45,7 @@ export function instantiate(attributes, column_types = {}, block) {
 export async function update(id = "all") {
     let object;
     if (id.isA(Array)) {
-        if (id.isAny(ActiveRecord.Base)) {
+        if (await id.isAny(ActiveRecord.Base)) {
             throw new ArgumentError("You are passing an array of ActiveRecord::Base instances to `update`. Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`.");
         }
         return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => await object.update(attributes[idx]));
@@ -65,7 +65,7 @@ export async function update(id = "all") {
 export async function updateBang(id = "all") {
     let object;
     if (id.isA(Array)) {
-        if (id.isAny(ActiveRecord.Base)) {
+        if (await id.isAny(ActiveRecord.Base)) {
             throw new ArgumentError("You are passing an array of ActiveRecord::Base instances to `update!`. Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`.");
         }
         return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => await object.updateBang(attributes[idx]));
@@ -144,7 +144,7 @@ export async function _deleteRecord(constraints) {
     return this.withConnection(c => c.delete(dm, `${this} Destroy`));
 }
 __PRISM_TODO("CallNode");
-export function inherited(subclass) {
+export async function inherited(subclass) {
     return subclass.classEval(() => {
         this._query_constraints_list = null;
         return this.has_query_constraints = false;
@@ -378,7 +378,7 @@ export function _queryConstraintsHash() {
 }
 export function destroyAssociations() {
 }
-export function destroyRow() {
+export async function destroyRow() {
     return this._deleteRow;
 }
 export function _deleteRow() {
@@ -389,8 +389,8 @@ export function _touchRow(attribute_names, time) {
     attribute_names.each(attr_name => this._writeAttribute(attr_name, time));
     return this._updateRow(attribute_names, "touch");
 }
-export function _updateRow(attribute_names, attempted_action = "update") {
-    return this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
+export async function _updateRow(attribute_names, attempted_action = "update") {
+    return await this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
 }
 export function createOrUpdate({ ...opts } = {}, block) {
     let result;
@@ -411,7 +411,7 @@ export async function _updateRecord(attribute_names = this.attributeNames(), blo
         this._trigger_update_callback = true;
     }
     else {
-        affected_rows = this._updateRow(attribute_names);
+        affected_rows = await this._updateRow(attribute_names);
         this._trigger_update_callback = affected_rows === 1;
     }
     this.previously_new_record = false;

--- a/scripts/prism-codegen/__snapshots__/relation.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation.js.snap
@@ -80,43 +80,43 @@ export class Relation {
         return this.first || this.constructor(attributes, block);
     }
     async findOrCreateBy(attributes, block) {
-        return this.findBy(attributes) || await this.createOrFindBy(attributes, block);
+        return await this.findBy(attributes) || await this.createOrFindBy(attributes, block);
     }
-    findOrCreateByBang(attributes, block) {
-        return this.findBy(attributes) || this.createOrFindByBang(attributes, block);
+    async findOrCreateByBang(attributes, block) {
+        return await this.findBy(attributes) || await this.createOrFindByBang(attributes, block);
     }
     async createOrFindBy(attributes, block) {
-        return this.withConnection(connection => {
+        return this.model.withConnection(connection => {
             try {
-                return this.transaction({ requires_new: true }, () => await this.create(attributes, block));
+                return this.model.transaction({ requires_new: true }, () => await this.create(attributes, block));
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
-                    return this.where(attributes).lock().findByBang(attributes);
+                    return await this.where(attributes).lock().findByBang(attributes);
                 }
                 else {
-                    return this.findByBang(attributes);
+                    return await this.findByBang(attributes);
                 }
             }
         });
     }
-    createOrFindByBang(attributes, block) {
-        return this.withConnection(connection => {
+    async createOrFindByBang(attributes, block) {
+        return this.model.withConnection(connection => {
             try {
-                return this.transaction({ requires_new: true }, () => this.createBang(attributes, block));
+                return this.model.transaction({ requires_new: true }, () => await this.createBang(attributes, block));
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
-                    return this.where(attributes).lock().findByBang(attributes);
+                    return await this.where(attributes).lock().findByBang(attributes);
                 }
                 else {
-                    return this.findByBang(attributes);
+                    return await this.findByBang(attributes);
                 }
             }
         });
     }
     async findOrInitializeBy(attributes, block) {
-        return this.findBy(attributes) || this.constructor(attributes, block);
+        return await this.findBy(attributes) || this.constructor(attributes, block);
     }
     async explain(...options) {
         return new ExplainProxy(this, options);
@@ -224,11 +224,11 @@ export class Relation {
         }
         else {
             collection = this.isEagerLoading ? this.applyJoinDependency : this;
-            this.withConnection(c => {
+            this.model.withConnection(c => {
                 column = c.visitor().compile(this.table[timestamp_column]);
                 select_values = `COUNT(*) AS ${this.model.adapterClass().quoteColumnName("size")}, MAX(%s) AS timestamp`;
                 if (collection.hasLimitOrOffset()) {
-                    query = collection.select(`${column} AS collection_cache_key_timestamp`);
+                    query = await collection.select(`${column} AS collection_cache_key_timestamp`);
                     if (this.distinctValue && await collection.selectValues().isEmpty()) {
                         query._selectBang(this.table[await Arel.star()]);
                     }
@@ -305,14 +305,14 @@ export class Relation {
             if (!await this.havingClause.isEmpty()) {
                 having_clause_ast = this.havingClause.ast();
             }
-            key = this.model.isCompositePrimaryKey() ? this.primaryKey.map(pk => this.table[pk]) : this.table[this.primaryKey];
+            key = this.model.isCompositePrimaryKey() ? this.model.primaryKey.map(pk => this.table[pk]) : this.table[this.model.primaryKey];
             stmt = arel.compileUpdate(values, key, having_clause_ast, group_values_arel_columns);
             return (await c.update(stmt, `${this.model} Update All`)).tap(() => this.reset);
         });
     }
     async update(id = "all") {
         if (id === "all") {
-            return this.each(record => await record.update(attributes));
+            return this.records.each(record => await record.update(attributes));
         }
         else {
             return await this.model.update(id, attributes);
@@ -320,7 +320,7 @@ export class Relation {
     }
     async updateBang(id = "all") {
         if (id === "all") {
-            return this.each(record => await record.updateBang(attributes));
+            return this.records.each(record => await record.updateBang(attributes));
         }
         else {
             return await this.model.updateBang(id, attributes);
@@ -376,7 +376,7 @@ export class Relation {
         if (this.none) {
             return 0;
         }
-        invalid_methods = INVALID_METHODS_FOR_DELETE_ALL.select(method => {
+        invalid_methods = await INVALID_METHODS_FOR_DELETE_ALL.select(method => {
             value = this.values[method];
             if (method === "distinct") {
                 return value;
@@ -395,7 +395,7 @@ export class Relation {
             if (!await this.havingClause.isEmpty()) {
                 having_clause_ast = this.havingClause.ast();
             }
-            key = this.model.isCompositePrimaryKey() ? this.primaryKey.map(pk => this.table[pk]) : this.table[this.primaryKey];
+            key = this.model.isCompositePrimaryKey() ? this.model.primaryKey.map(pk => this.table[pk]) : this.table[this.model.primaryKey];
             stmt = arel.compileDelete(key, having_clause_ast, group_values_arel_columns);
             return (await c.delete(stmt, `${this.model} Delete All`)).tap(() => this.reset);
         });
@@ -424,7 +424,7 @@ export class Relation {
     }
     loadAsync() {
         let result;
-        this.withConnection(c => {
+        this.model.withConnection(c => {
             if (!c.isAsyncEnabled()) {
                 return this.load;
             }
@@ -514,16 +514,16 @@ export class Relation {
         return this.readonlyValue;
     }
     async values() {
-        return this.values.dup();
+        return await this.values.dup();
     }
     valuesForQueries() {
         return this.values.except("extending", "skip_query_cache", "strict_loading");
     }
-    inspect() {
+    async inspect() {
         let subject, entries;
         subject = this.isLoaded ? this.records : this.annotate("loading for inspect");
         entries = subject.take([this.limitValue, 11].compact().min()).mapBang(x => x.inspect());
-        if (entries.size() === 11) {
+        if (await entries.size() === 11) {
             entries[10] = "...";
         }
         return `#<${this.class().name()} [${entries.join(", ")}]>`;
@@ -546,7 +546,7 @@ export class Relation {
         scope = this.strictLoadingValue ? StrictLoadingScope : null;
         return preload.each(associations => new ActiveRecord.Associations.Preloader({ records: records, associations: associations, scope: scope }).call());
     }
-    loadRecords(records) {
+    async loadRecords(records) {
         this.records = records.freeze();
         return this.loaded = true;
     }

--- a/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
@@ -85,11 +85,11 @@ export async function calculate(operation, column_name) {
     operation = operation.toString().downcase();
     if (this.none) {
         if (caseEq("count", operation) || caseEq("sum", operation)) {
-            result = this.groupValues.isAny() ? new Hash() : 0;
+            result = await this.groupValues.isAny() ? new Hash() : 0;
             return this.async ? new Promise.Complete(result) : result;
         }
         else if (caseEq("average", operation) || caseEq("minimum", operation) || caseEq("maximum", operation)) {
-            result = this.groupValues.isAny() ? new Hash() : null;
+            result = await this.groupValues.isAny() ? new Hash() : null;
             return this.async ? new Promise.Complete(result) : result;
         }
     }
@@ -165,10 +165,10 @@ export function asyncPick(...column_names) {
 }
 export async function ids() {
     let primary_key_array, result, relation, columns;
-    primary_key_array = this.Array(this.primaryKey);
+    primary_key_array = this.Array(this.model.primaryKey);
     if (this.isLoaded) {
         result = this.records.map(record => {
-            if (primary_key_array.isOne()) {
+            if (await primary_key_array.isOne()) {
                 return record._readAttribute(primary_key_array.first());
             }
             else {
@@ -177,8 +177,8 @@ export async function ids() {
         });
         return this.async ? new Promise.Complete(result) : result;
     }
-    if (this.hasInclude(this.primaryKey)) {
-        relation = this.applyJoinDependency.group(...primary_key_array);
+    if (this.hasInclude(this.model.primaryKey)) {
+        relation = await this.applyJoinDependency.group(...primary_key_array);
         return await relation.ids();
     }
     columns = this.arelColumns(primary_key_array);
@@ -222,7 +222,7 @@ export function performCalculation(operation, column_name) {
                 }
             }
             else if (this.groupValues.isAny() || this.selectValues.isEmpty() && this.orderValues.isEmpty()) {
-                column_name = this.primaryKey;
+                column_name = this.model.primaryKey;
             }
         }
         else if (this.isDistinctSelect(column_name)) {
@@ -348,7 +348,7 @@ export async function executeGroupedCalculation(operation, column_name, distinct
         });
     });
 }
-export function typeFor(field, block) {
+export async function typeFor(field, block) {
     let field_name;
     field_name = field.respondTo("name") ? field.name().toString() : field.toString().split(".").last();
     return this.model.typeForAttribute(field_name, block);
@@ -392,7 +392,7 @@ export function selectForCount() {
         return "all";
     }
     else {
-        return this.withConnection(conn => this.arelColumns(this.selectValues).map(column => conn.visitor().compile(column)).join(", "));
+        return this.model.withConnection(conn => this.arelColumns(this.selectValues).map(column => conn.visitor().compile(column)).join(", "));
     }
 }
 export function isBuildCountSubquery(operation, column_name, distinct) {

--- a/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
@@ -136,7 +136,7 @@ export function isExists(conditions = "none") {
     if (relation.whereClause().isContradiction()) {
         return false;
     }
-    return this.skipQueryCacheIfNecessary(() => this.withConnection(c => c.selectRows(relation.arel(), `${this.model.name()} Exists?`).size() === 1));
+    return this.skipQueryCacheIfNecessary(() => this.model.withConnection(c => c.selectRows(relation.arel(), `${this.model.name()} Exists?`).size() === 1));
 }
 export function isInclude(record) {
     let id;
@@ -152,7 +152,7 @@ export function isInclude(record) {
     }
 }
 const isMember = isInclude;
-export function raiseRecordNotFoundExceptionBang(ids = null, result_size = null, expected_size = null, key = this.primaryKey, not_found_ids = null) {
+export function raiseRecordNotFoundExceptionBang(ids = null, result_size = null, expected_size = null, key = this.model.primaryKey, not_found_ids = null) {
     let conditions, name, error;
     if (!this.whereClause.isEmpty()) {
         conditions = ` [${this.arel.whereSql(this.model)}]`;
@@ -195,7 +195,7 @@ export function constructRelationForExists(conditions) {
     }
     else {
         if (!(conditions === "none")) {
-            relation.whereBang({ [this.primaryKey]: conditions });
+            relation.whereBang({ [this.model.primaryKey]: conditions });
         }
     }
     return relation;
@@ -219,7 +219,7 @@ export function isUsingLimitableReflections(reflections) {
 }
 export async function findWithIds(...ids) {
     let expects_array, model_name, result, error_message;
-    if (this.primaryKey.nil()) {
+    if (this.model.primaryKey.nil()) {
         throw new UnknownPrimaryKey(this.model);
     }
     expects_array = this.model.isCompositePrimaryKey() ? (await (await ids.first()).first()).isA(Array) : (await ids.first()).isA(Array);
@@ -233,7 +233,7 @@ export async function findWithIds(...ids) {
     model_name = this.model.name();
     if (caseEq(0, ids.size())) {
         error_message = `Couldn't find ${model_name} without an ID`;
-        throw new RecordNotFound(error_message, model_name, this.primaryKey);
+        throw new RecordNotFound(error_message, model_name, this.model.primaryKey);
     }
     else if (caseEq(1, ids.size())) {
         result = await this.findOne(await ids.first());
@@ -253,7 +253,7 @@ export async function findOne(id) {
     if (__PRISM_TODO("CallNode")) {
         throw new ArgumentError("            You are passing an instance of ActiveRecord::Base to `find`.\n            Please pass the id of the object by calling `.id`.\n".squish());
     }
-    relation = this.model.isCompositePrimaryKey() ? this.where(this.primaryKey.zip(id).toH()) : this.where({ [this.primaryKey]: id });
+    relation = this.model.isCompositePrimaryKey() ? this.where(this.model.primaryKey.zip(id).toH()) : this.where({ [this.model.primaryKey]: id });
     record = await relation.take();
     if (!record) {
         this.raiseRecordNotFoundExceptionBang(id, 0, 1);
@@ -262,12 +262,12 @@ export async function findOne(id) {
 }
 export async function findSome(ids) {
     let relation, result, expected_size;
-    if (!this.orderValues.isPresent()) {
+    if (!await this.orderValues.isPresent()) {
         return await this.findSomeOrdered(ids);
     }
-    relation = this.where({ [this.primaryKey]: ids });
+    relation = this.where({ [this.model.primaryKey]: ids });
     if (!this.selectValues.isEmpty()) {
-        relation = relation.select(this.table[this.primaryKey]);
+        relation = await relation.select(this.table[this.model.primaryKey]);
     }
     result = relation.toA();
     expected_size = this.limitValue && ids.size() > this.limitValue ? this.limitValue : ids.size();
@@ -285,13 +285,13 @@ export async function findSomeOrdered(ids) {
     let relation, result;
     ids = ids.slice(this.offsetValue || 0, this.limitValue || ids.size()) || [];
     relation = this.except("limit", "offset");
-    relation = relation.where({ [this.primaryKey]: ids });
+    relation = relation.where({ [this.model.primaryKey]: ids });
     if (!this.selectValues.isEmpty()) {
-        relation = relation.select(this.table[this.primaryKey]);
+        relation = await relation.select(this.table[this.model.primaryKey]);
     }
     result = relation.records();
     if (result.size() === ids.size()) {
-        return result.inOrderOf("id", ids.map(id => this.model.typeForAttribute(this.primaryKey).cast(id)));
+        return result.inOrderOf("id", ids.map(id => this.model.typeForAttribute(this.model.primaryKey).cast(id)));
     }
     else {
         return this.raiseRecordNotFoundExceptionBang(ids, result.size(), ids.size());
@@ -362,7 +362,7 @@ export async function findLast(limit) {
     }
 }
 export function orderedRelation() {
-    if (this.orderValues.isEmpty() && (this.model.implicitOrderColumn() || !this.model.queryConstraintsList().nil() || this.primaryKey)) {
+    if (this.orderValues.isEmpty() && (this.model.implicitOrderColumn() || !this.model.queryConstraintsList().nil() || this.model.primaryKey)) {
         return this.order(this._orderColumns.map(column => this.table[column].asc()));
     }
     else {

--- a/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
@@ -38,7 +38,7 @@ export class WhereChain {
         });
         return this.scope;
     }
-    missing(...associations) {
+    async missing(...associations) {
         let reflection, association_conditions;
         associations.each(association => {
             reflection = this.scopeAssociationReflection(association);
@@ -98,7 +98,7 @@ export function eagerLoad(...args) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, args);
     return this.spawn.eagerLoadBang(...args);
 }
-export function eagerLoadBang(...args) {
+export async function eagerLoadBang(...args) {
     __PRISM_TODO("CallOperatorWriteNode");
     return this;
 }
@@ -113,7 +113,7 @@ export function preloadBang(...args) {
 export async function extractAssociated(association) {
     return this.preload(association).collect(association);
 }
-export function references(...table_names) {
+export async function references(...table_names) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, table_names);
     return this.spawn.referencesBang(...table_names);
 }
@@ -121,9 +121,9 @@ export function referencesBang(...table_names) {
     __PRISM_TODO("CallOperatorWriteNode");
     return this;
 }
-export function select(...fields, block) {
+export async function select(...fields, block) {
     if (block !== undefined) {
-        if (fields.isAny()) {
+        if (await fields.isAny()) {
             throw new ArgumentError("`select' with block doesn't take arguments.");
         }
         return __PRISM_TODO("SuperNode");
@@ -161,7 +161,7 @@ export function reselectBang(...args) {
     this.selectValues = args;
     return this;
 }
-export function group(...args) {
+export async function group(...args) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, args);
     return this.spawn.groupBang(...args);
 }
@@ -377,7 +377,7 @@ export function offsetBang(value) {
 export function lock(locks = true) {
     return this.spawn.lockBang(locks);
 }
-export function lockBang(locks = true) {
+export async function lockBang(locks = true) {
     if (caseEq(String, locks) || caseEq(TrueClass, locks) || caseEq(NilClass, locks)) {
         this.lockValue = locks || true;
     }
@@ -399,7 +399,7 @@ export function noneBang() {
 export function isNullRelation() {
     return this.none;
 }
-export function readonly(value = true) {
+export async function readonly(value = true) {
     return this.spawn.readonlyBang(value);
 }
 export function readonlyBang(value = true) {
@@ -426,7 +426,7 @@ export function createWithBang(value) {
     }
     return this;
 }
-export function from(value, subquery_name = null) {
+export async function from(value, subquery_name = null) {
     return this.spawn.fromBang(value, subquery_name);
 }
 export function fromBang(value, subquery_name = null) {
@@ -519,7 +519,7 @@ export function excludingBang(records) {
     return this;
 }
 export function arel(aliases = null) {
-    return this.arel ||= this.withConnection(c => this.buildArel(c, aliases));
+    return this.arel ||= this.model.withConnection(c => this.buildArel(c, aliases));
 }
 export function constructJoinDependency(associations, join_type) {
     return new ActiveRecord.Associations.JoinDependency(this.model, this.table, associations, join_type);
@@ -987,8 +987,8 @@ export function isTableNameMatches(from) {
 }
 export function reverseSqlOrder(order_query) {
     if (order_query.isEmpty()) {
-        if (this.primaryKey) {
-            return [this.table[this.primaryKey].desc()];
+        if (this.model.primaryKey) {
+            return [this.table[this.model.primaryKey].desc()];
         }
         throw new IrreversibleOrderError("Relation has no current order and table has no primary key to be used as default order");
     }

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -463,6 +463,38 @@ describe("prism-codegen", () => {
     expect(code).toContain("this.model.primaryKey");
   });
 
+  it("keeps a falsy prefix option in the table", async () => {
+    const { code } = await generateFromSource(`
+      class Relation
+        delegate :primary_key, to: :model, prefix: false
+        delegate :table_name, to: :model, prefix: nil
+
+        def describe
+          [primary_key, table_name]
+        end
+      end
+    `);
+    expect(code).toContain("this.model.primaryKey");
+    expect(code).toContain("this.model.tableName");
+  });
+
+  it("a singleton def does not suppress an instance delegation of the same name", async () => {
+    const { code } = await generateFromSource(`
+      class Relation
+        delegate :primary_key, to: :model
+
+        def self.primary_key
+          @primary_key
+        end
+
+        def describe
+          primary_key
+        end
+      end
+    `);
+    expect(code).toContain("return this.model.primaryKey;");
+  });
+
   it("leaves a prefixed delegate macro out of the table", async () => {
     const { code } = await generateFromSource(`
       class Relation

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import ts from "typescript";
-import { generateFromSource } from "./index.js";
+import { generateFromSource, delegationsFromSource } from "./index.js";
 import { summarizeCoverage, mergeCoverages } from "./coverage.js";
 import { Registry } from "./registry.js";
 import { tsToRubyFile } from "./naming.js";
@@ -411,5 +411,55 @@ describe("prism-codegen", () => {
     expect(merged.handled).toBe(18);
     expect(merged.passthrough).toBe(2);
     expect(merged.handledPct).toBeCloseTo(90);
+  });
+
+  it("resolves a delegate macro's methods through their receiver, not this", async () => {
+    const { code } = await generateFromSource(`
+      class Relation
+        delegate :primary_key, :table_name, to: :model
+        delegate :length, to: :records
+
+        def describe
+          "#{table_name}.#{primary_key} (#{length})"
+        end
+      end
+    `);
+    expect(code).toContain("this.model.tableName");
+    expect(code).toContain("this.model.primaryKey");
+    expect(code).toContain("this.records.length");
+  });
+
+  it("lets a real definition win over the delegate macro of the same name", async () => {
+    const { code } = await generateFromSource(`
+      class Relation
+        delegate :primary_key, to: :model
+
+        def primary_key
+          @primary_key
+        end
+
+        def describe
+          primary_key
+        end
+      end
+    `);
+    expect(code).toContain("return this.primaryKey;");
+    expect(code).not.toContain("this.model.primaryKey");
+  });
+
+  it("delegation tables inherit into the file family they are compiled into", async () => {
+    const inherited = await delegationsFromSource(`
+      module Delegation
+        delegate :primary_key, to: :model
+      end
+    `);
+    expect([...inherited]).toEqual([["primaryKey", "model"]]);
+    const { code } = await generateFromSource(
+      `class Relation; def describe; primary_key; end; end`,
+      undefined,
+      undefined,
+      inherited,
+    );
+    expect(code).toContain("this.model.primaryKey");
   });
 });

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -462,4 +462,41 @@ describe("prism-codegen", () => {
     );
     expect(code).toContain("this.model.primaryKey");
   });
+
+  it("leaves a prefixed delegate macro out of the table", async () => {
+    const { code } = await generateFromSource(`
+      class Relation
+        delegate :primary_key, to: :model, prefix: true
+
+        def describe
+          primary_key
+        end
+      end
+    `);
+    expect(code).toContain("return this.primaryKey;");
+    expect(code).not.toContain("this.model.primaryKey");
+  });
+
+  it("resolves an instance delegation only for instance methods", async () => {
+    const { code } = await generateFromSource(`
+      class Relation
+        delegate :primary_key, to: :model
+
+        def self.describe
+          primary_key
+        end
+
+        class << self
+          delegate :table_name, to: :arel_table
+        end
+
+        def name
+          table_name
+        end
+      end
+    `);
+    expect(code).toContain("static describe()");
+    expect(code).not.toContain("this.model.primaryKey");
+    expect(code).not.toContain("this.arelTable.tableName");
+  });
 });

--- a/scripts/prism-codegen/codegen.ts
+++ b/scripts/prism-codegen/codegen.ts
@@ -38,6 +38,7 @@ export class Codegen implements Emitter {
   constructor(
     private readonly registry: Registry,
     readonly asyncMethods: ReadonlySet<string> = new Set(),
+    readonly delegations: ReadonlyMap<string, string> = new Map(),
   ) {}
   private record(kind: string, handled: boolean): void {
     this.coverage.record(kind, handled);

--- a/scripts/prism-codegen/delegation.ts
+++ b/scripts/prism-codegen/delegation.ts
@@ -6,15 +6,21 @@ import { methodName, isJsIdentName } from "./naming.js";
 export type DelegationTable = ReadonlyMap<string, string>;
 
 /**
- * `delegate :a, :b, to: :model` generates `a`/`b` on the class, so a
+ * `delegate :a, :b, to: :model` generates instance methods `a`/`b`, so a
  * receiverless call to one of them is not a self-call — it reaches through
- * `model`. Names the file also defines with `def` are excluded: a real
- * definition wins over the macro-generated one.
+ * `model`.
+ *
+ * Four kinds of macro contribute nothing to the table, because resolving their
+ * calls to `this.<target>.<name>` would be wrong: `to: :class` and `to: :self`
+ * (not property reaches on `this`), `prefix:` (the generated method is named
+ * `<target>_<name>`, not `<name>`), macros written inside `class << self` (they
+ * generate singleton methods), and any name the file also defines with `def` (a
+ * real definition wins over the macro-generated one).
  */
 export function collectDelegations(program: PrismNode): DelegationTable {
   const table = new Map<string, string>();
   const defined = new Set<string>();
-  walk(program, table, defined);
+  walk(program, table, defined, false);
   for (const name of defined) table.delete(name);
   return table;
 }
@@ -27,13 +33,19 @@ export function mergeDelegations(
   return new Map([...inherited, ...own]);
 }
 
-function walk(node: PrismNode, table: Map<string, string>, defined: Set<string>): void {
+function walk(
+  node: PrismNode,
+  table: Map<string, string>,
+  defined: Set<string>,
+  inSingleton: boolean,
+): void {
   const kind = node.constructor?.name;
   if (kind === "DefNode") defined.add(methodName(String(node.name)));
-  if (kind === "CallNode" && String(node.name) === "delegate" && node.receiver == null) {
+  if (!inSingleton && kind === "CallNode" && String(node.name) === "delegate" && !node.receiver) {
     record(node, table);
   }
-  for (const child of node.compactChildNodes()) walk(child, table, defined);
+  const singletonBelow = inSingleton || kind === "SingletonClassNode";
+  for (const child of node.compactChildNodes()) walk(child, table, defined, singletonBelow);
 }
 
 function record(call: PrismNode, table: Map<string, string>): void {
@@ -48,21 +60,22 @@ function record(call: PrismNode, table: Map<string, string>): void {
   }
 }
 
-/**
- * The trailing `to: :receiver` keyword. `to: :class` and `to: :self` are not
- * property reaches on `this`, so they are left out of the table entirely.
- */
 function delegationTarget(node: PrismNode): string | undefined {
   if (node.constructor?.name !== "KeywordHashNode") return undefined;
+  let target: string | undefined;
   for (const assoc of (node.elements as PrismNode[]) ?? []) {
     const key = assoc.key as PrismNode | undefined;
     const value = assoc.value as PrismNode | undefined;
-    if (key?.constructor?.name !== "SymbolNode" || rubyStr(key.unescaped) !== "to") continue;
+    if (key?.constructor?.name !== "SymbolNode") return undefined;
+    const option = rubyStr(key.unescaped);
+    if (option === "prefix") return undefined;
+    if (option !== "to") continue;
     if (value?.constructor?.name !== "SymbolNode") return undefined;
     const raw = rubyStr(value.unescaped);
     if (raw === "class" || raw === "self") return undefined;
-    const target = methodName(raw);
-    return isJsIdentName(target) ? target : undefined;
+    const name = methodName(raw);
+    if (!isJsIdentName(name)) return undefined;
+    target = name;
   }
-  return undefined;
+  return target;
 }

--- a/scripts/prism-codegen/delegation.ts
+++ b/scripts/prism-codegen/delegation.ts
@@ -1,0 +1,68 @@
+import type { PrismNode } from "./types.js";
+import { rubyStr } from "./types.js";
+import { methodName, isJsIdentName } from "./naming.js";
+
+/** Delegated JS method name → the JS receiver it is delegated to. */
+export type DelegationTable = ReadonlyMap<string, string>;
+
+/**
+ * `delegate :a, :b, to: :model` generates `a`/`b` on the class, so a
+ * receiverless call to one of them is not a self-call — it reaches through
+ * `model`. Names the file also defines with `def` are excluded: a real
+ * definition wins over the macro-generated one.
+ */
+export function collectDelegations(program: PrismNode): DelegationTable {
+  const table = new Map<string, string>();
+  const defined = new Set<string>();
+  walk(program, table, defined);
+  for (const name of defined) table.delete(name);
+  return table;
+}
+
+/** Merge tables, with the file's own delegations winning over inherited ones. */
+export function mergeDelegations(
+  inherited: DelegationTable,
+  own: DelegationTable,
+): DelegationTable {
+  return new Map([...inherited, ...own]);
+}
+
+function walk(node: PrismNode, table: Map<string, string>, defined: Set<string>): void {
+  const kind = node.constructor?.name;
+  if (kind === "DefNode") defined.add(methodName(String(node.name)));
+  if (kind === "CallNode" && String(node.name) === "delegate" && node.receiver == null) {
+    record(node, table);
+  }
+  for (const child of node.compactChildNodes()) walk(child, table, defined);
+}
+
+function record(call: PrismNode, table: Map<string, string>): void {
+  const args = ((call.arguments_ as PrismNode | null)?.arguments_ as PrismNode[]) ?? [];
+  if (args.length < 2) return;
+  const target = delegationTarget(args[args.length - 1]);
+  if (!target) return;
+  for (const arg of args.slice(0, -1)) {
+    if (arg.constructor?.name !== "SymbolNode") return;
+    const name = methodName(rubyStr(arg.unescaped));
+    if (isJsIdentName(name)) table.set(name, target);
+  }
+}
+
+/**
+ * The trailing `to: :receiver` keyword. `to: :class` and `to: :self` are not
+ * property reaches on `this`, so they are left out of the table entirely.
+ */
+function delegationTarget(node: PrismNode): string | undefined {
+  if (node.constructor?.name !== "KeywordHashNode") return undefined;
+  for (const assoc of (node.elements as PrismNode[]) ?? []) {
+    const key = assoc.key as PrismNode | undefined;
+    const value = assoc.value as PrismNode | undefined;
+    if (key?.constructor?.name !== "SymbolNode" || rubyStr(key.unescaped) !== "to") continue;
+    if (value?.constructor?.name !== "SymbolNode") return undefined;
+    const raw = rubyStr(value.unescaped);
+    if (raw === "class" || raw === "self") return undefined;
+    const target = methodName(raw);
+    return isJsIdentName(target) ? target : undefined;
+  }
+  return undefined;
+}

--- a/scripts/prism-codegen/delegation.ts
+++ b/scripts/prism-codegen/delegation.ts
@@ -12,10 +12,13 @@ export type DelegationTable = ReadonlyMap<string, string>;
  *
  * Four kinds of macro contribute nothing to the table, because resolving their
  * calls to `this.<target>.<name>` would be wrong: `to: :class` and `to: :self`
- * (not property reaches on `this`), `prefix:` (the generated method is named
- * `<target>_<name>`, not `<name>`), macros written inside `class << self` (they
- * generate singleton methods), and any name the file also defines with `def` (a
- * real definition wins over the macro-generated one).
+ * (not property reaches on `this`), a truthy `prefix:` (the generated method is
+ * named `<prefix>_<name>`, not `<name>` — `prefix: false` and `prefix: nil` do
+ * prefix nothing, per `activesupport/lib/active_support/delegation.rb:72`),
+ * macros written inside `class << self` (they generate singleton methods), and
+ * any name the file also defines with an instance `def` (a real definition wins
+ * over the macro-generated one). A singleton `def self.x` does not suppress an
+ * instance `delegate :x` — Ruby keeps the two in separate namespaces.
  */
 export function collectDelegations(program: PrismNode): DelegationTable {
   const table = new Map<string, string>();
@@ -40,7 +43,9 @@ function walk(
   inSingleton: boolean,
 ): void {
   const kind = node.constructor?.name;
-  if (kind === "DefNode") defined.add(methodName(String(node.name)));
+  if (kind === "DefNode" && !inSingleton && !node.receiver) {
+    defined.add(methodName(String(node.name)));
+  }
   if (!inSingleton && kind === "CallNode" && String(node.name) === "delegate" && !node.receiver) {
     record(node, table);
   }
@@ -68,7 +73,7 @@ function delegationTarget(node: PrismNode): string | undefined {
     const value = assoc.value as PrismNode | undefined;
     if (key?.constructor?.name !== "SymbolNode") return undefined;
     const option = rubyStr(key.unescaped);
-    if (option === "prefix") return undefined;
+    if (option === "prefix" && isTruthy(value)) return undefined;
     if (option !== "to") continue;
     if (value?.constructor?.name !== "SymbolNode") return undefined;
     const raw = rubyStr(value.unescaped);
@@ -78,4 +83,9 @@ function delegationTarget(node: PrismNode): string | undefined {
     target = name;
   }
   return target;
+}
+
+function isTruthy(node: PrismNode | undefined): boolean {
+  const kind = node?.constructor?.name;
+  return kind !== undefined && kind !== "FalseNode" && kind !== "NilNode";
 }

--- a/scripts/prism-codegen/files.ts
+++ b/scripts/prism-codegen/files.ts
@@ -77,7 +77,15 @@ export const TARGET_FILES: TargetFile[] = [
   },
 ];
 export function rubyAbsPath(f: TargetFile): string {
-  return path.join(AR_ROOT, f.ruby.replace(/^active_record\//, ""));
+  return rubyAbsPathFor(f.ruby);
+}
+export function rubyAbsPathFor(ruby: string): string {
+  return path.join(AR_ROOT, ruby.replace(/^active_record\//, ""));
+}
+/** Rails compiles the Relation delegations from this one file into the family. */
+export const RELATION_DELEGATION_SOURCE = "active_record/relation/delegation.rb";
+export function inheritsRelationDelegation(ruby: string): boolean {
+  return ruby === "active_record/relation.rb" || ruby.startsWith("active_record/relation/");
 }
 export function railsLibRelPaths(): string[] {
   return TARGET_FILES.map((f) => f.ruby);

--- a/scripts/prism-codegen/golden.ts
+++ b/scripts/prism-codegen/golden.ts
@@ -2,7 +2,15 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { generateFromSource, type GenResult } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
-import { TARGET_FILES, rubyAbsPath, type TargetFile } from "./files.js";
+import {
+  TARGET_FILES,
+  rubyAbsPath,
+  rubyAbsPathFor,
+  inheritsRelationDelegation,
+  RELATION_DELEGATION_SOURCE,
+  type TargetFile,
+} from "./files.js";
+import { delegationsFromSource, type DelegationTable } from "./index.js";
 import { rubyFileToTs } from "./naming.js";
 
 export const SNAPSHOT_DIR = "scripts/prism-codegen/__snapshots__";
@@ -36,6 +44,22 @@ export function snapshotRelPathFor(outName: string): string {
   return "./" + path.posix.join("__snapshots__", outName + ".snap");
 }
 
+let relationDelegations: Promise<DelegationTable> | undefined;
+
+/**
+ * The delegation table a target inherits. Rails compiles `relation/delegation.rb`'s
+ * `delegate ... to: :model` / `to: :records` macros into every Relation subclass,
+ * so the whole Relation family resolves those names through their receiver. The
+ * source is parsed once per process and shared by every caller.
+ */
+export async function inheritedDelegationsFor(f: TargetFile): Promise<DelegationTable | undefined> {
+  if (!inheritsRelationDelegation(f.ruby)) return undefined;
+  relationDelegations ??= fs
+    .readFile(rubyAbsPathFor(RELATION_DELEGATION_SOURCE), "utf8")
+    .then(delegationsFromSource);
+  return relationDelegations;
+}
+
 /** Generate one target file's JS exactly as `pnpm codegen:generate` writes it. */
 export async function generateTarget(f: TargetFile): Promise<GeneratedTarget> {
   const outName = outNameFor(f);
@@ -44,6 +68,7 @@ export async function generateTarget(f: TargetFile): Promise<GeneratedTarget> {
     src,
     asyncMethodsForRailsFile(f.ruby),
     runtimeImportPathFor(outName),
+    await inheritedDelegationsFor(f),
   );
   return { ...result, file: f, outName };
 }

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -260,7 +260,7 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
       callArgs.push(blockToArrow(block, blockParams ?? [], e));
     }
   }
-  const delegatedTo = selfCall ? e.delegations.get(jsName) : undefined;
+  const delegatedTo = selfCall && !e.inSingleton ? e.delegations.get(jsName) : undefined;
   const self: ts.Expression = delegatedTo
     ? f.createPropertyAccessExpression(f.createThis(), delegatedTo)
     : f.createThis();

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -260,10 +260,14 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
       callArgs.push(blockToArrow(block, blockParams ?? [], e));
     }
   }
+  const delegatedTo = selfCall ? e.delegations.get(jsName) : undefined;
+  const self: ts.Expression = delegatedTo
+    ? f.createPropertyAccessExpression(f.createThis(), delegatedTo)
+    : f.createThis();
   const target: ts.Expression = recv
     ? f.createPropertyAccessExpression(recv, jsName)
     : selfCall
-      ? f.createPropertyAccessExpression(f.createThis(), jsName)
+      ? f.createPropertyAccessExpression(self, jsName)
       : f.createIdentifier(jsName);
   if (!recv && callArgs.length === 0 && !block && !hasParens(n)) return target;
   const call = f.createCallExpression(target, undefined, callArgs);

--- a/scripts/prism-codegen/handlers/structure.ts
+++ b/scripts/prism-codegen/handlers/structure.ts
@@ -110,7 +110,10 @@ function defAsMember(n: PrismNode, e: Emitter): ts.ClassElement | null {
   const isStatic =
     e.inSingleton ||
     (n.receiver != null && (n.receiver as PrismNode).constructor.name === "SelfNode");
+  const prevSingleton = e.inSingleton;
+  e.inSingleton = isStatic;
   const { params, body, isAsync } = defParts(n, e, isCtor ? "constructor" : name);
+  e.inSingleton = prevSingleton;
   if (!params) return null;
   e.coverage.record("DefNode", true);
   if (isCtor && !isStatic) {

--- a/scripts/prism-codegen/index.ts
+++ b/scripts/prism-codegen/index.ts
@@ -2,6 +2,7 @@ import { loadPrism } from "@ruby/prism";
 import ts from "typescript";
 import { Codegen } from "./codegen.js";
 import { defaultRegistry } from "./handlers/index.js";
+import { collectDelegations, mergeDelegations, type DelegationTable } from "./delegation.js";
 import type { Coverage, PrismNode } from "./types.js";
 let parsePromise:
   | Promise<
@@ -34,11 +35,14 @@ export async function generateFromSource(
   rubySource: string,
   asyncMethods: ReadonlySet<string> = new Set(),
   runtimeImportPath = "./runtime.js",
+  inheritedDelegations: DelegationTable = new Map(),
 ): Promise<GenResult> {
   const parse = await getParser();
   const result = parse(rubySource);
-  const gen = new Codegen(defaultRegistry(), asyncMethods);
-  const statements = gen.stmt(result.value as PrismNode, false);
+  const program = result.value as PrismNode;
+  const delegations = mergeDelegations(inheritedDelegations, collectDelegations(program));
+  const gen = new Codegen(defaultRegistry(), asyncMethods, delegations);
+  const statements = gen.stmt(program, false);
   const sourceFile = ts.factory.createSourceFile(
     statements,
     ts.factory.createToken(ts.SyntaxKind.EndOfFileToken),
@@ -77,3 +81,10 @@ export function countParseErrors(code: string): number {
 export { summarizeCoverage } from "./coverage.js";
 export { TARGET_FILES } from "./files.js";
 export { asyncMethodsForRailsFile } from "./async-source.js";
+export { type DelegationTable } from "./delegation.js";
+
+/** Standalone pre-pass: the delegation table a file contributes to its family. */
+export async function delegationsFromSource(rubySource: string): Promise<DelegationTable> {
+  const parse = await getParser();
+  return collectDelegations(parse(rubySource).value as PrismNode);
+}

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -7,6 +7,7 @@ import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js"
 import { TOPLEVEL } from "./codegen.js";
 import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath } from "./files.js";
 import { rubyFileToTs } from "./naming.js";
+import { inheritedDelegationsFor } from "./golden.js";
 import { scoreFile, indexPortTree, type ScoreEntry } from "./score.js";
 import {
   buildCatalog,
@@ -123,6 +124,8 @@ async function main() {
     const { code, perDef } = await generateFromSource(
       readFileSync(rubyAbsPath(f), "utf8"),
       asyncMethodsForRailsFile(f.ruby, asyncManifest),
+      undefined,
+      await inheritedDelegationsFor(f),
     );
     const cleanDefs = new Set(
       [...perDef].filter(([n, d]) => n !== TOPLEVEL && d.passthrough === 0).map(([n]) => n),

--- a/scripts/prism-codegen/score.test.ts
+++ b/scripts/prism-codegen/score.test.ts
@@ -269,4 +269,22 @@ describe("prism-codegen scorer", () => {
     );
     expect(score.entries).toEqual([]);
   });
+
+  it("scores a delegated self-call as matched against the port's receiver reach", async () => {
+    const score = await scoreRuby(
+      `
+      class Relation
+        delegate :primary_key, to: :model
+
+        def find_key
+          where(primary_key)
+        end
+      end
+    `,
+      `export function findKey(this: R) { return this.where(this.model.primaryKey); }`,
+    );
+    expect(score.entries).toEqual([
+      expect.objectContaining({ name: "findKey", status: "matched" }),
+    ]);
+  });
 });

--- a/scripts/prism-codegen/types.ts
+++ b/scripts/prism-codegen/types.ts
@@ -36,6 +36,7 @@ export interface Emitter {
   inClass: boolean;
   inSingleton: boolean;
   readonly asyncMethods: ReadonlySet<string>;
+  readonly delegations: ReadonlyMap<string, string>;
   inAsyncMethod: boolean;
 
   inLoop: boolean;


### PR DESCRIPTION
Rails' `delegate :x, to: :y` generates `x` on the class, so a receiverless
call to a delegated name is not a self-call — it reaches through `y`. The
generator was emitting `this.primaryKey` where the port (correctly) writes
`this.model.primaryKey`.

- New `scripts/prism-codegen/delegation.ts` pre-pass: walks the parsed program
  for receiverless `delegate` `CallNode`s with symbol args and a trailing
  `to:` keyword, building a JS-name → receiver table. `to: :class` / `to: :self`
  are excluded (not property reaches on `this`), and names the file also
  defines with `def` are dropped — a real definition wins over the macro.
- `relation/delegation.rb`'s table is parsed once and inherited by the Relation
  family (`relation.rb`, `relation/*.rb`), mirroring how Rails compiles those
  delegations into the per-model Relation subclass.
- `emitCall`'s `selfCall` branch consults the table and emits
  `this.<target>.<method>`, for instance methods only — a `def self.x` or a
  `class << self` body still resolves to `this.x`.
- Macros that do not generate a plain `<name>` instance method contribute
  nothing: a truthy `prefix:` (generates `<prefix>_<name>`; `prefix: false` and
  `prefix: nil` still delegate under the plain name, matching the truthiness
  test at `activesupport/lib/active_support/delegation.rb:72`), `to: :class` /
  `to: :self`, macros inside `class << self`, and any name the file also
  defines with an *instance* `def`. A singleton `def self.x` does not suppress
  an instance `delegate :x` — Ruby keeps the two in separate namespaces.

Effect: 29 generated call sites across the target files converge on the port's
receiver (`this.model.primaryKey`, `this.model.withConnection`, …).

**Scorer numbers are flat**: TOTAL stays 33 matched / 297 divergent / 10.0%
and the convergence guard reports 0 converged, 0 new residue rows. The
delegated reaches all land in defs whose skeletons diverge for unrelated
reasons (the port's `modelClass` spelling, restructured bodies), so no row
flips status. The story's stated 10.7% baseline is stale — `main` scores 10.0%
today, measured before and after this change. I tried canonicalizing
`modelClass` → `model` in the scorer's token table to unlock these rows; it
moved nothing, so it is not included here — registered as the follow-up story
`scorer-model-vs-modelclass-token` under the same RFC instead.

### Rebase onto #5815 (golden snapshots)

The Relation-family table is now built by `inheritedDelegationsFor()` in
`golden.ts`, memoised and shared by `generateTarget`, `codegen:generate` and
`codegen:score`, rather than duplicated in the two CLIs — `generateTarget` is
the single funnel #5815 introduced, and it keeps the goldens and the scorer on
one code path.

The golden images are refreshed in a separate commit. **Only 29 of the 83
changed lines are this branch.** The other 57 are pre-existing drift:
`asyncMethodsForRailsFile` derives each method's async-ness from the live
`packages/activerecord/src` tree, which has moved since #5815 checked the
images in, so `golden.test.ts` already fails on `main` today. I measured the
split by stubbing `collectDelegations` to return an empty table and
regenerating (57 lines), then regenerating normally (83). Every one of the 29
delegation lines is a `this.<receiver>.` insertion.

Two different counts of the same thing are both correct, so to be unambiguous:
**29 changed lines** are attributable to delegation, carrying **40 receiver
insertions** between them (37 `this.model.`, 2 `this.records.`,
1 on an `orderValues` line) — several lines gain more than one. A count of
*added lines that mention any receiver* runs higher still, because some lines
changed for both delegation and async reasons.

Coverage accounting is untouched (the pre-pass records nothing); parse errors
stay at 0.

Closes-story: delegate-macro-receiver-resolution
