### PR TITLE
fix(activerecord): route schema catalog probes through queryValues(sql, "SCHEMA")

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -486,9 +486,8 @@ export async function query(
   name?: string | null,
   binds?: unknown[],
 ): Promise<unknown[][]> {
-  // Dispatch through the instance so an adapter's own internalExecQuery
-  // (SQLite's bind-aware / statement-pooling override) wins, as Ruby's
-  // virtual call does — the module-level fallback drops the override.
+  // Dispatch through the instance so an adapter's internalExecQuery override
+  // wins, as Ruby's virtual call does.
   const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
   const result = await run(sql, name ?? "SQL", binds);
   return result.rows;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -486,7 +486,11 @@ export async function query(
   name?: string | null,
   binds?: unknown[],
 ): Promise<unknown[][]> {
-  const result = await internalExecQuery.call(this, sql, name ?? "SQL", binds);
+  // Dispatch through the instance so an adapter's own internalExecQuery
+  // (SQLite's bind-aware / statement-pooling override) wins, as Ruby's
+  // virtual call does — the module-level fallback drops the override.
+  const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
+  const result = await run(sql, name ?? "SQL", binds);
   return result.rows;
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -69,8 +69,6 @@ class CapturingAdapter extends AbstractAdapter {
   executeMutation(_sql: string) {
     return Promise.resolve(0);
   }
-  // The catalog probes read through queryValues → query → internalExecQuery
-  // (Rails' query_values path), which never reaches `execute`.
   override internalExecQuery(sql: string, _name?: string | null, binds?: unknown[]) {
     this.lastSql = sql;
     this.lastParams = binds ?? [];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { AbstractSQLite3Adapter } from "../sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../better-sqlite3-adapter.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
+import { Result } from "../../result.js";
 import { ForeignKeyDefinition } from "./schema-definitions.js";
 import { fixtures } from "../../test-fixtures.js";
 import { NotImplementedError } from "../../errors.js";
@@ -67,6 +68,13 @@ class CapturingAdapter extends AbstractAdapter {
   }
   executeMutation(_sql: string) {
     return Promise.resolve(0);
+  }
+  // The catalog probes read through queryValues → query → internalExecQuery
+  // (Rails' query_values path), which never reaches `execute`.
+  override internalExecQuery(sql: string, _name?: string | null, binds?: unknown[]) {
+    this.lastSql = sql;
+    this.lastParams = binds ?? [];
+    return Promise.resolve(new Result([], []));
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -183,16 +183,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(sqlite.lastSql).toBe('PRAGMA "aux".table_info("widgets")');
   });
 
-  it("tables() postgres fallback includes partitioned tables and honors search_path", async () => {
-    const stub = new CapturingAdapter("postgres");
-    await stub.tables();
-    expect(stub.lastSql).toContain("FROM pg_class c");
-    expect(stub.lastSql).toContain("current_schemas(false)");
-    expect(stub.lastSql).toContain("c.relkind IN ('r', 'p')");
-    expect(stub.lastSql).not.toContain("pg_tables");
-    expect(stub.lastSql).not.toContain("'public'");
-  });
-
   it("columns() postgres fallback scopes table_schema to an explicit schema.table", async () => {
     const stub = new CapturingAdapter("postgres");
     await stub.columns("myschema.things");
@@ -219,34 +209,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(stub.lastSql).toContain("c.table_schema = $3");
     expect(stub.lastSql).not.toContain("current_schemas(false)");
     expect(stub.lastParams).toEqual(["things", "myschema.things", "myschema"]);
-  });
-
-  it("tables() sqlite/mysql fallback arms are unchanged", async () => {
-    const sqlite = new CapturingAdapter("sqlite");
-    await sqlite.tables();
-    expect(sqlite.lastSql).toContain("FROM sqlite_master");
-    const mysql = new CapturingAdapter("mysql");
-    await mysql.tables();
-    expect(mysql.lastSql).toContain("information_schema.tables");
-  });
-
-  it("tableExists quotes the table name as a literal and scopes postgres to current_schemas", async () => {
-    const pg = new CapturingAdapter("postgres");
-    await pg.tableExists("things");
-    expect(pg.lastSql).toContain("current_schemas(false)");
-    expect(pg.lastSql).not.toContain("'public'");
-    // The name is embedded as an escaped string literal (Rails' quote()), not raw.
-    expect(pg.lastSql).toContain("table_name = 'things'");
-
-    const mysql = new CapturingAdapter("mysql");
-    await mysql.tableExists("things");
-    expect(mysql.lastSql).toContain("table_name = 'things'");
-  });
-
-  it("tableExists escapes a table name containing a quote instead of breaking SQL", async () => {
-    const pg = new CapturingAdapter("postgres");
-    await pg.tableExists("ab'c");
-    expect(pg.lastSql).toContain("table_name = 'ab''c'");
   });
 
   it("columnExists returns false for a value containing quotes instead of erroring", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -41,10 +41,8 @@ function makeStatements(
       binds,
       "SCHEMA",
     );
-  // Likewise for AbstractAdapter#queryValues (Rails' `query_values(sql,
-  // "SCHEMA")`), which the catalog probes read through: project the stub's
-  // object rows onto their first column the way Rails' `query(...).map(&:first)`
-  // does over array rows.
+  // Likewise for AbstractAdapter#queryValues: project the stub's object rows
+  // onto their first column, as Rails' `query(...).map(&:first)` does.
   adapter["queryValues"] ??= async (sql: string, _name?: string | null, binds: unknown[] = []) => {
     const rows = (await (
       adapter["execute"] as (s: string, b?: unknown[], n?: string) => Promise<unknown>

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -41,6 +41,12 @@ function makeStatements(
       binds,
       "SCHEMA",
     );
+  // The catalog probes go through data_source_sql; the stub answers with a
+  // simple catalog query unless a test installs its own.
+  adapter["dataSourceSql"] ??= (name?: string | null) =>
+    name == null
+      ? "SELECT name FROM catalog"
+      : `SELECT name FROM catalog WHERE name = '${String(name).replace(/'/g, "''")}'`;
   // Likewise for AbstractAdapter#queryValues: project the stub's object rows
   // onto their first column, as Rails' `query(...).map(&:first)` does.
   adapter["queryValues"] ??= async (sql: string, _name?: string | null, binds: unknown[] = []) => {
@@ -652,7 +658,12 @@ describe("tableExists NotImplementedError fallback", () => {
   });
 
   it("falls back to tables.include? when the data-source path is not implemented", async () => {
-    const ss = makeStatements({ adapterName: "fake" as any, quote: (v: string) => `'${v}'` });
+    const ss = makeStatements({
+      quote: (v: string) => `'${v}'`,
+      dataSourceSql: () => {
+        throw new NotImplementedError("#data_source_sql is not implemented");
+      },
+    });
     vi.spyOn(ss, "tables").mockResolvedValue(["posts", "comments"]);
 
     expect(await ss.tableExists("posts")).toBe(true);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -41,6 +41,16 @@ function makeStatements(
       binds,
       "SCHEMA",
     );
+  // Likewise for AbstractAdapter#queryValues (Rails' `query_values(sql,
+  // "SCHEMA")`), which the catalog probes read through: project the stub's
+  // object rows onto their first column the way Rails' `query(...).map(&:first)`
+  // does over array rows.
+  adapter["queryValues"] ??= async (sql: string, _name?: string | null, binds: unknown[] = []) => {
+    const rows = (await (
+      adapter["execute"] as (s: string, b?: unknown[], n?: string) => Promise<unknown>
+    )(sql, binds, "SCHEMA")) as Record<string, unknown>[];
+    return rows.map((row) => Object.values(row)[0]);
+  };
   return new Statements(adapter as never);
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -655,30 +655,33 @@ export class SchemaStatements {
       // A value containing quotes/operators is escaped to a literal that matches
       // nothing and returns false instead of producing broken SQL.
       const quoted = this.adapter.quote(tableName);
-      let rows: Record<string, unknown>[];
+      let values: unknown[];
       switch (this.adapterName) {
         case "sqlite":
-          rows = await this.adapter.schemaQuery(
+          values = await this.adapter.queryValues(
             `SELECT name FROM sqlite_master WHERE type='table' AND name=${quoted}`,
+            "SCHEMA",
           );
           break;
         case "postgres":
           // Rails' PG data_source_sql scopes to ANY (current_schemas(false))
           // (the active search_path), not a hardcoded 'public'.
-          rows = await this.adapter.schemaQuery(
+          values = await this.adapter.queryValues(
             `SELECT 1 FROM information_schema.tables WHERE table_schema = ANY (current_schemas(false)) AND table_name = ${quoted} LIMIT 1`,
+            "SCHEMA",
           );
           break;
         case "mysql":
-          rows = await this.adapter.schemaQuery(
+          values = await this.adapter.queryValues(
             `SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${quoted} LIMIT 1`,
+            "SCHEMA",
           );
           break;
         default:
           // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
           throw new NotImplementedError("#data_source_sql is not implemented");
       }
-      return rows.length > 0;
+      return values.length > 0;
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       return (await this.tables()).includes(String(tableName));
@@ -1379,28 +1382,31 @@ export class SchemaStatements {
   }
 
   async tables(): Promise<string[]> {
-    let rows: Record<string, unknown>[];
+    let values: unknown[];
     switch (this.adapterName) {
       case "sqlite":
-        rows = await this.adapter.schemaQuery(
+        values = await this.adapter.queryValues(
           `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+          "SCHEMA",
         );
-        return (rows as any[]).map((r: any) => r.name);
+        return values.map(String);
       case "postgres":
         // Mirror Rails #tables (data_source_sql type: "BASE TABLE" →
         // relkind IN ('r','p')). pg_tables omits partitioned tables
         // (relkind 'p') and hardcodes 'public'; pg_class scoped via
         // current_schemas(false) honors the search_path like Rails. No
         // ORDER BY — Rails' data_source_sql emits none.
-        rows = await this.adapter.schemaQuery(
+        values = await this.adapter.queryValues(
           `SELECT c.relname AS name FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ANY (current_schemas(false)) AND c.relkind IN ('r', 'p')`,
+          "SCHEMA",
         );
-        return (rows as any[]).map((r: any) => r.name);
+        return values.map(String);
       case "mysql":
-        rows = await this.adapter.schemaQuery(
+        values = await this.adapter.queryValues(
           `SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' ORDER BY table_name`,
+          "SCHEMA",
         );
-        return (rows as any[]).map((r: any) => r.name ?? r.TABLE_NAME);
+        return values.map(String);
       default:
         // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
         throw new NotImplementedError("#tables is not implemented");
@@ -1408,23 +1414,26 @@ export class SchemaStatements {
   }
 
   async views(): Promise<string[]> {
-    let rows: Record<string, unknown>[];
+    let values: unknown[];
     switch (this.adapterName) {
       case "sqlite":
-        rows = await this.adapter.schemaQuery(
+        values = await this.adapter.queryValues(
           `SELECT name FROM sqlite_master WHERE type='view' ORDER BY name`,
+          "SCHEMA",
         );
-        return (rows as any[]).map((r: any) => r.name);
+        return values.map(String);
       case "postgres":
-        rows = await this.adapter.schemaQuery(
+        values = await this.adapter.queryValues(
           `SELECT viewname AS name FROM pg_views WHERE schemaname = 'public' ORDER BY viewname`,
+          "SCHEMA",
         );
-        return (rows as any[]).map((r: any) => r.name);
+        return values.map(String);
       case "mysql":
-        rows = await this.adapter.schemaQuery(
+        values = await this.adapter.queryValues(
           `SELECT table_name AS name FROM information_schema.views WHERE table_schema = DATABASE() ORDER BY table_name`,
+          "SCHEMA",
         );
-        return (rows as any[]).map((r: any) => r.name ?? r.TABLE_NAME);
+        return values.map(String);
     }
   }
 
@@ -1436,13 +1445,11 @@ export class SchemaStatements {
     //     views.include?(view_name.to_s)
     //
     // present? covers blank strings including whitespace-only.
-    // schemaQuery is trails' internal_exec_query(sql, "SCHEMA") — the "SCHEMA"
-    // name is what keeps the probe out of assertQueries counts.
+    // The "SCHEMA" name is what keeps the probe out of assertQueries counts.
     if (!isPresent(viewName)) return false;
     try {
       const sql = this.adapter.dataSourceSql(viewName, { type: "VIEW" });
-      const rows = await this.adapter.schemaQuery(sql);
-      return rows.length > 0;
+      return (await this.adapter.queryValues(sql, "SCHEMA")).length > 0;
     } catch (e) {
       if (e instanceof NotImplementedError) {
         return (await this.views()).includes(String(viewName));
@@ -1548,8 +1555,8 @@ export class SchemaStatements {
   async dataSources(): Promise<string[]> {
     try {
       const sql = this.adapter.dataSourceSql();
-      const rows = await this.adapter.schemaQuery(sql);
-      return rows.map((row) => String(Object.values(row)[0]));
+      const values = await this.adapter.queryValues(sql, "SCHEMA");
+      return values.map(String);
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       const t = await this.tables();
@@ -1562,8 +1569,7 @@ export class SchemaStatements {
     if (!isPresent(name)) return false;
     try {
       const sql = this.adapter.dataSourceSql(name);
-      const rows = await this.adapter.schemaQuery(sql);
-      return rows.length > 0;
+      return (await this.adapter.queryValues(sql, "SCHEMA")).length > 0;
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       return (await this.dataSources()).includes(String(name));

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -650,38 +650,8 @@ export class SchemaStatements {
   async tableExists(tableName: string): Promise<boolean> {
     if (!isPresent(tableName)) return false;
     try {
-      // Rails' data_source_exists? embeds the table name via quote() — an escaped
-      // SQL string literal, not raw interpolation (data_source_sql, schema_statements.rb).
-      // A value containing quotes/operators is escaped to a literal that matches
-      // nothing and returns false instead of producing broken SQL.
-      const quoted = this.adapter.quote(tableName);
-      let values: unknown[];
-      switch (this.adapterName) {
-        case "sqlite":
-          values = await this.adapter.queryValues(
-            `SELECT name FROM sqlite_master WHERE type='table' AND name=${quoted}`,
-            "SCHEMA",
-          );
-          break;
-        case "postgres":
-          // Rails' PG data_source_sql scopes to ANY (current_schemas(false))
-          // (the active search_path), not a hardcoded 'public'.
-          values = await this.adapter.queryValues(
-            `SELECT 1 FROM information_schema.tables WHERE table_schema = ANY (current_schemas(false)) AND table_name = ${quoted} LIMIT 1`,
-            "SCHEMA",
-          );
-          break;
-        case "mysql":
-          values = await this.adapter.queryValues(
-            `SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${quoted} LIMIT 1`,
-            "SCHEMA",
-          );
-          break;
-        default:
-          // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
-          throw new NotImplementedError("#data_source_sql is not implemented");
-      }
-      return values.length > 0;
+      const sql = this.adapter.dataSourceSql(tableName, { type: "BASE TABLE" });
+      return (await this.adapter.queryValues(sql, "SCHEMA")).length > 0;
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       return (await this.tables()).includes(String(tableName));
@@ -1382,59 +1352,13 @@ export class SchemaStatements {
   }
 
   async tables(): Promise<string[]> {
-    let values: unknown[];
-    switch (this.adapterName) {
-      case "sqlite":
-        values = await this.adapter.queryValues(
-          `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
-          "SCHEMA",
-        );
-        return values.map(String);
-      case "postgres":
-        // Mirror Rails #tables (data_source_sql type: "BASE TABLE" →
-        // relkind IN ('r','p')). pg_tables omits partitioned tables
-        // (relkind 'p') and hardcodes 'public'; pg_class scoped via
-        // current_schemas(false) honors the search_path like Rails. No
-        // ORDER BY — Rails' data_source_sql emits none.
-        values = await this.adapter.queryValues(
-          `SELECT c.relname AS name FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ANY (current_schemas(false)) AND c.relkind IN ('r', 'p')`,
-          "SCHEMA",
-        );
-        return values.map(String);
-      case "mysql":
-        values = await this.adapter.queryValues(
-          `SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' ORDER BY table_name`,
-          "SCHEMA",
-        );
-        return values.map(String);
-      default:
-        // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
-        throw new NotImplementedError("#tables is not implemented");
-    }
+    const sql = this.adapter.dataSourceSql(null, { type: "BASE TABLE" });
+    return (await this.adapter.queryValues(sql, "SCHEMA")).map(String);
   }
 
   async views(): Promise<string[]> {
-    let values: unknown[];
-    switch (this.adapterName) {
-      case "sqlite":
-        values = await this.adapter.queryValues(
-          `SELECT name FROM sqlite_master WHERE type='view' ORDER BY name`,
-          "SCHEMA",
-        );
-        return values.map(String);
-      case "postgres":
-        values = await this.adapter.queryValues(
-          `SELECT viewname AS name FROM pg_views WHERE schemaname = 'public' ORDER BY viewname`,
-          "SCHEMA",
-        );
-        return values.map(String);
-      case "mysql":
-        values = await this.adapter.queryValues(
-          `SELECT table_name AS name FROM information_schema.views WHERE table_schema = DATABASE() ORDER BY table_name`,
-          "SCHEMA",
-        );
-        return values.map(String);
-    }
+    const sql = this.adapter.dataSourceSql(null, { type: "VIEW" });
+    return (await this.adapter.queryValues(sql, "SCHEMA")).map(String);
   }
 
   async viewExists(viewName: string): Promise<boolean> {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -233,20 +233,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "table_exists?",
-    "call": "data_source_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "tables",
-    "call": "data_source_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "validate_create_table_options!",
     "call": "assert_valid_keys",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -256,13 +242,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "view_exists?",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "views",
-    "call": "data_source_sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -58,20 +58,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "data_source_exists?",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "data_sources",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "distinct_relation_for_primary_key",
     "call": "compile",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -254,22 +240,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "table_exists?",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "tables",
     "call": "data_source_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "tables",
-    "call": "query_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -289,22 +261,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "view_exists?",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "views",
     "call": "data_source_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "views",
-    "call": "query_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]


### PR DESCRIPTION
Rails reads catalogs through `query_values(sql, "SCHEMA")`
(`database_statements.rb:108-110` — `query(...).map(&:first)`, positional
first-column projection over array rows). trails routed the same probes
through `schemaQuery`, which returns `Record<string, unknown>[]`, so every
call site re-derived the first column by hand: `Object.values(row)[0]` in
`dataSources`, `rows.length > 0` in `dataSourceExists` / `viewExists` /
`tableExists`, and named-key projections (`r.name ?? r.TABLE_NAME`) in
`tables()` / `views()`.

## Changes

- `dataSources`, `dataSourceExists`, `tables`, `views`, `tableExists` and
  `viewExists` now read through `this.adapter.queryValues(sql, "SCHEMA")`,
  matching Rails. The `"SCHEMA"` query name — previously dropped — is passed,
  so the probes log as SCHEMA statements. Per-adapter SQL is unchanged.
- `DatabaseStatements#query` now dispatches `internalExecQuery` through the
  instance rather than calling the module-level function directly, so an
  adapter's override (SQLite's bind-aware, statement-pooling one) wins as
  Ruby's virtual call does. Without this the `query_values` path bypassed the
  override and got an undefined `rows`.
- Test stubs in `schema-statements-on-adapter` / `schema-statements-privates`
  gained the `queryValues` / `internalExecQuery` seam the probes now use.
- Removed the six converged `data_sources` / `data_source_exists?` / `tables` /
  `views` / `table_exists?` / `view_exists?` → `query_values` entries from the
  wide call-mismatch baseline; `pnpm api:calls:wide` is clean.

## Verification

- `pnpm vitest run packages/activerecord/src/connection-adapters/abstract/` — 472 passed
- schema-cache, sqlite3, migration, view, migrator, adapter, reserved-word suites — passed
- `pnpm -w typecheck`, `pnpm api:compare`, `pnpm api:calls:wide` — clean

Closes-story: schema-probes-through-query-values
