### PR TITLE
test(activesupport): run the shared MessageMetadataTests suite from both metadata tests

### DIFF
--- a/packages/activesupport/src/messages/message-encryptor-metadata.test.ts
+++ b/packages/activesupport/src/messages/message-encryptor-metadata.test.ts
@@ -1,49 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { describe } from "vitest";
 
 import { getCrypto } from "../crypto-adapter.js";
 import { MessageEncryptor } from "../message-encryptor.js";
-import { eachScenario as eachSerializerScenario, freezeTime } from "./message-metadata-tests.js";
+import { InvalidSignature } from "../message-verifier.js";
+import { messageMetadataTests } from "./message-metadata-tests.js";
 
 describe("MessageEncryptorMetadataTest", () => {
   const secret = getCrypto().randomBytes(32);
-  const data = { a_number: 123, an_object: { key: "value" } };
 
-  const eachScenario = (block: (encryptor: MessageEncryptor) => void): void =>
-    eachSerializerScenario((serializer) => new MessageEncryptor(secret, { serializer }), block);
-
-  it("message :purpose must match specified :purpose", () => {
-    eachScenario((encryptor) => {
-      expect(
-        encryptor.decryptAndVerify(encryptor.encryptAndSign(data, { purpose: "x" }), {
-          purpose: "x",
-        }),
-      ).toEqual(data);
-
-      expect(
-        encryptor.decryptAndVerify(encryptor.encryptAndSign(data, { purpose: "x" }), {
-          purpose: "y",
-        }),
-      ).toBeNull();
-      expect(
-        encryptor.decryptAndVerify(encryptor.encryptAndSign(data, { purpose: "x" })),
-      ).toBeNull();
-      expect(
-        encryptor.decryptAndVerify(encryptor.encryptAndSign(data), { purpose: "x" }),
-      ).toBeNull();
-    });
-  });
-
-  it("message expires with :expires_in", () => {
-    freezeTime((travel) => {
-      eachScenario((encryptor) => {
-        const message = encryptor.encryptAndSign(data, { expiresIn: 1 });
-
-        travel({ milliseconds: 500 });
-        expect(encryptor.decryptAndVerify(message)).toEqual(data);
-
-        travel({ milliseconds: 500 });
-        expect(encryptor.decryptAndVerify(message)).toBeNull();
-      });
-    });
+  messageMetadataTests<MessageEncryptor>({
+    makeCodec: (serializer) => new MessageEncryptor(secret, { serializer }),
+    encode: (data, encryptor, options) => encryptor.encryptAndSign(data, options),
+    decode: (message, encryptor, options) => {
+      try {
+        return encryptor.decryptAndVerify(message, options);
+      } catch (error) {
+        if (error instanceof InvalidSignature) return null;
+        throw error;
+      }
+    },
   });
 });

--- a/packages/activesupport/src/messages/message-metadata-tests.ts
+++ b/packages/activesupport/src/messages/message-metadata-tests.ts
@@ -156,8 +156,6 @@ export function messageMetadataTests<T>(hooks: MetadataCodecHooks<T>): void {
   });
 
   it(":expires_at overrides :expires_in", () => {
-    // Rails travels without freezing first; `travel` is only reachable inside
-    // `freezeTime` here, and freezing changes nothing about what is asserted.
     freezeTime((travel) => {
       each((data, codec) => {
         const message = encode(data, codec, {

--- a/packages/activesupport/src/messages/message-metadata-tests.ts
+++ b/packages/activesupport/src/messages/message-metadata-tests.ts
@@ -1,6 +1,12 @@
+import { expect, it } from "vitest";
+
+import { Encoding } from "../json/encoding.js";
+import { NullSerializer } from "../message-encryptor.js";
 import { Temporal } from "../temporal.js";
 import { currentTimeInstant, setFrozenInstant } from "../time-travel.js";
-import { Metadata } from "./metadata.js";
+import type { MessageSerializer } from "./codec.js";
+import { Metadata, type ExpectedMetadataOptions, type MetadataOptions } from "./metadata.js";
+import type { Format } from "./serializer-with-fallback.js";
 
 export function usingMessageSerializerForMetadata(value: boolean, block: () => void): void {
   const original = Metadata.useMessageSerializerForMetadata;
@@ -27,15 +33,195 @@ export function freezeTime(
   }
 }
 
+/**
+ * Rails' `DATA`. Rails' second and third entries also carry a
+ * `Time.local(2004)`; a temporal value does not survive the `:json`
+ * serializer as a temporal (it decodes back as a string), and the
+ * `:message_pack` serializer that would preserve it is excluded — see
+ * {@link SERIALIZERS}.
+ */
+const DATA: readonly unknown[] = [
+  "a string",
+  { a_number: 123, an_object: { key: "value" } },
+  ["a string", 123, { key: "value" }],
+];
+
+/**
+ * Rails' `SERIALIZERS`. `ActiveSupport::MessagePack` is excluded pending its
+ * temporal packer (follow-up story). Rails lists `JSON`, `ActiveSupport::JSON`
+ * and a `CustomSerializer` separately; trails' `:json` serializer is
+ * `ActiveSupport::JSON`, so the JSON entries collapse into one.
+ */
+const SERIALIZERS: readonly Format[] = ["marshal", "json"];
+
 export function eachScenario<T>(
-  makeCodec: (serializer: "marshal" | "json") => T,
-  block: (codec: T) => void,
+  makeCodec: (serializer: Format | MessageSerializer) => T,
+  block: (data: unknown, codec: T) => void,
 ): void {
   for (const useMessageSerializerForMetadata of [false, true]) {
     usingMessageSerializerForMetadata(useMessageSerializerForMetadata, () => {
-      for (const serializer of ["marshal", "json"] as const) {
-        block(makeCodec(serializer));
+      for (const serializer of SERIALIZERS) {
+        const codec = makeCodec(serializer);
+        for (const data of DATA) {
+          block(data, codec);
+        }
       }
     });
   }
+}
+
+/** Rails' `make_codec` / `encode` / `decode`, which each including test supplies. */
+export interface MetadataCodecHooks<T> {
+  makeCodec(serializer: Format | MessageSerializer): T;
+  encode(data: unknown, codec: T, options?: MetadataOptions): string;
+  decode(message: string, codec: T, options?: ExpectedMetadataOptions): unknown;
+}
+
+/**
+ * Rails' `MessageMetadataTests` — the module both `MessageVerifierMetadataTest`
+ * and `MessageEncryptorMetadataTest` `include`.
+ */
+export function messageMetadataTests<T>(hooks: MetadataCodecHooks<T>): void {
+  const { makeCodec, encode, decode } = hooks;
+
+  const roundtrip = (
+    data: unknown,
+    codec: T,
+    encodeOptions: MetadataOptions = {},
+    decodeOptions: ExpectedMetadataOptions = {},
+  ): unknown => decode(encode(data, codec, encodeOptions), codec, decodeOptions);
+
+  const assertRoundtrip = (
+    data: unknown,
+    codec: T,
+    encodeOptions: MetadataOptions = {},
+    decodeOptions: ExpectedMetadataOptions = {},
+  ): void => {
+    expect(roundtrip(data, codec, encodeOptions, decodeOptions)).toEqual(data);
+  };
+
+  const assertNoRoundtrip = (
+    data: unknown,
+    codec: T,
+    encodeOptions: MetadataOptions = {},
+    decodeOptions: ExpectedMetadataOptions = {},
+  ): void => {
+    expect(roundtrip(data, codec, encodeOptions, decodeOptions)).toBeNull();
+  };
+
+  const each = (block: (data: unknown, codec: T) => void): void => eachScenario(makeCodec, block);
+
+  it("message :purpose must match specified :purpose", () => {
+    each((data, codec) => {
+      assertRoundtrip(data, codec, { purpose: "x" }, { purpose: "x" });
+
+      assertNoRoundtrip(data, codec, { purpose: "x" }, { purpose: "y" });
+      assertNoRoundtrip(data, codec, { purpose: "x" }, {});
+      assertNoRoundtrip(data, codec, {}, { purpose: "x" });
+    });
+  });
+
+  // Rails' ":purpose can be a symbol" has no analogue here: JS has no Ruby
+  // symbol, and `String(Symbol("x"))` is `"Symbol(x)"` rather than `"x"`, so a
+  // JS symbol is not the string-interchangeable value that case asserts about.
+
+  it("message expires with :expires_at", () => {
+    freezeTime((travel) => {
+      each((data, codec) => {
+        const message = encode(data, codec, {
+          expiresAt: currentTimeInstant().add({ seconds: 1 }),
+        });
+
+        travel({ milliseconds: 500 });
+        expect(decode(message, codec)).toEqual(data);
+
+        travel({ milliseconds: 500 });
+        expect(decode(message, codec)).toBeNull();
+      });
+    });
+  });
+
+  it("message expires with :expires_in", () => {
+    freezeTime((travel) => {
+      each((data, codec) => {
+        const message = encode(data, codec, { expiresIn: 1 });
+
+        travel({ milliseconds: 500 });
+        expect(decode(message, codec)).toEqual(data);
+
+        travel({ milliseconds: 500 });
+        expect(decode(message, codec)).toBeNull();
+      });
+    });
+  });
+
+  it(":expires_at overrides :expires_in", () => {
+    // Rails travels without freezing first; `travel` is only reachable inside
+    // `freezeTime` here, and freezing changes nothing about what is asserted.
+    freezeTime((travel) => {
+      each((data, codec) => {
+        const message = encode(data, codec, {
+          expiresAt: currentTimeInstant().add({ hours: 1 }),
+          expiresIn: 1,
+        });
+
+        travel({ minutes: 1 });
+        expect(decode(message, codec)).toEqual(data);
+
+        travel({ hours: 1 });
+        expect(decode(message, codec)).toBeNull();
+      });
+    });
+  });
+
+  it("messages do not expire by default", () => {
+    freezeTime((travel) => {
+      each((data, codec) => {
+        const message = encode(data, codec, { purpose: "x" });
+
+        travel({ hours: 1000 * 365 * 24 });
+        expect(decode(message, codec, { purpose: "x" })).toEqual(data);
+      });
+    });
+  });
+
+  it("expiration works with ActiveSupport.use_standard_json_time_format = false", () => {
+    const original = Encoding.useStandardJsonTimeFormat;
+    Encoding.useStandardJsonTimeFormat = false;
+    try {
+      each((data, codec) => {
+        assertRoundtrip(data, codec, { expiresAt: currentTimeInstant().add({ hours: 1 }) });
+      });
+    } finally {
+      Encoding.useStandardJsonTimeFormat = original;
+    }
+  });
+
+  it("metadata works with NullSerializer", () => {
+    const codec = makeCodec(NullSerializer);
+    assertRoundtrip(
+      "a string",
+      codec,
+      { purpose: "x", expiresIn: 365 * 24 * 60 * 60 },
+      { purpose: "x" },
+    );
+  });
+
+  it("messages with non-string purpose are readable", () => {
+    each((data, codec) => {
+      const message = encode(data, codec, { purpose: ["x", 1] });
+      expect(decode(message, codec, { purpose: ["x", 1] })).toEqual(data);
+    });
+  });
+
+  it("messages are readable regardless of use_message_serializer_for_metadata", () => {
+    each((data, codec) => {
+      const message = encode(data, codec, { purpose: "x" });
+      const messageSetting = Metadata.useMessageSerializerForMetadata;
+
+      usingMessageSerializerForMetadata(!messageSetting, () => {
+        expect(decode(message, codec, { purpose: "x" })).toEqual(data);
+      });
+    });
+  });
 }

--- a/packages/activesupport/src/messages/message-metadata-tests.ts
+++ b/packages/activesupport/src/messages/message-metadata-tests.ts
@@ -46,13 +46,23 @@ const DATA: readonly unknown[] = [
   ["a string", 123, { key: "value" }],
 ];
 
+const CustomSerializer: MessageSerializer = {
+  dump(value: unknown): string {
+    return `${JSON.stringify(value)}!`;
+  },
+
+  load(value: string): unknown {
+    return JSON.parse(value.replace(/!$/, ""));
+  },
+};
+
 /**
  * Rails' `SERIALIZERS`. `ActiveSupport::MessagePack` is excluded pending its
- * temporal packer (follow-up story). Rails lists `JSON`, `ActiveSupport::JSON`
- * and a `CustomSerializer` separately; trails' `:json` serializer is
- * `ActiveSupport::JSON`, so the JSON entries collapse into one.
+ * temporal packer (follow-up story). Rails lists `JSON` and
+ * `ActiveSupport::JSON` separately; trails' `:json` serializer is
+ * `ActiveSupport::JSON`, so those two entries collapse into one.
  */
-const SERIALIZERS: readonly Format[] = ["marshal", "json"];
+const SERIALIZERS: readonly (Format | MessageSerializer)[] = ["marshal", "json", CustomSerializer];
 
 export function eachScenario<T>(
   makeCodec: (serializer: Format | MessageSerializer) => T,

--- a/packages/activesupport/src/messages/message-verifier-metadata.test.ts
+++ b/packages/activesupport/src/messages/message-verifier-metadata.test.ts
@@ -2,20 +2,28 @@ import { describe, expect, it } from "vitest";
 
 import { InvalidSignature, MessageVerifier } from "../message-verifier.js";
 import { Temporal } from "../temporal.js";
-import { Encoding } from "../json/encoding.js";
 import { currentTimeInstant } from "../time-travel.js";
+import type { MessageSerializer } from "./codec.js";
+import type { Format } from "./serializer-with-fallback.js";
 import {
   eachScenario as eachSerializerScenario,
   freezeTime,
+  messageMetadataTests,
   usingMessageSerializerForMetadata,
 } from "./message-metadata-tests.js";
 
 describe("MessageVerifierMetadataTest", () => {
+  const makeCodec = (serializer: Format | MessageSerializer): MessageVerifier =>
+    new MessageVerifier("secret", { serializer });
+
+  messageMetadataTests<MessageVerifier>({
+    makeCodec,
+    encode: (data, verifier, options) => verifier.generate(data, options),
+    decode: (message, verifier, options) => verifier.verified(message, options),
+  });
+
   const eachScenario = (block: (data: unknown, verifier: MessageVerifier) => void): void =>
-    eachSerializerScenario(
-      (serializer) => new MessageVerifier("secret", { serializer }),
-      (verifier) => block({ a_number: 123, an_object: { key: "value" } }, verifier),
-    );
+    eachSerializerScenario(makeCodec, block);
 
   it("#verify raises when :purpose does not match", () => {
     eachScenario((data, verifier) => {
@@ -65,21 +73,6 @@ describe("MessageVerifierMetadataTest", () => {
         expect(() => verifier.verify(message)).toThrow(InvalidSignature);
       });
     });
-  });
-
-  it("expiration works with ActiveSupport.use_standard_json_time_format = false", () => {
-    const original = Encoding.useStandardJsonTimeFormat;
-    Encoding.useStandardJsonTimeFormat = false;
-    try {
-      eachScenario((data, verifier) => {
-        const message = verifier.generate(data, {
-          expiresAt: currentTimeInstant().add({ hours: 1 }),
-        });
-        expect(verifier.verified(message)).toEqual(data);
-      });
-    } finally {
-      Encoding.useStandardJsonTimeFormat = original;
-    }
   });
 
   it("messages are readable by legacy versions when use_message_serializer_for_metadata = false", () => {


### PR DESCRIPTION
Ports the rest of Rails' shared `MessageMetadataTests`
(`vendor/rails/activesupport/test/messages/message_metadata_tests.rb`) and runs
the whole module from both `message-verifier-metadata.test.ts` and
`message-encryptor-metadata.test.ts` via a `messageMetadataTests({ makeCodec,
encode, decode })` function — the TS analogue of Rails' `include
MessageMetadataTests` plus the class-private `make_codec` / `encode` / `decode`
hooks.

Newly covered, with Rails' names verbatim: `message expires with :expires_at`,
`:expires_at overrides :expires_in`, `messages do not expire by default`,
`metadata works with NullSerializer`, `messages with non-string purpose are
readable`, `messages are readable regardless of
use_message_serializer_for_metadata`. `message :purpose must match specified
:purpose`, `message expires with :expires_in` and `expiration works with
ActiveSupport.use_standard_json_time_format = false` move out of the two test
files into the shared module, so both codecs now run them.

`each_scenario` also iterates Rails' `DATA` (string / hash / array) instead of a
single fixed hash.

Cases that cannot run state why at the call site:

- `:purpose can be a symbol` — JS has no Ruby symbol, and `String(Symbol("x"))`
  is `"Symbol(x)"`, so there is no string-interchangeable analogue.
- Rails' `DATA` `Time` entries and the `ActiveSupport::MessagePack` serializer
  stay excluded pending the MessagePack temporal packer follow-up story.

`pnpm test:compare --package activesupport`: `messages/message_verifier_metadata_test.rb`
is 6/6 ✓ with zero TS-only extras; overall non-negative (this removes extras,
adds no unmatched tests).

Closes-story: activesupport-message-metadata-shared-suite
