### PR TITLE
refactor(activerecord): delete AbstractAdapter#schemaStatements accessor

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -136,7 +136,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       for (const type of ["SPATIAL", "FULLTEXT", "UNIQUE"]) {
         const sqls = await captureSql(
           () =>
-            adapter.schemaStatements().createTable("people", { id: false }, (t) => {
+            adapter.createTable("people", { id: false }, (t) => {
               t.index(["last_name"], { type });
             }),
           { stub: adapter },
@@ -150,7 +150,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
       const sqls = await captureSql(
         () =>
-          adapter.schemaStatements().createTable("people", { id: false }, (t) => {
+          adapter.createTable("people", { id: false }, (t) => {
             t.index(["last_name"], { length: { last_name: 10 }, using: "btree" });
           }),
         { stub: adapter },
@@ -163,7 +163,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       for (const type of ["SPATIAL", "FULLTEXT", "UNIQUE"]) {
         const sqls = await captureSql(
           () =>
-            adapter.schemaStatements().changeTable("people", { bulk: true }, (t) => {
+            adapter.changeTable("people", { bulk: true }, (t) => {
               return t.index("last_name", { type });
             }),
           { stub: adapter },
@@ -175,7 +175,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
       const sqls = await captureSql(
         () =>
-          adapter.schemaStatements().changeTable("people", { bulk: true }, (t) => {
+          adapter.changeTable("people", { bulk: true }, (t) => {
             return t.index("last_name", { length: 10, using: "btree", algorithm: "copy" });
           }),
         { stub: adapter },
@@ -225,16 +225,15 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("add column", async () => {
-      const sqls = await captureSql(
-        () => adapter.schemaStatements().addColumn("people", "last_name", "string"),
-        { stub: adapter },
-      );
+      const sqls = await captureSql(() => adapter.addColumn("people", "last_name", "string"), {
+        stub: adapter,
+      });
       expect(sqls[0]).toBe("ALTER TABLE `people` ADD `last_name` varchar(255)");
     });
 
     it("add column with limit", async () => {
       const sqls = await captureSql(
-        () => adapter.schemaStatements().addColumn("people", "key", "string", { limit: 32 }),
+        () => adapter.addColumn("people", "key", "string", { limit: 32 }),
         { stub: adapter },
       );
       expect(sqls[0]).toBe("ALTER TABLE `people` ADD `key` varchar(32)");
@@ -253,7 +252,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("add timestamps", async () => {
-      const ss = adapter.schemaStatements();
+      const ss = adapter;
       try {
         await ss.createTable("delete_me", { force: true });
         await ss.addTimestamps("delete_me", { null: true });
@@ -264,7 +263,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
     it("remove timestamps", async () => {
-      const ss = adapter.schemaStatements();
+      const ss = adapter;
       try {
         await ss.createTable("delete_me", { force: true }, (t) => {
           return t.timestamps({ null: true });
@@ -283,15 +282,13 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const sqls = await captureSql(
         () =>
           // eslint-disable-next-line blazetrails/require-table-teardown -- stub mode intercepts execute, so `temp` is never created (no teardown needed); mirrors Rails ActiveSchemaTest
-          adapter
-            .schemaStatements()
-            .createTable(
-              "temp",
-              { temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query" },
-              (t) => {
-                t.index(["zip"]);
-              },
-            ),
+          adapter.createTable(
+            "temp",
+            { temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query" },
+            (t) => {
+              t.index(["zip"]);
+            },
+          ),
         { stub: adapter },
       );
       expect(sqls[0]).toMatch(

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -1059,7 +1059,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     itIfSupports("native_partitioning", "list partition options is dumped", async () => {
       const options = "PARTITION BY LIST (kind)";
-      await adapter.schemaStatements().createTable("trains", { id: false, options }, (t) => {
+      await adapter.createTable("trains", { id: false, options }, (t) => {
         t.string("name");
         t.string("kind");
       });
@@ -1070,7 +1070,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     itIfSupports("native_partitioning", "range partition options is dumped", async () => {
       const options = "PARTITION BY RANGE (created_at)";
-      await adapter.schemaStatements().createTable("trains", { id: false, options }, (t) => {
+      await adapter.createTable("trains", { id: false, options }, (t) => {
         t.string("name");
         t.datetime("created_at", { null: false });
       });
@@ -1080,33 +1080,33 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("inherited table options is dumped", async () => {
-      await adapter.schemaStatements().createTable("transportation_modes", (t) => {
+      await adapter.createTable("transportation_modes", (t) => {
         t.string("name");
         t.string("kind");
       });
       const options = "INHERITS (transportation_modes)";
-      await adapter.schemaStatements().createTable("trains", { options });
+      await adapter.createTable("trains", { options });
       const lines: string[] = [];
       await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
       expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
 
     it("multiple inherited table options is dumped", async () => {
-      await adapter.schemaStatements().createTable("vehicles", (t) => {
+      await adapter.createTable("vehicles", (t) => {
         t.string("name");
       });
-      await adapter.schemaStatements().createTable("transportation_modes", (t) => {
+      await adapter.createTable("transportation_modes", (t) => {
         t.string("kind");
       });
       const options = "INHERITS (transportation_modes, vehicles)";
-      await adapter.schemaStatements().createTable("trains", { options });
+      await adapter.createTable("trains", { options });
       const lines: string[] = [];
       await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
       expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
 
     it("no partition options are dumped", async () => {
-      await adapter.schemaStatements().createTable("trains", (t) => {
+      await adapter.createTable("trains", (t) => {
         t.string("name");
       });
       const lines: string[] = [];
@@ -1128,7 +1128,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(lines.join("\n")).toContain(`comment: "a test table"`);
       await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
 
-      const ss = adapter.schemaStatements();
+      const ss = adapter;
       await ss.createTable("commented_table", { comment: "a test table" }, (t) => {
         t.string("name");
       });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -422,6 +422,26 @@ export interface AbstractAdapter {
     fnOrOptions?: ((t: Table) => void | Promise<void>) | { bulk?: boolean },
     fn?: (t: Table) => void | Promise<void>,
   ): Promise<void>;
+  /** @internal */
+  renameTableIndexes(
+    tableName: string,
+    newName: string,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+  /** @internal */
+  renameColumnIndexes(tableName: string, columnName: string, newColumnName: string): Promise<void>;
+  /** @internal */
+  stripTableNamePrefixAndSuffix(tableName: string): string;
+  /** @internal */
+  validateIndexLengthBang(tableName: string, newName: string, internal?: boolean): void;
+  /** @internal */
+  validateTableLengthBang(tableName: string): void;
+  /** @internal */
+  validateChangeColumnNullArgumentBang(value: unknown): void;
+  /** @internal */
+  extractNewDefaultValue(defaultOrChanges: unknown): unknown;
+  /** @internal */
+  extractNewCommentValue(commentOrChanges: unknown): unknown;
   tableAliasFor(tableName: string): string;
   // Provided by the DatabaseLimits mixin (included below); tableAliasFor
   // resolves it through here rather than a duplicate on SchemaStatements.
@@ -1471,18 +1491,6 @@ export class AbstractAdapter implements Quoting {
       if (includesBase || nameMatches) return entry.preventWrites;
     }
     return false;
-  }
-
-  /**
-   * @noRailsEquivalent CONVERGEABLE. Rails gains these bodies with `include SchemaStatements` on
-   *   the adapter, so there is no accessor to mirror; `include(AbstractAdapter, SchemaStatements)`
-   *   below is trails' equivalent and dispatch is plain prototype lookup + `super`, exactly as in
-   *   Ruby. That leaves this an identity function whose remaining job is typing the mixed-in
-   *   bodies at the call site. Story `delete-the-schema-statements-accessor` retires it and points
-   *   every caller at the adapter member directly.
-   */
-  schemaStatements(): SchemaStatements {
-    return this as unknown as SchemaStatements;
   }
 
   get schemaCache(): SchemaCache {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -302,11 +302,13 @@ describe("AbstractMysqlAdapter#renameColumn wiring", () => {
     adapter._execMutation = async (sql: string) => {
       events.push(`exec:${sql}`);
     };
-    adapter.schemaStatements = () => ({
-      renameColumnIndexes: async (tableName: string, columnName: string, newColumnName: string) => {
-        events.push(`indexes:${tableName}:${columnName}:${newColumnName}`);
-      },
-    });
+    adapter.renameColumnIndexes = async (
+      tableName: string,
+      columnName: string,
+      newColumnName: string,
+    ) => {
+      events.push(`indexes:${tableName}:${columnName}:${newColumnName}`);
+    };
     return { adapter, events };
   }
 
@@ -682,7 +684,7 @@ describe("AbstractMysqlAdapter#changeColumnNull (#1568)", () => {
   async function makeSequencingAdapter() {
     const events: Array<["exec", string] | ["changeColumn", unknown[]]> = [];
     const adapter = await makeMinimalMysqlAdapter({
-      schemaStatements: () => ({ validateChangeColumnNullArgumentBang: (_: boolean) => {} }),
+      validateChangeColumnNullArgumentBang: (_: boolean) => {},
       _execMutation: async (sql: string) => {
         events.push(["exec", sql]);
       },
@@ -718,11 +720,9 @@ describe("AbstractMysqlAdapter#changeColumnNull (#1568)", () => {
     const executed: string[] = [];
     const changeColumnCalls: unknown[] = [];
     const adapter = await makeMinimalMysqlAdapter({
-      schemaStatements: () => ({
-        validateChangeColumnNullArgumentBang: () => {
-          throw new Error("bad null arg");
-        },
-      }),
+      validateChangeColumnNullArgumentBang: () => {
+        throw new Error("bad null arg");
+      },
       _execMutation: async (sql: string) => {
         executed.push(sql);
       },
@@ -740,8 +740,8 @@ describe("AbstractMysqlAdapter#changeColumnNull (#1568)", () => {
 
 describe("AbstractMysqlAdapter#changeColumnComment (#1568)", () => {
   async function makeAdapterCapturingChangeColumn() {
-    // Use the real, inherited schemaStatements() so these tests exercise the
-    // production extractNewCommentValue path and catch regressions in it.
+    // Use the real, inherited extractNewCommentValue so these tests exercise
+    // the production path and catch regressions in it.
     const calls: Array<[string, string, string, Record<string, unknown>]> = [];
     const adapter = await makeMinimalMysqlAdapter({
       changeColumn: async (t: string, c: string, type: string, opts: Record<string, unknown>) => {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -730,7 +730,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     tableName: string,
     commentOrChanges: string | Record<string, string | null>,
   ): Promise<void> {
-    const raw = this.schemaStatements().extractNewCommentValue(commentOrChanges);
+    const raw = this.extractNewCommentValue(commentOrChanges);
     // Mirrors Rails: `comment = "" if comment.nil?` then `COMMENT #{quote(comment)}`.
     const c = raw == null ? "" : String(raw);
     await this._execMutation(
@@ -739,19 +739,19 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async renameTable(tableName: string, newName: string): Promise<void> {
-    this.schemaStatements().validateTableLengthBang(newName);
+    this.validateTableLengthBang(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, tableName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, newName);
     await this._execMutation(
       `RENAME TABLE ${this.quoteTableName(tableName)} TO ${this.quoteTableName(newName)}`,
     );
-    await this.schemaStatements().renameTableIndexes(tableName, newName);
+    await this.renameTableIndexes(tableName, newName);
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     await this.getDatabaseVersion();
-    this.schemaStatements().validateIndexLengthBang(tableName, newName);
+    this.validateIndexLengthBang(tableName, newName);
     if (!this.supportsRenameIndex()) {
       // Mirrors Rails AbstractAdapter#rename_index super path: drop the
       // existing index and recreate under the new name.
@@ -857,7 +857,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     defaultOrChanges: unknown,
   ): Promise<ChangeColumnDefaultDefinition> {
     const column = await this.columnFor(tableName, columnName);
-    const extracted = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
+    const extracted = this.extractNewDefaultValue(defaultOrChanges);
     // Normalize JS-only `undefined` → `null` so the schema-creation
     // visitor's SET branch produces `SET DEFAULT NULL` rather than the
     // bare `SET` that quoteDefaultExpression(undefined) → "" would emit.
@@ -877,7 +877,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     null_: boolean,
     default_?: unknown,
   ): Promise<void> {
-    this.schemaStatements().validateChangeColumnNullArgumentBang(null_);
+    this.validateChangeColumnNullArgumentBang(null_);
     if (!null_ && default_ != null) {
       const colId = this.quoteIdentifier(columnName);
       await this._execMutation(
@@ -901,7 +901,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // Rails too, so the type explicitly requires both.
     commentOrChanges: string | null | { from: unknown; to: string | null },
   ): Promise<void> {
-    const extracted = this.schemaStatements().extractNewCommentValue(commentOrChanges);
+    const extracted = this.extractNewCommentValue(commentOrChanges);
     // Normalize JS-only `undefined` → `null` so changeColumn doesn't
     // misinterpret an explicit clear (`{from, to: undefined}` shape) as
     // "no comment key present" and silently keep the existing comment.
@@ -966,7 +966,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // columnsHash() read re-reflects the renamed column rather than a stale entry.
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     await this._execMutation(`ALTER TABLE ${this.quoteTableName(tableName)} ${fragment}`);
-    await this.schemaStatements().renameColumnIndexes(tableName, columnName, newColumnName);
+    await this.renameColumnIndexes(tableName, columnName, newColumnName);
   }
 
   async addIndex(
@@ -976,7 +976,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   ): Promise<void> {
     const createIndex = await this.buildCreateIndexDefinition(tableName, columnName, options);
     if (!createIndex) return;
-    await this._execMutation(await this.schemaStatements().schemaCreation.accept(createIndex));
+    await this._execMutation(await this.schemaCreation.accept(createIndex));
   }
 
   /**
@@ -995,13 +995,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<CreateIndexDefinition | undefined> {
-    const ss = this.schemaStatements();
-    const [idx, algorithmClause, ifNotExists] = await ss.addIndexOptions(
+    const [idx, algorithmClause, ifNotExists] = await this.addIndexOptions(
       tableName,
       columnName,
       options,
     );
-    if (ifNotExists && (await ss.indexExists(tableName, idx.columns, { name: idx.name }))) {
+    if (ifNotExists && (await this.indexExists(tableName, idx.columns, { name: idx.name }))) {
       return undefined;
     }
     return new CreateIndexDefinition(idx, false, algorithmClause);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -339,7 +339,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(stub.allSql.at(-1)).toMatch(/CHECK \(price > 0\)/);
   });
 
-  it("schemaStatements() is the adapter itself, so Migration#schema reaches adapter overrides", async () => {
+  it("the DDL bodies are the adapter's own, so a subclass override wins", async () => {
     class OverridingAdapter extends SqliteCapturingAdapter {
       renameColumnCalls = 0;
       async renameColumn(tableName: string, oldName: string, newName: string) {
@@ -348,8 +348,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       }
     }
     const stub = new OverridingAdapter();
-    expect(stub.schemaStatements()).toBe(stub);
-    await stub.schemaStatements().renameColumn("widgets", "title", "name");
+    await stub.renameColumn("widgets", "title", "name");
     expect(stub.renameColumnCalls).toBe(1);
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4069,7 +4069,7 @@ export class PostgreSQLAdapter
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
-    this.schemaStatements().validateTableLengthBang(newName);
+    this.validateTableLengthBang(newName);
     const [oldSchema, unqualifiedOld] = this.extractSchemaQualifiedName(oldName);
     const [, unqualifiedNew] = this.extractSchemaQualifiedName(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, oldName);
@@ -4113,7 +4113,7 @@ export class PostgreSQLAdapter
         }
       }
     }
-    await this.schemaStatements().renameTableIndexes(oldName, newName);
+    await this.renameTableIndexes(oldName, newName);
   }
 
   async tables(): Promise<string[]> {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1677,13 +1677,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   async renameTable(tableName: string, newName: string): Promise<void> {
-    this.schemaStatements().validateTableLengthBang(newName);
+    this.validateTableLengthBang(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, tableName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, newName);
     await this.execute(
       `ALTER TABLE ${quoteTableName(tableName)} RENAME TO ${quoteTableName(newName)}`,
     );
-    await this.schemaStatements().renameTableIndexes(tableName, newName);
+    await this.renameTableIndexes(tableName, newName);
   }
 
   async addColumn(
@@ -1747,7 +1747,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // Rails' extract_new_default_value only unwraps a Hash when it carries BOTH
     // :from and :to (schema_statements.rb:1820); a bare structured default like
     // `{}` is the literal default, not a changes hash.
-    const newDefault = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
+    const newDefault = this.extractNewDefaultValue(defaultOrChanges);
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     await this.alterTable(tableName, undefined, undefined, undefined, (definition) => {
       // The raw value, not a literal: schemaCreation re-emits it through
@@ -1764,7 +1764,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     allowNull: boolean,
     defaultValue?: unknown,
   ): Promise<void> {
-    this.schemaStatements().validateChangeColumnNullArgumentBang(allowNull);
+    this.validateChangeColumnNullArgumentBang(allowNull);
     if (!allowNull && defaultValue !== undefined) {
       // Rails backfills NULLs via quote_default_expression, which serializes the
       // value through the column's cast type (abstract/schema_statements.rb).
@@ -1797,7 +1797,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     await this.alterTable(tableName, undefined, undefined, {
       rename: { [column.name]: newColumnName },
     });
-    await this.schemaStatements().renameColumnIndexes(tableName, column.name, newColumnName);
+    await this.renameColumnIndexes(tableName, column.name, newColumnName);
   }
 
   async addTimestamps(tableName: string, options?: Record<string, unknown>): Promise<void> {
@@ -2183,10 +2183,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     assertValidDeferrable(options.deferrable);
 
     await this.alterTable(fromTable, undefined, undefined, undefined, (definition) => {
-      definition.foreignKey(
-        this.schemaStatements().stripTableNamePrefixAndSuffix(toTable),
-        options,
-      );
+      definition.foreignKey(this.stripTableNamePrefixAndSuffix(toTable), options);
     });
   }
 
@@ -2215,7 +2212,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     delete matchOptions.validate;
 
     const inferred = String(matchOptions.column ?? "").replace(/_id$/, "");
-    const table = this.schemaStatements().stripTableNamePrefixAndSuffix(
+    const table = this.stripTableNamePrefixAndSuffix(
       toTable ?? (Base.pluralizeTableNames ? pluralize(inferred) : inferred),
     );
 
@@ -2229,8 +2226,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // single-column.
     const fkToRemove = existingFks.find(
       (fk) =>
-        this.schemaStatements().stripTableNamePrefixAndSuffix(fk.toTable) === table &&
-        fk.isDefinedFor(matchOptions),
+        this.stripTableNamePrefixAndSuffix(fk.toTable) === table && fk.isDefinedFor(matchOptions),
     );
 
     if (!fkToRemove) {
@@ -2328,7 +2324,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const caller = (definition: SQLite3TableDefinition): void => {
       for (const fk of fks) {
         const column = typeof fk.column === "string" ? (rename[fk.column] ?? fk.column) : fk.column;
-        const toTable = this.schemaStatements().stripTableNamePrefixAndSuffix(fk.toTable);
+        const toTable = this.stripTableNamePrefixAndSuffix(fk.toTable);
         definition.foreignKey(toTable, {
           column,
           primaryKey: fk.primaryKey,

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2367,7 +2367,7 @@ describeIfMysqlAdapter("BulkAlterTableMigrationsTest", () => {
       return (id as { autoIncrement?: boolean })?.autoIncrement === true;
     };
 
-    const ss = adapter.schemaStatements();
+    const ss = adapter;
     await ss.changeTable("delete_me", { bulk: true }, (t: any) => {
       t.change("id", "bigint", { autoIncrement: true });
     });

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -152,17 +152,14 @@ describe("MigrationTest", () => {
     const seen: unknown[] = [];
     class M extends Migration {}
     const m = new M();
-    const companion = {
-      updateTableDefinition(tableName: string, base: unknown) {
-        seen.push([tableName, base]);
-        return new AdapterTable(tableName, base as never);
-      },
-    };
     (m as unknown as { _connectionOverride: unknown })._connectionOverride = {
       quoteIdentifier: (n: string) => n,
       quoteTableName: (n: string) => n,
       quoteDefaultExpression: (v: unknown) => String(v),
-      schemaStatements: () => companion,
+      updateTableDefinition(tableName: string, base: unknown) {
+        seen.push([tableName, base]);
+        return new AdapterTable(tableName, base as never);
+      },
     };
 
     let yielded: unknown;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -327,7 +327,9 @@ export abstract class Migration {
     const conn = this.connection;
     if (!this._schema || this._schemaConn !== conn) {
       assertSchemaAdapter(conn);
-      this._schema = conn.schemaStatements ? conn.schemaStatements() : new SchemaStatements(conn);
+      // Rails has no separate schema object: `include SchemaStatements` puts the
+      // bodies on the adapter, so `schema` is the connection itself.
+      this._schema = conn as unknown as SchemaStatements;
       this._schemaConn = conn;
     }
     return this._schema;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -327,8 +327,6 @@ export abstract class Migration {
     const conn = this.connection;
     if (!this._schema || this._schemaConn !== conn) {
       assertSchemaAdapter(conn);
-      // Rails has no separate schema object: `include SchemaStatements` puts the
-      // bodies on the adapter, so `schema` is the connection itself.
       this._schema = conn as unknown as SchemaStatements;
       this._schemaConn = conn;
     }

--- a/packages/activerecord/src/reserved-word.test.ts
+++ b/packages/activerecord/src/reserved-word.test.ts
@@ -57,10 +57,9 @@ Associations.hasMany.call(Distinct, "values", { through: "groups" });
 
 fixtures({}, { useTransactionalTests: false });
 
-// `adapter.schemaStatements()` is optional on the adapter interface; fall back
-// to constructing one directly, mirroring schema-types.ts.
+// Rails' `include SchemaStatements` puts these bodies on the adapter itself.
 function schema(): SchemaStatements {
-  return Base.connection.schemaStatements?.() ?? new SchemaStatements(Base.connection);
+  return Base.connection as unknown as SchemaStatements;
 }
 
 const RESERVED_TABLES = ["values", "group", "distinct_select", "distinct", "select", "order"];

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -249,12 +249,7 @@ let _registry: CanonicalTableDef[] | null = null;
 export async function prepareSchema(
   adapter: DatabaseAdapter,
 ): Promise<{ ss: SchemaStatements; typeMap: Record<string, string | undefined> }> {
-  const { SchemaStatements: SchemaStatementsCtor } =
-    await import("../connection-adapters/abstract/schema-statements.js");
-  const withSs = adapter as unknown as { schemaStatements?: () => SchemaStatements };
-  const ss = withSs.schemaStatements
-    ? withSs.schemaStatements()
-    : new SchemaStatementsCtor(adapter);
+  const ss = adapter as unknown as SchemaStatements;
   const typeMap =
     adapter.adapterName === "postgres"
       ? COLUMN_TYPE_MAP_PG

--- a/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
@@ -55,10 +55,10 @@ describe("load_schema arm-probe guard", () => {
   });
 
   // `createTable` is not the only interception that lays nothing: `runTable`
-  // reaches the database through the SchemaStatements companion, so a cover
-  // that stubs the members *it* goes through is just as unsafe, and just as
-  // invisible outside the PG lane.
-  for (const method of ["dropTable", "addIndex", "execute", "schemaStatements"]) {
+  // reaches the database through the adapter's mixed-in SchemaStatements
+  // bodies, so a cover that stubs the members *they* go through is just as
+  // unsafe, and just as invisible outside the PG lane.
+  for (const method of ["dropTable", "addIndex", "execute", "schemaCreation"]) {
     it(`rejects an adapter whose ${method} a proxy intercepts`, async () => {
       await withAdapter(async (adapter) => {
         const probe = new Proxy(adapter, {

--- a/packages/activerecord/src/support/setup-second-pool.ts
+++ b/packages/activerecord/src/support/setup-second-pool.ts
@@ -28,7 +28,7 @@ export const ARUNIT2_TABLES = ["colleges", "courses", "professors", "courses_pro
  * the canonical shape from an earlier run.
  */
 async function createOtherDogsTable(adapter: DatabaseAdapter): Promise<void> {
-  await adapter.schemaStatements().createTable("dogs", { force: true }, () => {});
+  await adapter.createTable("dogs", { force: true }, () => {});
 }
 
 /**

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -56,7 +56,8 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
  * a member reached off the proxy is recorded and bound to a second recording
  * view, so the `this.<member>` calls the mixed-in body makes are recorded one
  * hop deep, while the calls that view then makes to the real adapter stay
- * unrecorded. That boundary — the one a cover can intercept — is the whole
+ * unrecorded. `this.adapter` — how a mixed-in body names the adapter, which is
+ * itself — is answered with the same view so that hop stays recorded. That boundary — the one a cover can intercept — is the whole
  * scope of this guard.
  *
  * `schemaCreation` is the one member the device cannot see through: the renderer
@@ -72,9 +73,6 @@ async function recordLayPath(): Promise<Set<string>> {
       get(target, prop, receiver) {
         if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
         touched.add(prop);
-        // `SchemaStatements` bodies reach the adapter as `this.adapter`, which on
-        // a mixed-in body is the adapter itself. Answer it with this same view so
-        // the hop through it stays recorded.
         if (prop === "adapter") return self;
         const value = Reflect.get(target, prop, target) as unknown;
         return typeof value === "function"

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -3,7 +3,6 @@ import "../sqlite/better-sqlite3.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
-import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
 import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
 
 /**
@@ -33,58 +32,59 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
     "capability read — skips expression indexes on adapters that lack them",
   ],
   ["supportsIndexesInCreate", "capability read — decides whether indexes ride inside CREATE TABLE"],
-  ["indexNameLength", "limit read used to validate/truncate an index name"],
+  ["adapter", "self-reference — the mixed-in SchemaStatements bodies reach the adapter through it"],
   [
-    "createTableDefinition",
+    "buildCreateTableDefinition",
     "definition factory — a stub returns no TableDefinition and dies at once, so it cannot silently lay nothing",
   ],
-  ["_config", "config read behind supportsForeignKeys/foreign_keys, not a DDL emitter"],
-  ["supportsForeignKeys", "capability read — decides whether an FK clause rides inline"],
-  ["nativeDatabaseTypes", "renderer input — the type map typeToSql resolves a column type against"],
-  ["quoteIdentifier", "renderer input — quotes a column name into the DDL string"],
-  ["quoteTableName", "renderer input — quotes a table name into the DDL string"],
-  ["quoteDefaultExpression", "renderer input — quotes a column default into the DDL string"],
-  ["quotedColumnsForIndex", "renderer input — builds the column list of a CREATE INDEX"],
+  [
+    "buildCreateIndexDefinition",
+    "definition factory — a stub returns no CreateIndexDefinition and dies at once",
+  ],
+  ["databaseVersion", "version read behind the index sort-order predicates"],
+  ["_databaseVersion", "memoized backing slot of the databaseVersion read"],
+  ["_statementPool", "prepared-statement slot clearCacheBang resets, not a DDL emitter"],
 ]);
 
 /**
  * Lay the canonical schema through a proxy that records every adapter member
  * the loader reaches for.
  *
- * `schemaStatements()` is answered with a `SchemaStatements` bound to the proxy.
- * That is instrumentation, not the production shape — in production the accessor
- * returns the adapter itself and the module bodies are the adapter's own. Binding
- * a module view to the proxy is what pins the *adapter* boundary specifically:
- * every `this.adapter.<member>` a module body makes is recorded one hop deep,
- * while the calls the real adapter then makes to itself stay unrecorded. That
- * boundary — the one a cover can intercept — is the whole scope of this guard.
+ * The mixed-in `SchemaStatements` bodies are the adapter's own methods, so a
+ * proxy that bound them to the real adapter would see only the loader's first
+ * call and nothing those bodies do. The recorder is therefore two levels deep:
+ * a member reached off the proxy is recorded and bound to a second recording
+ * view, so the `this.<member>` calls the mixed-in body makes are recorded one
+ * hop deep, while the calls that view then makes to the real adapter stay
+ * unrecorded. That boundary — the one a cover can intercept — is the whole
+ * scope of this guard.
  *
- * `schemaCreation` is the one member the device cannot see: a module view builds
- * its own SchemaCreation (Rails' `SchemaCreation.new(self)`), where in production
- * the adapter's own getter is what the mixed-in bodies hit. It stays in the
- * guarded set for that reason. The renderer's own quoting/type reads
- * (`quoteIdentifier`, `quoteDefaultExpression`, `nativeDatabaseTypes`, …) do come
- * back through the proxy and are exempted below as renderer inputs.
+ * `schemaCreation` is the one member the device cannot see through: the renderer
+ * it returns is built off the real adapter, so its own quoting/type reads
+ * (`quoteIdentifier`, `quoteDefaultExpression`, `nativeDatabaseTypes`, …) never
+ * come back through the proxy. It stays in the guarded set for that reason.
  */
 async function recordLayPath(): Promise<Set<string>> {
   const real = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
   const touched = new Set<string>();
-  const proxy: AbstractAdapter = new Proxy(real, {
-    get(target, prop, receiver) {
-      if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
-      touched.add(prop);
-      if (prop === "schemaStatements") {
-        return () =>
-          new SchemaStatements(
-            proxy as unknown as ConstructorParameters<typeof SchemaStatements>[0],
-          );
-      }
-      const value = Reflect.get(target, prop, target) as unknown;
-      return typeof value === "function"
-        ? (value as (...a: unknown[]) => unknown).bind(target)
-        : value;
-    },
-  });
+  const recorder = (inner: AbstractAdapter): AbstractAdapter => {
+    const self: AbstractAdapter = new Proxy(real, {
+      get(target, prop, receiver) {
+        if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
+        touched.add(prop);
+        // `SchemaStatements` bodies reach the adapter as `this.adapter`, which on
+        // a mixed-in body is the adapter itself. Answer it with this same view so
+        // the hop through it stays recorded.
+        if (prop === "adapter") return self;
+        const value = Reflect.get(target, prop, target) as unknown;
+        return typeof value === "function"
+          ? (value as (...a: unknown[]) => unknown).bind(inner)
+          : value;
+      },
+    });
+    return self;
+  };
+  const proxy: AbstractAdapter = recorder(recorder(real));
 
   try {
     await loadCanonicalSchema(proxy);
@@ -118,8 +118,8 @@ describe("STUBBED_DDL_METHODS", () => {
     // Floor: a proxy that recorded almost nothing would pass the subset check
     // vacuously.
     expect(touched.has("execute")).toBe(true);
-    expect(touched.has("schemaStatements")).toBe(true);
-    expect(touched.has("createTableDefinition")).toBe(true);
+    expect(touched.has("createTable")).toBe(true);
+    expect(touched.has("addIndex")).toBe(true);
 
     const unaccounted = [...touched]
       .filter((name) => !STUBBED_DDL_METHODS.includes(name) && !NON_EMITTING.has(name))

--- a/packages/activerecord/src/support/stubbed-ddl-methods.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.ts
@@ -2,9 +2,8 @@
  * The adapter members an arm-content cover can intercept to stop
  * `loadCanonicalSchema` from really laying its tables.
  *
- * `runTable` (canonical-schema.ts) does not call `adapter.createTable` — it
- * resolves a `SchemaStatements` companion through `adapter.schemaStatements()`
- * and lays every table through it, and that companion reaches the database via
+ * `runTable` (canonical-schema.ts) lays every table through the adapter's own
+ * mixed-in `SchemaStatements` bodies, which reach the database via
  * `adapter.execute` after rendering DDL through `adapter.schemaCreation`.
  * Indexes go the same way (`emitTableIndexes` → `ss.addIndex` →
  * `adapter.execute`), and a `force:` create drops through `dropTable` first.
@@ -36,5 +35,4 @@ export const STUBBED_DDL_METHODS: readonly string[] = [
   "addIndex",
   "execute",
   "schemaCreation",
-  "schemaStatements",
 ];


### PR DESCRIPTION
Deletes `AbstractAdapter#schemaStatements()`, which had become an identity
function (`return this as unknown as SchemaStatements`) once the dispatch
shim / companion-mixin duality was removed. Rails has no such accessor:
`include SchemaStatements` (`abstract_adapter.rb`) puts the bodies on the
adapter and callers just say `connection.create_table(...)`. The accessor's
`@noRailsEquivalent` justification no longer held, and the extra hop hid
which object was really being called.

- accessor and its `@noRailsEquivalent` entry deleted
- every call site (`sqlite3-adapter`, `abstract-mysql-adapter`,
  `postgresql-adapter`, `support/canonical-schema`, `support/setup-second-pool`,
  `migration.ts`, tests) now calls the adapter member directly
- the mixin members those call sites use (`validateTableLengthBang`,
  `renameTableIndexes`, `renameColumnIndexes`, `stripTableNamePrefixAndSuffix`,
  `validateIndexLengthBang`, `validateChangeColumnNullArgumentBang`,
  `extractNewDefaultValue`, `extractNewCommentValue`) are declared on
  AbstractAdapter's declaration-merged interface instead of cast at the call site
- `Migration#schema` resolves to the connection itself
- `support/stubbed-ddl-methods.test.ts` recorded its lay path through a
  `SchemaStatements` module view bound to the proxy. With the bodies now on the
  adapter, the recorder is a two-level proxy (calls a mixed-in body makes on
  `this` / `this.adapter` are recorded one hop deep, deeper self-calls are not),
  which keeps the same boundary. `NON_EMITTING` was re-derived against what the
  new boundary actually sees; `schemaStatements` is off `STUBBED_DDL_METHODS`.

Closes-story: delete-the-schema-statements-accessor
