### PR TITLE
refactor(activerecord): make the pre-snapshot boot reset purge-only by construction

### DIFF
--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -215,6 +215,13 @@ describe("purge-only pre-snapshot path", () => {
 
   const inertAdapter = { adapterName: "none" } as unknown as DatabaseAdapter;
 
+  // The sqlite arm lays its one table through createTable and nothing else, so
+  // stubbing that member runs the arm without touching a database.
+  const armOnlyAdapter = {
+    adapterName: "sqlite",
+    createTable: async () => {},
+  } as unknown as DatabaseAdapter;
+
   it("rejects a reset that runs before the boot-laid snapshot", async () => {
     const { dropAllTablesModule } = await freshModules();
 
@@ -225,11 +232,18 @@ describe("purge-only pre-snapshot path", () => {
 
   it("rejects a purge that runs after the adapter-specific arm", async () => {
     const { dropAllTablesModule, loadSchemaHelper } = await freshModules();
-    await loadSchemaHelper.loadAdapterSpecificSchema(inertAdapter);
+    await loadSchemaHelper.loadAdapterSpecificSchema(armOnlyAdapter);
 
     await expect(dropAllTablesModule.purgeToCanonicalTables(inertAdapter)).rejects.toThrow(
       /after the adapter-specific schema arm/,
     );
+  });
+
+  it("leaves the purge available on an adapter that has no arm to run", async () => {
+    const { dropAllTablesModule, loadSchemaHelper } = await freshModules();
+    await loadSchemaHelper.loadAdapterSpecificSchema(inertAdapter);
+
+    await expect(dropAllTablesModule.purgeToCanonicalTables(inertAdapter)).resolves.toBeUndefined();
   });
 
   it("rejects a purge that runs after the boot-laid snapshot", async () => {

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -213,8 +213,6 @@ describe("purge-only pre-snapshot path", () => {
     return { dropAllTablesModule, loadSchemaHelper };
   }
 
-  // adapterName is deliberately not one of the three real lanes: every guard
-  // under test throws before any statement would be issued.
   const inertAdapter = { adapterName: "none" } as unknown as DatabaseAdapter;
 
   it("rejects a reset that runs before the boot-laid snapshot", async () => {

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it, expect, beforeAll, vi } from "vitest";
 import { Base } from "../base.js";
-import { dropAllTables, resetTestTables } from "./drop-all-tables.js";
+import { dropAllTables, purgeToCanonicalTables, resetTestTables } from "./drop-all-tables.js";
 import { provisionSecondDatabase } from "./setup-second-pool.js";
 import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
@@ -192,5 +192,49 @@ describe("dropAllTables (shared worker database)", () => {
     expect(tables.length).toBeGreaterThan(0);
     expect(tables).toContain("items");
     expect(tables).toContain("posts");
+  });
+});
+
+/**
+ * The pre-snapshot path is purge-only by construction: it protects the canonical
+ * `schema.rb` half and nothing else, so the adapter-specific tables it drops are
+ * the caller's to re-lay. These cover the two ways that contract can be broken
+ * silently — a `reset` reaching the pre-snapshot path without meaning to, and
+ * the `test-setup-dy.ts` boot order flipping so the arm runs before the purge.
+ */
+describe("purge-only pre-snapshot path", () => {
+  async function freshModules(): Promise<{
+    dropAllTablesModule: typeof import("./drop-all-tables.js");
+    loadSchemaHelper: typeof import("./load-schema-helper.js");
+  }> {
+    vi.resetModules();
+    const dropAllTablesModule = await import("./drop-all-tables.js");
+    const loadSchemaHelper = await import("./load-schema-helper.js");
+    return { dropAllTablesModule, loadSchemaHelper };
+  }
+
+  // adapterName is deliberately not one of the three real lanes: every guard
+  // under test throws before any statement would be issued.
+  const inertAdapter = { adapterName: "none" } as unknown as DatabaseAdapter;
+
+  it("rejects a reset that runs before the boot-laid snapshot", async () => {
+    const { dropAllTablesModule } = await freshModules();
+
+    await expect(dropAllTablesModule.resetTestTables(inertAdapter)).rejects.toThrow(
+      /before recordBootLaidTables/,
+    );
+  });
+
+  it("rejects a purge that runs after the adapter-specific arm", async () => {
+    const { dropAllTablesModule, loadSchemaHelper } = await freshModules();
+    await loadSchemaHelper.loadAdapterSpecificSchema(inertAdapter);
+
+    await expect(dropAllTablesModule.purgeToCanonicalTables(inertAdapter)).rejects.toThrow(
+      /after the adapter-specific schema arm/,
+    );
+  });
+
+  it("rejects a purge that runs after the boot-laid snapshot", async () => {
+    await expect(purgeToCanonicalTables(adapter)).rejects.toThrow(/after recordBootLaidTables/);
   });
 });

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -1,4 +1,5 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { ActiveRecordError } from "../errors.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 
 /**
@@ -12,13 +13,28 @@ const BOOKKEEPING_TABLE_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Fallback for a reset that runs before {@link recordBootLaidTables} — the
- * canonical `schema.rb` mirror, which is the registry the load itself lays from.
- * The adapter-specific half is absent here; only the snapshot knows it.
+ * The canonical `schema.rb` mirror — the registry `loadCanonicalSchema` lays
+ * from. The `<adapter>_specific_schema.rb` half is deliberately absent: this is
+ * the *protected* set of {@link purgeToCanonicalTables}, whose whole job is to
+ * drop the adapter-specific tables so the arm can re-lay them.
  */
 const CANONICAL_TABLE_NAMES: ReadonlySet<string> = new Set(Object.keys(TEST_SCHEMA));
 
 let _bootLaidTableNames: ReadonlySet<string> | null = null;
+let _adapterSpecificSchemaLoaded = false;
+
+/**
+ * Records that the `<adapter>_specific_schema.rb` arm has run in this process,
+ * so {@link purgeToCanonicalTables} can refuse to run after it — a purge on that
+ * side of the arm drops `defaults`, `postgresql_times`, `binary_fields`, … and
+ * nothing re-lays them, which surfaces far away as `table "defaults" does not
+ * exist`.
+ *
+ * @internal Called by `loadAdapterSpecificSchema`; not for test files.
+ */
+export function noteAdapterSpecificSchemaLoaded(): void {
+  _adapterSpecificSchemaLoaded = true;
+}
 
 /**
  * Snapshot the tables the schema load just laid — both halves of Rails'
@@ -29,7 +45,7 @@ let _bootLaidTableNames: ReadonlySet<string> | null = null;
  * what is protected, on whichever lane is running, with nothing to keep in step.
  *
  * Every table then present must therefore *be* boot-laid. `test-setup-dy.ts`
- * guarantees that by running {@link resetTestTables} between the canonical load
+ * guarantees that by running {@link purgeToCanonicalTables} between the canonical load
  * and the adapter-specific arm: `DatabaseTasks.loadSchema` only drop+recreates
  * the tables the schema file declares, so on the shared PG/MySQL database a
  * bespoke table from a previous run would otherwise be snapshotted as boot-laid
@@ -42,8 +58,47 @@ export async function recordBootLaidTables(adapter: DatabaseAdapter): Promise<vo
   _bootLaidTableNames = new Set(laid);
 }
 
+/**
+ * Reset for a caller that runs *before* {@link recordBootLaidTables}, protecting
+ * only the canonical half — i.e. **purge-only by construction**: every
+ * adapter-specific table is dropped, and the caller owns re-laying them.
+ *
+ * The one caller is `test-setup-dy.ts`'s fast path, which purges between the
+ * canonical load and the adapter-specific arm and re-lays that arm immediately
+ * after (PR #5659). It is a separate entry point rather than a fallback inside
+ * {@link resetTestTables} so that intent is stated at the call site: a
+ * pre-snapshot reset that did *not* mean to lose the adapter-specific tables now
+ * throws instead of silently losing them.
+ *
+ * @internal Boot/template setup paths only.
+ */
+export async function purgeToCanonicalTables(adapter: DatabaseAdapter): Promise<void> {
+  if (_bootLaidTableNames !== null) {
+    throw new ActiveRecordError(
+      "purgeToCanonicalTables ran after recordBootLaidTables — the boot-laid " +
+        "snapshot is the protected set once it exists; call resetTestTables.",
+    );
+  }
+  if (_adapterSpecificSchemaLoaded) {
+    throw new ActiveRecordError(
+      "purgeToCanonicalTables ran after the adapter-specific schema arm — it " +
+        "would drop the tables that arm just laid (defaults, postgresql_times, " +
+        "binary_fields, …) with nothing to re-lay them. Purge first, then load.",
+    );
+  }
+  await resetTables(adapter, "reset", CANONICAL_TABLE_NAMES);
+}
+
 function bootLaidTableNames(): ReadonlySet<string> {
-  return _bootLaidTableNames ?? CANONICAL_TABLE_NAMES;
+  if (_bootLaidTableNames === null) {
+    throw new ActiveRecordError(
+      "resetTestTables ran before recordBootLaidTables — with no snapshot there " +
+        "is no set to protect. A deliberate pre-snapshot purge wants " +
+        "purgeToCanonicalTables, which drops the adapter-specific tables and " +
+        "expects its caller to re-lay them.",
+    );
+  }
+  return _bootLaidTableNames;
 }
 
 /**
@@ -53,7 +108,7 @@ function bootLaidTableNames(): ReadonlySet<string> {
  * MySQL and sqlite both go through `disableReferentialIntegrity`.
  */
 export async function dropAllTables(adapter: DatabaseAdapter): Promise<void> {
-  await resetTables(adapter, "drop-all");
+  await resetTables(adapter, "drop-all", new Set());
 }
 
 /**
@@ -68,20 +123,24 @@ export async function dropAllTables(adapter: DatabaseAdapter): Promise<void> {
  * `schema_migrations` / `ar_internal_metadata` bookkeeping tables.
  * Views/matviews are never canonical, so they are always dropped.
  *
- * Runs at worker boot only (`test-setup-dy.ts`), between the canonical load and
- * the adapter-specific arm. There is no between-test reset: Rails'
+ * Requires the boot-laid snapshot: the protected set is what
+ * {@link recordBootLaidTables} saw, never a declared stand-in. The pre-snapshot
+ * boot purge is {@link purgeToCanonicalTables}. There is no between-test reset: Rails'
  * `teardown_fixtures` rolls the per-test transaction back and never truncates
  * or drops (`test_fixtures.rb:146-158`), so a file that creates bespoke tables
  * owns dropping them itself.
  */
 export async function resetTestTables(adapter: DatabaseAdapter): Promise<void> {
-  await resetTables(adapter, "reset");
+  await resetTables(adapter, "reset", bootLaidTableNames());
 }
 
 type ResetMode = "drop-all" | "reset";
 
-async function resetTables(adapter: DatabaseAdapter, mode: ResetMode): Promise<void> {
-  const bootLaid = bootLaidTableNames();
+async function resetTables(
+  adapter: DatabaseAdapter,
+  mode: ResetMode,
+  bootLaid: ReadonlySet<string>,
+): Promise<void> {
   switch (adapter.adapterName) {
     case "postgres":
       await resetPgTables(adapter, mode, bootLaid);

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -639,11 +639,13 @@ function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
  *   Splitting a real load into its halves is how the two arms drifted apart
  *   before, so do not reach for this one to hand-roll `load_schema`.
  *
+ * Calling this marks the arm as run for `drop-all-tables.ts`, whose
+ * pre-snapshot purge drops exactly the tables laid here and so must never run
+ * on this side of the boot order.
+ *
  * @internal
  */
 export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
-  // Noted whether or not this adapter has an arm: what the marker guards is the
-  // *boot order*, and reaching this point at all means the purge is late.
   noteAdapterSpecificSchemaLoaded();
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
   if (adapterSpecificSchema) await adapterSpecificSchema(adapter);

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -5,6 +5,7 @@ import type { AbstractMysqlAdapter } from "../connection-adapters/abstract-mysql
 import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { ActiveRecordError } from "../errors.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
+import { noteAdapterSpecificSchemaLoaded } from "./drop-all-tables.js";
 import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
 
 /**
@@ -641,6 +642,9 @@ function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
  * @internal
  */
 export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
+  // Noted whether or not this adapter has an arm: what the marker guards is the
+  // *boot order*, and reaching this point at all means the purge is late.
+  noteAdapterSpecificSchemaLoaded();
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
   if (adapterSpecificSchema) await adapterSpecificSchema(adapter);
 }

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -639,14 +639,17 @@ function assertNotStubbed(adapter: DatabaseAdapter, method: string): void {
  *   Splitting a real load into its halves is how the two arms drifted apart
  *   before, so do not reach for this one to hand-roll `load_schema`.
  *
- * Calling this marks the arm as run for `drop-all-tables.ts`, whose
- * pre-snapshot purge drops exactly the tables laid here and so must never run
- * on this side of the boot order.
+ * An arm that runs marks itself for `drop-all-tables.ts`, whose pre-snapshot
+ * purge drops exactly the tables it lays and so must never run on this side of
+ * the boot order. An adapter with no arm — Rails' missing
+ * `adapter_specific_schema_file` — lays nothing and marks nothing.
  *
  * @internal
  */
 export async function loadAdapterSpecificSchema(adapter: DatabaseAdapter): Promise<void> {
-  noteAdapterSpecificSchemaLoaded();
   const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
-  if (adapterSpecificSchema) await adapterSpecificSchema(adapter);
+  if (adapterSpecificSchema) {
+    noteAdapterSpecificSchemaLoaded();
+    await adapterSpecificSchema(adapter);
+  }
 }

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -40,7 +40,7 @@ const mysqlExclusive = adapter === "mysql" && !!getEnv("AR_MYSQL_EXCLUSIVE_DB");
 const ownsDatabase =
   (adapter === "sqlite" && envConfig.database !== ":memory:") || pgExclusive || mysqlExclusive;
 
-const { recordBootLaidTables, dropAllTables, resetTestTables } =
+const { recordBootLaidTables, dropAllTables, purgeToCanonicalTables } =
   await import("./support/drop-all-tables.js");
 const { loadSchema, loadAdapterSpecificSchema } = await import("./support/load-schema-helper.js");
 const { canonicalSchemaUpToDate, stampCanonicalSchema } =
@@ -54,12 +54,14 @@ if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
   // Only the canonical arm is skipped here — those tables are already laid, and
   // now empty. The adapter-specific arm is re-run as on the full path: its
   // tables are `force: true` throughout, and a worker recycled onto a database
-  // an earlier worker's tests ran against finds them dropped — `resetTestTables`
-  // drops every table it did not snapshot as boot-laid.
+  // an earlier worker's tests ran against finds them dropped —
+  // `purgeToCanonicalTables` drops every table outside the canonical half, and
+  // the arm below re-lays the adapter-specific ones it took with it. That order
+  // is load-bearing, and the purge refuses to run on the wrong side of it.
   const conn = await Base.leaseConnection();
-  await resetTestTables(conn);
+  await purgeToCanonicalTables(conn);
   await loadAdapterSpecificSchema(conn);
-  // Re-stamp: `resetTestTables` drops `ar_internal_metadata` along with the
+  // Re-stamp: the purge drops `ar_internal_metadata` along with the
   // other bookkeeping tables, so the stamp this boot consumed is gone. What is
   // left behind is the same state the full-load arm below stamps — canonical
   // plus adapter-specific, laid and empty — so the next worker recycled onto

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -56,8 +56,7 @@ if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
   // tables are `force: true` throughout, and a worker recycled onto a database
   // an earlier worker's tests ran against finds them dropped —
   // `purgeToCanonicalTables` drops every table outside the canonical half, and
-  // the arm below re-lays the adapter-specific ones it took with it. That order
-  // is load-bearing, and the purge refuses to run on the wrong side of it.
+  // the arm below re-lays the adapter-specific ones it took with it.
   const conn = await Base.leaseConnection();
   await purgeToCanonicalTables(conn);
   await loadAdapterSpecificSchema(conn);


### PR DESCRIPTION
`bootLaidTableNames()` silently fell back to `CANONICAL_TABLE_NAMES` (the
`schema.rb` half only) when `recordBootLaidTables` had not run yet, so a
pre-snapshot `resetTestTables` dropped every `<adapter>_specific_schema.rb`
table (`defaults`, `postgresql_times`, `binary_fields`, …) with nothing marking
that as intentional. One caller wants exactly that (`test-setup-dy.ts`'s fast
path, which re-lays the arm right after); any other pre-snapshot caller — or a
reordering that moved the arm before the purge — would lose those tables for the
whole run, surfacing far away as `table "defaults" does not exist`.

- `purgeToCanonicalTables()` is now the explicit purge-only entry point,
  protecting the canonical half and dropping the adapter-specific tables for the
  caller to re-lay. The fast path calls it; behavior there is unchanged.
- `resetTestTables()` no longer has a fallback: it throws if the boot-laid
  snapshot is absent, pointing at the purge entry point.
- `loadAdapterSpecificSchema()` marks the arm as run, so a purge on the wrong
  side of the boot order throws instead of silently emptying the database.
- Covers for all three guards in `drop-all-tables.test.ts`.

Closes-story: boot-laid-fallback-silently-drops-adapter-specific-tables
