### PR TITLE
fix(activerecord): guard PG advisory lock ids and route through queryValue

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1379,3 +1379,50 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
     expect(adapter.typeToSql("datetime")).toBe("timestamp");
   });
 });
+
+// Rails has no test for the `is_a?(Integer) && bit_length <= 63` guard in
+// postgresql_adapter.rb:459-471, so these are trails-only covers for it. The
+// session-identity half of advisory locks is pinned by
+// PostgresqlConnectionTest#"get and release advisory lock" in connection.test.ts:
+// pg_advisory_unlock only returns true on the session that took the lock.
+describe("PostgreSQLAdapter advisory lock id guard (unit)", () => {
+  const message = "PostgreSQL requires advisory lock ids to be a signed 64 bit integer";
+
+  function makeAdapter(): PostgreSQLAdapter {
+    return new PostgreSQLAdapter({ host: "stub", port: 0 });
+  }
+
+  it("getAdvisoryLock raises ArgumentError for a string lock id", async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.getAdvisoryLock("some-lock-name")).rejects.toThrow(message);
+  });
+
+  it("releaseAdvisoryLock raises ArgumentError for a string lock id", async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.releaseAdvisoryLock("some-lock-name")).rejects.toThrow(message);
+  });
+
+  it("raises ArgumentError for a fractional lock id", async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.getAdvisoryLock(1.5)).rejects.toThrow(message);
+  });
+
+  it("raises ArgumentError for a lock id wider than 63 bits", async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.getAdvisoryLock(2n ** 63n)).rejects.toThrow(message);
+    await expect(adapter.getAdvisoryLock(-(2n ** 63n) - 1n)).rejects.toThrow(message);
+  });
+
+  it("accepts the signed 64 bit boundaries and interpolates them into the SQL", async () => {
+    const adapter = makeAdapter();
+    const queryValue = vi.spyOn(adapter, "queryValue").mockResolvedValue(true);
+
+    expect(await adapter.getAdvisoryLock(2n ** 63n - 1n)).toBe(true);
+    expect(await adapter.releaseAdvisoryLock(-(2n ** 63n))).toBe(true);
+
+    expect(queryValue.mock.calls.map((c) => c[0])).toEqual([
+      "SELECT pg_try_advisory_lock(9223372036854775807)",
+      "SELECT pg_advisory_unlock(-9223372036854775808)",
+    ]);
+  });
+});

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1381,10 +1381,7 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
 });
 
 // Rails has no test for the `is_a?(Integer) && bit_length <= 63` guard in
-// postgresql_adapter.rb:459-471, so these are trails-only covers for it. The
-// session-identity half of advisory locks is pinned by
-// PostgresqlConnectionTest#"get and release advisory lock" in connection.test.ts:
-// pg_advisory_unlock only returns true on the session that took the lock.
+// postgresql_adapter.rb:459-471, so these are trails-only covers for it.
 describe("PostgreSQLAdapter advisory lock id guard (unit)", () => {
   const message = "PostgreSQL requires advisory lock ids to be a signed 64 bit integer";
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3431,12 +3431,6 @@ export class PostgreSQLAdapter
     return true;
   }
 
-  // Advisory locks are session-scoped — acquire and release must use the same
-  // connection. `queryValue` satisfies that here: it runs through
-  // `internalExecQuery` -> `withRawConnection`, and this adapter owns exactly
-  // one persistent pg.Client (`_acquireFreshClient` returns `_rawConnection`),
-  // so every statement lands on the session the caller holds. That is why the
-  // formerly pinned-client routing could be dropped for Rails' primitive.
   async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     _assertPgAdvisoryLockId(lockId);
     return (await this.queryValue(`SELECT pg_try_advisory_lock(${lockId})`)) === true;
@@ -5156,11 +5150,9 @@ export class MoneyDecoder {
 /**
  * Mirrors the `lock_id.is_a?(Integer) && lock_id.bit_length <= 63` guard shared
  * by PostgreSQLAdapter#get_advisory_lock / #release_advisory_lock
- * (postgresql_adapter.rb:459-471). Ruby's Integer covers both of JS' integral
- * numeric types, so `number` (integral only) and `bigint` pass; strings — which
- * trails used to hash through `hashtext()` — and fractional numbers raise, as
- * they do in Rails. `bit_length <= 63` is exactly the signed 64-bit range,
- * negatives included (`(-2**63).bit_length == 63`).
+ * (postgresql_adapter.rb:459-471). Ruby's Integer spans both integral JS
+ * numeric types, so `number` and `bigint` pass; `bit_length <= 63` is the
+ * signed 64-bit range, negatives included (`(-2**63).bit_length == 63`).
  */
 function _assertPgAdvisoryLockId(lockId: number | bigint | string): void {
   const isInteger = typeof lockId === "bigint" || Number.isInteger(lockId);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3431,23 +3431,20 @@ export class PostgreSQLAdapter
     return true;
   }
 
-  // Advisory locks are session-scoped — acquire and release must use the
-  // same connection. With the dual-pool collapse the adapter owns one
-  // persistent pg.Client, so the lock naturally lives on `_rawConnection`
-  // for its duration with no separate checkout.
+  // Advisory locks are session-scoped — acquire and release must use the same
+  // connection. `queryValue` satisfies that here: it runs through
+  // `internalExecQuery` -> `withRawConnection`, and this adapter owns exactly
+  // one persistent pg.Client (`_acquireFreshClient` returns `_rawConnection`),
+  // so every statement lands on the session the caller holds. That is why the
+  // formerly pinned-client routing could be dropped for Rails' primitive.
   async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
-    const client = await this._acquireFreshClient();
-    const [sql, param] = _pgAdvisoryLockSql("pg_try_advisory_lock", "locked", lockId);
-    const result = await this._serializePinnedQuery(client, () => client.query(sql, [param]));
-    return result.rows[0]?.locked === true;
+    _assertPgAdvisoryLockId(lockId);
+    return (await this.queryValue(`SELECT pg_try_advisory_lock(${lockId})`)) === true;
   }
 
   async releaseAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
-    if (!this._rawConnection) return false;
-    const client = await this._acquireFreshClient();
-    const [sql, param] = _pgAdvisoryLockSql("pg_advisory_unlock", "unlocked", lockId);
-    const result = await this._serializePinnedQuery(client, () => client.query(sql, [param]));
-    return result.rows[0]?.unlocked === true;
+    _assertPgAdvisoryLockId(lockId);
+    return (await this.queryValue(`SELECT pg_advisory_unlock(${lockId})`)) === true;
   }
 
   supportsExplain(): boolean {
@@ -5156,14 +5153,20 @@ export class MoneyDecoder {
   }
 }
 
-function _pgAdvisoryLockSql(
-  fn: string,
-  col: string,
-  lockId: number | bigint | string,
-): [string, unknown] {
-  if (typeof lockId === "bigint") return [`SELECT ${fn}($1::bigint) AS ${col}`, lockId.toString()];
-  if (typeof lockId === "number") return [`SELECT ${fn}($1) AS ${col}`, lockId];
-  return [`SELECT ${fn}(hashtext($1)) AS ${col}`, lockId];
+/**
+ * Mirrors the `lock_id.is_a?(Integer) && lock_id.bit_length <= 63` guard shared
+ * by PostgreSQLAdapter#get_advisory_lock / #release_advisory_lock
+ * (postgresql_adapter.rb:459-471). Ruby's Integer covers both of JS' integral
+ * numeric types, so `number` (integral only) and `bigint` pass; strings — which
+ * trails used to hash through `hashtext()` — and fractional numbers raise, as
+ * they do in Rails. `bit_length <= 63` is exactly the signed 64-bit range,
+ * negatives included (`(-2**63).bit_length == 63`).
+ */
+function _assertPgAdvisoryLockId(lockId: number | bigint | string): void {
+  const isInteger = typeof lockId === "bigint" || Number.isInteger(lockId);
+  if (!isInteger || BigInt(lockId) < -(2n ** 63n) || BigInt(lockId) >= 2n ** 63n) {
+    throw new ArgumentError("PostgreSQL requires advisory lock ids to be a signed 64 bit integer");
+  }
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -170,13 +170,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "get_advisory_lock",
-    "call": "query_value",
-    "reason": "Deliberate deviation (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): PG advisory locks are session-scoped, so the lock must be taken on the pinned raw client and serialized against in-flight maintenance queries (_acquireFreshClient + _serializePinnedQuery). Routing through query_value would run it on whatever connection selectAll materializes and could hand the lock to a connection the caller does not hold. trails also accepts string lock ids (hashtext) that Rails rejects outright."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "get_database_version",
     "call": "with_raw_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -264,13 +257,6 @@
     "rubyName": "reconfigure_connection_timezone",
     "call": "raw_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "release_advisory_lock",
-    "call": "query_value",
-    "reason": "Deliberate deviation (RFC 0072 converge-pg-session-and-transaction-exec-primitive-routing): mirror of get_advisory_lock — the unlock must target the same pinned session that took the lock, so it runs on the pinned raw client rather than through query_value."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## What

Rails' `PostgreSQLAdapter#get_advisory_lock` / `#release_advisory_lock`
(`postgresql_adapter.rb:459-471`) raise `ArgumentError` unless the lock id is an
`Integer` with `bit_length <= 63`, then issue the statement via `query_value`.
trails silently accepted `string` lock ids (hashing them through `hashtext()`)
and ran the query on the pinned raw client via `_acquireFreshClient()` +
`_serializePinnedQuery()`.

This adds Rails' guard verbatim and converges the exec primitive.

## The routing question

The story flagged the pinned-client routing as possibly load-bearing, on the
premise that `queryValue` routes through `selectAll`, "which can materialize a
different connection". It does not: `queryValue` -> `query` ->
`internalExecQuery` -> `withRawConnection`, and the PG adapter owns exactly one
persistent `pg.Client` (`_acquireFreshClient` returns `_rawConnection` on the
fast path). Session identity therefore holds through `queryValue`, so the
deviation is redundant rather than load-bearing and both baseline entries are
dropped rather than re-reasoned.

The session-identity requirement stays pinned by
`PostgresqlConnectionTest#"get and release advisory lock"`
(`adapters/postgresql/connection.test.ts`) — `pg_advisory_unlock` returns true
only on the session that took the lock — plus the migrator's
`"lock released"` / `"migrator generates valid lock id"` covers in
`migration.test.ts`. All verified locally against PG 17.

## Guard semantics

Ruby's `Integer` covers both integral JS numeric types, so `number` (integral
only) and `bigint` pass — the migrator's `generateMigratorAdvisoryLockId`
returns a `bigint`. Strings and fractional numbers raise.
`bit_length <= 63` is exactly `[-2^63, 2^63-1]` (`(-2**63).bit_length == 63`).

## Tests

Rails has no test for this guard, so the covers are trails-only and live in
`postgresql-adapter.trails.test.ts` per the repo convention, with a comment
pointing at the Rails source line and at the test that pins session identity.

Wide call-mismatch baseline: 49 -> 47 entries for this file.

Closes-story: converge-pg-advisory-lock-id-guard-and-exec-routing
