### PR TITLE
fix(activerecord): stop forcing NOT NULL on canonical composite-PK columns

### DIFF
--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -66,8 +66,8 @@ interface IndexOpts {
  * Thin `create_table` block builder. Each `t.<type>()` maps to the same
  * `t.column(name, mappedType, options)` call `defineSchema` emits — including
  * the per-adapter type map, the single-column serial PK emitted inline at its
- * declared offset and the MySQL `DATETIME(6)` upgrade —
- * so the resulting DDL is identical. Indexes are collected and applied after the
+ * declared offset and the MySQL `DATETIME(6)` upgrade — so the resulting DDL is
+ * identical. Indexes are collected and applied after the
  * table is created (with the same expression-index / MySQL-length gating).
  */
 class TableBuilder {
@@ -100,13 +100,11 @@ class TableBuilder {
     } else if (o.default !== undefined) {
       options["default"] = o.default;
     }
-    // No NOT NULL is forced on composite-PK columns: Rails'
-    // visit_PrimaryKeyDefinition (schema_creation.rb:79-81) emits only
-    // `PRIMARY KEY (a, b)`, and schema.rb:243-250 declares cpk_books.author_id
-    // as a bare `t.integer`. SQLite does admit NULLs in a non-INTEGER primary
-    // key, so its cpk tables really are laxer than PG/MySQL's — but that is
-    // Rails' own SQLite behaviour, which its suite runs against unchanged, so
-    // reconciling it here would be a trails deviation, not a transcription.
+    // Composite-PK columns get no forced NOT NULL: schema.rb:243-250 declares
+    // them bare and visit_PrimaryKeyDefinition (schema_creation.rb:79-81) emits
+    // only `PRIMARY KEY (a, b)`. SQLite does admit NULLs in a non-INTEGER PK,
+    // but Rails runs its own suite against that, so adding one here to match
+    // PG/MySQL would be a deviation, not a transcription.
     // MySQL DATETIME without precision = DATETIME(0); upgrade to DATETIME(6)
     // unless an explicit precision (incl. null) opted out.
     if (
@@ -2191,9 +2189,8 @@ export async function canonicalRegistrySchema(): Promise<Schema> {
       assertSerialPkIsPlainInteger(def.name, def.meta.serialPk, columns[def.meta.serialPk]);
     }
     if (def.meta.primaryKey !== undefined && def.meta.serialPk === undefined) {
-      // Nothing to reconcile — `col` leaves composite-PK columns as declared —
-      // but a `primaryKey:` naming a column the block never declares is still a
-      // typo worth raising on, which is exactly what declaredSpec does.
+      // `col` leaves these as declared, so nothing to reconcile; declaredSpec
+      // still raises when `primaryKey:` names a column the block never declared.
       for (const column of def.meta.primaryKey) declaredSpec(def.name, column, columns[column]);
     }
     schema[def.name] = columns;

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -66,7 +66,7 @@ interface IndexOpts {
  * Thin `create_table` block builder. Each `t.<type>()` maps to the same
  * `t.column(name, mappedType, options)` call `defineSchema` emits — including
  * the per-adapter type map, the single-column serial PK emitted inline at its
- * declared offset, composite-PK NOT NULL, and the MySQL `DATETIME(6)` upgrade —
+ * declared offset and the MySQL `DATETIME(6)` upgrade —
  * so the resulting DDL is identical. Indexes are collected and applied after the
  * table is created (with the same expression-index / MySQL-length gating).
  */
@@ -78,7 +78,6 @@ class TableBuilder {
     private readonly adapterName: string,
     private readonly typeMap: Record<string, string | undefined>,
     private readonly serialPk: string | null,
-    private readonly compositePk: Set<string> | null,
   ) {}
 
   private col(name: string, primitive: string, o: ColOpts = {}): void {
@@ -101,8 +100,13 @@ class TableBuilder {
     } else if (o.default !== undefined) {
       options["default"] = o.default;
     }
-    // Composite-PK columns are NOT NULL (SQLite otherwise admits NULLs).
-    if (this.compositePk?.has(name)) options["null"] = false;
+    // No NOT NULL is forced on composite-PK columns: Rails'
+    // visit_PrimaryKeyDefinition (schema_creation.rb:79-81) emits only
+    // `PRIMARY KEY (a, b)`, and schema.rb:243-250 declares cpk_books.author_id
+    // as a bare `t.integer`. SQLite does admit NULLs in a non-INTEGER primary
+    // key, so its cpk tables really are laxer than PG/MySQL's — but that is
+    // Rails' own SQLite behaviour, which its suite runs against unchanged, so
+    // reconciling it here would be a trails deviation, not a transcription.
     // MySQL DATETIME without precision = DATETIME(0); upgrade to DATETIME(6)
     // unless an explicit precision (incl. null) opted out.
     if (
@@ -277,12 +281,9 @@ export async function runTable(
     createOpts.id = false;
   }
   if (meta.primaryKey !== undefined) createOpts.primaryKey = meta.primaryKey;
-  const compositePk =
-    meta.primaryKey !== undefined && meta.serialPk === undefined ? new Set(meta.primaryKey) : null;
-
   let builder!: TableBuilder;
   await ss.createTable(name, createOpts, (t: TableDefinition) => {
-    builder = new TableBuilder(t, adapter.adapterName, typeMap, meta.serialPk ?? null, compositePk);
+    builder = new TableBuilder(t, adapter.adapterName, typeMap, meta.serialPk ?? null);
     fn(builder);
   });
 
@@ -2144,7 +2145,7 @@ export async function canonicalForeignKeyDependents(): Promise<Map<string, strin
         dependents.set(toTable, children);
       },
     } as unknown as TableDefinition;
-    def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null, null));
+    def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null));
   }
   _dependents = dependents;
   return dependents;
@@ -2161,24 +2162,15 @@ export async function canonicalForeignKeyDependents(): Promise<Map<string, strin
  * type map is a near-identity and whose column path applies no adapter munging
  * (no MySQL `DATETIME(6)` upgrade, no `serial` PK rewrite), so what comes back
  * is the *declared* shape rather than one adapter's rendering of it. The probe
- * is likewise built with no `serialPk` and no composite-PK set, so `col`'s
- * generic branch runs for every column — both of the branches it skips rewrite
- * what was declared:
- *   - `serialPk` *discards* the declared options wholesale in favour of
- *     `serialIdType` + `{primaryKey: true}`;
- *   - the composite-PK branch forces `null: false`, which is a trails addition,
- *     not something `schema.rb` states. Rails' `visit_PrimaryKeyDefinition`
- *     (schema_creation.rb:79-81) emits nothing but `PRIMARY KEY (a, b)`, and
- *     schema.rb:243-250 declares `cpk_books.author_id` as a bare `t.integer`.
- *     Our NOT NULL exists so SQLite (which admits NULLs in a non-INTEGER PK)
- *     matches the other adapters; whether that is faithful is a live question,
- *     tracked separately — reporting the *declared* shape keeps this comparator
- *     honest about schema.rb either way, which is what it exists to check.
+ * is likewise built with no `serialPk`, so `col`'s generic branch runs for every
+ * column — the one branch it skips *discards* the declared options wholesale in
+ * favour of `serialIdType` + `{primaryKey: true}`. Composite-PK columns need no
+ * such handling any more: `col` no longer rewrites them, so what they declare is
+ * what the DDL carries.
  * Taking the generic branch is therefore the right reading, but only while no
- * PK column declares something those branches would have rewritten;
- * {@link assertSerialPkIsPlainInteger} and {@link assertCompositePkDeclaresNoNull}
- * fail loudly the moment one does, rather than letting the replay report a shape
- * the real DDL never had.
+ * `serialPk` column declares something that branch would have rewritten;
+ * {@link assertSerialPkIsPlainInteger} fails loudly the moment one does, rather
+ * than letting the replay report a shape the real DDL never had.
  *
  * @internal Read by `scripts/schema-compare/compare.ts`. Lives here, next to the
  * registry it replays, for the same reason as
@@ -2194,14 +2186,15 @@ export async function canonicalRegistrySchema(): Promise<Schema> {
       },
       foreignKey: () => {},
     } as unknown as TableDefinition;
-    def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null, null));
+    def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null));
     if (def.meta.serialPk !== undefined) {
       assertSerialPkIsPlainInteger(def.name, def.meta.serialPk, columns[def.meta.serialPk]);
     }
     if (def.meta.primaryKey !== undefined && def.meta.serialPk === undefined) {
-      for (const column of def.meta.primaryKey) {
-        assertCompositePkDeclaresNoNull(def.name, column, columns[column]);
-      }
+      // Nothing to reconcile — `col` leaves composite-PK columns as declared —
+      // but a `primaryKey:` naming a column the block never declares is still a
+      // typo worth raising on, which is exactly what declaredSpec does.
+      for (const column of def.meta.primaryKey) declaredSpec(def.name, column, columns[column]);
     }
     schema[def.name] = columns;
   }
@@ -2235,29 +2228,6 @@ function assertSerialPkIsPlainInteger(
       `${JSON.stringify(spec)}, but the serialPk path emits only serialIdType(...) with ` +
       `primaryKey: true — the declared type/options would never reach the DDL. Teach ` +
       `canonicalRegistrySchema to model the rendered form before declaring it this way.`,
-  );
-}
-
-/**
- * Guard the composite-PK branch the replay likewise skips. That branch overrides
- * whatever the column declared with `null: false`, so "declared" and "rendered"
- * agree only where the declaration says nothing about nullability (every live
- * composite-PK column today) or already says `null: false`. A column declared
- * `null: true` would be reported nullable here while the DDL made it NOT NULL —
- * precisely the silent mis-report {@link assertSerialPkIsPlainInteger} exists to
- * prevent.
- */
-function assertCompositePkDeclaresNoNull(
-  table: string,
-  column: string,
-  spec: ColumnSpec | undefined,
-): void {
-  if (declaredSpec(table, column, spec).null !== true) return;
-  throw new ActiveRecordError(
-    `canonical registry: composite-PK column ${table}.${column} declares null: true, but the ` +
-      `composite-PK path overrides it to null: false — the declared shape would never reach ` +
-      `the DDL. Teach canonicalRegistrySchema to model the rendered form before declaring it ` +
-      `this way.`,
   );
 }
 

--- a/packages/activerecord/src/support/schema-file-generator.test.ts
+++ b/packages/activerecord/src/support/schema-file-generator.test.ts
@@ -114,7 +114,7 @@ describe("generateSchemaFile", () => {
 
   it("keeps a single-column string custom PK as the array (non-serial) form", () => {
     expect(content).toContain('primaryKey: ["code"]');
-    // The string PK column is still emitted as a column (NOT NULL via composite path).
+    // The string PK column is still emitted as a column.
     expect(content).toContain('"code", "string"');
   });
 });

--- a/packages/activerecord/src/support/schema-file-generator.test.ts
+++ b/packages/activerecord/src/support/schema-file-generator.test.ts
@@ -89,11 +89,13 @@ describe("generateSchemaFile", () => {
     expect(content).toContain('default: () => "CURRENT_TIMESTAMP"');
   });
 
-  it("handles primaryKey:false, composite PK, and null:false on CPK columns", () => {
+  it("handles primaryKey:false and composite PK", () => {
     expect(content).toContain('"drafts", { id: false }');
     expect(content).toContain('primaryKey: ["book_id","edition_num"]');
-    expect(content).toContain('"book_id", "integer", { null: false }');
-    expect(content).toContain('"edition_num", "integer", { null: false }');
+    // Bare, as schema.rb declares composite-PK columns: Rails'
+    // visit_PrimaryKeyDefinition emits only PRIMARY KEY (a, b).
+    expect(content).toContain('"book_id", "integer", {}');
+    expect(content).toContain('"edition_num", "integer", {}');
   });
 
   it("does not emit force:cascade for non-mysql/pg adapters", () => {

--- a/packages/activerecord/src/support/schema-file-generator.ts
+++ b/packages/activerecord/src/support/schema-file-generator.ts
@@ -72,13 +72,7 @@ function serialIdType(spec: ColumnSpec | undefined, adapterName?: string): strin
   return isBig ? "bigint" : "integer";
 }
 
-function colOpts(
-  spec: ColumnSpec,
-  colName: string,
-  cpkCols: Set<string> | null,
-  primitive: string,
-  adapterName?: string,
-): string {
+function colOpts(spec: ColumnSpec, primitive: string, adapterName?: string): string {
   const parts: string[] = [];
   const hasPrecision = typeof spec === "object" && spec.precision !== undefined;
   if (typeof spec === "object") {
@@ -93,9 +87,6 @@ function colOpts(
     }
     if (spec.array) parts.push(`array: true`);
     if (spec.primary) parts.push(`primaryKey: true`);
-  }
-  if (cpkCols?.has(colName) && !parts.some((p) => p.startsWith("null:"))) {
-    parts.push(`null: false`);
   }
   // Mirrors schema-types.ts: MySQL DATETIME without precision defaults to
   // DATETIME(0), which rejects fractional seconds. Inject precision:6 unless
@@ -152,7 +143,6 @@ function generateCode(
     // schema-types.ts, which applies the same rule for the fixtures path.
     const serialPkName =
       Array.isArray(pk) && pk.length === 1 && isIntegerSpec(cols[pk[0]]) ? pk[0] : null;
-    const cpkCols = Array.isArray(pk) && serialPkName === null ? new Set(pk) : null;
 
     const tOptsEntries: string[] = [];
     if (pk === false) tOptsEntries.push(`id: false`);
@@ -198,7 +188,7 @@ function generateCode(
         }
         const primitive = typeof colSpec === "string" ? colSpec : colSpec.type;
         lines.push(
-          `    t.column(${JSON.stringify(colName)}, ${JSON.stringify(toArType(primitive))}, ${colOpts(colSpec, colName, cpkCols, primitive, adapterName)});`,
+          `    t.column(${JSON.stringify(colName)}, ${JSON.stringify(toArType(primitive))}, ${colOpts(colSpec, primitive, adapterName)});`,
         );
       }
       lines.push(...fkLines);

--- a/packages/activerecord/src/support/schema-types.ts
+++ b/packages/activerecord/src/support/schema-types.ts
@@ -114,10 +114,12 @@ export interface ForeignKeySpec {
 export interface WrappedTableSchema {
   columns: Record<string, ColumnSpec>;
   /**
-   * Table-level primary key. `string[]` builds a composite PK constraint
-   * over the listed columns (which are also marked NOT NULL, matching
-   * Rails semantics — SQLite otherwise lets NULLs slip through composite
-   * PKs). `false` builds the table without a PK. A single-string form is
+   * Table-level primary key. `string[]` builds a composite PK constraint over
+   * the listed columns and nothing else — Rails' `visit_PrimaryKeyDefinition`
+   * (`schema_creation.rb:79`) emits only `PRIMARY KEY (…)`, and schema.rb
+   * declares the columns bare (`cpk_books`, schema.rb:243-245), so nullability
+   * comes from the column's own declaration on every adapter. `false` builds
+   * the table without a PK. A single-string form is
    * intentionally not supported — pass `[name]` for a single-column
    * non-`id` primary key. Omit to keep the default auto-increment `id`.
    *

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -723,10 +723,9 @@ describe("against the canonical registry", () => {
   it("reports a composite-PK column with the nullability schema.rb declares", async () => {
     // Rails' visit_PrimaryKeyDefinition (schema_creation.rb:79-81) emits only
     // PRIMARY KEY (a, b), and schema.rb:243-250 declares cpk_books.author_id as
-    // a bare t.integer — so the declared view is nullable. The registry's
-    // NOT NULL forcing is a trails addition tracked separately; the replay must
-    // not paper over it, and assertCompositePkDeclaresNoNull raises if a column
-    // ever declares a nullability that branch would override.
+    // a bare t.integer — so the declared view is nullable, and the DDL the
+    // registry lays says the same: TableBuilder.col forces no NOT NULL on
+    // composite-PK columns.
     const registry = await canonicalRegistrySchema();
     expect(describeSpec(columnsOfRegistry(registry, "cpk_books", "author_id"))).toBe("integer");
   });


### PR DESCRIPTION
## What

`TableBuilder.col` (canonical-schema.ts) and `colOpts` (schema-file-generator.ts)
both forced `null: false` on every column named in a composite `primaryKey:`
array. Rails does not.

- `visit_PrimaryKeyDefinition` (`schema_creation.rb:79-81`) emits only
  `PRIMARY KEY (#{names})`.
- `test/schema/schema.rb:243-250` declares `cpk_books` as bare
  `t.integer :author_id` / `t.integer :id`; same for `cpk_chapters`, `carts`, etc.

The in-code justification was that SQLite admits NULLs in a non-INTEGER PK, so
the forcing made SQLite agree with PG/MySQL. That is a trails-authored
reconciliation of adapters, not a transcription of schema.rb — and Rails runs
its own suite against that laxer SQLite shape unchanged. Removed from both
schema sources, with the reasoning recorded at the call site
(`canonical-schema.ts`), not only in the story.

## Also

`assertCompositePkDeclaresNoNull` existed to catch the one case where the
registry replay's declared view could disagree with the rendered DDL (a column
declaring `null: true` that the branch would override). With the branch gone,
declared == rendered for composite-PK columns always, so the guard can no
longer fire and is removed. The primary-key loop in `canonicalRegistrySchema`
still calls `declaredSpec` per column, which preserves the other thing that
guard incidentally caught: a `primaryKey:` naming a column the `create_table`
block never declares. `assertSerialPkIsPlainInteger` is untouched.

## Verification

- `pnpm schema:compare` green: `new-inventions=0 option-divergences=4 (ceiling 4)
  transcription-drift=0` on both passes.
- `scripts/schema-compare/compare.test.ts`, `canonical-schema.test.ts`,
  `canonical-table-rebuild.test.ts`, `schema-file-generator.test.ts`,
  `primary-keys.test.ts`, `persistence.test.ts`, `schema-dumper.test.ts` pass.
- No test depended on the NOT NULL (no SQLite composite-PK NULL-key insert test
  exists, in trails or in Rails).
- The renamed generator test (`handles primaryKey:false, composite PK, and
  null:false on CPK columns` -> `handles primaryKey:false and composite PK`) is a
  bespoke infra test under `src/support/**`, which sits outside both
  `test:compare` populations — no Rails counterpart name was touched.

Closes-story: composite-pk-not-null-forcing-is-not-in-schema-rb
