### PR TITLE
refactor(activerecord): type SchemaCache#indexes as IndexDefinitionRow rows

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -13,6 +13,7 @@ import { Column as MysqlColumn } from "./mysql/column.js";
 import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { poolAbsent } from "./abstract/connection-pool.js";
+import type { IndexDefinitionRow } from "./abstract/schema-definitions.js";
 
 // ---------------------------------------------------------------------------
 // Helper: run callback inside pool.withConnection if available
@@ -74,7 +75,7 @@ export class SchemaCache {
   private _columnsHash = new Map<string, Record<string, Column>>();
   private _primaryKeys = new Map<string, string | string[] | null>();
   private _dataSourceExists = new Map<string, boolean>();
-  private _indexes = new Map<string, unknown[]>();
+  private _indexes = new Map<string, IndexDefinitionRow[]>();
   private _version: string | number | null = null;
   // When non-null, records the name of every table passed to
   // `clearDataSourceCacheBang` — i.e. every table touched by DDL
@@ -163,9 +164,11 @@ export class SchemaCache {
     }
 
     if (coder["indexes"] instanceof Map) {
-      this._indexes = coder["indexes"] as Map<string, unknown[]>;
+      this._indexes = coder["indexes"] as Map<string, IndexDefinitionRow[]>;
     } else if (coder["indexes"] && typeof coder["indexes"] === "object") {
-      this._indexes = new Map(Object.entries(coder["indexes"] as Record<string, unknown[]>));
+      this._indexes = new Map(
+        Object.entries(coder["indexes"] as Record<string, IndexDefinitionRow[]>),
+      );
     }
 
     this._version = (coder["version"] as string | number) ?? null;
@@ -374,7 +377,7 @@ export class SchemaCache {
     return pkCols.length === 1 ? pkCols[0] : pkCols;
   }
 
-  async indexes(pool: unknown, tableName: string): Promise<unknown[]> {
+  async indexes(pool: unknown, tableName: string): Promise<IndexDefinitionRow[]> {
     if (this._indexes.has(tableName)) {
       return this._indexes.get(tableName)!;
     }
@@ -638,7 +641,9 @@ export class SchemaCache {
     this._dataSourceExists = new Map(
       Object.entries((dataSources as Record<string, boolean>) ?? {}),
     );
-    this._indexes = new Map(Object.entries((indexes as Record<string, unknown[]>) ?? {}));
+    this._indexes = new Map(
+      Object.entries((indexes as Record<string, IndexDefinitionRow[]>) ?? {}),
+    );
 
     this.deriveColumnsHashAndDeduplicateValues();
   }
@@ -851,7 +856,7 @@ export class SchemaReflection {
     return this._cache?.isColumnsHash(pool, tableName) ?? false;
   }
 
-  async indexes(pool: unknown, tableName: string): Promise<unknown[]> {
+  async indexes(pool: unknown, tableName: string): Promise<IndexDefinitionRow[]> {
     return (await this.cache(pool)).indexes(pool, tableName);
   }
 
@@ -1038,7 +1043,7 @@ export class BoundSchemaReflection {
     return this._schemaReflection.isColumnsHash(this._pool, tableName);
   }
 
-  async indexes(tableName: string): Promise<unknown[]> {
+  async indexes(tableName: string): Promise<IndexDefinitionRow[]> {
     return this._schemaReflection.indexes(this._pool, tableName);
   }
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -25,6 +25,7 @@ import type {
   SchemaDumperMixinHost,
   Column,
 } from "./connection-adapters/abstract/schema-dumper.js";
+import type { IndexDefinitionRow } from "./connection-adapters/abstract/schema-definitions.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
@@ -90,19 +91,19 @@ export interface ColumnInfo {
   extra?: string | null;
 }
 
-export interface IndexInfo {
-  // A string for expression indexes (the raw expression), an array of column
-  // names otherwise — mirrors Rails' IndexDefinition#columns.
-  columns: string | string[];
-  unique: boolean;
+/**
+ * The dumper's view of an adapter index row: the adapter shape
+ * (`IndexDefinitionRow`) plus the dialect-specific options the dumper emits.
+ * `name` is widened to optional because `SchemaSource` implementations that
+ * aren't adapters (e.g. a dump being re-read) may not carry one, and
+ * `indexParts` already treats it as absent-able.
+ */
+export interface IndexInfo extends Omit<IndexDefinitionRow, "name"> {
   name?: string;
   /** Per-column max lengths (number for single-column, Record for multi). */
   lengths?: number | Record<string, number>;
-  /** Per-column sort order (e.g. "asc"/"desc"). */
-  orders?: string | Record<string, string>;
   /** Per-column operator class (Postgres). */
   opclasses?: string | Record<string, string>;
-  where?: string;
   using?: string;
   /** MySQL index access method (`"fulltext"` / `"spatial"`). */
   type?: string;


### PR DESCRIPTION
Types `SchemaCache#indexes` (and the `SchemaReflection` / `BoundSchemaReflection`
delegates, plus the backing `_indexes` map and its serialize/deserialize paths)
as `IndexDefinitionRow[]` instead of `unknown[]`, matching what every adapter's
`indexes()` already returns after #5858. Rails' `SchemaCache#indexes` returns the
adapter's `IndexDefinition` rows unchanged.

The dumper's `IndexInfo` now derives from `IndexDefinitionRow` (adding the
dialect-specific options the dumper emits: lengths/opclasses/using/type/
include/comment/nullsNotDistinct). Its one divergence — `name` widened to
optional — is justified in the doc comment at the declaration.

`pnpm typecheck` is clean; `packages/trailties/src/commands/db.test.ts` (incl.
`db schema:cache:dump`) and `schema-cache.test.ts` pass.

Closes-story: schema-cache-indexes-drop-unknown-return-type
