### PR TITLE
refactor(activerecord): converge Base.whereNot onto the where().not chain

### DIFF
--- a/packages/activerecord/dx-tests/query-chaining.test-d.ts
+++ b/packages/activerecord/dx-tests/query-chaining.test-d.ts
@@ -161,7 +161,7 @@ describe("query chaining DX", () => {
   it("Post.all() / Post.from(...) / Post.whereNot(...) preserve the generic", () => {
     expectTypeOf(Post.all()).toMatchTypeOf<Relation<Post>>();
     expectTypeOf(Post.from("posts")).toMatchTypeOf<Relation<Post>>();
-    expectTypeOf(Post.whereNot({ published: false })).toMatchTypeOf<Relation<Post>>();
+    expectTypeOf(Post.where().not({ published: false })).toMatchTypeOf<Relation<Post>>();
   });
 
   it("Post.joins / distinct / none / unscoped all return Relation<Post>", () => {
@@ -205,6 +205,6 @@ describe("query chaining DX", () => {
   it("Post.where accepts a Record or a SQL-string + binds", () => {
     assertType(Post.where({ title: "x" }));
     assertType(Post.where("title = ?", "x"));
-    assertType(Post.whereNot({ published: false }));
+    assertType(Post.where().not({ published: false }));
   });
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -261,6 +261,7 @@ import {
 import * as _Reflection from "./reflection.js";
 import * as _AssocInstance from "./associations/instance-methods.js";
 import { argumentError } from "./relation/query-methods.js";
+import type { WhereChain } from "./relation/query-methods.js";
 import {
   ScopeRegistry,
   scopeRegistry as _scopeRegistry,
@@ -2398,6 +2399,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.where
    */
+  static where<T extends typeof Base>(this: T): WhereChain<Relation<InstanceType<T>>>;
   static where<T extends typeof Base>(
     this: T,
     conditions: Record<string, unknown>,
@@ -2416,9 +2418,12 @@ export class Base extends Model {
   static where<T extends typeof Base>(this: T, node: Nodes.Node): Relation<InstanceType<T>>;
   static where<T extends typeof Base>(
     this: T,
-    conditionsOrSql: Record<string, unknown> | string | string[] | unknown[] | Nodes.Node,
+    conditionsOrSql?: Record<string, unknown> | string | string[] | unknown[] | Nodes.Node,
     ...rest: unknown[]
-  ): Relation<InstanceType<T>> {
+  ): Relation<InstanceType<T>> | WhereChain<Relation<InstanceType<T>>> {
+    if (conditionsOrSql === undefined) {
+      return this.all().where();
+    }
     if (conditionsOrSql instanceof Nodes.Node) {
       return this.all().where(conditionsOrSql);
     }
@@ -2451,47 +2456,6 @@ export class Base extends Model {
       return this.all().where(conditionsOrSql as unknown[]);
     }
     return this.all().where(conditionsOrSql);
-  }
-
-  static whereNot<T extends typeof Base>(
-    this: T,
-    conditions: Record<string, unknown>,
-  ): Relation<InstanceType<T>>;
-  static whereNot<T extends typeof Base>(this: T, conditions: unknown[]): Relation<InstanceType<T>>;
-  static whereNot<T extends typeof Base>(
-    this: T,
-    cols: string[],
-    tuples: unknown[][],
-  ): Relation<InstanceType<T>>;
-  static whereNot<T extends typeof Base>(
-    this: T,
-    conditions: Record<string, unknown> | string[] | unknown[],
-    tuples?: unknown[][],
-  ): Relation<InstanceType<T>> {
-    // Rails' `where.not` mirrors `where` — a single array argument is the
-    // sanitized-conditions form (`where.not(["name = ?", x])`, query_methods.rb:28)
-    // built via `build_where_clause(...).invert`; the composite-key form is the
-    // two-argument `whereNot(cols, tuples)`. Disambiguate by argument count, and
-    // require the column list to be all strings (symmetric with `where`) so a
-    // mixed-type array routes to the sanitized-conditions path.
-    if (
-      Array.isArray(conditions) &&
-      tuples !== undefined &&
-      conditions.every((c) => typeof c === "string")
-    ) {
-      if (!Array.isArray(tuples)) {
-        throw argumentError(
-          `${(this as { name?: string }).name ?? "Model"}.whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays`,
-        );
-      }
-      return this.all().whereNot(conditions as string[], tuples);
-    }
-    if (Array.isArray(conditions)) {
-      // Single-array sanitized-conditions form; any extra positional arg is
-      // dropped, matching Rails' `build_where_clause` overwrite (as in `where`).
-      return this.all().whereNot(conditions as unknown[]);
-    }
-    return this.all().whereNot(conditions);
   }
 
   // insertAll / upsertAll / updateAll / deleteAll / destroyBy / deleteBy

--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -269,7 +269,7 @@ describe("BindParameterTest", () => {
     let topics = Topic.where({ id: ids });
     expect(await topics.count()).toBe(await Topic.count());
 
-    topics = Topic.whereNot({ id: ids });
+    topics = Topic.where().not({ id: ids });
     expect(await topics.count()).toBe(0);
   });
 
@@ -283,7 +283,7 @@ describe("BindParameterTest", () => {
       let topics = Topic.where({ id: ids });
       expect(await topics.count()).toBe(await Topic.count());
 
-      topics = Topic.whereNot({ id: ids });
+      topics = Topic.where().not({ id: ids });
       expect(await topics.count()).toBe(0);
     } finally {
       conn.disableQueryCacheBang();

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -113,8 +113,8 @@ describe("EnumTest", () => {
     expect((await Book.where({ status: written }).first())?.id).not.toBe(book.id);
     expect((await Book.where({ status: [published, published] }).first())?.id).toBe(book.id);
     expect((await Book.where({ status: [written, written] }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: published }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: written }).first())?.id).toBe(book.id);
+    expect((await Book.where().not({ status: published }).first())?.id).not.toBe(book.id);
+    expect((await Book.where().not({ status: written }).first())?.id).toBe(book.id);
   });
 
   it("find via where with values.to_s", async () => {
@@ -126,8 +126,8 @@ describe("EnumTest", () => {
     expect((await Book.where({ status: written }).first())?.id).not.toBe(book.id);
     expect((await Book.where({ status: [published, published] }).first())?.id).toBe(book.id);
     expect((await Book.where({ status: [written, written] }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: published }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: written }).first())?.id).toBe(book.id);
+    expect((await Book.where().not({ status: published }).first())?.id).not.toBe(book.id);
+    expect((await Book.where().not({ status: written }).first())?.id).toBe(book.id);
     expect((await Book.where({ cover: (Book as any).covers.soft }).first())?.id).toBe(book.id);
   });
 
@@ -138,12 +138,12 @@ describe("EnumTest", () => {
     expect((await Book.where({ status: "written" }).first())?.id).not.toBe(book.id);
     expect((await Book.where({ status: ["published", "published"] }).first())?.id).toBe(book.id);
     expect((await Book.where({ status: ["written", "written"] }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: "published" }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: "written" }).first())?.id).toBe(book.id);
+    expect((await Book.where().not({ status: "published" }).first())?.id).not.toBe(book.id);
+    expect((await Book.where().not({ status: "written" }).first())?.id).toBe(book.id);
     expect((await Book.where({ last_read: "forgotten" }).first())?.id).toBe(books("ddd").id);
     expect(await Book.where({ status: "prohibited" }).first()).toBeNull();
     expect((await Book.where({ cover: "soft" }).first())?.id).toBe(book.id);
-    expect((await Book.whereNot({ cover: "hard" }).first())?.id).toBe(book.id);
+    expect((await Book.where().not({ cover: "hard" }).first())?.id).toBe(book.id);
   });
 
   it("find via where with strings", async () => {
@@ -152,8 +152,8 @@ describe("EnumTest", () => {
     expect((await Book.where({ status: "written" }).first())?.id).not.toBe(book.id);
     expect((await Book.where({ status: ["published", "published"] }).first())?.id).toBe(book.id);
     expect((await Book.where({ status: ["written", "written"] }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: "published" }).first())?.id).not.toBe(book.id);
-    expect((await Book.whereNot({ status: "written" }).first())?.id).toBe(book.id);
+    expect((await Book.where().not({ status: "published" }).first())?.id).not.toBe(book.id);
+    expect((await Book.where().not({ status: "written" }).first())?.id).toBe(book.id);
     expect((await Book.where({ last_read: "forgotten" }).first())?.id).toBe(books("ddd").id);
     expect(await Book.where({ status: "prohibited" }).first()).toBeNull();
   });
@@ -181,7 +181,7 @@ describe("EnumTest", () => {
     const enabled = String((Book as any).boolean_statuses.enabled);
     expect((await Book.where({ boolean_status: enabled }).last())?.id).toBe(created.id);
     expect((await Book.where({ cover: "soft" }).first())?.id).toBe(books("awdr").id);
-    expect((await Book.whereNot({ cover: "hard" }).first())?.id).toBe(books("awdr").id);
+    expect((await Book.where().not({ cover: "hard" }).first())?.id).toBe(books("awdr").id);
   });
 
   it("build from scope", () => {

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -425,7 +425,7 @@ describe("FinderTest", () => {
         .or(Topic.where({ id: big }))
         .exists(),
     ).toBe(true);
-    expect(await Topic.whereNot({ id: big }).exists()).toBe(true);
+    expect(await Topic.where().not({ id: big }).exists()).toBe(true);
 
     // Rails' 3-arg `predicate_builder[:id, val, :gt/:gteq/:lt/:lteq]` builds an
     // Arel comparison node whose right-hand side is a bind attribute; we stand
@@ -458,7 +458,7 @@ describe("FinderTest", () => {
     expect(inRel.toSql()).toMatch(/IN \(NULL\)/);
     expect(await inRel.exists()).toBe(false);
 
-    const notInRel = Topic.whereNot({ id: [big, negBig] });
+    const notInRel = Topic.where().not({ id: [big, negBig] });
     expect(notInRel.toSql()).toMatch(/NOT IN \(NULL\)/);
     expect(await notInRel.exists()).toBe(false);
   });

--- a/packages/activerecord/src/forbidden-attributes-protection.test.ts
+++ b/packages/activerecord/src/forbidden-attributes-protection.test.ts
@@ -117,14 +117,14 @@ describe("ForbiddenAttributesProtectionTest", () => {
   it("where not checks permitted", () => {
     const params = new ProtectedParams({ first_name: "Guille", gender: "m" });
 
-    expect(() => Person.whereNot(params)).toThrow(ForbiddenAttributesError);
+    expect(() => Person.where().not(params)).toThrow(ForbiddenAttributesError);
   });
 
   it("where not works with permitted params", async () => {
     const params = new ProtectedParams({ first_name: "Guille" }).permitBang();
     await Person.createBang(params);
 
-    const remaining = (await Person.whereNot(params)).filter(
+    const remaining = (await Person.where().not(params)).filter(
       (p) => p.readAttribute("first_name") === "Guille",
     );
     expect(remaining).toHaveLength(0);

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -337,12 +337,15 @@ describe("Relation#where — composite-key form", () => {
   it("Base.whereNot(cols, tuples) routes through Relation#whereNot composite form", async () => {
     await CpkBook.create({ id: [1, 100], title: "exclude" });
     await CpkBook.create({ id: [2, 200], title: "keep" });
-    const matched = await (CpkBook as any).whereNot(["author_id", "id"], [[1, 100]]).toArray();
+    const matched = await (CpkBook as any)
+      .where()
+      .not(["author_id", "id"], [[1, 100]])
+      .toArray();
     expect(matched.map((r: any) => r.title)).toEqual(["keep"]);
   });
 
   it("Base.whereNot(single array arg) routes to the sanitized-conditions form, not composite", () => {
-    const sql = (CpkBook as any).whereNot(["author_id = 1"]).toSql();
+    const sql = (CpkBook as any).where().not(["author_id = 1"]).toSql();
     expect(sql).toMatch(/NOT \(author_id = 1\)/);
   });
 
@@ -354,7 +357,7 @@ describe("Relation#where — composite-key form", () => {
     expect(() => (CpkBook as any).all().whereNot(["author_id", 5], [[1, 2]])).toThrow(
       /wrong number of bind variables/,
     );
-    expect(() => (CpkBook as any).whereNot(["author_id", 5], [[1, 2]])).toThrow(
+    expect(() => (CpkBook as any).where().not(["author_id", 5], [[1, 2]])).toThrow(
       /wrong number of bind variables/,
     );
   });

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -110,7 +110,6 @@ describe("DelegationTest", () => {
     //     QUERYING_METHODS name) below — `withCte` is the same delegator.
     const QUERYING_METHODS = [
       "where",
-      "whereNot",
       "select",
       "reselect",
       "order",

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -127,7 +127,7 @@ describe("RelationMergingTest", () => {
     const mary = authors("mary");
     const bob = authors("bob");
 
-    const nonMaryAndBob = Author.whereNot({ id: [mary, bob] });
+    const nonMaryAndBob = Author.where().not({ id: [mary, bob] });
 
     expect(await ids(nonMaryAndBob)).toEqual([david.id]);
 
@@ -141,7 +141,9 @@ describe("RelationMergingTest", () => {
     const mary = authors("mary");
     const bob = authors("bob");
 
-    const lessThanBob = Author.whereNot({ id: new Range(bob.id, Infinity) }).order("id");
+    const lessThanBob = Author.where()
+      .not({ id: new Range(bob.id, Infinity) })
+      .order("id");
 
     expect(await ids(lessThanBob)).toEqual([david.id, mary.id]);
 
@@ -155,7 +157,7 @@ describe("RelationMergingTest", () => {
     const mary = authors("mary");
     const bob = authors("bob");
 
-    const nonMaryAndBob = Author.whereNot({ id: [mary, bob] });
+    const nonMaryAndBob = Author.where().not({ id: [mary, bob] });
 
     const authorId = quoteTableName("authors.id");
     await assertQueriesMatch(

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -43,6 +43,8 @@ import { foreignKey } from "@blazetrails/activesupport";
  */
 export interface WhereChainScope<R> {
   whereNot(conditions: Record<string, unknown>): R;
+  whereNot(conditions: unknown[]): R;
+  whereNot(cols: string[], tuples: unknown[][]): R;
   whereAssociated(...associationNames: string[]): R;
   whereMissing(...associationNames: string[]): R;
   exists(conditions?: unknown): Promise<boolean>;
@@ -61,7 +63,20 @@ export class WhereChain<R = any> {
     this._scope = scope;
   }
 
-  not(conditions: Record<string, unknown>): R {
+  not(conditions: Record<string, unknown>): R;
+  not(conditions: unknown[]): R;
+  not(cols: string[], tuples: unknown[][]): R;
+  not(conditions: Record<string, unknown> | unknown[], tuples?: unknown[][]): R {
+    // Rails' `not` forwards `*args` to `build_where_clause(...).invert`
+    // (query_methods.rb:49), so it accepts every shape `where` does — including
+    // the sanitized-conditions array and the trails composite-key
+    // `(cols, tuples)` pair.
+    if (tuples !== undefined) {
+      return this._scope.whereNot(conditions as string[], tuples);
+    }
+    if (Array.isArray(conditions)) {
+      return this._scope.whereNot(conditions);
+    }
     return this._scope.whereNot(conditions);
   }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -67,10 +67,6 @@ export class WhereChain<R = any> {
   not(conditions: unknown[]): R;
   not(cols: string[], tuples: unknown[][]): R;
   not(conditions: Record<string, unknown> | unknown[], tuples?: unknown[][]): R {
-    // Rails' `not` forwards `*args` to `build_where_clause(...).invert`
-    // (query_methods.rb:49), so it accepts every shape `where` does — including
-    // the sanitized-conditions array and the trails composite-key
-    // `(cols, tuples)` pair.
     if (tuples !== undefined) {
       return this._scope.whereNot(conditions as string[], tuples);
     }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1115,7 +1115,7 @@ function invertWhereBang(this: QueryMethodsHost): any {
  * catch it the same way they would catch Rails' ArgumentError
  * (`catch err if err.name === 'ArgumentError'`). Exported so other
  * modules (PredicateBuilder, Relation public methods, Base.where /
- * Base.whereNot, etc.) can raise the same shape without
+ * WhereChain#not, etc.) can raise the same shape without
  * re-declaring the helper.
  */
 export function argumentError(message: string): Error {

--- a/packages/activerecord/src/relation/where-chain.trails.test.ts
+++ b/packages/activerecord/src/relation/where-chain.trails.test.ts
@@ -69,7 +69,7 @@ describe("WhereChain not inversion shapes (trails)", () => {
   fixtures(["posts", "authors", "authorAddresses", "customers"]);
 
   it("inverts an array containing null as NOT (IN ... OR IS NULL)", async () => {
-    const relation = Post.whereNot({
+    const relation = Post.where().not({
       title: [null, "Welcome to the weblog", "So I was thinking"],
     });
     // Positive ArrayHandler shape `(title IN (...) OR title IS NULL)`, inverted
@@ -85,7 +85,7 @@ describe("WhereChain not inversion shapes (trails)", () => {
 
   it("inverts a multi-column aggregate group as one NOT over the AND group", async () => {
     const david = await Customer.find(1);
-    const relation = Customer.whereNot({ address: david.address });
+    const relation = Customer.where().not({ address: david.address });
     // expand_from_hash builds the three mapped-column equalities positively;
     // WhereClause#invert wraps them in a single NOT(...) group.
     expect(relation.toSql()).toMatch(
@@ -103,7 +103,9 @@ describe("WhereChain not inversion shapes (trails)", () => {
     // Arel builds `gteq(begin) AND lt(end)`; And has no invert override, so
     // Node#invert yields `NOT (id >= 1 AND id < 5)` — not a re-derived
     // `(id < 1 OR id >= 5)`.
-    const sql = Post.whereNot({ id: new Range(1, 5, true) }).toSql();
+    const sql = Post.where()
+      .not({ id: new Range(1, 5, true) })
+      .toSql();
     expect(sql).toMatch(/NOT \(.*id.*>=.*AND.*id.*<.*\)/is);
   });
 
@@ -111,7 +113,7 @@ describe("WhereChain not inversion shapes (trails)", () => {
     // Rails WhereChain#not routes through build_where_clause (query_methods.rb:49),
     // which resolves alias_attribute keys before expand_from_hash — so
     // `where.not(newName: ...)` lands on the real `name` column, inverted.
-    const sql = Company.whereNot({ newName: "37signals" }).toSql();
+    const sql = Company.where().not({ newName: "37signals" }).toSql();
     expect(sql).toMatch(/["`]name["`]\s*!=/);
     expect(sql).not.toMatch(/newName/);
   });

--- a/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
+++ b/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
@@ -25,7 +25,7 @@ describe("where value defer-to-bind casting", () => {
   it("whereNot with an un-castable string binds it instead of IS NOT NULL", async () => {
     const first = topics("first");
     await first.update({ parent_id: 0 });
-    const rel = Topic.whereNot({ parent_id: "not-a-number" });
+    const rel = Topic.where().not({ parent_id: "not-a-number" });
     expect(rel.toSql()).not.toMatch(/IS NOT NULL/i);
     // `parent_id != NULL` matches nothing — including rows whose parent_id IS NULL.
     expect(await rel).toHaveLength(0);

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -308,7 +308,7 @@ describe("WhereTest", () => {
 
   it("where not polymorphic association", async () => {
     const sapphire = treasures("sapphire") as any;
-    const actual = await PriceEstimate.whereNot({ estimateOf: sapphire });
+    const actual = await PriceEstimate.where().not({ estimateOf: sapphire });
     const only = await PriceEstimate.where({ estimateOf: sapphire });
 
     const sapphireEstimateIds = [
@@ -327,7 +327,7 @@ describe("WhereTest", () => {
 
   it("where not polymorphic id and type as nand", async () => {
     const sapphire = treasures("sapphire") as any;
-    const actual = await PriceEstimate.whereNot({
+    const actual = await PriceEstimate.where().not({
       estimate_of_type: "Treasure",
       estimate_of_id: sapphire.id,
     });
@@ -382,7 +382,7 @@ describe("WhereTest", () => {
   it("polymorphic nested array where not", async () => {
     const treasure = treasures("diamond") as any;
     const car = cars("honda") as any;
-    const actual = await PriceEstimate.whereNot({ estimateOf: [treasure, car] });
+    const actual = await PriceEstimate.where().not({ estimateOf: [treasure, car] });
     const expected = [
       (priceEstimates("sapphire_1") as any).id,
       (priceEstimates("sapphire_2") as any).id,

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -376,15 +376,17 @@ describe("DefaultScopingTest", () => {
 
     const expected4 = names(await Developer.order("salary DESC"));
     const received4 = names(
-      await DeveloperOrderedBySalary.whereNot({ name: "Jamis" }).unscope({ where: "name" }),
+      await DeveloperOrderedBySalary.where().not({ name: "Jamis" }).unscope({ where: "name" }),
     );
     expect(received4.sort()).toEqual(expected4.sort());
 
     const expected5 = names(await Developer.order("salary DESC"));
     const received5 = names(
-      await DeveloperOrderedBySalary.whereNot({ name: ["Jamis", "David"] }).unscope({
-        where: "name",
-      }),
+      await DeveloperOrderedBySalary.where()
+        .not({ name: ["Jamis", "David"] })
+        .unscope({
+          where: "name",
+        }),
     );
     expect(received5.sort()).toEqual(expected5.sort());
 

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -332,7 +332,7 @@ describe("TransactionTest", () => {
   it("transaction does not apply default scope", async () => {
     // Regression test for https://github.com/rails/rails/issues/50368
     const topic = (await Topic.find((topics("fifth") as any).id)) as any;
-    await (Topic.whereNot({ id: topic.id }) as any).transaction(async () => {
+    await (Topic.where().not({ id: topic.id }) as any).transaction(async () => {
       expect(await Topic.find(topic.id)).not.toBeNull();
     });
   });

--- a/scripts/parity/fixtures/ar-06/query.ts
+++ b/scripts/parity/fixtures/ar-06/query.ts
@@ -1,3 +1,3 @@
 import { Customer } from "./models.js";
 
-export default Customer.whereNot({ orders_count: [1, 3, 5] });
+export default Customer.where().not({ orders_count: [1, 3, 5] });

--- a/scripts/parity/fixtures/ar-09/query.ts
+++ b/scripts/parity/fixtures/ar-09/query.ts
@@ -1,3 +1,3 @@
 import { User } from "./models.js";
 
-export default User.whereNot({ tall: true });
+export default User.where().not({ tall: true });

--- a/scripts/parity/fixtures/ar-123/query.ts
+++ b/scripts/parity/fixtures/ar-123/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.whereNot({ author_id: null });
+export default Book.where().not({ author_id: null });

--- a/scripts/parity/fixtures/ar-18/query.ts
+++ b/scripts/parity/fixtures/ar-18/query.ts
@@ -1,3 +1,3 @@
 import { User, Comment } from "./models.js";
 
-export default User.whereNot({ id: Comment.select("user_id").distinct() });
+export default User.where().not({ id: Comment.select("user_id").distinct() });

--- a/scripts/parity/fixtures/ar-49/query.ts
+++ b/scripts/parity/fixtures/ar-49/query.ts
@@ -1,3 +1,3 @@
 import { Customer } from "./models.js";
 
-export default Customer.whereNot({ last_name: null });
+export default Customer.where().not({ last_name: null });

--- a/scripts/parity/fixtures/ar-53/query.ts
+++ b/scripts/parity/fixtures/ar-53/query.ts
@@ -1,3 +1,3 @@
 import { Customer } from "./models.js";
 
-export default Customer.whereNot({ last_name: null }).whereNot({ email: null });
+export default Customer.where().not({ last_name: null }).whereNot({ email: null });

--- a/scripts/parity/fixtures/ar-73/query.ts
+++ b/scripts/parity/fixtures/ar-73/query.ts
@@ -1,4 +1,4 @@
 import { Range } from "@blazetrails/activerecord";
 import { Book } from "./models.js";
 
-export default Book.whereNot({ id: new Range(1, 5) });
+export default Book.where().not({ id: new Range(1, 5) });

--- a/scripts/parity/fixtures/ar-98/query.ts
+++ b/scripts/parity/fixtures/ar-98/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.whereNot({ status: "draft", active: false });
+export default Book.where().not({ status: "draft", active: false });


### PR DESCRIPTION
Rails has no `Model.where_not` — negation is reached through the zero-argument
`where`, which returns a `WhereChain`, with `not` defined on that chain
(`activerecord/lib/active_record/relation/query_methods.rb:49`).
`grep -rn "def where_not" vendor/rails` returns nothing.

trails already had the faithful form on `Relation` (`relation.ts:543-544` gives
`where()` a zero-arg `WhereChain` overload); `Base` was missing the delegation,
which is why the flattened `Base.whereNot` was invented.

## What changed

- `Base.where()` gains the zero-argument `WhereChain` overload, mirroring
  `Relation#where`, so `Model.where().not(...)` works at the class level as
  Rails' `Model.where.not(...)` does.
- `Base.whereNot` is retired; its class-level call sites migrate to
  `.where().not(...)` (including the 8 `scripts/parity` fixtures and the
  activerecord dx-tests).
- `WhereChain#not` gains the sanitized-conditions array and composite-key
  `(cols, tuples)` overloads it needs to carry those call sites. Rails' `not`
  forwards `*args` to `build_where_clause(...).invert`, so it already accepts
  every shape `where` does.
- `delegation.test.ts`'s `QUERYING_METHODS` sweep drops its `whereNot` entry:
  Rails' `QUERYING_METHODS` (`querying.rb:16`) lists `:where` but has no
  `:where_not`, so the entry was part of the same invention.
- `Relation#whereNot` is untouched (out of scope for this story).

No test names changed — only call sites inside them.

## Extra surface

`packages/activerecord/src/base.ts`: **19 novel → 18 novel** (146 moved,
unchanged). `whereNot` no longer appears in the base.ts novel list.

`pnpm api:calls:wide` re-run: ratchet OK (2281 baselined, 2101 unreviewed,
mark 2101 tight) — unchanged. Arity mismatches: 80, none in `WhereChain`.

Closes-story: converge-base-where-not-to-where-chain
