### PR TITLE
fix(activerecord): make index concise-options idempotent for expression indexes

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -3,6 +3,7 @@ import {
   ForeignKeyDefinition,
   CheckConstraintDefinition,
   ReferenceDefinition,
+  IndexDefinition,
   TableDefinition,
   type ReferenceDefinitionConnection,
 } from "./schema-definitions.js";
@@ -227,5 +228,19 @@ describe("ColumnMethods#primary_key", () => {
 
     expect(td.columns[0].type).toBe("primary_key");
     expect(td.columns[0].options.primaryKey).toBe(true);
+  });
+});
+
+describe("IndexDefinition concise options", () => {
+  it("leaves an already-collapsed scalar alone", () => {
+    const index = new IndexDefinition("posts", "index_posts_on_abc", false, ["a", "b", "c"], {
+      orders: "desc",
+      opclasses: "aaa",
+      lengths: 10,
+    });
+
+    expect(index.orders).toBe("desc");
+    expect(index.opclasses).toBe("aaa");
+    expect(index.lengths).toBe(10);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -581,9 +581,9 @@ export class IndexDefinition {
     columns: string | string[] = [],
     options: {
       where?: string;
-      orders?: Record<string, string>;
+      orders?: Record<string, string> | string;
       lengths?: number | null | Record<string, number>;
-      opclasses?: Record<string, string>;
+      opclasses?: Record<string, string> | string;
       type?: string;
       using?: string;
       include?: string[];
@@ -667,8 +667,9 @@ export class IndexDefinition {
   }
 
   /** @internal */
-  private conciseOptions<T>(options: Record<string, T>): Record<string, T> | T {
-    const values = Object.values(options);
+  private conciseOptions<T>(options: Record<string, T> | T): Record<string, T> | T {
+    if (options == null || typeof options !== "object") return options;
+    const values = Object.values(options as Record<string, T>);
     if (this.columns.length === values.length && new Set(values).size === 1) {
       return values[0];
     }

--- a/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
@@ -72,11 +72,16 @@ describe("SchemaCacheIndexDefinitionRoundTripTest", () => {
 
   it("expression indexes keep their raw expression through the cache", async () => {
     const live = [
-      new IndexDefinition("people", "index_people_on_lower_name", false, "lower(first_name)"),
+      new IndexDefinition("people", "index_people_on_lower_name", false, "lower(first_name)", {
+        orders: "desc",
+        opclasses: "text_pattern_ops",
+      }),
     ];
     const [loaded] = await roundTrip(live);
 
     expect(loaded.columns).toBe("lower(first_name)");
+    expect(loaded.orders).toBe("desc");
+    expect(loaded.opclasses).toBe("text_pattern_ops");
     expect(loaded.columnOptions()).toEqual(live[0].columnOptions());
     expect(loaded.isDefinedFor("lower(first_name)")).toBe(true);
   });

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -69,18 +69,20 @@ function rehydrateColumn(data: unknown): Column {
 /**
  * `IndexDefinition#conciseOptions` collapses a per-column option map to a bare
  * scalar when every key column shares the value, so a serialized row can carry
- * either shape. Re-expand the scalar to a per-column map before handing it back
- * to the constructor, which collapses it again — round-tripping a collapsed
- * value straight through would make `conciseOptions` walk the scalar itself.
+ * either shape. Re-expand the scalar over the key columns before handing it
+ * back to the constructor, which collapses it again. An expression index has no
+ * key columns to expand over — `columns` is the raw expression string — so its
+ * scalar passes straight through to `conciseOptions`, which leaves a non-map
+ * value alone.
  */
 function expandIndexOption<T>(
   columns: string | string[],
   value: unknown,
-): Record<string, T> | undefined {
+): Record<string, T> | T | undefined {
   if (value === null || value === undefined) return undefined;
   if (typeof value === "object") return value as Record<string, T>;
-  const cols = Array.isArray(columns) ? columns : [columns];
-  return Object.fromEntries(cols.map((c) => [c, value as T]));
+  if (!Array.isArray(columns)) return value as T;
+  return Object.fromEntries(columns.map((c) => [c, value as T]));
 }
 
 /**


### PR DESCRIPTION
**Rebased onto merged main.** A sibling story shipped the `rehydrateIndex` work as #5890 while this was in review, so this PR is reduced to the one residual bug that #5890's approach left behind — the two PRs no longer overlap.

`expandIndexOption` (schema-cache.ts) re-expands a collapsed `orders`/`lengths`/`opclasses` scalar over the key columns so the constructor's `conciseOptions` can collapse it again. An expression index has no key columns — `columns` is the raw expression string — so expanding produced a one-entry map keyed by the expression, which `conciseOptions` then refused to collapse (it compares against `columns.length`, i.e. the string's length). A cached expression index came back with `orders: { "lower(first_name)": "desc" }` where the reflected one had `"desc"`.

Two changes:

- `expandIndexOption` passes the scalar straight through when `columns` is a string.
- `IndexDefinition#conciseOptions` — unlike the dumper's module-level twin (`schema-dumper.ts:132`) — is guarded against a non-object argument, so a bare scalar returns unchanged instead of having `Object.values` walk its characters (`"aaa"` over three columns collapsed to `"a"`). Rails' `concise_options` (`schema_definitions.rb:65`) only ever sees a Hash, because Psych restores the struct rather than re-running the constructor; the guard is what makes the pass-through above safe.

Tests: the existing expression-index round-trip in `schema-cache.trails.test.ts` now carries scalar `orders`/`opclasses` and asserts they survive; a new `schema-definitions.trails.test.ts` case pins the constructor's scalar idempotence directly. Both fail on merged main (`expected { 'lower(first_name)': 'desc' } to be 'desc'` and `expected 'a' to be 'aaa'`) — verified.

`pnpm typecheck` clean; `schema-cache.trails.test.ts`, `schema-cache.test.ts`, `schema-definitions.trails.test.ts`, `schema-dumper.test.ts` and `packages/trailties/src/commands/db.test.ts` pass (227 passed, 30 pre-existing skips).

Closes-story: schema-cache-rehydrate-indexdefinition-on-load
