### PR TITLE
feat(prism-codegen): resolve mixin constants against defined module paths

### DIFF
--- a/scripts/prism-codegen/__snapshots__/persistence.js.snap
+++ b/scripts/prism-codegen/__snapshots__/persistence.js.snap
@@ -243,13 +243,13 @@ export async function updateAttributeBang(name, value) {
     return await this.saveBang({ validate: false });
 }
 export function update(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.save();
     });
 }
 export function updateBang(attributes) {
-    return this.withTransactionReturningStatus(() => {
+    return this.withTransactionReturningStatus(async () => {
         this.assignAttributes(attributes);
         return await this.saveBang();
     });

--- a/scripts/prism-codegen/rails-scope.test.ts
+++ b/scripts/prism-codegen/rails-scope.test.ts
@@ -3,6 +3,9 @@ import {
   mixinPathCandidates,
   parseMixinNames,
   reachableRailsDefs,
+  resetUnresolvedMixins,
+  resolveMixinPath,
+  unresolvedMixinReport,
   type RubySourceReader,
 } from "./rails-scope.js";
 import { buildAsyncManifest, crossFileAsyncNames } from "./async-source.js";
@@ -22,14 +25,31 @@ const RAILS: Record<string, string> = {
       end
     end
   `,
-  "relation/finder_methods.rb": `def find_by; end\ndef find; end`,
-  "relation/calculations.rb": `def calculate; end\ndef pluck; end`,
-  "relation/query_methods.rb": `def where; end`,
-  "relation/spawn_methods.rb": `def merge; end`,
-  "relation/batches.rb": `def find_each; end`,
-  "relation/explain.rb": `def explain; end`,
-  "relation/delegation.rb": `def klass; end`,
+  "relation/finder_methods.rb": railsModule(
+    "Relation::FinderMethods",
+    "def find_by; end\ndef find; end",
+  ),
+  "relation/calculations.rb": railsModule(
+    "Relation::Calculations",
+    "def calculate; end\ndef pluck; end",
+  ),
+  "relation/query_methods.rb": railsModule("Relation::QueryMethods", "def where; end"),
+  "relation/spawn_methods.rb": railsModule("Relation::SpawnMethods", "def merge; end"),
+  "relation/batches.rb": railsModule("Relation::Batches", "def find_each; end"),
+  "relation/explain.rb": railsModule("Relation::Explain", "def explain; end"),
+  "relation/delegation.rb": railsModule("Delegation", "def klass; end"),
 };
+
+function railsModule(constPath: string, body: string): string {
+  const segments = constPath.split("::");
+  const opens = segments.map((name, depth) => `${"  ".repeat(depth + 1)}module ${name}`).join("\n");
+  const indented = body
+    .split("\n")
+    .map((line) => `${"  ".repeat(segments.length + 1)}${line}`)
+    .join("\n");
+  const closes = segments.map((_, depth) => `${"  ".repeat(depth + 1)}end`).reverse();
+  return ["module ActiveRecord", opens, indented, ...closes, "end"].join("\n");
+}
 
 const reader: RubySourceReader = (rel) => RAILS[rel];
 
@@ -59,6 +79,46 @@ describe("prism-codegen rails scope", () => {
     expect(
       mixinPathCandidates("active_record/relation/query_methods.rb", "ActiveRecord::Core"),
     ).toEqual(["relation/query_methods/core.rb", "relation/core.rb", "core.rb"]);
+  });
+
+  it("picks the lexically nearest file that really defines a same-named constant", () => {
+    const sources: Record<string, string> = {
+      "relation.rb": `
+        module ActiveRecord
+          class Relation
+            include Calculations
+          end
+        end
+      `,
+      "relation/calculations.rb": railsModule("Relation::Calculations", "def pluck; end"),
+      "calculations.rb": railsModule("Calculations", "def sum; end"),
+    };
+    const read: RubySourceReader = (rel) => sources[rel];
+    expect(resolveMixinPath("relation.rb", "Calculations", read)).toBe("relation/calculations.rb");
+
+    // Same constant name, but the nested file defines a different module: the
+    // path guess would take it anyway, so resolution has to fall through.
+    sources["relation/calculations.rb"] = railsModule("Relation::Batches", "def find_each; end");
+    expect(resolveMixinPath("relation.rb", "Calculations", read)).toBe("calculations.rb");
+  });
+
+  it("resolves a nested constant to the file of the constant that encloses it", () => {
+    const sources: Record<string, string> = {
+      "query_cache.rb": railsModule("QueryCache::ClassMethods", "def cache; end"),
+    };
+    const read: RubySourceReader = (rel) => sources[rel];
+    expect(resolveMixinPath("base.rb", "QueryCache::ClassMethods", read)).toBe("query_cache.rb");
+  });
+
+  it("reports a mixin constant no file in the corpus defines", () => {
+    resetUnresolvedMixins();
+    const read: RubySourceReader = () => undefined;
+    expect(resolveMixinPath("relation.rb", "ActiveModel::AttributeMethods", read)).toBeUndefined();
+    expect(unresolvedMixinReport()).toEqual([
+      { fromRel: "relation.rb", moduleName: "ActiveModel::AttributeMethods" },
+    ]);
+    resetUnresolvedMixins();
+    expect(unresolvedMixinReport()).toEqual([]);
   });
 
   it("reaches the defs of every module a Rails file includes", () => {

--- a/scripts/prism-codegen/rails-scope.test.ts
+++ b/scripts/prism-codegen/rails-scope.test.ts
@@ -96,8 +96,6 @@ describe("prism-codegen rails scope", () => {
     const read: RubySourceReader = (rel) => sources[rel];
     expect(resolveMixinPath("relation.rb", "Calculations", read)).toBe("relation/calculations.rb");
 
-    // Same constant name, but the nested file defines a different module: the
-    // path guess would take it anyway, so resolution has to fall through.
     sources["relation/calculations.rb"] = railsModule("Relation::Batches", "def find_each; end");
     expect(resolveMixinPath("relation.rb", "Calculations", read)).toBe("calculations.rb");
   });

--- a/scripts/prism-codegen/rails-scope.test.ts
+++ b/scripts/prism-codegen/rails-scope.test.ts
@@ -108,6 +108,28 @@ describe("prism-codegen rails scope", () => {
     expect(resolveMixinPath("base.rb", "QueryCache::ClassMethods", read)).toBe("query_cache.rb");
   });
 
+  it("ignores a module line inside a heredoc body", () => {
+    const read: RubySourceReader = (rel) =>
+      rel === "sanitization.rb"
+        ? [
+            "module ActiveRecord",
+            "  QUERY = <<~SQL",
+            "module Decoy",
+            "  SQL",
+            "  module Sanitization",
+            "  end",
+            "end",
+          ].join("\n")
+        : undefined;
+    expect(resolveMixinPath("base.rb", "ActiveRecord::Sanitization", read)).toBe("sanitization.rb");
+  });
+
+  it("resolves a one-line module declaration", () => {
+    const read: RubySourceReader = (rel) =>
+      rel === "no_touching.rb" ? "module ActiveRecord\n  module NoTouching; end\nend" : undefined;
+    expect(resolveMixinPath("base.rb", "NoTouching", read)).toBe("no_touching.rb");
+  });
+
   it("reports a mixin constant no file in the corpus defines", () => {
     resetUnresolvedMixins();
     const read: RubySourceReader = () => undefined;

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -53,6 +53,102 @@ export function mixinPathCandidates(fromRel: string, moduleName: string): string
   return [...new Set([nested, sibling, tail])];
 }
 
+// The trailing alternation keeps `class << self` out (a singleton body is not
+// a constant) while admitting the `# :nodoc:` comment most Rails module
+// declarations carry and the `< Superclass` of a class declaration.
+const MODULE_DECL = /^([ \t]*)(?:module|class)[ \t]+([A-Z][\w:]*)[ \t]*(?:<[^<]|#|$)/;
+
+/**
+ * The full constant paths a Ruby source defines, e.g. `active_record/
+ * relation/calculations.rb` → `ActiveRecord::Relation::Calculations`. Nesting
+ * is read off the indentation rather than by matching `end`s: Rails indents
+ * consistently, and an `end`-counting scanner has to model every block-opening
+ * keyword to stay in sync, where a miscount silently corrupts every later path.
+ */
+export function moduleDefinitionPaths(rubySource: string): Set<string> {
+  const paths = new Set<string>();
+  const stack: { indent: number; name: string }[] = [];
+  for (const line of rubySource.split("\n")) {
+    const m = MODULE_DECL.exec(line);
+    if (!m) continue;
+    const indent = m[1].replace(/\t/g, "  ").length;
+    while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
+    stack.push({ indent, name: m[2] });
+    paths.add(stack.map((s) => s.name).join("::"));
+  }
+  return paths;
+}
+
+function definesModule(rubySource: string, moduleName: string): boolean {
+  const wanted = moduleName.replace(/^::/, "");
+  for (const defined of moduleDefinitionPaths(rubySource)) {
+    if (defined === wanted || defined.endsWith(`::${wanted}`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Every file that could define `moduleName`, nearest lexical scope first. A
+ * nested constant is often defined inside its parent's file rather than a file
+ * of its own (`QueryCache::ClassMethods` lives in `query_cache.rb`), so the
+ * paths of the enclosing constants are candidates too — with the full name
+ * still required, so `query_cache.rb` only answers for what it really defines.
+ */
+function resolutionCandidates(fromRel: string, moduleName: string): string[] {
+  const segments = moduleName.split("::");
+  const candidates = [
+    stripPrefix(fromRel),
+    ...segments.flatMap((_, i) =>
+      mixinPathCandidates(fromRel, segments.slice(0, segments.length - i).join("::")),
+    ),
+  ];
+  return [...new Set(candidates)];
+}
+
+/** An `include`/`extend` constant no file in the corpus was found to define. */
+export interface UnresolvedMixin {
+  fromRel: string;
+  moduleName: string;
+}
+
+const unresolvedMixins = new Map<string, UnresolvedMixin>();
+
+/**
+ * Every mixin constant that resolved to no file, deduplicated by call site.
+ * An unresolvable constant under-scopes the await decision for the file that
+ * includes it, so the misses are reported rather than silently dropped.
+ */
+export function unresolvedMixinReport(): UnresolvedMixin[] {
+  return [...unresolvedMixins.values()];
+}
+
+export function resetUnresolvedMixins(): void {
+  unresolvedMixins.clear();
+}
+
+/**
+ * The file a mixin constant referenced from `fromRel` resolves to, or
+ * `undefined` when nothing in the corpus defines it. The candidates are tried
+ * nearest-first, which is the order Ruby's lexical lookup uses, and each one
+ * has to actually define the constant — existing on disk is not enough, since
+ * Rails has same-named constants at different nesting levels.
+ */
+export function resolveMixinPath(
+  fromRel: string,
+  moduleName: string,
+  readSource: RubySourceReader,
+): string | undefined {
+  for (const candidate of resolutionCandidates(fromRel, moduleName)) {
+    const source = readSource(candidate);
+    if (source !== undefined && definesModule(source, moduleName)) return candidate;
+  }
+  unresolvedMixins.set(`${stripPrefix(fromRel)} :: ${moduleName}`, {
+    fromRel: stripPrefix(fromRel),
+    moduleName,
+  });
+  return undefined;
+}
+
 /** Reads one Rails source by its `active_record/`-relative path. */
 export type RubySourceReader = (railsRelPath: string) => string | undefined;
 
@@ -100,9 +196,8 @@ export function reachableRailsDefs(
     if (source === undefined) continue;
     for (const name of rubyDefinedMethods(source)) defs.add(name);
     for (const mixin of parseMixinNames(source)) {
-      for (const candidate of mixinPathCandidates(rel, mixin)) {
-        if (!seen.has(candidate) && readSource(candidate) !== undefined) queue.push(candidate);
-      }
+      const resolved = resolveMixinPath(rel, mixin, readSource);
+      if (resolved !== undefined && !seen.has(resolved)) queue.push(resolved);
     }
   }
   if (readSource === readRuby) reachableCache.set(railsRelPath, defs);

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -54,7 +54,9 @@ export function mixinPathCandidates(fromRel: string, moduleName: string): string
   return [...new Set([nested, sibling, tail])];
 }
 
-const MODULE_DECL = /^([ \t]*)(?:module|class)[ \t]+([A-Z][\w:]*)[ \t]*(?:<[^<]|#|$)/;
+const MODULE_DECL = /^([ \t]*)(?:module|class)[ \t]+([A-Z][\w:]*)[ \t]*(?:<[^<]|;|$)/;
+const HEREDOC_OPEN = /<<[-~]?([A-Z_]+)/;
+const COMMENT = /#(?!\{).*$/;
 
 /**
  * The full constant paths a Ruby source defines, e.g. `active_record/
@@ -63,15 +65,26 @@ const MODULE_DECL = /^([ \t]*)(?:module|class)[ \t]+([A-Z][\w:]*)[ \t]*(?:<[^<]|
  * consistently, and an `end`-counting scanner has to model every block-opening
  * keyword to stay in sync, where a miscount silently corrupts every later path.
  *
- * The declaration pattern's trailing alternation keeps `class << self` out — a
- * singleton body defines no constant — while admitting the `# :nodoc:` comment
- * most Rails declarations carry and the `< Superclass` of a class.
+ * Comments are stripped before matching and heredoc bodies are skipped
+ * wholesale: a `module Foo` line inside an embedded SQL/Ruby string defines
+ * nothing, and pushing it would corrupt every path derived after it. The
+ * declaration pattern's trailing alternation keeps `class << self` out — a
+ * singleton body defines no constant — while admitting the `< Superclass` of a
+ * class and the `; end` of a one-line declaration.
  */
 function moduleDefinitionPaths(rubySource: string): Set<string> {
   const paths = new Set<string>();
   const stack: { indent: number; name: string }[] = [];
+  let heredoc: string | undefined;
   for (const line of rubySource.split("\n")) {
-    const m = MODULE_DECL.exec(line);
+    if (heredoc !== undefined) {
+      if (line.trim() === heredoc) heredoc = undefined;
+      continue;
+    }
+    const code = line.replace(COMMENT, "");
+    const opened = HEREDOC_OPEN.exec(code);
+    if (opened) heredoc = opened[1];
+    const m = MODULE_DECL.exec(code);
     if (!m) continue;
     const indent = m[1].replace(/\t/g, "  ").length;
     while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -37,7 +37,8 @@ function stripPrefix(rel: string): string {
  * the constant lexically, which we cannot do from a path alone, so we try the
  * three layouts Rails actually uses: nested under the includer's own file
  * (`relation.rb` → `relation/finder_methods.rb`), a sibling of it, and the
- * `active_record/` root. Non-existent candidates are dropped by the caller.
+ * `active_record/` root. `resolveMixinPath` picks between them by asking which
+ * one really defines the constant.
  */
 export function mixinPathCandidates(fromRel: string, moduleName: string): string[] {
   const segments = moduleName
@@ -53,9 +54,6 @@ export function mixinPathCandidates(fromRel: string, moduleName: string): string
   return [...new Set([nested, sibling, tail])];
 }
 
-// The trailing alternation keeps `class << self` out (a singleton body is not
-// a constant) while admitting the `# :nodoc:` comment most Rails module
-// declarations carry and the `< Superclass` of a class declaration.
 const MODULE_DECL = /^([ \t]*)(?:module|class)[ \t]+([A-Z][\w:]*)[ \t]*(?:<[^<]|#|$)/;
 
 /**
@@ -64,8 +62,12 @@ const MODULE_DECL = /^([ \t]*)(?:module|class)[ \t]+([A-Z][\w:]*)[ \t]*(?:<[^<]|
  * is read off the indentation rather than by matching `end`s: Rails indents
  * consistently, and an `end`-counting scanner has to model every block-opening
  * keyword to stay in sync, where a miscount silently corrupts every later path.
+ *
+ * The declaration pattern's trailing alternation keeps `class << self` out — a
+ * singleton body defines no constant — while admitting the `# :nodoc:` comment
+ * most Rails declarations carry and the `< Superclass` of a class.
  */
-export function moduleDefinitionPaths(rubySource: string): Set<string> {
+function moduleDefinitionPaths(rubySource: string): Set<string> {
   const paths = new Set<string>();
   const stack: { indent: number; name: string }[] = [];
   for (const line of rubySource.split("\n")) {
@@ -122,6 +124,7 @@ export function unresolvedMixinReport(): UnresolvedMixin[] {
   return [...unresolvedMixins.values()];
 }
 
+/** Clears the report — for tests, and for a caller that reports per run. */
 export function resetUnresolvedMixins(): void {
   unresolvedMixins.clear();
 }

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -6,6 +6,7 @@ import { portMethodNames } from "./port-symbols.js";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js";
 import { TOPLEVEL } from "./codegen.js";
+import { unresolvedMixinReport } from "./rails-scope.js";
 import {
   TARGET_FILES,
   TRAILS_AR_SRC,
@@ -153,6 +154,21 @@ async function compositionCheck(): Promise<{ points: number; failure?: string }>
   return { points, failure: compositionFailureMessage(failures) };
 }
 
+/**
+ * Mixin constants no file in the corpus defines. Each one is a module missing
+ * from the await scope of the file that includes it, so the count is printed
+ * even without `--verbose` — a silent miss is what this reporting exists to
+ * prevent. Most are legitimately outside the corpus (`Enumerable`,
+ * `ActiveModel::*`), which is why it is a report and not a failure.
+ */
+function reportUnresolvedMixins(verbose: boolean): void {
+  const unresolved = unresolvedMixinReport();
+  if (!unresolved.length) return;
+  console.log(`\n  ${unresolved.length} mixin constants resolved to no file in the corpus.`);
+  if (!verbose) return;
+  for (const { fromRel, moduleName } of unresolved) console.log(`    ${fromRel} :: ${moduleName}`);
+}
+
 async function main() {
   const verbose = process.argv.includes("--verbose");
   const write = process.argv.includes("--write");
@@ -234,6 +250,7 @@ async function main() {
       `${(present ? ((totMatched + totReordered) / present) * 100 : 0).toFixed(1).padStart(6)}%`,
   );
   console.log(`\n  ${totElsewhere} defs resolved in a different port file than the Rails twin.`);
+  reportUnresolvedMixins(verbose);
   console.log(
     `\n  present-in-both = matched + divergent. "missing" = clean generated def with no` +
       `\n  port symbol under any name candidate — either a genuinely unported method, a` +


### PR DESCRIPTION
`mixinPathCandidates` mapped an `include`/`extend` constant to a file by
guessing three layouts and taking whichever existed on disk. Ruby resolves the
constant lexically, so the guess could pick a file that defines a different
module of the same name, and it resolved nothing at all for a module living
outside the three layouts — silently, so the under-scoped await decision left
no signal.

- `moduleDefinitionPaths` reads the constant paths a Ruby source actually
  defines off the declaration indentation, and `resolveMixinPath` now requires
  a candidate to define the constant rather than merely exist. Candidates are
  tried nearest-first, which is Ruby's lexical order.
- Candidate set widened to the includer's own file and the files of the
  enclosing constants, since a nested module is usually defined inside its
  parent's file (`QueryCache::ClassMethods` lives in `query_cache.rb`). Against
  vendored Rails this takes the unresolved count from 67 to 58, and the 58 that
  remain are genuinely outside `active_record/` (`ActiveSupport::Concern`,
  `ActiveModel::*`, `Enumerable`) — no AR module is silently skipped now.
- Unresolved constants are recorded and reported by `score-cli` (count always,
  call sites under `--verbose`).

The persistence golden moves: two block callbacks that contained an `await`
are now emitted `async`, which also clears the snapshot's
`countAwaitsOutsideAsync` assertion.

## Review round 1

Both fragility notes fixed rather than argued away, each with a test that fails
on the pre-fix scanner:

- Heredoc bodies are skipped, so a `module Foo` line inside an embedded
  SQL/Ruby string can no longer be pushed onto the indent stack and corrupt the
  paths derived after it. A scan of `activerecord/lib` for a heredoc body
  containing a `module`/`class` line found no live instance (the only hit was a
  `#`-commented `execute <<~SQL` example), so this closes the latent case.
- The declaration pattern now accepts `;`, so a one-line `module Foo; end`
  registers as a definition and the JSDoc's "the full constant paths a Ruby
  source defines" holds.

Comments are stripped before matching, which is what lets the pattern drop its
`#` alternation. The vendored-corpus unresolved count is unchanged at 58.

Closes-story: codegen-mixin-constant-resolution-by-index
