### PR TITLE
refactor(api-compare): reject the narrow seed reason in justifies() too

### DIFF
--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -7,6 +7,7 @@ import {
   renderJsdoc,
   buildExpectations,
 } from "./build.js";
+import { NARROW_DEFAULT_REASON } from "./missing-rails-call-tags.js";
 
 const reasonFor = () => DEFAULT_TAG_REASON;
 
@@ -316,6 +317,19 @@ describe("buildExpectations", () => {
     const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => DEFAULT_TAG_REASON);
     expect(tagged).toEqual([]);
+  });
+
+  it("mints no tag for a narrow-seeded row either, matching the wide policy", () => {
+    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const { text, tagged, skipped } = reconcileFileText(
+      "foo.ts",
+      FILE,
+      expectations,
+      () => NARROW_DEFAULT_REASON,
+    );
+    expect(tagged).toEqual([]);
+    expect(skipped).toEqual(["save"]);
+    expect(text ?? FILE).not.toContain("RFC 0044");
   });
 
   it("records every Ruby name that lands on one TS method", () => {

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -329,7 +329,7 @@ describe("buildExpectations", () => {
     );
     expect(tagged).toEqual([]);
     expect(skipped).toEqual(["save"]);
-    expect(text ?? FILE).not.toContain("RFC 0044");
+    expect(text ?? "").not.toContain(NARROW_DEFAULT_REASON);
   });
 
   it("records every Ruby name that lands on one TS method", () => {

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -46,6 +46,7 @@ import {
 import { loadSplitBaseline, writeSplitBaseline } from "./lint-call-mismatches-wide.js";
 import {
   DEFAULT_REASON,
+  NARROW_DEFAULT_REASON,
   TAG,
   type TagEntry,
   justifies,
@@ -64,7 +65,13 @@ export type { JsdocOrigin, TagEntry } from "./missing-rails-call-tags.js";
 export const DEFAULT_TAG_REASON = DEFAULT_REASON;
 // Reasons treated as placeholders: dropping them on convergence needs no
 // harvest report.
-const PLACEHOLDER_REASONS = new Set([DEFAULT_TAG_REASON, "unported (api:build stub)"]);
+const PLACEHOLDER_REASONS = new Set([
+  DEFAULT_TAG_REASON,
+  // The narrow baseline's seed: a tag can only ever have carried it by being
+  // minted from a narrow row's prose, and it justifies nothing either.
+  NARROW_DEFAULT_REASON,
+  "unported (api:build stub)",
+]);
 
 export interface ArtifactMismatch {
   package: string;

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -67,8 +67,6 @@ export const DEFAULT_TAG_REASON = DEFAULT_REASON;
 // harvest report.
 const PLACEHOLDER_REASONS = new Set([
   DEFAULT_TAG_REASON,
-  // The narrow baseline's seed: a tag can only ever have carried it by being
-  // minted from a narrow row's prose, and it justifies nothing either.
   NARROW_DEFAULT_REASON,
   "unported (api:build stub)",
 ]);

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -65,6 +65,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, PACKAGES, ROOT_DIR } from "./config.js";
 import { reportNonCanonicalBaselines, serializeBaseline } from "./baseline-json.js";
+import { NARROW_DEFAULT_REASON } from "./missing-rails-call-tags.js";
 
 const BASELINE_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -77,9 +78,9 @@ const BASELINE_PATH = path.join(
 // that have no Rails public-contract obligation.
 const ARTIFACT_PATH = path.join(OUTPUT_DIR, "call-mismatches.json");
 
-const DEFAULT_REASON =
-  "Baseline (RFC 0044): pre-existing call-set flag inherited when the ratchet " +
-  "landed; pending per-cluster burndown review.";
+// Defined in missing-rails-call-tags.ts so `justifies()` can reject this seed
+// the way it rejects the wide one (RFC 0083).
+const DEFAULT_REASON = NARROW_DEFAULT_REASON;
 
 // One flagged Ruby body call on a matched pair. The artifact groups several
 // `missing` calls under one (package, rubyName, tsFile) record; the baseline is

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -65,7 +65,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, PACKAGES, ROOT_DIR } from "./config.js";
 import { reportNonCanonicalBaselines, serializeBaseline } from "./baseline-json.js";
-import { NARROW_DEFAULT_REASON } from "./missing-rails-call-tags.js";
+import { NARROW_DEFAULT_REASON as DEFAULT_REASON } from "./missing-rails-call-tags.js";
 
 const BASELINE_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -77,10 +77,6 @@ const BASELINE_PATH = path.join(
 // the compare tooling, and gating them would ratchet internal-method bodies
 // that have no Rails public-contract obligation.
 const ARTIFACT_PATH = path.join(OUTPUT_DIR, "call-mismatches.json");
-
-// Defined in missing-rails-call-tags.ts so `justifies()` can reject this seed
-// the way it rejects the wide one (RFC 0083).
-const DEFAULT_REASON = NARROW_DEFAULT_REASON;
 
 // One flagged Ruby body call on a matched pair. The artifact groups several
 // `missing` calls under one (package, rubyName, tsFile) record; the baseline is

--- a/scripts/api-compare/missing-rails-call-tags.test.ts
+++ b/scripts/api-compare/missing-rails-call-tags.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { DEFAULT_REASON, suppressedCallsIn } from "./missing-rails-call-tags.js";
+import {
+  DEFAULT_REASON,
+  NARROW_DEFAULT_REASON,
+  suppressedCallsIn,
+} from "./missing-rails-call-tags.js";
 import { reconcileFileText } from "./build.js";
 
 const block = (...lines: string[]): string =>
@@ -85,6 +89,12 @@ describe("suppressedCallsIn", () => {
     expect(suppressedCallsIn(block(`@missingRailsCall synchronize — ${DEFAULT_REASON}`))).toEqual(
       [],
     );
+  });
+
+  it("does not treat the narrow baseline's seeded placeholder as a justification", () => {
+    expect(
+      suppressedCallsIn(block(`@missingRailsCall synchronize — ${NARROW_DEFAULT_REASON}`)),
+    ).toEqual([]);
   });
 
   it("treats the placeholder as unjustified even when api:build wrapped it", () => {

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -32,6 +32,18 @@ export const DEFAULT_REASON =
   "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; " +
   "bucket (b) equivalent or (c) noise pending per-cluster burndown review.";
 
+/**
+ * The narrow baseline's seeded `reason` — the RFC 0044 seed prose, stamped by
+ * `reseed()` in lint-call-mismatches.ts on a newly-flagged narrow call. It
+ * lives here, beside {@link DEFAULT_REASON}, so ONE predicate knows both seeds:
+ * a tag carrying it stands in for a reason exactly as the wide seed does, and
+ * `justifies()` rejecting only the wide one would let a narrow-seeded row
+ * suppress its wide flag — blessing a row nobody reviewed.
+ */
+export const NARROW_DEFAULT_REASON =
+  "Baseline (RFC 0044): pre-existing call-set flag inherited when the ratchet " +
+  "landed; pending per-cluster burndown review.";
+
 /** One parsed `@missingRailsCall` tag: the Ruby call name plus its raw lines
  *  (kept verbatim for idempotency) and the flattened reason text. */
 export interface TagEntry {
@@ -157,11 +169,13 @@ export function parseJsdoc(
 }
 
 /** True when a tag's reason argues the deviation, rather than standing in for
- *  one: real per-entry prose, not the {@link DEFAULT_REASON} seed. The single
- *  predicate behind both halves of the contract — a tag suppresses its flag if
- *  and only if its baseline row may be dropped. */
+ *  one: real per-entry prose, not the {@link DEFAULT_REASON} nor the
+ *  {@link NARROW_DEFAULT_REASON} seed. The single predicate behind both halves
+ *  of the contract — a tag suppresses its flag if and only if its baseline row
+ *  may be dropped — and it knows BOTH baselines' seeds, since a tag's prose is
+ *  migrated out of the narrow baseline as readily as the wide one. */
 export function justifies(reason: string): boolean {
-  return reason !== "" && reason !== DEFAULT_REASON;
+  return reason !== "" && reason !== DEFAULT_REASON && reason !== NARROW_DEFAULT_REASON;
 }
 
 /** The Ruby call names one JSDoc comment JUSTIFIES as deliberately not made,


### PR DESCRIPTION
`justifies()` rejected exactly one seed string — the wide baseline's RFC 0047
`DEFAULT_REASON`. The narrow baseline's own seed (RFC 0044, stamped by
`reseed()` in `lint-call-mismatches.ts`) was module-private, so a
`@missingRailsCall` tag carrying it WOULD have justified — suppressing a wide
flag with prose nobody wrote, and `api:build` would have minted such a tag and
migrated the row out of the baseline.

- `NARROW_DEFAULT_REASON` now lives in `missing-rails-call-tags.ts` beside the
  wide seed; `lint-call-mismatches.ts` re-uses it as its `DEFAULT_REASON`.
- `justifies()` rejects both seeds, so `api:build` mints no tag for a
  narrow-seeded row either (it falls through to `skipped`), matching the wide
  policy shipped in #5857. The narrow seed also joins `PLACEHOLDER_REASONS`, so
  dropping such a tag needs no harvest report.
- Unit coverage: narrow-seed case in `missing-rails-call-tags.test.ts` beside
  the wide one, plus a `reconcileFileText` case in `build.test.ts`.

Not currently live: no tag in the tree carries the narrow seed today, so
nothing was mis-suppressed — this closes the hole before `reseed()` stamps the
default on a newly-flagged narrow call.

## Gate: `api:calls:wide`

Measured before and after the change (full `pnpm build` first):

| | before | after |
| --- | --- | --- |
| wide flagged calls (artifact) | 1575 | 1575 |
| baselined entries / unreviewed | 2334 / 2159 | 2334 / 2159 |

Unmoved. (Both runs also report the same 5 pre-existing stale baseline rows in
`schema-statements.ts`, unrelated to this change.)

Closes-story: unify-narrow-and-wide-seed-reasons-in-justifies
