### PR TITLE
test(activerecord): cover Migration#executionStrategy honouring the configured class

### DIFF
--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -14,6 +14,7 @@ import { Migrator } from "./index.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migration, IllegalMigrationNameError } from "./migration.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
+import { ActiveRecord } from "./ar-config.js";
 import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { newRawTestAdapter } from "./test-adapter.js";
@@ -188,6 +189,20 @@ describe("Migration#createTable id option type", () => {
       const migration = new StrategyMigration();
       expect(migration.executionStrategy).toBeInstanceOf(DefaultStrategy);
       expect(migration.executionStrategy).toBe(migration.executionStrategy);
+    });
+
+    it("uses the class configured on ActiveRecord.migrationStrategy", () => {
+      class CustomStrategy extends DefaultStrategy {}
+      const previous = ActiveRecord.migrationStrategy;
+      ActiveRecord.migrationStrategy = CustomStrategy;
+      try {
+        const migration = new StrategyMigration();
+        const strategy = migration.executionStrategy as CustomStrategy;
+        expect(strategy).toBeInstanceOf(CustomStrategy);
+        expect(strategy.methodMissing("createTable")).toBe("hi mom!");
+      } finally {
+        ActiveRecord.migrationStrategy = previous;
+      }
     });
 
     it("forwards unknown calls through the strategy to the connection", async () => {


### PR DESCRIPTION
`Migration#executionStrategy` already reads `ActiveRecord.migrationStrategy`, constructs it with `this`, and memoizes per migration (`migration.ts:1356`) — that half of the story landed earlier. What was missing is the coverage: no test set `ActiveRecord.migrationStrategy` to a custom class, so a regression back to a hardcoded `new DefaultStrategy()` would stay invisible.

Adds a trails-only test that points the config at a `DefaultStrategy` subclass and asserts the migration builds that class and hands itself to it (via the strategy forwarding `createTable` to the migration's connection). Restores the previous config in a `finally`.

Closes-story: wire-migration-execution-strategy-to-configured-class