### PR TITLE
refactor(activerecord): mix PostgreSQL::SchemaStatements into PostgreSQLAdapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -374,6 +374,7 @@ export interface AbstractAdapter {
     options?: Omit<ForeignKeyLookupOptions, "toTable">,
   ): Promise<boolean>;
   addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
+  isUseForeignKeys(): boolean;
   removeForeignKey(
     fromTable: string,
     toTableOrOptions?: string | RemoveForeignKeyOptions,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -179,8 +179,6 @@ function toError(value: unknown): Error {
  * shape where driver params and adapter knobs share one hash.
  * Uses a connection pool internally for concurrent access.
  */
-// Merged with the `PostgreSQLAdapter` interface below (the `include
-// PostgreSQL::SchemaStatements` surface).
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class PostgreSQLAdapter
   extends AbstractAdapter
@@ -4692,10 +4690,9 @@ export class PostgreSQLAdapter
   }
 }
 
-// Declaration merge for `include(PostgreSQLAdapter, PostgreSQLSchemaStatements)` at
-// the bottom of this file: `include()` installs the module's methods on the
-// prototype at runtime, but TypeScript can't see them on the class type. Mirrors
-// the way AbstractAdapter declares its `include SchemaStatements` surface.
+// `include()` installs the module's methods on the prototype at runtime, where the
+// class type can't see them, so the `include PostgreSQL::SchemaStatements` surface
+// is declared here — the same shape AbstractAdapter uses for `SchemaStatements`.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface PostgreSQLAdapter {
   /** @internal */
@@ -5208,8 +5205,6 @@ captureUnwrappedExecute(PostgreSQLAdapter);
 dirtiesQueryCache(PostgreSQLAdapter, "execQuery", "execute");
 
 // Rails: `include PostgreSQL::SchemaStatements` (postgresql_adapter.rb:185).
-// Methods defined in the class body above win over the mixin, exactly as Ruby's
-// ancestry places the class above an included module.
 include(PostgreSQLAdapter, PostgreSQLSchemaStatements);
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -6,6 +6,7 @@ import {
   Notifications,
   getErrorReporter,
   runLoadHooks,
+  include,
 } from "@blazetrails/activesupport";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { isRubyTruthy } from "../ruby-truthy.js";
@@ -178,6 +179,9 @@ function toError(value: unknown): Error {
  * shape where driver params and adapter knobs share one hash.
  * Uses a connection pool internally for concurrent access.
  */
+// Merged with the `PostgreSQLAdapter` interface below (the `include
+// PostgreSQL::SchemaStatements` surface).
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class PostgreSQLAdapter
   extends AbstractAdapter
   implements
@@ -2602,10 +2606,6 @@ export class PostgreSQLAdapter
     await this.execute("SET standard_conforming_strings = on");
   }
 
-  async enumTypes(): Promise<[string, string[]][]> {
-    return this.pgSchemaStatements().enumTypes();
-  }
-
   // Mirrors: PostgreSQLAdapter#max_identifier_length (postgresql_adapter.rb:620)
   // Rails memoizes `query_value("SHOW max_identifier_length", "SCHEMA").to_i`
   // and reads it synchronously. trails queries are async, so the query lives in
@@ -3481,33 +3481,6 @@ export class PostgreSQLAdapter
     return true;
   }
 
-  // ---------------------------------------------------------------------------
-  // Schema management
-  // ---------------------------------------------------------------------------
-
-  async schemaNames(): Promise<string[]> {
-    return this.pgSchemaStatements().schemaNames();
-  }
-
-  async createSchema(
-    name: string,
-    options: { force?: boolean; ifNotExists?: boolean } = {},
-  ): Promise<void> {
-    await this.pgSchemaStatements().createSchema(name, options);
-  }
-
-  async dropSchema(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    await this.pgSchemaStatements().dropSchema(name, options);
-  }
-
-  async schemaExists(name: string): Promise<boolean> {
-    return this.pgSchemaStatements().schemaExists(name);
-  }
-
-  async currentSchema(): Promise<string> {
-    return this.pgSchemaStatements().currentSchema();
-  }
-
   quoteColumnName(name: string): string {
     return pgQuoteColumnName(name);
   }
@@ -3700,10 +3673,6 @@ export class PostgreSQLAdapter
     );
   }
 
-  columnsForDistinct(columns: string | string[], orders?: (string | Nodes.Node)[]): string {
-    return this.pgSchemaStatements().columnsForDistinct(columns, orders);
-  }
-
   async extensions(): Promise<string[]> {
     // Rails does not filter plpgsql or any built-in extension — the full list
     // (including pg_catalog.plpgsql) is returned, matching PostgreSQLAdapter#extensions.
@@ -3779,179 +3748,14 @@ export class PostgreSQLAdapter
     await this.reloadTypeMap();
   }
 
-  async indexes(tableName: string): Promise<IndexDefinition[]> {
-    return this.pgSchemaStatements().indexes(tableName);
-  }
-
-  async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
-    return this.pgSchemaStatements().indexNameExists(tableName, indexName);
-  }
-
-  async primaryKey(tableName: string): Promise<string | string[] | null> {
-    return this.pgSchemaStatements().primaryKey(tableName);
-  }
-
-  async pkAndSequenceFor(
-    tableName: string,
-  ): Promise<[string, { schema: string; name: string } | null] | null> {
-    return this.pgSchemaStatements().pkAndSequenceFor(tableName);
-  }
-
-  async resetPkSequence(tableName: string): Promise<void> {
-    await this.pgSchemaStatements().resetPkSequence(tableName);
-  }
-
-  async setPkSequence(tableName: string, value: number): Promise<void> {
-    await this.pgSchemaStatements().setPkSequence(tableName, value);
-  }
-
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
-    this.pgSchemaStatements().validateIndexLengthBang(tableName, newName);
+    this.validateIndexLengthBang(tableName, newName);
     const [schema] = this.extractSchemaQualifiedName(tableName);
     const qualifier = schema ? `${this.quoteTableName(schema)}.` : "";
     await this.execute(
       `ALTER INDEX ${qualifier}${this.quoteColumnName(oldName)} RENAME TO ${this.quoteTableName(newName)}`,
     );
-  }
-
-  async columns(tableName: string): Promise<Column[]> {
-    return this.pgSchemaStatements().columns(tableName);
-  }
-
-  async changeColumn(
-    tableName: string,
-    columnName: string,
-    type: string,
-    options: ColumnOptions & { using?: string; castAs?: string } = {},
-  ): Promise<void> {
-    await this.pgSchemaStatements().changeColumn(tableName, columnName, type, options);
-  }
-
-  async createJoinTable(
-    table1: string,
-    table2: string,
-    options?: JoinTableOptions | ((t: AbstractTableDefinition) => void),
-    fn?: (t: AbstractTableDefinition) => void,
-  ): Promise<void> {
-    await this.pgSchemaStatements().createJoinTable(table1, table2, options, fn);
-  }
-
-  async addColumn(
-    tableName: string,
-    columnName: string,
-    type: ColumnType,
-    options: ColumnOptions & {
-      comment?: string | null;
-      ifNotExists?: boolean;
-    } = {},
-  ): Promise<void> {
-    await this.pgSchemaStatements().addColumn(tableName, columnName, type, options);
-  }
-
-  async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
-    await this.pgSchemaStatements().renameColumn(tableName, columnName, newColumnName);
-  }
-
-  async changeColumnDefault(
-    tableName: string,
-    columnName: string,
-    defaultOrChanges: unknown,
-  ): Promise<void> {
-    await this.pgSchemaStatements().changeColumnDefault(tableName, columnName, defaultOrChanges);
-  }
-
-  buildChangeColumnDefinition(
-    tableName: string,
-    columnName: string,
-    type: string,
-    options: {
-      using?: string;
-      castAs?: string;
-      default?: unknown;
-      null?: boolean;
-      array?: boolean;
-    } = {},
-  ): ChangeColumnDefinition {
-    return this.pgSchemaStatements().buildChangeColumnDefinition(
-      tableName,
-      columnName,
-      type,
-      options,
-    );
-  }
-
-  async buildChangeColumnDefaultDefinition(
-    tableName: string,
-    columnName: string,
-    defaultOrChanges: unknown,
-  ): Promise<ChangeColumnDefaultDefinition | undefined> {
-    return this.pgSchemaStatements().buildChangeColumnDefaultDefinition(
-      tableName,
-      columnName,
-      defaultOrChanges,
-    );
-  }
-
-  async changeColumnNull(
-    tableName: string,
-    columnName: string,
-    nullable: boolean,
-    defaultValue: unknown = null,
-  ): Promise<void> {
-    await this.pgSchemaStatements().changeColumnNull(tableName, columnName, nullable, defaultValue);
-  }
-
-  async changeColumnComment(
-    tableName: string,
-    columnName: string,
-    commentOrChanges: string | null | { from?: string | null; to?: string | null },
-  ): Promise<void> {
-    await this.pgSchemaStatements().changeColumnComment(tableName, columnName, commentOrChanges);
-  }
-
-  async changeTableComment(
-    tableName: string,
-    commentOrChanges: string | null | { from?: string | null; to?: string | null },
-  ): Promise<void> {
-    await this.pgSchemaStatements().changeTableComment(tableName, commentOrChanges);
-  }
-
-  /** @internal */
-  async validateConstraint(tableName: string, constraintName: string): Promise<void> {
-    await this.pgSchemaStatements().validateConstraint(tableName, constraintName);
-  }
-
-  async validateCheckConstraint(
-    tableName: string,
-    nameOrOptions: string | { name: string },
-  ): Promise<void> {
-    await this.pgSchemaStatements().validateCheckConstraint(tableName, nameOrOptions);
-  }
-
-  async validateForeignKey(
-    fromTable: string,
-    toTable?: string,
-    options?: Omit<ForeignKeyLookupOptions, "toTable">,
-  ): Promise<void> {
-    await this.pgSchemaStatements().validateForeignKey(fromTable, toTable, options);
-  }
-
-  typeToSql(
-    type: string,
-    options: {
-      limit?: number;
-      precision?: number;
-      scale?: number;
-      array?: boolean;
-      enumType?: string;
-    } = {},
-  ): string {
-    return this.pgSchemaStatements().typeToSql(type, options);
-  }
-
-  foreignKeyColumnFor(tableName: string, columnName = "id"): string {
-    return this.pgSchemaStatements().foreignKeyColumnFor(tableName, columnName);
   }
 
   /**
@@ -3973,33 +3777,6 @@ export class PostgreSQLAdapter
     return this.sequenceNameFromParts(tableName, columnName, suffix) === sequenceName;
   }
 
-  /** @internal */
-  sequenceNameFromParts(tableName: string, columnName: string, suffix: string): string {
-    return this.pgSchemaStatements().sequenceNameFromParts(tableName, columnName, suffix);
-  }
-
-  /** @internal */
-  assertValidDeferrable(deferrable: unknown): void {
-    this.pgSchemaStatements().assertValidDeferrable(deferrable);
-  }
-
-  /** @internal */
-  extractForeignKeyAction(specifier: string): "cascade" | "nullify" | "restrict" | undefined {
-    return this.pgSchemaStatements().extractForeignKeyAction(specifier);
-  }
-
-  /** @internal */
-  extractConstraintDeferrable(
-    deferrable: boolean,
-    deferred: boolean,
-  ): "deferred" | "immediate" | false {
-    return this.pgSchemaStatements().extractConstraintDeferrable(deferrable, deferred);
-  }
-
-  async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    return this.pgSchemaStatements().foreignKeys(tableName);
-  }
-
   async foreignTables(): Promise<string[]> {
     const names = await this.queryValues(
       this.dataSourceSql(null, { type: "FOREIGN TABLE" }),
@@ -4015,10 +3792,6 @@ export class PostgreSQLAdapter
       "SCHEMA",
     );
     return names.length > 0;
-  }
-
-  quotedIncludeColumnsForIndex(columnNames: string | string[]): string {
-    return this.pgSchemaStatements().quotedIncludeColumnsForIndex(columnNames);
   }
 
   /** @internal */
@@ -4061,11 +3834,6 @@ export class PostgreSQLAdapter
   referenceNameForTable(tableName: string): string {
     const [, table] = this.extractSchemaQualifiedName(tableName);
     return singularize(table);
-  }
-
-  /** @internal */
-  async columnNamesFromColumnNumbers(tableOid: number, columnNumbers: number[]): Promise<string[]> {
-    return this.pgSchemaStatements().columnNamesFromColumnNumbers(tableOid, columnNumbers);
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
@@ -4116,18 +3884,6 @@ export class PostgreSQLAdapter
     await this.renameTableIndexes(oldName, newName);
   }
 
-  async tables(): Promise<string[]> {
-    return this.pgSchemaStatements().tables();
-  }
-
-  async views(): Promise<string[]> {
-    return this.pgSchemaStatements().views();
-  }
-
-  async tableExists(name: string): Promise<boolean> {
-    return this.pgSchemaStatements().tableExists(name);
-  }
-
   async addIndex(
     tableName: string,
     columns: string | string[],
@@ -4152,9 +3908,6 @@ export class PostgreSQLAdapter
     await this.getDatabaseVersion();
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
 
-    // Called on the adapter, not on pgSchemaStatements(): PG overrides
-    // add_index_options to quote a bare-column-name `:where`, and only the
-    // adapter's override is on this path.
     const createIndex = (await this.buildCreateIndexDefinition(tableName, columns, options))!;
     await this.execute(await this.schemaCreation.accept(createIndex));
 
@@ -4243,14 +3996,6 @@ export class PostgreSQLAdapter
     await super.addForeignKey(fromTable, toTable, options);
   }
 
-  async foreignKeyExists(
-    fromTable: string,
-    toTable?: string | ForeignKeyLookupOptions,
-    options: Omit<ForeignKeyLookupOptions, "toTable"> = {},
-  ): Promise<boolean> {
-    return this.pgSchemaStatements().foreignKeyExists(fromTable, toTable, options);
-  }
-
   // Mirrors: ReferentialIntegrity#disable_referential_integrity. Extracted to
   // postgresql/referential-integrity.ts (Rails houses this in the
   // ReferentialIntegrity module, not schema_statements.rb).
@@ -4258,79 +4003,6 @@ export class PostgreSQLAdapter
 
   // Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
   checkAllForeignKeysValidBang = checkAllForeignKeysValidBang;
-
-  async createDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
-    await this.pgSchemaStatements().createDatabase(name, options);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Enum types
-  // ---------------------------------------------------------------------------
-
-  async createEnum(
-    name: string,
-    values: string[],
-    options?: Record<string, unknown>,
-  ): Promise<void> {
-    await this.pgSchemaStatements().createEnum(name, values, options);
-  }
-
-  async dropEnum(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    await this.pgSchemaStatements().dropEnum(name, options);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Range types
-  // ---------------------------------------------------------------------------
-
-  /**
-   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
-   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
-   *   `execute("CREATE
-   *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
-   *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their
-   *   `reload_type_map` epilogue; the implementation and the full justification live at the emitting
-   *   call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately
-   *   PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather
-   *   than allowlisted, since Rails stubs only the enum quartet on the base.
-   */
-  async createRange(
-    name: string,
-    options: { subtype: string; subtypeDiff?: string },
-  ): Promise<void> {
-    await this.pgSchemaStatements().createRange(name, options);
-  }
-
-  /**
-   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
-   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
-   *   `execute("CREATE
-   *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
-   *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their
-   *   `reload_type_map` epilogue; the implementation and the full justification live at the emitting
-   *   call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately
-   *   PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather
-   *   than allowlisted, since Rails stubs only the enum quartet on the base.
-   */
-  async dropRange(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    await this.pgSchemaStatements().dropRange(name, options);
-  }
-
-  async renameEnum(name: string, newNameOrOptions: string | { to: string }): Promise<void> {
-    await this.pgSchemaStatements().renameEnum(name, newNameOrOptions);
-  }
-
-  async addEnumValue(
-    name: string,
-    value: string,
-    options: { before?: string; after?: string; ifNotExists?: boolean } = {},
-  ): Promise<void> {
-    await this.pgSchemaStatements().addEnumValue(name, value, options);
-  }
-
-  async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {
-    await this.pgSchemaStatements().renameEnumValue(name, options);
-  }
 
   async enumValues(name: string): Promise<string[]> {
     const [schema, enumName] = this.extractSchemaQualifiedName(name);
@@ -4532,172 +4204,6 @@ export class PostgreSQLAdapter
     return translated;
   }
 
-  async dropDatabase(name: string): Promise<void> {
-    await this.pgSchemaStatements().dropDatabase(name);
-  }
-
-  async recreateDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
-    await this.pgSchemaStatements().recreateDatabase(name, options);
-  }
-
-  /**
-   * The PostgreSQL-specific half of `PostgreSQL::SchemaStatements`, still a companion class
-   * rather than a mixin: every method below delegates into it. Story
-   * `dissolve-the-postgresql-schema-statements-companion` folds it onto the adapter the way
-   * MySQL's is folded on, at which point this accessor goes away.
-   * @internal
-   */
-  private pgSchemaStatements(): PostgreSQLSchemaStatements {
-    return new PostgreSQLSchemaStatements(this as unknown as DatabaseAdapter);
-  }
-
-  async dropTable(
-    ...args:
-      | [string, ...string[]]
-      | [string, ...string[], { ifExists?: boolean; force?: "cascade" }]
-  ): Promise<void> {
-    // Rails: PostgreSQLAdapter has no separate `drop_table` — the method comes
-    // solely from the included `PostgreSQL::SchemaStatements` module. Delegate
-    // here so schema-cache eviction + single-statement CASCADE behavior lives
-    // in one place (PostgreSQLSchemaStatements#dropTable).
-    await this.pgSchemaStatements().dropTable(...args);
-  }
-
-  async currentDatabase(): Promise<string> {
-    return this.pgSchemaStatements().currentDatabase();
-  }
-
-  async encoding(): Promise<string> {
-    return this.pgSchemaStatements().encoding();
-  }
-
-  async collation(): Promise<string> {
-    return this.pgSchemaStatements().collation();
-  }
-
-  async ctype(): Promise<string> {
-    return this.pgSchemaStatements().ctype();
-  }
-
-  async schemaSearchPath(): Promise<string> {
-    return this.pgSchemaStatements().schemaSearchPath();
-  }
-
-  async setSchemaSearchPath(searchPath: string | null): Promise<void> {
-    await this.pgSchemaStatements().setSchemaSearchPath(searchPath);
-  }
-
-  async clientMinMessages(): Promise<string> {
-    return this.pgSchemaStatements().clientMinMessages();
-  }
-
-  async setClientMinMessages(level: string): Promise<void> {
-    await this.pgSchemaStatements().setClientMinMessages(level);
-  }
-
-  async tableComment(tableName: string): Promise<string | null> {
-    return this.pgSchemaStatements().tableComment(tableName);
-  }
-
-  async tablePartitionDefinition(tableName: string): Promise<string | null> {
-    return this.pgSchemaStatements().tablePartitionDefinition(tableName);
-  }
-
-  async inheritedTableNames(tableName: string): Promise<string[]> {
-    return this.pgSchemaStatements().inheritedTableNames(tableName);
-  }
-
-  async tableOptions(tableName: string): Promise<Record<string, unknown>> {
-    return this.pgSchemaStatements().tableOptions(tableName);
-  }
-
-  async serialSequence(tableName: string, column: string): Promise<string | null> {
-    return this.pgSchemaStatements().serialSequence(tableName, column);
-  }
-
-  async defaultSequenceName(
-    tableName: string,
-    pk: string | string[] = "id",
-  ): Promise<string | null> {
-    return this.pgSchemaStatements().defaultSequenceName(tableName, pk);
-  }
-
-  async setPkSequenceBang(tableName: string, value: number): Promise<void> {
-    await this.pgSchemaStatements().setPkSequenceBang(tableName, value);
-  }
-
-  async resetPkSequenceBang(
-    tableName: string,
-    pk: string | null = null,
-    sequence: string | null = null,
-  ): Promise<void> {
-    await this.pgSchemaStatements().resetPkSequenceBang(tableName, pk, sequence);
-  }
-
-  async primaryKeys(tableName: string): Promise<string[]> {
-    return this.pgSchemaStatements().primaryKeys(tableName);
-  }
-
-  async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
-    return this.pgSchemaStatements().checkConstraints(tableName);
-  }
-
-  exclusionConstraintOptions(
-    tableName: string,
-    expression: string,
-    options: Record<string, unknown>,
-  ): Record<string, unknown> {
-    return this.pgSchemaStatements().exclusionConstraintOptions(tableName, expression, options);
-  }
-
-  async addExclusionConstraint(
-    tableName: string,
-    expression: string,
-    options: ExclusionConstraintOptions = {},
-  ): Promise<void> {
-    return this.pgSchemaStatements().addExclusionConstraint(tableName, expression, options);
-  }
-
-  async removeExclusionConstraint(
-    tableName: string,
-    expressionOrOptions?: string | Record<string, unknown> | null,
-    options: Record<string, unknown> = {},
-  ): Promise<void> {
-    return this.pgSchemaStatements().removeExclusionConstraint(
-      tableName,
-      expressionOrOptions,
-      options,
-    );
-  }
-
-  uniqueConstraintOptions(
-    tableName: string,
-    columnName: string | string[] | null | undefined,
-    options: Record<string, unknown>,
-  ): Record<string, unknown> {
-    return this.pgSchemaStatements().uniqueConstraintOptions(tableName, columnName, options);
-  }
-
-  async addUniqueConstraint(
-    tableName: string,
-    columnName?: string | string[] | null,
-    options: UniqueConstraintOptions = {},
-  ): Promise<void> {
-    return this.pgSchemaStatements().addUniqueConstraint(tableName, columnName, options);
-  }
-
-  async removeUniqueConstraint(
-    tableName: string,
-    columnNameOrOptions?: string | string[] | Record<string, unknown> | null,
-    options: Record<string, unknown> = {},
-  ): Promise<void> {
-    return this.pgSchemaStatements().removeUniqueConstraint(
-      tableName,
-      columnNameOrOptions,
-      options,
-    );
-  }
-
   indexName(
     tableName: string,
     options: { column?: string | string[]; name?: string; _usesLegacyIndexName?: boolean },
@@ -4732,8 +4238,7 @@ export class PostgreSQLAdapter
   ): Promise<[AbstractIndexDefinition, string | undefined, boolean]> {
     const opts = { ...options };
     if (typeof opts.where === "string") {
-      const ss = this.pgSchemaStatements();
-      if ((await ss.tableExists(tableName)) && (await ss.columnExists(tableName, opts.where))) {
+      if ((await this.tableExists(tableName)) && (await this.columnExists(tableName, opts.where))) {
         opts.where = this.quoteColumnName(opts.where);
       }
     }
@@ -4742,10 +4247,6 @@ export class PostgreSQLAdapter
 
   get schemaCreation(): PgSchemaCreation {
     return new PgSchemaCreation(this);
-  }
-
-  updateTableDefinition(tableName: string, base?: unknown): PgTable {
-    return this.pgSchemaStatements().updateTableDefinition(tableName, base ?? this);
   }
 
   createSchemaDumper(source: SchemaSource, options: Record<string, unknown> = {}): PgSchemaDumper {
@@ -4937,58 +4438,6 @@ export class PostgreSQLAdapter
     return super.addOptionsForIndexColumns(quotedColumns, options);
   }
 
-  async exclusionConstraints(tableName: string): Promise<ExclusionConstraintDefinition[]> {
-    return this.pgSchemaStatements().exclusionConstraints(tableName);
-  }
-
-  async uniqueConstraints(tableName: string): Promise<UniqueConstraintDefinition[]> {
-    return this.pgSchemaStatements().uniqueConstraints(tableName);
-  }
-
-  /** @internal */
-  exclusionConstraintName(tableName: string, options: Record<string, unknown> = {}): string {
-    return this.pgSchemaStatements().exclusionConstraintName(tableName, options);
-  }
-
-  /** @internal */
-  async exclusionConstraintFor(
-    tableName: string,
-    options: Record<string, unknown> = {},
-  ): Promise<ExclusionConstraintDefinition | undefined> {
-    return this.pgSchemaStatements().exclusionConstraintFor(tableName, options);
-  }
-
-  /** @internal */
-  async exclusionConstraintForBang(
-    tableName: string,
-    expression?: string | null,
-    options: Record<string, unknown> = {},
-  ): Promise<ExclusionConstraintDefinition> {
-    return this.pgSchemaStatements().exclusionConstraintForBang(tableName, expression, options);
-  }
-
-  /** @internal */
-  uniqueConstraintName(tableName: string, options: Record<string, unknown> = {}): string {
-    return this.pgSchemaStatements().uniqueConstraintName(tableName, options);
-  }
-
-  /** @internal */
-  async uniqueConstraintFor(
-    tableName: string,
-    options: Record<string, unknown> = {},
-  ): Promise<UniqueConstraintDefinition | undefined> {
-    return this.pgSchemaStatements().uniqueConstraintFor(tableName, options);
-  }
-
-  /** @internal */
-  async uniqueConstraintForBang(
-    tableName: string,
-    column?: string | string[] | null,
-    options: Record<string, unknown> = {},
-  ): Promise<UniqueConstraintDefinition> {
-    return this.pgSchemaStatements().uniqueConstraintForBang(tableName, column, options);
-  }
-
   /** @internal */
   extractSchemaQualifiedName(string: string): [string | null, string] {
     const name = Utils.extractSchemaQualifiedName(string);
@@ -5175,28 +4624,6 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Fetch raw column metadata rows from pg_attribute for a table.
-   * Mirrors: PostgreSQLAdapter#column_definitions
-   * @internal
-   */
-  async columnDefinitions(tableName: string): Promise<
-    {
-      attname: string;
-      format_type: string;
-      pg_get_expr: string | null;
-      attnotnull: boolean;
-      atttypid: number;
-      atttypmod: number;
-      collname: string | null;
-      comment: string | null;
-      identity: string | null;
-      attgenerated: string | null;
-    }[]
-  > {
-    return this.pgSchemaStatements().columnDefinitions(tableName);
-  }
-
-  /**
    * Build the per-adapter StatementPool (used on initialization).
    * Mirrors: PostgreSQLAdapter#build_statement_pool
    * @internal
@@ -5263,6 +4690,362 @@ export class PostgreSQLAdapter
   _rawConnectionForTest(): pg.Client | null {
     return this._rawConnection;
   }
+}
+
+// Declaration merge for `include(PostgreSQLAdapter, PostgreSQLSchemaStatements)` at
+// the bottom of this file: `include()` installs the module's methods on the
+// prototype at runtime, but TypeScript can't see them on the class type. Mirrors
+// the way AbstractAdapter declares its `include SchemaStatements` surface.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface PostgreSQLAdapter {
+  /** @internal */
+  validateIndexLengthBang(tableName: string, newName: string, internal?: boolean): void;
+
+  enumTypes(): Promise<[string, string[]][]>;
+
+  schemaNames(): Promise<string[]>;
+
+  createSchema(name: string, options?: { force?: boolean; ifNotExists?: boolean }): Promise<void>;
+
+  dropSchema(name: string, options?: { ifExists?: boolean }): Promise<void>;
+
+  schemaExists(name: string): Promise<boolean>;
+
+  currentSchema(): Promise<string>;
+
+  columnsForDistinct(columns: string | string[], orders?: (string | Nodes.Node)[]): string;
+
+  indexes(tableName: string): Promise<IndexDefinition[]>;
+
+  indexNameExists(tableName: string, indexName: string): Promise<boolean>;
+
+  primaryKey(tableName: string): Promise<string | string[] | null>;
+
+  pkAndSequenceFor(
+    tableName: string,
+  ): Promise<[string, { schema: string; name: string } | null] | null>;
+
+  resetPkSequence(tableName: string): Promise<void>;
+
+  setPkSequence(tableName: string, value: number): Promise<void>;
+
+  columns(tableName: string): Promise<Column[]>;
+
+  changeColumn(
+    tableName: string,
+    columnName: string,
+    type: string,
+    options?: ColumnOptions & { using?: string; castAs?: string },
+  ): Promise<void>;
+
+  createJoinTable(
+    table1: string,
+    table2: string,
+    options?: JoinTableOptions | ((t: AbstractTableDefinition) => void),
+    fn?: (t: AbstractTableDefinition) => void,
+  ): Promise<void>;
+
+  addColumn(
+    tableName: string,
+    columnName: string,
+    type: ColumnType,
+    options?: ColumnOptions & {
+      comment?: string | null;
+      ifNotExists?: boolean;
+    },
+  ): Promise<void>;
+
+  renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void>;
+
+  changeColumnDefault(
+    tableName: string,
+    columnName: string,
+    defaultOrChanges: unknown,
+  ): Promise<void>;
+
+  buildChangeColumnDefinition(
+    tableName: string,
+    columnName: string,
+    type: string,
+    options?: {
+      using?: string;
+      castAs?: string;
+      default?: unknown;
+      null?: boolean;
+      array?: boolean;
+    },
+  ): ChangeColumnDefinition;
+
+  buildChangeColumnDefaultDefinition(
+    tableName: string,
+    columnName: string,
+    defaultOrChanges: unknown,
+  ): Promise<ChangeColumnDefaultDefinition | undefined>;
+
+  changeColumnNull(
+    tableName: string,
+    columnName: string,
+    nullable: boolean,
+    defaultValue?: unknown,
+  ): Promise<void>;
+
+  changeColumnComment(
+    tableName: string,
+    columnName: string,
+    commentOrChanges: string | null | { from?: string | null; to?: string | null },
+  ): Promise<void>;
+
+  changeTableComment(
+    tableName: string,
+    commentOrChanges: string | null | { from?: string | null; to?: string | null },
+  ): Promise<void>;
+
+  /** @internal */
+  validateConstraint(tableName: string, constraintName: string): Promise<void>;
+
+  validateCheckConstraint(
+    tableName: string,
+    nameOrOptions: string | { name: string },
+  ): Promise<void>;
+
+  validateForeignKey(
+    fromTable: string,
+    toTable?: string,
+    options?: Omit<ForeignKeyLookupOptions, "toTable">,
+  ): Promise<void>;
+
+  typeToSql(
+    type: string,
+    options?: {
+      limit?: number;
+      precision?: number;
+      scale?: number;
+      array?: boolean;
+      enumType?: string;
+    },
+  ): string;
+
+  foreignKeyColumnFor(tableName: string, columnName?: string): string;
+
+  /** @internal */
+  sequenceNameFromParts(tableName: string, columnName: string, suffix: string): string;
+
+  /** @internal */
+  assertValidDeferrable(deferrable: unknown): void;
+
+  /** @internal */
+  extractForeignKeyAction(specifier: string): "cascade" | "nullify" | "restrict" | undefined;
+
+  /** @internal */
+  extractConstraintDeferrable(
+    deferrable: boolean,
+    deferred: boolean,
+  ): "deferred" | "immediate" | false;
+
+  foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
+
+  quotedIncludeColumnsForIndex(columnNames: string | string[]): string;
+
+  /** @internal */
+  columnNamesFromColumnNumbers(tableOid: number, columnNumbers: number[]): Promise<string[]>;
+
+  tables(): Promise<string[]>;
+
+  views(): Promise<string[]>;
+
+  tableExists(name: string): Promise<boolean>;
+
+  foreignKeyExists(
+    fromTable: string,
+    toTable?: string | ForeignKeyLookupOptions,
+    options?: Omit<ForeignKeyLookupOptions, "toTable">,
+  ): Promise<boolean>;
+
+  createDatabase(name: string, options?: CreateDatabaseOptions): Promise<void>;
+
+  createEnum(name: string, values: string[], options?: Record<string, unknown>): Promise<void>;
+
+  dropEnum(name: string, options?: { ifExists?: boolean }): Promise<void>;
+
+  /**
+   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
+   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
+   *   `execute("CREATE
+   *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
+   *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their
+   *   `reload_type_map` epilogue; the implementation and the full justification live at the emitting
+   *   call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately
+   *   PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather
+   *   than allowlisted, since Rails stubs only the enum quartet on the base.
+   */
+  createRange(name: string, options: { subtype: string; subtypeDiff?: string }): Promise<void>;
+
+  /**
+   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
+   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
+   *   `execute("CREATE
+   *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
+   *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their
+   *   `reload_type_map` epilogue; the implementation and the full justification live at the emitting
+   *   call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately
+   *   PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather
+   *   than allowlisted, since Rails stubs only the enum quartet on the base.
+   */
+  dropRange(name: string, options?: { ifExists?: boolean }): Promise<void>;
+
+  renameEnum(name: string, newNameOrOptions: string | { to: string }): Promise<void>;
+
+  addEnumValue(
+    name: string,
+    value: string,
+    options?: { before?: string; after?: string; ifNotExists?: boolean },
+  ): Promise<void>;
+
+  renameEnumValue(name: string, options: { from: string; to: string }): Promise<void>;
+
+  dropDatabase(name: string): Promise<void>;
+
+  recreateDatabase(name: string, options?: CreateDatabaseOptions): Promise<void>;
+
+  dropTable(
+    ...args:
+      | [string, ...string[]]
+      | [string, ...string[], { ifExists?: boolean; force?: "cascade" }]
+  ): Promise<void>;
+
+  currentDatabase(): Promise<string>;
+
+  encoding(): Promise<string>;
+
+  collation(): Promise<string>;
+
+  ctype(): Promise<string>;
+
+  schemaSearchPath(): Promise<string>;
+
+  setSchemaSearchPath(searchPath: string | null): Promise<void>;
+
+  clientMinMessages(): Promise<string>;
+
+  setClientMinMessages(level: string): Promise<void>;
+
+  tableComment(tableName: string): Promise<string | null>;
+
+  tablePartitionDefinition(tableName: string): Promise<string | null>;
+
+  inheritedTableNames(tableName: string): Promise<string[]>;
+
+  tableOptions(tableName: string): Promise<Record<string, unknown>>;
+
+  serialSequence(tableName: string, column: string): Promise<string | null>;
+
+  defaultSequenceName(tableName: string, pk?: string | string[]): Promise<string | null>;
+
+  setPkSequenceBang(tableName: string, value: number): Promise<void>;
+
+  resetPkSequenceBang(
+    tableName: string,
+    pk?: string | null,
+    sequence?: string | null,
+  ): Promise<void>;
+
+  primaryKeys(tableName: string): Promise<string[]>;
+
+  checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]>;
+
+  exclusionConstraintOptions(
+    tableName: string,
+    expression: string,
+    options: Record<string, unknown>,
+  ): Record<string, unknown>;
+
+  addExclusionConstraint(
+    tableName: string,
+    expression: string,
+    options?: ExclusionConstraintOptions,
+  ): Promise<void>;
+
+  removeExclusionConstraint(
+    tableName: string,
+    expressionOrOptions?: string | Record<string, unknown> | null,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+
+  uniqueConstraintOptions(
+    tableName: string,
+    columnName: string | string[] | null | undefined,
+    options: Record<string, unknown>,
+  ): Record<string, unknown>;
+
+  addUniqueConstraint(
+    tableName: string,
+    columnName?: string | string[] | null,
+    options?: UniqueConstraintOptions,
+  ): Promise<void>;
+
+  removeUniqueConstraint(
+    tableName: string,
+    columnNameOrOptions?: string | string[] | Record<string, unknown> | null,
+    options?: Record<string, unknown>,
+  ): Promise<void>;
+
+  updateTableDefinition(tableName: string, base?: unknown): PgTable;
+
+  exclusionConstraints(tableName: string): Promise<ExclusionConstraintDefinition[]>;
+
+  uniqueConstraints(tableName: string): Promise<UniqueConstraintDefinition[]>;
+
+  /** @internal */
+  exclusionConstraintName(tableName: string, options?: Record<string, unknown>): string;
+
+  /** @internal */
+  exclusionConstraintFor(
+    tableName: string,
+    options?: Record<string, unknown>,
+  ): Promise<ExclusionConstraintDefinition | undefined>;
+
+  /** @internal */
+  exclusionConstraintForBang(
+    tableName: string,
+    expression?: string | null,
+    options?: Record<string, unknown>,
+  ): Promise<ExclusionConstraintDefinition>;
+
+  /** @internal */
+  uniqueConstraintName(tableName: string, options?: Record<string, unknown>): string;
+
+  /** @internal */
+  uniqueConstraintFor(
+    tableName: string,
+    options?: Record<string, unknown>,
+  ): Promise<UniqueConstraintDefinition | undefined>;
+
+  /** @internal */
+  uniqueConstraintForBang(
+    tableName: string,
+    column?: string | string[] | null,
+    options?: Record<string, unknown>,
+  ): Promise<UniqueConstraintDefinition>;
+
+  /**
+   * Fetch raw column metadata rows from pg_attribute for a table.
+   * Mirrors: PostgreSQLAdapter#column_definitions
+   * @internal
+   */
+  columnDefinitions(tableName: string): Promise<
+    {
+      attname: string;
+      format_type: string;
+      pg_get_expr: string | null;
+      attnotnull: boolean;
+      atttypid: number;
+      atttypmod: number;
+      collname: string | null;
+      comment: string | null;
+      identity: string | null;
+      attgenerated: string | null;
+    }[]
+  >;
 }
 
 export type IndexDefinition = PgIndexDefinition;
@@ -5423,6 +5206,11 @@ dirtiesQueryCache(PostgreSQLAdapter, "execInsert", "rollbackDbTransaction", "rol
 // `internal_exec_query`.
 captureUnwrappedExecute(PostgreSQLAdapter);
 dirtiesQueryCache(PostgreSQLAdapter, "execQuery", "execute");
+
+// Rails: `include PostgreSQL::SchemaStatements` (postgresql_adapter.rb:185).
+// Methods defined in the class body above win over the mixin, exactly as Ruby's
+// ancestry places the class above an included module.
+include(PostgreSQLAdapter, PostgreSQLSchemaStatements);
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
 // at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { PostgreSQLSchemaStatements } from "./schema-statements-class.js";
+import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import { ForeignKeyDefinition } from "../abstract/schema-definitions.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
+
+// `PostgreSQL::SchemaStatements` is mixed into `PostgreSQLAdapter` (Rails:
+// `include PostgreSQL::SchemaStatements`), so the bodies under test are prototype
+// methods on the adapter. Give the fake adapter that prototype and call them the
+// way production does.
+function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
+  return Object.setPrototypeOf(adapter, PostgreSQLAdapter.prototype) as PostgreSQLAdapter;
+}
 
 function makeFakeAdapter() {
   const executed: string[] = [];
@@ -26,42 +34,42 @@ function makeFakeAdapter() {
 describe("PostgreSQLSchemaStatements#dropTable", () => {
   it("emits a single DROP TABLE statement with all table names joined", async () => {
     const { adapter, executed } = makeFakeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.dropTable("posts", "comments");
     expect(executed).toEqual([`DROP TABLE "posts", "comments"`]);
   });
 
   it("appends CASCADE when force: 'cascade'", async () => {
     const { adapter, executed } = makeFakeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.dropTable("posts", { force: "cascade" });
     expect(executed).toEqual([`DROP TABLE "posts" CASCADE`]);
   });
 
   it("appends IF EXISTS when ifExists: true", async () => {
     const { adapter, executed } = makeFakeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.dropTable("posts", { ifExists: true });
     expect(executed).toEqual([`DROP TABLE IF EXISTS "posts"`]);
   });
 
   it("combines IF EXISTS, multiple tables, and CASCADE", async () => {
     const { adapter, executed } = makeFakeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.dropTable("posts", "comments", { ifExists: true, force: "cascade" });
     expect(executed).toEqual([`DROP TABLE IF EXISTS "posts", "comments" CASCADE`]);
   });
 
   it("clears the schema cache for each table", async () => {
     const { adapter, clearedTables } = makeFakeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.dropTable("posts", "comments");
     expect(clearedTables).toEqual(["posts", "comments"]);
   });
 
   it("throws ArgumentError when called with no table names", async () => {
     const { adapter } = makeFakeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await expect(
       (ss as unknown as { dropTable: () => Promise<void> }).dropTable(),
     ).rejects.toBeInstanceOf(ArgumentError);
@@ -90,14 +98,14 @@ function makeSchemaAdapter() {
 describe("PostgreSQLSchemaStatements#dropSchema", () => {
   it("always appends CASCADE", async () => {
     const { adapter, execed } = makeSchemaAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.dropSchema("things");
     expect(execed).toEqual([`DROP SCHEMA "things" CASCADE`]);
   });
 
   it("appends IF EXISTS before CASCADE when ifExists: true", async () => {
     const { adapter, execed } = makeSchemaAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.dropSchema("things", { ifExists: true });
     expect(execed).toEqual([`DROP SCHEMA IF EXISTS "things" CASCADE`]);
   });
@@ -106,7 +114,7 @@ describe("PostgreSQLSchemaStatements#dropSchema", () => {
 describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
   it("memoizes the search path and only queries once", async () => {
     const { adapter } = makeSchemaAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(await ss.schemaSearchPath()).toBe('"$user", public');
     expect(await ss.schemaSearchPath()).toBe('"$user", public');
     expect(
@@ -116,7 +124,7 @@ describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
 
   it("setSchemaSearchPath updates the memo without re-querying", async () => {
     const { adapter, execed } = makeSchemaAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.setSchemaSearchPath("my_schema, public");
     expect(execed).toEqual([`SET search_path TO my_schema, public`]);
     expect(await ss.schemaSearchPath()).toBe("my_schema, public");
@@ -127,7 +135,7 @@ describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
 
   it("setSchemaSearchPath with null is a no-op", async () => {
     const { adapter, execed } = makeSchemaAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.setSchemaSearchPath(null);
     expect(execed).toEqual([]);
     expect(
@@ -137,7 +145,7 @@ describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
 
   it("setSchemaSearchPath with empty string is a no-op", async () => {
     const { adapter, execed } = makeSchemaAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.setSchemaSearchPath("");
     expect(execed).toEqual([]);
     expect(
@@ -164,7 +172,7 @@ describe("PostgreSQLSchemaStatements#addForeignKey use_foreign_keys? guard", () 
         executed.push(sql);
       }),
     } as unknown as DatabaseAdapter;
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(ss.isUseForeignKeys()).toBe(false);
     await ss.addForeignKey("articles", "authors", { column: "author_id" });
     expect(executed).toEqual([]);
@@ -182,7 +190,7 @@ describe("PostgreSQLSchemaStatements#addForeignKey use_foreign_keys? guard", () 
         executed.push(sql);
       }),
     } as unknown as DatabaseAdapter;
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     const fk = new ForeignKeyDefinition(
       "astronauts",
       "rockets",

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -4,10 +4,8 @@ import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import { ForeignKeyDefinition } from "../abstract/schema-definitions.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 
-// `PostgreSQL::SchemaStatements` is mixed into `PostgreSQLAdapter` (Rails:
-// `include PostgreSQL::SchemaStatements`), so the bodies under test are prototype
-// methods on the adapter. Give the fake adapter that prototype and call them the
-// way production does.
+// The bodies under test are prototype methods on the adapter, so give the fake
+// adapter that prototype and call them the way production does.
 function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
   return Object.setPrototypeOf(adapter, PostgreSQLAdapter.prototype) as PostgreSQLAdapter;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { PostgreSQLSchemaStatements } from "./schema-statements-class.js";
+import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import { Table as PgTable } from "./schema-definitions.js";
+
+// `PostgreSQL::SchemaStatements` is mixed into `PostgreSQLAdapter` (Rails:
+// `include PostgreSQL::SchemaStatements`), so the bodies under test are prototype
+// methods on the adapter. Give the fake adapter that prototype and call them the
+// way production does.
+function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
+  return Object.setPrototypeOf(adapter, PostgreSQLAdapter.prototype) as PostgreSQLAdapter;
+}
 
 interface FakeOptions {
   logger?: { warn: (msg: string) => void };
@@ -58,7 +66,7 @@ function makeAdapter(options: FakeOptions = {}) {
 // silently changing emitted DDL and dumped schema.
 describe("PostgreSQLSchemaStatements constraint name digests", () => {
   it("derives the exclusion constraint name Rails derives", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
+    const ss = withSchemaStatements(makeAdapter().adapter);
     expect(
       ss.exclusionConstraintName("invoices", {
         expression: "daterange(start_date, end_date) WITH &&",
@@ -67,21 +75,21 @@ describe("PostgreSQLSchemaStatements constraint name digests", () => {
   });
 
   it("derives the unique constraint name Rails derives from a column list", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
+    const ss = withSchemaStatements(makeAdapter().adapter);
     expect(ss.uniqueConstraintName("sections", { column: ["position"] })).toBe(
       "uniq_rails_1e07660b77",
     );
   });
 
   it("derives the unique constraint name Rails derives from usingIndex", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
+    const ss = withSchemaStatements(makeAdapter().adapter);
     expect(ss.uniqueConstraintName("sections", { usingIndex: "unique_index" })).toBe(
       "uniq_rails_79b901ffb4",
     );
   });
 
   it("returns an explicit :name option unchanged", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
+    const ss = withSchemaStatements(makeAdapter().adapter);
     expect(ss.exclusionConstraintName("invoices", { name: "my_excl", expression: "x" })).toBe(
       "my_excl",
     );
@@ -94,7 +102,7 @@ describe("PostgreSQLSchemaStatements constraint name digests", () => {
 describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", () => {
   it("setPkSequenceBang warns when the table has a primary key but no sequence", async () => {
     const warn = vi.fn();
-    const ss = new PostgreSQLSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
+    const ss = withSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
     await ss.setPkSequenceBang("postgresql_uuids", 42);
     expect(warn).toHaveBeenCalledWith(
@@ -104,7 +112,7 @@ describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", 
 
   it("resetPkSequenceBang warns when the table has a primary key but no sequence", async () => {
     const warn = vi.fn();
-    const ss = new PostgreSQLSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
+    const ss = withSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
     await ss.resetPkSequenceBang("postgresql_uuids");
     expect(warn).toHaveBeenCalledWith(
@@ -113,14 +121,14 @@ describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", 
   });
 
   it("stays silent when no logger is configured", async () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
+    const ss = withSchemaStatements(makeAdapter().adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
     await expect(ss.setPkSequenceBang("postgresql_uuids", 42)).resolves.toBeUndefined();
   });
 
   it("does not warn when the table has no primary key at all", async () => {
     const warn = vi.fn();
-    const ss = new PostgreSQLSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
+    const ss = withSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(null);
     await ss.setPkSequenceBang("postgresql_uuids", 42);
     expect(warn).not.toHaveBeenCalled();
@@ -135,7 +143,7 @@ describe("PostgreSQLSchemaStatements#indexNameExists", () => {
     const { adapter, sql } = makeAdapter({
       queryValue: async () => 1,
     });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(await ss.indexNameExists("my_schema.things", "my_schema.index_a")).toBe(true);
     expect(sql[0]).toContain("i.relname = 'index_a'");
     expect(sql[0]).not.toContain("'my_schema.index_a'");
@@ -157,7 +165,7 @@ describe("PostgreSQLSchemaStatements#pkAndSequenceFor", () => {
         },
       ],
     });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(await ss.pkAndSequenceFor("things")).toEqual([
       "id",
       { schema: "public", name: "things_id_seq" },
@@ -171,7 +179,7 @@ describe("PostgreSQLSchemaStatements#pkAndSequenceFor", () => {
         throw new Error("boom");
       },
     });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(await ss.pkAndSequenceFor("things")).toBeNull();
   });
 });
@@ -180,7 +188,7 @@ describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
   // Ruby's `max_pk ? true : false` is a nil check; 0 is truthy in Ruby.
   it("emits setval(..., 0, true) when the max primary key is 0", async () => {
     const { adapter, sql } = makeAdapter({ queryValue: async () => 0 });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.resetPkSequenceBang("things", "id", "public.things_id_seq");
     expect(sql.at(-1)).toContain(`SELECT setval('"public"."things_id_seq"', 0, true)`);
   });
@@ -189,7 +197,7 @@ describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
     const { adapter, sql } = makeAdapter({
       queryValue: async (text) => (text.includes("seqmin") ? 1 : null),
     });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     await ss.resetPkSequenceBang("things", "id", "public.things_id_seq");
     expect(sql.at(-1)).toContain(`SELECT setval('"public"."things_id_seq"', 1, false)`);
   });
@@ -198,7 +206,7 @@ describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
 describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", () => {
   it("truncates against the server's maxIdentifierLength, not a hardcoded 63", () => {
     const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     const name = ss.sequenceNameFromParts("a".repeat(40), "b".repeat(10), "seq");
     expect(name).toBe(`${"a".repeat(16)}_${"b".repeat(10)}_seq`);
     expect(name.length).toBe(31);
@@ -206,7 +214,7 @@ describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", (
 
   it("splits the overage across column and table under a short limit", () => {
     const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     const name = ss.sequenceNameFromParts("a".repeat(40), "b".repeat(30), "seq");
     expect(name).toBe(`${"a".repeat(13)}_${"b".repeat(13)}_seq`);
     expect(name.length).toBe(31);
@@ -214,7 +222,7 @@ describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", (
 
   it("leaves names within the limit untouched", () => {
     const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(ss.sequenceNameFromParts("things", "id", "seq")).toBe("things_id_seq");
   });
 });
@@ -222,13 +230,13 @@ describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", (
 describe("PostgreSQLSchemaStatements#typeToSql enum validation", () => {
   it("resolves an enum column to its enum type", () => {
     const { adapter } = makeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(ss.typeToSql("enum", { enumType: "color" })).toBe("color");
   });
 
   it("raises ArgumentError when enum_type is absent", () => {
     const { adapter } = makeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     expect(() => ss.typeToSql("enum")).toThrow(
       new ArgumentError("enum_type is required for enums"),
     );
@@ -238,7 +246,7 @@ describe("PostgreSQLSchemaStatements#typeToSql enum validation", () => {
 describe("PostgreSQLSchemaStatements#changeTable", () => {
   it("yields the PostgreSQL Table subclass", async () => {
     const { adapter } = makeAdapter();
-    const ss = new PostgreSQLSchemaStatements(adapter);
+    const ss = withSchemaStatements(adapter);
     let yielded: unknown;
     await ss.changeTable("things", (t) => {
       yielded = t;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -4,10 +4,8 @@ import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import { Table as PgTable } from "./schema-definitions.js";
 
-// `PostgreSQL::SchemaStatements` is mixed into `PostgreSQLAdapter` (Rails:
-// `include PostgreSQL::SchemaStatements`), so the bodies under test are prototype
-// methods on the adapter. Give the fake adapter that prototype and call them the
-// way production does.
+// The bodies under test are prototype methods on the adapter, so give the fake
+// adapter that prototype and call them the way production does.
 function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
   return Object.setPrototypeOf(adapter, PostgreSQLAdapter.prototype) as PostgreSQLAdapter;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -2,7 +2,6 @@ import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaStatements } from "../abstract/schema-statements.js";
-import { SchemaCreation as PgSchemaCreation } from "./schema-creation.js";
 import {
   AlterTable,
   ChangeColumnDefinition,
@@ -100,11 +99,6 @@ interface PgSchemaAdapter {
 export class PostgreSQLSchemaStatements extends SchemaStatements {
   private get pg(): PgSchemaAdapter {
     return this.adapter as unknown as PgSchemaAdapter;
-  }
-
-  /** Mirrors: PostgreSQL::SchemaStatements#schema_creation */
-  override get schemaCreation(): PgSchemaCreation {
-    return new PgSchemaCreation(this.adapter);
   }
 
   /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -2,27 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_enum_value",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_enum_value",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_enum_value",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "begin_isolated_db_transaction",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -51,51 +30,16 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "change_column",
-    "call": "partition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "change_column_for_alter",
+    "call": "new",
+    "reason": "Rails builds the deferred half of the ALTER with `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS body uses an arrow function, the JS analogue, so there is no `new` to match."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "change_column_null",
-    "call": "column_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "client_min_messages=",
-    "call": "internal_execute",
-    "reason": "Equivalent (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): setClientMinMessages does call the ported internal_execute primitive — `this.pg.internalExecute(\"SET client_min_messages TO '<level>'\", \"SCHEMA\")` in postgresql/schema-statements-class.ts. The call goes unmatched because this entry is anchored to postgresql-adapter.ts, whose setClientMinMessages is a one-line delegation into that statements class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "column_definitions",
-    "call": "query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "column_names_from_column_numbers",
-    "call": "compact",
-    "reason": "Ruby-ism: `.compact` drops attnums with no matching row; trails uses `.filter((name) => name != null)` on the same line."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "column_names_from_column_numbers",
-    "call": "values_at",
-    "reason": "Ruby-ism: `Hash[...].values_at(*column_numbers)` reads the pair-hash back in caller order; trails builds a `Map` and does `safeNums.map((n) => map.get(n))` on the same line."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "columns_for_distinct",
-    "call": "compact_blank",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "change_column_null_for_alter",
+    "call": "new",
+    "reason": "Rails builds the deferred half of the ALTER with `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS body uses an arrow function, the JS analogue, so there is no `new` to match."
   },
   {
     "package": "activerecord",
@@ -123,34 +67,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "configure_connection",
     "call": "stringify_keys",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "create_enum",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "create_enum",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "create_enum",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "create_enum",
-    "call": "quoted_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -205,20 +121,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "drop_enum",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "drop_enum",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "enable_extension",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -229,62 +131,6 @@
     "rubyName": "enable_extension",
     "call": "values_at",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "enum_types",
-    "call": "cast_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "enum_types",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exclusion_constraint_for",
-    "call": "detect",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exclusion_constraint_for",
-    "call": "exclusion_constraints",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exclusion_constraint_name",
-    "call": "first",
-    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Enumerable#first(n)` on the digest; JS uses `String#slice(0, n)`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exclusion_constraint_name",
-    "call": "hexdigest",
-    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Digest::SHA256.hexdigest`; JS uses the WebCrypto/`createHash` hex digest. The derivation is byte-identical — schema-statements-class.trails.test.ts pins `excl_rails_74c9160f55` against Rails' own literal."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exclusion_constraints",
-    "call": "split",
-    "reason": "Ruby-ism: Rails splits `constraintdef` on ' WHERE '; trails locates the same boundary with `search(/ WHERE /i)` + `slice`, which additionally makes the match case-insensitive."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exclusion_constraints",
-    "call": "to",
-    "reason": "Ruby-ism: `predicate.to(-3)` (String#to) is the second argument of the same `predicate.slice(1, -1)` call."
   },
   {
     "package": "activerecord",
@@ -366,34 +212,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "indexes",
-    "call": "column_names_from_column_numbers",
-    "reason": "SQL-side equivalent: column names are computed inside the query via `ARRAY(SELECT pg_get_indexdef(ix.indexrelid, k + 1, true) FROM generate_subscripts(ix.indkey, 1) AS k WHERE k < ix.indnkeyatts)`, which is the `indkey` -> name resolution Rails does in Ruby with `column_names_from_column_numbers`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "indexes",
-    "call": "query",
-    "reason": "SQL-side equivalent: trails' `indexes` runs its introspection SELECT through `schemaQuery` (postgresql/schema-statements-class.ts) because the body needs hash-keyed rows plus bind params for the `to_regclass` fast path; Rails' positional `query` has no bind-carrying form. Deliberately left for the separate `indexes` shape-convergence story."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "indexes",
-    "call": "quoted_scope",
-    "reason": "SQL-side equivalent: trails' `indexes` resolves the table through `parseSchemaQualifiedName` + bind params ($1/$2) instead of interpolating `quoted_scope`'s pre-quoted literals, so the scope is carried by binds rather than by a quoted_scope hash."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "indexes",
-    "call": "unquote_identifier",
-    "reason": "SQL-side equivalent: `pg_get_indexdef(..., k + 1, true)` returns already-unquoted column names, so there is no quoted identifier left to strip; the INCLUDE list is unquoted inline with `.replace(/^\"|\"$/g, '')`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "initialize",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -432,13 +250,6 @@
     "rubyName": "max_identifier_length",
     "call": "query_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "pk_and_sequence_for",
-    "call": "query",
-    "reason": "Deviation, justified at the call site (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): trails issues the single rewritten lookup through `schemaQuery` (query(sql, \"SCHEMA\")) rather than Rails' two `query` calls. See PostgreSQLSchemaStatements#pkAndSequenceFor."
   },
   {
     "package": "activerecord",
@@ -527,48 +338,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_column",
-    "call": "rename_column_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_enum",
-    "call": "exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_enum",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_enum_value",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_enum_value",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_enum_value",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "reset!",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -579,13 +348,6 @@
     "rubyName": "returning_column_values",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "schema_search_path=",
-    "call": "internal_execute",
-    "reason": "Equivalent (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): setSchemaSearchPath does call the ported internal_execute primitive — `this.pg.internalExecute(`SET search_path TO ${searchPath}`)` in postgresql/schema-statements-class.ts. Unmatched for the same reason as client_min_messages=: the entry is anchored to postgresql-adapter.ts, which only delegates."
   },
   {
     "package": "activerecord",
@@ -611,13 +373,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "table_options",
-    "call": "presence",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "translate_exception",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -628,34 +383,6 @@
     "rubyName": "translate_exception",
     "call": "try",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "unique_constraint_name",
-    "call": "first",
-    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Enumerable#first(n)` on the digest; JS uses `String#slice(0, n)`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "unique_constraint_name",
-    "call": "hexdigest",
-    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Digest::SHA256.hexdigest`; JS uses the WebCrypto/`createHash` hex digest. The derivation is byte-identical — schema-statements-class.trails.test.ts pins `uniq_rails_1e07660b77` / `uniq_rails_79b901ffb4` against Rails' own literals."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "unique_constraint_name",
-    "call": "map",
-    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Array#map(&:to_s)` coercing the column list; JS columns are already strings, so the join is direct."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "unique_constraints",
-    "call": "delete",
-    "reason": "Ruby-ism: `row['conkey'].delete('{}')` strips the PG array braces; trails uses `String(r.conkey).replace(/[{}]/g, \"\")` on the same line."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Rails' `PostgreSQLAdapter` does `include PostgreSQL::SchemaStatements`
(`postgresql_adapter.rb:185`). trails kept the PG half as a companion class
that the adapter reached through a private `pgSchemaStatements()` accessor
plus one thin delegator per method — the last adapter still doing that after
`remove-schema-statements-dispatch-shim-companion-mixin-duality` (MySQL was
already `include(AbstractMysqlAdapter, MysqlSchemaStatements)`).

## What changed

- `include(PostgreSQLAdapter, PostgreSQLSchemaStatements)` at the bottom of
  `postgresql-adapter.ts`, mirroring the MySQL wiring.
- Deleted the private `pgSchemaStatements()` accessor and all 85 delegators.
  Method bodies stay in `postgresql/schema-statements-class.ts` — the Rails
  layout file `api:compare` matches against.
- `include()` keeps class-body methods above the mixin, exactly as Ruby's
  ancestry does, so the adapter's own `addIndex` / `renameIndex` /
  `addIndexOptions` overrides still win and reach the base bodies via plain
  `super`. Their internal hops through the companion (`ss.tableExists(...)`,
  `ss.columnExists(...)`, `validateIndexLengthBang`) are now plain `this` calls.
- The companion's `schemaCreation` override is gone: the adapter's own getter
  is what the mixed-in bodies hit.
- A declaration-merged `interface PostgreSQLAdapter` carries the mixed-in
  signatures for TypeScript, mirroring how `AbstractAdapter` declares its own
  `include SchemaStatements` surface (`abstract-adapter.ts:209`). `include()`
  installs the methods on the prototype at runtime but the class type can't
  see them.
- `isUseForeignKeys()` added to the `AbstractAdapter` interface — it was
  reachable only through the companion's own class type before.
- `schema-statements-class.test.ts` / `.trails.test.ts` are re-pointed at the
  adapter: their fake adapters carry `PostgreSQLAdapter.prototype` instead of
  being wrapped in a companion instance. **No test names changed.**

## Verification

- `pnpm tsc -b packages/activerecord`, eslint, and `pnpm api:compare` clean
  (no manifest or ratchet drift).
- Against a private PG 17 stack: `packages/activerecord/src/adapters/postgresql`
  941 passed / 50 skipped; `connection-adapters` + `migration` 2248 passed /
  50 skipped.

## Note on size

1111 LOC (455+/656-), over the 500 ceiling. The flip is atomic and can't be
split: until every delegator is gone the accessor has to stay, and the type
surface moves in one piece with it. 656 of those lines are deletions and ~340
of the insertions are the mechanical signature-for-signature interface that
replaces the deleted delegator signatures.

Closes-story: dissolve-the-postgresql-schema-statements-companion
