### PR TITLE
refactor(activerecord): build MigrationContext with registered migrations instead of a subclass

### DIFF
--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -5,6 +5,7 @@
 // `migrationsPaths` rather than delegating to Migrator.
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import {
+  Migration,
   MigrationContext,
   Migrator,
   InvalidMigrationTimestampError,
@@ -59,6 +60,25 @@ describe("MigrationContext", () => {
       "20100201010101",
       "20100301010101",
     ]);
+  });
+
+  it("migrations answers the registered list when the context was built with one", () => {
+    const registered = [
+      {
+        version: "20100101010101",
+        name: "Registered",
+        migration: async () => new (class extends Migration {})(),
+      },
+    ];
+    const context = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid`],
+      undefined,
+      undefined,
+      registered,
+    );
+
+    expect(context.migrations).toBe(registered);
+    expect(Object.getPrototypeOf(context)).toBe(MigrationContext.prototype);
   });
 
   it("migrations raises for a migration timestamp in the future", () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1718,6 +1718,7 @@ export class MigrationContext {
   readonly migrationsPaths: string[];
   private readonly _schemaMigration?: SchemaMigration;
   private readonly _internalMetadata?: InternalMetadata;
+  private readonly _registeredMigrations?: MigrationProxy[];
 
   /**
    * Rails defaults `schema_migration` / `internal_metadata` from
@@ -1725,15 +1726,31 @@ export class MigrationContext {
    * from here, so they stay optional. A context built without them still
    * answers the connectionless half — `migrationsPaths`, `migrations` and the
    * file discovery under it — which is all the CLI's bootstrap needs.
+   *
+   * DEVIATION — `registeredMigrations`: Rails only ever discovers migrations
+   * from `migrations_paths`, and overrides `#migrations` in one test helper
+   * (`migrator_class`, `test/cases/migrator_test.rb`). trails cannot discover
+   * every caller's migrations from disk: `DatabaseTasks.registerMigrations`
+   * takes an in-memory `MigrationProxy[]` (a migration written in TS may never
+   * be a file under a scanned path — the trailties CLI loads them through its
+   * own `migration-loader`), and the ~24 `Migrator` callers likewise hold a
+   * pre-built list. Those callers previously reached a context only by
+   * subclassing it, which is worse: it puts a Rails test-only override in
+   * production code and makes `MigrationContext` non-constructible by anything
+   * that does not own a subclass. Accepting the list as per-instance
+   * constructor state — exactly how `migrationsPaths` is held — keeps
+   * `#migrations` a single un-overridden reader with one source per instance.
    */
   constructor(
     migrationsPaths: string[],
     schemaMigration?: SchemaMigration,
     internalMetadata?: InternalMetadata,
+    registeredMigrations?: MigrationProxy[],
   ) {
     this.migrationsPaths = migrationsPaths;
     this._schemaMigration = schemaMigration;
     this._internalMetadata = internalMetadata;
+    this._registeredMigrations = registeredMigrations;
   }
 
   /** Mirrors: ActiveRecord::MigrationContext#schema_migration */
@@ -1966,9 +1983,12 @@ export class MigrationContext {
    * (`migration.rb:1303-1315`). Discovery reads *this context's*
    * `migrationsPaths`, which Rails keeps as per-instance constructor state
    * (`attr_reader :migrations_paths`), so two contexts built for two migration
-   * directories do not collide.
+   * directories do not collide. A context built with `registeredMigrations`
+   * answers that list instead of scanning — see the constructor for why trails
+   * carries a second source.
    */
   get migrations(): MigrationProxy[] {
+    if (this._registeredMigrations) return this._registeredMigrations;
     const migrations = this.migrationFiles().map((file) => {
       const parsed = this.parseMigrationFilename(file);
       if (!parsed) throw new IllegalMigrationNameError(file);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -341,8 +341,8 @@ export class DatabaseTasks {
    * Rails reaches the run surface through `MigrationContext`
    * (`migration.rb:1211`), whose `#migrations` reads `migrations_paths` off
    * disk. trails registers migrations in memory per db_config, so the context
-   * answers that list instead — the same override Rails' own
-   * `migrator_class` test helper uses.
+   * answers that list instead, passed as constructor state (see
+   * `MigrationContext`'s constructor for why the list is a second source).
    */
   private static async _migrationContextFor(
     adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
@@ -353,14 +353,11 @@ export class DatabaseTasks {
     const { InternalMetadata } = await import("../internal-metadata.js");
     const migrations = this._migrationsFor(dbConfig);
     const paths = dbConfig.migrationsPaths;
-    return new (class extends MigrationContext {
-      override get migrations(): import("../migration.js").MigrationProxy[] {
-        return migrations;
-      }
-    })(
+    return new MigrationContext(
       paths == null ? [] : Array.isArray(paths) ? paths : [paths],
       new SchemaMigration(adapter),
       new InternalMetadata(adapter, { enabled: dbConfig.useMetadataTable }),
+      migrations,
     );
   }
 


### PR DESCRIPTION
`DatabaseTasks._migrationContextFor` built an anonymous `MigrationContext`
subclass that overrode the `migrations` getter — the override Rails uses only
in its `migrator_class` test helper, never in production code. That also meant
a caller holding a pre-built `MigrationProxy[]` had no way to reach a
`MigrationContext` without owning a subclass, which blocks
`migrator-run-surface-caller-migration` and its ~24 callers.

`MigrationContext`'s constructor now takes an optional fourth argument,
`registeredMigrations?: MigrationProxy[]`. When present, `#migrations` answers
that list instead of scanning `migrationsPaths` — per-instance constructor
state, exactly like `migrationsPaths`, so `#migrations` stays a single
un-overridden reader. The deviation (trails registers migrations in memory via
`DatabaseTasks.registerMigrations`, and trailties loads them through its own
`migration-loader`, so path discovery cannot be the only source) is justified
at the constructor.

The decision is written down in the `migrator-run-surface-caller-migration`
story in the tasks repo, with the shape its callers should adopt.

Closes-story: migration-context-built-by-subclass-override-not-paths