### PR TITLE
feat(prism-codegen): infer async defs for Rails files with no port twin

### DIFF
--- a/docs/infrastructure/prism-codegen-spike.md
+++ b/docs/infrastructure/prism-codegen-spike.md
@@ -327,7 +327,13 @@ computes at runtime:
    itself async, taken to a fixpoint so the marking propagates up chains of
    same-file callers. The seed is exactly the unambiguous manifest set above, so
    the receiver-blind guard still holds; the pass is skipped whenever a twin
-   exists, since there the port is the authority.
+   exists, since there the port is the authority. The body scan is textual, not
+   a parse: comments and string literals are stripped (`#{}` interpolation is
+   kept — it is real code), but a name reached only through metaprogramming
+   (`send(:perform_save)`) or named inside a heredoc still reads as a call, and
+   the marking is receiver-blind here too. The failure mode is a def marked
+   `async` that emits no `await`, and the fixpoint can propagate that to its
+   same-file callers.
 4. **Ruby stdlib idioms pass through untranslated.** `attributes.collect { }`,
    `arr.first`, `Array(x)`, `raise` — emitted verbatim; no runtime shim.
 5. **Metaprogramming is opaque.** `define_method`, `method_missing`, `send`,

--- a/docs/infrastructure/prism-codegen-spike.md
+++ b/docs/infrastructure/prism-codegen-spike.md
@@ -333,7 +333,11 @@ computes at runtime:
    (`send(:perform_save)`) or named inside a heredoc still reads as a call, and
    the marking is receiver-blind here too. The failure mode is a def marked
    `async` that emits no `await`, and the fixpoint can propagate that to its
-   same-file callers.
+   same-file callers. The body split also assumes a `def` is closed by an `end`
+   at its own column: Ruby's endless-method form (`def name(args) = expr`) has
+   no `end`, so its "body" would run forward to the next same-indent `end` and
+   merge unrelated methods. The vendored Rails corpus has zero such defs today,
+   so this is a latent gap rather than a live one.
 4. **Ruby stdlib idioms pass through untranslated.** `attributes.collect { }`,
    `arr.first`, `Array(x)`, `raise` — emitted verbatim; no runtime shim.
 5. **Metaprogramming is opaque.** `define_method`, `method_missing`, `send`,

--- a/docs/infrastructure/prism-codegen-spike.md
+++ b/docs/infrastructure/prism-codegen-spike.md
@@ -321,7 +321,13 @@ computes at runtime:
    defines async, and that Rails `def`s somewhere in the target set, is awaited
    too — the same unambiguous-global-hit rule the scorer's cross-file fallback
    uses, so a name async in several port files is declined rather than guessed.
-   Remaining limit: files with no port yet fall back to sync.
+   A file with no twin `.ts` at all — the population codegen is most useful for
+   — has no port to read, so it earns its async marking from its own bodies
+   instead (`inferAsyncFromBodies`): a `def` that reaches a known-async name is
+   itself async, taken to a fixpoint so the marking propagates up chains of
+   same-file callers. The seed is exactly the unambiguous manifest set above, so
+   the receiver-blind guard still holds; the pass is skipped whenever a twin
+   exists, since there the port is the authority.
 4. **Ruby stdlib idioms pass through untranslated.** `attributes.collect { }`,
    `arr.first`, `Array(x)`, `raise` — emitted verbatim; no runtime shim.
 5. **Metaprogramming is opaque.** `define_method`, `method_missing`, `send`,

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -93,6 +93,16 @@ export function crossFileAsyncNames(
 const DEF_LINE = /^(\s*)def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)(.*)$/;
 const RUBY_CALL = /[A-Za-z_][\w]*[?!]?/g;
 const RUBY_COMMENT = /#(?!\{).*$/gm;
+const RUBY_DQ_STRING = /"(?:[^"\\]|\\.)*"/g;
+const RUBY_SQ_STRING = /'(?:[^'\\]|\\.)*'/g;
+const RUBY_INTERPOLATION = /#\{([^}]*)\}/g;
+function stripStringLiterals(source: string): string {
+  return source
+    .replace(RUBY_DQ_STRING, (lit) =>
+      [...lit.matchAll(RUBY_INTERPOLATION)].map((m) => m[1]).join(" "),
+    )
+    .replace(RUBY_SQ_STRING, "");
+}
 export interface RubyDefBody {
   name: string;
   body: string;
@@ -103,10 +113,12 @@ export interface RubyDefBody {
  * own column). Rails source is uniformly formatted, so this is enough to ask
  * "what does this method call?" without a parse. A single-line `def x; ...;
  * end` closes on its own line rather than running to the next same-column
- * `end`, and comments are dropped so prose can never name an async method.
+ * `end`. Comments and string literals are dropped first so prose can never
+ * name an async method, but `#{}` interpolation survives — that is real code
+ * and a call inside it is a genuine call.
  */
 export function rubyDefBodies(rubySource: string): RubyDefBody[] {
-  const lines = rubySource.replace(RUBY_COMMENT, "").split("\n");
+  const lines = rubySource.replace(RUBY_COMMENT, "").split("\n").map(stripStringLiterals);
   const bodies: RubyDefBody[] = [];
   for (let i = 0; i < lines.length; i++) {
     const m = DEF_LINE.exec(lines[i]);
@@ -207,13 +219,14 @@ export function asyncMethodsForRailsFile(
 ): Set<string> {
   const short = railsRelPath.replace(/^active_record\//, "");
   const twinTsPath = rubyFileToTs(short);
-  const twinTs = readFileOr(path.join(TRAILS_AR_SRC, twinTsPath));
+  const twinTsAbs = path.join(TRAILS_AR_SRC, twinTsPath);
+  const twinTs = readFileOr(twinTsAbs);
   const relationFamily = short.startsWith("relation/") || short === "relation.rb";
   return resolveAsyncNames({
     twinTs,
     relationTs: relationFamily ? readFileOr(path.join(TRAILS_AR_SRC, "relation.ts")) : undefined,
     ownRubyDefs: relationFamily ? railsDefinedMethods(railsRelPath) : undefined,
     crossFile: crossFileAsyncNames(manifest, { twinTsPath, railsDefs: railsCorpusDefs() }),
-    inferFromRuby: twinTs === "" ? railsSource(railsRelPath) : undefined,
+    inferFromRuby: existsSync(twinTsAbs) ? undefined : railsSource(railsRelPath),
   });
 }

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -11,10 +11,12 @@ export function rubyDefinedMethods(rubySource: string): Set<string> {
   for (const m of rubySource.matchAll(RUBY_DEF)) defs.add(methodName(m[1]));
   return defs;
 }
-function railsDefinedMethods(railsRelPath: string): Set<string> {
+function railsSource(railsRelPath: string): string {
   const abs = path.join(AR_LIB, railsRelPath);
-  if (!existsSync(abs)) return new Set();
-  return rubyDefinedMethods(readFileSync(abs, "utf8"));
+  return existsSync(abs) ? readFileSync(abs, "utf8") : "";
+}
+function railsDefinedMethods(railsRelPath: string): Set<string> {
+  return rubyDefinedMethods(railsSource(railsRelPath));
 }
 const ASYNC_DECL = /\basync\s+(?:function\s+)?([A-Za-z_$][\w$]*)\s*[(<]/g;
 const ASYNC_ARROW = /\b(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*async\b/g;
@@ -88,11 +90,70 @@ export function crossFileAsyncNames(
   }
   return names;
 }
+const DEF_LINE = /^(\s*)def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)(.*)$/;
+const RUBY_CALL = /[A-Za-z_][\w]*[?!]?/g;
+export interface RubyDefBody {
+  name: string;
+  body: string;
+}
+/**
+ * Each `def` in a Ruby file paired with its body text, split on Ruby's
+ * indentation discipline (the `end` that closes a `def` sits at the `def`'s
+ * own column). Rails source is uniformly formatted, so this is enough to ask
+ * "what does this method call?" without a parse.
+ */
+export function rubyDefBodies(rubySource: string): RubyDefBody[] {
+  const lines = rubySource.split("\n");
+  const bodies: RubyDefBody[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = DEF_LINE.exec(lines[i]);
+    if (!m) continue;
+    const [, indent, rubyName, rest] = m;
+    const collected = [rest];
+    const closer = new RegExp(`^${indent}end\\b`);
+    for (let j = i + 1; j < lines.length; j++) {
+      if (closer.test(lines[j])) break;
+      collected.push(lines[j]);
+    }
+    bodies.push({ name: methodName(rubyName), body: collected.join("\n") });
+  }
+  return bodies;
+}
+/**
+ * Async names a file's own defs earn from what their bodies call: a method
+ * that reaches a known-async name is itself async, taken to a fixpoint so the
+ * marking propagates up a chain of same-file callers. Seeded only from
+ * unambiguous manifest hits, so the receiver-blind await rule never fires on a
+ * name that could be two different methods.
+ */
+export function inferAsyncFromBodies(rubySource: string, seed: ReadonlySet<string>): Set<string> {
+  const inferred = new Set<string>();
+  const bodies = rubyDefBodies(rubySource);
+  const reachesAsync = (body: string): boolean => {
+    for (const tok of body.matchAll(RUBY_CALL)) {
+      const name = methodName(tok[0]);
+      if (seed.has(name) || inferred.has(name)) return true;
+    }
+    return false;
+  };
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const { name, body } of bodies) {
+      if (inferred.has(name) || seed.has(name)) continue;
+      if (!reachesAsync(body)) continue;
+      inferred.add(name);
+      changed = true;
+    }
+  }
+  return inferred;
+}
 export function resolveAsyncNames(opts: {
   twinTs: string;
   relationTs?: string;
   ownRubyDefs?: ReadonlySet<string>;
   crossFile?: ReadonlySet<string>;
+  inferFromRuby?: string;
 }): Set<string> {
   const names = extractAsyncNames(opts.twinTs);
   if (opts.relationTs && opts.ownRubyDefs) {
@@ -101,6 +162,9 @@ export function resolveAsyncNames(opts: {
     }
   }
   for (const n of opts.crossFile ?? []) names.add(n);
+  if (opts.inferFromRuby !== undefined) {
+    for (const n of inferAsyncFromBodies(opts.inferFromRuby, names)) names.add(n);
+  }
   return names;
 }
 let manifestCache: AsyncManifest | undefined;
@@ -140,5 +204,8 @@ export function asyncMethodsForRailsFile(
     relationTs: relationFamily ? readFileOr(path.join(TRAILS_AR_SRC, "relation.ts")) : undefined,
     ownRubyDefs: relationFamily ? railsDefinedMethods(railsRelPath) : undefined,
     crossFile: crossFileAsyncNames(manifest, { twinTsPath, railsDefs: railsCorpusDefs() }),
+    // Only an unported file needs the body pass: with a twin `.ts` the port
+    // itself is the authority on which defs are async.
+    inferFromRuby: twinTs === "" ? railsSource(railsRelPath) : undefined,
   });
 }

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -92,6 +92,7 @@ export function crossFileAsyncNames(
 }
 const DEF_LINE = /^(\s*)def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)(.*)$/;
 const RUBY_CALL = /[A-Za-z_][\w]*[?!]?/g;
+const RUBY_COMMENT = /#(?!\{).*$/gm;
 export interface RubyDefBody {
   name: string;
   body: string;
@@ -100,10 +101,12 @@ export interface RubyDefBody {
  * Each `def` in a Ruby file paired with its body text, split on Ruby's
  * indentation discipline (the `end` that closes a `def` sits at the `def`'s
  * own column). Rails source is uniformly formatted, so this is enough to ask
- * "what does this method call?" without a parse.
+ * "what does this method call?" without a parse. A single-line `def x; ...;
+ * end` closes on its own line rather than running to the next same-column
+ * `end`, and comments are dropped so prose can never name an async method.
  */
 export function rubyDefBodies(rubySource: string): RubyDefBody[] {
-  const lines = rubySource.split("\n");
+  const lines = rubySource.replace(RUBY_COMMENT, "").split("\n");
   const bodies: RubyDefBody[] = [];
   for (let i = 0; i < lines.length; i++) {
     const m = DEF_LINE.exec(lines[i]);
@@ -111,9 +114,11 @@ export function rubyDefBodies(rubySource: string): RubyDefBody[] {
     const [, indent, rubyName, rest] = m;
     const collected = [rest];
     const closer = new RegExp(`^${indent}end\\b`);
-    for (let j = i + 1; j < lines.length; j++) {
-      if (closer.test(lines[j])) break;
-      collected.push(lines[j]);
+    if (!/(^|;)\s*end\s*$/.test(rest)) {
+      for (let j = i + 1; j < lines.length; j++) {
+        if (closer.test(lines[j])) break;
+        collected.push(lines[j]);
+      }
     }
     bodies.push({ name: methodName(rubyName), body: collected.join("\n") });
   }
@@ -148,6 +153,11 @@ export function inferAsyncFromBodies(rubySource: string, seed: ReadonlySet<strin
   }
   return inferred;
 }
+/**
+ * The async name set for one Rails file. `inferFromRuby` opts the file into
+ * the body pass and is passed only when the file has no twin `.ts`: with a
+ * port present the port itself is the authority on which defs are async.
+ */
 export function resolveAsyncNames(opts: {
   twinTs: string;
   relationTs?: string;
@@ -204,8 +214,6 @@ export function asyncMethodsForRailsFile(
     relationTs: relationFamily ? readFileOr(path.join(TRAILS_AR_SRC, "relation.ts")) : undefined,
     ownRubyDefs: relationFamily ? railsDefinedMethods(railsRelPath) : undefined,
     crossFile: crossFileAsyncNames(manifest, { twinTsPath, railsDefs: railsCorpusDefs() }),
-    // Only an unported file needs the body pass: with a twin `.ts` the port
-    // itself is the authority on which defs are async.
     inferFromRuby: twinTs === "" ? railsSource(railsRelPath) : undefined,
   });
 }

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -406,6 +406,30 @@ end`;
     expect(code).toContain("await this.performSave(names)");
     expect(code).toContain("await this.touchLater(names)");
   });
+  it("keeps a single-line def's body from running on to the next def", () => {
+    const inferred = inferAsyncFromBodies(
+      `module M
+  def cached?; @cached; end
+
+  def reload
+    perform_save
+  end
+end`,
+      new Set(["performSave"]),
+    );
+    expect(inferred.has("reload")).toBe(true);
+    expect(inferred.has("isCached")).toBe(false);
+  });
+  it("ignores an async name that only appears in a comment", () => {
+    const inferred = inferAsyncFromBodies(
+      `def reset
+  # unlike perform_save, this never touches the database
+  @cache = nil
+end`,
+      new Set(["performSave"]),
+    );
+    expect(inferred.size).toBe(0);
+  });
   it("infers nothing when no body reaches an unambiguous async name", () => {
     const inferred = inferAsyncFromBodies(
       `def reset

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -430,6 +430,28 @@ end`,
     );
     expect(inferred.size).toBe(0);
   });
+  it("ignores an async name that only appears inside a string literal", () => {
+    const inferred = inferAsyncFromBodies(
+      `def reset
+  raise ArgumentError, "cannot perform_save while resetting"
+end
+
+def label
+  'perform_save'
+end`,
+      new Set(["performSave"]),
+    );
+    expect(inferred.size).toBe(0);
+  });
+  it("still infers from a call inside string interpolation", () => {
+    const inferred = inferAsyncFromBodies(
+      `def describe
+  "saved as #{perform_save}"
+end`,
+      new Set(["performSave"]),
+    );
+    expect(inferred.has("describe")).toBe(true);
+  });
   it("infers nothing when no body reaches an unambiguous async name", () => {
     const inferred = inferAsyncFromBodies(
       `def reset

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -8,6 +8,7 @@ import {
   buildAsyncManifest,
   crossFileAsyncNames,
   extractAsyncNames,
+  inferAsyncFromBodies,
   resolveAsyncNames,
   rubyDefinedMethods,
 } from "./async-source.js";
@@ -374,6 +375,45 @@ describe("prism-codegen", () => {
       resolveAsyncNames({ twinTs: `export async function reload() {}`, crossFile }),
     );
     expect(code).toContain("await this.findBy(1)");
+  });
+  it("marks a def in an unported file async when its body reaches a known-async name", async () => {
+    const ruby = `module Touch
+  def touch_later(*names)
+    perform_save(names)
+  end
+
+  def touch_all(*names)
+    touch_later(names)
+  end
+
+  def normalize(names)
+    names.map(&:to_s)
+  end
+end`;
+    const manifest = buildAsyncManifest([
+      { path: "persistence.ts", source: `export async function performSave() {}` },
+    ]);
+    const crossFile = crossFileAsyncNames(manifest, {
+      twinTsPath: "touch.ts",
+      railsDefs: rubyDefinedMethods(`def perform_save; end`),
+    });
+    const names = resolveAsyncNames({ twinTs: "", crossFile, inferFromRuby: ruby });
+    expect(names.has("touchLater")).toBe(true);
+    expect(names.has("touchAll")).toBe(true);
+    expect(names.has("normalize")).toBe(false);
+    const { code } = await generateFromSource(ruby, names);
+    expect(code).toContain("export async function touchLater");
+    expect(code).toContain("await this.performSave(names)");
+    expect(code).toContain("await this.touchLater(names)");
+  });
+  it("infers nothing when no body reaches an unambiguous async name", () => {
+    const inferred = inferAsyncFromBodies(
+      `def reset
+  clear_cache
+end`,
+      new Set(),
+    );
+    expect(inferred.size).toBe(0);
   });
   it("declines the await when a name is async in more than one port file", () => {
     const manifest = buildAsyncManifest([


### PR DESCRIPTION
Closes the last Honest limit in `docs/infrastructure/prism-codegen-spike.md` #3:
a Rails file with no hand-written port emitted a fully sync file, because
`asyncMethodsForRailsFile` seeds from the twin `.ts` and the whole-program
manifest only supplies names that Rails `def`s elsewhere in `TARGET_FILES` —
the file's own defs got no async marking, so `structure.ts` emitted them sync
and `expressions.ts` (gated on `inAsyncMethod`) suppressed every `await`.

## What

- `rubyDefBodies` splits a Ruby file into `def` name + body text on Ruby's
  indentation discipline (the closing `end` sits at the `def`'s own column).
- `inferAsyncFromBodies` takes a fixpoint over those bodies: a def that reaches
  a known-async name is itself async, so the marking propagates up chains of
  same-file callers.
- `resolveAsyncNames` gains `inferFromRuby`; `asyncMethodsForRailsFile` passes
  it only when the twin `.ts` is absent — with a port present, the port is the
  authority on which defs are async.

The receiver-blind guard is preserved: the seed is exactly the existing
unambiguous cross-file manifest set (single async definition, intersected with
Rails defs), so an ambiguous name still never drags an `await` onto the wrong
call.

## Verification

- `pnpm codegen:score`: matched 33 / divergent 297 / 370 rows — identical to
  baseline `main`.
- `pnpm vitest run scripts/prism-codegen/` — 102/102 pass, including 20/20
  `golden.test.ts`.

## The `golden.test.ts` CI failure (resolved)

An earlier CI run on this PR (30715362716) failed `Rails API/Test Comparison`
with 9 `golden.test.ts` snapshot mismatches. That was **not environmental and
not a flake** — it was a genuine breakage on `main`, which this branch merely
inherited:

- `main` at f77afc670 (#5815, the commit that checked these snapshots in — and
  this branch's former base) failed the *same* job with the *same* 9 mismatches:
  run 30714710835, job 91408926519.
- `main` then went red a second time at 803f3c9.
- A central fix has since merged and `main` is green again.

This branch is now rebased onto green `main` (on top of #5815/#5816/#5818) and
the whole prism-codegen suite passes, golden snapshots included. Re-verified
after the rebase: generated output for all 9 targets is byte-identical to the
new `origin/main`, and `codegen:score` is unchanged at 33/297/370 — so this
diff remains inert for ported files and only activates on unported ones.

Closes-story: codegen-async-unported-file-inference
