### PR TITLE
test(eslint): retire schemaStatements from no-load-schema-with-stubbed-ddl fixtures

### DIFF
--- a/eslint/no-load-schema-with-stubbed-ddl.test.mjs
+++ b/eslint/no-load-schema-with-stubbed-ddl.test.mjs
@@ -139,7 +139,7 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
     {
       filename: FILENAME,
       code: `
-        const stub = { schemaStatements: () => ({ createTable: async () => {} }) };
+        const stub = { addIndex: async () => {} };
         await loadSchema(stub);
       `,
       errors: [{ messageId: "misrouted" }],
@@ -215,7 +215,7 @@ tester.run("no-load-schema-with-stubbed-ddl", rule, {
       filename: FILENAME,
       code: `
         class Probe extends BetterSQLite3Adapter {
-          schemaStatements = () => fakeSchemaStatements;
+          createTable = async () => {};
         }
         await loadSchema(new Probe(":memory:"));
       `,


### PR DESCRIPTION
Unit Tests were red on `main` @302e33ed.

PR #5841 deleted `AbstractAdapter#schemaStatements` and correspondingly dropped it from `STUBBED_DDL_METHODS` (`packages/activerecord/src/support/stubbed-ddl-methods.ts`), but two invalid fixtures in `eslint/no-load-schema-with-stubbed-ddl.test.mjs` still stubbed that member.

- The class-field fixture (`schemaStatements = () => fakeSchemaStatements;`) then produced no error — `Should have 1 error but had 0`, the failing assertion.
- The object-literal fixture only still fired because of the nested `createTable: async () => {}` key it happened to carry, not the member it was written to exercise.

Both fixtures now name a member the set still guards: the class-field form stubs `createTable`, the object-literal form `addIndex` (`createTable` there would collide with an existing fixture under RuleTester's duplicate-case check).

No rule or runtime change — the guarded set is unchanged and stays derived from its single declaration site.

Verification: `pnpm vitest run eslint/no-load-schema-with-stubbed-ddl.test.mjs` — 20 passed.

Closes-story: red-302e33ed