### PR TITLE
fix(activerecord): raise NotImplementedError from SchemaStatements#foreignKeys

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -13,6 +13,7 @@ import { BetterSQLite3Adapter } from "../better-sqlite3-adapter.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { ForeignKeyDefinition } from "./schema-definitions.js";
 import { fixtures } from "../../test-fixtures.js";
+import { NotImplementedError } from "../../errors.js";
 import { ambientConnection, withRocketTables } from "../../support/rocket-tables.js";
 import { adapterType } from "../../test-adapter.js";
 
@@ -299,15 +300,17 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       }
     }
     const stub = new FkStub();
-    // foreignKeys base path returns [] when adapter has no override
-    const fks = await stub.foreignKeys("any_table");
-    expect(fks).toEqual([]);
+    // The base body raises (schema_statements.rb:1103) when the adapter has no
+    // override; a recursion regression would surface as a stack overflow instead.
+    await expect(stub.foreignKeys("any_table")).rejects.toThrow(
+      new NotImplementedError("foreign_keys is not implemented"),
+    );
     // removeForeignKey base path resolves the real constraint via
-    // foreign_key_for! (Rails-faithful); against a stub with no foreign keys it
-    // raises ArgumentError promptly rather than recursing into a stack overflow.
+    // foreign_key_for! (Rails-faithful), so it surfaces that same raise promptly
+    // rather than recursing into a stack overflow.
     await expect(
       stub.removeForeignKey("products", { name: "fk_products_user_id" }),
-    ).rejects.toThrow(/no foreign key/i);
+    ).rejects.toThrow(new NotImplementedError("foreign_keys is not implemented"));
   });
 
   it("adapter overrides that call super reach the base body without self-dispatching", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -617,6 +617,22 @@ describe("distinctRelationForPrimaryKey", () => {
   });
 });
 
+describe("unsupported-adapter bodies", () => {
+  it("foreignKeys raises NotImplementedError", async () => {
+    const ss = makeStatements();
+
+    await expect(ss.foreignKeys("astronauts")).rejects.toThrow(
+      new NotImplementedError("foreign_keys is not implemented"),
+    );
+  });
+
+  it("checkConstraints raises NotImplementedError", async () => {
+    const ss = makeStatements();
+
+    await expect(ss.checkConstraints("astronauts")).rejects.toBeInstanceOf(NotImplementedError);
+  });
+});
+
 describe("tableExists NotImplementedError fallback", () => {
   it("returns false for a blank table name without querying", async () => {
     const execute = vi.fn().mockResolvedValue([]);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1373,11 +1373,9 @@ export class SchemaStatements {
     }
   }
 
-  // Rails raises `NotImplementedError, "foreign_keys is not implemented"` here
-  // (schema_statements.rb:1103). trails' `introspectForeignKeys` is built on the
-  // `[]`; story `converge-schema-statements-not-implemented-bodies` retires it.
   async foreignKeys(_tableName: string): Promise<ForeignKeyDefinition[]> {
-    return [];
+    // @nie disposition=TODO
+    throw new NotImplementedError("foreign_keys is not implemented");
   }
 
   async tables(): Promise<string[]> {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -165,7 +165,6 @@ export {
   introspectTables,
   introspectColumns,
   introspectPrimaryKey,
-  introspectForeignKeys,
 } from "./schema-introspection.js";
 export { generateModels } from "./model-codegen.js";
 export type { IntrospectedTable, GenerateModelsOptions } from "./model-codegen.js";

--- a/packages/activerecord/src/model-codegen.ts
+++ b/packages/activerecord/src/model-codegen.ts
@@ -21,8 +21,8 @@ import { metadataTableNames } from "./tasks/database-tasks.js";
 /**
  * One table worth of introspection data, sufficient for codegen.
  * Callers will assemble this by running introspectTables +
- * introspectPrimaryKey + introspectColumns + introspectForeignKeys
- * from schema-introspection.ts.
+ * introspectPrimaryKey + introspectColumns from
+ * schema-introspection.ts, plus the adapter's own `foreignKeys()`.
  */
 export interface IntrospectedTable {
   name: string;

--- a/packages/activerecord/src/schema-introspection.trails.test.ts
+++ b/packages/activerecord/src/schema-introspection.trails.test.ts
@@ -1,5 +1,5 @@
 // Trails-only unit tests for the trails-invented `introspect*` helpers
-// (introspectTables/Columns/Indexes/PrimaryKey/ForeignKeys) and their
+// (introspectTables/Columns/Indexes/PrimaryKey) and their
 // SchemaStatements fallback path — no 1:1 Rails counterpart exists. The scratch
 // tables these create (`widgets`, `more_testings`) are real Rails migration-test
 // table names (primary_keys_test.rb / migration/compatibility_test.rb), not
@@ -13,9 +13,7 @@ import {
   introspectColumns,
   introspectIndexes,
   introspectPrimaryKey,
-  introspectForeignKeys,
 } from "./schema-introspection.js";
-import { ForeignKeyDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 
 /**
  * Return a proxy over `adapter` that hides the named methods so the
@@ -259,73 +257,5 @@ describe("introspectPrimaryKey", () => {
     // primaryKey() stripped there is nothing to fall back to and the result is
     // empty; sqlite/postgres, whose columns() flag the PK, yield ["id"].
     expect(pk).toEqual(adapterType === "mysql" ? [] : ["id"]);
-  });
-});
-
-describe("introspectForeignKeys", () => {
-  it("uses adapter.foreignKeys() when the adapter implements it", async () => {
-    let calledWith: string | undefined;
-    const fk = new ForeignKeyDefinition("reviews", "books", "book_id", "id", "fk_reviews_book_id");
-    const adapter = {
-      async foreignKeys(table: string): Promise<ForeignKeyDefinition[]> {
-        calledWith = table;
-        return [fk];
-      },
-    } as unknown as Parameters<typeof introspectForeignKeys>[0];
-
-    const result = await introspectForeignKeys(adapter, "reviews");
-
-    expect(calledWith).toBe("reviews");
-    expect(result).toEqual([fk]);
-  });
-
-  it("returns composite FKs as comma-separated strings, not arrays", async () => {
-    // Confirms the `column: "a_id,b_id"` contract the codegen layer depends on.
-    const fk = new ForeignKeyDefinition(
-      "memberships",
-      "accounts",
-      "tenant_id,account_id",
-      "tenant_id,id",
-      "fk_memberships_composite",
-    );
-    const adapter = {
-      async foreignKeys(_t: string): Promise<ForeignKeyDefinition[]> {
-        return [fk];
-      },
-    } as unknown as Parameters<typeof introspectForeignKeys>[0];
-
-    const [result] = await introspectForeignKeys(adapter, "memberships");
-
-    expect(typeof result.column).toBe("string");
-    expect(result.column).toBe("tenant_id,account_id");
-    expect(typeof result.primaryKey).toBe("string");
-    expect(result.primaryKey).toBe("tenant_id,id");
-  });
-
-  it("returns [] from the SchemaStatements fallback when adapter lacks foreignKeys()", async () => {
-    const realAdapter = Base.connection;
-    await realAdapter.createTable("widgets", {}, (t) => {
-      t.string("name");
-    });
-
-    const stripped = withoutMethods(realAdapter, ["foreignKeys"]);
-
-    // SchemaStatements.foreignKeys() checks the underlying adapter for
-    // .foreignKeys() and returns [] when it's not a function. Our wrapper
-    // goes through that same fallback path when the adapter is stripped.
-    const fks = await introspectForeignKeys(stripped, "widgets");
-
-    expect(fks).toEqual([]);
-  });
-
-  it("returns [] for a real table with no foreign keys", async () => {
-    const realAdapter = Base.connection;
-    await realAdapter.createTable("widgets", {}, (t) => {
-      t.string("name");
-    });
-
-    const fks = await introspectForeignKeys(realAdapter, "widgets");
-
-    expect(fks).toEqual([]);
   });
 });

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -18,7 +18,6 @@ import {
   assertSchemaAdapter,
 } from "./connection-adapters/abstract/schema-statements.js";
 import type { Column } from "./connection-adapters/column.js";
-import type { ForeignKeyDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 
 type AdapterWithTables = { tables(): Promise<string[]> };
 type AdapterWithColumns = { columns(table: string): Promise<Column[]> };
@@ -27,9 +26,6 @@ type AdapterWithIndexes = {
 };
 type AdapterWithPrimaryKey = {
   primaryKey(table: string): Promise<string | string[] | null>;
-};
-type AdapterWithForeignKeys = {
-  foreignKeys(table: string): Promise<ForeignKeyDefinition[]>;
 };
 
 /** Minimal index descriptor shared by all adapters. */
@@ -60,9 +56,6 @@ function hasIndexes(a: unknown): a is AdapterWithIndexes {
 }
 function hasPrimaryKey(a: unknown): a is AdapterWithPrimaryKey {
   return typeof (a as AdapterWithPrimaryKey).primaryKey === "function";
-}
-function hasForeignKeys(a: unknown): a is AdapterWithForeignKeys {
-  return typeof (a as AdapterWithForeignKeys).foreignKeys === "function";
 }
 
 // Memoize `SchemaStatements` per-adapter so the fallback path doesn't
@@ -139,24 +132,4 @@ export async function introspectPrimaryKey(
   // Fallback: columns with primaryKey=true in declaration order.
   const cols = await introspectColumns(adapter, table);
   return cols.filter((c) => c.primaryKey).map((c) => c.name);
-}
-
-/**
- * Return foreign-key definitions for `table`. Uses `adapter.foreignKeys()`
- * when implemented (SQLite / PostgreSQL / MySQL2 all do), else falls back
- * to `SchemaStatements.foreignKeys()` — which itself degrades to an empty
- * array when the adapter can't surface constraint metadata. No portable
- * fallback parses `information_schema` / `PRAGMA foreign_key_list(...)`,
- * so `[]` is the honest answer for unsupported adapters.
- *
- * Note: `ForeignKeyDefinition.column` and `.primaryKey` are comma-separated
- * strings for composite foreign keys (e.g. "a_id,b_id"), not arrays.
- * Callers that care about composite FKs should check `.includes(",")`.
- */
-export async function introspectForeignKeys(
-  adapter: DatabaseAdapter,
-  table: string,
-): Promise<ForeignKeyDefinition[]> {
-  if (hasForeignKeys(adapter)) return adapter.foreignKeys(table);
-  return schemaStatementsFor(adapter).foreignKeys(table);
 }


### PR DESCRIPTION
Converges the two "unsupported adapter" bodies in abstract `SchemaStatements`.

- `foreignKeys` now raises `NotImplementedError("foreign_keys is not implemented")` (`schema_statements.rb:1103`) instead of returning `[]`, carrying the `@nie disposition=TODO` marker. `checkConstraints` already raised a bare `NotImplementedError`.
- The `[]` existed solely for `introspectForeignKeys` in `schema-introspection.ts` (trails-only infra, no Rails counterpart). It has **no production caller** — the schema dumper, model codegen and canonical table rebuild all reach `adapter.foreignKeys()` directly, and every real adapter (SQLite, PostgreSQL, MySQL) overrides it. So the helper, its `hasForeignKeys` guard and its `index.ts` export are deleted rather than taught to handle the raise.
- The `introspectForeignKeys` describe in `schema-introspection.trails.test.ts` goes with it; a regression pair in `schema-statements-privates.test.ts` pins both raises.

Closes-story: converge-schema-statements-not-implemented-bodies
