### PR TITLE
feat(prism-codegen): emit a call for paren-less self-calls the port declares as methods

### DIFF
--- a/scripts/prism-codegen/__snapshots__/core.js.snap
+++ b/scripts/prism-codegen/__snapshots__/core.js.snap
@@ -65,46 +65,46 @@ included(() => {
         return ActiveSupport.IsolatedExecutionState["active_record_connection_handler"] = handler;
     }
     export function asynchronousQueriesSession() {
-        return this.asynchronousQueriesTracker.currentSession();
+        return this.asynchronousQueriesTracker().currentSession();
     }
     export function asynchronousQueriesTracker() {
         return ActiveSupport.IsolatedExecutionState["active_record_asynchronous_queries_tracker"] ||= new AsynchronousQueriesTracker();
     }
     export function currentRole() {
-        this.connectedToStack.reverseEach(hash => {
+        this.connectedToStack().reverseEach(hash => {
             if (hash["role"] && hash["klasses"].isInclude(Base)) {
                 return hash["role"];
             }
-            if (hash["role"] && hash["klasses"].isInclude(this.connectionClassForSelf)) {
+            if (hash["role"] && hash["klasses"].isInclude(this.connectionClassForSelf())) {
                 return hash["role"];
             }
         });
         return this.defaultRole;
     }
     export function currentShard() {
-        this.connectedToStack.reverseEach(hash => {
+        this.connectedToStack().reverseEach(hash => {
             if (hash["shard"] && hash["klasses"].isInclude(Base)) {
                 return hash["shard"];
             }
-            if (hash["shard"] && hash["klasses"].isInclude(this.connectionClassForSelf)) {
+            if (hash["shard"] && hash["klasses"].isInclude(this.connectionClassForSelf())) {
                 return hash["shard"];
             }
         });
         return this.defaultShard;
     }
     export function currentPreventingWrites() {
-        this.connectedToStack.reverseEach(hash => {
+        this.connectedToStack().reverseEach(hash => {
             if (!hash["prevent_writes"].nil() && hash["klasses"].isInclude(Base)) {
                 return hash["prevent_writes"];
             }
-            if (!hash["prevent_writes"].nil() && hash["klasses"].isInclude(this.connectionClassForSelf)) {
+            if (!hash["prevent_writes"].nil() && hash["klasses"].isInclude(this.connectionClassForSelf())) {
                 return hash["prevent_writes"];
             }
         });
         return false;
     }
     export function isPreventingWrites(class_name) {
-        this.connectedToStack.reverseEach(hash => {
+        this.connectedToStack().reverseEach(hash => {
             if (!hash["prevent_writes"].nil() && hash["klasses"].isInclude(Base)) {
                 return hash["prevent_writes"];
             }
@@ -194,7 +194,7 @@ export async function findByBang(...args) {
     return await this.findBy(...args) || this.where(...args).raiseRecordNotFoundExceptionBang();
 }
 export function initializeGeneratedModules() {
-    return this.generatedAssociationMethods;
+    return this.generatedAssociationMethods();
 }
 export function generatedAssociationMethods() {
     return this.generated_association_methods ||= __PRISM_TODO("BeginNode");
@@ -227,11 +227,11 @@ export function inspect() {
     else if (this.isAbstractClass) {
         return `${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")}(abstract)`;
     }
-    else if (!this.isSchemaLoaded && !this.isConnected) {
+    else if (!this.isSchemaLoaded() && !this.isConnected) {
         return `${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")} (call '${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")}.load_schema' to load schema informations)`;
     }
     else if (this.isTableExists) {
-        attr_list = this.attributeTypes.map((name, type) => `${name}: ${type.type()}`) * ", ";
+        attr_list = this.attributeTypes().map((name, type) => `${name}: ${type.type()}`) * ", ";
         return `${__PRISM_SUPER_OUTSIDE_CORPUS("Core::ClassMethods#inspect")}(${attr_list})`;
     }
     else {
@@ -274,8 +274,8 @@ export function inherited(subclass) {
 export function relation() {
     let relation;
     relation = Relation.create(this);
-    if (this.isFinderNeedsTypeCondition && !this.isIgnoreDefaultScope) {
-        return relation.whereBang(this.typeCondition);
+    if (this.isFinderNeedsTypeCondition() && !this.isIgnoreDefaultScope()) {
+        return relation.whereBang(this.typeCondition());
     }
     else {
         return relation;
@@ -308,8 +308,8 @@ export function cachedFindBy(keys, values) {
 export function constructor(attributes = null, block) {
     this.new_record = true;
     this.attributes = this.class()._defaultAttributes().deepDup();
-    this.initInternals;
-    this.initializeInternalsCallback;
+    this.initInternals();
+    this.initializeInternalsCallback();
     if (block !== undefined) {
         block(this);
     }
@@ -324,7 +324,7 @@ export function initWith(coder, block) {
 export function initWithAttributes(attributes, new_record = false, block) {
     this.new_record = new_record;
     this.attributes = attributes;
-    this.initInternals;
+    this.initInternals();
     if (block !== undefined) {
         block(this);
     }
@@ -362,7 +362,7 @@ __PRISM_TODO("AliasMethodNode");
 export function hash() {
     let id;
     id = this.id();
-    if (this.isPrimaryKeyValuesPresent) {
+    if (this.isPrimaryKeyValuesPresent()) {
         return __PRISM_TODO("CallNode");
     }
     else {
@@ -410,19 +410,19 @@ export function connectionHandler() {
     return this.class().connectionHandler();
 }
 export function inspect() {
-    return this.inspectWithAttributes(this.attributesForInspect);
+    return this.inspectWithAttributes(this.attributesForInspect());
 }
 export function fullInspect() {
-    return this.inspectWithAttributes(this.allAttributesForInspect);
+    return this.inspectWithAttributes(this.allAttributesForInspect());
 }
 export function prettyPrint(pp) {
     let attr_names, attr_name, value;
-    if (this.isCustomInspectMethodDefined) {
+    if (this.isCustomInspectMethodDefined()) {
         return __PRISM_SUPER_OUTSIDE_CORPUS("Core#pretty_print");
     }
     return pp.objectAddressGroup(this, () => {
         if (this.attributes) {
-            attr_names = this.attributesForInspect.select(name => this.is_hasAttribute(name.toString()));
+            attr_names = this.attributesForInspect().select(name => this.is_hasAttribute(name.toString()));
             return pp.seplist(attr_names, this.proc(() => pp.text(",")), attr_name => {
                 attr_name = attr_name.toString();
                 pp.breakable(" ");
@@ -485,7 +485,7 @@ export function inspectWithAttributes(attributes_to_list) {
 }
 export function attributesForInspect() {
     if (this.class().attributesForInspect() === "all") {
-        return this.allAttributesForInspect;
+        return this.allAttributesForInspect();
     }
     else {
         return this.class().attributesForInspect();
@@ -495,5 +495,5 @@ export function allAttributesForInspect() {
     if (!this.attributes) {
         return [];
     }
-    return this.attributeNames;
+    return this.attributeNames();
 }

--- a/scripts/prism-codegen/__snapshots__/inheritance.js.snap
+++ b/scripts/prism-codegen/__snapshots__/inheritance.js.snap
@@ -23,7 +23,7 @@ export function constructor(attributes = null, block) {
         if (subclass.nil() && (scope_attributes = this.currentScope.scopeForCreate())) {
             subclass = this.subclassFromAttributes(scope_attributes);
         }
-        if (subclass.nil() && this.isBaseClass) {
+        if (subclass.nil() && this.isBaseClass()) {
             subclass = this.subclassFromAttributes(this.columnDefaults);
         }
     }
@@ -45,7 +45,7 @@ export function isDescendsFromActiveRecord() {
     }
 }
 export function isFinderNeedsTypeCondition() {
-    return "true" === (this.finder_needs_type_condition ||= this.isDescendsFromActiveRecord ? "false" : "true");
+    return "true" === (this.finder_needs_type_condition ||= this.isDescendsFromActiveRecord() ? "false" : "true");
 }
 attrReader("base_class");
 export function isBaseClass() {
@@ -106,7 +106,7 @@ export function dup() {
     return other;
 }
 export function initializeClone(other) {
-    return this.setBaseClass;
+    return this.setBaseClass();
 }
 __PRISM_TODO("CallNode");
 export function computeType(type_name) {
@@ -181,12 +181,12 @@ export function subclassFromAttributes(attrs) {
 }
 export function initializeDup(other) {
     Core.initializeDup.call(this, ...arguments);
-    return this.ensureProperType;
+    return this.ensureProperType();
 }
 __PRISM_TODO("CallNode");
 export function initializeInternalsCallback() {
     Core.initializeInternalsCallback.call(this, ...arguments);
-    return this.ensureProperType;
+    return this.ensureProperType();
 }
 export function ensureProperType() {
     let klass;

--- a/scripts/prism-codegen/__snapshots__/model-schema.js.snap
+++ b/scripts/prism-codegen/__snapshots__/model-schema.js.snap
@@ -83,11 +83,11 @@ export function ignoredColumns() {
     return this.ignored_columns || this.superclass.ignoredColumns();
 }
 export function ignoredColumns(columns) {
-    this.reloadSchemaFromCache;
+    this.reloadSchemaFromCache();
     return this.ignored_columns = columns.map(x => x.toString()).freeze();
 }
 export function sequenceName() {
-    if (this.isBaseClass) {
+    if (this.isBaseClass()) {
         return this.sequence_name ||= this.resetSequenceName;
     }
     else {
@@ -116,7 +116,7 @@ export function attributesBuilder() {
 }
 export function columnsHash() {
     if (!this.columns_hash) {
-        this.loadSchema;
+        this.loadSchema();
     }
     return this.columns_hash;
 }
@@ -127,14 +127,14 @@ export function _returningColumnsForInsert(connection) {
     return this._returning_columns_for_insert ||= __PRISM_TODO("BeginNode");
 }
 export function yamlEncoder() {
-    return this.yaml_encoder ||= new ActiveModel.AttributeSet.YAMLEncoder(this.attributeTypes);
+    return this.yaml_encoder ||= new ActiveModel.AttributeSet.YAMLEncoder(this.attributeTypes());
 }
 export function columnForAttribute(name) {
     name = name.toString();
     return this.columnsHash.fetch(name, () => new ConnectionAdapters.NullColumn(name));
 }
 export function columnDefaults() {
-    this.loadSchema;
+    this.loadSchema();
     return this.column_defaults ||= this._defaultAttributes.deepDup().toHash().freeze();
 }
 export function columnNames() {
@@ -151,23 +151,23 @@ export function resetColumnInformation() {
     this.connectionPool.activeConnection().clearCacheBang();
     ([this] + this.descendants).each(x => x.undefineAttributeMethods());
     this.schemaCache.clearDataSourceCacheBang(this.tableName);
-    this.reloadSchemaFromCache;
+    this.reloadSchemaFromCache();
     return this.initializeFindByCache;
 }
 export function loadSchema() {
-    if (this.isSchemaLoaded) {
+    if (this.isSchemaLoaded()) {
         return;
     }
     return this.load_schema_monitor.synchronize(() => {
         try {
-            if (this.isSchemaLoaded) {
+            if (this.isSchemaLoaded()) {
                 return;
             }
-            this.loadSchema;
+            this.loadSchema();
             return this.schema_loaded = true;
         }
         catch (e) {
-            this.reloadSchemaFromCache;
+            this.reloadSchemaFromCache();
             return this.raise;
         }
     });
@@ -226,7 +226,7 @@ export function undecoratedTableName(model_name) {
 }
 export function computeTableName() {
     let contained;
-    if (this.isBaseClass) {
+    if (this.isBaseClass()) {
         if (this.moduleParent < Base && !this.moduleParent.isAbstractClass()) {
             contained = this.moduleParent.tableName();
             if (this.moduleParent.pluralizeTableNames()) {

--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -51,7 +51,7 @@ export function update(id = "all") {
         return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => object.update(attributes[idx]));
     }
     else if (id === "all") {
-        return this.all.each(record => record.update(attributes));
+        return this.all().each(record => record.update(attributes));
     }
     else {
         if (__PRISM_TODO("CallNode")) {
@@ -71,7 +71,7 @@ export function updateBang(id = "all") {
         return id.map(one_id => this.find(one_id)).eachWithIndex((object, idx) => object.updateBang(attributes[idx]));
     }
     else if (id === "all") {
-        return this.all.each(record => record.updateBang(attributes));
+        return this.all().each(record => record.updateBang(attributes));
     }
     else {
         if (__PRISM_TODO("CallNode")) {
@@ -93,10 +93,10 @@ export function hasQueryConstraints() {
     return this.has_query_constraints;
 }
 export function queryConstraintsList() {
-    return this.query_constraints_list ||= this.isBaseClass || this.primaryKey !== this.baseClass.primaryKey() ? __PRISM_TODO("IfNode") : this.baseClass.queryConstraintsList();
+    return this.query_constraints_list ||= this.isBaseClass() || this.primaryKey !== this.baseClass.primaryKey() ? __PRISM_TODO("IfNode") : this.baseClass.queryConstraintsList();
 }
 export function compositeQueryConstraintsList() {
-    return this.composite_query_constraints_list ||= this.queryConstraintsList || this.Array(this.primaryKey);
+    return this.composite_query_constraints_list ||= this.queryConstraintsList() || this.Array(this.primaryKey);
 }
 export function _insertRecord(connection, values, returning) {
     let primary_key, primary_key_value, im;
@@ -117,7 +117,7 @@ export function _insertRecord(connection, values, returning) {
 export function _updateRecord(values, constraints) {
     let default_constraint, current_scope, um;
     constraints = constraints.map((name, value) => __PRISM_TODO("CallNode"));
-    default_constraint = this.buildDefaultConstraint;
+    default_constraint = this.buildDefaultConstraint();
     if (default_constraint) {
         constraints.push(default_constraint);
     }
@@ -132,7 +132,7 @@ export function _updateRecord(values, constraints) {
 export function _deleteRecord(constraints) {
     let default_constraint, current_scope, dm;
     constraints = constraints.map((name, value) => __PRISM_TODO("CallNode"));
-    default_constraint = this.buildDefaultConstraint;
+    default_constraint = this.buildDefaultConstraint();
     if (default_constraint) {
         constraints.push(default_constraint);
     }
@@ -194,18 +194,18 @@ export function saveBang({ ...options } = {}, block) {
     return this.createOrUpdate({ ...options }, block) || (() => { throw new RecordNotSaved("Failed to save the record", this); })();
 }
 __PRISM_TODO("DefNode");
-export function destroy() {
+export async function destroy() {
     if (this.isReadonly) {
-        this._raiseReadonlyRecordError;
+        this._raiseReadonlyRecordError();
     }
-    this.destroyAssociations;
-    this._trigger_destroy_callback ||= this.isPersisted && this.destroyRow > 0;
+    this.destroyAssociations();
+    this._trigger_destroy_callback ||= this.isPersisted && await this.destroyRow() > 0;
     this.destroyed = true;
     this.previously_new_record = false;
     return this.freeze;
 }
-export function destroyBang() {
-    return this.destroy || this._raiseRecordNotDestroyed;
+export async function destroyBang() {
+    return await this.destroy() || this._raiseRecordNotDestroyed();
 }
 export function becomes(klass) {
     let became;
@@ -245,13 +245,13 @@ export async function updateAttributeBang(name, value) {
 export function update(attributes) {
     return this.withTransactionReturningStatus(() => {
         this.assignAttributes(attributes);
-        return this.save;
+        return await this.save();
     });
 }
 export function updateBang(attributes) {
     return this.withTransactionReturningStatus(() => {
         this.assignAttributes(attributes);
-        return this.saveBang;
+        return await this.saveBang();
     });
 }
 export async function updateColumn(name, value) {
@@ -266,14 +266,14 @@ export function updateColumns(attributes) {
         throw new ActiveRecordError("cannot update a destroyed record");
     }
     if (this.isReadonly) {
-        this._raiseReadonlyRecordError;
+        this._raiseReadonlyRecordError();
     }
     attributes = attributes.transformKeys(key => {
         name = key.toString();
         name = this.class().attributeAliases()[name] || name;
         return this.verifyReadonlyAttribute(name) || name;
     });
-    update_constraints = this._queryConstraintsHash;
+    update_constraints = this._queryConstraintsHash();
     attributes = __PRISM_TODO("CallNode");
     affected_rows = this.class()._updateRecord(attributes, update_constraints);
     return affected_rows === 1;
@@ -318,12 +318,12 @@ export function reload(options = null) {
 export function touch(...names, { time = null } = {}) {
     let attribute_names, name, affected_rows;
     if (!this.isPersisted) {
-        this._raiseRecordNotTouchedError;
+        this._raiseRecordNotTouchedError();
     }
     if (this.isReadonly) {
-        this._raiseReadonlyRecordError;
+        this._raiseReadonlyRecordError();
     }
-    attribute_names = this.timestampAttributesForUpdateInModel;
+    attribute_names = this.timestampAttributesForUpdateInModel();
     attribute_names = (__PRISM_TODO("CallNode")).mapBang(name => {
         name = name.toString();
         name = this.class().attributeAliases()[name] || name;
@@ -350,12 +350,12 @@ export function strictLoadedAssociations() {
 export function _findRecord(options) {
     let all_queries, base;
     all_queries = options ? options["all_queries"] : null;
-    base = this.class().all({ all_queries: all_queries }).preload(this.strictLoadedAssociations);
+    base = this.class().all({ all_queries: all_queries }).preload(this.strictLoadedAssociations());
     if (options && options["lock"]) {
-        return base.lock(options["lock"]).findByBang(this._inMemoryQueryConstraintsHash);
+        return base.lock(options["lock"]).findByBang(this._inMemoryQueryConstraintsHash());
     }
     else {
-        return base.findByBang(this._inMemoryQueryConstraintsHash);
+        return base.findByBang(this._inMemoryQueryConstraintsHash());
     }
 }
 export function _inMemoryQueryConstraintsHash() {
@@ -371,7 +371,7 @@ export function isApplyScoping(options) {
 }
 export function _queryConstraintsHash() {
     if (this.class().queryConstraintsList().nil()) {
-        return { [this.primary_key]: this.idInDatabase };
+        return { [this.primary_key]: this.idInDatabase() };
     }
     else {
         return this.class().queryConstraintsList().indexWith(column_name => this.attributeInDatabase(column_name));
@@ -380,23 +380,23 @@ export function _queryConstraintsHash() {
 export function destroyAssociations() {
 }
 export function destroyRow() {
-    return this._deleteRow;
+    return this._deleteRow();
 }
 export function _deleteRow() {
-    return this.class()._deleteRecord(this._queryConstraintsHash);
+    return this.class()._deleteRecord(this._queryConstraintsHash());
 }
 export function _touchRow(attribute_names, time) {
-    time ||= this.currentTimeFromProperTimezone;
+    time ||= this.currentTimeFromProperTimezone();
     attribute_names.each(attr_name => this._writeAttribute(attr_name, time));
     return this._updateRow(attribute_names, "touch");
 }
 export function _updateRow(attribute_names, attempted_action = "update") {
-    return this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash);
+    return this.class()._updateRecord(this.attributesWithValues(attribute_names), this._queryConstraintsHash());
 }
 export function createOrUpdate({ ...opts } = {}, block) {
     let result;
     if (this.isReadonly) {
-        this._raiseReadonlyRecordError;
+        this._raiseReadonlyRecordError();
     }
     if (this.isDestroyed) {
         return false;

--- a/scripts/prism-codegen/__snapshots__/relation.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation.js.snap
@@ -25,7 +25,7 @@ export class Relation {
     }
     initializeCopy(other) {
         this.values = this.values.dup();
-        return this.reset;
+        return this.reset();
     }
     bindAttribute(name, value, block) {
         let reflection, attr, bind;
@@ -124,8 +124,8 @@ export class Relation {
     toAry() {
         return this.records.dup();
     }
-    records() {
-        this.load;
+    async records() {
+        await this.load();
         return this.records;
     }
     encodeWith(coder) {
@@ -147,7 +147,7 @@ export class Relation {
             return this.records.isEmpty();
         }
         else {
-            return !this.isExists;
+            return !this.isExists();
         }
     }
     isNone(...args, block) {
@@ -178,7 +178,7 @@ export class Relation {
         if (this.isLoaded) {
             return this.records.isOne();
         }
-        return this.limitedCount === 1;
+        return this.limitedCount() === 1;
     }
     isMany(block) {
         if (this.none) {
@@ -190,7 +190,7 @@ export class Relation {
         if (this.isLoaded) {
             return this.records.isMany();
         }
-        return this.limitedCount > 1;
+        return this.limitedCount() > 1;
     }
     cacheKey(timestamp_column = "updated_at") {
         this.cache_keys ||= {};
@@ -198,7 +198,7 @@ export class Relation {
     }
     async computeCacheKey(timestamp_column = "updated_at") {
         let query_signature, key;
-        query_signature = ActiveSupport.Digest.hexdigest(this.toSql);
+        query_signature = ActiveSupport.Digest.hexdigest(this.toSql());
         key = `${this.model.modelName().cacheKey()}/query-${query_signature}`;
         if (this.model.collectionCacheVersioning()) {
             return key;
@@ -223,7 +223,7 @@ export class Relation {
             }
         }
         else {
-            collection = this.isEagerLoading ? this.applyJoinDependency : this;
+            collection = this.isEagerLoading ? this.applyJoinDependency() : this;
             this.model.withConnection(c => {
                 column = c.visitor().compile(this.table[timestamp_column]);
                 select_values = `COUNT(*) AS ${this.model.adapterClass().quoteColumnName("size")}, MAX(%s) AS timestamp`;
@@ -299,7 +299,7 @@ export class Relation {
             values = Arel.sql(this.model.sanitizeSqlForAssignment(updates, this.table.name()));
         }
         return this.model.withConnection(c => {
-            arel = this.isEagerLoading ? this.applyJoinDependency.arel() : this.buildArel(c);
+            arel = this.isEagerLoading ? this.applyJoinDependency().arel() : this.buildArel(c);
             arel.source().left = this.table;
             group_values_arel_columns = this.arelColumns(this.groupValues.uniq());
             if (!this.havingClause.isEmpty()) {
@@ -307,7 +307,7 @@ export class Relation {
             }
             key = this.model.isCompositePrimaryKey() ? this.model.primaryKey.map(pk => this.table[pk]) : this.table[this.model.primaryKey];
             stmt = arel.compileUpdate(values, key, having_clause_ast, group_values_arel_columns);
-            return c.update(stmt, `${this.model} Update All`).tap(() => this.reset);
+            return c.update(stmt, `${this.model} Update All`).tap(() => this.reset());
         });
     }
     update(id = "all") {
@@ -369,7 +369,7 @@ export class Relation {
         return await this.updateAll(this.model.touchAttributesWithTime(...names, { time: time }));
     }
     destroyAll() {
-        return this.records.each(x => x.destroy()).tap(() => this.reset);
+        return this.records.each(x => x.destroy()).tap(() => this.reset());
     }
     deleteAll() {
         let invalid_methods, value, arel, group_values_arel_columns, having_clause_ast, key, stmt;
@@ -389,7 +389,7 @@ export class Relation {
             throw new ActiveRecordError(`delete_all doesn't support ${invalid_methods.join(", ")}`);
         }
         return this.model.withConnection(c => {
-            arel = this.isEagerLoading ? this.applyJoinDependency.arel() : this.buildArel(c);
+            arel = this.isEagerLoading ? this.applyJoinDependency().arel() : this.buildArel(c);
             arel.source().left = this.table;
             group_values_arel_columns = this.arelColumns(this.groupValues.uniq());
             if (!this.havingClause.isEmpty()) {
@@ -397,7 +397,7 @@ export class Relation {
             }
             key = this.model.isCompositePrimaryKey() ? this.model.primaryKey.map(pk => this.table[pk]) : this.table[this.model.primaryKey];
             stmt = arel.compileDelete(key, having_clause_ast, group_values_arel_columns);
-            return c.delete(stmt, `${this.model} Delete All`).tap(() => this.reset);
+            return c.delete(stmt, `${this.model} Delete All`).tap(() => this.reset());
         });
     }
     delete(id_or_array) {
@@ -426,7 +426,7 @@ export class Relation {
         let result;
         this.model.withConnection(c => {
             if (!c.isAsyncEnabled()) {
-                return this.load;
+                return this.load();
             }
             if (!this.isLoaded) {
                 result = this.execMainQuery({ async: !c.currentTransaction().isJoinable() });
@@ -459,9 +459,9 @@ export class Relation {
         }
         return this;
     }
-    reload() {
-        this.reset;
-        return this.load;
+    async reload() {
+        this.reset();
+        return await this.load();
     }
     reset() {
         this.future_result.cancel();
@@ -479,7 +479,7 @@ export class Relation {
         return this.to_sql ||= this.isEagerLoading ? this.applyJoinDependency((relation, join_dependency) => {
             relation = join_dependency.applyColumnAliases(relation);
             return relation.toSql();
-        }) : this.model.withConnection(conn => conn.unpreparedStatement(() => conn.toSql(this.arel)));
+        }) : this.model.withConnection(conn => conn.unpreparedStatement(() => conn.toSql(this.arel())));
     }
     whereValuesHash(relation_table_name = this.model.tableName()) {
         return this.whereClause.toH(relation_table_name);
@@ -655,7 +655,7 @@ export class Relation {
                 }));
             }
             else {
-                return this.model.withConnection(c => this.model._queryBySql(c, this.arel, { async: async }));
+                return this.model.withConnection(c => this.model._queryBySql(c, this.arel(), { async: async }));
             }
         });
     }

--- a/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/calculations.js.snap
@@ -49,25 +49,25 @@ export async function count(column_name = null, block) {
     }
 }
 export function asyncCount(column_name = null) {
-    return this.async.count(column_name);
+    return this.async().count(column_name);
 }
 export async function average(column_name) {
     return await this.calculate("average", column_name);
 }
 export function asyncAverage(column_name) {
-    return this.async.average(column_name);
+    return this.async().average(column_name);
 }
 export async function minimum(column_name) {
     return await this.calculate("minimum", column_name);
 }
 export function asyncMinimum(column_name) {
-    return this.async.minimum(column_name);
+    return this.async().minimum(column_name);
 }
 export async function maximum(column_name) {
     return await this.calculate("maximum", column_name);
 }
 export function asyncMaximum(column_name) {
-    return this.async.maximum(column_name);
+    return this.async().maximum(column_name);
 }
 export async function sum(initial_value_or_column = 0, block) {
     if (block !== undefined) {
@@ -78,7 +78,7 @@ export async function sum(initial_value_or_column = 0, block) {
     }
 }
 export function asyncSum(identity_or_column = null) {
-    return this.async.sum(identity_or_column);
+    return this.async().sum(identity_or_column);
 }
 export function calculate(operation, column_name) {
     let result, relation;
@@ -94,9 +94,9 @@ export function calculate(operation, column_name) {
         }
     }
     if (this.hasInclude(column_name)) {
-        relation = this.applyJoinDependency;
+        relation = this.applyJoinDependency();
         if (operation === "count") {
-            if (!(this.distinctValue || this.isDistinctSelect(column_name || this.selectForCount))) {
+            if (!(this.distinctValue || this.isDistinctSelect(column_name || this.selectForCount()))) {
                 relation.distinctBang();
                 relation.selectValues = this.Array(this.model.primaryKey() || this.table[Arel.star()]);
             }
@@ -130,7 +130,7 @@ export function pluck(...column_names) {
         }
     }
     if (this.hasInclude(column_names.first())) {
-        relation = this.applyJoinDependency;
+        relation = this.applyJoinDependency();
         return relation.pluck(...column_names);
     }
     else {
@@ -150,7 +150,7 @@ export function pluck(...column_names) {
     }
 }
 export function asyncPluck(...column_names) {
-    return this.async.pluck(...column_names);
+    return this.async().pluck(...column_names);
 }
 export function pick(...column_names) {
     let result;
@@ -161,7 +161,7 @@ export function pick(...column_names) {
     return this.limit(1).pluck(...column_names).then(x => x.first());
 }
 export function asyncPick(...column_names) {
-    return this.async.pick(...column_names);
+    return this.async().pick(...column_names);
 }
 export function ids() {
     let primary_key_array, result, relation, columns;
@@ -178,7 +178,7 @@ export function ids() {
         return this.async ? new Promise.Complete(result) : result;
     }
     if (this.hasInclude(this.model.primaryKey)) {
-        relation = this.applyJoinDependency.group(...primary_key_array);
+        relation = this.applyJoinDependency().group(...primary_key_array);
         return relation.ids();
     }
     columns = this.arelColumns(primary_key_array);
@@ -188,7 +188,7 @@ export function ids() {
     return result.then(result => this.typeCastPluckValues(result, columns));
 }
 export function asyncIds() {
-    return this.async.ids();
+    return this.async().ids();
 }
 __PRISM_TODO("CallNode");
 export function aggregateColumn(column_name) {
@@ -214,11 +214,11 @@ export function performCalculation(operation, column_name) {
     operation = operation.toString().downcase();
     distinct = this.distinctValue;
     if (operation === "count") {
-        column_name ||= this.selectForCount;
+        column_name ||= this.selectForCount();
         if (column_name === "all") {
             if (!distinct) {
                 if (this.groupValues.isEmpty()) {
-                    distinct = this.isDistinctSelect(this.selectForCount);
+                    distinct = this.isDistinctSelect(this.selectForCount());
                 }
             }
             else if (this.groupValues.isAny() || this.selectValues.isEmpty() && this.orderValues.isEmpty()) {
@@ -353,7 +353,7 @@ export function typeFor(field, block) {
     field_name = field.respondTo("name") ? field.name().toString() : field.toString().split(".").last();
     return this.model.typeForAttribute(field_name, block);
 }
-export function lookupCastTypeFromJoinDependencies(name, join_dependencies = this.buildJoinDependencies) {
+export function lookupCastTypeFromJoinDependencies(name, join_dependencies = this.buildJoinDependencies()) {
     let type;
     this.eachJoinDependencies(join_dependencies, join => {
         type = join.baseKlass().attributeTypes().fetch(name, null);

--- a/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/finder-methods.js.snap
@@ -25,17 +25,17 @@ export async function take(limit = null) {
         return await this.findTakeWithLimit(limit);
     }
     else {
-        return this.findTake;
+        return await this.findTake();
     }
 }
 export function takeBang() {
-    return this.take || this.raiseRecordNotFoundExceptionBang;
+    return this.take || this.raiseRecordNotFoundExceptionBang();
 }
 export async function sole() {
     let found, undesired;
     [found, undesired] = await this.first(2);
     if (found.nil()) {
-        return this.raiseRecordNotFoundExceptionBang;
+        return this.raiseRecordNotFoundExceptionBang();
     }
     else if (undesired.nil()) {
         return found;
@@ -56,14 +56,14 @@ export async function first(limit = null) {
     }
 }
 export function firstBang() {
-    return this.first || this.raiseRecordNotFoundExceptionBang;
+    return this.first || this.raiseRecordNotFoundExceptionBang();
 }
 export async function last(limit = null) {
     let result;
     if (this.isLoaded || this.hasLimitOrOffset) {
         return await this.findLast(limit);
     }
-    result = this.orderedRelation.limit(limit);
+    result = this.orderedRelation().limit(limit);
     result = result.reverseOrderBang();
     if (limit) {
         return result.reverse();
@@ -73,49 +73,49 @@ export async function last(limit = null) {
     }
 }
 export function lastBang() {
-    return this.last || this.raiseRecordNotFoundExceptionBang;
+    return this.last || this.raiseRecordNotFoundExceptionBang();
 }
 export async function second() {
     return await this.findNth(1);
 }
 export function secondBang() {
-    return this.second || this.raiseRecordNotFoundExceptionBang;
+    return this.second || this.raiseRecordNotFoundExceptionBang();
 }
 export async function third() {
     return await this.findNth(2);
 }
 export function thirdBang() {
-    return this.third || this.raiseRecordNotFoundExceptionBang;
+    return this.third || this.raiseRecordNotFoundExceptionBang();
 }
 export async function fourth() {
     return await this.findNth(3);
 }
 export function fourthBang() {
-    return this.fourth || this.raiseRecordNotFoundExceptionBang;
+    return this.fourth || this.raiseRecordNotFoundExceptionBang();
 }
 export async function fifth() {
     return await this.findNth(4);
 }
 export function fifthBang() {
-    return this.fifth || this.raiseRecordNotFoundExceptionBang;
+    return this.fifth || this.raiseRecordNotFoundExceptionBang();
 }
 export async function fortyTwo() {
     return await this.findNth(41);
 }
 export function fortyTwoBang() {
-    return this.fortyTwo || this.raiseRecordNotFoundExceptionBang;
+    return this.fortyTwo || this.raiseRecordNotFoundExceptionBang();
 }
 export async function thirdToLast() {
     return await this.findNthFromLast(3);
 }
 export function thirdToLastBang() {
-    return this.thirdToLast || this.raiseRecordNotFoundExceptionBang;
+    return this.thirdToLast || this.raiseRecordNotFoundExceptionBang();
 }
 export async function secondToLast() {
     return await this.findNthFromLast(2);
 }
 export function secondToLastBang() {
-    return this.secondToLast || this.raiseRecordNotFoundExceptionBang;
+    return this.secondToLast || this.raiseRecordNotFoundExceptionBang();
 }
 export function isExists(conditions = "none") {
     let relation;
@@ -155,7 +155,7 @@ const isMember = isInclude;
 export function raiseRecordNotFoundExceptionBang(ids = null, result_size = null, expected_size = null, key = this.model.primaryKey, not_found_ids = null) {
     let conditions, name, error;
     if (!this.whereClause.isEmpty()) {
-        conditions = ` [${this.arel.whereSql(this.model)}]`;
+        conditions = ` [${this.arel().whereSql(this.model)}]`;
     }
     name = this.model.name();
     if (ids.nil()) {
@@ -323,7 +323,7 @@ export function findNthWithLimit(index, limit) {
         return __PRISM_TODO("CallNode") || [];
     }
     else {
-        relation = this.orderedRelation;
+        relation = this.orderedRelation();
         if (this.limitValue) {
             limit = [this.limitValue - index, limit].min();
         }
@@ -344,7 +344,7 @@ export function findNthFromLast(index) {
         return this.records[-index];
     }
     else {
-        relation = this.orderedRelation;
+        relation = this.orderedRelation();
         if (relation.orderValues().isEmpty() || relation.hasLimitOrOffset()) {
             return relation.records()[-index];
         }
@@ -363,7 +363,7 @@ export function findLast(limit) {
 }
 export function orderedRelation() {
     if (this.orderValues.isEmpty() && (this.model.implicitOrderColumn() || !this.model.queryConstraintsList().nil() || this.model.primaryKey)) {
-        return this.order(this._orderColumns.map(column => this.table[column].asc()));
+        return this.order(this._orderColumns().map(column => this.table[column].asc()));
     }
     else {
         return this;

--- a/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
+++ b/scripts/prism-codegen/__snapshots__/relation/query-methods.js.snap
@@ -234,7 +234,7 @@ export function unscopeBang(...args) {
             if (!VALID_UNSCOPING_VALUES.isInclude(scope)) {
                 throw new ArgumentError(`Called unscope() with invalid unscoping argument ':${scope}'. Valid arguments are :${VALID_UNSCOPING_VALUES.toA().join(", :")}.`);
             }
-            this.assertModifiableBang;
+            this.assertModifiableBang();
             return this.values.delete(scope);
         }
         else if (caseEq(Hash, scope)) {
@@ -684,7 +684,7 @@ export function lookupTableKlassFromJoinDependencies(table_name) {
     });
     return null;
 }
-export function eachJoinDependencies(join_dependencies = this.buildJoinDependencies, block) {
+export function eachJoinDependencies(join_dependencies = this.buildJoinDependencies(), block) {
     return join_dependencies.each(join_dependency => join_dependency.each(block));
 }
 export function buildJoinDependencies() {
@@ -731,7 +731,7 @@ export function buildArel(connection, aliases = null) {
     }
     arel.distinct(this.distinctValue);
     if (!this.fromClause.isEmpty()) {
-        arel.from(this.buildFrom);
+        arel.from(this.buildFrom());
     }
     if (this.lockValue) {
         arel.lock(this.lockValue);
@@ -853,7 +853,7 @@ export function buildJoins(join_sources, aliases = null) {
     if (this.joinsValues.isEmpty() && this.leftOuterJoinsValues.isEmpty()) {
         return join_sources;
     }
-    [buckets, join_type] = this.buildJoinBuckets;
+    [buckets, join_type] = this.buildJoinBuckets();
     named_joins = buckets["named_join"];
     stashed_joins = buckets["stashed_join"];
     leading_joins = buckets["leading_join"];

--- a/scripts/prism-codegen/apply-cli.ts
+++ b/scripts/prism-codegen/apply-cli.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs/promises";
 import * as path from "node:path";
+import { portMethodsForRailsFile } from "./port-symbols.js";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
@@ -58,6 +59,10 @@ async function main() {
   const { code, perDef } = await generateFromSource(
     await fs.readFile(rubyAbsPath(target), "utf8"),
     asyncMethodsForRailsFile(target.ruby),
+    undefined,
+    undefined,
+    undefined,
+    portMethodsForRailsFile(target.ruby),
   );
   const plan = planApply({
     generatedCode: code,

--- a/scripts/prism-codegen/apply-cli.ts
+++ b/scripts/prism-codegen/apply-cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs/promises";
 import * as path from "node:path";
-import { portMethodsForRailsFile } from "./port-symbols.js";
+import { portMethodNames } from "./port-symbols.js";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
@@ -62,7 +62,7 @@ async function main() {
     undefined,
     undefined,
     undefined,
-    portMethodsForRailsFile(target.ruby),
+    portMethodNames(),
   );
   const plan = planApply({
     generatedCode: code,

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -75,20 +75,28 @@ export function clearAsyncProvenance(
  * by the AST, so unlike a bare name the manifest lookup cannot land on an
  * unrelated same-named method.
  *
- * A bare, paren-less, argument-less implicit self-call is excluded: the
- * emitter renders it as a property access rather than a call, so the target
- * holds a method reference, not the method's resolved value.
+ * A paren-less, argument-less implicit self-call counts only when the port
+ * index says the name is a method, since that is exactly when the emitter
+ * renders it as a call. Without that, the target holds a method reference
+ * rather than the method's resolved value, and awaiting its later calls would
+ * be awaiting the wrong thing.
  */
 export function hasAsyncProvenance(
   value: PrismNode | null | undefined,
   jsNameOf: (rubyName: string) => string,
   asyncMethods: ReadonlySet<string>,
+  portMethods: ReadonlySet<string> = new Set(),
 ): boolean {
   if (!value || value.constructor?.name !== "CallNode") return false;
   const receiver = value.receiver as PrismNode | null;
   if (receiver && receiver.constructor?.name !== "SelfNode") return false;
+  const jsName = jsNameOf(String(value.name));
   const invoked =
-    receiver != null || value.openingLoc != null || value.arguments_ != null || value.block != null;
+    receiver != null ||
+    value.openingLoc != null ||
+    value.arguments_ != null ||
+    value.block != null ||
+    portMethods.has(jsName);
   if (!invoked) return false;
-  return asyncMethods.has(jsNameOf(String(value.name)));
+  return asyncMethods.has(jsName);
 }

--- a/scripts/prism-codegen/codegen.ts
+++ b/scripts/prism-codegen/codegen.ts
@@ -44,6 +44,7 @@ export class Codegen implements Emitter {
     readonly asyncMethods: ReadonlySet<string> = new Set(),
     readonly delegations: ReadonlyMap<string, string> = new Map(),
     readonly linearization: Linearization | null = null,
+    readonly portMethods: ReadonlySet<string> = new Set(),
   ) {}
   private declined = false;
   decline(kind: string): void {

--- a/scripts/prism-codegen/from-ts.ts
+++ b/scripts/prism-codegen/from-ts.ts
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import * as path from "node:path";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
-import { portMethodsForRailsFile } from "./port-symbols.js";
+import { portMethodNames } from "./port-symbols.js";
 import { summarizeCoverage } from "./coverage.js";
 import { TOPLEVEL } from "./codegen.js";
 import { tsToRubyFile } from "./naming.js";
@@ -39,7 +39,7 @@ async function main() {
     undefined,
     undefined,
     undefined,
-    portMethodsForRailsFile(rel),
+    portMethodNames(),
   );
   const s = summarizeCoverage(coverage);
   const defs = [...perDef].filter(([name]) => name !== TOPLEVEL);

--- a/scripts/prism-codegen/from-ts.ts
+++ b/scripts/prism-codegen/from-ts.ts
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import * as path from "node:path";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
+import { portMethodsForRailsFile } from "./port-symbols.js";
 import { summarizeCoverage } from "./coverage.js";
 import { TOPLEVEL } from "./codegen.js";
 import { tsToRubyFile } from "./naming.js";
@@ -35,6 +36,10 @@ async function main() {
   const { code, coverage, perDef, parseErrorCount } = await generateFromSource(
     readFileSync(rb, "utf8"),
     asyncMethodsForRailsFile(rel),
+    undefined,
+    undefined,
+    undefined,
+    portMethodsForRailsFile(rel),
   );
   const s = summarizeCoverage(coverage);
   const defs = [...perDef].filter(([name]) => name !== TOPLEVEL);

--- a/scripts/prism-codegen/golden.ts
+++ b/scripts/prism-codegen/golden.ts
@@ -2,7 +2,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { generateFromSource, type GenResult } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
-import { portMethodsForRailsFile } from "./port-symbols.js";
+import { portMethodNames } from "./port-symbols.js";
 import {
   TARGET_FILES,
   rubyAbsPath,
@@ -88,7 +88,7 @@ export async function generateTarget(f: TargetFile): Promise<GeneratedTarget> {
     runtimeImportPathFor(outName),
     await inheritedDelegationsFor(f),
     await targetLinearization(),
-    portMethodsForRailsFile(f.ruby),
+    portMethodNames(),
   );
   return { ...result, file: f, outName };
 }

--- a/scripts/prism-codegen/golden.ts
+++ b/scripts/prism-codegen/golden.ts
@@ -2,6 +2,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { generateFromSource, type GenResult } from "./index.js";
 import { asyncMethodsForRailsFile } from "./async-source.js";
+import { portMethodsForRailsFile } from "./port-symbols.js";
 import {
   TARGET_FILES,
   rubyAbsPath,
@@ -87,6 +88,7 @@ export async function generateTarget(f: TargetFile): Promise<GeneratedTarget> {
     runtimeImportPathFor(outName),
     await inheritedDelegationsFor(f),
     await targetLinearization(),
+    portMethodsForRailsFile(f.ruby),
   );
   return { ...result, file: f, outName };
 }

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -279,7 +279,15 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
     : selfCall
       ? f.createPropertyAccessExpression(self, jsName)
       : f.createIdentifier(jsName);
-  if (!recv && callArgs.length === 0 && !block && !hasParens(n)) return target;
+  if (
+    !recv &&
+    callArgs.length === 0 &&
+    !block &&
+    !hasParens(n) &&
+    !emitsCall(jsName, selfCall, e)
+  ) {
+    return target;
+  }
   const call = f.createCallExpression(target, undefined, callArgs);
   return shouldAwaitCall({
     receiver: n.receiver as PrismNode | null,
@@ -291,10 +299,18 @@ function emitCall(n: PrismNode, e: Emitter): ts.Expression | null {
     ? f.createAwaitExpression(call)
     : call;
 }
+/**
+ * Whether a paren-less, argument-less self-call is rendered as a call. Ruby
+ * makes no distinction, so the port index decides: a name it declares as a
+ * method is invoked, a getter or an unknown name is read as a property.
+ */
+function emitsCall(jsName: string, selfCall: boolean, e: Emitter): boolean {
+  return selfCall && e.portMethods.has(jsName);
+}
 function trackAsyncProvenance(n: PrismNode, e: Emitter): void {
   const key = asyncBindingKey(n);
   if (!key) return;
-  if (hasAsyncProvenance(n.value as PrismNode | null, methodName, e.asyncMethods)) {
+  if (hasAsyncProvenance(n.value as PrismNode | null, methodName, e.asyncMethods, e.portMethods)) {
     e.asyncBindings.add(key);
   } else {
     e.asyncBindings.delete(key);

--- a/scripts/prism-codegen/index.ts
+++ b/scripts/prism-codegen/index.ts
@@ -84,7 +84,7 @@ export function countParseErrors(code: string): number {
 export { summarizeCoverage } from "./coverage.js";
 export { TARGET_FILES } from "./files.js";
 export { asyncMethodsForRailsFile } from "./async-source.js";
-export { portMethodsForRailsFile } from "./port-symbols.js";
+export { portMethodNames } from "./port-symbols.js";
 export { type DelegationTable } from "./delegation.js";
 export { buildLinearization, Linearization, parseIncludeOrder } from "./linearization.js";
 

--- a/scripts/prism-codegen/index.ts
+++ b/scripts/prism-codegen/index.ts
@@ -38,12 +38,13 @@ export async function generateFromSource(
   runtimeImportPath = "./runtime.js",
   inheritedDelegations: DelegationTable = new Map(),
   linearization: Linearization | null = null,
+  portMethods: ReadonlySet<string> = new Set(),
 ): Promise<GenResult> {
   const parse = await getParser();
   const result = parse(rubySource);
   const program = result.value as PrismNode;
   const delegations = mergeDelegations(inheritedDelegations, collectDelegations(program));
-  const gen = new Codegen(defaultRegistry(), asyncMethods, delegations, linearization);
+  const gen = new Codegen(defaultRegistry(), asyncMethods, delegations, linearization, portMethods);
   const statements = gen.stmt(program, false);
   const sourceFile = ts.factory.createSourceFile(
     statements,
@@ -83,6 +84,7 @@ export function countParseErrors(code: string): number {
 export { summarizeCoverage } from "./coverage.js";
 export { TARGET_FILES } from "./files.js";
 export { asyncMethodsForRailsFile } from "./async-source.js";
+export { portMethodsForRailsFile } from "./port-symbols.js";
 export { type DelegationTable } from "./delegation.js";
 export { buildLinearization, Linearization, parseIncludeOrder } from "./linearization.js";
 

--- a/scripts/prism-codegen/port-symbols.test.ts
+++ b/scripts/prism-codegen/port-symbols.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { generateFromSource } from "./index.js";
+import { buildPortSymbolManifest, extractPortSymbols, resolvePortMethods } from "./port-symbols.js";
+
+describe("port symbols", () => {
+  it("splits a port file into callables and readables", () => {
+    const syms = extractPortSymbols(`
+      export function buildRelation(this: Host): Relation {}
+      export const loadAll = async () => {};
+      export class Base {
+        static get arelTable(): Table {}
+        static tableName = "widgets";
+        static aliasAttribute = aliasAttribute;
+        save(): void {}
+        get name(): string {}
+      }
+    `);
+    expect([...syms.methods].sort()).toEqual(["buildRelation", "loadAll", "save"]);
+    expect([...syms.getters].sort()).toEqual(["aliasAttribute", "arelTable", "name", "tableName"]);
+  });
+
+  it("declines a name the port spells as a getter anywhere in the tree", () => {
+    const manifest = buildPortSymbolManifest([
+      { path: "core.ts", source: `export function arelTable(this: Host): Table {}` },
+      { path: "base.ts", source: `export class Base { static get arelTable(): Table {} }` },
+      { path: "relation.ts", source: `export function buildRelation(this: Host) {}` },
+    ]);
+    const names = resolvePortMethods({ twinTs: "", manifest });
+    expect(names.has("buildRelation")).toBe(true);
+    expect(names.has("arelTable")).toBe(false);
+  });
+
+  it("declines a name the twin file itself spells as a getter", () => {
+    const manifest = buildPortSymbolManifest([
+      { path: "core.ts", source: `export function tableName(this: Host): string {}` },
+    ]);
+    const names = resolvePortMethods({
+      twinTs: `export class Relation { get tableName(): string {} }`,
+      manifest,
+    });
+    expect(names.has("tableName")).toBe(false);
+  });
+
+  it("emits a call for a paren-less self-call the port declares as a method", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all
+          @relation = build_relation
+        end
+      end`,
+      new Set(),
+      "./runtime.js",
+      new Map(),
+      null,
+      new Set(["buildRelation"]),
+    );
+    expect(code).toContain("this.relation = this.buildRelation();");
+  });
+
+  it("keeps a property access for a paren-less self-call the port reads as a getter", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all
+          @relation = arel_table
+        end
+      end`,
+      new Set(),
+      "./runtime.js",
+      new Map(),
+      null,
+      new Set(["buildRelation"]),
+    );
+    expect(code).toContain("this.relation = this.arelTable;");
+  });
+
+  it("awards async provenance to a paren-less self-call once it emits a call", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all
+          @relation = build_relation
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+      "./runtime.js",
+      new Map(),
+      null,
+      new Set(["buildRelation"]),
+    );
+    expect(code).toContain("this.relation = await this.buildRelation();");
+    expect(code).toContain("await this.relation.load()");
+  });
+});

--- a/scripts/prism-codegen/port-symbols.test.ts
+++ b/scripts/prism-codegen/port-symbols.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { generateFromSource } from "./index.js";
-import { buildPortSymbolManifest, extractPortSymbols, resolvePortMethods } from "./port-symbols.js";
+import { callableNames, extractPortSymbols, mergePortSymbols } from "./port-symbols.js";
 
 describe("port symbols", () => {
   it("splits a port file into callables and readables", () => {
@@ -20,25 +20,15 @@ describe("port symbols", () => {
   });
 
   it("declines a name the port spells as a getter anywhere in the tree", () => {
-    const manifest = buildPortSymbolManifest([
-      { path: "core.ts", source: `export function arelTable(this: Host): Table {}` },
-      { path: "base.ts", source: `export class Base { static get arelTable(): Table {} }` },
-      { path: "relation.ts", source: `export function buildRelation(this: Host) {}` },
-    ]);
-    const names = resolvePortMethods({ twinTs: "", manifest });
+    const names = callableNames(
+      mergePortSymbols([
+        { path: "core.ts", source: `export function arelTable(this: Host): Table {}` },
+        { path: "base.ts", source: `export class Base { static get arelTable(): Table {} }` },
+        { path: "relation.ts", source: `export function buildRelation(this: Host) {}` },
+      ]),
+    );
     expect(names.has("buildRelation")).toBe(true);
     expect(names.has("arelTable")).toBe(false);
-  });
-
-  it("declines a name the twin file itself spells as a getter", () => {
-    const manifest = buildPortSymbolManifest([
-      { path: "core.ts", source: `export function tableName(this: Host): string {}` },
-    ]);
-    const names = resolvePortMethods({
-      twinTs: `export class Relation { get tableName(): string {} }`,
-      manifest,
-    });
-    expect(names.has("tableName")).toBe(false);
   });
 
   it("emits a call for a paren-less self-call the port declares as a method", async () => {

--- a/scripts/prism-codegen/port-symbols.ts
+++ b/scripts/prism-codegen/port-symbols.ts
@@ -1,0 +1,135 @@
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import ts from "typescript";
+import { rubyFileToTs } from "./naming.js";
+import { TRAILS_AR_SRC, portTreeFiles, type PortFile } from "./files.js";
+
+/**
+ * How the port spells a name: as something you call, or as something you read.
+ *
+ * Ruby draws no such line — `build_relation` and `name` are both calls — so a
+ * paren-less, argument-less self-call is only emitted with `()` when the port
+ * itself says the name is a method. A getter, a plain property, or a name the
+ * port never declares stays a property access, which is what the emitter has
+ * always produced.
+ */
+export interface PortSymbols {
+  methods: Set<string>;
+  getters: Set<string>;
+}
+
+function isFunctionValued(init: ts.Expression | undefined): boolean {
+  return init != null && (ts.isArrowFunction(init) || ts.isFunctionExpression(init));
+}
+
+function memberName(name: ts.PropertyName | undefined): string | null {
+  if (!name) return null;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return null;
+}
+
+/**
+ * Split one port file's declarations into callables and readables. A class
+ * property whose initializer is not literally a function is treated as a
+ * readable: a mixin assignment like `static aliasAttribute = aliasAttribute`
+ * cannot be told apart from `static table = "x"` here, and the conservative
+ * answer preserves the emitter's existing output. The same name declared as a
+ * function elsewhere in the tree still lands in `methods`.
+ */
+export function extractPortSymbols(source: string): PortSymbols {
+  const sf = ts.createSourceFile("port.ts", source, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS);
+  const methods = new Set<string>();
+  const getters = new Set<string>();
+  const visitClass = (decl: ts.ClassLikeDeclaration) => {
+    for (const m of decl.members) {
+      const name = memberName(m.name);
+      if (!name) continue;
+      if (ts.isMethodDeclaration(m)) methods.add(name);
+      else if (ts.isGetAccessor(m) || ts.isSetAccessor(m)) getters.add(name);
+      else if (ts.isPropertyDeclaration(m)) {
+        if (isFunctionValued(m.initializer)) methods.add(name);
+        else getters.add(name);
+      }
+    }
+  };
+  const visit = (node: ts.Node) => {
+    if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) visitClass(node);
+    else if (ts.isFunctionDeclaration(node) && node.name) methods.add(node.name.text);
+    else if (ts.isVariableStatement(node)) {
+      for (const d of node.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name)) continue;
+        if (isFunctionValued(d.initializer)) methods.add(d.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return { methods, getters };
+}
+
+/**
+ * Whole-port-tree view of the same split, indexed by name so a target file can
+ * resolve a name its own twin does not declare — the emitter's self-calls
+ * routinely name methods a module mixes in from elsewhere.
+ */
+export interface PortSymbolManifest {
+  methods: Map<string, Set<string>>;
+  getters: Map<string, Set<string>>;
+}
+
+function record(index: Map<string, Set<string>>, name: string, file: string): void {
+  const seen = index.get(name) ?? new Set<string>();
+  seen.add(file);
+  index.set(name, seen);
+}
+
+export function buildPortSymbolManifest(files: PortFile[]): PortSymbolManifest {
+  const methods = new Map<string, Set<string>>();
+  const getters = new Map<string, Set<string>>();
+  for (const { path: file, source } of files) {
+    const syms = extractPortSymbols(source);
+    for (const n of syms.methods) record(methods, n, file);
+    for (const n of syms.getters) record(getters, n, file);
+  }
+  return { methods, getters };
+}
+
+/**
+ * Names a paren-less self-call may be emitted as a call for: declared as a
+ * callable somewhere in the port tree (the twin file included) and as a
+ * readable nowhere in it.
+ *
+ * The veto is tree-wide rather than twin-only because the port implements many
+ * getters as `this`-typed mixin functions — `arelTable` is a plain exported
+ * function in `core.ts` and a `static get` on `Base`, and it is the class
+ * declaration that says how `this.arelTable` reads. A self-call carries no
+ * receiver type to pick between them, so any getter spelling anywhere makes
+ * the name ineligible and it keeps emitting as a property access.
+ */
+export function resolvePortMethods(opts: {
+  twinTs: string;
+  manifest: PortSymbolManifest;
+}): Set<string> {
+  const twin = extractPortSymbols(opts.twinTs);
+  const names = new Set<string>([...opts.manifest.methods.keys(), ...twin.methods]);
+  for (const name of [...opts.manifest.getters.keys(), ...twin.getters]) names.delete(name);
+  return names;
+}
+
+let manifestCache: PortSymbolManifest | undefined;
+export function defaultPortSymbolManifest(): PortSymbolManifest {
+  manifestCache ??= buildPortSymbolManifest(portTreeFiles());
+  return manifestCache;
+}
+
+export function portMethodsForRailsFile(
+  railsRelPath: string,
+  manifest: PortSymbolManifest = defaultPortSymbolManifest(),
+): Set<string> {
+  const twinTsAbs = path.join(
+    TRAILS_AR_SRC,
+    rubyFileToTs(railsRelPath.replace(/^active_record\//, "")),
+  );
+  const twinTs = existsSync(twinTsAbs) ? readFileSync(twinTsAbs, "utf8") : "";
+  return resolvePortMethods({ twinTs, manifest });
+}

--- a/scripts/prism-codegen/port-symbols.ts
+++ b/scripts/prism-codegen/port-symbols.ts
@@ -1,8 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import * as path from "node:path";
 import ts from "typescript";
-import { rubyFileToTs } from "./naming.js";
-import { TRAILS_AR_SRC, portTreeFiles, type PortFile } from "./files.js";
+import { portTreeFiles, type PortFile } from "./files.js";
 
 /**
  * How the port spells a name: as something you call, or as something you read.
@@ -30,10 +27,10 @@ function memberName(name: ts.PropertyName | undefined): string | null {
 
 /**
  * Split one port file's declarations into callables and readables. A class
- * property whose initializer is not literally a function is treated as a
- * readable: a mixin assignment like `static aliasAttribute = aliasAttribute`
- * cannot be told apart from `static table = "x"` here, and the conservative
- * answer preserves the emitter's existing output. The same name declared as a
+ * property whose initializer is not literally a function is a readable: a
+ * mixin assignment like `static aliasAttribute = aliasAttribute` cannot be
+ * told apart from `static table = "x"` here, and the conservative answer
+ * preserves the emitter's existing output. The same name declared as a
  * function elsewhere in the tree still lands in `methods`.
  */
 export function extractPortSymbols(source: string): PortSymbols {
@@ -57,8 +54,7 @@ export function extractPortSymbols(source: string): PortSymbols {
     else if (ts.isFunctionDeclaration(node) && node.name) methods.add(node.name.text);
     else if (ts.isVariableStatement(node)) {
       for (const d of node.declarationList.declarations) {
-        if (!ts.isIdentifier(d.name)) continue;
-        if (isFunctionValued(d.initializer)) methods.add(d.name.text);
+        if (ts.isIdentifier(d.name) && isFunctionValued(d.initializer)) methods.add(d.name.text);
       }
     }
     ts.forEachChild(node, visit);
@@ -67,69 +63,38 @@ export function extractPortSymbols(source: string): PortSymbols {
   return { methods, getters };
 }
 
-/**
- * Whole-port-tree view of the same split, indexed by name so a target file can
- * resolve a name its own twin does not declare — the emitter's self-calls
- * routinely name methods a module mixes in from elsewhere.
- */
-export interface PortSymbolManifest {
-  methods: Map<string, Set<string>>;
-  getters: Map<string, Set<string>>;
-}
-
-function record(index: Map<string, Set<string>>, name: string, file: string): void {
-  const seen = index.get(name) ?? new Set<string>();
-  seen.add(file);
-  index.set(name, seen);
-}
-
-export function buildPortSymbolManifest(files: PortFile[]): PortSymbolManifest {
-  const methods = new Map<string, Set<string>>();
-  const getters = new Map<string, Set<string>>();
-  for (const { path: file, source } of files) {
+/** The same split taken over a whole set of port files at once. */
+export function mergePortSymbols(files: PortFile[]): PortSymbols {
+  const merged: PortSymbols = { methods: new Set(), getters: new Set() };
+  for (const { source } of files) {
     const syms = extractPortSymbols(source);
-    for (const n of syms.methods) record(methods, n, file);
-    for (const n of syms.getters) record(getters, n, file);
+    for (const n of syms.methods) merged.methods.add(n);
+    for (const n of syms.getters) merged.getters.add(n);
   }
-  return { methods, getters };
+  return merged;
 }
 
 /**
  * Names a paren-less self-call may be emitted as a call for: declared as a
- * callable somewhere in the port tree (the twin file included) and as a
- * readable nowhere in it.
+ * callable somewhere in the port tree and as a readable nowhere in it.
  *
- * The veto is tree-wide rather than twin-only because the port implements many
+ * The veto is tree-wide rather than per-file because the port implements many
  * getters as `this`-typed mixin functions — `arelTable` is a plain exported
  * function in `core.ts` and a `static get` on `Base`, and it is the class
  * declaration that says how `this.arelTable` reads. A self-call carries no
- * receiver type to pick between them, so any getter spelling anywhere makes
- * the name ineligible and it keeps emitting as a property access.
+ * receiver type to pick between the two spellings, so any getter spelling
+ * anywhere makes the name ineligible and it keeps emitting bare.
  */
-export function resolvePortMethods(opts: {
-  twinTs: string;
-  manifest: PortSymbolManifest;
-}): Set<string> {
-  const twin = extractPortSymbols(opts.twinTs);
-  const names = new Set<string>([...opts.manifest.methods.keys(), ...twin.methods]);
-  for (const name of [...opts.manifest.getters.keys(), ...twin.getters]) names.delete(name);
+export function callableNames(symbols: PortSymbols): Set<string> {
+  const names = new Set(symbols.methods);
+  for (const name of symbols.getters) names.delete(name);
   return names;
 }
 
-let manifestCache: PortSymbolManifest | undefined;
-export function defaultPortSymbolManifest(): PortSymbolManifest {
-  manifestCache ??= buildPortSymbolManifest(portTreeFiles());
-  return manifestCache;
-}
+let cache: Set<string> | undefined;
 
-export function portMethodsForRailsFile(
-  railsRelPath: string,
-  manifest: PortSymbolManifest = defaultPortSymbolManifest(),
-): Set<string> {
-  const twinTsAbs = path.join(
-    TRAILS_AR_SRC,
-    rubyFileToTs(railsRelPath.replace(/^active_record\//, "")),
-  );
-  const twinTs = existsSync(twinTsAbs) ? readFileSync(twinTsAbs, "utf8") : "";
-  return resolvePortMethods({ twinTs, manifest });
+/** `callableNames` over the hand-written port tree, computed once per process. */
+export function portMethodNames(): Set<string> {
+  cache ??= callableNames(mergePortSymbols(portTreeFiles()));
+  return cache;
 }

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -2,7 +2,7 @@ import * as fs from "fs/promises";
 import { readFileSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { portMethodsForRailsFile } from "./port-symbols.js";
+import { portMethodNames } from "./port-symbols.js";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
@@ -133,7 +133,7 @@ async function main() {
       runtimeImportPathFor(outNameFor(f)),
       await inheritedDelegationsFor(f),
       await targetLinearization(),
-      portMethodsForRailsFile(f.ruby),
+      portMethodNames(),
     );
     const cleanDefs = new Set(
       [...perDef].filter(([n, d]) => n !== TOPLEVEL && d.passthrough === 0).map(([n]) => n),

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -2,6 +2,7 @@ import * as fs from "fs/promises";
 import { readFileSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { portMethodsForRailsFile } from "./port-symbols.js";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
@@ -132,6 +133,7 @@ async function main() {
       runtimeImportPathFor(outNameFor(f)),
       await inheritedDelegationsFor(f),
       await targetLinearization(),
+      portMethodsForRailsFile(f.ruby),
     );
     const cleanDefs = new Set(
       [...perDef].filter(([n, d]) => n !== TOPLEVEL && d.passthrough === 0).map(([n]) => n),

--- a/scripts/prism-codegen/types.ts
+++ b/scripts/prism-codegen/types.ts
@@ -47,6 +47,12 @@ export interface Emitter {
   inClass: boolean;
   inSingleton: boolean;
   readonly asyncMethods: ReadonlySet<string>;
+  /**
+   * Names the port declares as methods rather than getters. A paren-less,
+   * argument-less self-call is emitted as a call only for these; everything
+   * else stays a property access.
+   */
+  readonly portMethods: ReadonlySet<string>;
   readonly delegations: ReadonlyMap<string, string>;
   inAsyncMethod: boolean;
 


### PR DESCRIPTION
Emits a call for a paren-less, argument-less implicit self-call when the port index says the name is a method.

Previously `emitCall` short-circuited every such call to a bare property access, so Ruby's `@relation = build_relation` generated `this.relation = this.buildRelation;` — an unbound method reference. Ruby draws no call/read distinction; the port does, so the port index now decides.

- New `scripts/prism-codegen/port-symbols.ts` splits port declarations (via the TS parser) into callables (methods, function declarations, function-valued initializers) and readables (get/set accessors, plain properties), merged over the hand-written port tree.
- A name emits `()` only if it is a callable somewhere in the tree and a readable nowhere in it. The veto is tree-wide because the port implements getters as `this`-typed mixin functions — `arelTable` is an exported function in `core.ts` and a `static get` on `Base`, and the class declaration is what governs how `this.arelTable` reads.
- `hasAsyncProvenance` narrows its paren-less exclusion accordingly: such a call now counts as invoked when the port index resolves the name to a method, so provenance-based awaits reach it.
- Goldens regenerated (8 images). `pnpm codegen:score` matched stays at 32 — no regression.

Closes-story: codegen-parenless-self-call-emits-property-access

Known-invalid output in the golden diff: `persistence.js.snap` now emits `return await this.save();` inside the synchronous arrow passed to `withTransactionReturningStatus` (previously a bare `this.save`). The await-inside-a-non-async-block-arrow gap is tracked separately as `codegen-async-block-arrows`; this PR only makes it reachable, so those two lines are not validated output.
