### PR TITLE
fix(prism-codegen): scope reachable Rails defs by class nesting

### DIFF
--- a/scripts/prism-codegen/apply-cli.ts
+++ b/scripts/prism-codegen/apply-cli.ts
@@ -58,7 +58,7 @@ async function main() {
 
   const { code, perDef } = await generateFromSource(
     await fs.readFile(rubyAbsPath(target), "utf8"),
-    asyncMethodsForRailsFile(target.ruby),
+    await asyncMethodsForRailsFile(target.ruby),
     undefined,
     undefined,
     undefined,

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -6,7 +6,7 @@ import { ownRailsDefs, reachableRailsDefs } from "./rails-scope.js";
 import { resolvePath } from "../../vendor/sources.js";
 const AR_ROOT = resolvePath("activerecord");
 const AR_LIB = path.dirname(AR_ROOT);
-export { rubyDefinedMethods } from "./rails-scope.js";
+export { scopedRubyDefs } from "./rails-scope.js";
 function railsSource(railsRelPath: string): string {
   const abs = path.join(AR_LIB, railsRelPath);
   return existsSync(abs) ? readFileSync(abs, "utf8") : "";

--- a/scripts/prism-codegen/async-source.ts
+++ b/scripts/prism-codegen/async-source.ts
@@ -187,10 +187,10 @@ export function defaultAsyncManifest(): AsyncManifest {
   manifestCache ??= buildAsyncManifest(portTreeFiles());
   return manifestCache;
 }
-export function asyncMethodsForRailsFile(
+export async function asyncMethodsForRailsFile(
   railsRelPath: string,
   manifest: AsyncManifest = defaultAsyncManifest(),
-): Set<string> {
+): Promise<Set<string>> {
   const short = railsRelPath.replace(/^active_record\//, "");
   const twinTsPath = rubyFileToTs(short);
   const twinTsAbs = path.join(TRAILS_AR_SRC, twinTsPath);
@@ -199,10 +199,10 @@ export function asyncMethodsForRailsFile(
   return resolveAsyncNames({
     twinTs,
     relationTs: relationFamily ? readFileOr(path.join(TRAILS_AR_SRC, "relation.ts")) : undefined,
-    ownRubyDefs: relationFamily ? ownRailsDefs(railsRelPath) : undefined,
+    ownRubyDefs: relationFamily ? await ownRailsDefs(railsRelPath) : undefined,
     crossFile: crossFileAsyncNames(manifest, {
       twinTsPath,
-      railsDefs: reachableRailsDefs(railsRelPath),
+      railsDefs: await reachableRailsDefs(railsRelPath),
     }),
     inferFromRuby: existsSync(twinTsAbs) ? undefined : railsSource(railsRelPath),
   });

--- a/scripts/prism-codegen/codegen.test.ts
+++ b/scripts/prism-codegen/codegen.test.ts
@@ -10,7 +10,7 @@ import {
   extractAsyncNames,
   inferAsyncFromBodies,
   resolveAsyncNames,
-  rubyDefinedMethods,
+  scopedRubyDefs,
 } from "./async-source.js";
 import type { Coverage } from "./types.js";
 describe("prism-codegen", () => {
@@ -792,7 +792,7 @@ describe("prism-codegen", () => {
     expect(names.has("secondBang")).toBe(true);
     expect(names.has("pluck")).toBe(false);
   });
-  it("scopes the relation.ts supplement to the file's own Rails defs", () => {
+  it("scopes the relation.ts supplement to the file's own Rails defs", async () => {
     const twinTs = `export const Calculations = { count: inQueryConnection(performCount) };
       export async function performCount() {}`;
     const relationTs = `class Relation {
@@ -801,7 +801,7 @@ describe("prism-codegen", () => {
       async first() {}
       async isOne() {}
     }`;
-    const ownRubyDefs = rubyDefinedMethods(`
+    const ownRubyDefs = await scopedRubyDefs(`
       def count; end
       def pluck; end
       def ids; end
@@ -820,7 +820,7 @@ describe("prism-codegen", () => {
     ]);
     const crossFile = crossFileAsyncNames(manifest, {
       twinTsPath: "persistence.ts",
-      railsDefs: rubyDefinedMethods(`def find_by; end\ndef perform_save; end`),
+      railsDefs: await scopedRubyDefs(`def find_by; end\ndef perform_save; end`),
     });
     expect(crossFile.has("findBy")).toBe(true);
     expect(crossFile.has("performSave")).toBe(false);
@@ -851,7 +851,7 @@ end`;
     ]);
     const crossFile = crossFileAsyncNames(manifest, {
       twinTsPath: "touch.ts",
-      railsDefs: rubyDefinedMethods(`def perform_save; end`),
+      railsDefs: await scopedRubyDefs(`def perform_save; end`),
     });
     const names = resolveAsyncNames({ twinTs: "", crossFile, inferFromRuby: ruby });
     expect(names.has("touchLater")).toBe(true);
@@ -917,24 +917,24 @@ end`,
     );
     expect(inferred.size).toBe(0);
   });
-  it("declines the await when a name is async in more than one port file", () => {
+  it("declines the await when a name is async in more than one port file", async () => {
     const manifest = buildAsyncManifest([
       { path: "relation.ts", source: `class R { async reset() {} }` },
       { path: "connection-adapters/pool.ts", source: `class P { async reset() {} }` },
       { path: "persistence.ts", source: `export async function touch() {}` },
     ]);
-    const railsDefs = rubyDefinedMethods(`def reset; end\ndef touch; end`);
+    const railsDefs = await scopedRubyDefs(`def reset; end\ndef touch; end`);
     const crossFile = crossFileAsyncNames(manifest, { twinTsPath: "core.ts", railsDefs });
     expect(crossFile.has("reset")).toBe(false);
     expect(crossFile.has("touch")).toBe(true);
   });
-  it("keeps cross-file async names out unless Rails defines the method", () => {
+  it("keeps cross-file async names out unless Rails defines the method", async () => {
     const manifest = buildAsyncManifest([
       { path: "relation.ts", source: `class R { async then() {} }` },
     ]);
     const crossFile = crossFileAsyncNames(manifest, {
       twinTsPath: "core.ts",
-      railsDefs: rubyDefinedMethods(`def save; end`),
+      railsDefs: await scopedRubyDefs(`def save; end`),
     });
     expect(crossFile.has("then")).toBe(false);
   });

--- a/scripts/prism-codegen/from-ts.ts
+++ b/scripts/prism-codegen/from-ts.ts
@@ -35,7 +35,7 @@ async function main() {
   const rb = path.join(AR_LIB, rel);
   const { code, coverage, perDef, parseErrorCount } = await generateFromSource(
     readFileSync(rb, "utf8"),
-    asyncMethodsForRailsFile(rel),
+    await asyncMethodsForRailsFile(rel),
     undefined,
     undefined,
     undefined,

--- a/scripts/prism-codegen/golden.ts
+++ b/scripts/prism-codegen/golden.ts
@@ -84,7 +84,7 @@ export async function generateTarget(f: TargetFile): Promise<GeneratedTarget> {
   const src = await fs.readFile(rubyAbsPath(f), "utf8");
   const result = await generateFromSource(
     src,
-    asyncMethodsForRailsFile(f.ruby),
+    await asyncMethodsForRailsFile(f.ruby),
     runtimeImportPathFor(outName),
     await inheritedDelegationsFor(f),
     await targetLinearization(),

--- a/scripts/prism-codegen/rails-scope.test.ts
+++ b/scripts/prism-codegen/rails-scope.test.ts
@@ -141,8 +141,8 @@ describe("prism-codegen rails scope", () => {
     expect(unresolvedMixinReport()).toEqual([]);
   });
 
-  it("reaches the defs of every module a Rails file includes", () => {
-    const relation = reachableRailsDefs("active_record/relation.rb", reader);
+  it("reaches the defs of every module a Rails file includes", async () => {
+    const relation = await reachableRailsDefs("active_record/relation.rb", reader);
     expect(relation.has("scoping")).toBe(true);
     expect(relation.has("findBy")).toBe(true);
     expect(relation.has("calculate")).toBe(true);
@@ -150,24 +150,54 @@ describe("prism-codegen rails scope", () => {
     expect(relation.has("merge")).toBe(true);
     expect(relation.has("findEach")).toBe(true);
 
-    const finderMethods = reachableRailsDefs("active_record/relation/finder_methods.rb", reader);
+    const finderMethods = await reachableRailsDefs(
+      "active_record/relation/finder_methods.rb",
+      reader,
+    );
     expect(finderMethods.has("find")).toBe(true);
     expect(finderMethods.has("where")).toBe(false);
     expect(finderMethods.has("pluck")).toBe(false);
   });
 
-  it("declines a cross-file async name the generating Rails file cannot dispatch to", () => {
+  it("leaves an inner class's defs out of the enclosing file's scope", async () => {
+    const withInnerClass: RubySourceReader = (rel) =>
+      rel === "relation.rb"
+        ? `
+          module ActiveRecord
+            class Relation
+              class ExplainProxy
+                def explain_proxy_only; end
+              end
+              module ClassMethods
+                def mixed_in; end
+              end
+              def scoping; end
+              def self.create; end
+            end
+          end
+        `
+        : undefined;
+    const defs = await reachableRailsDefs("active_record/relation.rb", withInnerClass);
+    expect(defs.has("scoping")).toBe(true);
+    expect(defs.has("create")).toBe(true);
+    expect(defs.has("mixedIn")).toBe(true);
+    expect(defs.has("explainProxyOnly")).toBe(false);
+  });
+
+  it("declines a cross-file async name the generating Rails file cannot dispatch to", async () => {
     const manifest = buildAsyncManifest([
       { path: "relation/calculations.ts", source: `class C { async pluck() {} }` },
     ]);
-    const scoped = (railsRelPath: string, twinTsPath: string) =>
+    const scoped = async (railsRelPath: string, twinTsPath: string) =>
       crossFileAsyncNames(manifest, {
         twinTsPath,
-        railsDefs: reachableRailsDefs(railsRelPath, reader),
+        railsDefs: await reachableRailsDefs(railsRelPath, reader),
       });
-    expect(scoped("active_record/relation.rb", "relation.ts").has("pluck")).toBe(true);
+    expect((await scoped("active_record/relation.rb", "relation.ts")).has("pluck")).toBe(true);
     expect(
-      scoped("active_record/relation/finder_methods.rb", "relation/finder-methods.ts").has("pluck"),
+      (await scoped("active_record/relation/finder_methods.rb", "relation/finder-methods.ts")).has(
+        "pluck",
+      ),
     ).toBe(false);
   });
 });

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -5,14 +5,7 @@ import { methodName } from "./naming.js";
 import { rubyAbsPathFor } from "./files.js";
 import type { PrismNode } from "./types.js";
 
-const RUBY_DEF = /^\s*def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)/gm;
 const MIXIN_LINE = /^[ \t]*(?:include|extend)[ \t]+([A-Z][\w:]*(?:[ \t]*,[ \t]*[A-Z][\w:]*)*)/gm;
-
-export function rubyDefinedMethods(rubySource: string): Set<string> {
-  const defs = new Set<string>();
-  for (const m of rubySource.matchAll(RUBY_DEF)) defs.add(methodName(m[1]));
-  return defs;
-}
 
 let prismParse: Promise<Awaited<ReturnType<typeof loadPrism>>> | undefined;
 
@@ -210,7 +203,7 @@ const readRuby: RubySourceReader = (rel) => {
   return existsSync(abs) ? readFileSync(abs, "utf8") : undefined;
 };
 
-/** Ruby method names defined directly in one Rails file. */
+/** Ruby method names one Rails file defines in its own class/module scope. */
 export function ownRailsDefs(railsRelPath: string): Promise<Set<string>> {
   return scopedRubyDefs(readRuby(stripPrefix(railsRelPath)) ?? "");
 }

--- a/scripts/prism-codegen/rails-scope.ts
+++ b/scripts/prism-codegen/rails-scope.ts
@@ -1,7 +1,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import * as path from "node:path";
+import { loadPrism } from "@ruby/prism";
 import { methodName } from "./naming.js";
 import { rubyAbsPathFor } from "./files.js";
+import type { PrismNode } from "./types.js";
 
 const RUBY_DEF = /^\s*def\s+(?:self\.)?([A-Za-z_][\w]*[?!=]?)/gm;
 const MIXIN_LINE = /^[ \t]*(?:include|extend)[ \t]+([A-Z][\w:]*(?:[ \t]*,[ \t]*[A-Z][\w:]*)*)/gm;
@@ -10,6 +12,41 @@ export function rubyDefinedMethods(rubySource: string): Set<string> {
   const defs = new Set<string>();
   for (const m of rubySource.matchAll(RUBY_DEF)) defs.add(methodName(m[1]));
   return defs;
+}
+
+let prismParse: Promise<Awaited<ReturnType<typeof loadPrism>>> | undefined;
+
+/**
+ * The method names a Ruby file's own class/module can dispatch to, honouring
+ * class nesting. A `def` inside a class nested in the file's class — Relation's
+ * `ExplainProxy#pluck` (relation.rb:6) — belongs to that inner object, not to
+ * the file's, so it is out of scope. Nested *modules* (`ClassMethods`) stay in:
+ * Rails mixes them into the enclosing class, so their defs really are reachable.
+ *
+ * `class << self` bodies and `def self.x` are kept: a generated file's
+ * class-level self-calls dispatch to them.
+ */
+export async function scopedRubyDefs(rubySource: string): Promise<Set<string>> {
+  prismParse ??= loadPrism();
+  const parse = await prismParse;
+  const defs = new Set<string>();
+  walkScoped((parse(rubySource).value as unknown as PrismNode) ?? null, 0, defs);
+  return defs;
+}
+
+function walkScoped(node: PrismNode | null, classDepth: number, defs: Set<string>): void {
+  if (!node?.constructor) return;
+  const kind = node.constructor.name;
+  if (kind === "ClassNode") {
+    if (classDepth >= 1) return;
+    for (const child of node.compactChildNodes()) walkScoped(child, classDepth + 1, defs);
+    return;
+  }
+  if (kind === "DefNode") {
+    defs.add(methodName(String(node.name)));
+    return;
+  }
+  for (const child of node.compactChildNodes()) walkScoped(child, classDepth, defs);
 }
 
 /**
@@ -174,8 +211,8 @@ const readRuby: RubySourceReader = (rel) => {
 };
 
 /** Ruby method names defined directly in one Rails file. */
-export function ownRailsDefs(railsRelPath: string): Set<string> {
-  return rubyDefinedMethods(readRuby(stripPrefix(railsRelPath)) ?? "");
+export function ownRailsDefs(railsRelPath: string): Promise<Set<string>> {
+  return scopedRubyDefs(readRuby(stripPrefix(railsRelPath)) ?? "");
 }
 
 const reachableCache = new Map<string, Set<string>>();
@@ -191,14 +228,14 @@ const reachableCache = new Map<string, Set<string>>();
  * in unrelated files indistinguishable, and the async one dragged an await
  * onto the sync one's self-call.
  *
- * `def`s are collected flat, so a `def` in an inner class (`Relation`'s
- * `ExplainProxy`) counts as reachable. That errs toward the old, wider scope
- * and never drops a name the file really can dispatch to.
+ * `def`s are attributed to their enclosing class, so a `def` in an inner class
+ * (`Relation`'s `ExplainProxy`) is not reachable from the outer file — see
+ * `scopedRubyDefs`.
  */
-export function reachableRailsDefs(
+export async function reachableRailsDefs(
   railsRelPath: string,
   readSource: RubySourceReader = readRuby,
-): Set<string> {
+): Promise<Set<string>> {
   const cached = readSource === readRuby ? reachableCache.get(railsRelPath) : undefined;
   if (cached) return cached;
   const defs = new Set<string>();
@@ -210,7 +247,7 @@ export function reachableRailsDefs(
     seen.add(rel);
     const source = readSource(rel);
     if (source === undefined) continue;
-    for (const name of rubyDefinedMethods(source)) defs.add(name);
+    for (const name of await scopedRubyDefs(source)) defs.add(name);
     for (const mixin of parseMixinNames(source)) {
       const resolved = resolveMixinPath(rel, mixin, readSource);
       if (resolved !== undefined && !seen.has(resolved)) queue.push(resolved);

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -203,7 +203,7 @@ async function main() {
     }
     const { code, perDef } = await generateFromSource(
       readFileSync(rubyAbsPath(f), "utf8"),
-      asyncMethodsForRailsFile(f.ruby, asyncManifest),
+      await asyncMethodsForRailsFile(f.ruby, asyncManifest),
       runtimeImportPathFor(outNameFor(f)),
       await inheritedDelegationsFor(f),
       await targetLinearization(),


### PR DESCRIPTION
`reachableRailsDefs` collected `def`s with a flat line regex, blind to class
nesting, so `Relation::ExplainProxy`'s `pluck`/`sum`/`average`/`count`
(relation.rb:6-47) counted as reachable from `active_record/relation.rb`.

Replaces the regex with a prism walk (`scopedRubyDefs`) that attributes each
`def` to its enclosing class: a `def` in a class nested inside the file's own
class is out of scope. Nested *modules* (`ClassMethods`) stay in — Rails mixes
them into the enclosing class — and `def self.x` / `class << self` bodies stay
in, since class-level self-calls dispatch to them.

Not sourced from `linearization.ts`'s `indexModuleDefs()`: that index exists for
`super` resolution, so it drops `def self.x` and `class << self` bodies, which
this scope needs (generated class-level self-calls dispatch to them), and it
keys by full constant path, which would need a separate rule to decide that
`Relation::ClassMethods` is in scope while `Relation::ExplainProxy` is not.

`RUBY_DEF` and `rubyDefinedMethods` are gone — the prism walk is the only def
scanner now.

This makes `reachableRailsDefs` / `ownRailsDefs` / `asyncMethodsForRailsFile`
async; all four call sites (`golden.ts`, `score-cli.ts`, `from-ts.ts`,
`apply-cli.ts`) were already async.

Goldens are unchanged (no await dropped) and `pnpm codegen:score` still reports
35 matched.

Closes-story: codegen-scope-defs-respect-class-nesting
