### PR TITLE
feat(codegen): add codegen:apply draft scaffolding command

### DIFF
--- a/docs/infrastructure/prism-codegen-spike.md
+++ b/docs/infrastructure/prism-codegen-spike.md
@@ -449,6 +449,36 @@ residue rows in the seeded baseline. That number is the burndown target, not a
 verdict: most rows differ by several tokens at once, which the per-call exclude
 lists cannot explain on their own.
 
+## Scaffolding accelerator (`pnpm codegen:apply`)
+
+```
+pnpm codegen:apply <rails-file> <method> [--dry-run]
+```
+
+Inserts the generated body for one clean def into the Rails twin port file, at
+the Rails-layout position — immediately after the nearest preceding generated
+def that is already ported, or before the nearest following one, or at end of
+file when no sibling is ported yet.
+
+**Draft-only contract.** The command is a typing accelerator, not a porting
+step:
+
+- It writes an unreviewed machine draft carrying a loud
+  `// PRISM-CODEGEN DRAFT` marker. The porting agent finishes the body against
+  `vendor/rails` under normal `test:compare` discipline and deletes the marker
+  before committing.
+- It never stages, commits, or formats anything, and it must **never** be wired
+  into an autofix step, a lint-staged entry, or a git hook. Nothing in CI runs
+  it.
+- It refuses rather than duplicating: if the method already exists in the twin
+  file, or if the global port index resolves it in any other file, the command
+  exits non-zero with the resolving file named. This is what the cross-file
+  resolver in the scorer buys us.
+- It refuses defs the generator could not translate cleanly (any
+  `__PRISM_TODO` passthrough) — those are hand-port work.
+
+`--dry-run` reports the insertion point without touching the file.
+
 ## Productionization roadmap
 
 Pursue only if the scaffolding value justifies it. Sequenced by the coverage
@@ -529,6 +559,8 @@ machinery:
 - Coverage metric: per-file + rollup + passthrough leaders (above).
 - Golden snapshots: `scripts/prism-codegen/__snapshots__/` + `pnpm codegen:snapshot`
   (above).
+- Scaffolding accelerator: `pnpm codegen:apply <rails-file> <method>` (draft
+  only — see above).
 - Convergence guard: `pnpm codegen:score --guard` + the checked-in residue
   baseline (above).
 - This RFC.

--- a/docs/infrastructure/prism-codegen-spike.md
+++ b/docs/infrastructure/prism-codegen-spike.md
@@ -470,10 +470,14 @@ step:
 - It never stages, commits, or formats anything, and it must **never** be wired
   into an autofix step, a lint-staged entry, or a git hook. Nothing in CI runs
   it.
-- It refuses rather than duplicating: if the method already exists in the twin
-  file, or if the global port index resolves it in any other file, the command
-  exits non-zero with the resolving file named. This is what the cross-file
-  resolver in the scorer buys us.
+- It refuses rather than duplicating, reusing the scorer's own `resolvePortFn`
+  so the two agree on what "already ported" means — including the arity guard on
+  the `isX` → `x` fallback candidate. If the method resolves in the twin file, or
+  if the global index has any cross-file hit under those same candidate rules,
+  the command exits non-zero naming the file(s). Note the deliberate asymmetry
+  with the scorer: an _ambiguous_ cross-file name (several files, so the scorer
+  leaves the row `missing`) still refuses here, because scaffolding on top of a
+  collision is how a duplicate gets written.
 - It refuses defs the generator could not translate cleanly (any
   `__PRISM_TODO` passthrough) — those are hand-port work.
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "codegen:generate": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/prism-codegen/generate.ts",
     "codegen:from-ts": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/prism-codegen/from-ts.ts",
     "codegen:score": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/prism-codegen/score-cli.ts",
+    "codegen:apply": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/prism-codegen/apply-cli.ts",
     "codegen:snapshot": "pnpm vendor:fetch >/dev/null && pnpm vitest run scripts/prism-codegen/golden.test.ts -u"
   },
   "devDependencies": {

--- a/scripts/prism-codegen/apply-cli.ts
+++ b/scripts/prism-codegen/apply-cli.ts
@@ -59,22 +59,13 @@ async function main() {
     await fs.readFile(rubyAbsPath(target), "utf8"),
     asyncMethodsForRailsFile(target.ruby),
   );
-  const def = perDef.get(methodName);
-  if (def && def.passthrough > 0) {
-    console.error(
-      `${methodName} generated with ${def.passthrough} passthrough node(s) — the draft ` +
-        `would be riddled with __PRISM_TODO. Port it by hand.`,
-    );
-    process.exitCode = 1;
-    return;
-  }
-
   const plan = planApply({
     generatedCode: code,
     portSource,
     portFile: tsFile,
     methodName,
     globalIndex: indexPortTree(portTreeFiles()),
+    passthrough: perDef.get(methodName)?.passthrough,
   });
   if (plan.status === "refused") {
     console.error(`refused: ${plan.reason}`);

--- a/scripts/prism-codegen/apply-cli.ts
+++ b/scripts/prism-codegen/apply-cli.ts
@@ -1,0 +1,105 @@
+import * as fs from "fs/promises";
+import * as path from "node:path";
+import { generateFromSource } from "./index.js";
+import { asyncMethodsForRailsFile } from "./async-source.js";
+import { TOPLEVEL } from "./codegen.js";
+import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath } from "./files.js";
+import { rubyFileToTs } from "./naming.js";
+import { indexPortTree } from "./score.js";
+import { planApply } from "./apply.js";
+
+const USAGE =
+  "usage: pnpm codegen:apply <rails-file> <method> [--dry-run]\n\n" +
+  "  <rails-file>  a TARGET_FILES entry, e.g. active_record/persistence.rb\n" +
+  "                (the active_record/ prefix is optional)\n" +
+  "  <method>      the camelCase generated def name, as shown by codegen:score\n\n" +
+  "Writes a DRAFT body, marker-commented, at the Rails-layout position in the\n" +
+  "twin port file. Draft only: never run from an autofix or commit hook, and\n" +
+  "never commit a body that still carries the marker.";
+
+async function main() {
+  const args = process.argv.slice(2).filter((a) => a !== "--dry-run");
+  const dryRun = process.argv.includes("--dry-run");
+  if (args.length !== 2) {
+    console.error(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+  const [rawFile, methodName] = args;
+  const wanted = rawFile.replace(/^active_record\//, "");
+  const target = TARGET_FILES.find((f) => f.ruby.replace(/^active_record\//, "") === wanted);
+  if (!target) {
+    console.error(
+      `unknown Rails file: ${rawFile}\n\nknown files:\n` +
+        TARGET_FILES.map((f) => `  ${f.ruby}`).join("\n"),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (methodName === TOPLEVEL) {
+    console.error("the file's toplevel body is not a scaffoldable def.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const tsFile = rubyFileToTs(wanted);
+  const portPath = path.join(TRAILS_AR_SRC, tsFile);
+  let portSource;
+  try {
+    portSource = await fs.readFile(portPath, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    console.error(`no port file at ${portPath} — create the twin file first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { code, perDef } = await generateFromSource(
+    await fs.readFile(rubyAbsPath(target), "utf8"),
+    asyncMethodsForRailsFile(target.ruby),
+  );
+  const def = perDef.get(methodName);
+  if (def && def.passthrough > 0) {
+    console.error(
+      `${methodName} generated with ${def.passthrough} passthrough node(s) — the draft ` +
+        `would be riddled with __PRISM_TODO. Port it by hand.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const plan = planApply({
+    generatedCode: code,
+    portSource,
+    portFile: tsFile,
+    methodName,
+    globalIndex: indexPortTree(portTreeFiles()),
+  });
+  if (plan.status === "refused") {
+    console.error(`refused: ${plan.reason}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const where = plan.insertedAfter
+    ? `after ${plan.insertedAfter}`
+    : plan.insertedBefore
+      ? `before ${plan.insertedBefore}`
+      : "at end of file";
+  if (dryRun) {
+    console.log(`would insert ${methodName} ${where} in ${portPath}`);
+    return;
+  }
+  await fs.writeFile(portPath, plan.source, "utf8");
+  console.log(
+    `inserted DRAFT ${methodName} ${where} in ${portPath}.\n` +
+      `It is unreviewed machine output: finish it, run the tests, and delete the\n` +
+      `marker comment before committing. Nothing was staged or committed.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/prism-codegen/apply.test.ts
+++ b/scripts/prism-codegen/apply.test.ts
@@ -91,6 +91,42 @@ describe("prism-codegen apply", () => {
     });
   });
 
+  it("scaffolds past a fallback candidate whose arity disagrees", () => {
+    const result = planApply({
+      generatedCode: "function isReadonly() {\n  return true;\n}",
+      portSource: "export function readonly(value) {}\n",
+      portFile: "core.ts",
+      methodName: "isReadonly",
+    });
+    expect(result.status).toBe("applied");
+  });
+
+  it("refuses on an ambiguous cross-file name rather than scaffolding a duplicate", () => {
+    const result = plan("export function first() {}\n", "second", [
+      { path: "persistence.ts", source: "export function first() {}\n" },
+      { path: "relation/calculations.ts", source: "export function second() {}\n" },
+      { path: "relation/finder_methods.ts", source: "export function second() {}\n" },
+    ]);
+    expect(result.status).toBe("refused");
+    if (result.status !== "refused") return;
+    expect(result.reason).toContain(
+      "already ported in relation/calculations.ts, relation/finder_methods.ts",
+    );
+  });
+
+  it("refuses a def the generator could not translate cleanly", () => {
+    const result = planApply({
+      generatedCode: generated,
+      portSource: "export function first() {}\n",
+      portFile: "persistence.ts",
+      methodName: "second",
+      passthrough: 3,
+    });
+    expect(result.status).toBe("refused");
+    if (result.status !== "refused") return;
+    expect(result.reason).toContain("3 passthrough node(s)");
+  });
+
   it("refuses a method the generator does not emit", () => {
     const result = plan("export function first() {}\n", "fourth");
     expect(result.status).toBe("refused");

--- a/scripts/prism-codegen/apply.test.ts
+++ b/scripts/prism-codegen/apply.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { APPLY_MARKER, planApply } from "./apply.js";
+import { indexPortTree } from "./score.js";
+
+const generated = [
+  "function first() {\n  return 1;\n}",
+  "function second() {\n  return 2;\n}",
+  "function third() {\n  return 3;\n}",
+].join("\n");
+
+const plan = (portSource: string, methodName: string, tree?: { path: string; source: string }[]) =>
+  planApply({
+    generatedCode: generated,
+    portSource,
+    portFile: "persistence.ts",
+    methodName,
+    globalIndex: tree ? indexPortTree(tree) : undefined,
+  });
+
+describe("prism-codegen apply", () => {
+  it("inserts the draft after the nearest preceding def in Rails order", () => {
+    const result = plan("export function first() {}\n\nexport function third() {}\n", "second");
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied") return;
+    expect(result.insertedAfter).toBe("first");
+    expect(result.source).toBe(
+      "export function first() {}\n\n" +
+        `${APPLY_MARKER}\nfunction second() {\n  return 2;\n}\n\n` +
+        "export function third() {}\n",
+    );
+  });
+
+  it("falls forward to the nearest following def when nothing precedes it", () => {
+    const result = plan("export function third() {}\n", "second");
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied") return;
+    expect(result.insertedBefore).toBe("third");
+    expect(result.source.indexOf(APPLY_MARKER)).toBeLessThan(
+      result.source.indexOf("export function third"),
+    );
+  });
+
+  it("appends at end of file when no generated sibling is ported yet", () => {
+    const result = plan("export const x = 1;\n", "second");
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied") return;
+    expect(result.insertedAfter).toBeUndefined();
+    expect(result.source).toBe(
+      `export const x = 1;\n\n${APPLY_MARKER}\nfunction second() {\n  return 2;\n}\n`,
+    );
+  });
+
+  it("anchors on a top-level arrow's statement, not on the arrow itself", () => {
+    const result = plan("export const first = () => 1;\n", "second");
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied") return;
+    expect(result.source).toBe(
+      "export const first = () => 1;\n\n" +
+        `${APPLY_MARKER}\nfunction second() {\n  return 2;\n}\n`,
+    );
+  });
+
+  it("refuses when the method is already defined in the twin file", () => {
+    const result = plan("export function second() {}\n", "second");
+    expect(result).toEqual({
+      status: "refused",
+      reason: "second is already defined in persistence.ts.",
+    });
+  });
+
+  it("refuses when the global index resolves the method in another file", () => {
+    const result = plan("export function first() {}\n", "second", [
+      { path: "persistence.ts", source: "export function first() {}\n" },
+      { path: "relation/calculations.ts", source: "export function second() {}\n" },
+    ]);
+    expect(result.status).toBe("refused");
+    if (result.status !== "refused") return;
+    expect(result.reason).toContain("already ported in relation/calculations.ts");
+  });
+
+  it("refuses when only the predicate name candidate is ported", () => {
+    const result = planApply({
+      generatedCode: "function isPersisted() {\n  return true;\n}",
+      portSource: "export function persisted() {}\n",
+      portFile: "persistence.ts",
+      methodName: "isPersisted",
+    });
+    expect(result).toEqual({
+      status: "refused",
+      reason: "isPersisted is already defined in persistence.ts.",
+    });
+  });
+
+  it("refuses a method the generator does not emit", () => {
+    const result = plan("export function first() {}\n", "fourth");
+    expect(result.status).toBe("refused");
+    if (result.status !== "refused") return;
+    expect(result.reason).toContain("no generated def named fourth");
+  });
+});

--- a/scripts/prism-codegen/apply.ts
+++ b/scripts/prism-codegen/apply.ts
@@ -1,0 +1,150 @@
+import ts from "typescript";
+import { indexPortFile, nameCandidates, type GlobalPortIndex } from "./score.js";
+
+/**
+ * The draft marker. It is deliberately loud and greppable: a scaffolded body is
+ * NOT a port — it is a starting point the porting agent finishes under normal
+ * test-compare discipline, and no scaffolded body may be committed carrying
+ * this line.
+ */
+export const APPLY_MARKER =
+  "// PRISM-CODEGEN DRAFT — machine-scaffolded from the Rails source. Not a port:\n" +
+  "// review against vendor/rails, finish it, and delete this marker before committing.";
+
+export interface ApplyRequest {
+  generatedCode: string;
+  portSource: string;
+  portFile: string;
+  methodName: string;
+  globalIndex?: GlobalPortIndex;
+}
+
+export type ApplyPlan =
+  | { status: "applied"; source: string; insertedAfter?: string; insertedBefore?: string }
+  | { status: "refused"; reason: string };
+
+function generatedFunctions(generatedCode: string): { name: string; text: string }[] {
+  const sf = ts.createSourceFile(
+    "gen.js",
+    generatedCode,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.JS,
+  );
+  const out: { name: string; text: string }[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name) &&
+      node.body
+    ) {
+      out.push({ name: node.name.text, text: node.getText(sf).trim() });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return out;
+}
+
+/**
+ * The top-level statement a port symbol belongs to — an arrow initializer's own
+ * position points at the arrow, not at the `export const` we have to insert
+ * around.
+ */
+function topLevelStatement(fn: ts.Node): ts.Node {
+  let node: ts.Node = fn;
+  while (node.parent && !ts.isSourceFile(node.parent)) node = node.parent;
+  return node;
+}
+
+function findLocal(
+  port: ReturnType<typeof indexPortFile>,
+  name: string,
+): ts.FunctionLikeDeclaration | undefined {
+  for (const candidate of nameCandidates(name)) {
+    const found = port.byName.get(candidate);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function elsewhereHit(
+  globalIndex: GlobalPortIndex | undefined,
+  portFile: string,
+  name: string,
+): string | undefined {
+  if (!globalIndex) return undefined;
+  for (const candidate of nameCandidates(name)) {
+    for (const hit of globalIndex.byName.get(candidate) ?? []) {
+      if (hit.file !== portFile) return hit.file;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Plan a draft insertion. Pure: it returns the would-be port source, never
+ * touches disk, and refuses whenever the method already has a home — the whole
+ * point of the cross-file resolver is that a method ported into a different
+ * file is not duplicated here.
+ */
+export function planApply(req: ApplyRequest): ApplyPlan {
+  const generated = generatedFunctions(req.generatedCode);
+  const targetIndex = generated.findIndex((g) => g.name === req.methodName);
+  if (targetIndex === -1) {
+    return {
+      status: "refused",
+      reason:
+        `no generated def named ${req.methodName} — the scorer only scaffolds clean ` +
+        `generated defs, so check \`pnpm codegen:score --verbose\` for the exact name.`,
+    };
+  }
+
+  const port = indexPortFile(req.portSource);
+  if (findLocal(port, req.methodName)) {
+    return {
+      status: "refused",
+      reason: `${req.methodName} is already defined in ${req.portFile}.`,
+    };
+  }
+  const elsewhere = elsewhereHit(req.globalIndex, req.portFile, req.methodName);
+  if (elsewhere) {
+    return {
+      status: "refused",
+      reason:
+        `${req.methodName} is already ported in ${elsewhere} — scaffolding it into ` +
+        `${req.portFile} would duplicate it.`,
+    };
+  }
+
+  const anchorBefore = (() => {
+    for (let i = targetIndex - 1; i >= 0; i--) {
+      const fn = findLocal(port, generated[i].name);
+      if (fn) return { name: generated[i].name, fn };
+    }
+    return undefined;
+  })();
+  const anchorAfter = (() => {
+    for (let i = targetIndex + 1; i < generated.length; i++) {
+      const fn = findLocal(port, generated[i].name);
+      if (fn) return { name: generated[i].name, fn };
+    }
+    return undefined;
+  })();
+
+  const block = `${APPLY_MARKER}\n${generated[targetIndex].text}`;
+  if (anchorBefore) {
+    const at = topLevelStatement(anchorBefore.fn).getEnd();
+    const source = `${req.portSource.slice(0, at)}\n\n${block}${req.portSource.slice(at)}`;
+    return { status: "applied", source, insertedAfter: anchorBefore.name };
+  }
+  if (anchorAfter) {
+    const stmt = topLevelStatement(anchorAfter.fn);
+    const at = stmt.getStart(stmt.getSourceFile());
+    const source = `${req.portSource.slice(0, at)}${block}\n\n${req.portSource.slice(at)}`;
+    return { status: "applied", source, insertedBefore: anchorAfter.name };
+  }
+  const trimmed = req.portSource.replace(/\s*$/, "");
+  return { status: "applied", source: `${trimmed}\n\n${block}\n` };
+}

--- a/scripts/prism-codegen/apply.ts
+++ b/scripts/prism-codegen/apply.ts
@@ -1,5 +1,11 @@
 import ts from "typescript";
-import { indexPortFile, nameCandidates, type GlobalPortIndex } from "./score.js";
+import {
+  crossFileHits,
+  indexPortFile,
+  resolvePortFn,
+  type GlobalPortIndex,
+  type PortIndex,
+} from "./score.js";
 
 /**
  * The draft marker. It is deliberately loud and greppable: a scaffolded body is
@@ -17,13 +23,21 @@ export interface ApplyRequest {
   portFile: string;
   methodName: string;
   globalIndex?: GlobalPortIndex;
+  /** `__PRISM_TODO` passthrough count for this def, from the generator's `perDef` tally. */
+  passthrough?: number;
 }
 
 export type ApplyPlan =
   | { status: "applied"; source: string; insertedAfter?: string; insertedBefore?: string }
   | { status: "refused"; reason: string };
 
-function generatedFunctions(generatedCode: string): { name: string; text: string }[] {
+interface GeneratedDef {
+  name: string;
+  text: string;
+  fn: ts.FunctionLikeDeclaration;
+}
+
+function generatedFunctions(generatedCode: string): GeneratedDef[] {
   const sf = ts.createSourceFile(
     "gen.js",
     generatedCode,
@@ -31,7 +45,7 @@ function generatedFunctions(generatedCode: string): { name: string; text: string
     true,
     ts.ScriptKind.JS,
   );
-  const out: { name: string; text: string }[] = [];
+  const out: GeneratedDef[] = [];
   const visit = (node: ts.Node) => {
     if (
       (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) &&
@@ -39,7 +53,7 @@ function generatedFunctions(generatedCode: string): { name: string; text: string
       ts.isIdentifier(node.name) &&
       node.body
     ) {
-      out.push({ name: node.name.text, text: node.getText(sf).trim() });
+      out.push({ name: node.name.text, text: node.getText(sf).trim(), fn: node });
     }
     ts.forEachChild(node, visit);
   };
@@ -58,29 +72,9 @@ function topLevelStatement(fn: ts.Node): ts.Node {
   return node;
 }
 
-function findLocal(
-  port: ReturnType<typeof indexPortFile>,
-  name: string,
-): ts.FunctionLikeDeclaration | undefined {
-  for (const candidate of nameCandidates(name)) {
-    const found = port.byName.get(candidate);
-    if (found) return found;
-  }
-  return undefined;
-}
-
-function elsewhereHit(
-  globalIndex: GlobalPortIndex | undefined,
-  portFile: string,
-  name: string,
-): string | undefined {
-  if (!globalIndex) return undefined;
-  for (const candidate of nameCandidates(name)) {
-    for (const hit of globalIndex.byName.get(candidate) ?? []) {
-      if (hit.file !== portFile) return hit.file;
-    }
-  }
-  return undefined;
+function localHit(port: PortIndex, def: GeneratedDef): ts.FunctionLikeDeclaration | undefined {
+  const resolved = resolvePortFn(def.name, def.fn, port);
+  return resolved?.fn;
 }
 
 /**
@@ -101,39 +95,53 @@ export function planApply(req: ApplyRequest): ApplyPlan {
     };
   }
 
+  if (req.passthrough) {
+    return {
+      status: "refused",
+      reason:
+        `${req.methodName} generated with ${req.passthrough} passthrough node(s) — the ` +
+        `draft would be riddled with __PRISM_TODO. Port it by hand.`,
+    };
+  }
+
   const port = indexPortFile(req.portSource);
-  if (findLocal(port, req.methodName)) {
+  const target = generated[targetIndex];
+  if (resolvePortFn(target.name, target.fn, port)) {
     return {
       status: "refused",
       reason: `${req.methodName} is already defined in ${req.portFile}.`,
     };
   }
-  const elsewhere = elsewhereHit(req.globalIndex, req.portFile, req.methodName);
-  if (elsewhere) {
+  const elsewhere = req.globalIndex
+    ? [
+        ...new Set(crossFileHits(target.name, target.fn, req.globalIndex).map((h) => h.file)),
+      ].filter((file) => file !== req.portFile)
+    : [];
+  if (elsewhere.length) {
     return {
       status: "refused",
       reason:
-        `${req.methodName} is already ported in ${elsewhere} — scaffolding it into ` +
-        `${req.portFile} would duplicate it.`,
+        `${req.methodName} is already ported in ${elsewhere.join(", ")} — scaffolding it ` +
+        `into ${req.portFile} would duplicate it.`,
     };
   }
 
   const anchorBefore = (() => {
     for (let i = targetIndex - 1; i >= 0; i--) {
-      const fn = findLocal(port, generated[i].name);
+      const fn = localHit(port, generated[i]);
       if (fn) return { name: generated[i].name, fn };
     }
     return undefined;
   })();
   const anchorAfter = (() => {
     for (let i = targetIndex + 1; i < generated.length; i++) {
-      const fn = findLocal(port, generated[i].name);
+      const fn = localHit(port, generated[i]);
       if (fn) return { name: generated[i].name, fn };
     }
     return undefined;
   })();
 
-  const block = `${APPLY_MARKER}\n${generated[targetIndex].text}`;
+  const block = `${APPLY_MARKER}\n${target.text}`;
   if (anchorBefore) {
     const at = topLevelStatement(anchorBefore.fn).getEnd();
     const source = `${req.portSource.slice(0, at)}\n\n${block}${req.portSource.slice(at)}`;

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -21,7 +21,7 @@ export interface GlobalPortIndex {
   byName: Map<string, { fn: ts.FunctionLikeDeclaration; file: string }[]>;
 }
 
-interface PortIndex {
+export interface PortIndex {
   byName: Map<string, ts.FunctionLikeDeclaration>;
 }
 
@@ -313,7 +313,33 @@ export function scoreFile(
   };
 }
 
-function resolvePortFn(
+/**
+ * Every cross-file port symbol a generated def could plausibly be, under the same
+ * name-candidate and arity rules as {@link resolvePortFn}. `resolvePortFn` only
+ * *resolves* an unambiguous hit; `codegen:apply` also needs the ambiguous ones,
+ * so it can refuse instead of scaffolding a probable duplicate.
+ */
+export function crossFileHits(
+  name: string,
+  genFn: ts.FunctionLikeDeclaration,
+  globalIndex: GlobalPortIndex,
+): { fn: ts.FunctionLikeDeclaration; file: string }[] {
+  const out: { fn: ts.FunctionLikeDeclaration; file: string }[] = [];
+  const candidates = nameCandidates(name);
+  for (let i = 0; i < candidates.length; i++) {
+    for (const hit of globalIndex.byName.get(candidates[i]) ?? []) {
+      if (i === 0 || paramCount(hit.fn) === paramCount(genFn)) out.push(hit);
+    }
+  }
+  return out;
+}
+
+/**
+ * The single resolution rule shared by the scorer and `codegen:apply`: a
+ * primary-name hit in the twin file wins, then an arity-agreeing fallback
+ * candidate, then an unambiguous cross-file hit.
+ */
+export function resolvePortFn(
   name: string,
   genFn: ts.FunctionLikeDeclaration,
   port: PortIndex,


### PR DESCRIPTION
Makes the spike's "scaffolding accelerator" verdict operational: `pnpm codegen:apply <rails-file> <method> [--dry-run]` inserts the generated body for one clean def into the Rails twin port file, at the Rails-layout position.

- Insertion point follows generated (Rails) order: after the nearest preceding generated def already ported, else before the nearest following one, else end of file. Anchors on the enclosing top-level statement, so a `export const x = () => …` port symbol is not split.
- Refuses rather than duplicating: the method already defined in the twin file, or resolved by the global port index in **any** other file (the cross-file resolver from #5727), or not emitted cleanly by the generator (any `__PRISM_TODO` passthrough).
- Every insertion carries a loud `// PRISM-CODEGEN DRAFT` marker.

Draft-only contract, documented in `docs/infrastructure/prism-codegen-spike.md`: the command never stages, commits, or formats, and is not wired into any autofix step, lint-staged entry, git hook, or CI job. The porting agent finishes the body against `vendor/rails` under normal test-compare discipline and deletes the marker before committing.

Verified end-to-end against `active_record/persistence.rb`: `becomes` refused (already in the twin), `createOrUpdate` refused (resolves in `callbacks.ts`), `inherited` inserted after `_deleteRecord` (reverted, not committed).

Closes-story: codegen-apply-scaffolding