### PR TITLE
refactor(api-compare): drop the getAllTsFiles pass-through wrapper

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -17,13 +17,13 @@ import {
   extractFileConstants,
   extractFileLocalHelpers,
   extractFromProgram,
-  getAllTsFiles,
   harvestObjectLiteralMethods,
   packageFingerprint,
   tsLiteralValue,
 } from "./extract-ts-api.js";
 import { collectTsFileNames } from "./extra-surface.js";
 import { overlappingSubDirs, packageSrcDir } from "./config.js";
+import { COMPARED_TS_FILES, walkTsFilesSync } from "./ts-file-walk.js";
 import type { ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 
 const VIRTUAL = "virtual.ts";
@@ -2044,8 +2044,10 @@ describe("sub-package de-overlap", () => {
 
   it("omits an excluded subdir from the walked file list", () => {
     const { srcDir, subDir } = fixture();
-    expect(getAllTsFiles(srcDir)).toContain(path.join(subDir, "helper.ts"));
-    expect(getAllTsFiles(srcDir, [subDir])).toEqual([path.join(srcDir, "parent.ts")]);
+    expect(walkTsFilesSync(srcDir, COMPARED_TS_FILES)).toContain(path.join(subDir, "helper.ts"));
+    expect(walkTsFilesSync(srcDir, COMPARED_TS_FILES, [subDir])).toEqual([
+      path.join(srcDir, "parent.ts"),
+    ]);
   });
 
   it("omits an excluded subdir's classes even when the parent imports them", () => {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -259,7 +259,7 @@ export async function main() {
 
   for (const pkg of PACKAGES) {
     const pkgDir = packageSrcDir(pkg);
-    const files = getAllTsFiles(pkgDir, overlappingSubDirs(pkg));
+    const files = walkTsFilesSync(pkgDir, COMPARED_TS_FILES, overlappingSubDirs(pkg));
     const dirName = PACKAGE_DIR_OVERRIDES[pkg] ?? pkg;
     const pkgRoot = path.join(ROOT_DIR, "packages", dirName);
     const tsConfigPath = path.join(pkgRoot, "tsconfig.json");
@@ -410,7 +410,7 @@ interface PendingReExport {
 
 function extractPackage(pkgName: string, srcDir: string): WorkerOutput {
   const subPackageDirs = overlappingSubDirs(pkgName);
-  const files = getAllTsFiles(srcDir, subPackageDirs);
+  const files = walkTsFilesSync(srcDir, COMPARED_TS_FILES, subPackageDirs);
 
   // Create a TypeScript program
   const dirName = PACKAGE_DIR_OVERRIDES[pkgName] ?? pkgName;
@@ -2694,11 +2694,6 @@ function memberVisibility(member: ts.ClassElement): "public" | "private" | "prot
 
 function isExported(node: ts.Node): boolean {
   return hasModifier(node, ts.SyntaxKind.ExportKeyword);
-}
-
-/** The compared population: what api-compare measures against Rails. */
-export function getAllTsFiles(dir: string, excludeDirs: readonly string[] = []): string[] {
-  return walkTsFilesSync(dir, COMPARED_TS_FILES, excludeDirs);
 }
 
 // Run main() only on the main thread when invoked as a script.


### PR DESCRIPTION
`getAllTsFiles` in `extract-ts-api.ts` was a pass-through to
`walkTsFilesSync(dir, COMPARED_TS_FILES, excludeDirs)` left behind by #5679.
Removed it; both in-file callers now call `walkTsFilesSync` directly so the
population is named at every call site. The two test assertions moved onto
`walkTsFilesSync` in place.

Pure rename-through: `api:compare` / `api:extra` report identical counts
(no manifest churn).

Closes-story: retire-getalltsfiles-passthrough-wrapper
