### PR TITLE
feat(prism-codegen): award awaits to receivers with local async provenance

### DIFF
--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -30,6 +30,10 @@ export function shouldAwaitCall(opts: {
  * The provenance-tracking key for a variable read or write: `@name` for an
  * instance variable, `name` for a local. Anything else has no key, so it can
  * neither record nor claim local async provenance.
+ *
+ * Provenance is recorded per write and retracted by a later write whose value
+ * has none: after `@rel = arg` the receiver is unpinned again, so awaiting its
+ * calls would be a guess.
  */
 export function asyncBindingKey(node: PrismNode | null | undefined): string | null {
   const kind = node?.constructor?.name;
@@ -45,6 +49,10 @@ export function asyncBindingKey(node: PrismNode | null | undefined): string | nu
  * a method the async manifest resolves. The receiver of such a call is fixed
  * by the AST, so unlike a bare name the manifest lookup cannot land on an
  * unrelated same-named method.
+ *
+ * A bare, paren-less, argument-less implicit self-call is excluded: the
+ * emitter renders it as a property access rather than a call, so the target
+ * holds a method reference, not the method's resolved value.
  */
 export function hasAsyncProvenance(
   value: PrismNode | null | undefined,
@@ -54,5 +62,8 @@ export function hasAsyncProvenance(
   if (!value || value.constructor?.name !== "CallNode") return false;
   const receiver = value.receiver as PrismNode | null;
   if (receiver && receiver.constructor?.name !== "SelfNode") return false;
+  const invoked =
+    receiver != null || value.openingLoc != null || value.arguments_ != null || value.block != null;
+  if (!invoked) return false;
   return asyncMethods.has(jsNameOf(String(value.name)));
 }

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -9,15 +9,50 @@ import type { PrismNode } from "./types.js";
  * a no-op only for as long as the generated output is never executed — once it
  * is applied, an await in a sync path is a behavioural change. So the rule is
  * narrowed to the receivers the AST actually pins down: an implicit self-call,
- * or an explicit `self.`. Anything reached through a local, a param, an ivar,
- * a constant, or a call chain is left bare.
+ * an explicit `self.`, or a receiver whose async provenance was established
+ * inside the enclosing def (see {@link asyncBindingKey}). Anything else — a
+ * param, a constant, a call chain, an ivar of unknown origin — is left bare.
  */
 export function shouldAwaitCall(opts: {
   receiver: PrismNode | null | undefined;
   jsName: string;
   inAsyncMethod: boolean;
   asyncMethods: ReadonlySet<string>;
+  asyncBindings?: ReadonlySet<string>;
 }): boolean {
   if (!opts.inAsyncMethod || !opts.asyncMethods.has(opts.jsName)) return false;
-  return !opts.receiver || opts.receiver.constructor?.name === "SelfNode";
+  if (!opts.receiver || opts.receiver.constructor?.name === "SelfNode") return true;
+  const key = asyncBindingKey(opts.receiver);
+  return key != null && (opts.asyncBindings?.has(key) ?? false);
+}
+
+/**
+ * The provenance-tracking key for a variable read or write: `@name` for an
+ * instance variable, `name` for a local. Anything else has no key, so it can
+ * neither record nor claim local async provenance.
+ */
+export function asyncBindingKey(node: PrismNode | null | undefined): string | null {
+  const kind = node?.constructor?.name;
+  if (!node || !kind) return null;
+  if (kind.startsWith("InstanceVariable")) return `@${String(node.name)}`;
+  if (kind.startsWith("LocalVariable")) return String(node.name);
+  return null;
+}
+
+/**
+ * Whether an assigned value pins the target's type down well enough to award
+ * awaits on its later use: a self-call (implicit, or explicit `self.`) naming
+ * a method the async manifest resolves. The receiver of such a call is fixed
+ * by the AST, so unlike a bare name the manifest lookup cannot land on an
+ * unrelated same-named method.
+ */
+export function hasAsyncProvenance(
+  value: PrismNode | null | undefined,
+  jsNameOf: (rubyName: string) => string,
+  asyncMethods: ReadonlySet<string>,
+): boolean {
+  if (!value || value.constructor?.name !== "CallNode") return false;
+  const receiver = value.receiver as PrismNode | null;
+  if (receiver && receiver.constructor?.name !== "SelfNode") return false;
+  return asyncMethods.has(jsNameOf(String(value.name)));
 }

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -44,6 +44,31 @@ export function asyncBindingKey(node: PrismNode | null | undefined): string | nu
 }
 
 /**
+ * Drop the write target's async provenance, recursing into the nested targets
+ * of a destructuring write. Every rebind that does not itself establish
+ * provenance has to go through here.
+ */
+export function clearAsyncProvenance(
+  target: PrismNode | null | undefined,
+  bindings: Set<string>,
+): void {
+  if (!target) return;
+  const key = asyncBindingKey(target);
+  if (key) {
+    bindings.delete(key);
+    return;
+  }
+  if (target.constructor?.name !== "MultiTargetNode") return;
+  for (const nested of [
+    ...((target.lefts as PrismNode[]) ?? []),
+    ...((target.rights as PrismNode[]) ?? []),
+    (target.rest as PrismNode | null) ?? null,
+  ]) {
+    clearAsyncProvenance(nested, bindings);
+  }
+}
+
+/**
  * Whether an assigned value pins the target's type down well enough to award
  * awaits on its later use: a self-call (implicit, or explicit `self.`) naming
  * a method the async manifest resolves. The receiver of such a call is fixed

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -142,6 +142,19 @@ describe("prism-codegen", () => {
     expect(code).not.toContain("await arg.load()");
     expect(code).not.toContain("await this.other.load()");
   });
+  it("claims no provenance from a paren-less self-call, which emits a method reference", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all
+          @relation = build_relation
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("this.relation = this.buildRelation;");
+    expect(code).not.toContain("await this.relation.load()");
+  });
   it("stops awaiting a receiver reassigned from an unknown value", async () => {
     const { code } = await generateFromSource(
       `module M
@@ -156,6 +169,30 @@ describe("prism-codegen", () => {
     );
     expect(code).toContain("await this.relation.load()");
     expect(code.match(/await this\.relation\.load\(\)/g)).toHaveLength(1);
+  });
+  it("stops awaiting a receiver rebound by a logical or destructuring write", async () => {
+    const orWrite = await generateFromSource(
+      `module M
+        def load_all(arg)
+          @relation = build_relation()
+          @relation ||= arg
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(orWrite.code).not.toContain("await this.relation.load()");
+    const multiWrite = await generateFromSource(
+      `module M
+        def load_all(arg)
+          rel = build_relation()
+          rel, other = arg
+          rel.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(multiWrite.code).not.toContain("await rel.load()");
   });
   it("does not carry async provenance across defs", async () => {
     const { code } = await generateFromSource(

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -194,6 +194,43 @@ describe("prism-codegen", () => {
     );
     expect(multiWrite.code).not.toContain("await rel.load()");
   });
+  it("stops awaiting a receiver rebound by an operator write", async () => {
+    const ivarWrite = await generateFromSource(
+      `module M
+        def load_all(arg)
+          @relation = build_relation()
+          @relation += arg
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(ivarWrite.code).not.toContain("await this.relation.load()");
+    const localWrite = await generateFromSource(
+      `module M
+        def load_all(arg)
+          rel = build_relation()
+          rel += arg
+          rel.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(localWrite.code).not.toContain("await rel.load()");
+  });
+  it("stops awaiting a receiver rebound by a nested destructuring target", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(arg)
+          rel = build_relation()
+          first, (rel, _rest) = arg
+          rel.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).not.toContain("await rel.load()");
+  });
   it("does not carry async provenance across defs", async () => {
     const { code } = await generateFromSource(
       `module M

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -110,6 +110,68 @@ describe("prism-codegen", () => {
     expect(code).not.toContain("await this.scope.first()");
     expect(code).not.toContain("await ids.first().first()");
   });
+  it("awaits through a receiver assigned from an async self-call", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all
+          @relation = build_relation()
+          @relation.load
+          rel = self.build_relation
+          rel.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("this.relation = await this.buildRelation()");
+    expect(code).toContain("await this.relation.load()");
+    expect(code).toContain("await rel.load()");
+  });
+  it("leaves a receiver of unknown provenance bare", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(arg)
+          @relation.load
+          arg.load
+          @other = arg
+          @other.load
+        end
+      end`,
+      new Set(["load", "loadAll"]),
+    );
+    expect(code).not.toContain("await this.relation.load()");
+    expect(code).not.toContain("await arg.load()");
+    expect(code).not.toContain("await this.other.load()");
+  });
+  it("stops awaiting a receiver reassigned from an unknown value", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(arg)
+          @relation = build_relation()
+          @relation.load
+          @relation = arg
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("await this.relation.load()");
+    expect(code.match(/await this\.relation\.load\(\)/g)).toHaveLength(1);
+  });
+  it("does not carry async provenance across defs", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all
+          @relation = build_relation()
+          @relation.load
+        end
+        def reload_all
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "reloadAll", "buildRelation"]),
+    );
+    expect(code.match(/await this\.relation\.load\(\)/g)).toHaveLength(1);
+  });
   it("never awaits async-named calls inside a sync method", async () => {
     const { code } = await generateFromSource(
       `module M

--- a/scripts/prism-codegen/codegen.ts
+++ b/scripts/prism-codegen/codegen.ts
@@ -38,6 +38,7 @@ export class Codegen implements Emitter {
   readonly helpers = new Set<string>();
   blockParamName: string | null = null;
   declared = new Set<string>();
+  asyncBindings = new Set<string>();
   constructor(
     private readonly registry: Registry,
     readonly asyncMethods: ReadonlySet<string> = new Set(),

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -4,7 +4,7 @@ import type { Registry } from "../registry.js";
 import { methodName, isJsIdentName, isBindableIdent } from "../naming.js";
 import { rubyStr } from "../types.js";
 import { TOPLEVEL } from "../codegen.js";
-import { shouldAwaitCall } from "../await-policy.js";
+import { asyncBindingKey, hasAsyncProvenance, shouldAwaitCall } from "../await-policy.js";
 const f = ts.factory;
 const INFIX: Record<string, ts.BinaryOperator> = {
   "==": ts.SyntaxKind.EqualsEqualsEqualsToken,
@@ -43,11 +43,13 @@ export function registerExpressions(r: Registry): void {
   r.on("LocalVariableWriteNode", (n, e) => {
     if (!isBindableIdent(String(n.name))) return null;
     e.declared.add(String(n.name));
+    trackAsyncProvenance(n, e);
     return f.createAssignment(f.createIdentifier(String(n.name)), e.expr(n.value as PrismNode));
   });
-  r.on("InstanceVariableWriteNode", (n, e) =>
-    f.createAssignment(thisProp(n.name), e.expr(n.value as PrismNode)),
-  );
+  r.on("InstanceVariableWriteNode", (n, e) => {
+    trackAsyncProvenance(n, e);
+    return f.createAssignment(thisProp(n.name), e.expr(n.value as PrismNode));
+  });
   r.on("ClassVariableWriteNode", (n, e) =>
     f.createAssignment(
       f.createPropertyAccessExpression(
@@ -277,9 +279,24 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
     jsName,
     inAsyncMethod: e.inAsyncMethod,
     asyncMethods: e.asyncMethods,
+    asyncBindings: e.asyncBindings,
   })
     ? f.createAwaitExpression(call)
     : call;
+}
+/**
+ * Record — or retract — the write target's async provenance. A later
+ * assignment from a value of unknown type has to clear the key: the receiver
+ * is no longer pinned down, so awaiting its calls would be a guess again.
+ */
+function trackAsyncProvenance(n: PrismNode, e: Emitter): void {
+  const key = asyncBindingKey(n);
+  if (!key) return;
+  if (hasAsyncProvenance(n.value as PrismNode | null, methodName, e.asyncMethods)) {
+    e.asyncBindings.add(key);
+  } else {
+    e.asyncBindings.delete(key);
+  }
 }
 function symToProcArrow(prop: string): ts.ArrowFunction {
   return f.createArrowFunction(

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -67,6 +67,7 @@ export function registerExpressions(r: Registry): void {
   );
   r.on("MultiWriteNode", (n, e) => {
     if (n.rest || !((n.lefts as PrismNode[]) ?? []).every(isEmittableTarget)) return null;
+    for (const l of (n.lefts as PrismNode[]) ?? []) clearAsyncProvenance(l, e);
     const lefts = ((n.lefts as PrismNode[]) ?? []).map((l) => e.expr(l));
     return f.createAssignment(f.createArrayLiteralExpression(lefts), e.expr(n.value as PrismNode));
   });
@@ -134,6 +135,7 @@ function logicalWrite(
   n: PrismNode,
   e: Emitter,
 ): ts.Expression {
+  clearAsyncProvenance(n, e);
   return f.createBinaryExpression(target, op as ts.BinaryOperator, e.expr(n.value as PrismNode));
 }
 function argExprs(node: PrismNode | undefined | null, e: Emitter): ts.Expression[] {
@@ -284,11 +286,10 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
     ? f.createAwaitExpression(call)
     : call;
 }
-/**
- * Record — or retract — the write target's async provenance. A later
- * assignment from a value of unknown type has to clear the key: the receiver
- * is no longer pinned down, so awaiting its calls would be a guess again.
- */
+function clearAsyncProvenance(n: PrismNode, e: Emitter): void {
+  const key = asyncBindingKey(n);
+  if (key) e.asyncBindings.delete(key);
+}
 function trackAsyncProvenance(n: PrismNode, e: Emitter): void {
   const key = asyncBindingKey(n);
   if (!key) return;

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -4,7 +4,12 @@ import type { Registry } from "../registry.js";
 import { methodName, isJsIdentName, isBindableIdent } from "../naming.js";
 import { rubyStr } from "../types.js";
 import { TOPLEVEL } from "../codegen.js";
-import { asyncBindingKey, hasAsyncProvenance, shouldAwaitCall } from "../await-policy.js";
+import {
+  asyncBindingKey,
+  clearAsyncProvenance,
+  hasAsyncProvenance,
+  shouldAwaitCall,
+} from "../await-policy.js";
 const f = ts.factory;
 const INFIX: Record<string, ts.BinaryOperator> = {
   "==": ts.SyntaxKind.EqualsEqualsEqualsToken,
@@ -67,7 +72,7 @@ export function registerExpressions(r: Registry): void {
   );
   r.on("MultiWriteNode", (n, e) => {
     if (n.rest || !((n.lefts as PrismNode[]) ?? []).every(isEmittableTarget)) return null;
-    for (const l of (n.lefts as PrismNode[]) ?? []) clearAsyncProvenance(l, e);
+    for (const l of (n.lefts as PrismNode[]) ?? []) clearAsyncProvenance(l, e.asyncBindings);
     const lefts = ((n.lefts as PrismNode[]) ?? []).map((l) => e.expr(l));
     return f.createAssignment(f.createArrayLiteralExpression(lefts), e.expr(n.value as PrismNode));
   });
@@ -135,7 +140,7 @@ function logicalWrite(
   n: PrismNode,
   e: Emitter,
 ): ts.Expression {
-  clearAsyncProvenance(n, e);
+  clearAsyncProvenance(n, e.asyncBindings);
   return f.createBinaryExpression(target, op as ts.BinaryOperator, e.expr(n.value as PrismNode));
 }
 function argExprs(node: PrismNode | undefined | null, e: Emitter): ts.Expression[] {
@@ -285,10 +290,6 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
   })
     ? f.createAwaitExpression(call)
     : call;
-}
-function clearAsyncProvenance(n: PrismNode, e: Emitter): void {
-  const key = asyncBindingKey(n);
-  if (key) e.asyncBindings.delete(key);
 }
 function trackAsyncProvenance(n: PrismNode, e: Emitter): void {
   const key = asyncBindingKey(n);

--- a/scripts/prism-codegen/handlers/misc.ts
+++ b/scripts/prism-codegen/handlers/misc.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { rubyStr, type Emitter, type PrismNode } from "../types.js";
 import type { Registry } from "../registry.js";
 import { methodName, isJsIdentName, isBindableIdent } from "../naming.js";
+import { clearAsyncProvenance } from "../await-policy.js";
 import { normalizeModuleName, OUTSIDE_CORPUS, type SuperResolution } from "../linearization.js";
 const f = ts.factory;
 const COMPOUND: Record<string, ts.BinaryOperator> = {
@@ -42,6 +43,7 @@ export function registerMisc(r: Registry): void {
     const op = COMPOUND[String(n.binaryOperator)];
     if (!op || !isBindableIdent(String(n.name))) return null;
     e.declared.add(String(n.name));
+    clearAsyncProvenance(n, e.asyncBindings);
     return f.createBinaryExpression(
       f.createIdentifier(String(n.name)),
       op,
@@ -51,6 +53,7 @@ export function registerMisc(r: Registry): void {
   r.on("InstanceVariableOperatorWriteNode", (n, e) => {
     const op = COMPOUND[String(n.binaryOperator)];
     if (!op) return null;
+    clearAsyncProvenance(n, e.asyncBindings);
     return f.createBinaryExpression(thisProp(n.name), op, e.expr(n.value as PrismNode));
   });
   r.on("CallOperatorWriteNode", (n, e) => {

--- a/scripts/prism-codegen/handlers/structure.ts
+++ b/scripts/prism-codegen/handlers/structure.ts
@@ -162,6 +162,12 @@ function defParts(
       declared: Set<string>;
     }
   ).declared = new Set();
+  const prevBindings = e.asyncBindings;
+  (
+    e as {
+      asyncBindings: Set<string>;
+    }
+  ).asyncBindings = new Set();
   e.inAsyncMethod = isAsync;
   e.inLoop = false;
   const params = emitParams(n.parameters as PrismNode | undefined, e);
@@ -187,6 +193,11 @@ function defParts(
       declared: Set<string>;
     }
   ).declared = prevDeclared;
+  (
+    e as {
+      asyncBindings: Set<string>;
+    }
+  ).asyncBindings = prevBindings;
   e.inAsyncMethod = prevAsync;
   e.inLoop = prevLoop;
   e.blockParamName = prevBlockName;

--- a/scripts/prism-codegen/types.ts
+++ b/scripts/prism-codegen/types.ts
@@ -56,6 +56,11 @@ export interface Emitter {
 
   blockParamName: string | null;
   readonly declared: Set<string>;
+  /**
+   * Receivers with locally established async provenance, keyed as
+   * `@ivar` / `local`. Scoped to the enclosing def, like `declared`.
+   */
+  readonly asyncBindings: Set<string>;
 }
 export interface Coverage {
   record(kind: string, handled: boolean): void;


### PR DESCRIPTION
## What

PR #5822 narrowed await insertion to self-receivers only, trading false
positives for false negatives: `@relation.load` where `@relation` was just
assigned from an async self-call emitted bare, silently yielding a pending
promise once the output is applied.

This recovers those awaits, and only those. `scripts/prism-codegen/await-policy.ts`
gains two helpers:

- `hasAsyncProvenance(value, …)` — true when an assigned value is an *invoked*
  self-call (implicit or explicit `self.`) naming a method in the async
  manifest. The receiver is pinned by the AST, so unlike a bare name the
  manifest lookup cannot land on an unrelated same-named method. A paren-less,
  argument-less implicit self-call is excluded, because the emitter renders
  that as a property access — the target holds a method reference, not the
  method's value.
- `asyncBindingKey(node)` — `@name` for an ivar, `name` for a local; `null` for
  anything else, so params, constants and call chains can neither record nor
  claim provenance.

The emitter tracks those keys in a per-def `asyncBindings` set (scoped and
restored alongside `declared` in `defParts`). Provenance is retracted by every
later rebind that does not carry it, all routed through the exported
`clearAsyncProvenance`: a plain write from an unknown value, a `||=` / `&&=`
logical write, an operator write (`+=` and friends, in `handlers/misc.ts`), and
destructuring `MultiWriteNode` targets — including nested `MultiTargetNode`
targets, which it recurses into. After `@relation = arg` the receiver is
unpinned again and its calls go back to bare.

The conservative default is untouched for everything else.

## Newly added awaits

None in the checked-in goldens — the snapshots and `pnpm codegen:generate`
output are byte-identical to `main`. The pattern (ivar or local assigned from
an invoked async self-call and then called _within the same def_) does not
occur in the current corpus; the inference exists for the wider apply surface.
`pnpm codegen:score` matched count is unchanged at 32.

## Review round 1

Both findings fixed, each with a test verified to fail without the fix:

1. Operator writes (`@relation += arg`) did not retract provenance. Both
   `LocalVariableOperatorWriteNode` and `InstanceVariableOperatorWriteNode` now
   call `clearAsyncProvenance`.
2. Nested destructuring targets (`first, (rel, _rest) = arg`) were not cleared.
   `clearAsyncProvenance` moved to `await-policy.ts` and now recurses through a
   `MultiTargetNode`'s `lefts` / `rights` / `rest`.

## Tests

`scripts/prism-codegen/codegen.test.ts` (129 pass) covers: ivar and local
assigned from an async self-call (awaited on later use); ivar of unknown
provenance and a param receiver (left bare); a paren-less self-call claiming no
provenance; retraction on reassignment from an unknown value, on `||=`, on
`+=`, on a destructuring write, and on a nested destructuring target; and no
provenance carry-over across defs.

Closes-story: codegen-await-local-receiver-inference
