### PR TITLE
docs(activerecord): re-reason createRange/dropRange as PERMANENT trails surface

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2020,8 +2020,8 @@ export class AbstractAdapter implements Quoting {
   async dropEnum(_name: string): Promise<void> {}
 
   // No `createRange`/`dropRange` here on purpose. Rails stubs only the enum
-  // quartet on the abstract base (create_enum/drop_enum/rename_enum/
-  // rename_enum_value, abstract_adapter.rb:576-595) — there is no range-type
+  // helpers on the abstract base (create_enum/drop_enum/rename_enum/
+  // add_enum_value/rename_enum_value, abstract_adapter.rb:576-593) — there is no range-type
   // DDL anywhere in Rails, so a no-op base stub would be inventing an abstract
   // hook Rails never had. The trails-only range helpers live where the DDL is
   // actually emitted, PostgreSQL::SchemaStatements (postgresql/

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4828,8 +4828,8 @@ export interface PostgreSQLAdapter {
    *   `createRange`/`dropRange` are modelled on the shape of Rails' own enum type-DDL helpers
    *   (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571, `rename_enum` :579,
    *   `add_enum_value` :588, `rename_enum_value` :606, all five stubbed as no-ops on the base at
-   *   abstract_adapter.rb:576-593), including their
-   *   `reload_type_map` epilogue; the implementation lives at the emitting call site,
+   *   abstract_adapter.rb:576-593), including their `reload_type_map` epilogue; the
+   *   implementation lives at the emitting call site,
    *   connection-adapters/postgresql/schema-statements-class.ts. Deliberately PostgreSQL-only: the
    *   no-op stubs that shadowed these on AbstractAdapter were deleted rather than allowlisted,
    *   since Rails stubs only the enum helpers on the base.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4818,28 +4818,33 @@ export interface PostgreSQLAdapter {
   dropEnum(name: string, options?: { ifExists?: boolean }): Promise<void>;
 
   /**
-   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
-   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
-   *   `execute("CREATE
-   *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
-   *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their
-   *   `reload_type_map` epilogue; the implementation and the full justification live at the emitting
-   *   call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately
-   *   PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather
-   *   than allowlisted, since Rails stubs only the enum quartet on the base.
+   * @noRailsEquivalent PERMANENT. Rails supports PostgreSQL range *column* types first-class but
+   *   ships no range-type DDL helper, because Ruby has `Range` as a core type: a Rails app that
+   *   wants a custom range creates it with a raw `execute("CREATE TYPE … AS RANGE")` and leans on
+   *   the language for the value side. JavaScript has no Range analogue, so trails cannot lean on
+   *   the language the same way — making range support first-class here requires the DDL step to
+   *   be explicit adapter surface rather than an incidental raw `execute`. That is a deliberate
+   *   trails feature, not unfinished porting, so it is permanent rather than convergeable.
+   *   `createRange`/`dropRange` are modelled on the shape of Rails' own type-DDL quartet
+   *   (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571, `rename_enum`,
+   *   `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-580), including their
+   *   `reload_type_map` epilogue; the implementation lives at the emitting call site,
+   *   connection-adapters/postgresql/schema-statements-class.ts. Deliberately PostgreSQL-only: the
+   *   no-op stubs that shadowed these on AbstractAdapter were deleted rather than allowlisted,
+   *   since Rails stubs only the enum quartet on the base.
    */
   createRange(name: string, options: { subtype: string; subtypeDiff?: string }): Promise<void>;
 
   /**
-   * @noRailsEquivalent CONVERGEABLE (story: delete-invented-pg-range-ddl-helpers).
-   * Rails has no range-type DDL helper anywhere — ranges are created with a raw
-   *   `execute("CREATE
-   *   TYPE … AS RANGE")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers
-   *   (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their
-   *   `reload_type_map` epilogue; the implementation and the full justification live at the emitting
-   *   call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately
-   *   PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather
-   *   than allowlisted, since Rails stubs only the enum quartet on the base.
+   * @noRailsEquivalent PERMANENT. The teardown half of `createRange` — see that method for the full
+   *   reasoning: trails makes PostgreSQL range types first-class, and unlike Ruby (whose core
+   *   `Range` lets a Rails app get away with a raw `execute("CREATE TYPE … AS RANGE")`) JavaScript
+   *   has no Range analogue to lean on, so the DDL step is deliberate trails surface. Modelled on
+   *   Rails' type-DDL quartet (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571,
+   *   `rename_enum`, `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-580),
+   *   including their `reload_type_map` epilogue. Deliberately PostgreSQL-only: the no-op stubs
+   *   that shadowed these on AbstractAdapter were deleted rather than allowlisted, since Rails
+   *   stubs only the enum quartet on the base.
    */
   dropRange(name: string, options?: { ifExists?: boolean }): Promise<void>;
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4827,7 +4827,7 @@ export interface PostgreSQLAdapter {
    *   trails feature, not unfinished porting, so it is permanent rather than convergeable.
    *   `createRange`/`dropRange` are modelled on the shape of Rails' own type-DDL quartet
    *   (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571, `rename_enum`,
-   *   `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-580), including their
+   *   `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-592), including their
    *   `reload_type_map` epilogue; the implementation lives at the emitting call site,
    *   connection-adapters/postgresql/schema-statements-class.ts. Deliberately PostgreSQL-only: the
    *   no-op stubs that shadowed these on AbstractAdapter were deleted rather than allowlisted,
@@ -4841,7 +4841,7 @@ export interface PostgreSQLAdapter {
    *   `Range` lets a Rails app get away with a raw `execute("CREATE TYPE … AS RANGE")`) JavaScript
    *   has no Range analogue to lean on, so the DDL step is deliberate trails surface. Modelled on
    *   Rails' type-DDL quartet (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571,
-   *   `rename_enum`, `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-580),
+   *   `rename_enum`, `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-592),
    *   including their `reload_type_map` epilogue. Deliberately PostgreSQL-only: the no-op stubs
    *   that shadowed these on AbstractAdapter were deleted rather than allowlisted, since Rails
    *   stubs only the enum quartet on the base.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4825,13 +4825,14 @@ export interface PostgreSQLAdapter {
    *   the language the same way — making range support first-class here requires the DDL step to
    *   be explicit adapter surface rather than an incidental raw `execute`. That is a deliberate
    *   trails feature, not unfinished porting, so it is permanent rather than convergeable.
-   *   `createRange`/`dropRange` are modelled on the shape of Rails' own type-DDL quartet
-   *   (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571, `rename_enum`,
-   *   `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-592), including their
+   *   `createRange`/`dropRange` are modelled on the shape of Rails' own enum type-DDL helpers
+   *   (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571, `rename_enum` :579,
+   *   `add_enum_value` :588, `rename_enum_value` :606, all five stubbed as no-ops on the base at
+   *   abstract_adapter.rb:576-593), including their
    *   `reload_type_map` epilogue; the implementation lives at the emitting call site,
    *   connection-adapters/postgresql/schema-statements-class.ts. Deliberately PostgreSQL-only: the
    *   no-op stubs that shadowed these on AbstractAdapter were deleted rather than allowlisted,
-   *   since Rails stubs only the enum quartet on the base.
+   *   since Rails stubs only the enum helpers on the base.
    */
   createRange(name: string, options: { subtype: string; subtypeDiff?: string }): Promise<void>;
 
@@ -4840,11 +4841,12 @@ export interface PostgreSQLAdapter {
    *   reasoning: trails makes PostgreSQL range types first-class, and unlike Ruby (whose core
    *   `Range` lets a Rails app get away with a raw `execute("CREATE TYPE … AS RANGE")`) JavaScript
    *   has no Range analogue to lean on, so the DDL step is deliberate trails surface. Modelled on
-   *   Rails' type-DDL quartet (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571,
-   *   `rename_enum`, `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-592),
-   *   including their `reload_type_map` epilogue. Deliberately PostgreSQL-only: the no-op stubs
-   *   that shadowed these on AbstractAdapter were deleted rather than allowlisted, since Rails
-   *   stubs only the enum quartet on the base.
+   *   Rails' enum type-DDL helpers (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571,
+   *   `rename_enum` :579, `add_enum_value` :588, `rename_enum_value` :606, all five stubbed as
+   *   no-ops on the base at abstract_adapter.rb:576-593), including their `reload_type_map`
+   *   epilogue. Deliberately PostgreSQL-only: the no-op stubs that shadowed these on
+   *   AbstractAdapter were deleted rather than allowlisted, since Rails stubs only the enum
+   *   helpers on the base.
    */
   dropRange(name: string, options?: { ifExists?: boolean }): Promise<void>;
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1668,10 +1668,16 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       parts.push(`SUBTYPE_DIFF = ${quoteQualifiedIdentifier(options.subtypeDiff, "subtypeDiff")}`);
     }
     await this.pg.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
-    // createRange/dropRange are trails additions (Rails has no range-type DDL
-    // helper), but they follow the pattern of Rails' own type-DDL helpers
-    // (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), which
-    // all `reload_type_map` after mutating the type universe. reloadTypeMap
+    // createRange/dropRange are deliberate, permanent trails surface, not
+    // unfinished porting: Rails supports PG range *column* types first-class but
+    // ships no range-type DDL helper because Ruby has a core `Range` to lean on,
+    // so a raw `execute("CREATE TYPE … AS RANGE")` suffices there. JavaScript has
+    // no Range analogue, so first-class range support in trails needs the DDL
+    // step to be explicit adapter surface. The shape is modelled on Rails' own
+    // type-DDL quartet (create_enum postgresql_adapter.rb:541, drop_enum :571,
+    // rename_enum, rename_enum_value; stubbed on the base at
+    // abstract_adapter.rb:576-580), which all `reload_type_map` after mutating
+    // the type universe. reloadTypeMap
     // also drops the prepared-statement name map, so a cached write-path plan
     // built against a prior incarnation of the type (drop + recreate reassigns
     // the OID) is re-prepared instead of raising

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1674,9 +1674,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // so a raw `execute("CREATE TYPE … AS RANGE")` suffices there. JavaScript has
     // no Range analogue, so first-class range support in trails needs the DDL
     // step to be explicit adapter surface. The shape is modelled on Rails' own
-    // type-DDL quartet (create_enum postgresql_adapter.rb:541, drop_enum :571,
-    // rename_enum, rename_enum_value; stubbed on the base at
-    // abstract_adapter.rb:576-592), which all `reload_type_map` after mutating
+    // enum type-DDL helpers (create_enum postgresql_adapter.rb:541, drop_enum
+    // :571, rename_enum :579, add_enum_value :588, rename_enum_value :606; all
+    // five stubbed as no-ops on the base at
+    // abstract_adapter.rb:576-593), which all `reload_type_map` after mutating
     // the type universe. reloadTypeMap
     // also drops the prepared-statement name map, so a cached write-path plan
     // built against a prior incarnation of the type (drop + recreate reassigns

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1676,7 +1676,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // step to be explicit adapter surface. The shape is modelled on Rails' own
     // type-DDL quartet (create_enum postgresql_adapter.rb:541, drop_enum :571,
     // rename_enum, rename_enum_value; stubbed on the base at
-    // abstract_adapter.rb:576-580), which all `reload_type_map` after mutating
+    // abstract_adapter.rb:576-592), which all `reload_type_map` after mutating
     // the type universe. reloadTypeMap
     // also drops the prepared-statement name map, so a cached write-path plan
     // built against a prior incarnation of the type (drop + recreate reassigns


### PR DESCRIPTION
## What

`createRange` / `dropRange` on the PostgreSQL adapter were tagged
`@noRailsEquivalent CONVERGEABLE`, pointing at a story to delete them. The owner
decision (2026-07-30) is KEEP: the tag reason was accurate ("Rails has no
equivalent") but not a *reason*.

Rails supports PostgreSQL range **column** types first-class but ships no
range-type DDL helper, because Ruby has `Range` as a core type — a Rails app
that wants a custom range gets away with a raw
`execute("CREATE TYPE … AS RANGE")` and leans on the language for the value
side. JavaScript has no Range analogue, so making range support first-class in
trails requires the DDL step to be explicit adapter surface. That is a
deliberate trails feature, not unfinished porting.

## Changes

- Both `@noRailsEquivalent` reasons rewritten at the declaration sites in
  `connection-adapters/postgresql-adapter.ts` and reclassified
  `CONVERGEABLE` → `PERMANENT`.
- The reason names Rails' type-DDL quartet as the modelled shape
  (`create_enum` postgresql_adapter.rb:541, `drop_enum` :571, `rename_enum`,
  `rename_enum_value`, stubbed on the base at abstract_adapter.rb:576-580).
- Matching rewrite of the implementation-site comment in
  `connection-adapters/postgresql/schema-statements-class.ts`.

No behavior change, no test changes, no allowlist entry.
`pnpm api:extra --package activerecord` is clean (0 unclassified, no stale tags).

Closes-story: delete-invented-pg-range-ddl-helpers
