### PR TITLE
refactor(activerecord): converge adapter indexes() return type

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -390,13 +390,15 @@ export interface AbstractAdapter {
   dataSourceSql(name?: string | null, options?: { type?: string }): string;
   columns(tableName: string): Promise<Column[]>;
   primaryKey(tableName: string): Promise<string | string[] | null>;
-  /**
-   * drift-ok: the SchemaStatements base spells out the row shape, but the
-   * concrete adapters override `indexes` with `Promise<unknown[]>`, so
-   * narrowing here makes every one of them unassignable to AbstractAdapter.
-   * Converging the adapters is `converge-adapter-indexes-return-type`.
-   */
-  indexes(tableName: string): Promise<unknown[]>;
+  indexes(tableName: string): Promise<
+    Array<{
+      name: string;
+      columns: string | string[];
+      unique: boolean;
+      where?: string;
+      orders?: Record<string, string> | string;
+    }>
+  >;
   foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
   foreignKeyExists(
     fromTable: string,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2147,7 +2147,16 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return fields.map((field) => newColumnFromField(this, tableName, field, fields));
   }
 
-  async indexes(tableName: string): Promise<unknown[]> {
+  async indexes(tableName: string): Promise<
+    Array<{
+      table: string;
+      name: string;
+      columns: string[] | string;
+      unique: boolean;
+      where?: string;
+      orders: Record<string, string>;
+    }>
+  > {
     return sqliteIndexes(this, tableName);
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -100,7 +100,19 @@ const INDEX_ON_REGEX =
  * adapter delegates here. Schema-qualified names (e.g. `temp.widgets`) place
  * the qualifier before the PRAGMA keyword.
  */
-export async function indexes(adapter: DatabaseAdapter, tableName: string): Promise<unknown[]> {
+export async function indexes(
+  adapter: DatabaseAdapter,
+  tableName: string,
+): Promise<
+  Array<{
+    table: string;
+    name: string;
+    columns: string[] | string;
+    unique: boolean;
+    where?: string;
+    orders: Record<string, string>;
+  }>
+> {
   const { schema, bare } = splitTableName(tableName);
   const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
   const rows = (await adapter.schemaQuery(


### PR DESCRIPTION
`AbstractAdapter`'s declaration-merged interface declared
`indexes(tableName: string): Promise<unknown[]>`, while the mixed-in
`SchemaStatements#indexes` returns the spelled-out row shape.

The earlier attempt at narrowing failed because `AbstractSQLite3Adapter#indexes`
(and the `sqlite3/schema-statements.ts` helper behind it) were typed
`Promise<unknown[]>`. Typing the SQLite helper with the row shape it already
builds at runtime makes the SQLite adapter assignable, so the interface can now
declare the mixin's shape. The MySQL and PostgreSQL adapters already returned
structurally-compatible spelled-out shapes (`PgIndexDefinition`, the MySQL row
type), so they needed no change.

With the member no longer drifting, the `drift-ok:` waiver on
`AbstractAdapter#indexes` is deleted. `scripts/mixin-declaration-drift.test.ts`
passes and the drift lint itself reports no drift.

`pnpm typecheck` is clean across the workspace — none of the ~50 previously
reported errors reappear.

Closes-story: converge-adapter-indexes-return-type
