### PR TITLE
feat(prism-codegen): emit block arrows async when their body awaits

### DIFF
--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -10,7 +10,7 @@ extend(ActiveSupport.Concern);
 export function create(attributes = null, block) {
     let object;
     if (attributes.isA(Array)) {
-        return attributes.collect(attr => await this.create(attr, block));
+        return attributes.collect(async (attr) => await this.create(attr, block));
     }
     else {
         object = this.constructor(attributes, block);
@@ -21,7 +21,7 @@ export function create(attributes = null, block) {
 export function createBang(attributes = null, block) {
     let object;
     if (attributes.isA(Array)) {
-        return attributes.collect(attr => await this.createBang(attr, block));
+        return attributes.collect(async (attr) => await this.createBang(attr, block));
     }
     else {
         object = this.constructor(attributes, block);

--- a/scripts/prism-codegen/__snapshots__/relation.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation.js.snap
@@ -54,7 +54,7 @@ export class Relation {
     }
     async create(attributes = null, block) {
         if (attributes.isA(Array)) {
-            return attributes.collect(attr => await this.create(attr, block));
+            return attributes.collect(async (attr) => await this.create(attr, block));
         }
         else {
             block = this.currentScopeRestoringBlock(block);
@@ -63,7 +63,7 @@ export class Relation {
     }
     async createBang(attributes = null, block) {
         if (attributes.isA(Array)) {
-            return attributes.collect(attr => await this.createBang(attr, block));
+            return attributes.collect(async (attr) => await this.createBang(attr, block));
         }
         else {
             block = this.currentScopeRestoringBlock(block);
@@ -86,9 +86,9 @@ export class Relation {
         return await this.findBy(attributes) || await this.createOrFindByBang(attributes, block);
     }
     createOrFindBy(attributes, block) {
-        return this.model.withConnection(connection => {
+        return this.model.withConnection(async (connection) => {
             try {
-                return this.model.transaction({ requires_new: true }, () => await this.create(attributes, block));
+                return this.model.transaction({ requires_new: true }, async () => await this.create(attributes, block));
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
@@ -101,9 +101,9 @@ export class Relation {
         });
     }
     createOrFindByBang(attributes, block) {
-        return this.model.withConnection(connection => {
+        return this.model.withConnection(async (connection) => {
             try {
-                return this.model.transaction({ requires_new: true }, () => await this.createBang(attributes, block));
+                return this.model.transaction({ requires_new: true }, async () => await this.createBang(attributes, block));
             }
             catch (e) {
                 if (connection.isTransactionOpen()) {
@@ -613,7 +613,7 @@ export class Relation {
     }
     execQueries(block) {
         let rows, records;
-        return this.skipQueryCacheIfNecessary(() => {
+        return this.skipQueryCacheIfNecessary(async () => {
             rows = __PRISM_TODO("IfNode");
             records = this.instantiateRecords(rows, block);
             if (!this.skipPreloadingValue) {

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -247,6 +247,21 @@ describe("prism-codegen", () => {
     );
     expect(code.match(/await this\.relation\.load\(\)/g)).toHaveLength(1);
   });
+  it("marks a block arrow async when its own body awaits, not when only a nested one does", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def create(attrs)
+          attrs.collect { |attr| save(attr) }
+          attrs.each { |attr| attr.each { |x| save(x) } }
+          attrs.each { |attr| attr.size }
+        end
+      end`,
+      new Set(["save", "create"]),
+    );
+    expect(code).toContain("attrs.collect(async (attr) => await this.save(attr))");
+    expect(code).toContain("attrs.each(attr => attr.each(async (x) => await this.save(x)))");
+    expect(code).toContain("attrs.each(attr => attr.size())");
+  });
   it("never awaits async-named calls inside a sync method", async () => {
     const { code } = await generateFromSource(
       `module M

--- a/scripts/prism-codegen/golden.test.ts
+++ b/scripts/prism-codegen/golden.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import * as fs from "fs/promises";
-import { countParseErrors } from "./index.js";
+import { countAwaitsOutsideAsync, countParseErrors } from "./index.js";
 import {
   generateTarget,
   outNameFor,
@@ -24,6 +24,11 @@ describe.skipIf(!vendored)("prism-codegen golden output", () => {
     it(`has zero parse errors in the checked-in image for ${f.ruby}`, async () => {
       const snapshot = await fs.readFile(snapshotPathFor(outName), "utf8");
       expect(countParseErrors(snapshot)).toBe(0);
+    });
+
+    it(`has no await outside an async function in the checked-in image for ${f.ruby}`, async () => {
+      const snapshot = await fs.readFile(snapshotPathFor(outName), "utf8");
+      expect(countAwaitsOutsideAsync(snapshot)).toBe(0);
     });
   }
 });

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -325,7 +325,7 @@ function blockToArrow(block: PrismNode, names: string[], e: Emitter): ts.ArrowFu
   e.inLoop = prevLoop;
   if (body.length === 1 && ts.isReturnStatement(body[0]) && body[0].expression) {
     return f.createArrowFunction(
-      undefined,
+      asyncModifiers(body[0].expression),
       undefined,
       params,
       undefined,
@@ -333,14 +333,44 @@ function blockToArrow(block: PrismNode, names: string[], e: Emitter): ts.ArrowFu
       body[0].expression,
     );
   }
+  const blockBody = f.createBlock(body, true);
   return f.createArrowFunction(
-    undefined,
+    asyncModifiers(blockBody),
     undefined,
     params,
     undefined,
     undefined,
-    f.createBlock(body, true),
+    blockBody,
   );
+}
+
+function asyncModifiers(body: ts.Node): ts.Modifier[] | undefined {
+  return containsAwait(body) ? [f.createToken(ts.SyntaxKind.AsyncKeyword)] : undefined;
+}
+
+// Nested functions have their own async scope, so the walk stops at their boundary.
+function containsAwait(node: ts.Node): boolean {
+  let found = false;
+  const visit = (child: ts.Node): void => {
+    if (found) return;
+    if (ts.isAwaitExpression(child)) {
+      found = true;
+      return;
+    }
+    if (
+      ts.isFunctionDeclaration(child) ||
+      ts.isFunctionExpression(child) ||
+      ts.isArrowFunction(child) ||
+      ts.isMethodDeclaration(child) ||
+      ts.isClassDeclaration(child) ||
+      ts.isClassExpression(child)
+    ) {
+      return;
+    }
+    ts.forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
 }
 function blockParamNames(params: PrismNode | undefined): string[] | null {
   if (!params) return [];

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -348,7 +348,6 @@ function asyncModifiers(body: ts.Node): ts.Modifier[] | undefined {
   return containsAwait(body) ? [f.createToken(ts.SyntaxKind.AsyncKeyword)] : undefined;
 }
 
-// Nested functions have their own async scope, so the walk stops at their boundary.
 function containsAwait(node: ts.Node): boolean {
   let found = false;
   const visit = (child: ts.Node): void => {

--- a/scripts/prism-codegen/index.ts
+++ b/scripts/prism-codegen/index.ts
@@ -80,6 +80,36 @@ export function countParseErrors(code: string): number {
     ).parseDiagnostics ?? []
   ).length;
 }
+/** Awaits that land in a function not marked `async` — invalid JS the printer cannot catch. */
+export function countAwaitsOutsideAsync(code: string): number {
+  const source = ts.createSourceFile(
+    "gen.js",
+    code,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.JS,
+  );
+  let count = 0;
+  const walk = (node: ts.Node, inAsync: boolean): void => {
+    if (ts.isAwaitExpression(node) && !inAsync) count += 1;
+    const isFunction =
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node) ||
+      ts.isConstructorDeclaration(node);
+    const scope = isFunction
+      ? ((node as { modifiers?: readonly ts.ModifierLike[] }).modifiers ?? []).some(
+          (m) => m.kind === ts.SyntaxKind.AsyncKeyword,
+        )
+      : inAsync;
+    node.forEachChild((child) => walk(child, scope));
+  };
+  walk(source, true);
+  return count;
+}
 export { summarizeCoverage } from "./coverage.js";
 export { TARGET_FILES } from "./files.js";
 export { asyncMethodsForRailsFile } from "./async-source.js";


### PR DESCRIPTION
`emitCall` wraps calls in `await` based on the enclosing **def**'s
`inAsyncMethod`, so an `await` inside a Ruby block landed in an arrow that was
never marked `async` — invalid JS that only survived because goldens are printed
through the TS factory rather than re-parsed.

`blockToArrow` now scans the emitted arrow body for an `await` and adds the
`async` modifier when it finds one. The walk stops at nested function and class
boundaries, so an inner arrow's `await` does not leak `async` outward, and the
enclosing def's `async` is still decided independently.

Goldens regenerated: the five known sites (`create`/`createBang` in
persistence and relation, `createOrFindBy`, `createOrFindByBang`, `execQueries`)
now emit `async` arrows. A parse-and-walk check over every `__snapshots__/*.snap`
confirms no `await` remains inside a non-async function.

Closes-story: codegen-async-block-arrows
