### PR TITLE
refactor(activerecord): retire standalone SchemaStatements construction

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } 
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { isValidUuid, normalizeUuid } from "../../connection-adapters/postgresql/oid/uuid.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { SchemaStatements } from "../../connection-adapters/abstract/schema-statements.js";
 import { RecordNotFound } from "../../errors.js";
 import { itIfSupports } from "../../support/supports.js";
 import { fixtures } from "../../test-fixtures.js";
@@ -796,10 +795,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("createTable round-trips uuid PK default", async () => {
-      const ss = new SchemaStatements(adapter);
       await adapter.exec(`DROP TABLE IF EXISTS pg_uuids_rt`);
       try {
-        await ss.createTable("pg_uuids_rt", {
+        await adapter.createTable("pg_uuids_rt", {
           id: "uuid",
           default: () => "gen_random_uuid()",
           force: "cascade",

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -220,6 +220,7 @@ export interface AbstractAdapter {
           primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;
+          default?: unknown;
           options?: string;
           comment?: string;
           charset?: string;
@@ -227,6 +228,8 @@ export interface AbstractAdapter {
           temporary?: boolean;
           as?: string;
           autoIncrement?: boolean;
+          limit?: number;
+          precision?: number;
         }
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -5,6 +5,8 @@ import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { ActiveRecord } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { SchemaStatements } from "./abstract/schema-statements.js";
+import type { SchemaQuoter } from "./abstract/assert-schema-adapter.js";
+import { include } from "@blazetrails/activesupport";
 import { TableDefinition } from "./abstract/schema-definitions.js";
 import type { AbstractAdapter } from "./abstract-adapter.js";
 import { newRawTestAdapter } from "../test-adapter.js";
@@ -717,20 +719,31 @@ describe("SchemaReflectionTest", () => {
 // Tests that are NOT skipped already pass because the relevant adapter override
 // already calls clearDataSourceCacheBang (dropTable in all three adapters).
 
-function makeMockAdapter(cache: SchemaCache) {
-  return {
-    adapterName: "sqlite" as const,
-    quoteIdentifier: (n: string) => `"${n}"`,
-    quoteTableName: (n: string) => `"${n}"`,
-    executeMutation: vi.fn().mockResolvedValue(0),
-    execute: vi.fn().mockResolvedValue([]),
-    schemaCache: cache,
-    pool: {},
-    quoteDefaultExpression: (_v: unknown) => "",
-    supportsDatetimeWithPrecision: () => false,
-    createTableDefinition: (n: string, opts: Record<string, unknown>) =>
-      new TableDefinition(n, { ...opts, adapterName: "sqlite" }),
-  };
+class MockAdapter {
+  adapterName = "sqlite" as const;
+  quoteIdentifier = (n: string) => `"${n}"`;
+  quoteTableName = (n: string) => `"${n}"`;
+  executeMutation = vi.fn().mockResolvedValue(0);
+  execute = vi.fn().mockResolvedValue([]);
+  schemaCache: SchemaCache;
+  pool = {};
+  quoteDefaultExpression = (_v: unknown) => "";
+  supportsDatetimeWithPrecision = () => false;
+  createTableDefinition = (n: string, opts: Record<string, unknown>) =>
+    new TableDefinition(n, { ...opts, adapterName: "sqlite" });
+
+  constructor(cache: SchemaCache) {
+    this.schemaCache = cache;
+  }
+
+  // SchemaStatements' bodies reach the adapter through `this.adapter`; on a
+  // real adapter that self-reference is AbstractAdapter#adapter.
+  adapter = this as unknown as AbstractAdapter & SchemaQuoter;
+}
+include(MockAdapter, SchemaStatements);
+
+function makeMockAdapter(cache: SchemaCache): MockAdapter & SchemaStatements {
+  return new MockAdapter(cache) as MockAdapter & SchemaStatements;
 }
 
 describe("DDL cache-invalidation safety-net", () => {
@@ -751,10 +764,9 @@ describe("DDL cache-invalidation safety-net", () => {
       return [];
     });
 
-    const ss = new SchemaStatements(adapter as any);
     // The adapter is a mock: no DDL reaches a database.
     // eslint-disable-next-line blazetrails/require-table-teardown
-    await ss.dropTable("posts");
+    await adapter.dropTable("posts");
 
     expect(cache.isCached("posts")).toBe(false);
     expect(order).toEqual(["clear:posts", "sql"]);
@@ -777,8 +789,7 @@ describe("DDL cache-invalidation safety-net", () => {
       return [];
     });
 
-    const ss = new SchemaStatements(adapter as any);
-    await ss.dropJoinTable("accounts", "people");
+    await adapter.dropJoinTable("accounts", "people");
 
     expect(cache.isCached("accounts_people")).toBe(false);
     expect(order).toEqual(["clear:accounts_people", "sql"]);
@@ -790,8 +801,8 @@ describe("DDL cache-invalidation safety-net", () => {
     // Pre-seed new name too (could be stale from a previous run)
     cache.setColumns("articles", [makeColumn("id", "integer")]);
 
-    const ss = new SchemaStatements(makeMockAdapter(cache) as any);
-    await ss.renameTable("posts", "articles");
+    const adapter = makeMockAdapter(cache);
+    await adapter.renameTable("posts", "articles");
 
     expect(cache.isCached("posts")).toBe(false);
     expect(cache.isCached("articles")).toBe(false);
@@ -802,8 +813,8 @@ describe("DDL cache-invalidation safety-net", () => {
     // Stale entry from a prior create (e.g. after a test dropped the table)
     cache.setColumns("posts", [makeColumn("id", "integer")]);
 
-    const ss = new SchemaStatements(makeMockAdapter(cache) as any);
-    await ss.createTable("posts");
+    const adapter = makeMockAdapter(cache);
+    await adapter.createTable("posts");
 
     expect(cache.isCached("posts")).toBe(false);
   });
@@ -812,8 +823,8 @@ describe("DDL cache-invalidation safety-net", () => {
     const cache = new SchemaCache();
     cache.setColumns("posts", [makeColumn("id", "integer")]);
 
-    const ss = new SchemaStatements(makeMockAdapter(cache) as any);
-    await ss.addColumn("posts", "title", "string");
+    const adapter = makeMockAdapter(cache);
+    await adapter.addColumn("posts", "title", "string");
 
     expect(cache.isCached("posts")).toBe(false);
   });
@@ -822,8 +833,8 @@ describe("DDL cache-invalidation safety-net", () => {
     const cache = new SchemaCache();
     cache.setColumns("posts", [makeColumn("id", "integer"), makeColumn("title", "varchar")]);
 
-    const ss = new SchemaStatements(makeMockAdapter(cache) as any);
-    await ss.removeColumn("posts", "title");
+    const adapter = makeMockAdapter(cache);
+    await adapter.removeColumn("posts", "title");
 
     expect(cache.isCached("posts")).toBe(false);
   });
@@ -832,8 +843,8 @@ describe("DDL cache-invalidation safety-net", () => {
     const cache = new SchemaCache();
     cache.setColumns("posts", [makeColumn("id", "integer"), makeColumn("title", "varchar")]);
 
-    const ss = new SchemaStatements(makeMockAdapter(cache) as any);
-    await ss.addIndex("posts", ["title"]);
+    const adapter = makeMockAdapter(cache);
+    await adapter.addIndex("posts", ["title"]);
 
     expect(cache.isCached("posts")).toBe(false);
   });
@@ -842,8 +853,8 @@ describe("DDL cache-invalidation safety-net", () => {
     const cache = new SchemaCache();
     cache.setColumns("posts", [makeColumn("id", "integer"), makeColumn("title", "varchar")]);
 
-    const ss = new SchemaStatements(makeMockAdapter(cache) as any);
-    await ss.removeIndex("posts", { name: "index_posts_on_title" });
+    const adapter = makeMockAdapter(cache);
+    await adapter.removeIndex("posts", { name: "index_posts_on_title" });
 
     expect(cache.isCached("posts")).toBe(false);
   });
@@ -852,8 +863,8 @@ describe("DDL cache-invalidation safety-net", () => {
     const cache = new SchemaCache();
     cache.setColumns("posts", [makeColumn("id", "integer"), makeColumn("title", "varchar")]);
 
-    const ss = new SchemaStatements(makeMockAdapter(cache) as any);
-    await ss.changeColumn("posts", "title", "text");
+    const adapter = makeMockAdapter(cache);
+    await adapter.changeColumn("posts", "title", "text");
 
     expect(cache.isCached("posts")).toBe(false);
   });
@@ -875,8 +886,7 @@ describe("DDL cache-invalidation safety-net", () => {
       return [];
     });
 
-    const ss = new SchemaStatements(adapter as any);
-    await ss.renameColumn("posts", "title", "headline");
+    await adapter.renameColumn("posts", "title", "headline");
 
     expect(cache.isCached("posts")).toBe(false);
     expect(order).toEqual(["clear:posts", "sql"]);
@@ -899,11 +909,10 @@ describe("DDL cache-invalidation safety-net", () => {
       return [];
     });
 
-    const ss = new SchemaStatements(adapter as any);
-    vi.spyOn(ss, "indexes").mockResolvedValue([
+    vi.spyOn(adapter, "indexes").mockResolvedValue([
       { table: "posts", name: "index_posts_on_title", columns: ["title"], unique: false } as any,
     ]);
-    await ss.renameIndex("posts", "index_posts_on_title", "index_posts_on_headline");
+    await adapter.renameIndex("posts", "index_posts_on_title", "index_posts_on_headline");
 
     expect(cache.isCached("posts")).toBe(false);
     expect(order[0]).toBe("clear:posts");

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -320,17 +320,10 @@ export abstract class Migration {
     return this.connection.adapterName as "sqlite" | "postgres" | "mysql";
   }
 
-  private _schema?: SchemaStatements;
-  private _schemaConn?: DatabaseAdapter;
-
   get schema(): SchemaStatements {
     const conn = this.connection;
-    if (!this._schema || this._schemaConn !== conn) {
-      assertSchemaAdapter(conn);
-      this._schema = conn as unknown as SchemaStatements;
-      this._schemaConn = conn;
-    }
-    return this._schema;
+    assertSchemaAdapter(conn);
+    return conn as unknown as SchemaStatements;
   }
 
   /**

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -20,8 +20,6 @@
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import type { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
-import { assertSchemaAdapter } from "./connection-adapters/abstract/assert-schema-adapter.js";
 import type * as SchemaIntrospectionModule from "./schema-introspection.js";
 import * as adapterDumper from "./connection-adapters/abstract/schema-dumper.js";
 import type {
@@ -247,7 +245,6 @@ class AdapterSchemaSource implements SchemaSource {
   get adapter(): DatabaseAdapter {
     return this._adapter;
   }
-  private _schema?: SchemaStatements;
 
   /** @internal */
   constructor(adapter: DatabaseAdapter) {
@@ -329,18 +326,7 @@ class AdapterSchemaSource implements SchemaSource {
       include?: string[];
       comment?: string;
     };
-    let raw: RichIdx[];
-    const adapterAny = this._adapter as unknown as { indexes?(t: string): Promise<unknown[]> };
-    if (typeof adapterAny.indexes === "function") {
-      raw = (await adapterAny.indexes(tableName)) as RichIdx[];
-    } else {
-      if (!this._schema) {
-        const mod = await import("./connection-adapters/abstract/schema-statements.js");
-        assertSchemaAdapter(this._adapter);
-        this._schema = new mod.SchemaStatements(this._adapter);
-      }
-      raw = (await this._schema.indexes(tableName)) as RichIdx[];
-    }
+    const raw = (await this._adapter.indexes(tableName)) as RichIdx[];
     return raw.map((idx) => ({
       columns: idx.columns,
       unique: idx.unique,

--- a/packages/activerecord/src/schema-introspection.trails.test.ts
+++ b/packages/activerecord/src/schema-introspection.trails.test.ts
@@ -1,9 +1,8 @@
 // Trails-only unit tests for the trails-invented `introspect*` helpers
-// (introspectTables/Columns/Indexes/PrimaryKey) and their
-// SchemaStatements fallback path — no 1:1 Rails counterpart exists. The scratch
-// tables these create (`widgets`, `more_testings`) are real Rails migration-test
-// table names (primary_keys_test.rb / migration/compatibility_test.rb), not
-// freshly-invented ones, per the RFC 0048 fidelity contract.
+// (introspectTables/Columns/Indexes/PrimaryKey) — no 1:1 Rails counterpart
+// exists. The scratch tables these create (`widgets`) are real Rails
+// migration-test table names (primary_keys_test.rb), not freshly-invented
+// ones, per the RFC 0048 fidelity contract.
 import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "./base.js";
 import { adapterType } from "./test-adapter.js";
@@ -15,26 +14,6 @@ import {
   introspectPrimaryKey,
 } from "./schema-introspection.js";
 
-/**
- * Return a proxy over `adapter` that hides the named methods so the
- * SchemaStatements fallback path inside `introspect*` runs. Keeping
- * the real adapter underneath means adapterName + execute()
- * work, so SchemaStatements' query dispatch can complete.
- */
-function withoutMethods<A extends object>(adapter: A, hidden: string[]): A {
-  const hiddenSet = new Set(hidden);
-  return new Proxy(adapter, {
-    get(target, prop, receiver) {
-      if (typeof prop === "string" && hiddenSet.has(prop)) return undefined;
-      return Reflect.get(target, prop, receiver);
-    },
-    has(target, prop) {
-      if (typeof prop === "string" && hiddenSet.has(prop)) return false;
-      return Reflect.has(target, prop);
-    },
-  });
-}
-
 // Ride the primary schema-loaded pool (`Base.connection`) instead of the
 // sidecar test pool.
 fixtures({}, { useTransactionalTests: false });
@@ -42,7 +21,7 @@ fixtures({}, { useTransactionalTests: false });
 // The tables these tests create leak into the shared
 // per-worker DB; drop them by name so they don't collide with sibling files.
 afterEach(async () => {
-  await Base.connection.dropTable("widgets", "more_testings", { ifExists: true });
+  await Base.connection.dropTable("widgets", { ifExists: true });
 });
 
 describe("introspectTables", () => {
@@ -59,20 +38,6 @@ describe("introspectTables", () => {
 
     expect(called).toBe(true);
     expect(tables).toEqual(["users", "posts"]);
-  });
-
-  it("falls back to SchemaStatements when the adapter doesn't implement tables()", async () => {
-    const realAdapter = Base.connection;
-    await realAdapter.createTable("widgets", {}, () => {});
-    await realAdapter.createTable("more_testings", {}, () => {});
-
-    // Strip `tables()` so introspectTables routes through SchemaStatements.
-    const stripped = withoutMethods(realAdapter, ["tables"]);
-
-    const tables = await introspectTables(stripped);
-
-    expect(tables).toContain("widgets");
-    expect(tables).toContain("more_testings");
   });
 });
 
@@ -91,22 +56,6 @@ describe("introspectColumns", () => {
 
     expect(calledWith).toBe("users");
     expect(cols).toBe(fakeCols);
-  });
-
-  it("falls back to SchemaStatements when the adapter doesn't implement columns()", async () => {
-    const realAdapter = Base.connection;
-    await realAdapter.createTable("widgets", {}, (t) => {
-      t.string("name");
-      t.integer("age");
-    });
-
-    // Strip `columns()` so introspectColumns routes through SchemaStatements.
-    const stripped = withoutMethods(realAdapter, ["columns"]);
-
-    const cols = await introspectColumns(stripped, "widgets");
-    const names = cols.map((c) => c.name).sort();
-
-    expect(names).toEqual(["age", "id", "name"]);
   });
 });
 
@@ -127,24 +76,9 @@ describe("introspectIndexes", () => {
     expect(idxs).toBe(fakeIndexes);
   });
 
-  it("falls back to SchemaStatements when the adapter doesn't implement indexes()", async () => {
-    const realAdapter = Base.connection;
-    await realAdapter.createTable("widgets", {}, (t) => {
-      t.string("name");
-    });
-    await realAdapter.addIndex("widgets", ["name"], { name: "idx_widgets_name" });
-
-    const stripped = withoutMethods(realAdapter, ["indexes"]);
-
-    const idxs = await introspectIndexes(stripped, "widgets");
-
-    expect(idxs.some((i) => i.name === "idx_widgets_name")).toBe(true);
-  });
-
-  // `orders` (per-column DESC) is recovered by all three fallback arms; `where`
-  // (partial-index predicate) only by adapters that support partial indexes
-  // (sqlite/postgres — MySQL has none).
-  it("surfaces where/orders carried by the fallback SchemaStatements.indexes()", async () => {
+  // `where` (partial-index predicate) is only reflected by adapters that
+  // support partial indexes (sqlite/postgres — MySQL has none).
+  it("surfaces where/orders carried by adapter.indexes()", async () => {
     const supportsPartial = adapterType === "sqlite" || adapterType === "postgres";
     const realAdapter = Base.connection;
     await realAdapter.createTable("widgets", {}, (t) => {
@@ -157,9 +91,7 @@ describe("introspectIndexes", () => {
       order: { name: "desc" },
     });
 
-    const stripped = withoutMethods(realAdapter, ["indexes"]);
-
-    const idxs = await introspectIndexes(stripped, "widgets");
+    const idxs = await introspectIndexes(realAdapter, "widgets");
     const idx = idxs.find((i) => i.name === "idx_widgets_name_partial");
 
     // `where` and `orders` are now statically visible on IntrospectedIndex,
@@ -180,12 +112,12 @@ describe("introspectIndexes", () => {
     expect(idx?.where).toBe(supportsPartial ? "active" : undefined);
   });
 
-  // The postgres fallback arm builds `columns` from a `pg_attribute` join that
-  // drops expression columns (attnum 0), so it must instead surface the raw
+  // The postgres indexes() implementation builds `columns` from a `pg_attribute` join
+  // that drops expression columns (attnum 0), so it must instead surface the raw
   // expression string parsed from pg_get_indexdef, mirroring the concrete
   // PostgreSQLSchemaStatements#indexes / Rails (schema_statements.rb:117).
   it.skipIf(adapterType !== "postgres")(
-    "surfaces expression-index columns from the fallback SchemaStatements.indexes()",
+    "surfaces expression-index columns from adapter.indexes()",
     async () => {
       const realAdapter = Base.connection;
       await realAdapter.createTable("widgets", {}, (t) => {
@@ -193,9 +125,7 @@ describe("introspectIndexes", () => {
       });
       await realAdapter.addIndex("widgets", "lower(name)", { name: "idx_widgets_lower_name" });
 
-      const stripped = withoutMethods(realAdapter, ["indexes"]);
-
-      const idxs = await introspectIndexes(stripped, "widgets");
+      const idxs = await introspectIndexes(realAdapter, "widgets");
       const idx = idxs.find((i) => i.name === "idx_widgets_lower_name");
 
       expect(idx?.columns).toBe("lower((name)::text)");
@@ -237,25 +167,5 @@ describe("introspectPrimaryKey", () => {
     } as unknown as Parameters<typeof introspectPrimaryKey>[0];
 
     expect(await introspectPrimaryKey(adapter, "t")).toEqual([]);
-  });
-
-  it("falls back to columns with primaryKey===true when adapter lacks primaryKey()", async () => {
-    const realAdapter = Base.connection;
-    await realAdapter.createTable("widgets", {}, (t) => {
-      t.string("name");
-    });
-
-    const stripped = withoutMethods(realAdapter, ["primaryKey"]);
-
-    const pk = await introspectPrimaryKey(stripped, "widgets");
-
-    // The fallback derives the key from columns whose reflected `primaryKey`
-    // flag is set. MySQL/MariaDB's columns() carries no per-column primary flag
-    // — matching Rails' MySQL::Column (abstract_mysql_adapter.rb /
-    // mysql/schema_statements.rb#new_column_from_field), which passes no primary
-    // argument and resolves the key solely via @connection.primary_key. So with
-    // primaryKey() stripped there is nothing to fall back to and the result is
-    // empty; sqlite/postgres, whose columns() flag the PK, yield ["id"].
-    expect(pk).toEqual(adapterType === "mysql" ? [] : ["id"]);
   });
 });

--- a/packages/activerecord/src/schema-introspection.ts
+++ b/packages/activerecord/src/schema-introspection.ts
@@ -2,31 +2,18 @@
  * Shared adapter-introspection helpers used by schema dumpers.
  *
  * Adapter-introspection helpers used by `SchemaDumper` (DSL output —
- * `db/schema.ts`) and related tooling. Adapters prefer their own
- * `tables()` / `columns()` implementations when available and fall back
- * to the portable `SchemaStatements` queries otherwise. PostgreSQL and
- * SQLite adapters implement these with adapter-specific semantics
- * (e.g. PG respects the current `search_path`).
+ * `db/schema.ts`) and related tooling. Every adapter carries `tables()` /
+ * `columns()` / `indexes()` / `primaryKey()` from Rails'
+ * `include SchemaStatements`, so these call straight through; PostgreSQL and
+ * SQLite adapters override them with adapter-specific semantics (e.g. PG
+ * respects the current `search_path`).
  *
  * Keeping this in one module means future changes to introspection
  * semantics stay in one place.
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import {
-  SchemaStatements,
-  assertSchemaAdapter,
-} from "./connection-adapters/abstract/schema-statements.js";
 import type { Column } from "./connection-adapters/column.js";
-
-type AdapterWithTables = { tables(): Promise<string[]> };
-type AdapterWithColumns = { columns(table: string): Promise<Column[]> };
-type AdapterWithIndexes = {
-  indexes(table: string): Promise<Array<{ name: string; columns: string[]; unique: boolean }>>;
-};
-type AdapterWithPrimaryKey = {
-  primaryKey(table: string): Promise<string | string[] | null>;
-};
 
 /** Minimal index descriptor shared by all adapters. */
 export interface IntrospectedIndex {
@@ -45,78 +32,34 @@ export interface IntrospectedIndex {
   orders?: Record<string, string> | string;
 }
 
-function hasTables(a: unknown): a is AdapterWithTables {
-  return typeof (a as AdapterWithTables).tables === "function";
-}
-function hasColumns(a: unknown): a is AdapterWithColumns {
-  return typeof (a as AdapterWithColumns).columns === "function";
-}
-function hasIndexes(a: unknown): a is AdapterWithIndexes {
-  return typeof (a as AdapterWithIndexes).indexes === "function";
-}
-function hasPrimaryKey(a: unknown): a is AdapterWithPrimaryKey {
-  return typeof (a as AdapterWithPrimaryKey).primaryKey === "function";
-}
-
-// Memoize `SchemaStatements` per-adapter so the fallback path doesn't
-// reinstantiate on every call (and per-table when `adapter.columns()`
-// is absent). WeakMap lets GC reclaim the helper when the adapter is
-// disposed.
-const SCHEMA_STATEMENTS = new WeakMap<object, SchemaStatements>();
-function schemaStatementsFor(adapter: DatabaseAdapter): SchemaStatements {
-  const key = adapter as unknown as object;
-  let s = SCHEMA_STATEMENTS.get(key);
-  if (!s) {
-    assertSchemaAdapter(adapter);
-    s = new SchemaStatements(adapter);
-    SCHEMA_STATEMENTS.set(key, s);
-  }
-  return s;
-}
-
-/**
- * Return the table names reported by the adapter. Uses
- * `adapter.tables()` when the adapter implements it, else falls back
- * to `new SchemaStatements(adapter).tables()` (memoized per adapter).
- */
+/** Return the table names reported by the adapter. */
 export async function introspectTables(adapter: DatabaseAdapter): Promise<string[]> {
-  if (hasTables(adapter)) return adapter.tables();
-  return schemaStatementsFor(adapter).tables();
+  return adapter.tables();
 }
 
-/**
- * Return the Column objects for `table`. Uses `adapter.columns()`
- * when implemented, else falls back to
- * `new SchemaStatements(adapter).columns(table)` (memoized per adapter
- * so a loop that dumps many tables reuses a single helper).
- */
+/** Return the Column objects for `table`. */
 export async function introspectColumns(
   adapter: DatabaseAdapter,
   table: string,
 ): Promise<Column[]> {
-  if (hasColumns(adapter)) return adapter.columns(table);
-  return schemaStatementsFor(adapter).columns(table);
+  return adapter.columns(table);
 }
 
 /**
- * Return index descriptors for `table`. Uses `adapter.indexes()` when
- * implemented (preferred — adapter-specific semantics like SQLite's
- * `origin === "c"` filter that excludes constraint-generated autoindexes
- * are applied), else falls back to `SchemaStatements.indexes()`.
+ * Return index descriptors for `table`. Adapter-specific semantics (like
+ * SQLite's `origin === "c"` filter that excludes constraint-generated
+ * autoindexes) are applied by the adapter's own override.
  */
 export async function introspectIndexes(
   adapter: DatabaseAdapter,
   table: string,
 ): Promise<IntrospectedIndex[]> {
-  if (hasIndexes(adapter)) return adapter.indexes(table) as Promise<IntrospectedIndex[]>;
-  return schemaStatementsFor(adapter).indexes(table);
+  return adapter.indexes(table) as Promise<IntrospectedIndex[]>;
 }
 
 /**
  * Return primary key column names for `table` in PK-position order (matching
- * Rails' `PRAGMA table_info` pk-field sort). Uses `adapter.primaryKey()` when
- * implemented, else derives from `columns()` filtered to primaryKey===true —
- * which preserves declaration order but loses composite PK position.
+ * Rails' `PRAGMA table_info` pk-field sort).
  *
  * Returns an empty array when the table has no primary key.
  */
@@ -124,12 +67,7 @@ export async function introspectPrimaryKey(
   adapter: DatabaseAdapter,
   table: string,
 ): Promise<string[]> {
-  if (hasPrimaryKey(adapter)) {
-    const pk = await adapter.primaryKey(table);
-    if (pk === null) return [];
-    return Array.isArray(pk) ? pk : [pk];
-  }
-  // Fallback: columns with primaryKey=true in declaration order.
-  const cols = await introspectColumns(adapter, table);
-  return cols.filter((c) => c.primaryKey).map((c) => c.name);
+  const pk = await adapter.primaryKey(table);
+  if (pk === null) return [];
+  return Array.isArray(pk) ? pk : [pk];
 }


### PR DESCRIPTION
Retires the two standalone `SchemaStatements` companion construction sites, which Rails has no analogue for.

- `schema-introspection.ts`: the `introspect*` helpers now call `adapter.tables()` / `columns()` / `indexes()` / `primaryKey()` directly. Every adapter carries those from `include SchemaStatements` (`abstract_adapter.rb:35`), so the `has*` probes and the per-adapter `new SchemaStatements(adapter)` WeakMap stood in for a shape that cannot occur.
- `migration.ts`: `Migration#schema` drops the `_schema` / `_schemaConn` memo and resolves to the connection, mirroring `migration.rb:800`.
- The trails-only fallback tests are removed with the fallback; the real-adapter `where` / `orders` and expression-index assertions now run against `adapter.indexes()`.

No standalone `new SchemaStatements(...)` remains outside the class's own tests.

Closes-story: retire-standalone-schema-statements-construction
