### PR TITLE
refactor(activerecord): read the bare primary_key delegate in ordered-relation paths

### DIFF
--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -462,9 +462,6 @@ export async function performFirstBang(this: FinderRelation): Promise<any> {
 }
 
 function orderByPk(rel: FinderRelation, direction: "asc" | "desc"): any {
-  // Stands in for `ordered_relation` on the non-reversible-order arm of `last`,
-  // so the read uses the same bare `primary_key` delegate Rails reads there
-  // (finder_methods.rb:641) rather than the model receiver `_order_columns` uses.
   const pk = rel.primaryKey;
   if (Array.isArray(pk)) {
     return rel.order(...pk.map((col: string) => ({ [col]: direction })));
@@ -962,8 +959,6 @@ export async function findLast(rel: FinderRelation, limit?: number): Promise<any
 /** @internal */
 export function orderedRelation(rel: FinderRelation): any {
   const mc = rel.model as any;
-  // Rails reads the bare `primary_key` delegate here (finder_methods.rb:641);
-  // only `_order_columns` goes through the `model.primary_key` receiver.
   const pk = rel.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
   const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -462,7 +462,10 @@ export async function performFirstBang(this: FinderRelation): Promise<any> {
 }
 
 function orderByPk(rel: FinderRelation, direction: "asc" | "desc"): any {
-  const pk = rel._modelClass.primaryKey;
+  // Stands in for `ordered_relation` on the non-reversible-order arm of `last`,
+  // so the read uses the same bare `primary_key` delegate Rails reads there
+  // (finder_methods.rb:641) rather than the model receiver `_order_columns` uses.
+  const pk = rel.primaryKey;
   if (Array.isArray(pk)) {
     return rel.order(...pk.map((col: string) => ({ [col]: direction })));
   }
@@ -959,7 +962,9 @@ export async function findLast(rel: FinderRelation, limit?: number): Promise<any
 /** @internal */
 export function orderedRelation(rel: FinderRelation): any {
   const mc = rel.model as any;
-  const pk = mc?.primaryKey;
+  // Rails reads the bare `primary_key` delegate here (finder_methods.rb:641);
+  // only `_order_columns` goes through the `model.primary_key` receiver.
+  const pk = rel.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
   const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;
   if (!hasOrder(rel) && (implicitOrder || constraintsList != null || pk)) {


### PR DESCRIPTION
Rails splits the primary-key reads in the ordered-relation cluster across two receivers: `ordered_relation` reads the bare `primary_key` delegate (`finder_methods.rb:641`) while `_order_columns` reads `model.primary_key` (`:655`). trails collapsed both onto a `_modelClass.primaryKey` read, so neither call was faithfully represented.

- `orderedRelation`'s gate now reads `rel.primaryKey` (the delegate).
- `orderByPk` — the stand-in for `ordered_relation` on `last`'s non-reversible-order arm — reads the delegate too.
- `_orderColumns` keeps the `model.primaryKey` receiver, matching `:655`.

Value-identical at runtime; the win is call-graph fidelity. `pnpm api:calls:wide` stays green with the baseline unchanged (2326 baselined, 2153 unreviewed, mark tight).

Closes-story: converge-order-by-pk-receiver-split