### PR TITLE
refactor(activerecord): drop Migrator#internalMetadata public reader

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2934,10 +2934,6 @@ export class Migrator {
     return list.includes(stored);
   }
 
-  get internalMetadata(): InternalMetadata {
-    return this._internalMetadata;
-  }
-
   /**
    * @internal The shared helper of {@link checkEnvironment} and
    * {@link checkProtectedEnvironments}, which are `Tasks::DatabaseTasks`

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -73,7 +73,7 @@ describe("Migrator trails extensions", () => {
       environment: "test",
     });
     await migrator.up();
-    const env = await migrator.internalMetadata.get("environment");
+    const env = await new InternalMetadata(adapter).get("environment");
     expect(env).toBe(envName(adapter));
   });
 
@@ -205,7 +205,7 @@ describe("Migrator trails extensions", () => {
     // Rails' record_environment returns early when down? (migration.rb:1511).
     const migrator = new Migrator(adapter, [makeMigration("1", "M1")], { environment: "test" });
     await migrator.down();
-    expect(await migrator.internalMetadata.get("environment")).toBeNull();
+    expect(await new InternalMetadata(adapter).get("environment")).toBeNull();
   });
 
   it("checkEnvironment raises NoEnvironmentInSchemaError when no environment stored", async () => {
@@ -218,7 +218,7 @@ describe("Migrator trails extensions", () => {
       environment: "production",
     });
     await migrator1.up();
-    await migrator1.internalMetadata.set("environment", "production");
+    await new InternalMetadata(adapter).set("environment", "production");
 
     const migrator2 = new Migrator(adapter, [makeMigration("1", "M1")], {
       environment: "development",
@@ -231,7 +231,7 @@ describe("Migrator trails extensions", () => {
       environment: "development",
     });
     await migrator.up();
-    await migrator.internalMetadata.set("environment", "development");
+    await new InternalMetadata(adapter).set("environment", "development");
     await expect(migrator.checkEnvironment()).resolves.toBeUndefined();
   });
 
@@ -240,7 +240,7 @@ describe("Migrator trails extensions", () => {
       environment: "production",
     });
     await migrator.up();
-    await migrator.internalMetadata.set("environment", "production");
+    await new InternalMetadata(adapter).set("environment", "production");
     await expect(migrator.checkProtectedEnvironments()).rejects.toThrow(ProtectedEnvironmentError);
   });
 
@@ -261,7 +261,7 @@ describe("Migrator trails extensions", () => {
       environment: "development",
     });
     await migrator.up();
-    await migrator.internalMetadata.set("environment", "development");
+    await new InternalMetadata(adapter).set("environment", "development");
     await expect(migrator.checkProtectedEnvironments()).resolves.toBeUndefined();
   });
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1144,7 +1144,7 @@ export class CreatePosts extends Migration {
   it("checkProtectedEnvironmentsBang raises when stored env is protected", async () => {
     const {
       DatabaseTasks,
-      Migrator,
+      InternalMetadata,
       ProtectedEnvironmentError,
       DatabaseConfigurations,
       HashConfig,
@@ -1155,13 +1155,13 @@ export class CreatePosts extends Migration {
     const dbFile = path.join(tmpDir, "prod.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
-      const migrator = new Migrator(adapter, []);
+      const internalMetadata = new InternalMetadata(adapter);
       // Rails' last_stored_environment returns nil at current_version == 0, so
       // record a version (as database_tasks_test.rb does) to make the DB stamped.
       await new SchemaMigration(adapter).createTable();
       await new SchemaMigration(adapter).createVersion("1");
-      await migrator.internalMetadata.createTable();
-      await migrator.internalMetadata.set("environment", "production");
+      await internalMetadata.createTable();
+      await internalMetadata.set("environment", "production");
     } finally {
       await adapter.close();
     }
@@ -1188,7 +1188,7 @@ export class CreatePosts extends Migration {
   it("checkProtectedEnvironmentsBang raises EnvironmentMismatchError when stored != current", async () => {
     const {
       DatabaseTasks,
-      Migrator,
+      InternalMetadata,
       EnvironmentMismatchError,
       DatabaseConfigurations,
       HashConfig,
@@ -1199,13 +1199,13 @@ export class CreatePosts extends Migration {
     const dbFile = path.join(tmpDir, "staging.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
-      const migrator = new Migrator(adapter, []);
+      const internalMetadata = new InternalMetadata(adapter);
       // Rails' last_stored_environment returns nil at current_version == 0, so
       // record a version (as database_tasks_test.rb does) to make the DB stamped.
       await new SchemaMigration(adapter).createTable();
       await new SchemaMigration(adapter).createVersion("1");
-      await migrator.internalMetadata.createTable();
-      await migrator.internalMetadata.set("environment", "staging");
+      await internalMetadata.createTable();
+      await internalMetadata.set("environment", "staging");
     } finally {
       await adapter.close();
     }
@@ -1227,7 +1227,7 @@ export class CreatePosts extends Migration {
   });
 
   it("DISABLE_DATABASE_ENVIRONMENT_CHECK bypasses the check", async () => {
-    const { DatabaseTasks, Migrator, DatabaseConfigurations, HashConfig } =
+    const { DatabaseTasks, InternalMetadata, DatabaseConfigurations, HashConfig } =
       await import("@blazetrails/activerecord");
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
@@ -1235,13 +1235,13 @@ export class CreatePosts extends Migration {
     const dbFile = path.join(tmpDir, "prod2.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
-      const migrator = new Migrator(adapter, []);
+      const internalMetadata = new InternalMetadata(adapter);
       // Rails' last_stored_environment returns nil at current_version == 0, so
       // record a version (as database_tasks_test.rb does) to make the DB stamped.
       await new SchemaMigration(adapter).createTable();
       await new SchemaMigration(adapter).createVersion("1");
-      await migrator.internalMetadata.createTable();
-      await migrator.internalMetadata.set("environment", "production");
+      await internalMetadata.createTable();
+      await internalMetadata.set("environment", "production");
     } finally {
       await adapter.close();
     }
@@ -1267,7 +1267,8 @@ export class CreatePosts extends Migration {
   });
 
   it("Migrator.checkProtectedEnvironments is read-only and a no-op on fresh DB", async () => {
-    const { Migrator, ProtectedEnvironmentError, Base } = await import("@blazetrails/activerecord");
+    const { Migrator, InternalMetadata, ProtectedEnvironmentError, Base } =
+      await import("@blazetrails/activerecord");
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
 
@@ -1284,13 +1285,14 @@ export class CreatePosts extends Migration {
       expect(await migrator.protectedEnvironment()).toBe(false);
 
       // Verify no ar_internal_metadata was created by the check.
-      expect(await migrator.internalMetadata.tableExists()).toBe(false);
+      const internalMetadata = new InternalMetadata(adapter);
+      expect(await internalMetadata.tableExists()).toBe(false);
 
       // After stamping as production, both calls reflect the protected state.
       await new SchemaMigration(adapter).createTable();
       await new SchemaMigration(adapter).createVersion("1");
-      await migrator.internalMetadata.createTable();
-      await migrator.internalMetadata.set("environment", "production");
+      await internalMetadata.createTable();
+      await internalMetadata.set("environment", "production");
       expect(await migrator.protectedEnvironment()).toBe(true);
       await expect(migrator.checkProtectedEnvironments()).rejects.toBeInstanceOf(
         ProtectedEnvironmentError,
@@ -1323,24 +1325,6 @@ export class CreatePosts extends Migration {
       await expect(disabledMeta.set("environment", "test")).rejects.toBeInstanceOf(
         EnvironmentStorageError,
       );
-    } finally {
-      await adapter.close();
-    }
-  });
-
-  it("Migrator plumbs internalMetadataEnabled=false through to InternalMetadata", async () => {
-    const { Migrator, EnvironmentStorageError } = await import("@blazetrails/activerecord");
-    const { BetterSQLite3Adapter } =
-      await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
-
-    const dbFile = path.join(tmpDir, "disabled-migrator.sqlite3");
-    const adapter = new BetterSQLite3Adapter(dbFile);
-    try {
-      const migrator = new Migrator(adapter, [], { internalMetadataEnabled: false });
-      expect(migrator.internalMetadata.enabled).toBe(false);
-      await expect(
-        migrator.internalMetadata.set("environment", "production"),
-      ).rejects.toBeInstanceOf(EnvironmentStorageError);
     } finally {
       await adapter.close();
     }
@@ -1420,7 +1404,7 @@ export class CreatePosts extends Migration {
   it("SQLiteDatabaseTasks.truncateAll deletes user tables but keeps schema_migrations + ar_internal_metadata", async () => {
     const {
       SQLiteDatabaseTasks,
-      Migrator,
+      InternalMetadata,
       HashConfig: HC,
     } = await import("@blazetrails/activerecord");
     const { BetterSQLite3Adapter } =
@@ -1431,8 +1415,7 @@ export class CreatePosts extends Migration {
     try {
       await seedAdapter.executeMutation("CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT)");
       await seedAdapter.executeMutation("INSERT INTO posts (title) VALUES ('a'), ('b')");
-      const migrator = new Migrator(seedAdapter, []);
-      await migrator.internalMetadata.createTableAndSetFlags("development");
+      await new InternalMetadata(seedAdapter).createTableAndSetFlags("development");
       await seedAdapter.executeMutation(
         "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR NOT NULL PRIMARY KEY)",
       );

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -388,15 +388,6 @@ function metadataTableEnabled(raw?: RawConfig): boolean {
   return raw == null || (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
 }
 
-/**
- * `db:environment:set` stamps the metadata table without running migrations —
- * Rails reads it off the connection pool there (`databases.rake:12-15`)
- * rather than going through a `Migrator`.
- */
-function internalMetadataFor(adapter: DatabaseAdapter, raw?: RawConfig): InternalMetadata {
-  return new InternalMetadata(adapter, { enabled: metadataTableEnabled(raw) });
-}
-
 async function runMigrate(
   adapter: DatabaseAdapter,
   raw: RawConfig,
@@ -734,7 +725,9 @@ export function dbCommand(): Command {
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, prefix }) => {
         const envName = resolveEnv();
-        const internalMetadata = internalMetadataFor(adapter, raw);
+        const internalMetadata = new InternalMetadata(adapter, {
+          enabled: metadataTableEnabled(raw),
+        });
         if (!internalMetadata.enabled) {
           const { EnvironmentStorageError } = await import("@blazetrails/activerecord");
           throw new EnvironmentStorageError();

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -18,6 +18,7 @@ import { discoverMigrations } from "../migration-loader.js";
 import {
   DatabaseTasks,
   HashConfig,
+  InternalMetadata,
   Migrator,
   eachCurrentEnvironment,
 } from "@blazetrails/activerecord";
@@ -377,12 +378,23 @@ function createMigrator(
   raw?: RawConfig,
 ): Migrator {
   const envName = resolveEnv();
-  const internalMetadataEnabled =
-    raw == null || (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
   return new Migrator(adapter, migrations, {
     environment: envName,
-    internalMetadataEnabled,
+    internalMetadataEnabled: metadataTableEnabled(raw),
   });
+}
+
+function metadataTableEnabled(raw?: RawConfig): boolean {
+  return raw == null || (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
+}
+
+/**
+ * `db:environment:set` stamps the metadata table without running migrations —
+ * Rails reads it off the connection pool there (`databases.rake:12-15`)
+ * rather than going through a `Migrator`.
+ */
+function internalMetadataFor(adapter: DatabaseAdapter, raw?: RawConfig): InternalMetadata {
+  return new InternalMetadata(adapter, { enabled: metadataTableEnabled(raw) });
 }
 
 async function runMigrate(
@@ -722,12 +734,12 @@ export function dbCommand(): Command {
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, prefix }) => {
         const envName = resolveEnv();
-        const migrator = createMigrator(adapter, [], raw);
-        if (!migrator.internalMetadata.enabled) {
+        const internalMetadata = internalMetadataFor(adapter, raw);
+        if (!internalMetadata.enabled) {
           const { EnvironmentStorageError } = await import("@blazetrails/activerecord");
           throw new EnvironmentStorageError();
         }
-        await migrator.internalMetadata.createTableAndSetFlags(envName);
+        await internalMetadata.createTableAndSetFlags(envName);
         console.log(`${prefix}Stamped schema with environment: ${envName}`);
       });
     });


### PR DESCRIPTION
## What

Removes `Migrator#internalMetadata`, a public reader trails invented. Rails'
`Migrator` holds `@internal_metadata` as a plain ivar with no reader
(`migration.rb:1421-1432`); the public accessor is
`MigrationContext#internal_metadata` (`migration.rb:1214-1218`), which trails
already has. This is the sibling of the `schemaMigration` getter removed in
#5845.

## How

- `Migrator` keeps the collaborator as private `_internalMetadata` state only.
- `db:environment:set` builds an `InternalMetadata` directly instead of
  reaching through a `Migrator` — Rails reads it off the pool there
  (`databases.rake:12-15`), never off a migrator. The `useMetadataTable`
  resolution `createMigrator` did is factored into `metadataTableEnabled`.
- Test callers construct an `InternalMetadata` against the same adapter.
- Drops `db.test.ts`'s "Migrator plumbs internalMetadataEnabled=false through
  to InternalMetadata", which only observed the removed reader. Both halves it
  covered still are: the `EnvironmentStorageError` arm by "InternalMetadata
  with enabled=false refuses set writes with EnvironmentStorageError", and the
  Migrator plumbing by "Migrator with internalMetadataEnabled=false migrates
  without stamping".

## Verification

`pnpm typecheck`, `pnpm api:compare` (no ratchet movement), and the touched
suites: `migrator.trails.test.ts` (54), `db.test.ts` (104),
`migration.test.ts` + `migration-context.trails.test.ts` (84).

Closes-story: migrator-internal-metadata-public-reader
