### PR TITLE
fix(prism-codegen): regenerate goldens for the async manifest

### DIFF
--- a/scripts/prism-codegen/__snapshots__/associations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/associations.js.snap
@@ -77,7 +77,7 @@ export function hasOne(name, scope = null, { ...options } = {}) {
     reflection = Builder.HasOne.build(this, name, scope, options);
     return Reflection.addReflection(this, name, reflection);
 }
-export function belongsTo(name, scope = null, { ...options } = {}) {
+export async function belongsTo(name, scope = null, { ...options } = {}) {
     let reflection;
     reflection = Builder.BelongsTo.build(this, name, scope, options);
     return Reflection.addReflection(this, name, reflection);

--- a/scripts/prism-codegen/__snapshots__/core.js.snap
+++ b/scripts/prism-codegen/__snapshots__/core.js.snap
@@ -178,7 +178,7 @@ export async function find(...ids, block) {
     }
     return await this.cachedFindBy([this.primaryKey], [id]) || (() => { throw new RecordNotFound(`Couldn't find ${this.name} with '${this.primaryKey}'=${id}`, this.name, this.primaryKey, id); })();
 }
-export function findBy(...args) {
+export async function findBy(...args) {
     let hash;
     if (this.isScopeAttributes) {
         return __PRISM_TODO("ForwardingSuperNode");
@@ -188,10 +188,10 @@ export function findBy(...args) {
         return __PRISM_TODO("ForwardingSuperNode");
     }
     hash = __PRISM_TODO("CallNode");
-    return this.cachedFindBy(hash.keys(), hash.values());
+    return await this.cachedFindBy(hash.keys(), hash.values());
 }
-export function findByBang(...args) {
-    return this.findBy(...args) || this.where(...args).raiseRecordNotFoundExceptionBang();
+export async function findByBang(...args) {
+    return await this.findBy(...args) || this.where(...args).raiseRecordNotFoundExceptionBang();
 }
 export function initializeGeneratedModules() {
     return this.generatedAssociationMethods;
@@ -219,7 +219,7 @@ export function inspectionFilter() {
         return this.inspection_filter ||= __PRISM_TODO("BeginNode");
     }
 }
-export function inspect() {
+export async function inspect() {
     let attr_list;
     if (this === Base || this.isSingletonClass) {
         return __PRISM_TODO("ForwardingSuperNode");
@@ -253,7 +253,7 @@ export function cachedFindByStatement(connection, key, block) {
     return cache.computeIfAbsent(key, () => StatementCache.create(connection, block));
 }
 __PRISM_TODO("CallNode");
-export function inherited(subclass) {
+export async function inherited(subclass) {
     let klass;
     subclass.initializeFindByCache();
     if (!subclass.isBaseClass()) {
@@ -359,7 +359,7 @@ export function encodeWith(coder) {
 }
 __PRISM_TODO("DefNode");
 __PRISM_TODO("AliasMethodNode");
-export function hash() {
+export async function hash() {
     let id;
     id = this.id();
     if (this.isPrimaryKeyValuesPresent) {
@@ -377,7 +377,7 @@ export function isFrozen() {
     return this.attributes.isFrozen();
 }
 __PRISM_TODO("DefNode");
-export function isPresent() {
+export async function isPresent() {
     return true;
 }
 export function isBlank() {
@@ -409,7 +409,7 @@ export function readonlyBang() {
 export function connectionHandler() {
     return this.class().connectionHandler();
 }
-export function inspect() {
+export async function inspect() {
     return this.inspectWithAttributes(this.attributesForInspect);
 }
 export function fullInspect() {
@@ -422,11 +422,11 @@ export async function prettyPrint(pp) {
     }
     return pp.objectAddressGroup(this, () => {
         if (this.attributes) {
-            attr_names = this.attributesForInspect.select(name => this.is_hasAttribute(name.toString()));
+            attr_names = await this.attributesForInspect.select(name => this.is_hasAttribute(name.toString()));
             return pp.seplist(attr_names, this.proc(() => pp.text(",")), attr_name => {
                 attr_name = attr_name.toString();
                 pp.breakable(" ");
-                return pp.group(1, () => {
+                return await pp.group(1, () => {
                     pp.text(attr_name);
                     pp.text(":");
                     pp.breakable();

--- a/scripts/prism-codegen/__snapshots__/inheritance.js.snap
+++ b/scripts/prism-codegen/__snapshots__/inheritance.js.snap
@@ -99,7 +99,7 @@ export function polymorphicClassFor(name) {
         return this.computeType(name);
     }
 }
-export function dup() {
+export async function dup() {
     let other;
     other = __PRISM_TODO("ForwardingSuperNode");
     other.setBaseClass();
@@ -136,7 +136,7 @@ export function setBaseClass() {
     return this.base_class = __PRISM_TODO("IfNode");
 }
 __PRISM_TODO("CallNode");
-export function inherited(subclass) {
+export async function inherited(subclass) {
     subclass.setBaseClass();
     subclass.instanceVariableSet("@_type_candidates_cache", new Concurrent.Map());
     return subclass.classEval(() => this.finder_needs_type_condition = null);

--- a/scripts/prism-codegen/__snapshots__/model-schema.js.snap
+++ b/scripts/prism-codegen/__snapshots__/model-schema.js.snap
@@ -114,7 +114,7 @@ export function isTableExists() {
 export function attributesBuilder() {
     return this.attributes_builder ||= __PRISM_TODO("BeginNode");
 }
-export function columnsHash() {
+export async function columnsHash() {
     if (!this.columns_hash) {
         this.loadSchema;
     }
@@ -129,7 +129,7 @@ export function _returningColumnsForInsert(connection) {
 export function yamlEncoder() {
     return this.yaml_encoder ||= new ActiveModel.AttributeSet.YAMLEncoder(this.attributeTypes);
 }
-export function columnForAttribute(name) {
+export async function columnForAttribute(name) {
     name = name.toString();
     return this.columnsHash.fetch(name, () => new ConnectionAdapters.NullColumn(name));
 }
@@ -194,7 +194,7 @@ export function reloadSchemaFromCache(recursive = true) {
     }
 }
 __PRISM_TODO("CallNode");
-export function inherited(child_class) {
+export async function inherited(child_class) {
     child_class.initializeLoadSchemaMonitor();
     child_class.reloadSchemaFromCache(false);
     return child_class.classEval(() => this.ignored_columns = null);

--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -45,7 +45,7 @@ export function instantiate(attributes, column_types = {}, block) {
 export async function update(id = "all") {
     let object;
     if (id.isA(Array)) {
-        if (id.isAny(ActiveRecord.Base)) {
+        if (await id.isAny(ActiveRecord.Base)) {
             throw new ArgumentError("You are passing an array of ActiveRecord::Base instances to `update`. Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`.");
         }
         return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => await object.update(attributes[idx]));
@@ -65,7 +65,7 @@ export async function update(id = "all") {
 export async function updateBang(id = "all") {
     let object;
     if (id.isA(Array)) {
-        if (id.isAny(ActiveRecord.Base)) {
+        if (await id.isAny(ActiveRecord.Base)) {
             throw new ArgumentError("You are passing an array of ActiveRecord::Base instances to `update!`. Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`.");
         }
         return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => await object.updateBang(attributes[idx]));
@@ -144,7 +144,7 @@ export async function _deleteRecord(constraints) {
     return this.withConnection(c => c.delete(dm, `${this} Destroy`));
 }
 __PRISM_TODO("CallNode");
-export function inherited(subclass) {
+export async function inherited(subclass) {
     return subclass.classEval(() => {
         this._query_constraints_list = null;
         return this.has_query_constraints = false;
@@ -378,7 +378,7 @@ export function _queryConstraintsHash() {
 }
 export function destroyAssociations() {
 }
-export function destroyRow() {
+export async function destroyRow() {
     return this._deleteRow;
 }
 export function _deleteRow() {
@@ -389,8 +389,8 @@ export function _touchRow(attribute_names, time) {
     attribute_names.each(attr_name => this._writeAttribute(attr_name, time));
     return this._updateRow(attribute_names, "touch");
 }
-export function _updateRow(attribute_names, attempted_action = "update") {
-    return this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
+export async function _updateRow(attribute_names, attempted_action = "update") {
+    return await this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
 }
 export function createOrUpdate({ ...opts } = {}, block) {
     let result;
@@ -411,7 +411,7 @@ export async function _updateRecord(attribute_names = this.attributeNames(), blo
         this._trigger_update_callback = true;
     }
     else {
-        affected_rows = this._updateRow(attribute_names);
+        affected_rows = await this._updateRow(attribute_names);
         this._trigger_update_callback = affected_rows === 1;
     }
     this.previously_new_record = false;

--- a/scripts/prism-codegen/__snapshots__/relation.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation.js.snap
@@ -80,10 +80,10 @@ export class Relation {
         return this.first || this.constructor(attributes, block);
     }
     async findOrCreateBy(attributes, block) {
-        return this.findBy(attributes) || await this.createOrFindBy(attributes, block);
+        return await this.findBy(attributes) || await this.createOrFindBy(attributes, block);
     }
-    findOrCreateByBang(attributes, block) {
-        return this.findBy(attributes) || this.createOrFindByBang(attributes, block);
+    async findOrCreateByBang(attributes, block) {
+        return await this.findBy(attributes) || await this.createOrFindByBang(attributes, block);
     }
     async createOrFindBy(attributes, block) {
         return this.withConnection(connection => {
@@ -92,31 +92,31 @@ export class Relation {
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
-                    return this.where(attributes).lock().findByBang(attributes);
+                    return await this.where(attributes).lock().findByBang(attributes);
                 }
                 else {
-                    return this.findByBang(attributes);
+                    return await this.findByBang(attributes);
                 }
             }
         });
     }
-    createOrFindByBang(attributes, block) {
+    async createOrFindByBang(attributes, block) {
         return this.withConnection(connection => {
             try {
-                return this.transaction({ requires_new: true }, () => this.createBang(attributes, block));
+                return this.transaction({ requires_new: true }, () => await this.createBang(attributes, block));
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
-                    return this.where(attributes).lock().findByBang(attributes);
+                    return await this.where(attributes).lock().findByBang(attributes);
                 }
                 else {
-                    return this.findByBang(attributes);
+                    return await this.findByBang(attributes);
                 }
             }
         });
     }
     async findOrInitializeBy(attributes, block) {
-        return this.findBy(attributes) || this.constructor(attributes, block);
+        return await this.findBy(attributes) || this.constructor(attributes, block);
     }
     async explain(...options) {
         return new ExplainProxy(this, options);
@@ -228,7 +228,7 @@ export class Relation {
                 column = c.visitor().compile(this.table[timestamp_column]);
                 select_values = `COUNT(*) AS ${this.model.adapterClass().quoteColumnName("size")}, MAX(%s) AS timestamp`;
                 if (collection.hasLimitOrOffset()) {
-                    query = collection.select(`${column} AS collection_cache_key_timestamp`);
+                    query = await collection.select(`${column} AS collection_cache_key_timestamp`);
                     if (this.distinctValue && await collection.selectValues().isEmpty()) {
                         query._selectBang(this.table[await Arel.star()]);
                     }
@@ -376,7 +376,7 @@ export class Relation {
         if (this.none) {
             return 0;
         }
-        invalid_methods = INVALID_METHODS_FOR_DELETE_ALL.select(method => {
+        invalid_methods = await INVALID_METHODS_FOR_DELETE_ALL.select(method => {
             value = this.values[method];
             if (method === "distinct") {
                 return value;
@@ -514,16 +514,16 @@ export class Relation {
         return this.readonlyValue;
     }
     async values() {
-        return this.values.dup();
+        return await this.values.dup();
     }
     valuesForQueries() {
         return this.values.except("extending", "skip_query_cache", "strict_loading");
     }
-    inspect() {
+    async inspect() {
         let subject, entries;
         subject = this.isLoaded ? this.records : this.annotate("loading for inspect");
         entries = subject.take([this.limitValue, 11].compact().min()).mapBang(x => x.inspect());
-        if (entries.size() === 11) {
+        if (await entries.size() === 11) {
             entries[10] = "...";
         }
         return `#<${this.class().name()} [${entries.join(", ")}]>`;
@@ -546,7 +546,7 @@ export class Relation {
         scope = this.strictLoadingValue ? StrictLoadingScope : null;
         return preload.each(associations => new ActiveRecord.Associations.Preloader({ records: records, associations: associations, scope: scope }).call());
     }
-    loadRecords(records) {
+    async loadRecords(records) {
         this.records = records.freeze();
         return this.loaded = true;
     }

--- a/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
@@ -85,11 +85,11 @@ export async function calculate(operation, column_name) {
     operation = operation.toString().downcase();
     if (this.none) {
         if (caseEq("count", operation) || caseEq("sum", operation)) {
-            result = this.groupValues.isAny() ? new Hash() : 0;
+            result = await this.groupValues.isAny() ? new Hash() : 0;
             return this.async ? new Promise.Complete(result) : result;
         }
         else if (caseEq("average", operation) || caseEq("minimum", operation) || caseEq("maximum", operation)) {
-            result = this.groupValues.isAny() ? new Hash() : null;
+            result = await this.groupValues.isAny() ? new Hash() : null;
             return this.async ? new Promise.Complete(result) : result;
         }
     }
@@ -168,7 +168,7 @@ export async function ids() {
     primary_key_array = this.Array(this.primaryKey);
     if (this.isLoaded) {
         result = this.records.map(record => {
-            if (primary_key_array.isOne()) {
+            if (await primary_key_array.isOne()) {
                 return record._readAttribute(primary_key_array.first());
             }
             else {
@@ -178,7 +178,7 @@ export async function ids() {
         return this.async ? new Promise.Complete(result) : result;
     }
     if (this.hasInclude(this.primaryKey)) {
-        relation = this.applyJoinDependency.group(...primary_key_array);
+        relation = await this.applyJoinDependency.group(...primary_key_array);
         return await relation.ids();
     }
     columns = this.arelColumns(primary_key_array);
@@ -348,7 +348,7 @@ export async function executeGroupedCalculation(operation, column_name, distinct
         });
     });
 }
-export function typeFor(field, block) {
+export async function typeFor(field, block) {
     let field_name;
     field_name = field.respondTo("name") ? field.name().toString() : field.toString().split(".").last();
     return this.model.typeForAttribute(field_name, block);

--- a/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
@@ -262,12 +262,12 @@ export async function findOne(id) {
 }
 export async function findSome(ids) {
     let relation, result, expected_size;
-    if (!this.orderValues.isPresent()) {
+    if (!await this.orderValues.isPresent()) {
         return await this.findSomeOrdered(ids);
     }
     relation = this.where({ [this.primaryKey]: ids });
     if (!this.selectValues.isEmpty()) {
-        relation = relation.select(this.table[this.primaryKey]);
+        relation = await relation.select(this.table[this.primaryKey]);
     }
     result = relation.toA();
     expected_size = this.limitValue && ids.size() > this.limitValue ? this.limitValue : ids.size();
@@ -287,7 +287,7 @@ export async function findSomeOrdered(ids) {
     relation = this.except("limit", "offset");
     relation = relation.where({ [this.primaryKey]: ids });
     if (!this.selectValues.isEmpty()) {
-        relation = relation.select(this.table[this.primaryKey]);
+        relation = await relation.select(this.table[this.primaryKey]);
     }
     result = relation.records();
     if (result.size() === ids.size()) {

--- a/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
@@ -38,7 +38,7 @@ export class WhereChain {
         });
         return this.scope;
     }
-    missing(...associations) {
+    async missing(...associations) {
         let reflection, association_conditions;
         associations.each(association => {
             reflection = this.scopeAssociationReflection(association);
@@ -98,7 +98,7 @@ export function eagerLoad(...args) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, args);
     return this.spawn.eagerLoadBang(...args);
 }
-export function eagerLoadBang(...args) {
+export async function eagerLoadBang(...args) {
     __PRISM_TODO("CallOperatorWriteNode");
     return this;
 }
@@ -113,7 +113,7 @@ export function preloadBang(...args) {
 export async function extractAssociated(association) {
     return this.preload(association).collect(association);
 }
-export function references(...table_names) {
+export async function references(...table_names) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, table_names);
     return this.spawn.referencesBang(...table_names);
 }
@@ -121,9 +121,9 @@ export function referencesBang(...table_names) {
     __PRISM_TODO("CallOperatorWriteNode");
     return this;
 }
-export function select(...fields, block) {
+export async function select(...fields, block) {
     if (block !== undefined) {
-        if (fields.isAny()) {
+        if (await fields.isAny()) {
             throw new ArgumentError("`select' with block doesn't take arguments.");
         }
         return __PRISM_TODO("SuperNode");
@@ -161,7 +161,7 @@ export function reselectBang(...args) {
     this.selectValues = args;
     return this;
 }
-export function group(...args) {
+export async function group(...args) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, args);
     return this.spawn.groupBang(...args);
 }
@@ -377,7 +377,7 @@ export function offsetBang(value) {
 export function lock(locks = true) {
     return this.spawn.lockBang(locks);
 }
-export function lockBang(locks = true) {
+export async function lockBang(locks = true) {
     if (caseEq(String, locks) || caseEq(TrueClass, locks) || caseEq(NilClass, locks)) {
         this.lockValue = locks || true;
     }
@@ -399,7 +399,7 @@ export function noneBang() {
 export function isNullRelation() {
     return this.none;
 }
-export function readonly(value = true) {
+export async function readonly(value = true) {
     return this.spawn.readonlyBang(value);
 }
 export function readonlyBang(value = true) {
@@ -426,7 +426,7 @@ export function createWithBang(value) {
     }
     return this;
 }
-export function from(value, subquery_name = null) {
+export async function from(value, subquery_name = null) {
     return this.spawn.fromBang(value, subquery_name);
 }
 export function fromBang(value, subquery_name = null) {


### PR DESCRIPTION
The per-target golden snapshots checked in by #5815 were generated before #5814's whole-program async manifest landed. Merge order put #5814 first, so `main` @f77afc67 fails the **Codegen golden output snapshots** step — every method the manifest marks async diffs against the stale image.

Regenerated with `pnpm codegen:snapshot`. The diff is `async`/`await` markers only; no other emitted output changed.

Closes-story: red-f77afc67