### PR TITLE
refactor(activerecord): port Core#== / #<=> in core.ts as equals / compare

### DIFF
--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -88,7 +88,7 @@ describe("AggregationsTest", () => {
     await CustomerModel.updateAll({ gps_location: "24x113" });
     await david.reload();
     expect(david.readAttribute("gps_location")).toBe("24x113");
-    expect(david.gpsLocation.isEqual(new GpsLocation("24x113"))).toBe(true);
+    expect(david.gpsLocation.equals(new GpsLocation("24x113"))).toBe(true);
   });
 
   // Rails: test_allow_nil_address_set_to_nil
@@ -151,12 +151,12 @@ describe("AggregationsTest", () => {
 
   // Rails: test_gps_equality
   it("gps equality", () => {
-    expect(new GpsLocation("39x110").isEqual(new GpsLocation("39x110"))).toBe(true);
+    expect(new GpsLocation("39x110").equals(new GpsLocation("39x110"))).toBe(true);
   });
 
   // Rails: test_gps_inequality
   it("gps inequality", () => {
-    expect(new GpsLocation("39x110").isEqual(new GpsLocation("39x111"))).toBe(false);
+    expect(new GpsLocation("39x110").equals(new GpsLocation("39x111"))).toBe(false);
   });
 
   // Rails: test_custom_constructor

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -249,7 +249,7 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     const theirs = Array.isArray(other) ? other : await other;
     if (ours.length !== theirs.length) return false;
     for (let i = 0; i < ours.length; i++) {
-      if (!ours[i].isEqual(theirs[i])) return false;
+      if (!ours[i].equals(theirs[i])) return false;
     }
     return true;
   }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1341,7 +1341,7 @@ function diffHooks(assoc: CollectionAssociation): {
 
 /** @internal */
 export function includesRecord(records: Base[], record: Base): boolean {
-  return records.some((r) => (r as unknown as { isEqual(o: unknown): boolean }).isEqual(record));
+  return records.some((r) => (r as unknown as { equals(o: unknown): boolean }).equals(record));
 }
 
 /** @internal */
@@ -1444,7 +1444,7 @@ function finishReplaceOnTarget(
  * @internal
  */
 function indexInTarget(assoc: CollectionAssociation, record: Base): number {
-  return assoc.target.findIndex((r) => r === record || r.isEqual(record));
+  return assoc.target.findIndex((r) => r === record || r.equals(record));
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -177,7 +177,7 @@ export type AssociationProxy<
  * order-sensitive. Used by `replace` for `other_array != original_target`.
  */
 function sameRecordList(a: Base[], b: Base[]): boolean {
-  return a.length === b.length && a.every((record, i) => record.isEqual(b[i]));
+  return a.length === b.length && a.every((record, i) => record.equals(b[i]));
 }
 
 /**
@@ -1654,7 +1654,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   private _indexInTarget(record: T): number {
-    return this._target.findIndex((r) => r === record || r.isEqual(record));
+    return this._target.findIndex((r) => r === record || r.equals(record));
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -780,7 +780,7 @@ describe("HasManyAssociationsTest", () => {
     await firm.reload();
     const clients = await firm.clients;
     expect(clients.length).toBe(2);
-    expect(clients.some((c: any) => c.isEqual(companies("first_client")))).toBe(false);
+    expect(clients.some((c: any) => c.equals(companies("first_client")))).toBe(false);
   });
 
   it("association size calculation works with default scoped selects when not previously fetched", async () => {

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -815,7 +815,7 @@ function deleteThroughRecords(assoc: HasManyThroughAssociation, records: Base[])
 function distribution(records: Base[]): Array<{ record: Base; count: number }> {
   const buckets: Array<{ record: Base; count: number }> = [];
   for (const record of records) {
-    const bucket = buckets.find((b) => b.record.isEqual(record));
+    const bucket = buckets.find((b) => b.record.equals(record));
     if (bucket) bucket.count += 1;
     else buckets.push({ record, count: 1 });
   }
@@ -824,7 +824,7 @@ function distribution(records: Base[]): Array<{ record: Base; count: number }> {
 
 /** @internal */
 function markOccurrence(buckets: Array<{ record: Base; count: number }>, record: Base): boolean {
-  const bucket = buckets.find((b) => b.record.isEqual(record));
+  const bucket = buckets.find((b) => b.record.equals(record));
   if (!bucket || bucket.count <= 0) return false;
   bucket.count -= 1;
   return true;

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -732,7 +732,7 @@ export class HasOneAssociation extends SingularAssociation {
 export function sameRecord(a: Base | null, b: Base | null): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
-  return (a as { isEqual?: (other: unknown) => boolean }).isEqual?.(b) === true;
+  return (a as { equals?: (other: unknown) => boolean }).equals?.(b) === true;
 }
 
 /**

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -859,10 +859,10 @@ describe("HasOneAssociationsTest", () => {
     const pirate = pirates("blackbeard") as any;
     const origShip = await readHasOne(pirate, "ship");
 
-    expect(origShip.isEqual(ships("black_pearl"))).toBe(true);
+    expect(origShip.equals(ships("black_pearl"))).toBe(true);
     const newShip = await pirate.createShip();
-    expect(newShip.isEqual(ships("black_pearl"))).toBe(false);
-    expect((await readHasOne(pirate, "ship")).isEqual(newShip)).toBe(true);
+    expect(newShip.equals(ships("black_pearl"))).toBe(false);
+    expect((await readHasOne(pirate, "ship")).equals(newShip)).toBe(true);
     expect(newShip.isNewRecord()).toBe(true);
     expect(await newShip.isInvalid()).toBe(true);
     expect(origShip.pirate_id).toBeNull();
@@ -913,7 +913,7 @@ describe("HasOneAssociationsTest", () => {
     }
     expect(error).toBeInstanceOf(RecordNotSaved);
 
-    expect((await readHasOne(pirate, "ship")).isEqual(ships("black_pearl"))).toBe(true);
+    expect((await readHasOne(pirate, "ship")).equals(ships("black_pearl"))).toBe(true);
     expect((await readHasOne(pirate, "ship")).pirate_id).toBe(pirate.id);
     expect(error.message).toBe(
       "Failed to remove the existing associated ship. " +
@@ -936,7 +936,7 @@ describe("HasOneAssociationsTest", () => {
 
     expect(error.message).toBe("Failed to save the new associated ship.");
     expect(error.record).toBe(newShip);
-    expect((await readHasOne(pirate, "ship")).isEqual(ships("black_pearl"))).toBe(true);
+    expect((await readHasOne(pirate, "ship")).equals(ships("black_pearl"))).toBe(true);
     expect((await readHasOne(pirate, "ship")).pirate_id).toBe(pirate.id);
     expect((await ships("black_pearl").reload()).pirate_id).toBe(pirate.id);
     expect(newShip.pirate_id).toBeNull();

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -27,6 +27,7 @@ import {
   AttributedDeveloper,
 } from "./test-helpers/models/developer.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
+import { Category } from "./test-helpers/models/category.js";
 import { Car } from "./test-helpers/models/car.js";
 import { Bulb } from "./test-helpers/models/bulb.js";
 import "./support/canonical-model-index.js";
@@ -91,7 +92,7 @@ describe("BasicsTest", () => {
     }
     const u1 = await User.create({ name: "a" });
     const u2 = await User.find(u1.id);
-    expect(u1.isEqual(u2)).toBe(true);
+    expect(u1.equals(u2)).toBe(true);
   });
 
   it("equality of new records", () => {
@@ -102,7 +103,7 @@ describe("BasicsTest", () => {
     }
     const u1 = new User({ name: "a" });
     const u2 = new User({ name: "a" });
-    expect(u1.isEqual(u2)).toBe(false);
+    expect(u1.equals(u2)).toBe(false);
   });
 
   it("all", async () => {
@@ -169,7 +170,7 @@ describe("BasicsTest", () => {
     }
     const u1 = new User({ name: "a" });
     const u2 = new User({ name: "a" });
-    expect(u1.isEqual(u2)).toBe(false);
+    expect(u1.equals(u2)).toBe(false);
   });
 
   it("distinct delegates to scoped", () => {
@@ -291,7 +292,7 @@ describe("BasicsTest", () => {
     const u1 = new User({ name: "a" });
     const u2 = new User({ name: "a" });
     // new records are not equal
-    expect(u1.isEqual(u2)).toBe(false);
+    expect(u1.equals(u2)).toBe(false);
   });
 
   it("create after initialize with block", async () => {
@@ -335,7 +336,7 @@ describe("BasicsTest", () => {
     }
     const u1 = await User.create({ name: "a" });
     const u2 = await User.find(u1.id);
-    expect(u1.isEqual(u2)).toBe(true);
+    expect(u1.equals(u2)).toBe(true);
   });
 
   it("failed comparison of unlike class records", () => {
@@ -351,7 +352,7 @@ describe("BasicsTest", () => {
     }
     const u = new User({ name: "a" });
     const p = new Post({ title: "a" });
-    expect(u.isEqual(p as any)).toBe(false);
+    expect(u.equals(p as any)).toBe(false);
   });
 
   it("table name guesses with inherited prefixes and suffixes", () => {
@@ -384,15 +385,13 @@ describe("BasicsTest", () => {
     const pk = Subscriber.columnsHash()[Subscriber.primaryKey as string];
     expect(pk.name, "nick should be primary key").toBe("nick");
   });
-  it("comparison with different objects", () => {
-    class Post extends Base {
-      static {
-        this.attribute("title", "string");
-      }
-    }
-    const p = Post.new({ title: "a" }) as any;
-    expect(p).not.toEqual("a string");
-    expect(p).not.toEqual(null);
+  it("comparison with different objects", async () => {
+    const topic = await CanonicalTopic.create({});
+    const category = await Category.create({ name: "comparison" });
+    // Rails: `assert_nil topic <=> category` — `Core#<=>` is `compare` here,
+    // and Ruby's nil (incomparable) is `undefined`.
+    expect(topic.compare(category)).toBeUndefined();
+    expect(topic.equals(category)).toBe(false);
   });
 
   it("comparison with different objects in array", async () => {
@@ -2076,7 +2075,7 @@ describe("BasicsTest", () => {
     class B extends Base {}
     const a = new A();
     const b = new B();
-    expect(a.isEqual(b as any)).toBe(false);
+    expect(a.equals(b as any)).toBe(false);
   });
 
   it("dup with aggregate of same name as attribute", async () => {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -388,8 +388,6 @@ describe("BasicsTest", () => {
   it("comparison with different objects", async () => {
     const topic = await CanonicalTopic.create({});
     const category = await Category.create({ name: "comparison" });
-    // Rails: `assert_nil topic <=> category` — `Core#<=>` is `compare` here,
-    // and Ruby's nil (incomparable) is `undefined`.
     expect(topic.compare(category)).toBeUndefined();
     expect(topic.equals(category)).toBe(false);
   });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -240,7 +240,8 @@ import {
 import {
   inspect as _inspect,
   attributeForInspect as _attributeForInspect,
-  isEqual as _isEqual,
+  equals as _equals,
+  compare as _compare,
   hash as _hash,
   isPresent as _isPresent,
   isBlank as _isBlank,
@@ -4454,7 +4455,14 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Core#==
    */
-  declare isEqual: (other: unknown) => boolean;
+  declare equals: (other: unknown) => boolean;
+
+  /**
+   * Order two records by primary key.
+   *
+   * Mirrors: ActiveRecord::Core#<=>
+   */
+  declare compare: (other: unknown) => number | undefined;
 
   /**
    * Return a value that dedups records the way Ruby's `hash` + `eql?` do.
@@ -4582,10 +4590,6 @@ export class Base extends Model {
 
   declare isPresent: () => boolean;
   declare isBlank: () => boolean;
-
-  equals(other: unknown): boolean {
-    return this.isEqual(other);
-  }
 
   // Associations instance methods wired via include() below;
   // signatures declared on the merged `interface Base` at the bottom
@@ -4908,7 +4912,8 @@ include(Base, {
   inspect: _inspect,
   prettyPrint: _Core.prettyPrint,
   attributeForInspect: _attributeForInspect,
-  isEqual: _isEqual,
+  equals: _equals,
+  compare: _compare,
   hash: _hash,
   isPresent: _isPresent,
   isBlank: _isBlank,

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -178,3 +178,24 @@ describe("configurations is a single process-global registry", () => {
     expect(resolved.database).toBe("db/global.sqlite3");
   });
 });
+
+describe("compare", () => {
+  fixtures(["topics"]);
+
+  // Rails' `Core#<=>` is `to_key <=> other_object.to_key`; Ruby's nil result
+  // (incomparable) has no TS equivalent, so trails returns `undefined`.
+  it("orders same-class records by primary key and reports nil as undefined", async () => {
+    const first = await Topic.find(1);
+    const second = await Topic.find(3);
+
+    expect(first.compare(second)).toBe(-1);
+    expect(second.compare(first)).toBe(1);
+    expect(first.compare(first)).toBe(0);
+
+    // Two new records both have a nil to_key, which Ruby compares as 0.
+    expect(new Topic({ title: "a" }).compare(new Topic({ title: "b" }))).toBe(0);
+    // A persisted record against a new one is `nil <=> [1]` — incomparable.
+    expect(first.compare(new Topic({ title: "a" }))).toBeUndefined();
+    expect(first.compare("not a topic")).toBeUndefined();
+  });
+});

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { fixtures } from "./test-fixtures.js";
 import { Topic } from "./test-helpers/models/topic.js";
+import { Reply } from "./test-helpers/models/reply.js";
 import { Base } from "./index.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
@@ -197,5 +198,11 @@ describe("compare", () => {
     // A persisted record against a new one is `nil <=> [1]` — incomparable.
     expect(first.compare(new Topic({ title: "a" }))).toBeUndefined();
     expect(first.compare("not a topic")).toBeUndefined();
+
+    // `is_a?(self.class)` is subclass-permissive in one direction only: a Reply
+    // is_a? Topic, but a Topic is not is_a? Reply.
+    const reply = await Reply.find(2);
+    expect(first.compare(reply)).toBe(-1);
+    expect(reply.compare(first)).toBeUndefined();
   });
 });

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -380,9 +380,6 @@ function compareKeys(a: unknown[] | null, b: unknown[] | null): number | undefin
   return Math.sign(a.length - b.length);
 }
 
-// Ruby compares key components with `<=>`, which is `nil` for values of
-// different types; JS `<` would silently coerce, so mixed types report
-// "incomparable" (`undefined`) instead.
 function compareValues(a: unknown, b: unknown): number | undefined {
   if (typeof a !== typeof b) return undefined;
   if (typeof a === "number" || typeof a === "bigint" || typeof a === "string") {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -54,7 +54,8 @@ import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
 export interface Core {
   inspect(): string;
   attributeForInspect(attr: string): string;
-  isEqual(other: unknown): boolean;
+  equals(other: unknown): boolean;
+  compare(other: unknown): number | undefined;
   isPresent(): boolean;
   isBlank(): boolean;
   isReadonly(): boolean;
@@ -158,7 +159,7 @@ export async function prettyPrint(
  *
  * Mirrors: ActiveRecord::Core#==
  */
-export function isEqual(this: CoreRecord, other: unknown): boolean {
+export function equals(this: CoreRecord, other: unknown): boolean {
   // Rails' Object#== identity check (`super`): same exact object.
   if (this === other) return true;
   if (other === null || other === undefined) return false;
@@ -181,7 +182,7 @@ const identityHashKeys = new WeakMap<object, symbol>();
 // Per-constructor identity tokens. Rails combines `self.class.hash` with the
 // id, so the class *object's* identity — not its name — participates in the
 // hash. Keying on `constructor.name` would collide two distinct model classes
-// that happen to share a JS name, whereas `isEqual` demands exact constructor
+// that happen to share a JS name, whereas `equals` demands exact constructor
 // identity; this WeakMap gives each constructor a stable, unique token.
 const constructorHashTokens = new WeakMap<object, number>();
 let nextConstructorToken = 0;
@@ -343,6 +344,51 @@ export function isFrozen(this: FrozenRecord): boolean {
 export function freeze<T extends FrozenRecord>(this: T): T {
   this._attributes = this._attributes.deepDup().freeze();
   return this;
+}
+
+/**
+ * Order two records by primary key, so arrays of records sort.
+ *
+ * Ruby's `to_key <=> other_object.to_key` is `Array#<=>` (element-wise, then
+ * by length) when both keys are present, and `nil <=> nil` (`0`) when neither
+ * record has one. A mixed nil/array pair — one persisted record, one new —
+ * compares as `nil`, spelled `undefined` here. The `else` arm is Ruby's
+ * `super` (`Object#<=>`): `0` for equal objects, `nil` otherwise.
+ *
+ * Mirrors: ActiveRecord::Core#<=>
+ */
+export function compare(this: CoreRecord, otherObject: unknown): number | undefined {
+  if (otherObject instanceof (this.constructor as new (...args: never[]) => unknown)) {
+    return compareKeys(
+      (this as unknown as ComparableRecord).toKey(),
+      (otherObject as ComparableRecord).toKey(),
+    );
+  }
+  return equals.call(this, otherObject) ? 0 : undefined;
+}
+
+interface ComparableRecord {
+  toKey(): unknown[] | null;
+}
+
+function compareKeys(a: unknown[] | null, b: unknown[] | null): number | undefined {
+  if (a === null || b === null) return a === null && b === null ? 0 : undefined;
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const cmp = compareValues(a[i], b[i]);
+    if (cmp !== 0) return cmp;
+  }
+  return Math.sign(a.length - b.length);
+}
+
+// Ruby compares key components with `<=>`, which is `nil` for values of
+// different types; JS `<` would silently coerce, so mixed types report
+// "incomparable" (`undefined`) instead.
+function compareValues(a: unknown, b: unknown): number | undefined {
+  if (typeof a !== typeof b) return undefined;
+  if (typeof a === "number" || typeof a === "bigint" || typeof a === "string") {
+    return a === (b as typeof a) ? 0 : a < (b as typeof a) ? -1 : 1;
+  }
+  return a === b ? 0 : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -55,6 +55,8 @@ export interface Core {
   inspect(): string;
   attributeForInspect(attr: string): string;
   equals(other: unknown): boolean;
+  freeze(): this;
+  isFrozen(): boolean;
   compare(other: unknown): number | undefined;
   isPresent(): boolean;
   isBlank(): boolean;
@@ -65,8 +67,6 @@ export interface Core {
   strictLoadingMode(): StrictLoadingMode;
   isStrictLoadingAll(): boolean;
   isStrictLoadingNPlusOneOnly(): boolean;
-  isFrozen(): boolean;
-  freeze(): this;
 }
 
 export { InspectionMask } from "./attribute-inspection.js";
@@ -245,6 +245,71 @@ function primaryKeyValuesEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
+ * Clone and freeze the attribute set. Subsequent writes to `_attributes`
+ * (e.g. `writeAttribute`, `writeFromUser`) raise. Associations remain
+ * accessible since they aren't stored in the attribute set. The clone
+ * step ensures records sharing an attribute reference (e.g. via
+ * `clone()` / `becomes`) aren't accidentally frozen together.
+ *
+ * Mirrors: ActiveRecord::Core#freeze — `@attributes = @attributes.clone.freeze; self` in Rails.
+ */
+export function freeze<T extends FrozenRecord>(this: T): T {
+  this._attributes = this._attributes.deepDup().freeze();
+  return this;
+}
+
+/**
+ * Returns true if this record's attribute set has been frozen.
+ *
+ * Mirrors: ActiveRecord::Core#frozen? — `@attributes.frozen?` in Rails.
+ */
+export function isFrozen(this: FrozenRecord): boolean {
+  return this._attributes.isFrozen();
+}
+
+/**
+ * Order two records by primary key, so arrays of records sort.
+ *
+ * Ruby's `to_key <=> other_object.to_key` is `Array#<=>` (element-wise, then
+ * by length) when both keys are present, and `nil <=> nil` (`0`) when neither
+ * record has one. A mixed nil/array pair — one persisted record, one new —
+ * compares as `nil`, spelled `undefined` here. The `else` arm is Ruby's
+ * `super` (`Object#<=>`): `0` for equal objects, `nil` otherwise.
+ *
+ * Mirrors: ActiveRecord::Core#<=>
+ */
+export function compare(this: CoreRecord, otherObject: unknown): number | undefined {
+  if (otherObject instanceof (this.constructor as new (...args: never[]) => unknown)) {
+    return compareKeys(
+      (this as unknown as ComparableRecord).toKey(),
+      (otherObject as ComparableRecord).toKey(),
+    );
+  }
+  return equals.call(this, otherObject) ? 0 : undefined;
+}
+
+interface ComparableRecord {
+  toKey(): unknown[] | null;
+}
+
+function compareKeys(a: unknown[] | null, b: unknown[] | null): number | undefined {
+  if (a === null || b === null) return a === null && b === null ? 0 : undefined;
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const cmp = compareValues(a[i], b[i]);
+    if (cmp !== 0) return cmp;
+  }
+  return Math.sign(a.length - b.length);
+}
+
+function compareValues(a: unknown, b: unknown): number | undefined {
+  if (typeof a !== typeof b) return undefined;
+  if (typeof a === "number" || typeof a === "bigint" || typeof a === "string") {
+    return a === (b as typeof a) ? 0 : a < (b as typeof a) ? -1 : 1;
+  }
+  return a === b ? 0 : undefined;
+}
+
+/**
  * Check if this record is present (persisted and not destroyed).
  *
  * Mirrors: ActiveRecord::Core#present?
@@ -263,7 +328,7 @@ export function isBlank(this: CoreRecord): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Readonly / strict-loading / freeze instance predicates and setters.
+// Readonly / strict-loading instance predicates and setters.
 // Mirrors the corresponding defs in activerecord/lib/active_record/core.rb.
 // ---------------------------------------------------------------------------
 
@@ -321,71 +386,6 @@ export function strictLoadingBang<T extends StrictLoadingFields>(
   this._strictLoadingMode = mode;
   this._strictLoading = value;
   return this;
-}
-
-/**
- * Returns true if this record's attribute set has been frozen.
- *
- * Mirrors: ActiveRecord::Core#frozen? — `@attributes.frozen?` in Rails.
- */
-export function isFrozen(this: FrozenRecord): boolean {
-  return this._attributes.isFrozen();
-}
-
-/**
- * Clone and freeze the attribute set. Subsequent writes to `_attributes`
- * (e.g. `writeAttribute`, `writeFromUser`) raise. Associations remain
- * accessible since they aren't stored in the attribute set. The clone
- * step ensures records sharing an attribute reference (e.g. via
- * `clone()` / `becomes`) aren't accidentally frozen together.
- *
- * Mirrors: ActiveRecord::Core#freeze — `@attributes = @attributes.clone.freeze; self` in Rails.
- */
-export function freeze<T extends FrozenRecord>(this: T): T {
-  this._attributes = this._attributes.deepDup().freeze();
-  return this;
-}
-
-/**
- * Order two records by primary key, so arrays of records sort.
- *
- * Ruby's `to_key <=> other_object.to_key` is `Array#<=>` (element-wise, then
- * by length) when both keys are present, and `nil <=> nil` (`0`) when neither
- * record has one. A mixed nil/array pair — one persisted record, one new —
- * compares as `nil`, spelled `undefined` here. The `else` arm is Ruby's
- * `super` (`Object#<=>`): `0` for equal objects, `nil` otherwise.
- *
- * Mirrors: ActiveRecord::Core#<=>
- */
-export function compare(this: CoreRecord, otherObject: unknown): number | undefined {
-  if (otherObject instanceof (this.constructor as new (...args: never[]) => unknown)) {
-    return compareKeys(
-      (this as unknown as ComparableRecord).toKey(),
-      (otherObject as ComparableRecord).toKey(),
-    );
-  }
-  return equals.call(this, otherObject) ? 0 : undefined;
-}
-
-interface ComparableRecord {
-  toKey(): unknown[] | null;
-}
-
-function compareKeys(a: unknown[] | null, b: unknown[] | null): number | undefined {
-  if (a === null || b === null) return a === null && b === null ? 0 : undefined;
-  for (let i = 0; i < Math.min(a.length, b.length); i++) {
-    const cmp = compareValues(a[i], b[i]);
-    if (cmp !== 0) return cmp;
-  }
-  return Math.sign(a.length - b.length);
-}
-
-function compareValues(a: unknown, b: unknown): number | undefined {
-  if (typeof a !== typeof b) return undefined;
-  if (typeof a === "number" || typeof a === "bigint" || typeof a === "string") {
-    return a === (b as typeof a) ? 0 : a < (b as typeof a) ? -1 : 1;
-  }
-  return a === b ? 0 : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6224,7 +6224,7 @@ export class Relation<T extends Base> {
     const a = await this.toArray();
     const b = await other;
     if (a.length !== b.length) return false;
-    return a.every((rec, i) => rec.isEqual(b[i]));
+    return a.every((rec, i) => rec.equals(b[i]));
   }
 
   /**
@@ -6357,7 +6357,7 @@ export class Relation<T extends Base> {
       !this._havingClause.isEmpty()
     ) {
       const records = await this.toArray();
-      return records.some((r) => r.isEqual(record));
+      return records.some((r) => r.equals(record));
     }
     // Unloaded fast path: probe existence by primary key. Composite-PK models
     // (Rails `record.class.composite_primary_key?`) carry a tuple id, which

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -849,7 +849,7 @@ const RECORD_DELEGATES: Record<string, RecordDelegate> = {
   // aliases `eql?` to `==` (id equality) — so this must use record equality, not
   // JS identity via `Array#includes`.
   isIntersect: (records, other: Base[]) =>
-    records.some((record) => other.some((o) => record.isEqual(o))),
+    records.some((record) => other.some((o) => record.equals(o))),
   reverse: (records) => [...records].reverse(),
   compact: (records) => records.filter((record) => record != null),
   index: (records, valueOrFn: Base | ((record: Base) => unknown)) => {

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -65,7 +65,7 @@ async function recordsIntersection(rel: any, other: readonly unknown[]): Promise
   // loads the same record twice still yields it once. filter() alone would keep
   // those duplicates, so track seen records and skip a repeat.
   const eq = (a: any, o: unknown): boolean =>
-    typeof a?.isEqual === "function" ? a.isEqual(o) : a === o;
+    typeof a?.equals === "function" ? a.equals(o) : a === o;
   const result: unknown[] = [];
   for (const r of records) {
     if (!other.some((o) => eq(r, o))) continue;

--- a/packages/activerecord/src/test-helpers/models/customer.ts
+++ b/packages/activerecord/src/test-helpers/models/customer.ts
@@ -17,7 +17,7 @@ export class Address {
     return this.city === otherAddress.city && this.country === otherAddress.country;
   }
 
-  isEqual(other: unknown): boolean {
+  equals(other: unknown): boolean {
     if (!(other instanceof Address)) return false;
     return (
       other.street === this.street && other.city === this.city && other.country === this.country
@@ -59,7 +59,7 @@ export class GpsLocation {
     return this.gpsLocation.split("x")[1] ?? "";
   }
 
-  isEqual(other: GpsLocation): boolean {
+  equals(other: GpsLocation): boolean {
     return this.latitude === other.latitude && this.longitude === other.longitude;
   }
 }

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -173,7 +173,8 @@ const PORTED_METHODS_FROM_UNPORTED_MIXINS: Record<string, string[]> = {
  *
  * `to_a`/`to_ary` camelize to `toA`/`toAry`; the JS spelling of that protocol
  * is `toArray`. `==` is an operator — TS has no operator overloading, so the
- * port is a named `equals`. Ruby copy semantics come from `Object#clone`/`#dup`
+ * port is a named `equals`, and `<=>` a named `compare` (the spelling
+ * OPERATOR_SPELLING_BY_FQN already pins for every class that ports it). Ruby copy semantics come from `Object#clone`/`#dup`
  * (never `def`ed in Rails) plus the `initialize_copy` hook the class DOES
  * define; JS has no `Object#clone`, so the faithful port of that pair is a
  * `clone`/`dup` method on the class.
@@ -182,6 +183,7 @@ const MIRROR_CANDIDATE_OVERRIDES: Record<string, string[]> = {
   to_a: ["toArray"],
   to_ary: ["toArray"],
   "==": ["equals"],
+  "<=>": ["compare"],
   initialize_copy: ["clone", "dup"],
   initialize_dup: ["dup"],
   initialize_clone: ["clone"],

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -51,6 +51,9 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // and `compare`. `===` / `=~` share that line but have no TS member, so they
   // stay unmapped.
   "ActiveModel::Name": { "==": ["equals"], "<=>": ["compare"] },
+  // core.rb:631 `def ==(comparison_object)` / :665 `def <=>(other_object)` →
+  // core.ts `equals` / `compare`. The aliased `eql?` (:637) has no TS member.
+  "ActiveRecord::Core": { "==": ["equals"], "<=>": ["compare"] },
   // association_relation.rb:14 `def ==(other)` → association-relation.ts `equals`.
   "ActiveRecord::AssociationRelation": { "==": ["equals"] },
   // reflection.rb:440 `def ==(other_aggregation)` → reflection.ts `equals`

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -273,15 +273,13 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
       }
       // Standalone modules port to top-level functions, which have no
       // staticness — every entry stays bare regardless of whether Ruby declared
-      // it on the module or its singleton.
+      // it on the module or its singleton. Operator SPELLINGS still apply
+      // (`ActiveRecord::Core#==` → core.ts `equals`); only staticness is lost.
       for (const m of mergeBySourceLine(
         tagStatic(host.instanceMethods, false),
         tagStatic(host.classMethods, true),
       )) {
         const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
-        // Operators port to top-level functions here too (`ActiveRecord::Core#==`
-        // → core.ts `equals`), so the class-specific spelling still applies —
-        // staticness is what a standalone module drops, not the mapping.
         pushMethod(b.names, b.seen, m.name, false, operatorSpelling(host.fqn, m.name));
       }
     }

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -279,7 +279,10 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
         tagStatic(host.classMethods, true),
       )) {
         const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
-        pushMethod(b.names, b.seen, m.name, false);
+        // Operators port to top-level functions here too (`ActiveRecord::Core#==`
+        // → core.ts `equals`), so the class-specific spelling still applies —
+        // staticness is what a standalone module drops, not the mapping.
+        pushMethod(b.names, b.seen, m.name, false, operatorSpelling(host.fqn, m.name));
       }
     }
   };


### PR DESCRIPTION
`ActiveRecord::Core` defines both equality operators in `core.rb` (`==` at :631,
`<=>` at :665). Our port had neither in `core.ts`: `==` was implemented there as
`isEqual` and re-exposed from `base.ts` as an `equals` wrapper, and `<=>` had no
counterpart at all. Method-order could therefore map neither operator into
`core.ts`, and an `OPERATOR_SPELLING_BY_FQN` entry would have been dead.

- `core.ts` `isEqual` → `equals` (the spelling every other `==` port already
  uses), with all call sites renamed; the `base.ts` wrapper is gone and `equals`
  is wired through the mixin table like the rest of Core.
- New `core.ts` `compare`, mirroring core.rb:665: `to_key <=> other.to_key` for
  same-class records, Ruby's `super` (`0` when equal, else `nil` → `undefined`)
  otherwise. Key components of differing types are incomparable rather than
  coerced by JS `<`.
- `OPERATOR_SPELLING_BY_FQN` gains `ActiveRecord::Core`. That entry was dead as
  written because the manifest builder only consulted `operatorSpelling` for
  classes and class-flattened mixins, never for standalone modules — whose
  methods port to top-level functions, `Core#==` included. Fixed in
  `build-rails-file-structure-manifest.ts`.
- `extra-surface.ts` learns `<=>` → `compare` alongside the existing
  `==` → `equals`, so the new member is a recognized operator port rather than
  novel surface.
- `base_test.rb`'s `test_comparison_with_different_objects` now asserts what
  Rails asserts (`assert_nil topic <=> category`) on canonical `Topic` /
  `Category`, replacing bespoke local classes that tested nothing about `<=>`.

Closes-story: core-equality-operators-live-in-base-not-core
