### PR TITLE
test(activerecord): narrow the stubbed-DDL recorder getter fallback

### DIFF
--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -56,6 +56,18 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
 ]);
 
 /**
+ * A getter whose body reads a private field brand-checks its receiver and
+ * throws when the recording view is that receiver. That is the one throw the
+ * recorder may answer by re-reading off the real adapter; anything else is a
+ * genuine failure in the getter body, and swallowing it would let the trace go
+ * quietly shallower for that member instead of failing — the drift the guard's
+ * staleness rule exists to prevent. Match the brand-check shape only.
+ */
+function isPrivateFieldBrandCheck(error: unknown): boolean {
+  return error instanceof TypeError && /private (member|field|method)/i.test(error.message);
+}
+
+/**
  * Lay the canonical schema through a proxy that records every adapter member
  * the loader reaches for.
  *
@@ -101,7 +113,8 @@ async function recordLayPath(): Promise<Set<string>> {
         let value: unknown;
         try {
           value = Reflect.get(target, prop, self);
-        } catch {
+        } catch (error) {
+          if (!isPrivateFieldBrandCheck(error)) throw error;
           value = Reflect.get(target, prop, target);
         }
         return typeof value === "function"
@@ -174,6 +187,26 @@ describe("STUBBED_DDL_METHODS", () => {
         `${stale.join(", ")}. Delete them from this file — an exemption nobody can re-derive ` +
         `from the code is how the guarded set drifts back out of date.`,
     ).toEqual([]);
+  });
+
+  test("falls back only for a private-field brand check", () => {
+    class Branded {
+      #field = 1;
+      get value(): number {
+        return this.#field;
+      }
+    }
+    const branded = new Branded();
+    let brandCheck: unknown;
+    try {
+      Reflect.get(branded, "value", new Proxy(branded, {}));
+    } catch (error) {
+      brandCheck = error;
+    }
+
+    expect(isPrivateFieldBrandCheck(brandCheck)).toBe(true);
+    expect(isPrivateFieldBrandCheck(new TypeError("something genuinely broke"))).toBe(false);
+    expect(isPrivateFieldBrandCheck(new Error("Cannot read private member #x"))).toBe(false);
   });
 
   test("gives every exemption a reason", () => {


### PR DESCRIPTION
The stubbed-DDL guard's recorder evaluates getters with the recording view as
receiver so the `schemaCreation` renderer stays pinned. Getters backed by a
private field brand-check their receiver and throw on a proxy, so the recorder
falls back to the real adapter — but the bare `catch` could not tell that
brand-check `TypeError` from a genuine failure in a getter body. A getter that
started throwing for a real reason was silently re-evaluated unrecorded and the
trace went quietly shallower for that member instead of failing.

Narrow the fallback to the brand-check shape (`TypeError` whose message names a
private member/field/method) and rethrow anything else, with a test covering
both directions. The renderer-boundary floor assertions still pass on sqlite.

Closes-story: guard-recorder-getter-fallback-swallows-real-errors
