### PR TITLE
refactor(activerecord): route raw joins in _applyJoinsToManager on Rails' stash guard

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3341,13 +3341,9 @@ export class Relation<T extends Base> {
     // left-outer JD and folding it into the stash. This keeps the shape identical
     // to the subquery `from(relation)` path.
     //
-    // The emptiness checks below mirror buildJoinBuckets exactly: Rails' guard is
-    // `joins_values.empty?`, and `_namedInnerJoins` + `_joinValues` partition
-    // `joins_values` (an eager JoinDependency pushed by `_withEagerJoinDependency`
-    // is a named join value, so it is already covered — `_eagerLoadAssociations`
-    // must NOT be a term here, exactly as it must not arm `hasStashed` below).
-    // `_joinClauses` is trails-only compensation for raw join clauses living
-    // outside `joins_values`.
+    // The emptiness checks below are Rails' `joins_values.empty?`, which
+    // `_namedInnerJoins` + `_joinValues` partition; `_joinClauses` is trails-only
+    // compensation for raw join clauses living outside `joins_values`.
     //
     // Fires whenever left_outer_joins_values is non-empty (Rails' `unless
     // left_outer_joins_values.empty?`, query_methods.rb:1828), even when the
@@ -3362,9 +3358,8 @@ export class Relation<T extends Base> {
     const leftOuterIsNamed = pureLeftOuter && this._leftOuterJoinsValues.length > 0;
     if (this._leftOuterJoinsValues.length > 0 && !leftOuterIsNamed) {
       // query_methods.rb:1843: `stashed_left_joins.unshift` — unconditional, so
-      // `stashed_left_joins` is non-empty (Rails: truthy) on this branch even
-      // when the resolved association list is empty. That truthiness is what
-      // arms the raw-join routing below.
+      // `stashed_left_joins` is non-empty (Ruby: truthy) here even when the
+      // resolved association list is empty.
       leftStashed.unshift(
         QueryMethodBangs.constructJoinDependency.call(
           this as any,
@@ -3374,25 +3369,17 @@ export class Relation<T extends Base> {
       );
     }
 
-    // Mirror Rails build_join_buckets routing (query_methods.rb:1847-1863). The
-    // eager stash is the trailing `joins_values` JoinDependency whose base_klass
-    // is this model (query_methods.rb:1848-1850) — a cross-klass merged JD fails
-    // that test and stays in the stream for `select_named_joins`, so it does NOT
-    // arm the guard. When a stash exists, non-LeadingJoin nodes go to join_node
-    // (appended after the association joins); otherwise every node goes to
-    // leading_join (Rails' else branch) and leads them. The mere presence of
-    // named inner joins, eager-load associations or left-outer values does not
-    // arm it: named inner joins are still in `joins` at this point and only
-    // become a JoinDependency later (query_methods.rb:1865).
+    // query_methods.rb:1848-1850: the eager stash is the trailing `joins_values`
+    // JoinDependency whose base_klass is this model — a cross-klass merged JD
+    // fails that test and stays in the stream for `select_named_joins`.
     const lastJoinsValue = this._joinsValues[this._joinsValues.length - 1];
     const stashedEagerLoad =
       lastJoinsValue instanceof JoinDependency && lastJoinsValue.baseKlass === this._modelClass;
     const hasStashed = stashedEagerLoad || leftStashed.length > 0;
-    // Only the LEADING run of raw join values is routed by `hasStashed`
-    // (query_methods.rb:1855-1862, `while joins.first.is_a?(Arel::Nodes::Join)`);
-    // a raw join sitting BEHIND a named join falls through to
+    // query_methods.rb:1855-1862: only the LEADING run of Join nodes is routed by
+    // `hasStashed`; a raw join BEHIND a named join falls through to
     // `select_named_joins`, which buckets it as a join_node unconditionally
-    // (query_methods.rb:1866-1867). `_joinsValues` is the unified store, so it
+    // (query_methods.rb:1866-1867). Iterate the unified `_joinsValues`, which
     // preserves the raw-vs-named interleaving `_joinValues` alone cannot see.
     const toJoinNode = (v: string | Nodes.Join): Nodes.Join =>
       typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3285,26 +3285,8 @@ export class Relation<T extends Base> {
     // `AliasTracker` and dedup via the JD `walk` fold — no separate eager
     // tracker, no table-name skip filter. The shared emitter handles raw join
     // clauses, the shared AliasTracker, and the left_outer/joins/eager dedup fold.
-    //
-    // Mirror Rails build_join_buckets routing (query_methods.rb:1856-1863):
-    // when stashed joins exist, non-LeadingJoin nodes go to join_node (appended
-    // after), LeadingJoin goes to leading_join (prepended before). Without
-    // stashed joins all nodes go to leading_join (Rails' else branch).
-    const hasStashed =
-      this._eagerLoadAssociations.length > 0 ||
-      this._leftOuterJoinsValues.length > 0 ||
-      this._namedInnerJoins.length > 0;
     const leadingJoins: Nodes.Join[] = [];
     const joinNodes: Nodes.Join[] = [];
-    for (const v of this._joinValues) {
-      const node: Nodes.Join =
-        typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v;
-      if (!(node instanceof Nodes.LeadingJoin) && hasStashed) {
-        joinNodes.push(node);
-      } else {
-        leadingJoins.push(node);
-      }
-    }
     // Left_outer_joins_values resolved via JoinDependency. Exclude associations
     // already covered by _eagerLoadAssociations OR by includes promoted to eager
     // load (includes().references()) — both cause _buildEagerJoinManager to emit
@@ -3331,9 +3313,8 @@ export class Relation<T extends Base> {
     // Rails pushes the CTE join_node in the left-outer section (query_methods.rb:1832)
     // BEFORE the `joins_values` loop appends its nodes to the same bucket
     // (query_methods.rb:1852-1863), so `buckets[:join_node]` is
-    // `[...cteNodes, ...joinsValuesNodes]`. Here the `_joinValues` loop already
-    // ran and populated `joinNodes`, so collect the CTE nodes separately and
-    // `unshift` them to the front to preserve that Rails order.
+    // `[...cteNodes, ...joinsValuesNodes]`. This method runs the two sections in
+    // that same order, so the CTE nodes are simply pushed first.
     const cteOuterJoinNodes: Nodes.Join[] = [];
     const leftStashed: JoinDependency[] = [];
     const leftAssociations = _qm.selectNamedJoins.call(
@@ -3350,7 +3331,7 @@ export class Relation<T extends Base> {
         }
       },
     );
-    if (cteOuterJoinNodes.length > 0) joinNodes.unshift(...cteOuterJoinNodes);
+    joinNodes.push(...cteOuterJoinNodes);
     // Mirror Rails build_join_buckets' `if joins_values.empty?` short-circuit
     // (query_methods.rb:1838-1842), matching buildJoinBuckets' named_join /
     // early-return branch (query-methods.ts:2782-2789). When left-outer values
@@ -3360,18 +3341,75 @@ export class Relation<T extends Base> {
     // left-outer JD and folding it into the stash. This keeps the shape identical
     // to the subquery `from(relation)` path.
     //
-    // The four emptiness checks below mirror buildJoinBuckets exactly.
-    const pureLeftOuter =
-      this._eagerLoadAssociations.length === 0 &&
-      this._namedInnerJoins.length === 0 &&
-      this._joinValues.length === 0 &&
-      this._joinClauses.length === 0;
-    // Fire whenever left_outer_joins_values is non-empty (Rails' `unless
+    // The emptiness checks below mirror buildJoinBuckets exactly: Rails' guard is
+    // `joins_values.empty?`, and `_namedInnerJoins` + `_joinValues` partition
+    // `joins_values` (an eager JoinDependency pushed by `_withEagerJoinDependency`
+    // is a named join value, so it is already covered — `_eagerLoadAssociations`
+    // must NOT be a term here, exactly as it must not arm `hasStashed` below).
+    // `_joinClauses` is trails-only compensation for raw join clauses living
+    // outside `joins_values`.
+    //
+    // Fires whenever left_outer_joins_values is non-empty (Rails' `unless
     // left_outer_joins_values.empty?`, query_methods.rb:1828), even when the
     // resolved `leftAssociations` is empty — e.g. left_outer_joins_values held only
     // a CTE symbol, already routed into `joinNodes` above. Rails returns early there
     // too (`buckets[:named_join] = left_joins` with an empty `left_joins`); the
     // empty-named early return emits the same SQL as the stash-fold path.
+    const pureLeftOuter =
+      this._namedInnerJoins.length === 0 &&
+      this._joinValues.length === 0 &&
+      this._joinClauses.length === 0;
+    const leftOuterIsNamed = pureLeftOuter && this._leftOuterJoinsValues.length > 0;
+    if (this._leftOuterJoinsValues.length > 0 && !leftOuterIsNamed) {
+      // query_methods.rb:1843: `stashed_left_joins.unshift` — unconditional, so
+      // `stashed_left_joins` is non-empty (Rails: truthy) on this branch even
+      // when the resolved association list is empty. That truthiness is what
+      // arms the raw-join routing below.
+      leftStashed.unshift(
+        QueryMethodBangs.constructJoinDependency.call(
+          this as any,
+          leftAssociations as any,
+          Nodes.OuterJoin,
+        ),
+      );
+    }
+
+    // Mirror Rails build_join_buckets routing (query_methods.rb:1847-1863). The
+    // eager stash is the trailing `joins_values` JoinDependency whose base_klass
+    // is this model (query_methods.rb:1848-1850) — a cross-klass merged JD fails
+    // that test and stays in the stream for `select_named_joins`, so it does NOT
+    // arm the guard. When a stash exists, non-LeadingJoin nodes go to join_node
+    // (appended after the association joins); otherwise every node goes to
+    // leading_join (Rails' else branch) and leads them. The mere presence of
+    // named inner joins, eager-load associations or left-outer values does not
+    // arm it: named inner joins are still in `joins` at this point and only
+    // become a JoinDependency later (query_methods.rb:1865).
+    const lastJoinsValue = this._joinsValues[this._joinsValues.length - 1];
+    const stashedEagerLoad =
+      lastJoinsValue instanceof JoinDependency && lastJoinsValue.baseKlass === this._modelClass;
+    const hasStashed = stashedEagerLoad || leftStashed.length > 0;
+    // Only the LEADING run of raw join values is routed by `hasStashed`
+    // (query_methods.rb:1855-1862, `while joins.first.is_a?(Arel::Nodes::Join)`);
+    // a raw join sitting BEHIND a named join falls through to
+    // `select_named_joins`, which buckets it as a join_node unconditionally
+    // (query_methods.rb:1866-1867). `_joinsValues` is the unified store, so it
+    // preserves the raw-vs-named interleaving `_joinValues` alone cannot see.
+    const toJoinNode = (v: string | Nodes.Join): Nodes.Join =>
+      typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v;
+    let leading = true;
+    for (const v of this._joinsValues) {
+      if (this._isNamedJoinValue(v)) {
+        leading = false;
+        continue;
+      }
+      const node = toJoinNode(v as string | Nodes.Join);
+      if (leading && (node instanceof Nodes.LeadingJoin || !hasStashed)) {
+        leadingJoins.push(node);
+      } else {
+        joinNodes.push(node);
+      }
+    }
+
     // Rails: `alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)`
     // (query_methods.rb:1894) — the converged `Relation#aliasTracker`, built
     // once here (this method is the live-path half of the `build_joins` split)
@@ -3389,32 +3427,11 @@ export class Relation<T extends Base> {
       }
       return memoTracker;
     };
-    if (pureLeftOuter && this._leftOuterJoinsValues.length > 0) {
-      _qm.emitJoinPlan.call(this as any, manager, {
-        leadingJoins,
-        joinNodes,
-        stashedJoins: [...leftStashed],
-        namedJoins: leftAssociations as any,
-        aliases,
-        tracker,
-      });
-      return;
-    }
-    const leftOuterJd =
-      leftAssociations.length > 0
-        ? QueryMethodBangs.constructJoinDependency.call(
-            this as any,
-            leftAssociations as any,
-            Nodes.OuterJoin,
-          )
-        : null;
-    if (leftOuterJd) leftStashed.unshift(leftOuterJd);
-    const stashedJoins: JoinDependency[] = [...leftStashed];
     _qm.emitJoinPlan.call(this as any, manager, {
       leadingJoins,
       joinNodes,
-      stashedJoins,
-      namedJoins: [],
+      stashedJoins: [...leftStashed],
+      namedJoins: leftOuterIsNamed ? (leftAssociations as any) : [],
       aliases,
       tracker,
     });

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -87,13 +87,10 @@ describe("build_joins from(subquery) dedup", () => {
     );
   });
 
-  // The live half of the `build_joins` split (`_applyJoinsToManager`) armed its
-  // raw-join routing on the mere presence of named inner joins / eager-load
-  // associations / left-outer values, so an ordinary `joins("comments")` pushed a
-  // leading raw join into `join_node` and it trailed the association joins —
-  // while the subquery half (`buildJoinBuckets`, armed on Rails'
-  // `stashed_eager_load || stashed_left_joins`) led with it. Both halves now
-  // route identically.
+  // Rails arms the leading-raw-join routing on `stashed_eager_load ||
+  // stashed_left_joins` alone (query_methods.rb:1857) — a named inner join is
+  // still in `joins` at that point and does not arm it. Both halves of the
+  // `build_joins` split must therefore lead with the raw join here.
   it("routes a leading raw join the same way on the live path and the from-subquery path", () => {
     const q = (name: string) => escapeRegExp(quoteTableName(name));
     const leading = new RegExp(

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -87,16 +87,44 @@ describe("build_joins from(subquery) dedup", () => {
     );
   });
 
+  // The live half of the `build_joins` split (`_applyJoinsToManager`) armed its
+  // raw-join routing on the mere presence of named inner joins / eager-load
+  // associations / left-outer values, so an ordinary `joins("comments")` pushed a
+  // leading raw join into `join_node` and it trailed the association joins —
+  // while the subquery half (`buildJoinBuckets`, armed on Rails'
+  // `stashed_eager_load || stashed_left_joins`) led with it. Both halves now
+  // route identically.
+  it("routes a leading raw join the same way on the live path and the from-subquery path", () => {
+    const q = (name: string) => escapeRegExp(quoteTableName(name));
+    const leading = new RegExp(
+      `FROM ${q("posts")} CROSS JOIN categories INNER JOIN ${q("comments")}`,
+    );
+    for (const build of [
+      () => Post.joins("CROSS JOIN categories").joins("comments"),
+      () => Post.joins("CROSS JOIN categories").joins("comments").merge(Comment.joins("post")),
+    ]) {
+      const liveSql = (build() as unknown as { toSql(): string }).toSql();
+      const subSql = (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql();
+      expect(liveSql).toMatch(leading);
+      expect(subSql).toContain(liveSql.slice(liveSql.indexOf('FROM "posts"')));
+    }
+  });
+
   // Rails only shifts the LEADING run of Arel Join nodes out of `joins`
   // (query_methods.rb:1855-1862); a Join node sitting BEHIND a named join falls
   // through to the `select_named_joins` block, which buckets it as a join_node
   // unconditionally (query_methods.rb:1866-1867) — so it is appended after the
   // association joins even when the leading-loop guard is off.
   it("appends a raw join that trails a named join instead of leading with it", () => {
-    const rel = Post.joins("comments").joins("CROSS JOIN categories");
-    const sql = (Post.from(rel, "posts") as unknown as { toSql(): string }).toSql();
+    const build = () => Post.joins("comments").joins("CROSS JOIN categories");
     const q = (name: string) => escapeRegExp(quoteTableName(name));
-    expect(sql).toMatch(new RegExp(`FROM ${q("posts")} INNER JOIN ${q("comments")}`));
-    expect(sql).toMatch(new RegExp(`INNER JOIN ${q("comments")}[^)]*CROSS JOIN categories`));
+    // Both halves of the split see the raw-vs-named interleaving, so both append.
+    for (const sql of [
+      (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql(),
+      (build() as unknown as { toSql(): string }).toSql(),
+    ]) {
+      expect(sql).toMatch(new RegExp(`FROM ${q("posts")} INNER JOIN ${q("comments")}`));
+      expect(sql).toMatch(new RegExp(`INNER JOIN ${q("comments")}[^)]*CROSS JOIN categories`));
+    }
   });
 });


### PR DESCRIPTION
The two halves of trails' `build_joins` split disagreed on where a raw join node
goes, and the live half was the wrong one.

Rails `build_join_buckets` routes raw `joins_values` join nodes on
`stashed_eager_load || stashed_left_joins` alone
(`query_methods.rb:1856-1863`). `Relation#_applyJoinsToManager` instead armed on
`_eagerLoadAssociations.length > 0 || _leftOuterJoinsValues.length > 0 ||
_namedInnerJoins.length > 0`, so an ordinary named inner join made a leading raw
join trail the association joins, while the subquery half (`buildJoinBuckets`,
converged in #5747) led with it:

```ts
Post.joins("CROSS JOIN categories").joins("comments");
// subquery: FROM "posts" CROSS JOIN categories INNER JOIN "comments" ON …
// live:     FROM "posts" INNER JOIN "comments" ON … CROSS JOIN categories
```

Changes:

- `_applyJoinsToManager` now runs the two sections in Rails' order (left-outer
  block, then the `joins_values` loop), so the CTE join nodes are pushed rather
  than `unshift`ed and the two emit branches collapse into one call.
- `hasStashed` arms only on the trailing `joins_values` JoinDependency whose
  `baseKlass` is this model (a cross-klass merged JD does not arm it) or on a
  non-empty left-outer stash. The left-outer JD is now `unshift`ed
  unconditionally on the non-early-return branch, matching Rails' truthy
  (possibly empty) `stashed_left_joins`.
- The routing loop walks the unified `_joinsValues` instead of the derived
  `_joinValues`, so only the LEADING run of raw values is routed by the guard —
  a raw join behind a named join is bucketed as a `join_node` unconditionally
  (`query_methods.rb:1866-1867`), as Rails does. Previously the live path could
  not see that interleaving at all.
- `pureLeftOuter` drops its `_eagerLoadAssociations` term for the same reason:
  Rails' guard is `joins_values.empty?`, which `_namedInnerJoins` +
  `_joinValues` already partition (an eager JD pushed by
  `_withEagerJoinDependency` is a named join value).

Regression coverage in `relation/build-joins-from-subquery-dedup.test.ts`, which
already pairs the two paths: the new test fails on baseline, and the existing
trailing-raw-join test now asserts the live path too.

Closes-story: converge-apply-joins-to-manager-raw-join-routing
