### PR TITLE
refactor(api-compare): scope option-key and literal per-file maps to the package

### DIFF
--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1387,12 +1387,14 @@ export function main() {
     // Same signatures, but ONLY from this package — no dep packages. Feeds the
     // calls-parity ported-with-args gate; see resolvePortedWithArgsSigs.
     const tsParamsByNameInPkg = new Map<string, ParamInfo[][]>();
-    // Per-(file, name) counterpart. Separate from tsParamsByFileName, which
-    // also holds dep-package files: relative paths collide across packages
-    // (`attribute-methods.ts` exists in both activemodel and activerecord), so
-    // a same-file lookup there would still let a dep signature open the gate.
+    // Per-(file, name) counterpart, package-only: relative paths collide across
+    // packages (`attribute-methods.ts` exists in both activemodel and
+    // activerecord), so a same-file map that also held dep-package files would
+    // still let a dep signature open the gate. Feeds the ported-with-args gate
+    // and the literal-default check.
     const tsParamsByFileNameInPkg = new Map<string, Map<string, ParamInfo[][]>>();
-    // Per-(file, name) resolved options-object keys (null = uncheckable).
+    // Per-(file, name) resolved options-object keys (null = uncheckable),
+    // package-only for the same collision reason as tsParamsByFileNameInPkg.
     // Scoped per-FILE — unlike arity's global pool — so a sibling adapter's
     // same-named method (e.g. PostgreSQL `createDatabase`) can't lend its keys
     // to a different adapter's Ruby method and manufacture a cross-adapter
@@ -1401,8 +1403,6 @@ export function main() {
     // against the file the method actually MATCHED in (the real-type file for
     // include-chain matches), where the union within that file still applies.
     const tsOptionKeysByFileName = new Map<string, Map<string, (string[] | null)[]>>();
-    // Literal-default candidates scoped per (file, name) — unlike arity's global pool.
-    const tsParamsByFileName = new Map<string, Map<string, ParamInfo[][]>>();
     // Body call-sets scoped per (file, name) for the advisory calls-parity check.
     const tsCallsByFileName = new Map<string, Map<string, string[][]>>();
     const tsMissingCallTagsByFileName = new Map<string, Map<string, Set<string>>>();
@@ -1459,14 +1459,11 @@ export function main() {
         const pkgByName = tsParamsByFileNameInPkg.get(file) ?? new Map<string, ParamInfo[][]>();
         pkgByName.set(m.name, [...(pkgByName.get(m.name) ?? []), m.params]);
         tsParamsByFileNameInPkg.set(file, pkgByName);
-      }
-      const byName = tsParamsByFileName.get(file) ?? new Map<string, ParamInfo[][]>();
-      byName.set(m.name, [...(byName.get(m.name) ?? []), m.params]);
-      tsParamsByFileName.set(file, byName);
-      if (m.optionKeys !== undefined) {
-        const byName = tsOptionKeysByFileName.get(file) ?? new Map<string, (string[] | null)[]>();
-        byName.set(m.name, [...(byName.get(m.name) ?? []), m.optionKeys]);
-        tsOptionKeysByFileName.set(file, byName);
+        if (m.optionKeys !== undefined) {
+          const byName = tsOptionKeysByFileName.get(file) ?? new Map<string, (string[] | null)[]>();
+          byName.set(m.name, [...(byName.get(m.name) ?? []), m.optionKeys]);
+          tsOptionKeysByFileName.set(file, byName);
+        }
       }
       if (m.missingRailsCalls !== undefined) {
         const byName = tsMissingCallTagsByFileName.get(file) ?? new Map<string, Set<string>>();
@@ -1891,7 +1888,7 @@ export function main() {
       const checkLiterals = (rubyName: string, tsName: string, tsFile: string) => {
         const rubyParams = rubyParamsByName.get(rubyName);
         if (!rubyParams) return;
-        const candidates = tsParamsByFileName.get(tsFile)?.get(tsName) ?? [];
+        const candidates = tsParamsByFileNameInPkg.get(tsFile)?.get(tsName) ?? [];
         if (candidates.length === 0) return;
         const res = compareDefaults(rubyParams, candidates);
         literalsCompared += res.compared;


### PR DESCRIPTION
The per-file maps behind the advisory option-key and literal-default checks (`tsOptionKeysByFileName`, `tsParamsByFileName`) were populated for this package **and** its dep packages. Their keys are package-RELATIVE paths, which collide across packages (`attribute-methods.ts` exists in both activemodel and activerecord, `schema-statements.ts` in several adapters), so a same-file lookup could return a dep package's signatures — defeating the per-FILE scoping those checks deliberately rely on, in exactly the way their comments warn about.

PR #5855 already fixed this for the calls-parity ported-with-args gate via `tsParamsByFileNameInPkg`. This applies the same scoping to the two remaining consumers:

- `checkLiterals` now resolves against `tsParamsByFileNameInPkg`; `tsParamsByFileName` was then byte-for-byte redundant and is deleted.
- Option keys are recorded only under the `package` scope in `recordTsParams`.
- Both comments now state that the scoping is package-only and why.

## Delta (full `API_COMPARE_FORCE=1 pnpm api:compare`, after `pnpm build`)

- Option keys: 97 pairs compared, 15 likely-real, 62 differ — **unchanged**.
- Literals: 581 compared, 0 differ — **unchanged**; `skipped` 62 → 60 (two dep-package candidate sets no longer leak in).
- No committed baselines move (`scripts/api-compare/output/` is gitignored); working tree is clean apart from `compare.ts`.

`scripts/api-compare/compare.test.ts` passes (124 tests).

Closes-story: scope-per-file-option-key-and-literal-maps-to-package