### PR TITLE
feat(prism-codegen): scope self-call await decisions to the file's own Rails ancestry

### DIFF
--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -67,9 +67,9 @@ export function buildAsyncManifest(files: PortFile[]): AsyncManifest {
 }
 /**
  * Names the manifest resolves to exactly one async definition outside the twin
- * file. Ambiguous names (async in several port files) are declined: the await
- * rule is receiver-blind, so a name that could be two different methods must
- * not drag an await onto the wrong call.
+ * file, restricted to the `railsDefs` the calling file can actually dispatch
+ * to. Ambiguous names (async in several port files) are declined: a name that
+ * could be two different methods must not drag an await onto the wrong call.
  */
 export function crossFileAsyncNames(
   manifest: AsyncManifest,

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -1,22 +1,15 @@
 import { existsSync, readFileSync } from "node:fs";
 import * as path from "node:path";
 import { rubyFileToTs, methodName } from "./naming.js";
-import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath, type PortFile } from "./files.js";
+import { TRAILS_AR_SRC, portTreeFiles, type PortFile } from "./files.js";
+import { ownRailsDefs, reachableRailsDefs } from "./rails-scope.js";
 import { resolvePath } from "../../vendor/sources.js";
 const AR_ROOT = resolvePath("activerecord");
 const AR_LIB = path.dirname(AR_ROOT);
-const RUBY_DEF = /^\s*def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)/gm;
-export function rubyDefinedMethods(rubySource: string): Set<string> {
-  const defs = new Set<string>();
-  for (const m of rubySource.matchAll(RUBY_DEF)) defs.add(methodName(m[1]));
-  return defs;
-}
+export { rubyDefinedMethods } from "./rails-scope.js";
 function railsSource(railsRelPath: string): string {
   const abs = path.join(AR_LIB, railsRelPath);
   return existsSync(abs) ? readFileSync(abs, "utf8") : "";
-}
-function railsDefinedMethods(railsRelPath: string): Set<string> {
-  return rubyDefinedMethods(railsSource(railsRelPath));
 }
 const ASYNC_DECL = /\basync\s+(?:function\s+)?([A-Za-z_$][\w$]*)\s*[(<]/g;
 const ASYNC_ARROW = /\b(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*async\b/g;
@@ -194,25 +187,6 @@ export function defaultAsyncManifest(): AsyncManifest {
   manifestCache ??= buildAsyncManifest(portTreeFiles());
   return manifestCache;
 }
-let railsCorpusDefsCache: Set<string> | undefined;
-/**
- * Every method Rails defines across the codegen target set. A cross-file async
- * name only earns an await when it is also a Rails method — that keeps
- * incidental TS-only helpers (and same-named library calls) out of the
- * receiver-blind await rule, the same intersect-with-Rails-defs guard the
- * relation.ts supplement has always used.
- */
-function railsCorpusDefs(): Set<string> {
-  if (railsCorpusDefsCache) return railsCorpusDefsCache;
-  const defs = new Set<string>();
-  for (const f of TARGET_FILES) {
-    const abs = rubyAbsPath(f);
-    if (!existsSync(abs)) continue;
-    for (const n of rubyDefinedMethods(readFileSync(abs, "utf8"))) defs.add(n);
-  }
-  railsCorpusDefsCache = defs;
-  return defs;
-}
 export function asyncMethodsForRailsFile(
   railsRelPath: string,
   manifest: AsyncManifest = defaultAsyncManifest(),
@@ -225,8 +199,11 @@ export function asyncMethodsForRailsFile(
   return resolveAsyncNames({
     twinTs,
     relationTs: relationFamily ? readFileOr(path.join(TRAILS_AR_SRC, "relation.ts")) : undefined,
-    ownRubyDefs: relationFamily ? railsDefinedMethods(railsRelPath) : undefined,
-    crossFile: crossFileAsyncNames(manifest, { twinTsPath, railsDefs: railsCorpusDefs() }),
+    ownRubyDefs: relationFamily ? ownRailsDefs(railsRelPath) : undefined,
+    crossFile: crossFileAsyncNames(manifest, {
+      twinTsPath,
+      railsDefs: reachableRailsDefs(railsRelPath),
+    }),
     inferFromRuby: existsSync(twinTsAbs) ? undefined : railsSource(railsRelPath),
   });
 }

--- a/scripts/prism-codegen/rails-scope.test.ts
+++ b/scripts/prism-codegen/rails-scope.test.ts
@@ -19,6 +19,7 @@ describe("prism-codegen rails scope", () => {
     expect(names).toEqual([
       "Enumerable",
       "FinderMethods",
+      "Calculations",
       "ActiveRecord::Delegation::DelegateCache",
     ]);
   });
@@ -36,8 +37,11 @@ describe("prism-codegen rails scope", () => {
   it("reaches the defs of the modules a Rails file includes", () => {
     const relation = reachableRailsDefs("active_record/relation.rb");
     expect(relation.has("findBy")).toBe(true);
-    expect(relation.has("pluck")).toBe(true);
+    expect(relation.has("calculate")).toBe(true);
+    expect(relation.has("where")).toBe(true);
+    expect(relation.has("scoping")).toBe(true);
     expect(reachableRailsDefs("active_record/relation/finder_methods.rb").has("pluck")).toBe(false);
+    expect(reachableRailsDefs("active_record/relation/finder_methods.rb").has("where")).toBe(false);
   });
 
   it("declines a cross-file async name the generating Rails file cannot dispatch to", () => {

--- a/scripts/prism-codegen/rails-scope.test.ts
+++ b/scripts/prism-codegen/rails-scope.test.ts
@@ -1,10 +1,37 @@
 import { describe, it, expect } from "vitest";
-import { mixinPathCandidates, parseMixinNames, reachableRailsDefs } from "./rails-scope.js";
 import {
-  asyncMethodsForRailsFile,
-  buildAsyncManifest,
-  crossFileAsyncNames,
-} from "./async-source.js";
+  mixinPathCandidates,
+  parseMixinNames,
+  reachableRailsDefs,
+  type RubySourceReader,
+} from "./rails-scope.js";
+import { buildAsyncManifest, crossFileAsyncNames } from "./async-source.js";
+
+/**
+ * Rails' own layout, trimmed to the shape that matters: `relation.rb` mixes in
+ * seven modules on one `include` line (relation.rb:68), and `finder_methods.rb`
+ * mixes in nothing.
+ */
+const RAILS: Record<string, string> = {
+  "relation.rb": `
+    module ActiveRecord
+      class Relation
+        include Enumerable
+        include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
+        def scoping; end
+      end
+    end
+  `,
+  "relation/finder_methods.rb": `def find_by; end\ndef find; end`,
+  "relation/calculations.rb": `def calculate; end\ndef pluck; end`,
+  "relation/query_methods.rb": `def where; end`,
+  "relation/spawn_methods.rb": `def merge; end`,
+  "relation/batches.rb": `def find_each; end`,
+  "relation/explain.rb": `def explain; end`,
+  "relation/delegation.rb": `def klass; end`,
+};
+
+const reader: RubySourceReader = (rel) => RAILS[rel];
 
 describe("prism-codegen rails scope", () => {
   it("reads the include/extend constants out of a Ruby source", () => {
@@ -34,14 +61,19 @@ describe("prism-codegen rails scope", () => {
     ).toEqual(["relation/query_methods/core.rb", "relation/core.rb", "core.rb"]);
   });
 
-  it("reaches the defs of the modules a Rails file includes", () => {
-    const relation = reachableRailsDefs("active_record/relation.rb");
+  it("reaches the defs of every module a Rails file includes", () => {
+    const relation = reachableRailsDefs("active_record/relation.rb", reader);
+    expect(relation.has("scoping")).toBe(true);
     expect(relation.has("findBy")).toBe(true);
     expect(relation.has("calculate")).toBe(true);
     expect(relation.has("where")).toBe(true);
-    expect(relation.has("scoping")).toBe(true);
-    expect(reachableRailsDefs("active_record/relation/finder_methods.rb").has("pluck")).toBe(false);
-    expect(reachableRailsDefs("active_record/relation/finder_methods.rb").has("where")).toBe(false);
+    expect(relation.has("merge")).toBe(true);
+    expect(relation.has("findEach")).toBe(true);
+
+    const finderMethods = reachableRailsDefs("active_record/relation/finder_methods.rb", reader);
+    expect(finderMethods.has("find")).toBe(true);
+    expect(finderMethods.has("where")).toBe(false);
+    expect(finderMethods.has("pluck")).toBe(false);
   });
 
   it("declines a cross-file async name the generating Rails file cannot dispatch to", () => {
@@ -49,19 +81,13 @@ describe("prism-codegen rails scope", () => {
       { path: "relation/calculations.ts", source: `class C { async pluck() {} }` },
     ]);
     const scoped = (railsRelPath: string, twinTsPath: string) =>
-      crossFileAsyncNames(manifest, { twinTsPath, railsDefs: reachableRailsDefs(railsRelPath) });
+      crossFileAsyncNames(manifest, {
+        twinTsPath,
+        railsDefs: reachableRailsDefs(railsRelPath, reader),
+      });
     expect(scoped("active_record/relation.rb", "relation.ts").has("pluck")).toBe(true);
     expect(
       scoped("active_record/relation/finder_methods.rb", "relation/finder-methods.ts").has("pluck"),
     ).toBe(false);
-  });
-
-  it("keeps a name async where Rails defines it and sync where it does not", () => {
-    expect(asyncMethodsForRailsFile("active_record/relation/calculations.rb").has("pluck")).toBe(
-      true,
-    );
-    expect(asyncMethodsForRailsFile("active_record/relation/finder_methods.rb").has("pluck")).toBe(
-      false,
-    );
   });
 });

--- a/scripts/prism-codegen/rails-scope.test.ts
+++ b/scripts/prism-codegen/rails-scope.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { mixinPathCandidates, parseMixinNames, reachableRailsDefs } from "./rails-scope.js";
+import {
+  asyncMethodsForRailsFile,
+  buildAsyncManifest,
+  crossFileAsyncNames,
+} from "./async-source.js";
+
+describe("prism-codegen rails scope", () => {
+  it("reads the include/extend constants out of a Ruby source", () => {
+    const names = parseMixinNames(`
+      class Relation
+        include Enumerable
+        include FinderMethods, Calculations
+        extend ActiveRecord::Delegation::DelegateCache
+        included_modules
+      end
+    `);
+    expect(names).toEqual([
+      "Enumerable",
+      "FinderMethods",
+      "ActiveRecord::Delegation::DelegateCache",
+    ]);
+  });
+
+  it("offers the nested, sibling and root layouts for a mixin constant", () => {
+    expect(mixinPathCandidates("active_record/relation.rb", "FinderMethods")).toEqual([
+      "relation/finder_methods.rb",
+      "finder_methods.rb",
+    ]);
+    expect(
+      mixinPathCandidates("active_record/relation/query_methods.rb", "ActiveRecord::Core"),
+    ).toEqual(["relation/query_methods/core.rb", "relation/core.rb", "core.rb"]);
+  });
+
+  it("reaches the defs of the modules a Rails file includes", () => {
+    const relation = reachableRailsDefs("active_record/relation.rb");
+    expect(relation.has("findBy")).toBe(true);
+    expect(relation.has("pluck")).toBe(true);
+    expect(reachableRailsDefs("active_record/relation/finder_methods.rb").has("pluck")).toBe(false);
+  });
+
+  it("declines a cross-file async name the generating Rails file cannot dispatch to", () => {
+    const manifest = buildAsyncManifest([
+      { path: "relation/calculations.ts", source: `class C { async pluck() {} }` },
+    ]);
+    const scoped = (railsRelPath: string, twinTsPath: string) =>
+      crossFileAsyncNames(manifest, { twinTsPath, railsDefs: reachableRailsDefs(railsRelPath) });
+    expect(scoped("active_record/relation.rb", "relation.ts").has("pluck")).toBe(true);
+    expect(
+      scoped("active_record/relation/finder_methods.rb", "relation/finder-methods.ts").has("pluck"),
+    ).toBe(false);
+  });
+
+  it("keeps a name async where Rails defines it and sync where it does not", () => {
+    expect(asyncMethodsForRailsFile("active_record/relation/calculations.rb").has("pluck")).toBe(
+      true,
+    );
+    expect(asyncMethodsForRailsFile("active_record/relation/finder_methods.rb").has("pluck")).toBe(
+      false,
+    );
+  });
+});

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -49,10 +49,17 @@ export function mixinPathCandidates(fromRel: string, moduleName: string): string
   return [...new Set([nested, sibling, tail])];
 }
 
+/** Ruby method names defined directly in one Rails file. */
+export function ownRailsDefs(railsRelPath: string): Set<string> {
+  return rubyDefinedMethods(readRuby(stripPrefix(railsRelPath)) ?? "");
+}
+
 function readRuby(rel: string): string | undefined {
   const abs = rubyAbsPathFor(rel);
   return existsSync(abs) ? readFileSync(abs, "utf8") : undefined;
 }
+
+const reachableCache = new Map<string, Set<string>>();
 
 /**
  * Every Ruby method name reachable from `railsRelPath` — the file's own `def`s
@@ -65,6 +72,8 @@ function readRuby(rel: string): string | undefined {
  * onto the sync one's self-call.
  */
 export function reachableRailsDefs(railsRelPath: string): Set<string> {
+  const cached = reachableCache.get(railsRelPath);
+  if (cached) return cached;
   const defs = new Set<string>();
   const seen = new Set<string>();
   const queue = [stripPrefix(railsRelPath)];
@@ -81,5 +90,6 @@ export function reachableRailsDefs(railsRelPath: string): Set<string> {
       }
     }
   }
+  reachableCache.set(railsRelPath, defs);
   return defs;
 }

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -53,21 +53,25 @@ export function mixinPathCandidates(fromRel: string, moduleName: string): string
   return [...new Set([nested, sibling, tail])];
 }
 
+/** Reads one Rails source by its `active_record/`-relative path. */
+export type RubySourceReader = (railsRelPath: string) => string | undefined;
+
+const readRuby: RubySourceReader = (rel) => {
+  const abs = rubyAbsPathFor(rel);
+  return existsSync(abs) ? readFileSync(abs, "utf8") : undefined;
+};
+
 /** Ruby method names defined directly in one Rails file. */
 export function ownRailsDefs(railsRelPath: string): Set<string> {
   return rubyDefinedMethods(readRuby(stripPrefix(railsRelPath)) ?? "");
-}
-
-function readRuby(rel: string): string | undefined {
-  const abs = rubyAbsPathFor(rel);
-  return existsSync(abs) ? readFileSync(abs, "utf8") : undefined;
 }
 
 const reachableCache = new Map<string, Set<string>>();
 
 /**
  * Every Ruby method name reachable from `railsRelPath` — the file's own `def`s
- * plus those of the modules it includes/extends, transitively.
+ * plus those of the modules it includes/extends, transitively. `readSource`
+ * defaults to the vendored Rails checkout.
  *
  * The await rule is taken on a bare callee name, so the set it consults has to
  * be the set of methods the generated file's `self` could actually dispatch
@@ -79,8 +83,11 @@ const reachableCache = new Map<string, Set<string>>();
  * `ExplainProxy`) counts as reachable. That errs toward the old, wider scope
  * and never drops a name the file really can dispatch to.
  */
-export function reachableRailsDefs(railsRelPath: string): Set<string> {
-  const cached = reachableCache.get(railsRelPath);
+export function reachableRailsDefs(
+  railsRelPath: string,
+  readSource: RubySourceReader = readRuby,
+): Set<string> {
+  const cached = readSource === readRuby ? reachableCache.get(railsRelPath) : undefined;
   if (cached) return cached;
   const defs = new Set<string>();
   const seen = new Set<string>();
@@ -89,15 +96,15 @@ export function reachableRailsDefs(railsRelPath: string): Set<string> {
     const rel = queue.shift() as string;
     if (seen.has(rel)) continue;
     seen.add(rel);
-    const source = readRuby(rel);
+    const source = readSource(rel);
     if (source === undefined) continue;
     for (const name of rubyDefinedMethods(source)) defs.add(name);
     for (const mixin of parseMixinNames(source)) {
       for (const candidate of mixinPathCandidates(rel, mixin)) {
-        if (!seen.has(candidate) && existsSync(rubyAbsPathFor(candidate))) queue.push(candidate);
+        if (!seen.has(candidate) && readSource(candidate) !== undefined) queue.push(candidate);
       }
     }
   }
-  reachableCache.set(railsRelPath, defs);
+  if (readSource === readRuby) reachableCache.set(railsRelPath, defs);
   return defs;
 }

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -4,7 +4,7 @@ import { methodName } from "./naming.js";
 import { rubyAbsPathFor } from "./files.js";
 
 const RUBY_DEF = /^\s*def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)/gm;
-const MIXIN_LINE = /^[ \t]*(?:include|extend)[ \t]+([A-Z][\w:]*)/gm;
+const MIXIN_LINE = /^[ \t]*(?:include|extend)[ \t]+([A-Z][\w:]*(?:[ \t]*,[ \t]*[A-Z][\w:]*)*)/gm;
 
 export function rubyDefinedMethods(rubySource: string): Set<string> {
   const defs = new Set<string>();
@@ -12,9 +12,13 @@ export function rubyDefinedMethods(rubySource: string): Set<string> {
   return defs;
 }
 
-/** The `include Foo` / `extend Foo::Bar` constant names in a Ruby source. */
+/**
+ * The `include Foo` / `extend Foo::Bar` constant names in a Ruby source. One
+ * `include` can name several modules — `Relation` mixes in seven of them on a
+ * single line — so every constant on the line is returned, not just the first.
+ */
 export function parseMixinNames(rubySource: string): string[] {
-  return [...rubySource.matchAll(MIXIN_LINE)].map((m) => m[1]);
+  return [...rubySource.matchAll(MIXIN_LINE)].flatMap((m) => m[1].split(",").map((n) => n.trim()));
 }
 
 function underscore(segment: string): string {
@@ -70,6 +74,10 @@ const reachableCache = new Map<string, Set<string>>();
  * to. Scoping it to the whole target corpus made two same-named Rails methods
  * in unrelated files indistinguishable, and the async one dragged an await
  * onto the sync one's self-call.
+ *
+ * `def`s are collected flat, so a `def` in an inner class (`Relation`'s
+ * `ExplainProxy`) counts as reachable. That errs toward the old, wider scope
+ * and never drops a name the file really can dispatch to.
  */
 export function reachableRailsDefs(railsRelPath: string): Set<string> {
   const cached = reachableCache.get(railsRelPath);

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { methodName } from "./naming.js";
+import { rubyAbsPathFor } from "./files.js";
+
+const RUBY_DEF = /^\s*def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)/gm;
+const MIXIN_LINE = /^[ \t]*(?:include|extend)[ \t]+([A-Z][\w:]*)/gm;
+
+export function rubyDefinedMethods(rubySource: string): Set<string> {
+  const defs = new Set<string>();
+  for (const m of rubySource.matchAll(RUBY_DEF)) defs.add(methodName(m[1]));
+  return defs;
+}
+
+/** The `include Foo` / `extend Foo::Bar` constant names in a Ruby source. */
+export function parseMixinNames(rubySource: string): string[] {
+  return [...rubySource.matchAll(MIXIN_LINE)].map((m) => m[1]);
+}
+
+function underscore(segment: string): string {
+  return segment
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z\d])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+}
+
+function stripPrefix(rel: string): string {
+  return rel.replace(/^active_record\//, "");
+}
+
+/**
+ * Where a mixin constant referenced from `fromRel` could live. Ruby resolves
+ * the constant lexically, which we cannot do from a path alone, so we try the
+ * three layouts Rails actually uses: nested under the includer's own file
+ * (`relation.rb` → `relation/finder_methods.rb`), a sibling of it, and the
+ * `active_record/` root. Non-existent candidates are dropped by the caller.
+ */
+export function mixinPathCandidates(fromRel: string, moduleName: string): string[] {
+  const segments = moduleName
+    .split("::")
+    .map(underscore)
+    .filter((s) => s !== "active_record");
+  if (!segments.length) return [];
+  const tail = `${segments.join("/")}.rb`;
+  const from = stripPrefix(fromRel);
+  const nested = `${from.replace(/\.rb$/, "")}/${tail}`;
+  const dir = path.posix.dirname(from);
+  const sibling = dir === "." ? tail : `${dir}/${tail}`;
+  return [...new Set([nested, sibling, tail])];
+}
+
+function readRuby(rel: string): string | undefined {
+  const abs = rubyAbsPathFor(rel);
+  return existsSync(abs) ? readFileSync(abs, "utf8") : undefined;
+}
+
+/**
+ * Every Ruby method name reachable from `railsRelPath` — the file's own `def`s
+ * plus those of the modules it includes/extends, transitively.
+ *
+ * The await rule is taken on a bare callee name, so the set it consults has to
+ * be the set of methods the generated file's `self` could actually dispatch
+ * to. Scoping it to the whole target corpus made two same-named Rails methods
+ * in unrelated files indistinguishable, and the async one dragged an await
+ * onto the sync one's self-call.
+ */
+export function reachableRailsDefs(railsRelPath: string): Set<string> {
+  const defs = new Set<string>();
+  const seen = new Set<string>();
+  const queue = [stripPrefix(railsRelPath)];
+  while (queue.length) {
+    const rel = queue.shift() as string;
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    const source = readRuby(rel);
+    if (source === undefined) continue;
+    for (const name of rubyDefinedMethods(source)) defs.add(name);
+    for (const mixin of parseMixinNames(source)) {
+      for (const candidate of mixinPathCandidates(rel, mixin)) {
+        if (!seen.has(candidate) && existsSync(rubyAbsPathFor(candidate))) queue.push(candidate);
+      }
+    }
+  }
+  return defs;
+}


### PR DESCRIPTION
`shouldAwaitCall` is receiver-aware (#5822) but the eligible-name side was still
corpus-wide: `crossFileAsyncNames` awaited a self-call whenever the bare name was
async in exactly one port file and Rails `def`d it *anywhere* in `TARGET_FILES`.
Two same-named Rails methods in unrelated files were indistinguishable, so the
async one dragged an await onto the sync one's self-call.

This replaces `railsCorpusDefs()` with `reachableRailsDefs(railsRelPath)`
(new `scripts/prism-codegen/rails-scope.ts`): the generating file's own `def`s
plus those of the modules it `include`/`extend`s, transitively. Mixin constants
are resolved by trying the three layouts Rails uses (nested under the includer's
file, sibling, `active_record/` root); non-existent candidates are dropped.

The per-file eligible sets narrow sharply (e.g. `relation/finder_methods.rb`
drops `pluck`, `calculate`, `updateColumns`, …, all defined in other Rails
files). `pnpm codegen:score` is unchanged (32 matched, 299 divergent, 9.7%) and
`pnpm codegen:snapshot` regenerates the goldens byte-identical — every name the
current goldens await is still in scope, so the change is purely a tightening
ahead of `codegen-apply-scaffolding` making it behavioural.

Closes-story: codegen-await-self-call-name-scoping
