### PR TITLE
refactor(activerecord): converge attributeSetCoder/hasAttributeDefinition onto Rails names

### DIFF
--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -182,7 +182,7 @@ describe("AttributeMethodsTest", () => {
 
   it("attribute_method? returns false if the table does not exist", async () => {
     class Ghost extends Base {}
-    expect(Ghost.hasAttributeDefinition("nonexistent")).toBe(false);
+    expect(Ghost.hasAttribute("nonexistent")).toBe(false);
   });
 
   it("typecast attribute from select to false", async () => {
@@ -242,8 +242,8 @@ describe("AttributeMethodsTest", () => {
         this.attribute("breed", "string");
       }
     }
-    expect(Dog.hasAttributeDefinition("name")).toBe(true);
-    expect(Dog.hasAttributeDefinition("breed")).toBe(true);
+    expect(Dog.hasAttribute("name")).toBe(true);
+    expect(Dog.hasAttribute("breed")).toBe(true);
   });
 
   function makeModel() {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -625,7 +625,7 @@ describe("BasicsTest", () => {
     }
     Animal.tableName = "animals";
     expect(Animal.tableName).toBe("animals");
-    expect(Animal.hasAttributeDefinition("type")).toBe(true);
+    expect(Animal.hasAttribute("type")).toBe(true);
   });
 
   it("resetting column information doesn't remove attribute methods", () => {
@@ -634,7 +634,7 @@ describe("BasicsTest", () => {
         this.attribute("title", "string");
       }
     }
-    expect(Post.hasAttributeDefinition("title")).toBe(true);
+    expect(Post.hasAttribute("title")).toBe(true);
   });
 
   it("ignored columns don't prevent explicit declaration of attribute methods", () => {
@@ -644,8 +644,8 @@ describe("BasicsTest", () => {
         this.attribute("internal_flag", "boolean");
       }
     }
-    expect(Post.hasAttributeDefinition("title")).toBe(true);
-    expect(Post.hasAttributeDefinition("internal_flag")).toBe(true);
+    expect(Post.hasAttribute("title")).toBe(true);
+    expect(Post.hasAttribute("internal_flag")).toBe(true);
   });
 
   it("ignored columns not included in SELECT", async () => {
@@ -1878,8 +1878,8 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(User.hasAttributeDefinition("name")).toBe(true);
-    expect(User.hasAttributeDefinition("nonexistent")).toBe(false);
+    expect(User.hasAttribute("name")).toBe(true);
+    expect(User.hasAttribute("nonexistent")).toBe(false);
   });
 
   it("no limit offset", () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -121,6 +121,7 @@ import {
   beforeOrAroundCallbackSources,
   sanitizeForMassAssignment,
   isMassAssignmentEmpty,
+  resolveAliasNameIn,
 } from "@blazetrails/activemodel";
 import { SignedGlobalID as _SignedGlobalIDCtor } from "@blazetrails/globalid/signed-global-id";
 import * as Inheritance from "./inheritance.js";
@@ -1589,7 +1590,6 @@ export class Base extends Model {
 
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods
   declare static columnNames: typeof ModelSchema.columnNames;
-  declare static hasAttributeDefinition: typeof ModelSchema.hasAttributeDefinition;
   declare static columnsHash: typeof ModelSchema.columnsHash;
   declare static contentColumns: typeof ModelSchema.contentColumns;
   declare static quotedTableName: typeof ModelSchema.quotedTableName;
@@ -1601,7 +1601,7 @@ export class Base extends Model {
   declare static nextSequenceValue: typeof ModelSchema.nextSequenceValue;
   declare static attributesBuilder: typeof ModelSchema.attributesBuilder;
   declare static columns: typeof ModelSchema.columns;
-  declare static attributeSetCoder: typeof ModelSchema.attributeSetCoder;
+  declare static yamlEncoder: typeof ModelSchema.yamlEncoder;
   declare static columnForAttribute: typeof ModelSchema.columnForAttribute;
   declare static symbolColumnToString: typeof ModelSchema.symbolColumnToString;
   declare static resetColumnInformation: typeof ModelSchema.resetColumnInformation;
@@ -4621,7 +4621,10 @@ export class Base extends Model {
   }
 
   static hasAttribute(name: string): boolean {
-    return this.hasAttributeDefinition(name);
+    // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
+    // (attribute_methods.rb:256) before checking `attribute_types`.
+    const defs = this._attributeDefinitions;
+    return defs.has(resolveAliasNameIn(this as never, defs, String(name)));
   }
 
   // --- TokenFor instance methods (token-for.ts, wired at runtime via generatesTokenFor) ---

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,7 +1,6 @@
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
-import { resolveAliasNameIn } from "@blazetrails/activemodel";
 import {
   Attribute,
   AttributeSetBuilder,
@@ -286,19 +285,6 @@ export function columnNames(this: typeof Base): string[] {
     return frozen as string[];
   }
   return names;
-}
-
-/**
- * Check if a model class has a given attribute defined. Backs the Rails-named
- * public accessor `Base.hasAttribute` (Rails' `has_attribute?`, attribute_methods.rb).
- *
- * @internal
- */
-export function hasAttributeDefinition(this: typeof Base, name: string): boolean {
-  // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
-  // (attribute_methods.rb:256) before checking `attribute_types`.
-  const defs = this._attributeDefinitions;
-  return defs.has(resolveAliasNameIn(this as never, defs, String(name)));
 }
 
 /**
@@ -784,8 +770,14 @@ export function columns(this: SchemaHost): any[] {
   return this._columns;
 }
 
-/** @internal */
-export function attributeSetCoder(this: SchemaHost): AttributeSetCoder {
+/**
+ * Rails: `@yaml_encoder ||= ActiveModel::AttributeSet::YAMLEncoder.new(attribute_types)`
+ * (model_schema.rb:446). trails' coder is codec-agnostic (JSON by default) rather
+ * than YAML-only, but the accessor keeps the Rails name.
+ *
+ * @internal
+ */
+export function yamlEncoder(this: SchemaHost): AttributeSetCoder {
   return new AttributeSetCoder(typeRegistry);
 }
 
@@ -1560,7 +1552,6 @@ export async function tableExists(this: SchemaHost): Promise<boolean> {
 export const ClassMethods = {
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods
   columnNames,
-  hasAttributeDefinition,
   columnsHash,
   contentColumns,
   createTable,
@@ -1573,18 +1564,13 @@ export const ClassMethods = {
   nextSequenceValue,
   attributesBuilder,
   columns,
-  attributeSetCoder,
+  yamlEncoder,
   columnForAttribute,
   symbolColumnToString,
   resetColumnInformation,
   _returningColumnsForInsert,
   loadSchemaFromAdapter,
 };
-
-/** @internal */
-function yamlEncoder(this: SchemaHost): AttributeSetCoder {
-  return attributeSetCoder.call(this);
-}
 
 /** @internal */
 function initializeLoadSchemaMonitor(this: SchemaHost): void {


### PR DESCRIPTION
Converges the two `base.ts` re-declared internal helpers flagged as category (c)
renames.

**`attributeSetCoder` → `yamlEncoder`** — Rails names this `yaml_encoder`
(`model_schema.rb:446`). The tree carried both spellings: the implementation as
`attributeSetCoder` (model-schema.ts:788) plus a private `yamlEncoder` alias
(model-schema.ts:1585). Kept exactly one, the Rails one; the non-YAML nature of
trails' codec-agnostic coder is now a comment at the definition rather than a
rename.

**`hasAttributeDefinition` → folded into `hasAttribute`** — Rails writes this as
one method (`has_attribute?`, `attribute_methods.rb:256`). The helper body moved
into `Base.hasAttribute`, and the extra name is gone.

Test call sites updated (no test names changed).

`pnpm api:extra --package activerecord --novel-only`, `base.ts`:
- before: 19 novel
- after: 17 novel (`attributeSetCoder`, `hasAttributeDefinition` both gone)

`pnpm api:calls:wide`: OK (2273 baselined, 2093 unreviewed) — no baseline drift.

Closes-story: converge-model-schema-coder-and-attribute-definition-names
