### PR TITLE
refactor(activerecord): make checkCurrentProtectedEnvironmentBang check one config

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -16,11 +16,66 @@ import { fixtures } from "../test-fixtures.js";
 import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
-  it("raises an error when called with protected environment", async () => {
-    await expect(DatabaseTasks.checkProtectedEnvironmentsBang("production")).rejects.toThrow(
-      /production/,
-    );
-  });
+  // Rails: `if current_adapter?(:SQLite3Adapter) && !in_memory_db?`
+  // (database_tasks_test.rb:62).
+  it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
+    "raises an error when called with protected environment",
+    async () => {
+      // Rails: test_raises_an_error_when_called_with_protected_environment —
+      // stamp the config's metadata with the current env, assert the guard
+      // passes, then protect that env and assert it raises.
+      const protectedEnvironments = Base.protectedEnvironments;
+      const currentEnv = DatabaseConfigurations.currentEnv();
+      const env = "arunit";
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-protected-env-"));
+      const dbFile = path.join(tmp, "primary.sqlite3");
+      DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+        [env]: { primary: { adapter: "sqlite3", database: dbFile } },
+      });
+      DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+
+      const { BetterSQLite3Adapter } =
+        await import("../connection-adapters/better-sqlite3-adapter.js");
+      const adapter = new BetterSQLite3Adapter(dbFile);
+      try {
+        await adapter.executeMutation(
+          "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR(255) PRIMARY KEY NOT NULL)",
+        );
+        await adapter.executeMutation("INSERT INTO schema_migrations (version) VALUES ('1')");
+        await adapter.executeMutation(
+          "CREATE TABLE IF NOT EXISTS ar_internal_metadata (key VARCHAR PRIMARY KEY NOT NULL, value VARCHAR, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)",
+        );
+        await adapter.executeMutation(
+          `INSERT INTO ar_internal_metadata (key, value, created_at, updated_at) VALUES ('environment', '${currentEnv}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        );
+      } finally {
+        await adapter.close();
+      }
+
+      try {
+        expect(protectedEnvironments).not.toContain(currentEnv);
+        // Assert no error
+        await DatabaseTasks.checkProtectedEnvironmentsBang(env);
+
+        Base.protectedEnvironments = [currentEnv];
+        await expect(DatabaseTasks.checkProtectedEnvironmentsBang(env)).rejects.toThrow(
+          ProtectedEnvironmentError,
+        );
+      } finally {
+        Base.protectedEnvironments = protectedEnvironments;
+        // Explicit teardown for the raw-created tables; the tmp dir goes too.
+        const cleanup = new BetterSQLite3Adapter(dbFile);
+
+        await cleanup.executeMutation("DROP TABLE IF EXISTS schema_migrations");
+
+        await cleanup.executeMutation("DROP TABLE IF EXISTS ar_internal_metadata");
+        await cleanup.close();
+        DatabaseTasks.databaseConfiguration = null;
+        DatabaseTasks.clearRegisteredTasks();
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.skip("raises an error when called with protected environment which name is a symbol", () => {
     // PERMANENT-SKIP: Ruby-only (Symbol env names) — protected_environments
@@ -46,7 +101,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
       );
       await adapter.executeMutation("INSERT INTO schema_migrations (version) VALUES ('1')");
       // dbFile lives under a per-test tmpdir, not the shared worker database.
-      // eslint-disable-next-line blazetrails/require-table-teardown
+
       await adapter.executeMutation("DROP TABLE IF EXISTS ar_internal_metadata");
     } finally {
       await adapter.close();

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -344,7 +344,8 @@ export class DatabaseTasks {
    * answers that list instead — the same override Rails' own
    * `migrator_class` test helper uses.
    */
-  private static async _migrationContextFor(
+  /** @internal */
+  static async _migrationContextFor(
     adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
     dbConfig: DatabaseConfig,
   ): Promise<import("../migration.js").MigrationContext> {
@@ -635,26 +636,8 @@ export class DatabaseTasks {
       return;
     }
 
-    const { NoDatabaseError } = await import("../errors.js");
-    const { EnvironmentMismatchError } = await import("../migration.js");
-
     for (const config of configs) {
-      try {
-        await this.withTemporaryConnection(config, async (adapter) => {
-          const context = await this._migrationContextFor(adapter, config);
-          const current = context.currentEnvironment;
-          const stored = await context.lastStoredEnvironment();
-          if (stored && (await context.protectedEnvironment())) {
-            throw new ProtectedEnvironmentError(stored);
-          }
-          if (stored && stored !== current) {
-            throw new EnvironmentMismatchError(current, stored);
-          }
-        });
-      } catch (error) {
-        if (error instanceof NoDatabaseError) continue;
-        throw error;
-      }
+      await checkCurrentProtectedEnvironmentBang(config);
     }
   }
 
@@ -1603,9 +1586,24 @@ export function structureLoadFlagsFor(adapter: string): string | string[] | null
 export async function checkCurrentProtectedEnvironmentBang(
   dbConfig: DatabaseConfig,
 ): Promise<void> {
-  await DatabaseTasks.withTemporaryConnection(dbConfig, async () => {
-    await DatabaseTasks.checkProtectedEnvironmentsBang(dbConfig.envName);
-  });
+  const { NoDatabaseError } = await import("../errors.js");
+  const { EnvironmentMismatchError } = await import("../migration.js");
+  try {
+    await DatabaseTasks.withTemporaryConnection(dbConfig, async (adapter) => {
+      const context = await DatabaseTasks._migrationContextFor(adapter, dbConfig);
+      const current = context.currentEnvironment;
+      const stored = await context.lastStoredEnvironment();
+      if (stored && (await context.protectedEnvironment())) {
+        throw new ProtectedEnvironmentError(stored);
+      }
+      if (stored && stored !== current) {
+        throw new EnvironmentMismatchError(current, stored);
+      }
+    });
+  } catch (error) {
+    if (error instanceof NoDatabaseError) return;
+    throw error;
+  }
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -592,13 +592,8 @@ export class DatabaseTasks {
    * exactly:
    *   - If DISABLE_DATABASE_ENVIRONMENT_CHECK is set in the environment,
    *     this is a no-op (escape hatch for intentional production ops).
-   *   - For each config in the target environment, read the stored
-   *     `environment` key from InternalMetadata.
-   *   - Raise ProtectedEnvironmentError if that stored env is in
-   *     Base.protectedEnvironments.
-   *   - Raise EnvironmentMismatchError if a stored env exists but differs
-   *     from the current env.
-   *   - Swallow NoDatabaseError (can't check a database that isn't there).
+   *   - Otherwise run {@link checkCurrentProtectedEnvironmentBang} against
+   *     every config in the target environment.
    */
   static async checkProtectedEnvironmentsBang(environment?: string): Promise<void> {
     // Rails: `return if ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]`.
@@ -608,35 +603,7 @@ export class DatabaseTasks {
     if (proc?.env?.DISABLE_DATABASE_ENVIRONMENT_CHECK !== undefined) return;
 
     const envName = this._normalizeEnv(environment);
-    const { Base } = await import("../base.js");
-    this._baseClass = Base;
-    const protectedEnvs = Base.protectedEnvironments ?? ["production"];
-
-    // Include hidden / `databaseTasks: false` / replica configs so the
-    // guard is a superset of everything a destructive task might touch —
-    // a hidden config stamped as production should still
-    // block the operation even though the regular configsFor filter
-    // would have hidden it.
-    const configs = this.databaseConfiguration
-      ? this.databaseConfiguration.configsFor({ envName, includeHidden: true })
-      : [];
-    if (configs.length === 0) {
-      // Two reasons configsFor can come back empty:
-      //   (a) DatabaseTasks.databaseConfiguration was never set (e.g.
-      //       in-memory tests or a stand-alone CLI invocation with
-      //       just DatabaseTasks.env). Fall back to an env-name-only
-      //       check so a flat "production" still raises.
-      //   (b) DatabaseConfigurations is registered but has no entries
-      //       for this env. Rails' check_protected_environments! loops
-      //       over 0 configs and performs no checks — don't raise just
-      //       because the requested env is in the protected list.
-      if (!this.databaseConfiguration && protectedEnvs.includes(envName)) {
-        throw new ProtectedEnvironmentError(envName);
-      }
-      return;
-    }
-
-    for (const config of configs) {
+    for (const config of this.configsFor(envName)) {
       await checkCurrentProtectedEnvironmentBang(config);
     }
   }

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -107,6 +107,6 @@ await recordBootLaidTables(await Base.leaseConnection());
 const { provisionSecondDatabase } = await import("./support/setup-second-pool.js");
 await provisionSecondDatabase();
 
-// Clear DatabaseTasks global state so database-tasks.test.ts sees the null
-// invariant it expects (it tests checkProtectedEnvironmentsBang with no config).
+// Clear DatabaseTasks global state so database-tasks.test.ts starts from the
+// null invariant it expects and registers its own configurations per test.
 DatabaseTasks.databaseConfiguration = null;

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -307,8 +307,8 @@ async function withRegisteredConfigurations<T>(
  * Run Rails' `check_protected_environments!` guard with a temporarily-
  * registered `DatabaseTasks.databaseConfiguration` so it actually consults
  * the stored env in `ar_internal_metadata`. Without the registration the
- * guard falls back to checking only the current env name, which misses
- * `EnvironmentMismatchError` and the protected-stamp case.
+ * guard has no configs to loop over and silently checks nothing, which
+ * misses `EnvironmentMismatchError` and the protected-stamp case.
  */
 async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "check_protected_environments!",
-    "call": "check_current_protected_environment!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "check_schema_file",
     "call": "exist?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Inverts the protected-environment dependency to match Rails.

`checkCurrentProtectedEnvironmentBang(dbConfig)` used to open a temporary
connection and then delegate to `DatabaseTasks.checkProtectedEnvironmentsBang(dbConfig.envName)`,
which re-resolved `configsFor({ envName })` and re-opened a temporary
connection per config — a single-config check fanned back out to every config
sharing that env name.

Now it performs the stored/current/protected comparison for exactly the one
config it is handed (`database_tasks.rb:635-650`), and
`checkProtectedEnvironmentsBang` is the outer loop calling it per config
(`database_tasks.rb:65-71`).

`_migrationContextFor` drops `private` so the module-level function can reach
it; it stays underscore-prefixed and `@internal`.

Existing protected-environment tests pass unchanged.

Closes-story: check-current-protected-environment-is-per-config
