### PR TITLE
refactor(activerecord): converge PG indexes() onto Rails' indkey/INCLUDE shape

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -17,6 +17,7 @@ import {
 import { withSecondAdapter } from "../../support/second-connection.js";
 import { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 import { captureSql } from "../../testing/sql-capture.js";
+import { itIfSupports } from "../../support/supports.js";
 
 async function withExtensionDisabled(
   adapter: PostgreSQLAdapter,
@@ -98,6 +99,22 @@ describeIfPg("PostgreSQLAdapter", () => {
         | undefined;
       expect(nndIdx?.nullsNotDistinct).toBe(await expectedNullsNotDistinctValue(adapter));
     });
+
+    itIfSupports(
+      "index_include",
+      "indexes() keeps INCLUDE columns out of the key column list",
+      async () => {
+        await adapter.exec(
+          `CREATE TABLE "ex_idx_incl" ("id" SERIAL PRIMARY KEY, "n" INTEGER, "d" TEXT)`,
+        );
+        await adapter.exec(`CREATE INDEX "ex_idx_incl_i" ON "ex_idx_incl" ("n") INCLUDE ("d")`);
+        const index = (await adapter.indexes("ex_idx_incl")).find(
+          (i) => i.name === "ex_idx_incl_i",
+        )!;
+        expect(index.columns).toEqual(["n"]);
+        expect(index.include).toEqual(["d"]);
+      },
+    );
 
     it("pk and sequence for table with serial pk", async () => {
       await adapter.exec(`CREATE TABLE "ex_serial" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -13,6 +13,7 @@ function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
 interface FakeOptions {
   logger?: { warn: (msg: string) => void };
   schemaQuery?: (sql: string) => Promise<Record<string, unknown>[]>;
+  query?: (sql: string) => Promise<unknown[][]>;
   queryValue?: (sql: string) => Promise<unknown>;
   maxIdentifierLength?: number;
 }
@@ -47,6 +48,10 @@ function makeAdapter(options: FakeOptions = {}) {
     schemaQuery: vi.fn(async (text: string) => {
       sql.push(text);
       return options.schemaQuery ? await options.schemaQuery(text) : [];
+    }),
+    query: vi.fn(async (text: string) => {
+      sql.push(text);
+      return options.query ? await options.query(text) : [];
     }),
     queryValue: vi.fn(async (text: string) => {
       sql.push(text);
@@ -256,19 +261,22 @@ describe("PostgreSQLSchemaStatements#changeTable", () => {
 describe("PostgreSQLSchemaStatements#indexes", () => {
   it("keeps the schema-qualified table name from the argument", async () => {
     const { adapter } = makeAdapter({
-      schemaQuery: async () => [
-        {
-          index_name: "index_things_on_name",
-          is_unique: false,
-          using: "btree",
-          columns: ["name"],
-          has_expressions: false,
-          definition: "CREATE INDEX index_things_on_name ON my_schema.things USING btree (name)",
-          options: [0],
-          is_valid: true,
-          comment: null,
-        },
-      ],
+      // Rails' `indexes` runs two positional `query` calls: the pg_index scan,
+      // then the attnum -> attname lookup behind columnNamesFromColumnNumbers.
+      query: async (text) =>
+        text.includes("pg_attribute")
+          ? [[1, "name"]]
+          : [
+              [
+                "index_things_on_name",
+                false,
+                "1",
+                "CREATE INDEX index_things_on_name ON my_schema.things USING btree (name)",
+                12345,
+                null,
+                true,
+              ],
+            ],
     });
     const ss = withSchemaStatements(adapter);
     const [index] = await ss.indexes("my_schema.things");

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -261,8 +261,6 @@ describe("PostgreSQLSchemaStatements#changeTable", () => {
 describe("PostgreSQLSchemaStatements#indexes", () => {
   it("keeps the schema-qualified table name from the argument", async () => {
     const { adapter } = makeAdapter({
-      // Rails' `indexes` runs two positional `query` calls: the pg_index scan,
-      // then the attnum -> attname lookup behind columnNamesFromColumnNumbers.
       query: async (text) =>
         text.includes("pg_attribute")
           ? [[1, "name"]]

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -63,7 +63,6 @@ interface PgSchemaAdapter {
   extractSchemaQualifiedName(string: string): [string | null, string];
   maxIdentifierLength(): number;
   getDatabaseVersion(): Promise<number>;
-  supportsIndexInclude(): boolean;
   dataSourceSql(name?: string | null, options?: { type?: string }): string;
   quotedScope(
     name?: string | null,
@@ -130,112 +129,92 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // ---------------------------------------------------------------------------
 
   async indexes(tableName: string): Promise<IndexDefinition[]> {
-    // supportsIndexInclude() reads databaseVersion; ensure it's populated.
-    await this.pg.getDatabaseVersion();
-    const [schema, table] = this.pg.extractSchemaQualifiedName(tableName);
+    const scope = this.pg.quotedScope(tableName);
 
-    let tableCondition: string;
-    const binds: unknown[] = [];
-
-    if (schema) {
-      binds.push(table, schema);
-      tableCondition = `t.relname = $1 AND n.nspname = $2`;
-    } else {
-      binds.push(tableName);
-      tableCondition = `t.oid = to_regclass($1)`;
-    }
-
-    // ix.indnkeyatts was added in PG11 (covering indexes); on older servers
-    // INCLUDE columns don't exist, so all indkey columns are key columns.
-    const includeFilter = this.pg.supportsIndexInclude() ? `WHERE k < ix.indnkeyatts` : "";
-
-    const rows = await this.pg.schemaQuery(
-      `SELECT i.relname AS index_name,
-              ix.indisunique AS is_unique,
-              am.amname AS using,
-              ARRAY(
-                SELECT pg_get_indexdef(ix.indexrelid, k + 1, true)
-                FROM generate_subscripts(ix.indkey, 1) AS k
-                ${includeFilter}
-                ORDER BY k
-              ) AS columns,
-              (ix.indexprs IS NOT NULL) AS has_expressions,
-              pg_get_indexdef(ix.indexrelid) AS definition,
-              ix.indoption AS options,
-              ix.indisvalid AS is_valid,
-              obj_description(ix.indexrelid, 'pg_class') AS comment
+    const result = await this.pg.query(
+      `SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid), t.oid,
+                      pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid
        FROM pg_class t
-       JOIN pg_index ix ON t.oid = ix.indrelid
-       JOIN pg_class i ON i.oid = ix.indexrelid
-       JOIN pg_namespace n ON n.oid = t.relnamespace
-       JOIN pg_am am ON am.oid = i.relam
-       WHERE ${tableCondition}
-         AND i.relkind IN ('i', 'I')
-         AND ix.indisprimary = false
+       INNER JOIN pg_index d ON t.oid = d.indrelid
+       INNER JOIN pg_class i ON d.indexrelid = i.oid
+       LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
+       WHERE i.relkind IN ('i', 'I')
+         AND d.indisprimary = 'f'
+         AND t.relname = ${scope.name}
+         AND n.nspname = ${scope.schema}
        ORDER BY i.relname`,
-      binds,
+      "SCHEMA",
     );
 
-    return rows.map((row) => {
-      const def = row.definition as string;
+    return Promise.all(
+      result.map(async (row) => {
+        const indexName = row[0] as string;
+        const unique = row[1] as boolean;
+        const indkey = toS(row[2])
+          .split(" ")
+          .map((n) => Number(n));
+        const inddef = row[3] as string;
+        const oid = Number(row[4]);
+        const comment = row[5] as string | null;
+        const valid = row[6] as boolean;
 
-      // Extract the expressions, INCLUDE, NULLS NOT DISTINCT, and WHERE clauses.
-      // Mirrors Rails' regex: / USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?\z/m
-      const defMatch = def.match(
-        / USING \w+? \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?$/s,
-      );
-      const expressions = defMatch?.[1] ?? "";
-      const includeStr = defMatch?.[2];
-      const nullsNotDistinctStr = defMatch?.[3];
-      const whereStr = defMatch?.[4];
+        // Mirrors Rails' regex: / USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?\z/m
+        const defMatch = inddef.match(
+          / USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?$/s,
+        );
+        const using = defMatch?.[1] ?? "";
+        const expressions = defMatch?.[2] ?? "";
+        const includeStr = defMatch?.[3];
+        const nullsNotDistinctStr = defMatch?.[4];
+        const whereStr = defMatch?.[5];
 
-      const include = includeStr
-        ? includeStr.split(",").map((c) => c.trim().replace(/^"|"$/g, "").replace(/""/g, '"'))
-        : undefined;
-      const where = whereStr?.trim();
-      const nullsNotDistinct = nullsNotDistinctStr ? true : undefined;
+        const orders: Record<string, string> = {};
+        const opclasses: Record<string, string> = {};
+        const includeColumns = includeStr
+          ? includeStr.split(",").map((c) => unquoteIdentifier(c.trim().replace(/""/g, '"')))
+          : [];
 
-      // Mirrors Rails (postgresql/schema_statements.rb:117-118): an expression
-      // index (`indkey.include?(0)`) stores `columns` as the raw expression
-      // string, so a conflict target / schema dump emits it verbatim rather
-      // than quoting it as a column name. Plain indexes keep the column array
-      // and parse opclasses/orders.
-      const hasExpressions = row.has_expressions as boolean;
-      const columns: string | string[] = hasExpressions ? expressions : (row.columns as string[]);
+        // Mirrors Rails (postgresql/schema_statements.rb:117-118): an expression
+        // index (`indkey.include?(0)`) stores `columns` as the raw expression
+        // string, so a conflict target / schema dump emits it verbatim rather
+        // than quoting it as a column name.
+        let columns: string | string[];
+        if (indkey.includes(0)) {
+          columns = expressions;
+        } else {
+          const names = await this.columnNamesFromColumnNumbers(oid, indkey);
 
-      const opclassesMap: Record<string, string> = {};
-      const ordersMap: Record<string, string> = {};
-      if (!hasExpressions) {
-        // Mirrors Rails regex: /(?<column>\w+)"?\s?(?<opclass>\w+_ops(_\w+)?)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/
-        const COL_RE = /(\w+)"?\s?(\w+_ops(?:_\w+)?)?\s?(DESC)?\s?(NULLS (?:FIRST|LAST))?/g;
-        for (const [, column, opclass, desc, nulls] of expressions.matchAll(COL_RE)) {
-          if (opclass) opclassesMap[column] = opclass;
-          if (nulls) {
-            ordersMap[column] = [desc, nulls].filter(Boolean).join(" ");
-          } else if (desc) {
-            ordersMap[column] = "desc";
+          // prevent INCLUDE columns from being matched
+          columns = names.filter((c) => !includeColumns.includes(c));
+
+          // add info on sort order (only desc order is explicitly specified, asc is the default)
+          // and non-default opclasses
+          // Mirrors Rails regex: /(?<column>\w+)"?\s?(?<opclass>\w+_ops(_\w+)?)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/
+          const COL_RE = /(\w+)"?\s?(\w+_ops(?:_\w+)?)?\s?(DESC)?\s?(NULLS (?:FIRST|LAST))?/g;
+          for (const [, column, opclass, desc, nulls] of expressions.matchAll(COL_RE)) {
+            if (opclass) opclasses[column] = opclass;
+            if (nulls) {
+              orders[column] = [desc, nulls].filter(Boolean).join(" ");
+            } else if (desc) {
+              orders[column] = "desc";
+            }
           }
         }
-      }
 
-      return new IndexDefinition(
-        tableName,
-        row.index_name as string,
-        row.is_unique as boolean,
-        columns,
-        {
-          using: row.using as string,
-          orders: ordersMap,
-          opclasses: opclassesMap,
-          include,
-          where,
-          nullsNotDistinct,
+        return new IndexDefinition(tableName, indexName, unique, columns, {
+          orders,
+          opclasses,
+          where: whereStr?.trim(),
+          using,
+          // Mirrors Rails' `include_columns.presence` — an empty list → nil.
+          include: includeColumns.length > 0 ? includeColumns : undefined,
+          nullsNotDistinct: nullsNotDistinctStr ? true : undefined,
           // Mirrors Rails' `comment.presence` — blank (incl. whitespace-only) → nil.
-          comment: (row.comment as string | null)?.trim() ? (row.comment as string) : undefined,
-          valid: row.is_valid as boolean,
-        },
-      );
-    });
+          comment: comment?.trim() ? comment : undefined,
+          valid,
+        });
+      }),
+    );
   }
 
   async indexNameExists(tableName: string, indexName: string): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -151,7 +151,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         const indexName = row[0] as string;
         const unique = row[1] as boolean;
         const indkey = toS(row[2])
-          .split(" ")
+          .split(/\s+/)
+          .filter((n) => n !== "")
           .map((n) => Number(n));
         const inddef = row[3] as string;
         const oid = Number(row[4]);
@@ -204,9 +205,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         return new IndexDefinition(tableName, indexName, unique, columns, {
           orders,
           opclasses,
-          where: whereStr?.trim(),
+          where: whereStr,
           using,
-          // Mirrors Rails' `include_columns.presence` — an empty list → nil.
           include: includeColumns.length > 0 ? includeColumns : undefined,
           nullsNotDistinct: nullsNotDistinctStr ? true : undefined,
           // Mirrors Rails' `comment.presence` — blank (incl. whitespace-only) → nil.


### PR DESCRIPTION
Converges `PostgreSQL::SchemaStatements#indexes` onto Rails' body shape
(`vendor/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb:86-152`).
PR #5384 deliberately left this one method alone: it needed a body reshape, not
a primitive swap.

## What changed

- **Column names come from `indkey`, not SQL.** The query now selects raw
  `d.indkey` and the body resolves names through
  `columnNamesFromColumnNumbers(oid, indkey)`, exactly as Rails does. The
  SQL-side `ARRAY(SELECT pg_get_indexdef(ix.indexrelid, k + 1, true) ... WHERE
  k < ix.indnkeyatts)` form is gone.
- **The INCLUDE-rejection branch is ported.** Because `indkey` covers included
  columns too, Rails rejects them (`columns.reject! { |c|
  include_columns.include?(c) }`, :122-123). trails' old SQL filter meant that
  branch had no counterpart at all; it now exists.
- **Scope is `quotedScope`, not binds.** The query interpolates
  `quotedScope(tableName)`'s pre-quoted literals through the positional
  `query(sql, "SCHEMA")` primitive, replacing `parseSchemaQualifiedName` +
  `$1`/`$2` binds and the `t.oid = to_regclass($1)` fast path. That fast path
  was a real behavioural deviation — it made an unqualified name resolve to a
  single relation rather than Rails' `ANY (current_schemas(false))` match — so
  it is removed rather than justified.
- Expression-vs-plain is decided by `indkey.includes(0)` (Rails' test) instead
  of `indexprs IS NOT NULL`, `using` is derived from the index-definition regex
  like Rails, and INCLUDE column names are unquoted through `unquoteIdentifier`
  in Rails' order.
- `getDatabaseVersion()` / `supportsIndexInclude()` are no longer needed here.

## Tests

The Rails-named coverage this story asks for already exists verbatim in
`packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts` —
`include index`, `include multiple columns index`, `include keyword column
name`, `include escaped quotes column name`, `expression index`, `partial
index`, `index with opclass`, `invalid index`. They now exercise the Rails-shaped
body; all 67 pass against PG, along with the PG adapter suite, schema dumper,
schema cache, comment, reserved-word, timestamp and migration index suites
(1085 tests).

`schema-statements-class.trails.test.ts`'s `indexes` fake was stubbing
`schemaQuery`; it now stubs the two positional `query` calls Rails makes.

One TS-only cover is added in `postgresql-adapter.trails.test.ts`: Rails' own
INCLUDE tests only assert `index.include`, so nothing pinned the newly ported
`reject!` branch. `indexes() keeps INCLUDE columns out of the key column list`
asserts `columns == ["n"]` for `CREATE INDEX ... ("n") INCLUDE ("d")` and fails
with `['n','d']` when the filter is removed.

## Ratchet

`pnpm api:calls:wide` passes. The six wide entries this story names
(`query`, `quoted_scope`, `column_names_from_column_numbers`,
`unquote_identifier`, `compact`, `presence`) were already deleted from the
baseline by #5844, which mixed `PostgreSQL::SchemaStatements` into the adapter
and pruned 279 lines from
`call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json`
(`git show 1fee12ae2 --numstat`) — the six `indexes` entries among them. There is
nothing left to subtract. This PR removes the divergence those
entries described rather than the entries themselves; the gate stays green with
no `indexes` mismatch reappearing.

## Review responses

**"tests are not Rails-verbatim names."** They are — under this repo's Ruby →
vitest naming convention, `def test_include_index` maps to
`it("include index")` and `def test_expression_index` to
`it("expression index")`. `pnpm test:compare` is the authority on that mapping
and it scores the file 67/67 with **0 missing and 0 extra**:

```
adapters/postgresql/postgresql_adapter_test.rb  postgresql-adapter.test.ts  67 0 0 0 0 0 67 ✓
```

Rails defines those methods at `postgresql_adapter_test.rb:354` and `:387`; the
ports sit at `postgresql-adapter.test.ts:529` and `:569`, plus the three
sibling INCLUDE cases (`include multiple columns index`, `include keyword
column name`, `include escaped quotes column name`). Renaming them to a
`test_`-prefixed spelling would break the matcher and is exactly what
CLAUDE.md forbids, so no change here.

**"api:calls:wide could not be confirmed."** It needs a build first — the tool
refuses to measure against missing `packages/*/dist` on purpose. After
`pnpm build`:

```
wide call-mismatches ratchet: OK (2326 baselined, 2153 unreviewed, mark 2153 tight)
```

The baseline cannot shrink because the entries this story targets are already
gone (see Ratchet above); the criterion is satisfied in substance — the
divergence they described is what this diff removes.

Closes-story: converge-pg-indexes-body-shape
