### PR TITLE
fix(activerecord): drop retired IndexDefinitionRow from schema cache and dumper

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -163,6 +163,10 @@ export class SchemaCache {
       );
     }
 
+    // Rails round-trips indexes through Psych, which restores real
+    // `IndexDefinition` objects; our JSON round-trip yields bare records, so a
+    // cache loaded from a dump carries the fields but not the derived methods.
+    // Deliberately left as-is here — rehydrating them is its own change.
     if (coder["indexes"] instanceof Map) {
       this._indexes = coder["indexes"] as Map<string, IndexDefinition[]>;
     } else if (coder["indexes"] && typeof coder["indexes"] === "object") {

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -13,7 +13,7 @@ import { Column as MysqlColumn } from "./mysql/column.js";
 import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { poolAbsent } from "./abstract/connection-pool.js";
-import type { IndexDefinitionRow } from "./abstract/schema-definitions.js";
+import type { IndexDefinition } from "./abstract/schema-definitions.js";
 
 // ---------------------------------------------------------------------------
 // Helper: run callback inside pool.withConnection if available
@@ -75,7 +75,7 @@ export class SchemaCache {
   private _columnsHash = new Map<string, Record<string, Column>>();
   private _primaryKeys = new Map<string, string | string[] | null>();
   private _dataSourceExists = new Map<string, boolean>();
-  private _indexes = new Map<string, IndexDefinitionRow[]>();
+  private _indexes = new Map<string, IndexDefinition[]>();
   private _version: string | number | null = null;
   // When non-null, records the name of every table passed to
   // `clearDataSourceCacheBang` — i.e. every table touched by DDL
@@ -164,10 +164,10 @@ export class SchemaCache {
     }
 
     if (coder["indexes"] instanceof Map) {
-      this._indexes = coder["indexes"] as Map<string, IndexDefinitionRow[]>;
+      this._indexes = coder["indexes"] as Map<string, IndexDefinition[]>;
     } else if (coder["indexes"] && typeof coder["indexes"] === "object") {
       this._indexes = new Map(
-        Object.entries(coder["indexes"] as Record<string, IndexDefinitionRow[]>),
+        Object.entries(coder["indexes"] as Record<string, IndexDefinition[]>),
       );
     }
 
@@ -377,7 +377,7 @@ export class SchemaCache {
     return pkCols.length === 1 ? pkCols[0] : pkCols;
   }
 
-  async indexes(pool: unknown, tableName: string): Promise<IndexDefinitionRow[]> {
+  async indexes(pool: unknown, tableName: string): Promise<IndexDefinition[]> {
     if (this._indexes.has(tableName)) {
       return this._indexes.get(tableName)!;
     }
@@ -641,9 +641,7 @@ export class SchemaCache {
     this._dataSourceExists = new Map(
       Object.entries((dataSources as Record<string, boolean>) ?? {}),
     );
-    this._indexes = new Map(
-      Object.entries((indexes as Record<string, IndexDefinitionRow[]>) ?? {}),
-    );
+    this._indexes = new Map(Object.entries((indexes as Record<string, IndexDefinition[]>) ?? {}));
 
     this.deriveColumnsHashAndDeduplicateValues();
   }
@@ -856,7 +854,7 @@ export class SchemaReflection {
     return this._cache?.isColumnsHash(pool, tableName) ?? false;
   }
 
-  async indexes(pool: unknown, tableName: string): Promise<IndexDefinitionRow[]> {
+  async indexes(pool: unknown, tableName: string): Promise<IndexDefinition[]> {
     return (await this.cache(pool)).indexes(pool, tableName);
   }
 
@@ -1043,7 +1041,7 @@ export class BoundSchemaReflection {
     return this._schemaReflection.isColumnsHash(this._pool, tableName);
   }
 
-  async indexes(tableName: string): Promise<IndexDefinitionRow[]> {
+  async indexes(tableName: string): Promise<IndexDefinition[]> {
     return this._schemaReflection.indexes(this._pool, tableName);
   }
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -25,7 +25,6 @@ import type {
   SchemaDumperMixinHost,
   Column,
 } from "./connection-adapters/abstract/schema-dumper.js";
-import type { IndexDefinitionRow } from "./connection-adapters/abstract/schema-definitions.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
@@ -92,18 +91,26 @@ export interface ColumnInfo {
 }
 
 /**
- * The dumper's view of an adapter index row: the adapter shape
- * (`IndexDefinitionRow`) plus the dialect-specific options the dumper emits.
- * `name` is widened to optional because `SchemaSource` implementations that
- * aren't adapters (e.g. a dump being re-read) may not carry one, and
- * `indexParts` already treats it as absent-able.
+ * The dumper's view of an adapter index row: the `IndexDefinition` fields the
+ * dumper reads plus the dialect-specific options it emits. Every field is
+ * optional-able because `SchemaSource` implementations that aren't adapters
+ * (e.g. a dump being re-read) may not carry them — `indexParts` already treats
+ * `name` as absent-able — so this stays a structural view rather than
+ * extending the class.
  */
-export interface IndexInfo extends Omit<IndexDefinitionRow, "name"> {
+export interface IndexInfo {
+  // A string for expression indexes (the raw expression), an array of column
+  // names otherwise — mirrors Rails' IndexDefinition#columns.
+  columns: string | string[];
+  unique: boolean;
   name?: string;
   /** Per-column max lengths (number for single-column, Record for multi). */
   lengths?: number | Record<string, number>;
+  /** Per-column sort order (e.g. "asc"/"desc"). */
+  orders?: string | Record<string, string>;
   /** Per-column operator class (Postgres). */
   opclasses?: string | Record<string, string>;
+  where?: string;
   using?: string;
   /** MySQL index access method (`"fulltext"` / `"spatial"`). */
   type?: string;


### PR DESCRIPTION
`Virtualized DX Type Tests` (and `pnpm typecheck`) fail on main @9aa215ed:

```
schema-cache.ts(16,15): error TS2724: '"./abstract/schema-definitions.js"' has no exported member named 'IndexDefinitionRow'.
schema-dumper.ts(28,15): error TS2724: ... 'IndexDefinitionRow'.
schema-dumper.ts(1002,36): error TS7006: Parameter 'c' implicitly has an 'any' type.
```

Root cause is a merge race: PR #5877 retired `IndexDefinitionRow` while PR #5879 landed 16 seconds later adding imports of it to `schema-cache.ts` and `schema-dumper.ts`. Neither PR's CI ever saw the other's tree.

- `SchemaCache#indexes` (and the `SchemaReflection` / `BoundSchemaReflection` delegates, plus the backing `_indexes` map) are typed `IndexDefinition[]` — what every adapter's `indexes()` returns after PR #5877.
- The dumper's `IndexInfo` returns to its pre-#5879 standalone declaration, unchanged. It cannot extend `IndexDefinition`: the class's `orders` / `lengths` / `opclasses` are required and typed to conflict with the dumper's optional dialect-specific fields, and `IndexInfo` also describes non-adapter `SchemaSource`s (a dump being re-read) that carry none of them. That also clears the cascading `TS7006` on line 1002, which was fallout from the broken `Omit<>`.

No behavior change — types only.

## Known gap, deliberately not fixed here

`initWith` / `marshalLoad` cast bare decoded-JSON records to `IndexDefinition[]`, so a cache loaded from a dump has the fields but not the derived methods. Rails has no such split (Psych restores real objects); columns already have the trails equivalent in `rehydrateColumn`, indexes never got one. Rehydrating them is a behavior change with a real trap — `IndexDefinition`'s private `conciseOptions` is not guarded against a non-object argument, so feeding an already-collapsed scalar back through the constructor runs `Object.values("desc")` — so it does not belong in a red-CI unblock. Noted in a comment at the site and filed as `0061-ci-failures/schema-cache-rehydrate-indexdefinition-on-load` with the full analysis.

## Verification

- `pnpm test:types:virtualized` — clean; fails on baseline with the three errors above.
- `pnpm typecheck` — clean.
- `pnpm vitest run packages/activerecord/src/connection-adapters/schema-cache.test.ts packages/activerecord/src/schema-dumper.test.ts` — 97 passed, 30 skipped.
- No remaining `IndexDefinitionRow` reference anywhere in the repo.

The type-check jobs are themselves the regression guard; there is no runtime behavior to add a test for.

Closes-story: red-9aa215ed
