### PR TITLE
chore(prism-codegen): refresh persistence golden for branch-flow async provenance

### DIFF
--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -243,13 +243,13 @@ export async function updateAttributeBang(name, value) {
     return await this.saveBang({ validate: false });
 }
 export function update(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.save();
     });
 }
 export function updateBang(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.saveBang();
     });


### PR DESCRIPTION
## Problem

`Rails API/Test Comparison` fails on `main` @a1a112ef at the **Codegen golden output snapshots** step (`pnpm vitest run scripts/prism-codegen/golden.test.ts`), two failures:

- `emits the checked-in image for active_record/persistence.rb` — snapshot mismatch
- `has no await outside an async function in the checked-in image for active_record/persistence.rb` — expected 0, got 2

## Cause

80a203a6b (`feat(prism-codegen): scope async provenance to branch flow`) changed the emitter so the blocks passed to `withTransactionReturningStatus` in `update` / `updateBang` are now emitted as `async () => {`. The checked-in golden was not refreshed, so it still holds the old non-async arrows — which is also exactly why the await-outside-async invariant reported 2 violations.

## Fix

Refresh the golden via `pnpm codegen:snapshot`. Two lines change; the new image is strictly more correct (the `await`s inside those arrows now sit in `async` functions).

## Verification

`pnpm vitest run scripts/prism-codegen/golden.test.ts` → 30 passed (was 28 passed / 2 failed).

Closes-story: red-a1a112ef
