### PR TITLE
refactor(activerecord): drop SchemaCache#columns' null-pool guard

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -12,7 +12,6 @@ import type { ColumnJSON } from "./column.js";
 import { Column as MysqlColumn } from "./mysql/column.js";
 import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
-import { NullPool } from "./abstract/connection-pool.js";
 import { IndexDefinition } from "./abstract/schema-definitions.js";
 
 // ---------------------------------------------------------------------------
@@ -303,12 +302,6 @@ export class SchemaCache {
     if (this._columns.has(tableName)) {
       return this._columns.get(tableName);
     }
-
-    // Null-pool guard: a caller may pass `null` (or the NullPool a standalone
-    // adapter carries) to consult only the warm cache. Neither can yield a
-    // connection, so return undefined and let the caller fall back to the
-    // schema-less NullColumn shape.
-    if (pool == null || pool instanceof NullPool) return undefined;
 
     return withConnection(pool, async (connection) => {
       if (typeof connection.columns === "function") {


### PR DESCRIPTION
Rails' `SchemaCache#columns` (`schema_cache.rb:350-360`) has no null-pool guard. `AbstractAdapter#schema_cache` (`abstract_adapter.rb:298-300`) resolves `@pool.schema_cache || BoundSchemaReflection.for_lone_connection(...)`, so a standalone adapter's NullPool is swapped for a `FakePool` wrapping the connection itself — by construction every pool reaching `columns` can yield a connection.

#5885 moved the production call sites onto that FakePool shape but left the guard standing. All remaining callers now bind a real pool or a `FakePool`:

- `model-schema.ts` `loadSchemaFromCache` / `reflectColumnNames` — `new FakePool(adapter)`
- `abstract-adapter.ts` `columnForAttribute` — `new FakePool(this)` when `pool` is null/NullPool
- `BoundSchemaReflection` — a real pool, or `FakePool` via `forLoneConnection`
- `SchemaCache#add` — passes a connection

Removes the guard and the now-unused `NullPool` import. The existing tests that pass `null` all hit the warm-cache early return above the guard, so they are unaffected.

Closes-story: drop-schema-cache-columns-null-pool-guard