### PR TITLE
refactor(activerecord): build pg create_database options by iterating merged hash

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1263,11 +1263,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
   });
 
-  // Rails builds create_database's option string by iterating the *merged*
-  // options hash, so keys it has no arm for fall through the `else` and
-  // contribute nothing — they are neither emitted nor rejected. Rails covers
-  // only encoding/collation/ctype; the remaining arms and the pass-through are
-  // trails-side regression cover.
   describe("createDatabase option string", () => {
     it("emits the remaining option arms in merged-hash order", async () => {
       const sqls = await captureSql(

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../errors.js";
 import { withSecondAdapter } from "../../support/second-connection.js";
 import { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
+import { captureSql } from "../../testing/sql-capture.js";
 
 async function withExtensionDisabled(
   adapter: PostgreSQLAdapter,
@@ -1259,6 +1260,38 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("addColumn datetime null precision omits precision suffix", async () => {
       await adapter.addColumn("dt_prec_test", "happened_at", "datetime", { precision: null });
       expect(await columnSqlType("happened_at")).toBe("timestamp without time zone");
+    });
+  });
+
+  // Rails builds create_database's option string by iterating the *merged*
+  // options hash, so keys it has no arm for fall through the `else` and
+  // contribute nothing — they are neither emitted nor rejected. Rails covers
+  // only encoding/collation/ctype; the remaining arms and the pass-through are
+  // trails-side regression cover.
+  describe("createDatabase option string", () => {
+    it("emits the remaining option arms in merged-hash order", async () => {
+      const sqls = await captureSql(
+        () =>
+          adapter.createDatabase("db", {
+            owner: "alice",
+            template: "template0",
+            tablespace: "fast",
+            connectionLimit: -1,
+          }),
+        { stub: adapter },
+      );
+      expect(sqls[0]).toBe(
+        `CREATE DATABASE "db" ENCODING = 'utf8' OWNER = "alice" TEMPLATE = "template0"` +
+          ` TABLESPACE = "fast" CONNECTION LIMIT = -1`,
+      );
+    });
+
+    it("ignores keys it has no arm for instead of rejecting them", async () => {
+      const sqls = await captureSql(
+        () => adapter.createDatabase("db", { adapter: "postgresql", host: "localhost" }),
+        { stub: adapter },
+      );
+      expect(sqls[0]).toBe(`CREATE DATABASE "db" ENCODING = 'utf8'`);
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -530,25 +530,40 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // ---------------------------------------------------------------------------
 
   async createDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
-    const encoding = options.encoding ?? "utf8";
-    let optionString = ` ENCODING = ${this.pg.quoteLiteral(encoding)}`;
-    if (options.collation)
-      optionString += ` LC_COLLATE = ${this.pg.quoteLiteral(options.collation)}`;
-    if (options.ctype) optionString += ` LC_CTYPE = ${this.pg.quoteLiteral(options.ctype)}`;
-    if (options.owner) optionString += ` OWNER = ${this.pg.quoteIdentifier(options.owner)}`;
-    if (options.template)
-      optionString += ` TEMPLATE = ${this.pg.quoteIdentifier(options.template)}`;
-    if (options.tablespace)
-      optionString += ` TABLESPACE = ${this.pg.quoteIdentifier(options.tablespace)}`;
-    if (options.connectionLimit != null) {
-      const limit = options.connectionLimit;
-      if (!Number.isInteger(limit) || (limit < 0 && limit !== -1)) {
-        throw new ArgumentError(
-          `connectionLimit must be -1 (unlimited) or a non-negative integer, got: ${limit}`,
-        );
+    // Rails: `{ encoding: "utf8" }.merge!(options.symbolize_keys)` — spreading a
+    // later `encoding` overwrites the value while keeping the default's leading
+    // position, which is what `merge!` does and what the emitted order asserts.
+    const mergedOptions: CreateDatabaseOptions = { encoding: "utf8", ...options };
+
+    let optionString = "";
+    for (const [key, value] of Object.entries(mergedOptions)) {
+      switch (key) {
+        case "owner":
+          optionString += ` OWNER = "${String(value)}"`;
+          break;
+        case "template":
+          optionString += ` TEMPLATE = "${String(value)}"`;
+          break;
+        case "encoding":
+          optionString += ` ENCODING = '${String(value)}'`;
+          break;
+        case "collation":
+          optionString += ` LC_COLLATE = '${String(value)}'`;
+          break;
+        case "ctype":
+          optionString += ` LC_CTYPE = '${String(value)}'`;
+          break;
+        case "tablespace":
+          optionString += ` TABLESPACE = "${String(value)}"`;
+          break;
+        case "connectionLimit":
+          optionString += ` CONNECTION LIMIT = ${String(value)}`;
+          break;
+        default:
+          break;
       }
-      optionString += ` CONNECTION LIMIT = ${limit}`;
     }
+
     await this.execute(`CREATE DATABASE ${this.pg.quoteIdentifier(name)}${optionString}`);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -530,9 +530,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // ---------------------------------------------------------------------------
 
   async createDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
-    // Rails: `{ encoding: "utf8" }.merge!(options.symbolize_keys)` — spreading a
-    // later `encoding` overwrites the value while keeping the default's leading
-    // position, which is what `merge!` does and what the emitted order asserts.
     const mergedOptions: CreateDatabaseOptions = { encoding: "utf8", ...options };
 
     let optionString = "";
@@ -564,11 +561,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       }
     }
 
-    await this.execute(`CREATE DATABASE ${this.pg.quoteIdentifier(name)}${optionString}`);
+    await this.execute(`CREATE DATABASE ${this.pg.quoteTableName(name)}${optionString}`);
   }
 
   async dropDatabase(name: string): Promise<void> {
-    await this.execute(`DROP DATABASE IF EXISTS ${this.pg.quoteIdentifier(name)}`);
+    await this.execute(`DROP DATABASE IF EXISTS ${this.pg.quoteTableName(name)}`);
   }
 
   async recreateDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -96,6 +96,10 @@ interface PgSchemaAdapter {
   _schemaSearchPathMemo: string | null;
 }
 
+function toS(value: unknown): string {
+  return value == null ? "" : String(value);
+}
+
 export class PostgreSQLSchemaStatements extends SchemaStatements {
   private get pg(): PgSchemaAdapter {
     return this as unknown as PgSchemaAdapter;
@@ -536,25 +540,25 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     for (const [key, value] of Object.entries(mergedOptions)) {
       switch (key) {
         case "owner":
-          optionString += ` OWNER = "${String(value)}"`;
+          optionString += ` OWNER = "${toS(value)}"`;
           break;
         case "template":
-          optionString += ` TEMPLATE = "${String(value)}"`;
+          optionString += ` TEMPLATE = "${toS(value)}"`;
           break;
         case "encoding":
-          optionString += ` ENCODING = '${String(value)}'`;
+          optionString += ` ENCODING = '${toS(value)}'`;
           break;
         case "collation":
-          optionString += ` LC_COLLATE = '${String(value)}'`;
+          optionString += ` LC_COLLATE = '${toS(value)}'`;
           break;
         case "ctype":
-          optionString += ` LC_CTYPE = '${String(value)}'`;
+          optionString += ` LC_CTYPE = '${toS(value)}'`;
           break;
         case "tablespace":
-          optionString += ` TABLESPACE = "${String(value)}"`;
+          optionString += ` TABLESPACE = "${toS(value)}"`;
           break;
         case "connectionLimit":
-          optionString += ` CONNECTION LIMIT = ${String(value)}`;
+          optionString += ` CONNECTION LIMIT = ${toS(value)}`;
           break;
         default:
           break;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -29,8 +29,5 @@ export interface CreateDatabaseOptions {
   template?: string;
   tablespace?: string;
   connectionLimit?: number;
-  // Rails passes a whole database config here (`create_database config[:database], config`),
-  // so unrecognised keys must reach the option-string builder's no-op arm rather
-  // than being rejected at the call site.
   [key: string]: unknown;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -29,4 +29,8 @@ export interface CreateDatabaseOptions {
   template?: string;
   tablespace?: string;
   connectionLimit?: number;
+  // Rails passes a whole database config here (`create_database config[:database], config`),
+  // so unrecognised keys must reach the option-string builder's no-op arm rather
+  // than being rejected at the call site.
+  [key: string]: unknown;
 }


### PR DESCRIPTION
## What

`PostgreSQL::SchemaStatements#create_database` builds its option string with
`each_with_object` over the **merged** options hash
(`vendor/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb:22-51`).
Two consequences trails did not reproduce:

1. An unrecognised key still reaches the `else` arm and contributes nothing —
   Rails is routinely called as `create_database config[:database], config`, so
   the hash carries `adapter`, `host`, … trails' fixed `if` chain over a typed
   `CreateDatabaseOptions` silently dropped anything the interface did not name,
   and the interface rejected such a call outright.
2. `owner` / `template` / `tablespace` are raw double-quote interpolations
   (`" OWNER = \"#{value}\""`), not `quoteIdentifier` — these agree on ordinary
   names but diverge on embedded quotes.

This ports the `each_with_object` loop verbatim (default `encoding: "utf8"`
spread first, matching `merge!`'s in-place position for an overwritten key) and
widens `CreateDatabaseOptions` with an index signature so unrecognised keys
reach the no-op arm. The database name now goes through `quoteTableName`, which
is what Rails' `quote_table_name(name)` is (`schema_statements.rb:45`, and
`:53` for `drop_database`).

Also drops the `connectionLimit` `ArgumentError` validation, a trails invention
Rails has no counterpart for and no test covered.

## Review responses

**`connection_limit` vs `connectionLimit` (schema-statements-class.ts:556).**
Keeping `connectionLimit` only. Rails' `symbolize_keys` normalises the
*string-vs-symbol* distinction, which has no JS analogue — object keys are
already strings — so it does not imply a snake_case key surface. The Rails key
*spelling* maps to trails' repo-wide camelCase convention (CLAUDE.md:
"camelCase only"), which is how every trails config key is already spelled: the
option is read as `configurationHash.encoding` in
`tasks/postgresql-database-tasks.ts:273`, and the sibling MySQL
`createDatabase` dispatches on `options.collation` / `options.charset`
(`connection-adapters/abstract-mysql-adapter.ts:652-660`). `connection_limit`
appears nowhere in the TS tree. Adding a snake_case alias would introduce a key
spelling that exists in no other trails surface, so the correct convergence is
the camelCase arm alone.

## Tests

`test_create_database_with_encoding` / `test_create_database_with_collation_and_ctype`
already exist verbatim in `adapters/postgresql/active-schema.test.ts` and still
pass. Rails covers only encoding/collation/ctype, so the remaining arms and the
unknown-key pass-through get trails-side regression cover in
`postgresql-adapter.trails.test.ts`.

`pnpm api:calls:wide` passes; the `create_database` `merge!` / `symbolize_keys`
wide-baseline entries this story named were already removed by #5726's
inert-receiver suppression, so the baseline is unchanged here.

Closes-story: converge-pg-create-database-option-string-construction
