### PR TITLE
refactor(activerecord): converge pkAndSequenceFor onto Rails' two-query Name shape

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -39,6 +39,7 @@ import { NullPool } from "../../connection-adapters/abstract/connection-pool.js"
 import { QueryAttribute } from "../../relation/query-attribute.js";
 import { Value, Integer } from "../../type.js";
 import { withSecondAdapter } from "../../support/second-connection.js";
+import { Name } from "../../connection-adapters/postgresql/utils.js";
 
 const EX_DEFAULT = "id serial primary key, number integer, data character varying(255)";
 
@@ -355,7 +356,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect(result).not.toBeNull();
         const [pk, seq] = result!;
         expect(pk).toBe("id");
-        expect(`${seq!.schema}.${seq!.name}`).toBe(await adapter.defaultSequenceName("ex", "id"));
+        expect(seq!.toString()).toBe(await adapter.defaultSequenceName("ex", "id"));
       });
     });
 
@@ -367,9 +368,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           expect(result).not.toBeNull();
           const [pk, seq] = result!;
           expect(pk).toBe("code");
-          expect(`${seq!.schema}.${seq!.name}`).toBe(
-            await adapter.defaultSequenceName("ex", "code"),
-          );
+          expect(seq!.toString()).toBe(await adapter.defaultSequenceName("ex", "code"));
         },
         "code serial primary key",
       );
@@ -433,7 +432,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
         const result = await adapter.pkAndSequenceFor("ex");
         expect(result).not.toBeNull();
-        expect(result![1]).toEqual({ schema: "public", name: "ex_id_seq" });
+        expect(result![1]).toEqual(new Name("public", "ex_id_seq"));
 
         await adapter.exec(
           `DELETE FROM pg_depend WHERE objid = 'ex2_id_seq'::regclass AND refobjid = 'ex'::regclass AND deptype = 'a'`,

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -126,7 +126,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const result = await adapter.pkAndSequenceFor("ex_custom_seqt");
       expect(result).not.toBeNull();
       expect(result![0]).toBe("id");
-      expect(result![1]!.name).toBe("ex_custom_seq");
+      expect(result![1]!.identifier).toBe("ex_custom_seq");
     });
 
     it("columns for distinct", async () => {

--- a/packages/activerecord/src/adapters/postgresql/rename-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/rename-table.test.ts
@@ -57,7 +57,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const result = await adapter.pkAndSequenceFor("after_rename");
       expect(result).not.toBeNull();
       const [pk, seq] = result!;
-      expect(seq!.name).toBe(`after_rename_${pk}_seq`);
+      expect(seq!.identifier).toBe(`after_rename_${pk}_seq`);
     });
 
     it("renaming a table also renames the primary key index", async () => {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -577,7 +577,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(result1).not.toBeNull();
       expect(result1![0]).toBe("id");
       expect(result1![1]!.schema).toBe(SCHEMA_NAME);
-      expect(result1![1]!.name).toBe(`${PK_TABLE_NAME}_id_seq`);
+      expect(result1![1]!.identifier).toBe(`${PK_TABLE_NAME}_id_seq`);
 
       const result2 = await adapter.pkAndSequenceFor(
         `"${SCHEMA_NAME}"."${UNMATCHED_PK_TABLE_NAME}"`,
@@ -585,7 +585,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(result2).not.toBeNull();
       expect(result2![0]).toBe("id");
       expect(result2![1]!.schema).toBe(SCHEMA_NAME);
-      expect(result2![1]!.name).toBe(UNMATCHED_SEQUENCE_NAME);
+      expect(result2![1]!.identifier).toBe(UNMATCHED_SEQUENCE_NAME);
     });
 
     it("current schema", async () => {
@@ -656,7 +656,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const tableName = `${SCHEMA_NAME}.${PK_TABLE_NAME}`;
       await adapter.setPkSequenceBang(tableName, 123);
       const result = await adapter.pkAndSequenceFor(`"${SCHEMA_NAME}"."${PK_TABLE_NAME}"`);
-      const qualifiedSeq = `"${result![1]!.schema}"."${result![1]!.name}"`;
+      const qualifiedSeq = result![1]!.quoted();
       const rows = await adapter.execute(`SELECT nextval('${qualifiedSeq}') AS val`);
       expect(Number(rows[0].val)).toBe(124);
       await adapter.resetPkSequenceBang(tableName);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3845,11 +3845,10 @@ export class PostgreSQLAdapter
         const seqSuffix = `_${pk}_seq`;
         const maxSeqPrefix = maxLen - seqSuffix.length;
         const expectedOldSeq = `${unqualifiedOld.slice(0, maxSeqPrefix)}${seqSuffix}`;
-        if (seq.name === expectedOldSeq) {
+        if (seq.identifier === expectedOldSeq) {
           const newSeqName = `${unqualifiedNew.slice(0, maxSeqPrefix)}${seqSuffix}`;
-          const qualifiedOldSeq = `${this.quoteIdentifier(seq.schema)}.${this.quoteIdentifier(seq.name)}`;
           await this.exec(
-            `ALTER SEQUENCE IF EXISTS ${qualifiedOldSeq} RENAME TO ${this.quoteIdentifier(newSeqName)}`,
+            `ALTER SEQUENCE IF EXISTS ${seq.quoted()} RENAME TO ${this.quoteIdentifier(newSeqName)}`,
           );
         }
       }
@@ -4693,9 +4692,7 @@ export interface PostgreSQLAdapter {
 
   primaryKey(tableName: string): Promise<string | string[] | null>;
 
-  pkAndSequenceFor(
-    tableName: string,
-  ): Promise<[string, { schema: string; name: string } | null] | null>;
+  pkAndSequenceFor(tableName: string): Promise<[string, Name | null] | null>;
 
   resetPkSequence(tableName: string): Promise<void>;
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -3,6 +3,7 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import { Table as PgTable } from "./schema-definitions.js";
+import { Name } from "./utils.js";
 
 // The bodies under test are prototype methods on the adapter, so give the fake
 // adapter that prototype and call them the way production does.
@@ -13,6 +14,7 @@ function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
 interface FakeOptions {
   logger?: { warn: (msg: string) => void };
   schemaQuery?: (sql: string) => Promise<Record<string, unknown>[]>;
+  query?: (sql: string) => Promise<unknown[][]>;
   queryValue?: (sql: string) => Promise<unknown>;
   maxIdentifierLength?: number;
 }
@@ -47,6 +49,10 @@ function makeAdapter(options: FakeOptions = {}) {
     schemaQuery: vi.fn(async (text: string) => {
       sql.push(text);
       return options.schemaQuery ? await options.schemaQuery(text) : [];
+    }),
+    query: vi.fn(async (text: string) => {
+      sql.push(text);
+      return options.query ? await options.query(text) : [];
     }),
     queryValue: vi.fn(async (text: string) => {
       sql.push(text);
@@ -149,36 +155,44 @@ describe("PostgreSQLSchemaStatements#indexNameExists", () => {
 });
 
 describe("PostgreSQLSchemaStatements#pkAndSequenceFor", () => {
-  // Rails' fallback query selects `nsp.nspname` — the TABLE's namespace — and a
-  // CASE that strips everything through the dot, so the sequence's own schema
-  // never survives (schema_statements.rb:382-407).
-  it("pairs the table schema with the bare sequence name on the default_expr fallback", async () => {
-    const { adapter } = makeAdapter({
-      schemaQuery: async () => [
-        {
-          pk: "id",
-          seq: null,
-          default_expr: "nextval('other_schema.things_id_seq'::regclass)",
-          schema_name: "public",
-        },
-      ],
+  it("falls back to the pg_attrdef query when the pg_depend lookup finds nothing", async () => {
+    const { adapter, sql } = makeAdapter({
+      query: async (text) =>
+        text.includes("pg_depend") ? [] : [["id", "public", "things_id_seq"]],
     });
     const ss = withSchemaStatements(adapter);
     expect(await ss.pkAndSequenceFor("things")).toEqual([
       "id",
-      { schema: "public", name: "things_id_seq" },
+      new Name("public", "things_id_seq"),
     ]);
+    expect(sql).toHaveLength(2);
+    expect(sql[0]).toContain("pg_depend");
+    expect(sql[1]).toContain("pg_attrdef");
+  });
+
+  it("returns a null sequence when the fallback row carries no sequence name", async () => {
+    const { adapter } = makeAdapter({
+      query: async (text) => (text.includes("pg_depend") ? [] : [["id", "public", null]]),
+    });
+    const ss = withSchemaStatements(adapter);
+    expect(await ss.pkAndSequenceFor("pg_uuids")).toEqual(["id", null]);
   });
 
   // Rails' bare `rescue nil` covers the whole method, not just unknown tables.
   it("returns null when the lookup raises", async () => {
     const { adapter } = makeAdapter({
-      schemaQuery: async () => {
+      query: async () => {
         throw new Error("boom");
       },
     });
     const ss = withSchemaStatements(adapter);
     expect(await ss.pkAndSequenceFor("things")).toBeNull();
+  });
+
+  it("returns null when neither query matches", async () => {
+    const { adapter } = makeAdapter({ query: async () => [] });
+    const ss = withSchemaStatements(adapter);
+    expect(await ss.pkAndSequenceFor("unobtainium")).toBeNull();
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1774,82 +1774,65 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     return names as string[];
   }
 
-  async pkAndSequenceFor(
-    tableName: string,
-  ): Promise<[string, { schema: string; name: string } | null] | null> {
+  async pkAndSequenceFor(tableName: string): Promise<[string, Name | null] | null> {
     // Rails wraps the whole of `pk_and_sequence_for` in a bare `rescue nil`, so
     // ANY error — not just an unknown table — yields nil.
     try {
-      // Mirrors Rails pk_and_sequence_for's `#{quote(quote_table_name(table))}::regclass`:
-      // regclass resolves a schema-qualified or bare name itself, and the quoting
-      // keeps a mixed-case name like "CamelCase" case-sensitive.
-      //
-      // Deviation: `to_regclass(...)` rather than a bare `::regclass` cast. The
-      // outer `rescue nil` already turns an unknown table into nil either way,
-      // but PG aborts the enclosing transaction when the cast raises — and a
-      // Ruby rescue leaves the transaction untouched. to_regclass yields NULL
-      // (hence no rows, hence nil) without ever entering the aborted state.
-      const tableCondition = `t.oid = to_regclass(${this.pg.quote(this.pg.quoteTableName(tableName))})`;
+      const quotedTable = this.pg.quote(this.pg.quoteTableName(tableName));
 
-      const rows = await this.pg.schemaQuery(
-        `SELECT a.attname AS pk,
-                pg_get_serial_sequence(quote_ident(n.nspname) || '.' || quote_ident(t.relname), a.attname) AS seq,
-                pg_get_expr(ad.adbin, ad.adrelid) AS default_expr,
-                n.nspname AS schema_name
-         FROM pg_index i
-         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-         JOIN pg_class t ON t.oid = i.indrelid
-         JOIN pg_namespace n ON n.oid = t.relnamespace
-         LEFT JOIN pg_attrdef ad ON ad.adrelid = t.oid AND ad.adnum = a.attnum
-         WHERE ${tableCondition}
-           AND i.indisprimary = true
-         -- Resolve the FIRST primary-key column deterministically (mirrors Rails
-         -- pk_and_sequence_for's cons.conkey[1]); without the ORDER BY a composite
-         -- PK's ANY(i.indkey) join could return an arbitrary column under LIMIT 1.
-         ORDER BY array_position(i.indkey, a.attnum)
-         LIMIT 1`,
-      );
+      // First try looking for a sequence with a dependency on the
+      // given table's primary key.
+      let result = (
+        await this.pg.query(
+          `SELECT attr.attname, nsp.nspname, seq.relname
+           FROM pg_class      seq,
+                pg_attribute  attr,
+                pg_depend     dep,
+                pg_constraint cons,
+                pg_namespace  nsp
+           WHERE seq.oid           = dep.objid
+             AND seq.relkind       = 'S'
+             AND attr.attrelid     = dep.refobjid
+             AND attr.attnum       = dep.refobjsubid
+             AND attr.attrelid     = cons.conrelid
+             AND attr.attnum       = cons.conkey[1]
+             AND seq.relnamespace  = nsp.oid
+             AND cons.contype      = 'p'
+             AND dep.classid       = 'pg_class'::regclass
+             AND dep.refobjid      = ${quotedTable}::regclass`,
+          "SCHEMA",
+        )
+      )[0];
 
-      if (rows.length === 0) return null;
-
-      const pk = rows[0].pk as string;
-      const tableSchema = rows[0].schema_name as string;
-      let seq: { schema: string; name: string } | null = null;
-
-      if (rows[0].seq) {
-        const fullSeq = rows[0].seq as string;
-        const parts = splitQuotedIdentifier(fullSeq);
-        seq =
-          parts.length > 1
-            ? { schema: parts[0], name: parts[1] }
-            : { schema: tableSchema, name: parts[0] };
-      } else {
-        const defaultExpr = rows[0].default_expr as string | null;
-        if (defaultExpr) {
-          const match = defaultExpr.match(/nextval\('([^']+)'::regclass\)/);
-          if (match) {
-            // Rails' fallback query pairs `nsp.nspname` — the TABLE's namespace —
-            // with a CASE that strips everything through the dot, so a
-            // `nextval('other_schema.seq')` default still yields
-            // `Name.new(table_schema, "seq")`. Keep the sequence identifier only.
-            const parts = splitQuotedIdentifier(match[1]);
-            seq = { schema: tableSchema, name: parts[parts.length - 1] };
-          }
-        }
+      if (result == null || result.length === 0) {
+        result = (
+          await this.pg.query(
+            `SELECT attr.attname, nsp.nspname,
+               CASE
+                 WHEN pg_get_expr(def.adbin, def.adrelid) !~* 'nextval' THEN NULL
+                 WHEN split_part(pg_get_expr(def.adbin, def.adrelid), '''', 2) ~ '.' THEN
+                   substr(split_part(pg_get_expr(def.adbin, def.adrelid), '''', 2),
+                          strpos(split_part(pg_get_expr(def.adbin, def.adrelid), '''', 2), '.')+1)
+                 ELSE split_part(pg_get_expr(def.adbin, def.adrelid), '''', 2)
+               END
+             FROM pg_class       t
+             JOIN pg_attribute   attr ON (t.oid = attrelid)
+             JOIN pg_attrdef     def  ON (adrelid = attrelid AND adnum = attnum)
+             JOIN pg_constraint  cons ON (conrelid = adrelid AND adnum = conkey[1])
+             JOIN pg_namespace   nsp  ON (t.relnamespace = nsp.oid)
+             WHERE t.oid = ${quotedTable}::regclass
+               AND cons.contype = 'p'
+               AND pg_get_expr(def.adbin, def.adrelid) ~* 'nextval|uuid_generate|gen_random_uuid'`,
+            "SCHEMA",
+          )
+        )[0];
       }
 
-      if (seq) return [pk, seq];
-
-      // No owning sequence. Mirrors Rails pk_and_sequence_for: its fallback query
-      // matches `nextval|uuid_generate|gen_random_uuid` defaults, so a uuid-default
-      // pk still returns a row (with a nil sequence) → `[pk, nil]`, whereas a pk
-      // with no such default matches neither query and yields nil (the whole
-      // result). See uuid_test.rb#test_pk_and_sequence_for_with_uuid_primary_key.
-      const defaultExpr = rows[0].default_expr as string | null;
-      if (defaultExpr && /uuid_generate|gen_random_uuid/i.test(defaultExpr)) {
-        return [pk, null];
+      const [pk, schema, identifier] = result as unknown as [string, string | null, string | null];
+      if (identifier != null) {
+        return [pk, new Name(schema, identifier)];
       }
-      return null;
+      return [pk, null];
     } catch {
       return null;
     }
@@ -1909,7 +1892,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const [pk, seq] = result ?? [null, null];
     if (!pk) return;
     if (seq) {
-      const quotedSequence = this.pg.quoteTableName(`${seq.schema}.${seq.name}`);
+      const quotedSequence = this.pg.quoteTableName(seq.toString());
       await this.queryValue(`SELECT setval(${this.pg.quote(quotedSequence)}, ${value})`, "SCHEMA");
     } else {
       this.pg.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
@@ -1928,7 +1911,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     if (!pk || !sequence) {
       const [defaultPk, defaultSeq] = (await this.pkAndSequenceFor(tableName)) ?? [null, null];
       pk = pk ?? defaultPk;
-      sequence = sequence ?? (defaultSeq ? `${defaultSeq.schema}.${defaultSeq.name}` : null);
+      sequence = sequence ?? defaultSeq?.toString() ?? null;
     }
 
     if (pk && !sequence) {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -155,7 +155,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const result = await adapter.pkAndSequenceFor(tableName);
       expect(result).not.toBeNull();
       const [, seq] = result!;
-      const seqName = `${seq!.schema}.${seq!.name}`;
+      const seqName = seq!.toString();
       await adapter.schemaQuery(`SELECT setval($1::regclass, 123)`, [seqName]);
       const before = await adapter.schemaQuery(`SELECT nextval($1::regclass) AS n`, [seqName]);
       expect(Number(before[0].n)).toBe(124);
@@ -169,7 +169,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const result = await adapter.pkAndSequenceFor(tableName);
       expect(result).not.toBeNull();
       const [, seq] = result!;
-      const seqName = `${seq!.schema}.${seq!.name}`;
+      const seqName = seq!.toString();
       await adapter.setPkSequenceBang(tableName, 123);
       const rows = await adapter.schemaQuery(`SELECT nextval($1::regclass) AS n`, [seqName]);
       expect(Number(rows[0].n)).toBe(124);


### PR DESCRIPTION
Rails' `PostgreSQL::SchemaStatements#pk_and_sequence_for`
(`schema_statements.rb:359-411`) runs TWO `query` calls — a pg_depend lookup on
the primary key's owned sequence, then a pg_attrdef fallback — and returns
`[pk, PostgreSQL::Name.new(*result)]`.

trails ran a single rewritten pg_index query whose `LEFT JOIN pg_attrdef`
folded the fallback into one result set, reconstructed the sequence name in
TypeScript (`pg_get_serial_sequence`, a `nextval(...)` regex, a
`uuid_generate` probe), and returned a plain `{ schema, name }` object.

- Port Rails' two queries verbatim, including the `::regclass` casts and the
  `dep.classid = 'pg_class'::regclass` filter that
  `test_pk_and_sequence_for_with_collision_pg_class_oid` exercises — under the
  old single query that test passed for the wrong reason.
- Return `[pk, Name]`; `[pk, null]` when the fallback CASE yields no sequence
  (the uuid primary key case), and `null` when neither query matches — Ruby's
  `result.shift` on nil raising into the bare `rescue nil`.
- Callers read `.identifier` / `.quoted()` / `.toString()` off the `Name`;
  `renameTable` now mirrors Rails' `seq.identifier` / `seq.quoted`
  (`schema_statements.rb:452-454`).

## Two notes on the story's stated scope

**The three wide-baseline entries do not exist.** `pk_and_sequence_for` /
`last`, `new`, `query` are not in
`call-mismatches-wide-exclude/activerecord/connection-adapters/` — #5844's
mixin-flip baseline retune already dropped them. `pnpm api:calls:wide` passes
with no baseline edit and no `pk_and_sequence_for` row in the mismatch output,
so there was nothing to remove.

**The `to_regclass` deviation is retired, not preserved.** The old code used
`to_regclass(...)` in place of `::regclass` so an unknown table would not abort
an enclosing PG transaction. Rails has exactly the same abort behavior, so that
workaround was ratifying a divergence rather than porting one; this uses
`::regclass`. `pk and sequence for returns nil if table not found` passes.

## Verification

- 331 tests across the five affected PG files pass against a live PostgreSQL 17
  (`postgresql-adapter.test.ts`, `postgresql-adapter.trails.test.ts`,
  `rename-table.test.ts`, `schema.test.ts`,
  `connection-adapters/postgresql/schema-statements.test.ts`).
- `pnpm api:calls:wide`: OK.
- The two trails unit tests that asserted the invented `{ schema, name }`
  fallback shape are replaced by four covering the two-query order, the
  null-sequence row, the rescue, and the no-match case.

Closes-story: converge-pg-pk-and-sequence-for-onto-two-query-name-shape
