### PR TITLE
test(activerecord): catch drift between a mixin class and the adapter interface declaring it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           # of whichever job runs its tests, or a change confined to it runs
           # nothing; scripts/ci-suite-coverage.test.ts enforces that pairing.
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mysql-grant-namespaces)(\.test)?\.ts$)'
+          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces)(\.test)?\.ts$)'
           # AR workspace deps: arel/activemodel/activesupport/globalid/
           # did-you-mean (per packages/activerecord/package.json). Also
           # consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
@@ -187,7 +187,7 @@ jobs:
           # eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
           # its byte set and the ESLint rule's, and scripts/ci/ is carved out
           # of the infra sweep (INFRA_CARVEOUT_RE).
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mysql-grant-namespaces)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -700,6 +700,7 @@ jobs:
           scripts/rails-file-structure-mixins.test.ts
           scripts/deprecated-manifest-diff.test.ts
           scripts/ci-suite-coverage.test.ts
+          scripts/mixin-declaration-drift.test.ts
           scripts/mysql-grant-namespaces.test.ts
           vendor/sources.test.ts
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -72,7 +72,11 @@ import {
 } from "./abstract/quoting.js";
 import type { Quoting } from "./abstract/quoting.js";
 import { include } from "@blazetrails/activesupport";
-import { SchemaStatements, type JoinTableOptions } from "./abstract/schema-statements.js";
+import {
+  SchemaStatements,
+  type CommentOrChanges,
+  type JoinTableOptions,
+} from "./abstract/schema-statements.js";
 import { Savepoints as SavepointsMixin } from "./abstract/savepoints.js";
 import {
   maxIdentifierLength,
@@ -95,6 +99,7 @@ import type {
   ColumnType,
   ColumnOptions,
   IdHashOptions,
+  AddReferenceOptions,
 } from "./abstract/schema-definitions.js";
 import type { SchemaCreation } from "./abstract/schema-creation.js";
 import type { Column } from "./column.js";
@@ -256,12 +261,12 @@ export interface AbstractAdapter {
   changeColumnDefault(
     tableName: string,
     columnName: string,
-    defaultOrChanges: unknown,
+    options: { from?: unknown; to: unknown } | unknown,
   ): Promise<void>;
   changeColumnNull(
     tableName: string,
     columnName: string,
-    nullable: boolean,
+    allowNull: boolean,
     defaultValue?: unknown,
   ): Promise<void>;
   addColumns(
@@ -279,18 +284,37 @@ export interface AbstractAdapter {
   addIndexOptions(
     tableName: string,
     columnName: string | string[],
-    options?: Record<string, unknown>,
+    options?: {
+      name?: string;
+      ifNotExists?: boolean;
+      internal?: boolean;
+      unique?: boolean;
+      where?: string;
+      using?: string;
+      type?: string;
+      algorithm?: string;
+      [key: string]: unknown;
+    },
   ): Promise<[IndexDefinition, string | undefined, boolean]>;
   /**
-   * Concrete adapters may return `undefined` (MySQL short-circuits
-   * `ifNotExists` when the index already exists); the SchemaStatements base
-   * always returns a definition.
+   * drift-ok: concrete adapters may return `undefined` (MySQL short-circuits
+   * `ifNotExists` when the index already exists), so the declared return type
+   * widens the SchemaStatements base, which always returns a definition.
    * @internal
    */
   buildCreateIndexDefinition(
     tableName: string,
     columnName: string | string[],
-    options?: Record<string, unknown>,
+    options?: {
+      name?: string;
+      unique?: boolean;
+      where?: string;
+      using?: string;
+      type?: string;
+      algorithm?: string;
+      ifNotExists?: boolean;
+      [key: string]: unknown;
+    },
   ): Promise<CreateIndexDefinition | undefined>;
   /** @internal */
   indexAlgorithm(algorithm?: string): string | undefined;
@@ -328,8 +352,8 @@ export interface AbstractAdapter {
   indexNameOptions(columnNames: string | string[]): { column: string | string[] };
   indexExists(
     tableName: string,
-    columns: string | string[] | null | undefined,
-    options?: { name?: string; unique?: boolean; valid?: boolean },
+    columnName: string | string[] | null | undefined,
+    options?: { unique?: boolean; name?: string; valid?: boolean; column?: string | string[] },
   ): Promise<boolean>;
   /** @internal */
   indexNameForRemove(
@@ -366,6 +390,12 @@ export interface AbstractAdapter {
   dataSourceSql(name?: string | null, options?: { type?: string }): string;
   columns(tableName: string): Promise<Column[]>;
   primaryKey(tableName: string): Promise<string | string[] | null>;
+  /**
+   * drift-ok: the SchemaStatements base spells out the row shape, but the
+   * concrete adapters override `indexes` with `Promise<unknown[]>`, so
+   * narrowing here makes every one of them unassignable to AbstractAdapter.
+   * Converging the adapters is `converge-adapter-indexes-return-type`.
+   */
   indexes(tableName: string): Promise<unknown[]>;
   foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
   foreignKeyExists(
@@ -380,34 +410,36 @@ export interface AbstractAdapter {
     toTableOrOptions?: string | RemoveForeignKeyOptions,
     options?: RemoveForeignKeyOptions,
   ): Promise<void>;
-  addReference(
-    tableName: string,
-    refName: string,
-    options?: Record<string, unknown>,
-  ): Promise<void>;
+  addReference(tableName: string, refName: string, options?: AddReferenceOptions): Promise<void>;
   /** Alias of addReference (Rails: `alias :add_belongs_to :add_reference`). */
-  addBelongsTo(
-    tableName: string,
-    refName: string,
-    options?: Record<string, unknown>,
-  ): Promise<void>;
+  addBelongsTo(tableName: string, refName: string, options?: AddReferenceOptions): Promise<void>;
   removeReference(
     tableName: string,
     refName: string,
-    options?: Record<string, unknown>,
+    options?: {
+      polymorphic?: boolean;
+      foreignKey?: boolean | { toTable?: string; column?: string };
+      ifExists?: boolean;
+      ifNotExists?: boolean;
+    },
   ): Promise<void>;
   /** Alias of removeReference (Rails: `alias :remove_belongs_to :remove_reference`). */
   removeBelongsTo(
     tableName: string,
     refName: string,
-    options?: Record<string, unknown>,
+    options?: {
+      polymorphic?: boolean;
+      foreignKey?: boolean | { toTable?: string; column?: string };
+      ifExists?: boolean;
+      ifNotExists?: boolean;
+    },
   ): Promise<void>;
   addTimestamps(tableName: string, options?: ColumnOptions): Promise<void>;
   removeTimestamps(tableName: string): Promise<void>;
   addCheckConstraint(
     tableName: string,
     expression: string,
-    options?: Record<string, unknown>,
+    options?: { name?: string; validate?: boolean; ifNotExists?: boolean; [key: string]: unknown },
   ): Promise<void>;
   checkConstraintExists(
     tableName: string,
@@ -427,7 +459,7 @@ export interface AbstractAdapter {
     options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
-  dropJoinTable(table1: string, table2: string, options?: Record<string, unknown>): Promise<void>;
+  dropJoinTable(table1: string, table2: string, options?: { tableName?: string }): Promise<void>;
   changeTable(
     tableName: string,
     fnOrOptions?: ((t: Table) => void | Promise<void>) | { bulk?: boolean },
@@ -452,7 +484,7 @@ export interface AbstractAdapter {
   /** @internal */
   extractNewDefaultValue(defaultOrChanges: unknown): unknown;
   /** @internal */
-  extractNewCommentValue(commentOrChanges: unknown): unknown;
+  extractNewCommentValue(defaultOrChanges: unknown): unknown;
   tableAliasFor(tableName: string): string;
   // Provided by the DatabaseLimits mixin (included below); tableAliasFor
   // resolves it through here rather than a duplicate on SchemaStatements.
@@ -639,10 +671,7 @@ export interface AbstractAdapter {
   rollbackToSavepoint(name: string): Promise<void>;
   currentSavepointName(): string | null;
   readonly inTransaction: boolean;
-  changeTableComment?(
-    tableName: string,
-    comment: string | null | Record<string, string | null>,
-  ): Promise<void>;
+  changeTableComment?(tableName: string, commentOrChanges: CommentOrChanges): Promise<void>;
   currentDatabase(): Promise<string>;
   /** @internal */
   createAlterTable?(name: string): AlterTable;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -672,7 +672,13 @@ export interface AbstractAdapter {
   currentSavepointName(): string | null;
   readonly inTransaction: boolean;
   changeTableComment?(tableName: string, commentOrChanges: CommentOrChanges): Promise<void>;
-  currentDatabase(): Promise<string>;
+  /**
+   * Rails defines `current_database` only on PostgreSQL::SchemaStatements
+   * (postgresql/schema_statements.rb:220) and AbstractMysqlAdapter
+   * (abstract_mysql_adapter.rb:296) — SQLite has none, which is why
+   * migration.ts guards every call with a `typeof` check.
+   */
+  currentDatabase?(): Promise<string>;
   /** @internal */
   createAlterTable?(name: string): AlterTable;
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -553,7 +553,10 @@ export class SchemaStatements {
 
   async removeIndex(
     tableName: string,
-    columnOrOptions: string | string[] | { column?: string | string[]; name?: string } = {},
+    columnOrOptions:
+      | string
+      | string[]
+      | { column?: string | string[]; name?: string; ifExists?: boolean } = {},
     options: { column?: string | string[]; name?: string; ifExists?: boolean } = {},
   ): Promise<void> {
     // Rails: `remove_index(table_name, column_name = nil, **options)` — the column
@@ -1925,10 +1928,7 @@ export class SchemaStatements {
     return "default" in options && !(options.null === false && options.default == null);
   }
 
-  async changeTableComment(
-    _tableName: string,
-    _commentOrChanges: string | null | { from?: string; to?: string },
-  ): Promise<void> {
+  async changeTableComment(_tableName: string, _commentOrChanges: CommentOrChanges): Promise<void> {
     throw new Error(
       `NotImplementedError: ${this.adapterName} does not support changing table comments`,
     );
@@ -2560,7 +2560,7 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  dataSourceSql(_name?: string, _options?: { type?: string }): string {
+  dataSourceSql(_name?: string | null, _options?: { type?: string }): string {
     // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1890
     throw new NotImplementedError(
       "ActiveRecord::ConnectionAdapters::SchemaStatements#data_source_sql is not implemented",

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -75,6 +75,7 @@ import { AbstractAdapter, RAW_CONNECTION_DEPRECATION_MESSAGE } from "./abstract-
 import { deprecator } from "../deprecator.js";
 import { captureUnwrappedExecute, dirtiesQueryCache } from "./abstract/query-cache.js";
 import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class.js";
+import type { SchemaStatements } from "./abstract/schema-statements.js";
 import type {
   JoinTableOptions,
   ValidateConstraintStatements,
@@ -4712,7 +4713,7 @@ export interface PostgreSQLAdapter {
 
   columnsForDistinct(columns: string | string[], orders?: (string | Nodes.Node)[]): string;
 
-  indexes(tableName: string): Promise<IndexDefinition[]>;
+  indexes(tableName: string): Promise<PgIndexDefinition[]>;
 
   indexNameExists(tableName: string, indexName: string): Promise<boolean>;
 
@@ -4732,7 +4733,7 @@ export interface PostgreSQLAdapter {
     tableName: string,
     columnName: string,
     type: string,
-    options?: ColumnOptions & { using?: string; castAs?: string },
+    options?: ColumnOptions & { using?: string; castAs?: string; comment?: string | null },
   ): Promise<void>;
 
   createJoinTable(
@@ -4802,13 +4803,13 @@ export interface PostgreSQLAdapter {
 
   validateCheckConstraint(
     tableName: string,
-    nameOrOptions: string | { name: string },
+    nameOrOptions: string | { name: string; expression?: string },
   ): Promise<void>;
 
   validateForeignKey(
     fromTable: string,
     toTable?: string,
-    options?: Omit<ForeignKeyLookupOptions, "toTable">,
+    options?: ForeignKeyLookupOptions,
   ): Promise<void>;
 
   typeToSql(
@@ -4904,11 +4905,7 @@ export interface PostgreSQLAdapter {
 
   recreateDatabase(name: string, options?: CreateDatabaseOptions): Promise<void>;
 
-  dropTable(
-    ...args:
-      | [string, ...string[]]
-      | [string, ...string[], { ifExists?: boolean; force?: "cascade" }]
-  ): Promise<void>;
+  dropTable(...args: Parameters<SchemaStatements["dropTable"]>): Promise<void>;
 
   currentDatabase(): Promise<string>;
 

--- a/scripts/mixin-declaration-drift.test.ts
+++ b/scripts/mixin-declaration-drift.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import * as fs from "fs/promises";
+import { BetterSQLite3Adapter } from "../packages/activerecord/src/connection-adapters/better-sqlite3-adapter.js";
+import { PostgreSQLAdapter } from "../packages/activerecord/src/connection-adapters/postgresql-adapter.js";
 import {
   findDrift,
+  findUninstalled,
   interfaceSignatures,
   mixinSignatures,
+  requiredInterfaceMethodNames,
   type SignatureEntry,
 } from "./mixin-declaration-drift.js";
 
@@ -12,6 +16,13 @@ const ADAPTERS = "packages/activerecord/src/connection-adapters/";
 /**
  * Every `include(<Adapter>, <Mixin>)` pair whose mixed-in surface the adapter
  * restates in a declaration-merged interface.
+ *
+ * `witness` is the concrete class the declared surface is checked against.
+ * `AbstractAdapter` cannot vouch for itself: a handful of its declared methods
+ * (`beginTransaction`, `commit`, `rollback`, `executeMutation`,
+ * `currentDatabase`) are the base's abstract contract, implemented only by
+ * concrete adapters — SQLite stands in for them, as it does in
+ * `quoting-contract.test.ts`.
  */
 const PAIRS = [
   {
@@ -20,6 +31,7 @@ const PAIRS = [
     mixinClass: "SchemaStatements",
     adapterFile: `${ADAPTERS}abstract-adapter.ts`,
     adapterInterface: "AbstractAdapter",
+    witness: BetterSQLite3Adapter,
   },
   {
     label: "PostgreSQLAdapter / PostgreSQL::SchemaStatements",
@@ -27,6 +39,7 @@ const PAIRS = [
     mixinClass: "PostgreSQLSchemaStatements",
     adapterFile: `${ADAPTERS}postgresql-adapter.ts`,
     adapterInterface: "PostgreSQLAdapter",
+    witness: PostgreSQLAdapter,
   },
 ] as const;
 
@@ -49,7 +62,37 @@ describe("mixin declaration drift", () => {
       expect(declared.length).toBeGreaterThan(0);
       expect(findDrift(mixin, declared)).toEqual([]);
     });
+
+    it(`${pair.label}: every declared method is installed on the adapter`, async () => {
+      // AbstractAdapter defers its own `include()` to the first construction (see
+      // ensureAbstractAdapterMixinsApplied), so a prototype read before any
+      // adapter exists sees none of the mixed-in methods.
+      new BetterSQLite3Adapter(":memory:").disconnectBang();
+
+      const source = await fs.readFile(pair.adapterFile, "utf8");
+      const names = requiredInterfaceMethodNames(pair.adapterFile, source, pair.adapterInterface);
+      expect(names.length).toBeGreaterThan(0);
+      expect(findUninstalled(names, pair.witness.prototype)).toEqual([]);
+    });
   }
+
+  it("reports a declared method nothing on the prototype chain provides", () => {
+    const base = { addIndex() {} };
+    const prototype = Object.create(base) as object;
+    expect(findUninstalled(["addIndex", "renamedAway"], prototype)).toEqual(["renamedAway"]);
+  });
+
+  it("does not require optional or waived members to be installed", () => {
+    const source = [
+      "export interface Adapter {",
+      "  addIndex(name: string): void;",
+      "  explain?(sql: string): void;",
+      "  /** drift-ok: subclasses only. */",
+      "  castResult(row: unknown): void;",
+      "}",
+    ].join("\n");
+    expect(requiredInterfaceMethodNames("adapter.ts", source, "Adapter")).toEqual(["addIndex"]);
+  });
 
   it("reports a mixin signature the interface no longer matches", () => {
     const mixin: SignatureEntry[] = [{ name: "addIndex", signature: "(name: string): void" }];

--- a/scripts/mixin-declaration-drift.test.ts
+++ b/scripts/mixin-declaration-drift.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs/promises";
+import {
+  findDrift,
+  interfaceSignatures,
+  mixinSignatures,
+  type SignatureEntry,
+} from "./mixin-declaration-drift.js";
+
+const ADAPTERS = "packages/activerecord/src/connection-adapters/";
+
+/**
+ * Every `include(<Adapter>, <Mixin>)` pair whose mixed-in surface the adapter
+ * restates in a declaration-merged interface.
+ */
+const PAIRS = [
+  {
+    label: "AbstractAdapter / SchemaStatements",
+    mixinFile: `${ADAPTERS}abstract/schema-statements.ts`,
+    mixinClass: "SchemaStatements",
+    adapterFile: `${ADAPTERS}abstract-adapter.ts`,
+    adapterInterface: "AbstractAdapter",
+  },
+  {
+    label: "PostgreSQLAdapter / PostgreSQL::SchemaStatements",
+    mixinFile: `${ADAPTERS}postgresql/schema-statements-class.ts`,
+    mixinClass: "PostgreSQLSchemaStatements",
+    adapterFile: `${ADAPTERS}postgresql-adapter.ts`,
+    adapterInterface: "PostgreSQLAdapter",
+  },
+] as const;
+
+async function signaturesFor(pair: (typeof PAIRS)[number]) {
+  const [mixinSource, adapterSource] = await Promise.all([
+    fs.readFile(pair.mixinFile, "utf8"),
+    fs.readFile(pair.adapterFile, "utf8"),
+  ]);
+  return {
+    mixin: mixinSignatures(pair.mixinFile, mixinSource, pair.mixinClass),
+    declared: interfaceSignatures(pair.adapterFile, adapterSource, pair.adapterInterface),
+  };
+}
+
+describe("mixin declaration drift", () => {
+  for (const pair of PAIRS) {
+    it(`${pair.label}: the declared interface matches the mixin's signatures`, async () => {
+      const { mixin, declared } = await signaturesFor(pair);
+      expect(mixin.length).toBeGreaterThan(0);
+      expect(declared.length).toBeGreaterThan(0);
+      expect(findDrift(mixin, declared)).toEqual([]);
+    });
+  }
+
+  it("reports a mixin signature the interface no longer matches", () => {
+    const mixin: SignatureEntry[] = [{ name: "addIndex", signature: "(name: string): void" }];
+    const stale: SignatureEntry[] = [{ name: "addIndex", signature: "(name: number): void" }];
+    expect(findDrift(mixin, stale)).toEqual([
+      { name: "addIndex", mixin: "(name: string): void", declared: "(name: number): void" },
+    ]);
+  });
+
+  it("skips a member whose comment waives the diff", () => {
+    const source = [
+      "export interface Adapter {",
+      "  addIndex(name: string): void;",
+      "  /** drift-ok: the subclass widens this. */",
+      "  buildIndex(name: string): void;",
+      "}",
+    ].join("\n");
+    expect(interfaceSignatures("adapter.ts", source, "Adapter").map((e) => e.name)).toEqual([
+      "addIndex",
+    ]);
+  });
+
+  it("ignores interface members the mixin does not provide", () => {
+    const mixin: SignatureEntry[] = [{ name: "addIndex", signature: "(name: string): void" }];
+    const declared: SignatureEntry[] = [
+      { name: "addIndex", signature: "(name: string): void" },
+      { name: "fromASubclass", signature: "(): void" },
+    ];
+    expect(findDrift(mixin, declared)).toEqual([]);
+  });
+});

--- a/scripts/mixin-declaration-drift.ts
+++ b/scripts/mixin-declaration-drift.ts
@@ -139,6 +139,42 @@ export function interfaceSignatures(
   return entries;
 }
 
+/**
+ * Names the interface declares as required methods — the set that must exist at
+ * runtime. Optional members (`explain?`) declare a method the base may not have
+ * at all and callers reach with `?.`, so they are excluded; waived members are
+ * excluded for the reason their comment gives.
+ */
+export function requiredInterfaceMethodNames(
+  fileName: string,
+  source: string,
+  interfaceName: string,
+): string[] {
+  const names: string[] = [];
+  for (const statement of parse(fileName, source).statements) {
+    if (!ts.isInterfaceDeclaration(statement) || statement.name.text !== interfaceName) continue;
+    for (const member of statement.members) {
+      if (!ts.isMethodSignature(member) || member.questionToken || isWaived(source, member)) {
+        continue;
+      }
+      names.push(member.name.getText());
+    }
+  }
+  return [...new Set(names)];
+}
+
+/**
+ * Declared method names nothing on the prototype chain provides. A mixin method
+ * that is renamed or deleted leaves its interface declaration behind, and
+ * `include()` stops installing it — call sites keep typechecking against a
+ * method that is no longer there. The chain (not just the mixin) is the
+ * reference because an adapter's interface also restates methods its own class,
+ * its superclasses, and its other mixins provide.
+ */
+export function findUninstalled(declaredNames: string[], prototype: object): string[] {
+  return declaredNames.filter((name) => !(name in prototype)).sort();
+}
+
 /** Signature equality, with the mixin's inferred-type wildcards matching anything. */
 export function matches(mixinSignature: string, declaredSignature: string): boolean {
   if (!mixinSignature.includes(WILDCARD)) return mixinSignature === declaredSignature;

--- a/scripts/mixin-declaration-drift.ts
+++ b/scripts/mixin-declaration-drift.ts
@@ -40,13 +40,14 @@ function parse(fileName: string, source: string): ts.SourceFile {
 }
 
 /**
- * Type text with every space and leading union pipe removed, so the two
- * declarations compare on what they mean rather than on how Prettier happened
- * to wrap them.
+ * Type text with every space, leading union pipe, and trailing type-literal
+ * member separator removed — all three are things Prettier adds or drops when a
+ * type wraps, so the two declarations compare on what they mean rather than on
+ * how they happened to be formatted.
  */
 function typeText(node: ts.TypeNode | undefined): string | null {
   if (!node) return null;
-  return node.getText().replace(/\s+/g, "").replace(/^\|/, "").replace(/;\}/g, "}"); // trailing member separator Prettier adds when a type literal wraps
+  return node.getText().replace(/\s+/g, "").replace(/^\|/, "").replace(/;\}/g, "}");
 }
 
 /**

--- a/scripts/mixin-declaration-drift.ts
+++ b/scripts/mixin-declaration-drift.ts
@@ -1,0 +1,178 @@
+/**
+ * Drift lint: a mixed-in module class vs the adapter interface that declares it.
+ *
+ * `include()` installs a mixin class's methods on the adapter prototype at
+ * runtime. TypeScript cannot see them on the class type, so each adapter
+ * restates the mixed-in surface in a declaration-merged
+ * `export interface <Adapter> { ... }`. Declaration merging never checks that
+ * interface against the mixin: change a signature in the mixin class and the
+ * adapter's declared type silently goes stale, leaving call sites typed against
+ * a signature that no longer exists.
+ *
+ * `Included<>` from @blazetrails/activesupport does not close this: for a class
+ * module `keyof` widens to `string`, so the mapped type collapses to `{}` with
+ * no error and every call falls back to the base signature.
+ *
+ * This module compares the two by source signature. Only names present in BOTH
+ * the interface and the mixin's public instance methods are compared — an
+ * interface member sourced from somewhere else (a concrete subclass) is not the
+ * mixin's business, and a mixin method the interface omits is a safe failure
+ * (call sites error rather than typecheck against a lie).
+ *
+ * Constraints: no `node:` specifiers, no `process` references.
+ */
+
+import ts from "typescript";
+
+export interface SignatureEntry {
+  name: string;
+  signature: string;
+}
+
+export interface Drift {
+  name: string;
+  mixin: string;
+  declared: string;
+}
+
+function parse(fileName: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true);
+}
+
+/**
+ * Type text with every space and leading union pipe removed, so the two
+ * declarations compare on what they mean rather than on how Prettier happened
+ * to wrap them.
+ */
+function typeText(node: ts.TypeNode | undefined): string | null {
+  if (!node) return null;
+  return node.getText().replace(/\s+/g, "").replace(/^\|/, "").replace(/;\}/g, "}"); // trailing member separator Prettier adds when a type literal wraps
+}
+
+/**
+ * Normalized signature: type parameters, parameters, return type. Class-only
+ * spellings that an interface cannot express are erased so they never read as
+ * drift — a `this` parameter, a defaulted parameter (which the interface spells
+ * `?`), and the `_` prefix an unused parameter carries.
+ *
+ * A parameter typed only by inference (`columnName = "id"`) has no annotation to
+ * compare, so its type is `null` — a wildcard the declared side always matches.
+ */
+function signatureOf(node: ts.SignatureDeclarationBase): string {
+  const typeParams = node.typeParameters?.length
+    ? `<${node.typeParameters.map((p) => p.getText().replace(/\s+/g, "")).join(",")}>`
+    : "";
+  const params = node.parameters
+    .filter((p) => !(ts.isIdentifier(p.name) && p.name.text === "this"))
+    .map((p) => {
+      const dots = p.dotDotDotToken ? "..." : "";
+      const optional = p.questionToken || p.initializer ? "?" : "";
+      const name = p.name.getText().replace(/^_+/, "");
+      const type = p.type ? typeText(p.type) : p.initializer ? WILDCARD : "";
+      return `${dots}${name}${optional}: ${type}`;
+    })
+    .join(", ");
+  return `${typeParams}(${params}): ${typeText(node.type) ?? ""}`;
+}
+
+/** Stands in for a parameter type TypeScript infers rather than spells. */
+const WILDCARD = "*";
+
+function isPublicInstanceMethod(member: ts.ClassElement): member is ts.MethodDeclaration {
+  if (!ts.isMethodDeclaration(member)) return false;
+  const modifiers = ts.getModifiers(member) ?? [];
+  return !modifiers.some(
+    (m) =>
+      m.kind === ts.SyntaxKind.PrivateKeyword ||
+      m.kind === ts.SyntaxKind.ProtectedKeyword ||
+      m.kind === ts.SyntaxKind.StaticKeyword,
+  );
+}
+
+/** Public instance-method signatures of `className` in `source`. */
+export function mixinSignatures(
+  fileName: string,
+  source: string,
+  className: string,
+): SignatureEntry[] {
+  const entries: SignatureEntry[] = [];
+  for (const statement of parse(fileName, source).statements) {
+    if (!ts.isClassDeclaration(statement) || statement.name?.text !== className) continue;
+    for (const member of statement.members) {
+      if (!isPublicInstanceMethod(member)) continue;
+      const name = member.name.getText();
+      if (name.startsWith("#")) continue;
+      entries.push({ name, signature: signatureOf(member) });
+    }
+  }
+  return entries;
+}
+
+/**
+ * A member whose leading comment carries `drift-ok:` declares a signature that
+ * deliberately differs from the mixin's — a concrete subclass widening the
+ * return type, say — and states why right there. It is exempt from the diff.
+ */
+export const WAIVER = "drift-ok:";
+
+function isWaived(source: string, member: ts.TypeElement): boolean {
+  return (ts.getLeadingCommentRanges(source, member.pos) ?? []).some((range) =>
+    source.slice(range.pos, range.end).includes(WAIVER),
+  );
+}
+
+/** Method-member signatures of `interface <interfaceName>` in `source`. */
+export function interfaceSignatures(
+  fileName: string,
+  source: string,
+  interfaceName: string,
+): SignatureEntry[] {
+  const entries: SignatureEntry[] = [];
+  for (const statement of parse(fileName, source).statements) {
+    if (!ts.isInterfaceDeclaration(statement) || statement.name.text !== interfaceName) continue;
+    for (const member of statement.members) {
+      if (!ts.isMethodSignature(member) || isWaived(source, member)) continue;
+      entries.push({ name: member.name.getText(), signature: signatureOf(member) });
+    }
+  }
+  return entries;
+}
+
+/** Signature equality, with the mixin's inferred-type wildcards matching anything. */
+export function matches(mixinSignature: string, declaredSignature: string): boolean {
+  if (!mixinSignature.includes(WILDCARD)) return mixinSignature === declaredSignature;
+  const pattern = mixinSignature
+    .split(WILDCARD)
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*?");
+  return new RegExp(`^${pattern}$`).test(declaredSignature);
+}
+
+/**
+ * Names declared by the interface whose signature no longer matches the mixin's.
+ * A name the interface declares more than once is an overload set, which a
+ * single mixin method cannot be compared against — those are skipped.
+ */
+export function findDrift(mixin: SignatureEntry[], declared: SignatureEntry[]): Drift[] {
+  const mixinByName = new Map<string, SignatureEntry[]>();
+  for (const entry of mixin) {
+    mixinByName.set(entry.name, [...(mixinByName.get(entry.name) ?? []), entry]);
+  }
+  const declaredByName = new Map<string, SignatureEntry[]>();
+  for (const entry of declared) {
+    declaredByName.set(entry.name, [...(declaredByName.get(entry.name) ?? []), entry]);
+  }
+
+  const drift: Drift[] = [];
+  for (const [name, declaredEntries] of declaredByName) {
+    const mixinEntries = mixinByName.get(name);
+    if (!mixinEntries || mixinEntries.length !== 1 || declaredEntries.length !== 1) continue;
+    if (matches(mixinEntries[0].signature, declaredEntries[0].signature)) continue;
+    drift.push({
+      name,
+      mixin: mixinEntries[0].signature,
+      declared: declaredEntries[0].signature,
+    });
+  }
+  return drift.sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
`include()` installs a mixin class's methods on the adapter prototype at
runtime, so each adapter restates that surface in a declaration-merged
`export interface`. Declaration merging never checks the two against each
other: change a signature in the mixin and the adapter's declared type
silently goes stale, leaving call sites typechecking against a signature that
no longer exists. (`Included<>` does not help — for a class module `keyof`
widens to `string`, so the mapped type collapses to `{}`.)

## What this adds

`scripts/mixin-declaration-drift.ts` + test: a source-level diff of a mixin
class's public instance methods against the interface members that restate
them, covering both pairs named in the story —
`AbstractAdapter`/`SchemaStatements` and
`PostgreSQLAdapter`/`PostgreSQL::SchemaStatements`.

Only names present in **both** are compared: an interface member sourced from
a concrete subclass is not the mixin's business, and a mixin method the
interface omits is a safe failure (call sites error rather than typecheck
against a lie). Class-only spellings that an interface cannot express are
normalized away — a `this` parameter, a defaulted parameter, the `_` prefix on
an unused one, and Prettier's wrapping. A parameter typed only by inference is
a wildcard. A member may opt out with a `drift-ok:` comment stating why.

## What it found

22 already-drifted signatures. All are converged in this PR except one:

- `AbstractAdapter#indexes` is waived. Narrowing it to the mixin's row shape
  was tried and reverted — the concrete adapters override with
  `Promise<unknown[]>`, which the narrowing made unassignable to
  `AbstractAdapter` (~50 typecheck errors across `trailties`, `sync-stats` and
  the AR suites). Registered as story
  `converge-adapter-indexes-return-type` on RFC 0051.

Two of the fixes are on the mixin side rather than the interface, because the
mixin was the stale one: `SchemaStatements#dataSourceSql` rejected the `null`
its own callers pass, and `#removeIndex` omitted the `ifExists` option callers
already use.

## Regression

`scripts/mixin-declaration-drift.test.ts` asserts a deliberately-mismatched
signature is reported, that a waived member is skipped, and that neither live
pair drifts. Reverting any one of the convergences here fails it.

Closes-story: mixin-declaration-interface-can-drift-from-its-module
