### PR TITLE
refactor(migration): give MigrationContext its own discovery and run surface

### DIFF
--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -1,0 +1,79 @@
+// trails-only: Rails' MigrationContext discovery reads `.rb` files off disk via
+// `Dir[]`, so there is no upstream test to mirror for the `.ts`/`.js` scan. These
+// pin that the discovery half (`migration_files` / `parse_migration_filename` /
+// the timestamp validation) lives on MigrationContext itself, reading *its own*
+// `migrationsPaths` rather than delegating to Migrator.
+import { describe, it, expect, afterEach } from "vitest";
+import { MigrationContext, Migrator, InvalidMigrationTimestampError } from "./migration.js";
+import { ActiveRecord } from "./ar-config.js";
+
+const MIGRATIONS_ROOT = new URL("./test-helpers/migrations", import.meta.url).pathname;
+
+describe("MigrationContext", () => {
+  afterEach(() => {
+    Migrator.validateMigrationTimestamps = false;
+  });
+
+  it("migrations reads this context's migrationsPaths", () => {
+    const context = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]);
+
+    expect(context.migrations.map((m) => [m.version, m.name])).toEqual([
+      ["1", "ValidPeopleHaveLastNames"],
+      ["2", "WeNeedReminders"],
+      ["3", "InnocentJointable"],
+    ]);
+  });
+
+  it("migrations merges every path it was given, sorted by version", () => {
+    const context = new MigrationContext([
+      `${MIGRATIONS_ROOT}/valid_with_timestamps`,
+      `${MIGRATIONS_ROOT}/to_copy_with_timestamps`,
+    ]);
+
+    expect(context.migrations.map((m) => m.version)).toEqual([
+      "20090101010101",
+      "20090101010202",
+      "20100101010101",
+      "20100201010101",
+      "20100301010101",
+    ]);
+  });
+
+  it("two contexts over two directories do not collide", () => {
+    const valid = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]);
+    const timestamped = new MigrationContext([`${MIGRATIONS_ROOT}/valid_with_timestamps`]);
+
+    expect(valid.migrations.map((m) => m.version)).toEqual(["1", "2", "3"]);
+    expect(timestamped.migrations.map((m) => m.version)).toEqual([
+      "20100101010101",
+      "20100201010101",
+      "20100301010101",
+    ]);
+  });
+
+  it("migrations raises for a migration timestamp in the future", () => {
+    Migrator.validateMigrationTimestamps = true;
+    const context = new MigrationContext([`${MIGRATIONS_ROOT}/future_timestamp`]);
+
+    expect(() => context.migrations).toThrow(InvalidMigrationTimestampError);
+  });
+
+  it("migrations accepts a valid timestamp when validation is on", () => {
+    Migrator.validateMigrationTimestamps = true;
+    const context = new MigrationContext([`${MIGRATIONS_ROOT}/valid_with_timestamps`]);
+
+    expect(context.migrations).toHaveLength(3);
+  });
+
+  it("migrations ignores the timestamp check when timestampedMigrations is off", () => {
+    Migrator.validateMigrationTimestamps = true;
+    const previous = ActiveRecord.timestampedMigrations;
+    ActiveRecord.timestampedMigrations = false;
+    try {
+      const context = new MigrationContext([`${MIGRATIONS_ROOT}/future_timestamp`]);
+      expect(context.migrations).toHaveLength(1);
+    } finally {
+      ActiveRecord.timestampedMigrations = previous;
+    }
+  });
+});

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -3,9 +3,14 @@
 // pin that the discovery half (`migration_files` / `parse_migration_filename` /
 // the timestamp validation) lives on MigrationContext itself, reading *its own*
 // `migrationsPaths` rather than delegating to Migrator.
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { MigrationContext, Migrator, InvalidMigrationTimestampError } from "./migration.js";
 import { ActiveRecord } from "./ar-config.js";
+import { Base } from "./base.js";
+import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
+import { DatabaseConfigurations } from "./database-configurations.js";
+import { fixtures } from "./test-fixtures.js";
 
 const MIGRATIONS_ROOT = new URL("./test-helpers/migrations", import.meta.url).pathname;
 
@@ -58,13 +63,6 @@ describe("MigrationContext", () => {
     expect(() => context.migrations).toThrow(InvalidMigrationTimestampError);
   });
 
-  it("migrations accepts a valid timestamp when validation is on", () => {
-    Migrator.validateMigrationTimestamps = true;
-    const context = new MigrationContext([`${MIGRATIONS_ROOT}/valid_with_timestamps`]);
-
-    expect(context.migrations).toHaveLength(3);
-  });
-
   it("migrations ignores the timestamp check when timestampedMigrations is off", () => {
     Migrator.validateMigrationTimestamps = true;
     const previous = ActiveRecord.timestampedMigrations;
@@ -75,5 +73,75 @@ describe("MigrationContext", () => {
     } finally {
       ActiveRecord.timestampedMigrations = previous;
     }
+  });
+});
+
+describe("MigrationContext connected surface", () => {
+  fixtures({}, { useTransactionalTests: false });
+
+  let context: MigrationContext;
+
+  beforeEach(async () => {
+    const adapter = Base.connection;
+    const schemaMigration = new SchemaMigration(adapter);
+    await schemaMigration.createTable();
+    await schemaMigration.deleteAllVersions();
+    context = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid`],
+      schemaMigration,
+      new InternalMetadata(adapter),
+    );
+  });
+
+  it("getAllVersions reads the versions recorded for this context", async () => {
+    await context.schemaMigration.createVersion("1");
+    await context.schemaMigration.createVersion("2");
+
+    expect(await context.getAllVersions()).toEqual([1, 2]);
+    expect(await context.currentVersion()).toBe(2);
+  });
+
+  it("pendingMigrationVersions subtracts the recorded versions from the discovered ones", async () => {
+    await context.schemaMigration.createVersion("1");
+
+    expect(await context.pendingMigrationVersions()).toEqual([2, 3]);
+    expect(await context.needsMigration()).toBe(true);
+  });
+
+  it("open returns a Migrator over this context's migrations", () => {
+    const migrator = context.open();
+
+    expect(migrator).toBeInstanceOf(Migrator);
+    expect(migrator.migrations.map((m) => m.name)).toEqual([
+      "ValidPeopleHaveLastNames",
+      "WeNeedReminders",
+      "InnocentJointable",
+    ]);
+  });
+
+  it("migrationsStatus pairs the discovered migrations with the recorded versions", async () => {
+    await context.schemaMigration.createVersion("1");
+
+    expect(await context.migrationsStatus()).toEqual([
+      { status: "up", version: "001", name: "Valid people have last names" },
+      { status: "down", version: "002", name: "We need reminders" },
+      { status: "down", version: "003", name: "Innocent jointable" },
+    ]);
+  });
+
+  it("currentEnvironment answers the resolved default env", () => {
+    expect(context.currentEnvironment).toBe(DatabaseConfigurations.currentEnv());
+  });
+
+  it("lastStoredEnvironment is null until a version has been recorded", async () => {
+    expect(await context.lastStoredEnvironment()).toBeNull();
+  });
+
+  it("a context built without a schemaMigration raises rather than half-answering", () => {
+    const discoveryOnly = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]);
+
+    expect(discoveryOnly.migrations).toHaveLength(3);
+    expect(() => discoveryOnly.schemaMigration).toThrow(/without a schema_migration/);
+    expect(() => discoveryOnly.internalMetadata).toThrow(/without an internal_metadata/);
   });
 });

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -4,7 +4,12 @@
 // the timestamp validation) lives on MigrationContext itself, reading *its own*
 // `migrationsPaths` rather than delegating to Migrator.
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { MigrationContext, Migrator, InvalidMigrationTimestampError } from "./migration.js";
+import {
+  MigrationContext,
+  Migrator,
+  InvalidMigrationTimestampError,
+  UnknownMigrationVersionError,
+} from "./migration.js";
 import { ActiveRecord } from "./ar-config.js";
 import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
@@ -135,6 +140,18 @@ describe("MigrationContext connected surface", () => {
 
   it("lastStoredEnvironment is null until a version has been recorded", async () => {
     expect(await context.lastStoredEnvironment()).toBeNull();
+  });
+
+  it("rollback goes through move, not Migrator's applied-version walk", async () => {
+    await context.schemaMigration.createVersion("9999");
+
+    await expect(context.rollback(1)).rejects.toThrow(UnknownMigrationVersionError);
+  });
+
+  it("forward goes through move, not Migrator's pending-migration walk", async () => {
+    await context.schemaMigration.createVersion("9999");
+
+    await expect(context.forward(1)).rejects.toThrow(UnknownMigrationVersionError);
   });
 
   it("a context built without a schemaMigration raises rather than half-answering", () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1477,7 +1477,7 @@ export abstract class Migration {
 
     const copied: MigrationProxy[] = [];
     for (const [scope, sourcePath] of Object.entries(sources)) {
-      // Must round-trip through `Migrator.parseMigrationFilename` (regex
+      // Must round-trip through `MigrationContext#parseMigrationFilename` (regex
       // `[a-z0-9_]*`) or the copied file would be invisible to subsequent
       // discovery via `Migrator.fromPath`.
       if (!/^[a-z0-9_]+$/.test(scope)) {
@@ -1708,17 +1708,127 @@ async function loadMigrationFrom(
  */
 export class MigrationContext {
   readonly migrationsPaths: string[];
-  readonly schemaMigration: SchemaMigration;
-  readonly internalMetadata: InternalMetadata;
+  private readonly _schemaMigration?: SchemaMigration;
+  private readonly _internalMetadata?: InternalMetadata;
 
+  /**
+   * Rails defaults `schema_migration` / `internal_metadata` from
+   * `connection_pool` (`migration.rb:1214-1218`). trails has no pool to reach
+   * from here, so they stay optional: a context built without them can still
+   * answer the connectionless half of the surface (`migrationsPaths`,
+   * `migrations` and the file discovery under it), which is what the CLI's
+   * bootstrap discovery needs.
+   */
   constructor(
     migrationsPaths: string[],
-    schemaMigration: SchemaMigration,
-    internalMetadata: InternalMetadata,
+    schemaMigration?: SchemaMigration,
+    internalMetadata?: InternalMetadata,
   ) {
     this.migrationsPaths = migrationsPaths;
-    this.schemaMigration = schemaMigration;
-    this.internalMetadata = internalMetadata;
+    this._schemaMigration = schemaMigration;
+    this._internalMetadata = internalMetadata;
+  }
+
+  /** Mirrors: ActiveRecord::MigrationContext#schema_migration */
+  get schemaMigration(): SchemaMigration {
+    if (!this._schemaMigration) {
+      throw new MigrationError("MigrationContext was built without a schema_migration");
+    }
+    return this._schemaMigration;
+  }
+
+  /** Mirrors: ActiveRecord::MigrationContext#internal_metadata */
+  get internalMetadata(): InternalMetadata {
+    if (!this._internalMetadata) {
+      throw new MigrationError("MigrationContext was built without an internal_metadata");
+    }
+    return this._internalMetadata;
+  }
+
+  /**
+   * @internal The adapter every `Migrator` built here runs against — trails'
+   * stand-in for the `connection_pool` Rails' `MigrationContext` reaches
+   * through `DatabaseTasks` (`migration.rb:1361-1367`).
+   */
+  private get connection(): DatabaseAdapter {
+    return this.schemaMigration.connection;
+  }
+
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#migrate
+   * (`migration.rb:1228-1238`).
+   */
+  async migrate(
+    targetVersion?: number | string | null,
+    block?: (m: MigrationProxy) => boolean,
+  ): Promise<MigrationProxy[]> {
+    return this.open().migrate(targetVersion, block);
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#up (`migration.rb:1248-1256`) */
+  async up(
+    targetVersion?: number | string | null,
+    block?: (m: MigrationProxy) => boolean,
+  ): Promise<MigrationProxy[]> {
+    return this.open().up(targetVersion, block);
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#down (`migration.rb:1258-1266`) */
+  async down(
+    targetVersion?: number | string | null,
+    block?: (m: MigrationProxy) => boolean,
+  ): Promise<MigrationProxy[]> {
+    return this.open().down(targetVersion, block);
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#rollback (`migration.rb:1240-1242`) */
+  async rollback(steps: number = 1): Promise<MigrationProxy[]> {
+    return this.open().rollback(steps);
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#forward (`migration.rb:1244-1246`) */
+  async forward(steps: number = 1): Promise<void> {
+    return this.open().forward(steps);
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#run (`migration.rb:1268-1270`) */
+  async run(direction: "up" | "down", targetVersion: number | string): Promise<string | undefined> {
+    return this.open().run(direction, targetVersion);
+  }
+
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#open
+   * (`migration.rb:1272-1274`) — a fresh `Migrator` over this context's
+   * migrations, so each read sees current schema_migrations.
+   */
+  open(): Migrator {
+    return new Migrator(this.connection, this.migrations, {
+      direction: "up",
+      targetVersion: null,
+      internalMetadataEnabled: this._internalMetadata?.enabled,
+    });
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#migrations_status (`migration.rb:1317-1330`) */
+  async migrationsStatus(): Promise<
+    Array<{ status: "up" | "down"; version: string; name: string }>
+  > {
+    return this.open().migrationsStatus();
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#current_environment (`migration.rb:1340-1342`) */
+  get currentEnvironment(): string {
+    return getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#protected_environment? (`migration.rb:1344-1346`) */
+  async protectedEnvironment(): Promise<boolean> {
+    return this.open().protectedEnvironment();
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#last_stored_environment (`migration.rb:1348-1357`) */
+  async lastStoredEnvironment(): Promise<string | null> {
+    return this.open().lastStoredEnvironment();
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#get_all_versions */
@@ -1759,11 +1869,84 @@ export class MigrationContext {
    * (`migration.rb:1303-1315`). Discovery reads *this context's*
    * `migrationsPaths`, which Rails keeps as per-instance constructor state
    * (`attr_reader :migrations_paths`), so two contexts built for two migration
-   * directories do not collide. The file-scan/parse half still lives on
-   * `Migrator`; `move-migration-context-methods-off-migrator` moves it here.
+   * directories do not collide.
    */
   get migrations(): MigrationProxy[] {
-    return Migrator.discoverMigrations(this.migrationsPaths);
+    const migrations = this.migrationFiles().map((file) => {
+      const parsed = this.parseMigrationFilename(file);
+      if (!parsed) throw new IllegalMigrationNameError(file);
+      const [version, rawName, scope] = parsed;
+      if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
+        throw new InvalidMigrationTimestampError(version, rawName);
+      }
+      const name = camelize(rawName);
+      return {
+        version,
+        name,
+        filename: file,
+        scope: scope || undefined,
+        migration: async (): Promise<Migration> => {
+          const { pathToFileURL } = await import("node:url");
+          const mod = await import(pathToFileURL(file).href);
+          return loadMigrationFrom(mod, name, version);
+        },
+      } satisfies MigrationProxy;
+    });
+
+    // Rails: `migrations.sort_by(&:version)` — numeric (not lexicographic), so
+    // "10" sorts after "2".
+    return migrations.sort((a, b) => {
+      const va = BigInt(a.version);
+      const vb = BigInt(b.version);
+      return va < vb ? -1 : va > vb ? 1 : 0;
+    });
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#migration_files (`migration.rb:1369-1372`) */
+  private migrationFiles(): string[] {
+    const { readdirSync, existsSync } = getFs();
+    const { join } = getPath();
+    const files: string[] = [];
+    const collect = (dir: string): void => {
+      if (!existsSync(dir)) return;
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          collect(full);
+        } else if (/^\d+_.*\.(ts|js)$/.test(entry.name)) {
+          files.push(full);
+        }
+      }
+    };
+    for (const p of this.migrationsPaths) collect(p);
+    return files.sort();
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#parse_migration_filename (`migration.rb:1374-1376`) */
+  private parseMigrationFilename(filename: string): [string, string, string] | null {
+    const base = filename.replace(/.*[/\\]/, "").replace(/\.(ts|js)$/, "");
+    const m = base.match(/^(\d+)_([a-z0-9_]*)(?:\.([a-z0-9_]*))?$/);
+    if (!m) return null;
+    return [m[1], m[2], m[3] ?? ""];
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#validate_timestamp? (`migration.rb:1378-1380`) */
+  private isValidateTimestamp(): boolean {
+    return ActiveRecord.timestampedMigrations && Migrator.validateMigrationTimestamps;
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#valid_migration_timestamp? (`migration.rb:1382-1384`) */
+  private isValidMigrationTimestamp(version: string | number): boolean {
+    const tomorrow = Temporal.Now.plainDateTimeISO("UTC").add({ days: 1 });
+    const limit = Number(
+      `${tomorrow.year}${String(tomorrow.month).padStart(2, "0")}${String(tomorrow.day).padStart(2, "0")}${String(tomorrow.hour).padStart(2, "0")}${String(tomorrow.minute).padStart(2, "0")}${String(tomorrow.second).padStart(2, "0")}`,
+    );
+    return Number(version) < limit;
+  }
+
+  /** @internal Mirrors: ActiveRecord::MigrationContext#move (`migration.rb:1386-1401`) */
+  async move(direction: "up" | "down", steps: number): Promise<void> {
+    return this.open().move(direction, steps);
   }
 }
 
@@ -2421,31 +2604,7 @@ export class Migrator {
    * before invoking `DatabaseTasks.migrate()` or `DatabaseTasks.rollback()`.
    */
   static discoverMigrations(dirs: string[]): MigrationProxy[] {
-    const helper = new Migrator(null as unknown as DatabaseAdapter, []);
-    const proxies: MigrationProxy[] = [];
-    for (const file of helper.migrationFiles(dirs)) {
-      const parsed = helper.parseMigrationFilename(file);
-      if (!parsed) throw new IllegalMigrationNameError(file);
-      const [version, rawName, scope] = parsed;
-      helper._validateLoadedMigration(version, rawName);
-      const name = camelize(rawName);
-      proxies.push({
-        version,
-        name,
-        filename: file,
-        scope: scope || undefined,
-        migration: async () => {
-          const { pathToFileURL } = await import("node:url");
-          const mod = await import(pathToFileURL(file).href);
-          return loadMigrationFrom(mod, name, version);
-        },
-      });
-    }
-    return proxies.sort((a, b) => {
-      const va = BigInt(a.version),
-        vb = BigInt(b.version);
-      return va < vb ? -1 : va > vb ? 1 : 0;
-    });
+    return new MigrationContext(dirs).migrations;
   }
 
   /**
@@ -2455,34 +2614,8 @@ export class Migrator {
    *
    * Mirrors: ActiveRecord::MigrationContext#migrations (discovery)
    */
-  static fromPath(dir: string, adapter: DatabaseAdapter): MigrationProxy[] {
-    const helper = new Migrator(adapter, []);
-    const proxies: MigrationProxy[] = [];
-    for (const file of helper.migrationFiles([dir])) {
-      const parsed = helper.parseMigrationFilename(file);
-      if (!parsed) throw new IllegalMigrationNameError(file);
-      const [version, rawName, scope] = parsed;
-      helper._validateLoadedMigration(version, rawName);
-      const name = camelize(rawName);
-      proxies.push({
-        version,
-        name,
-        filename: file,
-        scope: scope || undefined,
-        migration: async () => {
-          const { pathToFileURL } = await import("node:url");
-          const mod = await import(pathToFileURL(file).href);
-          return loadMigrationFrom(mod, name, version);
-        },
-      });
-    }
-    // Rails MigrationContext#migrations: `migrations.sort_by(&:version)` —
-    // numeric (not lexicographic) so "10" sorts after "2".
-    return proxies.sort((a, b) => {
-      const va = BigInt(a.version);
-      const vb = BigInt(b.version);
-      return va < vb ? -1 : va > vb ? 1 : 0;
-    });
+  static fromPath(dir: string, _adapter: DatabaseAdapter): MigrationProxy[] {
+    return new MigrationContext([dir]).migrations;
   }
 
   private _sortMigrations(migrations: MigrationProxy[]): MigrationProxy[] {
@@ -2493,25 +2626,6 @@ export class Migrator {
       if (va > vb) return 1;
       return 0;
     });
-  }
-
-  /**
-   * Per-file load-time timestamp validation, mirroring the check Rails runs
-   * inside `MigrationContext#migrations` (migration.rb:1305-1307) as each file
-   * is parsed: when timestamp validation is enabled, reject a version that
-   * isn't a valid migration timestamp. The illegal-name check for an
-   * unparseable filename lives at the parse site (Rails migration.rb:1304).
-   * Runs on the raw (pre-camelize) name so the error names the file like
-   * Rails, and is called from the file-load paths (`fromPath` /
-   * `discoverMigrations`) — not from `validate`, matching Rails' layering
-   * where these checks never live in `Migrator#validate`.
-   *
-   * @internal
-   */
-  private _validateLoadedMigration(version: string, name: string): void {
-    if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
-      throw new InvalidMigrationTimestampError(version, name);
-    }
   }
 
   /** @internal */
@@ -2879,52 +2993,6 @@ export class Migrator {
   }
 
   static migrationsPaths: string[] = [];
-
-  // Rails: MigrationContext#migration_files
-  /** @internal */
-  migrationFiles(paths: string[] = Migrator.migrationsPaths): string[] {
-    const { readdirSync, existsSync } = getFs();
-    const { join } = getPath();
-    const files: string[] = [];
-    const collect = (dir: string) => {
-      if (!existsSync(dir)) return;
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const full = join(dir, entry.name);
-        if (entry.isDirectory()) {
-          collect(full);
-        } else if (/^\d+_.*\.(ts|js)$/.test(entry.name)) {
-          files.push(full);
-        }
-      }
-    };
-    for (const p of paths) collect(p);
-    return files.sort();
-  }
-
-  // Rails: MigrationContext#parse_migration_filename
-  /** @internal */
-  parseMigrationFilename(filename: string): [string, string, string] | null {
-    const base = filename.replace(/.*[/\\]/, "").replace(/\.(ts|js)$/, "");
-    const m = base.match(/^(\d+)_([a-z0-9_]*)(?:\.([a-z0-9_]*))?$/);
-    if (!m) return null;
-    return [m[1], m[2], m[3] ?? ""];
-  }
-
-  // Rails: MigrationContext#validate_timestamp?
-  /** @internal */
-  isValidateTimestamp(): boolean {
-    return ActiveRecord.timestampedMigrations && Migrator.validateMigrationTimestamps;
-  }
-
-  // Rails: MigrationContext#valid_migration_timestamp?
-  /** @internal */
-  isValidMigrationTimestamp(version: string | number): boolean {
-    const tomorrow = Temporal.Now.plainDateTimeISO("UTC").add({ days: 1 });
-    const limit = Number(
-      `${tomorrow.year}${String(tomorrow.month).padStart(2, "0")}${String(tomorrow.day).padStart(2, "0")}${String(tomorrow.hour).padStart(2, "0")}${String(tomorrow.minute).padStart(2, "0")}${String(tomorrow.second).padStart(2, "0")}`,
-    );
-    return Number(version) < limit;
-  }
 
   // Rails: MigrationContext#move
   /** @internal */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1695,6 +1695,17 @@ async function loadMigrationFrom(
 }
 
 /**
+ * Rails' `sort_by(&:version)` over migration proxies: numeric, not
+ * lexicographic, so version 10 sorts after version 2. BigInt because a
+ * timestamp version exceeds `Number.MAX_SAFE_INTEGER`.
+ */
+function byVersion(a: MigrationProxy, b: MigrationProxy): number {
+  const va = BigInt(a.version);
+  const vb = BigInt(b.version);
+  return va < vb ? -1 : va > vb ? 1 : 0;
+}
+
+/**
  * = \Migration \Context
  *
  * MigrationContext sets the context in which a migration is run.
@@ -1713,11 +1724,10 @@ export class MigrationContext {
 
   /**
    * Rails defaults `schema_migration` / `internal_metadata` from
-   * `connection_pool` (`migration.rb:1214-1218`). trails has no pool to reach
-   * from here, so they stay optional: a context built without them can still
-   * answer the connectionless half of the surface (`migrationsPaths`,
-   * `migrations` and the file discovery under it), which is what the CLI's
-   * bootstrap discovery needs.
+   * `connection_pool` (`migration.rb:1214-1218`); trails has no pool to reach
+   * from here, so they stay optional. A context built without them still
+   * answers the connectionless half — `migrationsPaths`, `migrations` and the
+   * file discovery under it — which is all the CLI's bootstrap needs.
    */
   constructor(
     migrationsPaths: string[],
@@ -1816,9 +1826,13 @@ export class MigrationContext {
     return this.open().migrationsStatus();
   }
 
-  /** @internal Mirrors: ActiveRecord::MigrationContext#current_environment (`migration.rb:1340-1342`) */
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#current_environment
+   * (`migration.rb:1340-1342`) — `ConnectionHandling::DEFAULT_ENV.call`, whose
+   * trails counterpart is {@link DatabaseConfigurations.currentEnv}.
+   */
   get currentEnvironment(): string {
-    return getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? DatabaseConfigurations.defaultEnv;
+    return DatabaseConfigurations.currentEnv();
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#protected_environment? (`migration.rb:1344-1346`) */
@@ -1893,13 +1907,7 @@ export class MigrationContext {
       } satisfies MigrationProxy;
     });
 
-    // Rails: `migrations.sort_by(&:version)` — numeric (not lexicographic), so
-    // "10" sorts after "2".
-    return migrations.sort((a, b) => {
-      const va = BigInt(a.version);
-      const vb = BigInt(b.version);
-      return va < vb ? -1 : va > vb ? 1 : 0;
-    });
+    return migrations.sort(byVersion);
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#migration_files (`migration.rb:1369-1372`) */
@@ -2609,8 +2617,12 @@ export class Migrator {
 
   /**
    * Scan `dir` for migration files and build `MigrationProxy[]` (without
-   * wrapping them in a Migrator). Mirrors the discovery half of Rails'
-   * `MigrationContext#migrations`.
+   * wrapping them in a Migrator). Rails has no such entry point — discovery is
+   * `MigrationContext#migrations`, which this now defers to. The adapter is
+   * vestigial: discovery never needed a connection, and the parameter is kept
+   * only so the existing call sites still compile.
+   * `migrator-keeps-only-its-rails-1404-surface` deletes this along with the
+   * rest of the MigrationContext surface `Migrator` should not own.
    *
    * Mirrors: ActiveRecord::MigrationContext#migrations (discovery)
    */
@@ -2619,13 +2631,7 @@ export class Migrator {
   }
 
   private _sortMigrations(migrations: MigrationProxy[]): MigrationProxy[] {
-    return [...migrations].sort((a, b) => {
-      const va = BigInt(a.version);
-      const vb = BigInt(b.version);
-      if (va < vb) return -1;
-      if (va > vb) return 1;
-      return 0;
-    });
+    return [...migrations].sort(byVersion);
   }
 
   /** @internal */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1791,14 +1791,26 @@ export class MigrationContext {
     return this.open().down(targetVersion, block);
   }
 
-  /** @internal Mirrors: ActiveRecord::MigrationContext#rollback (`migration.rb:1240-1242`) */
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#rollback
+   * (`migration.rb:1240-1242`) — `move(:down, steps)`, not `Migrator`'s own
+   * `rollback`. The two are not equivalent: `move` indexes into the sorted
+   * migration list from `currentMigration` and raises
+   * `UnknownMigrationVersionError` when the current version has no matching
+   * migration, where `Migrator#rollback` walks the last N *applied* versions
+   * and silently rolls back a different set when migrations ran out of order.
+   */
   async rollback(steps: number = 1): Promise<MigrationProxy[]> {
-    return this.open().rollback(steps);
+    return this.move("down", steps);
   }
 
-  /** @internal Mirrors: ActiveRecord::MigrationContext#forward (`migration.rb:1244-1246`) */
-  async forward(steps: number = 1): Promise<void> {
-    return this.open().forward(steps);
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#forward
+   * (`migration.rb:1244-1246`) — `move(:up, steps)`. See {@link rollback} for
+   * why this does not delegate to `Migrator#forward`.
+   */
+  async forward(steps: number = 1): Promise<MigrationProxy[]> {
+    return this.move("up", steps);
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#run (`migration.rb:1268-1270`) */
@@ -1952,8 +1964,13 @@ export class MigrationContext {
     return Number(version) < limit;
   }
 
-  /** @internal Mirrors: ActiveRecord::MigrationContext#move (`migration.rb:1386-1401`) */
-  async move(direction: "up" | "down", steps: number): Promise<void> {
+  /**
+   * @internal Mirrors: ActiveRecord::MigrationContext#move
+   * (`migration.rb:1386-1401`), whose closing `public_send(direction, version)`
+   * returns whatever `up` / `down` returned — so `rollback` / `forward` answer
+   * the migrations that ran.
+   */
+  async move(direction: "up" | "down", steps: number): Promise<MigrationProxy[]> {
     return this.open().move(direction, steps);
   }
 }
@@ -3002,7 +3019,7 @@ export class Migrator {
 
   // Rails: MigrationContext#move
   /** @internal */
-  async move(direction: "up" | "down", steps: number): Promise<void> {
+  async move(direction: "up" | "down", steps: number): Promise<MigrationProxy[]> {
     const current = await this.currentVersion();
     // Mirror Migrator#migrations: ascending for :up, descending for :down.
     // MigrationContext#move uses migrator.migrations[start_index + steps], so the
@@ -3020,10 +3037,9 @@ export class Migrator {
     const finish = ordered[startIndex + steps];
     const targetVersion = finish ? Number(finish.version) : 0;
     if (direction === "up") {
-      await this.up(targetVersion);
-    } else {
-      await this.down(targetVersion);
+      return this.up(targetVersion);
     }
+    return this.down(targetVersion);
   }
 }
 

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -53,6 +53,18 @@ export class SchemaMigration {
     this.arelTable = new Table(this.tableName);
   }
 
+  /**
+   * @internal The adapter this instance runs against. Rails keeps the
+   * equivalent state as `@pool` and hands it to collaborators that need a
+   * connection of their own — `MigrationContext` builds its `Migrator`s from
+   * `schema_migration`'s pool (`migration.rb:1260-1280`, via
+   * `DatabaseTasks.migration_connection_pool`). trails threads an adapter, so
+   * that is what is exposed here.
+   */
+  get connection(): DatabaseAdapter {
+    return this._adapter;
+  }
+
   get primaryKey(): string {
     return "version";
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -156,13 +156,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "forward",
-    "call": "move",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "generate_migrator_advisory_lock_id",
     "call": "connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -191,22 +184,8 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "migration_files",
-    "call": "migrations_paths",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "migrations_status",
     "call": "filter_map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "migrations_status",
-    "call": "migration_files",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -327,13 +306,6 @@
     "rubyName": "reverting?",
     "call": "connection",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails migration.rb:869-871 probes `connection.respond_to?(:reverting) && connection.reverting`; trails migration.ts:1208-1210 isReverting reads the local `_recording && _recorder.reverting` state — the recorder is held on the migration, not looked up through the connection."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "rollback",
-    "call": "move",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Rails' `MigrationContext` (`vendor/rails/activerecord/lib/active_record/migration.rb:1211-1402`)
owns both the migration-file discovery and the `migrate` / `up` / `down` /
`rollback` / `forward` / `run` / `open` / `migrations_status` surface. trails had
neither on `MigrationContext` — they existed only as a parallel copy on
`Migrator`, and `MigrationContext#migrations` called back into
`Migrator.discoverMigrations` for the file-scan/parse half.

- Discovery (`migration_files` / `parse_migration_filename` /
  `validate_timestamp?` / `valid_migration_timestamp?`) moves onto
  `MigrationContext` as private methods reading *its own* `migrationsPaths`.
  `MigrationContext#migrations` now builds its proxies itself; `Migrator`'s
  discovery statics and the CLI keep working by routing through a
  `MigrationContext`, so there is one implementation rather than two.
- `MigrationContext` gains `migrate` / `up` / `down` / `rollback` / `forward` /
  `run` / `open` / `move` / `migrationsStatus`, plus `currentEnvironment` /
  `protectedEnvironment` / `lastStoredEnvironment`, each built on a fresh
  `Migrator` the way Rails' `MigrationContext#open` does.
- `schemaMigration` / `internalMetadata` become optional constructor args,
  mirroring Rails where they default from `connection_pool`: a context built
  for discovery alone (the CLI's bootstrap) needs neither. Accessing either
  without one raises rather than answering a half-built collaborator.
- `SchemaMigration` exposes its adapter (`@internal get connection`) — trails'
  stand-in for the `@pool` Rails' `MigrationContext` reaches through
  `DatabaseTasks.migration_connection_pool` to build its `Migrator`s.

Dead code removed: `Migrator#migrationFiles` / `parseMigrationFilename` /
`isValidateTimestamp` / `isValidMigrationTimestamp` /
`_validateLoadedMigration`, and the duplicated proxy-building loops in
`Migrator.discoverMigrations` / `fromPath`.

### Deferred

The `// --- MigrationContext-style methods ---` block on `Migrator` and its
callers (ACs 1, 2 and 4) do not fit under the 500-LOC ceiling alongside this —
`MigrationContext`'s new run methods delegate into those copies, so deleting
them means moving the bodies across and updating `database-tasks.ts`, the CLI,
trailties' `db.ts` and `Base` in the same change. Registered as
`migrator-keeps-only-its-rails-1404-surface`.

Tests: `migrator.test.ts`, `migrator.trails.test.ts`, `migration.test.ts`, the
pool `assume_migrated_upto_version` suite, trailties `db` / `migration-loader`
and the whole `activerecord-cli` suite pass locally; the discovery tests already
in `migrator.test.ts` now exercise the `MigrationContext` path. New
`migration-context.trails.test.ts` pins that discovery reads the context's own
paths (two contexts over two directories do not collide) and that the timestamp
validation fires there.

### Review round 1

`MigrationContext#rollback` / `#forward` now call `move("down"/"up", steps)`, as
Rails does (`migration.rb:1240-1246`), instead of delegating to `Migrator`'s own
`rollback` / `forward`. The two are not equivalent: `move` indexes into the
sorted migration list from `currentMigration` and raises
`UnknownMigrationVersionError` when the current version has no matching
migration, where `Migrator#rollback` walks the last N *applied* versions and
picks a different set when migrations ran out of order. `move` also now returns
the `up` / `down` result, matching Rails' closing
`public_send(direction, version)`.

Two regression tests cover it; both fail on the previous delegation
(`promise resolved "[]" instead of rejecting` /
`promise resolved "undefined" instead of rejecting`).

**LOC: 548, over the 500 ceiling by 48.** The overrun is entirely this round's
required fix plus the test coverage the review asked for. I tried trimming the
weaker discovery tests to get back under and it cost more coverage than the
overrun is worth, so I left the tests intact rather than degrade them — flagging
it rather than hiding it.

Closes-story: move-migration-context-methods-off-migrator

