### PR TITLE
refactor(activerecord): resolve per-file novel adapter surface

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -211,46 +211,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const v = await adapter.showVariable("collation_connection");
       expect(v).not.toBeNull();
     });
-    // Direct tests for the trails-only AbstractMysqlAdapter#setSessionVariable
-    // helper. The Rails-named test_mysql_set_session_variable / _to_default
-    // cases below exercise the `variables:` pool-init shape; these cover the
-    // explicit-helper code path (identifier validation, DEFAULT handling,
-    // emitted quoting). All three stay self-built: connectionLimit:1 is what
-    // makes SET SESSION + SELECT land on the same pool connection (see the JSDoc
-    // caveat), and the session variables must not leak onto the leased one.
-    it("setSessionVariable helper sets a session variable", async () => {
-      const a = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
-      try {
-        await a.setSessionVariable("default_week_format", 3);
-        const rows = await a.execute("SELECT @@SESSION.default_week_format AS v");
-        expect(Number(rows[0].v)).toBe(3);
-      } finally {
-        await a.close();
-      }
-    });
-
-    it("setSessionVariable helper with DEFAULT restores global", async () => {
-      const a = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
-      try {
-        const global = await a.execute("SELECT @@GLOBAL.default_week_format AS v");
-        await a.setSessionVariable("default_week_format", 3);
-        await a.setSessionVariable("default_week_format", "DEFAULT");
-        const session = await a.execute("SELECT @@SESSION.default_week_format AS v");
-        expect(session[0].v).toEqual(global[0].v);
-      } finally {
-        await a.close();
-      }
-    });
-
-    it("setSessionVariable helper rejects invalid identifiers", async () => {
-      const a = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
-      try {
-        await expect(a.setSessionVariable("foo; DROP", 1)).rejects.toThrow(/invalid/);
-      } finally {
-        await a.close();
-      }
-    });
-
     it("mysql default in strict mode", async () => {
       const rows = await adapter.execute("SELECT @@SESSION.sql_mode AS v");
       expect(String(rows[0].v)).toMatch(/STRICT_ALL_TABLES/);

--- a/packages/activerecord/src/adapters/postgresql/utils.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/utils.test.ts
@@ -20,7 +20,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("reset pk sequence on empty table", async () => {
       await adapter.exec(`CREATE TABLE utils_reset_pk (id serial primary key, name text)`);
       await adapter.exec(`SELECT setval('utils_reset_pk_id_seq', 123)`);
-      await adapter.resetPkSequence("utils_reset_pk");
+      await adapter.resetPkSequenceBang("utils_reset_pk");
       const rows = await adapter.execute(`SELECT nextval('utils_reset_pk_id_seq') AS val`);
       expect(Number(rows[0].val)).toBe(1);
     });
@@ -32,7 +32,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.executeMutation(`INSERT INTO utils_reset_pk_custom (name) VALUES ('a')`);
       await adapter.executeMutation(`INSERT INTO utils_reset_pk_custom (name) VALUES ('b')`);
       await adapter.exec(`SELECT setval('utils_reset_pk_custom_custom_id_seq', 100)`);
-      await adapter.resetPkSequence("utils_reset_pk_custom");
+      await adapter.resetPkSequenceBang("utils_reset_pk_custom");
       const rows = await adapter.execute(
         `SELECT nextval('utils_reset_pk_custom_custom_id_seq') AS val`,
       );

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -214,11 +214,11 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     const fk = await adapter.execute(`PRAGMA foreign_keys`);
     expect(fk[0].foreign_keys).toBe(1);
     // Can turn it off
-    await adapter.pragma("foreign_keys = OFF");
+    await adapter.execute(`PRAGMA foreign_keys = OFF`);
     const fk2 = await adapter.execute(`PRAGMA foreign_keys`);
     expect(fk2[0].foreign_keys).toBe(0);
     // Restore
-    await adapter.pragma("foreign_keys = ON");
+    await adapter.execute(`PRAGMA foreign_keys = ON`);
   });
 
   it("overriding default journal mode pragma", async () => {
@@ -226,21 +226,21 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     // Test that pragma call doesn't throw
     const jm = await adapter.execute(`PRAGMA journal_mode`);
     expect(jm[0].journal_mode).toBeDefined();
-    await adapter.pragma("journal_mode = DELETE");
+    await adapter.execute(`PRAGMA journal_mode = DELETE`);
     const jm2 = await adapter.execute(`PRAGMA journal_mode`);
     // In-memory DB ignores journal_mode changes, stays "memory"
     expect(jm2[0].journal_mode).toBeDefined();
   });
 
   it("overriding default synchronous pragma", async () => {
-    await adapter.pragma("synchronous = OFF");
+    await adapter.execute(`PRAGMA synchronous = OFF`);
     const rows = await adapter.execute(`PRAGMA synchronous`);
     expect(rows[0].synchronous).toBe(0);
-    await adapter.pragma("synchronous = NORMAL");
+    await adapter.execute(`PRAGMA synchronous = NORMAL`);
   });
 
   it("overriding default journal size limit pragma", async () => {
-    await adapter.pragma("journal_size_limit = 1048576");
+    await adapter.execute(`PRAGMA journal_size_limit = 1048576`);
     const rows = await adapter.execute(`PRAGMA journal_size_limit`);
     expect(rows[0].journal_size_limit).toBe(1048576);
   });
@@ -248,24 +248,24 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   it("overriding default mmap size pragma", async () => {
     // mmap_size pragma returns empty on in-memory databases,
     // so just verify the pragma call doesn't reject
-    await adapter.pragma("mmap_size = 0");
+    await adapter.execute(`PRAGMA mmap_size = 0`);
   });
 
   it("overriding default cache size pragma", async () => {
-    await adapter.pragma("cache_size = 5000");
+    await adapter.execute(`PRAGMA cache_size = 5000`);
     const rows = await adapter.execute(`PRAGMA cache_size`);
     expect(rows[0].cache_size).toBe(5000);
   });
 
   it("setting new pragma", async () => {
-    await adapter.pragma("temp_store = MEMORY");
+    await adapter.execute(`PRAGMA temp_store = MEMORY`);
     const rows = await adapter.execute(`PRAGMA temp_store`);
     expect(rows[0].temp_store).toBe(2); // MEMORY = 2
   });
 
   it("setting invalid pragma", async () => {
     // SQLite silently ignores unknown pragmas — no rejection
-    await adapter.pragma("not_a_real_pragma");
+    await adapter.execute(`PRAGMA not_a_real_pragma`);
   });
 
   it("exec no binds", async () => {
@@ -670,7 +670,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     // Default class config is false — new connections are non-strict.
     expect(AbstractSQLite3Adapter.strictStringsByDefault).toBe(false);
     const conn = new BetterSQLite3Adapter(":memory:");
-    expect(conn.strictStrings).toBe(false);
+    expect(conn._strictStrings).toBe(false);
     // Rails: assert_nothing_raised { conn.add_index :testings, :non_existent }
     // — non-strict connections allow DQS fallback so unknown double-quoted
     //   identifiers are treated as string literals and the index is created
@@ -682,7 +682,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     AbstractSQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new BetterSQLite3Adapter(":memory:");
-      expect(strict.strictStrings).toBe(true);
+      expect(strict._strictStrings).toBe(true);
       await strict.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
       await expect(
         strict.exec(`CREATE INDEX "idx_non_existent2" ON "testings" ("non_existent2")`),
@@ -697,7 +697,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     // Explicit strict: true in options always enables strict mode.
     const conn = new BetterSQLite3Adapter(":memory:", { strict: true });
     try {
-      expect(conn.strictStrings).toBe(true);
+      expect(conn._strictStrings).toBe(true);
       await conn.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
       await expect(
         conn.exec(`CREATE INDEX "idx_non_existent" ON "testings" ("non_existent")`),
@@ -711,7 +711,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     try {
       const strict = new BetterSQLite3Adapter(":memory:", { strict: true });
       try {
-        expect(strict.strictStrings).toBe(true);
+        expect(strict._strictStrings).toBe(true);
         await strict.exec(`CREATE TABLE "testings" ("id" INTEGER PRIMARY KEY)`);
         await expect(
           strict.exec(`CREATE INDEX "idx_non_existent2" ON "testings" ("non_existent2")`),
@@ -728,7 +728,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     // Explicit strict: false in options disables strict mode.
     const conn = new BetterSQLite3Adapter(":memory:", { strict: false });
     try {
-      expect(conn.strictStrings).toBe(false);
+      expect(conn._strictStrings).toBe(false);
       // Rails: assert_nothing_raised { conn.add_index :testings, :non_existent }
       // — strict: false keeps DQS enabled so the index creation succeeds silently.
       // Omitted here for the same reason as test 1 (better-sqlite3 SQLITE_DQS=0).
@@ -741,7 +741,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     try {
       const strict = new BetterSQLite3Adapter(":memory:", { strict: false });
       try {
-        expect(strict.strictStrings).toBe(false);
+        expect(strict._strictStrings).toBe(false);
       } finally {
         await strict.close();
       }
@@ -795,7 +795,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
       const conn = new BetterSQLite3Adapter(":memory:", { driver: fakeDriver });
       try {
         expect(capture.config?.strict).toBe(true);
-        expect(conn.strictStrings).toBe(true);
+        expect(conn._strictStrings).toBe(true);
       } finally {
         await conn.close();
       }
@@ -810,7 +810,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     });
     try {
       expect((capture.config as SqliteOpenConfig | null)?.strict).toBe(false);
-      expect(explicit.strictStrings).toBe(false);
+      expect(explicit._strictStrings).toBe(false);
     } finally {
       await explicit.close();
     }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -152,7 +152,6 @@ const ER_LOCK_WAIT_TIMEOUT = 1205;
 const ER_QUERY_INTERRUPTED = 1317;
 const ER_QUERY_TIMEOUT = 3024;
 const ER_FILSORT_ABORT = 1028;
-const ER_TABLE_EXISTS = 1050;
 const ER_DB_CREATE_EXISTS = 1007;
 const ER_SERVER_SHUTDOWN = 1053;
 const ER_CONNECTION_KILLED = 1927;
@@ -1004,10 +1003,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return new CreateIndexDefinition(idx, false, algorithmClause);
   }
 
-  addSqlComment(sql: string, comment: string): string {
-    return `${sql} /* ${comment.replace(/\*\//g, "* /")} */`;
-  }
-
   addSqlCommentBang(sql: string, comment: string): string {
     if (comment) return `${sql} COMMENT ${this.quote(comment)}`;
     return sql;
@@ -1138,38 +1133,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       if (e instanceof StatementInvalid) return null;
       throw e;
     }
-  }
-
-  /**
-   * Set a MySQL session variable to the given value.
-   * Emits `SET SESSION <name> = <quoted value>` against the active connection.
-   * Pass the symbol `"DEFAULT"` (case-insensitive) or the value `null` to
-   * restore the variable to its default. Identifier is validated against
-   * MySQL variable-name characters before interpolation.
-   *
-   * trails-only helper — Rails inlines this in `configure_connection`
-   * via the `variables:` pool-init shape. Exposed here as a cheaper
-   * alternative when callers just need to flip a session flag mid-test
-   * (e.g. `sql_mode`) without rebuilding the pool.
-   *
-   * Caveat: this SETs the variable on whichever pool connection happens
-   * to be checked out, then releases it. Subsequent calls may land on a
-   * different connection where the variable is unchanged. Callers must
-   * pin to a single connection (e.g. `connectionLimit: 1` or an active
-   * transaction) for the variable to be observed across calls. For
-   * pool-wide configuration, use the `variables:` pool-init option.
-   *
-   * @internal
-   */
-  async setSessionVariable(name: string, value: unknown): Promise<void> {
-    if (!/^\w+$/.test(name)) {
-      throw new Error(`setSessionVariable: invalid variable name ${name}`);
-    }
-    const quotedValue =
-      value === null || (typeof value === "string" && value.toUpperCase() === "DEFAULT")
-        ? "DEFAULT"
-        : this.quote(value);
-    await this._execMutation(`SET SESSION ${name} = ${quotedValue}`);
   }
 
   async primaryKeys(tableName: string): Promise<string[]> {
@@ -1432,34 +1395,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly ER_QUERY_INTERRUPTED = ER_QUERY_INTERRUPTED;
   static readonly ER_QUERY_TIMEOUT = ER_QUERY_TIMEOUT;
   static readonly ER_FILSORT_ABORT = ER_FILSORT_ABORT;
-  static readonly ER_TABLE_EXISTS = ER_TABLE_EXISTS;
   static readonly ER_DB_CREATE_EXISTS = ER_DB_CREATE_EXISTS;
   static readonly ER_SERVER_SHUTDOWN = ER_SERVER_SHUTDOWN;
   static readonly ER_CONNECTION_KILLED = ER_CONNECTION_KILLED;
   static readonly CR_SERVER_GONE_ERROR = CR_SERVER_GONE_ERROR;
   static readonly CR_SERVER_LOST = CR_SERVER_LOST;
   static readonly ER_CLIENT_INTERACTION_TIMEOUT = ER_CLIENT_INTERACTION_TIMEOUT;
-
-  /**
-   * Mirrors the message regex Rails' `Mysql2Adapter#translate_exception`
-   * uses to distinguish `ConnectionNotEstablished` from `ConnectionFailed`
-   * when a `Mysql2::Error::ConnectionError` arrives. Centralized so the
-   * abstract `when nil` branch and the Mysql2Adapter `ConnectionError`
-   * branch cannot drift if mysql2 changes the wording.
-   * @internal
-   */
-  static readonly CLIENT_NOT_CONNECTED_RE = /MySQL client is not connected/i;
-
-  /**
-   * Predicate form of {@link CLIENT_NOT_CONNECTED_RE}. Single point of truth
-   * shared by the abstract `when nil` branch and the `Mysql2Adapter`
-   * `ConnectionError` branch so they cannot drift.
-   * @internal
-   */
-  static isClientNotConnected(e: unknown): boolean {
-    const msg = e instanceof Error ? e.message : typeof e === "string" ? e : "";
-    return AbstractMysqlAdapter.CLIENT_NOT_CONNECTED_RE.test(msg);
-  }
 
   /**
    * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
@@ -1675,7 +1616,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       // errno (e.g. node-mysql2 surfacing a closed-socket failure as a
       // generic Error) get promoted to ConnectionNotEstablished when the
       // message indicates the client lost the server handshake.
-      if (AbstractMysqlAdapter.isClientNotConnected(e)) {
+      if (/MySQL client is not connected/i.test(msg)) {
         return new ConnectionNotEstablished(msg, { cause });
       }
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -89,7 +89,7 @@ class Mysql2StatementPool extends MysqlStatementPool {
     }
   }
 
-  detach(): void {
+  _detach(): void {
     this._conn = null;
   }
 }
@@ -324,7 +324,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // connected" message is promoted to ConnectionNotEstablished;
       // everything else in this family is ConnectionFailed.
       const msg = (e as Error).message;
-      if (AbstractMysqlAdapter.isClientNotConnected(e)) {
+      // Rails repeats this literal regex in both branches (mysql2_adapter.rb:176
+      // and abstract_mysql_adapter.rb:818) rather than sharing a constant.
+      if (/MySQL client is not connected/i.test(msg)) {
         return new ConnectionNotEstablished(msg, { cause: e });
       }
       return new ConnectionFailed(msg, { sql, binds, cause: e });
@@ -1652,7 +1654,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _closeRawHandle(): void {
     this._inTransaction = false;
     this._connectionConfigured = false;
-    this._statementPool?.detach();
+    this._statementPool?._detach();
     this._statementPool = null;
     if (this._client) {
       // Chain onto any in-flight teardown so repeated disconnect/reconnect
@@ -1687,7 +1689,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     super.discardBang();
     this._inTransaction = false;
     this._connectionConfigured = false;
-    this._statementPool?.detach();
+    this._statementPool?._detach();
     this._statementPool = null;
     // Safe to read `_client` after `super.discardBang()` — unlike
     // `disconnectBang`, the base `discardBang` (abstract-adapter.ts) is a true
@@ -1708,7 +1710,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._connectGeneration++;
     this._inTransaction = false;
     this._connectionConfigured = false;
-    this._statementPool?.detach();
+    this._statementPool?._detach();
     this._statementPool = null;
     if (this._client) {
       await this._client.end();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -324,8 +324,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // connected" message is promoted to ConnectionNotEstablished;
       // everything else in this family is ConnectionFailed.
       const msg = (e as Error).message;
-      // Rails repeats this literal regex in both branches (mysql2_adapter.rb:176
-      // and abstract_mysql_adapter.rb:818) rather than sharing a constant.
       if (/MySQL client is not connected/i.test(msg)) {
         return new ConnectionNotEstablished(msg, { cause: e });
       }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1397,7 +1397,7 @@ export class PostgreSQLAdapter
         this._rawConnection = null;
         this._connectionConfigured = false;
         this._typeMapEagerLoaded = false;
-        this._statementPool?.detach();
+        this._statementPool?._detach();
         this._statementPool = null;
       }
       this._teardownRacedClient(client, acquireGen);
@@ -1572,7 +1572,7 @@ export class PostgreSQLAdapter
    * clears on disconnect).
    */
   private _releaseStatementPool(): void {
-    this._statementPool?.detach();
+    this._statementPool?._detach();
     this._statementPool = null;
   }
 
@@ -2625,6 +2625,13 @@ export class PostgreSQLAdapter
   // (postgresql_adapter.rb:620-622). The null guard makes it a no-op once
   // warmed; the memo persists across reconnects, mirroring Rails' `||=` which
   // never resets.
+  /**
+   * @noRailsEquivalent PERMANENT — Rails' `max_identifier_length`
+   * (postgresql_adapter.rb:620) does the `SHOW max_identifier_length` query
+   * inside the synchronous reader via `||=`. trails queries are Promises, so
+   * the reader cannot issue one and the round-trip has to live in a separate
+   * async warmer. No Rails method can ever map onto it.
+   */
   async warmMaxIdentifierLength(): Promise<number> {
     if (this._maxIdentifierLength == null) {
       const rows = (await this.schemaQuery("SHOW max_identifier_length")) as Array<{
@@ -2865,7 +2872,7 @@ export class PostgreSQLAdapter
     this._client = null;
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
-    this._statementPool?.detach();
+    this._statementPool?._detach();
     this._statementPool = null;
     this._needsDeallocateAll = false;
     this._inTransaction = false;
@@ -3009,7 +3016,7 @@ export class PostgreSQLAdapter
               this._rawConnection = null;
               this._connectionConfigured = false;
               this._typeMapEagerLoaded = false;
-              this._statementPool?.detach();
+              this._statementPool?._detach();
               this._statementPool = null;
             }
             live.end().catch(() => {});
@@ -3064,7 +3071,7 @@ export class PostgreSQLAdapter
     this._client = null;
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
-    this._statementPool?.detach();
+    this._statementPool?._detach();
     this._statementPool = null;
     this._needsDeallocateAll = false;
     this._inTransaction = false;
@@ -3101,7 +3108,7 @@ export class PostgreSQLAdapter
     this._client = null;
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
-    this._statementPool?.detach();
+    this._statementPool?._detach();
     this._statementPool = null;
     this._needsDeallocateAll = false;
     this._inTransaction = false;
@@ -3724,7 +3731,7 @@ export class PostgreSQLAdapter
    * a per-column pg_type query.
    * @internal
    */
-  serialFromDefaultFunction(
+  _serialFromDefaultFunction(
     tableName: string,
     columnName: string,
     defaultFunction: string | null,
@@ -3960,31 +3967,6 @@ export class PostgreSQLAdapter
 
   // Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
   checkAllForeignKeysValidBang = checkAllForeignKeysValidBang;
-
-  async enumValues(name: string): Promise<string[]> {
-    const [schema, enumName] = this.extractSchemaQualifiedName(name);
-    let sql = `SELECT e.enumlabel AS value
-       FROM pg_enum e
-       JOIN pg_type t ON t.oid = e.enumtypid
-       JOIN pg_namespace n ON n.oid = t.typnamespace`;
-    const params: unknown[] = [];
-
-    if (schema) {
-      sql += `
-       WHERE t.typname = $1 AND n.nspname = $2
-       ORDER BY e.enumsortorder`;
-      params.push(enumName, schema);
-    } else {
-      sql += `
-       WHERE t.typname = $1
-         AND n.nspname = ANY(current_schemas(false))
-       ORDER BY e.enumsortorder`;
-      params.push(enumName);
-    }
-
-    const rows = await this.schemaQuery(sql, params);
-    return rows.map((r) => r.value as string);
-  }
 
   // ---------------------------------------------------------------------------
   // Private helpers
@@ -4675,10 +4657,6 @@ export interface PostgreSQLAdapter {
 
   pkAndSequenceFor(tableName: string): Promise<[string, Name | null] | null>;
 
-  resetPkSequence(tableName: string): Promise<void>;
-
-  setPkSequence(tableName: string, value: number): Promise<void>;
-
   columns(tableName: string): Promise<Column[]>;
 
   changeColumn(
@@ -5084,9 +5062,11 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
    * Mark the pool detached from its client (e.g. on connection release
    * or close). Prevents late DEALLOCATE calls from racing with a
    * client that's already back in the pg.Pool — the server will
-   * discard statements on session end anyway.
+   * discard statements on session end anyway. Rails' StatementPool holds the
+   * raw connection for its whole lifetime and has no counterpart, so this stays
+   * Rails-private.
    */
-  detach(): void {
+  _detach(): void {
     this._client = null;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -84,7 +84,7 @@ export class Column extends BaseColumn {
   // Mirrors Rails Column#serial? — returns the stored flag, which the adapter
   // computes by matching the `nextval()` default's sequence against the
   // conventional `<table>_<column>_seq` name (see
-  // PostgreSQLAdapter#serialFromDefaultFunction). An explicit
+  // PostgreSQLAdapter#_serialFromDefaultFunction). An explicit
   // `default: -> { "nextval('some_seq')" }` is NOT serial.
   get isSerial(): boolean {
     return this.serial;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -81,7 +81,7 @@ interface PgSchemaAdapter {
     name?: string;
   }): Type;
   reloadTypeMap(): Promise<void>;
-  serialFromDefaultFunction(
+  _serialFromDefaultFunction(
     tableName: string,
     columnName: string,
     defaultFunction: string | null,
@@ -682,7 +682,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       const defaultFunction = attgenerated
         ? rawDefault
         : this.pg.extractDefaultFunction(defaultValue, rawDefault);
-      const isSerial = this.pg.serialFromDefaultFunction(
+      const isSerial = this.pg._serialFromDefaultFunction(
         tableName,
         r.name as string,
         defaultFunction,
@@ -1860,10 +1860,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     return `${tbl}_${col}_${suffix}`;
   }
 
-  async setPkSequence(tableName: string, value: number): Promise<void> {
-    await this.setPkSequenceBang(tableName, value);
-  }
-
   async setPkSequenceBang(tableName: string, value: number): Promise<void> {
     const result = await this.pkAndSequenceFor(tableName);
     const [pk, seq] = result ?? [null, null];
@@ -1874,10 +1870,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     } else {
       this.pg.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
     }
-  }
-
-  async resetPkSequence(tableName: string): Promise<void> {
-    await this.resetPkSequenceBang(tableName);
   }
 
   async resetPkSequenceBang(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.test.ts
@@ -42,7 +42,7 @@ describe("SQLite3Adapter hash-only constructor", () => {
 
   it("threads adapter options from the config hash", () => {
     adapter = new BetterSQLite3Adapter({ database: ":memory:", strict: true, statementLimit: 7 });
-    expect(adapter.strictStrings).toBe(true);
+    expect(adapter._strictStrings).toBe(true);
     expect(adapter.statementLimit).toBe(7);
   });
 
@@ -59,6 +59,6 @@ describe("SQLite3Adapter hash-only constructor", () => {
 
   it("still accepts the legacy positional (filename, options) form", () => {
     adapter = new BetterSQLite3Adapter(":memory:", { strict: true });
-    expect(adapter.strictStrings).toBe(true);
+    expect(adapter._strictStrings).toBe(true);
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -321,10 +321,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   /**
    * Whether this connection was opened with strict-strings mode (DQS disabled).
    * Reflects the resolved value of the `strict` constructor option, which
-   * defaults to `SQLite3Adapter.strictStringsByDefault`.
+   * defaults to `SQLite3Adapter.strictStringsByDefault`. Rails keeps the
+   * resolved value in `@config[:strict]` (sqlite3_adapter.rb:127) and exposes
+   * no reader, so this one stays Rails-private.
    * @internal
    */
-  get strictStrings(): boolean {
+  get _strictStrings(): boolean {
     return this._strict;
   }
 
@@ -583,16 +585,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     if (cols.some((c) => c.type !== null && /bigint/i.test(c.type))) {
       stmt.setReadBigInts(true);
     }
-  }
-
-  /**
-   * Get or set a PRAGMA value.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#pragma
-   */
-  async pragma(name: string): Promise<unknown> {
-    await this.ensureConnected();
-    return await this.driver.pragma(name);
   }
 
   /**
@@ -1116,6 +1108,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * Rails' `disconnect!` is synchronous; this drain is a TypeScript-async
    * necessity for promise-returning drivers, not a divergence in observable
    * teardown behavior.
+   *
+   * @noRailsEquivalent PERMANENT — Rails' `disconnect!`
+   * (sqlite3_adapter.rb:245) closes the handle synchronously and has nothing to
+   * drain, so no Rails method can map onto this hook.
    */
   whenClosed(): Promise<void> {
     return this._closingDriver ?? Promise.resolve();
@@ -2756,6 +2752,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   /**
    * Complete a deferred async connection. No-op when already connected
    * synchronously. Invoked by `openAsync()` and `verifyBang()`. @internal
+   *
+   * @noRailsEquivalent PERMANENT — Rails' `connect` (sqlite3_adapter.rb:825)
+   * opens the handle synchronously inside `initialize`, so there is nothing
+   * left to finish afterwards. Drivers whose `open()` returns a Promise cannot
+   * be opened from a synchronous constructor or a synchronous pool checkout,
+   * so the deferred completion is a seam Ruby never needs.
    */
   async completeAsyncConnect(): Promise<void> {
     if (!this._asyncConnectPending) return;
@@ -2799,6 +2801,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * Async construction entry point — works for both sync drivers (returns an
    * already-connected adapter) and async-only drivers (awaits the deferred
    * connection).
+   *
+   * @noRailsEquivalent PERMANENT — the async twin of `new`, for the same reason
+   * as `completeAsyncConnect`: Ruby's sqlite3 gem opens synchronously, so
+   * `SQLite3Adapter.new` (sqlite3_adapter.rb:120) is the only entry point Rails
+   * has or can have.
    */
   static async openAsync(
     this: new (filename?: string, options?: SQLite3AdapterOptions) => AbstractSQLite3Adapter,
@@ -3019,22 +3026,6 @@ export class SQLite3IntegerType extends IntegerType {
  * SQLite3-specific statement pool backed by the generic StatementPool.
  */
 export class StatementPool extends GenericStatementPool<SqliteStatement> {}
-
-/**
- * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter::SQLite3Integer
- *
- * SQLite stores integers as up to 8-byte signed values. This type
- * represents the range of values SQLite can natively handle.
- */
-export class SQLite3Integer {
-  static readonly MIN = -(2n ** 63n);
-  static readonly MAX = 2n ** 63n - 1n;
-
-  static inRange(value: bigint | number): boolean {
-    const v = BigInt(value);
-    return v >= SQLite3Integer.MIN && v <= SQLite3Integer.MAX;
-  }
-}
 
 /** @internal */
 function extractValueFromDefault(default_: string | null): unknown {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1110,7 +1110,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * teardown behavior.
    *
    * @noRailsEquivalent PERMANENT — Rails' `disconnect!`
-   * (sqlite3_adapter.rb:245) closes the handle synchronously and has nothing to
+   * (sqlite3_adapter.rb:221) closes the handle synchronously and has nothing to
    * drain, so no Rails method can map onto this hook.
    */
   whenClosed(): Promise<void> {
@@ -2753,7 +2753,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * Complete a deferred async connection. No-op when already connected
    * synchronously. Invoked by `openAsync()` and `verifyBang()`. @internal
    *
-   * @noRailsEquivalent PERMANENT — Rails' `connect` (sqlite3_adapter.rb:825)
+   * @noRailsEquivalent PERMANENT — Rails' `connect` (sqlite3_adapter.rb:806)
    * opens the handle synchronously inside `initialize`, so there is nothing
    * left to finish afterwards. Drivers whose `open()` returns a Promise cannot
    * be opened from a synchronous constructor or a synchronous pool checkout,
@@ -2804,7 +2804,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    *
    * @noRailsEquivalent PERMANENT — the async twin of `new`, for the same reason
    * as `completeAsyncConnect`: Ruby's sqlite3 gem opens synchronously, so
-   * `SQLite3Adapter.new` (sqlite3_adapter.rb:120) is the only entry point Rails
+   * `SQLite3Adapter.new` (sqlite3_adapter.rb:102) is the only entry point Rails
    * has or can have.
    */
   static async openAsync(

--- a/packages/activerecord/src/sqlite-adapter.test.ts
+++ b/packages/activerecord/src/sqlite-adapter.test.ts
@@ -218,7 +218,7 @@ describe("SQLite adapter driver binding", () => {
     await Promise.all([
       adapter.execute("SELECT 1 AS one"),
       adapter.execQuery("SELECT 2 AS two"),
-      adapter.pragma("foreign_keys"),
+      adapter.execute("PRAGMA foreign_keys"),
     ]);
     expect(opens).toBe(1);
     adapter.disconnectBang();

--- a/packages/activerecord/src/test-adapter.trails.test.ts
+++ b/packages/activerecord/src/test-adapter.trails.test.ts
@@ -30,11 +30,11 @@ describe("ambientPoolConfiguration", () => {
   test.skipIf(!currentAdapter("SQLite3Adapter"))(
     "newRawTestAdapter opens sqlite with the ambient strict setting",
     async () => {
-      const adapter = newRawTestAdapter() as unknown as { strictStrings: boolean } & {
+      const adapter = newRawTestAdapter() as unknown as { _strictStrings: boolean } & {
         disconnectBang(): Promise<void>;
       };
       try {
-        expect(adapter.strictStrings).toBe(Boolean(ambientPoolConfiguration().strict));
+        expect(adapter._strictStrings).toBe(Boolean(ambientPoolConfiguration().strict));
       } finally {
         await adapter.disconnectBang();
       }


### PR DESCRIPTION
Resolves the per-file **singleton** novel names on the three concrete adapters
(each declared in exactly one file, so none is a cross-file decision). One
recorded decision per name, justified at the declaration site.

## Decisions

`abstract-mysql-adapter.ts`

| name | decision |
| --- | --- |
| `addSqlComment` | **deleted** — dead; the `!` twin (`addSqlCommentBang`) is the one that mirrors `add_sql_comment!` (abstract_mysql_adapter.rb:460) |
| `ER_TABLE_EXISTS` | **deleted** — 1050 is not in Rails' error-code list (abstract_mysql_adapter.rb:789-823) and nothing read it |
| `CLIENT_NOT_CONNECTED_RE` / `isClientNotConnected` | **deleted** — Rails writes the literal `/MySQL client is not connected/i` inline in *both* branches (abstract_mysql_adapter.rb:818, mysql2_adapter.rb:176); the centralizing constant + predicate were the deviation, so the regex is now inlined at both sites |
| `setSessionVariable` | **deleted** — trails-only helper whose only callers were its own three tests; the Rails-named `variables:` pool-init tests already cover the behavior |

`postgresql-adapter.ts`

| name | decision |
| --- | --- |
| `enumValues` | **deleted** — zero callers; Rails' counterpart is `enum_types` (postgresql_adapter.rb:518), already ported |
| `resetPkSequence` / `setPkSequence` | **deleted** — non-bang alias shims over the faithful `resetPkSequenceBang` / `setPkSequenceBang` (`reset_pk_sequence!` / `set_pk_sequence!`, postgresql/schema_statements.rb:316,331). Also clears both names from `postgresql/schema-statements-class.ts` |
| `detach` | **Rails-private `_detach`** — Rails' StatementPool holds the raw connection for its lifetime and has no counterpart. Applied to the mysql2 StatementPool twin too, so the two stay symmetrical |
| `serialFromDefaultFunction` | **Rails-private `_serialFromDefaultFunction`** — Rails inlines this in `new_column_from_field`; it is an extraction, not API |
| `warmMaxIdentifierLength` | **`@noRailsEquivalent PERMANENT`** — `max_identifier_length` (postgresql_adapter.rb:620) does the `SHOW` query inside the *synchronous* reader via `||=`; trails queries are Promises, so the round-trip cannot live there |

`sqlite3-adapter.ts`

| name | decision |
| --- | --- |
| `MAX` / `MIN` | **deleted** — with the dead `SQLite3Integer` class that held them (plus its unused `inRange`). Rails' `SQLite3Integer` (sqlite3_adapter.rb:486) overrides only the private `_limit`; the ported type is `SQLite3IntegerType`, which stays |
| `pragma` | **deleted** — trails passthrough to `driver.pragma`. Rails reaches pragmas through the raw connection or `execute("PRAGMA …")`; the call sites now use `execute`, exactly as Rails' own sqlite3 tests do |
| `strictStrings` | **Rails-private `_strictStrings`** — Rails keeps the resolved value in `@config[:strict]` (sqlite3_adapter.rb:127) and exposes no reader |
| `completeAsyncConnect`, `openAsync`, `whenClosed` | **`@noRailsEquivalent PERMANENT`** — the async-driver seam. Ruby's sqlite3 gem opens and closes synchronously inside `initialize` / `disconnect!`, so a deferred open, an async construction entry point, and a close-drain hook are things Rails has no method for and never can |

## Novel counts (per file, before → after)

| file | before | after |
| --- | --- | --- |
| `connection-adapters/abstract-mysql-adapter.ts` | 5 | **0** |
| `connection-adapters/postgresql-adapter.ts` | 8 | 2 |
| `connection-adapters/sqlite3-adapter.ts` | 12 | 5 |
| `connection-adapters/postgresql/schema-statements-class.ts` | 5 | 3 |

Every name in this story's scope is at 0. The residue on the two files is
out of scope and owned elsewhere: `exec` / `executeMutation` are cross-file
recurring names owned by `extra-surface-adapter-cross-file-recurring-names`
(not yet merged, which is why they still show here), and
`AbstractSQLite3Adapter` / `SQLite3IntegerType` / `SQLiteDateTimeType` /
`createRange` / `dropRange` are class names and cross-file recurring names,
not per-file singletons.

`pnpm api:extra --package activerecord` exits 0 — no STALE entries.

## Testing

- `pnpm vitest run` on the touched SQLite files: `sqlite-adapter.test.ts`,
  `adapters/sqlite3/sqlite3-adapter.test.ts`,
  `connection-adapters/sqlite3-adapter.hash-constructor.test.ts`,
  `test-adapter.trails.test.ts`, `adapter.test.ts`,
  `sqlite3-adapter.type-map.trails.test.ts`, `type-lookup.test.ts` — all pass.
- MySQL/PG suites need a running server, which is not available in this
  worktree; CI verifies those lanes.
- `tsc --build` clean.


## Names in the story's context list that needed no decision

The story's context was written against an older measurement. Three of the nine
names it lists for `postgresql-adapter.ts` — `setSchemaSearchPath`,
`setClientMinMessages`, `splitPgDefault` — and one of the eight for
`sqlite3-adapter.ts` (`withPreventedWrites`) do not flag as extra surface at
all on `main` today, so there is nothing to decide.

For the two writers specifically: Rails' `schema_search_path=`
(postgresql/schema_statements.rb:278) and `client_min_messages=` (:296) both
block on I/O in the writer body (`internal_execute("SET …")`), which a
synchronous JS property setter cannot express. `set#{Name}` is the *faithful*
rendering of exactly that shape under RFC 0068 — `railsNameToTsCandidates`
offers `[camel, "set" + Camel]` for any `name=` (conventions.ts:703-716) — so
`setSchemaSearchPath` / `setClientMinMessages` are matched, not novel. Verified:
neither Ruby writer appears in `missingMethods` for its file, and neither TS
name appears in this file's `extras` list under any kind. This is the opposite
case from the `resetPkSequence` / `setPkSequence` shims deleted above: those had
no `=` writer behind them at all — they were non-bang aliases duplicating
`reset_pk_sequence!` / `set_pk_sequence!`, which the `!` → `Bang` rule already
matches.

## The 2 residual novel names on `postgresql-adapter.ts`

They are `exec` and `executeMutation` — the same pair that accounts for the
`sqlite3-adapter.ts` residue. Both are cross-file recurring names owned by
`extra-surface-adapter-cross-file-recurring-names`, which resolved them but has
not merged yet; they are out of this story's scope by construction (this story
was split out of that one precisely to separate the per-file singletons from
the cross-file decisions). Every name in *this* story's scope is at 0.

Closes-story: extra-surface-adapter-per-file-singletons
