### PR TITLE
feat(prism-codegen): exclude non-falling-through arms from await provenance merge

### DIFF
--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -243,13 +243,13 @@ export async function updateAttributeBang(name, value) {
     return await this.saveBang({ validate: false });
 }
 export function update(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.save();
     });
 }
 export function updateBang(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.saveBang();
     });

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -78,13 +78,47 @@ export function clearAsyncProvenance(
 export function scopeAsyncArm<T>(
   bindings: Set<string>,
   emit: () => T,
-): { value: T; after: Set<string> } {
+  body?: PrismNode | null,
+): AsyncArm<T> {
   const before = new Set(bindings);
   const value = emit();
   const after = new Set(bindings);
   bindings.clear();
   for (const key of before) bindings.add(key);
-  return { value, after };
+  return { value, after, terminal: body !== undefined && !fallsThrough(body) };
+}
+
+export interface AsyncArm<T = unknown> {
+  value: T;
+  after: Set<string>;
+  terminal: boolean;
+}
+
+/**
+ * Whether control can reach the statement after `node`. An arm ending in
+ * `return`, `next`, `break`, or `raise` cannot, so it is not a path into the
+ * code following the branch and must not take part in the merge below.
+ *
+ * `break`/`next` are terminal relative to the enclosing branch only; a loop
+ * body is never handed to this function, since a body ending in `break` does
+ * reach the code after the loop.
+ */
+export function fallsThrough(node: PrismNode | null | undefined): boolean {
+  const kind = node?.constructor?.name;
+  if (!node || !kind) return true;
+  if (kind === "StatementsNode") {
+    const kids = node.compactChildNodes();
+    return kids.length === 0 || fallsThrough(kids[kids.length - 1]);
+  }
+  if (kind === "ReturnNode" || kind === "NextNode" || kind === "BreakNode") return false;
+  if (kind === "CallNode") return String(node.name) !== "raise" || node.receiver != null;
+  if (kind === "IfNode" || kind === "UnlessNode") {
+    const sub = (node.subsequent ?? node.elseClause) as PrismNode | null;
+    if (!sub) return true;
+    const elseBody = sub.constructor.name === "ElseNode" ? (sub.statements as PrismNode) : sub;
+    return fallsThrough(node.statements as PrismNode | null) || fallsThrough(elseBody);
+  }
+  return true;
 }
 
 /**
@@ -97,12 +131,18 @@ export function scopeAsyncArm<T>(
  * that never assigned, and awaiting there is the false positive the policy
  * exists to avoid. Retraction is the safe direction, so it stays eager: a key
  * dropped by any arm is dropped outright, exhaustive or not.
+ *
+ * Arms that cannot fall through are excluded from both directions: they are
+ * not paths into the code after the construct, so neither what they establish
+ * nor what they retract says anything about it. A branch whose every arm is
+ * terminal therefore leaves the enclosing bindings exactly as they were.
  */
 export function mergeAsyncArms(
   bindings: Set<string>,
-  arms: ReadonlyArray<ReadonlySet<string>>,
+  allArms: ReadonlyArray<{ after: ReadonlySet<string>; terminal?: boolean }>,
   exhaustive: boolean,
 ): void {
+  const arms = allArms.filter((arm) => !arm.terminal).map((arm) => arm.after);
   for (const key of [...bindings]) {
     if (arms.some((arm) => !arm.has(key))) bindings.delete(key);
   }

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -84,45 +84,78 @@ export interface AsyncArm<T = unknown> {
  * `body` is the arm's Ruby body, used to decide whether the arm can fall
  * through into the code after the construct. Omit it for an arm that always
  * can — a loop body reaches past the loop even when it ends in `break`.
+ * `inLoop` is the emitter's loop state at the arm, which decides whether a
+ * trailing `next`/`break` is emitted as real control flow.
  */
 export function scopeAsyncArm<T>(
   bindings: Set<string>,
   emit: () => T,
   body?: PrismNode | null,
+  inLoop = false,
 ): AsyncArm<T> {
   const before = new Set(bindings);
   const value = emit();
   const after = new Set(bindings);
   bindings.clear();
   for (const key of before) bindings.add(key);
-  return { value, after, terminal: !fallsThrough(body) };
+  return { value, after, terminal: !fallsThrough(body, inLoop) };
 }
 
 /**
- * Whether control can reach the statement after `node`. An arm ending in
- * `return`, `next`, `break`, or `raise` cannot, so it is not a path into the
- * code following the branch and must not take part in the merge below.
+ * Whether control can reach the statement after `node`, judged by what the
+ * emitter actually produces rather than by Ruby semantics: a `raise`,
+ * `next`, or `break` the handlers decline to convert is emitted as a plain
+ * expression and does reach the next statement, so treating it as terminal
+ * would drop a live retraction and award a false-positive await.
  *
  * `break`/`next` are terminal relative to the enclosing branch only; a loop
  * body is never handed to this function, since a body ending in `break` does
  * reach the code after the loop.
  */
-export function fallsThrough(node: PrismNode | null | undefined): boolean {
+export function fallsThrough(node: PrismNode | null | undefined, inLoop = false): boolean {
   const kind = node?.constructor?.name;
   if (!node || !kind) return true;
   if (kind === "StatementsNode") {
     const kids = node.compactChildNodes();
-    return kids.length === 0 || fallsThrough(kids[kids.length - 1]);
+    return kids.length === 0 || fallsThrough(kids[kids.length - 1], inLoop);
   }
-  if (kind === "ReturnNode" || kind === "NextNode" || kind === "BreakNode") return false;
-  if (kind === "CallNode") return String(node.name) !== "raise" || node.receiver != null;
+  if (kind === "ReturnNode") return false;
+  if (kind === "NextNode") return inLoop && argumentCount(node) > 0;
+  if (kind === "BreakNode") return !inLoop || argumentCount(node) > 0;
+  if (kind === "CallNode") return !isRaiseThrow(node);
   if (kind === "IfNode" || kind === "UnlessNode") {
     const sub = (node.subsequent ?? node.elseClause) as PrismNode | null;
     if (!sub) return true;
     const elseBody = sub.constructor.name === "ElseNode" ? (sub.statements as PrismNode) : sub;
-    return fallsThrough(node.statements as PrismNode | null) || fallsThrough(elseBody);
+    return (
+      fallsThrough(node.statements as PrismNode | null, inLoop) || fallsThrough(elseBody, inLoop)
+    );
   }
   return true;
+}
+
+/**
+ * Whether a call is a `raise` the emitter renders as a `throw`. Any other
+ * shape — a bare re-raise, a `raise` with a block, a multi-argument `raise`
+ * whose head is not a constant — is emitted as an ordinary call, so it must
+ * not be read as terminating control flow.
+ */
+export function isRaiseThrow(node: PrismNode): boolean {
+  if (node.constructor?.name !== "CallNode") return false;
+  if (String(node.name) !== "raise" || node.receiver || node.block) return false;
+  const args = raiseArguments(node);
+  if (args.length === 0) return false;
+  if (args.length === 1) return true;
+  const head = args[0].constructor.name;
+  return head === "ConstantReadNode" || head === "ConstantPathNode";
+}
+
+export function raiseArguments(node: PrismNode): PrismNode[] {
+  return ((node.arguments_ as PrismNode | null)?.arguments_ as PrismNode[]) ?? [];
+}
+
+function argumentCount(node: PrismNode): number {
+  return raiseArguments(node).length;
 }
 
 /**

--- a/scripts/prism-codegen/await-policy.ts
+++ b/scripts/prism-codegen/await-policy.ts
@@ -68,12 +68,22 @@ export function clearAsyncProvenance(
   }
 }
 
+export interface AsyncArm<T = unknown> {
+  value: T;
+  after: Set<string>;
+  terminal: boolean;
+}
+
 /**
  * Emit one arm of a branching construct against a private copy of the binding
  * set, and hand back both the emitted value and the bindings the arm ended
  * with. The caller's set is left exactly as it was, so sibling arms all start
  * from the same state and nothing an arm did escapes until
  * {@link mergeAsyncArms} decides what survives.
+ *
+ * `body` is the arm's Ruby body, used to decide whether the arm can fall
+ * through into the code after the construct. Omit it for an arm that always
+ * can — a loop body reaches past the loop even when it ends in `break`.
  */
 export function scopeAsyncArm<T>(
   bindings: Set<string>,
@@ -85,13 +95,7 @@ export function scopeAsyncArm<T>(
   const after = new Set(bindings);
   bindings.clear();
   for (const key of before) bindings.add(key);
-  return { value, after, terminal: body !== undefined && !fallsThrough(body) };
-}
-
-export interface AsyncArm<T = unknown> {
-  value: T;
-  after: Set<string>;
-  terminal: boolean;
+  return { value, after, terminal: !fallsThrough(body) };
 }
 
 /**

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -381,6 +381,34 @@ describe("prism-codegen", () => {
     );
     expect(code).toContain("await this.relation.load()");
   });
+  it("keeps provenance across a guard clause that returns", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag, arg)
+          @relation = build_relation()
+          return nil if flag
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("await this.relation.load()");
+  });
+  it("awards no await from provenance established only in an arm that returns", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag)
+          if flag
+            @relation = build_relation()
+            return nil
+          end
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).not.toContain("await this.relation.load()");
+  });
   it("leaves bindings untouched when every arm of a branch returns", async () => {
     const { code } = await generateFromSource(
       `module M

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -381,6 +381,60 @@ describe("prism-codegen", () => {
     );
     expect(code).toContain("await this.relation.load()");
   });
+  it("treats a raise the emitter does not turn into a throw as falling through", async () => {
+    for (const tail of ["raise", "raise error_class, 1, 2"]) {
+      const { code } = await generateFromSource(
+        `module M
+          def load_all(flag, arg)
+            @relation = build_relation()
+            if flag
+              @relation = arg
+              ${tail}
+            end
+            @relation.load
+          end
+        end`,
+        new Set(["load", "loadAll", "buildRelation"]),
+      );
+      expect(code).not.toContain("throw");
+      expect(code).not.toContain("await this.relation.load()");
+    }
+  });
+  it("treats a next carrying a value as falling through, since no continue is emitted", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag, arg)
+          @relation = build_relation()
+          while flag
+            if flag
+              @relation = arg
+              next 5
+            end
+          end
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).not.toContain("continue");
+    expect(code).not.toContain("await this.relation.load()");
+  });
+  it("treats a break outside a loop as falling through, since no break is emitted", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag, arg)
+          @relation = build_relation()
+          if flag
+            @relation = arg
+            break
+          end
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).not.toContain("await this.relation.load()");
+  });
   it("keeps provenance across a guard clause that returns", async () => {
     const { code } = await generateFromSource(
       `module M

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -332,6 +332,73 @@ describe("prism-codegen", () => {
     );
     expect(code).toContain("await this.relation.load()");
   });
+  it("awaits after a branch whose other arm returns instead of falling through", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag)
+          if flag
+            return nil
+          else
+            @relation = build_relation()
+          end
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("await this.relation.load()");
+  });
+  it("awaits after a case whose only non-returning arm establishes provenance", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag)
+          case flag
+          when :skip
+            return nil
+          else
+            @relation = build_relation()
+          end
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("await this.relation.load()");
+  });
+  it("ignores a retraction inside an arm that raises instead of falling through", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag, arg)
+          @relation = build_relation()
+          if flag
+            @relation = arg
+            raise ArgumentError, "no"
+          end
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("await this.relation.load()");
+  });
+  it("leaves bindings untouched when every arm of a branch returns", async () => {
+    const { code } = await generateFromSource(
+      `module M
+        def load_all(flag, arg)
+          @relation = build_relation()
+          if flag
+            @relation = arg
+            return nil
+          else
+            return arg
+          end
+          @relation.load
+        end
+      end`,
+      new Set(["load", "loadAll", "buildRelation"]),
+    );
+    expect(code).toContain("await this.relation.load()");
+  });
   it("stops awaiting a receiver rebound by an operator write", async () => {
     const ivarWrite = await generateFromSource(
       `module M

--- a/scripts/prism-codegen/handlers/control.ts
+++ b/scripts/prism-codegen/handlers/control.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import type { Emitter, PrismNode } from "../types.js";
 import type { Registry } from "../registry.js";
 import type { AsyncArm } from "../await-policy.js";
-import { mergeAsyncArms, scopeAsyncArm } from "../await-policy.js";
+import { isRaiseThrow, mergeAsyncArms, raiseArguments, scopeAsyncArm } from "../await-policy.js";
 const f = ts.factory;
 export function registerControl(r: Registry): void {
   r.onStmt("IfNode", (n, e, isLast) => [ifStmt(n, e, isLast, false)]);
@@ -14,8 +14,8 @@ export function registerControl(r: Registry): void {
     if (!consNode || !altNode) return null;
     let cond = e.expr(n.predicate as PrismNode);
     if (neg) cond = f.createLogicalNot(cond);
-    const consArm = scopeAsyncArm(e.asyncBindings, () => e.expr(consNode), consNode);
-    const altArm = scopeAsyncArm(e.asyncBindings, () => e.expr(altNode), altNode);
+    const consArm = scopeAsyncArm(e.asyncBindings, () => e.expr(consNode), consNode, e.inLoop);
+    const altArm = scopeAsyncArm(e.asyncBindings, () => e.expr(altNode), altNode, e.inLoop);
     mergeAsyncArms(e.asyncBindings, [consArm, altArm], true);
     const cons = consArm.value;
     const alt = altArm.value;
@@ -64,6 +64,7 @@ export function registerControl(r: Registry): void {
       e.asyncBindings,
       () => f.createBlock(e.stmts((n.statements as PrismNode) ?? null, isLast), true),
       (n.statements as PrismNode) ?? null,
+      e.inLoop,
     );
     let catchClause: ts.CatchClause | undefined;
     let catchArm: AsyncArm<ts.Block> | undefined;
@@ -73,6 +74,7 @@ export function registerControl(r: Registry): void {
         e.asyncBindings,
         () => f.createBlock(e.stmts((rescue.statements as PrismNode) ?? null, isLast), true),
         (rescue.statements as PrismNode) ?? null,
+        e.inLoop,
       );
       catchClause = f.createCatchClause(f.createVariableDeclaration(ref), catchArm.value);
     }
@@ -83,24 +85,18 @@ export function registerControl(r: Registry): void {
     return [f.createTryStatement(tryArm.value, catchClause, finallyBlock)];
   });
   r.onStmt("CallNode", (n, e) => {
-    if (String(n.name) !== "raise" || n.receiver || n.block) return null;
-    const args = ((n.arguments_ as PrismNode | null)?.arguments_ as PrismNode[]) ?? [];
-    if (args.length === 0) return null;
+    if (!isRaiseThrow(n)) return null;
+    const args = raiseArguments(n);
     if (args.length === 1) return [f.createThrowStatement(e.expr(args[0]))];
-    const head = args[0];
-    const headKind = head.constructor.name;
-    if (headKind === "ConstantReadNode" || headKind === "ConstantPathNode") {
-      return [
-        f.createThrowStatement(
-          f.createNewExpression(
-            e.expr(head),
-            undefined,
-            args.slice(1).map((a) => e.expr(a)),
-          ),
+    return [
+      f.createThrowStatement(
+        f.createNewExpression(
+          e.expr(args[0]),
+          undefined,
+          args.slice(1).map((a) => e.expr(a)),
         ),
-      ];
-    }
-    return null;
+      ),
+    ];
   });
 }
 function ifStmt(n: PrismNode, e: Emitter, isLast: boolean, negate: boolean): ts.Statement {
@@ -110,6 +106,7 @@ function ifStmt(n: PrismNode, e: Emitter, isLast: boolean, negate: boolean): ts.
     e.asyncBindings,
     () => f.createBlock(e.stmts((n.statements as PrismNode) ?? null, isLast), true),
     (n.statements as PrismNode) ?? null,
+    e.inLoop,
   );
   const sub = (n.subsequent ?? n.elseClause) as PrismNode | null;
   let elseArm: AsyncArm<ts.Statement> | undefined;
@@ -118,9 +115,10 @@ function ifStmt(n: PrismNode, e: Emitter, isLast: boolean, negate: boolean): ts.
       e.asyncBindings,
       () => f.createBlock(e.stmts((sub.statements as PrismNode) ?? null, isLast), true),
       (sub.statements as PrismNode) ?? null,
+      e.inLoop,
     );
   } else if (sub && sub.constructor.name === "IfNode") {
-    elseArm = scopeAsyncArm(e.asyncBindings, () => ifStmt(sub, e, isLast, false), sub);
+    elseArm = scopeAsyncArm(e.asyncBindings, () => ifStmt(sub, e, isLast, false), sub, e.inLoop);
   }
   mergeAsyncArms(e.asyncBindings, elseArm ? [thenArm, elseArm] : [thenArm], elseArm != null);
   return f.createIfStatement(cond, thenArm.value, elseArm?.value);
@@ -149,6 +147,7 @@ function caseStmt(n: PrismNode, e: Emitter, isLast: boolean): ts.Statement[] | n
       () =>
         f.createBlock(e.stmts((n.elseClause as PrismNode).statements as PrismNode, isLast), true),
       (n.elseClause as PrismNode).statements as PrismNode,
+      e.inLoop,
     );
     arms.push(elseArm);
     out = elseArm.value;
@@ -166,6 +165,7 @@ function caseStmt(n: PrismNode, e: Emitter, isLast: boolean): ts.Statement[] | n
       e.asyncBindings,
       () => f.createBlock(e.stmts((w.statements as PrismNode) ?? null, isLast), true),
       (w.statements as PrismNode) ?? null,
+      e.inLoop,
     );
     arms.push(arm);
     out = f.createIfStatement(cond, arm.value, out);

--- a/scripts/prism-codegen/handlers/control.ts
+++ b/scripts/prism-codegen/handlers/control.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import type { Emitter, PrismNode } from "../types.js";
 import type { Registry } from "../registry.js";
+import type { AsyncArm } from "../await-policy.js";
 import { mergeAsyncArms, scopeAsyncArm } from "../await-policy.js";
 const f = ts.factory;
 export function registerControl(r: Registry): void {
@@ -13,9 +14,9 @@ export function registerControl(r: Registry): void {
     if (!consNode || !altNode) return null;
     let cond = e.expr(n.predicate as PrismNode);
     if (neg) cond = f.createLogicalNot(cond);
-    const consArm = scopeAsyncArm(e.asyncBindings, () => e.expr(consNode));
-    const altArm = scopeAsyncArm(e.asyncBindings, () => e.expr(altNode));
-    mergeAsyncArms(e.asyncBindings, [consArm.after, altArm.after], true);
+    const consArm = scopeAsyncArm(e.asyncBindings, () => e.expr(consNode), consNode);
+    const altArm = scopeAsyncArm(e.asyncBindings, () => e.expr(altNode), altNode);
+    mergeAsyncArms(e.asyncBindings, [consArm, altArm], true);
     const cons = consArm.value;
     const alt = altArm.value;
     return f.createConditionalExpression(
@@ -59,20 +60,23 @@ export function registerControl(r: Registry): void {
     if (rescue?.subsequent) return null;
     const ensure = n.ensureClause as PrismNode | undefined;
     if (!rescue && !ensure) return e.stmts((n.statements as PrismNode) ?? null, isLast);
-    const tryArm = scopeAsyncArm(e.asyncBindings, () =>
-      f.createBlock(e.stmts((n.statements as PrismNode) ?? null, isLast), true),
+    const tryArm = scopeAsyncArm(
+      e.asyncBindings,
+      () => f.createBlock(e.stmts((n.statements as PrismNode) ?? null, isLast), true),
+      (n.statements as PrismNode) ?? null,
     );
     let catchClause: ts.CatchClause | undefined;
-    let catchArm: Set<string> | undefined;
+    let catchArm: AsyncArm<ts.Block> | undefined;
     if (rescue) {
       const ref = rescue.reference ? String((rescue.reference as PrismNode).name) : "e";
-      const arm = scopeAsyncArm(e.asyncBindings, () =>
-        f.createBlock(e.stmts((rescue.statements as PrismNode) ?? null, isLast), true),
+      catchArm = scopeAsyncArm(
+        e.asyncBindings,
+        () => f.createBlock(e.stmts((rescue.statements as PrismNode) ?? null, isLast), true),
+        (rescue.statements as PrismNode) ?? null,
       );
-      catchArm = arm.after;
-      catchClause = f.createCatchClause(f.createVariableDeclaration(ref), arm.value);
+      catchClause = f.createCatchClause(f.createVariableDeclaration(ref), catchArm.value);
     }
-    mergeAsyncArms(e.asyncBindings, catchArm ? [tryArm.after, catchArm] : [tryArm.after], true);
+    mergeAsyncArms(e.asyncBindings, catchArm ? [tryArm, catchArm] : [tryArm], true);
     const finallyBlock = ensure
       ? f.createBlock(e.stmts((ensure.statements as PrismNode) ?? null, false), true)
       : undefined;
@@ -102,23 +106,23 @@ export function registerControl(r: Registry): void {
 function ifStmt(n: PrismNode, e: Emitter, isLast: boolean, negate: boolean): ts.Statement {
   let cond = e.expr(n.predicate as PrismNode);
   if (negate) cond = f.createLogicalNot(cond);
-  const thenArm = scopeAsyncArm(e.asyncBindings, () =>
-    f.createBlock(e.stmts((n.statements as PrismNode) ?? null, isLast), true),
+  const thenArm = scopeAsyncArm(
+    e.asyncBindings,
+    () => f.createBlock(e.stmts((n.statements as PrismNode) ?? null, isLast), true),
+    (n.statements as PrismNode) ?? null,
   );
   const sub = (n.subsequent ?? n.elseClause) as PrismNode | null;
-  let elseArm: { value: ts.Statement; after: Set<string> } | undefined;
+  let elseArm: AsyncArm<ts.Statement> | undefined;
   if (sub && sub.constructor.name === "ElseNode") {
-    elseArm = scopeAsyncArm(e.asyncBindings, () =>
-      f.createBlock(e.stmts((sub.statements as PrismNode) ?? null, isLast), true),
+    elseArm = scopeAsyncArm(
+      e.asyncBindings,
+      () => f.createBlock(e.stmts((sub.statements as PrismNode) ?? null, isLast), true),
+      (sub.statements as PrismNode) ?? null,
     );
   } else if (sub && sub.constructor.name === "IfNode") {
-    elseArm = scopeAsyncArm(e.asyncBindings, () => ifStmt(sub, e, isLast, false));
+    elseArm = scopeAsyncArm(e.asyncBindings, () => ifStmt(sub, e, isLast, false), sub);
   }
-  mergeAsyncArms(
-    e.asyncBindings,
-    elseArm ? [thenArm.after, elseArm.after] : [thenArm.after],
-    elseArm != null,
-  );
+  mergeAsyncArms(e.asyncBindings, elseArm ? [thenArm, elseArm] : [thenArm], elseArm != null);
   return f.createIfStatement(cond, thenArm.value, elseArm?.value);
 }
 function loop(n: PrismNode, e: Emitter, negate: boolean): ts.Statement {
@@ -130,20 +134,23 @@ function loop(n: PrismNode, e: Emitter, negate: boolean): ts.Statement {
     f.createBlock(e.stmts((n.statements as PrismNode) ?? null, false), true),
   );
   e.inLoop = prevLoop;
-  mergeAsyncArms(e.asyncBindings, [body.after], false);
+  mergeAsyncArms(e.asyncBindings, [body], false);
   return f.createWhileStatement(cond, body.value);
 }
 function caseStmt(n: PrismNode, e: Emitter, isLast: boolean): ts.Statement[] | null {
   const conds = (n.conditions as PrismNode[]) ?? [];
   if (conds.some((w) => w.constructor.name !== "WhenNode")) return null;
   const subject = n.predicate ? e.expr(n.predicate as PrismNode) : undefined;
-  const arms: Set<string>[] = [];
+  const arms: AsyncArm<ts.Block>[] = [];
   let out: ts.Statement | undefined;
   if (n.elseClause) {
-    const elseArm = scopeAsyncArm(e.asyncBindings, () =>
-      f.createBlock(e.stmts((n.elseClause as PrismNode).statements as PrismNode, isLast), true),
+    const elseArm = scopeAsyncArm(
+      e.asyncBindings,
+      () =>
+        f.createBlock(e.stmts((n.elseClause as PrismNode).statements as PrismNode, isLast), true),
+      (n.elseClause as PrismNode).statements as PrismNode,
     );
-    arms.push(elseArm.after);
+    arms.push(elseArm);
     out = elseArm.value;
   }
   for (let i = conds.length - 1; i >= 0; i--) {
@@ -155,10 +162,12 @@ function caseStmt(n: PrismNode, e: Emitter, isLast: boolean): ts.Statement[] | n
         : e.expr(c),
     );
     const cond = tests.reduce((a, b) => f.createLogicalOr(a, b));
-    const arm = scopeAsyncArm(e.asyncBindings, () =>
-      f.createBlock(e.stmts((w.statements as PrismNode) ?? null, isLast), true),
+    const arm = scopeAsyncArm(
+      e.asyncBindings,
+      () => f.createBlock(e.stmts((w.statements as PrismNode) ?? null, isLast), true),
+      (w.statements as PrismNode) ?? null,
     );
-    arms.push(arm.after);
+    arms.push(arm);
     out = f.createIfStatement(cond, arm.value, out);
   }
   mergeAsyncArms(e.asyncBindings, arms, n.elseClause != null);

--- a/scripts/prism-codegen/handlers/expressions.ts
+++ b/scripts/prism-codegen/handlers/expressions.ts
@@ -344,7 +344,7 @@ function blockToArrow(block: PrismNode, names: string[], e: Emitter): ts.ArrowFu
   );
   const body = arm.value;
   e.inLoop = prevLoop;
-  mergeAsyncArms(e.asyncBindings, [arm.after], false);
+  mergeAsyncArms(e.asyncBindings, [arm], false);
   if (body.length === 1 && ts.isReturnStatement(body[0]) && body[0].expression) {
     return f.createArrowFunction(
       asyncModifiers(body[0].expression),


### PR DESCRIPTION
## What

`mergeAsyncArms` treated every arm of an `if`/`case`/`begin` as a path into the
code after the construct. An arm ending in `return`, `next`, `break`, or
`raise` is not:

```ruby
if flag
  return nil
else
  @relation = build_relation()
end
@relation.load   # only the else arm reaches here — the await was legitimate
```

Arms that cannot fall through are now excluded from the merge, in both the
addition and the eager-retraction direction. A branch whose every arm is
terminal leaves the enclosing bindings untouched.

`fallsThrough` judges terminality by **what the emitter actually produces**,
not by Ruby semantics — a `raise`/`next`/`break` the handlers decline to
convert is emitted as a plain expression and does reach the next statement, so
treating it as terminal would drop a live retraction and award a false-positive
await:

- `raise` counts only when it becomes a `throw`; the predicate (`isRaiseThrow`)
  is shared with the `raise` handler in `control.ts` so the two cannot drift.
- `next` is terminal outside a loop (emitted as `return`) or inside one with no
  argument (`continue`); `next <value>` in a loop is not.
- `break` is terminal only inside a loop with no argument.
- A `while` body is never tested, since a body ending in `break` does reach the
  code after the loop.

## Notes

- `pnpm codegen:score` matched count unchanged (35); full `scripts/prism-codegen`
  suite green (194 tests).
- The persistence golden is regenerated: it was already stale on `main` — the
  `withTransactionReturningStatus` block arrow rendered without `async` around
  an `await`, so `golden.test.ts` fails on a clean `main` checkout.

Closes-story: codegen-await-provenance-terminal-arms
