### PR TITLE
fix(activerecord): build PG index definitions from the tableName argument

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -252,3 +252,26 @@ describe("PostgreSQLSchemaStatements#changeTable", () => {
     expect(yielded).toBeInstanceOf(PgTable);
   });
 });
+
+describe("PostgreSQLSchemaStatements#indexes", () => {
+  it("keeps the schema-qualified table name from the argument", async () => {
+    const { adapter } = makeAdapter({
+      schemaQuery: async () => [
+        {
+          index_name: "index_things_on_name",
+          is_unique: false,
+          using: "btree",
+          columns: ["name"],
+          has_expressions: false,
+          definition: "CREATE INDEX index_things_on_name ON my_schema.things USING btree (name)",
+          options: [0],
+          is_valid: true,
+          comment: null,
+        },
+      ],
+    });
+    const ss = withSchemaStatements(adapter);
+    const [index] = await ss.indexes("my_schema.things");
+    expect(index.table).toBe("my_schema.things");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -163,8 +163,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
               pg_get_indexdef(ix.indexrelid) AS definition,
               ix.indoption AS options,
               ix.indisvalid AS is_valid,
-              obj_description(ix.indexrelid, 'pg_class') AS comment,
-              t.relname AS table_name
+              obj_description(ix.indexrelid, 'pg_class') AS comment
        FROM pg_class t
        JOIN pg_index ix ON t.oid = ix.indrelid
        JOIN pg_class i ON i.oid = ix.indexrelid
@@ -220,7 +219,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       }
 
       return new IndexDefinition(
-        row.table_name as string,
+        // Rails builds the definition from the `table_name` ARGUMENT
+        // (postgresql/schema_statements.rb:137), so a schema-qualified lookup
+        // keeps its qualifier instead of collapsing to `pg_class.relname`.
+        tableName,
         row.index_name as string,
         row.is_unique as boolean,
         columns,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -219,9 +219,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       }
 
       return new IndexDefinition(
-        // Rails builds the definition from the `table_name` ARGUMENT
-        // (postgresql/schema_statements.rb:137), so a schema-qualified lookup
-        // keeps its qualifier instead of collapsing to `pg_class.relname`.
         tableName,
         row.index_name as string,
         row.is_unique as boolean,


### PR DESCRIPTION
Rails' PostgreSQL `indexes()` builds `IndexDefinition.new(table_name, ...)` from
the **argument** (`postgresql/schema_statements.rb:137`); trails passed
`row.table_name` — the bare `pg_class.relname` — so `indexes("myschema.posts")`
yielded `table: "posts"` where Rails yields `"myschema.posts"`.

- PG `indexes()` now passes the `tableName` argument as the definition's table,
  and the query drops the `t.relname AS table_name` select (Rails' query at
  `:89-99` doesn't select it either). The lookup still scopes through the
  parsed schema/table, as Rails does via `quoted_scope`.
- Test covers the schema-qualified `indexes("schema.table")` table value.

On the `include` half of the story: Rails passes `include: include_columns.presence`
(`:146`), so an index with no INCLUDE clause gets `nil`, not `[]`. trails' `undefined`
already matches — no change needed there, and changing it to `[]` would have been a
divergence.

Closes-story: pg-indexes-table-and-include-match-rails
