### PR TITLE
feat(prism-codegen): resolve module-level super by static linearization

### DIFF
--- a/scripts/prism-codegen/__snapshots__/associations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/associations.js.snap
@@ -54,10 +54,11 @@ export function isAssociationCached(name) {
 }
 export function initializeDup(...rest) {
     this.association_cache = {};
-    return __PRISM_TODO("ForwardingSuperNode");
+    return Inheritance.initializeDup.call(this, ...arguments);
 }
 __PRISM_TODO("CallNode");
 export function initInternals() {
+    Persistence.initInternals.call(this, ...arguments);
     return this.association_cache = {};
 }
 export function associationInstanceGet(name) {

--- a/scripts/prism-codegen/__snapshots__/core.js.snap
+++ b/scripts/prism-codegen/__snapshots__/core.js.snap
@@ -167,25 +167,25 @@ export function initializeFindByCache() {
 export async function find(...ids, block) {
     let id;
     if (!(ids.length() === 1)) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#find");
     }
     if (block !== undefined || this.primaryKey.nil() || this.isScopeAttributes) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#find");
     }
     id = ids.first();
     if (StatementCache.isUnsupportedValue(id)) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#find");
     }
     return await this.cachedFindBy([this.primaryKey], [id]) || (() => { throw new RecordNotFound(`Couldn't find ${this.name} with '${this.primaryKey}'=${id}`, this.name, this.primaryKey, id); })();
 }
 export async function findBy(...args) {
     let hash;
     if (this.isScopeAttributes) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#find_by");
     }
     hash = args.first();
     if (!__PRISM_TODO("CallNode")) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#find_by");
     }
     hash = __PRISM_TODO("CallNode");
     return await this.cachedFindBy(hash.keys(), hash.values());
@@ -222,20 +222,20 @@ export function inspectionFilter() {
 export async function inspect() {
     let attr_list;
     if (this === Base || this.isSingletonClass) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect");
     }
     else if (this.isAbstractClass) {
-        return `${__PRISM_TODO("ForwardingSuperNode")}(abstract)`;
+        return `${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")}(abstract)`;
     }
     else if (!this.isSchemaLoaded && !this.isConnected) {
-        return `${__PRISM_TODO("ForwardingSuperNode")} (call '${__PRISM_TODO("ForwardingSuperNode")}.load_schema' to load schema informations)`;
+        return `${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")} (call '${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")}.load_schema' to load schema informations)`;
     }
     else if (this.isTableExists) {
         attr_list = this.attributeTypes.map((name, type) => `${name}: ${type.type()}`) * ", ";
-        return `${__PRISM_TODO("ForwardingSuperNode")}(${attr_list})`;
+        return `${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")}(${attr_list})`;
     }
     else {
-        return `${__PRISM_TODO("ForwardingSuperNode")}(Table doesn't exist)`;
+        return `${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")}(Table doesn't exist)`;
     }
 }
 export function arelTable() {
@@ -339,7 +339,7 @@ export function initializeDup(other) {
     this.previously_new_record = false;
     this.destroyed = false;
     this._start_transaction_state = null;
-    return __PRISM_TODO("ForwardingSuperNode");
+    return __PRISM_SUPER_OUTSIDE_CORPUS("Core#initialize_dup");
 }
 export function initAttributes(_) {
     let attrs;
@@ -366,7 +366,7 @@ export async function hash() {
         return __PRISM_TODO("CallNode");
     }
     else {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core#hash");
     }
 }
 export function freeze() {
@@ -418,7 +418,7 @@ export function fullInspect() {
 export async function prettyPrint(pp) {
     let attr_names, attr_name, value;
     if (this.isCustomInspectMethodDefined) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Core#pretty_print");
     }
     return pp.objectAddressGroup(this, () => {
         if (this.attributes) {

--- a/scripts/prism-codegen/__snapshots__/inheritance.js.snap
+++ b/scripts/prism-codegen/__snapshots__/inheritance.js.snap
@@ -101,7 +101,7 @@ export function polymorphicClassFor(name) {
 }
 export async function dup() {
     let other;
-    other = __PRISM_TODO("ForwardingSuperNode");
+    other = __PRISM_SUPER_OUTSIDE_CORPUS("Inheritance::ClassMethods#dup");
     other.setBaseClass();
     return other;
 }
@@ -146,7 +146,7 @@ export function discriminateClassForRecord(record) {
         return this.findStiClass(record[this.inheritanceColumn]);
     }
     else {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Inheritance::ClassMethods#discriminate_class_for_record");
     }
 }
 export function isUsingSingleTableInheritance(record) {
@@ -180,10 +180,12 @@ export function subclassFromAttributes(attrs) {
     }
 }
 export function initializeDup(other) {
+    Core.initializeDup.call(this, ...arguments);
     return this.ensureProperType;
 }
 __PRISM_TODO("CallNode");
 export function initializeInternalsCallback() {
+    Core.initializeInternalsCallback.call(this, ...arguments);
     return this.ensureProperType;
 }
 export function ensureProperType() {

--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -340,6 +340,7 @@ export function touch(...names, { time = null } = {}) {
 }
 __PRISM_TODO("CallNode");
 export function initInternals() {
+    Core.initInternals.call(this, ...arguments);
     this._trigger_destroy_callback = this._trigger_update_callback = null;
     return this.previously_new_record = false;
 }

--- a/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
@@ -42,7 +42,7 @@ export async function count(column_name = null, block) {
         if (!column_name.nil()) {
             throw new ArgumentError("Column name argument is not supported when a block is passed.");
         }
-        return __PRISM_TODO("SuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("Calculations#count");
     }
     else {
         return await this.calculate("count", column_name);

--- a/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
@@ -10,7 +10,7 @@ require("active_support/core_ext/string/filters");
 const ONE_AS_ONE = "1 AS one";
 export async function find(...args, block) {
     if (block !== undefined) {
-        return __PRISM_TODO("ForwardingSuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("FinderMethods#find");
     }
     return await this.findWithIds(...args);
 }

--- a/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
@@ -126,7 +126,7 @@ export async function select(...fields, block) {
         if (await fields.isAny()) {
             throw new ArgumentError("`select' with block doesn't take arguments.");
         }
-        return __PRISM_TODO("SuperNode");
+        return __PRISM_SUPER_OUTSIDE_CORPUS("QueryMethods#select");
     }
     this.checkIfMethodHasArgumentsBang(this.__callee__, fields, "Call `select' with at least one field.");
     fields = this.processSelectArgs(fields);

--- a/scripts/prism-codegen/codegen.ts
+++ b/scripts/prism-codegen/codegen.ts
@@ -44,6 +44,11 @@ export class Codegen implements Emitter {
     readonly delegations: ReadonlyMap<string, string> = new Map(),
     readonly linearization: Linearization | null = null,
   ) {}
+  private declined = false;
+  decline(kind: string): void {
+    this.declined = true;
+    this.record(kind, false);
+  }
   private record(kind: string, handled: boolean): void {
     this.coverage.record(kind, handled);
     const d = this.perDef.get(this.currentDef) ?? { total: 0, passthrough: 0 };
@@ -58,7 +63,8 @@ export class Codegen implements Emitter {
     if (handler) {
       const built = handler(node, this);
       if (built) {
-        this.record(kind, true);
+        if (this.declined) this.declined = false;
+        else this.record(kind, true);
         return built;
       }
     }

--- a/scripts/prism-codegen/codegen.ts
+++ b/scripts/prism-codegen/codegen.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { Registry } from "./registry.js";
+import type { Linearization } from "./linearization.js";
 import type { Coverage, Emitter, PrismNode } from "./types.js";
 const f = ts.factory;
 class CoverageTally implements Coverage {
@@ -28,6 +29,8 @@ export class Codegen implements Emitter {
     }
   >();
   currentDef = TOPLEVEL;
+  currentRubyDef = TOPLEVEL;
+  currentModule: string | null = null;
   inClass = false;
   inSingleton = false;
   inAsyncMethod = false;
@@ -39,6 +42,7 @@ export class Codegen implements Emitter {
     private readonly registry: Registry,
     readonly asyncMethods: ReadonlySet<string> = new Set(),
     readonly delegations: ReadonlyMap<string, string> = new Map(),
+    readonly linearization: Linearization | null = null,
   ) {}
   private record(kind: string, handled: boolean): void {
     this.coverage.record(kind, handled);

--- a/scripts/prism-codegen/convergence-baseline.json
+++ b/scripts/prism-codegen/convergence-baseline.json
@@ -7,6 +7,7 @@
   "active_record/associations.rb::hasAndBelongsToMany::divergent",
   "active_record/associations.rb::hasMany::divergent",
   "active_record/associations.rb::hasOne::divergent",
+  "active_record/associations.rb::initializeDup::divergent",
   "active_record/associations.rb::initInternals::divergent",
   "active_record/associations.rb::isAssociationCached::divergent",
   "active_record/core.rb::allAttributesForInspect::divergent",

--- a/scripts/prism-codegen/convergence-signoff.json
+++ b/scripts/prism-codegen/convergence-signoff.json
@@ -15,6 +15,11 @@
     "reason": "`@strict_loading_mode == :n_plus_one_only` vs `strictLoadingMode.call(this) === \"n_plus_one_only\"` — the port routes the ivar read through the `strictLoadingMode` accessor, which is the same read."
   },
   {
+    "rubyFile": "active_record/inheritance.rb",
+    "name": "initializeInternalsCallback",
+    "reason": "Rails' body is `super; ensure_proper_type` and the generated def now realizes that super as `Core.initializeInternalsCallback.call(this, ...)`. The port holds only this module's contribution (`ensureProperType.call(this)`, inheritance.ts:824) because base.ts orchestrates the chain explicitly at both constructor branches (base.ts:3212, 3291) — the composition-point pattern from #5727. Same two reaches, one of them relocated to the composition point."
+  },
+  {
     "rubyFile": "active_record/persistence.rb",
     "name": "isNewRecord",
     "reason": "Ruby reads the ivar `@new_record`; the port reads the `_newRecord` field. Same single read — the whole divergence is the ivar spelling."

--- a/scripts/prism-codegen/golden.ts
+++ b/scripts/prism-codegen/golden.ts
@@ -11,6 +11,7 @@ import {
   type TargetFile,
 } from "./files.js";
 import { delegationsFromSource, type DelegationTable } from "./index.js";
+import { buildLinearization, type Linearization } from "./linearization.js";
 import { rubyFileToTs } from "./naming.js";
 
 export const SNAPSHOT_DIR = "scripts/prism-codegen/__snapshots__";
@@ -60,6 +61,22 @@ export async function inheritedDelegationsFor(f: TargetFile): Promise<Delegation
   return relationDelegations;
 }
 
+let linearizationPromise: Promise<Linearization> | undefined;
+
+/**
+ * The `super` linearization over the whole target set. It is part of the
+ * generated image, so it is memoized rather than rebuilt per target — every
+ * target must see the same ancestry and def index.
+ */
+export function targetLinearization(): Promise<Linearization> {
+  linearizationPromise ??= (async () => {
+    const sources = await Promise.all(TARGET_FILES.map((t) => fs.readFile(rubyAbsPath(t), "utf8")));
+    const base = TARGET_FILES.findIndex((t) => t.ruby === "active_record/base.rb");
+    return buildLinearization(base < 0 ? "" : sources[base], sources);
+  })();
+  return linearizationPromise;
+}
+
 /** Generate one target file's JS exactly as `pnpm codegen:generate` writes it. */
 export async function generateTarget(f: TargetFile): Promise<GeneratedTarget> {
   const outName = outNameFor(f);
@@ -69,6 +86,7 @@ export async function generateTarget(f: TargetFile): Promise<GeneratedTarget> {
     asyncMethodsForRailsFile(f.ruby),
     runtimeImportPathFor(outName),
     await inheritedDelegationsFor(f),
+    await targetLinearization(),
   );
   return { ...result, file: f, outName };
 }

--- a/scripts/prism-codegen/handlers/misc.ts
+++ b/scripts/prism-codegen/handlers/misc.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { rubyStr, type Emitter, type PrismNode } from "../types.js";
 import type { Registry } from "../registry.js";
 import { methodName, isJsIdentName, isBindableIdent } from "../naming.js";
+import { normalizeModuleName, OUTSIDE_CORPUS, type SuperResolution } from "../linearization.js";
 const f = ts.factory;
 const COMPOUND: Record<string, ts.BinaryOperator> = {
   "+": ts.SyntaxKind.PlusEqualsToken,
@@ -14,17 +15,29 @@ export function registerMisc(r: Registry): void {
   r.on("SplatNode", (n, e) => f.createSpreadElement(e.expr((n.expression as PrismNode) ?? null)));
   r.onManyStmt(["ForwardingSuperNode", "SuperNode"], (n, e, isLast) => {
     if (e.inClass || isLast) return null;
+    // A resolvable module-level super is a real call; only unresolvable ones
+    // flatten away (the port realizes those chains at the composition point).
+    if (resolveSuper(e)?.kind === "resolved") return null;
     return [];
   });
   r.onMany(["ForwardingSuperNode", "SuperNode"], (n, e) => {
-    if (!e.inClass) return null;
-    const args =
-      n.constructor.name === "ForwardingSuperNode"
-        ? [f.createSpreadElement(f.createIdentifier("arguments"))]
-        : (((n.arguments_ as PrismNode | null)?.arguments_ as PrismNode[]) ?? []).map((x) =>
-            e.expr(x),
-          );
-    return f.createCallExpression(f.createSuper(), undefined, args);
+    const args = superArgs(n, e);
+    if (e.inClass) return f.createCallExpression(f.createSuper(), undefined, args);
+    const resolution = resolveSuper(e);
+    if (!resolution) return null;
+    if (resolution.kind === "outside-corpus") {
+      return f.createCallExpression(f.createIdentifier(OUTSIDE_CORPUS), undefined, [
+        f.createStringLiteral(`${normalizeModuleName(e.currentModule ?? "")}#${e.currentRubyDef}`),
+      ]);
+    }
+    const target = f.createPropertyAccessExpression(
+      f.createIdentifier(resolution.module.split("::").join("$")),
+      methodName(resolution.method),
+    );
+    return f.createCallExpression(f.createPropertyAccessExpression(target, "call"), undefined, [
+      f.createThis(),
+      ...args,
+    ]);
   });
   r.on("LocalVariableOperatorWriteNode", (n, e) => {
     const op = COMPOUND[String(n.binaryOperator)];
@@ -121,4 +134,16 @@ function symName(node: PrismNode): string | null {
   if (!node || node.constructor.name !== "SymbolNode") return null;
   const s = methodName(rubyStr(node.unescaped));
   return isBindableIdent(s) ? s : null;
+}
+function resolveSuper(e: Emitter): SuperResolution | null {
+  if (!e.linearization || !e.currentModule) return null;
+  return e.linearization.resolve(e.currentModule, e.currentRubyDef);
+}
+function superArgs(n: PrismNode, e: Emitter): ts.Expression[] {
+  if (n.constructor.name === "ForwardingSuperNode") {
+    return [f.createSpreadElement(f.createIdentifier("arguments"))];
+  }
+  return (((n.arguments_ as PrismNode | null)?.arguments_ as PrismNode[]) ?? []).map((x) =>
+    e.expr(x),
+  );
 }

--- a/scripts/prism-codegen/handlers/misc.ts
+++ b/scripts/prism-codegen/handlers/misc.ts
@@ -15,8 +15,6 @@ export function registerMisc(r: Registry): void {
   r.on("SplatNode", (n, e) => f.createSpreadElement(e.expr((n.expression as PrismNode) ?? null)));
   r.onManyStmt(["ForwardingSuperNode", "SuperNode"], (n, e, isLast) => {
     if (e.inClass || isLast) return null;
-    // A resolvable module-level super is a real call; only unresolvable ones
-    // flatten away (the port realizes those chains at the composition point).
     if (resolveSuper(e)?.kind === "resolved") return null;
     return [];
   });
@@ -26,6 +24,7 @@ export function registerMisc(r: Registry): void {
     const resolution = resolveSuper(e);
     if (!resolution) return null;
     if (resolution.kind === "outside-corpus") {
+      e.decline(n.constructor.name);
       return f.createCallExpression(f.createIdentifier(OUTSIDE_CORPUS), undefined, [
         f.createStringLiteral(`${normalizeModuleName(e.currentModule ?? "")}#${e.currentRubyDef}`),
       ]);

--- a/scripts/prism-codegen/handlers/structure.ts
+++ b/scripts/prism-codegen/handlers/structure.ts
@@ -10,7 +10,10 @@ export function registerStructure(r: Registry): void {
   });
   r.onStmt("ModuleNode", (n, e) => {
     const name = constName(n.constantPath as PrismNode, n.name);
+    const prevModule = e.currentModule;
+    e.currentModule = prevModule ? `${prevModule}::${name}` : name;
     const body = topLevel((n.body as PrismNode) ?? null, e);
+    e.currentModule = prevModule;
     if (body.length) {
       ts.addSyntheticLeadingComment(
         body[0],
@@ -144,6 +147,8 @@ function defParts(
 } {
   const isAsync = defName !== "constructor" && e.asyncMethods.has(defName);
   const prevDef = e.currentDef;
+  const prevRubyDef = e.currentRubyDef;
+  e.currentRubyDef = String(n.name);
   const prevDeclared = e.declared;
   const prevAsync = e.inAsyncMethod;
   const prevLoop = e.inLoop;
@@ -173,6 +178,7 @@ function defParts(
   const locals = [...e.declared].filter((d) => !paramNames.has(d));
   const body = f.createBlock([...hoistDecl(locals), ...bodyStmts], true);
   e.currentDef = prevDef;
+  e.currentRubyDef = prevRubyDef;
   (
     e as {
       declared: Set<string>;

--- a/scripts/prism-codegen/handlers/structure.ts
+++ b/scripts/prism-codegen/handlers/structure.ts
@@ -35,9 +35,12 @@ export function registerStructure(r: Registry): void {
         ]
       : undefined;
     const prev = e.inClass;
+    const prevModule = e.currentModule;
     e.inClass = true;
+    e.currentModule = prevModule ? `${prevModule}::${name}` : name;
     const members = classMembers((n.body as PrismNode) ?? null, e);
     e.inClass = prev;
+    e.currentModule = prevModule;
     return [
       f.createClassDeclaration(
         [f.createToken(ts.SyntaxKind.ExportKeyword)],

--- a/scripts/prism-codegen/index.ts
+++ b/scripts/prism-codegen/index.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import { Codegen } from "./codegen.js";
 import { defaultRegistry } from "./handlers/index.js";
 import { collectDelegations, mergeDelegations, type DelegationTable } from "./delegation.js";
+import type { Linearization } from "./linearization.js";
 import type { Coverage, PrismNode } from "./types.js";
 let parsePromise:
   | Promise<
@@ -36,12 +37,13 @@ export async function generateFromSource(
   asyncMethods: ReadonlySet<string> = new Set(),
   runtimeImportPath = "./runtime.js",
   inheritedDelegations: DelegationTable = new Map(),
+  linearization: Linearization | null = null,
 ): Promise<GenResult> {
   const parse = await getParser();
   const result = parse(rubySource);
   const program = result.value as PrismNode;
   const delegations = mergeDelegations(inheritedDelegations, collectDelegations(program));
-  const gen = new Codegen(defaultRegistry(), asyncMethods, delegations);
+  const gen = new Codegen(defaultRegistry(), asyncMethods, delegations, linearization);
   const statements = gen.stmt(program, false);
   const sourceFile = ts.factory.createSourceFile(
     statements,
@@ -82,6 +84,7 @@ export { summarizeCoverage } from "./coverage.js";
 export { TARGET_FILES } from "./files.js";
 export { asyncMethodsForRailsFile } from "./async-source.js";
 export { type DelegationTable } from "./delegation.js";
+export { buildLinearization, Linearization, parseIncludeOrder } from "./linearization.js";
 
 /** Standalone pre-pass: the delegation table a file contributes to its family. */
 export async function delegationsFromSource(rubySource: string): Promise<DelegationTable> {

--- a/scripts/prism-codegen/linearization.test.ts
+++ b/scripts/prism-codegen/linearization.test.ts
@@ -110,6 +110,38 @@ describe("super linearization", () => {
     expect(code).toContain('__PRISM_SUPER_OUTSIDE_CORPUS("Persistence#reload_only_here")');
   });
 
+  it("counts an outside-corpus super as a decline, not a clean translation", async () => {
+    const { perDef } = await generateFromSource(
+      PERSISTENCE_RB,
+      new Set(),
+      "./runtime.js",
+      await linearization(),
+    );
+    expect(perDef.get("touch")?.passthrough).toBe(0);
+    expect(perDef.get("reloadOnlyHere")?.passthrough).toBe(1);
+  });
+
+  it("still flattens an unresolvable statement-position super", async () => {
+    const { code } = await generateFromSource(
+      `
+        module ActiveRecord
+          module Core
+            def touch(*names)
+              super
+              1
+            end
+          end
+        end
+      `,
+      new Set(),
+      "./runtime.js",
+      await linearization(),
+    );
+    expect(code).toContain("return 1;");
+    expect(code).not.toContain("OUTSIDE_CORPUS");
+    expect(code).not.toContain(".call(this");
+  });
+
   it("leaves class-position super untouched when no linearization is supplied", async () => {
     const { code } = await generateFromSource(`
       class Widget < Base

--- a/scripts/prism-codegen/linearization.test.ts
+++ b/scripts/prism-codegen/linearization.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { generateFromSource } from "./index.js";
+import { buildLinearization, indexModuleDefs, parseIncludeOrder } from "./linearization.js";
+
+const BASE_RB = `
+  module ActiveRecord
+    class Base
+      include Core
+      include Persistence
+      include Timestamp
+    end
+  end
+`;
+const CORE_RB = `
+  module ActiveRecord
+    module Core
+      def touch(*names)
+        1
+      end
+    end
+  end
+`;
+const PERSISTENCE_RB = `
+  module ActiveRecord
+    module Persistence
+      def touch(*names)
+        super
+      end
+      def reload_only_here
+        super
+      end
+    end
+  end
+`;
+const TIMESTAMP_RB = `
+  module ActiveRecord
+    module Timestamp
+      def touch(name, time)
+        x = super(name)
+        x
+      end
+    end
+  end
+`;
+
+async function linearization() {
+  return buildLinearization(BASE_RB, [CORE_RB, PERSISTENCE_RB, TIMESTAMP_RB]);
+}
+
+describe("super linearization", () => {
+  it("reads the include order out of ActiveRecord::Base", async () => {
+    expect(parseIncludeOrder(BASE_RB)).toEqual(["Core", "Persistence", "Timestamp"]);
+  });
+
+  it("indexes the methods each vendored module defines", async () => {
+    const defs = await indexModuleDefs([CORE_RB, PERSISTENCE_RB]);
+    expect([...(defs.get("Core") ?? [])]).toEqual(["touch"]);
+    expect([...(defs.get("Persistence") ?? [])]).toEqual(["touch", "reload_only_here"]);
+  });
+
+  it("resolves a super to the next definer in the ancestry", async () => {
+    const lin = await linearization();
+    expect(lin.resolve("Timestamp", "touch")).toEqual({
+      kind: "resolved",
+      module: "Persistence",
+      method: "touch",
+    });
+    expect(lin.resolve("Persistence", "touch")).toEqual({
+      kind: "resolved",
+      module: "Core",
+      method: "touch",
+    });
+  });
+
+  it("declines a super with no further definer as outside the corpus", async () => {
+    const lin = await linearization();
+    expect(lin.resolve("Core", "touch")).toEqual({ kind: "outside-corpus" });
+    expect(lin.resolve("Persistence", "reload_only_here")).toEqual({ kind: "outside-corpus" });
+    expect(lin.resolve("ActiveModel::Naming", "touch")).toEqual({ kind: "outside-corpus" });
+  });
+
+  it("emits a value-position super as a direct next-definer call", async () => {
+    const { code } = await generateFromSource(
+      TIMESTAMP_RB,
+      new Set(),
+      "./runtime.js",
+      await linearization(),
+    );
+    expect(code).toContain("x = Persistence.touch.call(this, name);");
+    expect(code).not.toContain("__PRISM_TODO");
+  });
+
+  it("forwards the enclosing arguments through a bare super", async () => {
+    const { code } = await generateFromSource(
+      PERSISTENCE_RB,
+      new Set(),
+      "./runtime.js",
+      await linearization(),
+    );
+    expect(code).toContain("Core.touch.call(this, ...arguments)");
+  });
+
+  it("marks a super with no next definer as resolving outside the corpus", async () => {
+    const { code } = await generateFromSource(
+      PERSISTENCE_RB,
+      new Set(),
+      "./runtime.js",
+      await linearization(),
+    );
+    expect(code).toContain('__PRISM_SUPER_OUTSIDE_CORPUS("Persistence#reload_only_here")');
+  });
+
+  it("leaves class-position super untouched when no linearization is supplied", async () => {
+    const { code } = await generateFromSource(`
+      class Widget < Base
+        def save
+          super
+        end
+      end
+    `);
+    expect(code).toContain("super(...arguments)");
+  });
+});

--- a/scripts/prism-codegen/linearization.test.ts
+++ b/scripts/prism-codegen/linearization.test.ts
@@ -133,6 +133,7 @@ describe("super linearization", () => {
       `,
       new Set(),
       "./runtime.js",
+      new Map(),
       await linearization(),
     );
     expect(code).toContain("super(...arguments)");
@@ -144,6 +145,7 @@ describe("super linearization", () => {
       TIMESTAMP_RB,
       new Set(),
       "./runtime.js",
+      new Map(),
       await linearization(),
     );
     expect(code).toContain("x = Persistence.touch.call(this, name);");
@@ -155,6 +157,7 @@ describe("super linearization", () => {
       PERSISTENCE_RB,
       new Set(),
       "./runtime.js",
+      new Map(),
       await linearization(),
     );
     expect(code).toContain("Core.touch.call(this, ...arguments)");
@@ -165,6 +168,7 @@ describe("super linearization", () => {
       PERSISTENCE_RB,
       new Set(),
       "./runtime.js",
+      new Map(),
       await linearization(),
     );
     expect(code).toContain('__PRISM_SUPER_OUTSIDE_CORPUS("Persistence#reload_only_here")');
@@ -175,6 +179,7 @@ describe("super linearization", () => {
       PERSISTENCE_RB,
       new Set(),
       "./runtime.js",
+      new Map(),
       await linearization(),
     );
     expect(perDef.get("touch")?.passthrough).toBe(0);
@@ -195,6 +200,7 @@ describe("super linearization", () => {
       `,
       new Set(),
       "./runtime.js",
+      new Map(),
       await linearization(),
     );
     expect(code).toContain("return 1;");

--- a/scripts/prism-codegen/linearization.test.ts
+++ b/scripts/prism-codegen/linearization.test.ts
@@ -79,6 +79,66 @@ describe("super linearization", () => {
     expect(lin.resolve("ActiveModel::Naming", "touch")).toEqual({ kind: "outside-corpus" });
   });
 
+  it("indexes a nested class under its own path, not the enclosing module's", async () => {
+    const defs = await indexModuleDefs([
+      `
+        module ActiveRecord
+          module Core
+            class ExplainProxy
+              def then
+                1
+              end
+            end
+          end
+        end
+      `,
+    ]);
+    expect(defs.get("Core")).toBeUndefined();
+    expect([...(defs.get("Core::ExplainProxy") ?? [])]).toEqual(["then"]);
+  });
+
+  it("keeps singleton methods out of the instance-ancestry index", async () => {
+    const defs = await indexModuleDefs([
+      `
+        module ActiveRecord
+          module Core
+            class << self
+              def touch
+                1
+              end
+            end
+            def self.reset
+              2
+            end
+          end
+        end
+      `,
+    ]);
+    expect(defs.get("Core")).toBeUndefined();
+  });
+
+  it("attributes a super inside a nested class to that class, not the module", async () => {
+    const { code } = await generateFromSource(
+      `
+        module ActiveRecord
+          module Persistence
+            class Proxy
+              def touch(name)
+                x = super
+                x
+              end
+            end
+          end
+        end
+      `,
+      new Set(),
+      "./runtime.js",
+      await linearization(),
+    );
+    expect(code).toContain("super(...arguments)");
+    expect(code).not.toContain(".touch.call(this");
+  });
+
   it("emits a value-position super as a direct next-definer call", async () => {
     const { code } = await generateFromSource(
       TIMESTAMP_RB,

--- a/scripts/prism-codegen/linearization.ts
+++ b/scripts/prism-codegen/linearization.ts
@@ -1,0 +1,108 @@
+import { loadPrism } from "@ruby/prism";
+import type { PrismNode } from "./types.js";
+
+export interface ResolvedSuper {
+  kind: "resolved";
+  module: string;
+  method: string;
+}
+export interface OutsideCorpusSuper {
+  kind: "outside-corpus";
+}
+export type SuperResolution = ResolvedSuper | OutsideCorpusSuper;
+
+export const OUTSIDE_CORPUS = "__PRISM_SUPER_OUTSIDE_CORPUS";
+const AR = "ActiveRecord::";
+const INCLUDE_LINE = /^[ \t]*include[ \t]+([A-Z][\w:]*)[ \t]*$/gm;
+
+export function normalizeModuleName(name: string): string {
+  return name.startsWith(AR) ? name.slice(AR.length) : name;
+}
+
+/**
+ * The `include Foo` names in `ActiveRecord::Base`, in source order. Ruby
+ * inserts each included module directly above the includer, so the last
+ * `include` wins — the ancestry is this list reversed.
+ */
+export function parseIncludeOrder(baseSource: string): string[] {
+  return [...baseSource.matchAll(INCLUDE_LINE)].map((m) => normalizeModuleName(m[1]));
+}
+
+export class Linearization {
+  /** Nearest-first ancestry: `ancestry[0]` is the module `Base` sees first. */
+  constructor(
+    readonly ancestry: readonly string[],
+    private readonly defs: ReadonlyMap<string, ReadonlySet<string>>,
+  ) {}
+
+  /** Ruby method names defined directly by `module`. */
+  definitionsOf(module: string): ReadonlySet<string> {
+    return this.defs.get(normalizeModuleName(module)) ?? new Set();
+  }
+
+  /**
+   * The module a `super` inside `module`'s `method` dispatches to, or an
+   * outside-corpus decline when the remaining ancestry has no definer (the
+   * real target is ActiveModel/Object, which we do not index).
+   */
+  resolve(module: string, method: string): SuperResolution {
+    const from = this.ancestry.indexOf(normalizeModuleName(module));
+    if (from < 0) return { kind: "outside-corpus" };
+    for (const next of this.ancestry.slice(from + 1)) {
+      if (this.definitionsOf(next).has(method)) return { kind: "resolved", module: next, method };
+    }
+    return { kind: "outside-corpus" };
+  }
+}
+
+/** Ruby method names defined directly under each `module`/`class` path. */
+export async function indexModuleDefs(
+  sources: Iterable<string>,
+): Promise<Map<string, Set<string>>> {
+  const parse = await loadPrism();
+  const index = new Map<string, Set<string>>();
+  for (const source of sources) {
+    walk((parse(source).value as unknown as PrismNode) ?? null, [], index);
+  }
+  return index;
+}
+
+export async function buildLinearization(
+  baseSource: string,
+  moduleSources: Iterable<string>,
+): Promise<Linearization> {
+  const defs = await indexModuleDefs(moduleSources);
+  return new Linearization([...parseIncludeOrder(baseSource)].reverse(), defs);
+}
+
+function walk(node: PrismNode | null, path: string[], index: Map<string, Set<string>>): void {
+  if (!node?.constructor) return;
+  const kind = node.constructor.name;
+  if (kind === "ModuleNode" || kind === "ClassNode") {
+    const nested = [...path, constPath(node.constantPath as PrismNode | undefined, node.name)];
+    for (const child of node.compactChildNodes()) walk(child, nested, index);
+    return;
+  }
+  if (kind === "DefNode" && !node.receiver && path.length) {
+    const owner = normalizeModuleName(path.join("::"));
+    const set = index.get(owner) ?? new Set<string>();
+    set.add(String(node.name));
+    index.set(owner, set);
+    return;
+  }
+  for (const child of node.compactChildNodes()) walk(child, path, index);
+}
+
+function constPath(path: PrismNode | undefined, name: unknown): string {
+  if (path?.constructor.name === "ConstantPathNode") {
+    const parts: string[] = [];
+    let cur: PrismNode | undefined = path;
+    while (cur && cur.constructor.name === "ConstantPathNode") {
+      parts.unshift(String(cur.name));
+      cur = cur.parent as PrismNode | undefined;
+    }
+    if (cur) parts.unshift(String(cur.name));
+    return parts.join("::");
+  }
+  return String(name ?? "Anon");
+}

--- a/scripts/prism-codegen/linearization.ts
+++ b/scripts/prism-codegen/linearization.ts
@@ -55,7 +55,11 @@ export class Linearization {
   }
 }
 
-/** Ruby method names defined directly under each `module`/`class` path. */
+/**
+ * Ruby method names defined directly under each `module`/`class` path.
+ * `def self.x` and `class << self` bodies are skipped: singleton methods live
+ * on a separate ancestry from the instance chain `super` resolution walks.
+ */
 export async function indexModuleDefs(
   sources: Iterable<string>,
 ): Promise<Map<string, Set<string>>> {
@@ -83,6 +87,7 @@ function walk(node: PrismNode | null, path: string[], index: Map<string, Set<str
     for (const child of node.compactChildNodes()) walk(child, nested, index);
     return;
   }
+  if (kind === "SingletonClassNode") return;
   if (kind === "DefNode" && !node.receiver && path.length) {
     const owner = normalizeModuleName(path.join("::"));
     const set = index.get(owner) ?? new Set<string>();

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -6,8 +6,13 @@ import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
 import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath } from "./files.js";
+import {
+  inheritedDelegationsFor,
+  outNameFor,
+  runtimeImportPathFor,
+  targetLinearization,
+} from "./golden.js";
 import { rubyFileToTs } from "./naming.js";
-import { inheritedDelegationsFor } from "./golden.js";
 import { scoreFile, indexPortTree, type ScoreEntry } from "./score.js";
 import {
   buildCatalog,
@@ -124,8 +129,9 @@ async function main() {
     const { code, perDef } = await generateFromSource(
       readFileSync(rubyAbsPath(f), "utf8"),
       asyncMethodsForRailsFile(f.ruby, asyncManifest),
-      undefined,
+      runtimeImportPathFor(outNameFor(f)),
       await inheritedDelegationsFor(f),
+      await targetLinearization(),
     );
     const cleanDefs = new Set(
       [...perDef].filter(([n, d]) => n !== TOPLEVEL && d.passthrough === 0).map(([n]) => n),

--- a/scripts/prism-codegen/types.ts
+++ b/scripts/prism-codegen/types.ts
@@ -26,6 +26,11 @@ export interface Emitter {
   stmt(node: PrismNode, isLast: boolean): ts.Statement[];
   stmts(node: PrismNode | null | undefined, implicitReturn: boolean): ts.Statement[];
   readonly coverage: Coverage;
+  /**
+   * Record a node the handler chose not to translate faithfully. Keeps the
+   * enclosing def out of the "clean" set even though a marker was emitted.
+   */
+  decline(kind: string): void;
   readonly perDef: Map<
     string,
     {

--- a/scripts/prism-codegen/types.ts
+++ b/scripts/prism-codegen/types.ts
@@ -1,4 +1,5 @@
 import type ts from "typescript";
+import type { Linearization } from "./linearization.js";
 export interface PrismNode {
   constructor: {
     name: string;
@@ -33,6 +34,11 @@ export interface Emitter {
     }
   >;
   currentDef: string;
+  /** The Ruby name of the enclosing `def`, before name-convention mapping. */
+  currentRubyDef: string;
+  /** `::`-joined path of the enclosing `module`/`class`, if any. */
+  currentModule: string | null;
+  readonly linearization: Linearization | null;
   inClass: boolean;
   inSingleton: boolean;
   readonly asyncMethods: ReadonlySet<string>;


### PR DESCRIPTION
## What

A static-linearization pre-pass for the prism codegen, so module-level `super`
becomes a direct next-definer call instead of being flattened away or declined.

- `scripts/prism-codegen/linearization.ts` — parses the `include` order out of
  `ActiveRecord::Base` (ancestry = reverse include order), indexes which
  vendored module defines which Ruby method (prism walk over module/class
  paths), and resolves `Module#method` to its next definer.
- `ForwardingSuperNode` / `SuperNode` in both statement and value position now
  emit `NextModule.method.call(this, ...args)` when resolvable. Bare `super`
  forwards `...arguments`; `super(a)` passes its own args.
- Supers with no further definer in the corpus (they land in
  ActiveModel/Object) emit a `__PRISM_SUPER_OUTSIDE_CORPUS("M#m")` marker.
  Unresolvable statement-position supers keep the flattening behaviour from
  #5727; class-position `super` is untouched.
- An outside-corpus marker is recorded as a *decline* (`Emitter#decline`), so a
  def containing one never scores as a clean translation.

On the real corpus this resolves e.g. `Persistence.initInternals.call(this, ...)`
inside `associations.rb` — matching the hand-maintained composition chain in
`packages/activerecord/src/associations.ts`.

## Scorer

`score-cli.ts` now generates through the same memoized `targetLinearization()`
and runtime path as `golden.ts`, so the scored image is the generated image and
the conformance guard can see resolved supers. Two defs become clean as a
result:

- `inheritance.rb::initializeInternalsCallback` — signed off in
  `convergence-signoff.json`: Rails' `super; ensure_proper_type` is realized at
  base.ts's composition points (base.ts:3212, 3291), so the port method holds
  only its own contribution (inheritance.ts:824). Same reaches, one relocated.
- `associations.rb::initializeDup` — added to the baseline as unreviewed
  residue; its port match resolves to an unrelated symbol, so there is no
  equivalence to sign off.

## Tests

`scripts/prism-codegen/linearization.test.ts` covers the resolvable chain,
the single-definer outside-corpus decline, forwarded args, explicit args in
value position, and the untouched class-position path.

Closes-story: static-super-linearization
