### PR TITLE
feat(api-compare): stop minting inert placeholder @missingRailsCall tags

### DIFF
--- a/docs/infrastructure/api-build-stub-generation-plan.md
+++ b/docs/infrastructure/api-build-stub-generation-plan.md
@@ -205,14 +205,34 @@ On every run, for every **existing** matched method, `api:build`:
    below for why the sibling tag reads differently). No new parser dep
    either way.
 3. Diffs:
-   - **newly missing** (in artifact, not tagged): add a tag. Reason source
-     precedence: (a) the curated `reason` from the matching
+   - **newly missing** (in artifact, not tagged): add a tag **only when there
+     is a curated reason to migrate** — the `reason` from the matching
      `call-mismatches-wide-exclude/<pkg>/<tsFile>.json` row (and, for narrow
      entries, `call-mismatches-exclude.json`), keyed by
-     `(package, tsFile, rubyName, call)`; (b) otherwise the literal
-     `unported (api:build stub)` / wide `DEFAULT_REASON` placeholder. This is
-     the migration path: the first full run pulls every curated reason into
-     the JSDoc.
+     `(package, tsFile, rubyName, call)`, when it is neither blank nor the
+     seeded placeholder. This is the migration path: the first full run pulls
+     every curated reason into the JSDoc.
+
+     A call whose baseline reason is still the placeholder (the seeded RFC
+     0044/0047 default strings / `unported (api:build stub)`) gets **no tag**
+     (RFC 0083). A placeholder tag justifies nothing — `justifies()` rejects
+     it, and it must, since `api:build` would otherwise mint one per
+     still-missing call and a single run would move the whole ~3088-row wide
+     baseline into tags and zero the gate — so minting it only adds inert
+     prose to a source file while the reason keeps living in the baseline
+     JSON. The generator therefore only ever produces load-bearing tags, and
+     `api:build --package <pkg> --dry-run` reports zero files changed on a
+     tree whose deviations are all still baselined. The run reports the
+     skipped count so the waiting-on-prose backlog stays visible.
+
+     Rejected alternatives: an opt-in `--seed-placeholders` flag (keeps ~90
+     LOC of generator and its round-trip surface alive for a scratch-space
+     convenience an editor already provides — a human writing a cluster's
+     reasons types the tag with the prose, not the placeholder first); and
+     keeping the current behavior documented as scratch space (the edits are
+     indistinguishable in review from load-bearing ones, and every one of
+     them has to be reverted or rewritten by hand).
+
    - **now satisfied** (tagged, not in artifact): drop the tag. If its reason
      is a known placeholder (the seeded RFC 0044/0047 default strings or
      `unported (api:build stub)`), drop silently. If it is human-authored
@@ -223,6 +243,7 @@ On every run, for every **existing** matched method, `api:build`:
    - **unchanged**: keep the tag byte-for-byte (tags are emitted in the
      ratchet's `compareKeys` code-unit order so a re-run with no diff is a
      no-op — idempotency is "second run produces zero edits").
+
 4. **Never edits a method body.** The only mutations are JSDoc blocks and
    whole-method insertions. A method whose body is hand-written but whose
    JSDoc is stale gets only a JSDoc edit.
@@ -314,10 +335,9 @@ report). They therefore share:
     unjustified one would suppress drift with no argument for it.
   - `@missingRailsCall`: raised by `parseJsdoc` (`build.ts`), with the same
     `<tag> needs a reason: <file>:<line> — <what to write>` message shape. A
-    bare tag in the tree is necessarily **hand-authored**: the generator
-    always writes a reason — either the curated baseline row's prose or a
-    placeholder (`unported (api:build stub)` / the wide `DEFAULT_REASON`) —
-    so there is no generated bare tag to protect. Backfilling a hand-written
+    bare tag in the tree is necessarily **hand-authored**: the generator only
+    emits a tag when it has a curated baseline row's prose to carry, so there
+    is no generated bare tag to protect. Backfilling a hand-written
     bare tag with a placeholder would silently convert an unjustified
     allowlist entry into a blessed one, which is exactly the failure mode the
     sibling tag rejects.
@@ -344,12 +364,12 @@ report). They therefore share:
   textually identical to an ordinary doc comment on the inserted declaration;
   only the diff distinguishes them, so that one stays a review-time concern.
 
-  The placeholder path is unaffected: a generator-authored placeholder is a
-  non-empty reason, so it parses, round-trips byte-for-byte via `rawLines`,
-  and still drops without a harvest report when the call converges. Reason
-  precedence (3a) falls back to the placeholder if a curated baseline row's
-  `reason` is ever blank, so the generator can never write a tag its own
-  parser would reject on the next run.
+  Placeholder tags predating RFC 0083 are unaffected: a placeholder is a
+  non-empty reason, so it parses, is kept byte-for-byte via `rawLines` on a
+  re-run, and still drops without a harvest report when the call converges.
+  The generator can never write a tag its own parser would reject on the next
+  run, because a blank curated `reason` now means "no tag" rather than "tag
+  with a placeholder".
 
 Two things are deliberately **not** shared, and the difference is load-bearing:
 

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -98,6 +98,15 @@ describe("renderJsdoc", () => {
     const { rest } = parseJsdoc("/**\n * @missingRailsCall a — x\n */");
     expect(renderJsdoc(rest, [], "  ")).toBeNull();
   });
+
+  it("keeps a one-line doc comment verbatim when there are no entries", () => {
+    const one = "  /** Mirrors Rails' Dot#edge — push edge, run block, pop. */";
+    expect(renderJsdoc([one], [], "  ")).toBe(one);
+  });
+
+  it("returns null for an empty one-line comment with no entries", () => {
+    expect(renderJsdoc(["  /** */"], [], "  ")).toBeNull();
+  });
 });
 
 const FILE = [
@@ -136,8 +145,20 @@ describe("reconcileFileText", () => {
     const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
     const r = reconcileFileText("foo.ts", src, expectations, () => DEFAULT_TAG_REASON);
     expect(r.text).toBeNull();
-    expect(r.skipped).toBe(1);
+    expect(r.skipped).toEqual(["save"]);
     expect(r.tagged).toEqual([]);
+  });
+
+  it("never deletes a one-line doc comment on a method it mints no tag for", () => {
+    const src = [
+      "export class Foo {",
+      "  /** Mirrors Rails' Foo#bar. */",
+      "  bar(): void {}",
+      "}",
+    ].join("\n");
+    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const r = reconcileFileText("foo.ts", src, expectations, () => DEFAULT_TAG_REASON);
+    expect(r.text).toBeNull();
   });
 
   it("still harvests a human-authored reason when its call converges", () => {

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -64,7 +64,7 @@ describe("parseJsdoc", () => {
 describe("reconcile", () => {
   it("keeps still-missing, adds new, drops satisfied", () => {
     const { entries } = parseJsdoc("/**\n * @missingRailsCall a — kept note\n */");
-    const r = reconcile(entries, new Set(["a", "b"]), reasonFor);
+    const r = reconcile(entries, new Set(["a", "b"]), () => "curated");
     expect(r.kept.map((e) => e.call)).toEqual(["a"]);
     expect(r.kept[0].reason).toBe("kept note");
     expect(r.added.map((e) => e.call)).toEqual(["b"]);
@@ -73,9 +73,23 @@ describe("reconcile", () => {
     expect(r2.dropped.map((e) => e.call)).toEqual(["a"]);
   });
 
-  it("falls back to the placeholder when a curated reason is blank", () => {
+  it("mints no tag when the curated reason is blank", () => {
     const r = reconcile([], new Set(["a"]), () => "  ");
-    expect(r.added[0].reason).toBe(DEFAULT_TAG_REASON);
+    expect(r.added).toEqual([]);
+    expect(r.skipped).toEqual(["a"]);
+  });
+
+  it("mints no tag when the baseline reason is still the placeholder", () => {
+    const r = reconcile([], new Set(["a"]), reasonFor);
+    expect(r.added).toEqual([]);
+    expect(r.skipped).toEqual(["a"]);
+  });
+
+  it("keeps a pre-existing placeholder tag rather than rewriting it", () => {
+    const { entries } = parseJsdoc(`/**\n * @missingRailsCall a — ${DEFAULT_TAG_REASON}\n */`);
+    const r = reconcile(entries, new Set(["a"]), reasonFor);
+    expect(r.kept.map((e) => e.call)).toEqual(["a"]);
+    expect(r.skipped).toEqual([]);
   });
 });
 
@@ -115,6 +129,20 @@ describe("reconcileFileText", () => {
     expect(text!).toContain("bar(): void {}");
     expect(text!).toContain("baz(): void {}");
     expect(harvested.map((h) => h.entry.call)).toEqual(["stale_call"]);
+  });
+
+  it("produces zero edits when every missing call is still baselined by placeholder", () => {
+    const src = ["export class Foo {", "  bar(): void {}", "}"].join("\n");
+    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const r = reconcileFileText("foo.ts", src, expectations, () => DEFAULT_TAG_REASON);
+    expect(r.text).toBeNull();
+    expect(r.skipped).toBe(1);
+    expect(r.tagged).toEqual([]);
+  });
+
+  it("still harvests a human-authored reason when its call converges", () => {
+    const r = reconcileFileText("foo.ts", FILE, new Map(), () => DEFAULT_TAG_REASON);
+    expect(r.harvested.map((h) => h.entry.reason)).toEqual(["placeholder to drop"]);
   });
 
   it("is idempotent: a second run produces zero edits", () => {

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -8,8 +8,11 @@
  * written by `pnpm api:compare --wide-calls`) and, for each matched TS
  * method, rewrites its JSDoc so that:
  *
- *   - every currently-missing Rails call carries one
- *     `@missingRailsCall <ruby_call> — <reason>` tag;
+ *   - every currently-missing Rails call WITH a curated baseline reason carries
+ *     one `@missingRailsCall <ruby_call> — <reason>` tag. A call whose reason is
+ *     still the seeded placeholder gets no tag: the placeholder suppresses
+ *     nothing, so minting it would only add inert prose to a source file while
+ *     the reason kept living in the baseline JSON (RFC 0083);
  *   - tags for now-satisfied calls are dropped (human-authored reasons are
  *     harvested to stdout, never destroyed unseen);
  *   - existing tags that still apply are kept byte-for-byte (idempotent:
@@ -92,9 +95,19 @@ export interface ReconcileResult {
   kept: TagEntry[];
   added: TagEntry[];
   dropped: TagEntry[];
+  /** Missing calls with no curated reason to migrate: no tag is minted for
+   *  them, so they stay in the baseline until a human writes the prose. */
+  skipped: string[];
 }
 
-/** Diff existing entries against the expected missing-call set. */
+/** Diff existing entries against the expected missing-call set.
+ *
+ *  A call whose baseline reason is still {@link DEFAULT_TAG_REASON} (or blank)
+ *  mints NO tag: a placeholder tag suppresses nothing (`justifies` rejects it),
+ *  so it would only add inert prose to a source file while the reason kept
+ *  living in the baseline JSON. The generator therefore only ever writes
+ *  load-bearing tags, and a tree whose deviations are all still baselined
+ *  reconciles to zero edits. */
 export function reconcile(
   existing: TagEntry[],
   expected: ReadonlySet<string>,
@@ -103,15 +116,19 @@ export function reconcile(
   const byCall = new Map(existing.map((e) => [e.call, e]));
   const kept: TagEntry[] = [];
   const added: TagEntry[] = [];
+  const skipped: string[] = [];
   for (const call of [...expected].sort()) {
     const have = byCall.get(call);
-    if (have) kept.push(have);
-    // A blank curated reason would emit a tag this tool's own parser rejects
-    // on the next run; the placeholder keeps the generated path round-trippable.
-    else added.push({ call, reason: reasonFor(call).trim() || DEFAULT_TAG_REASON, rawLines: [] });
+    if (have) {
+      kept.push(have);
+      continue;
+    }
+    const reason = reasonFor(call).trim();
+    if (!justifies(reason)) skipped.push(call);
+    else added.push({ call, reason, rawLines: [] });
   }
   const dropped = existing.filter((e) => !expected.has(e.call));
-  return { kept, added, dropped };
+  return { kept, added, dropped, skipped };
 }
 
 // Wrap a new tag entry to lines at ~80 cols with a two-space hang indent.
@@ -214,12 +231,17 @@ export function reconcileFileText(
    *  host-class duplicates, prototype-patched methods, …) — reported, never
    *  silently dropped. */
   unmatched: string[];
+  /** Missing calls left untagged for want of a curated reason (see
+   *  `reconcile`) — counted so a zero-edit run still says how much is waiting
+   *  on human prose. */
+  skipped: number;
 } {
   const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
   const edits: Edit[] = [];
   const harvested: { tsName: string; entry: TagEntry }[] = [];
   const tagged: { rubyName: string; call: string }[] = [];
   const seen = new Set<string>();
+  let skipped = 0;
 
   const visit = (node: ts.Node): void => {
     let name: string | null = null;
@@ -269,6 +291,7 @@ export function reconcileFileText(
         const r = reconcile(entries, expected, (c) =>
           exp ? firstCuratedReason(exp.rubyNames, c, reasonFor) : DEFAULT_TAG_REASON,
         );
+        skipped += r.skipped.length;
         if (exp) {
           for (const e of [...r.kept, ...r.added]) {
             if (!justifies(e.reason)) continue;
@@ -300,12 +323,12 @@ export function reconcileFileText(
   visit(sf);
 
   const unmatched = [...expectations.keys()].filter((n) => !seen.has(n)).sort();
-  if (edits.length === 0) return { text: null, harvested, tagged, unmatched };
+  if (edits.length === 0) return { text: null, harvested, tagged, unmatched, skipped };
   let out = text;
   for (const e of edits.sort((a, b) => b.start - a.start)) {
     out = out.slice(0, e.start) + e.text + out.slice(e.end);
   }
-  return { text: out, harvested, tagged, unmatched };
+  return { text: out, harvested, tagged, unmatched, skipped };
 }
 
 /** (tsFile → tsName → expectation) for one package: every call the artifact
@@ -372,6 +395,7 @@ async function main(argv: string[]): Promise<number> {
   const byFile = buildExpectations(artifact, pkg, onlyFile);
 
   let changed = 0;
+  let skipped = 0;
   const migrated = new Set<string>();
   const srcDir = packageSrcDir(pkg);
   for (const [tsFile, expectations] of [...byFile.entries()].sort()) {
@@ -397,7 +421,8 @@ async function main(argv: string[]): Promise<number> {
       console.error(`api:build: ${err instanceof Error ? err.message : String(err)}`);
       return 1;
     }
-    const { text: next, harvested, tagged, unmatched } = reconciled;
+    const { text: next, harvested, tagged, unmatched, skipped: fileSkipped } = reconciled;
+    skipped += fileSkipped;
     for (const t of tagged) migrated.add(keyOf({ package: pkg, tsFile, ...t }));
     for (const h of harvested) {
       console.log(`harvested (${tsFile} ${h.tsName} ${h.entry.call}): ${h.entry.reason}`);
@@ -420,6 +445,13 @@ async function main(argv: string[]): Promise<number> {
       `${path.relative(ROOT_DIR, WIDE_BASELINE_DIR)}/.`,
   );
   console.log(`api:build: ${changed} file(s) ${dryRun ? "would change" : "updated"} (${pkg}).`);
+  if (skipped > 0) {
+    console.log(
+      `api:build: ${skipped} missing call(s) left untagged — their baseline reason is still ` +
+        "the seeded placeholder. Write per-entry prose in " +
+        `${path.relative(ROOT_DIR, WIDE_BASELINE_DIR)}/ (or at the call site) to migrate them.`,
+    );
+  }
   return 0;
 }
 

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -150,6 +150,12 @@ function renderEntry(e: TagEntry, indent: string): string[] {
   return lines;
 }
 
+const oneLineProse = (line: string): string =>
+  line
+    .replace(/^\s*\/\*\*\s?/, "")
+    .replace(/\s*\*\/\s*$/, "")
+    .trim();
+
 /** Rebuild a JSDoc comment from its non-tag lines plus reconciled entries.
  *  Returns null when nothing remains (comment should be removed entirely). */
 export function renderJsdoc(rest: string[], entries: TagEntry[], indent: string): string | null {
@@ -159,10 +165,16 @@ export function renderJsdoc(rest: string[], entries: TagEntry[], indent: string)
   if (body.length === 0 || !body[0].trimStart().startsWith("/**")) {
     body = [`${indent}/**`, `${indent} */`];
   }
+  // A one-line `/** ... */` comment keeps its prose on the `/**` line, where
+  // the `head`/`hasProse` split below cannot see it — returning it verbatim is
+  // what keeps an ordinary doc comment on an untagged method from being
+  // deleted as "tags-only".
+  if (ordered.length === 0 && body.length === 1) {
+    return oneLineProse(body[0]) === "" ? null : body[0];
+  }
   // Normalize a one-line `/** ... */` comment to block form when tags exist.
   if (ordered.length > 0 && body.length === 1) {
-    const one = body[0];
-    const inner = one.replace(/^\s*\/\*\*\s?/, "").replace(/\s*\*\/\s*$/, "");
+    const inner = oneLineProse(body[0]);
     body = [`${indent}/**`, ...(inner ? [`${indent} * ${inner}`] : []), `${indent} */`];
   }
   const closeIdx = body.findIndex((l) => l.trim().endsWith("*/"));
@@ -206,7 +218,7 @@ function firstCuratedReason(
 ): string {
   for (const rubyName of rubyNames) {
     const reason = reasonFor(rubyName, call);
-    if (reason !== DEFAULT_TAG_REASON) return reason;
+    if (justifies(reason.trim())) return reason;
   }
   return DEFAULT_TAG_REASON;
 }
@@ -231,17 +243,17 @@ export function reconcileFileText(
    *  host-class duplicates, prototype-patched methods, …) — reported, never
    *  silently dropped. */
   unmatched: string[];
-  /** Missing calls left untagged for want of a curated reason (see
-   *  `reconcile`) — counted so a zero-edit run still says how much is waiting
-   *  on human prose. */
-  skipped: number;
+  /** Every missing call left untagged for want of a curated reason (see
+   *  `reconcile`), so a zero-edit run still says how much is waiting on human
+   *  prose. */
+  skipped: string[];
 } {
   const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
   const edits: Edit[] = [];
   const harvested: { tsName: string; entry: TagEntry }[] = [];
   const tagged: { rubyName: string; call: string }[] = [];
   const seen = new Set<string>();
-  let skipped = 0;
+  const skipped: string[] = [];
 
   const visit = (node: ts.Node): void => {
     let name: string | null = null;
@@ -291,7 +303,7 @@ export function reconcileFileText(
         const r = reconcile(entries, expected, (c) =>
           exp ? firstCuratedReason(exp.rubyNames, c, reasonFor) : DEFAULT_TAG_REASON,
         );
-        skipped += r.skipped.length;
+        skipped.push(...r.skipped);
         if (exp) {
           for (const e of [...r.kept, ...r.added]) {
             if (!justifies(e.reason)) continue;
@@ -422,7 +434,7 @@ async function main(argv: string[]): Promise<number> {
       return 1;
     }
     const { text: next, harvested, tagged, unmatched, skipped: fileSkipped } = reconciled;
-    skipped += fileSkipped;
+    skipped += fileSkipped.length;
     for (const t of tagged) migrated.add(keyOf({ package: pkg, tsFile, ...t }));
     for (const h of harvested) {
       console.log(`harvested (${tsFile} ${h.tsName} ${h.entry.call}): ${h.entry.reason}`);

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -157,7 +157,12 @@ const oneLineProse = (line: string): string =>
     .trim();
 
 /** Rebuild a JSDoc comment from its non-tag lines plus reconciled entries.
- *  Returns null when nothing remains (comment should be removed entirely). */
+ *  Returns null when nothing remains (comment should be removed entirely).
+ *
+ *  A one-line `/** ... *\/` comment keeps its prose on the `/**` line, which
+ *  the `head`/`hasProse` split cannot see; with no entries it is returned
+ *  verbatim, so an ordinary doc comment on an untagged method is not deleted
+ *  as "tags-only". */
 export function renderJsdoc(rest: string[], entries: TagEntry[], indent: string): string | null {
   // Order entries by call name (code-unit order, matching the ratchet).
   const ordered = [...entries].sort((a, b) => (a.call < b.call ? -1 : a.call > b.call ? 1 : 0));
@@ -165,10 +170,6 @@ export function renderJsdoc(rest: string[], entries: TagEntry[], indent: string)
   if (body.length === 0 || !body[0].trimStart().startsWith("/**")) {
     body = [`${indent}/**`, `${indent} */`];
   }
-  // A one-line `/** ... */` comment keeps its prose on the `/**` line, where
-  // the `head`/`hasProse` split below cannot see it — returning it verbatim is
-  // what keeps an ordinary doc comment on an untagged method from being
-  // deleted as "tags-only".
   if (ordered.length === 0 && body.length === 1) {
     return oneLineProse(body[0]) === "" ? null : body[0];
   }

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -16,16 +16,17 @@
 export const TAG = "@missingRailsCall";
 
 /**
- * The reason `api:build` stamps on a tag it mints with nothing curated to
- * migrate — the RFC 0047 seed prose, shared with the wide baseline's
- * `DEFAULT_REASON` (an entry carrying it is what the unreviewed high-water
- * mark counts).
+ * The wide baseline's seeded `reason` — the RFC 0047 seed prose. An entry
+ * carrying it is what the unreviewed high-water mark counts.
  *
- * A tag carrying it is deliberately NOT a justification: `api:build` mints one
- * per still-missing call, so if the placeholder suppressed, a single
- * `api:build --package <pkg>` run would move the whole baseline into inert
- * tags and zero the wide gate. It has to be replaced with real per-entry prose
- * before the call leaves the population.
+ * A tag carrying it is deliberately NOT a justification: it stands in for a
+ * reason rather than arguing one, so if it suppressed, the whole baseline would
+ * be blessed by prose nobody wrote. It has to be replaced with real per-entry
+ * prose before the call leaves the population.
+ *
+ * `api:build` no longer MINTS tags carrying it (RFC 0083) — it only writes a
+ * tag it has curated prose to migrate — but tags predating that policy still
+ * carry it in the tree.
  */
 export const DEFAULT_REASON =
   "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; " +
@@ -60,8 +61,8 @@ const ANY_TAG_LINE = /^\s*\*?\s?@\S/;
  *  `@` tag) attach to the preceding entry.
  *
  *  An empty reason is a hard error, matching `@noRailsEquivalent` (RFC 0080):
- *  every tag in the tree is written with a reason — the generator always emits
- *  the curated baseline row's prose or a placeholder — so a bare tag is
+ *  every tag in the tree is written with a reason — the generator only emits a
+ *  tag when it has a curated baseline row's prose to carry — so a bare tag is
  *  necessarily hand-authored, and backfilling it with a placeholder would turn
  *  an unjustified allowlist entry into a silently blessed one. The family's
  *  empty-reason contract is stated in


### PR DESCRIPTION
## Decision: option 1 — `api:build` never mints placeholder tags

`api:build` now writes a `@missingRailsCall` tag **only when it has a curated
baseline reason to migrate** (`reason` neither blank nor `DEFAULT_REASON`).

### Why

PR #5754 made the tag load-bearing, but only for real per-entry prose:
`justifies()` rejects `DEFAULT_REASON`. That guard is required — a placeholder
that suppressed would let one `pnpm api:build --package activerecord` run move
the whole ~3088-row wide baseline into tags and zero the gate.

The consequence was a generator emitting edits that do nothing:
`pnpm api:build --package arel --dry-run` reported 11 files would change and 0
baseline rows would migrate. Each of those edits added inert prose to a source
file — the reason still lived in the baseline JSON, the tag was decoration until
a human replaced it, and in review it was indistinguishable from a load-bearing
tag.

With this change the generator only ever produces load-bearing tags, and
reconciling a tree whose deviations are all still baselined is a zero-edit run.

### Rejected alternatives

- **Option 2 — keep minting behind `--seed-placeholders`.** Keeps the generator
  path and its round-trip surface alive for a scratch-space convenience an
  editor already provides: a human writing a cluster's reasons types the tag
  with the prose, not the placeholder first.
- **Option 3 — keep current behavior, document it as scratch space.** The edits
  are indistinguishable in review from load-bearing ones, and every one of them
  has to be reverted or rewritten by hand.

### What changed

- `reconcile` skips a call with no curated reason instead of adding a
  placeholder entry, and reports it in a new `skipped: string[]`.
- `reconcileFileText` propagates `skipped`; the CLI prints the count so the
  waiting-on-prose backlog stays visible on an otherwise-silent run.
- `firstCuratedReason` now asks `justifies()` rather than comparing against
  `DEFAULT_TAG_REASON` by hand, so blank and placeholder are one rule.
- Parser untouched. Pre-existing placeholder tags in the tree are still parsed
  and kept byte-for-byte — nothing in the tree is rewritten or removed.
- `harvested` reporting is unchanged: a human-authored reason dropped on
  convergence is still printed (covered by a new test).
- Docs (`api-build-stub-generation-plan.md`) updated for the new policy.

### Second commit: a prose-deleting bug the policy made reachable

`renderJsdoc` computes `hasProse` over `head` — the lines *before* the closing
delimiter — which is empty for a one-line `/** ... */` comment. So a one-liner
with no reconciled entries was classified tags-only and **deleted**. It was
unreachable before (a method with an expectation always got at least a
placeholder tag, so `ordered.length > 0`); with no placeholders it went live,
and the arel dry-run hit it immediately on `visitors/dot.ts`:

```
-  /** Mirrors Rails' Dot#edge — push edge, run block, pop. */
-  /** Mirrors Rails' Dot#with_node — link incoming edge then push node. */
```

Fixed by returning a one-line comment verbatim when there are no entries
(and `null` only when it is genuinely empty). Two `renderJsdoc` tests plus a
`reconcileFileText` regression test cover it.

### Verified on the merged tree

`pnpm api:compare --wide-calls`, then `api:build --package <pkg> --dry-run` for
every package. Files changed now tracks rows migrated, and every package with
nothing curated to migrate is a zero-edit run:

| package | files would change | rows would migrate |
| --- | --- | --- |
| arel | 0 (was 11) | 0 |
| actionpack / actionview / nokogiri / did-you-mean | 0 | 0 |
| globalid | 1 | 1 |
| trailties | 2 | 2 |
| rack | 3 | 6 |
| activemodel | 4 | 6 |
| activesupport | 12 | 12 |
| activerecord | 92 | 137 |

(No baselines or source files are committed by this PR — the dry-runs were
verification only.)

### Out of scope

The narrow baseline (`call-mismatches-exclude.json`) has its own RFC 0044 seed
string that `justifies()` does not know about. All 14 of its rows carry curated
prose today, so nothing changes; unifying the two seeds is a `justifies()`
change that would move the gate and belongs to its own story.

### Tests

`build.test.ts` reconcile/idempotency coverage updated, not deleted:

- the placeholder-fallback test became "mints no tag when the curated reason is
  blank" (asserts `added` empty, `skipped` names the call);
- new: no tag when the baseline reason is still the placeholder; a pre-existing
  placeholder tag is kept rather than rewritten; `reconcileFileText` produces
  zero edits when every missing call is still baselined by placeholder;
  `harvested` still fires for real prose; the three one-line-JSDoc cases above.

`pnpm vitest run scripts/api-compare/build.test.ts` — 31 passed;
`missing-rails-call-tags.test.ts` + `lint-missing-rails-call-reasons.test.ts` —
18 passed.

Closes-story: decide-api-build-placeholder-tag-policy
