### PR TITLE
refactor(activerecord): classify the base.ts novel extra surface

### DIFF
--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -67,7 +67,6 @@ describe("basic CRUD DX — defining and using a model", () => {
     expectTypeOf(await User.findBy({ email: "d@example.com" })).toEqualTypeOf<User | null>();
     expectTypeOf(await User.findByBang({ email: "d@example.com" })).toEqualTypeOf<User>();
     expectTypeOf(await User.findSoleBy({ email: "d@example.com" })).toEqualTypeOf<User>();
-    expectTypeOf(await User.findByAttribute("name", "dean")).toEqualTypeOf<User | null>();
   });
 
   it("ordinal + cardinality finders all carry User through", async () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -232,11 +232,7 @@ import {
   noTouching as _noTouchingBlock,
   isAppliedTo as _isNoTouchingApplied,
 } from "./no-touching.js";
-import {
-  suppress as _suppressBlock,
-  isSuppressed as _isSuppressed,
-  registry as _suppressorRegistry,
-} from "./suppressor.js";
+import { suppress as _suppressBlock, registry as _suppressorRegistry } from "./suppressor.js";
 import {
   inspect as _inspect,
   attributeForInspect as _attributeForInspect,
@@ -1404,6 +1400,13 @@ export class Base extends Model {
    * a getter can't await without wrapping instances in a `Proxy`.
    *
    * @internal
+   * @noRailsEquivalent PERMANENT No `def ensure_schema_loaded` exists anywhere
+   * in Rails: Ruby reflects lazily and synchronously from `method_missing` /
+   * `define_attribute_methods` around
+   * `vendor/rails/activerecord/lib/active_record/model_schema.rb:534`
+   * (`def load_schema`), where the blocking DB round-trip is invisible to the
+   * caller. Every trails DB call is a promise, so the lazy hook has to be an
+   * awaitable named entry point on the query/persistence path.
    */
   static ensureSchemaLoaded(this: typeof Base): Promise<void> {
     // A model whose declared attributes are all virtual (e.g. Rails'
@@ -1947,10 +1950,6 @@ export class Base extends Model {
     return _suppressBlock(this, fn);
   }
 
-  static get isSuppressed(): boolean {
-    return _isSuppressed(this);
-  }
-
   static get registry(): Record<string, true | undefined> {
     return _suppressorRegistry();
   }
@@ -2329,20 +2328,6 @@ export class Base extends Model {
   ) => Promise<InstanceType<T>>;
 
   /**
-   * Dynamic finder by a single attribute name.
-   * e.g., User.findByName("Alice") → User.findBy({ name: "Alice" })
-   *
-   * Mirrors: ActiveRecord::Base.find_by_* dynamic finders
-   */
-  static async findByAttribute<T extends typeof Base>(
-    this: T,
-    attribute: string,
-    value: unknown,
-  ): Promise<InstanceType<T> | null> {
-    return this.findBy({ [attribute]: value });
-  }
-
-  /**
    * Check if a dynamic finder method name is valid.
    *
    * Mirrors: ActiveRecord::Base.respond_to_missing?
@@ -2665,6 +2650,14 @@ export class Base extends Model {
    *
    * Rails: `Base.new(attributes = nil, &block)` — recurses on arrays and
    * yields each record to the block before returning.
+   *
+   * @noRailsEquivalent PERMANENT Ruby never writes `def new` for this — the
+   * allocator is `Class#new` and the model side is
+   * `vendor/rails/activerecord/lib/active_record/core.rb:471` (`def
+   * initialize`), so no `.rb` can ever declare a matching name. TS reserves
+   * `new` for the constructor, which cannot recurse over an array of attribute
+   * hashes nor yield each record to a block, so the `Model.new(attrs, &block)`
+   * semantics have to live on a static factory of the same name.
    */
   static new<T extends typeof Base>(
     this: T,
@@ -4453,6 +4446,11 @@ export class Base extends Model {
    * Compare two records for equality based on class and primary key.
    *
    * Mirrors: ActiveRecord::Core#==
+   *
+   * @noRailsEquivalent PERMANENT This is `def ==` at
+   * `vendor/rails/activerecord/lib/active_record/core.rb:631`. TS cannot name a
+   * method `==` and cannot overload the operator, so the ported body needs a
+   * spelled-out identifier; there is no `def is_equal` in Rails to match it.
    */
   declare isEqual: (other: unknown) => boolean;
 
@@ -4462,16 +4460,6 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Core#hash
    */
   declare hash: () => unknown;
-
-  /**
-   * Return a string suitable for use as a URL slug.
-   * Override in subclasses for friendly URLs.
-   *
-   * Mirrors: ActiveRecord::Base#to_param
-   */
-  toSlug(): string | null {
-    return this.toParam();
-  }
 
   // becomesBang / updateAttributeBang extracted to persistence.ts.
 
@@ -4660,7 +4648,28 @@ export class Base extends Model {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Base extends Included<typeof AutosaveAssociation> {
   association(name: string): AssociationInstance;
+  /**
+   * Explicitly load a `belongsTo` target and resolve to it.
+   *
+   * @noRailsEquivalent PERMANENT Ruby has no counterpart because it needs none:
+   * `post.author` is a plain reader that blocks on I/O
+   * (`vendor/rails/activerecord/lib/active_record/associations/builder/association.rb:102`
+   * generates it via `define_readers`), so `def load_belongs_to` exists nowhere
+   * in Rails. A JS getter cannot await, so the async half of the reader has to be
+   * a separately named method. It is also the deliberate strict-loading escape
+   * hatch: an explicit call bumps the bypass count for the duration of the load
+   * (`associations/instance-methods.ts:104`), which is how a caller says "this
+   * lazy load is intentional" — the role Ruby fills by simply calling the
+   * reader.
+   */
   loadBelongsTo(name: string): Promise<Base | null>;
+  /**
+   * Explicitly load a `hasOne` target and resolve to it.
+   *
+   * @noRailsEquivalent PERMANENT Same reasoning as {@link Base.loadBelongsTo}:
+   * no `def load_has_one` exists in Rails, the Ruby reader blocks on I/O, and
+   * the explicit call doubles as the strict-loading bypass.
+   */
   loadHasOne(name: string): Promise<Base | null>;
   readAttributeForValidation(attribute: string): unknown;
   validate(context?: ValidationContextArg): Promise<boolean>;


### PR DESCRIPTION
Classifies all 20 novel extras `pnpm api:extra --package activerecord
--novel-only` reports for `packages/activerecord/src/base.ts`.

**base.ts novel: 20 → 12** (0 moved, before and after).

Every "no Rails counterpart" claim below was verified by grepping the
snake_case name as a Ruby `def` across the whole of `vendor/rails`; all 19
greps returned nothing, so each positive citation is a *related* Rails method,
named with `file:line`.

### (a) Invention removed — 3

| name | verdict |
| --- | --- |
| `toSlug` (was base.ts:4472) | Pure duplicate: the body is `return this.toParam()`, and `toParam` is the real port of `def to_param` (`activerecord/lib/active_record/integration.rb:57`). Zero callers in the tree. Deleted. |
| `findByAttribute` (was base.ts:2337) | Rails' dynamic finders are generated through `method_missing`, not a named helper (`activerecord/lib/active_record/dynamic_matchers.rb:15`, `FindBy` at :93). Zero runtime callers; the only reference was one `dx-tests` type assertion, removed with it. |
| `Base.isSuppressed` (was base.ts:1950) | `suppressor.rb` defines only `registry`, `suppress`, `save`, `save!` — no `suppressed?` predicate. Zero callers: the live path is `isSuppressed` in `suppressor.ts`, imported directly by `persistence.ts:44`, which is untouched. Deleted the `Base` getter only. |

### (b) Allowed with a written reason — 5

All five are irreducible: no Ruby `def` can ever exist to match them. Applied
as `@noRailsEquivalent PERMANENT` tags (the sole allow mechanism since RFC 0080
retired `extra-surface-allow.json`).

- **`loadBelongsTo` / `loadHasOne`** — the anchor finding. Ruby needs no
  counterpart: `post.author` is a plain generated reader that blocks on I/O
  (`associations/builder/association.rb:102`, `define_readers`). A JS getter
  cannot await, so the async half of the reader must be a separately named
  method. It also carries a second, deliberate role — an explicit call bumps
  the strict-loading bypass count for the duration of the load
  (`associations/instance-methods.ts:104`), which is how a caller declares a
  lazy load intentional. Ruby fills that role by simply calling the reader.
  Both roles are now written down on the declarations.
- **`new`** — Ruby never writes `def new`; the allocator is `Class#new` and the
  model side is `def initialize` (`core.rb:471`). TS reserves `new` for the
  constructor, which can neither recurse over an array of attribute hashes nor
  yield each record to a block, so `Model.new(attrs, &block)` needs a static
  factory.
- **`isEqual`** — this *is* `def ==` (`core.rb:631`). TS cannot name a method
  `==` or overload the operator.
- **`ensureSchemaLoaded`** — Rails reflects lazily and *synchronously* from
  `method_missing`, around `def load_schema` (`model_schema.rb:534`), so the
  round-trip is invisible to the caller. Every trails DB call is a promise, so
  the hook must be an awaitable named entry point.

### (c) Convergeable — 12 left counted, 5 stories filed

Per the direction on #5342, convergeable surface is **not** allowlisted — the
novel count stays honest and the work is scheduled. Filed under RFC 0072:

| story | names | base.ts |
| --- | --- | --- |
| `port-respond-to-missing-finder-to-dynamic-matchers` | `respondToMissingFinder` | :2325 |
| `converge-attribute-names-list-instance-accessor` | `attributeNamesList` | :4176 |
| `converge-is-touching-suppressed-to-no-touching-predicate` | `isTouchingSuppressed` | :1735 |
| `converge-base-where-not-to-where-chain` | `whereNot` | :2453 |
| `converge-model-schema-coder-and-attribute-definition-names` | `attributeSetCoder`, `hasAttributeDefinition` | :1598, :1586 |

The remaining 6 are `declare static` mixin echoes whose home file already
carries the finding, so fixing the home fixes `base.ts` in lockstep — no new
story:

- `adapterClassSync` → `connection-handling.ts` (1 novel) and
  `database-configurations/database-config.ts` (3 novel); Rails
  `def adapter_class`, `connection_handling.rb:338`.
- `validatesUniqueness` → `validations.ts` + `validations/uniqueness.ts` (1
  novel each); Rails `def validates_uniqueness_of`, `uniqueness.rb:291`.
- `withCte` → `querying.ts` (1 novel); note `base.ts` already declares the
  faithful `with` alias alongside it.
- `findGlobalId`, `findSignedGlobalId`, `findSignedGlobalIdBang` — already
  documented in-file as un-suppressed on purpose and owned by tasks 0023
  `globalid-model-side-finders-are-uncalled-trails-invention`.

### Notes

- On the mixin-host names the story flagged: `attributeNamesList` and `isEqual`
  are genuinely declared on `base.ts` and got real verdicts (c and b
  respectively). `toSlug` was the only one of the three that turned out to be
  removable — and for its own reason, not as host-interface artifact.
- `@internal` does **not** suppress an extra: `ensureSchemaLoaded` was already
  tagged `@internal` and still flagged. `@noRailsEquivalent` is the mechanism.
- `pnpm api:calls:wide` re-run: ratchet OK (2296 baselined, 2121 unreviewed).

Closes-story: extra-surface-base-accessors-classify
