### PR TITLE
fix(activerecord): compare protected-env stored value against the global default env

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
@@ -50,30 +50,34 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
   }
 
   it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
-    "compares the stored environment against the config's own environment",
+    "compares the stored environment against the global default environment",
     async () => {
-      expect(DatabaseTasks.env).not.toBe(env);
-      await stampedConfig();
+      // Rails compares `migration_context.current_environment`
+      // (`DEFAULT_ENV.call`) rather than the db_config's own env, so a config
+      // under `storyenv` stamped with the global default env passes.
+      await stampedConfig(DatabaseConfigurations.currentEnv());
       await DatabaseTasks.checkProtectedEnvironmentsBang(env);
     },
   );
 
   it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
-    "reports the config's own environment as current on a mismatch",
+    "reports the global default environment as current on a mismatch",
     async () => {
+      const current = DatabaseConfigurations.currentEnv();
+      expect(current).not.toBe(env);
       await stampedConfig("otherenv");
       const error = await DatabaseTasks.checkProtectedEnvironmentsBang(env).catch(
         (e: unknown) => e,
       );
       expect(error).toBeInstanceOf(EnvironmentMismatchError);
       expect((error as Error).message).toMatch(
-        new RegExp(`last run in \`otherenv\`[\\s\\S]*running in \`${env}\``),
+        new RegExp(`last run in \`otherenv\`[\\s\\S]*running in \`${current}\``),
       );
     },
   );
 
   it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
-    "raises when the config's own environment is protected",
+    "raises when the stored environment is protected",
     async () => {
       const protectedEnvironments = Base.protectedEnvironments;
       await stampedConfig();

--- a/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
@@ -52,9 +52,6 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
   it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
     "compares the stored environment against the global default environment",
     async () => {
-      // Rails compares `migration_context.current_environment`
-      // (`DEFAULT_ENV.call`) rather than the db_config's own env, so a config
-      // under `storyenv` stamped with the global default env passes.
       await stampedConfig(DatabaseConfigurations.currentEnv());
       await DatabaseTasks.checkProtectedEnvironmentsBang(env);
     },

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -642,12 +642,7 @@ export class DatabaseTasks {
       try {
         await this.withTemporaryConnection(config, async (adapter) => {
           const context = await this._migrationContextFor(adapter, config);
-          // Rails reads `migration_context.current_environment`, i.e. the global
-          // `DEFAULT_ENV.call` (`database_tasks.rb:638`). trails compares against
-          // the config's own env instead — pinned by
-          // database-tasks-protected-environments-env.trails.test.ts, since
-          // `checkProtectedEnvironmentsBang` takes the environment explicitly.
-          const current = config.envName;
+          const current = context.currentEnvironment;
           const stored = await context.lastStoredEnvironment();
           if (stored && (await context.protectedEnvironment())) {
             throw new ProtectedEnvironmentError(stored);


### PR DESCRIPTION
Converges `DatabaseTasks.checkProtectedEnvironmentsBang` with Rails'
`check_current_protected_environment!` (`database_tasks.rb:635-650`): `current`
is `migration_context.current_environment`, i.e. `DEFAULT_ENV.call`
(`migration.rb:1340-1342`), **not** the db_config's own env.

trails compared against `config.envName`, so a config declared under a
non-default env always looked like a mismatch against a stored default-env
stamp. The old behavior was ratified by
`database-tasks-protected-environments-env.trails.test.ts`; that test is
rewritten to assert Rails' semantics (stored vs. global default env), and the
protected-env case is renamed to say what it actually checks — the *stored*
environment.

Closes-story: check-protected-environments-current-env-is-config-env
