### PR TITLE
feat(prism-codegen): check port composition points against Base's MRO

### DIFF
--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -171,8 +171,14 @@ describe("_applyScopeAttributes — multiparameter path", () => {
   });
 });
 
-describe("_applyScopeAttributes — STI type column wins over scope", () => {
-  it("STI type column is not overwritten by a scope that sets type", async () => {
+describe("_applyScopeAttributes — a scope that sets type wins over the STI default", () => {
+  // Rails' MRO decides this. base.rb:303-304 includes Inheritance before
+  // Scoping, so Scoping is nearer, and both bodies are `super; <contribution>`
+  // (inheritance.rb:349-352, scoping.rb:53-56) — the unwind runs
+  // ensure_proper_type first and populate_with_current_scope_attributes last,
+  // so the scope's type overwrites the STI class name. This test used to
+  // assert the reverse, pinning the port's hand-rolled composition order.
+  it("scope that sets type overwrites the STI type column", async () => {
     class Vehicle extends Base {
       static {
         this._tableName = "vehicles";
@@ -183,11 +189,10 @@ describe("_applyScopeAttributes — STI type column wins over scope", () => {
     Vehicle.inheritanceColumn = "type";
     class Car extends Vehicle {}
 
-    // Scope includes type: "Vehicle" — but new Car() should still have type: "Car"
     const rel = Vehicle.where({ type: "Vehicle" });
     await Vehicle.scoping(rel, async () => {
       const car = new Car({});
-      expect(car.readAttribute("type")).toBe("Car");
+      expect(car.readAttribute("type")).toBe("Vehicle");
     });
   });
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3199,8 +3199,13 @@ export class Base extends Model {
       // Re-snapshot so mp attrs are part of the initial clean state.
       (this as any)._dirty.snapshot((this as any)._attributes);
       if (!wasSuppressed) {
-        // Mirrors Rails' initialize_internals_callback chain order:
-        //   populate_with_current_scope_attributes (scoping) → ensure_proper_type (STI)
+        // Rails realizes this chain through `super`; the port calls each
+        // module's contribution here, so this call order IS the MRO and the
+        // marker below is checked against it by `pnpm codegen:score`.
+        // prism-mro: initialize_internals_callback
+        //   Inheritance=inheritanceInitializeInternalsCallback
+        //   Scoping=_applyScopeAttributes Core=~
+        inheritanceInitializeInternalsCallback.call(this as any);
         // Guard before allocating the Set — the no-scope case is the hot path.
         if (_shouldApplyScopeAttributes(ctor)) {
           _applyScopeAttributes(
@@ -3209,7 +3214,6 @@ export class Base extends Model {
             new Set([...Object.keys(multiparams), ...Object.keys(regular)]),
           );
         }
-        inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         if (assocPending) {
@@ -3282,13 +3286,14 @@ export class Base extends Model {
       _Core.initInternals.call(this as any);
       _applyCompositePrimaryKey(this as unknown as Base, ctor2, attrs);
       if (!wasSuppressed2) {
-        // Mirrors Rails' initialize_internals_callback chain order:
-        //   populate_with_current_scope_attributes (scoping) → ensure_proper_type (STI)
+        // prism-mro: initialize_internals_callback
+        //   Inheritance=inheritanceInitializeInternalsCallback
+        //   Scoping=_applyScopeAttributes Core=~
+        inheritanceInitializeInternalsCallback.call(this as any);
         // Guard before allocating the Set — the no-scope case is the hot path.
         if (_shouldApplyScopeAttributes(ctor2)) {
           _applyScopeAttributes(ctor2, this as any, new Set(Object.keys(attrs)));
         }
-        inheritanceInitializeInternalsCallback.call(this as any);
         // Re-snapshot so internals writes are part of the initial clean state.
         (this as any)._dirty.snapshot((this as any)._attributes);
         // Assign store accessor keys after the clean baseline so they appear

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3199,9 +3199,6 @@ export class Base extends Model {
       // Re-snapshot so mp attrs are part of the initial clean state.
       (this as any)._dirty.snapshot((this as any)._attributes);
       if (!wasSuppressed) {
-        // Rails realizes this chain through `super`; the port calls each
-        // module's contribution here, so this call order IS the MRO and the
-        // marker below is checked against it by `pnpm codegen:score`.
         // prism-mro: initialize_internals_callback
         //   Inheritance=inheritanceInitializeInternalsCallback
         //   Scoping=_applyScopeAttributes Core=~

--- a/scripts/prism-codegen/composition.test.ts
+++ b/scripts/prism-codegen/composition.test.ts
@@ -75,6 +75,16 @@ function markerOf(source: string) {
   return parseCompositionMarkers("base.ts", source)[0];
 }
 
+/** Expected order with `SCOPING_RB` swapped for a variant body. */
+async function orderFor(scoping: string[]) {
+  const sources = [BASE_RB, CORE_RB, INHERITANCE_RB, ...scoping];
+  return expectedCompositionOrder(
+    await buildLinearization(BASE_RB, sources),
+    await indexSuperPositions(sources),
+    "initialize_internals_callback",
+  );
+}
+
 describe("composition-point MRO check", () => {
   it("parses a marker's ruby method and module bindings", () => {
     const marker = markerOf(CONVERGED);
@@ -95,37 +105,18 @@ describe("composition-point MRO check", () => {
   });
 
   it("orders pre-super contributions by ancestry", async () => {
-    const preSuper = SCOPING_RB.replace(
-      "super\n        populate_with_current_scope_attributes",
-      "populate_with_current_scope_attributes\n        super",
-    );
-    const sources = [BASE_RB, CORE_RB, INHERITANCE_RB, preSuper];
     expect(
-      expectedCompositionOrder(
-        await buildLinearization(BASE_RB, sources),
-        await indexSuperPositions(sources),
-        "initialize_internals_callback",
-      ),
+      await orderFor([
+        SCOPING_RB.replace(
+          "super\n        populate_with_current_scope_attributes",
+          "populate_with_current_scope_attributes\n        super",
+        ),
+      ]),
     ).toEqual(["Scoping", "Inheritance"]);
   });
 
   it("stops the chain at a definer that never calls super", async () => {
-    const noSuper = SCOPING_RB.replace("super\n", "");
-    const sources = [BASE_RB, CORE_RB, INHERITANCE_RB, noSuper];
-    expect(
-      expectedCompositionOrder(
-        await buildLinearization(BASE_RB, sources),
-        await indexSuperPositions(sources),
-        "initialize_internals_callback",
-      ),
-    ).toEqual(["Scoping"]);
-  });
-
-  it("reads the realized order from the call sites below the marker", () => {
-    expect(realizedCompositionOrder(markerOf(CONVERGED), CONVERGED).order).toEqual([
-      "Inheritance",
-      "Scoping",
-    ]);
+    expect(await orderFor([SCOPING_RB.replace("super\n", "")])).toEqual(["Scoping"]);
   });
 
   it("reads each composition point's own call sites, not the next point's", () => {
@@ -195,9 +186,6 @@ describe("composition-point MRO check", () => {
     expect(unresolvedAncestryMessage(["Marshalling::Methods"])).toContain(
       "1 ancestry module(s) of ActiveRecord::Base have no vendored source",
     );
-  });
-
-  it("reports no failure when nothing drifted", () => {
     expect(compositionFailureMessage([])).toBeUndefined();
   });
 });

--- a/scripts/prism-codegen/composition.test.ts
+++ b/scripts/prism-codegen/composition.test.ts
@@ -20,34 +20,23 @@ const BASE_RB = `
     end
   end
 `;
-const CORE_RB = `
-  module ActiveRecord
-    module Core
-      def initialize_internals_callback
+
+/** A definer of `initialize_internals_callback` with `body` as its statements. */
+function definer(name: string, body: string): string {
+  return `
+    module ActiveRecord
+      module ${name}
+        def initialize_internals_callback
+          ${body}
+        end
       end
     end
-  end
-`;
-const INHERITANCE_RB = `
-  module ActiveRecord
-    module Inheritance
-      def initialize_internals_callback
-        super
-        ensure_proper_type
-      end
-    end
-  end
-`;
-const SCOPING_RB = `
-  module ActiveRecord
-    module Scoping
-      def initialize_internals_callback
-        super
-        populate_with_current_scope_attributes
-      end
-    end
-  end
-`;
+  `;
+}
+
+const CORE_RB = definer("Core", "");
+const INHERITANCE_RB = definer("Inheritance", "super\n          ensure_proper_type");
+const SCOPING_RB = definer("Scoping", "super\n          populate_with_current_scope_attributes");
 const SOURCES = [BASE_RB, CORE_RB, INHERITANCE_RB, SCOPING_RB];
 
 const MARKER =
@@ -107,16 +96,15 @@ describe("composition-point MRO check", () => {
   it("orders pre-super contributions by ancestry", async () => {
     expect(
       await orderFor([
-        SCOPING_RB.replace(
-          "super\n        populate_with_current_scope_attributes",
-          "populate_with_current_scope_attributes\n        super",
-        ),
+        definer("Scoping", "populate_with_current_scope_attributes\n          super"),
       ]),
     ).toEqual(["Scoping", "Inheritance"]);
   });
 
   it("stops the chain at a definer that never calls super", async () => {
-    expect(await orderFor([SCOPING_RB.replace("super\n", "")])).toEqual(["Scoping"]);
+    expect(await orderFor([definer("Scoping", "populate_with_current_scope_attributes")])).toEqual([
+      "Scoping",
+    ]);
   });
 
   it("reads each composition point's own call sites, not the next point's", () => {

--- a/scripts/prism-codegen/composition.test.ts
+++ b/scripts/prism-codegen/composition.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkCompositionPoint,
+  compositionFailureMessage,
+  expectedCompositionOrder,
+  indexSuperPositions,
+  parseCompositionMarkers,
+  realizedCompositionOrder,
+  rubyPathForModule,
+} from "./composition.js";
+import { buildLinearization } from "./linearization.js";
+
+const BASE_RB = `
+  module ActiveRecord
+    class Base
+      include Core
+      include Inheritance
+      include Scoping
+    end
+  end
+`;
+const CORE_RB = `
+  module ActiveRecord
+    module Core
+      def initialize_internals_callback
+      end
+    end
+  end
+`;
+const INHERITANCE_RB = `
+  module ActiveRecord
+    module Inheritance
+      def initialize_internals_callback
+        super
+        ensure_proper_type
+      end
+    end
+  end
+`;
+const SCOPING_RB = `
+  module ActiveRecord
+    module Scoping
+      def initialize_internals_callback
+        super
+        populate_with_current_scope_attributes
+      end
+    end
+  end
+`;
+const SOURCES = [BASE_RB, CORE_RB, INHERITANCE_RB, SCOPING_RB];
+
+const MARKER =
+  "// prism-mro: initialize_internals_callback\n" +
+  "//   Inheritance=inheritanceInitializeInternalsCallback\n" +
+  "//   Scoping=applyScopeAttributes Core=~\n";
+
+const CONVERGED = `${MARKER}
+  inheritanceInitializeInternalsCallback.call(this);
+  if (shouldApplyScopeAttributes(ctor)) applyScopeAttributes(ctor, this);
+`;
+const REORDERED = `${MARKER}
+  if (shouldApplyScopeAttributes(ctor)) applyScopeAttributes(ctor, this);
+  inheritanceInitializeInternalsCallback.call(this);
+`;
+
+async function inputs() {
+  return {
+    linearization: await buildLinearization(BASE_RB, SOURCES),
+    positions: await indexSuperPositions(SOURCES),
+  };
+}
+
+function markerOf(source: string) {
+  return parseCompositionMarkers("base.ts", source)[0];
+}
+
+describe("composition-point MRO check", () => {
+  it("parses a marker's ruby method and module bindings", () => {
+    const marker = markerOf(CONVERGED);
+    expect(marker.method).toBe("initialize_internals_callback");
+    expect(marker.contributions).toEqual([
+      { module: "Inheritance", identifier: "inheritanceInitializeInternalsCallback" },
+      { module: "Scoping", identifier: "applyScopeAttributes" },
+      { module: "Core", identifier: "~" },
+    ]);
+  });
+
+  it("orders post-super contributions by reverse ancestry", async () => {
+    const { linearization, positions } = await inputs();
+    expect(linearization.ancestry).toEqual(["Scoping", "Inheritance", "Core"]);
+    expect(
+      expectedCompositionOrder(linearization, positions, "initialize_internals_callback"),
+    ).toEqual(["Inheritance", "Scoping"]);
+  });
+
+  it("orders pre-super contributions by ancestry", async () => {
+    const preSuper = SCOPING_RB.replace(
+      "super\n        populate_with_current_scope_attributes",
+      "populate_with_current_scope_attributes\n        super",
+    );
+    const sources = [BASE_RB, CORE_RB, INHERITANCE_RB, preSuper];
+    expect(
+      expectedCompositionOrder(
+        await buildLinearization(BASE_RB, sources),
+        await indexSuperPositions(sources),
+        "initialize_internals_callback",
+      ),
+    ).toEqual(["Scoping", "Inheritance"]);
+  });
+
+  it("stops the chain at a definer that never calls super", async () => {
+    const noSuper = SCOPING_RB.replace("super\n", "");
+    const sources = [BASE_RB, CORE_RB, INHERITANCE_RB, noSuper];
+    expect(
+      expectedCompositionOrder(
+        await buildLinearization(BASE_RB, sources),
+        await indexSuperPositions(sources),
+        "initialize_internals_callback",
+      ),
+    ).toEqual(["Scoping"]);
+  });
+
+  it("reads the realized order from the call sites below the marker", () => {
+    expect(realizedCompositionOrder(markerOf(CONVERGED), CONVERGED).order).toEqual([
+      "Inheritance",
+      "Scoping",
+    ]);
+  });
+
+  it("passes when the composition point matches the MRO", async () => {
+    const { linearization, positions } = await inputs();
+    expect(
+      checkCompositionPoint(markerOf(CONVERGED), CONVERGED, linearization, positions),
+    ).toBeUndefined();
+  });
+
+  it("fails when a composition point is reordered", async () => {
+    const { linearization, positions } = await inputs();
+    const failure = checkCompositionPoint(markerOf(REORDERED), REORDERED, linearization, positions);
+    expect(failure).toContain("drifted from ActiveRecord::Base's MRO");
+    expect(failure).toContain("MRO order:      Inheritance → Scoping");
+    expect(failure).toContain("realized order: Scoping → Inheritance");
+    expect(compositionFailureMessage([failure!])).toContain("1 composition point(s) drifted");
+  });
+
+  it("fails when a definer the MRO reaches is not declared", async () => {
+    const { linearization, positions } = await inputs();
+    const source = CONVERGED.replace(" Core=~", "");
+    expect(checkCompositionPoint(markerOf(source), source, linearization, positions)).toContain(
+      "not declared: Core",
+    );
+  });
+
+  it("fails when a declared identifier has no call site below the marker", async () => {
+    const { linearization, positions } = await inputs();
+    const source = CONVERGED.replace(/applyScopeAttributes\(ctor, this\)/, "somethingElse()");
+    expect(checkCompositionPoint(markerOf(source), source, linearization, positions)).toContain(
+      "no call site below the marker: applyScopeAttributes",
+    );
+  });
+
+  it("maps an ancestry entry to its vendored source path", () => {
+    expect(rubyPathForModule("Scoping")).toBe("active_record/scoping.rb");
+    expect(rubyPathForModule("ActiveRecord::Locking::Optimistic")).toBe(
+      "active_record/locking/optimistic.rb",
+    );
+  });
+
+  it("reports no failure when nothing drifted", () => {
+    expect(compositionFailureMessage([])).toBeUndefined();
+  });
+});

--- a/scripts/prism-codegen/composition.test.ts
+++ b/scripts/prism-codegen/composition.test.ts
@@ -6,7 +6,8 @@ import {
   indexSuperPositions,
   parseCompositionMarkers,
   realizedCompositionOrder,
-  rubyPathForModule,
+  rubyPathCandidatesForModule,
+  unresolvedAncestryMessage,
 } from "./composition.js";
 import { buildLinearization } from "./linearization.js";
 
@@ -166,10 +167,33 @@ describe("composition-point MRO check", () => {
     );
   });
 
-  it("maps an ancestry entry to its vendored source path", () => {
-    expect(rubyPathForModule("Scoping")).toBe("active_record/scoping.rb");
-    expect(rubyPathForModule("ActiveRecord::Locking::Optimistic")).toBe(
+  it("treats a bare reference as no call site", async () => {
+    const { linearization, positions } = await inputs();
+    const source = CONVERGED.replace(
+      "applyScopeAttributes(ctor, this)",
+      "const contribution = applyScopeAttributes",
+    );
+    expect(checkCompositionPoint(markerOf(source), source, linearization, positions)).toContain(
+      "no call site below the marker: applyScopeAttributes",
+    );
+  });
+
+  it("maps an ancestry entry to its vendored source paths, parent file last", () => {
+    expect(rubyPathCandidatesForModule("Scoping")).toEqual(["active_record/scoping.rb"]);
+    expect(rubyPathCandidatesForModule("ActiveRecord::Locking::Optimistic")).toEqual([
       "active_record/locking/optimistic.rb",
+      "active_record/locking.rb",
+    ]);
+    expect(rubyPathCandidatesForModule("Marshalling::Methods")).toContain(
+      "active_record/marshalling.rb",
+    );
+  });
+
+  it("fails when an ancestry module's source did not load", () => {
+    expect(unresolvedAncestryMessage([])).toBeUndefined();
+    expect(unresolvedAncestryMessage(["ActiveModel::API"])).toBeUndefined();
+    expect(unresolvedAncestryMessage(["Marshalling::Methods"])).toContain(
+      "1 ancestry module(s) of ActiveRecord::Base have no vendored source",
     );
   });
 

--- a/scripts/prism-codegen/composition.test.ts
+++ b/scripts/prism-codegen/composition.test.ts
@@ -127,6 +127,13 @@ describe("composition-point MRO check", () => {
     ]);
   });
 
+  it("reads each composition point's own call sites, not the next point's", () => {
+    const source = `${CONVERGED}\n${REORDERED}`;
+    const [first, second] = parseCompositionMarkers("base.ts", source);
+    expect(realizedCompositionOrder(first, source).order).toEqual(["Inheritance", "Scoping"]);
+    expect(realizedCompositionOrder(second, source).order).toEqual(["Scoping", "Inheritance"]);
+  });
+
   it("passes when the composition point matches the MRO", async () => {
     const { linearization, positions } = await inputs();
     expect(

--- a/scripts/prism-codegen/composition.ts
+++ b/scripts/prism-codegen/composition.ts
@@ -1,0 +1,266 @@
+/**
+ * Composition-point ↔ MRO check (RFC 0086).
+ *
+ * Rails realizes a chain like `initialize_internals_callback` through `super`:
+ * every module in `ActiveRecord::Base`'s ancestry contributes a fragment, and
+ * the execution order falls out of the include order plus where each body puts
+ * its `super`. The port has no `super` chain — `base.ts` calls each module's
+ * contribution explicitly at a *composition point*. That call order is
+ * hand-maintained and can silently drift from `base.rb`'s include order; until
+ * now the only record of a realized chain was a per-row sign-off.
+ *
+ * A composition point declares itself in the port source with a marker:
+ *
+ *   // prism-mro: initialize_internals_callback Inheritance=ensureProperType \
+ *   //   Scoping=_applyScopeAttributes Core=~
+ *
+ * `Module=identifier` binds a definer to the port symbol that realizes its
+ * contribution; `Module=~` records a definer whose body contributes nothing
+ * (Rails' `Core#initialize_internals_callback` is empty). Every definer the
+ * MRO reaches must be declared — omission is drift, not silence.
+ *
+ * The check derives the expected execution order from the ancestry and the
+ * super position of each Ruby body, reads the realized order out of the port
+ * source below the marker, and fails when they differ.
+ *
+ * Hard rules: no node:* imports, no process.*, async fs only — this module is
+ * pure (prism aside); score-cli.ts supplies the sources.
+ */
+
+import { loadPrism } from "@ruby/prism";
+import { constPath, normalizeModuleName, type Linearization } from "./linearization.js";
+import type { PrismNode } from "./types.js";
+
+/** A definer's body relative to its `super` call. */
+export interface SuperPosition {
+  /** The body calls `super` at all — the chain continues past this module. */
+  hasSuper: boolean;
+  /** Statements run before `super` (so: in ancestry order). */
+  before: boolean;
+  /** Statements run after `super` (so: in reverse ancestry order). */
+  after: boolean;
+}
+
+/** Marker syntax: `prism-mro: <ruby_method> Module=identifier ...` */
+const MARKER = /prism-mro:[ \t]*([a-z_][\w?!]*)((?:[\s/*]+[A-Z][\w:]*=[\w~$]+)+)/g;
+const BINDING = /([A-Z][\w:]*)=([\w~$]+)/g;
+/** A definer whose contribution the port does not realize (empty Ruby body). */
+const UNREALIZED = "~";
+
+export interface Contribution {
+  module: string;
+  /** Port symbol realizing the contribution, or `~` when there is none. */
+  identifier: string;
+}
+
+export interface CompositionMarker {
+  /** Port file the marker lives in, relative to the port root. */
+  file: string;
+  /** Ruby method name of the chain, e.g. `initialize_internals_callback`. */
+  method: string;
+  contributions: Contribution[];
+  /** Offset of the marker in the source; the realized order is read below it. */
+  offset: number;
+}
+
+export function parseCompositionMarkers(file: string, source: string): CompositionMarker[] {
+  return [...source.matchAll(MARKER)].map((m) => ({
+    file,
+    method: m[1],
+    contributions: [...m[2].matchAll(BINDING)].map((b) => ({
+      module: normalizeModuleName(b[1]),
+      identifier: b[2],
+    })),
+    offset: m.index + m[0].length,
+  }));
+}
+
+/**
+ * Where each `Module#method` body puts its `super`. Keyed `Module#method`,
+ * mirroring `indexModuleDefs`' module paths so both indexes agree on naming.
+ */
+export async function indexSuperPositions(
+  sources: Iterable<string>,
+): Promise<Map<string, SuperPosition>> {
+  const parse = await loadPrism();
+  const index = new Map<string, SuperPosition>();
+  for (const source of sources) {
+    walk((parse(source).value as unknown as PrismNode) ?? null, [], index);
+  }
+  return index;
+}
+
+/**
+ * The order the contributions to `method` actually run in, nearest-definer
+ * first. A body's pre-`super` statements run on the way down the ancestry and
+ * its post-`super` statements on the way back up, so the expected order is the
+ * pre-super definers in ancestry order followed by the post-super definers in
+ * reverse. The walk stops at the first definer that never calls `super`: the
+ * rest of the ancestry is unreachable.
+ */
+export function expectedCompositionOrder(
+  linearization: Linearization,
+  positions: ReadonlyMap<string, SuperPosition>,
+  method: string,
+): string[] {
+  const before: string[] = [];
+  const after: string[] = [];
+  for (const module of reachedDefiners(linearization, positions, method)) {
+    const position = positions.get(`${module}#${method}`)!;
+    if (position.before) before.push(module);
+    if (position.after) after.unshift(module);
+  }
+  return [...before, ...after];
+}
+
+/**
+ * Every module the chain actually dispatches through, nearest first —
+ * contributing ones and no-ops alike (Rails' `Core#initialize_internals_callback`
+ * is empty). The port must declare all of them, so that a body growing a
+ * contribution cannot slip in unnoticed.
+ */
+export function reachedDefiners(
+  linearization: Linearization,
+  positions: ReadonlyMap<string, SuperPosition>,
+  method: string,
+): string[] {
+  const reached: string[] = [];
+  for (const module of linearization.ancestry) {
+    if (!linearization.definitionsOf(module).has(method)) continue;
+    const position = positions.get(`${module}#${method}`);
+    if (!position) continue;
+    reached.push(module);
+    if (!position.hasSuper) break;
+  }
+  return reached;
+}
+
+/**
+ * The order the port realizes the contributions in: the declared identifiers
+ * sorted by where they are first called below the marker. Identifiers bound to
+ * `~` have no call site and are not part of the realized order.
+ */
+export function realizedCompositionOrder(
+  marker: CompositionMarker,
+  source: string,
+): { order: string[]; missing: string[] } {
+  const below = source.slice(marker.offset);
+  const order: { module: string; at: number }[] = [];
+  const missing: string[] = [];
+  for (const { module, identifier } of marker.contributions) {
+    if (identifier === UNREALIZED) continue;
+    const at = below.search(new RegExp(`\\b${identifier}\\b[\\s(.]`));
+    if (at < 0) missing.push(identifier);
+    else order.push({ module, at });
+  }
+  return { order: order.sort((a, b) => a.at - b.at).map((c) => c.module), missing };
+}
+
+/**
+ * Drift at one composition point, or `undefined` when the realized order
+ * matches the MRO. Three ways to drift: an undeclared definer (the port either
+ * dropped a contribution or the include order grew one), a declared identifier
+ * with no call site below the marker, and a realized order that does not match
+ * the expected one.
+ */
+export function checkCompositionPoint(
+  marker: CompositionMarker,
+  source: string,
+  linearization: Linearization,
+  positions: ReadonlyMap<string, SuperPosition>,
+): string | undefined {
+  const expected = expectedCompositionOrder(linearization, positions, marker.method);
+  const declared = new Set(marker.contributions.map((c) => c.module));
+  const undeclared = reachedDefiners(linearization, positions, marker.method).filter(
+    (m) => !declared.has(m),
+  );
+  const { order, missing } = realizedCompositionOrder(marker, source);
+  const expectedRealized = expected.filter((m) =>
+    marker.contributions.some((c) => c.module === m && c.identifier !== UNREALIZED),
+  );
+  const problems: string[] = [];
+  if (undeclared.length) {
+    problems.push(
+      `  definers reached by the MRO but not declared: ${undeclared.join(", ")} ` +
+        `(declare each as Module=identifier, or Module=~ when it contributes nothing)`,
+    );
+  }
+  if (missing.length) {
+    problems.push(
+      `  declared identifiers with no call site below the marker: ${missing.join(", ")}`,
+    );
+  }
+  if (problems.length === 0 && sameOrder(order, expectedRealized)) return undefined;
+  if (!sameOrder(order, expectedRealized)) {
+    problems.push(
+      `  MRO order:      ${expectedRealized.join(" → ") || "(none)"}\n` +
+        `  realized order: ${order.join(" → ") || "(none)"}`,
+    );
+  }
+  return (
+    `prism-codegen composition point: ${marker.file} :: ${marker.method} drifted ` +
+    `from ActiveRecord::Base's MRO.\n${problems.join("\n")}`
+  );
+}
+
+/**
+ * Vendored path a `Base` ancestry entry's source lives at, by Rails' own
+ * file-per-module convention (`Locking::Optimistic` → `locking/optimistic.rb`).
+ * The check needs every ancestor's body, not just the codegen target set:
+ * `Scoping` contributes to `initialize_internals_callback` and is not a target.
+ */
+export function rubyPathForModule(name: string): string {
+  const parts = normalizeModuleName(name)
+    .split("::")
+    .map((part) => part.replace(/([a-z\d])([A-Z])/g, "$1_$2").toLowerCase());
+  return `active_record/${parts.join("/")}.rb`;
+}
+
+export function compositionFailureMessage(failures: readonly string[]): string | undefined {
+  if (failures.length === 0) return undefined;
+  return [
+    `prism-codegen composition check: ${failures.length} composition point(s) drifted.`,
+    "",
+    "The port calls each module's contribution explicitly where Rails uses `super`,",
+    "so the call order at the composition point IS the MRO. Reorder the calls (or",
+    "the marker's bindings) to match, or fix the marker if the chain changed.",
+    "",
+    ...failures,
+  ].join("\n");
+}
+
+function sameOrder(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((m, i) => m === b[i]);
+}
+
+function walk(node: PrismNode | null, path: string[], index: Map<string, SuperPosition>): void {
+  if (!node?.constructor) return;
+  const kind = node.constructor.name;
+  if (kind === "ModuleNode" || kind === "ClassNode") {
+    const nested = [...path, constPath(node.constantPath as PrismNode | undefined, node.name)];
+    for (const child of node.compactChildNodes()) walk(child, nested, index);
+    return;
+  }
+  if (kind === "SingletonClassNode") return;
+  if (kind === "DefNode" && !node.receiver && path.length) {
+    const owner = normalizeModuleName(path.join("::"));
+    index.set(`${owner}#${String(node.name)}`, superPositionOf(node));
+    return;
+  }
+  for (const child of node.compactChildNodes()) walk(child, path, index);
+}
+
+function superPositionOf(def: PrismNode): SuperPosition {
+  const statements = ((def.body as PrismNode | undefined)?.body as PrismNode[] | undefined) ?? [];
+  const at = statements.findIndex(containsSuper);
+  if (at < 0) return { hasSuper: false, before: statements.length > 0, after: false };
+  return { hasSuper: true, before: at > 0, after: at < statements.length - 1 };
+}
+
+function containsSuper(node: PrismNode | null): boolean {
+  if (!node?.constructor) return false;
+  const kind = node.constructor.name;
+  if (kind === "SuperNode" || kind === "ForwardingSuperNode") return true;
+  if (kind === "DefNode" || kind === "ModuleNode" || kind === "ClassNode") return false;
+  return node.compactChildNodes().some((child) => containsSuper(child as PrismNode | null));
+}

--- a/scripts/prism-codegen/composition.ts
+++ b/scripts/prism-codegen/composition.ts
@@ -241,7 +241,7 @@ export function unresolvedAncestryMessage(unresolved: readonly string[]): string
     "",
     "Their bodies are invisible to the check, so a contribution they make to a",
     "guarded chain would be dropped without a word. Fix the path derivation, or",
-    "teach `isExternalAncestor` about the component the module really lives in.",
+    "teach `isExternalAncestor` where the module really lives.",
     "",
     ...real.map((name) => `  ${name} → ${rubyPathCandidatesForModule(name).join(", ")}`),
   ].join("\n");
@@ -252,9 +252,9 @@ export function compositionFailureMessage(failures: readonly string[]): string |
   return [
     `prism-codegen composition check: ${failures.length} composition point(s) drifted.`,
     "",
-    "The port calls each module's contribution explicitly where Rails uses `super`,",
-    "so the call order at the composition point IS the MRO. Reorder the calls (or",
-    "the marker's bindings) to match, or fix the marker if the chain changed.",
+    "The port calls each contribution explicitly where Rails uses `super`, so the",
+    "call order at a composition point IS the MRO. Reorder the calls to match, or",
+    "fix the marker if the chain itself changed.",
     "",
     ...failures,
   ].join("\n");

--- a/scripts/prism-codegen/composition.ts
+++ b/scripts/prism-codegen/composition.ts
@@ -25,13 +25,14 @@ import { loadPrism } from "@ruby/prism";
 import { constPath, normalizeModuleName, type Linearization } from "./linearization.js";
 import type { PrismNode } from "./types.js";
 
-/** A definer's body relative to its `super` call. */
+/**
+ * A definer's body relative to its `super` call: whether the chain continues
+ * past this module, and whether statements run before it (in ancestry order)
+ * or after it (in reverse).
+ */
 export interface SuperPosition {
-  /** The body calls `super` at all — the chain continues past this module. */
   hasSuper: boolean;
-  /** Statements run before `super` (so: in ancestry order). */
   before: boolean;
-  /** Statements run after `super` (so: in reverse ancestry order). */
   after: boolean;
 }
 
@@ -48,19 +49,14 @@ export interface Contribution {
 }
 
 export interface CompositionMarker {
-  /** Port file the marker lives in, relative to the port root. */
   file: string;
   /** Ruby method name of the chain, e.g. `initialize_internals_callback`. */
   method: string;
   contributions: Contribution[];
-  /** Offset of the marker's end; the realized order is read from here. */
+  /** The marker's own region — `[offset, end)`, ending at the next marker or
+   * the file's end. A file can hold several composition points (base.ts has
+   * one per constructor branch) and each must read only its own call sites. */
   offset: number;
-  /**
-   * Offset the marker's region ends at — the next marker, or the end of the
-   * file. A file can hold several composition points (base.ts has one per
-   * constructor branch) and each must read only its own call sites: an
-   * unbounded scan would let a later point's calls stand in for a missing one.
-   */
   end: number;
 }
 
@@ -78,10 +74,7 @@ export function parseCompositionMarkers(file: string, source: string): Compositi
   }));
 }
 
-/**
- * Where each `Module#method` body puts its `super`. Keyed `Module#method`,
- * mirroring `indexModuleDefs`' module paths so both indexes agree on naming.
- */
+/** Where each body puts its `super`, keyed `Module#method` as `indexModuleDefs` keys modules. */
 export async function indexSuperPositions(
   sources: Iterable<string>,
 ): Promise<Map<string, SuperPosition>> {
@@ -184,22 +177,20 @@ export function checkCompositionPoint(
   const problems: string[] = [];
   if (undeclared.length) {
     problems.push(
-      `  definers reached by the MRO but not declared: ${undeclared.join(", ")} ` +
-        `(declare each as Module=identifier, or Module=~ when it contributes nothing)`,
+      `  reached by the MRO but not declared: ${undeclared.join(", ")} ` +
+        "(declare each as Module=identifier, or Module=~ when it contributes nothing)",
     );
   }
   if (missing.length) {
-    problems.push(
-      `  declared identifiers with no call site below the marker: ${missing.join(", ")}`,
-    );
+    problems.push(`  declared with no call site below the marker: ${missing.join(", ")}`);
   }
-  if (problems.length === 0 && sameOrder(order, expectedRealized)) return undefined;
   if (!sameOrder(order, expectedRealized)) {
     problems.push(
       `  MRO order:      ${expectedRealized.join(" → ") || "(none)"}\n` +
         `  realized order: ${order.join(" → ") || "(none)"}`,
     );
   }
+  if (problems.length === 0) return undefined;
   return (
     `prism-codegen composition point: ${marker.file} :: ${marker.method} drifted ` +
     `from ActiveRecord::Base's MRO.\n${problems.join("\n")}`
@@ -225,8 +216,7 @@ export function rubyPathCandidatesForModule(name: string): string[] {
  * Ancestry entries living in another Rails component, which no path under
  * `activerecord/lib/active_record/` resolves — outside the corpus in the sense
  * `Linearization#resolve` means it. Every OTHER unresolved entry must fail
- * loudly: a definer whose source never loaded is invisible to both indexes, so
- * its contribution would be dropped from the expected order in silence.
+ * loudly: a definer whose source never loaded is invisible to both indexes.
  */
 export function isExternalAncestor(name: string): boolean {
   return /^Active(Model|Support)::/.test(name);

--- a/scripts/prism-codegen/composition.ts
+++ b/scripts/prism-codegen/composition.ts
@@ -59,12 +59,20 @@ export interface CompositionMarker {
   /** Ruby method name of the chain, e.g. `initialize_internals_callback`. */
   method: string;
   contributions: Contribution[];
-  /** Offset of the marker in the source; the realized order is read below it. */
+  /** Offset of the marker's end; the realized order is read from here. */
   offset: number;
+  /**
+   * Offset the marker's region ends at — the next marker, or the end of the
+   * file. A file can hold several composition points (base.ts has one per
+   * constructor branch) and each must read only its own call sites: an
+   * unbounded scan would let a later point's calls stand in for a missing one.
+   */
+  end: number;
 }
 
 export function parseCompositionMarkers(file: string, source: string): CompositionMarker[] {
-  return [...source.matchAll(MARKER)].map((m) => ({
+  const matches = [...source.matchAll(MARKER)];
+  return matches.map((m, i) => ({
     file,
     method: m[1],
     contributions: [...m[2].matchAll(BINDING)].map((b) => ({
@@ -72,6 +80,7 @@ export function parseCompositionMarkers(file: string, source: string): Compositi
       identifier: b[2],
     })),
     offset: m.index + m[0].length,
+    end: matches[i + 1]?.index ?? source.length,
   }));
 }
 
@@ -144,12 +153,13 @@ export function realizedCompositionOrder(
   marker: CompositionMarker,
   source: string,
 ): { order: string[]; missing: string[] } {
-  const below = source.slice(marker.offset);
+  const below = source.slice(marker.offset, marker.end);
   const order: { module: string; at: number }[] = [];
   const missing: string[] = [];
   for (const { module, identifier } of marker.contributions) {
     if (identifier === UNREALIZED) continue;
-    const at = below.search(new RegExp(`\\b${identifier}\\b[\\s(.]`));
+    const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const at = below.search(new RegExp(`\\b${escaped}\\b[\\s(.]`));
     if (at < 0) missing.push(identifier);
     else order.push({ module, at });
   }

--- a/scripts/prism-codegen/composition.ts
+++ b/scripts/prism-codegen/composition.ts
@@ -1,21 +1,19 @@
 /**
  * Composition-point ↔ MRO check (RFC 0086).
  *
- * Rails realizes a chain like `initialize_internals_callback` through `super`:
- * each module in `ActiveRecord::Base`'s ancestry contributes a fragment, and
- * the execution order falls out of the include order plus where each body puts
- * its `super`. The port has no `super` chain — `base.ts` calls the
- * contributions explicitly at a *composition point*, in an order that is
- * hand-maintained and can silently drift from `base.rb`. A composition point
- * declares itself with a marker:
+ * Rails realizes a chain like `initialize_internals_callback` through `super`,
+ * so its execution order falls out of `Base`'s include order plus where each
+ * body puts its `super`. The port has no `super` chain — `base.ts` calls the
+ * contributions explicitly at a *composition point*, in a hand-maintained
+ * order that can silently drift. A composition point declares itself with a
+ * marker:
  *
  *   // prism-mro: initialize_internals_callback Inheritance=ensureProperType \
  *   //   Scoping=_applyScopeAttributes Core=~
  *
  * `Module=identifier` binds a definer to the port symbol realizing it;
- * `Module=~` records a definer whose Ruby body contributes nothing (Rails'
- * `Core#initialize_internals_callback` is empty). Every definer the MRO
- * reaches must be declared — omission is drift, not silence.
+ * `Module=~` records a definer whose Ruby body contributes nothing. Every
+ * definer the MRO reaches must be declared — omission is drift, not silence.
  *
  * Hard rules: no node:* imports, no process.*, async fs only — this module is
  * pure (prism aside); score-cli.ts supplies the sources.

--- a/scripts/prism-codegen/composition.ts
+++ b/scripts/prism-codegen/composition.ts
@@ -2,26 +2,20 @@
  * Composition-point ↔ MRO check (RFC 0086).
  *
  * Rails realizes a chain like `initialize_internals_callback` through `super`:
- * every module in `ActiveRecord::Base`'s ancestry contributes a fragment, and
+ * each module in `ActiveRecord::Base`'s ancestry contributes a fragment, and
  * the execution order falls out of the include order plus where each body puts
- * its `super`. The port has no `super` chain — `base.ts` calls each module's
- * contribution explicitly at a *composition point*. That call order is
- * hand-maintained and can silently drift from `base.rb`'s include order; until
- * now the only record of a realized chain was a per-row sign-off.
- *
- * A composition point declares itself in the port source with a marker:
+ * its `super`. The port has no `super` chain — `base.ts` calls the
+ * contributions explicitly at a *composition point*, in an order that is
+ * hand-maintained and can silently drift from `base.rb`. A composition point
+ * declares itself with a marker:
  *
  *   // prism-mro: initialize_internals_callback Inheritance=ensureProperType \
  *   //   Scoping=_applyScopeAttributes Core=~
  *
- * `Module=identifier` binds a definer to the port symbol that realizes its
- * contribution; `Module=~` records a definer whose body contributes nothing
- * (Rails' `Core#initialize_internals_callback` is empty). Every definer the
- * MRO reaches must be declared — omission is drift, not silence.
- *
- * The check derives the expected execution order from the ancestry and the
- * super position of each Ruby body, reads the realized order out of the port
- * source below the marker, and fails when they differ.
+ * `Module=identifier` binds a definer to the port symbol realizing it;
+ * `Module=~` records a definer whose Ruby body contributes nothing (Rails'
+ * `Core#initialize_internals_callback` is empty). Every definer the MRO
+ * reaches must be declared — omission is drift, not silence.
  *
  * Hard rules: no node:* imports, no process.*, async fs only — this module is
  * pure (prism aside); score-cli.ts supplies the sources.
@@ -100,12 +94,10 @@ export async function indexSuperPositions(
 }
 
 /**
- * The order the contributions to `method` actually run in, nearest-definer
- * first. A body's pre-`super` statements run on the way down the ancestry and
- * its post-`super` statements on the way back up, so the expected order is the
- * pre-super definers in ancestry order followed by the post-super definers in
- * reverse. The walk stops at the first definer that never calls `super`: the
- * rest of the ancestry is unreachable.
+ * The order the contributions to `method` run in. A body's pre-`super`
+ * statements run on the way down the ancestry and its post-`super` statements
+ * on the way back up, so it is the pre-super definers in ancestry order
+ * followed by the post-super definers in reverse.
  */
 export function expectedCompositionOrder(
   linearization: Linearization,
@@ -123,10 +115,10 @@ export function expectedCompositionOrder(
 }
 
 /**
- * Every module the chain actually dispatches through, nearest first —
- * contributing ones and no-ops alike (Rails' `Core#initialize_internals_callback`
- * is empty). The port must declare all of them, so that a body growing a
- * contribution cannot slip in unnoticed.
+ * Every module the chain dispatches through, nearest first — contributing ones
+ * and no-ops alike, so a body that grows a contribution cannot slip in
+ * unnoticed. Stops at the first definer that never calls `super`: the rest of
+ * the ancestry is unreachable.
  */
 export function reachedDefiners(
   linearization: Linearization,
@@ -145,9 +137,10 @@ export function reachedDefiners(
 }
 
 /**
- * The order the port realizes the contributions in: the declared identifiers
- * sorted by where they are first called below the marker. Identifiers bound to
- * `~` have no call site and are not part of the realized order.
+ * The declared identifiers, ordered by where they are first *called* in the
+ * marker's region. A bare reference (`const cb = ensureProperType`) is not a
+ * call site: what the MRO orders is when each contribution runs, and only an
+ * invocation places one in that order. `~` bindings have no call site.
  */
 export function realizedCompositionOrder(
   marker: CompositionMarker,
@@ -159,7 +152,7 @@ export function realizedCompositionOrder(
   for (const { module, identifier } of marker.contributions) {
     if (identifier === UNREALIZED) continue;
     const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const at = below.search(new RegExp(`\\b${escaped}\\b[\\s(.]`));
+    const at = below.search(new RegExp(`\\b${escaped}\\s*(?:\\(|\\.(?:call|apply)\\s*\\()`));
     if (at < 0) missing.push(identifier);
     else order.push({ module, at });
   }
@@ -214,16 +207,44 @@ export function checkCompositionPoint(
 }
 
 /**
- * Vendored path a `Base` ancestry entry's source lives at, by Rails' own
- * file-per-module convention (`Locking::Optimistic` → `locking/optimistic.rb`).
- * The check needs every ancestor's body, not just the codegen target set:
- * `Scoping` contributes to `initialize_internals_callback` and is not a target.
+ * Vendored paths a `Base` ancestry entry's source may live at, most specific
+ * first: Rails is mostly file-per-module (`Locking::Optimistic` →
+ * `locking/optimistic.rb`), but a nested module can also be declared in its
+ * parent's file (`Marshalling::Methods` lives in `marshalling.rb`). The check
+ * needs every ancestor's body, not just the codegen target set — `Scoping`
+ * contributes to `initialize_internals_callback` and is not a target.
  */
-export function rubyPathForModule(name: string): string {
+export function rubyPathCandidatesForModule(name: string): string[] {
   const parts = normalizeModuleName(name)
     .split("::")
     .map((part) => part.replace(/([a-z\d])([A-Z])/g, "$1_$2").toLowerCase());
-  return `active_record/${parts.join("/")}.rb`;
+  return parts.map((_, i) => `active_record/${parts.slice(0, parts.length - i).join("/")}.rb`);
+}
+
+/**
+ * Ancestry entries living in another Rails component, which no path under
+ * `activerecord/lib/active_record/` resolves — outside the corpus in the sense
+ * `Linearization#resolve` means it. Every OTHER unresolved entry must fail
+ * loudly: a definer whose source never loaded is invisible to both indexes, so
+ * its contribution would be dropped from the expected order in silence.
+ */
+export function isExternalAncestor(name: string): boolean {
+  return /^Active(Model|Support)::/.test(name);
+}
+
+export function unresolvedAncestryMessage(unresolved: readonly string[]): string | undefined {
+  const real = unresolved.filter((name) => !isExternalAncestor(name));
+  if (real.length === 0) return undefined;
+  return [
+    `prism-codegen composition check: ${real.length} ancestry module(s) of ` +
+      "ActiveRecord::Base have no vendored source at the path derived for them.",
+    "",
+    "Their bodies are invisible to the check, so a contribution they make to a",
+    "guarded chain would be dropped without a word. Fix the path derivation, or",
+    "teach `isExternalAncestor` about the component the module really lives in.",
+    "",
+    ...real.map((name) => `  ${name} → ${rubyPathCandidatesForModule(name).join(", ")}`),
+  ].join("\n");
 }
 
 export function compositionFailureMessage(failures: readonly string[]): string | undefined {

--- a/scripts/prism-codegen/convergence-signoff.json
+++ b/scripts/prism-codegen/convergence-signoff.json
@@ -17,7 +17,7 @@
   {
     "rubyFile": "active_record/inheritance.rb",
     "name": "initializeInternalsCallback",
-    "reason": "Rails' body is `super; ensure_proper_type` and the generated def now realizes that super as `Core.initializeInternalsCallback.call(this, ...)`. The port holds only this module's contribution (`ensureProperType.call(this)`, inheritance.ts:824) because base.ts orchestrates the chain explicitly at both constructor branches (base.ts:3212, 3291) — the composition-point pattern from #5727. Same two reaches, one of them relocated to the composition point."
+    "reason": "Rails' body is `super; ensure_proper_type` and the generated def now realizes that super as `Core.initializeInternalsCallback.call(this, ...)`. The port holds only this module's contribution (`ensureProperType.call(this)`, inheritance.ts:824) because base.ts orchestrates the chain explicitly at both constructor branches — the composition-point pattern from #5727. Same two reaches, one of them relocated to the composition point, whose order is now machine-checked against Base's MRO by the `prism-mro:` markers there (composition.ts)."
   },
   {
     "rubyFile": "active_record/persistence.rb",

--- a/scripts/prism-codegen/linearization.ts
+++ b/scripts/prism-codegen/linearization.ts
@@ -98,7 +98,8 @@ function walk(node: PrismNode | null, path: string[], index: Map<string, Set<str
   for (const child of node.compactChildNodes()) walk(child, path, index);
 }
 
-function constPath(path: PrismNode | undefined, name: unknown): string {
+/** Full constant path of a `module`/`class` node, e.g. `ActiveRecord::Scoping`. */
+export function constPath(path: PrismNode | undefined, name: unknown): string {
   if (path?.constructor.name === "ConstantPathNode") {
     const parts: string[] = [];
     let cur: PrismNode | undefined = path;

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -17,7 +17,8 @@ import {
   compositionFailureMessage,
   indexSuperPositions,
   parseCompositionMarkers,
-  rubyPathForModule,
+  rubyPathCandidatesForModule,
+  unresolvedAncestryMessage,
 } from "./composition.js";
 import { buildLinearization, parseIncludeOrder } from "./linearization.js";
 import {
@@ -108,6 +109,18 @@ async function readSignOffSource(): Promise<string> {
   }
 }
 
+/** The first of `candidates` that exists under the vendored ActiveRecord tree. */
+async function firstReadable(candidates: readonly string[]): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    try {
+      return await fs.readFile(rubyAbsPathFor(candidate), "utf8");
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Every `prism-mro:` marker in the port tree, checked against the ancestry of
  * `ActiveRecord::Base`. Built from the ancestry's own sources rather than the
@@ -117,13 +130,14 @@ async function readSignOffSource(): Promise<string> {
 async function compositionCheck(): Promise<{ points: number; failure?: string }> {
   const baseSource = await fs.readFile(rubyAbsPathFor("active_record/base.rb"), "utf8");
   const sources = [baseSource];
+  const unresolved: string[] = [];
   for (const module of parseIncludeOrder(baseSource)) {
-    try {
-      sources.push(await fs.readFile(rubyAbsPathFor(rubyPathForModule(module)), "utf8"));
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
-    }
+    const source = await firstReadable(rubyPathCandidatesForModule(module));
+    if (source === undefined) unresolved.push(module);
+    else sources.push(source);
   }
+  const unresolvedFailure = unresolvedAncestryMessage(unresolved);
+  if (unresolvedFailure) return { points: 0, failure: unresolvedFailure };
   const linearization = await buildLinearization(baseSource, sources);
   const positions = await indexSuperPositions(sources);
   const failures: string[] = [];

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -5,7 +5,21 @@ import { fileURLToPath } from "node:url";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
-import { TARGET_FILES, TRAILS_AR_SRC, portTreeFiles, rubyAbsPath } from "./files.js";
+import {
+  TARGET_FILES,
+  TRAILS_AR_SRC,
+  portTreeFiles,
+  rubyAbsPath,
+  rubyAbsPathFor,
+} from "./files.js";
+import {
+  checkCompositionPoint,
+  compositionFailureMessage,
+  indexSuperPositions,
+  parseCompositionMarkers,
+  rubyPathForModule,
+} from "./composition.js";
+import { buildLinearization, parseIncludeOrder } from "./linearization.js";
 import {
   inheritedDelegationsFor,
   outNameFor,
@@ -92,6 +106,36 @@ async function readSignOffSource(): Promise<string> {
       { cause: e },
     );
   }
+}
+
+/**
+ * Every `prism-mro:` marker in the port tree, checked against the ancestry of
+ * `ActiveRecord::Base`. Built from the ancestry's own sources rather than the
+ * codegen target set: a chain's definers (e.g. `Scoping`) are often not
+ * targets, and a missing body would silently drop a contribution.
+ */
+async function compositionCheck(): Promise<{ points: number; failure?: string }> {
+  const baseSource = await fs.readFile(rubyAbsPathFor("active_record/base.rb"), "utf8");
+  const sources = [baseSource];
+  for (const module of parseIncludeOrder(baseSource)) {
+    try {
+      sources.push(await fs.readFile(rubyAbsPathFor(rubyPathForModule(module)), "utf8"));
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+  }
+  const linearization = await buildLinearization(baseSource, sources);
+  const positions = await indexSuperPositions(sources);
+  const failures: string[] = [];
+  let points = 0;
+  for (const { path: file, source } of portTreeFiles()) {
+    for (const marker of parseCompositionMarkers(file, source)) {
+      points++;
+      const failure = checkCompositionPoint(marker, source, linearization, positions);
+      if (failure) failures.push(failure);
+    }
+  }
+  return { points, failure: compositionFailureMessage(failures) };
 }
 
 async function main() {
@@ -215,6 +259,14 @@ async function main() {
     );
   }
   console.log();
+
+  const composition = await compositionCheck();
+  if (composition.failure) {
+    console.error(composition.failure);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`  composition points: ${composition.points} checked against Base's MRO — OK\n`);
 
   const stale = staleSignOffs([...catalogued.map((c) => c.row), ...uncatalogued], signOffs);
   const staleFailure = staleSignOffMessage(stale);


### PR DESCRIPTION
## What

Makes the port's hand-maintained composition points checkable against
`ActiveRecord::Base`'s MRO. #5817 gave us the static linearization; nothing
used it to verify that the order in which `base.ts` calls each module's
contribution matches the order Rails' `super` chain would run them in.

- `scripts/prism-codegen/composition.ts` — parses `prism-mro:` markers out of
  the port tree (`Module=identifier`, or `Module=~` for a definer whose Ruby
  body contributes nothing), derives the expected execution order from the
  ancestry plus each body's `super` position (pre-`super` statements run in
  ancestry order, post-`super` ones in reverse; the walk stops at the first
  definer that never calls `super`), reads the realized order from the call
  sites below the marker, and reports drift.
- Fails on three things: a definer the MRO reaches that the marker does not
  declare, a declared identifier with no call site below the marker, and a
  realized order that differs from the MRO order.
- `score-cli.ts` runs it over the whole port tree on every `pnpm codegen:score`.
  The linearization is built from the ancestry's own sources rather than the
  codegen target set — `Scoping` contributes to
  `initialize_internals_callback` but is not a target.

## The drift it found

Both `Scoping#initialize_internals_callback` and
`Inheritance#initialize_internals_callback` are `super; <contribution>`, so
Rails unwinds `ensure_proper_type` **before**
`populate_with_current_scope_attributes`. The port ran the scope attributes
first (and a comment asserted that was Rails' order). Both composition points
in `base.ts` are swapped to match, and now carry markers. Scoping,
inheritance, base and persistence suites pass locally.

## Tests

`composition.test.ts` covers marker parsing, both super positions, the
no-`super` chain stop, and — per the acceptance criteria — that the check
fails when a composition point is reordered.

Closes-story: composition-chain-mro-check

## Review follow-ups

- An ancestry module whose Ruby source never loaded was invisible to both the
  def index and the super-position index, so a contribution it made to a
  guarded chain would drop out of the expected order in silence.
  `unresolvedAncestryMessage` now hard-fails before either index is built,
  except for entries in another Rails component (`isExternalAncestor`). This
  immediately caught `Marshalling::Methods`, which is declared inside
  `marshalling.rb` rather than a file of its own — path derivation now falls
  back to each enclosing prefix.
- The call-site scan requires an actual invocation (`f(`, `f.call(`,
  `f.apply(`), not a bare reference: what the MRO orders is when each
  contribution *runs*.
- Each composition point's scan is bounded to its own region (up to the next
  marker), so a later point's calls can't stand in for a missing one, and the
  identifier is escaped before regex use.

## Size

551 LOC (additions + deletions), ~10% over the 500 ceiling. It is one
self-contained checker plus its tests — splitting it would either ship the
check without the tests or the parser without the check. Trimmed twice
(prose, fixtures, message assembly) to get from 587 down to this.
