### PR TITLE
feat(api-compare): report dropped seeded wide baseline rows on reseed

### DIFF
--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -114,8 +114,11 @@ import {
   nextMark,
   renderExcess,
   droppedReviewed,
+  droppedSeeded,
   markSlack,
   renderDroppedReviewed,
+  renderDroppedSeeded,
+  DROPPED_SEEDED_KEYS_ARG,
   renderSlack,
   renderWriteSummary,
   unreviewedEntries,
@@ -445,7 +448,7 @@ async function readJsonIfPresent<T>(file: string): Promise<T | undefined> {
   }
 }
 
-async function main(write: boolean): Promise<number> {
+async function main(write: boolean, showSeededKeys = false): Promise<number> {
   const baseline = await loadBaseline();
   const artifact = await loadArtifact();
   const current = flattenArtifact(artifact);
@@ -491,6 +494,11 @@ async function main(write: boolean): Promise<number> {
     console.log(renderWriteSummary(count, newly, mark, path.relative(ROOT_DIR, MARK_PATH)));
     const dropped = renderDroppedReviewed(droppedReviewed(next, baseline, DEFAULT_REASON));
     if (dropped) console.log(dropped);
+    const seeded = renderDroppedSeeded(
+      droppedSeeded(next, baseline, DEFAULT_REASON),
+      showSeededKeys,
+    );
+    if (seeded) console.log(seeded);
     return 0;
   }
 
@@ -618,7 +626,7 @@ async function runAsScript(): Promise<void> {
         process.exit(2);
       }
     }
-    process.exit(await main(argv.includes("--write")));
+    process.exit(await main(argv.includes("--write"), argv.includes(DROPPED_SEEDED_KEYS_ARG)));
   }
   let top: number;
   try {

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -84,7 +84,10 @@
  *
  * `--write` regenerates the baseline from the current wide artifact, preserving
  * the `reason` of entries that still flag and dropping stale rows, then
- * repartitions it across the split files (adding/removing files as needed).
+ * repartitions it across the split files (adding/removing files as needed). It
+ * reports the rows it dropped so the author can tell a converged port from a
+ * widened resolution gate: reviewed rows are listed individually, seeded rows
+ * are counted, and `--show-dropped-seeded` lists the seeded keys too.
  *
  * Hard rules: no node:* imports, no process.* in the library surface (the CLI
  * entry guard is the sole exception, matching lint-call-mismatches.ts), async fs.
@@ -448,7 +451,7 @@ async function readJsonIfPresent<T>(file: string): Promise<T | undefined> {
   }
 }
 
-async function main(write: boolean, showSeededKeys = false): Promise<number> {
+async function main(write: boolean, showSeededKeys: boolean): Promise<number> {
   const baseline = await loadBaseline();
   const artifact = await loadArtifact();
   const current = flattenArtifact(artifact);

--- a/scripts/api-compare/unreviewed-ratchet.test.ts
+++ b/scripts/api-compare/unreviewed-ratchet.test.ts
@@ -5,6 +5,9 @@ import * as path from "path";
 import type { ExcludeEntry } from "./lint-call-mismatches.js";
 import {
   droppedReviewed,
+  droppedSeeded,
+  renderDroppedSeeded,
+  DROPPED_SEEDED_KEYS_ARG,
   loadMark,
   newlySeeded,
   renderDroppedReviewed,
@@ -170,6 +173,38 @@ describe("droppedReviewed", () => {
   it("names each dropped reviewed row so the author can spot-check it", () => {
     const msg = renderDroppedReviewed([entry("a", "verified: real divergence")]);
     expect(msg).toContain("1 reviewed entr(ies)");
+    expect(msg).toContain("activerecord  relation.ts  load  a");
+  });
+});
+
+describe("droppedSeeded", () => {
+  it("reports a seeded row that stopped flagging", () => {
+    const prior = [entry("a"), entry("b")];
+    expect(droppedSeeded([entry("b")], prior, SEED).map((e) => e.call)).toEqual(["a"]);
+  });
+
+  it("leaves dropped hand-reviewed rows to droppedReviewed", () => {
+    expect(droppedSeeded([], [entry("a", "verified: real divergence")], SEED)).toEqual([]);
+  });
+
+  it("ignores seeded rows that still flag", () => {
+    expect(droppedSeeded([entry("a")], [entry("a")], SEED)).toEqual([]);
+  });
+
+  it("says nothing when no seeded row was dropped", () => {
+    expect(renderDroppedSeeded([], true)).toBe("");
+  });
+
+  it("reports a count and points at the flag when keys are not requested", () => {
+    const msg = renderDroppedSeeded([entry("a"), entry("b")], false);
+    expect(msg).toContain("2 seeded entr(ies)");
+    expect(msg).toContain(DROPPED_SEEDED_KEYS_ARG);
+    expect(msg).not.toContain("relation.ts");
+  });
+
+  it("names each dropped seeded row when the keys are requested", () => {
+    const msg = renderDroppedSeeded([entry("a")], true);
+    expect(msg).toContain("1 seeded entr(ies)");
     expect(msg).toContain("activerecord  relation.ts  load  a");
   });
 });

--- a/scripts/api-compare/unreviewed-ratchet.ts
+++ b/scripts/api-compare/unreviewed-ratchet.ts
@@ -91,6 +91,42 @@ export function renderDroppedReviewed(dropped: ExcludeEntry[]): string {
   ].join("\n");
 }
 
+/**
+ * Baseline rows this reseed dropped that still carried the seed reason. These
+ * are the same two-cause ambiguity as {@link droppedReviewed} — converged port
+ * vs. widened gate — but nobody ever wrote prose for them, so listing every key
+ * would bury the reviewed listing (seeded rows are the overwhelming majority of
+ * the baseline). They are reported as a COUNT by default, with the keys behind
+ * a flag: a widened gate that silently clears hundreds of rows shows up as a
+ * number nobody expected, which is the signal that was missing in PR #5869.
+ */
+export function droppedSeeded(
+  next: ExcludeEntry[],
+  prior: ExcludeEntry[],
+  defaultReason: string,
+): ExcludeEntry[] {
+  const kept = new Set(next.map(keyOf));
+  return unreviewedEntries(prior, defaultReason).filter((e) => !kept.has(keyOf(e)));
+}
+
+export const DROPPED_SEEDED_KEYS_ARG = "--show-dropped-seeded";
+
+export function renderDroppedSeeded(dropped: ExcludeEntry[], showKeys: boolean): string {
+  if (dropped.length === 0) return "";
+  const lines = [
+    ``,
+    `${dropped.length} seeded entr(ies) (reason never reviewed) no longer flag and were dropped.`,
+    `A widened resolution gate clears rows exactly like a converged port does; if that count is ` +
+      `larger than the change you made, it is the gate, not the port.`,
+  ];
+  if (showKeys) {
+    lines.push(...dropped.map((e) => `  · ${e.package}  ${e.tsFile}  ${e.rubyName}  ${e.call}`));
+  } else {
+    lines.push(`  Re-run with \`${DROPPED_SEEDED_KEYS_ARG}\` to list the keys.`);
+  }
+  return lines.join("\n");
+}
+
 export function parseMark(text: string): number {
   const parsed = JSON.parse(text) as unknown;
   const max = (parsed as UnreviewedMark | null)?.max;

--- a/scripts/api-compare/unreviewed-ratchet.ts
+++ b/scripts/api-compare/unreviewed-ratchet.ts
@@ -120,7 +120,7 @@ export function renderDroppedSeeded(dropped: ExcludeEntry[], showKeys: boolean):
       `larger than the change you made, it is the gate, not the port.`,
   ];
   if (showKeys) {
-    lines.push(...dropped.map((e) => `  · ${e.package}  ${e.tsFile}  ${e.rubyName}  ${e.call}`));
+    lines.push(...dropped.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.rubyName}  ${e.call}`));
   } else {
     lines.push(`  Re-run with \`${DROPPED_SEEDED_KEYS_ARG}\` to list the keys.`);
   }


### PR DESCRIPTION
`renderDroppedReviewed` only lists dropped baseline rows carrying a hand-written
reason, so rows still on `DEFAULT_REASON` — the overwhelming majority of the
wide baseline — vanish on a reseed with no signal at all. That is how five
seeded `schema-statements.json` rows disappeared in #5869 without anyone
establishing whether the port converged or a resolution gate widened.

This adds `droppedSeeded` / `renderDroppedSeeded`: a reseed now prints a COUNT
of dropped seeded rows, with the keys behind `--show-dropped-seeded` (listing
thousands of keys by default would bury the reviewed listing, which stays
exactly as-is — it is the louder signal).

Closes-story: report-dropped-seeded-wide-rows
