### PR TITLE
refactor(associations): drop the singular no-reflection load fallback

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2382,22 +2382,6 @@ describe("AssociationsTest", () => {
     expect(comments.map((c) => (c as any).body).sort()).toEqual(["A", "B"]);
   });
 
-  // Same no-reflection fallback path as the has_many case above, through loadHasOne.
-  it("has one loads via inline fallback resolving composite owner key from query constraints", async () => {
-    const post = await ShardedBlogPost.create({ blog_id: 7, title: "Post" });
-    await ShardedComment.create({ blog_id: 7, blog_post_id: (post as any).id, body: "Only" });
-    const comment = await findTarget(
-      post,
-      "freshComment",
-      {
-        className: "ShardedComment",
-        foreignKey: ["blog_id", "blog_post_id"],
-      },
-      "hasOne",
-    );
-    expect((comment as any)?.body).toBe("Only");
-  });
-
   // Exercises the inline (no-reflection) fallback against a composite-PK owner
   // WITHOUT query_constraints (CpkOrder's PK is `[shop_id, id]`). Invoked with a
   // scalar FK and an unregistered association name, the fallback must collapse
@@ -2415,23 +2399,6 @@ describe("AssociationsTest", () => {
     });
     expect(agreements).toHaveLength(2);
     expect(agreements.map((a) => (a as any).signature).sort()).toEqual(["abc", "def"]);
-  });
-
-  // Same no-reflection fallback path as above, through loadHasOne.
-  it("has one loads via inline fallback resolving composite owner key as id attribute", async () => {
-    const order = await CpkOrder.create({ shop_id: 1 });
-    const [, orderId] = order.id as [number, number];
-    await CpkOrderAgreement.create({ order_id: orderId, signature: "only" });
-    const agreement = await findTarget(
-      order,
-      "freshAgreement",
-      {
-        className: "CpkOrderAgreement",
-        foreignKey: "order_id",
-      },
-      "hasOne",
-    );
-    expect((agreement as any)?.signature).toBe("only");
   });
 
   // The inline (no-reflection) fallback must build from
@@ -2483,34 +2450,6 @@ describe("AssociationsTest", () => {
       as: "parent",
     });
     expect(children.map((c) => (c as any).title)).toEqual(["match"]);
-  });
-
-  // Same no-reflection polymorphic fallback path as above, through loadHasOne.
-  it("has one loads via inline fallback resolving polymorphic owner key from query constraints", async () => {
-    const post = await ShardedBlogPost.create({ blog_id: 7, title: "Parent" });
-    const pid = (post as any).id;
-    await ShardedBlogPost.create({
-      blog_id: 7,
-      parent_id: pid,
-      parent_type: "ShardedBlogPost",
-      title: "match",
-    });
-    await ShardedBlogPost.create({
-      blog_id: 9,
-      parent_id: pid,
-      parent_type: "ShardedBlogPost",
-      title: "wrongShard",
-    });
-    const child = await findTarget(
-      post,
-      "freshChild",
-      {
-        className: "ShardedBlogPost",
-        as: "parent",
-      },
-      "hasOne",
-    );
-    expect((child as any)?.title).toBe("match");
   });
 
   // `buildHasManyRelation` (the seeded scope behind CollectionProxy /

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -4,8 +4,6 @@ import {
   _builtAssociationScope,
   _canRouteThroughViaDisableJoinsAssociationScope,
   _findTargetReachable,
-  _inlineOwnerKey,
-  _inlinePolymorphicKeys,
   _loadSingularThroughViaDisableJoinsScope,
   _ownerChainReflection,
   _routeThroughViaAssociationScope,
@@ -23,12 +21,11 @@ import {
 } from "../associations.js";
 import { Association } from "./association.js";
 import { ownerForeignKeyColumns } from "./foreign-association.js";
-import { CompositePrimaryKeyMismatchError } from "./errors.js";
+import { AssociationNotFoundError, CompositePrimaryKeyMismatchError } from "./errors.js";
 import {
   routeThroughCheckValidity,
   validateThroughReflection,
 } from "./validate-through-reflection.js";
-import { polymorphicName } from "../inheritance.js";
 import { camelize, underscore } from "@blazetrails/activesupport";
 import { strictLoadingViolationBang } from "../core.js";
 import { RecordInvalid } from "../validations.js";
@@ -399,8 +396,6 @@ async function _findBelongsToTarget(
   }
 
   const ctor = record.constructor as typeof Base;
-  const defaultFk = `${underscore(assocName)}_id`;
-
   // Polymorphic: use the _type column to determine the target model
   let targetModel: typeof Base;
   if (options.polymorphic) {
@@ -420,36 +415,24 @@ async function _findBelongsToTarget(
     validateInverseOf(targetModel, assocName, options.inverseOf);
   }
 
-  // Resolve foreign key and primary key (may be arrays for CPK).
-  const foreignKey =
-    options.foreignKey ??
-    (options.queryConstraints
-      ? options.queryConstraints
-      : Array.isArray(targetModel.primaryKey) && !options.primaryKey
-        ? targetModel.primaryKey.map((col: string) => `${underscore(assocName)}_${col}`)
-        : defaultFk);
-  const primaryKey = options.primaryKey ?? targetModel.primaryKey;
-
-  // Route through AssociationScope when reflection is registered.
   // For polymorphic belongsTo, AssociationScope receives the
   // runtime-resolved klass; the reflection's own joinPrimaryKey
   // returns associationPrimaryKey (target's PK) and joinForeignKey
   // returns the owner-side FK, so the WHERE shape is identical to
   // the non-polymorphic case.
   const reflection = ctor._reflectOnAssociation?.(assocName);
+  // Rails constructs an Association from a validated reflection
+  // (association.rb:41-45); a name the model never declared raises from
+  // `association` (associations.rb:56) long before any load runs.
+  if (!reflection) throw new AssociationNotFoundError(record, assocName);
   // Null-FK short-circuit: avoid a query when owner's FK column is null.
   // The check must read the SAME columns the eventual query uses —
-  // reflection.joinForeignKey when routing through AssociationScope,
-  // options-derived foreignKey otherwise. Reading from a different
-  // column would silently return null while a real query would have
-  // found the row (or vice versa).
-  const fkColsForCheck = reflection
-    ? Array.isArray(reflection.joinForeignKey)
-      ? reflection.joinForeignKey
-      : [reflection.joinForeignKey]
-    : Array.isArray(foreignKey)
-      ? foreignKey
-      : [foreignKey];
+  // reflection.joinForeignKey. Reading from a different column would
+  // silently return null while a real query would have found the row (or
+  // vice versa).
+  const fkColsForCheck = Array.isArray(reflection.joinForeignKey)
+    ? reflection.joinForeignKey
+    : [reflection.joinForeignKey];
   for (const fk of fkColsForCheck) {
     const v = record._readAttribute(fk);
     if (v === null || v === undefined) return null;
@@ -464,49 +447,21 @@ async function _findBelongsToTarget(
   const staleSnapshot = staleCols.map((col) => record._readAttribute(col));
 
   let result: Base | null;
-  if (reflection) {
-    if (!_skipSingularStatementCache(reflection, targetModel, options)) {
-      // Statement-cache path (Rails `Association#find_target` via
-      // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
-      result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
-    } else {
-      const built = _builtAssociationScope(record, assocName, reflection, targetModel);
-      const baseRelation = _scopeForAssociation(targetModel);
-      let rel = baseRelation.merge(built);
-      rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
-      // Rails' normal singular-load path (`Association#find_target` via the
-      // statement cache) returns an array and calls `Array#first` — no ORDER BY
-      // in SQL. `take` (unordered LIMIT 1) is the closest equivalent; `first`
-      // would route through `ordered_relation` and add a spurious ORDER BY. See
-      // has_one_associations_test `test_has_one_does_not_use_order_by`.
-      result = await rel.take();
-    }
+  if (!_skipSingularStatementCache(reflection, targetModel, options)) {
+    // Statement-cache path (Rails `Association#find_target` via
+    // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
+    result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
   } else {
-    // Inline fallback: no reflection registered.
-    if (Array.isArray(foreignKey)) {
-      const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
-      if (pkCols.length !== foreignKey.length) {
-        // Route through the reflection's canonical checkValidityBang (Rails'
-        // single raise site) so the error carries the Rails-faithful message.
-        routeThroughCheckValidity(ctor, assocName);
-        // No reflection registered (lower-level test helper) — minimal guard.
-        throw new CompositePrimaryKeyMismatchError({
-          activeRecord: ctor.name,
-          name: assocName,
-          primaryKey: pkCols,
-          foreignKey,
-        });
-      }
-      const conditions: Record<string, unknown> = {};
-      for (let i = 0; i < foreignKey.length; i++) {
-        conditions[pkCols[i]] = record._readAttribute(foreignKey[i]);
-      }
-      result = await targetModel.findBy(conditions);
-    } else {
-      result = await targetModel.findBy({
-        [primaryKey as string]: record._readAttribute(foreignKey),
-      });
-    }
+    const built = _builtAssociationScope(record, assocName, reflection, targetModel);
+    const baseRelation = _scopeForAssociation(targetModel);
+    let rel = baseRelation.merge(built);
+    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
+    // Rails' normal singular-load path (`Association#find_target` via the
+    // statement cache) returns an array and calls `Array#first` — no ORDER BY
+    // in SQL. `take` (unordered LIMIT 1) is the closest equivalent; `first`
+    // would route through `ordered_relation` and add a spurious ORDER BY. See
+    // has_one_associations_test `test_has_one_does_not_use_order_by`.
+    result = await rel.take();
   }
 
   // Rails' `find_target` is synchronous, so it never observes the owner's
@@ -636,6 +591,10 @@ async function _findHasOneTarget(
   // in a single Rails-faithful path). reflection.isCollection() === false
   // for hasOne, so AssociationScope.scope adds limit(1) automatically.
   const reflection = ctor._reflectOnAssociation?.(assocName);
+  // Rails constructs an Association from a validated reflection
+  // (association.rb:41-45); a name the model never declared raises from
+  // `association` (associations.rb:56) long before any load runs.
+  if (!reflection) throw new AssociationNotFoundError(record, assocName);
   // Null-PK short-circuit: read the SAME columns the eventual query
   // reads. For non-through, reflection.joinForeignKey is the owner-
   // side activeRecordPrimaryKey for hasOne. For through reflections the
@@ -654,68 +613,18 @@ async function _findHasOneTarget(
   }
 
   let result: Base | null;
-  if (reflection) {
-    if (!_skipSingularStatementCache(reflection, targetModel, options)) {
-      // Statement-cache path (Rails `Association#find_target` via
-      // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
-      result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
-    } else {
-      const built = _builtAssociationScope(record, assocName, reflection, targetModel);
-      const baseRelation = _scopeForAssociation(targetModel);
-      let rel = baseRelation.merge(built);
-      rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
-      // Unordered LIMIT 1: Rails' singular load returns an array and calls
-      // `Array#first`, emitting no ORDER BY. `take` matches; `first` would add one.
-      result = await rel.take();
-    }
+  if (!_skipSingularStatementCache(reflection, targetModel, options)) {
+    // Statement-cache path (Rails `Association#find_target` via
+    // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
+    result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
   } else {
-    // Inline fallback: no reflection registered.
-    if (Array.isArray(foreignKey)) {
-      const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
-      const pkCols = Array.isArray(ownerKey) ? ownerKey : [ownerKey];
-      if (pkCols.length !== foreignKey.length) {
-        // Route through the reflection's canonical checkValidityBang (Rails'
-        // single raise site) so the error carries the Rails-faithful message.
-        routeThroughCheckValidity(ctor, assocName);
-        // No reflection registered (lower-level test helper) — minimal guard.
-        throw new CompositePrimaryKeyMismatchError({
-          activeRecord: ctor.name,
-          name: assocName,
-          primaryKey: pkCols,
-          foreignKey,
-        });
-      }
-      const conditions: Record<string, unknown> = {};
-      for (let i = 0; i < foreignKey.length; i++) {
-        conditions[foreignKey[i]] = record._readAttribute(pkCols[i]);
-      }
-      result = await targetModel.findBy(conditions);
-    } else if (options.as) {
-      const typeCol = `${underscore(options.as)}_type`;
-      const { fkCols, ownerKeyCols } = _inlinePolymorphicKeys(
-        ctor,
-        options,
-        primaryKey,
-        foreignKey,
-      );
-      const conditions: Record<string, unknown> = { [typeCol]: polymorphicName(ctor) };
-      for (let i = 0; i < fkCols.length; i++) {
-        conditions[fkCols[i]] = record._readAttribute(ownerKeyCols[i]);
-      }
-      result = await targetModel.findBy(conditions);
-    } else if (options.scope) {
-      const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
-      let rel = targetModel
-        .all()
-        .where({ [foreignKey]: record._readAttribute(ownerKey as string) });
-      rel = applyAssociationScope(rel, options.scope, record);
-      result = await rel.take();
-    } else {
-      const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
-      result = await targetModel.findBy({
-        [foreignKey]: record._readAttribute(ownerKey as string),
-      });
-    }
+    const built = _builtAssociationScope(record, assocName, reflection, targetModel);
+    const baseRelation = _scopeForAssociation(targetModel);
+    let rel = baseRelation.merge(built);
+    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
+    // Unordered LIMIT 1: Rails' singular load returns an array and calls
+    // `Array#first`, emitting no ORDER BY. `take` matches; `first` would add one.
+    result = await rel.take();
   }
 
   // Set inverse_of: store reference back to the owner. Resolve via the

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -396,6 +396,9 @@ async function _findBelongsToTarget(
   }
 
   const ctor = record.constructor as typeof Base;
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  if (!reflection) throw new AssociationNotFoundError(record, assocName);
+
   // Polymorphic: use the _type column to determine the target model
   let targetModel: typeof Base;
   if (options.polymorphic) {
@@ -420,11 +423,6 @@ async function _findBelongsToTarget(
   // returns associationPrimaryKey (target's PK) and joinForeignKey
   // returns the owner-side FK, so the WHERE shape is identical to
   // the non-polymorphic case.
-  const reflection = ctor._reflectOnAssociation?.(assocName);
-  // Rails constructs an Association from a validated reflection
-  // (association.rb:41-45); a name the model never declared raises from
-  // `association` (associations.rb:56) long before any load runs.
-  if (!reflection) throw new AssociationNotFoundError(record, assocName);
   // Null-FK short-circuit: avoid a query when owner's FK column is null.
   // The check must read the SAME columns the eventual query uses —
   // reflection.joinForeignKey. Reading from a different column would
@@ -543,6 +541,9 @@ async function _findHasOneTarget(
   }
 
   const ctor = record.constructor as typeof Base;
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  if (!reflection) throw new AssociationNotFoundError(record, assocName);
+
   const className = options.className ?? camelize(assocName);
   const primaryKey = options.primaryKey ?? ctor.primaryKey;
 
@@ -565,7 +566,6 @@ async function _findHasOneTarget(
       // single raise site) so the error carries the Rails-faithful message;
       // a no-op for polymorphic `:as` (Rails permits no composite key there).
       routeThroughCheckValidity(ctor, assocName);
-      // No reflection resolvable — minimal trails-only fallback guard.
       throw new CompositePrimaryKeyMismatchError({
         activeRecord: ctor.name,
         name: assocName,
@@ -578,7 +578,6 @@ async function _findHasOneTarget(
       // single raise site) so the error carries the Rails-faithful message;
       // a no-op for polymorphic `:as` (Rails permits no composite key there).
       routeThroughCheckValidity(ctor, assocName);
-      // No reflection resolvable — minimal trails-only fallback guard.
       throw new CompositePrimaryKeyMismatchError({
         activeRecord: ctor.name,
         name: assocName,
@@ -590,11 +589,6 @@ async function _findHasOneTarget(
   // Route through AssociationScope (handles scalar, composite, :as, STI
   // in a single Rails-faithful path). reflection.isCollection() === false
   // for hasOne, so AssociationScope.scope adds limit(1) automatically.
-  const reflection = ctor._reflectOnAssociation?.(assocName);
-  // Rails constructs an Association from a validated reflection
-  // (association.rb:41-45); a name the model never declared raises from
-  // `association` (associations.rb:56) long before any load runs.
-  if (!reflection) throw new AssociationNotFoundError(record, assocName);
   // Null-PK short-circuit: read the SAME columns the eventual query
   // reads. For non-through, reflection.joinForeignKey is the owner-
   // side activeRecordPrimaryKey for hasOne. For through reflections the
@@ -642,7 +636,10 @@ async function _findHasOneTarget(
  * Loads a singular association's target.
  *
  * Mirrors: ActiveRecord::Associations::SingularAssociation#find_target
- * (`singular_association.rb:47`).
+ * (`singular_association.rb:47`). Like Rails, which builds an `Association`
+ * from a validated reflection (`association.rb:41-45`), an association name the
+ * model never declared raises `AssociationNotFoundError` (`associations.rb:56`)
+ * before any load runs.
  *
  * DEVIATION: Rails' `find_target(async: false)` takes no macro parameter and
  * has no dispatcher layer — it is the loader body itself, and

--- a/packages/activerecord/src/associations/singular-find-target-undeclared.trails.test.ts
+++ b/packages/activerecord/src/associations/singular-find-target-undeclared.trails.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Trails-only surface: `findTarget` is an engine function callers reach with a
+ * bare association name, where Rails reaches `SingularAssociation#find_target`
+ * only as a method on an `Association` already built from a validated
+ * reflection (`association.rb:41-45`). A name the model never declared raises
+ * `AssociationNotFoundError` from `association` (`associations.rb:56`) in Rails,
+ * so the engine entry point has to raise the same error rather than rebuilding a
+ * WHERE clause from raw options. No verbatim Rails test mirrors this, because in
+ * Rails the loader is unreachable for an undeclared name.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { AssociationNotFoundError } from "./errors.js";
+import { findTarget } from "./singular-association.js";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Author } from "../test-helpers/models/author.js";
+
+describe("SingularAssociation#findTarget — undeclared association name", () => {
+  const { posts } = fixtures(["posts", "authors"]);
+
+  beforeAll(() => {
+    registerModel(Post);
+    registerModel(Author);
+  });
+
+  it("raises AssociationNotFoundError for a belongs_to name with no reflection", async () => {
+    const post = posts("welcome");
+    await expect(
+      findTarget(post, "undeclaredAuthor", { className: "Author" }, "belongsTo"),
+    ).rejects.toThrow(AssociationNotFoundError);
+  });
+
+  it("raises AssociationNotFoundError for a has_one name with no reflection", async () => {
+    const post = posts("welcome");
+    await expect(
+      findTarget(post, "undeclaredComment", { className: "Comment" }, "hasOne"),
+    ).rejects.toThrow(AssociationNotFoundError);
+  });
+});


### PR DESCRIPTION
Rails constructs an `Association` from a validated reflection
(`association.rb:41-45`), so a name the model never declared raises
`AssociationNotFoundError` from `association` (`associations.rb:56`) long before
any load runs. trails' singular loaders instead carried a no-reflection fallback
that rebuilt a WHERE clause from raw `options`.

**Reachability, by instrumentation** — both fallbacks were instrumented per
branch and the association + strict-loading suites run (94 files, 2196 tests):

| branch | live entries |
| --- | --- |
| belongs_to composite | none |
| belongs_to scalar | none |
| has_one composite | `ShardedBlogPost#freshComment` |
| has_one polymorphic `as` | `ShardedBlogPost#freshChild` |
| has_one `scope` | none |
| has_one scalar | `CpkOrder#freshAgreement` |

Every live entry comes from a trails-invented test that calls `findTarget`
directly with an undeclared name, for the sole purpose of covering the fallback.
Those three tests are removed with it rather than converted: `fresh_comment` /
`fresh_child` / `fresh_agreement` have no Rails counterpart, so declaring them on
the canonical models would invent associations Rails does not have. Their
`findHasManyTarget` siblings remain and still cover the shared `_inlineOwnerKey`
/ `_inlinePolymorphicKeys` helpers (the has_many fallback is out of scope here).

Both loaders now raise `AssociationNotFoundError` at the top, before any of the
loader body runs — Rails raises from `association` itself, and raising later
would let the has_one polymorphic `:as` composite-key guard throw
`CompositePrimaryKeyMismatchError` for an undeclared name instead. The
downstream `reflection ? ... : options-derived` branching collapses with the
fallback.

Both raises are covered by `singular-find-target-undeclared.trails.test.ts`
(trails-only: in Rails the loader is unreachable for an undeclared name). Both
new tests fail against `origin/main`.

Association and strict-loading suites pass (2195 tests), as do the adjacent
suites that call `loadHasOne` / `loadBelongsTo` (1223 tests). No test renames.
`api:extra` reports 0 novel surface for the file; no new call-mismatch entries.

Note: this file also changes in #5911 (still open); whichever lands second
rebases.

Closes-story: drop-singular-no-reflection-fallback
