### PR TITLE
refactor(activerecord): retire poolAbsent/realPool for Rails' FakePool binding

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -26,8 +26,8 @@ import { IsolatedExecutionState, Notifications } from "@blazetrails/activesuppor
 import type { EventPayload } from "@blazetrails/activesupport";
 import { ActiveRecord } from "../ar-config.js";
 import { Result, type ColumnTypes } from "../result.js";
-import { SchemaCache, SchemaReflection, BoundSchemaReflection } from "./schema-cache.js";
-import { NullPool, poolAbsent } from "./abstract/connection-pool.js";
+import { SchemaCache, SchemaReflection, BoundSchemaReflection, FakePool } from "./schema-cache.js";
+import { NullPool } from "./abstract/connection-pool.js";
 import { stripSqlComments } from "./sql-classification.js";
 import {
   TransactionManager,
@@ -1749,7 +1749,7 @@ export class AbstractAdapter implements Quoting {
     // so the no-pool branch expires a leased connection and otherwise no-ops
     // (matching NullPool#checkin).
     const pool = this.pool as { checkin?: (conn: unknown) => void } | null;
-    if (!poolAbsent(pool) && pool && typeof pool.checkin === "function") {
+    if (pool && !(pool instanceof NullPool) && typeof pool.checkin === "function") {
       pool.checkin(this);
     } else if (this._inUse) {
       this.expire();
@@ -2627,22 +2627,24 @@ export class AbstractAdapter implements Quoting {
     // A `TableAlias` relation may carry a `SqlLiteral` name (set-op / subquery
     // derived table); unwrap to the bare identifier for the schema-cache lookup.
     const tableName = relationName(attribute.relation.name);
-    let hash = await (this.schemaCache as any).columnsHash(this.pool, tableName);
-    if (!hash && poolAbsent(this.pool) && typeof (this as any).columns === "function") {
-      // Bare-adapter path (no pool): the null-pool guard in columnsHash blocks the
-      // DB fallback. Fetch directly so callers like caseSensitiveComparison can
-      // resolve collations even when the schema cache was cleared by model
-      // class creation (resetColumnInformation).
+    // Mirrors Rails' `schema_cache.columns_hash(table_name)`: a standalone
+    // adapter carries a NullPool, whose `schema_cache` is nil, so Rails binds
+    // the reflection to a `FakePool` over the connection itself
+    // (abstract_adapter.rb:298). Pass that same FakePool here so the cold-cache
+    // lookup reflects through this adapter instead of bailing on the null-pool
+    // guard — callers like `caseSensitiveComparison` need the collation even
+    // when model class creation cleared the cache (resetColumnInformation).
+    const cache = this.schemaCache as any;
+    if (this.pool == null || this.pool instanceof NullPool) {
+      let hash: Record<string, import("./column.js").Column> | undefined;
       try {
-        const cols: import("./column.js").Column[] = await (this as any).columns(tableName);
-        if (cols?.length) {
-          this.schemaCache.setColumns(tableName, cols);
-          hash = this.schemaCache.getCachedColumnsHash(tableName);
-        }
+        hash = await cache.columnsHash(new FakePool(this), tableName);
       } catch {
-        // no connection — return undefined below
+        // no connection / no such table — return undefined below
       }
+      return hash?.[attribute.name];
     }
+    const hash = await cache.columnsHash(this.pool, tableName);
     return hash?.[attribute.name];
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2627,24 +2627,12 @@ export class AbstractAdapter implements Quoting {
     // A `TableAlias` relation may carry a `SqlLiteral` name (set-op / subquery
     // derived table); unwrap to the bare identifier for the schema-cache lookup.
     const tableName = relationName(attribute.relation.name);
-    // Mirrors Rails' `schema_cache.columns_hash(table_name)`: a standalone
-    // adapter carries a NullPool, whose `schema_cache` is nil, so Rails binds
-    // the reflection to a `FakePool` over the connection itself
-    // (abstract_adapter.rb:298). Pass that same FakePool here so the cold-cache
-    // lookup reflects through this adapter instead of bailing on the null-pool
-    // guard — callers like `caseSensitiveComparison` need the collation even
-    // when model class creation cleared the cache (resetColumnInformation).
-    const cache = this.schemaCache as any;
-    if (this.pool == null || this.pool instanceof NullPool) {
-      let hash: Record<string, import("./column.js").Column> | undefined;
-      try {
-        hash = await cache.columnsHash(new FakePool(this), tableName);
-      } catch {
-        // no connection / no such table — return undefined below
-      }
-      return hash?.[attribute.name];
-    }
-    const hash = await cache.columnsHash(this.pool, tableName);
+    // A standalone adapter's NullPool has no `schemaCache`, which is Rails'
+    // signal to bind the reflection to the connection itself
+    // (abstract_adapter.rb:298).
+    const pool =
+      this.pool == null || this.pool instanceof NullPool ? new FakePool(this) : this.pool;
+    const hash = await (this.schemaCache as any).columnsHash(pool, tableName);
     return hash?.[attribute.name];
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -164,36 +164,6 @@ export class NullPool implements AbstractPool {
 }
 
 /**
- * True when `pool` is not a real, connection-owning pool — i.e. it is either
- * `null` or a {@link NullPool}. A standalone adapter (constructed outside a
- * pool) carries a NullPool by default, matching Rails' `@pool = NullPool.new`;
- * the schema-cache / bare-adapter fallbacks that historically keyed off
- * `pool == null` use this so a NullPool is treated the same as "no pool".
- *
- * @noRailsEquivalent CONVERGEABLE (story: converge-nullpool-protocol-retire-poolabsent-realpool).
- * Rails' `NullPool` answers the whole pool protocol, so
- * Ruby callers never ask whether a pool is real. See above.
- */
-export function poolAbsent(pool: unknown): boolean {
-  return pool == null || pool instanceof NullPool;
-}
-
-/**
- * Returns `pool` when it is a real, connection-owning pool, else `null` — the
- * NullPool-aware form of the historical `adapter.pool ?? fallback` idiom. Use
- * `realPool(adapter.pool) ?? adapter` where code previously wrote
- * `adapter.pool ?? adapter` to yield a schema-cache target that can actually
- * check out a connection.
- *
- * @noRailsEquivalent CONVERGEABLE (story: converge-nullpool-protocol-retire-poolabsent-realpool).
- * NullPool-aware form of `adapter.pool ?? fallback`;
- * unnecessary in Rails for the same reason as `poolAbsent`. See above.
- */
-export function realPool(pool: unknown): unknown | null {
-  return poolAbsent(pool) ? null : pool;
-}
-
-/**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Lease
  */
 export class Lease {

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -304,10 +304,8 @@ export class SchemaCache {
 
     // Null-pool guard: a caller may pass `null` (or the NullPool a standalone
     // adapter carries) to consult only the warm cache. Neither can yield a
-    // connection — Rails never gets here because `AbstractAdapter#schema_cache`
-    // binds a `FakePool` over the adapter itself when `pool.schema_cache` is
-    // nil (abstract_adapter.rb:298) — so return undefined and let the caller
-    // fall back to the schema-less NullColumn shape.
+    // connection, so return undefined and let the caller fall back to the
+    // schema-less NullColumn shape.
     if (pool == null || pool instanceof NullPool) return undefined;
 
     return withConnection(pool, async (connection) => {

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -12,7 +12,7 @@ import type { ColumnJSON } from "./column.js";
 import { Column as MysqlColumn } from "./mysql/column.js";
 import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
-import { poolAbsent } from "./abstract/connection-pool.js";
+import { NullPool } from "./abstract/connection-pool.js";
 import { IndexDefinition } from "./abstract/schema-definitions.js";
 
 // ---------------------------------------------------------------------------
@@ -302,11 +302,13 @@ export class SchemaCache {
       return this._columns.get(tableName);
     }
 
-    // Null-pool guard: callers (e.g. `columnForAttribute` before a pool is
-    // attached) may pass `pool: null` to consult only the warm cache. Don't
-    // attempt to acquire a connection in that case — return undefined and
-    // let the caller fall back to the schema-less NullColumn shape.
-    if (poolAbsent(pool)) return undefined;
+    // Null-pool guard: a caller may pass `null` (or the NullPool a standalone
+    // adapter carries) to consult only the warm cache. Neither can yield a
+    // connection — Rails never gets here because `AbstractAdapter#schema_cache`
+    // binds a `FakePool` over the adapter itself when `pool.schema_cache` is
+    // nil (abstract_adapter.rb:298) — so return undefined and let the caller
+    // fall back to the schema-less NullColumn shape.
+    if (pool == null || pool instanceof NullPool) return undefined;
 
     return withConnection(pool, async (connection) => {
       if (typeof connection.columns === "function") {
@@ -524,13 +526,10 @@ export class SchemaCache {
    * only population path is `add(pool, table_name)`, which issues the
    * introspection queries itself behind `pool.with_connection`.
    *
-   * That is exactly why the one production caller cannot use `add()`: it has no
-   * pool. `AbstractAdapter#columnForAttribute`'s bare-adapter branch
-   * (`abstract-adapter.ts`, the `poolAbsent(this.pool)` fallback) runs on a
-   * standalone adapter, where `add()` and the `columnsHash` DB fallback both
-   * bail on the null-pool guard. It calls the adapter's own `columns()`
-   * directly and seeds the result here, then reads it straight back via
-   * {@link getCachedColumnsHash}.
+   * It survives as the write half of the sync readers below: `columns()` seeds
+   * every reflection through it, so `getCachedColumnsHash` and friends can
+   * answer query-free. Rails needs no such writer because its readers may block
+   * on a checkout.
    *
    * Also warms `_dataSourceExists` — a table whose columns just came back
    * demonstrably exists — which is what lets the sync readers above answer
@@ -538,8 +537,8 @@ export class SchemaCache {
    *
    * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
    * Rails populates only via `add(pool, table_name)`,
-   * which needs a pool; the one caller is the bare-adapter path that has
-   * none. See above.
+   * which issues the introspection queries itself; trails needs a sync writer
+   * to back its sync, query-free readers. See above.
    */
   setColumns(tableName: string, cols: Column[]): void {
     this.reconcilePrimaryKeyFlags(tableName, cols);

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -2,7 +2,6 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { ArgumentError, SerializeCastValue } from "@blazetrails/activemodel";
 import { IndexDefinition } from "./connection-adapters/abstract/schema-definitions.js";
-import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { ActiveRecordError, UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
 
@@ -10,6 +9,7 @@ import { stiName, isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
 import { Result } from "./result.js";
+import { FakePool } from "./connection-adapters/schema-cache.js";
 import { withPooledOrDirectConnection } from "./connection-handling.js";
 
 let _quoteSqlValue: ((v: unknown, dialect?: AdapterName) => string) | undefined;
@@ -528,7 +528,7 @@ export class InsertAll {
     } else {
       const cache = conn.schemaCache;
       if (!cache || typeof cache.indexes !== "function") return [];
-      indexes = await cache.indexes(realPool(conn.pool) ?? conn, tableName);
+      indexes = await cache.indexes(new FakePool(conn), tableName);
     }
     return indexes.filter((i: any) => i.unique);
   }
@@ -550,7 +550,7 @@ export class InsertAll {
     } else {
       const cache = conn.schemaCache;
       if (!cache || typeof cache.primaryKeys !== "function") return [];
-      pk = await cache.primaryKeys(realPool(conn.pool) ?? conn, tableName);
+      pk = await cache.primaryKeys(new FakePool(conn), tableName);
     }
     if (pk == null) return [];
     return Array.isArray(pk) ? pk : [pk];

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1242,10 +1242,8 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   const cache = startingAdapter.schemaCache;
   if (!cache) return;
   const table = this.tableName;
-  // Resolve the schemaCache target the way Rails does for a lone connection:
-  // `BoundSchemaReflection.for_lone_connection` wraps the connection we already
-  // hold in a FakePool (schema_cache.rb:155). That matters here beyond fidelity
-  // — on lone-connection pools (SQLite :memory: + size 1) the connection is
+  // Rails' `for_lone_connection` shape (schema_cache.rb:155): on
+  // lone-connection pools (SQLite :memory: + size 1) the connection is
   // permanently checked out, so routing through pool.withConnection deadlocks.
   const pool = new FakePool(startingAdapter);
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -19,7 +19,6 @@ import {
 } from "./inheritance.js";
 import { singularize } from "@blazetrails/activesupport";
 import { modelRegistry } from "./associations.js";
-import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { TableNotSpecified } from "./errors.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
@@ -1243,17 +1242,12 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   const cache = startingAdapter.schemaCache;
   if (!cache) return;
   const table = this.tableName;
-  // Resolve a target for schemaCache lookups. If `.pool` is an actual ConnectionPool
-  // (has `withConnection`), wrap startingAdapter in a FakePool — mirroring
-  // Rails' BoundSchemaReflection.for_lone_connection. On lone-connection
-  // pools (SQLite :memory: + size 1) the connection is already permanently
-  // checked out, so calling pool.withConnection would deadlock; FakePool
-  // yields the connection we already hold.
-  const candidate = realPool(startingAdapter.pool) ?? startingAdapter;
-  const pool =
-    candidate && typeof (candidate as { withConnection?: unknown }).withConnection === "function"
-      ? new FakePool(startingAdapter)
-      : candidate;
+  // Resolve the schemaCache target the way Rails does for a lone connection:
+  // `BoundSchemaReflection.for_lone_connection` wraps the connection we already
+  // hold in a FakePool (schema_cache.rb:155). That matters here beyond fidelity
+  // — on lone-connection pools (SQLite :memory: + size 1) the connection is
+  // permanently checked out, so routing through pool.withConnection deadlocks.
+  const pool = new FakePool(startingAdapter);
 
   if (typeof cache.dataSourceExists === "function") {
     const exists = await cache.dataSourceExists(pool, table);
@@ -1329,12 +1323,7 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
     // doesn't deadlock on withConnection.
     const cache = conn.schemaCache;
     if (cache && typeof cache.columnsHash === "function") {
-      const candidate = realPool(conn.pool) ?? conn;
-      const pool =
-        candidate &&
-        typeof (candidate as { withConnection?: unknown }).withConnection === "function"
-          ? new FakePool(conn)
-          : candidate;
+      const pool = new FakePool(conn);
       const hash = (await cache.columnsHash(pool, table)) as Record<string, unknown> | undefined;
       if (hash) {
         const names = Object.keys(hash);
@@ -1542,8 +1531,7 @@ export async function tableExists(this: SchemaHost): Promise<boolean> {
   const conn = reflectionAdapter(this);
   const cache = conn.schemaCache;
   if (!cache || typeof cache.dataSourceExists !== "function") return true;
-  const pool = realPool(conn.pool) ?? conn;
-  const exists = await cache.dataSourceExists(pool, this.tableName);
+  const exists = await cache.dataSourceExists(new FakePool(conn), this.tableName);
   return exists !== false;
 }
 

--- a/packages/activerecord/src/test-fixtures/fixture-connection.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.ts
@@ -1,6 +1,6 @@
 import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
-import { realPool, type ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
+import { NullPool, type ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 
 /**
  * The connection the fixture machinery seeds and pins through.
@@ -37,13 +37,14 @@ export function leaseFixtureConnection(): DatabaseAdapter {
  * model (join-table/tableless sets), the model is one of the lightweight
  * `{ tableName, ... }` stubs some infra tests pass, or it has no pool
  * established (a directly-assigned `Model.adapter`, whose `connectionPool()`
- * throws).
+ * throws), or it carries the NullPool a standalone adapter is born with.
  */
 function modelFixturePool(model: unknown): ConnectionPool | null {
   const host = model as { connectionPool?: () => ConnectionPool } | null;
   if (host === null || typeof host.connectionPool !== "function") return null;
   try {
-    return realPool(host.connectionPool()) as ConnectionPool | null;
+    const pool = host.connectionPool();
+    return pool == null || pool instanceof NullPool ? null : pool;
   } catch {
     return null;
   }
@@ -71,7 +72,11 @@ export async function leaseFixtureConnectionFor(
 ): Promise<DatabaseAdapter> {
   const modelPool = modelFixturePool(model);
   if (modelPool === null) return fixtureConnection;
-  const fixturePool = realPool(fixtureConnection.pool) as ConnectionPool | null;
+  const rawFixturePool = fixtureConnection.pool;
+  const fixturePool =
+    rawFixturePool == null || rawFixturePool instanceof NullPool
+      ? null
+      : (rawFixturePool as ConnectionPool);
   if (fixturePool === null || fixturePool === modelPool) return fixtureConnection;
   return await modelPool.leaseConnection();
 }

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -7,7 +7,7 @@
 import { beforeEach, afterEach, type TaskContext } from "vitest";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
-import { realPool } from "../connection-adapters/abstract/connection-pool.js";
+import { NullPool } from "../connection-adapters/abstract/connection-pool.js";
 
 interface TxnHost {
   transactionManager: {
@@ -54,7 +54,7 @@ function tm(adapter: TransactionalFixturesAdapter): TxnHost["transactionManager"
  */
 async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Promise<void> {
   const sc = adapter.schemaCache;
-  const pool = realPool(adapter.pool);
+  const pool = adapter.pool == null || adapter.pool instanceof NullPool ? null : adapter.pool;
   if (!sc || pool === null) return;
   try {
     await sc.addAll(pool);
@@ -81,7 +81,7 @@ async function reReflectTouchedTables(adapter: TransactionalFixturesAdapter): Pr
   if (!sc) return;
   const touched = sc.takeTouchedTables();
   if (touched.size === 0) return;
-  const pool = realPool(adapter.pool);
+  const pool = adapter.pool == null || adapter.pool instanceof NullPool ? null : adapter.pool;
   for (const table of touched) {
     // Drop the stale (post-DDL) entry first, then re-read the rolled-back
     // shape from the live DB. Raw adapters without a pool can't re-reflect

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -354,8 +354,6 @@ async function isCoveredByUniqueIndex(
  * assigned adapter carries, which exposes neither `withConnection` nor
  * `indexes`, so the cache would introspect the NullPool and quietly yield `[]`
  * — leaving covered_by_unique_index? permanently false for every such model.
- * It also keeps the lookup on the transaction-pinned connection resolved
- * below rather than checking a second one out of the pool.
  *
  * @internal
  */

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -8,8 +8,8 @@
 import { EachValidator, ArgumentError } from "@blazetrails/activemodel";
 import { isBlank } from "@blazetrails/activesupport";
 import { UnknownPrimaryKey } from "../errors.js";
+import { FakePool } from "../connection-adapters/schema-cache.js";
 import { threadedConnectionFor } from "../connection-handling.js";
-import { realPool } from "../connection-adapters/abstract/connection-pool.js";
 
 /**
  * Shared scope option validation — called eagerly from validatesUniqueness (declaration time)
@@ -348,11 +348,14 @@ async function isCoveredByUniqueIndex(
  * serve a stale, pre-index list and silently keep the optimization off after a
  * migration adds the covering index.
  *
- * The pool target must be `realPool(pool) ?? adapter`, NOT `pool ?? adapter`: a
- * directly assigned adapter carries a NullPool, which exposes neither
- * `withConnection` nor `indexes`, so the cache would introspect the NullPool and
- * quietly yield `[]` — leaving covered_by_unique_index? permanently false for
- * every such model.
+ * The pool target is a `FakePool` over the adapter we already hold — Rails'
+ * `BoundSchemaReflection.for_lone_connection` shape (schema_cache.rb:155).
+ * Passing `adapter.pool` directly would hand the cache the NullPool a directly
+ * assigned adapter carries, which exposes neither `withConnection` nor
+ * `indexes`, so the cache would introspect the NullPool and quietly yield `[]`
+ * — leaving covered_by_unique_index? permanently false for every such model.
+ * It also keeps the lookup on the transaction-pinned connection resolved
+ * below rather than checking a second one out of the pool.
  *
  * @internal
  */
@@ -370,7 +373,7 @@ async function tableIndexes(
 
   const cache = adapter.schemaCache;
   if (!cache || typeof cache.indexes !== "function") return [];
-  return (await cache.indexes(realPool(adapter.pool) ?? adapter, tableName)) as Index[];
+  return (await cache.indexes(new FakePool(adapter), tableName)) as Index[];
 }
 
 /**


### PR DESCRIPTION
## What

Retires the two exported `connection-pool.ts` helpers `poolAbsent(pool)` and
`realPool(pool)`, which existed to centralize a question Rails never asks.

## Why

Rails' standalone adapter carries `@pool = NullPool.new`
(`connection_pool.rb:14`), and `NullPool#schema_cache` is `nil`. That nil is
the signal: `AbstractAdapter#schema_cache` (`abstract_adapter.rb:298`) reads
`@pool.schema_cache || BoundSchemaReflection.for_lone_connection(@pool.schema_reflection, self)`,
and `for_lone_connection` wraps the connection in a `FakePool` whose
`with_connection` just yields it (`schema_cache.rb:143-157`). So Ruby callers
never branch on "is this pool real" — the binding is decided once, and every
schema-cache lookup goes through a pool-shaped object that can always produce
a connection.

Trails already ports both `FakePool` and `BoundSchemaReflection.forLoneConnection`,
so the deviation is convergeable: the answer to the acceptance criterion is
**yes**, and `NullPool#checkout` keeping its throw is not the obstacle
(nothing in these paths calls it).

## How

- Every schema-cache call site that computed `realPool(conn.pool) ?? conn`
  now passes `new FakePool(conn)` — Rails' lone-connection shape.
  `model-schema.ts` was already collapsing to exactly that (its `candidate`
  dance ended at `new FakePool(adapter)` whenever the candidate had
  `withConnection`), so the branch is gone; the FakePool is also what keeps
  lone-connection pools (SQLite `:memory:`, size 1, permanently checked out)
  from deadlocking on `pool.withConnection`.
- `AbstractAdapter#columnForAttribute` binds the same FakePool on a bare
  adapter, so `columnsHash` reaches the DB instead of bailing on the
  null-pool guard. Its hand-rolled `columns()` + `schemaCache.setColumns()` +
  `getCachedColumnsHash()` fallback is deleted — the cache's own `columns()`
  already calls `setColumns`, so warming is unchanged.
- The genuinely pool-identity checks that remain (fixture pool comparison,
  `close`'s `pool.checkin`, the cache's null-pool guard) are inlined
  `instanceof NullPool` tests. They add no exported surface, which is what
  made the helpers extra API in the first place.

Behavior-preserving: the schema-cache-pool-target invariant (the cache must
never be handed a bare/NullPool) is now expressed by the FakePool binding
rather than by `realPool`.

## Verification

- `pnpm api:extra --package activerecord` →
  `connection-adapters/abstract/connection-pool.ts — 0 novel, 10 moved`.
- `pnpm typecheck`, `pnpm lint` clean.
- Tests: `insert-all`, `uniqueness-validation{,.trails}`, `schema-cache`,
  `standalone-connection`, `abstract-adapter{,.lifecycle}`, `adapter-leasing`,
  `model-schema`, and the whole `test-fixtures/` group pass locally.
  MySQL-lane `case_sensitivity_test` (the `columnForAttribute` collation path)
  is excluded locally and covered by CI.

No test renames.

Closes-story: converge-nullpool-protocol-retire-poolabsent-realpool
