### PR TITLE
ci(api-compare): open a maintenance PR when the main wide reseed drifts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1403,6 +1403,14 @@ jobs:
       needs.changes.outputs.comparison_affected == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      # contents: write and pull-requests: write for the main-only wide
+      # ratchet reseed step, which pushes the reseed to a maintenance branch
+      # and opens/updates its PR. Declaring `permissions:` zeroes every
+      # unlisted scope, so contents must be listed even though it is part of
+      # the default token.
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-pnpm
@@ -1505,7 +1513,14 @@ jobs:
           echo "::error title=Wide ratchet baseline drift::${{ github.sha }} left the committed wide call-mismatch baseline out of sync with a clean reseed. Run \`pnpm api:calls:wide:reseed\` and commit the result."
           git --no-pager diff --stat -- "$baseline" "$mark"
           git --no-pager diff -- "$baseline" "$mark"
+          # Publish the reseed as a single rolling maintenance PR so `main`
+          # gets fixed without waiting on a human noticing the red run. The
+          # step still fails afterwards: the PR is the remedy, the failure is
+          # the signal, and a missed PR must not silently swallow the drift.
+          bash scripts/ci/open-wide-baseline-pr.sh
           exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Wide call-mismatches ratchet
         # Gates the RFC 0047 wide artifact against the split call-mismatches-wide-exclude/ baseline dir.
         # Fails on a new wide mismatch, a stale baseline entry, or more

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1513,10 +1513,10 @@ jobs:
           echo "::error title=Wide ratchet baseline drift::${{ github.sha }} left the committed wide call-mismatch baseline out of sync with a clean reseed. Run \`pnpm api:calls:wide:reseed\` and commit the result."
           git --no-pager diff --stat -- "$baseline" "$mark"
           git --no-pager diff -- "$baseline" "$mark"
-          # Publish the reseed as a single rolling maintenance PR so `main`
+          # Publishes the reseed as a single rolling maintenance PR so `main`
           # gets fixed without waiting on a human noticing the red run. The
-          # step still fails afterwards: the PR is the remedy, the failure is
-          # the signal, and a missed PR must not silently swallow the drift.
+          # step still fails afterwards: the PR is the remedy, the red run is
+          # the signal, and a missed PR must not swallow the drift.
           bash scripts/ci/open-wide-baseline-pr.sh
           exit 1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1520,7 +1520,13 @@ jobs:
           bash scripts/ci/open-wide-baseline-pr.sh
           exit 1
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer MAINTENANCE_PR_TOKEN (PAT or GitHub App installation token)
+          # when configured: GitHub does not trigger workflow runs from events
+          # authored by GITHUB_TOKEN, so on the fallback the maintenance PR
+          # opens with no checks and needs a close/reopen before it can merge.
+          # The script says so in the PR body when it lands on the fallback.
+          GH_TOKEN: ${{ secrets.MAINTENANCE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          MAINTENANCE_PR_TOKEN_SET: ${{ secrets.MAINTENANCE_PR_TOKEN != '' }}
       - name: Wide call-mismatches ratchet
         # Gates the RFC 0047 wide artifact against the split call-mismatches-wide-exclude/ baseline dir.
         # Fails on a new wide mismatch, a stale baseline entry, or more

--- a/scripts/ci/open-wide-baseline-pr.sh
+++ b/scripts/ci/open-wide-baseline-pr.sh
@@ -45,7 +45,14 @@ The \`Wide ratchet baseline reseed (main)\` step found the committed wide
 call-mismatch baseline out of sync with a clean reseed after ${sha}. This
 commit is that reseed, produced by \`pnpm api:calls:wide:reseed\`."
 
-git push --force origin "$BRANCH"
+# Push under the same token that will open the PR, not the checkout's
+# persisted credentials, so a configured MAINTENANCE_PR_TOKEN also owns the
+# push event and the branch's own workflow runs.
+remote="origin"
+if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+  remote="https://x-access-token:${GH_TOKEN:-$GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+fi
+git push --force "$remote" "HEAD:refs/heads/${BRANCH}"
 
 readonly TITLE="chore(api-compare): reseed the wide ratchet baseline (${shortSha})"
 body=$(
@@ -62,6 +69,20 @@ scratch on each drifting merge, so this PR always reflects the newest baseline
 — review the diff as it stands rather than commit by commit.
 EOF
 )
+
+# GitHub refuses to trigger workflows from events authored by GITHUB_TOKEN, so
+# on the fallback token this PR opens with no checks at all and cannot satisfy
+# required status checks. Say so in the body rather than leaving a maintainer
+# to work out why the checks list is empty.
+if [[ "${MAINTENANCE_PR_TOKEN_SET:-false}" != "true" ]]; then
+  body="${body}
+
+**CI will not start on its own here.** This PR was authored by
+\`GITHUB_TOKEN\`, and GitHub does not trigger workflow runs from events that
+token creates. Close and reopen the PR (or push any commit to the branch) to
+start the checks. Setting a \`MAINTENANCE_PR_TOKEN\` secret — a PAT or GitHub
+App token with contents+pull-requests write — removes this step."
+fi
 
 # A closed-but-unmerged PR still owns the branch and makes `gh pr create`
 # refuse to open a second one, so reopen that instead of failing. A MERGED one

--- a/scripts/ci/open-wide-baseline-pr.sh
+++ b/scripts/ci/open-wide-baseline-pr.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 # RFC 0083. Called by the `Wide ratchet baseline reseed (main)` step in ci.yml
-# once a reseed has already been written into the working tree and shown to
-# differ from the committed baseline.
+# once a reseed has been written into the working tree and shown to differ from
+# the committed baseline.
 #
 # Failing the step is only half the fix: until somebody hand-reseeds, every
 # branch cut from `main` inherits the wide-gate failure (#5869 paid for that
-# diagnosis). So carry the reseed onto a single, fixed maintenance branch and
-# open/refresh one PR for it. The branch is force-pushed to exactly one commit
-# on top of the drifting merge, so N consecutive drifting merges collapse into
-# one PR that always reflects the newest baseline rather than N stale ones.
+# diagnosis). So carry the reseed onto one fixed maintenance branch and
+# open/refresh a single PR for it.
 #
-# The caller still exits non-zero afterwards — the PR is the remedy, the red
-# run is the signal, and losing the signal to a PR nobody opens is the failure
-# mode this whole step exists to avoid.
+# The branch is force-pushed to exactly one commit on top of the drifting
+# merge — it is a rolling snapshot, not a history. N consecutive drifting
+# merges therefore collapse into one PR carrying the newest baseline, and two
+# generated files never have to be merged against each other. The PR is opened
+# ready rather than draft: it is mechanical, and a draft would sit unmergeable
+# while `main` stays stale. The caller still exits non-zero afterwards, so the
+# drift stays visible even if nobody looks at the PR.
+#
+# `pnpm install` earlier in the job has already run husky's `prepare`, so the
+# commit below neutralises core.hooksPath: a full lint-staged/tsc pre-commit
+# run over generated JSON would cost minutes and can only fail the publish.
 
 set -euo pipefail
 
@@ -24,27 +30,21 @@ sha="${GITHUB_SHA:-$(git rev-parse HEAD)}"
 shortSha="${sha:0:12}"
 
 if [[ -z "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
-  echo "::warning title=Wide baseline maintenance PR skipped::No GitHub token available; reseed was not published." >&2
+  echo "::warning title=Wide baseline maintenance PR skipped::No GitHub token available; the reseed for ${shortSha} was not published." >&2
   exit 0
 fi
 
-# The runner's checkout is detached at the merge SHA; commit the reseed on a
-# throwaway local ref so nothing depends on the checkout's branch state.
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 git checkout -B "$BRANCH" "$sha"
 git add -- "$BASELINE_DIR" "$UNREVIEWED"
-git commit --message "chore(api-compare): reseed the wide ratchet baseline for ${shortSha}
+git -c core.hooksPath=/dev/null commit --message "chore(api-compare): reseed the wide ratchet baseline for ${shortSha}
 
 The \`Wide ratchet baseline reseed (main)\` step found the committed wide
 call-mismatch baseline out of sync with a clean reseed after ${sha}. This
 commit is that reseed, produced by \`pnpm api:calls:wide:reseed\`."
 
-# Force — the branch is a rolling snapshot, not a history. If a previous
-# drifting merge left a commit here, its baseline is already superseded by
-# this one, and a merge/rebase would only manufacture conflicts between two
-# generated files.
 git push --force origin "$BRANCH"
 
 readonly TITLE="chore(api-compare): reseed the wide ratchet baseline (${shortSha})"
@@ -57,19 +57,30 @@ Merge commit \`${sha}\` left \`${BASELINE_DIR}/\` and \`${UNREVIEWED}\` out of
 sync with a clean reseed, so every branch cut from \`main\` afterwards inherits
 the wide call-mismatches ratchet failure. This PR carries the reseed.
 
-Regenerated locally with \`pnpm api:calls:wide:reseed\`. The branch is rebuilt
-from scratch on each drifting merge, so this PR always reflects the newest
-baseline — review the diff as it stands rather than commit by commit.
+Regenerated with \`pnpm api:calls:wide:reseed\`. The branch is rebuilt from
+scratch on each drifting merge, so this PR always reflects the newest baseline
+— review the diff as it stands rather than commit by commit.
 EOF
 )
 
-existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
-if [[ -n "$existing" ]]; then
-  gh pr edit "$existing" --title "$TITLE" --body "$body"
-  echo "::notice title=Wide baseline maintenance PR updated::#${existing} now carries the reseed for ${shortSha}."
-else
-  # Deliberately not a draft: this is mechanical, ready to merge, and a draft
-  # would sit unreviewable while `main` stays stale.
+# A closed-but-unmerged PR still owns the branch and makes `gh pr create`
+# refuse to open a second one, so reopen that instead of failing. A MERGED one
+# is spent — the branch has since been rebuilt from a later merge — so it takes
+# the create path like a fresh branch.
+existing=$(
+  gh pr list --head "$BRANCH" --state all --limit 1 \
+    --json number,state --jq '.[0] // empty | select(.state != "MERGED") | "\(.number) \(.state)"'
+)
+
+if [[ -z "$existing" ]]; then
   url=$(gh pr create --base main --head "$BRANCH" --title "$TITLE" --body "$body")
   echo "::notice title=Wide baseline maintenance PR opened::${url}"
+  exit 0
 fi
+
+read -r number state <<<"$existing"
+if [[ "$state" == "CLOSED" ]]; then
+  gh pr reopen "$number"
+fi
+gh pr edit "$number" --title "$TITLE" --body "$body"
+echo "::notice title=Wide baseline maintenance PR updated::#${number} now carries the reseed for ${shortSha}."

--- a/scripts/ci/open-wide-baseline-pr.sh
+++ b/scripts/ci/open-wide-baseline-pr.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# RFC 0083. Called by the `Wide ratchet baseline reseed (main)` step in ci.yml
+# once a reseed has already been written into the working tree and shown to
+# differ from the committed baseline.
+#
+# Failing the step is only half the fix: until somebody hand-reseeds, every
+# branch cut from `main` inherits the wide-gate failure (#5869 paid for that
+# diagnosis). So carry the reseed onto a single, fixed maintenance branch and
+# open/refresh one PR for it. The branch is force-pushed to exactly one commit
+# on top of the drifting merge, so N consecutive drifting merges collapse into
+# one PR that always reflects the newest baseline rather than N stale ones.
+#
+# The caller still exits non-zero afterwards — the PR is the remedy, the red
+# run is the signal, and losing the signal to a PR nobody opens is the failure
+# mode this whole step exists to avoid.
+
+set -euo pipefail
+
+readonly BRANCH="maintenance/wide-ratchet-baseline"
+readonly BASELINE_DIR="scripts/api-compare/call-mismatches-wide-exclude"
+readonly UNREVIEWED="scripts/api-compare/call-mismatches-wide-unreviewed.json"
+
+sha="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+shortSha="${sha:0:12}"
+
+if [[ -z "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
+  echo "::warning title=Wide baseline maintenance PR skipped::No GitHub token available; reseed was not published." >&2
+  exit 0
+fi
+
+# The runner's checkout is detached at the merge SHA; commit the reseed on a
+# throwaway local ref so nothing depends on the checkout's branch state.
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git checkout -B "$BRANCH" "$sha"
+git add -- "$BASELINE_DIR" "$UNREVIEWED"
+git commit --message "chore(api-compare): reseed the wide ratchet baseline for ${shortSha}
+
+The \`Wide ratchet baseline reseed (main)\` step found the committed wide
+call-mismatch baseline out of sync with a clean reseed after ${sha}. This
+commit is that reseed, produced by \`pnpm api:calls:wide:reseed\`."
+
+# Force — the branch is a rolling snapshot, not a history. If a previous
+# drifting merge left a commit here, its baseline is already superseded by
+# this one, and a merge/rebase would only manufacture conflicts between two
+# generated files.
+git push --force origin "$BRANCH"
+
+readonly TITLE="chore(api-compare): reseed the wide ratchet baseline (${shortSha})"
+body=$(
+  cat <<EOF
+Automated maintenance PR from the \`Wide ratchet baseline reseed (main)\` step
+(RFC 0083).
+
+Merge commit \`${sha}\` left \`${BASELINE_DIR}/\` and \`${UNREVIEWED}\` out of
+sync with a clean reseed, so every branch cut from \`main\` afterwards inherits
+the wide call-mismatches ratchet failure. This PR carries the reseed.
+
+Regenerated locally with \`pnpm api:calls:wide:reseed\`. The branch is rebuilt
+from scratch on each drifting merge, so this PR always reflects the newest
+baseline — review the diff as it stands rather than commit by commit.
+EOF
+)
+
+existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+if [[ -n "$existing" ]]; then
+  gh pr edit "$existing" --title "$TITLE" --body "$body"
+  echo "::notice title=Wide baseline maintenance PR updated::#${existing} now carries the reseed for ${shortSha}."
+else
+  # Deliberately not a draft: this is mechanical, ready to merge, and a draft
+  # would sit unreviewable while `main` stays stale.
+  url=$(gh pr create --base main --head "$BRANCH" --title "$TITLE" --body "$body")
+  echo "::notice title=Wide baseline maintenance PR opened::${url}"
+fi


### PR DESCRIPTION
RFC 0083. The `Wide ratchet baseline reseed (main)` step (added by #5874) only
fails on drift, so `main` stays stale until a human notices the red run and
every branch cut in the meantime inherits the wide-gate failure — the cost
#5869 paid.

This adds `scripts/ci/open-wide-baseline-pr.sh`, called by that step after it
prints the drift diff. It commits the already-written reseed onto a fixed
`maintenance/wide-ratchet-baseline` branch (force-pushed as a rolling one-commit
snapshot on top of the drifting merge), then opens or retitles a single PR
titled with the causing merge SHA. N consecutive drifting merges therefore
collapse into one open PR carrying the newest baseline, not N stale ones.

The step still `exit 1`s afterwards: the PR is the remedy, the red run is the
signal. Without a token the script warns and no-ops rather than failing twice.

The `rails-comparison` job gains `contents: write` / `pull-requests: write`
(and, since declaring `permissions:` zeroes unlisted scopes, nothing else).

Closes-story: open-maintenance-pr-for-wide-baseline-drift