### PR TITLE
refactor(activerecord): route relation primary_key reads through the delegate

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3866,7 +3866,7 @@ export class Relation<T extends Base> {
     updateValues: [Nodes.Node, unknown][] | Nodes.SqlLiteral | Nodes.BoundSqlLiteral,
   ): Promise<number> {
     const table = this._modelClass.arelTable;
-    const primaryKey = this._modelClass.primaryKey;
+    const primaryKey = this.primaryKey;
     let stmtAst;
     if (typeof primaryKey === "string" || Array.isArray(primaryKey)) {
       const arel = this._eagerLoadingForSql()
@@ -4654,7 +4654,7 @@ export class Relation<T extends Base> {
     useRanges?: boolean | null;
   } = {}): BatchEnumerator<LoadedRelation<Relation<T>>> {
     const self = this;
-    const pk = this._modelClass.primaryKey;
+    const pk = this.primaryKey;
     const effectiveCursor = cursor ?? pk;
     const cursorArr = Array.isArray(effectiveCursor) ? effectiveCursor : [effectiveCursor];
     _ensureValidOptionsForBatchingBang(cursorArr, start, finish, (order ?? "asc") as any);
@@ -4667,7 +4667,7 @@ export class Relation<T extends Base> {
       if (!cursorIncludesPk) {
         const cache = self._modelClass.schemaCache();
         const pool = self._modelClass.connectionPool();
-        const idxs = (await cache.indexes(pool, self._modelClass.tableName)) as Array<{
+        const idxs = (await cache.indexes(pool, self.tableName)) as Array<{
           unique: boolean;
           where?: string | null;
           columns: string[];

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -62,6 +62,8 @@ interface CalculationConnection {
 
 interface CalculationRelation {
   model: CalculationRelation["_modelClass"];
+  /** Rails `delegate :primary_key, to: :model` (delegation.rb:106). */
+  primaryKey: string | string[];
   _modelClass: {
     arelTable: any;
     primaryKey: string | string[];
@@ -764,8 +766,8 @@ export async function performCount(
   // grouped calculation — groupedAggregate has no hasInclude guard.
   if (this._groupColumns.length > 0 && hasInclude(this, column ?? null)) {
     // CPK + grouped eagerLoad not yet supported; fall through to plain groupedAggregate.
-    if (!Array.isArray(this._modelClass.primaryKey)) {
-      const pk = this._modelClass.primaryKey;
+    if (!Array.isArray(this.model.primaryKey)) {
+      const pk = this.model.primaryKey;
       // Mirror `calculate` (calculations.rb:217-238): apply the eager join then
       // dispatch to the grouped calculation. The eager associations stay on the
       // relation so `groupedAggregate` folds them through the shared
@@ -803,7 +805,7 @@ export async function performCount(
     // nodes in place, so the id and count queries cannot share one instance.
     const eagerJoined = (): CalculationRelation => eagerJoinedRelation(this, false);
     if (eagerJoined() !== this) {
-      const pk = this._modelClass.primaryKey;
+      const pk = this.model.primaryKey;
       if (!Array.isArray(pk)) {
         const table = this._modelClass.arelTable;
         if (this._limitValue !== null || this._offsetValue !== null) {
@@ -1154,7 +1156,7 @@ export async function performCount(
   }
 
   if (this._isDistinct) {
-    const pk = this._modelClass.primaryKey;
+    const pk = this.primaryKey;
     if (Array.isArray(pk)) {
       // Multi-column DISTINCT COUNT requires a subquery since
       // COUNT(DISTINCT col1, col2) isn't valid on SQLite/PG

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -352,6 +352,7 @@ function makeFindSomeRel(
   return {
     _modelClass: postModelStub,
     model: postModelStub,
+    primaryKey: postModelStub.primaryKey,
     _limitValue: opts.limit ?? null,
     _offsetValue: opts.offset ?? null,
     // ordered=true simulates a relation with ORDER BY (findSome stays in the accounting path)
@@ -406,6 +407,7 @@ describe("findSome — narrows to pk column when select_values non-empty (ordere
     const rel: any = {
       _modelClass: postModelStub,
       model: postModelStub,
+      primaryKey: postModelStub.primaryKey,
       _limitValue: null,
       _offsetValue: null,
       _orderClauses: ["id ASC"],
@@ -452,6 +454,7 @@ function makeFindSomeOrderedRel(
   return {
     _modelClass: postModelStub,
     model: postModelStub,
+    primaryKey: postModelStub.primaryKey,
     _limitValue: opts.limit ?? null,
     _offsetValue: opts.offset ?? null,
     _orderClauses: [],
@@ -586,7 +589,7 @@ function makeRelForOrder(mc: {
   implicitOrderColumn?: string | null;
   _queryConstraintsList?: string[] | null;
 }): any {
-  return { _modelClass: mc, model: mc };
+  return { _modelClass: mc, model: mc, primaryKey: mc.primaryKey };
 }
 
 describe("_orderColumns — Rails _order_columns precedence", () => {
@@ -631,6 +634,7 @@ describe("finder not-found message fidelity", () => {
     const rel: any = {
       _modelClass: carModelStub,
       model: carModelStub,
+      primaryKey: carModelStub.primaryKey,
       raiseRecordNotFoundExceptionBang,
       _whereClause: { isEmpty: () => true },
       findBy: async () => null,
@@ -652,6 +656,7 @@ describe("finder not-found message fidelity", () => {
     const rel: any = {
       _modelClass: mercedesModelStub,
       model: mercedesModelStub,
+      primaryKey: mercedesModelStub.primaryKey,
       _limitValue: null,
       _offsetValue: null,
       selectValues: [],

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -264,6 +264,8 @@ export function raiseNotFoundSingle(
 
 interface FinderRelation {
   model: FinderRelation["_modelClass"];
+  /** Rails `delegate :primary_key, to: :model` (delegation.rb:106). */
+  primaryKey: string | string[];
   _modelClass: {
     name: string;
     primaryKey: string | string[];
@@ -314,7 +316,7 @@ function buildPkWhere(pk: string[], tuple: unknown[]): Record<string, unknown> {
 
 /** @internal */
 export async function performFind(this: FinderRelation, ...args: unknown[]): Promise<any> {
-  const pk = this._modelClass.primaryKey;
+  const pk = this.primaryKey;
   const modelName = this._modelClass.name;
   const normalized = normalizeFindArgs(modelName, pk, args);
   if (normalized.emptyArray) return [];
@@ -841,11 +843,11 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
     if (Object.keys(conditions).length > 0) relation = relation.where(conditions);
   } else {
     // Scalar → PK lookup (Rails' else branch: `where!(primary_key => conditions)`).
-    const pk = (rel as any)._modelClass.primaryKey;
+    const pk = rel.primaryKey;
     if (Array.isArray(pk)) {
       relation = relation.where(buildPkWhere(pk, conditions as unknown[]));
     } else {
-      relation = relation.where({ [pk as string]: conditions });
+      relation = relation.where({ [pk]: conditions });
     }
   }
   return relation;
@@ -853,7 +855,7 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
 
 /** @internal */
 export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<any> {
-  const normalized = normalizeFindArgs(rel.model.name, rel.model.primaryKey, ids);
+  const normalized = normalizeFindArgs(rel.model.name, rel.primaryKey, ids);
   if (normalized.emptyArray) return [];
   if (normalized.wantArray) {
     return findSome(rel, normalized.ids);
@@ -863,7 +865,7 @@ export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<
 
 /** @internal */
 export async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
-  const pk = rel.model.primaryKey;
+  const pk = rel.primaryKey;
   const conditions = Array.isArray(pk) ? buildPkWhere(pk, id as unknown[]) : { [pk]: id };
   const record = await (rel as any).findBy(conditions);
   if (!record) {
@@ -877,7 +879,7 @@ export async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
 export async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
   if (!hasOrder(rel)) return findSomeOrdered(rel, ids);
 
-  const pk = (rel as any)._modelClass.primaryKey as string;
+  const pk = rel.primaryKey as string;
   let relation = (rel as any).where({ [pk]: ids });
   // Rails: `relation = relation.select(table[primary_key]) unless select_values.empty?`
   if ((rel as any).selectValues.length > 0) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -156,6 +156,8 @@ export type OrderArg =
 // Uses TS `private` keyword fields which are accessible at runtime.
 // ---------------------------------------------------------------------------
 interface QueryMethodsHost {
+  /** Rails `delegate :primary_key, to: :model` (delegation.rb:106). */
+  primaryKey: string | string[];
   _whereClause: WhereClause;
   _orderClauses: Array<string | [string, "asc" | "desc"] | Nodes.Node>;
   _rawOrderClauses: string[];
@@ -1573,7 +1575,7 @@ function uniqBang(this: QueryMethodsHost, name?: string): any {
 }
 
 function excludingBang(this: QueryMethodsHost, records: any[]): any {
-  const primaryKey = this._modelClass.primaryKey;
+  const primaryKey = this.primaryKey;
   if (Array.isArray(primaryKey)) {
     throw new Error("excluding does not support models with composite primary keys");
   }


### PR DESCRIPTION
Rails' `Relation` delegates `primary_key` / `table_name` to `model`
(`delegation.rb:106`), and the Rails bodies call the **bare delegate**. Our
ported bodies read `_modelClass.primaryKey` directly, so the ported call graph
omits the delegate hop Rails makes. Sibling of #5325 (which converged the
`model` accessor reads and deliberately left `primaryKey` alone); the faithful
target is `this.primaryKey`, not `this.model.primaryKey`.

Each read was checked against its Rails counterpart body before rewriting.

## Routed through the bare delegate

| trails | Rails counterpart |
| --- | --- |
| `relation.ts` `_execUpdateAll` | `relation.rb:1028-1031` — `primary_key.map` / `table[primary_key]` |
| `relation.ts` `inBatches` (cursor default) | `batches.rb:259` — `cursor: primary_key` |
| `relation.ts` `inBatches` (index probe) | `batches.rb:314-315` — `Array(primary_key)`, `model.schema_cache.indexes(table_name)` |
| `relation/calculations.ts` `performCount` distinct arm | `calculations.rb:447` — `column_name = primary_key` |
| `relation/query-methods.ts` `excludingBang` | `query_methods.rb:1588` — `predicate_builder[primary_key, records]` |
| `relation/finder-methods.ts` `performFind` | `finder_methods.rb:492-494` |
| `relation/finder-methods.ts` scalar-conditions branch | `finder_methods.rb:451` — `where!(primary_key => conditions)` |
| `relation/finder-methods.ts` `findWithIds` / `findOne` | `finder_methods.rb:528-531` |
| `relation/finder-methods.ts` `findSome` | `finder_methods.rb:544-545` |

Host interfaces (`CalculationRelation`, `QueryMethodsHost`, `FinderRelation`)
gained the `primaryKey` delegate member; one test stub literal grew the same
field.

## Routed through `model` (Rails really says `model.primary_key`)

- `relation/calculations.ts` `performCount` eager-load arms — `calculations.rb:237`
  is `Array(model.primary_key || table[Arel.star])`, so `this.model.primaryKey`
  is the faithful form here, not the bare delegate.

## Left alone (noted per acceptance criteria)

- `relation.ts` `unscoped()` — this IS the delegate body; `_modelClass.unscoped()`
  is what `delegate :unscoped, to: :model` means.
- `relation.ts` `_isKnownColumn`, `relation/calculations.ts` `buildAggNode` /
  `aggregateColumn` PK fallbacks, `relation/merged-join-alias-tracker.ts` —
  trails-invented helpers with no Rails counterpart body.
- `relation/finder-methods.ts` `orderByPk` — Rails `ordered_relation` reads
  `model.primary_key` (`finder_methods.rb:654-655`), which is a different
  receiver than the flagged call; out of scope for this pass.
- `relation/predicate-builder.ts` `associatedTable.primaryKey` — matches Rails
  `predicate_builder.rb:114` exactly.

## Ratchet

`pnpm api:calls:wide:reseed` produces **no baseline diff** — the wide extractor
is receiver-agnostic for property reads, so these rewrites neither add nor
remove entries. The remaining 9 `primary_key` wide entries in this cluster stay
baselined: they sit on ported methods (`relation.ts` `calculate`,
`ensure_valid_options_for_batching!`, `relation/batches.ts`
`batch_on_unloaded_relation`, `relation/calculations.ts` `perform_calculation` /
`execute_grouped_calculation`) whose trails bodies are thin dispatch shims with
no PK logic at all — closing those needs body-level convergence, not a read
rewrite. `pnpm api:calls:wide` is green (2326 baselined, mark 2153 tight).

Behavior-preserving: value-identical at runtime; the win is call-graph fidelity.

Closes-story: converge-relation-primary-key-delegate-reads
