### PR TITLE
refactor(associations): unify the singular loaders into one Rails-shaped findTarget

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -874,15 +874,10 @@ describe("PreloaderTest", () => {
     expect(fav.association("author").target.name).toBe("Mary");
     expect(fav.association("favoriteAuthor").target.name).toBe("Bob");
     spy.mockClear();
-    const reloadedAuthor = (await findTarget(
-      fav,
-      "author",
-      {
-        inverseOf: "authorFavorites",
-      },
-      "belongsTo",
-    )) as any;
-    const reloadedFavorite = (await findTarget(fav, "favoriteAuthor", {}, "belongsTo")) as any;
+    const reloadedAuthor = (await findTarget(fav, "author", {
+      inverseOf: "authorFavorites",
+    })) as any;
+    const reloadedFavorite = (await findTarget(fav, "favoriteAuthor", {})) as any;
     expect(reloadedAuthor.name).toBe("Mary");
     expect(reloadedFavorite.name).toBe("Bob");
     expect(spy).not.toHaveBeenCalled();
@@ -1038,7 +1033,7 @@ describe("PreloaderTest", () => {
     const maryPost = posts("misc_by_mary");
     const mary = authors("mary");
 
-    const loadedBob = await findTarget(bobPost, "author", {}, "belongsTo");
+    const loadedBob = await findTarget(bobPost, "author", {});
     expect(bobPost.association("author").isLoaded()).toBe(true);
     expect(maryPost.association("author").isLoaded()).toBe(false);
 
@@ -1224,7 +1219,7 @@ describe("PreloaderTest", () => {
   it("preload loaded belongs to association with composite foreign key", async () => {
     const comment = shardedComments("great_comment_blog_post_one");
 
-    await findTarget(comment, "blogPost", { className: "ShardedBlogPost" }, "belongsTo");
+    await findTarget(comment, "blogPost", { className: "ShardedBlogPost" });
 
     const sqls = await captureSql(async () => {
       await new Preloader({ records: [comment], associations: ["blogPost"] }).call();
@@ -1661,6 +1656,7 @@ describe("AssociationsTest", () => {
   let CpkOrder: typeof Base;
   let CpkBook: typeof Base;
   let CpkOrderAgreement: typeof Base;
+  let CpkOrderWithPrimaryKeyAssociatedBook: typeof Base;
   let CpkCar: typeof Base;
   let CpkCarReview: typeof Base;
   let Person: typeof Base;
@@ -1707,6 +1703,7 @@ describe("AssociationsTest", () => {
     CpkOrder = cpkMod.CpkOrder as never;
     CpkBook = cpkMod.CpkBook as never;
     CpkOrderAgreement = cpkMod.CpkOrderAgreement as never;
+    CpkOrderWithPrimaryKeyAssociatedBook = cpkMod.CpkOrderWithPrimaryKeyAssociatedBook as never;
     CpkCar = cpkMod.CpkCar as never;
     CpkCarReview = cpkMod.CpkCarReview as never;
     Person = (await import("./test-helpers/models/person.js")).Person as never;
@@ -1739,6 +1736,7 @@ describe("AssociationsTest", () => {
     registerModel("CpkOrder", CpkOrder);
     registerModel("CpkBook", CpkBook);
     registerModel("CpkOrderAgreement", CpkOrderAgreement);
+    registerModel("CpkOrderWithPrimaryKeyAssociatedBook", CpkOrderWithPrimaryKeyAssociatedBook);
     registerModel("CpkCar", CpkCar);
     registerModel("CpkCarReview", CpkCarReview);
     registerModel("Person", Person);
@@ -2399,6 +2397,25 @@ describe("AssociationsTest", () => {
     });
     expect(agreements).toHaveLength(2);
     expect(agreements.map((a) => (a as any).signature).sort()).toEqual(["abc", "def"]);
+  });
+
+  // Rails only ever loads a singular association from a reflection
+  // (association.rb:41-45), and declares both composite-key has_one shapes on
+  // Cpk::Order (cpk/order.rb:14, 45), so the composite-FK and
+  // scalar-FK-on-a-composite-PK owner key derivations are covered through real
+  // reflections.
+  it("has one loads through a declared reflection with a composite foreign key", async () => {
+    const order = await CpkOrder.create({ shop_id: 1 });
+    const [shopId, orderId] = order.id as [number, number];
+    await CpkBook.create({ id: [1, 90001], shop_id: shopId, order_id: orderId, title: "Only" });
+    expect((await (order as any).loadHasOne("book"))?.title).toBe("Only");
+  });
+
+  it("has one loads through a declared reflection with a scalar foreign key on a composite primary key owner", async () => {
+    const order = await CpkOrderWithPrimaryKeyAssociatedBook.create({ shop_id: 1 });
+    const [, orderId] = order.id as [number, number];
+    await CpkBook.create({ id: [1, 90002], order_id: orderId, title: "Only" });
+    expect((await (order as any).loadHasOne("book"))?.title).toBe("Only");
   });
 
   // The inline (no-reflection) fallback must build from

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -127,13 +127,13 @@ describe("Association scope cache", () => {
 
     const spy = vi.spyOn(StatementCache, "create");
 
-    const r1 = await findTarget(p1, "author", opts, "belongsTo");
+    const r1 = await findTarget(p1, "author", opts);
     expect((r1 as any)?.id).toBe(authors("david").id);
     const afterFirst = spy.mock.calls.length;
     expect(afterFirst).toBe(1);
 
     // Second owner's load reuses the cached statement — no recompile.
-    const r2 = await findTarget(p2, "author", opts, "belongsTo");
+    const r2 = await findTarget(p2, "author", opts);
     expect((r2 as any)?.id).toBe(authors("bob").id);
     expect(spy.mock.calls.length).toBe(afterFirst);
   });
@@ -183,14 +183,14 @@ describe("Association scope cache — through singular loads", () => {
 
     const spy = vi.spyOn(StatementCache, "create");
 
-    const c1 = await findTarget(groucho, "club", { through: "currentMembership" }, "hasOne");
+    const c1 = await findTarget(groucho, "club", { through: "currentMembership" });
     expect((c1 as any)?.id).toBe(clubs("boring_club").id);
     const afterFirst = spy.mock.calls.length;
     expect(afterFirst).toBe(1);
 
     // Second owner's load reuses the compiled statement — no recompile — and
     // still resolves through its OWN current membership.
-    const c2 = await findTarget(blarpy, "club", { through: "currentMembership" }, "hasOne");
+    const c2 = await findTarget(blarpy, "club", { through: "currentMembership" });
     expect((c2 as any)?.id).toBe(clubs("outrageous_club").id);
     expect(spy.mock.calls.length).toBe(afterFirst);
   });

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -730,16 +730,11 @@ describe("AssociationScope", () => {
     const membership = await Membership.create({ member_id: member.id });
     const memberDetail = await MemberDetail.create({ member_id: member.id });
 
-    const loaded = (await findSingularTarget(
-      memberDetail,
-      "membership",
-      {
-        className: "Membership",
-        through: "member",
-        source: "membership",
-      },
-      "hasOne",
-    )) as Membership | null;
+    const loaded = (await findSingularTarget(memberDetail, "membership", {
+      className: "Membership",
+      through: "member",
+      source: "membership",
+    })) as Membership | null;
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toBe(membership.id);
   });
@@ -779,16 +774,11 @@ describe("AssociationScope", () => {
     const club = await Club.create({ name: "Great club" });
     await CurrentMembership.create({ member_id: member.id, club_id: club.id });
 
-    const loaded = (await findSingularTarget(
-      member,
-      "club",
-      {
-        className: "Club",
-        through: "currentMembership",
-        source: "club",
-      },
-      "hasOne",
-    )) as Club | null;
+    const loaded = (await findSingularTarget(member, "club", {
+      className: "Club",
+      through: "currentMembership",
+      source: "club",
+    })) as Club | null;
     expect(loaded).not.toBeNull();
     expect(loaded!.name).toBe("Great club");
   });

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -320,12 +320,7 @@ export class BelongsToAssociation extends SingularAssociation {
     // which the stale-key check cannot see. See `_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;
     try {
-      return await findTarget(
-        this.owner,
-        this.reflection.name,
-        this.reflection.options,
-        "belongsTo",
-      );
+      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
     } finally {
       this._loaderWritebackSuppressed--;
     }

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -2847,16 +2847,11 @@ describe("HasManyAssociationsTest", () => {
     registerModel(InvValPost);
     const author = await InvValAuthor.create({ name: "Alice" });
     const post = await InvValPost.create({ author_id: author.id, title: "A", body: "body" });
-    const loaded = await findTarget(
-      post,
-      "author",
-      {
-        className: "InvValAuthor",
-        foreignKey: "author_id",
-        inverseOf: "inv_val_posts",
-      },
-      "belongsTo",
-    );
+    const loaded = await findTarget(post, "author", {
+      className: "InvValAuthor",
+      foreignKey: "author_id",
+      inverseOf: "inv_val_posts",
+    });
     expect(loaded).not.toBeNull();
     expect(loaded!.name).toBe("Alice");
   });

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -1120,15 +1120,10 @@ export async function findTarget(
       throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
     }
   } else if (throughAssoc.type === "hasOne") {
-    const one = await findSingularTarget(record, throughAssoc.name, throughAssoc.options, "hasOne");
+    const one = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
     throughRecords = one ? [one] : [];
   } else if (throughAssoc.type === "belongsTo") {
-    const one = await findSingularTarget(
-      record,
-      throughAssoc.name,
-      throughAssoc.options,
-      "belongsTo",
-    );
+    const one = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
     throughRecords = one ? [one] : [];
   } else {
     throughRecords = [];

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -582,7 +582,7 @@ export class HasOneAssociation extends SingularAssociation {
     // See `Association#_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;
     try {
-      return await findTarget(this.owner, this.reflection.name, this.reflection.options, "hasOne");
+      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
     } finally {
       this._loaderWritebackSuppressed--;
     }
@@ -770,7 +770,7 @@ async function preloadDestroyInverseBelongsTo(
   if (typeof (target as any).association !== "function") return;
   const ownFk = JSON.stringify((assoc as any).foreignKeyColumns());
 
-  for (const ref of reflectOnAllAssociations(targetCtor, "belongsTo")) {
+  for (const ref of reflectOnAllAssociations(targetCtor)) {
     const concrete = ref as unknown as { name: string; foreignKey: unknown; klass?: typeof Base };
     let fk: unknown;
     let klass: typeof Base | undefined;

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -770,7 +770,7 @@ async function preloadDestroyInverseBelongsTo(
   if (typeof (target as any).association !== "function") return;
   const ownFk = JSON.stringify((assoc as any).foreignKeyColumns());
 
-  for (const ref of reflectOnAllAssociations(targetCtor)) {
+  for (const ref of reflectOnAllAssociations(targetCtor, "belongsTo")) {
     const concrete = ref as unknown as { name: string; foreignKey: unknown; klass?: typeof Base };
     let fk: unknown;
     let klass: typeof Base | undefined;

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -735,19 +735,9 @@ export async function findTarget(
 
   let throughRecord: Base | null;
   if (throughAssoc.type === "hasOne") {
-    throughRecord = await findSingularTarget(
-      record,
-      throughAssoc.name,
-      throughAssoc.options,
-      "hasOne",
-    );
+    throughRecord = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
   } else if (throughAssoc.type === "belongsTo") {
-    throughRecord = await findSingularTarget(
-      record,
-      throughAssoc.name,
-      throughAssoc.options,
-      "belongsTo",
-    );
+    throughRecord = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
   } else if (throughAssoc.type === "hasMany") {
     const throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
     throughRecord = throughRecords[0] ?? null;
@@ -764,9 +754,9 @@ export async function findTarget(
 
   if (sourceAssoc) {
     if (sourceAssoc.type === "belongsTo") {
-      return findSingularTarget(throughRecord, sourceName, sourceAssoc.options, "belongsTo");
+      return findSingularTarget(throughRecord, sourceName, sourceAssoc.options);
     } else if (sourceAssoc.type === "hasOne") {
-      return findSingularTarget(throughRecord, sourceName, sourceAssoc.options, "hasOne");
+      return findSingularTarget(throughRecord, sourceName, sourceAssoc.options);
     }
   }
 

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -163,7 +163,7 @@ export function association(this: Base, name: string): AssociationInstance {
 export async function loadBelongsTo(this: Base, name: string): Promise<Base | null> {
   const assocDef = assertSingularAssociation.call(this, name, "belongsTo");
   const result = await bypassStrictLoading.call(this, () =>
-    findTarget(this, name, (assocDef.options ?? {}) as any, "belongsTo"),
+    findTarget(this, name, (assocDef.options ?? {}) as any),
   );
   // Loader writeback: this is the tail of this function's own query, not a
   // caller replacing the target. See Association#_setTargetFromLoader.
@@ -181,7 +181,7 @@ export async function loadBelongsTo(this: Base, name: string): Promise<Base | nu
 export async function loadHasOne(this: Base, name: string): Promise<Base | null> {
   const assocDef = assertSingularAssociation.call(this, name, "hasOne");
   const result = await bypassStrictLoading.call(this, () =>
-    findTarget(this, name, (assocDef.options ?? {}) as any, "hasOne"),
+    findTarget(this, name, (assocDef.options ?? {}) as any),
   );
   // Loader writeback: this is the tail of this function's own query, not a
   // caller replacing the target. See Association#_setTargetFromLoader.

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -260,12 +260,7 @@ describe("AutomaticInverseFindingTests", () => {
     const comment = (await Comment.first())!;
     const rating = await Rating.createBang({ comment_id: (comment as any).id });
 
-    const ratingComment = (await findTarget(
-      rating,
-      "comment",
-      { inverseOf: "ratings" },
-      "belongsTo",
-    )) as any;
+    const ratingComment = (await findTarget(rating, "comment", { inverseOf: "ratings" })) as any;
     expect(ratingComment.id).toBe((comment as any).id);
 
     ratingComment.body = "Fennec foxes are the smallest of the foxes.";
@@ -275,7 +270,7 @@ describe("AutomaticInverseFindingTests", () => {
   it("has many and belongs to automatic inverse shares objects on comment", async () => {
     const rating = await Rating.createBang({});
     const comment = (await Comment.first())!;
-    await findTarget(rating, "comment", { inverseOf: "ratings" }, "belongsTo");
+    await findTarget(rating, "comment", { inverseOf: "ratings" });
     (rating as any).comment = comment;
 
     expect((rating as any).comment).toBe(comment);
@@ -412,7 +407,7 @@ describe("InverseHasOneTests", () => {
 
   it("parent instance should be shared with child on find", async () => {
     const human = humans("gordon");
-    const face = (await findTarget(human, "face", { inverseOf: "human" }, "hasOne"))!;
+    const face = (await findTarget(human, "face", { inverseOf: "human" }))!;
     expect((face as any).human.name).toBe(human.name);
     (human as any).name = "Bongo";
     expect((face as any).human.name).toBe((human as any).name);
@@ -498,26 +493,16 @@ describe("InverseHasOneTests", () => {
   it("trying to use inverses that dont exist should raise an error", async () => {
     const human = (await Human.first())!;
     await expect(
-      findTarget(
-        human,
-        "confusedFace",
-        { className: "Face", inverseOf: "cnffusedHuman" },
-        "hasOne",
-      ),
+      findTarget(human, "confusedFace", { className: "Face", inverseOf: "cnffusedHuman" }),
     ).rejects.toThrow(InverseOfAssociationNotFoundError);
   });
 
   it("trying to use inverses that dont exist should have suggestions for fix", async () => {
     const human = (await Human.first())!;
-    const err = await findTarget(
-      human,
-      "confusedFace",
-      {
-        className: "Face",
-        inverseOf: "cnffusedHuman",
-      },
-      "hasOne",
-    ).catch((e) => e);
+    const err = await findTarget(human, "confusedFace", {
+      className: "Face",
+      inverseOf: "cnffusedHuman",
+    }).catch((e) => e);
     expect(err).toBeInstanceOf(InverseOfAssociationNotFoundError);
     expect(err.detailedMessage()).toMatch(/Did you mean\?/);
     expect(err.corrections[0]).toBe("confusedHuman");
@@ -852,14 +837,9 @@ describe("InverseHasManyTests", () => {
     const post1 = (await Post.first())!;
     const post2 = (await Post.all().order("id").offset(1).first())!;
     const comment = (await findHasManyTarget(post1, "comments", { inverseOf: "post" }))[0] as any;
-    expect(await findTarget(comment, "post", { inverseOf: "comments" }, "belongsTo")).toBe(post1);
+    expect(await findTarget(comment, "post", { inverseOf: "comments" })).toBe(post1);
     await comment.updateBang({ post_id: (post2 as any).id });
-    const reloaded = (await findTarget(
-      comment,
-      "post",
-      { inverseOf: "comments" },
-      "belongsTo",
-    )) as any;
+    const reloaded = (await findTarget(comment, "post", { inverseOf: "comments" })) as any;
     expect(reloaded.id).toBe((post2 as any).id);
   });
 
@@ -902,7 +882,7 @@ describe("InverseBelongsToTests", () => {
 
   it("child instance should be shared with parent on find", async () => {
     const face = faces("trusting");
-    const human = (await findTarget(face, "human", { inverseOf: "face" }, "belongsTo"))!;
+    const human = (await findTarget(face, "human", { inverseOf: "face" }))!;
     expect((human as any).face.description).toBe((face as any).description);
     (face as any).description = "gormless";
     expect((human as any).face.description).toBe((face as any).description);
@@ -954,7 +934,7 @@ describe("InverseBelongsToTests", () => {
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {
     const interest = interests("trainspotting");
-    const human = (await findTarget(interest, "human", { inverseOf: "interests" }, "belongsTo"))!;
+    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
     // Rails: human.interests.detect { |_iz| _iz.id == interest.id } — block-find
     // over the CollectionProxy (Enumerable#detect loads the target), not the AR
     // PK finder.
@@ -970,12 +950,7 @@ describe("InverseBelongsToTests", () => {
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
     await withHasManyInversing(Human, async () => {
       const interest = interests("trainspotting");
-      const human = (await findTarget(
-        interest,
-        "human",
-        { inverseOf: "interests" },
-        "belongsTo",
-      )) as any;
+      const human = (await findTarget(interest, "human", { inverseOf: "interests" })) as any;
       const cached = human._associationCache("interests")?.target as any[];
       const iz = cached.find((i: any) => i.id === (interest as any).id);
       expect(iz).toBeDefined();
@@ -1000,16 +975,11 @@ describe("InverseBelongsToTests", () => {
   it("with has many inversing does not trigger association callbacks on set when the inverse is a has many", async () => {
     await withHasManyInversing(Interest, async () => {
       const interest = interests("trainspotting");
-      const human = (await findTarget(
-        interest,
-        "humanWithCallbacks",
-        {
-          className: "Human",
-          foreignKey: "human_id",
-          inverseOf: "interestsWithCallbacks",
-        },
-        "belongsTo",
-      )) as any;
+      const human = (await findTarget(interest, "humanWithCallbacks", {
+        className: "Human",
+        foreignKey: "human_id",
+        inverseOf: "interestsWithCallbacks",
+      })) as any;
       expect(human.addCallbackCalled).toBe(false);
     });
   });
@@ -1047,33 +1017,23 @@ describe("InverseBelongsToTests", () => {
 
   it("unscope does not set inverse when incorrect", async () => {
     const interest = interests("trainspotting");
-    const human = (await findTarget(interest, "human", { inverseOf: "interests" }, "belongsTo"))!;
+    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
     const createdHuman = await Human.create({ name: "wrong human" });
     const foundInterest = await (createdHuman as any).interests
       .or((human as any).interests)
       .detect((thisInterest: any) => (interest as any).id === thisInterest.id);
-    const foundHuman = await findTarget(
-      foundInterest,
-      "human",
-      { inverseOf: "interests" },
-      "belongsTo",
-    );
+    const foundHuman = await findTarget(foundInterest, "human", { inverseOf: "interests" });
     expect((foundHuman as any).id).toBe((human as any).id);
   });
 
   it("or does not set inverse when incorrect", async () => {
     const interest = interests("trainspotting");
-    const human = (await findTarget(interest, "human", { inverseOf: "interests" }, "belongsTo"))!;
+    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
     const createdHuman = await Human.create({ name: "wrong human" });
     const foundInterest = await (createdHuman as any).interests
       .unscope("where")
       .detect((thisInterest: any) => (interest as any).id === thisInterest.id);
-    const foundHuman = await findTarget(
-      foundInterest,
-      "human",
-      { inverseOf: "interests" },
-      "belongsTo",
-    );
+    const foundHuman = await findTarget(foundInterest, "human", { inverseOf: "interests" });
     expect((foundHuman as any).id).toBe((human as any).id);
   });
 
@@ -1092,26 +1052,16 @@ describe("InverseBelongsToTests", () => {
   it("trying to use inverses that dont exist should raise an error", async () => {
     const face = (await Face.first())!;
     await expect(
-      findTarget(
-        face,
-        "confusedHuman",
-        { className: "Human", inverseOf: "cnffusedFace" },
-        "belongsTo",
-      ),
+      findTarget(face, "confusedHuman", { className: "Human", inverseOf: "cnffusedFace" }),
     ).rejects.toThrow(InverseOfAssociationNotFoundError);
   });
 
   it("trying to use inverses that dont exist should have suggestions for fix", async () => {
     const face = (await Face.first())!;
-    const err = await findTarget(
-      face,
-      "confusedHuman",
-      {
-        className: "Human",
-        inverseOf: "cnffusedFace",
-      },
-      "belongsTo",
-    ).catch((e) => e);
+    const err = await findTarget(face, "confusedHuman", {
+      className: "Human",
+      inverseOf: "cnffusedFace",
+    }).catch((e) => e);
     expect(err).toBeInstanceOf(InverseOfAssociationNotFoundError);
     expect(err.detailedMessage()).toMatch(/Did you mean\?/);
     expect(err.corrections[0]).toBe("confusedFace");
@@ -1136,15 +1086,10 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("child instance should be shared with parent on find", async () => {
     const face = faces("confused");
-    const human = (await findTarget(
-      face,
-      "polymorphicHuman",
-      {
-        polymorphic: true,
-        inverseOf: "polymorphicFace",
-      },
-      "belongsTo",
-    )) as any;
+    const human = (await findTarget(face, "polymorphicHuman", {
+      polymorphic: true,
+      inverseOf: "polymorphicFace",
+    })) as any;
     expect(human.polymorphicFace.description).toBe((face as any).description);
     (face as any).description = "gormless";
     expect(human.polymorphicFace.description).toBe((face as any).description);
@@ -1154,15 +1099,10 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("eager loaded child instance should be shared with parent on find", async () => {
     let face = (await Face.where({ description: "confused" }).includes("human"))[0] as any;
-    let human = (await findTarget(
-      face,
-      "polymorphicHuman",
-      {
-        polymorphic: true,
-        inverseOf: "polymorphicFace",
-      },
-      "belongsTo",
-    )) as any;
+    let human = (await findTarget(face, "polymorphicHuman", {
+      polymorphic: true,
+      inverseOf: "polymorphicFace",
+    })) as any;
     expect(human.polymorphicFace.description).toBe(face.description);
     face.description = "gormless";
     expect(human.polymorphicFace.description).toBe(face.description);
@@ -1172,15 +1112,10 @@ describe("InversePolymorphicBelongsToTests", () => {
     face = (
       await Face.where({ description: "confused" }).includes("human").order("humans.id")
     )[0] as any;
-    human = (await findTarget(
-      face,
-      "polymorphicHuman",
-      {
-        polymorphic: true,
-        inverseOf: "polymorphicFace",
-      },
-      "belongsTo",
-    )) as any;
+    human = (await findTarget(face, "polymorphicHuman", {
+      polymorphic: true,
+      inverseOf: "polymorphicFace",
+    })) as any;
     expect(human.polymorphicFace.description).toBe(face.description);
     face.description = "gormless";
     expect(human.polymorphicFace.description).toBe(face.description);
@@ -1259,15 +1194,10 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {
     const interest = interests("llama_wrangling");
-    const human = (await findTarget(
-      interest,
-      "polymorphicHuman",
-      {
-        polymorphic: true,
-        inverseOf: "polymorphicInterests",
-      },
-      "belongsTo",
-    )) as any;
+    const human = (await findTarget(interest, "polymorphicHuman", {
+      polymorphic: true,
+      inverseOf: "polymorphicInterests",
+    })) as any;
     // Rails: human.polymorphic_interests.detect { |_iz| _iz.id == interest.id }
     const iz = await human.polymorphicInterests.detect((i: any) => i.id === (interest as any).id);
     expect(iz).toBeDefined();
@@ -1281,15 +1211,10 @@ describe("InversePolymorphicBelongsToTests", () => {
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
     await withHasManyInversing(Human, async () => {
       const interest = interests("llama_wrangling");
-      const human = (await findTarget(
-        interest,
-        "polymorphicHuman",
-        {
-          polymorphic: true,
-          inverseOf: "polymorphicInterests",
-        },
-        "belongsTo",
-      )) as any;
+      const human = (await findTarget(interest, "polymorphicHuman", {
+        polymorphic: true,
+        inverseOf: "polymorphicInterests",
+      })) as any;
       const cached = human._associationCache("polymorphicInterests")?.target as any[];
       const iz = cached.find((i: any) => i.id === (interest as any).id);
       expect(iz).toBeDefined();
@@ -1311,15 +1236,10 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("trying to access inverses that dont exist shouldnt raise an error", async () => {
     const face = (await Face.first())!;
-    await findTarget(
-      face,
-      "puzzledPolymorphicHuman",
-      {
-        polymorphic: true,
-        inverseOf: "puzzledPolymorphicFace",
-      },
-      "belongsTo",
-    );
+    await findTarget(face, "puzzledPolymorphicHuman", {
+      polymorphic: true,
+      inverseOf: "puzzledPolymorphicFace",
+    });
   });
 
   it("trying to set polymorphic inverses that dont exist at all should raise an error", async () => {
@@ -1354,8 +1274,8 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
 
   it("that we can load associations that have the same reciprocal name from different models", async () => {
     const interest = (await Interest.first())!;
-    await findTarget(interest, "zine", { inverseOf: "interests" }, "belongsTo");
-    await findTarget(interest, "human", { inverseOf: "interests" }, "belongsTo");
+    await findTarget(interest, "zine", { inverseOf: "interests" });
+    await findTarget(interest, "human", { inverseOf: "interests" });
   });
 
   it("that we can create associations that have the same reciprocal name from different models", async () => {
@@ -1390,15 +1310,10 @@ describe("InverseBelongsToTests", () => {
       const main = await BrokenBranch.create({});
       const feature = await association(main, "branches").create({});
       const topic = association(feature, "branches").build({});
-      const err = await findTarget(
-        topic,
-        "branch",
-        {
-          className: "BrokenBranch",
-          inverseOf: "branch",
-        },
-        "belongsTo",
-      ).catch((e) => e);
+      const err = await findTarget(topic, "branch", {
+        className: "BrokenBranch",
+        inverseOf: "branch",
+      }).catch((e) => e);
       expect(err).toBeInstanceOf(InverseOfAssociationRecursiveError);
       expect((err as Error).message).toBe(
         "Inverse association branch (:branch in BrokenBranch) is recursive.",

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -308,12 +308,7 @@ describe("AssociationsJoinModelTest", () => {
 
     expect(tagging.taggable_type).toBe("Post");
     expect(tagging.taggable_id).toBe(Number(thinking.id));
-    const taggable = (await findTarget(
-      tagging,
-      "taggable",
-      { polymorphic: true },
-      "belongsTo",
-    )) as Base;
+    const taggable = (await findTarget(tagging, "taggable", { polymorphic: true })) as Base;
     expect(taggable.id).toBe(thinking.id);
   });
 
@@ -326,12 +321,7 @@ describe("AssociationsJoinModelTest", () => {
 
     expect(tagging.taggable_type).toBe("Post");
     expect(tagging.taggable_id).toBe(Number(post.id));
-    const taggable = (await findTarget(
-      tagging,
-      "taggable",
-      { polymorphic: true },
-      "belongsTo",
-    )) as Base;
+    const taggable = (await findTarget(tagging, "taggable", { polymorphic: true })) as Base;
     expect(taggable.id).toBe(post.id);
   });
 
@@ -1168,15 +1158,10 @@ describe("AssociationsJoinModelTest", () => {
 
   it("polymorphic has many going through join model with custom foreign key", async () => {
     const tagging = await Tagging.find(taggings("welcome_general").id);
-    const superTag = (await findTarget(
-      tagging,
-      "superTag",
-      {
-        className: "Tag",
-        foreignKey: "super_tag_id",
-      },
-      "belongsTo",
-    )) as Base;
+    const superTag = (await findTarget(tagging, "superTag", {
+      className: "Tag",
+      foreignKey: "super_tag_id",
+    })) as Base;
     expect(superTag.id).toBe(tags("misc").id);
     const post = await Post.find(posts("welcome").id);
     const superTagsList = (await (post as any).superTags.toArray()) as Base[];

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -313,351 +313,103 @@ function scopeForCreate(assoc: SingularAssociation): Record<string, unknown> {
 }
 
 /**
- * Load a belongs_to association's target.
+ * belongs_to's cached-target read. Unlike has_one it validates `inverse_of`
+ * even on a cached hit, and honors `stale_target?` so a reassigned foreign key
+ * re-queries.
  *
- * Mirrors: ActiveRecord::Associations::SingularAssociation#find_target
- * (`singular_association.rb:47`), as specialized for belongs_to by
- * `BelongsToAssociation#find_target?` (`belongs_to_association.rb:124`) —
- * the reachability gate is `_findTargetReachable(..., "belongsTo")` below.
- *
- * It lives here rather than in `belongs-to-association.ts` because
- * `belongs_to_association.rb` defines no `find_target` of its own: Rails
- * inherits the singular one and specializes only the `find_target?` predicate.
- * Putting the loader under the belongs_to file would name a method Rails does
- * not declare there.
+ * Rails has no counterpart: it caches the target on the association instance,
+ * so `find_target` is only ever reached on a miss.
  *
  * @internal
  */
-async function _findBelongsToTarget(
+function _belongsToCachedHit(
   record: Base,
   assocName: string,
   options: AssociationOptions,
-): Promise<Base | null> {
-  // Rails runs `reflection.check_validity!` in `Association#initialize`
-  // (now mirrored in the `Association` constructor via
-  // `validateReflectionValidity`), so a recursive/missing `inverse_of` already
-  // surfaced at first access. No load-path recursion shim is needed here.
-
-  // Check cached (inverse_of) first, then preloaded.
-  // Even for cached/preloaded hits, wire inverseOf so the parent's association
-  // cache points back to this child instance (mirrors Rails behavior).
-  // For non-polymorphic associations, validate inverseOf before checking whether
-  // the value is null: an invalid name must throw even when the cached value is
-  // null (e.g. preloader stored null for a missing row), consistent with the
-  // cache-miss path that validates before the FK/null short-circuit.
-  // Read the loaded target off the singular holder (Rails' @target), with the
-  // legacy mirror + preload fallback for direct-loader calls on undeclared
-  // names. A loaded-nil target (null) is distinguished from "not loaded".
+): { hit: boolean; value: Base | null } {
   const loaded = _loadedSingularTarget(record, assocName);
-  if (loaded) {
-    const cached = loaded.value;
-    if (options.inverseOf && !options.polymorphic) {
-      // Resolve target class from instance if available, otherwise from options.
-      const targetModel =
-        (cached?.constructor as typeof Base | undefined) ??
-        resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
-      validateInverseOf(targetModel, assocName, options.inverseOf);
-    }
-    if (cached) {
-      // Honor staleness (Rails' `stale_target?`): if the owner's FK changed so
-      // it no longer points at the cached target, the cache is stale — fall
-      // through to re-query. `_cacheSingularTarget` routes singular inverse
-      // writes through `inversedFrom` (→ `replace_keys` → `loadedBang`), so the
-      // holder's `isStaleTarget()` snapshot is now authoritative.
-      const holder = record._associationInstances.get(assocName) as
-        | { isStaleTarget?: () => boolean }
-        | undefined;
-      const stale = typeof holder?.isStaleTarget === "function" && holder.isStaleTarget();
-      if (!stale) {
-        const inverseName = _resolveInverseName(
-          record.constructor as typeof Base,
-          assocName,
-          options,
-        );
-        if (inverseName) _wireInverseAssociation(record, cached, inverseName);
-        return cached;
-      }
-    } else {
-      return cached;
-    }
-  }
+  if (!loaded) return { hit: false, value: null };
+  const cached = loaded.value;
 
-  // Strict loading check: this is a lazy load. Gated by `find_target?` — a
-  // new-record owner without the FK present never reaches `find_target` and so
-  // never raises (it falls through to the null-FK short-circuit below).
-  if (
-    _violatesStrictLoading(record, options) &&
-    _findTargetReachable(record, assocName, options, "belongsTo")
-  ) {
-    strictLoadingViolationBang(record, assocName, {
-      polymorphic: options.polymorphic,
-      className: options.className,
-    });
-  }
-
-  const ctor = record.constructor as typeof Base;
-  const reflection = ctor._reflectOnAssociation?.(assocName);
-  if (!reflection) throw new AssociationNotFoundError(record, assocName);
-
-  // Polymorphic: use the _type column to determine the target model
-  let targetModel: typeof Base;
-  if (options.polymorphic) {
-    const typeCol = options.foreignType ?? `${underscore(assocName)}_type`;
-    const typeName = record._readAttribute(typeCol) as string | null;
-    if (!typeName) return null;
-    // Rails resolves a polymorphic belongs_to's target via the owner class's
-    // polymorphic_class_for, which honors store_full_class_name and (when off)
-    // namespace-relative compute_type — not a bare global registry lookup.
-    targetModel = ctor.polymorphicClassFor(typeName);
-  } else {
-    const className = options.className ?? camelize(assocName);
-    targetModel = resolveAssocClass(record, assocName, className);
-  }
-
+  // Validate inverseOf before the null check: an invalid name must throw even
+  // when the cached value is null (e.g. the preloader stored null for a missing
+  // row), consistent with the cache-miss path.
   if (options.inverseOf && !options.polymorphic) {
+    const targetModel =
+      (cached?.constructor as typeof Base | undefined) ??
+      resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
     validateInverseOf(targetModel, assocName, options.inverseOf);
   }
+  if (!cached) return { hit: true, value: null };
 
-  // For polymorphic belongsTo, AssociationScope receives the
-  // runtime-resolved klass; the reflection's own joinPrimaryKey
-  // returns associationPrimaryKey (target's PK) and joinForeignKey
-  // returns the owner-side FK, so the WHERE shape is identical to
-  // the non-polymorphic case.
-  // Null-FK short-circuit: avoid a query when owner's FK column is null.
-  // The check must read the SAME columns the eventual query uses —
-  // reflection.joinForeignKey. Reading from a different column would
-  // silently return null while a real query would have found the row (or
-  // vice versa).
-  const fkColsForCheck = Array.isArray(reflection.joinForeignKey)
-    ? reflection.joinForeignKey
-    : [reflection.joinForeignKey];
-  for (const fk of fkColsForCheck) {
-    const v = record._readAttribute(fk);
-    if (v === null || v === undefined) return null;
-  }
-  // The staleness key mirrors Rails' `stale_state`: the FK column(s), plus the
-  // `foreign_type` for a polymorphic belongs_to
-  // (belongs_to_polymorphic_association.rb:43-46), so a reassignment that keeps
-  // the same id but changes the target class is still detected below.
-  const staleCols = options.polymorphic
-    ? [...fkColsForCheck, options.foreignType ?? `${underscore(assocName)}_type`]
-    : fkColsForCheck;
-  const staleSnapshot = staleCols.map((col) => record._readAttribute(col));
-
-  let result: Base | null;
-  if (!_skipSingularStatementCache(reflection, targetModel, options)) {
-    // Statement-cache path (Rails `Association#find_target` via
-    // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
-    result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
-  } else {
-    const built = _builtAssociationScope(record, assocName, reflection, targetModel);
-    const baseRelation = _scopeForAssociation(targetModel);
-    let rel = baseRelation.merge(built);
-    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
-    // Rails' normal singular-load path (`Association#find_target` via the
-    // statement cache) returns an array and calls `Array#first` — no ORDER BY
-    // in SQL. `take` (unordered LIMIT 1) is the closest equivalent; `first`
-    // would route through `ordered_relation` and add a spurious ORDER BY. See
-    // has_one_associations_test `test_has_one_does_not_use_order_by`.
-    result = await rel.take();
+  // `_cacheSingularTarget` routes singular inverse writes through
+  // `inversedFrom` (→ `replace_keys` → `loadedBang`), so the holder's
+  // `isStaleTarget()` snapshot is authoritative.
+  const holder = record._associationInstances.get(assocName) as
+    | { isStaleTarget?: () => boolean }
+    | undefined;
+  if (typeof holder?.isStaleTarget === "function" && holder.isStaleTarget()) {
+    return { hit: false, value: null };
   }
 
-  // Rails' `find_target` is synchronous, so it never observes the owner's
-  // foreign key change mid-load. Our loader awaits DB I/O: an in-flight reader
-  // query (e.g. `node.parent` accessed but never awaited) can still be pending
-  // when the caller synchronously reassigns the association
-  // (`node.parent = other`) with a new FK. Once RFC 0063 made `save` genuinely
-  // await the validation chain, that window widened enough for the stale query
-  // to resolve mid-save and `syncToAssociationInstance` clobber the
-  // freshly-assigned holder target with the old record — dropping the FK change
-  // from `previousChanges`. If the owner's stale key moved off the snapshot we
-  // queried, the fetched record is stale: leave the holder's newer target
-  // intact and return it instead of the stale row.
-  const fkMovedDuringLoad = staleCols.some(
-    (col, i) => record._readAttribute(col) !== staleSnapshot[i],
-  );
-  if (fkMovedDuringLoad) {
-    const holder = record._associationInstances.get(assocName) as
-      | { isLoaded?: () => boolean; target?: Base | null }
-      | undefined;
-    if (holder?.isLoaded?.()) return holder.target ?? null;
-  }
-
-  // Set inverse_of: store reference back to the owner. Resolve via the
-  // reflection so automatic_inverse_of also wires the parent — mirrors
-  // ActiveRecord::Associations::Association#set_inverse_instance.
-  if (result) {
-    const inverseName = _resolveInverseName(ctor, assocName, options);
-    if (inverseName) _wireInverseAssociation(record, result, inverseName);
-  }
-
-  syncToAssociationInstance(record, assocName, result);
-  return result;
+  const inverseName = _resolveInverseName(record.constructor as typeof Base, assocName, options);
+  if (inverseName) _wireInverseAssociation(record, cached, inverseName);
+  return { hit: true, value: cached };
 }
 
 /**
- * The has_one arm of `findTarget`.
+ * has_one's polymorphic `:as` key guard: a composite FK is always rejected, and
+ * a composite owner PK collapses to "id" when present (matching Rails'
+ * `join_id_for`); otherwise it is rejected too.
  *
  * @internal
  */
-async function _findHasOneTarget(
+function _validateHasOnePolymorphicKeys(
   record: Base,
   assocName: string,
   options: AssociationOptions,
-): Promise<Base | null> {
-  if (options.through) {
-    validateThroughReflection(record.constructor as typeof Base, assocName);
-  }
-  // Read the loaded target off the singular holder (Rails' @target), with the
-  // legacy mirror + preload fallback for direct-loader calls on undeclared names.
-  const loaded = _loadedSingularTarget(record, assocName);
-  if (loaded) {
-    return loaded.value;
-  }
-
-  // Strict loading check. Gated by `find_target?`: a new-record owner without
-  // the FK present never reaches `find_target` and so never raises.
-  if (
-    _violatesStrictLoading(record, options) &&
-    _findTargetReachable(record, assocName, options, "foreign")
-  ) {
-    strictLoadingViolationBang(record, assocName, { className: options.className });
-  }
-
-  // Handle has_one :through. Same routing rules as findTarget —
-  // route through AssociationScope's JOIN-based path for the simple
-  // shape; everything else falls back to the 2-step `HasOneThroughAssociation#findTarget`.
-  if (options.through) {
-    const ctorEarly = record.constructor as typeof Base;
-    const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
-    if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
-      return _loadSingularThroughViaDisableJoinsScope(record, reflEarly, options);
-    }
-    if (!_routeThroughViaAssociationScope(record, reflEarly, options)) {
-      const { findTarget } = await import("./has-one-through-association.js");
-      return findTarget(record, assocName, options);
-    }
-    // Fall through into the AssociationScope path below.
-  }
-
+): void {
+  if (!options.as) return;
   const ctor = record.constructor as typeof Base;
-  const reflection = ctor._reflectOnAssociation?.(assocName);
-  if (!reflection) throw new AssociationNotFoundError(record, assocName);
-
-  const className = options.className ?? camelize(assocName);
   const primaryKey = options.primaryKey ?? ctor.primaryKey;
-
-  const targetModel = resolveAssocClass(record, assocName, className);
-
-  if (options.inverseOf) {
-    validateInverseOf(targetModel, assocName, options.inverseOf);
-  }
-
   const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, { ...options, primaryKey });
   const foreignKey: string | string[] =
     foreignKeyColumns.length === 1 ? foreignKeyColumns[0] : foreignKeyColumns;
-
-  // Polymorphic `:as` requires a scalar FK. A composite FK is always
-  // rejected. A composite owner PK collapses to "id" when present
-  // (matching Rails' join_id_for); otherwise reject.
-  if (options.as) {
-    if (Array.isArray(foreignKey)) {
-      // Route through the reflection's canonical checkValidityBang (Rails'
-      // single raise site) so the error carries the Rails-faithful message;
-      // a no-op for polymorphic `:as` (Rails permits no composite key there).
-      routeThroughCheckValidity(ctor, assocName);
-      throw new CompositePrimaryKeyMismatchError({
-        activeRecord: ctor.name,
-        name: assocName,
-        primaryKey,
-        foreignKey,
-      });
-    }
-    if (Array.isArray(primaryKey) && !primaryKey.includes("id")) {
-      // Route through the reflection's canonical checkValidityBang (Rails'
-      // single raise site) so the error carries the Rails-faithful message;
-      // a no-op for polymorphic `:as` (Rails permits no composite key there).
-      routeThroughCheckValidity(ctor, assocName);
-      throw new CompositePrimaryKeyMismatchError({
-        activeRecord: ctor.name,
-        name: assocName,
-        primaryKey,
-        foreignKey,
-      });
-    }
+  if (!Array.isArray(foreignKey) && !(Array.isArray(primaryKey) && !primaryKey.includes("id"))) {
+    return;
   }
-  // Route through AssociationScope (handles scalar, composite, :as, STI
-  // in a single Rails-faithful path). reflection.isCollection() === false
-  // for hasOne, so AssociationScope.scope adds limit(1) automatically.
-  // Null-PK short-circuit: read the SAME columns the eventual query
-  // reads. For non-through, reflection.joinForeignKey is the owner-
-  // side activeRecordPrimaryKey for hasOne. For through reflections the
-  // owner-side column is on `_ownerChainReflection` (chain.last).
-  const reflForOwnerFk = _ownerChainReflection(reflection);
-  const pkCheckCols = reflForOwnerFk
-    ? Array.isArray(reflForOwnerFk.joinForeignKey)
-      ? reflForOwnerFk.joinForeignKey
-      : [reflForOwnerFk.joinForeignKey]
-    : Array.isArray(primaryKey)
-      ? primaryKey
-      : [primaryKey];
-  for (const pk of pkCheckCols) {
-    const v = record._readAttribute(pk);
-    if (v === null || v === undefined) return null;
-  }
-
-  let result: Base | null;
-  if (!_skipSingularStatementCache(reflection, targetModel, options)) {
-    // Statement-cache path (Rails `Association#find_target` via
-    // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
-    result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
-  } else {
-    const built = _builtAssociationScope(record, assocName, reflection, targetModel);
-    const baseRelation = _scopeForAssociation(targetModel);
-    let rel = baseRelation.merge(built);
-    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
-    // Unordered LIMIT 1: Rails' singular load returns an array and calls
-    // `Array#first`, emitting no ORDER BY. `take` matches; `first` would add one.
-    result = await rel.take();
-  }
-
-  // Set inverse_of: store reference back to the owner. Resolve via the
-  // reflection so automatic_inverse_of also wires the parent.
-  if (result) {
-    const inverseName = _resolveInverseName(ctor, assocName, options);
-    if (inverseName) _wireInverseAssociation(record, result, inverseName);
-  }
-
-  syncToAssociationInstance(record, assocName, result);
-  return result;
+  // Route through the reflection's canonical checkValidityBang (Rails' single
+  // raise site) so the error carries the Rails-faithful message; it is a no-op
+  // for polymorphic `:as`, which Rails never allows a composite key on.
+  routeThroughCheckValidity(ctor, assocName);
+  throw new CompositePrimaryKeyMismatchError({
+    activeRecord: ctor.name,
+    name: assocName,
+    primaryKey,
+    foreignKey,
+  });
 }
 
 /**
  * Loads a singular association's target.
  *
  * Mirrors: ActiveRecord::Associations::SingularAssociation#find_target
- * (`singular_association.rb:47`). Like Rails, which builds an `Association`
- * from a validated reflection (`association.rb:41-45`), an association name the
- * model never declared raises `AssociationNotFoundError` (`associations.rb:56`)
- * before any load runs.
+ * (`singular_association.rb:47`), which delegates the query itself to
+ * `Association#find_target` (`association.rb`) and takes `Array#first` of the
+ * loaded rows. Like Rails, which builds an `Association` from a validated
+ * reflection (`association.rb:41-45`), a name the model never declared raises
+ * `AssociationNotFoundError` (`associations.rb:56`) before any load runs.
  *
- * DEVIATION: Rails' `find_target(async: false)` takes no macro parameter and
- * has no dispatcher layer — it is the loader body itself, and
- * `BelongsToAssociation` overrides only the `find_target?` predicate
- * (`belongs_to_association.rb:124-126`), never `find_target`. One Rails body
- * serves both macros because the difference lives entirely in the `scope` the
- * reflection builds.
+ * One body serves belongs_to and has_one, as in Rails, because the macro
+ * difference lives in the scope the reflection builds — `_builtAssociationScope`
+ * below is reached identically for both. `BelongsToAssociation` overrides only
+ * the `find_target?` predicate (`belongs_to_association.rb:124-126`), never
+ * `find_target`, which is why there is no belongs_to override here either.
  *
- * trails' two loaders arrived as separate engine functions and have not
- * converged, so `macro` stands in for the receiver class Rails dispatches on.
- * It is required rather than defaulted because both loaders are also called
- * for association names with no registered reflection, where `options` alone
- * cannot tell a belongs_to from a has_one and a default would silently
- * mis-dispatch.
- *
- * Collapsing the two arms into one Rails-shaped body — dropping this
- * parameter — is story `converge-singular-find-target-dispatcher`
- * (RFC 0072).
+ * The macro-conditional steps are the ones Rails has no counterpart for: the
+ * cached-target read (trails caches on the owner, Rails on the association
+ * instance) and the has_one `:through` routing. They are named helpers rather
+ * than inline branches so this body keeps the shape of Rails'.
  *
  * @internal
  */
@@ -665,9 +417,146 @@ export async function findTarget(
   record: Base,
   assocName: string,
   options: AssociationOptions,
-  macro: "belongsTo" | "hasOne",
 ): Promise<Base | null> {
-  return macro === "belongsTo"
-    ? _findBelongsToTarget(record, assocName, options)
-    : _findHasOneTarget(record, assocName, options);
+  const ctor = record.constructor as typeof Base;
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  if (!reflection) throw new AssociationNotFoundError(record, assocName);
+  const isBelongsTo = reflection.macro === "belongsTo";
+
+  if (options.through) {
+    validateThroughReflection(ctor, assocName);
+  }
+
+  // Rails runs `reflection.check_validity!` in `Association#initialize`
+  // (mirrored in the `Association` constructor via
+  // `validateReflectionValidity`), so a recursive/missing `inverse_of` has
+  // already surfaced by now — no load-path recursion shim is needed.
+  if (isBelongsTo) {
+    const cached = _belongsToCachedHit(record, assocName, options);
+    if (cached.hit) return cached.value;
+  } else {
+    const loaded = _loadedSingularTarget(record, assocName);
+    if (loaded) return loaded.value;
+  }
+
+  // Rails `Association#find_target`'s first statement. Gated by `find_target?`:
+  // a new-record owner without the key present never reaches `find_target` and
+  // so never raises.
+  if (
+    _violatesStrictLoading(record, options) &&
+    _findTargetReachable(record, assocName, options, isBelongsTo ? "belongsTo" : "foreign")
+  ) {
+    strictLoadingViolationBang(record, assocName, {
+      polymorphic: isBelongsTo ? options.polymorphic : undefined,
+      className: options.className,
+    });
+  }
+
+  // has_one :through. Rails expresses `:through` inside the scope chain; trails
+  // still routes the shapes AssociationScope cannot build through the two-step
+  // `HasOneThroughAssociation#findTarget`.
+  if (!isBelongsTo && options.through) {
+    if (_canRouteThroughViaDisableJoinsAssociationScope(reflection, options)) {
+      return _loadSingularThroughViaDisableJoinsScope(record, reflection, options);
+    }
+    if (!_routeThroughViaAssociationScope(record, reflection, options)) {
+      const { findTarget: findThroughTarget } = await import("./has-one-through-association.js");
+      return findThroughTarget(record, assocName, options);
+    }
+    // Otherwise fall through to the scope path below.
+  }
+
+  let targetModel: typeof Base;
+  if (isBelongsTo && options.polymorphic) {
+    const typeCol = options.foreignType ?? `${underscore(assocName)}_type`;
+    const typeName = record._readAttribute(typeCol) as string | null;
+    if (!typeName) return null;
+    // Rails resolves a polymorphic belongs_to via the owner class's
+    // polymorphic_class_for, honoring store_full_class_name and (when off)
+    // namespace-relative compute_type — not a bare global registry lookup.
+    targetModel = ctor.polymorphicClassFor(typeName);
+  } else {
+    targetModel = resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
+  }
+
+  if (options.inverseOf && !(isBelongsTo && options.polymorphic)) {
+    validateInverseOf(targetModel, assocName, options.inverseOf);
+  }
+
+  if (!isBelongsTo) {
+    _validateHasOnePolymorphicKeys(record, assocName, options);
+  }
+
+  // Null-key short-circuit: read the SAME columns the eventual query reads, or
+  // a mismatch silently returns null where a real query would have found the
+  // row. That is `joinForeignKey` on the owner-side chain reflection for both
+  // macros — the owner's FK for belongs_to, its activeRecordPrimaryKey for
+  // has_one.
+  const ownerSideReflection = _ownerChainReflection(reflection) ?? reflection;
+  const keyColsForCheck = Array.isArray(ownerSideReflection.joinForeignKey)
+    ? ownerSideReflection.joinForeignKey
+    : [ownerSideReflection.joinForeignKey];
+  for (const col of keyColsForCheck) {
+    const v = record._readAttribute(col);
+    if (v === null || v === undefined) return null;
+  }
+
+  // The staleness key mirrors Rails' `stale_state`: the FK column(s), plus
+  // `foreign_type` for a polymorphic belongs_to
+  // (belongs_to_polymorphic_association.rb:43-46), so a reassignment keeping the
+  // same id but changing the target class is still detected after the await.
+  const staleCols =
+    isBelongsTo && options.polymorphic
+      ? [...keyColsForCheck, options.foreignType ?? `${underscore(assocName)}_type`]
+      : keyColsForCheck;
+  const staleSnapshot: unknown[] = isBelongsTo
+    ? staleCols.map((col: string) => record._readAttribute(col))
+    : [];
+
+  let result: Base | null;
+  if (!_skipSingularStatementCache(reflection, targetModel, options)) {
+    // Rails `Association#find_target` via `reflection.association_scope_cache`
+    // / `sc.execute(binds, c)`.
+    result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
+  } else {
+    // Rails' `scope.to_a` arm: AssociationScope builds the macro-specific WHERE
+    // (scalar, composite, `:as`, STI, polymorphic) for both macros, and adds
+    // LIMIT 1 because `reflection.isCollection()` is false.
+    const built = _builtAssociationScope(record, assocName, reflection, targetModel);
+    const baseRelation = _scopeForAssociation(targetModel);
+    let rel = baseRelation.merge(built);
+    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
+    // Rails returns the array and calls `Array#first` — no ORDER BY in SQL.
+    // `take` (unordered LIMIT 1) matches; `first` would route through
+    // `ordered_relation` and add one. See has_one_associations_test
+    // `test_has_one_does_not_use_order_by`.
+    result = await rel.take();
+  }
+
+  // Rails' `find_target` is synchronous and never observes the owner's foreign
+  // key changing mid-load. Ours awaits DB I/O: an in-flight reader query (e.g.
+  // `node.parent` accessed but never awaited) can still be pending when the
+  // caller reassigns the association with a new FK. Once RFC 0063 made `save`
+  // genuinely await the validation chain, that window widened enough for the
+  // stale query to resolve mid-save and clobber the freshly-assigned holder
+  // target, dropping the FK change from `previousChanges`.
+  if (
+    isBelongsTo &&
+    staleCols.some((col: string, i: number) => record._readAttribute(col) !== staleSnapshot[i])
+  ) {
+    const holder = record._associationInstances.get(assocName) as
+      | { isLoaded?: () => boolean; target?: Base | null }
+      | undefined;
+    if (holder?.isLoaded?.()) return holder.target ?? null;
+  }
+
+  // Mirrors `Association#set_inverse_instance`: resolve via the reflection so
+  // automatic_inverse_of wires the parent too.
+  if (result) {
+    const inverseName = _resolveInverseName(ctor, assocName, options);
+    if (inverseName) _wireInverseAssociation(record, result, inverseName);
+  }
+
+  syncToAssociationInstance(record, assocName, result);
+  return result;
 }

--- a/packages/activerecord/src/associations/singular-find-target-undeclared.trails.test.ts
+++ b/packages/activerecord/src/associations/singular-find-target-undeclared.trails.test.ts
@@ -26,15 +26,15 @@ describe("SingularAssociation#findTarget — undeclared association name", () =>
 
   it("raises AssociationNotFoundError for a belongs_to name with no reflection", async () => {
     const post = posts("welcome");
-    await expect(
-      findTarget(post, "undeclaredAuthor", { className: "Author" }, "belongsTo"),
-    ).rejects.toThrow(AssociationNotFoundError);
+    await expect(findTarget(post, "undeclaredAuthor", { className: "Author" })).rejects.toThrow(
+      AssociationNotFoundError,
+    );
   });
 
   it("raises AssociationNotFoundError for a has_one name with no reflection", async () => {
     const post = posts("welcome");
-    await expect(
-      findTarget(post, "undeclaredComment", { className: "Comment" }, "hasOne"),
-    ).rejects.toThrow(AssociationNotFoundError);
+    await expect(findTarget(post, "undeclaredComment", { className: "Comment" })).rejects.toThrow(
+      AssociationNotFoundError,
+    );
   });
 });

--- a/packages/activerecord/src/delegate.ts
+++ b/packages/activerecord/src/delegate.ts
@@ -38,9 +38,9 @@ export function delegate(
 
         let target: Base | null = null;
         if (assocDef.type === "belongsTo") {
-          target = await findTarget(this, assocName, assocDef.options, "belongsTo");
+          target = await findTarget(this, assocName, assocDef.options);
         } else if (assocDef.type === "hasOne") {
-          target = await findTarget(this, assocName, assocDef.options, "hasOne");
+          target = await findTarget(this, assocName, assocDef.options);
         }
 
         if (!target) return null;

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -360,12 +360,12 @@ describe("StrictLoadingTest", () => {
 
       const preloaded = (await Developer.all().includes("ship").first())!;
       expect(preloaded.isStrictLoading()).toBe(true);
-      const loaded = await findTarget(preloaded, "ship", { className: "Ship" }, "hasOne");
+      const loaded = await findTarget(preloaded, "ship", { className: "Ship" });
       expect(loaded?.id).toBe(ship.id);
 
       await preloaded.reload();
 
-      const reloaded = await findTarget(preloaded, "ship", { className: "Ship" }, "hasOne");
+      const reloaded = await findTarget(preloaded, "ship", { className: "Ship" });
       expect(reloaded?.id).toBe(ship.id);
     });
   });
@@ -428,7 +428,7 @@ describe("StrictLoadingTest", () => {
     await expect(association(loaded!, "contracts").toArray()).rejects.toThrow(
       StrictLoadingViolationError,
     );
-    await expect(findTarget(loaded!, "ship", { className: "Ship" }, "hasOne")).rejects.toThrow(
+    await expect(findTarget(loaded!, "ship", { className: "Ship" })).rejects.toThrow(
       StrictLoadingViolationError,
     );
   });
@@ -563,16 +563,11 @@ describe("StrictLoadingTest", () => {
     await developer!.updateColumn("mentor_id", mentor.id);
 
     await expect(
-      findTarget(
-        developer!,
-        "strictLoadingMentor",
-        {
-          className: "Mentor",
-          foreignKey: "mentor_id",
-          strictLoading: true,
-        },
-        "belongsTo",
-      ),
+      findTarget(developer!, "strictLoadingMentor", {
+        className: "Mentor",
+        foreignKey: "mentor_id",
+        strictLoading: true,
+      }),
     ).rejects.toThrow(StrictLoadingViolationError);
   });
 
@@ -583,9 +578,9 @@ describe("StrictLoadingTest", () => {
       const developer = await Developer.first();
       await developer!.updateColumn("mentor_id", mentor.id);
 
-      await expect(
-        findTarget(developer!, "mentor", { className: "Mentor" }, "belongsTo"),
-      ).rejects.toThrow(StrictLoadingViolationError);
+      await expect(findTarget(developer!, "mentor", { className: "Mentor" })).rejects.toThrow(
+        StrictLoadingViolationError,
+      );
     });
   });
 
@@ -596,16 +591,11 @@ describe("StrictLoadingTest", () => {
       const developer = await Developer.first();
       await developer!.updateColumn("mentor_id", mentor.id);
 
-      const loaded = await findTarget(
-        developer!,
-        "strictLoadingOffMentor",
-        {
-          className: "Mentor",
-          foreignKey: "mentor_id",
-          strictLoading: false,
-        },
-        "belongsTo",
-      );
+      const loaded = await findTarget(developer!, "strictLoadingOffMentor", {
+        className: "Mentor",
+        foreignKey: "mentor_id",
+        strictLoading: false,
+      });
       expect(loaded?.id).toBe(mentor.id);
     });
   });
@@ -618,16 +608,11 @@ describe("StrictLoadingTest", () => {
 
     const developer = (await Developer.all().includes("strictLoadingMentor").first())!;
 
-    const loaded = await findTarget(
-      developer,
-      "strictLoadingMentor",
-      {
-        className: "Mentor",
-        foreignKey: "mentor_id",
-        strictLoading: true,
-      },
-      "belongsTo",
-    );
+    const loaded = await findTarget(developer, "strictLoadingMentor", {
+      className: "Mentor",
+      foreignKey: "mentor_id",
+      strictLoading: true,
+    });
     expect(loaded?.id).toBe(mentor.id);
   });
 
@@ -639,7 +624,7 @@ describe("StrictLoadingTest", () => {
       await first!.updateColumn("mentor_id", mentor.id);
 
       const developer = (await Developer.all().includes("mentor").first())!;
-      const loaded = await findTarget(developer, "mentor", { className: "Mentor" }, "belongsTo");
+      const loaded = await findTarget(developer, "mentor", { className: "Mentor" });
       expect(loaded?.id).toBe(mentor.id);
     });
   });
@@ -651,15 +636,10 @@ describe("StrictLoadingTest", () => {
     await ship!.updateColumn("developer_id", developer!.id);
 
     await expect(
-      findTarget(
-        developer!,
-        "strictLoadingShip",
-        {
-          className: "Ship",
-          strictLoading: true,
-        },
-        "hasOne",
-      ),
+      findTarget(developer!, "strictLoadingShip", {
+        className: "Ship",
+        strictLoading: true,
+      }),
     ).rejects.toThrow(StrictLoadingViolationError);
   });
 
@@ -670,7 +650,7 @@ describe("StrictLoadingTest", () => {
       const ship = await Ship.first();
       await ship!.updateColumn("developer_id", developer!.id);
 
-      await expect(findTarget(developer!, "ship", { className: "Ship" }, "hasOne")).rejects.toThrow(
+      await expect(findTarget(developer!, "ship", { className: "Ship" })).rejects.toThrow(
         StrictLoadingViolationError,
       );
     });
@@ -682,15 +662,10 @@ describe("StrictLoadingTest", () => {
     await ship!.updateColumn("developer_id", developers("david").id);
 
     const developer = (await Developer.all().includes("strictLoadingShip").first())!;
-    const loaded = await findTarget(
-      developer,
-      "strictLoadingShip",
-      {
-        className: "Ship",
-        strictLoading: true,
-      },
-      "hasOne",
-    );
+    const loaded = await findTarget(developer, "strictLoadingShip", {
+      className: "Ship",
+      strictLoading: true,
+    });
     expect(loaded).not.toBeNull();
   });
 
@@ -701,7 +676,7 @@ describe("StrictLoadingTest", () => {
       await ship!.updateColumn("developer_id", developers("david").id);
 
       const developer = (await Developer.all().includes("ship").first())!;
-      const loaded = await findTarget(developer, "ship", { className: "Ship" }, "hasOne");
+      const loaded = await findTarget(developer, "ship", { className: "Ship" });
       expect(loaded).not.toBeNull();
     });
   });
@@ -852,9 +827,7 @@ describe("StrictLoadingTest", () => {
     treasure.strictLoadingBang();
     expect(treasure.isStrictLoading()).toBe(true);
 
-    await expect(
-      findTarget(treasure, "looter", { polymorphic: true }, "belongsTo"),
-    ).rejects.toThrow(
+    await expect(findTarget(treasure, "looter", { polymorphic: true })).rejects.toThrow(
       "`Treasure` is marked for strict_loading. " +
         "The polymorphic association named `:looter` cannot be lazily loaded.",
     );
@@ -875,7 +848,7 @@ describe("StrictLoadingTest", () => {
       logged = event.payload.reflection.strictLoadingViolationMessage(event.payload.owner);
     });
     try {
-      await findTarget(treasure, "looter", { polymorphic: true }, "belongsTo");
+      await findTarget(treasure, "looter", { polymorphic: true });
       expect(logged).toBe(
         "`Treasure` is marked for strict_loading. " +
           "The polymorphic association named `:looter` cannot be lazily loaded.",

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -69,15 +69,13 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
   it("does not raise on lazy loading a has_one on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
-    await expect(findTarget(developer, "ship", optionsFor("ship"), "hasOne")).resolves.toBeNull();
+    await expect(findTarget(developer, "ship", optionsFor("ship"))).resolves.toBeNull();
   });
 
   it("does not raise on lazy loading a belongs_to on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
-    await expect(
-      findTarget(developer, "firm", optionsFor("firm"), "belongsTo"),
-    ).resolves.toBeNull();
+    await expect(findTarget(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
   });
 
   it("does not raise on lazy loading a habtm on a new strict-loading owner without the foreign key", async () => {
@@ -94,16 +92,14 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     developer.firm_id = null as unknown as number;
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(false);
-    await expect(
-      findTarget(developer, "firm", optionsFor("firm"), "belongsTo"),
-    ).resolves.toBeNull();
+    await expect(findTarget(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
   });
 
   it("raises on lazy loading a belongs_to on a new strict-loading owner with the foreign key present", async () => {
     const developer = new Developer({ name: "New Dev", firm_id: 1 });
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(true);
-    await expect(findTarget(developer, "firm", optionsFor("firm"), "belongsTo")).rejects.toThrow(
+    await expect(findTarget(developer, "firm", optionsFor("firm"))).rejects.toThrow(
       StrictLoadingViolationError,
     );
   });

--- a/packages/activerecord/src/test-helpers/models/bulb.ts
+++ b/packages/activerecord/src/test-helpers/models/bulb.ts
@@ -36,7 +36,7 @@ export class Bulb extends Base {
     });
     this.afterCreate(async (record: Bulb) => {
       record.countAfterCreate = await Bulb.unscoped(async () => {
-        const car = await findTarget(record, "car", {}, "belongsTo");
+        const car = await findTarget(record, "car", {});
         return car ? await association(car, "bulbs").count() : undefined;
       });
     });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/singular-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/singular-association.json
@@ -4,13 +4,6 @@
     "tsFile": "associations/singular-association.ts",
     "rubyName": "find_target",
     "call": "first",
-    "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; the take() (unordered LIMIT 1) in the _findHasOneTarget / _findBelongsToTarget arms is the SQL-level equivalent — Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/singular-association.ts",
-    "rubyName": "find_target",
-    "call": "scope",
-    "reason": "findTarget is currently a macro dispatcher, so the scope construction Rails does inline lives in the two private arms it delegates to (_findBelongsToTarget / _findHasOneTarget), which call _builtAssociationScope / _scopeForAssociation. Same satisfied-via-extracted-helper shape as the foreign_key_present? entries in has-one-association.json. This entry is temporary: story converge-singular-find-target-dispatcher (RFC 0072) collapses the arms into one Rails-shaped body that makes the call directly, and removes this entry."
+    "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; take() (unordered LIMIT 1) is the SQL-level equivalent — Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
   }
 ]


### PR DESCRIPTION
## Summary

`SingularAssociation#find_target`
(`vendor/rails/activerecord/lib/active_record/associations/singular_association.rb:47-55`)
is a single loader body with signature `find_target(async: false)` — no macro
parameter and no dispatcher. `BelongsToAssociation` overrides only the
`find_target?` predicate (`belongs_to_association.rb:124-126`), never
`find_target`; one body serves both macros because the difference lives
entirely in the scope the reflection builds.

trails carried a dispatcher instead: `findTarget(record, assocName, options, macro)`
routing to `_findBelongsToTarget` / `_findHasOneTarget`, an artifact of the two
loaders having been relocated by two independently-specced stories. This
collapses them into one body, `findTarget(record, assocName, options)`.

Now that #5925 removed the no-reflection fallback, the body requires a
reflection up front — matching Rails, which builds an `Association` from a
validated reflection (`association.rb:41-45`) and raises
`AssociationNotFoundError` for an undeclared name (`associations.rb:56`). The
macro therefore comes straight off that reflection; nothing is inferred, and no
caller passes one. The reflection path itself (statement cache, or
`_builtAssociationScope` merged into the target scope and taken) was
byte-identical in both arms, because AssociationScope already builds the
macro-specific WHERE — so it is written once.

What stays macro-conditional is the owner-side cached-target read
(`_belongsToCachedHit`), `has_one :through` routing, and the polymorphic `:as`
key guard (`_validateHasOnePolymorphicKeys`). They are named helpers so the main
body keeps Rails' shape.

The cached read is convergeable and is filed as story
`converge-singular-cached-target-read` (RFC 0072): Rails' `find_target` reads no
cache — `load_target` does (`association.rb:190`) — and trails'
`Association#loadTarget` already mirrors that, so the engine's read is redundant
on the association path and load-bearing only for callers that bypass the
association object. Moving it out means reconciling two staleness rules and
relocating a lazy `inverse_of` validation, which is its own change rather than
part of the dispatcher collapse.

The `scope` entry is removed from the wide call-mismatch baseline: the unified
body makes the call directly. The `first` entry stays — it is `Array#first`
over an already-materialized array, justified separately.

## Coverage

The two composite-key singular loads are exercised through declared
reflections, the way Rails exercises them: `Cpk::Order#book` (composite foreign
key, `cpk/order.rb:14`) and `Cpk::OrderWithPrimaryKeyAssociatedBook#book`
(scalar foreign key on a composite-PK owner, `cpk/order.rb:45`) — the latter
previously had no test coverage at all.

## Verification

- `associations/singular-association.ts`: 0 novel extra surface.
- `api:compare` green; wide call ratchet OK (2264 baselined).
- 2186 tests passing across 94 association / strict-loading suites on SQLite;
  2178 across 93 on PostgreSQL and on MySQL. No test renames.
- Net -267 lines.

Rebased onto current `main` after #5925 (`drop-singular-no-reflection-fallback`,
the follow-up story filed from this PR) landed first — the unification is
against the slimmer post-#5925 arms.

Every non-test change outside `singular-association.ts` is a call-site edit
dropping the `macro` argument — audited line by line after review caught one
over-reach in the sweep (`preloadDestroyInverseBelongsTo` had lost its
`"belongsTo"` filter on `reflectOnAllAssociations`; restored).

Note: `api:extra` currently fails on clean `main` with a stale
`@noRailsEquivalent` tag on `base.ts equals`, unrelated to this diff and
reproducible with this branch stashed.

Closes-story: converge-singular-find-target-dispatcher
