### PR TITLE
refactor(activerecord): route checkConstraintExists through checkConstraintFor

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -424,14 +424,18 @@ export class CheckConstraintDefinition {
     return this.name ? !statelessTest(SchemaDumper.chkIgnorePattern, this.name) : false;
   }
 
-  isDefinedFor(options: { name: string; expression?: string; validate?: boolean }): boolean {
+  isDefinedFor(options: {
+    name: string | null | undefined;
+    expression?: string;
+    validate?: boolean;
+  }): boolean {
     // Mirrors Rails CheckConstraintDefinition#defined_for?(name:, expression: nil,
     // ...): it matches on name (and validate) only — the expression is accepted
     // but never compared (it is used upstream to derive the name). A raw-string
     // expression compare would spuriously fail against the adapter's normalized
     // form (e.g. PostgreSQL's `pg_get_constraintdef`).
     return (
-      this.name === options.name.toString() &&
+      this.name === (options.name == null ? "" : options.name.toString()) &&
       (options.validate === undefined || options.validate === this.validate)
     );
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -4,7 +4,12 @@ import {
   canRemoveIndexByName,
   indexNameForRemoveFrom,
 } from "./schema-statements.js";
-import { ForeignKeyDefinition, TableDefinition, type ColumnType } from "./schema-definitions.js";
+import {
+  CheckConstraintDefinition,
+  ForeignKeyDefinition,
+  TableDefinition,
+  type ColumnType,
+} from "./schema-definitions.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { NotImplementedError } from "../../errors.js";
 
@@ -210,7 +215,7 @@ describe("SchemaStatements privates (PR 8)", () => {
     const ss = makeStatements();
     const name = ss.checkConstraintName("users", { expression: "age > 0" });
     vi.spyOn(ss, "checkConstraints").mockResolvedValue([
-      { tableName: "users", expression: "age > 0", name, validate: true } as any,
+      new CheckConstraintDefinition("users", "age > 0", name),
     ]);
     await ss.addCheckConstraint("users", "age > 0", { ifNotExists: true });
     expect((ss as any).adapter.execute).not.toHaveBeenCalled();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -224,7 +224,12 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect((ss as any).adapter.execute).toHaveBeenCalled();
   });
 
-  it("checkConstraintExists matches by expression when name is present but undefined", async () => {
+  it("checkConstraintExists returns false when an explicit undefined name is supplied", async () => {
+    // Rails: check_constraint_for passes `defined_for?(name: chk_name, **options)`,
+    // where an explicit `name: nil` in options overrides chk_name; defined_for?
+    // then compares `self.name == nil.to_s` ("") — false for any real constraint.
+    // An explicit `undefined` is the JS analogue, so it must not match, and must
+    // not raise on `name.toString()`.
     const ss = makeStatements();
     const name = ss.checkConstraintName("users", { expression: "age > 0" });
     vi.spyOn(ss, "checkConstraints").mockResolvedValue([
@@ -232,7 +237,7 @@ describe("SchemaStatements privates (PR 8)", () => {
     ]);
     expect(
       await ss.checkConstraintExists("users", { name: undefined, expression: "age > 0" }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   // PR 8b helpers

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -224,6 +224,17 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect((ss as any).adapter.execute).toHaveBeenCalled();
   });
 
+  it("checkConstraintExists matches by expression when name is present but undefined", async () => {
+    const ss = makeStatements();
+    const name = ss.checkConstraintName("users", { expression: "age > 0" });
+    vi.spyOn(ss, "checkConstraints").mockResolvedValue([
+      new CheckConstraintDefinition("users", "age > 0", name),
+    ]);
+    expect(
+      await ss.checkConstraintExists("users", { name: undefined, expression: "age > 0" }),
+    ).toBe(true);
+  });
+
   // PR 8b helpers
   it("validateIndexLengthBang throws when name too long", () => {
     const ss = makeStatements();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1772,19 +1772,13 @@ export class SchemaStatements {
     options: { name?: string; expression?: string },
   ): Promise<boolean> {
     if (!options.name && !options.expression) {
-      throw new Error("At least one of :name or :expression must be supplied");
+      throw new ArgumentError("At least one of :name or :expression must be supplied");
     }
-    try {
-      const constraints = await this.checkConstraints(tableName);
-      return constraints.some((c) => {
-        if (options.name && c.name === options.name) return true;
-        if (options.expression && c.expression === options.expression) return true;
-        return false;
-      });
-    } catch (e) {
-      if (e instanceof NotImplementedError) return false;
-      throw e;
-    }
+    // Only pass `name` when present: checkConstraintFor derives one from the
+    // expression, and an explicit `name: undefined` would clobber it.
+    const lookup: { name?: string; expression?: string } = { expression: options.expression };
+    if (options.name !== undefined) lookup.name = options.name;
+    return (await this.checkConstraintFor(tableName, lookup)) !== undefined;
   }
 
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2470,7 +2470,7 @@ export class SchemaStatements {
     }
     const chkName = this.checkConstraintName(tableName, options);
     const constraints = await this.checkConstraints(tableName);
-    return constraints.find((chk) => chk.isDefinedFor({ ...options, name: chkName }));
+    return constraints.find((chk) => chk.isDefinedFor({ name: chkName, ...options }));
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1774,11 +1774,7 @@ export class SchemaStatements {
     if (!options.name && !options.expression) {
       throw new ArgumentError("At least one of :name or :expression must be supplied");
     }
-    // Only pass `name` when present: checkConstraintFor derives one from the
-    // expression, and an explicit `name: undefined` would clobber it.
-    const lookup: { name?: string; expression?: string } = { expression: options.expression };
-    if (options.name !== undefined) lookup.name = options.name;
-    return (await this.checkConstraintFor(tableName, lookup)) !== undefined;
+    return (await this.checkConstraintFor(tableName, options)) !== undefined;
   }
 
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {
@@ -2474,7 +2470,7 @@ export class SchemaStatements {
     }
     const chkName = this.checkConstraintName(tableName, options);
     const constraints = await this.checkConstraints(tableName);
-    return constraints.find((chk) => chk.isDefinedFor({ name: chkName, ...options }));
+    return constraints.find((chk) => chk.isDefinedFor({ ...options, name: chkName }));
   }
 
   /** @internal */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "check_constraint_exists?",
-    "call": "check_constraint_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "check_constraint_name",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Converges `SchemaStatements#checkConstraintExists` with Rails.

Rails `check_constraint_exists?` ([schema_statements.rb:1341](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb)) is an argument check plus `check_constraint_for(...).present?`. The unsupported-adapter case is handled by `check_constraint_for` (`:1797`), which opens with `return unless supports_check_constraints?` — an unsupported adapter never calls `check_constraints`, so it never reaches the raise.

trails instead wrapped `checkConstraints(tableName)` in a try/catch that swallowed `NotImplementedError` and returned `false`, and inlined a name/expression detect loop rather than routing through `checkConstraintName` + `isDefinedFor`.

`checkConstraintFor` / `checkConstraintForBang` already existed with the supports guard (added by #5812 follow-up work), so this PR just points `checkConstraintExists` at them and deletes the invented rescue. It also raises `ArgumentError` rather than bare `Error`.

One test fixture updated: `schema-statements-privates.test.ts` mocked `checkConstraints` with a plain object literal cast to `any`; matching now goes through `CheckConstraintDefinition#isDefinedFor`, so the mock returns a real `CheckConstraintDefinition`.

Closes-story: converge-check-constraint-exists-on-the-supports-guard
