### PR TITLE
fix(activerecord): flatten CollectionAssociation#find args recursively

### DIFF
--- a/packages/activerecord/src/associations/collection-association-find-not-found.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-association-find-not-found.trails.test.ts
@@ -38,7 +38,11 @@ describe("CollectionAssociation#find not-found path", () => {
     const proxy = internals(firm).clientsOfFirm;
     const clients = await proxy.load();
     expect(clients.length).toBeGreaterThan(0);
-    return { proxy, presentId: Number(internals(clients[0])._readAttribute("id")) };
+    return {
+      proxy,
+      presentId: Number(internals(clients[0])._readAttribute("id")),
+      presentIds: clients.map((c) => Number(internals(c)._readAttribute("id"))),
+    };
   }
 
   it("raises RecordNotFound with the scoped message when a single id misses", async () => {
@@ -65,6 +69,16 @@ describe("CollectionAssociation#find not-found path", () => {
 
     const found = (await proxy.find(String(presentId))) as Base;
     expect(Number(internals(found)._readAttribute("id"))).toBe(presentId);
+  });
+
+  it("flattens a nested array argument recursively, the way Ruby's Array#flatten does", async () => {
+    const { proxy, presentIds } = await loadedClientsOfFirm();
+    expect(presentIds.length).toBeGreaterThan(1);
+
+    const found = (await proxy.find([presentIds])) as Base[];
+    expect(found.map((r) => Number(internals(r)._readAttribute("id"))).sort()).toEqual(
+      [...presentIds].sort(),
+    );
   });
 
   it("raises RecordNotFound when no id is passed", async () => {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -362,7 +362,9 @@ export class CollectionAssociation extends Association {
     const scope = this.scope();
 
     if (this.reflection.options.inverseOf && this.isLoaded()) {
-      const argsFlatten = (args as any[]).flat();
+      // Ruby's `Array#flatten` is recursive, so `find([[id]])` collapses to a
+      // single scannable id (collection_association.rb:96).
+      const argsFlatten = (args as any[]).flat(Infinity);
       const model = scope.model;
 
       if (argsFlatten.length === 0) {
@@ -1254,7 +1256,7 @@ export class CollectionAssociation extends Association {
 
   private findByScan(args: unknown[]): Base | Array<Base | undefined> | undefined {
     const expectsArray = Array.isArray(args[0]);
-    const ids = args.flat().filter((id) => id != null);
+    const ids = args.flat(Infinity).filter((id) => id != null);
     // Rails compares `args.flatten.compact.map(&:to_s)` against `r.id.to_s`
     // (collection_association.rb:523,527), so both sides land in string shape
     // and `find("1")` matches an Integer PK. Each key goes through

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -362,8 +362,6 @@ export class CollectionAssociation extends Association {
     const scope = this.scope();
 
     if (this.reflection.options.inverseOf && this.isLoaded()) {
-      // Ruby's `Array#flatten` is recursive, so `find([[id]])` collapses to a
-      // single scannable id (collection_association.rb:96).
       const argsFlatten = (args as any[]).flat(Infinity);
       const model = scope.model;
 


### PR DESCRIPTION
Ruby's `Array#flatten` is recursive. Both trails call sites used JS
`Array.prototype.flat()` at its default depth of 1:

- `CollectionAssociation#find` (`collection_association.rb:96`, `args.flatten`)
- `CollectionAssociation#findByScan` (`collection_association.rb:523`,
  `args.flatten.compact.map(&:to_s).uniq`)

So `find([[a, b]])` on a loaded `inverse_of` collection left the inner array
intact: `normalize` rendered it as a joined composite-shaped key matching no
scalar target PK, and the expected-count arithmetic (`argsFlatten.length`) was
wrong for the same input. Both sites now use `flat(Infinity)`; the
flatten → compact → stringify → uniq ordering at `:523` is unchanged.

Regression coverage added to the trails-only
`collection-association-find-not-found.trails.test.ts` (no Rails counterpart
test for the nested-array shape). It fails on baseline — `find([presentIds])`
returns `[undefined]` instead of the records.

Closes-story: converge-collection-find-recursive-flatten
