### PR TITLE
feat(prism-codegen): drop the async keyword from defs that never await

### DIFF
--- a/scripts/prism-codegen/__snapshots__/associations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/associations.js.snap
@@ -33,7 +33,7 @@ eagerAutoload(() => {
     autoload("DisableJoinsAssociationScope");
     autoload("AliasTracker");
 });
-export async function eagerLoadBang() {
+export function eagerLoadBang() {
     Preloader.eagerLoadBang();
     return JoinDependency.eagerLoadBang();
 }
@@ -78,7 +78,7 @@ export function hasOne(name, scope = null, { ...options } = {}) {
     reflection = Builder.HasOne.build(this, name, scope, options);
     return Reflection.addReflection(this, name, reflection);
 }
-export async function belongsTo(name, scope = null, { ...options } = {}) {
+export function belongsTo(name, scope = null, { ...options } = {}) {
     let reflection;
     reflection = Builder.BelongsTo.build(this, name, scope, options);
     return Reflection.addReflection(this, name, reflection);

--- a/scripts/prism-codegen/__snapshots__/core.js.snap
+++ b/scripts/prism-codegen/__snapshots__/core.js.snap
@@ -219,7 +219,7 @@ export function inspectionFilter() {
         return this.inspection_filter ||= __PRISM_TODO("BeginNode");
     }
 }
-export async function inspect() {
+export function inspect() {
     let attr_list;
     if (this === Base || this.isSingletonClass) {
         return __PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect");
@@ -253,7 +253,7 @@ export function cachedFindByStatement(connection, key, block) {
     return cache.computeIfAbsent(key, () => StatementCache.create(connection, block));
 }
 __PRISM_TODO("CallNode");
-export async function inherited(subclass) {
+export function inherited(subclass) {
     let klass;
     subclass.initializeFindByCache();
     if (!subclass.isBaseClass()) {
@@ -281,7 +281,7 @@ export function relation() {
         return relation;
     }
 }
-export async function cachedFindBy(keys, values) {
+export function cachedFindBy(keys, values) {
     let statement, wheres;
     return this.withConnection(connection => {
         statement = this.cachedFindByStatement(connection, keys, params => {
@@ -359,7 +359,7 @@ export function encodeWith(coder) {
 }
 __PRISM_TODO("DefNode");
 __PRISM_TODO("AliasMethodNode");
-export async function hash() {
+export function hash() {
     let id;
     id = this.id();
     if (this.isPrimaryKeyValuesPresent) {
@@ -377,7 +377,7 @@ export function isFrozen() {
     return this.attributes.isFrozen();
 }
 __PRISM_TODO("DefNode");
-export async function isPresent() {
+export function isPresent() {
     return true;
 }
 export function isBlank() {
@@ -409,13 +409,13 @@ export function readonlyBang() {
 export function connectionHandler() {
     return this.class().connectionHandler();
 }
-export async function inspect() {
+export function inspect() {
     return this.inspectWithAttributes(this.attributesForInspect);
 }
 export function fullInspect() {
     return this.inspectWithAttributes(this.allAttributesForInspect);
 }
-export async function prettyPrint(pp) {
+export function prettyPrint(pp) {
     let attr_names, attr_name, value;
     if (this.isCustomInspectMethodDefined) {
         return __PRISM_SUPER_OUTSIDE_CORPUS("Core#pretty_print");
@@ -465,7 +465,7 @@ export function isCustomInspectMethodDefined() {
     return this.class().instanceMethod("inspect").owner() !== ActiveRecord.Base.instanceMethod("inspect").owner();
 }
 export class InspectionMask extends DelegateClass(String) {
-    async prettyPrint(pp) {
+    prettyPrint(pp) {
         return pp.text(this.__getobj__);
     }
 }

--- a/scripts/prism-codegen/__snapshots__/inheritance.js.snap
+++ b/scripts/prism-codegen/__snapshots__/inheritance.js.snap
@@ -99,7 +99,7 @@ export function polymorphicClassFor(name) {
         return this.computeType(name);
     }
 }
-export async function dup() {
+export function dup() {
     let other;
     other = __PRISM_SUPER_OUTSIDE_CORPUS("Inheritance::ClassMethods#dup");
     other.setBaseClass();
@@ -136,7 +136,7 @@ export function setBaseClass() {
     return this.base_class = __PRISM_TODO("IfNode");
 }
 __PRISM_TODO("CallNode");
-export async function inherited(subclass) {
+export function inherited(subclass) {
     subclass.setBaseClass();
     subclass.instanceVariableSet("@_type_candidates_cache", new Concurrent.Map());
     return subclass.classEval(() => this.finder_needs_type_condition = null);

--- a/scripts/prism-codegen/__snapshots__/model-schema.js.snap
+++ b/scripts/prism-codegen/__snapshots__/model-schema.js.snap
@@ -114,7 +114,7 @@ export function isTableExists() {
 export function attributesBuilder() {
     return this.attributes_builder ||= __PRISM_TODO("BeginNode");
 }
-export async function columnsHash() {
+export function columnsHash() {
     if (!this.columns_hash) {
         this.loadSchema;
     }
@@ -129,7 +129,7 @@ export function _returningColumnsForInsert(connection) {
 export function yamlEncoder() {
     return this.yaml_encoder ||= new ActiveModel.AttributeSet.YAMLEncoder(this.attributeTypes);
 }
-export async function columnForAttribute(name) {
+export function columnForAttribute(name) {
     name = name.toString();
     return this.columnsHash.fetch(name, () => new ConnectionAdapters.NullColumn(name));
 }
@@ -194,7 +194,7 @@ export function reloadSchemaFromCache(recursive = true) {
     }
 }
 __PRISM_TODO("CallNode");
-export async function inherited(child_class) {
+export function inherited(child_class) {
     child_class.initializeLoadSchemaMonitor();
     child_class.reloadSchemaFromCache(false);
     return child_class.classEval(() => this.ignored_columns = null);

--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -7,7 +7,7 @@ require("active_record/insert_all");
 // module ActiveRecord
 extend(ActiveSupport.Concern);
 // module ClassMethods
-export async function create(attributes = null, block) {
+export function create(attributes = null, block) {
     let object;
     if (attributes.isA(Array)) {
         return attributes.collect(attr => await this.create(attr, block));
@@ -18,7 +18,7 @@ export async function create(attributes = null, block) {
         return object;
     }
 }
-export async function createBang(attributes = null, block) {
+export function createBang(attributes = null, block) {
     let object;
     if (attributes.isA(Array)) {
         return attributes.collect(attr => await this.createBang(attr, block));

--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -42,7 +42,7 @@ export function instantiate(attributes, column_types = {}, block) {
     klass = this.discriminateClassForRecord(attributes);
     return this.instantiateInstanceOf(klass, attributes, column_types, block);
 }
-export async function update(id = "all") {
+export function update(id = "all") {
     let object;
     if (id.isA(Array)) {
         if (id.isAny(ActiveRecord.Base)) {
@@ -62,7 +62,7 @@ export async function update(id = "all") {
         return object;
     }
 }
-export async function updateBang(id = "all") {
+export function updateBang(id = "all") {
     let object;
     if (id.isA(Array)) {
         if (id.isAny(ActiveRecord.Base)) {
@@ -98,7 +98,7 @@ export function queryConstraintsList() {
 export function compositeQueryConstraintsList() {
     return this.composite_query_constraints_list ||= this.queryConstraintsList || this.Array(this.primaryKey);
 }
-export async function _insertRecord(connection, values, returning) {
+export function _insertRecord(connection, values, returning) {
     let primary_key, primary_key_value, im;
     primary_key = this.primaryKey();
     primary_key_value = null;
@@ -114,7 +114,7 @@ export async function _insertRecord(connection, values, returning) {
     }
     return connection.insert(im, `${this} Create`, primary_key || false, primary_key_value, { returning: returning });
 }
-export async function _updateRecord(values, constraints) {
+export function _updateRecord(values, constraints) {
     let default_constraint, current_scope, um;
     constraints = constraints.map((name, value) => __PRISM_TODO("CallNode"));
     default_constraint = this.buildDefaultConstraint;
@@ -129,7 +129,7 @@ export async function _updateRecord(values, constraints) {
     um.wheres = constraints;
     return this.withConnection(c => c.update(um, `${this} Update`));
 }
-export async function _deleteRecord(constraints) {
+export function _deleteRecord(constraints) {
     let default_constraint, current_scope, dm;
     constraints = constraints.map((name, value) => __PRISM_TODO("CallNode"));
     default_constraint = this.buildDefaultConstraint;
@@ -144,7 +144,7 @@ export async function _deleteRecord(constraints) {
     return this.withConnection(c => c.delete(dm, `${this} Destroy`));
 }
 __PRISM_TODO("CallNode");
-export async function inherited(subclass) {
+export function inherited(subclass) {
     return subclass.classEval(() => {
         this._query_constraints_list = null;
         return this.has_query_constraints = false;
@@ -182,7 +182,7 @@ export function isDestroyed() {
 export function isPersisted() {
     return !(this.new_record || this.destroyed);
 }
-export async function save({ ...options } = {}, block) {
+export function save({ ...options } = {}, block) {
     try {
         return this.createOrUpdate({ ...options }, block);
     }
@@ -190,11 +190,11 @@ export async function save({ ...options } = {}, block) {
         return false;
     }
 }
-export async function saveBang({ ...options } = {}, block) {
+export function saveBang({ ...options } = {}, block) {
     return this.createOrUpdate({ ...options }, block) || (() => { throw new RecordNotSaved("Failed to save the record", this); })();
 }
 __PRISM_TODO("DefNode");
-export async function destroy() {
+export function destroy() {
     if (this.isReadonly) {
         this._raiseReadonlyRecordError;
     }
@@ -204,7 +204,7 @@ export async function destroy() {
     this.previously_new_record = false;
     return this.freeze;
 }
-export async function destroyBang() {
+export function destroyBang() {
     return this.destroy || this._raiseRecordNotDestroyed;
 }
 export function becomes(klass) {
@@ -242,13 +242,13 @@ export async function updateAttributeBang(name, value) {
     this.publicSend(`${name}=`, value);
     return await this.saveBang({ validate: false });
 }
-export async function update(attributes) {
+export function update(attributes) {
     return this.withTransactionReturningStatus(() => {
         this.assignAttributes(attributes);
         return this.save;
     });
 }
-export async function updateBang(attributes) {
+export function updateBang(attributes) {
     return this.withTransactionReturningStatus(() => {
         this.assignAttributes(attributes);
         return this.saveBang;
@@ -257,7 +257,7 @@ export async function updateBang(attributes) {
 export async function updateColumn(name, value) {
     return await this.updateColumns({ [name]: value });
 }
-export async function updateColumns(attributes) {
+export function updateColumns(attributes) {
     let name, update_constraints, affected_rows;
     if (this.isNewRecord) {
         throw new ActiveRecordError("cannot update a new record");
@@ -283,7 +283,7 @@ export function increment(attribute, by = 1) {
     this[attribute] += by;
     return this;
 }
-export async function incrementBang(attribute, by = 1, { touch = null } = {}) {
+export function incrementBang(attribute, by = 1, { touch = null } = {}) {
     let change;
     this.increment(attribute, by);
     change = this.publicSend(attribute) - (this.publicSend(__PRISM_TODO("InterpolatedSymbolNode")) || 0);
@@ -301,10 +301,10 @@ export function toggle(attribute) {
     this[attribute] = !this.publicSend(`${attribute}?`);
     return this;
 }
-export async function toggleBang(attribute) {
+export function toggleBang(attribute) {
     return this.toggle(attribute).updateAttribute(attribute, this[attribute]);
 }
-export async function reload(options = null) {
+export function reload(options = null) {
     let fresh_object;
     this.class().connectionPool().clearQueryCache();
     fresh_object = this.isApplyScoping(options) ? this._findRecord((options || {}).merge({ all_queries: true })) : this.class().unscoped(() => this._findRecord(options));
@@ -379,7 +379,7 @@ export function _queryConstraintsHash() {
 }
 export function destroyAssociations() {
 }
-export async function destroyRow() {
+export function destroyRow() {
     return this._deleteRow;
 }
 export function _deleteRow() {
@@ -390,7 +390,7 @@ export function _touchRow(attribute_names, time) {
     attribute_names.each(attr_name => this._writeAttribute(attr_name, time));
     return this._updateRow(attribute_names, "touch");
 }
-export async function _updateRow(attribute_names, attempted_action = "update") {
+export function _updateRow(attribute_names, attempted_action = "update") {
     return this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
 }
 export function createOrUpdate({ ...opts } = {}, block) {

--- a/scripts/prism-codegen/__snapshots__/relation.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation.js.snap
@@ -85,7 +85,7 @@ export class Relation {
     async findOrCreateByBang(attributes, block) {
         return await this.findBy(attributes) || await this.createOrFindByBang(attributes, block);
     }
-    async createOrFindBy(attributes, block) {
+    createOrFindBy(attributes, block) {
         return this.model.withConnection(connection => {
             try {
                 return this.model.transaction({ requires_new: true }, () => await this.create(attributes, block));
@@ -100,7 +100,7 @@ export class Relation {
             }
         });
     }
-    async createOrFindByBang(attributes, block) {
+    createOrFindByBang(attributes, block) {
         return this.model.withConnection(connection => {
             try {
                 return this.model.transaction({ requires_new: true }, () => await this.createBang(attributes, block));
@@ -611,7 +611,7 @@ export class Relation {
         expr = value < 0 ? expr - bind : expr + bind;
         return expr.expr();
     }
-    async execQueries(block) {
+    execQueries(block) {
         let rows, records;
         return this.skipQueryCacheIfNecessary(() => {
             rows = __PRISM_TODO("IfNode");

--- a/scripts/prism-codegen/__snapshots__/relation.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation.js.snap
@@ -76,7 +76,7 @@ export class Relation {
     async firstOrCreateBang(attributes = null, block) {
         return this.first || await this.createBang(attributes, block);
     }
-    async firstOrInitialize(attributes = null, block) {
+    firstOrInitialize(attributes = null, block) {
         return this.first || this.constructor(attributes, block);
     }
     async findOrCreateBy(attributes, block) {
@@ -118,20 +118,20 @@ export class Relation {
     async findOrInitializeBy(attributes, block) {
         return await this.findBy(attributes) || this.constructor(attributes, block);
     }
-    async explain(...options) {
+    explain(...options) {
         return new ExplainProxy(this, options);
     }
     toAry() {
         return this.records.dup();
     }
-    async records() {
+    records() {
         this.load;
         return this.records;
     }
     encodeWith(coder) {
         return coder.representSeq(null, this.records);
     }
-    async size() {
+    size() {
         if (this.isLoaded) {
             return this.records.length();
         }
@@ -139,7 +139,7 @@ export class Relation {
             return this.count("all");
         }
     }
-    async isEmpty() {
+    isEmpty() {
         if (this.none) {
             return true;
         }
@@ -150,7 +150,7 @@ export class Relation {
             return !this.isExists;
         }
     }
-    async isNone(...args, block) {
+    isNone(...args, block) {
         if (this.none) {
             return true;
         }
@@ -159,7 +159,7 @@ export class Relation {
         }
         return this.isEmpty;
     }
-    async isAny(...args, block) {
+    isAny(...args, block) {
         if (this.none) {
             return false;
         }
@@ -168,7 +168,7 @@ export class Relation {
         }
         return !this.isEmpty;
     }
-    async isOne(...args, block) {
+    isOne(...args, block) {
         if (this.none) {
             return false;
         }
@@ -180,7 +180,7 @@ export class Relation {
         }
         return this.limitedCount === 1;
     }
-    async isMany(block) {
+    isMany(block) {
         if (this.none) {
             return false;
         }
@@ -192,7 +192,7 @@ export class Relation {
         }
         return this.limitedCount > 1;
     }
-    async cacheKey(timestamp_column = "updated_at") {
+    cacheKey(timestamp_column = "updated_at") {
         this.cache_keys ||= {};
         return this.cache_keys[timestamp_column] ||= this.model.collectionCacheKey(this, timestamp_column);
     }
@@ -213,7 +213,7 @@ export class Relation {
             return this.cache_versions[timestamp_column] ||= await this.computeCacheVersion(timestamp_column);
         }
     }
-    async computeCacheVersion(timestamp_column) {
+    computeCacheVersion(timestamp_column) {
         let size, timestamp, collection, column, select_values, query, subquery_alias, subquery_column, arel, column_type;
         timestamp_column = timestamp_column.toString();
         if (this.isLoaded) {
@@ -258,7 +258,7 @@ export class Relation {
             return `${size}`;
         }
     }
-    async cacheKeyWithVersion() {
+    cacheKeyWithVersion() {
         let version;
         if (version = this.cacheVersion) {
             return `${this.cacheKey}-${version}`;
@@ -267,7 +267,7 @@ export class Relation {
             return this.cacheKey;
         }
     }
-    async scoping({ all_queries = null } = {}, block) {
+    scoping({ all_queries = null } = {}, block) {
         let registry;
         registry = this.model.scopeRegistry();
         if (this.isGlobalScope(registry) && all_queries === false) {
@@ -280,7 +280,7 @@ export class Relation {
             return this._scoping(this, registry, all_queries, block);
         }
     }
-    async updateAll(updates) {
+    updateAll(updates) {
         let attr, values, arel, group_values_arel_columns, having_clause_ast, key, stmt;
         if (updates.isBlank()) {
             throw new ArgumentError("Empty list of attributes to change");
@@ -310,7 +310,7 @@ export class Relation {
             return c.update(stmt, `${this.model} Update All`).tap(() => this.reset);
         });
     }
-    async update(id = "all") {
+    update(id = "all") {
         if (id === "all") {
             return this.records.each(record => record.update(attributes));
         }
@@ -318,7 +318,7 @@ export class Relation {
             return this.model.update(id, attributes);
         }
     }
-    async updateBang(id = "all") {
+    updateBang(id = "all") {
         if (id === "all") {
             return this.records.each(record => record.updateBang(attributes));
         }
@@ -329,19 +329,19 @@ export class Relation {
     async insert(attributes, { returning = null, unique_by = null, record_timestamps = null } = {}) {
         return await this.insertAll([attributes], { returning: returning, unique_by: unique_by, record_timestamps: record_timestamps });
     }
-    async insertAll(attributes, { returning = null, unique_by = null, record_timestamps = null } = {}) {
+    insertAll(attributes, { returning = null, unique_by = null, record_timestamps = null } = {}) {
         return InsertAll.execute(this, attributes, { on_duplicate: "skip", returning: returning, unique_by: unique_by, record_timestamps: record_timestamps });
     }
     async insertBang(attributes, { returning = null, record_timestamps = null } = {}) {
         return await this.insertAllBang([attributes], { returning: returning, record_timestamps: record_timestamps });
     }
-    async insertAllBang(attributes, { returning = null, record_timestamps = null } = {}) {
+    insertAllBang(attributes, { returning = null, record_timestamps = null } = {}) {
         return InsertAll.execute(this, attributes, { on_duplicate: "raise", returning: returning, record_timestamps: record_timestamps });
     }
     async upsert(attributes, { ...kwargs } = {}) {
         return await this.upsertAll([attributes], { ...kwargs });
     }
-    async upsertAll(attributes, { on_duplicate = "update", update_only = null, returning = null, unique_by = null, record_timestamps = null } = {}) {
+    upsertAll(attributes, { on_duplicate = "update", update_only = null, returning = null, unique_by = null, record_timestamps = null } = {}) {
         return InsertAll.execute(this, attributes, { on_duplicate: on_duplicate, update_only: update_only, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps });
     }
     async updateCounters(counters) {
@@ -368,10 +368,10 @@ export class Relation {
     async touchAll(...names, { time = null } = {}) {
         return await this.updateAll(this.model.touchAttributesWithTime(...names, { time: time }));
     }
-    async destroyAll() {
+    destroyAll() {
         return this.records.each(x => x.destroy()).tap(() => this.reset);
     }
-    async deleteAll() {
+    deleteAll() {
         let invalid_methods, value, arel, group_values_arel_columns, having_clause_ast, key, stmt;
         if (this.none) {
             return 0;
@@ -400,13 +400,13 @@ export class Relation {
             return c.delete(stmt, `${this.model} Delete All`).tap(() => this.reset);
         });
     }
-    async delete(id_or_array) {
+    delete(id_or_array) {
         if (id_or_array.nil() || (id_or_array.isA(Array) && id_or_array.isEmpty())) {
             return 0;
         }
         return this.where({ [this.model.primaryKey()]: id_or_array }).deleteAll();
     }
-    async destroy(id) {
+    destroy(id) {
         let multiple_ids;
         multiple_ids = this.model.isCompositePrimaryKey() ? id.first().isA(Array) : id.isA(Array);
         if (multiple_ids) {
@@ -416,10 +416,10 @@ export class Relation {
             return this.find(id).destroy();
         }
     }
-    async destroyBy(...args) {
+    destroyBy(...args) {
         return this.where(...args).destroyAll();
     }
-    async deleteBy(...args) {
+    deleteBy(...args) {
         return this.where(...args).deleteAll();
     }
     loadAsync() {
@@ -459,7 +459,7 @@ export class Relation {
         }
         return this;
     }
-    async reload() {
+    reload() {
         this.reset;
         return this.load;
     }
@@ -498,7 +498,7 @@ export class Relation {
     joinedIncludesValues() {
         return __PRISM_TODO("CallNode");
     }
-    async prettyPrint(pp) {
+    prettyPrint(pp) {
         let subject, entries;
         subject = this.isLoaded ? this.records : this.annotate("loading for pp");
         entries = subject.take([this.limitValue, 11].compact().min());
@@ -507,19 +507,19 @@ export class Relation {
         }
         return pp.pp(entries);
     }
-    async isBlank() {
+    isBlank() {
         return this.records.isBlank();
     }
     isReadonly() {
         return this.readonlyValue;
     }
-    async values() {
+    values() {
         return this.values.dup();
     }
     valuesForQueries() {
         return this.values.except("extending", "skip_query_cache", "strict_loading");
     }
-    async inspect() {
+    inspect() {
         let subject, entries;
         subject = this.isLoaded ? this.records : this.annotate("loading for inspect");
         entries = subject.take([this.limitValue, 11].compact().min()).mapBang(x => x.inspect());
@@ -537,7 +537,7 @@ export class Relation {
     aliasTracker(joins = [], aliases = null) {
         return ActiveRecord.Associations.AliasTracker.create(this.model.connectionPool(), this.table.name(), joins, aliases);
     }
-    async preloadAssociations(records) {
+    preloadAssociations(records) {
         let preload, scope;
         preload = this.preloadValues;
         if (!this.isEagerLoading) {
@@ -546,7 +546,7 @@ export class Relation {
         scope = this.strictLoadingValue ? StrictLoadingScope : null;
         return preload.each(associations => new ActiveRecord.Associations.Preloader({ records: records, associations: associations, scope: scope }).call());
     }
-    async loadRecords(records) {
+    loadRecords(records) {
         this.records = records.freeze();
         return this.loaded = true;
     }
@@ -628,7 +628,7 @@ export class Relation {
             return records;
         });
     }
-    async execMainQuery({ async = false } = {}) {
+    execMainQuery({ async = false } = {}) {
         let relation;
         if (this.none) {
             if (async) {

--- a/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
@@ -80,7 +80,7 @@ export async function sum(initial_value_or_column = 0, block) {
 export function asyncSum(identity_or_column = null) {
     return this.async.sum(identity_or_column);
 }
-export async function calculate(operation, column_name) {
+export function calculate(operation, column_name) {
     let result, relation;
     operation = operation.toString().downcase();
     if (this.none) {
@@ -110,7 +110,7 @@ export async function calculate(operation, column_name) {
         return this.performCalculation(operation, column_name);
     }
 }
-export async function pluck(...column_names) {
+export function pluck(...column_names) {
     let result, relation, columns;
     if (this.none) {
         if (this.async) {
@@ -152,7 +152,7 @@ export async function pluck(...column_names) {
 export function asyncPluck(...column_names) {
     return this.async.pluck(...column_names);
 }
-export async function pick(...column_names) {
+export function pick(...column_names) {
     let result;
     if (this.isLoaded && this.isAllAttributes(column_names)) {
         result = this.records.pick(...column_names);
@@ -163,7 +163,7 @@ export async function pick(...column_names) {
 export function asyncPick(...column_names) {
     return this.async.pick(...column_names);
 }
-export async function ids() {
+export function ids() {
     let primary_key_array, result, relation, columns;
     primary_key_array = this.Array(this.model.primaryKey);
     if (this.isLoaded) {
@@ -247,7 +247,7 @@ export function operationOverAggregateColumn(column, operation, distinct) {
         return column.publicSend(operation);
     }
 }
-export async function executeSimpleCalculation(operation, column_name, distinct) {
+export function executeSimpleCalculation(operation, column_name, distinct) {
     let relation, query_builder, column, select_value, query_result, type;
     if (this.isBuildCountSubquery(operation, column_name, distinct)) {
         if (this.limitValue === 0) {
@@ -277,7 +277,7 @@ export async function executeSimpleCalculation(operation, column_name, distinct)
         return this.typeCastCalculatedValue(result.castValues().first(), operation, type);
     });
 }
-export async function executeGroupedCalculation(operation, column_name, distinct) {
+export function executeGroupedCalculation(operation, column_name, distinct) {
     let group_fields, association, associated, relation, column_alias_tracker, group_aliases, field, group_columns, column, column_alias, select_value, select_values, aliaz, result, key_ids, key_records, key_types, hash_rows, type, key;
     group_fields = this.groupValues;
     if (group_fields.size() > 1) {
@@ -348,7 +348,7 @@ export async function executeGroupedCalculation(operation, column_name, distinct
         });
     });
 }
-export async function typeFor(field, block) {
+export function typeFor(field, block) {
     let field_name;
     field_name = field.respondTo("name") ? field.name().toString() : field.toString().split(".").last();
     return this.model.typeForAttribute(field_name, block);

--- a/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
@@ -14,10 +14,10 @@ export async function find(...args, block) {
     }
     return await this.findWithIds(...args);
 }
-export async function findBy(arg, ...args) {
+export function findBy(arg, ...args) {
     return this.where(arg, ...args).take();
 }
-export async function findByBang(arg, ...args) {
+export function findByBang(arg, ...args) {
     return this.where(arg, ...args).takeBang();
 }
 export async function take(limit = null) {
@@ -28,7 +28,7 @@ export async function take(limit = null) {
         return this.findTake;
     }
 }
-export async function takeBang() {
+export function takeBang() {
     return this.take || this.raiseRecordNotFoundExceptionBang;
 }
 export async function sole() {
@@ -44,7 +44,7 @@ export async function sole() {
         throw new ActiveRecord.SoleRecordExceeded(this.model);
     }
 }
-export async function findSoleBy(arg, ...args) {
+export function findSoleBy(arg, ...args) {
     return this.where(arg, ...args).sole();
 }
 export async function first(limit = null) {
@@ -55,7 +55,7 @@ export async function first(limit = null) {
         return await this.findNth(0);
     }
 }
-export async function firstBang() {
+export function firstBang() {
     return this.first || this.raiseRecordNotFoundExceptionBang;
 }
 export async function last(limit = null) {
@@ -72,49 +72,49 @@ export async function last(limit = null) {
         return result.first();
     }
 }
-export async function lastBang() {
+export function lastBang() {
     return this.last || this.raiseRecordNotFoundExceptionBang;
 }
 export async function second() {
     return await this.findNth(1);
 }
-export async function secondBang() {
+export function secondBang() {
     return this.second || this.raiseRecordNotFoundExceptionBang;
 }
 export async function third() {
     return await this.findNth(2);
 }
-export async function thirdBang() {
+export function thirdBang() {
     return this.third || this.raiseRecordNotFoundExceptionBang;
 }
 export async function fourth() {
     return await this.findNth(3);
 }
-export async function fourthBang() {
+export function fourthBang() {
     return this.fourth || this.raiseRecordNotFoundExceptionBang;
 }
 export async function fifth() {
     return await this.findNth(4);
 }
-export async function fifthBang() {
+export function fifthBang() {
     return this.fifth || this.raiseRecordNotFoundExceptionBang;
 }
 export async function fortyTwo() {
     return await this.findNth(41);
 }
-export async function fortyTwoBang() {
+export function fortyTwoBang() {
     return this.fortyTwo || this.raiseRecordNotFoundExceptionBang;
 }
 export async function thirdToLast() {
     return await this.findNthFromLast(3);
 }
-export async function thirdToLastBang() {
+export function thirdToLastBang() {
     return this.thirdToLast || this.raiseRecordNotFoundExceptionBang;
 }
 export async function secondToLast() {
     return await this.findNthFromLast(2);
 }
-export async function secondToLastBang() {
+export function secondToLastBang() {
     return this.secondToLast || this.raiseRecordNotFoundExceptionBang;
 }
 export function isExists(conditions = "none") {
@@ -248,7 +248,7 @@ export async function findWithIds(...ids) {
         return await this.findSome(ids);
     }
 }
-export async function findOne(id) {
+export function findOne(id) {
     let relation, record;
     if (__PRISM_TODO("CallNode")) {
         throw new ArgumentError("            You are passing an instance of ActiveRecord::Base to `find`.\n            Please pass the id of the object by calling `.id`.\n".squish());
@@ -281,7 +281,7 @@ export async function findSome(ids) {
         return this.raiseRecordNotFoundExceptionBang(ids, result.size(), expected_size);
     }
 }
-export async function findSomeOrdered(ids) {
+export function findSomeOrdered(ids) {
     let relation, result;
     ids = ids.slice(this.offsetValue || 0, this.limitValue || ids.size()) || [];
     relation = this.except("limit", "offset");
@@ -297,7 +297,7 @@ export async function findSomeOrdered(ids) {
         return this.raiseRecordNotFoundExceptionBang(ids, result.size(), ids.size());
     }
 }
-export async function findTake() {
+export function findTake() {
     if (this.isLoaded) {
         return this.records.first();
     }
@@ -305,7 +305,7 @@ export async function findTake() {
         return this.take ||= this.limit(1).records().first();
     }
 }
-export async function findTakeWithLimit(limit) {
+export function findTakeWithLimit(limit) {
     if (this.isLoaded) {
         return this.records.take(limit);
     }
@@ -317,7 +317,7 @@ export async function findNth(index) {
     this.offsets ||= {};
     return this.offsets[index] ||= (await this.findNthWithLimit(index, 1)).first();
 }
-export async function findNthWithLimit(index, limit) {
+export function findNthWithLimit(index, limit) {
     let relation;
     if (this.isLoaded) {
         return __PRISM_TODO("CallNode") || [];
@@ -338,7 +338,7 @@ export async function findNthWithLimit(index, limit) {
         }
     }
 }
-export async function findNthFromLast(index) {
+export function findNthFromLast(index) {
     let relation;
     if (this.isLoaded) {
         return this.records[-index];
@@ -353,7 +353,7 @@ export async function findNthFromLast(index) {
         }
     }
 }
-export async function findLast(limit) {
+export function findLast(limit) {
     if (limit) {
         return this.records.last(limit);
     }

--- a/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
@@ -38,7 +38,7 @@ export class WhereChain {
         });
         return this.scope;
     }
-    async missing(...associations) {
+    missing(...associations) {
         let reflection, association_conditions;
         associations.each(association => {
             reflection = this.scopeAssociationReflection(association);
@@ -98,7 +98,7 @@ export function eagerLoad(...args) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, args);
     return this.spawn.eagerLoadBang(...args);
 }
-export async function eagerLoadBang(...args) {
+export function eagerLoadBang(...args) {
     __PRISM_TODO("CallOperatorWriteNode");
     return this;
 }
@@ -110,10 +110,10 @@ export function preloadBang(...args) {
     __PRISM_TODO("CallOperatorWriteNode");
     return this;
 }
-export async function extractAssociated(association) {
+export function extractAssociated(association) {
     return this.preload(association).collect(association);
 }
-export async function references(...table_names) {
+export function references(...table_names) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, table_names);
     return this.spawn.referencesBang(...table_names);
 }
@@ -121,7 +121,7 @@ export function referencesBang(...table_names) {
     __PRISM_TODO("CallOperatorWriteNode");
     return this;
 }
-export async function select(...fields, block) {
+export function select(...fields, block) {
     if (block !== undefined) {
         if (fields.isAny()) {
             throw new ArgumentError("`select' with block doesn't take arguments.");
@@ -161,7 +161,7 @@ export function reselectBang(...args) {
     this.selectValues = args;
     return this;
 }
-export async function group(...args) {
+export function group(...args) {
     this.checkIfMethodHasArgumentsBang(this.__callee__, args);
     return this.spawn.groupBang(...args);
 }
@@ -377,7 +377,7 @@ export function offsetBang(value) {
 export function lock(locks = true) {
     return this.spawn.lockBang(locks);
 }
-export async function lockBang(locks = true) {
+export function lockBang(locks = true) {
     if (caseEq(String, locks) || caseEq(TrueClass, locks) || caseEq(NilClass, locks)) {
         this.lockValue = locks || true;
     }
@@ -399,7 +399,7 @@ export function noneBang() {
 export function isNullRelation() {
     return this.none;
 }
-export async function readonly(value = true) {
+export function readonly(value = true) {
     return this.spawn.readonlyBang(value);
 }
 export function readonlyBang(value = true) {
@@ -426,7 +426,7 @@ export function createWithBang(value) {
     }
     return this;
 }
-export async function from(value, subquery_name = null) {
+export function from(value, subquery_name = null) {
     return this.spawn.fromBang(value, subquery_name);
 }
 export function fromBang(value, subquery_name = null) {

--- a/scripts/prism-codegen/async-keyword.test.ts
+++ b/scripts/prism-codegen/async-keyword.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { generateFromSource } from "./index.js";
+
+async function gen(ruby: string, asyncMethods: string[]): Promise<string> {
+  const { code } = await generateFromSource(ruby, new Set(asyncMethods));
+  return code;
+}
+
+describe("async keyword", () => {
+  it("keeps async on a def whose body awaits", async () => {
+    const code = await gen("class R\n  def a\n    size()\n  end\nend\n", ["a", "size"]);
+    expect(code).toContain("await this.size()");
+    expect(code).toContain("async a()");
+  });
+
+  it("drops async from a def the receiver rule left await-free", async () => {
+    const code = await gen("class R\n  def a\n    rows.size\n  end\nend\n", ["a", "size"]);
+    expect(code).not.toContain("await");
+    expect(code).not.toContain("async a()");
+    expect(code).toContain("a() {");
+  });
+
+  it("drops async from a def the manifest names but that never awaits", async () => {
+    const code = await gen("class R\n  def a\n    1\n  end\nend\n", ["a"]);
+    expect(code).not.toContain("async a()");
+  });
+
+  it("keeps async when only one of several calls awaits", async () => {
+    const ruby = "class R\n  def a\n    rows.size\n    size()\n  end\nend\n";
+    expect(await gen(ruby, ["a", "size"])).toContain("async a()");
+  });
+
+  it("looks through nested control flow for the await", async () => {
+    const ruby = "class R\n  def a\n    if b\n      size()\n    end\n  end\nend\n";
+    expect(await gen(ruby, ["a", "size"])).toContain("async a()");
+  });
+
+  it("leaves a constructor alone", async () => {
+    const code = await gen("class R\n  def initialize\n    @a = 1\n  end\nend\n", ["constructor"]);
+    expect(code).not.toContain("async constructor");
+  });
+});

--- a/scripts/prism-codegen/async-keyword.test.ts
+++ b/scripts/prism-codegen/async-keyword.test.ts
@@ -35,6 +35,13 @@ describe("async keyword", () => {
     expect(await gen(ruby, ["a", "size"])).toContain("async a()");
   });
 
+  it("does not count an await that belongs to a nested block", async () => {
+    const ruby = "class R\n  def a\n    xs.collect { |x| size() }\n  end\nend\n";
+    const code = await gen(ruby, ["a", "size"]);
+    expect(code).toContain("await this.size()");
+    expect(code).not.toContain("async a()");
+  });
+
   it("leaves a constructor alone", async () => {
     const code = await gen("class R\n  def initialize\n    @a = 1\n  end\nend\n", ["constructor"]);
     expect(code).not.toContain("async constructor");

--- a/scripts/prism-codegen/handlers/structure.ts
+++ b/scripts/prism-codegen/handlers/structure.ts
@@ -180,6 +180,7 @@ function defParts(
     params === null ? [] : e.stmts((n.body as PrismNode) ?? null, defName !== "constructor");
   const locals = [...e.declared].filter((d) => !paramNames.has(d));
   const body = f.createBlock([...hoistDecl(locals), ...bodyStmts], true);
+  const keepsAsync = isAsync && containsAwait(body);
   e.currentDef = prevDef;
   e.currentRubyDef = prevRubyDef;
   (
@@ -190,7 +191,18 @@ function defParts(
   e.inAsyncMethod = prevAsync;
   e.inLoop = prevLoop;
   e.blockParamName = prevBlockName;
-  return { params, body, isAsync };
+  return { params, body, isAsync: keepsAsync };
+}
+/**
+ * Whether an emitted method body actually awaits. The manifest marks a def
+ * async by name alone, so once `shouldAwaitCall` declines every await inside
+ * one, the keyword is left describing nothing — and a no-op `async` is not
+ * inert here: it makes the def match the manifest's async name on the next
+ * regeneration, which is how the async surface widens on its own.
+ */
+function containsAwait(node: ts.Node): boolean {
+  if (ts.isAwaitExpression(node)) return true;
+  return ts.forEachChild(node, containsAwait) ?? false;
 }
 function emitParams(params: PrismNode | undefined, e: Emitter): ts.ParameterDeclaration[] | null {
   if (!params) return [];

--- a/scripts/prism-codegen/handlers/structure.ts
+++ b/scripts/prism-codegen/handlers/structure.ts
@@ -199,10 +199,20 @@ function defParts(
  * one, the keyword is left describing nothing — and a no-op `async` is not
  * inert here: it makes the def match the manifest's async name on the next
  * regeneration, which is how the async surface widens on its own.
+ *
+ * The walk stops at nested functions: an await inside a block's arrow belongs
+ * to that arrow, not to the method around it. Those arrows are not marked async
+ * today, so the emitted arrow is invalid either way — but scoping the question
+ * correctly here is what keeps this rule right once that gap is closed.
  */
 function containsAwait(node: ts.Node): boolean {
   if (ts.isAwaitExpression(node)) return true;
-  return ts.forEachChild(node, containsAwait) ?? false;
+  return (
+    ts.forEachChild(node, (child) => {
+      if (ts.isFunctionLike(child)) return false;
+      return containsAwait(child);
+    }) ?? false
+  );
 }
 function emitParams(params: PrismNode | undefined, e: Emitter): ts.ParameterDeclaration[] | null {
   if (!params) return [];


### PR DESCRIPTION
**Rewritten after #5822 landed.** This PR originally carried a receiver
classifier — literals, Kernel casts, guarded locals, constants, native-typed
members — to decide which call sites deserved an `await`. #5822 shipped a
stricter rule from the sibling story `codegen-await-receiver-awareness`:
`shouldAwaitCall` awaits only an implicit self-call or an explicit `self.`,
leaving anything reached through a local, param, ivar, constant, or call chain
bare. That subsumes every site this story named — all six are non-self
receivers, and all six lose their `await` on `main` today. The classifier is
now dead weight, so it is gone; the branch was reset to `main` and reduced to
the one acceptance criterion #5822 did not cover.

## What is left

> methods that become async _only_ because of such a call site lose their
> `async`

A def's `async` comes from `asyncMethods.has(defName)` — the manifest, by name,
independent of its body. With 64 awaits removed by #5822 and the rest of the
receiver-blind ones before it, **107 defs across the goldens now carry an
`async` keyword describing nothing**: `async values() { return this.values.dup(); }`,
`async prettyPrint(pp)`, `async isBlank()`, and so on.

That is not inert. A no-op `async` still makes the def match the manifest's
async name on the next regeneration, so it keeps re-earning awaits at every
call site named after it — the self-widening loop this story was opened for.

`defParts` now revisits the keyword against the body it just emitted:
`isAsync && containsAwait(body)`. No re-emission — the body is byte-identical
either way, since `inAsyncMethod` only ever gated awaits that were not emitted.

`containsAwait` stops at nested function boundaries: an `await` inside a
block's arrow belongs to that arrow, not to the method around it. Those arrows
are not marked `async` today, so the emitted arrow is invalid JS either way —
but scoping the question correctly here is what keeps this rule right once that
gap closes. Registered as `codegen-async-block-arrows` (RFC 0086), which is the
root cause behind the arrow-async point raised twice in review.

## Golden diff

107 lines change and every one is an `async` keyword removal — verified
pairwise, stripping `async ` from each `-` line reproduces its `+` line
exactly. No other output moves, no call site gains or loses an `await`, and
the 0-parse-errors invariant holds.

Five of those 107 come from the function-boundary rule: `create`, `createBang`,
`createOrFindBy`, `createOrFindByBang`, and `execQueries` hold their only
`await` inside a block arrow. They emit as non-async functions wrapping a
non-async arrow that awaits — no worse than before, since that arrow was
already invalid, and well-formed once `codegen-async-block-arrows` lands.

`pnpm vitest run scripts/prism-codegen` is green (128 tests), including seven
new ones in `async-keyword.test.ts` covering the await-bearing, await-free,
never-awaited, mixed, nested-control-flow, nested-block, and constructor cases.

62 LOC excluding snapshots.

Closes-story: await-precision-receiver-blind
