### PR TITLE
refactor(activerecord): fold live-path eager loading through joins_values and build_arel

### DIFF
--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -1117,14 +1117,14 @@ export class JoinDependency {
    * then `relation._select!(-> { aliases.columns })`. When the relation carries
    * an explicit `select`, the base table's alias columns shrink to its primary
    * key (`!join_root_alias`); the relation's own select list then supplies the
-   * rest of the projection. Returns the alias-column Arel nodes so callers that
-   * build the projection manually (the eager-load SelectManager) can append them
-   * after the relation's explicit select.
+   * rest of the projection. The select value is a thunk, as in Rails, so the
+   * alias columns are resolved during `build_select` — after `build_joins` has
+   * aliased this dependency's nodes against the shared AliasTracker.
    */
-  applyColumnAliases(relation: any): Nodes.As[] {
+  applyColumnAliases(relation: any): any {
     this._joinRootAlias = (relation?.selectValues?.length ?? 0) === 0;
     this._aliasesCache = undefined;
-    return this._buildSelectArelNodes();
+    return relation._selectBang(() => this._buildSelectArelNodes());
   }
 
   each(callback: (part: JoinPart, index: number) => void): void {

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -317,10 +317,10 @@ describe("RelationTest", () => {
   });
 
   it("includes().references() + leftJoins(): no duplicate LEFT OUTER JOIN in SQL", () => {
-    // Regression: includes promoted to eager load via references() causes
-    // _buildEagerJoinManager to emit the LEFT OUTER JOIN. The pendingLeftOuter
-    // filter must exclude promoted includes so leftJoins(:assoc) doesn't emit
-    // a second JOIN for the same association.
+    // Regression: includes promoted to eager load via references() puts the eager
+    // JoinDependency in `joins_values`, and `leftJoins(:assoc)` constructs a
+    // left-outer JD for the same association. Both fold into one
+    // `join_constraints` call, so the JD `walk` dedups them to a single JOIN.
     class Author extends Base {
       static {
         this.tableName = "authors";

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -917,3 +917,25 @@ describe("aliasTracker (trails)", () => {
     expect(seeded.aliasedTableFor(table, "comments_posts").right).toBe("comments_posts");
   });
 });
+
+describe("apply_join_dependency limitable reflections (trails)", () => {
+  fixtures([]);
+
+  it("materializes distinct parent ids when a joined reflection is a collection", () => {
+    // finder_methods.rb:463-470 gates the distinct_relation_for_primary_key
+    // rewrite on BOTH using_limitable_reflections? clauses: the eager
+    // JoinDependency's reflections AND those of
+    // select_association_list(joins_values) + left_outer_joins_values. `author`
+    // is singular, but the joined `comments` collection is not, so a limit here
+    // takes the rewrite rather than a direct LIMIT on the fanned-out join.
+    const sql = CanonPost.eagerLoad("author").joins("comments").limit(1).toSql();
+    expect(sql).toMatch(/WHERE .*IN \(SELECT DISTINCT /);
+    expect(sql).not.toMatch(/\bLIMIT 1\s*$/);
+  });
+
+  it("applies the limit directly when every eager and joined reflection is singular", () => {
+    const sql = CanonPost.eagerLoad("author").limit(1).toSql();
+    expect(sql).not.toContain("SELECT DISTINCT");
+    expect(sql).toMatch(/\bLIMIT 1\s*$/);
+  });
+});

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2818,14 +2818,13 @@ export class Relation<T extends Base> {
       }
     }
 
-    const manager = this._buildEagerJoinManager(jd, basePk, limitedIds);
-
-    const [sqlBase, eagerBinds] = this._compileAstWithBinds(manager.ast);
-    let sql = sqlBase;
-    if (this._annotations.length > 0) {
-      const comments = this._annotationComments();
-      sql = `${sql} ${comments}`;
-    }
+    // Rails' `apply_join_dependency { |relation, jd| … relation.to_sql }`
+    // (relation.rb:1211-1214): build arel from the yielded relation, so CTEs and
+    // annotate() comments fold in through the ordinary path.
+    const eagerRelation = this._applyEagerJoinDependency(jd, basePk, limitedIds);
+    jd.applyColumnAliases(eagerRelation);
+    const manager = eagerRelation._buildArel();
+    const [sql, eagerBinds] = this._compileAstWithBinds(manager.ast);
 
     // Read through selectAll (not execute) so the adapter-reported result
     // column_types are available to type-cast extra/computed `select` columns
@@ -4845,11 +4844,7 @@ export class Relation<T extends Base> {
       eagerSpecs as any,
       Nodes.OuterJoin,
     );
-    const rel = this._clone();
-    rel._eagerLoadAssociations = [];
-    rel._includesAssociations = [];
-    rel._preloadAssociations = [];
-    QueryMethodBangs.joinsBang.call(rel as any, joinDependency as any);
+    const rel = this._exceptEagerValues(joinDependency);
 
     // Rails `apply_join_dependency`, for a limit/offset over non-limitable
     // (collection) reflections, replaces the relation with
@@ -5192,75 +5187,49 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Shared helper used by both _buildEagerSql (toSql path) and _executeEagerLoad
-   * (execution path). Builds a SelectManager with JoinDependency column aliases,
-   * LEFT OUTER JOINs, WHERE/ORDER/DISTINCT/GROUP/HAVING/LOCK/HINTS applied, and
-   * LIMIT/OFFSET handling via the limitable-reflections check.
+   * Mirrors Rails `apply_join_dependency` (finder_methods.rb:456-488) for the
+   * eager-load paths that construct their JoinDependency locally: return the
+   * relation Rails yields to its block — `except(:includes, :eager_load,
+   * :preload).joins!(join_dependency)`. The caller then builds arel from it, so
+   * projections, wheres, order, distinct, group, having, lock and hints all come
+   * from the ordinary `build_arel` path.
    *
-   * Mirrors: ActiveRecord::Relation#apply_join_dependency +
-   *          ActiveRecord::Associations::JoinDependency#apply_column_aliases
+   * Rails resolves a limit/offset over non-limitable (collection) reflections by
+   * EXECUTING `distinct_relation_for_primary_key` and rewriting the relation as
+   * `pk IN (ids)` with limit/offset cleared. `limitedIds` is that materialized
+   * list on the async path; the synchronous `toSql` path cannot execute a query,
+   * so it nests the same DISTINCT-pk query inline as a subquery — the one
+   * deviation, kept in the same relation-rewrite shape.
    */
-  private _buildEagerJoinManager(
+  private _applyEagerJoinDependency(
     jd: JoinDependency,
     basePk: string,
     limitedIds?: unknown[],
-  ): SelectManager {
-    const table = this._modelClass.arelTable;
-
-    // Emit the manual joins AND the eager JoinDependency through the single
-    // `build_joins` port (`emitJoinPlan`), folding `jd` into `stashedJoins` the
-    // way Rails `apply_join_dependency` folds the eager JD into `joins_values`.
-    // One shared `AliasTracker` spans every join, and `walk` dedups an eager node
-    // that coincides with a manual INNER / left-outer join — replacing the former
-    // parallel eager tracker (`_buildEagerSharedJoinTracker`) and the
-    // `_dedupedManualJoinTables` table-name skip. The fold aliases `jd`'s nodes
-    // in place, so the column-alias projection below reads their resolved tables
-    // (a deduped node now points at the manual join's un-aliased table).
-    const manager = table.project();
-    this._withEagerJoinDependency(jd)._applyJoinsToManager(manager);
-
-    // Mirrors Rails' apply_column_aliases + `_select!(-> { aliases.columns })`:
-    // an explicit `select` keeps its own projection and the JoinDependency only
-    // contributes the base PK (t0_r0) plus the joined tables' alias columns.
-    // Without a select, the base table projects every column as `t0_r*`. Runs
-    // AFTER `emitJoinPlan` so each node's emit-time alias is resolved.
-    const selectCols = this._selectColumns ?? [];
-    const aliasNodes = jd.applyColumnAliases(this);
-    const projection =
-      selectCols.length > 0 ? [...this.arelColumns(selectCols), ...aliasNodes] : aliasNodes;
-    manager.project(...(projection as Parameters<typeof manager.project>));
-
-    this._applyWheresToManager(manager, table);
-    this._applyOrderToManager(manager, table);
-    if (this._isDistinct) manager.distinct();
-    for (const col of this._groupColumns) manager.group(groupColumnToArel(col, table));
-    if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
-    if (this._lockValue) manager.lock(this._lockValue);
-    if (this._optimizerHints.length > 0) manager.optimizerHints(...this._optimizerHints);
-
-    // LIMIT/OFFSET: use a subquery for collection associations to avoid fan-out
-    // (mirrors Rails' using_limitable_reflections? check in finder_methods.rb).
-    // Non-collection associations (belongsTo, hasOne) are limitable — apply directly.
+  ): Relation<T> {
+    let rel = this._exceptEagerValues(jd);
     const hasLimit = this._limitValue !== null || this._offsetValue !== null;
-    if (hasLimit) {
-      const isLimitable = jd.nodes.every((n) => n.assocType !== "hasMany");
-      if (isLimitable) {
-        if (this._limitValue !== null) manager.take(this._limitValue);
-        if (this._offsetValue !== null) manager.skip(this._offsetValue);
-      } else if (limitedIds !== undefined) {
-        // Execution path: the limited parent IDs were materialized in a
-        // separate query (mirrors Rails' distinct_relation_for_primary_key),
-        // so embed them as a literal `pk IN (...)` list — no nested LIMIT
-        // subquery. MariaDB rejects `IN (SELECT ... LIMIT n)` (ER_NOT_SUPPORTED_YET).
-        manager.where(table.get(basePk).in(limitedIds));
-      } else {
-        // toSql/synchronous path: no separate query is possible, so emit the
-        // parent-ID subquery inline (`pk IN (SELECT DISTINCT ... LIMIT n)`).
-        manager.where(table.get(basePk).in(this._buildEagerIdSubquery(jd, basePk)));
-      }
+    if (hasLimit && jd.nodes.some((n) => n.assocType === "hasMany")) {
+      const ids = limitedIds ?? this._buildEagerIdSubquery(jd, basePk);
+      rel = rel.where(this._modelClass.arelTable.get(basePk).in(ids as never));
+      rel._limitValue = null;
+      rel._offsetValue = null;
     }
+    return rel;
+  }
 
-    return manager;
+  /**
+   * Rails `except(:includes, :eager_load, :preload).joins!(join_dependency)`
+   * (finder_methods.rb:460) — the relation rewrite both `apply_join_dependency`
+   * entry points share. With the JoinDependency in `joins_values`, `build_joins`
+   * folds it into the single `join_constraints` call alongside the manual joins,
+   * under one shared AliasTracker and the `walk` dedup.
+   */
+  private _exceptEagerValues(jd: JoinDependency): Relation<T> {
+    const rel = this._withEagerJoinDependency(jd);
+    rel._eagerLoadAssociations = [];
+    rel._includesAssociations = [];
+    rel._preloadAssociations = [];
+    return rel;
   }
 
   /**
@@ -5296,8 +5265,8 @@ export class Relation<T extends Base> {
     // This subquery is its own `build_joins` statement: fold the eager JD into
     // `stashedJoins` so it emits through the single `emitJoinPlan` port with one
     // shared `AliasTracker` spanning the eager JoinDependency and the manual
-    // joins, deduping coinciding nodes via `walk` — same threading as
-    // `_buildEagerJoinManager`.
+    // joins, deduping coinciding nodes via `walk` — same threading as the
+    // relation `_applyEagerJoinDependency` yields.
     this._withEagerJoinDependency(jd)._applyJoinsToManager(idSubquery);
     this._applyWheresToManager(idSubquery, table);
     this._applyOrderToManager(idSubquery, table);
@@ -5410,7 +5379,9 @@ export class Relation<T extends Base> {
     this._addEagerSpecsToJoinDependency(jd, allEager);
     if (jd.nodes.length === 0) return null;
 
-    return this._buildEagerJoinManager(jd, basePk);
+    const eagerRelation = this._applyEagerJoinDependency(jd, basePk);
+    jd.applyColumnAliases(eagerRelation);
+    return eagerRelation._buildSelectManager();
   }
 
   /**
@@ -5425,19 +5396,16 @@ export class Relation<T extends Base> {
     // in which case projections, FROM, and ORDER BY must all reference the alias
     // so they stay consistent with the WHERE clause the predicate builder wrote.
     const table = this.table;
-    const projections = this._buildProjections(table);
     // `Table#project` seeds a SelectManager whose FROM is the table. A table
     // ALIAS (Nodes.TableAlias, from `Relation.create(Model, table: alias)`) is a
     // plain AST node without that factory helper, so seed the manager directly —
     // `new SelectManager(node)` sets FROM to the alias (`developers omg_developers`).
-    const manager =
-      table instanceof Table
-        ? table.project(...(projections as any))
-        : ((m) => {
-            if (projections.length > 0) m.project(...(projections as any));
-            return m;
-          })(new SelectManager(table as any));
+    const manager = table instanceof Table ? table.project() : new SelectManager(table as any);
 
+    // Rails `build_arel` runs `build_joins` BEFORE `build_select`
+    // (query_methods.rb), which is what lets a Proc select value —
+    // `apply_column_aliases`' `-> { aliases.columns }` — read the JoinDependency
+    // aliases that `join_constraints` only resolves at join-emit time.
     this._applyJoinsToManager(manager, aliases);
 
     this._applyWheresToManager(manager, table);
@@ -5452,6 +5420,9 @@ export class Relation<T extends Base> {
     }
 
     if (!this._havingClause.isEmpty()) manager.having(this._havingClause.ast);
+
+    const projections = this._buildProjections(table);
+    if (projections.length > 0) manager.project(...(projections as any));
 
     if (this._lockValue) {
       manager.lock(this._lockValue);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2601,8 +2601,8 @@ export class Relation<T extends Base> {
    * (e.g. `Post.includes(:comments, :author).joins(:comments)` join-loads both,
    * with `author` as a deduped OUTER join). So once any include is also in
    * `joins(...)`, promote every include — mirroring `_includesToPromoteFromReferences`.
-   * `_buildEagerJoinManager` then skips re-emitting the eager OUTER JOIN for the
-   * intersecting tables (the named INNER JOIN already covers them).
+   * The eager JoinDependency then rides in `joins_values`, so the JD `walk` fold
+   * dedups the intersecting tables against the named INNER JOIN.
    */
   private _includesToPromoteFromJoins(): AssociationSpec[] {
     if (this._joinedIncludesValues().length === 0) return [];
@@ -3287,19 +3287,15 @@ export class Relation<T extends Base> {
     // clauses, the shared AliasTracker, and the left_outer/joins/eager dedup fold.
     const leadingJoins: Nodes.Join[] = [];
     const joinNodes: Nodes.Join[] = [];
-    // Left_outer_joins_values resolved via JoinDependency. Exclude associations
-    // already covered by _eagerLoadAssociations OR by includes promoted to eager
-    // load (includes().references()) — both cause _buildEagerJoinManager to emit
-    // LEFT OUTER JOINs, so re-emitting here would duplicate JOINs / raise
-    // ambiguous-column errors. (The subquery path folds eager as a stashed JD
-    // instead, so it has no equivalent filter.) When named INNER joins are also
-    // present the left-outer JD folds into the inner JD's join_constraints (Rails
-    // build_join_buckets: stashed_left_joins.unshift), deduping a both-ways
-    // association to a single INNER JOIN via `walk`.
+    // Left_outer_joins_values resolved via JoinDependency. When named INNER joins
+    // are also present the left-outer JD folds into the inner JD's
+    // join_constraints (Rails build_join_buckets: stashed_left_joins.unshift),
+    // deduping a both-ways association to a single INNER JOIN via `walk`. The
+    // eager JoinDependency rides in `joins_values` and is folded into the SAME
+    // `join_constraints` call, so an association named in BOTH `left_outer_joins`
+    // and `eager_load`/promoted `includes` dedups through that fold too — no
+    // exclusion filter, exactly as in Rails and in the subquery half.
     _qm.assertValidLeftOuterJoinsBang(this._leftOuterJoinsValues);
-    const promotedIncludes = this._includesToPromoteFromReferences();
-    const eagerCovered = new Set([...this._eagerLoadAssociations, ...promotedIncludes]);
-    const pendingLeftOuter = this._leftOuterJoinsValues.filter((v) => !eagerCovered.has(v));
     // Partition CTE-name symbols out of the left-outer values into LEFT OUTER
     // JOIN nodes, mirroring buildJoinBuckets' `select_named_joins` block
     // (query_methods.rb:1830-1836). Only true associations remain for the JD;
@@ -3319,7 +3315,7 @@ export class Relation<T extends Base> {
     const leftStashed: JoinDependency[] = [];
     const leftAssociations = _qm.selectNamedJoins.call(
       this as any,
-      pendingLeftOuter,
+      this._leftOuterJoinsValues,
       leftStashed,
       (left: unknown) => {
         if (left instanceof _qm.CTEJoin) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3291,10 +3291,10 @@ export class Relation<T extends Base> {
     // are also present the left-outer JD folds into the inner JD's
     // join_constraints (Rails build_join_buckets: stashed_left_joins.unshift),
     // deduping a both-ways association to a single INNER JOIN via `walk`. The
-    // eager JoinDependency rides in `joins_values` and is folded into the SAME
-    // `join_constraints` call, so an association named in BOTH `left_outer_joins`
-    // and `eager_load`/promoted `includes` dedups through that fold too — no
-    // exclusion filter, exactly as in Rails and in the subquery half.
+    // eager JoinDependency rides in `joins_values` and folds into the SAME
+    // `join_constraints` call, so `walk` decides what a left-outer value already
+    // covered by `eager_load` emits — no exclusion filter here, matching Rails
+    // and the subquery half.
     _qm.assertValidLeftOuterJoinsBang(this._leftOuterJoinsValues);
     // Partition CTE-name symbols out of the left-outer values into LEFT OUTER
     // JOIN nodes, mirroring buildJoinBuckets' `select_named_joins` block

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2810,7 +2810,7 @@ export class Relation<T extends Base> {
     // This avoids `IN (SELECT ... LIMIT n)`, which MariaDB does not support.
     let limitedIds: unknown[] | undefined;
     const hasLimit = this._limitValue !== null || this._offsetValue !== null;
-    if (hasLimit && jd.nodes.some((n) => n.assocType === "hasMany")) {
+    if (hasLimit && !this._eagerJoinDependencyIsLimitable(jd)) {
       limitedIds = await this._materializeLimitedIds(jd, basePk);
       if (limitedIds.length === 0) {
         this._records = [];
@@ -3204,8 +3204,8 @@ export class Relation<T extends Base> {
     // `columns_for_distinct`), which projects the pk as a single column. Rails
     // only takes that `distinct_relation_for_primary_key` path for a limit/offset
     // over NON-limitable (collection) reflections (finder_methods.rb:463-488), so
-    // bypass a composite PK only in exactly that case — mirroring the narrower
-    // `hasLimit && jd hasMany` guard the eager execute path already applies. A
+    // bypass a composite PK only in exactly that case — the same two-clause
+    // `using_limitable_reflections?` test the eager paths apply. A
     // composite-PK `includes(:belongs_to)` (limitable) with a limit still JOINs,
     // as does the through-preloader's own unlimited `includes(source)` query, so
     // a scoped source through a composite-PK model JOINs like Rails. The
@@ -5208,13 +5208,30 @@ export class Relation<T extends Base> {
   ): Relation<T> {
     let rel = this._exceptEagerValues(jd);
     const hasLimit = this._limitValue !== null || this._offsetValue !== null;
-    if (hasLimit && jd.nodes.some((n) => n.assocType === "hasMany")) {
+    if (hasLimit && !this._eagerJoinDependencyIsLimitable(jd)) {
       const ids = limitedIds ?? this._buildEagerIdSubquery(jd, basePk);
       rel = rel.where(this._modelClass.arelTable.get(basePk).in(ids as never));
       rel._limitValue = null;
       rel._offsetValue = null;
     }
     return rel;
+  }
+
+  /**
+   * Rails' two-clause `using_limitable_reflections?` guard in
+   * `apply_join_dependency` (finder_methods.rb:463-470), for the paths that
+   * already hold the eager JoinDependency: BOTH its own reflections AND those of
+   * `select_association_list(joins_values) ∪ select_association_list(left_outer_joins_values)`
+   * must be non-collection. A collection reflection in `joins`/`leftOuterJoins`
+   * forces the distinct-parent-id rewrite even when every eager reflection is
+   * singular. Sibling of `_applyJoinDependencyIsLimitable`, which resolves the
+   * first clause from specs instead of a built dependency.
+   */
+  private _eagerJoinDependencyIsLimitable(jd: JoinDependency): boolean {
+    return (
+      this.usingLimitableReflections(jd.reflections as never) &&
+      this._joinsReflectionsAreLimitable()
+    );
   }
 
   /**

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -124,4 +124,48 @@ describe("build_joins from(subquery) dedup", () => {
       expect(sql).toMatch(new RegExp(`INNER JOIN ${q("comments")}[^)]*CROSS JOIN categories`));
     }
   });
+
+  // The live path folds the eager JoinDependency into `joins_values`
+  // (`apply_join_dependency`, finder_methods.rb:457-461) exactly as the subquery
+  // path does, so an association named in BOTH `joins` and `eager_load` dedups
+  // through the single `join_constraints` `walk` fold (join_dependency.rb:
+  // `walk(join_root, oj.join_root, …)` when `join_root.match?`) — there is no
+  // live-path exclusion filter deciding which value to drop before emission.
+  it("dedups an association named in both joins and eager_load", () => {
+    const liveSql = (
+      Post.joins("author").eagerLoad("author") as unknown as { toSql(): string }
+    ).toSql();
+    expect((liveSql.match(/INNER JOIN/g) ?? []).length).toBe(1);
+    expect(liveSql).not.toContain("LEFT OUTER JOIN");
+  });
+
+  // Rails walks each stashed JoinDependency against the SAME `join_root`
+  // (join_dependency.rb#join_constraints), so a second stash for an association
+  // the first stash already joined is `missing` again and emits a second,
+  // alias_tracker-aliased join — it is NOT deduped. With no named joins, both the
+  // left-outer JD and the eager stash walk an empty join_root, so
+  // `eager_load(:x).left_outer_joins(:x)` legitimately emits two joins.
+  it("emits the eager and left_outer joins separately when there is no named join to walk against", () => {
+    const liveSql = (
+      Post.eagerLoad("author").leftOuterJoins("author") as unknown as { toSql(): string }
+    ).toSql();
+    const q = (name: string) => escapeRegExp(quoteTableName(name));
+    expect((liveSql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2);
+    expect(liveSql).toMatch(new RegExp(`LEFT OUTER JOIN ${q("authors")} ${q("authors_posts")}`));
+  });
+
+  // Live and `from(relation)` subquery paths must emit the same join sequence for
+  // an eager + left-outer + raw-join combination: one shared `build_joins` call
+  // with one AliasTracker on both halves.
+  it("emits the same joins for eager_load + left_outer_joins + a raw join on both paths", () => {
+    const build = () =>
+      Post.joins("CROSS JOIN categories").eagerLoad("author").leftOuterJoins("comments");
+    const liveSql = (build() as unknown as { toSql(): string }).toSql();
+    const subSql = (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql();
+    // The eager live path projects `t0_r*` aliases, so compare from the FROM on:
+    // the whole join sequence of the live query is the subquery's inner query.
+    const liveFrom = liveSql.slice(liveSql.indexOf('FROM "posts"'));
+    expect(liveFrom).toContain("CROSS JOIN categories");
+    expect(subSql).toContain(liveFrom);
+  });
 });

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -27,6 +27,16 @@ import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 describe("build_joins from(subquery) dedup", () => {
   fixtures([]);
 
+  // The FROM clause onward — the whole join sequence. Adapter-quoted (MySQL uses
+  // backticks), so a hardcoded `FROM "posts"` would miss there and slice to the
+  // string's tail, leaving the containment assertions vacuously true.
+  const fromClause = (sql: string): string => {
+    const marker = `FROM ${quoteTableName("posts")}`;
+    const at = sql.indexOf(marker);
+    expect(at).toBeGreaterThanOrEqual(0);
+    return sql.slice(at);
+  };
+
   it("emits a single INNER JOIN (no LEFT OUTER JOIN) through the from-subquery", () => {
     const sub = Post.joins("author").leftOuterJoins("author");
     const sql = (Post.from(sub, "posts") as unknown as { toSql(): string }).toSql();
@@ -68,7 +78,7 @@ describe("build_joins from(subquery) dedup", () => {
     // Base `comments` join + the merged cross-klass `post` JoinDependency.
     expect((liveSql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2);
     // The whole FROM…joins structure of the live path is the subquery's inner query.
-    expect(subSql).toContain(liveSql.slice(liveSql.indexOf('FROM "posts"')));
+    expect(subSql).toContain(fromClause(liveSql));
   });
 
   // Rails arms build_join_buckets' raw-join routing on `stashed_eager_load ||
@@ -103,7 +113,7 @@ describe("build_joins from(subquery) dedup", () => {
       const liveSql = (build() as unknown as { toSql(): string }).toSql();
       const subSql = (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql();
       expect(liveSql).toMatch(leading);
-      expect(subSql).toContain(liveSql.slice(liveSql.indexOf('FROM "posts"')));
+      expect(subSql).toContain(fromClause(liveSql));
     }
   });
 
@@ -164,7 +174,7 @@ describe("build_joins from(subquery) dedup", () => {
     const subSql = (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql();
     // The eager live path projects `t0_r*` aliases, so compare from the FROM on:
     // the whole join sequence of the live query is the subquery's inner query.
-    const liveFrom = liveSql.slice(liveSql.indexOf('FROM "posts"'));
+    const liveFrom = fromClause(liveSql);
     expect(liveFrom).toContain("CROSS JOIN categories");
     expect(subSql).toContain(liveFrom);
   });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2955,11 +2955,10 @@ export function buildJoinBuckets(
  * stashed JoinDependencies to fold into the primary named/left JD. Both the
  * live SQL path (`_applyJoinsToManager`) and the `from(relation)` subquery path
  * (`buildJoins`) compute a plan and hand it to the shared emitter, so there is
- * one Rails `build_joins` port. The two callers differ only in how they fill
- * the plan (eager handling: the live path pre-emits eager JOINs via
- * `_buildEagerJoinManager` and excludes them here, while `buildJoins` folds
- * eager into `stashedJoins` via `buildJoinBuckets`) and in `aliases` (only the
- * subquery path threads a tracker in from `build_from`).
+ * one Rails `build_joins` port. Both fill the plan the same way for eager
+ * loading — the eager JoinDependency rides in `joins_values` (Rails
+ * `apply_join_dependency`) and is stashed from there — and differ only in
+ * `aliases` (only the subquery path threads a tracker in from `build_from`).
  *
  * @internal
  */

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -485,6 +485,9 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   const normalized = flat.map((c: any) => {
     if (c instanceof Nodes.Node) return c;
     if (typeof c === "symbol") return c;
+    // Rails' `_select!(-> { aliases.columns })` (join_dependency.rb:155) stores
+    // the Proc itself; `arel_columns` calls it at build_select time.
+    if (typeof c === "function") return c;
     if (typeof c === "object" && c !== null && "value" in c)
       return new Nodes.SqlLiteral((c as { value: string }).value);
     return String(c);
@@ -504,10 +507,12 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
     if (bucket) bucket.push(node);
     else seenNodeHashes.set(h, [node]);
   };
+  const seenThunks = new Set<unknown>();
   for (const existing of this._selectColumns) {
     if (typeof existing === "string") seenStrings.add(existing);
     else if (typeof existing === "symbol") seenStrings.add(symbolToName(existing));
     else if (existing instanceof Nodes.Node) addNodeToSeen(existing);
+    else if (typeof existing === "function") seenThunks.add(existing);
     else seenStrings.add((existing as { value: string }).value);
   }
   for (const col of normalized) {
@@ -521,6 +526,12 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
       if (!nodeIsDuplicate(col)) {
         this._selectColumns.push(col);
         addNodeToSeen(col);
+      }
+    } else if (typeof col === "function") {
+      // Ruby `|=` dedups Procs by object identity.
+      if (!seenThunks.has(col)) {
+        this._selectColumns.push(col);
+        seenThunks.add(col);
       }
     } else {
       const key = (col as { value: string }).value;


### PR DESCRIPTION
## What

Makes the eager-load path go through `joins_values` and the ordinary
`build_arel`, as Rails does, and deletes both bespoke compensations that the
two-path shape required.

Rails has exactly one eager-join path: `apply_join_dependency` rewrites the
relation as `except(:includes, :eager_load, :preload).joins!(join_dependency)`
(finder_methods.rb:460) and yields it; `to_sql`'s block applies
`apply_column_aliases` and calls `relation.to_sql` (relation.rb:1211-1214), so
the SQL is built by the normal `build_arel`. `build_join_buckets` pops the
stashed JD (query_methods.rb:1847-1850) and folds it into the single
`join_constraints(stashed_joins, …)` call, where `walk` dedups.

### 1. The `eagerCovered` / `pendingLeftOuter` filter is gone

`_applyJoinsToManager` dropped any `left_outer_joins` value already covered by
`eager_load` or by an `includes().references()` promotion. Rails has no such
filter. `left_outer_joins_values` now reaches `selectNamedJoins` unfiltered,
exactly as in the subquery half.

### 2. `_buildEagerJoinManager` is gone

It was a parallel SelectManager builder re-implementing projections, wheres,
order, distinct, group, having, lock, hints and limit/offset. It is replaced by
`_applyEagerJoinDependency`, which returns the relation Rails yields; callers do
`jd.applyColumnAliases(rel)` then build arel from it. Three supporting ports
make that work:

- `JoinDependency#apply_column_aliases` now does what Rails does —
  `relation._select!(-> { aliases.columns })` (join_dependency.rb:153-156) —
  instead of returning nodes for a caller to project by hand.
- `_select!` keeps a thunk verbatim. `arel_columns` already had Rails' `when
  Proc then field.call` branch (query_methods.rb:1667).
- `_buildSelectManager` runs `build_select` after `build_joins`, matching
  `build_arel` (query_methods.rb), which is what lets that thunk read aliases
  `join_constraints` only resolves at join-emit time.

`applyJoinDependency` and the eager paths now share `_exceptEagerValues` for the
relation rewrite.

### 3. The distinct-pk rewrite is gated on Rails' full test

Both eager branches previously asked only whether the eager JoinDependency held
a `hasMany` node. Rails (finder_methods.rb:463-470) requires BOTH
`using_limitable_reflections?` clauses — the eager dependency's reflections AND
those of `select_association_list(joins_values)` +
`select_association_list(left_outer_joins_values)`. So
`eagerLoad(:author).joins(:comments).limit(1)` now materializes distinct parent
ids instead of applying LIMIT to the fanned-out join. `_eagerJoinDependencyIsLimitable`
is the shared guard; `_eagerLoadBypassesJoinDependency` already used the same
two-clause test, so all three sites now agree.

### Remaining deviation

Rails resolves a limit/offset over non-limitable reflections by *executing*
`distinct_relation_for_primary_key` and rewriting the relation as `pk IN (ids)`
with limit/offset cleared. The async path does exactly that (`_materializeLimitedIds`).
The synchronous `toSql` path cannot execute a query, so it nests the same
DISTINCT-pk query inline as a subquery — same relation-rewrite shape, justified
at the call site.

## Behavior

- `joins(:x).eager_load(:x)` dedups to one INNER JOIN via the JD `walk` fold.
- `eager_load(:x).left_outer_joins(:x)` emits two joins (second
  alias_tracker-aliased). That is Rails: `join_constraints` walks every stashed
  JD against the *same* `join_root`, so with no named join the second stash is
  `missing` again. The filter used to hide this.
- `includes(:x).references(:x).left_outer_joins(:x)` still emits one join —
  `references_eager_loaded_tables?` counts the left-outer table as joined, so no
  promotion happens.

## Tests

`relation/build-joins-from-subquery-dedup.test.ts` gains three cases (no
renames): the joins/eager_load dedup, the two-stash non-dedup, and a
live-vs-`from(relation)` SQL equality check for eager + left-outer + raw-join.
`relation.trails.test.ts` gains two cases covering both sides of the
`using_limitable_reflections?` gate.

Locally: all of `relation/`, `scoping/`, `associations/` (90 files), plus
relations/finder/calculations — ~5600 tests, green. api:compare
`activerecord 6083/6148` and test:compare `14876/22203` unchanged from baseline.

Closes-story: converge-live-eager-join-through-joins-values
