### PR TITLE
feat(prism-codegen): canonicalize the port's modelClass receiver against Rails' model

### DIFF
--- a/scripts/prism-codegen/score.test.ts
+++ b/scripts/prism-codegen/score.test.ts
@@ -127,6 +127,20 @@ describe("prism-codegen scorer", () => {
     expect(score.entries).toEqual([expect.objectContaining({ name: "tally", status: "matched" })]);
   });
 
+  it("canonicalizes the port's `_modelClass` backing field against Rails' `model`", async () => {
+    const score = await scoreRuby(
+      `def table_name
+         model.table_name
+       end`,
+      `export function tableName(this: R): string {
+         return this._modelClass.tableName;
+       }`,
+    );
+    expect(score.entries).toEqual([
+      expect.objectContaining({ name: "tableName", status: "matched" }),
+    ]);
+  });
+
   it("rejects a predicate fallback candidate that collides with a different-arity method", async () => {
     // Rails readonly? (0 args) must NOT match the port of Rails readonly(value).
     const score = await scoreRuby(

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -206,6 +206,12 @@ const TOKEN_CANON: Record<string, string> = {
   inject: "reduce",
   toA: "toArray",
   size: "length",
+  // Relation's reach for its model class. Rails spells it `model` (relation.rb
+  // `attr_reader :model`, plus `delegate ..., to: :model`); the port's public
+  // accessor is also `model`, but internal call sites read the private backing
+  // field `_modelClass`, which normalizes to `modelClass`. Same receiver, two
+  // spellings — canonicalize so skeleton diffs show only real divergences.
+  modelClass: "model",
 };
 
 export function normalizeName(name: string): string {

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -206,11 +206,6 @@ const TOKEN_CANON: Record<string, string> = {
   inject: "reduce",
   toA: "toArray",
   size: "length",
-  // Relation's reach for its model class. Rails spells it `model` (relation.rb
-  // `attr_reader :model`, plus `delegate ..., to: :model`); the port's public
-  // accessor is also `model`, but internal call sites read the private backing
-  // field `_modelClass`, which normalizes to `modelClass`. Same receiver, two
-  // spellings — canonicalize so skeleton diffs show only real divergences.
   modelClass: "model",
 };
 


### PR DESCRIPTION
## Finding

`modelClass` is **not** a divergent spelling of Rails' `model` — it is the port's
private backing field. `Relation#model` (and its `klass` alias) already exists in
`packages/activerecord/src/relation.ts:6237-6246` mirroring `relation.rb`'s
`attr_reader :model` / `alias :klass :model`; internal call sites just read
`this._modelClass` directly, which `normalizeName` strips to `modelClass`.
`scripts/api-compare/arity.ts:104` already registers `modelClass` as a deliberate
explicit-receiver spelling. So the scorer is the right place to fix it, not the
port — renaming the field would touch 183 sites across 25 files, far past the
LOC ceiling, for zero semantic change.

## Measured effect

Adding `modelClass: "model"` to `TOKEN_CANON` **does not increase the matched
count** (33 before, 33 after; conformance 10.0% either way). This reconfirms the
measurement taken during #5816. Diffing `--verbose` skeletons shows the entry
does fire — it rewrites the port token on 13 defs — but every one of those defs
diverges structurally as well, e.g.:

```
relation/query_methods.rb :: isStructurallyCompatible
  gen:  ref:empty ref:structurallyIncompatibleValuesFor
  port: if ref:model ref:model ref:areStructurallyCompatible
```

No def is separated from its twin by the receiver spelling alone, so no row can
flip today.

## Why land it anyway

The divergent skeletons are the convergence-guard review queue. Leaving the two
spellings distinct puts pure-naming noise in every one of those 13 diffs, which
is exactly the false signal a reviewer has to re-triage each pass. With the entry
in, a `ref:model` mismatch in a skeleton means a real receiver difference, and
the rows will flip on their own as the structural work lands.

`pnpm codegen:score --guard`: OK — 353 residue rows, 0 baseline rows converged,
6 signed off.

Closes-story: scorer-model-vs-modelclass-token
