### PR TITLE
refactor(activerecord): delegate CollectionProxy#find to the association

### DIFF
--- a/packages/activerecord/src/associations/collection-association-find-not-found.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-association-find-not-found.trails.test.ts
@@ -9,11 +9,10 @@
  * association scope's conditions.
  *
  * `CollectionProxy#find` is a bare delegation (collection_proxy.rb:107-109), so
- * driving the proxy is driving the association body. These cases sit outside
- * the ported Rails tests: Rails' own `test_raise_record_not_found_error_when_*`
- * assert only that a `RecordNotFound` escapes, not the message payload, and the
- * partial-miss count and `to_s`-shaped key comparison have no Rails test at
- * all.
+ * driving the proxy drives the association body. These cases sit outside the
+ * ported Rails tests, which assert only that a `RecordNotFound` escapes — not
+ * the message payload — and cover neither the partial-miss count nor the
+ * `to_s`-shaped key comparison.
  */
 import { describe, it, expect } from "vitest";
 import { Base, RecordNotFound } from "../index.js";

--- a/packages/activerecord/src/associations/collection-association-find-not-found.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-association-find-not-found.trails.test.ts
@@ -1,5 +1,6 @@
 /**
- * `CollectionAssociation#find` not-found path. Rails keeps the decision in
+ * `CollectionAssociation#find` not-found path, reached the way application code
+ * reaches it — through `CollectionProxy#find`. Rails keeps the decision in
  * `find` (collection_association.rb:104-108): `find_by_scan` only scans and
  * returns, then `find` raises through
  * `scope.raise_record_not_found_exception!(args_flatten, result_size,
@@ -7,10 +8,12 @@
  * a `RecordNotFound` carrying the model name, the primary key, and the
  * association scope's conditions.
  *
- * The public `CollectionProxy#find` reimplements the scan rather than
- * delegating to the association (a separate divergence), so these cover the
- * association instance directly, the way
- * `collection-association-bigint-number-key-match.test.ts` does.
+ * `CollectionProxy#find` is a bare delegation (collection_proxy.rb:107-109), so
+ * driving the proxy is driving the association body. These cases sit outside
+ * the ported Rails tests: Rails' own `test_raise_record_not_found_error_when_*`
+ * assert only that a `RecordNotFound` escapes, not the message payload, and the
+ * partial-miss count and `to_s`-shaped key comparison have no Rails test at
+ * all.
  */
 import { describe, it, expect } from "vitest";
 import { Base, RecordNotFound } from "../index.js";
@@ -20,8 +23,10 @@ import { Firm } from "../test-helpers/models/company.js";
 
 type RecordInternals = {
   _readAttribute(name: string): unknown;
-  _associationInstances: Map<string, { find(...args: unknown[]): Promise<Base | Base[] | null> }>;
-  clientsOfFirm: { load(): Promise<Base[]> };
+  clientsOfFirm: {
+    load(): Promise<Base[]>;
+    find(...args: unknown[]): Promise<Base | Base[]>;
+  };
 };
 
 const internals = (record: Base): RecordInternals => record as unknown as RecordInternals;
@@ -31,18 +36,16 @@ describe("CollectionAssociation#find not-found path", () => {
 
   async function loadedClientsOfFirm() {
     const firm = (await Firm.find(companies("first_firm").id)) as Base;
-    const clients = await internals(firm).clientsOfFirm.load();
+    const proxy = internals(firm).clientsOfFirm;
+    const clients = await proxy.load();
     expect(clients.length).toBeGreaterThan(0);
-    return {
-      assoc: internals(firm)._associationInstances.get("clientsOfFirm")!,
-      presentId: Number(internals(clients[0])._readAttribute("id")),
-    };
+    return { proxy, presentId: Number(internals(clients[0])._readAttribute("id")) };
   }
 
   it("raises RecordNotFound with the scoped message when a single id misses", async () => {
-    const { assoc } = await loadedClientsOfFirm();
+    const { proxy } = await loadedClientsOfFirm();
 
-    const error = await assoc.find(245324523).catch((e: unknown) => e);
+    const error = await proxy.find(245324523).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(RecordNotFound);
     const notFound = error as RecordNotFound;
     expect(notFound.model).toBe("Client");
@@ -51,24 +54,24 @@ describe("CollectionAssociation#find not-found path", () => {
   });
 
   it("raises RecordNotFound reporting found/expected counts when one of several ids misses", async () => {
-    const { assoc, presentId } = await loadedClientsOfFirm();
+    const { proxy, presentId } = await loadedClientsOfFirm();
 
-    const error = await assoc.find([presentId, 245324523]).catch((e: unknown) => e);
+    const error = await proxy.find([presentId, 245324523]).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(RecordNotFound);
     expect((error as RecordNotFound).message).toContain("(found 1 results, but was looking for 2)");
   });
 
   it("matches a numeric PK against a string id, the way Rails' to_s comparison does", async () => {
-    const { assoc, presentId } = await loadedClientsOfFirm();
+    const { proxy, presentId } = await loadedClientsOfFirm();
 
-    const found = (await assoc.find(String(presentId))) as Base;
+    const found = (await proxy.find(String(presentId))) as Base;
     expect(Number(internals(found)._readAttribute("id"))).toBe(presentId);
   });
 
   it("raises RecordNotFound when no id is passed", async () => {
-    const { assoc } = await loadedClientsOfFirm();
+    const { proxy } = await loadedClientsOfFirm();
 
-    const error = await assoc.find().catch((e: unknown) => e);
+    const error = await proxy.find().catch((e: unknown) => e);
     expect(error).toBeInstanceOf(RecordNotFound);
     expect((error as RecordNotFound).message).toBe("Couldn't find Client without an ID");
   });

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -32,9 +32,6 @@ import {
   performLast as basePerformLast,
   findTake as baseFindTake,
   findTakeWithLimit as baseFindTakeWithLimit,
-  normalizeFindArgs,
-  raiseNotFoundAll,
-  raiseNotFoundSingle,
 } from "../relation/finder-methods.js";
 import type { Nodes } from "@blazetrails/arel";
 import { underscore, singularize, camelize, constantize } from "@blazetrails/activesupport";
@@ -3322,126 +3319,24 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override find(id: unknown): Promise<T>;
   override find(...ids: unknown[]): Promise<T | T[]>;
   override async find(...args: unknown[]): Promise<T | T[]> {
-    // Rails-faithful cache gate: CollectionAssociation#find in Rails
-    // only uses the in-memory loaded target when BOTH `inverse_of` is
-    // declared AND the association is `loaded?`. Otherwise it
-    // delegates to `scope.find(...)` (i.e. Relation.find via SQL).
-    // Gate runs FIRST so the non-cache path doesn't do duplicate
-    // arg-normalization — super.find runs its own normalize.
-    const inverseOf = this._assocDef.options.inverseOf;
-    const useCache = !!inverseOf && this._targetLoaded;
-    if (!useCache) {
-      // Non-cache path mirrors Rails `CollectionAssociation#find` →
-      // `scope.find(*args)`: it queries through a FRESH association
-      // scope built from the owner's current foreign-key state, never
-      // the (possibly stale) loaded target. Routing `super.find` on the
-      // proxy itself would scan `this`'s loaded `_records` when the
-      // collection was loaded earlier (e.g. an empty `to_a` before the
-      // owner was saved), so a record created later via belongs_to
-      // assignment is missed even though it is persisted with the FK.
-      // `scope()` rebuilds the WHERE from the live owner, so the DB
-      // query finds it. Enforce strict-loading the same way the other
-      // query-executing proxy methods do.
-      this._checkStrictLoading();
-      return (await this.scope().find(...args)) as T | T[];
-    }
-
-    const targetModel = this.model;
-    const pk = targetModel.primaryKey ?? "id";
-    const composite = Array.isArray(pk);
-
-    // Shared arg normalization + deterministic-error raising (empty
-    // list / composite arity). Same message + id shape as
-    // Relation.performFind.
-    const normalized = normalizeFindArgs(targetModel.name, pk, args);
-    const { ids, wantArray, tuples } = normalized;
-
-    const records = this._target;
-
-    // Cast incoming ids through the target model's attribute types so
-    // in-memory find matches Relation.find's WHERE-condition casting
-    // (e.g. proxy.find("1") on an integer PK — the DB path's QueryAttribute
-    // bind casts at compile time, so the loaded-target path must cast too).
-    // For composite keys, cast each tuple element by its PK column.
-    const typeFor = (col: string): { cast(value: unknown): unknown } =>
-      targetModel.typeForAttribute(col);
-    const castId = (id: unknown): unknown => {
-      if (composite) {
-        const cols = pk;
-        const values = id as unknown[];
-        return cols.map((c, i) => typeFor(c).cast(values[i]));
-      }
-      return typeFor(pk).cast(id);
+    // Rails (collection_proxy.rb:107-109) is a bare delegation:
+    //   def find(*args)
+    //     return super if block_given?
+    //     @association.find(*args)
+    //   end
+    // The `block_given?` arm forwards to `Enumerable#find`'s predicate form,
+    // which has no trails analogue (this `find` takes ids only — the block
+    // form is `Array#find` over an awaited collection), so only the
+    // delegation arm exists. `CollectionAssociation#find` owns the whole
+    // decision: the `inverse_of && loaded?` in-memory scan, the not-found
+    // raising through `scope.raise_record_not_found_exception!`, and the
+    // `scope.find(*args)` fallback. That fallback builds a FRESH scope from
+    // the owner's current foreign-key state, so a proxy loaded empty before
+    // the owner was saved still queries rather than scanning a stale target.
+    const assoc = this._record.association(this._assocName) as unknown as {
+      find(...args: unknown[]): Promise<Base | Base[] | null>;
     };
-
-    // Index records by PK once — O(records + ids) instead of
-    // O(records × ids). Composite keys join with a NUL separator
-    // (unambiguous + bigint-safe; JSON.stringify throws on bigint
-    // and this codebase's big_integer type casts to bigint).
-    const TUPLE_SEP = "\u0000";
-    const keyForTuple = (tuple: unknown[]): string => tuple.map((x) => String(x)).join(TUPLE_SEP);
-    const keyForRecord = (r: Base): string => {
-      if (composite) {
-        const cols = pk;
-        return keyForTuple(cols.map((c) => r._readAttribute(c)));
-      }
-      return String(r._readAttribute(pk));
-    };
-    const keyForCastedId = (castedId: unknown): string => {
-      if (composite) return keyForTuple(castedId as unknown[]);
-      return String(castedId);
-    };
-    const byPk = new Map<string, T>();
-    for (const r of records) byPk.set(keyForRecord(r), r);
-
-    // Rails calls `scope.raise_record_not_found_exception!`, so the message
-    // carries the association scope's WHERE clause (owner FK + scope
-    // conditions + STI type). Mirror that by threading the scope's
-    // `[WHERE …]` conditions clause into the not-found raisers. Computed
-    // lazily (only when raising) — building the scope relation is wasted
-    // work on the hot path where every id is found.
-    // Built exactly as Rails' raise_record_not_found_exception! does
-    // (finder_methods.rb:418): `" [#{arel.where_sql(model)}]" unless
-    // where_clause.empty?` — off the scope relation, since Rails raises via
-    // `scope.raise_record_not_found_exception!`.
-    const conditionsClause = (): string => {
-      const scope = this.scope() as unknown as {
-        _whereClause: { isEmpty(): boolean };
-        arel(): { whereSql(engine: unknown): Nodes.SqlLiteral | null };
-      };
-      return scope._whereClause.isEmpty()
-        ? ""
-        : ` [${scope.arel().whereSql(targetModel)?.value ?? ""}]`;
-    };
-
-    // Composite + any-multi: always use the "Couldn't find all" shape
-    // (matches performFind). Simple-PK single-id uses "with 'pk'=id".
-    if (tuples || wantArray || ids.length > 1) {
-      // Duplicate-id handling matches performFind: compare distinct
-      // found keys to requested count. `find([1, 1])` raises.
-      const castedIds = ids.map(castId);
-      const uniqueFoundKeys = new Set(castedIds.map(keyForCastedId).filter((k) => byPk.has(k)));
-      if (uniqueFoundKeys.size !== ids.length) {
-        raiseNotFoundAll(
-          targetModel.name,
-          pk,
-          normalized,
-          uniqueFoundKeys.size,
-          ids.length,
-          conditionsClause(),
-        );
-      }
-      // Return in DB/load order, matching performFind.
-      const wantedKeys = new Set(castedIds.map(keyForCastedId));
-      const found = records.filter((r) => wantedKeys.has(keyForRecord(r)));
-      return wantArray ? found : found[0];
-    }
-
-    // Simple PK, single scalar id.
-    const id = ids[0];
-    const match = byPk.get(keyForCastedId(castId(id)));
-    if (!match) raiseNotFoundSingle(targetModel.name, pk as string, id, conditionsClause());
-    return match;
+    return (await assoc.find(...args)) as T | T[];
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3313,26 +3313,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Find records within the association by id or array of ids.
    *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#find
+   * Mirrors: ActiveRecord::Associations::CollectionProxy#find — a bare
+   * delegation to `@association.find(*args)`. Rails' `return super if
+   * block_given?` arm forwards to `Enumerable#find`'s predicate form, which
+   * has no analogue here (this `find` takes ids only; the block form is
+   * `Array#find` over an awaited collection).
    */
   override find(ids: unknown[]): Promise<T[]>;
   override find(id: unknown): Promise<T>;
   override find(...ids: unknown[]): Promise<T | T[]>;
   override async find(...args: unknown[]): Promise<T | T[]> {
-    // Rails (collection_proxy.rb:107-109) is a bare delegation:
-    //   def find(*args)
-    //     return super if block_given?
-    //     @association.find(*args)
-    //   end
-    // The `block_given?` arm forwards to `Enumerable#find`'s predicate form,
-    // which has no trails analogue (this `find` takes ids only — the block
-    // form is `Array#find` over an awaited collection), so only the
-    // delegation arm exists. `CollectionAssociation#find` owns the whole
-    // decision: the `inverse_of && loaded?` in-memory scan, the not-found
-    // raising through `scope.raise_record_not_found_exception!`, and the
-    // `scope.find(*args)` fallback. That fallback builds a FRESH scope from
-    // the owner's current foreign-key state, so a proxy loaded empty before
-    // the owner was saved still queries rather than scanning a stale target.
     const assoc = this._record.association(this._assocName) as unknown as {
       find(...args: unknown[]): Promise<Base | Base[] | null>;
     };


### PR DESCRIPTION
Rails' `CollectionProxy#find` is a one-line delegation
(`collection_proxy.rb:107-109`):

```ruby
def find(*args)
  return super if block_given?
  @association.find(*args)
end
```

trails reimplemented the whole scan in the proxy — its own `inverse_of &&
_targetLoaded` gate, its own `normalizeFindArgs` call, its own
`_checkStrictLoading()`, and its own in-memory match keyed through
`typeForAttribute(...).cast` + `String(...)`. That shadowed
`CollectionAssociation#find` on every public path: `owner.things.find(id)`
never reached it, only `coerceToRecords` did. So the convergence in #5875
landed on a method application code could not reach, and its regression
coverage had to drive the association instance directly.

The proxy now delegates. The association body owns the whole decision — the
`inverse_of && loaded?` scan, the not-found raising through
`scope.raise_record_not_found_exception!`, and the `scope.find(*args)`
fallback. That fallback builds a fresh scope from the owner's current
foreign-key state, so a proxy loaded empty before the owner was saved still
queries rather than scanning a stale target (the property the deleted proxy
comment described). Target sharing makes the delegation sound:
`CollectionAssociation` forwards `target`/`loaded` to the proxy's store via
`_sharedStore`, so `isLoaded()` / `target` on the association *are* the
proxy's.

`return super if block_given?` has no arm here: this `find` takes ids only,
and `Enumerable#find`'s predicate form is `Array#find` over an awaited
collection. Noted at the call site.

## Behaviour dropped as divergence, not relocated

- **`_checkStrictLoading()`.** Rails raises `StrictLoadingViolationError` from
  `Association#find_target`, which `scope.find` does not go through. No Rails
  test covers `proxy.find` under strict loading, and no trails test did either
  (checked all of `strict-loading*.test.ts`).
- **Casting ids through `typeForAttribute` before the scan.** Rails'
  `find_by_scan` compares `args.flatten.compact.map(&:to_s)` against
  `r.id.to_s`; the association's `normalizeAssociationKey` + `String(...)` is
  that shape. The string-id-vs-numeric-PK case is pinned by a test.
- **`normalizeFindArgs`' composite-PK arity errors on the loaded path.** Rails'
  `find_by_scan` raises nothing — `find` does the `Array(result).size !=
  args_flatten.size` check afterwards.

## Tests

`collection-association-find-not-found.trails.test.ts` now drives the proxy
instead of reaching into `_associationInstances` — with the delegation in
place, driving the proxy *is* driving the association body. It keeps the
message-payload assertions (model / primary key / found-vs-expected counts /
`to_s` key match) that Rails' own `test_raise_record_not_found_error_when_*`
do not make. Those Rails tests, ported in #5875, now genuinely exercise the
association path.

Green locally: the whole `packages/activerecord/src/associations/` tree (90
files, 1974 tests), plus `associations.test.ts`, `nested-attributes.test.ts`,
`primary-keys.test.ts`, and every `strict-loading*` file. `pnpm api:compare` /
`pnpm api:extra` leave no manifest churn.

Closes-story: converge-collection-proxy-find-delegation
