### PR TITLE
fix(prism-codegen): refresh persistence golden so block arrows carry async

### DIFF
--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -243,13 +243,13 @@ export async function updateAttributeBang(name, value) {
     return await this.saveBang({ validate: false });
 }
 export function update(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.save();
     });
 }
 export function updateBang(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.saveBang();
     });

--- a/scripts/prism-codegen/async-keyword.test.ts
+++ b/scripts/prism-codegen/async-keyword.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateFromSource } from "./index.js";
+import { generateFromSource, countAwaitsOutsideAsync } from "./index.js";
 
 async function gen(ruby: string, asyncMethods: string[]): Promise<string> {
   const { code } = await generateFromSource(ruby, new Set(asyncMethods));
@@ -40,6 +40,14 @@ describe("async keyword", () => {
     const code = await gen(ruby, ["a", "size"]);
     expect(code).toContain("await this.size()");
     expect(code).not.toContain("async a()");
+  });
+
+  it("marks a multi-statement block arrow async when its body awaits", async () => {
+    const ruby = "class R\n  def a\n    tx { assign(1); save() }\n  end\nend\n";
+    const code = await gen(ruby, ["a", "save"]);
+    expect(code).toContain("this.tx(async () => {");
+    expect(code).toContain("return await this.save()");
+    expect(countAwaitsOutsideAsync(code)).toBe(0);
   });
 
   it("leaves a constructor alone", async () => {

--- a/scripts/prism-codegen/handlers/structure.ts
+++ b/scripts/prism-codegen/handlers/structure.ts
@@ -212,9 +212,8 @@ function defParts(
  * regeneration, which is how the async surface widens on its own.
  *
  * The walk stops at nested functions: an await inside a block's arrow belongs
- * to that arrow, not to the method around it. Those arrows are not marked async
- * today, so the emitted arrow is invalid either way — but scoping the question
- * correctly here is what keeps this rule right once that gap is closed.
+ * to that arrow, not to the method around it — `blockToArrow` marks such an
+ * arrow async itself, so the await is already inside an async function.
  */
 function containsAwait(node: ts.Node): boolean {
   if (ts.isAwaitExpression(node)) return true;


### PR DESCRIPTION
The checked-in `persistence.js.snap` image emitted `return await this.save();` inside a non-async arrow passed to `withTransactionReturningStatus` — invalid JS, and the golden test's `countAwaitsOutsideAsync` assertion fails on `main` today.

The generator already handles the shape: `blockToArrow` marks a block arrow async when its emitted body awaits, and the def-level `containsAwait` correctly stops at nested functions so the enclosing def stays sync. The golden simply predated #5831 making this shape reachable. Regenerated it, added a unit test for the multi-statement block-arrow shape, and corrected the now-stale comment in `structure.ts` that claimed those arrows are never marked async.

`pnpm codegen:score` matched count unchanged (32).

Closes-story: codegen-await-inside-non-async-block-arrow