### PR TITLE
feat(api-compare): lower unreviewed marks for rows api:build drops

### DIFF
--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -413,11 +413,12 @@ describe("lowerMarksForDropped", () => {
       "activerecord/relation.json": 3,
       "activerecord/base.json": 2,
     });
-    const marks = await lowerMarksForDropped(
+    const { marks, moved } = await lowerMarksForDropped(
       dir,
       [seeded("relation.ts", "save")],
       [seeded("relation.ts", "merge!"), seeded("base.ts", "save")],
     );
+    expect(moved).toEqual(["activerecord/relation.json"]);
     expect(marks.get("activerecord/relation.json")).toBe(1);
     expect(marks.get("activerecord/base.json")).toBe(2);
     expect(await fs.readFile(path.join(dir, "activerecord/base.json"), "utf-8")).toBe(
@@ -427,7 +428,7 @@ describe("lowerMarksForDropped", () => {
 
   it("deletes a shard whose source has no unreviewed rows left", async () => {
     const dir = await tmpMarkDir({ "activerecord/relation.json": 1 });
-    const marks = await lowerMarksForDropped(dir, [seeded("relation.ts", "save")], []);
+    const { marks } = await lowerMarksForDropped(dir, [seeded("relation.ts", "save")], []);
     expect(marks.has("activerecord/relation.json")).toBe(false);
     await expect(
       fs.readFile(path.join(dir, "activerecord/relation.json"), "utf-8"),
@@ -437,7 +438,7 @@ describe("lowerMarksForDropped", () => {
   it("writes nothing when the run dropped no rows", async () => {
     const dir = await tmpMarkDir({ "activerecord/relation.json": 3 });
     const before = await fs.stat(path.join(dir, "activerecord/relation.json"));
-    const marks = await lowerMarksForDropped(dir, [], [seeded("relation.ts", "merge!")]);
+    const { marks } = await lowerMarksForDropped(dir, [], [seeded("relation.ts", "merge!")]);
     expect(marks.get("activerecord/relation.json")).toBe(3);
     expect((await fs.stat(path.join(dir, "activerecord/relation.json"))).mtimeMs).toBe(
       before.mtimeMs,
@@ -446,11 +447,12 @@ describe("lowerMarksForDropped", () => {
 
   it("never raises a mark that already sits below the remaining count", async () => {
     const dir = await tmpMarkDir({ "activerecord/relation.json": 1 });
-    const marks = await lowerMarksForDropped(
+    const { marks, moved } = await lowerMarksForDropped(
       dir,
       [seeded("relation.ts", "save")],
       [seeded("relation.ts", "merge!"), seeded("relation.ts", "reset")],
     );
+    expect(moved).toEqual([]);
     expect(marks.get("activerecord/relation.json")).toBe(1);
   });
 });

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -434,6 +434,16 @@ describe("lowerMarksForDropped", () => {
     ).rejects.toThrow(/ENOENT/);
   });
 
+  it("writes nothing when the run dropped no rows", async () => {
+    const dir = await tmpMarkDir({ "activerecord/relation.json": 3 });
+    const before = await fs.stat(path.join(dir, "activerecord/relation.json"));
+    const marks = await lowerMarksForDropped(dir, [], [seeded("relation.ts", "merge!")]);
+    expect(marks.get("activerecord/relation.json")).toBe(3);
+    expect((await fs.stat(path.join(dir, "activerecord/relation.json"))).mtimeMs).toBe(
+      before.mtimeMs,
+    );
+  });
+
   it("never raises a mark that already sits below the remaining count", async () => {
     const dir = await tmpMarkDir({ "activerecord/relation.json": 1 });
     const marks = await lowerMarksForDropped(

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterAll, describe, expect, it } from "vitest";
 import {
   DEFAULT_TAG_REASON,
   parseJsdoc,
@@ -6,7 +9,9 @@ import {
   reconcileFileText,
   renderJsdoc,
   buildExpectations,
+  lowerMarksForDropped,
 } from "./build.js";
+import { serializeBaseline } from "./baseline-json.js";
 import { NARROW_DEFAULT_REASON } from "./missing-rails-call-tags.js";
 
 const reasonFor = () => DEFAULT_TAG_REASON;
@@ -377,5 +382,65 @@ describe("reconcileFileText with two Ruby names on one TS method", () => {
       rubyName === "bar_all" ? "curated" : DEFAULT_TAG_REASON,
     );
     expect(text!).toContain("@missingRailsCall save — curated");
+  });
+});
+
+describe("lowerMarksForDropped", () => {
+  const tmpDirs: string[] = [];
+  async function tmpMarkDir(shards: Record<string, number>): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "api-build-marks-"));
+    tmpDirs.push(dir);
+    for (const [rel, max] of Object.entries(shards)) {
+      await fs.mkdir(path.dirname(path.join(dir, rel)), { recursive: true });
+      await fs.writeFile(path.join(dir, rel), serializeBaseline({ max }));
+    }
+    return dir;
+  }
+  afterAll(async () => {
+    for (const dir of tmpDirs.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  const seeded = (tsFile: string, call: string) => ({
+    package: "activerecord",
+    tsFile,
+    rubyName: "bar",
+    call,
+    reason: DEFAULT_TAG_REASON,
+  });
+
+  it("lowers only the shard of a source whose seeded rows were dropped", async () => {
+    const dir = await tmpMarkDir({
+      "activerecord/relation.json": 3,
+      "activerecord/base.json": 2,
+    });
+    const marks = await lowerMarksForDropped(
+      dir,
+      [seeded("relation.ts", "save")],
+      [seeded("relation.ts", "merge!"), seeded("base.ts", "save")],
+    );
+    expect(marks.get("activerecord/relation.json")).toBe(1);
+    expect(marks.get("activerecord/base.json")).toBe(2);
+    expect(await fs.readFile(path.join(dir, "activerecord/base.json"), "utf-8")).toBe(
+      serializeBaseline({ max: 2 }),
+    );
+  });
+
+  it("deletes a shard whose source has no unreviewed rows left", async () => {
+    const dir = await tmpMarkDir({ "activerecord/relation.json": 1 });
+    const marks = await lowerMarksForDropped(dir, [seeded("relation.ts", "save")], []);
+    expect(marks.has("activerecord/relation.json")).toBe(false);
+    await expect(
+      fs.readFile(path.join(dir, "activerecord/relation.json"), "utf-8"),
+    ).rejects.toThrow(/ENOENT/);
+  });
+
+  it("never raises a mark that already sits below the remaining count", async () => {
+    const dir = await tmpMarkDir({ "activerecord/relation.json": 1 });
+    const marks = await lowerMarksForDropped(
+      dir,
+      [seeded("relation.ts", "save")],
+      [seeded("relation.ts", "merge!"), seeded("relation.ts", "reset")],
+    );
+    expect(marks.get("activerecord/relation.json")).toBe(1);
   });
 });

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -410,29 +410,32 @@ export function buildExpectations(
  * value. Only-shrink comes free from `nextMarks` (it takes the min), and a
  * shard that reaches 0 is deleted rather than left as `{"max": 0}`.
  *
- * Returns the marks now on disk. Dropping nothing writes nothing: a run with no
+ * Returns the marks now on disk alongside the shards this run actually moved,
+ * so the caller reports its own footprint rather than the whole tree's size. Dropping nothing writes nothing: a run with no
  * migrations must not rewrite the tree it has no measurement for.
  */
 export async function lowerMarksForDropped(
   markDir: string,
   droppedEntries: ExcludeEntry[],
   remaining: ExcludeEntry[],
-): Promise<MarkSet> {
+): Promise<{ marks: MarkSet; moved: string[] }> {
   const marks = await loadMarks(markDir);
   const touched = new Set(droppedEntries.map(relPathFor));
-  if (touched.size === 0) return marks;
+  if (touched.size === 0) return { marks, moved: [] };
   const counts = unreviewedCounts(remaining, DEFAULT_TAG_REASON, relPathFor);
   const scoped: MarkSet = new Map();
   for (const rel of touched) if (marks.has(rel)) scoped.set(rel, counts.get(rel) ?? 0);
   const lowered = nextMarks(scoped, marks);
   const next = new Map(marks);
+  const moved: string[] = [];
   for (const rel of scoped.keys()) {
     const max = lowered.get(rel);
     if (max === undefined) next.delete(rel);
     else next.set(rel, max);
+    if (next.get(rel) !== marks.get(rel)) moved.push(rel);
   }
   await writeMarks(markDir, next);
-  return next;
+  return { marks: next, moved: moved.sort() };
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -513,11 +516,13 @@ async function main(argv: string[]): Promise<number> {
   const dropped = droppedEntries.length;
   if (dropped > 0 && !dryRun) {
     await writeSplitBaseline(remaining, WIDE_BASELINE_DIR);
-    const marks = await lowerMarksForDropped(MARK_DIR, droppedEntries, remaining);
+    const { marks, moved } = await lowerMarksForDropped(MARK_DIR, droppedEntries, remaining);
     console.log(
-      `api:build: lowered ${path.relative(ROOT_DIR, MARK_DIR)}/ for the source(s) rewritten ` +
-        `above (${marks.size} shard(s) remain, totalling ${totalMark(marks)}).`,
+      `api:build: lowered ${moved.length} unreviewed high-water mark(s) under ` +
+        `${path.relative(ROOT_DIR, MARK_DIR)}/ for the source(s) rewritten above ` +
+        `(${totalMark(marks)} unreviewed entr(ies) still marked repo-wide).`,
     );
+    for (const rel of moved) console.log(`  - ${rel}`);
   }
   console.log(
     `api:build: ${dropped} baseline entr(ies) ${dryRun ? "would migrate" : "migrated"} to ` +

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -20,7 +20,10 @@
  *   - a tag with no reason fails the run (see the empty-reason contract in
  *     docs/infrastructure/api-build-stub-generation-plan.md);
  *   - reasons for newly-added tags migrate from the committed baselines
- *     (call-mismatches-wide-exclude/, call-mismatches-exclude.json).
+ *     (call-mismatches-wide-exclude/, call-mismatches-exclude.json);
+ *   - the unreviewed high-water marks of the sources whose baseline rows were
+ *     dropped are lowered in step, so a migration never leaves the wide gate's
+ *     slack arm red pending a whole-repo reseed (RFC 0083).
  *
  * Method bodies are NEVER edited — only JSDoc blocks.
  *
@@ -398,7 +401,7 @@ export function buildExpectations(
  * Lower the unreviewed high-water marks of the sources whose baseline rows this
  * run just migrated into `@missingRailsCall` tags (RFC 0083).
  *
- * A dropped row that carried the seeded {@link DEFAULT_REASON} in the WIDE
+ * A dropped row that carried the seeded {@link DEFAULT_TAG_REASON} in the WIDE
  * baseline (its tag reason came from the curated narrow one, which wins) leaves
  * its shard stale-HIGH, and the gate's slack arm reds on the next run — with a
  * whole-repo `api:calls:wide:reseed`, a compare regeneration this run never
@@ -406,6 +409,9 @@ export function buildExpectations(
  * actually rewritten are recomputed, so every other shard keeps its committed
  * value. Only-shrink comes free from `nextMarks` (it takes the min), and a
  * shard that reaches 0 is deleted rather than left as `{"max": 0}`.
+ *
+ * Returns the marks now on disk. Dropping nothing writes nothing: a run with no
+ * migrations must not rewrite the tree it has no measurement for.
  */
 export async function lowerMarksForDropped(
   markDir: string,
@@ -414,6 +420,7 @@ export async function lowerMarksForDropped(
 ): Promise<MarkSet> {
   const marks = await loadMarks(markDir);
   const touched = new Set(droppedEntries.map(relPathFor));
+  if (touched.size === 0) return marks;
   const counts = unreviewedCounts(remaining, DEFAULT_TAG_REASON, relPathFor);
   const scoped: MarkSet = new Map();
   for (const rel of touched) if (marks.has(rel)) scoped.set(rel, counts.get(rel) ?? 0);

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -43,7 +43,20 @@ import {
   loadBaseline as loadNarrowBaseline,
   missingScope,
 } from "./lint-call-mismatches.js";
-import { loadSplitBaseline, writeSplitBaseline } from "./lint-call-mismatches-wide.js";
+import {
+  MARK_DIR,
+  loadSplitBaseline,
+  relPathFor,
+  writeSplitBaseline,
+} from "./lint-call-mismatches-wide.js";
+import {
+  type MarkSet,
+  loadMarks,
+  nextMarks,
+  totalMark,
+  unreviewedCounts,
+  writeMarks,
+} from "./unreviewed-ratchet.js";
 import {
   DEFAULT_REASON,
   NARROW_DEFAULT_REASON,
@@ -381,6 +394,40 @@ export function buildExpectations(
   return byFile;
 }
 
+/**
+ * Lower the unreviewed high-water marks of the sources whose baseline rows this
+ * run just migrated into `@missingRailsCall` tags (RFC 0083).
+ *
+ * A dropped row that carried the seeded {@link DEFAULT_REASON} in the WIDE
+ * baseline (its tag reason came from the curated narrow one, which wins) leaves
+ * its shard stale-HIGH, and the gate's slack arm reds on the next run — with a
+ * whole-repo `api:calls:wide:reseed`, a compare regeneration this run never
+ * needed, as the only remedy. The shard makes the fix precise: only the sources
+ * actually rewritten are recomputed, so every other shard keeps its committed
+ * value. Only-shrink comes free from `nextMarks` (it takes the min), and a
+ * shard that reaches 0 is deleted rather than left as `{"max": 0}`.
+ */
+export async function lowerMarksForDropped(
+  markDir: string,
+  droppedEntries: ExcludeEntry[],
+  remaining: ExcludeEntry[],
+): Promise<MarkSet> {
+  const marks = await loadMarks(markDir);
+  const touched = new Set(droppedEntries.map(relPathFor));
+  const counts = unreviewedCounts(remaining, DEFAULT_TAG_REASON, relPathFor);
+  const scoped: MarkSet = new Map();
+  for (const rel of touched) if (marks.has(rel)) scoped.set(rel, counts.get(rel) ?? 0);
+  const lowered = nextMarks(scoped, marks);
+  const next = new Map(marks);
+  for (const rel of scoped.keys()) {
+    const max = lowered.get(rel);
+    if (max === undefined) next.delete(rel);
+    else next.set(rel, max);
+  }
+  await writeMarks(markDir, next);
+  return next;
+}
+
 async function main(argv: string[]): Promise<number> {
   const pkgIdx = argv.indexOf("--package");
   const pkg = pkgIdx !== -1 ? argv[pkgIdx + 1] : undefined;
@@ -455,8 +502,16 @@ async function main(argv: string[]): Promise<number> {
     }
   }
   const remaining = wideBaseline.filter((e) => !migrated.has(keyOf(e)));
-  const dropped = wideBaseline.length - remaining.length;
-  if (dropped > 0 && !dryRun) await writeSplitBaseline(remaining, WIDE_BASELINE_DIR);
+  const droppedEntries = wideBaseline.filter((e) => migrated.has(keyOf(e)));
+  const dropped = droppedEntries.length;
+  if (dropped > 0 && !dryRun) {
+    await writeSplitBaseline(remaining, WIDE_BASELINE_DIR);
+    const marks = await lowerMarksForDropped(MARK_DIR, droppedEntries, remaining);
+    console.log(
+      `api:build: lowered ${path.relative(ROOT_DIR, MARK_DIR)}/ for the source(s) rewritten ` +
+        `above (${marks.size} shard(s) remain, totalling ${totalMark(marks)}).`,
+    );
+  }
   console.log(
     `api:build: ${dropped} baseline entr(ies) ${dryRun ? "would migrate" : "migrated"} to ` +
       `@missingRailsCall tags and ${dryRun ? "would be" : "were"} dropped from ` +

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -176,7 +176,7 @@ const ARTIFACT_PATH = path.join(OUTPUT_DIR, "call-mismatches-wide.json");
 // Committed high-water marks for the unreviewed-reason counter (RFC 0083),
 // sharded per source file exactly like the baseline above so the two trees
 // share one merge-conflict boundary; see unreviewed-ratchet.ts.
-const MARK_DIR = path.join(
+export const MARK_DIR = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "call-mismatches-wide-unreviewed",
 );


### PR DESCRIPTION
`api:build` migrates wide-baseline rows into `@missingRailsCall` tags and drops them from the split baseline, but never touched the sharded unreviewed high-water marks under `scripts/api-compare/call-mismatches-wide-unreviewed/`. A dropped row still carrying the seeded `DEFAULT_REASON` left its shard stale-HIGH, so the wide gate's slack arm (`slackByPath`) red on the next run and the only fix was a full `pnpm api:calls:wide:reseed` — a compare regeneration the `api:build` author did not otherwise need.

`build.ts` already knows exactly which (package, tsFile) it rewrote, so it now recomputes and lowers just those shards via `nextMarks` + `writeMarks`. Only-shrink is free (`nextMarks` takes the min), a shard that reaches 0 is deleted rather than left as `{"max": 0}`, every untouched shard keeps its committed value, and `--dry-run` writes neither the baseline nor the marks.

Closes-story: api-build-lower-unreviewed-marks-on-drop