### PR TITLE
fix(activerecord): port migrated? guards into executeMigrationInTransaction

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2254,11 +2254,6 @@ export class Migrator {
    *
    * Reads the direction and target version this Migrator was constructed with,
    * as Rails does with `@direction` / `@target_version`.
-   *
-   * The already-applied guards replicate the skip logic in Rails'
-   * `execute_migration_in_transaction` (migration.rb:1528-1530), which checks
-   * `migrated.include?(migration.version)` before running. Our `_runMigration`
-   * doesn't carry that check, so the guard lives here instead.
    */
   async runWithoutLock(): Promise<string | undefined> {
     // Rails' `Migrator#run` is only ever built with a target version; a nil one
@@ -2275,11 +2270,7 @@ export class Migrator {
     const proxy = this._migrations.find((m) => m.version === key);
     if (!proxy) throw new UnknownMigrationVersionError(targetVersion);
     await this.recordEnvironment();
-    const applied = await this.migrated();
-    if (this.isUp() && applied.has(key)) return undefined;
-    if (this.isDown() && !applied.has(key)) return undefined;
-    await this._runMigration(proxy, this._direction);
-    return proxy.version;
+    return this.executeMigrationInTransaction(proxy);
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#migrate_without_lock */
@@ -2348,9 +2339,20 @@ export class Migrator {
     return this._invalidTarget(this._targetVersion);
   }
 
-  /** @internal Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction */
-  async executeMigrationInTransaction(proxy: MigrationProxy): Promise<void> {
+  /**
+   * @internal Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction
+   *
+   * Rails' early returns yield nil; the version is returned only when the
+   * migration actually ran, which is what `run_without_lock` hands back to
+   * `MigrationContext#run`.
+   */
+  async executeMigrationInTransaction(proxy: MigrationProxy): Promise<string | undefined> {
+    const applied = await this.migrated();
+    if (this.isDown() && !applied.has(proxy.version)) return undefined;
+    if (this.isUp() && applied.has(proxy.version)) return undefined;
+
     await this._runMigration(proxy, this._direction);
+    return proxy.version;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#target */

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -77,6 +77,43 @@ describe("Migrator trails extensions", () => {
     expect(env).toBe(envName(adapter));
   });
 
+  it("executeMigrationInTransaction skips migrations already in migrated", async () => {
+    const calls: Array<[string, number]> = [];
+    const proxy = makeMigration(
+      "1",
+      "M1",
+      async () => void calls.push(["up", 1]),
+      async () => void calls.push(["down", 1]),
+    );
+
+    // Called directly, so nothing has run `runnable()` / `_ensureSchemaTable()`
+    // for us — the guards read `migrated`, which needs the table present.
+    await new SchemaMigration(adapter).createTable();
+    await new InternalMetadata(adapter).createTable();
+
+    const up = new Migrator(adapter, [proxy]);
+    expect(await up.executeMigrationInTransaction(proxy)).toBe("1");
+    expect(calls).toEqual([["up", 1]]);
+
+    // A second Migrator sees version 1 as applied, so the up guard skips it and
+    // the down guard lets the revert through — without pre-filtering by
+    // runnable().
+    const again = new Migrator(adapter, [proxy]);
+    expect(await again.executeMigrationInTransaction(proxy)).toBeUndefined();
+    expect(calls).toEqual([["up", 1]]);
+
+    const down = new Migrator(adapter, [proxy], { direction: "down" });
+    expect(await down.executeMigrationInTransaction(proxy)).toBe("1");
+    expect(calls).toEqual([
+      ["up", 1],
+      ["down", 1],
+    ]);
+
+    const downAgain = new Migrator(adapter, [proxy], { direction: "down" });
+    expect(await downAgain.executeMigrationInTransaction(proxy)).toBeUndefined();
+    expect(calls).toHaveLength(2);
+  });
+
   it("up and down raise UnknownMigrationVersionError for an unknown target", async () => {
     // Rails routes both through a per-run Migrator whose migrate_without_lock
     // starts with `raise UnknownMigrationVersionError if invalid_target?`

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -95,9 +95,6 @@ describe("Migrator trails extensions", () => {
     expect(await up.executeMigrationInTransaction(proxy)).toBe("1");
     expect(calls).toEqual([["up", 1]]);
 
-    // A second Migrator sees version 1 as applied, so the up guard skips it and
-    // the down guard lets the revert through — without pre-filtering by
-    // runnable().
     const again = new Migrator(adapter, [proxy]);
     expect(await again.executeMigrationInTransaction(proxy)).toBeUndefined();
     expect(calls).toEqual([["up", 1]]);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -310,13 +310,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "run_without_lock",
-    "call": "execute_migration_in_transaction",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "up_only",
     "call": "execute_block",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Ports Rails' two `execute_migration_in_transaction` early-return guards (`vendor/rails/activerecord/lib/active_record/migration.rb:1528-1530`) into trails' `executeMigrationInTransaction`, which had neither.

`runWithoutLock` carried equivalent inline guards instead; it now delegates to `executeMigrationInTransaction` exactly as Rails' `run_without_lock` does (migration.rb:1499), so the logic lives in one place — Rails' place.

`executeMigrationInTransaction` returns the version when it ran and `undefined` when a guard skipped it, mirroring Rails' nil-on-early-return; that is what `MigrationContext#run` hands back, so `run()`'s existing return contract is unchanged.

No behaviour change for `migrateWithoutLock`: `runnable()` already pre-filters to exactly the set the guards admit.

Regression test verified to fail with the guards removed.

Closes-story: execute-migration-in-transaction-missing-migrated-guards
