### PR TITLE
refactor(activerecord): converge attributeNamesList onto the Rails attributeNames name

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1035,9 +1035,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Rails intersects the *instance* `attribute_names` of both records
     // (collection_association.rb:340) — the actually-loaded keys, not the class
     // set — so a collection loaded under a `select` projection only refreshes
-    // the columns both rows actually carry. the instance
-    // `attributeNames()` reads `_attributes.keys()`; the class-level static of
-    // the same name would write columns absent from a partially-loaded dbRecord.
+    // the columns both rows actually carry. The instance
+    // `attributeNames()` reads `_attributes.keys()`; using the class-level
+    // static would write columns absent from a partially-loaded dbRecord.
     const dbNames = new Set(dbRecord.attributeNames());
     const changed = new Set(
       (memRecord as unknown as { changedAttributeNamesToSave: string[] })

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1035,10 +1035,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Rails intersects the *instance* `attribute_names` of both records
     // (collection_association.rb:340) — the actually-loaded keys, not the class
     // set — so a collection loaded under a `select` projection only refreshes
-    // the columns both rows actually carry. `attributeNamesList` is trails'
-    // instance-level mirror (reads `_attributes.keys()`); using the class set
-    // here would write columns absent from a partially-loaded dbRecord.
-    const dbNames = new Set(dbRecord.attributeNamesList);
+    // the columns both rows actually carry. the instance
+    // `attributeNames()` reads `_attributes.keys()`; the class-level static of
+    // the same name would write columns absent from a partially-loaded dbRecord.
+    const dbNames = new Set(dbRecord.attributeNames());
     const changed = new Set(
       (memRecord as unknown as { changedAttributeNamesToSave: string[] })
         .changedAttributeNamesToSave,
@@ -1049,7 +1049,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `record[name]` (`read_attribute`, collection_association.rb:342) for every
     // name here — the value is already type-cast from the fresh row. Both sides
     // use the raw read/write pair, mirroring `_write_attribute` on the Rails side.
-    for (const name of memRecord.attributeNamesList) {
+    for (const name of memRecord.attributeNames()) {
       if (!dbNames.has(name) || changed.has(name) || readonly.has(name)) continue;
       memRecord._writeAttribute(name, dbRecord._readAttribute(name));
     }

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -683,9 +683,6 @@ function classAttributeNames(this: AttributeNamesHost): string[] {
   return names;
 }
 
-// The class-level `attribute_names` lives on ClassMethods so it can coexist
-// with the instance method of the same name (Ruby scopes them separately;
-// a TS module has one name slot).
 export const ClassMethods = {
   attributeNames: classAttributeNames,
 };

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -32,7 +32,7 @@ import {
 export interface AttributeMethods {
   hasAttribute(name: string): boolean;
   attributePresent(name: string): boolean;
-  attributeNamesList: string[];
+  attributeNames(): string[];
 }
 
 interface AttributeRecord {
@@ -123,7 +123,7 @@ export function attributePresent(this: AttributeRecord, name: string): boolean {
  *
  * Mirrors: ActiveRecord::AttributeMethods#attribute_names
  */
-export function attributeNamesList(this: AttributeRecord): string[] {
+export function attributeNames(this: AttributeRecord): string[] {
   return [...this._attributes.keys()];
 }
 
@@ -636,7 +636,7 @@ interface AttributeNamesHost {
  * walk `column_names` first and append the non-column declarations in
  * declaration order.
  */
-export function attributeNames(this: AttributeNamesHost): string[] {
+function classAttributeNames(this: AttributeNamesHost): string[] {
   // Rails' `@attribute_names ||= ...freeze` memo, own-property per class (a
   // subclass never reads its parent's memo — Rails nils `@attribute_names` in
   // `inherited`), revision-stamped so the reset paths that clear
@@ -682,6 +682,13 @@ export function attributeNames(this: AttributeNamesHost): string[] {
   }
   return names;
 }
+
+// The class-level `attribute_names` lives on ClassMethods so it can coexist
+// with the instance method of the same name (Ruby scopes them separately;
+// a TS module has one name slot).
+export const ClassMethods = {
+  attributeNames: classAttributeNames,
+};
 
 // ---------------------------------------------------------------------------
 // Instance methods mirrored from attribute_methods.rb

--- a/packages/activerecord/src/attribute-methods/read.test.ts
+++ b/packages/activerecord/src/attribute-methods/read.test.ts
@@ -4,7 +4,7 @@ import { fixtures } from "../test-fixtures.js";
 import {
   defineAttributeMethods,
   isAttributeMethodsGenerated,
-  attributeNames,
+  ClassMethods,
 } from "../attribute-methods.js";
 
 fixtures({});
@@ -25,7 +25,7 @@ describe("ReadTest", () => {
       static _attributeMethodsGenerated = false;
       static defineAttributeMethods = defineAttributeMethods;
       static attributeMethodsGenerated = isAttributeMethodsGenerated;
-      static attributeNames = attributeNames;
+      static attributeNames = ClassMethods.attributeNames;
     }
     return Klass;
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -168,11 +168,11 @@ import {
   hasAttribute as _hasAttribute,
   _hasAttribute as _privateHasAttribute,
   attributePresent as _attributePresent,
-  attributeNamesList as _attributeNamesList,
+  attributeNames as _attributeNames,
   accessedFields as _accessedFields,
   attributesForCreate as _attributesForCreate,
   attributesForUpdate as _attributesForUpdate,
-  attributeNames as _attributeNames,
+  ClassMethods as AttributeMethodsClassMethods,
   isAttributeMethod as _isAttributeMethod,
   isDangerousAttributeMethod as _isDangerousAttributeMethod,
   defineAttributeMethods as _defineAttributeMethods,
@@ -4176,12 +4176,12 @@ export class Base extends Model {
   /** @internal */
   declare storeAccessorFor: (storeAttribute: string) => typeof import("./store.js").HashAccessor;
 
-  get attributeNamesList(): string[] {
-    return _attributeNamesList.call(this as any);
+  attributeNames(): string[] {
+    return _attributeNames.call(this as any);
   }
 
   static attributeNames(): string[] {
-    return _attributeNames.call(this);
+    return AttributeMethodsClassMethods.attributeNames.call(this);
   }
 
   /**


### PR DESCRIPTION
Converges the trails-only `attributeNamesList` instance accessor onto Rails'
name, `attribute_names` (`activerecord/lib/active_record/attribute_methods.rb:334`).
The `List` suffix existed to dodge a collision with the class method of the same
name (attribute_methods.rb:236) — in Ruby those live in different scopes, and in
TS a static and an instance member occupy different slots, so no suffix is needed.

- `attribute-methods.ts`: instance `attributeNamesList` → `attributeNames`; the
  `AttributeMethods` interface member follows.
- The class-level `attributeNames` moves under the existing repo convention
  `export const ClassMethods = { ... }` (as in `counter-cache.ts`,
  `readonly-attributes.ts`, `timestamp.ts`), because a TS module has a single
  name slot while Ruby scopes `ClassMethods#attribute_names` separately.
- `base.ts`: the instance member becomes a **method** rather than a getter, so it
  matches Rails (`def attribute_names`) and ActiveModel's
  `Attributes#attributeNames(): string[]`. As a getter it was structurally
  incompatible with `ActiveModel::Model`, which `tsc` surfaced across
  `transactions.ts` and several tests. `static attributeNames()` stays intact and
  unshadowed.
- Call sites updated: `associations/collection-proxy.ts` (2), plus
  `attribute-methods/read.test.ts`, which imported the class-level function.

No test names changed.

### api:extra (`--package activerecord --novel-only`)

| file | before | after |
| --- | --- | --- |
| `base.ts` | 19 novel | 18 novel |
| `attribute-methods.ts` | 1 novel | 0 (file drops off the report) |

`pnpm api:calls:wide` re-run: ratchet OK (2281 baselined, 2101 unreviewed).

Tests: `attribute-methods.test.ts`, `attribute-methods.trails.test.ts`,
`attribute-methods/read.test.ts`, `associations/collection-proxy.test.ts`,
`attributes.test.ts` all pass; `pnpm typecheck` clean.

Closes-story: converge-attribute-names-list-instance-accessor
