### PR TITLE
refactor(activerecord): route excluding's deferred arm through the predicate builder's table

### DIFF
--- a/packages/activerecord/src/excluding.trails.test.ts
+++ b/packages/activerecord/src/excluding.trails.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Trails-only: Rails materializes `relations.flat_map(&:ids)` eagerly inside
+ * the synchronous `excluding!`, so it has a single arm and no deferred marker
+ * to pin. trails defers unloaded relation args, and that arm must read the
+ * primary-key attribute off the predicate builder's own table — Rails'
+ * `predicate_builder[primary_key, records]` (predicate_builder.rb:53-55) — not
+ * off the model's default arel table.
+ */
+import { describe, it, expect } from "vitest";
+import "./index.js";
+import { Nodes } from "@blazetrails/arel";
+import { fixtures } from "./test-fixtures.js";
+import { registerModel } from "./associations.js";
+import { Relation } from "./relation.js";
+import { Post } from "./test-helpers/models/post.js";
+
+registerModel(Post);
+
+describe("excluding deferred arm (trails)", () => {
+  fixtures(["posts"]);
+
+  it("reads the primary key off the predicate builder's table for an unloaded relation", () => {
+    const aliased = new Relation(Post, Post.arelTable.alias("p"));
+    const relation = aliased.excluding(Post.where({ title: "Welcome to the weblog" }));
+
+    const predicate = relation.whereClause.predicates.at(-1) as Nodes.NotIn;
+    const attribute = predicate.left as Nodes.Attribute;
+    expect(attribute.relation).toBeInstanceOf(Nodes.TableAlias);
+    expect((attribute.relation as Nodes.TableAlias).name).toBe("p");
+  });
+});

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1638,9 +1638,6 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // marker carries a pk-select subquery only as a `toSql()` display fallback for
   // the (rare) no-load path; eager materialization here would require an async
   // `excluding`, breaking the chainable contract.
-  // Same read as the literal arm: Rails' `predicate_builder[primary_key, ...]`
-  // takes the attribute off the builder's own arel table, not the model's
-  // default one (an aliased relation carries different table metadata).
   const attribute = this.predicateBuilder.table.arelTable.get(pk);
   // Mirror the array handler's `x.is_a?(Base) ? x.id : x` deref.
   const literalIds = literalRecords.map((r) => (isBaseInstance(r) ? (r as any).id : r));

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1638,7 +1638,10 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // marker carries a pk-select subquery only as a `toSql()` display fallback for
   // the (rare) no-load path; eager materialization here would require an async
   // `excluding`, breaking the chainable contract.
-  const attribute = (this._modelClass as any).arelTable.get(pk);
+  // Same read as the literal arm: Rails' `predicate_builder[primary_key, ...]`
+  // takes the attribute off the builder's own arel table, not the model's
+  // default one (an aliased relation carries different table metadata).
+  const attribute = this.predicateBuilder.table.arelTable.get(pk);
   // Mirror the array handler's `x.is_a?(Base) ? x.id : x` deref.
   const literalIds = literalRecords.map((r) => (isBaseInstance(r) ? (r as any).id : r));
   // Build the positive `IN (subquery)` (Rails builds positively and inverts);


### PR DESCRIPTION
Rails' `excluding!` builds its predicate with
`predicate_builder[primary_key, records].invert`, and `PredicateBuilder#[]`
reads the attribute off the builder's **own** arel table
(`predicate_builder.rb:53-55`). trails' literal arm already did that; the
deferred (`DeferredIdsNotIn`) arm still read
`this._modelClass.arelTable.get(pk)`, so an aliased relation — or one whose
predicate builder carries different table metadata — resolved the deferred
arm's attribute against the model's default table.

Both arms now read `predicateBuilder.table.arelTable`.

Regression test (`excluding.trails.test.ts`, trails-only: Rails materializes
relation ids eagerly and has no deferred arm) exercises `excluding` with an
unloaded relation argument on an aliased relation; it fails on baseline
(attribute resolves to `posts`, not the `p` alias).

`pnpm api:calls:wide`: OK (2254 baselined, 2074 unreviewed) — unchanged.

Closes-story: converge-excluding-deferred-arm-predicate-builder-table
