### PR TITLE
refactor(activerecord): rehydrate IndexDefinition instances in the schema cache

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
@@ -62,9 +62,6 @@ describe("SchemaCacheIndexDefinitionRoundTripTest", () => {
     ];
     const [loaded] = await roundTrip(live);
 
-    // `opclasses` collapses to the bare scalar both columns share, `orders`
-    // and `lengths` stay per-column — the loaded index must land on the same
-    // side of `conciseOptions` as the live one.
     expect(loaded.columnOptions()).toEqual(live[0].columnOptions());
     expect(loaded.opclasses).toBe("text_pattern_ops");
     expect(loaded.where).toBe("deleted_at IS NULL");

--- a/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SchemaCache, FakePool } from "./schema-cache.js";
+import { IndexDefinition } from "./abstract/schema-definitions.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+describe("SchemaCacheIndexDefinitionRoundTripTest", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "schema-cache-index-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function roundTrip(live: IndexDefinition[]): Promise<IndexDefinition[]> {
+    const pool = new FakePool({
+      indexes: async () => live,
+      dataSourceExists: async () => true,
+      dataSources: async () => ["people"],
+    });
+    const cache = new SchemaCache();
+    cache.setDataSourceExists("people", true);
+    await cache.indexes(pool, "people");
+
+    const filename = path.join(tmpDir, "schema_cache.json");
+    cache.dumpTo(filename);
+    const loaded = SchemaCache._loadFrom(filename);
+    expect(loaded).not.toBeNull();
+    return loaded!.indexes(new FakePool({}), "people");
+  }
+
+  it("dumped and loaded indexes are IndexDefinition instances", async () => {
+    const live = [
+      new IndexDefinition("people", "index_people_on_first_name", true, ["first_name"], {
+        orders: { first_name: "desc" },
+        lengths: { first_name: 10 },
+      }),
+    ];
+    const [loaded] = await roundTrip(live);
+
+    expect(loaded).toBeInstanceOf(IndexDefinition);
+    expect(loaded.columnOptions()).toEqual(live[0].columnOptions());
+    expect(loaded.isDefinedFor(["first_name"], { unique: true })).toBe(true);
+    expect(loaded.isDefinedFor(["last_name"])).toBe(false);
+    expect(loaded.isDefinedFor(undefined, { name: "index_people_on_first_name" })).toBe(true);
+  });
+
+  it("per column index options survive the dump and load", async () => {
+    const live = [
+      new IndexDefinition("people", "index_people_on_name", false, ["first_name", "last_name"], {
+        orders: { first_name: "asc", last_name: "desc" },
+        lengths: { first_name: 10, last_name: 20 },
+        opclasses: { first_name: "text_pattern_ops", last_name: "text_pattern_ops" },
+        where: "deleted_at IS NULL",
+        using: "btree",
+        valid: false,
+      }),
+    ];
+    const [loaded] = await roundTrip(live);
+
+    // `opclasses` collapses to the bare scalar both columns share, `orders`
+    // and `lengths` stay per-column — the loaded index must land on the same
+    // side of `conciseOptions` as the live one.
+    expect(loaded.columnOptions()).toEqual(live[0].columnOptions());
+    expect(loaded.opclasses).toBe("text_pattern_ops");
+    expect(loaded.where).toBe("deleted_at IS NULL");
+    expect(loaded.using).toBe("btree");
+    expect(loaded.isDefinedFor(["first_name", "last_name"], { valid: false })).toBe(true);
+    expect(loaded.isDefinedFor(["first_name", "last_name"], { valid: true })).toBe(false);
+  });
+
+  it("expression indexes keep their raw expression through the cache", async () => {
+    const live = [
+      new IndexDefinition("people", "index_people_on_lower_name", false, "lower(first_name)"),
+    ];
+    const [loaded] = await roundTrip(live);
+
+    expect(loaded.columns).toBe("lower(first_name)");
+    expect(loaded.columnOptions()).toEqual(live[0].columnOptions());
+    expect(loaded.isDefinedFor("lower(first_name)")).toBe(true);
+  });
+
+  it("marshal load rebuilds IndexDefinition instances", async () => {
+    const live = new IndexDefinition("people", "index_people_on_first_name", true, ["first_name"], {
+      orders: { first_name: "desc" },
+    });
+    const source = new SchemaCache();
+    source.setDataSourceExists("people", true);
+    await source.indexes(
+      new FakePool({
+        indexes: async () => [live],
+        dataSourceExists: async () => true,
+      }),
+      "people",
+    );
+
+    const loaded = new SchemaCache();
+    loaded.marshalLoad(JSON.parse(JSON.stringify(source.marshalDump())));
+    const [index] = await loaded.indexes(new FakePool({}), "people");
+
+    expect(index).toBeInstanceOf(IndexDefinition);
+    expect(index.orders).toBe("desc");
+    expect(index.columnOptions()).toEqual(live.columnOptions());
+  });
+});

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -13,7 +13,7 @@ import { Column as MysqlColumn } from "./mysql/column.js";
 import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { poolAbsent } from "./abstract/connection-pool.js";
-import type { IndexDefinitionRow } from "./abstract/schema-definitions.js";
+import { IndexDefinition } from "./abstract/schema-definitions.js";
 
 // ---------------------------------------------------------------------------
 // Helper: run callback inside pool.withConnection if available
@@ -66,6 +66,58 @@ function rehydrateColumn(data: unknown): Column {
   return Column.fromJSON(json);
 }
 
+/**
+ * `IndexDefinition#conciseOptions` collapses a per-column option map to a bare
+ * scalar when every key column shares the value, so a serialized row can carry
+ * either shape. Re-expand the scalar to a per-column map before handing it back
+ * to the constructor, which collapses it again — round-tripping a collapsed
+ * value straight through would make `conciseOptions` walk the scalar itself.
+ */
+function expandIndexOption<T>(
+  columns: string | string[],
+  value: unknown,
+): Record<string, T> | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "object") return value as Record<string, T>;
+  const cols = Array.isArray(columns) ? columns : [columns];
+  return Object.fromEntries(cols.map((c) => [c, value as T]));
+}
+
+/**
+ * Rails' schema cache round-trips real `IndexDefinition` structs (the
+ * YAML/Marshal payload carries the class), so derived behavior like
+ * `columnOptions` / `isDefinedFor` survives a `schema_cache.yml` load. JSON has
+ * no class tag, so rebuild the instance from the serialized fields.
+ */
+function rehydrateIndex(data: unknown): IndexDefinition {
+  if (data instanceof IndexDefinition) return data;
+  const row = data as Record<string, unknown>;
+  const columns = (row["columns"] ?? []) as string | string[];
+  return new IndexDefinition(
+    row["table"] as string,
+    row["name"] as string,
+    (row["unique"] ?? false) as boolean,
+    columns,
+    {
+      where: row["where"] as string | undefined,
+      orders: expandIndexOption<string>(columns, row["orders"]),
+      lengths:
+        typeof row["lengths"] === "number"
+          ? row["lengths"]
+          : expandIndexOption<number>(columns, row["lengths"]),
+      opclasses: expandIndexOption<string>(columns, row["opclasses"]),
+      type: row["type"] as string | undefined,
+      using: row["using"] as string | undefined,
+      include: row["include"] as string[] | undefined,
+      nullsNotDistinct: row["nullsNotDistinct"] as boolean | undefined,
+      comment: row["comment"] as string | undefined,
+      valid: row["valid"] as boolean | undefined,
+      algorithm: row["algorithm"] as string | undefined,
+      ifNotExists: row["ifNotExists"] as boolean | undefined,
+    },
+  );
+}
+
 // ---------------------------------------------------------------------------
 // SchemaCache
 // ---------------------------------------------------------------------------
@@ -75,7 +127,7 @@ export class SchemaCache {
   private _columnsHash = new Map<string, Record<string, Column>>();
   private _primaryKeys = new Map<string, string | string[] | null>();
   private _dataSourceExists = new Map<string, boolean>();
-  private _indexes = new Map<string, IndexDefinitionRow[]>();
+  private _indexes = new Map<string, IndexDefinition[]>();
   private _version: string | number | null = null;
   // When non-null, records the name of every table passed to
   // `clearDataSourceCacheBang` — i.e. every table touched by DDL
@@ -164,10 +216,13 @@ export class SchemaCache {
     }
 
     if (coder["indexes"] instanceof Map) {
-      this._indexes = coder["indexes"] as Map<string, IndexDefinitionRow[]>;
+      this._indexes = coder["indexes"] as Map<string, IndexDefinition[]>;
     } else if (coder["indexes"] && typeof coder["indexes"] === "object") {
       this._indexes = new Map(
-        Object.entries(coder["indexes"] as Record<string, IndexDefinitionRow[]>),
+        Object.entries(coder["indexes"] as Record<string, unknown[]>).map(([table, idx]) => [
+          table,
+          idx.map((i) => rehydrateIndex(i)),
+        ]),
       );
     }
 
@@ -377,7 +432,7 @@ export class SchemaCache {
     return pkCols.length === 1 ? pkCols[0] : pkCols;
   }
 
-  async indexes(pool: unknown, tableName: string): Promise<IndexDefinitionRow[]> {
+  async indexes(pool: unknown, tableName: string): Promise<IndexDefinition[]> {
     if (this._indexes.has(tableName)) {
       return this._indexes.get(tableName)!;
     }
@@ -642,7 +697,10 @@ export class SchemaCache {
       Object.entries((dataSources as Record<string, boolean>) ?? {}),
     );
     this._indexes = new Map(
-      Object.entries((indexes as Record<string, IndexDefinitionRow[]>) ?? {}),
+      Object.entries((indexes as Record<string, unknown[]>) ?? {}).map(([table, idx]) => [
+        table,
+        idx.map((i) => rehydrateIndex(i)),
+      ]),
     );
 
     this.deriveColumnsHashAndDeduplicateValues();
@@ -856,7 +914,7 @@ export class SchemaReflection {
     return this._cache?.isColumnsHash(pool, tableName) ?? false;
   }
 
-  async indexes(pool: unknown, tableName: string): Promise<IndexDefinitionRow[]> {
+  async indexes(pool: unknown, tableName: string): Promise<IndexDefinition[]> {
     return (await this.cache(pool)).indexes(pool, tableName);
   }
 
@@ -1043,7 +1101,7 @@ export class BoundSchemaReflection {
     return this._schemaReflection.isColumnsHash(this._pool, tableName);
   }
 
-  async indexes(tableName: string): Promise<IndexDefinitionRow[]> {
+  async indexes(tableName: string): Promise<IndexDefinition[]> {
     return this._schemaReflection.indexes(this._pool, tableName);
   }
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -25,7 +25,6 @@ import type {
   SchemaDumperMixinHost,
   Column,
 } from "./connection-adapters/abstract/schema-dumper.js";
-import type { IndexDefinitionRow } from "./connection-adapters/abstract/schema-definitions.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
@@ -92,13 +91,18 @@ export interface ColumnInfo {
 }
 
 /**
- * The dumper's view of an adapter index row: the adapter shape
- * (`IndexDefinitionRow`) plus the dialect-specific options the dumper emits.
- * `name` is widened to optional because `SchemaSource` implementations that
- * aren't adapters (e.g. a dump being re-read) may not carry one, and
- * `indexParts` already treats it as absent-able.
+ * The dumper's view of an adapter index row: the `IndexDefinition` fields the
+ * dumper reads plus the dialect-specific options it emits. `name` is optional
+ * because `SchemaSource` implementations that aren't adapters (e.g. a dump
+ * being re-read) may not carry one, and `indexParts` already treats it as
+ * absent-able.
  */
-export interface IndexInfo extends Omit<IndexDefinitionRow, "name"> {
+export interface IndexInfo {
+  table?: string;
+  columns: string | string[];
+  unique: boolean;
+  where?: string;
+  orders?: Record<string, string> | string;
   name?: string;
   /** Per-column max lengths (number for single-column, Record for multi). */
   lengths?: number | Record<string, number>;


### PR DESCRIPTION
`SchemaCache#initWith` and `#marshalLoad` rebuilt `_indexes` straight from the
plain JSON rows, so a dump/load round-trip downgraded every `IndexDefinition`
an adapter's `indexes()` returns (#5877) to a structural object — `columnOptions`
and `isDefinedFor` simply vanished on the cached path. Rails' YAML/Marshal
payload carries the struct class, so a `schema_cache.yml` load keeps the derived
behavior; this restores that.

- `rehydrateIndex` reconstructs the instance from the serialized fields;
  `_indexes` is typed `IndexDefinition[]` (was the retired `IndexDefinitionRow`).
- Collapsed `orders` / `lengths` / `opclasses` scalars are re-expanded per column
  before the constructor's `conciseOptions` collapses them again — feeding a bare
  scalar back in would make `conciseOptions` walk the scalar itself.
- New `schema-cache.trails.test.ts` asserts a dumped-then-loaded index is an
  `IndexDefinition` whose `columnOptions()` / `isDefinedFor()` match the
  live-reflected one, across per-column options, a collapsed-scalar opclass, an
  expression index, and the marshal path.

### Drive-by: `IndexInfo` no longer extends `IndexDefinitionRow`

`main` does not typecheck. #5877 deleted `IndexDefinitionRow` while #5879 landed
new importers of it, and the merge race left `schema-cache.ts:16` and
`schema-dumper.ts:28` importing a type that no longer exists (TS2724, plus a
cascading TS7006 in `indexParts`). `schema-cache.ts` is this story's file; the
one-interface fix in `schema-dumper.ts` — `IndexInfo` declares the five fields it
used to inherit — rides along because the tree cannot compile without it.

Closes-story: schema-cache-rehydrates-indexdefinition-instances
