### PR TITLE
feat(prism-codegen): gate await insertion on the call's receiver

### DIFF
--- a/scripts/prism-codegen/__snapshots__/associations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/associations.js.snap
@@ -34,8 +34,8 @@ eagerAutoload(() => {
     autoload("AliasTracker");
 });
 export async function eagerLoadBang() {
-    await Preloader.eagerLoadBang();
-    return await JoinDependency.eagerLoadBang();
+    Preloader.eagerLoadBang();
+    return JoinDependency.eagerLoadBang();
 }
 export function association(name) {
     let association, reflection;

--- a/scripts/prism-codegen/__snapshots__/core.js.snap
+++ b/scripts/prism-codegen/__snapshots__/core.js.snap
@@ -422,11 +422,11 @@ export async function prettyPrint(pp) {
     }
     return pp.objectAddressGroup(this, () => {
         if (this.attributes) {
-            attr_names = await this.attributesForInspect.select(name => this.is_hasAttribute(name.toString()));
+            attr_names = this.attributesForInspect.select(name => this.is_hasAttribute(name.toString()));
             return pp.seplist(attr_names, this.proc(() => pp.text(",")), attr_name => {
                 attr_name = attr_name.toString();
                 pp.breakable(" ");
-                return await pp.group(1, () => {
+                return pp.group(1, () => {
                     pp.text(attr_name);
                     pp.text(":");
                     pp.breakable();

--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -14,7 +14,7 @@ export async function create(attributes = null, block) {
     }
     else {
         object = this.constructor(attributes, block);
-        await object.save();
+        object.save();
         return object;
     }
 }
@@ -25,7 +25,7 @@ export async function createBang(attributes = null, block) {
     }
     else {
         object = this.constructor(attributes, block);
-        await object.saveBang();
+        object.saveBang();
         return object;
     }
 }
@@ -45,40 +45,40 @@ export function instantiate(attributes, column_types = {}, block) {
 export async function update(id = "all") {
     let object;
     if (id.isA(Array)) {
-        if (await id.isAny(ActiveRecord.Base)) {
+        if (id.isAny(ActiveRecord.Base)) {
             throw new ArgumentError("You are passing an array of ActiveRecord::Base instances to `update`. Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`.");
         }
-        return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => await object.update(attributes[idx]));
+        return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => object.update(attributes[idx]));
     }
     else if (id === "all") {
-        return this.all.each(record => await record.update(attributes));
+        return this.all.each(record => record.update(attributes));
     }
     else {
         if (__PRISM_TODO("CallNode")) {
             throw new ArgumentError("You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.");
         }
         object = this.find(id);
-        await object.update(attributes);
+        object.update(attributes);
         return object;
     }
 }
 export async function updateBang(id = "all") {
     let object;
     if (id.isA(Array)) {
-        if (await id.isAny(ActiveRecord.Base)) {
+        if (id.isAny(ActiveRecord.Base)) {
             throw new ArgumentError("You are passing an array of ActiveRecord::Base instances to `update!`. Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`.");
         }
-        return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => await object.updateBang(attributes[idx]));
+        return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => object.updateBang(attributes[idx]));
     }
     else if (id === "all") {
-        return this.all.each(record => await record.updateBang(attributes));
+        return this.all.each(record => record.updateBang(attributes));
     }
     else {
         if (__PRISM_TODO("CallNode")) {
             throw new ArgumentError("You are passing an instance of ActiveRecord::Base to `update!`. Please pass the id of the object by calling `.id`.");
         }
         object = this.find(id);
-        await object.updateBang(attributes);
+        object.updateBang(attributes);
         return object;
     }
 }
@@ -127,7 +127,7 @@ export async function _updateRecord(values, constraints) {
     um = new Arel.UpdateManager(this.arelTable);
     um.set(values.transformKeys(name => this.arelTable[name]));
     um.wheres = constraints;
-    return this.withConnection(c => await c.update(um, `${this} Update`));
+    return this.withConnection(c => c.update(um, `${this} Update`));
 }
 export async function _deleteRecord(constraints) {
     let default_constraint, current_scope, dm;
@@ -275,7 +275,7 @@ export async function updateColumns(attributes) {
     });
     update_constraints = this._queryConstraintsHash;
     attributes = __PRISM_TODO("CallNode");
-    affected_rows = await this.class()._updateRecord(attributes, update_constraints);
+    affected_rows = this.class()._updateRecord(attributes, update_constraints);
     return affected_rows === 1;
 }
 export function increment(attribute, by = 1) {
@@ -302,7 +302,7 @@ export function toggle(attribute) {
     return this;
 }
 export async function toggleBang(attribute) {
-    return await this.toggle(attribute).updateAttribute(attribute, this[attribute]);
+    return this.toggle(attribute).updateAttribute(attribute, this[attribute]);
 }
 export async function reload(options = null) {
     let fresh_object;
@@ -390,7 +390,7 @@ export function _touchRow(attribute_names, time) {
     return this._updateRow(attribute_names, "touch");
 }
 export async function _updateRow(attribute_names, attempted_action = "update") {
-    return await this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
+    return this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
 }
 export function createOrUpdate({ ...opts } = {}, block) {
     let result;

--- a/scripts/prism-codegen/__snapshots__/relation.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation.js.snap
@@ -92,7 +92,7 @@ export class Relation {
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
-                    return await this.where(attributes).lock().findByBang(attributes);
+                    return this.where(attributes).lock().findByBang(attributes);
                 }
                 else {
                     return await this.findByBang(attributes);
@@ -107,7 +107,7 @@ export class Relation {
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
-                    return await this.where(attributes).lock().findByBang(attributes);
+                    return this.where(attributes).lock().findByBang(attributes);
                 }
                 else {
                     return await this.findByBang(attributes);
@@ -133,7 +133,7 @@ export class Relation {
     }
     async size() {
         if (this.isLoaded) {
-            return await this.records.length();
+            return this.records.length();
         }
         else {
             return this.count("all");
@@ -144,7 +144,7 @@ export class Relation {
             return true;
         }
         if (this.isLoaded) {
-            return await this.records.isEmpty();
+            return this.records.isEmpty();
         }
         else {
             return !this.isExists;
@@ -154,7 +154,7 @@ export class Relation {
         if (this.none) {
             return true;
         }
-        if (await args.isPresent() || block !== undefined) {
+        if (args.isPresent() || block !== undefined) {
             return super(...arguments);
         }
         return this.isEmpty;
@@ -163,7 +163,7 @@ export class Relation {
         if (this.none) {
             return false;
         }
-        if (await args.isPresent() || block !== undefined) {
+        if (args.isPresent() || block !== undefined) {
             return super(...arguments);
         }
         return !this.isEmpty;
@@ -172,11 +172,11 @@ export class Relation {
         if (this.none) {
             return false;
         }
-        if (await args.isPresent() || block !== undefined) {
+        if (args.isPresent() || block !== undefined) {
             return super(...arguments);
         }
         if (this.isLoaded) {
-            return await this.records.isOne();
+            return this.records.isOne();
         }
         return this.limitedCount === 1;
     }
@@ -188,7 +188,7 @@ export class Relation {
             return super(...arguments);
         }
         if (this.isLoaded) {
-            return await this.records.isMany();
+            return this.records.isMany();
         }
         return this.limitedCount > 1;
     }
@@ -199,7 +199,7 @@ export class Relation {
     async computeCacheKey(timestamp_column = "updated_at") {
         let query_signature, key;
         query_signature = ActiveSupport.Digest.hexdigest(this.toSql);
-        key = `${await this.model.modelName().cacheKey()}/query-${query_signature}`;
+        key = `${this.model.modelName().cacheKey()}/query-${query_signature}`;
         if (this.model.collectionCacheVersioning()) {
             return key;
         }
@@ -217,7 +217,7 @@ export class Relation {
         let size, timestamp, collection, column, select_values, query, subquery_alias, subquery_column, arel, column_type;
         timestamp_column = timestamp_column.toString();
         if (this.isLoaded) {
-            size = await this.records.size();
+            size = this.records.size();
             if (size > 0) {
                 timestamp = this.records.map(record => record.readAttribute(timestamp_column)).max();
             }
@@ -228,9 +228,9 @@ export class Relation {
                 column = c.visitor().compile(this.table[timestamp_column]);
                 select_values = `COUNT(*) AS ${this.model.adapterClass().quoteColumnName("size")}, MAX(%s) AS timestamp`;
                 if (collection.hasLimitOrOffset()) {
-                    query = await collection.select(`${column} AS collection_cache_key_timestamp`);
-                    if (this.distinctValue && await collection.selectValues().isEmpty()) {
-                        query._selectBang(this.table[await Arel.star()]);
+                    query = collection.select(`${column} AS collection_cache_key_timestamp`);
+                    if (this.distinctValue && collection.selectValues().isEmpty()) {
+                        query._selectBang(this.table[Arel.star()]);
                     }
                     subquery_alias = "subquery_for_cache_key";
                     subquery_column = `${subquery_alias}.collection_cache_key_timestamp`;
@@ -241,7 +241,7 @@ export class Relation {
                     query.selectValues = [select_values % column];
                     arel = query.arel();
                 }
-                [size, timestamp] = await c.selectRows(arel, null).first();
+                [size, timestamp] = c.selectRows(arel, null).first();
                 if (size) {
                     column_type = this.model.typeForAttribute(timestamp_column);
                     return timestamp = column_type.deserialize(timestamp);
@@ -282,7 +282,7 @@ export class Relation {
     }
     async updateAll(updates) {
         let attr, values, arel, group_values_arel_columns, having_clause_ast, key, stmt;
-        if (await updates.isBlank()) {
+        if (updates.isBlank()) {
             throw new ArgumentError("Empty list of attributes to change");
         }
         if (this.none) {
@@ -302,28 +302,28 @@ export class Relation {
             arel = this.isEagerLoading ? this.applyJoinDependency.arel() : this.buildArel(c);
             arel.source().left = this.table;
             group_values_arel_columns = this.arelColumns(this.groupValues.uniq());
-            if (!await this.havingClause.isEmpty()) {
+            if (!this.havingClause.isEmpty()) {
                 having_clause_ast = this.havingClause.ast();
             }
             key = this.model.isCompositePrimaryKey() ? this.model.primaryKey.map(pk => this.table[pk]) : this.table[this.model.primaryKey];
             stmt = arel.compileUpdate(values, key, having_clause_ast, group_values_arel_columns);
-            return (await c.update(stmt, `${this.model} Update All`)).tap(() => this.reset);
+            return c.update(stmt, `${this.model} Update All`).tap(() => this.reset);
         });
     }
     async update(id = "all") {
         if (id === "all") {
-            return this.records.each(record => await record.update(attributes));
+            return this.records.each(record => record.update(attributes));
         }
         else {
-            return await this.model.update(id, attributes);
+            return this.model.update(id, attributes);
         }
     }
     async updateBang(id = "all") {
         if (id === "all") {
-            return this.records.each(record => await record.updateBang(attributes));
+            return this.records.each(record => record.updateBang(attributes));
         }
         else {
-            return await this.model.updateBang(id, attributes);
+            return this.model.updateBang(id, attributes);
         }
     }
     async insert(attributes, { returning = null, unique_by = null, record_timestamps = null } = {}) {
@@ -346,7 +346,7 @@ export class Relation {
     }
     async updateCounters(counters) {
         let touch, updates, attr, names, options, touch_updates;
-        touch = await counters.delete("touch");
+        touch = counters.delete("touch");
         updates = {};
         counters.each((counter_name, value) => {
             attr = this.table[counter_name];
@@ -359,7 +359,7 @@ export class Relation {
             names = Array.wrap(names);
             options = names.extractOptionsBang();
             touch_updates = this.model.touchAttributesWithTime(...names, { ...options });
-            if (!await touch_updates.isEmpty()) {
+            if (!touch_updates.isEmpty()) {
                 updates.mergeBang(touch_updates);
             }
         }
@@ -376,51 +376,51 @@ export class Relation {
         if (this.none) {
             return 0;
         }
-        invalid_methods = await INVALID_METHODS_FOR_DELETE_ALL.select(method => {
+        invalid_methods = INVALID_METHODS_FOR_DELETE_ALL.select(method => {
             value = this.values[method];
             if (method === "distinct") {
                 return value;
             }
             else {
-                return await value.isAny();
+                return value.isAny();
             }
         });
-        if (await invalid_methods.isAny()) {
+        if (invalid_methods.isAny()) {
             throw new ActiveRecordError(`delete_all doesn't support ${invalid_methods.join(", ")}`);
         }
         return this.model.withConnection(c => {
             arel = this.isEagerLoading ? this.applyJoinDependency.arel() : this.buildArel(c);
             arel.source().left = this.table;
             group_values_arel_columns = this.arelColumns(this.groupValues.uniq());
-            if (!await this.havingClause.isEmpty()) {
+            if (!this.havingClause.isEmpty()) {
                 having_clause_ast = this.havingClause.ast();
             }
             key = this.model.isCompositePrimaryKey() ? this.model.primaryKey.map(pk => this.table[pk]) : this.table[this.model.primaryKey];
             stmt = arel.compileDelete(key, having_clause_ast, group_values_arel_columns);
-            return (await c.delete(stmt, `${this.model} Delete All`)).tap(() => this.reset);
+            return c.delete(stmt, `${this.model} Delete All`).tap(() => this.reset);
         });
     }
     async delete(id_or_array) {
-        if (id_or_array.nil() || (id_or_array.isA(Array) && await id_or_array.isEmpty())) {
+        if (id_or_array.nil() || (id_or_array.isA(Array) && id_or_array.isEmpty())) {
             return 0;
         }
-        return await this.where({ [this.model.primaryKey()]: id_or_array }).deleteAll();
+        return this.where({ [this.model.primaryKey()]: id_or_array }).deleteAll();
     }
     async destroy(id) {
         let multiple_ids;
-        multiple_ids = this.model.isCompositePrimaryKey() ? (await id.first()).isA(Array) : id.isA(Array);
+        multiple_ids = this.model.isCompositePrimaryKey() ? id.first().isA(Array) : id.isA(Array);
         if (multiple_ids) {
             return this.find(id).each(x => x.destroy());
         }
         else {
-            return await this.find(id).destroy();
+            return this.find(id).destroy();
         }
     }
     async destroyBy(...args) {
-        return await this.where(...args).destroyAll();
+        return this.where(...args).destroyAll();
     }
     async deleteBy(...args) {
-        return await this.where(...args).deleteAll();
+        return this.where(...args).deleteAll();
     }
     loadAsync() {
         let result;
@@ -502,19 +502,19 @@ export class Relation {
         let subject, entries;
         subject = this.isLoaded ? this.records : this.annotate("loading for pp");
         entries = subject.take([this.limitValue, 11].compact().min());
-        if (await entries.size() === 11) {
+        if (entries.size() === 11) {
             entries[10] = "...";
         }
         return pp.pp(entries);
     }
     async isBlank() {
-        return await this.records.isBlank();
+        return this.records.isBlank();
     }
     isReadonly() {
         return this.readonlyValue;
     }
     async values() {
-        return await this.values.dup();
+        return this.values.dup();
     }
     valuesForQueries() {
         return this.values.except("extending", "skip_query_cache", "strict_loading");
@@ -523,7 +523,7 @@ export class Relation {
         let subject, entries;
         subject = this.isLoaded ? this.records : this.annotate("loading for inspect");
         entries = subject.take([this.limitValue, 11].compact().min()).mapBang(x => x.inspect());
-        if (await entries.size() === 11) {
+        if (entries.size() === 11) {
             entries[10] = "...";
         }
         return `#<${this.class().name()} [${entries.join(", ")}]>`;

--- a/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
@@ -71,7 +71,7 @@ export function asyncMaximum(column_name) {
 }
 export async function sum(initial_value_or_column = 0, block) {
     if (block !== undefined) {
-        return await this.map(block).sum(initial_value_or_column);
+        return this.map(block).sum(initial_value_or_column);
     }
     else {
         return await this.calculate("sum", initial_value_or_column);
@@ -85,11 +85,11 @@ export async function calculate(operation, column_name) {
     operation = operation.toString().downcase();
     if (this.none) {
         if (caseEq("count", operation) || caseEq("sum", operation)) {
-            result = await this.groupValues.isAny() ? new Hash() : 0;
+            result = this.groupValues.isAny() ? new Hash() : 0;
             return this.async ? new Promise.Complete(result) : result;
         }
         else if (caseEq("average", operation) || caseEq("minimum", operation) || caseEq("maximum", operation)) {
-            result = await this.groupValues.isAny() ? new Hash() : null;
+            result = this.groupValues.isAny() ? new Hash() : null;
             return this.async ? new Promise.Complete(result) : result;
         }
     }
@@ -104,7 +104,7 @@ export async function calculate(operation, column_name) {
                 relation.orderValues = [];
             }
         }
-        return await relation.calculate(operation, column_name);
+        return relation.calculate(operation, column_name);
     }
     else {
         return this.performCalculation(operation, column_name);
@@ -121,7 +121,7 @@ export async function pluck(...column_names) {
         }
     }
     if (this.isLoaded && this.isAllAttributes(column_names)) {
-        result = await this.records.pluck(...column_names);
+        result = this.records.pluck(...column_names);
         if (this.async) {
             return new Promise.Complete(result);
         }
@@ -131,7 +131,7 @@ export async function pluck(...column_names) {
     }
     if (this.hasInclude(column_names.first())) {
         relation = this.applyJoinDependency;
-        return await relation.pluck(...column_names);
+        return relation.pluck(...column_names);
     }
     else {
         this.model.disallowRawSqlBang(this.flattenedArgs(column_names));
@@ -155,10 +155,10 @@ export function asyncPluck(...column_names) {
 export async function pick(...column_names) {
     let result;
     if (this.isLoaded && this.isAllAttributes(column_names)) {
-        result = await this.records.pick(...column_names);
+        result = this.records.pick(...column_names);
         return this.async ? new Promise.Complete(result) : result;
     }
-    return (await this.limit(1).pluck(...column_names)).then(x => x.first());
+    return this.limit(1).pluck(...column_names).then(x => x.first());
 }
 export function asyncPick(...column_names) {
     return this.async.pick(...column_names);
@@ -168,7 +168,7 @@ export async function ids() {
     primary_key_array = this.Array(this.model.primaryKey);
     if (this.isLoaded) {
         result = this.records.map(record => {
-            if (await primary_key_array.isOne()) {
+            if (primary_key_array.isOne()) {
                 return record._readAttribute(primary_key_array.first());
             }
             else {
@@ -178,8 +178,8 @@ export async function ids() {
         return this.async ? new Promise.Complete(result) : result;
     }
     if (this.hasInclude(this.model.primaryKey)) {
-        relation = await this.applyJoinDependency.group(...primary_key_array);
-        return await relation.ids();
+        relation = this.applyJoinDependency.group(...primary_key_array);
+        return relation.ids();
     }
     columns = this.arelColumns(primary_key_array);
     relation = this.spawn;

--- a/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
@@ -15,10 +15,10 @@ export async function find(...args, block) {
     return await this.findWithIds(...args);
 }
 export async function findBy(arg, ...args) {
-    return await this.where(arg, ...args).take();
+    return this.where(arg, ...args).take();
 }
 export async function findByBang(arg, ...args) {
-    return await this.where(arg, ...args).takeBang();
+    return this.where(arg, ...args).takeBang();
 }
 export async function take(limit = null) {
     if (limit) {
@@ -45,7 +45,7 @@ export async function sole() {
     }
 }
 export async function findSoleBy(arg, ...args) {
-    return await this.where(arg, ...args).sole();
+    return this.where(arg, ...args).sole();
 }
 export async function first(limit = null) {
     if (limit) {
@@ -69,7 +69,7 @@ export async function last(limit = null) {
         return result.reverse();
     }
     else {
-        return await result.first();
+        return result.first();
     }
 }
 export async function lastBang() {
@@ -222,12 +222,12 @@ export async function findWithIds(...ids) {
     if (this.model.primaryKey.nil()) {
         throw new UnknownPrimaryKey(this.model);
     }
-    expects_array = this.model.isCompositePrimaryKey() ? (await (await ids.first()).first()).isA(Array) : (await ids.first()).isA(Array);
-    if (expects_array && (await ids.first()).isEmpty()) {
+    expects_array = this.model.isCompositePrimaryKey() ? ids.first().first().isA(Array) : ids.first().isA(Array);
+    if (expects_array && ids.first().isEmpty()) {
         return [];
     }
     if (expects_array) {
-        ids = await ids.first();
+        ids = ids.first();
     }
     ids = ids.compact().uniq();
     model_name = this.model.name();
@@ -236,7 +236,7 @@ export async function findWithIds(...ids) {
         throw new RecordNotFound(error_message, model_name, this.model.primaryKey);
     }
     else if (caseEq(1, ids.size())) {
-        result = await this.findOne(await ids.first());
+        result = await this.findOne(ids.first());
         if (expects_array) {
             return [result];
         }
@@ -254,7 +254,7 @@ export async function findOne(id) {
         throw new ArgumentError("            You are passing an instance of ActiveRecord::Base to `find`.\n            Please pass the id of the object by calling `.id`.\n".squish());
     }
     relation = this.model.isCompositePrimaryKey() ? this.where(this.model.primaryKey.zip(id).toH()) : this.where({ [this.model.primaryKey]: id });
-    record = await relation.take();
+    record = relation.take();
     if (!record) {
         this.raiseRecordNotFoundExceptionBang(id, 0, 1);
     }
@@ -262,12 +262,12 @@ export async function findOne(id) {
 }
 export async function findSome(ids) {
     let relation, result, expected_size;
-    if (!await this.orderValues.isPresent()) {
+    if (!this.orderValues.isPresent()) {
         return await this.findSomeOrdered(ids);
     }
     relation = this.where({ [this.model.primaryKey]: ids });
     if (!this.selectValues.isEmpty()) {
-        relation = await relation.select(this.table[this.model.primaryKey]);
+        relation = relation.select(this.table[this.model.primaryKey]);
     }
     result = relation.toA();
     expected_size = this.limitValue && ids.size() > this.limitValue ? this.limitValue : ids.size();
@@ -287,7 +287,7 @@ export async function findSomeOrdered(ids) {
     relation = this.except("limit", "offset");
     relation = relation.where({ [this.model.primaryKey]: ids });
     if (!this.selectValues.isEmpty()) {
-        relation = await relation.select(this.table[this.model.primaryKey]);
+        relation = relation.select(this.table[this.model.primaryKey]);
     }
     result = relation.records();
     if (result.size() === ids.size()) {
@@ -299,15 +299,15 @@ export async function findSomeOrdered(ids) {
 }
 export async function findTake() {
     if (this.isLoaded) {
-        return await this.records.first();
+        return this.records.first();
     }
     else {
-        return this.take ||= await this.limit(1).records().first();
+        return this.take ||= this.limit(1).records().first();
     }
 }
 export async function findTakeWithLimit(limit) {
     if (this.isLoaded) {
-        return await this.records.take(limit);
+        return this.records.take(limit);
     }
     else {
         return this.limit(limit).toA();
@@ -315,7 +315,7 @@ export async function findTakeWithLimit(limit) {
 }
 export async function findNth(index) {
     this.offsets ||= {};
-    return this.offsets[index] ||= await (await this.findNthWithLimit(index, 1)).first();
+    return this.offsets[index] ||= (await this.findNthWithLimit(index, 1)).first();
 }
 export async function findNthWithLimit(index, limit) {
     let relation;
@@ -349,16 +349,16 @@ export async function findNthFromLast(index) {
             return relation.records()[-index];
         }
         else {
-            return await relation.reverseOrder().offset(index - 1).first();
+            return relation.reverseOrder().offset(index - 1).first();
         }
     }
 }
 export async function findLast(limit) {
     if (limit) {
-        return await this.records.last(limit);
+        return this.records.last(limit);
     }
     else {
-        return await this.records.last();
+        return this.records.last();
     }
 }
 export function orderedRelation() {

--- a/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
@@ -123,7 +123,7 @@ export function referencesBang(...table_names) {
 }
 export async function select(...fields, block) {
     if (block !== undefined) {
-        if (await fields.isAny()) {
+        if (fields.isAny()) {
             throw new ArgumentError("`select' with block doesn't take arguments.");
         }
         return __PRISM_TODO("SuperNode");

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -1,29 +1,23 @@
 import type { PrismNode } from "./types.js";
 
 /**
+ * Whether a generated call gets an `await`.
+ *
  * The async manifest resolves names, not methods: two Rails files can define
  * the same `def`, and a call like `ids.first` or `record.update` names an
  * async port method while targeting something else entirely. Awaiting those is
- * a no-op today only because the generated output is never executed — once it
- * is applied, an await in a sync path is a behavioural change. So the await
- * rule is narrowed to the receivers whose identity the AST actually pins down:
- * an implicit self-call, or an explicit `self.`. Anything reached through a
- * local, a param, an ivar, a constant, or a chain is left bare.
+ * a no-op only for as long as the generated output is never executed — once it
+ * is applied, an await in a sync path is a behavioural change. So the rule is
+ * narrowed to the receivers the AST actually pins down: an implicit self-call,
+ * or an explicit `self.`. Anything reached through a local, a param, an ivar,
+ * a constant, or a call chain is left bare.
  */
-export type AwaitReceiver = "self" | "other";
-
-export function awaitReceiverKind(receiver: PrismNode | null | undefined): AwaitReceiver {
-  if (!receiver) return "self";
-  return receiver.constructor?.name === "SelfNode" ? "self" : "other";
-}
-
 export function shouldAwaitCall(opts: {
   receiver: PrismNode | null | undefined;
   jsName: string;
   inAsyncMethod: boolean;
   asyncMethods: ReadonlySet<string>;
 }): boolean {
-  if (!opts.inAsyncMethod) return false;
-  if (!opts.asyncMethods.has(opts.jsName)) return false;
-  return awaitReceiverKind(opts.receiver) === "self";
+  if (!opts.inAsyncMethod || !opts.asyncMethods.has(opts.jsName)) return false;
+  return !opts.receiver || opts.receiver.constructor?.name === "SelfNode";
 }

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -1,0 +1,29 @@
+import type { PrismNode } from "./types.js";
+
+/**
+ * The async manifest resolves names, not methods: two Rails files can define
+ * the same `def`, and a call like `ids.first` or `record.update` names an
+ * async port method while targeting something else entirely. Awaiting those is
+ * a no-op today only because the generated output is never executed — once it
+ * is applied, an await in a sync path is a behavioural change. So the await
+ * rule is narrowed to the receivers whose identity the AST actually pins down:
+ * an implicit self-call, or an explicit `self.`. Anything reached through a
+ * local, a param, an ivar, a constant, or a chain is left bare.
+ */
+export type AwaitReceiver = "self" | "other";
+
+export function awaitReceiverKind(receiver: PrismNode | null | undefined): AwaitReceiver {
+  if (!receiver) return "self";
+  return receiver.constructor?.name === "SelfNode" ? "self" : "other";
+}
+
+export function shouldAwaitCall(opts: {
+  receiver: PrismNode | null | undefined;
+  jsName: string;
+  inAsyncMethod: boolean;
+  asyncMethods: ReadonlySet<string>;
+}): boolean {
+  if (!opts.inAsyncMethod) return false;
+  if (!opts.asyncMethods.has(opts.jsName)) return false;
+  return awaitReceiverKind(opts.receiver) === "self";
+}

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -91,6 +91,25 @@ describe("prism-codegen", () => {
     expect(code).toContain("export function name(");
     expect(code).not.toContain("await this.log");
   });
+  it("awaits self-calls but leaves a same-named call on an unrelated receiver bare", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(ids)
+          first
+          self.first
+          ids.first
+          @scope.first
+          ids.first.first
+        end
+      end`,
+      new Set(["first", "loadAll"]),
+    );
+    expect(code).toContain("await this.first()");
+    expect(code).toContain("ids.first()");
+    expect(code).not.toContain("await ids.first()");
+    expect(code).not.toContain("await this.scope.first()");
+    expect(code).not.toContain("await ids.first().first()");
+  });
   it("never awaits async-named calls inside a sync method", async () => {
     const { code } = await generateFromSource(
       `module M

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -273,7 +273,7 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
   if (!recv && callArgs.length === 0 && !block && !hasParens(n)) return target;
   const call = f.createCallExpression(target, undefined, callArgs);
   return shouldAwaitCall({
-    receiver: hasRecv ? (n.receiver as PrismNode) : null,
+    receiver: n.receiver as PrismNode | null,
     jsName,
     inAsyncMethod: e.inAsyncMethod,
     asyncMethods: e.asyncMethods,

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -4,6 +4,7 @@ import type { Registry } from "../registry.js";
 import { methodName, isJsIdentName, isBindableIdent } from "../naming.js";
 import { rubyStr } from "../types.js";
 import { TOPLEVEL } from "../codegen.js";
+import { shouldAwaitCall } from "../await-policy.js";
 const f = ts.factory;
 const INFIX: Record<string, ts.BinaryOperator> = {
   "==": ts.SyntaxKind.EqualsEqualsEqualsToken,
@@ -271,7 +272,14 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
       : f.createIdentifier(jsName);
   if (!recv && callArgs.length === 0 && !block && !hasParens(n)) return target;
   const call = f.createCallExpression(target, undefined, callArgs);
-  return e.inAsyncMethod && e.asyncMethods.has(jsName) ? f.createAwaitExpression(call) : call;
+  return shouldAwaitCall({
+    receiver: hasRecv ? (n.receiver as PrismNode) : null,
+    jsName,
+    inAsyncMethod: e.inAsyncMethod,
+    asyncMethods: e.asyncMethods,
+  })
+    ? f.createAwaitExpression(call)
+    : call;
 }
 function symToProcArrow(prop: string): ts.ArrowFunction {
   return f.createArrowFunction(


### PR DESCRIPTION
`crossFileAsyncNames` resolves *names*, not methods: any call whose name is
async in exactly one port file and `def`ed somewhere in `TARGET_FILES` got an
`await`, regardless of what it was called on. That put `await` on
`ids.first()`, `args.isPresent()`, `record.update(...)`, `Arel.star()` and
friends — a no-op today only because the generated output is never executed,
but a behavioural change the moment codegen output is applied.

Await insertion now consults the receiver the generated AST actually pins
down: an implicit self-call or an explicit `self.` receiver stays eligible;
anything reached through a local, param, ivar, constant, or call chain is left
bare. The policy lives in `await-policy.ts` so the rule has one home.

Effect on the checked-in goldens: 64 bogus `await`s removed, none added.
`pnpm codegen:score` matched count is unchanged (33 with and without the
change, measured on this base) — the scorer's skeleton tokens ignore `await`.

Rebased onto #5816/#5818. An earlier commit here refreshed goldens that were
stale on `main`; those landed independently, so it was dropped in the rebase
and the snapshot diff is now purely await-removals.

Closes-story: codegen-await-receiver-awareness
