### PR TITLE
refactor(activerecord): converge signedIdVerifierSecret onto the Base accessor

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -893,11 +893,6 @@ function writePathValueNode(
   return new Nodes.BindParam(raw);
 }
 
-// Backing store for Base.signedIdVerifierSecret. Rails' class_attribute is
-// per-class-overridable; trails keeps a single value since Rails only ever sets
-// it on Base.
-let _signedIdVerifierSecretValue: string | (() => string | null | undefined) | null = null;
-
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
   // --- Translation mixin (wired via extend() after class) ---
@@ -1023,6 +1018,9 @@ export class Base extends Model {
 
   /** Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier */
   declare static signedIdVerifier: _MessageVerifier;
+
+  /** Mirrors: ActiveRecord::SignedId#signed_id_verifier_secret */
+  declare static signedIdVerifierSecret: string | (() => string | null | undefined) | null;
 
   static _requireConcreteClass(): void {
     // Rails: `abstract_class? || self == Base` (inheritance.rb:57) — Base
@@ -1821,20 +1819,6 @@ export class Base extends Model {
     options?: Parameters<typeof _NestedAttributes.acceptsNestedAttributesFor>[2],
   ): void {
     _NestedAttributes.acceptsNestedAttributesFor(this, associationName, options);
-  }
-
-  /**
-   * Rails: `class_attribute :signed_id_verifier_secret, instance_writer: false`
-   * declared in `ActiveRecord::SignedId`'s `included do` block, i.e. on Base.
-   *
-   * Mirrors: ActiveRecord::Base.signed_id_verifier_secret
-   */
-  static get signedIdVerifierSecret(): string | (() => string | null | undefined) | null {
-    return _signedIdVerifierSecretValue;
-  }
-
-  static set signedIdVerifierSecret(value: string | (() => string | null | undefined) | null) {
-    _signedIdVerifierSecretValue = value;
   }
 
   /** Mirrors: ActiveRecord.verbose_query_logs, verbose_query_logs= */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -127,8 +127,6 @@ import * as Inheritance from "./inheritance.js";
 import * as SignedId from "./signed-id.js";
 import {
   signedId as _signedId,
-  signedIdVerifierSecret as _signedIdVerifierSecret,
-  setSignedIdVerifierSecret as _setSignedIdVerifierSecret,
   findSigned as _findSigned,
   findSignedBang as _findSignedBang,
 } from "./signed-id.js";
@@ -894,6 +892,11 @@ function writePathValueNode(
   if (def?.type?.name === "array") return arelSql(adapter.quote(raw));
   return new Nodes.BindParam(raw);
 }
+
+// Backing store for Base.signedIdVerifierSecret. Rails' class_attribute is
+// per-class-overridable; trails keeps a single value since Rails only ever sets
+// it on Base.
+let _signedIdVerifierSecretValue: string | (() => string | null | undefined) | null = null;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
@@ -1821,16 +1824,17 @@ export class Base extends Model {
   }
 
   /**
-   * Secret backing signed_id_verifier (process-global in trails).
+   * Rails: `class_attribute :signed_id_verifier_secret, instance_writer: false`
+   * declared in `ActiveRecord::SignedId`'s `included do` block, i.e. on Base.
    *
    * Mirrors: ActiveRecord::Base.signed_id_verifier_secret
    */
   static get signedIdVerifierSecret(): string | (() => string | null | undefined) | null {
-    return _signedIdVerifierSecret();
+    return _signedIdVerifierSecretValue;
   }
 
   static set signedIdVerifierSecret(value: string | (() => string | null | undefined) | null) {
-    _setSignedIdVerifierSecret(value);
+    _signedIdVerifierSecretValue = value;
   }
 
   /** Mirrors: ActiveRecord.verbose_query_logs, verbose_query_logs= */

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -8,7 +8,6 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { travel, travelBack } from "@blazetrails/activesupport";
 import { Base, RecordNotFound, registerModel } from "./index.js";
 import { UnknownPrimaryKey } from "./errors.js";
-import { setSignedIdVerifierSecret } from "./signed-id.js";
 import { Account } from "./test-helpers/models/account.js";
 import { Toy } from "./test-helpers/models/toy.js";
 import { Company } from "./test-helpers/models/company.js";
@@ -43,14 +42,14 @@ describe("SignedIdTest", () => {
   let account: Account;
   let toy: Toy;
   beforeEach(async () => {
-    setSignedIdVerifierSecret(SIGNED_ID_VERIFIER_TEST_SECRET);
+    Base.signedIdVerifierSecret = SIGNED_ID_VERIFIER_TEST_SECRET;
     account = (await Account.first())!;
     toy = (await Toy.first())!;
   });
 
   afterEach(() => {
     travelBack();
-    setSignedIdVerifierSecret(SIGNED_ID_VERIFIER_TEST_SECRET);
+    Base.signedIdVerifierSecret = SIGNED_ID_VERIFIER_TEST_SECRET;
   });
 
   it("find signed record", async () => {
@@ -203,22 +202,24 @@ describe("SignedIdTest", () => {
   });
 
   it("fail to work without a signed_id_verifier_secret", async () => {
-    setSignedIdVerifierSecret(null);
+    Base.signedIdVerifierSecret = null;
+    (Account as any)._signedIdVerifier = null;
 
     try {
       expect(() => (account as any).signedId()).toThrow();
     } finally {
-      setSignedIdVerifierSecret(SIGNED_ID_VERIFIER_TEST_SECRET);
+      Base.signedIdVerifierSecret = SIGNED_ID_VERIFIER_TEST_SECRET;
     }
   });
 
   it("fail to work without when signed_id_verifier_secret lambda is nil", async () => {
-    setSignedIdVerifierSecret(() => null);
+    Base.signedIdVerifierSecret = () => null;
+    (Account as any)._signedIdVerifier = null;
 
     try {
       expect(() => (account as any).signedId()).toThrow();
     } finally {
-      setSignedIdVerifierSecret(SIGNED_ID_VERIFIER_TEST_SECRET);
+      Base.signedIdVerifierSecret = SIGNED_ID_VERIFIER_TEST_SECRET;
     }
   });
 

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -12,39 +12,6 @@ import { UnknownPrimaryKey } from "./errors.js";
  * Mirrors: ActiveRecord::SignedId
  */
 
-let _signedIdVerifierSecret: string | (() => string | null | undefined) | null = null;
-const _cachedVerifierClasses = new Set<any>();
-
-/**
- * Rails: `class_attribute :signed_id_verifier_secret, instance_writer: false` —
- * the secret backing `signed_id_verifier`. Trails holds it in a module-level
- * variable (the secret is process-global, not per-model); expose the reader so
- * `Model.signedIdVerifierSecret` matches Rails (the `=`/`?` forms map to the
- * same accessor; the imperative setter is `setSignedIdVerifierSecret`).
- *
- * Mirrors: ActiveRecord::SignedId#signed_id_verifier_secret
- */
-export function signedIdVerifierSecret(): string | (() => string | null | undefined) | null {
-  return _signedIdVerifierSecret;
-}
-
-/**
- * Set the secret used for signed ID verification.
- * Clears any cached verifiers so they pick up the new secret.
- *
- * Mirrors: ActiveRecord::Base.signed_id_verifier_secret=
- * @internal
- */
-export function setSignedIdVerifierSecret(
-  secret: string | (() => string | null | undefined) | null,
-): void {
-  _signedIdVerifierSecret = secret;
-  for (const cls of _cachedVerifierClasses) {
-    cls._signedIdVerifier = null;
-  }
-  _cachedVerifierClasses.clear();
-}
-
 /** Mirrors: ActiveRecord::SignedId::ClassMethods */
 export class ClassMethods {
   /** Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier */
@@ -53,7 +20,10 @@ export class ClassMethods {
       return (this as any)._signedIdVerifier;
     }
 
-    const secret = _signedIdVerifierSecret;
+    const secret = (this as any).signedIdVerifierSecret as
+      | string
+      | (() => string | null | undefined)
+      | null;
     const resolvedSecret = typeof secret === "function" ? secret() : secret;
     if (!resolvedSecret) {
       throw new Error(
@@ -66,7 +36,6 @@ export class ClassMethods {
       url_safe: true,
     });
     (this as any)._signedIdVerifier = verifier;
-    _cachedVerifierClasses.add(this);
     return verifier;
   }
 

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -12,8 +12,25 @@ import { UnknownPrimaryKey } from "./errors.js";
  * Mirrors: ActiveRecord::SignedId
  */
 
+let _signedIdVerifierSecret: string | (() => string | null | undefined) | null = null;
+
 /** Mirrors: ActiveRecord::SignedId::ClassMethods */
 export class ClassMethods {
+  /**
+   * Rails: `class_attribute :signed_id_verifier_secret, instance_writer: false`,
+   * declared in `ActiveRecord::SignedId`'s `included do` block. Trails backs it
+   * with a single value — Rails only ever sets it on `ActiveRecord::Base`.
+   *
+   * Mirrors: ActiveRecord::SignedId#signed_id_verifier_secret
+   */
+  static get signedIdVerifierSecret(): string | (() => string | null | undefined) | null {
+    return _signedIdVerifierSecret;
+  }
+
+  static set signedIdVerifierSecret(value: string | (() => string | null | undefined) | null) {
+    _signedIdVerifierSecret = value;
+  }
+
   /** Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier */
   static get signedIdVerifier(): MessageVerifier {
     if ((this as any)._signedIdVerifier) {


### PR DESCRIPTION
Removes `setSignedIdVerifierSecret` from `signed-id.ts` — the `set`-prefixed
writer half of Rails' `class_attribute :signed_id_verifier_secret,
instance_writer: false`
(`vendor/rails/activerecord/lib/active_record/signed_id.rb:13`), which is TS
surface Rails does not have; `api:extra` reported it as the last `1 novel` for
`signed-id.ts` after #5387.

The secret is now a static accessor pair on `SignedId.ClassMethods` — the same
place Rails declares it (the concern's `included do`) — reached on `Base` via the
existing `extend(Base, SignedId.ClassMethods)` wiring, with `base.ts` carrying
only the `declare static` (the shape already used for `signedIdVerifier`).
`signed_id_verifier` now reads the secret off the receiver class, exactly as
Rails does.

Also drops the cached-verifier registry: Rails does **not** invalidate cached
verifiers when the secret is reassigned; its own tests clear the memo by hand
(`Account.instance_variable_set :@signed_id_verifier, nil` —
`signed_id_test.rb:161,172`). The two ported tests that swap the secret now do
the same, so a trails invention goes away with no behaviour change.

Verification:
- `signed-id.test.ts` — 29/29 green.
- `api:compare` activerecord 6083/6148 (unchanged), and the three
  `signed_id_verifier_secret` / `?` / `=` file-placement mismatches
  (`expectedFile: signed-id.ts`, `actualFile: base.ts`) are resolved.
- `api:extra` — `signed-id.ts` no longer listed at all; `base.ts` unchanged at
  20 novel. No allowlist entry, no `@noRailsEquivalent`.

Closes-story: converge-signed-id-verifier-secret-writer

## Reviewer note — cache invalidation on secret assignment

Raised: dropping the registry means `Base.signedIdVerifierSecret = ...` no
longer clears a memoized `Account._signedIdVerifier`.

That is Rails' behaviour, deliberately. `signed_id_verifier_secret` is a plain
`class_attribute` (`signed_id.rb:13`) — its writer is generated by
`ActiveSupport`, does nothing but store, and knows nothing about verifiers.
`signed_id_verifier` memoizes into `@signed_id_verifier` with `||=`
(`signed_id.rb:82-93`) and is never invalidated by an assignment anywhere in
Rails. Rails' own tests are the proof: both nil-secret cases assign the secret
**and then** clear the memo by hand — `Account.instance_variable_set
:@signed_id_verifier, nil` (`signed_id_test.rb:161` and `:172`) — which would be
dead code if the writer invalidated.

Preserving a global invalidating writer would mean keeping the trails invention
this story exists to remove, and would make our port fail Rails' semantics: a
model that has taken a verifier keeps it until explicitly replaced. The two
ported tests now mirror Rails line-for-line (clear `_signedIdVerifier` after
reassigning the secret), so no stale verifier leaks across secret changes in the
suite; `signed-id.test.ts` is 29/29 green.
