### PR TITLE
feat(prism-codegen): canonicalize the port's arelTable reach against Rails' table

### DIFF
--- a/scripts/prism-codegen/score.test.ts
+++ b/scripts/prism-codegen/score.test.ts
@@ -141,6 +141,22 @@ describe("prism-codegen scorer", () => {
     ]);
   });
 
+  it("canonicalizes the port's `arelTable` reach against Rails' `table` reader", async () => {
+    const score = await scoreRuby(
+      `def order_column
+         table[primary_key]
+       end`,
+      `export function orderColumn(this: R): unknown {
+         return this._modelClass.arelTable.get(this.primaryKey);
+       }`,
+    );
+    expect(score.entries).toEqual([
+      expect.objectContaining({ name: "orderColumn", status: "divergent" }),
+    ]);
+    expect(score.entries[0].portSkeleton).toContain("ref:table");
+    expect(score.entries[0].portSkeleton).not.toContain("ref:arelTable");
+  });
+
   it("rejects a predicate fallback candidate that collides with a different-arity method", async () => {
     // Rails readonly? (0 args) must NOT match the port of Rails readonly(value).
     const score = await scoreRuby(

--- a/scripts/prism-codegen/score.test.ts
+++ b/scripts/prism-codegen/score.test.ts
@@ -144,17 +144,15 @@ describe("prism-codegen scorer", () => {
   it("canonicalizes the port's `arelTable` reach against Rails' `table` reader", async () => {
     const score = await scoreRuby(
       `def order_column
-         table[primary_key]
+         table.name
        end`,
       `export function orderColumn(this: R): unknown {
-         return this._modelClass.arelTable.get(this.primaryKey);
+         return this.arelTable.name;
        }`,
     );
     expect(score.entries).toEqual([
-      expect.objectContaining({ name: "orderColumn", status: "divergent" }),
+      expect.objectContaining({ name: "orderColumn", status: "matched" }),
     ]);
-    expect(score.entries[0].portSkeleton).toContain("ref:table");
-    expect(score.entries[0].portSkeleton).not.toContain("ref:arelTable");
   });
 
   it("rejects a predicate fallback candidate that collides with a different-arity method", async () => {

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -206,10 +206,6 @@ const TOKEN_CANON: Record<string, string> = {
   inject: "reduce",
   toA: "toArray",
   size: "length",
-  // relation.rb:71 reads `attr_reader :table, :model, ...` — the port spells that
-  // same pair `_modelClass.arelTable`, so both readers need canonicalizing or the
-  // skeleton diff shows a pure-naming `ref:` mismatch on every def that reaches
-  // the relation's Arel table.
   modelClass: "model",
   arelTable: "table",
 };

--- a/scripts/prism-codegen/score.ts
+++ b/scripts/prism-codegen/score.ts
@@ -206,7 +206,12 @@ const TOKEN_CANON: Record<string, string> = {
   inject: "reduce",
   toA: "toArray",
   size: "length",
+  // relation.rb:71 reads `attr_reader :table, :model, ...` — the port spells that
+  // same pair `_modelClass.arelTable`, so both readers need canonicalizing or the
+  // skeleton diff shows a pure-naming `ref:` mismatch on every def that reaches
+  // the relation's Arel table.
   modelClass: "model",
+  arelTable: "table",
 };
 
 export function normalizeName(name: string): string {


### PR DESCRIPTION
Sweeps `scripts/api-compare/arity.ts`'s explicit-receiver spelling list against
the scorer's `TOKEN_CANON`, following #5818's `modelClass: "model"` entry.

## Sweep result

For each name on `arity.ts:101-118` (`host`, `recordOrClass`, `target`,
`adapter`, `node`, `entry`, `branch`, `association`, `date`, `input`,
`connections`, `targets`, `tags`, `controller`, `collection`, `validator`,
`record`, `klass`, `rel`, `relation`, `assoc`, `owner`, `proxy`, `builder`,
`scope`, `conn`, `connection`, `pool`, `batch`, `reflection`, `self`)
I compared the port
spelling against its Rails twin and measured how often each appears as a
`ref:` token in the scorer's divergent skeletons. **None of them needs an
entry**: they are either spelled identically on both sides (`target`,
`adapter`, `association`, `owner`, `relation`, `connectionPool`,
`connectionHandler`) or never surface as a skeleton token at all (`host`,
`recordOrClass`, `node`, `entry`, `branch`, `date`, `input`, `connections`,
`targets`, `tags`, `controller`, `validator`, `proxy`, `builder`, `batch`,
`reflection`, `record`, `klass`) — those are parameter names, and a property access *through* a
parameter tokens as the property, not the receiver. `klass` in particular is
already dead on the Rails side: modern `relation.rb` reads `model`.

The one genuine analogue the sweep did turn up is `arelTable` ↔ Rails' `table`
— literally the sibling reader on the same `attr_reader` line #5818 drew from:

```ruby
# relation.rb:71
attr_reader :table, :model, :loaded, :predicate_builder
```

The port spells that pair `this._modelClass.arelTable`, so the `model` half
was canonicalized by #5818 and the `table` half was still emitting a
pure-naming `ref:arelTable` vs `ref:table` mismatch. This adds
`arelTable: "table"`. It does not collapse two distinct receivers: every
`arelTable` reach in the port is the model's `Arel::Table`, which is exactly
what Rails' `@table` holds (`@table = klass.arel_table`).

Deliberately **not** added, because they would collapse distinct receivers or
paper over a separate codegen bug rather than a receiver spelling:
`reflectionAdapter` vs Rails' `adapter_class` (different objects), and
`associationInstances` vs `association_cache` (the gen side emits the ivar
un-camelized — a naming-path bug, not a receiver rename).

## Measured

`pnpm codegen:score` matched count: **33 before, 33 after** — flat, exactly as
#5818 predicted, because all 13 defs the entry touches also diverge
structurally. The value is denoising. Total token-level skeleton noise across
the 297 divergent defs drops **3613 → 3587** (−26), strictly monotone: 13 defs
lose their spurious `ref:` pair, 3 are neutral, 0 regress.

Skeletons cleaned:

- `relation.rb`: `bindAttribute`, `updateAll`, `updateCounters`, `deleteAll`,
  `_substituteValues`, `_incrementAttribute`
- `relation/query_methods.rb`: `buildArel`, `buildSelect`, `buildWithJoinNode`,
  `reverseSqlOrder`, `orderColumn`
- `relation/finder_methods.rb`: `findSome`, `findSomeOrdered`

`pnpm codegen:score --guard` stays green (353 residue rows, unchanged).

## Test

`score.test.ts` gains a case where the spelling is the *only* difference
between the Rails body and the port body, so the entry flips the def from
divergent to `matched`. Verified it fails with the entry removed.

Closes-story: scorer-explicit-receiver-canon-sweep
