### PR TITLE
refactor(activerecord): decide the novel adapter class names in connection-adapters

### DIFF
--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -131,7 +131,7 @@ describe("lookupCastTypeFromJoinDependencies integration", () => {
       constructor: { name: string };
     } | null;
     expect(castType).toBeTruthy();
-    // The joined Topic's concrete datetime type (e.g. SQLiteDateTimeType), not
+    // The joined Topic's concrete datetime type (e.g. SQLite3DateTime), not
     // the default ValueType the base CalcAuthor returns for unknown columns.
     expect(castType?.constructor.name).not.toBe("ValueType");
   });

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -18,7 +18,7 @@ import { ActiveRecord } from "../../ar-config.js";
 /**
  * Return the IANA timezone string for SQL datetime serialization/deserialization,
  * based on `ActiveRecord.default_timezone`. Shared by all instant formatters and
- * by `SQLiteDateTimeType#cast` so both directions always agree on the timezone.
+ * by `SQLite3DateTime#cast` so both directions always agree on the timezone.
  */
 export function defaultSqlTimezone(): string {
   return ActiveRecord.defaultTimezone === "utc" ? "UTC" : Temporal.Now.timeZoneId();

--- a/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
@@ -10,6 +10,14 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream.
  */
 export class BetterSQLite3Adapter extends AbstractSQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
@@ -12,7 +12,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
  *
  * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
  * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared

--- a/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
@@ -11,7 +11,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
  *
  * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
  * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared

--- a/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
@@ -9,6 +9,14 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream.
  */
 export class ExpoSQLiteAdapter extends AbstractSQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/libsql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-adapter.ts
@@ -11,7 +11,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
  *
  * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
  * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared

--- a/packages/activerecord/src/connection-adapters/libsql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-adapter.ts
@@ -9,6 +9,14 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream.
  */
 export class LibSQLAdapter extends AbstractSQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
@@ -14,6 +14,14 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  *
  * Thin subclass of `AbstractSQLite3Adapter`: all SQLite dialect, quoting, and
  * schema logic lives in the abstract base.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream.
  */
 export class LibSQLRemoteAdapter extends AbstractSQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
@@ -16,7 +16,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base.
  *
  * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
  * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared

--- a/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
@@ -26,6 +26,14 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * default — without it the replica is caller-driven only — and the loop lives
  * in the libsql handle, so it stops on `disconnect`/`close`; there is no
  * adapter-owned JS timer to clear.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream.
  */
 export class LibSQLReplicaAdapter extends AbstractSQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
@@ -36,6 +44,11 @@ export class LibSQLReplicaAdapter extends AbstractSQLite3Adapter {
    * Pull the latest changes from the remote primary into the local replica.
    * Caller-driven — there is no background sync. Reaches the libsql connection's
    * `sync()` escape hatch (not part of the core `SqliteConnection` interface).
+   *
+   * @noRailsEquivalent PERMANENT — a member of a driver-variant class Rails has
+   * no counterpart for (see the class tag above): Rails' only SQLite class is
+   * `SQLite3Adapter` (sqlite3_adapter.rb:30), bound to the sqlite3 gem, which
+   * has no embedded-replica mode and so nothing to name this after.
    */
   async syncReplica(): Promise<void> {
     const conn = (await this.sqliteConnection()) as Partial<SyncableSqliteConnection>;

--- a/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
@@ -28,7 +28,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * adapter-owned JS timer to clear.
  *
  * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
  * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared

--- a/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
@@ -11,7 +11,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
  *
  * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
  * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared

--- a/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
@@ -9,6 +9,14 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:15), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream.
  */
 export class NodeSQLiteAdapter extends AbstractSQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -133,6 +133,15 @@ import { SchemaDumper as Sqlite3SchemaDumper } from "./sqlite3/schema-dumper.js"
  * Stored datetime strings are interpreted according to
  * ActiveRecord.default_timezone (defaulting to UTC), matching the timezone
  * selection used when formatting instants for SQLite.
+ *
+ * @noRailsEquivalent PERMANENT — Rails' `initialize_type_map`
+ * (sqlite3_adapter.rb:499-502) registers exactly one SQLite-specific type,
+ * `SQLite3Integer`; datetime columns fall through to `Type::DateTime`, because
+ * Ruby's `Time`/`DateTime` carry a zone and the sqlite3 gem's TEXT values parse
+ * straight into one. The JS analogue splits: `Temporal.PlainDateTime` (no zone)
+ * vs `Temporal.Instant`, so an offset-less TEXT datetime needs a zone applied
+ * before it is a usable value. That is a Temporal-language gap with no upstream
+ * class to converge onto.
  */
 export class SQLiteDateTimeType extends ARDateTimeType {
   override cast(value: unknown): DateTimeCastResult | null {
@@ -1182,7 +1191,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * `sql_type` verbatim. trails' SQLite type map recovers the scalar hints off the
    * cast type at lookup time: limits via `register_class_with_limit`, temporal/
    * decimal precision via `register_class_with_precision`, and the 8-byte INTEGER
-   * default on `SQLite3IntegerType#_limit` (private) so the public `limit` stays
+   * default on `SQLite3Integer#_limit` (private) so the public `limit` stays
    * nil for bare integers — dumps stay bare and `c_int_1..8` keep their 1..8.
    *
    * `type` comes straight from `cast_type.type` (no base-name fallback). For an
@@ -2951,7 +2960,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   static override initializeTypeMap(m: TypeMap): void {
     super.initializeTypeMap(m);
 
-    const sqlite3Int = (limit?: number) => new SQLite3IntegerType({ limit });
+    const sqlite3Int = (limit?: number) => new SQLite3Integer({ limit });
     m.registerType("string", new StringType());
     m.registerType("text", new TextType());
     m.registerType("integer", sqlite3Int());
@@ -2995,7 +3004,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     m.registerType(/int/i, undefined, (k) => sqlite3Int(this.extractLimit(k)));
     // Explicit "bigint" registered after /int/i so it takes priority on exact
     // matches. Like `/int/i`, it carries no explicit limit — the 8-byte default
-    // lives on `SQLite3IntegerType#_limit`, so the public `limit` stays nil and
+    // lives on `SQLite3Integer#_limit`, so the public `limit` stays nil and
     // reflected `bigint` columns dump bare (Rails resolves "bigint" via the same
     // `%r(int)i` → `SQLite3Integer` registration with a nil `limit`).
     m.registerType("bigint", sqlite3Int());
@@ -3014,7 +3023,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
  * `limit` reader nil), so `fetch_type_metadata` reflects a nil `limit` and
  * schema dumps stay bare for unlimited integers — mirror that split here.
  */
-export class SQLite3IntegerType extends IntegerType {
+export class SQLite3Integer extends IntegerType {
   protected override _limit(): number {
     return this.limit ?? 8;
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -143,7 +143,7 @@ import { SchemaDumper as Sqlite3SchemaDumper } from "./sqlite3/schema-dumper.js"
  * before it is a usable value. That is a Temporal-language gap with no upstream
  * class to converge onto.
  */
-export class SQLiteDateTimeType extends ARDateTimeType {
+export class SQLite3DateTime extends ARDateTimeType {
   override cast(value: unknown): DateTimeCastResult | null {
     const result = super.cast(value);
     if (result instanceof Temporal.PlainDateTime) {
@@ -2984,11 +2984,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // precision-parsing factory. Registration order matters: /date/i and /time/i both
     // match "datetime", so datetime is registered last — reverse-registration lookup
     // matches it first (mirrors the base-map date/time/datetime ordering). better-sqlite3
-    // returns datetime columns as TEXT; SQLiteDateTimeType converts offset-less strings
+    // returns datetime columns as TEXT; SQLite3DateTime converts offset-less strings
     // to Temporal.Instant using the configured default_timezone.
     this.registerClassWithPrecision(m, /date/i, DateType);
     this.registerClassWithPrecision(m, /time/i, TimeType);
-    this.registerClassWithPrecision(m, /datetime/i, SQLiteDateTimeType);
+    this.registerClassWithPrecision(m, /datetime/i, SQLite3DateTime);
     m.aliasType(/timestamp/i, "datetime");
     m.registerType("blob", new BinaryType());
     m.registerType("binary", new BinaryType());

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -4,7 +4,7 @@ import { BinaryData } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
-import { type AbstractSQLite3Adapter, SQLiteDateTimeType } from "../sqlite3-adapter.js";
+import { type AbstractSQLite3Adapter, SQLite3DateTime } from "../sqlite3-adapter.js";
 import { Date as DateType } from "../../type/date.js";
 import { Time as TimeType } from "../../type/time.js";
 import {
@@ -371,8 +371,8 @@ describe("SQLite3::Quoting", () => {
       );
       const rows = await adapter.execute(`SELECT "ts" FROM "quoting_events" LIMIT 1`);
       const raw = rows[0].ts as string;
-      // SQLiteDateTimeType converts the offset-less UTC string → Temporal.Instant.
-      const cast = new SQLiteDateTimeType().cast(raw);
+      // SQLite3DateTime converts the offset-less UTC string → Temporal.Instant.
+      const cast = new SQLite3DateTime().cast(raw);
       expect(cast).toBeInstanceOf(Temporal.Instant);
       // Microsecond precision is preserved end-to-end.
       expect((cast as Temporal.Instant).epochNanoseconds).toBe(instant.epochNanoseconds);
@@ -383,7 +383,7 @@ describe("SQLite3::Quoting", () => {
       await adapter.executeMutation(`INSERT INTO "quoting_events" ("dt") VALUES (${quote(dt)})`);
       const rows = await adapter.execute(`SELECT "dt" FROM "quoting_events" LIMIT 1`);
       const raw = rows[0].dt as string;
-      const cast = new SQLiteDateTimeType().cast(raw) as Temporal.Instant;
+      const cast = new SQLite3DateTime().cast(raw) as Temporal.Instant;
       expect(cast).toBeInstanceOf(Temporal.Instant);
       const zdt = cast.toZonedDateTimeISO("UTC");
       expect(zdt.microsecond).toBe(654321 % 1000); // 321 µs

--- a/packages/activerecord/src/support/schema-types.ts
+++ b/packages/activerecord/src/support/schema-types.ts
@@ -288,7 +288,7 @@ export const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
 // SQLite has type affinity rules but accepts native datetime/date/time/json
 // type names — they store as TEXT/BLOB under the hood while preserving the
 // declared type for schema reflection (so the type registry resolves to
-// SQLiteDateTimeType/DateType/TimeType/JsonType on load). datetime/date/time/
+// SQLite3DateTime/DateType/TimeType/JsonType on load). datetime/date/time/
 // json all now inherit the native names from COLUMN_TYPE_MAP_MYSQL; `binary`
 // inherits the BLOB mapping likewise.
 /** @internal */


### PR DESCRIPTION
Decides every novel class name the extra-surface report flagged across
`connection-adapters/`, one decision per name, with case-(2) renames attempted
before any tag was written.

## Decisions

| Name | Decision | Anchor |
| --- | --- | --- |
| `BetterSQLite3Adapter`, `ExpoSQLiteAdapter`, `LibSQLAdapter`, `LibSQLRemoteAdapter`, `LibSQLReplicaAdapter`, `NodeSQLiteAdapter` | `@noRailsEquivalent PERMANENT` | `sqlite3_adapter.rb:14` (`gem "sqlite3"`) + `:30` (the single `SQLite3Adapter`) — Ruby binds one driver, so there is no upstream class per JS client |
| `LibSQLReplicaAdapter#syncReplica` | `@noRailsEquivalent PERMANENT` | same; the sqlite3 gem has no embedded-replica mode |
| `SQLite3IntegerType` | **renamed** → `SQLite3Integer` | `sqlite3_adapter.rb:486` — Rails declares this class; the `Type` suffix was a trails invention. PR #5918 freed the name by deleting a dead duplicate |
| `SQLiteDateTimeType` | **renamed** → `SQLite3DateTime`, plus `@noRailsEquivalent PERMANENT` | `sqlite3_adapter.rb:499-502` — `initialize_type_map` registers `SQLite3Integer` and nothing else; Ruby's zone-carrying `Time` needs no sqlite datetime override, whereas `Temporal.PlainDateTime` vs `Instant` does. The `Type` suffix was a trails outlier — `type/date-time.ts` declares `DateTime`, `type/text.ts` `Text`, `type/unsigned-integer.ts` `UnsignedInteger`, and the suffix only ever appears as a local import alias — so it is spelled `SQLite3DateTime`, matching `SQLite3Integer` in the same file |
| `AbstractSQLite3Adapter` | **rename, deferred** — NOT tagged | It is a renamed port of `SQLite3Adapter` (`sqlite3_adapter.rb:30`); the whole file's method set is `moved` onto it, so a tag would be exactly the mistake this story exists to prevent. 228 references across 60 files — over the 500-LOC ceiling on its own |
| `PostgreSQLSchemaStatements` | **rename attempted and reverted** — NOT tagged | Blocked by api:compare short-name resolution (below) |

Both deferred names are registered as
`0072-api-compare-parity-burndown/stories/adapter-class-name-renames-sqlite3-and-pg-schema-statements`,
with the full evidence.

## Why the pg rename was reverted

Renaming `PostgreSQLSchemaStatements` → `SchemaStatements` (Rails'
`PostgreSQL::SchemaStatements`, and the convention the rest of
`connection-adapters/postgresql/` already follows) costs one matched method:
data layer 7724 → 7723, losing `quote_schema_name`.
`include(PostgreSQLAdapter, X)` is recorded as the bare short name `X`
(`extract-ts-api.ts:1084`), and `resolveParent` (`compare.ts:1549`) breaks a
duplicated short name by shared leading path segments. Against
`connection-adapters/postgresql-adapter.ts`, the abstract, postgresql and
sqlite3 `SchemaStatements` all score 1, so the tie lands on the abstract class
and the pg class's methods drop off `PostgreSQLAdapter`. The trails-only
flattened name is what keeps that resolution unambiguous today — the tooling
rewards the divergence, so the fix belongs with the tooling, not with a tag
here.

## Totals

- `pnpm api:compare` — data layer 7724/7816, overall 11789/17536: **unchanged**
  from `origin/main` (the `SQLite3Integer` rename is net-zero).
- `pnpm test:compare` — 14876/22203: **unchanged** (no test file touched; no
  test name reworded).
- `pnpm api:extra --package activerecord` — activerecord novel 549 → 548, and
  the six driver-variant adapter files plus `libsql-replica-adapter.ts` now
  report **0** novel names. `sqlite3-adapter.ts` is down to `AbstractSQLite3Adapter`
  (deferred story above) and `exec` / `executeMutation` (owned by other stories);
  `postgresql/schema-statements-class.ts` to `PostgreSQLSchemaStatements` plus
  `createRange` / `dropRange` (other stories).
- The one STALE `@noRailsEquivalent` entry the run reports (`base.ts` `equals`)
  is pre-existing on `origin/main` — verified by re-running the whole pipeline
  on a clean checkout — and is not touched here.

## Tests

`pnpm vitest run` on `sqlite3/quoting.test.ts`,
`sqlite3-adapter.type-map.trails.test.ts`,
`adapters/sqlite3/sqlite3-adapter.trails.test.ts`,
`sqlite3-adapter.hash-constructor.test.ts`, `sqlite3-introspection.test.ts`
and `scripts/api-compare/extra-surface.test.ts` — all pass.

Closes-story: extra-surface-adapter-class-names
