### PR TITLE
refactor(trailties): route db migrate/migrate:up/migrate:down through DatabaseTasks

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1065,7 +1065,14 @@ export class DatabaseTasks {
     return migrator.currentVersionReadOnly();
   }
 
-  static async migrateAll(): Promise<void> {
+  /**
+   * @param options.targetVersion "Migrate up to here" — the in-process
+   *   stand-in for Rails' `ENV["VERSION"]`, which `migrate_all` reads through
+   *   `target_version` in `db_configs_with_versions`. See {@link migrate}.
+   */
+  static async migrateAll({
+    targetVersion,
+  }: { targetVersion?: number | string | null } = {}): Promise<void> {
     const configs = this.configsFor(this._normalizeEnv());
 
     // Rails: initialize_database for every config before the single-primary fast path or version loop.
@@ -1080,11 +1087,11 @@ export class DatabaseTasks {
     // (TS: `isPrimary()`) lives on HashConfig/UrlConfig, not the abstract
     // DatabaseConfig, so reach it structurally off the concrete instance.
     if (configs.length === 1 && (configs[0] as { isPrimary?(): boolean }).isPrimary?.()) {
-      await this.migrate(undefined, { skipInitialize: true });
+      await this.migrate(undefined, { skipInitialize: true, targetVersion });
       return;
     }
 
-    const mappedVersions = await this.dbConfigsWithVersions();
+    const mappedVersions = await this.dbConfigsWithVersions(undefined, targetVersion);
     const sorted = Array.from(mappedVersions.entries()).sort(([a], [b]) =>
       BigInt(String(a)) < BigInt(String(b)) ? -1 : BigInt(String(a)) > BigInt(String(b)) ? 1 : 0,
     );
@@ -1140,12 +1147,22 @@ export class DatabaseTasks {
     if (seed && this.seedLoader) await this.loadSeed();
   }
 
+  /**
+   * @param targetVersionOverride In-process stand-in for Rails'
+   *   `ENV["VERSION"]`, which this reads through {@link targetVersion} when
+   *   not supplied. See {@link migrate}.
+   */
   static async dbConfigsWithVersions(
     environment?: string,
+    targetVersionOverride?: number | string | null,
   ): Promise<Map<string | number, DatabaseConfig[]>> {
     const dbConfigsWithVersions = new Map<string | number, DatabaseConfig[]>();
     const env = this._normalizeEnv(environment);
-    const targetVersion = this.targetVersion();
+    const explicit =
+      typeof targetVersionOverride === "string"
+        ? targetVersionOverride.trim() || null
+        : (targetVersionOverride ?? null);
+    const targetVersion = explicit === null ? this.targetVersion() : Number(explicit);
     for (const config of this.configsFor(env)) {
       await this.withTemporaryPool(config, async (pool) => {
         const context = await this._migrationContextFor(await pool.leaseConnection(), config);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -376,6 +376,15 @@ export class DatabaseTasks {
     });
   }
 
+  /**
+   * @param version Exact-version *filter* — only the migration with this
+   *   version runs (`db:migrate:up` / `:down` semantics). Rails' `db:migrate`
+   *   rake task never passes it.
+   * @param options.targetVersion "Migrate up to here", the in-process stand-in
+   *   for Rails' `ENV["VERSION"]` that {@link targetVersion} reads. trails has
+   *   no env writer, so a CLI `--version` flag hands the target down through
+   *   this option instead of the `version` argument, which would filter.
+   */
   static async migrate(
     version?: number | string,
     {
@@ -383,12 +392,6 @@ export class DatabaseTasks {
       targetVersion,
     }: { skipInitialize?: boolean; targetVersion?: number | string | null } = {},
   ): Promise<void> {
-    // `targetVersion` is the in-process stand-in for Rails' `ENV["VERSION"]`:
-    // the rake task never passes an argument, so `target_version` reads the
-    // env. trails has no env writer (`getEnv` is read-only), so a CLI
-    // `--version` flag has to hand the target down explicitly. It must NOT
-    // travel as `version` — that argument is the exact-version *filter*
-    // (migrate:up semantics), not "migrate up to here".
     const raw = version ?? targetVersion ?? this.targetVersion();
     const effectiveVersion = typeof raw === "string" ? raw.trim() || null : raw;
     this.checkTargetVersion(effectiveVersion ?? undefined);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -378,9 +378,18 @@ export class DatabaseTasks {
 
   static async migrate(
     version?: number | string,
-    { skipInitialize = false }: { skipInitialize?: boolean } = {},
+    {
+      skipInitialize = false,
+      targetVersion,
+    }: { skipInitialize?: boolean; targetVersion?: number | string | null } = {},
   ): Promise<void> {
-    const raw = version ?? this.targetVersion();
+    // `targetVersion` is the in-process stand-in for Rails' `ENV["VERSION"]`:
+    // the rake task never passes an argument, so `target_version` reads the
+    // env. trails has no env writer (`getEnv` is read-only), so a CLI
+    // `--version` flag has to hand the target down explicitly. It must NOT
+    // travel as `version` — that argument is the exact-version *filter*
+    // (migrate:up semantics), not "migrate up to here".
+    const raw = version ?? targetVersion ?? this.targetVersion();
     const effectiveVersion = typeof raw === "string" ? raw.trim() || null : raw;
     this.checkTargetVersion(effectiveVersion ?? undefined);
 
@@ -452,6 +461,21 @@ export class DatabaseTasks {
   /** @internal Same deviation as {@link rollback}, for `db:forward` (`databases.rake:279`). */
   static async forward(steps: number = 1): Promise<void> {
     await this._stepMigrations("forward", steps);
+  }
+
+  /**
+   * @internal Same deviation as {@link rollback}: `db:migrate:up` /
+   * `db:migrate:down` (`railties/databases.rake:174-177`, `:205-208`) inline
+   * `migration_connection_pool.migration_context.run(direction, target_version)`.
+   * The body lives here because the CLI has no pool handle of its own.
+   */
+  static async runMigration(direction: "up" | "down", version: number | string): Promise<void> {
+    this.checkTargetVersion(version);
+    const pool = await this.migrationConnectionPool();
+    const adapter = await pool.leaseConnection();
+    const context = await this._migrationContextFor(adapter, pool.dbConfig);
+    await context.run(direction, version);
+    adapter.schemaCache?.clear();
   }
 
   private static async _stepMigrations(

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1066,6 +1066,50 @@ export class CreatePosts extends Migration {
     }
   });
 
+  it("db migrate --version migrates up to that version, not only that version", async () => {
+    // Guards the DatabaseTasks.migrate seam: an explicit positional argument
+    // there is an exact-version *filter* (migrate:up semantics), so --version
+    // has to travel as the target version instead. With three migrations and
+    // a target of the second, target semantics runs the first two.
+    const dbFile = path.join(tmpDir, "test.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+  test: { adapter: "sqlite3", database: ${JSON.stringify(dbFile)} },
+};`,
+    );
+    for (const [version, table, cls] of [
+      ["20260101000000", "posts", "CreatePosts"],
+      ["20260101000001", "comments", "CreateComments"],
+      ["20260101000002", "authors", "CreateAuthors"],
+    ]) {
+      fs.writeFileSync(
+        path.join(tmpDir, "db", "migrations", `${version}-create-${table}.ts`),
+        `import { Migration } from "@blazetrails/activerecord";
+export class ${cls} extends Migration {
+  async up() { await this.createTable(${JSON.stringify(table)}, (t) => { t.string("title"); }); }
+  async down() { await this.dropTable(${JSON.stringify(table)}); }
+}`,
+      );
+    }
+
+    await runDb(["migrate", "--version=20260101000001"]);
+
+    const { BetterSQLite3Adapter } =
+      await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
+    const a = new BetterSQLite3Adapter(dbFile);
+    try {
+      const rows = (await a.execute(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('posts','comments','authors')`,
+      )) as Array<{ name: string }>;
+      const names = rows.map((r) => r.name).sort();
+      expect(names).toEqual(["comments", "posts"]);
+    } finally {
+      await a.close();
+    }
+  });
+
   it("db migrate:down reverts the named migration", async () => {
     const dbFile = path.join(tmpDir, "test.sqlite3");
     fs.writeFileSync(

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1066,6 +1066,12 @@ export class CreatePosts extends Migration {
     }
   });
 
+  it("db migrate:up raises for an unknown version when no migrations exist", async () => {
+    await expect(runDb(["migrate:up", "--version=20260101000000"])).rejects.toThrow(
+      /No migration with version number 20260101000000/,
+    );
+  });
+
   it("db migrate --version migrates up to that version, not only that version", async () => {
     // Guards the DatabaseTasks.migrate seam: an explicit positional argument
     // there is an exact-version *filter* (migrate:up semantics), so --version

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { env, setEnv } from "@blazetrails/activesupport/process-adapter";
+import {
+  env,
+  setEnv,
+  getProcessAdapter,
+  registerProcessAdapter,
+} from "@blazetrails/activesupport/process-adapter";
 import { createProgram } from "../cli.js";
 import {
   loadDatabaseConfig,
@@ -2099,6 +2104,75 @@ export class CreateDogs extends Migration {
     expect(await tableExists(animalsDb, "dogs")).toBe(true);
     expect(await tableExists(primaryDb, "users")).toBe(true);
     expect(logs).toContain("All migrations are up to date.");
+  });
+
+  it("db:migrate respects timestamp ordering across databases", async () => {
+    const primaryDb = path.join(tmpDir, "ordering-primary.sqlite3");
+    const animalsDb = path.join(tmpDir, "ordering-animals.sqlite3");
+    fs.writeFileSync(
+      path.join(tmpDir, "config", "database.ts"),
+      `export default {
+  development: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+  },
+};`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    const migration = (cls: string, table: string) =>
+      `import { Migration } from "@blazetrails/activerecord";
+export class ${cls} extends Migration {
+  async up() { await this.createTable(${JSON.stringify(table)}, (t) => { t.string("name"); }); }
+  async down() { await this.dropTable(${JSON.stringify(table)}); }
+}`;
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000001-one-migration.ts"),
+      migration("OneMigration", "ones"),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000002-two-migration.ts"),
+      migration("TwoMigration", "twos"),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations", "20260101000003-three-migration.ts"),
+      migration("ThreeMigration", "threes"),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "db", "migrations_animals", "20260101000004-four-migration.ts"),
+      migration("FourMigration", "fours"),
+    );
+
+    await runDb(["create"]);
+
+    const previous = getProcessAdapter();
+    let output = "";
+    registerProcessAdapter({
+      ...previous,
+      stdout: {
+        ...previous.stdout,
+        write: (chunk: string) => {
+          output += chunk;
+          return true;
+        },
+      },
+    });
+    try {
+      await runDb(["migrate"]);
+    } finally {
+      registerProcessAdapter(previous);
+    }
+
+    const entries = [...output.matchAll(/^== (\d+).+migrated/gm)].map((m) => m[1]);
+    expect(entries).toEqual([
+      "20260101000001",
+      "20260101000002",
+      "20260101000003",
+      "20260101000004",
+    ]);
   });
 
   it("db migrate --database=animals targets only the named DB", async () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -2166,12 +2166,15 @@ export class ${cls} extends Migration {
       registerProcessAdapter(previous);
     }
 
-    const entries = [...output.matchAll(/^== (\d+).+migrated/gm)].map((m) => m[1]);
+    const entries = [...output.matchAll(/^\[(\w+)\] == (\d+).+migrated/gm)].map((m) => [
+      m[1],
+      m[2],
+    ]);
     expect(entries).toEqual([
-      "20260101000001",
-      "20260101000002",
-      "20260101000003",
-      "20260101000004",
+      ["primary", "20260101000001"],
+      ["animals", "20260101000002"],
+      ["primary", "20260101000003"],
+      ["animals", "20260101000004"],
     ]);
   });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -578,11 +578,11 @@ async function withMigrationTasksForDb(
     config: HashConfig;
   },
   operation: () => Promise<void>,
-  opts?: { afterPending?: (pending: number) => void },
+  opts?: { afterPending?: (pending: number) => void; runWhenEmpty?: boolean },
 ): Promise<void> {
   const mDirs = await migrationsDirsForConfig(ctx.name, ctx.raw);
   const migrations = await discoverMigrationsFromDirs(mDirs);
-  if (migrations.length === 0) {
+  if (migrations.length === 0 && !opts?.runWhenEmpty) {
     console.log(`${ctx.prefix}No migrations found.`);
     return;
   }
@@ -615,20 +615,9 @@ export function dbCommand(): Command {
       // to null so an empty VERSION="" doesn't fail BigInt parsing.
       const rawVersion = opts.version != null ? String(opts.version).trim() : env.VERSION?.trim();
       const targetVersion = rawVersion && rawVersion.length > 0 ? rawVersion : null;
-      // Rails' `db:migrate` is `DatabaseTasks.migrate_all` + `db:_dump`, and
-      // the per-database `db:migrate:<name>` is
-      // `with_temporary_pool_for_each { DatabaseTasks.migrate }` + `db:_dump:<name>`
-      // (`databases.rake:88-92`, `:118-126`). forEachDatabase is the
-      // with_temporary_pool_for_each analogue, so both shapes route through
-      // the per-config task here; that keeps the `[name] ` output prefix and
-      // the per-config dump migrate_all has no seam for.
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(
           ctx,
-          // targetVersion, not the positional argument: an explicit argument to
-          // DatabaseTasks.migrate is an exact-version filter (migrate:up
-          // semantics), whereas --version means "migrate up to this version",
-          // which is what Rails' ENV["VERSION"] does.
           () => DatabaseTasks.migrate(undefined, { targetVersion }),
           {
             afterPending: (pending) => {
@@ -773,7 +762,9 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
-        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("up", opts.version));
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("up", opts.version), {
+          runWhenEmpty: true,
+        });
       });
     });
 
@@ -784,7 +775,9 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
-        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("down", opts.version));
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("down", opts.version), {
+          runWhenEmpty: true,
+        });
       });
     });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -539,45 +539,6 @@ async function runDrop(opts: DatabaseOpts = {}): Promise<void> {
 }
 
 /**
- * Shared helper for migrate/rollback/forward — discover migrations for
- * the named DB, construct a Migrator, run the caller-provided operation,
- * log output, and dump the schema. Extracts the pattern so the three
- * commands can't drift.
- */
-async function withMigratorForDb(
-  ctx: {
-    adapter: DatabaseAdapter;
-    raw: RawConfig;
-    name: string;
-    prefix: string;
-    config: HashConfig;
-  },
-  operation: (migrator: Migrator) => Promise<void>,
-  opts?: {
-    skipDump?: boolean;
-    /** Called after migration completes — use for messages that
-     *  should appear after the migration output. */
-    afterOutput?: (migrator: Migrator) => void | Promise<void>;
-  },
-): Promise<void> {
-  const mDirs = await migrationsDirsForConfig(ctx.name, ctx.raw);
-  const migrations = await discoverMigrationsFromDirs(mDirs);
-  if (migrations.length === 0) {
-    console.log(`${ctx.prefix}No migrations found.`);
-    return;
-  }
-  const migrator = new Migrator(ctx.adapter, migrations, {
-    environment: ctx.config.envName,
-    internalMetadataEnabled: ctx.config.useMetadataTable,
-  });
-  await withPrefixedStdout(ctx.prefix, async () => {
-    await operation(migrator);
-    if (opts?.afterOutput) await opts.afterOutput(migrator);
-  });
-  if (!opts?.skipDump) await dumpSchemaAfterMigrate(ctx.raw, ctx.config);
-}
-
-/**
  * Migration output goes to stdout (Rails' Migration#write is `puts`), so the
  * per-database prefix is applied by swapping in a stdout-wrapping process
  * adapter for the duration of the run.
@@ -654,16 +615,24 @@ export function dbCommand(): Command {
       // to null so an empty VERSION="" doesn't fail BigInt parsing.
       const rawVersion = opts.version != null ? String(opts.version).trim() : env.VERSION?.trim();
       const targetVersion = rawVersion && rawVersion.length > 0 ? rawVersion : null;
+      // Rails' `db:migrate` is `DatabaseTasks.migrate_all` + `db:_dump`, and
+      // the per-database `db:migrate:<name>` is
+      // `with_temporary_pool_for_each { DatabaseTasks.migrate }` + `db:_dump:<name>`
+      // (`databases.rake:88-92`, `:118-126`). forEachDatabase is the
+      // with_temporary_pool_for_each analogue, so both shapes route through
+      // the per-config task here; that keeps the `[name] ` output prefix and
+      // the per-config dump migrate_all has no seam for.
       await forEachDatabase(opts, async (ctx) => {
-        await withMigratorForDb(
+        await withMigrationTasksForDb(
           ctx,
-          async (migrator) => {
-            await migrator.migrate(targetVersion);
-          },
+          // targetVersion, not the positional argument: an explicit argument to
+          // DatabaseTasks.migrate is an exact-version filter (migrate:up
+          // semantics), whereas --version means "migrate up to this version",
+          // which is what Rails' ENV["VERSION"] does.
+          () => DatabaseTasks.migrate(undefined, { targetVersion }),
           {
-            afterOutput: async (migrator) => {
-              const pending = await migrator.pendingMigrations();
-              if (pending.length === 0) {
+            afterPending: (pending) => {
+              if (pending === 0) {
                 console.log(`${ctx.prefix}All migrations are up to date.`);
               }
             },
@@ -803,12 +772,8 @@ export function dbCommand(): Command {
     .requiredOption("--version <version>", "Migration version to run up")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
-        const mDirs = await migrationsDirsForConfig(name, raw);
-        const migrations = await discoverMigrationsFromDirs(mDirs);
-        const migrator = createMigrator(adapter, migrations, raw);
-        await migrator.run("up", opts.version);
-        await dumpSchemaAfterMigrate(raw, config);
+      await forEachDatabase(opts, async (ctx) => {
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("up", opts.version));
       });
     });
 
@@ -818,12 +783,8 @@ export function dbCommand(): Command {
     .requiredOption("--version <version>", "Migration version to run down")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix, config }) => {
-        const mDirs = await migrationsDirsForConfig(name, raw);
-        const migrations = await discoverMigrationsFromDirs(mDirs);
-        const migrator = createMigrator(adapter, migrations, raw);
-        await migrator.run("down", opts.version);
-        await dumpSchemaAfterMigrate(raw, config);
+      await forEachDatabase(opts, async (ctx) => {
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("down", opts.version));
       });
     });
 
@@ -1035,9 +996,7 @@ export function dbCommand(): Command {
       await runDrop(primary);
       await runCreate(primary);
       await forEachDatabase(primary, async (ctx) => {
-        await withMigratorForDb(ctx, async (migrator) => {
-          await migrator.migrate(null);
-        });
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.migrate());
         await withSeedAdapter(ctx.adapter, () => runSeed(ctx.prefix));
       });
     });
@@ -1049,9 +1008,7 @@ export function dbCommand(): Command {
       const primary: DatabaseOpts = { database: "primary" };
       await runCreate(primary);
       await forEachDatabase(primary, async (ctx) => {
-        await withMigratorForDb(ctx, async (migrator) => {
-          await migrator.migrate(null);
-        });
+        await withMigrationTasksForDb(ctx, () => DatabaseTasks.migrate());
         await withSeedAdapter(ctx.adapter, () => runSeed(ctx.prefix));
       });
     });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -542,14 +542,21 @@ async function runDrop(opts: DatabaseOpts = {}): Promise<void> {
  * Migration output goes to stdout (Rails' Migration#write is `puts`), so the
  * per-database prefix is applied by swapping in a stdout-wrapping process
  * adapter for the duration of the run.
+ *
+ * A callback prefix is resolved per write, for runs like `migrate_all` that
+ * interleave databases within one wrapped block and so have no single prefix.
  */
-async function withPrefixedStdout(prefix: string, fn: () => Promise<void>): Promise<void> {
-  const prevAdapter = prefix ? getProcessAdapter() : null;
+async function withPrefixedStdout(
+  prefix: string | (() => string),
+  fn: () => Promise<void>,
+): Promise<void> {
+  const resolvePrefix = typeof prefix === "function" ? prefix : () => prefix;
+  const prevAdapter = prefix === "" ? null : getProcessAdapter();
   if (prevAdapter) {
     registerProcessAdapter({
       ...prevAdapter,
       stdout: {
-        write: (chunk) => prevAdapter.stdout.write(`${prefix}${chunk}`),
+        write: (chunk) => prevAdapter.stdout.write(`${resolvePrefix()}${chunk}`),
         get isTTY() {
           return prevAdapter.stdout.isTTY;
         },
@@ -629,9 +636,23 @@ async function runMigrateAll(targetVersion: string | null): Promise<void> {
   const primary = entries.find((e) => e.name === "primary") ?? entries[0];
   const configs = entries.map((e) => e.hashConfig);
   const multiDb = entries.length > 1;
+  // migrate_all interleaves databases by version, so the prefix has to follow
+  // whichever config it currently has established rather than being fixed for
+  // the whole run.
+  const { Base } = await import("@blazetrails/activerecord");
+  const currentDbPrefix = (): string => {
+    if (!multiDb) return "";
+    try {
+      const name = Base.connectionDbConfig()?.name;
+      return name ? `[${name}] ` : "";
+    } catch {
+      return "";
+    }
+  };
+
   await withRegisteredConfigurations(configs, envName, () =>
     DatabaseTasks.withTemporaryPool(primary.hashConfig, async () => {
-      await DatabaseTasks.migrateAll({ targetVersion });
+      await withPrefixedStdout(currentDbPrefix, () => DatabaseTasks.migrateAll({ targetVersion }));
       for (const { name, raw, hashConfig } of entries) {
         const prefix = multiDb ? `[${name}] ` : "";
         await DatabaseTasks.withTemporaryPool(hashConfig, async (pool) => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -600,6 +600,55 @@ async function withMigrationTasksForDb(
   await dumpSchemaAfterMigrate(ctx.raw, ctx.config);
 }
 
+/**
+ * `db:migrate` — `DatabaseTasks.migrate_all` followed by `db:_dump`
+ * (`railties/databases.rake:88-92`). `migrate_all` owns the multi-database
+ * routing (single-primary fast path, then `db_configs_with_versions` sorted so
+ * one timestamp runs across every config before the next), so the migrations
+ * for each config are registered up front and the whole run happens inside a
+ * single `configs_for` registration rather than a per-database loop.
+ */
+async function runMigrateAll(targetVersion: string | null): Promise<void> {
+  const envName = resolveEnv();
+  const entries = await taskableDatabaseEntries({}, envName);
+  const migrationsFor = new Map<string, Awaited<ReturnType<typeof discoverMigrations>>>();
+  for (const { name, raw, hashConfig } of entries) {
+    const migrations = await discoverMigrationsFromDirs(await migrationsDirsForConfig(name, raw));
+    migrationsFor.set(name, migrations);
+    DatabaseTasks.registerMigrations(migrations, hashConfig);
+  }
+  if ([...migrationsFor.values()].every((m) => m.length === 0)) {
+    console.log("No migrations found.");
+    return;
+  }
+
+  // Rails' `load_config` leaves the primary connection established, which is
+  // what `migrate_all`'s single-primary fast path migrates directly. The dump
+  // stays inside that same scope so a `:memory:` database — whose data dies
+  // with its pool — is dumped from the connection that was just migrated.
+  const primary = entries.find((e) => e.name === "primary") ?? entries[0];
+  const configs = entries.map((e) => e.hashConfig);
+  const multiDb = entries.length > 1;
+  await withRegisteredConfigurations(configs, envName, () =>
+    DatabaseTasks.withTemporaryPool(primary.hashConfig, async () => {
+      await DatabaseTasks.migrateAll({ targetVersion });
+      for (const { name, raw, hashConfig } of entries) {
+        const prefix = multiDb ? `[${name}] ` : "";
+        await DatabaseTasks.withTemporaryPool(hashConfig, async (pool) => {
+          const migrations = migrationsFor.get(name) ?? [];
+          const migrator = new Migrator(await pool.leaseConnection(), migrations, {
+            environment: hashConfig.envName,
+            internalMetadataEnabled: hashConfig.useMetadataTable,
+          });
+          const pending = await migrator.pendingMigrations();
+          if (pending.length === 0) console.log(`${prefix}All migrations are up to date.`);
+          await dumpSchemaAfterMigrate(raw, hashConfig);
+        });
+      }
+    }),
+  );
+}
+
 export function dbCommand(): Command {
   const cmd = new Command("db");
   cmd.description("Database management commands");
@@ -615,6 +664,10 @@ export function dbCommand(): Command {
       // to null so an empty VERSION="" doesn't fail BigInt parsing.
       const rawVersion = opts.version != null ? String(opts.version).trim() : env.VERSION?.trim();
       const targetVersion = rawVersion && rawVersion.length > 0 ? rawVersion : null;
+      if (opts.database === undefined) {
+        await runMigrateAll(targetVersion);
+        return;
+      }
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(
           ctx,


### PR DESCRIPTION
Removes the last CLI-side reimplementation of the migration run loop.
`db migrate`, `migrate:up` and `migrate:down` went through
`withMigratorForDb`, which discovered migrations and constructed a bare
`Migrator`; PR #5616 had already moved `rollback` / `forward` /
`migrate:redo` onto the `DatabaseTasks` seam.

- `db migrate` → `DatabaseTasks.migrate()` under `withMigrationTasksForDb`,
  which is the `with_temporary_pool_for_each(env:, name:) { DatabaseTasks.migrate }`
  + `db:_dump:<name>` shape of `databases.rake:118-126`. `forEachDatabase`
  already wraps each config in `DatabaseTasks.withTemporaryPool`, so it is the
  `with_temporary_pool_for_each` analogue; keeping both the all-databases and
  `--database` cases on it preserves the `[name] ` output prefix and the
  per-config dump that `migrate_all` has no seam for.
- `migrate:up` / `migrate:down` → new `@internal DatabaseTasks.runMigration`,
  which is `migration_connection_pool.migration_context.run(direction, target_version)`
  from `databases.rake:174-177` / `:205-208`. Same documented deviation as the
  existing `DatabaseTasks.rollback` / `forward`: the body lives in
  `DatabaseTasks` because the CLI has no pool handle of its own.
- `--version` semantics preserved. It cannot travel as the positional argument
  to `DatabaseTasks.migrate` — that argument is an exact-version *filter*
  (`migrate:up` semantics), while the flag means "migrate up to this version",
  i.e. Rails' `ENV["VERSION"]` → `target_version`. Since `getEnv` is read-only
  and `process.*` is off limits, `migrate` gains a `targetVersion` option that
  stands in for the env read. Justified at the call site.
- `withMigratorForDb` deleted; `reset` / `setup`, its other two callers, moved
  onto the same seam.

`withMigrationTasksForDb`'s "No migrations found." early return is right for
`db migrate` but wrong for `migrate:up` / `migrate:down`, which must still
raise `UnknownMigrationVersionError` for a version that does not exist
(`databases.rake:174-177`). Those two pass `runWhenEmpty` so they reach the
run surface either way.

Two regression tests. The first asserts the target-vs-filter distinction: three
migrations, `db migrate --version <second>` must apply the first two.
Verified it fails when `--version` is routed through the positional argument.
The second asserts `migrate:up --version=<unknown>` still raises with no
migration files present; verified it fails without `runWhenEmpty`.

All 107 `db.test.ts` tests pass, including the existing multi-db migrate
coverage.

Closes-story: trailties-db-migrate-delegates-to-database-tasks
