### PR TITLE
ci(api-compare): detect wide ratchet baseline drift on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1488,18 +1488,17 @@ jobs:
         run: pnpm exec tsx scripts/api-compare/lint-call-mismatches-wide.ts
       - name: Wide ratchet baseline reseed drift
         # RFC 0083. The ratchet above only READS the committed baseline, so a
-        # change that converges or seeds rows can pass the ratchet and still
-        # leave the baseline stale; detected only on `main`, every branch cut
-        # afterwards inherits the failure (#5869 paid for that diagnosis on 5
-        # unrelated STALE rows). So this runs on every event, `pull_request`
-        # included, and fails the PR that introduces the drift instead of the
-        # `main` run after it merges. The old `main`-only arm is deliberately
-        # gone rather than kept as a backstop: `main` runs the identical step,
-        # so a separate gated copy would only duplicate it. `--write` mutates
-        # the baseline in the workspace, hence its position AFTER the ratchet —
-        # reseeding first would make the ratchet gate its own output. `--write`
-        # skips its own regeneration under CI, so this reuses the artifact the
-        # extraction step above wrote.
+        # change that converges or seeds rows passes it and still leaves the
+        # baseline stale. Runs on every event, `pull_request` included, so the
+        # PR that introduces the drift fails rather than the `main` run after
+        # it merges — every branch cut after that merge inherits the failure
+        # (#5869 paid for that diagnosis on 5 unrelated STALE rows). No
+        # separate `main`-only arm: `main` runs this identical step, so a
+        # gated copy would only duplicate it. Ordered AFTER the ratchet
+        # because `--write` mutates the baseline in the workspace; reseeding
+        # first would make the ratchet gate its own output. `--write` skips
+        # its own regeneration under CI, reusing the extraction step's
+        # artifact.
         run: |
           set -euo pipefail
           pnpm exec tsx scripts/api-compare/lint-call-mismatches-wide.ts --write
@@ -1513,7 +1512,7 @@ jobs:
             echo "Wide ratchet baseline is in sync with a clean reseed."
             exit 0
           fi
-          echo "::error title=Wide ratchet baseline drift::This branch leaves the committed wide call-mismatch baseline out of sync with a clean reseed. Run \`pnpm api:calls:wide:reseed\` and commit the result."
+          echo "::error title=Wide ratchet baseline drift::This branch leaves the committed wide call-mismatch baseline out of sync with a clean reseed. Prefer the reviewable fix shown in the diff below — delete the stale \`call-mismatches-wide-exclude/\` entries your change converged, and give any newly seeded rows a real reason. \`pnpm api:calls:wide:reseed\` produces the same end state mechanically, at the cost of reordering untouched packages (see CONTRIBUTING.md)."
           git --no-pager diff --stat -- "$baseline" "$mark"
           git --no-pager diff -- "$baseline" "$mark"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1479,16 +1479,27 @@ jobs:
         # (output/call-mismatches-wide.json) over WIDE_SIGNIFICANT_CALLS (all
         # ported names except `super`). Distinct file from the narrow run above.
         run: pnpm exec tsx scripts/api-compare/compare.ts --wide-calls
-      - name: Wide ratchet baseline reseed (main)
-        # RFC 0083. The ratchet below only READS the committed baseline, so a
-        # merge that converges or seeds rows leaves `main` stale and every
-        # branch cut afterwards inherits the failure (#5869 paid for that
-        # diagnosis on 5 unrelated STALE rows). Reseeding on the merge itself
-        # attributes the drift to the commit that caused it. Non-PR events only
-        # — on a branch the ratchet below is already the signal. `--write`
+      - name: Wide call-mismatches ratchet
+        # Gates the RFC 0047 wide artifact against the split call-mismatches-wide-exclude/ baseline dir.
+        # Fails on a new wide mismatch, a stale baseline entry, or more
+        # still-unreviewed (seeded-default-reason) entries than the committed
+        # high-water mark in call-mismatches-wide-unreviewed.json; reseed with
+        # `pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write`.
+        run: pnpm exec tsx scripts/api-compare/lint-call-mismatches-wide.ts
+      - name: Wide ratchet baseline reseed drift
+        # RFC 0083. The ratchet above only READS the committed baseline, so a
+        # change that converges or seeds rows can pass the ratchet and still
+        # leave the baseline stale; detected only on `main`, every branch cut
+        # afterwards inherits the failure (#5869 paid for that diagnosis on 5
+        # unrelated STALE rows). So this runs on every event, `pull_request`
+        # included, and fails the PR that introduces the drift instead of the
+        # `main` run after it merges. The old `main`-only arm is deliberately
+        # gone rather than kept as a backstop: `main` runs the identical step,
+        # so a separate gated copy would only duplicate it. `--write` mutates
+        # the baseline in the workspace, hence its position AFTER the ratchet —
+        # reseeding first would make the ratchet gate its own output. `--write`
         # skips its own regeneration under CI, so this reuses the artifact the
-        # step above wrote.
-        if: github.event_name != 'pull_request'
+        # extraction step above wrote.
         run: |
           set -euo pipefail
           pnpm exec tsx scripts/api-compare/lint-call-mismatches-wide.ts --write
@@ -1502,17 +1513,10 @@ jobs:
             echo "Wide ratchet baseline is in sync with a clean reseed."
             exit 0
           fi
-          echo "::error title=Wide ratchet baseline drift::${{ github.sha }} left the committed wide call-mismatch baseline out of sync with a clean reseed. Run \`pnpm api:calls:wide:reseed\` and commit the result."
+          echo "::error title=Wide ratchet baseline drift::This branch leaves the committed wide call-mismatch baseline out of sync with a clean reseed. Run \`pnpm api:calls:wide:reseed\` and commit the result."
           git --no-pager diff --stat -- "$baseline" "$mark"
           git --no-pager diff -- "$baseline" "$mark"
           exit 1
-      - name: Wide call-mismatches ratchet
-        # Gates the RFC 0047 wide artifact against the split call-mismatches-wide-exclude/ baseline dir.
-        # Fails on a new wide mismatch, a stale baseline entry, or more
-        # still-unreviewed (seeded-default-reason) entries than the committed
-        # high-water mark in call-mismatches-wide-unreviewed.json; reseed with
-        # `pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write`.
-        run: pnpm exec tsx scripts/api-compare/lint-call-mismatches-wide.ts
       - name: Conventions doc up to date
         # docs/ruby-ts-conventions.md is generated from explainConventions()
         # in conventions.ts; fail if it drifts so the agent-facing doc can't


### PR DESCRIPTION
RFC 0083. The `Wide ratchet baseline reseed` step was gated
`if: github.event_name != 'pull_request'`, so a PR could merge with
`scripts/api-compare/call-mismatches-wide-exclude/` and
`call-mismatches-wide-unreviewed.json` out of sync with a clean reseed — the
drift only surfaced on the `main` run afterwards, at which point every branch
cut inherits the wide-gate failure (the cost #5869 paid).

The step now runs on every event, `pull_request` included, so the PR that
introduces the drift is the one that fails, with the existing
`::error title=Wide ratchet baseline drift` annotation and diff output.

Two details:

- **Ordering.** `--write` mutates the baseline in the workspace, so the drift
  check now runs *after* the `Wide call-mismatches ratchet` step. Reseeding
  first would have made the ratchet gate its own output on PRs.
- **The `main`-only arm is removed, not kept as a backstop.** `main` runs the
  identical ungated step, so a separate gated copy would only duplicate it.
  Noted at the call site.

No maintenance-PR / true-up machinery is reintroduced.

Closes-story: detect-wide-baseline-drift-on-prs
