### PR TITLE
refactor(activerecord): drop the SchemaStatements adapter constructor and self-getter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1194,20 +1194,6 @@ export class AbstractAdapter implements Quoting {
     return "Abstract";
   }
 
-  /**
-   * Returns `this` typed as `AbstractAdapter & SchemaQuoter`. SchemaStatements
-   * methods (mixed in via `include()` below) reference `this.adapter` to
-   * call quoting and execution helpers on the adapter — when those methods
-   * run with `this` bound to an adapter instance, `this.adapter` must
-   * resolve to the same object.
-   * @internal
-   */
-  protected get adapter(): import("./abstract/assert-schema-adapter.js").SchemaQuoter &
-    AbstractAdapter {
-    return this as unknown as import("./abstract/assert-schema-adapter.js").SchemaQuoter &
-      AbstractAdapter;
-  }
-
   /** @internal */
   protected _qi(name: string): string {
     return this.quoteIdentifier(name);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version.trails.test.ts
@@ -23,9 +23,9 @@ function makeStatements(
     },
     config: {},
   };
-  const ss = new SchemaStatements(
-    adapter as unknown as ConstructorParameters<typeof SchemaStatements>[0],
-  );
+  // The bodies under test are prototype methods mixed into the adapter, so
+  // give the fake adapter that prototype and call them the way production does.
+  const ss = Object.setPrototypeOf(adapter, SchemaStatements.prototype) as SchemaStatements;
   return { ss, executed };
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -11,11 +11,12 @@ import {
   type ColumnType,
 } from "./schema-definitions.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
+import { NATIVE_DATABASE_TYPES_BY_ADAPTER } from "./native-database-types.js";
 import { NotImplementedError } from "../../errors.js";
 
 function makeStatements(
   adapterOverrides: Record<string, unknown> = {},
-  Statements: new (adapter: never) => SchemaStatements = SchemaStatements,
+  Statements: { prototype: SchemaStatements } = SchemaStatements,
 ) {
   const adapter: Record<string, unknown> = {
     adapterName: "sqlite" as const,
@@ -41,6 +42,9 @@ function makeStatements(
       binds,
       "SCHEMA",
     );
+  // Real hosts override AbstractAdapter#native_database_types (the abstract one
+  // is `{}`); the stub answers with SQLite's table so typeToSql resolves.
+  adapter["nativeDatabaseTypes"] ??= () => NATIVE_DATABASE_TYPES_BY_ADAPTER["sqlite"];
   // The catalog probes go through data_source_sql; the stub answers with a
   // simple catalog query unless a test installs its own.
   adapter["dataSourceSql"] ??= (name?: string | null) =>
@@ -55,7 +59,9 @@ function makeStatements(
     )(sql, binds, "SCHEMA")) as Record<string, unknown>[];
     return rows.map((row) => Object.values(row)[0]);
   };
-  return new Statements(adapter as never);
+  // The bodies under test are prototype methods mixed into the adapter, so
+  // give the stub adapter that prototype and call them the way production does.
+  return Object.setPrototypeOf(adapter, Statements.prototype) as SchemaStatements;
 }
 
 describe("SchemaStatements privates (PR 8)", () => {
@@ -232,10 +238,10 @@ describe("SchemaStatements privates (PR 8)", () => {
       new CheckConstraintDefinition("users", "age > 0", name),
     ]);
     await ss.addCheckConstraint("users", "age > 0", { ifNotExists: true });
-    expect((ss as any).adapter.execute).not.toHaveBeenCalled();
+    expect((ss as any).execute).not.toHaveBeenCalled();
 
     await ss.addCheckConstraint("users", "age > 0", {});
-    expect((ss as any).adapter.execute).toHaveBeenCalled();
+    expect((ss as any).execute).toHaveBeenCalled();
   });
 
   it("checkConstraintExists returns false when an explicit undefined name is supplied", async () => {
@@ -449,7 +455,7 @@ describe("SchemaStatements privates (PR 8)", () => {
       "fk_rails_composite",
     );
     vi.spyOn(ss, "foreignKeys").mockResolvedValue([fk]);
-    const executeMutation = (ss as any).adapter.executeMutation as ReturnType<typeof vi.fn>;
+    const executeMutation = (ss as any).executeMutation as ReturnType<typeof vi.fn>;
     executeMutation.mockClear();
 
     await ss.addForeignKey("astronauts", "rockets", {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-reflection-probes.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-reflection-probes.trails.test.ts
@@ -7,9 +7,10 @@
  * through `execute`, which names the query "SQL" and inflated `assertQueries`
  * counts in any suite that straddled a reflection read.
  *
- * The concrete adapters override most of these, so the probes are exercised
- * against a bare `SchemaStatements` bound to the live connection — that is the
- * code path the abstract bodies actually own.
+ * The concrete adapters override most of these, so the probes are exercised by
+ * layering just the abstract bodies over the live connection — that is the code
+ * path the abstract bodies actually own, while everything they delegate to
+ * (`dataSourceSql`, `schemaQuery`) still resolves on the real adapter.
  */
 import { describe, it, expect } from "vitest";
 import { Base } from "../../index.js";
@@ -26,7 +27,19 @@ describe("SchemaStatements reflection probes", () => {
   }
 
   function statements(): SchemaStatements {
-    return new SchemaStatements(conn() as never);
+    const host = Object.create(conn()) as SchemaStatements;
+    const proto = Object.getOwnPropertyDescriptors(SchemaStatements.prototype);
+    for (const name of [
+      "tables",
+      "views",
+      "dataSources",
+      "dataSourceExists",
+      "columns",
+      "primaryKey",
+    ] as const) {
+      Object.defineProperty(host, name, proto[name]);
+    }
+    return host;
   }
 
   it("issues tables and views as SCHEMA queries", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -285,13 +285,13 @@ interface SchemaMigrationPool {
   };
 }
 
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 /**
  * `SchemaStatements` is only ever mixed into an adapter (`include()` at the
  * bottom of each adapter module), so its bodies call plain `this` methods the
  * way Rails' module does. This merged interface gives those calls the adapter's
  * type. @internal
  */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SchemaStatements
   extends
     Omit<
@@ -306,8 +306,9 @@ export interface SchemaStatements
     >,
     SchemaQuoter {}
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SchemaStatements {
+  /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
+
   /**
    * `AbstractAdapter#pool` is typed `unknown` (it holds a NullPool until a real
    * ConnectionPool claims the connection); narrow it once here. @internal

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -285,34 +285,50 @@ interface SchemaMigrationPool {
   };
 }
 
-export class SchemaStatements {
-  constructor(protected readonly adapter: DatabaseAdapter & SchemaQuoter) {}
+/**
+ * `SchemaStatements` is only ever mixed into an adapter (`include()` at the
+ * bottom of each adapter module), so its bodies call plain `this` methods the
+ * way Rails' module does. This merged interface gives those calls the adapter's
+ * type. @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SchemaStatements
+  extends
+    Omit<
+      DatabaseAdapter,
+      | "addColumns"
+      | "currentDatabase"
+      | "createEnum"
+      | "dropEnum"
+      | "renameEnum"
+      | "addEnumValue"
+      | "renameEnumValue"
+    >,
+    SchemaQuoter {}
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class SchemaStatements {
   /**
    * `AbstractAdapter#pool` is typed `unknown` (it holds a NullPool until a real
    * ConnectionPool claims the connection); narrow it once here. @internal
    */
   private get _pool(): SchemaMigrationPool {
-    return this.adapter.pool as SchemaMigrationPool;
-  }
-
-  protected get adapterName(): AdapterName {
-    // Base AbstractAdapter#adapterName is typed `string` (Rails-faithful
-    // "Abstract"); concrete adapters return a real AdapterName. Narrow here.
-    return this.adapter.adapterName as AdapterName;
+    return this.pool as SchemaMigrationPool;
   }
 
   /** Mirrors: SchemaStatements#schema_creation — `SchemaCreation.new(self)`. */
   get schemaCreation(): SchemaCreation {
-    return new SchemaCreation(this.adapterName, this.adapter);
+    // Base AbstractAdapter#adapterName is typed `string` (Rails-faithful
+    // "Abstract"); concrete adapters return a real AdapterName.
+    return new SchemaCreation(this.adapterName as AdapterName, this);
   }
 
   protected _qi(name: string): string {
-    return this.adapter.quoteIdentifier(name);
+    return this.quoteIdentifier(name);
   }
 
   protected _qt(tableName: string): string {
-    return this.adapter.quoteTableName(tableName);
+    return this.quoteTableName(tableName);
   }
 
   /**
@@ -400,7 +416,7 @@ export class SchemaStatements {
     }
 
     if (!options.force) {
-      this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, name);
+      this.schemaCache?.clearDataSourceCacheBang(this.pool, name);
     }
 
     const td = this.buildCreateTableDefinition(name, options, definer);
@@ -409,10 +425,10 @@ export class SchemaStatements {
     // `t.index order:` runs through SchemaCreation's synchronous
     // supportsIndexSortOrder gate, which yields false on a cold connection
     // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
-    await this.adapter.getDatabaseVersion?.();
-    await this.adapter.execute(await this.schemaCreation.accept(td));
+    await this.getDatabaseVersion?.();
+    await this.execute(await this.schemaCreation.accept(td));
 
-    if (!this.adapter.supportsIndexesInCreate?.()) {
+    if (!this.supportsIndexesInCreate?.()) {
       for (const idx of td.indexes) {
         await this.addIndex(name, idx.columns, {
           unique: idx.unique,
@@ -434,15 +450,15 @@ export class SchemaStatements {
       }
     }
 
-    if (this.adapter.supportsComments?.() && !this.adapter.supportsCommentsInCreate?.()) {
+    if (this.supportsComments?.() && !this.supportsCommentsInCreate?.()) {
       const tableComment = presence(td.comment);
-      if (tableComment != null && typeof this.adapter.changeTableComment === "function") {
-        await this.adapter.changeTableComment(name, tableComment);
+      if (tableComment != null && typeof this.changeTableComment === "function") {
+        await this.changeTableComment(name, tableComment);
       }
       // Mirrors Rails: adapters that can't inline column comments in CREATE
       // emit a COMMENT ON COLUMN per column so inline `comment:` options
       // round-trip through columns().
-      const commentAdapter = this.adapter as {
+      const commentAdapter = this as {
         changeColumnComment?(t: string, c: string, comment: string | null): Promise<void>;
       };
       if (typeof commentAdapter.changeColumnComment === "function") {
@@ -488,8 +504,8 @@ export class SchemaStatements {
     }
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     for (const name of tableNames) {
-      this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, name);
-      await this.adapter.execute(`DROP TABLE${ifExists} ${this._qt(name)}`);
+      this.schemaCache?.clearDataSourceCacheBang(this.pool, name);
+      await this.execute(`DROP TABLE${ifExists} ${this._qt(name)}`);
     }
   }
 
@@ -501,8 +517,8 @@ export class SchemaStatements {
   ): Promise<void> {
     const addColumnDef = await this.buildAddColumnDefinition(tableName, columnName, type, options);
     if (!addColumnDef) return;
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(await this.schemaCreation.accept(addColumnDef));
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
+    await this.execute(await this.schemaCreation.accept(addColumnDef));
   }
 
   async removeColumn(
@@ -517,15 +533,13 @@ export class SchemaStatements {
     if (options.ifExists && !(await this.columnExists(tableName, columnName))) {
       return;
     }
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(
-      `ALTER TABLE ${this._qi(tableName)} DROP COLUMN ${this._qi(columnName)}`,
-    );
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
+    await this.execute(`ALTER TABLE ${this._qi(tableName)} DROP COLUMN ${this._qi(columnName)}`);
   }
 
   async renameColumn(tableName: string, oldName: string, newName: string): Promise<void> {
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
+    await this.execute(
       `ALTER TABLE ${this._qi(tableName)} RENAME COLUMN ${this._qi(oldName)} TO ${this._qi(newName)}`,
     );
   }
@@ -541,14 +555,14 @@ export class SchemaStatements {
     // `databaseVersion` synchronously and silently yield `false` on a cold
     // connection (`undefined?.gte(...) !== true`); addIndex runs on the
     // shared-worker reconstruct path before any query warms the cache.
-    await this.adapter.getDatabaseVersion?.();
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    await this.getDatabaseVersion?.();
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     const createIndex = await this.buildCreateIndexDefinition(
       tableName,
       columns,
       options as Record<string, unknown>,
     );
-    await this.adapter.execute(await this.schemaCreation.accept(createIndex));
+    await this.execute(await this.schemaCreation.accept(createIndex));
   }
 
   async removeIndex(
@@ -581,7 +595,7 @@ export class SchemaStatements {
       if (!present) return;
     }
 
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     // Rails resolves the concrete index name via `index_name_for_remove`, which
     // raises ArgumentError when the spec matches no index (or is ambiguous), and
     // then drops by that real name — never a silent DROP ... IF EXISTS.
@@ -590,9 +604,9 @@ export class SchemaStatements {
     const indexName = await this.indexNameForRemove(tableName, positional, resolveOpts);
 
     if (this.adapterName === "mysql") {
-      await this.adapter.execute(`DROP INDEX ${this._qi(indexName)} ON ${this._qi(tableName)}`);
+      await this.execute(`DROP INDEX ${this._qi(indexName)} ON ${this._qi(tableName)}`);
     } else {
-      await this.adapter.execute(`DROP INDEX ${this._qi(indexName)}`);
+      await this.execute(`DROP INDEX ${this._qi(indexName)}`);
     }
   }
 
@@ -602,7 +616,7 @@ export class SchemaStatements {
     type: ColumnType,
     options: ColumnOptions = {},
   ): Promise<void> {
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     const sqlType = this.schemaCreation.typeToSql(type, options);
     const table = this._qi(tableName);
     const col = this._qi(columnName);
@@ -612,8 +626,8 @@ export class SchemaStatements {
       const defaultClause =
         options.default === undefined
           ? ""
-          : ` DEFAULT ${await this.adapter.quoteDefaultExpression(options.default)}`;
-      await this.adapter.execute(
+          : ` DEFAULT ${await this.quoteDefaultExpression(options.default)}`;
+      await this.execute(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
     } else if (this.adapterName === "postgres") {
@@ -625,33 +639,33 @@ export class SchemaStatements {
       }
       if (options.default !== undefined) {
         clauses.push(
-          `ALTER COLUMN ${col} SET DEFAULT ${await this.adapter.quoteDefaultExpression(options.default)}`,
+          `ALTER COLUMN ${col} SET DEFAULT ${await this.quoteDefaultExpression(options.default)}`,
         );
       }
-      await this.adapter.execute(`ALTER TABLE ${table} ${clauses.join(", ")}`);
+      await this.execute(`ALTER TABLE ${table} ${clauses.join(", ")}`);
     } else {
       const nullable = options.null === false ? " NOT NULL" : "";
       const defaultClause =
         options.default === undefined
           ? ""
-          : ` DEFAULT ${await this.adapter.quoteDefaultExpression(options.default)}`;
-      await this.adapter.execute(
+          : ` DEFAULT ${await this.quoteDefaultExpression(options.default)}`;
+      await this.execute(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
     }
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, oldName);
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, newName);
-    await this.adapter.execute(`ALTER TABLE ${this._qi(oldName)} RENAME TO ${this._qi(newName)}`);
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, oldName);
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, newName);
+    await this.execute(`ALTER TABLE ${this._qi(oldName)} RENAME TO ${this._qi(newName)}`);
   }
 
   async tableExists(tableName: string): Promise<boolean> {
     if (!isPresent(tableName)) return false;
     try {
-      const sql = this.adapter.dataSourceSql(tableName, { type: "BASE TABLE" });
-      return (await this.adapter.queryValues(sql, "SCHEMA")).length > 0;
+      const sql = this.dataSourceSql(tableName, { type: "BASE TABLE" });
+      return (await this.queryValues(sql, "SCHEMA")).length > 0;
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       return (await this.tables()).includes(String(tableName));
@@ -701,9 +715,9 @@ export class SchemaStatements {
     // (extract_new_default_value, schema_statements.rb:1820); a bare structured
     // default like `{ to: 1 }` without :from is the literal default.
     const defaultVal = this.extractNewDefaultValue(options);
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    const clause = await this.adapter.quoteDefaultExpression(defaultVal);
-    await this.adapter.execute(
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
+    const clause = await this.quoteDefaultExpression(defaultVal);
+    await this.execute(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET DEFAULT ${clause || "NULL"}`,
     );
   }
@@ -716,13 +730,13 @@ export class SchemaStatements {
   ): Promise<void> {
     this.validateChangeColumnNullArgumentBang(allowNull);
     if (!allowNull && defaultValue !== undefined) {
-      const quoted = await this.adapter.quoteDefaultExpression(defaultValue);
-      await this.adapter.execute(
+      const quoted = await this.quoteDefaultExpression(defaultValue);
+      await this.execute(
         `UPDATE ${this._qi(tableName)} SET ${this._qi(columnName)} = ${quoted} WHERE ${this._qi(columnName)} IS NULL`,
       );
     }
     const constraint = allowNull ? "DROP NOT NULL" : "SET NOT NULL";
-    await this.adapter.execute(
+    await this.execute(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} ${constraint}`,
     );
   }
@@ -827,7 +841,7 @@ export class SchemaStatements {
     // table_name_prefix/suffix to to_table and re-runs foreign_key_options
     // idempotently (column/name already filled above), mirroring Rails.
     at.addForeignKey(toTable, opts as Partial<AddForeignKeyOptions>);
-    await this.adapter.execute(await this.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async removeForeignKey(
@@ -865,7 +879,7 @@ export class SchemaStatements {
     // (MySQL/MariaDB `DROP FOREIGN KEY`) rather than a hardcoded `DROP CONSTRAINT`.
     const at = this.createAlterTable(fromTable);
     at.dropForeignKey(fk.name);
-    await this.adapter.execute(await this.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async addCheckConstraint(
@@ -878,7 +892,7 @@ export class SchemaStatements {
       [key: string]: unknown;
     } = {},
   ): Promise<void> {
-    const support = this.adapter as { supportsCheckConstraints?: () => boolean };
+    const support = this as { supportsCheckConstraints?: () => boolean };
     if (
       typeof support.supportsCheckConstraints === "function" &&
       !support.supportsCheckConstraints()
@@ -893,7 +907,7 @@ export class SchemaStatements {
 
     const at = this.createAlterTable(tableName);
     at.addCheckConstraint(expression, resolved);
-    await this.adapter.execute(await this.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async removeCheckConstraint(
@@ -931,12 +945,12 @@ export class SchemaStatements {
     // (MySQL `DROP CHECK`) rather than a hardcoded `DROP CONSTRAINT`.
     const at = this.createAlterTable(tableName);
     at.dropCheckConstraint(chk.name);
-    await this.adapter.execute(await this.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
     const fragments = await this.addTimestampsForAlter(tableName, options);
-    await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
+    await this.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
   }
 
   async removeTimestamps(tableName: string): Promise<void> {
@@ -988,8 +1002,8 @@ export class SchemaStatements {
     const callback = typeof fnOrOptions === "function" ? fnOrOptions : fn;
 
     const supportsBulk =
-      typeof (this.adapter as any).supportsBulkAlter === "function" &&
-      (this.adapter as any).supportsBulkAlter() === true;
+      typeof (this as any).supportsBulkAlter === "function" &&
+      (this as any).supportsBulkAlter() === true;
 
     if (options.bulk && supportsBulk) {
       const recorder = new CommandRecorder(this);
@@ -1007,7 +1021,7 @@ export class SchemaStatements {
 
     const oldIndexDef = (await this.indexes(tableName)).find((i) => i.name === oldName);
     if (!oldIndexDef) return;
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     await this.addIndex(tableName, oldIndexDef.columns, {
       name: newName,
       unique: oldIndexDef.unique,
@@ -1048,12 +1062,12 @@ export class SchemaStatements {
         "You must specify at least one column name. Example: remove_columns(:people, :first_name)",
       );
     }
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     const fragments = this.removeColumnsForAlter(tableName, columns, { ...opts } as Record<
       string,
       unknown
     >);
-    await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
+    await this.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
   }
 
   async addColumns(
@@ -1076,12 +1090,10 @@ export class SchemaStatements {
   }
 
   async columns(tableName: string): Promise<Column[]> {
-    switch (this.adapterName) {
+    switch (this.adapterName as AdapterName) {
       case "sqlite": {
         const { prefix, bare } = this._sqliteSchemaPrefix(tableName);
-        const rows = await this.adapter.schemaQuery(
-          `PRAGMA ${prefix}table_info(${this._qi(bare)})`,
-        );
+        const rows = await this.schemaQuery(`PRAGMA ${prefix}table_info(${this._qi(bare)})`);
         return rows.map((row: any) => {
           const meta = deduplicate(new SqlTypeMetadata({ sqlType: row.type, type: row.type }));
           return new Column(row.name, row.dflt_value, meta, row.notnull === 0, {
@@ -1103,7 +1115,7 @@ export class SchemaStatements {
         } else {
           schemaClause = "ANY (current_schemas(false))";
         }
-        const rows = await this.adapter.schemaQuery(
+        const rows = await this.schemaQuery(
           `SELECT c.column_name, c.data_type, c.udt_name, c.character_maximum_length, c.numeric_precision, c.numeric_scale, c.is_nullable, c.column_default,
             CASE WHEN pk.attname IS NOT NULL THEN true ELSE false END AS is_primary_key
           FROM information_schema.columns c
@@ -1147,7 +1159,7 @@ export class SchemaStatements {
         });
       }
       case "mysql": {
-        const rows = await this.adapter.schemaQuery(
+        const rows = await this.schemaQuery(
           `SELECT column_name, column_key, data_type, character_maximum_length, numeric_precision, numeric_scale, is_nullable, column_default FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? ORDER BY ordinal_position`,
           [tableName],
         );
@@ -1206,13 +1218,13 @@ export class SchemaStatements {
       orders?: Record<string, string> | string;
     }>
   > {
-    switch (this.adapterName) {
+    switch (this.adapterName as AdapterName) {
       case "sqlite":
         // Share the concrete SQLite3 introspection so this fallback arm
         // produces the same result shape (skips `sqlite_*` auto-indexes,
         // recovers partial-index WHERE clauses and expression/DESC columns
         // from the index SQL) rather than a lower-fidelity subset.
-        return sqliteIndexes(this.adapter, tableName) as Promise<
+        return sqliteIndexes(this as unknown as DatabaseAdapter, tableName) as Promise<
           Array<{
             name: string;
             columns: string | string[];
@@ -1226,7 +1238,7 @@ export class SchemaStatements {
         // key has attnum 0 with no pg_attribute row, so an inner join would drop
         // the entire index. LEFT JOIN keeps the row (attname NULL) so the
         // has_expressions arm can substitute the raw pg_get_indexdef expression.
-        const rows = await this.adapter.schemaQuery(
+        const rows = await this.schemaQuery(
           `SELECT i.relname AS name, ix.indisunique AS unique, array_agg(a.attname ORDER BY k.n) AS columns,
                   bool_or(ix.indexprs IS NOT NULL) AS has_expressions,
                   pg_get_indexdef(i.oid) AS definition
@@ -1283,7 +1295,7 @@ export class SchemaStatements {
         });
       }
       case "mysql": {
-        const rows = await this.adapter.schemaQuery(
+        const rows = await this.schemaQuery(
           `SHOW INDEX FROM ${this._qt(tableName)} WHERE Key_name != 'PRIMARY'`,
         );
         const indexMap = new Map<
@@ -1321,24 +1333,22 @@ export class SchemaStatements {
   }
 
   async primaryKey(tableName: string): Promise<string | string[] | null> {
-    switch (this.adapterName) {
+    switch (this.adapterName as AdapterName) {
       case "sqlite": {
         const { prefix, bare } = this._sqliteSchemaPrefix(tableName);
-        const rows = await this.adapter.schemaQuery(
-          `PRAGMA ${prefix}table_info(${this._qi(bare)})`,
-        );
+        const rows = await this.schemaQuery(`PRAGMA ${prefix}table_info(${this._qi(bare)})`);
         const pk = (rows as any[]).find((r: any) => r.pk > 0);
         return pk ? pk.name : null;
       }
       case "postgres": {
-        const rows = await this.adapter.schemaQuery(
+        const rows = await this.schemaQuery(
           `SELECT a.attname FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = to_regclass($1) AND i.indisprimary LIMIT 1`,
           [tableName],
         );
         return rows.length > 0 ? (rows[0] as any).attname : null;
       }
       case "mysql": {
-        const rows = await this.adapter.schemaQuery(
+        const rows = await this.schemaQuery(
           `SHOW KEYS FROM \`${tableName}\` WHERE Key_name = 'PRIMARY'`,
         );
         return rows.length > 0 ? (rows[0] as any).Column_name : null;
@@ -1352,13 +1362,13 @@ export class SchemaStatements {
   }
 
   async tables(): Promise<string[]> {
-    const sql = this.adapter.dataSourceSql(null, { type: "BASE TABLE" });
-    return (await this.adapter.queryValues(sql, "SCHEMA")).map(String);
+    const sql = this.dataSourceSql(null, { type: "BASE TABLE" });
+    return (await this.queryValues(sql, "SCHEMA")).map(String);
   }
 
   async views(): Promise<string[]> {
-    const sql = this.adapter.dataSourceSql(null, { type: "VIEW" });
-    return (await this.adapter.queryValues(sql, "SCHEMA")).map(String);
+    const sql = this.dataSourceSql(null, { type: "VIEW" });
+    return (await this.queryValues(sql, "SCHEMA")).map(String);
   }
 
   async viewExists(viewName: string): Promise<boolean> {
@@ -1372,8 +1382,8 @@ export class SchemaStatements {
     // The "SCHEMA" name is what keeps the probe out of assertQueries counts.
     if (!isPresent(viewName)) return false;
     try {
-      const sql = this.adapter.dataSourceSql(viewName, { type: "VIEW" });
-      return (await this.adapter.queryValues(sql, "SCHEMA")).length > 0;
+      const sql = this.dataSourceSql(viewName, { type: "VIEW" });
+      return (await this.queryValues(sql, "SCHEMA")).length > 0;
     } catch (e) {
       if (e instanceof NotImplementedError) {
         return (await this.views()).includes(String(viewName));
@@ -1390,7 +1400,7 @@ export class SchemaStatements {
     tableName: string,
   ): Promise<Array<{ name: string; columns: string[]; unique: boolean }>> {
     return (
-      this.adapter as unknown as {
+      this as unknown as {
         indexes(t: string): Promise<Array<{ name: string; columns: string[]; unique: boolean }>>;
       }
     ).indexes(tableName);
@@ -1478,8 +1488,8 @@ export class SchemaStatements {
 
   async dataSources(): Promise<string[]> {
     try {
-      const sql = this.adapter.dataSourceSql();
-      const values = await this.adapter.queryValues(sql, "SCHEMA");
+      const sql = this.dataSourceSql();
+      const values = await this.queryValues(sql, "SCHEMA");
       return values.map(String);
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
@@ -1492,8 +1502,8 @@ export class SchemaStatements {
   async dataSourceExists(name: string): Promise<boolean> {
     if (!isPresent(name)) return false;
     try {
-      const sql = this.adapter.dataSourceSql(name);
-      return (await this.adapter.queryValues(sql, "SCHEMA")).length > 0;
+      const sql = this.dataSourceSql(name);
+      return (await this.queryValues(sql, "SCHEMA")).length > 0;
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       return (await this.dataSources()).includes(String(name));
@@ -1524,10 +1534,10 @@ export class SchemaStatements {
       ...tdOptions,
       id: false,
       adapterName: this.adapterName,
-      adapter: this.adapter,
+      adapter: this,
     };
-    const tableDefinition = this.adapter.createTableDefinition
-      ? this.adapter.createTableDefinition(tableName, ctdOptions)
+    const tableDefinition = this.createTableDefinition
+      ? this.createTableDefinition(tableName, ctdOptions)
       : this.createTableDefinition(tableName, ctdOptions);
     tableDefinition.setPrimaryKey(
       tableName,
@@ -1580,7 +1590,7 @@ export class SchemaStatements {
     // Mirrors abstract/schema_statements.rb#build_add_column_definition:
     // default datetime precision to 6 when the adapter supports it.
     if (
-      this.adapter.supportsDatetimeWithPrecision?.() &&
+      this.supportsDatetimeWithPrecision?.() &&
       type === "datetime" &&
       !("precision" in colOpts)
     ) {
@@ -1588,9 +1598,6 @@ export class SchemaStatements {
     }
     // Mirrors Rails' `build_add_column_definition` (abstract/schema_statements.rb:1697):
     // `alter_table = create_alter_table(name); alter_table.add_column(...)`.
-    // Going through `this.createAlterTable` (rather than `this.adapter.createAlterTable`)
-    // statically routes to the SchemaStatements mixin's TableDefinition-carrying
-    // default, so adapter-specific column normalization is preserved by default.
     const at = this.createAlterTable(tableName);
     at.addColumn(columnName, type, colOpts);
     return at;
@@ -1708,7 +1715,7 @@ export class SchemaStatements {
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {
     const at = new AlterTable(tableName);
     at.dropConstraint(constraintName);
-    await this.adapter.execute(await this.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async dumpSchemaInformation(): Promise<string | null> {
@@ -1736,9 +1743,7 @@ export class SchemaStatements {
     // numeric `version.to_i` to `quote`, emitting an unquoted numeric literal —
     // pass `verNum`, not the `ver` string, so adapter dispatch matches.
     if (!migrated.includes(verNum)) {
-      await this.adapter.execute(
-        `INSERT INTO ${smTable} (version) VALUES (${this.adapter.quote(verNum)})`,
-      );
+      await this.execute(`INSERT INTO ${smTable} (version) VALUES (${this.quote(verNum)})`);
     }
 
     // Insert all known migration versions below the target that haven't been run
@@ -1750,7 +1755,7 @@ export class SchemaStatements {
           `Duplicate migration ${duplicate}. Please renumber your migrations to resolve the conflict.`,
         );
       }
-      await this.adapter.execute(this.insertVersionsSql(inserting));
+      await this.execute(this.insertVersionsSql(inserting));
     }
   }
 
@@ -1780,9 +1785,9 @@ export class SchemaStatements {
     // relation joins another table (the whole reason this path exists).
     const tableName = (relation.table as { name?: string } | undefined)?.name;
     const quoteCol = (c: string): string =>
-      typeof this.adapter.quoteColumnName === "function" ? this.adapter.quoteColumnName(c) : c;
+      typeof this.quoteColumnName === "function" ? this.quoteColumnName(c) : c;
     const pkColumns = pkNames.map((c) =>
-      tableName != null ? `${this.adapter.quoteTableName(tableName)}.${quoteCol(c)}` : quoteCol(c),
+      tableName != null ? `${this.quoteTableName(tableName)}.${quoteCol(c)}` : quoteCol(c),
     );
     const values = this.columnsForDistinct(pkColumns, (relation.orderValues as string[]) ?? []);
 
@@ -1803,7 +1808,7 @@ export class SchemaStatements {
     const arel = typeof limited.arel === "function" ? limited.arel() : limited;
     const sql = typeof arel === "string" ? arel : (arel?.toSql?.() ?? String(arel));
     const pkLen = pkNames.length;
-    const adapter = this.adapter as any;
+    const adapter = this as any;
     const rows: unknown[][] =
       typeof adapter.selectRows === "function"
         ? ((await adapter.selectRows(sql, "SQL")) as unknown[][])
@@ -1892,8 +1897,8 @@ export class SchemaStatements {
     const normalized = algorithm.toLowerCase();
 
     const adapterAlgorithms =
-      typeof (this.adapter as any).indexAlgorithms === "function"
-        ? ((this.adapter as any).indexAlgorithms() as Record<string, string>)
+      typeof (this as any).indexAlgorithms === "function"
+        ? ((this as any).indexAlgorithms() as Record<string, string>)
         : null;
 
     if (adapterAlgorithms) {
@@ -1949,7 +1954,7 @@ export class SchemaStatements {
   }
 
   isUseForeignKeys(): boolean {
-    const adapter = this.adapter as any;
+    const adapter = this as any;
     const supportsForeignKeys =
       typeof adapter.supportsForeignKeys === "function" ? adapter.supportsForeignKeys() : true;
     return supportsForeignKeys && this.isForeignKeysEnabled();
@@ -1965,8 +1970,8 @@ export class SchemaStatements {
     for (const { cmd: command, args } of operations) {
       const [table, ...arguments_] = args as [string, ...unknown[]];
       const forAlterTarget =
-        typeof (this.adapter as any)[`${command}ForAlter`] === "function"
-          ? (this.adapter as any)
+        typeof (this as any)[`${command}ForAlter`] === "function"
+          ? (this as any)
           : typeof (this as any)[`${command}ForAlter`] === "function"
             ? (this as any)
             : null;
@@ -1983,9 +1988,7 @@ export class SchemaStatements {
         }
       } else {
         if (sqlFragments.length > 0) {
-          await this.adapter.execute(
-            `ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`,
-          );
+          await this.execute(`ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`);
           sqlFragments.length = 0;
         }
         for (const proc of nonCombinable) await proc();
@@ -2001,7 +2004,7 @@ export class SchemaStatements {
     }
 
     if (sqlFragments.length > 0) {
-      await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`);
+      await this.execute(`ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`);
     }
     for (const proc of nonCombinable) await proc();
   }
@@ -2099,7 +2102,7 @@ export class SchemaStatements {
       length?: number | Record<string, number>;
     } = {},
   ): Map<string, string> {
-    const adapter = this.adapter as any;
+    const adapter = this as any;
     if (typeof adapter.supportsIndexSortOrder === "function" && adapter.supportsIndexSortOrder()) {
       quotedColumns = this.addIndexSortOrder(quotedColumns, options);
     }
@@ -2216,7 +2219,7 @@ export class SchemaStatements {
     return new TableDefinition(name, {
       ...options,
       adapterName: this.adapterName as any,
-      adapter: this.adapter,
+      adapter: this,
     });
   }
 
@@ -2254,7 +2257,7 @@ export class SchemaStatements {
    * @internal
    */
   fetchTypeMetadata(sqlType: string | null): SqlTypeMetadata {
-    const castType = this.adapter.lookupCastType(sqlType) as Type;
+    const castType = this.lookupCastType(sqlType) as Type;
     return new SqlTypeMetadata({
       sqlType,
       // Rails' `cast_type.type` (schema_statements.rb:1721) — `Type#type` is a
@@ -2297,7 +2300,7 @@ export class SchemaStatements {
    * adapter-level override still wins.
    */
   stripTableNamePrefixAndSuffix(tableName: string): string {
-    const adapter = this.adapter as any;
+    const adapter = this as any;
     const prefix: string = adapter.tableNamePrefix ?? globalTableNamePrefix();
     const suffix: string = adapter.tableNameSuffix ?? globalTableNameSuffix();
     const str = String(tableName);
@@ -2360,7 +2363,7 @@ export class SchemaStatements {
 
   /** @internal */
   isForeignKeysEnabled(): boolean {
-    const adapter = this.adapter as any;
+    const adapter = this as any;
     // Rails: `foreign_keys_enabled?` is `@config.fetch(:foreign_keys, true)`.
     // AbstractAdapter stores its config in `_config` (there is no `config`
     // getter), so read the real config hash; a missing key defaults to true.
@@ -2389,7 +2392,7 @@ export class SchemaStatements {
     tableName: string,
     options: { name?: string; expression?: string } = {},
   ): Promise<CheckConstraintDefinition | undefined> {
-    const adapter = this.adapter as any;
+    const adapter = this as any;
     if (
       typeof adapter.supportsCheckConstraints === "function" &&
       !adapter.supportsCheckConstraints()
@@ -2420,7 +2423,7 @@ export class SchemaStatements {
     // Resolve through the adapter (which carries the DatabaseLimits mixin) so an
     // adapter overriding indexNameLength/maxIdentifierLength propagates here,
     // falling back to the DatabaseLimits base default for a bare adapter.
-    const adapter = this.adapter as unknown as { indexNameLength?(): number };
+    const adapter = this as unknown as { indexNameLength?(): number };
     const limit = adapter.indexNameLength ? adapter.indexNameLength() : maxIdentifierLength();
     if (newName.length > limit) {
       throw new ArgumentError(
@@ -2431,7 +2434,7 @@ export class SchemaStatements {
 
   /** @internal */
   validateTableLengthBang(tableName: string): void {
-    const adapter = this.adapter as unknown as { tableNameLength?(): number };
+    const adapter = this as unknown as { tableNameLength?(): number };
     const limit = adapter.tableNameLength ? adapter.tableNameLength() : maxIdentifierLength();
     if (tableName.length > limit) {
       throw new ArgumentError(
@@ -2506,7 +2509,7 @@ export class SchemaStatements {
 
   /** @internal */
   renameColumnSql(_tableName: string, columnName: string, newColumnName: string): string {
-    return `RENAME COLUMN ${this.adapter.quoteIdentifier(columnName)} TO ${this.adapter.quoteIdentifier(newColumnName)}`;
+    return `RENAME COLUMN ${this.quoteIdentifier(columnName)} TO ${this.quoteIdentifier(newColumnName)}`;
   }
 
   /** @internal */
@@ -2516,7 +2519,7 @@ export class SchemaStatements {
     _type?: ColumnType,
     _options: ColumnOptions = {},
   ): string {
-    return `DROP COLUMN ${this.adapter.quoteIdentifier(columnName)}`;
+    return `DROP COLUMN ${this.quoteIdentifier(columnName)}`;
   }
 
   /** @internal */
@@ -2532,7 +2535,7 @@ export class SchemaStatements {
   async addTimestampsForAlter(tableName: string, options: ColumnOptions = {}): Promise<string[]> {
     const opts: ColumnOptions = { ...options };
     if (opts.null == null) opts.null = false;
-    if (!("precision" in opts) && (this.adapter as any).supportsDatetimeWithPrecision?.()) {
+    if (!("precision" in opts) && (this as any).supportsDatetimeWithPrecision?.()) {
       opts.precision = 6;
     }
     return [
@@ -2553,14 +2556,14 @@ export class SchemaStatements {
     if (Array.isArray(versions)) {
       // Ruby's Array#reverse returns a new array; copy before reversing so we
       // don't mutate the caller's array (e.g. pool.schemaMigration.versions).
-      const rows = [...versions].reverse().map((v) => `(${this.adapter.quote(v)})`);
+      const rows = [...versions].reverse().map((v) => `(${this.quote(v)})`);
       return `INSERT INTO ${smTable} (version) VALUES\n${rows.join(",\n")};`;
     }
-    return `INSERT INTO ${smTable} (version) VALUES (${this.adapter.quote(versions)});`;
+    return `INSERT INTO ${smTable} (version) VALUES (${this.quote(versions)});`;
   }
 
   /** @internal */
-  dataSourceSql(_name?: string, _options?: { type?: string }): string {
+  dataSourceSql(_name?: string | null, _options?: { type?: string }): string {
     // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
     throw new NotImplementedError(
       "ActiveRecord::ConnectionAdapters::SchemaStatements#data_source_sql is not implemented",

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
@@ -4,7 +4,10 @@ import { Table as MysqlTable } from "./schema-definitions.js";
 
 describe("MysqlSchemaStatements#changeTable", () => {
   it("yields the MySQL Table subclass", async () => {
-    const ss = new MysqlSchemaStatements({ adapterName: "mysql" } as never);
+    const ss = Object.setPrototypeOf(
+      { adapterName: "mysql" },
+      MysqlSchemaStatements.prototype,
+    ) as MysqlSchemaStatements;
     let yielded: unknown;
     await ss.changeTable("things", (t) => {
       yielded = t;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -30,7 +30,7 @@ import type { AddIndexOptions, SchemaStatementsLike } from "../abstract/schema-d
 export class MysqlSchemaStatements extends BaseSchemaStatements {
   private _mysqlSchemaCreation?: MysqlSchemaCreation;
   override get schemaCreation(): MysqlSchemaCreation {
-    return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this.adapter));
+    return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this));
   }
 
   /** Mirrors: MySQL::SchemaStatements#update_table_definition */
@@ -66,7 +66,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
       return;
     }
     const createDef = new CreateIndexDefinition(idx, false, algorithmClause);
-    await this.adapter.execute(await this.schemaCreation.accept(createDef));
+    await this.execute(await this.schemaCreation.accept(createDef));
   }
 
   /** Mirrors: MySQL::SchemaStatements#remove_column */
@@ -91,9 +91,9 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     const hasOpts = last !== null && last !== undefined && typeof last === "object";
     const opts = (hasOpts ? last : {}) as { temporary?: boolean };
     if (opts.temporary) {
-      return (
-        this.adapter as unknown as { dropTable(...args: unknown[]): Promise<void> }
-      ).dropTable(...(args as unknown[]));
+      return (this as unknown as { dropTable(...args: unknown[]): Promise<void> }).dropTable(
+        ...(args as unknown[]),
+      );
     }
 
     return super.dropTable(...(args as any));

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -82,21 +82,27 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     return super.removeColumn(tableName, columnName, type, options);
   }
 
+  /** Mirrors: AbstractMysqlAdapter#drop_table */
   override async dropTable(
     ...args:
       | [string, ...string[]]
       | [string, ...string[], { ifExists?: boolean; force?: "cascade"; temporary?: boolean }]
   ): Promise<void> {
-    const last = args[args.length - 1];
-    const hasOpts = last !== null && last !== undefined && typeof last === "object";
-    const opts = (hasOpts ? last : {}) as { temporary?: boolean };
-    if (opts.temporary) {
-      return (this as unknown as { dropTable(...args: unknown[]): Promise<void> }).dropTable(
-        ...(args as unknown[]),
-      );
+    const [tableNames, options] = this._splitTableNamesAndOptions(args) as [
+      string[],
+      { ifExists?: boolean; force?: "cascade"; temporary?: boolean },
+    ];
+    if (tableNames.length === 0) {
+      throw new ArgumentError("dropTable requires at least one table name");
     }
-
-    return super.dropTable(...(args as any));
+    const temporary = options.temporary ? " TEMPORARY" : "";
+    const ifExists = options.ifExists ? " IF EXISTS" : "";
+    const cascade = options.force === "cascade" ? " CASCADE" : "";
+    for (const name of tableNames) {
+      this.schemaCache?.clearDataSourceCacheBang(this.pool, name);
+    }
+    const quoted = tableNames.map((n) => this.quoteTableName(n)).join(", ");
+    await this.execute(`DROP${temporary} TABLE${ifExists} ${quoted}${cascade}`);
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -98,7 +98,7 @@ interface PgSchemaAdapter {
 
 export class PostgreSQLSchemaStatements extends SchemaStatements {
   private get pg(): PgSchemaAdapter {
-    return this.adapter as unknown as PgSchemaAdapter;
+    return this as unknown as PgSchemaAdapter;
   }
 
   /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */
@@ -114,10 +114,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     const cascade = options.force === "cascade" ? " CASCADE" : "";
     for (const name of tableNames) {
-      this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, name);
+      this.schemaCache?.clearDataSourceCacheBang(this.pool, name);
     }
     const quoted = tableNames.map((n) => this._qt(n)).join(", ");
-    await this.adapter.execute(`DROP TABLE${ifExists} ${quoted}${cascade}`);
+    await this.execute(`DROP TABLE${ifExists} ${quoted}${cascade}`);
   }
 
   // ---------------------------------------------------------------------------
@@ -275,10 +275,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   quotedIncludeColumnsForIndex(columnNames: string | string[]): string {
-    if (typeof columnNames === "string") return this.adapter.quoteColumnName(columnNames);
-    const quotedColumns = new Map(
-      columnNames.map((name) => [name, this.adapter.quoteColumnName(name)]),
-    );
+    if (typeof columnNames === "string") return this.quoteColumnName(columnNames);
+    const quotedColumns = new Map(columnNames.map((name) => [name, this.quoteColumnName(name)]));
     return Array.from(this.addOptionsForIndexColumns(quotedColumns).values()).join(", ");
   }
 
@@ -507,12 +505,12 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       await this.dropSchema(name, { ifExists: true });
     }
     const ifNotExists = options.ifNotExists ? " IF NOT EXISTS" : "";
-    await this.adapter.execute(`CREATE SCHEMA${ifNotExists} ${this.quoteSchemaName(name)}`);
+    await this.execute(`CREATE SCHEMA${ifNotExists} ${this.quoteSchemaName(name)}`);
   }
 
   async dropSchema(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
     const ifExists = options.ifExists ? " IF EXISTS" : "";
-    await this.adapter.execute(`DROP SCHEMA${ifExists} ${this.quoteSchemaName(name)} CASCADE`);
+    await this.execute(`DROP SCHEMA${ifExists} ${this.quoteSchemaName(name)} CASCADE`);
   }
 
   async schemaExists(name: string): Promise<boolean> {
@@ -551,11 +549,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       }
       optionString += ` CONNECTION LIMIT = ${limit}`;
     }
-    await this.adapter.execute(`CREATE DATABASE ${this.pg.quoteIdentifier(name)}${optionString}`);
+    await this.execute(`CREATE DATABASE ${this.pg.quoteIdentifier(name)}${optionString}`);
   }
 
   async dropDatabase(name: string): Promise<void> {
-    await this.adapter.execute(`DROP DATABASE IF EXISTS ${this.pg.quoteIdentifier(name)}`);
+    await this.execute(`DROP DATABASE IF EXISTS ${this.pg.quoteIdentifier(name)}`);
   }
 
   async recreateDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
@@ -899,7 +897,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const clause = await this.pg.schemaCreation.accept(changeColDef);
     // Route DDL through the public `execute` (not the raw `exec`) so the
     // dirties_query_cache wrapper clears the query cache on schema changes.
-    await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${clause}`);
+    await this.execute(`ALTER TABLE ${this._qt(tableName)} ${clause}`);
     if ("comment" in options) {
       await this.changeColumnComment(tableName, columnName, options.comment ?? null);
     }
@@ -936,8 +934,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // Mirrors PostgreSQL::SchemaStatements#rename_column: clear the statement
     // cache, rename, then fix up index names that embed the column name.
     this.pg.clearCacheBang();
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
+    await this.execute(
       `ALTER TABLE ${this._qt(tableName)} RENAME COLUMN ${this._qi(columnName)} TO ${this._qi(newColumnName)}`,
     );
     await this.renameColumnIndexes(tableName, columnName, newColumnName);
@@ -947,8 +945,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     this.validateIndexLengthBang(tableName, newName);
 
     const [schema] = this.pg.extractSchemaQualifiedName(tableName);
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
+    await this.execute(
       `ALTER INDEX ${schema ? `${this._qt(schema)}.` : ""}${this._qi(oldName)} RENAME TO ${this._qt(newName)}`,
     );
   }
@@ -963,8 +961,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // sees the new default rather than a stale (always-warm) entry. Safe to clear
     // first: buildChangeColumnDefaultDefinition's column lookup queries
     // pg_catalog directly, not the cache.
-    this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
+    await this.execute(
       `ALTER TABLE ${this._qt(tableName)} ${await this.changeColumnDefaultForAlter(tableName, columnName, defaultOrChanges)}`,
     );
   }
@@ -1021,13 +1019,13 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       // Rails guards the pre-ALTER UPDATE with `if column` — skip it when the
       // column can't be found rather than quoting against an undefined column.
       if (col) {
-        const expr = await this.adapter.quoteDefaultExpression(defaultValue, col);
-        await this.adapter.execute(
+        const expr = await this.quoteDefaultExpression(defaultValue, col);
+        await this.execute(
           `UPDATE ${quotedTable} SET ${quotedCol} = ${expr} WHERE ${quotedCol} IS NULL`,
         );
       }
     }
-    await this.adapter.execute(
+    await this.execute(
       `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} ${nullable ? "DROP" : "SET"} NOT NULL`,
     );
   }
@@ -1042,8 +1040,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // the COMMENT ON statement.
     this.pg.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges) as string | null;
-    await this.adapter.execute(
-      `COMMENT ON COLUMN ${this.adapter.quoteTableName(tableName)}.${this.adapter.quoteColumnName(columnName)} IS ${this.pg.quote(comment)}`,
+    await this.execute(
+      `COMMENT ON COLUMN ${this.quoteTableName(tableName)}.${this.quoteColumnName(columnName)} IS ${this.pg.quote(comment)}`,
     );
   }
 
@@ -1054,9 +1052,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // Mirrors PostgreSQL::SchemaStatements#change_table_comment.
     this.pg.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges) as string | null;
-    await this.adapter.execute(
-      `COMMENT ON TABLE ${this._qt(tableName)} IS ${this.pg.quote(comment)}`,
-    );
+    await this.execute(`COMMENT ON TABLE ${this._qt(tableName)} IS ${this.pg.quote(comment)}`);
   }
 
   // ---------------------------------------------------------------------------
@@ -1067,7 +1063,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   async validateConstraint(tableName: string, constraintName: string): Promise<void> {
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.validateConstraint(constraintName);
-    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.pg.schemaCreation.accept(at));
   }
 
   async validateCheckConstraint(
@@ -1226,7 +1222,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // (now converged): it applies table_name_prefix/suffix and re-runs
     // foreign_key_options idempotently (column/name already filled above).
     at.addForeignKey(toTable, fkOptions as Partial<AddForeignKeyOptions>);
-    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.pg.schemaCreation.accept(at));
   }
 
   override async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
@@ -1275,7 +1271,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const opts = this.exclusionConstraintOptions(tableName, expression, options);
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.addExclusionConstraint(expression, opts);
-    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.pg.schemaCreation.accept(at));
   }
 
   async removeExclusionConstraint(
@@ -1413,7 +1409,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.addUniqueConstraint(columnName as string | string[], opts);
-    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.pg.schemaCreation.accept(at));
   }
 
   async removeUniqueConstraint(
@@ -1769,7 +1765,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
        FROM (
          SELECT indrelid, indkey, generate_subscripts(indkey, 1) idx
            FROM pg_index
-          WHERE indrelid = ${this.adapter.quote(this.adapter.quoteTableName(tableName))}::regclass
+          WHERE indrelid = ${this.quote(this.quoteTableName(tableName))}::regclass
             AND indisprimary
        ) i
        JOIN pg_attribute a
@@ -1917,10 +1913,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     if (!pk) return;
     if (seq) {
       const quotedSequence = this.pg.quoteTableName(`${seq.schema}.${seq.name}`);
-      await this.adapter.queryValue(
-        `SELECT setval(${this.pg.quote(quotedSequence)}, ${value})`,
-        "SCHEMA",
-      );
+      await this.queryValue(`SELECT setval(${this.pg.quote(quotedSequence)}, ${value})`, "SCHEMA");
     } else {
       this.pg.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
     }
@@ -1948,7 +1941,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     if (!pk || !sequence) return;
 
     const quotedSequence = this.pg.quoteTableName(sequence);
-    const maxPk = await this.adapter.queryValue(
+    const maxPk = await this.queryValue(
       `SELECT MAX(${this.pg.quoteColumnName(pk)}) FROM ${this.pg.quoteTableName(tableName)}`,
       "SCHEMA",
     );
@@ -1957,16 +1950,16 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       const dbVersion = await this.pg.getDatabaseVersion();
       minvalue =
         dbVersion >= 100000
-          ? await this.adapter.queryValue(
+          ? await this.queryValue(
               `SELECT seqmin FROM pg_sequence WHERE seqrelid = ${this.pg.quote(quotedSequence)}::regclass`,
               "SCHEMA",
             )
-          : await this.adapter.queryValue(`SELECT min_value FROM ${quotedSequence}`, "SCHEMA");
+          : await this.queryValue(`SELECT min_value FROM ${quotedSequence}`, "SCHEMA");
     }
 
     // Ruby's `max_pk ? true : false` is a nil check — 0 is truthy in Ruby, so a
     // table whose max primary key is 0 must still emit `true`.
-    await this.adapter.queryValue(
+    await this.queryValue(
       `SELECT setval(${this.pg.quote(quotedSequence)}, ${maxPk ?? minvalue}, ${maxPk == null ? "false" : "true"})`,
       "SCHEMA",
     );

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -32,7 +32,6 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
     "capability read — skips expression indexes on adapters that lack them",
   ],
   ["supportsIndexesInCreate", "capability read — decides whether indexes ride inside CREATE TABLE"],
-  ["adapter", "self-reference — the mixed-in SchemaStatements bodies reach the adapter through it"],
   [
     "buildCreateTableDefinition",
     "definition factory — a stub returns no TableDefinition and dies at once, so it cannot silently lay nothing",
@@ -109,7 +108,6 @@ async function recordLayPath(): Promise<Set<string>> {
       get(target, prop, receiver) {
         if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
         touched.add(prop);
-        if (prop === "adapter") return self;
         let value: unknown;
         try {
           value = Reflect.get(target, prop, self);


### PR DESCRIPTION
`SchemaStatements` is only ever mixed into an adapter now
(`include(AbstractAdapter, SchemaStatements)`,
`include(AbstractMysqlAdapter, MysqlSchemaStatements)`, and since #5844
`include(PostgreSQLAdapter, PostgreSQLSchemaStatements)`), so the companion-class
scaffold that predated the mixin flip is dead weight whose only remaining effect
was to make the bodies read unlike Rails.

- `this.adapter.x(...)` → `this.x(...)` across the abstract (120), PostgreSQL
  (32) and MySQL (3) schema-statements bodies.
- `SchemaStatements`' `constructor(protected readonly adapter: ...)` is gone; the
  class has no constructor. A merged `interface SchemaStatements extends
  Omit<AbstractAdapter, ...>, SchemaQuoter {}` gives the plain `this` calls the
  adapter's type (the same declaration-merging idiom `Base`, `Relation` and
  `PostgreSQLAdapter` already use). The `Omit` list covers the handful of members
  the class declares itself with a different shape.
- `AbstractAdapter`'s `protected get adapter()` (which returned `this` purely so
  those bodies resolved) is deleted along with its `@internal` JSDoc. Rails has
  no such member.
- The redundant `protected get adapterName()` narrowing override is gone too; the
  two sites that need the narrow `AdapterName` narrow at the call site.
- Unit tests that constructed these classes directly are re-pointed at the
  prototype, the way #5844 did for `postgresql/schema-statements-class.test.ts`.
  The reflection-probe test layers only the probes under test over the live
  connection so the adapter's own `dataSourceSql` still resolves.

SQLite lane green locally (`connection-adapters` + `migration` + `migration.trails`);
typecheck and api:compare clean.

Closes-story: drop-schema-statements-adapter-constructor-and-self-getter
