### PR TITLE
refactor(activerecord): rename AbstractSQLite3Adapter and PostgreSQLSchemaStatements to Rails names

### DIFF
--- a/packages/activerecord/src/adapters/index.ts
+++ b/packages/activerecord/src/adapters/index.ts
@@ -4,6 +4,6 @@
 // ExpoSQLiteAdapter) are reachable via their own
 // `./connection-adapters/<x>-adapter.js` export entries, which is where the
 // optional `better-sqlite3` / `expo-sqlite` peer dep actually gets loaded.
-export { AbstractSQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
+export { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 export { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 export { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -4,9 +4,9 @@ import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { BigIntegerType, IntegerType, BooleanType } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 const bigType = new BigIntegerType();
 const intType = new IntegerType();
 const boolType = new BooleanType();
@@ -15,7 +15,7 @@ describeIfSqlite("SQLite3 bigint round-trip", () => {
   fixtures([]);
 
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     await adapter.exec(`
       CREATE TABLE "big_items" (
         "id"     INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -6,16 +6,16 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 describeIfSqlite("SQLite3CollationTest", () => {
   fixtures([]);
 
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     await adapter.dropTable("collation_table_sqlite3", { ifExists: true });
     await adapter.exec(`CREATE TABLE "collation_table_sqlite3" (
       "id" INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
@@ -3,7 +3,7 @@ import "../../index.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 type Row = Record<string, unknown>;
 
@@ -24,8 +24,8 @@ interface TableRebuildInternals {
 fixtures([]);
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
-  let db: AbstractSQLite3Adapter;
-  let leased: AbstractSQLite3Adapter | undefined;
+  let db: SQLite3Adapter;
+  let leased: SQLite3Adapter | undefined;
   const internals = (): TableRebuildInternals => db as unknown as TableRebuildInternals;
 
   const dropCopyTargets = async (): Promise<void> => {
@@ -35,7 +35,7 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   };
 
   beforeEach(async () => {
-    db = leased = Base.connection as AbstractSQLite3Adapter;
+    db = leased = Base.connection as SQLite3Adapter;
     await dropCopyTargets();
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -7,9 +7,9 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 class JsonDataType extends Base {
   static {
@@ -21,7 +21,7 @@ describeIfSqlite("SQLite3JSONTest", () => {
   fixtures([]);
 
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     // Mirrors Rails JSONSharedTestCases#setup creating the table ad-hoc:
     //   t.json "payload", default: {}
     //   t.json "settings"

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -6,16 +6,16 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 // -- Rails test class: quoting_test.rb --
 describeIfSqlite("SQLite3QuotingTest", () => {
   fixtures([]);
 
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
   });
 
   afterEach(async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -10,11 +10,11 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 beforeEach(async () => {
   adapter = new BetterSQLite3Adapter(":memory:");
@@ -108,7 +108,7 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   // The guard itself lives in preprocess_query's check_if_write_query, so it
   // covers execute and executeMutation alike.
   it("errors when a write is routed through execute while preventing writes", async () => {
-    const connection = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    const connection = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     await expect(
       Base.whilePreventingWrites(() =>
         connection.execute(`INSERT INTO subscribers(nick) VALUES ('pq')`),
@@ -117,7 +117,7 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   });
 
   it("does not prevent a read routed through execute while preventing writes", async () => {
-    const connection = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    const connection = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     await Base.whilePreventingWrites(async () => {
       await expect(
         connection.execute(`SELECT * FROM subscribers WHERE nick = 'pq'`),

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
@@ -6,17 +6,17 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 // -- Rails test class: sqlite3_adapter_prevent_writes_test.rb --
 describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   fixtures([], { useTransactionalTests: false });
 
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
   });
 
   afterEach(async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -4,7 +4,7 @@
 import { it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { itIfSupports } from "../../support/supports.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { Notifications } from "@blazetrails/activesupport";
 import type {
@@ -15,7 +15,7 @@ import type {
 } from "../../sqlite-adapter.js";
 import { assertLogged } from "./test-helper.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 beforeEach(() => {
   adapter = new BetterSQLite3Adapter(":memory:");
@@ -668,7 +668,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
 
   it("strict strings by default", async () => {
     // Default class config is false — new connections are non-strict.
-    expect(AbstractSQLite3Adapter.strictStringsByDefault).toBe(false);
+    expect(SQLite3Adapter.strictStringsByDefault).toBe(false);
     const conn = new BetterSQLite3Adapter(":memory:");
     expect(conn._strictStrings).toBe(false);
     // Rails: assert_nothing_raised { conn.add_index :testings, :non_existent }
@@ -679,7 +679,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     await conn.close();
 
     // Setting the class config propagates to new connections.
-    AbstractSQLite3Adapter.strictStringsByDefault = true;
+    SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new BetterSQLite3Adapter(":memory:");
       expect(strict._strictStrings).toBe(true);
@@ -689,7 +689,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
       ).rejects.toThrow(/no such column/i);
       await strict.close();
     } finally {
-      AbstractSQLite3Adapter.strictStringsByDefault = false;
+      SQLite3Adapter.strictStringsByDefault = false;
     }
   });
 
@@ -707,7 +707,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     }
 
     // Explicit strict: true also overrides the class config (still strict).
-    AbstractSQLite3Adapter.strictStringsByDefault = true;
+    SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new BetterSQLite3Adapter(":memory:", { strict: true });
       try {
@@ -720,7 +720,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
         await strict.close();
       }
     } finally {
-      AbstractSQLite3Adapter.strictStringsByDefault = false;
+      SQLite3Adapter.strictStringsByDefault = false;
     }
   });
 
@@ -737,7 +737,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     }
 
     // Explicit strict: false overrides strictStringsByDefault = true.
-    AbstractSQLite3Adapter.strictStringsByDefault = true;
+    SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new BetterSQLite3Adapter(":memory:", { strict: false });
       try {
@@ -746,7 +746,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
         await strict.close();
       }
     } finally {
-      AbstractSQLite3Adapter.strictStringsByDefault = false;
+      SQLite3Adapter.strictStringsByDefault = false;
     }
   });
 
@@ -789,8 +789,8 @@ describeIfSqlite("SQLite3AdapterTest", () => {
       },
     };
 
-    const originalDefault = AbstractSQLite3Adapter.strictStringsByDefault;
-    AbstractSQLite3Adapter.strictStringsByDefault = true;
+    const originalDefault = SQLite3Adapter.strictStringsByDefault;
+    SQLite3Adapter.strictStringsByDefault = true;
     try {
       const conn = new BetterSQLite3Adapter(":memory:", { driver: fakeDriver });
       try {
@@ -800,7 +800,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
         await conn.close();
       }
     } finally {
-      AbstractSQLite3Adapter.strictStringsByDefault = originalDefault;
+      SQLite3Adapter.strictStringsByDefault = originalDefault;
     }
 
     capture.config = null;

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 
 describe("SqliteAdapter", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
 
   beforeEach(() => {
     adapter = new BetterSQLite3Adapter(":memory:");
@@ -75,10 +75,10 @@ describe("SqliteAdapter", () => {
 
 describe("SQLite3Adapter._isMemoryFilename", () => {
   const isMemoryFilename = (
-    AbstractSQLite3Adapter as unknown as {
+    SQLite3Adapter as unknown as {
       _isMemoryFilename(filename: string): boolean;
     }
-  )._isMemoryFilename.bind(AbstractSQLite3Adapter);
+  )._isMemoryFilename.bind(SQLite3Adapter);
 
   it("treats :memory: as in-memory", () => {
     expect(isMemoryFilename(":memory:")).toBe(true);
@@ -102,7 +102,7 @@ describe("SQLite3Adapter._isMemoryFilename", () => {
 });
 
 describe("SQLite3Adapter pragmas option", () => {
-  let adapter: AbstractSQLite3Adapter | undefined;
+  let adapter: SQLite3Adapter | undefined;
 
   afterEach(async () => {
     await adapter?.close();

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
@@ -1,13 +1,13 @@
 import { it, expect, afterEach } from "vitest";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 
 describeIfSqlite("SQLite3StatementPoolTest", () => {
   // Track every adapter created so a failing assertion can't leak an
   // open SQLite handle into later tests.
-  const openAdapters: AbstractSQLite3Adapter[] = [];
-  const track = (adapter: AbstractSQLite3Adapter): AbstractSQLite3Adapter => {
+  const openAdapters: SQLite3Adapter[] = [];
+  const track = (adapter: SQLite3Adapter): SQLite3Adapter => {
     openAdapters.push(adapter);
     return adapter;
   };

--- a/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
@@ -9,7 +9,7 @@
 import { it, expect, afterEach } from "vitest";
 import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { TransactionIsolationError } from "../../errors.js";
 
@@ -19,7 +19,7 @@ import { TransactionIsolationError } from "../../errors.js";
 // `file::memory:?cache=shared` next to the repo, so afterEach unlinks it.
 const SHARED_CACHE_DB = "file::memory:?cache=shared";
 
-const openAdapters: AbstractSQLite3Adapter[] = [];
+const openAdapters: SQLite3Adapter[] = [];
 afterEach(async () => {
   while (openAdapters.length) {
     try {
@@ -38,14 +38,14 @@ afterEach(async () => {
   }
 });
 
-function withConn(opts: { sharedCache?: boolean } = {}): AbstractSQLite3Adapter {
+function withConn(opts: { sharedCache?: boolean } = {}): SQLite3Adapter {
   const filename = opts.sharedCache ? SHARED_CACHE_DB : ":memory:";
   const adapter = new BetterSQLite3Adapter(filename);
   openAdapters.push(adapter);
   return adapter;
 }
 
-function readUncommitted(conn: AbstractSQLite3Adapter): boolean {
+function readUncommitted(conn: SQLite3Adapter): boolean {
   const row = (conn as any).driver.prepare("PRAGMA read_uncommitted").get() as {
     read_uncommitted: number;
   };

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
@@ -9,7 +9,7 @@ import { FixtureSet } from "../../fixtures.js";
 import { fixtures } from "../../test-fixtures.js";
 import { virtualColumnFixtureData } from "../../test-helpers/fixtures/virtual-columns.js";
 import { itIfSupports } from "../../support/supports.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import type { Column } from "../../connection-adapters/sqlite3/column.js";
 
 beforeAll(() => {
@@ -22,7 +22,7 @@ afterAll(() => {
 
 fixtures([], { useTransactionalTests: false });
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 class VirtualColumn extends Base {
   static tableName = "virtual_columns";
@@ -32,7 +32,7 @@ class VirtualColumn extends Base {
 }
 
 beforeEach(async () => {
-  adapter = Base.connection as AbstractSQLite3Adapter;
+  adapter = Base.connection as SQLite3Adapter;
   await adapter.createTable("virtual_columns", { force: true }, (t) => {
     t.string("name");
     t.virtual("upper_name", { type: "string", as: "UPPER(name)", stored: true });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
@@ -3,10 +3,10 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import type { Column } from "../../connection-adapters/sqlite3/column.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 // TS-only regression coverage: Rails' alter_table rebuilds from columns(from)
 // and re-adds generated columns with as:/stored: (sqlite3_adapter.rb:623),
@@ -16,7 +16,7 @@ describeIfSqlite("SQLite3VirtualColumnTest trails extras", () => {
   fixtures([]);
 
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     await adapter.dropTable("virtual_columns", { ifExists: true });
     await adapter.exec(
       `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "column1" integer)`,

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -6,16 +6,16 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
-import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
-let adapter: AbstractSQLite3Adapter;
+let adapter: SQLite3Adapter;
 
 describeIfSqlite("SQLite3VirtualTableTest", () => {
   fixtures([]);
 
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as AbstractSQLite3Adapter;
+    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     await adapter.createVirtualTable("searchables", "fts5", [
       "content",
       "meta UNINDEXED",

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -144,7 +144,7 @@ const postgresqlLoader: AdapterLoader = async () =>
 register("sqlite3", sqlite3Loader);
 register("node-sqlite", nodeSqliteLoader);
 // `expo-sqlite`'s driver only implements async `open()`. It's now openable via
-// the async construction path (`AbstractSQLite3Adapter.openAsync()` / the pool's
+// the async construction path (`SQLite3Adapter.openAsync()` / the pool's
 // async checkout, which awaits `completeAsyncConnect()` in `verifyBang`).
 register("expo-sqlite", expoSqliteLoader);
 register("libsql", libsqlLoader);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1297,7 +1297,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * fresh `TypeMap` (abstract_mysql_adapter.rb:711). trails keeps that Rails
    * name for the registration pass and puts the allocate-then-register wrapper
    * behind the Rails-private `_` prefix, matching the already-converged
-   * spelling on `AbstractSQLite3Adapter._buildTypeMap`.
+   * spelling on `SQLite3Adapter._buildTypeMap`.
    */
   protected static _buildTypeMap(
     this: typeof AbstractMysqlAdapter,
@@ -1334,7 +1334,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * The memoized native type map. Rails reaches it through the adapter's own
    * `type_map` (abstract_adapter.rb) and never exposes a separate public
    * accessor, so this stays Rails-private (`_` prefix) — the same spelling
-   * `AbstractSQLite3Adapter` uses for its `_nativeTypeMap` slot.
+   * `SQLite3Adapter` uses for its `_nativeTypeMap` slot.
    */
   get _nativeTypeMap(): TypeMap {
     if (!this._typeMap) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -8,7 +8,7 @@
  * native) keep a throwaway `:memory:` adapter.
  */
 import { describe, it, expect, afterEach } from "vitest";
-import { AbstractSQLite3Adapter } from "../sqlite3-adapter.js";
+import { SQLite3Adapter } from "../sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../better-sqlite3-adapter.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { Result } from "../../result.js";
@@ -20,7 +20,7 @@ import { adapterType } from "../../test-adapter.js";
 
 const guardsIfNotExists = adapterType !== "sqlite";
 
-let adapter: AbstractSQLite3Adapter | undefined;
+let adapter: SQLite3Adapter | undefined;
 
 afterEach(async () => {
   await adapter?.close();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1229,7 +1229,7 @@ export class SchemaStatements {
         return rows.map((row: any) => {
           // Recover the partial-index WHERE predicate and per-column DESC
           // directions from the index definition, mirroring the concrete
-          // PostgreSQLSchemaStatements#indexes parsing.
+          // PostgreSQL::SchemaStatements#indexes parsing.
           const def = (row.definition as string) ?? "";
           const defMatch = def.match(
             / USING \w+? \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?$/s,

--- a/packages/activerecord/src/connection-adapters/adapter-args.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.ts
@@ -78,7 +78,7 @@ function isRemoteLibsqlUrl(url: string): boolean {
  *   sqlite / sqlite3 / node-sqlite → sqlite
  *
  * SQLite client-library adapters share the `(filename, options)` constructor
- * shape (their subclasses inherit it from `AbstractSQLite3Adapter`), so they
+ * shape (their subclasses inherit it from `SQLite3Adapter`), so they
  * normalize to `sqlite` for argument building. This only affects
  * constructor-argument shape; class resolution still keys off the raw name.
  */

--- a/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
@@ -1,12 +1,12 @@
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { betterSqlite3Driver } from "../sqlite/better-sqlite3.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 
 /**
  * SQLite adapter backed by the `better-sqlite3` client library — the default
  * for the `sqlite3` adapter name.
  *
- * Thin subclass of `AbstractSQLite3Adapter`: all SQLite dialect, quoting, and
+ * Thin subclass of `SQLite3Adapter`: all SQLite dialect, quoting, and
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
@@ -19,7 +19,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * base and binds each client in its own thin subclass; there is nothing to
  * converge these names onto upstream.
  */
-export class BetterSQLite3Adapter extends AbstractSQLite3Adapter {
+export class BetterSQLite3Adapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
     return betterSqlite3Driver;
   }

--- a/packages/activerecord/src/connection-adapters/dbconsole-option-keys.test.ts
+++ b/packages/activerecord/src/connection-adapters/dbconsole-option-keys.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "./postgresql-adapter.js";
 
 // The Rails `dbconsole` PTY exec is unported (see scripts/api-compare/
@@ -30,19 +30,19 @@ describe("AbstractMysqlAdapter.dbconsole option keys", () => {
   });
 });
 
-describe("AbstractSQLite3Adapter.dbconsole option keys", () => {
+describe("SQLite3Adapter.dbconsole option keys", () => {
   it("prepends -#{mode} and -header before the database path", () => {
     expect(
-      AbstractSQLite3Adapter.dbconsole({ database: "db.sqlite3" }, { mode: "html", header: true }),
+      SQLite3Adapter.dbconsole({ database: "db.sqlite3" }, { mode: "html", header: true }),
     ).toEqual(["-html", "-header", "db.sqlite3"]);
   });
 
   it("omits the flags when mode/header are absent", () => {
-    expect(AbstractSQLite3Adapter.dbconsole({ database: "db.sqlite3" })).toEqual(["db.sqlite3"]);
+    expect(SQLite3Adapter.dbconsole({ database: "db.sqlite3" })).toEqual(["db.sqlite3"]);
   });
 
   it("keeps a Ruby-truthy empty-string mode", () => {
-    expect(AbstractSQLite3Adapter.dbconsole({ database: "db.sqlite3" }, { mode: "" })).toEqual([
+    expect(SQLite3Adapter.dbconsole({ database: "db.sqlite3" }, { mode: "" })).toEqual([
       "-",
       "db.sqlite3",
     ]);

--- a/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
@@ -1,11 +1,11 @@
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { expoSqliteDriver } from "../sqlite/expo-sqlite.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 
 /**
  * SQLite adapter backed by `expo-sqlite` for Expo / React Native runtimes.
  *
- * Thin subclass of `AbstractSQLite3Adapter`: all SQLite dialect, quoting, and
+ * Thin subclass of `SQLite3Adapter`: all SQLite dialect, quoting, and
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
@@ -18,7 +18,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * base and binds each client in its own thin subclass; there is nothing to
  * converge these names onto upstream.
  */
-export class ExpoSQLiteAdapter extends AbstractSQLite3Adapter {
+export class ExpoSQLiteAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
     return expoSqliteDriver;
   }

--- a/packages/activerecord/src/connection-adapters/libsql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-adapter.ts
@@ -1,11 +1,11 @@
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { libsqlDriver } from "../sqlite/libsql.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 
 /**
  * SQLite adapter backed by the `libsql` client (Turso/libSQL, local-file MVP).
  *
- * Thin subclass of `AbstractSQLite3Adapter`: all SQLite dialect, quoting, and
+ * Thin subclass of `SQLite3Adapter`: all SQLite dialect, quoting, and
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
@@ -18,7 +18,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * base and binds each client in its own thin subclass; there is nothing to
  * converge these names onto upstream.
  */
-export class LibSQLAdapter extends AbstractSQLite3Adapter {
+export class LibSQLAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
     return libsqlDriver;
   }

--- a/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
@@ -1,18 +1,18 @@
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { libsqlRemoteDriver } from "../sqlite/libsql.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 
 /**
  * SQLite adapter backed by the `libsql` client for remote Turso connections
  * (`libsql://`, `https://`, `wss://`, etc.).
  *
  * Remote handles are network-backed; construction goes through the async-open
- * path (`AbstractSQLite3Adapter.openAsync()` / `completeAsyncConnect()`). Pass
+ * path (`SQLite3Adapter.openAsync()` / `completeAsyncConnect()`). Pass
  * credentials as `driverOptions: { authToken }` in adapter options, or provide
  * `authToken` as a top-level key in a database.yml config (it is lifted into
  * `driverOptions` by `buildAdapterArg`).
  *
- * Thin subclass of `AbstractSQLite3Adapter`: all SQLite dialect, quoting, and
+ * Thin subclass of `SQLite3Adapter`: all SQLite dialect, quoting, and
  * schema logic lives in the abstract base.
  *
  * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
@@ -23,7 +23,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * base and binds each client in its own thin subclass; there is nothing to
  * converge these names onto upstream.
  */
-export class LibSQLRemoteAdapter extends AbstractSQLite3Adapter {
+export class LibSQLRemoteAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
     return libsqlRemoteDriver;
   }

--- a/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
@@ -1,7 +1,7 @@
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { ConfigurationError } from "../errors.js";
 import { libsqlReplicaDriver, type SyncableSqliteConnection } from "../sqlite/libsql.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 
 /**
  * SQLite adapter backed by the `libsql` client in **embedded-replica** mode:
@@ -16,7 +16,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * adapter's `database`/filename argument.
  *
  * Construction is network-backed (initial sync), so it goes through the
- * async-open path (`AbstractSQLite3Adapter.openAsync()`). All SQLite dialect,
+ * async-open path (`SQLite3Adapter.openAsync()`). All SQLite dialect,
  * quoting, and schema logic lives in the abstract base; this subclass binds the
  * replica driver and adds the caller-driven {@link syncReplica} trigger.
  *
@@ -35,7 +35,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * base and binds each client in its own thin subclass; there is nothing to
  * converge these names onto upstream.
  */
-export class LibSQLReplicaAdapter extends AbstractSQLite3Adapter {
+export class LibSQLReplicaAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
     return libsqlReplicaDriver;
   }

--- a/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
@@ -1,11 +1,11 @@
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { nodeSqliteDriver } from "../sqlite/node-sqlite.js";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 
 /**
  * SQLite adapter backed by the built-in `node:sqlite` module (Node 22.5+).
  *
- * Thin subclass of `AbstractSQLite3Adapter`: all SQLite dialect, quoting, and
+ * Thin subclass of `SQLite3Adapter`: all SQLite dialect, quoting, and
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
@@ -18,7 +18,7 @@ import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
  * base and binds each client in its own thin subclass; there is nothing to
  * converge these names onto upstream.
  */
-export class NodeSQLiteAdapter extends AbstractSQLite3Adapter {
+export class NodeSQLiteAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
     return nodeSqliteDriver;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -74,8 +74,8 @@ import {
 import { AbstractAdapter, RAW_CONNECTION_DEPRECATION_MESSAGE } from "./abstract-adapter.js";
 import { deprecator } from "../deprecator.js";
 import { captureUnwrappedExecute, dirtiesQueryCache } from "./abstract/query-cache.js";
-import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class.js";
-import type { SchemaStatements } from "./abstract/schema-statements.js";
+import { SchemaStatements } from "./postgresql/schema-statements-class.js";
+import type { SchemaStatements as AbstractSchemaStatements } from "./abstract/schema-statements.js";
 import type {
   JoinTableOptions,
   ValidateConstraintStatements,
@@ -3725,7 +3725,7 @@ export class PostgreSQLAdapter
 
   /**
    * The serial detection Rails inlines in `new_column_from_field`, extracted so
-   * PostgreSQLSchemaStatements#columns can share it: that path cannot delegate
+   * PostgreSQL::SchemaStatements#columns can share it: that path cannot delegate
    * to newColumnFromField because it batch-preloads the row OIDs and resolves
    * types through lookupCastTypeFromColumn, where fetchTypeMetadata would issue
    * a per-column pg_type query.
@@ -4842,7 +4842,7 @@ export interface PostgreSQLAdapter {
 
   recreateDatabase(name: string, options?: CreateDatabaseOptions): Promise<void>;
 
-  dropTable(...args: Parameters<SchemaStatements["dropTable"]>): Promise<void>;
+  dropTable(...args: Parameters<AbstractSchemaStatements["dropTable"]>): Promise<void>;
 
   currentDatabase(): Promise<string>;
 
@@ -5145,7 +5145,7 @@ captureUnwrappedExecute(PostgreSQLAdapter);
 dirtiesQueryCache(PostgreSQLAdapter, "execQuery", "execute");
 
 // Rails: `include PostgreSQL::SchemaStatements` (postgresql_adapter.rb:185).
-include(PostgreSQLAdapter, PostgreSQLSchemaStatements);
+include(PostgreSQLAdapter, SchemaStatements);
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
 // at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -29,7 +29,7 @@ function makeFakeAdapter() {
   return { adapter, executed, clearedTables };
 }
 
-describe("PostgreSQLSchemaStatements#dropTable", () => {
+describe("SchemaStatements#dropTable", () => {
   it("emits a single DROP TABLE statement with all table names joined", async () => {
     const { adapter, executed } = makeFakeAdapter();
     const ss = withSchemaStatements(adapter);
@@ -93,7 +93,7 @@ function makeSchemaAdapter() {
   return { adapter, execed };
 }
 
-describe("PostgreSQLSchemaStatements#dropSchema", () => {
+describe("SchemaStatements#dropSchema", () => {
   it("always appends CASCADE", async () => {
     const { adapter, execed } = makeSchemaAdapter();
     const ss = withSchemaStatements(adapter);
@@ -109,7 +109,7 @@ describe("PostgreSQLSchemaStatements#dropSchema", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
+describe("SchemaStatements#schemaSearchPath", () => {
   it("memoizes the search path and only queries once", async () => {
     const { adapter } = makeSchemaAdapter();
     const ss = withSchemaStatements(adapter);
@@ -152,7 +152,7 @@ describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements#addForeignKey use_foreign_keys? guard", () => {
+describe("SchemaStatements#addForeignKey use_foreign_keys? guard", () => {
   it("is a no-op when the adapter does not support foreign keys (Rails super guard)", async () => {
     // Rails PG add_foreign_key is `assert_valid_deferrable(deferrable); super`,
     // and the abstract super begins with `return unless use_foreign_keys?`.

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -68,7 +68,7 @@ function makeAdapter(options: FakeOptions = {}) {
 // migration/exclusion_constraint_test.rb and migration/unique_constraint_test.rb,
 // so drift in the identifier shape or digest slice fails here rather than
 // silently changing emitted DDL and dumped schema.
-describe("PostgreSQLSchemaStatements constraint name digests", () => {
+describe("SchemaStatements constraint name digests", () => {
   it("derives the exclusion constraint name Rails derives", () => {
     const ss = withSchemaStatements(makeAdapter().adapter);
     expect(
@@ -103,7 +103,7 @@ describe("PostgreSQLSchemaStatements constraint name digests", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", () => {
+describe("SchemaStatements sequence helpers warn without a sequence", () => {
   it("setPkSequenceBang warns when the table has a primary key but no sequence", async () => {
     const warn = vi.fn();
     const ss = withSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
@@ -142,7 +142,7 @@ describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", 
 // Rails' index_name_exists? runs BOTH arguments through quoted_scope and
 // compares `i.relname = index[:name]` (schema_statements.rb:67-81), so a
 // schema-qualified index name matches on its bare identifier.
-describe("PostgreSQLSchemaStatements#indexNameExists", () => {
+describe("SchemaStatements#indexNameExists", () => {
   it("parses the index name through quotedScope rather than quoting it raw", async () => {
     const { adapter, sql } = makeAdapter({
       queryValue: async () => 1,
@@ -154,7 +154,7 @@ describe("PostgreSQLSchemaStatements#indexNameExists", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements#pkAndSequenceFor", () => {
+describe("SchemaStatements#pkAndSequenceFor", () => {
   it("falls back to the pg_attrdef query when the pg_depend lookup finds nothing", async () => {
     const { adapter, sql } = makeAdapter({
       query: async (text) =>
@@ -196,7 +196,7 @@ describe("PostgreSQLSchemaStatements#pkAndSequenceFor", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
+describe("SchemaStatements#resetPkSequenceBang", () => {
   // Ruby's `max_pk ? true : false` is a nil check; 0 is truthy in Ruby.
   it("emits setval(..., 0, true) when the max primary key is 0", async () => {
     const { adapter, sql } = makeAdapter({ queryValue: async () => 0 });
@@ -215,7 +215,7 @@ describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", () => {
+describe("SchemaStatements sequenceNameFromParts identifier budget", () => {
   it("truncates against the server's maxIdentifierLength, not a hardcoded 63", () => {
     const { adapter } = makeAdapter({ maxIdentifierLength: 31 });
     const ss = withSchemaStatements(adapter);
@@ -239,7 +239,7 @@ describe("PostgreSQLSchemaStatements sequenceNameFromParts identifier budget", (
   });
 });
 
-describe("PostgreSQLSchemaStatements#typeToSql enum validation", () => {
+describe("SchemaStatements#typeToSql enum validation", () => {
   it("resolves an enum column to its enum type", () => {
     const { adapter } = makeAdapter();
     const ss = withSchemaStatements(adapter);
@@ -255,7 +255,7 @@ describe("PostgreSQLSchemaStatements#typeToSql enum validation", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements#changeTable", () => {
+describe("SchemaStatements#changeTable", () => {
   it("yields the PostgreSQL Table subclass", async () => {
     const { adapter } = makeAdapter();
     const ss = withSchemaStatements(adapter);
@@ -267,7 +267,7 @@ describe("PostgreSQLSchemaStatements#changeTable", () => {
   });
 });
 
-describe("PostgreSQLSchemaStatements#indexes", () => {
+describe("SchemaStatements#indexes", () => {
   it("keeps the schema-qualified table name from the argument", async () => {
     const { adapter } = makeAdapter({
       query: async (text) =>

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1,7 +1,7 @@
 import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
-import { SchemaStatements } from "../abstract/schema-statements.js";
+import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
 import {
   AlterTable,
   ChangeColumnDefinition,
@@ -99,7 +99,7 @@ function toS(value: unknown): string {
   return value == null ? "" : String(value);
 }
 
-export class PostgreSQLSchemaStatements extends SchemaStatements {
+export class SchemaStatements extends AbstractSchemaStatements {
   private get pg(): PgSchemaAdapter {
     return this as unknown as PgSchemaAdapter;
   }
@@ -109,7 +109,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     return new PgTable(tableName, (base ?? this) as SchemaStatementsConstraintLike);
   }
 
-  override async dropTable(...args: Parameters<SchemaStatements["dropTable"]>): Promise<void> {
+  override async dropTable(
+    ...args: Parameters<AbstractSchemaStatements["dropTable"]>
+  ): Promise<void> {
     const [tableNames, options] = this._splitTableNamesAndOptions(args);
     if (tableNames.length === 0) {
       throw new ArgumentError("dropTable requires at least one table name");

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import type { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { Base } from "../base.js";
 
 describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
 
   beforeEach(async () => {
     adapter = new BetterSQLite3Adapter(":memory:");
@@ -43,7 +43,7 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
 });
 
 describe("SQLite3Adapter alterTable under a table name prefix/suffix", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
 
   beforeEach(async () => {
     adapter = new BetterSQLite3Adapter(":memory:");

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 
@@ -10,7 +10,7 @@ import { ArgumentError } from "@blazetrails/activemodel";
 // the file (or `:memory:`). trails accepts that Rails-shaped hash while keeping
 // the legacy positional `(filename, options)` form as a bridge.
 describe("SQLite3Adapter hash-only constructor", () => {
-  let adapter: AbstractSQLite3Adapter | undefined;
+  let adapter: SQLite3Adapter | undefined;
   let tmpDir: string | undefined;
 
   afterEach(async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { FloatType, DecimalType, IntegerType } from "@blazetrails/activemodel";
 import { QueryAttribute } from "../relation/query-attribute.js";
@@ -13,7 +13,7 @@ import { QueryAttribute } from "../relation/query-attribute.js";
 // as SQLITE_INTEGER (`LOWER(1) => '1'`). The adapter's type cast converts
 // integer-valued numbers to BigInt so they bind as SQLITE_INTEGER.
 describe("SQLite3Adapter integer bind serialization", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
   let tmpDir: string;
 
   beforeEach(() => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.query-transformers.test.ts
@@ -3,7 +3,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { Base } from "../base.js";
 import { fixtures } from "../test-fixtures.js";
 import { describeIfSqlite } from "../support/describe-if-sqlite.js";
-import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import type { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { ActiveRecord } from "../ar-config.js";
 import type { QueryTransformer } from "../query-transformers.js";
 
@@ -15,11 +15,11 @@ fixtures([]);
 // payload — the Rails-faithful ordering where preprocess_query runs before
 // raw_execute's log block.
 describeIfSqlite("SQLite3Adapter queryTransformers wiring", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
   let savedTransformers: QueryTransformer[];
 
   beforeEach(() => {
-    adapter = Base.connection as AbstractSQLite3Adapter;
+    adapter = Base.connection as SQLite3Adapter;
     savedTransformers = ActiveRecord.queryTransformers.slice();
     ActiveRecord.queryTransformers.length = 0;
   });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.timeout-config.trails.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { deprecator } from "../deprecator.js";
 
 describe("SQLite3Adapter timeout config coercion", () => {
-  let adapter: AbstractSQLite3Adapter | undefined;
+  let adapter: SQLite3Adapter | undefined;
 
   afterEach(async () => {
     await adapter?.close();

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.transactions.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.transactions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { RecordNotUnique, TransactionIsolationError } from "../errors.js";
 
@@ -11,7 +11,7 @@ import { RecordNotUnique, TransactionIsolationError } from "../errors.js";
 // This keeps the adapter portable to async drivers (node:sqlite, wa-sqlite, expo-sqlite).
 
 describe("SQLite3Adapter transaction control", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
   let tmpDir: string;
 
   beforeEach(async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -205,7 +205,7 @@ function _isSqliteMissingDbError(error: unknown): boolean {
   );
 }
 
-export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
+export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   override get adapterName(): AdapterName {
     return "sqlite";
   }
@@ -401,7 +401,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     } else {
       filename = filenameOrConfig;
     }
-    this._memoryDatabase = AbstractSQLite3Adapter._isMemoryFilename(filename);
+    this._memoryDatabase = SQLite3Adapter._isMemoryFilename(filename);
     // Mirrors the non-`:memory:`/non-`file:` branch of Rails'
     // `SQLite3Adapter#initialize`: expand the path and create its parent
     // directory before the driver opens the handle below.
@@ -411,7 +411,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     this._config = { ...options };
     this._filename = filename;
     this._readonly = options.readonly ?? false;
-    this._strict = options.strict ?? AbstractSQLite3Adapter.strictStringsByDefault;
+    this._strict = options.strict ?? SQLite3Adapter.strictStringsByDefault;
     (this._config as SQLite3AdapterOptions).strict = this._strict;
     // Rails: `SQLite3Adapter#default_prepared_statements` inherits the
     // abstract adapter's `true`. Mirror that default and let options
@@ -426,7 +426,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // Sync-driver path resolves synchronously; the async path is flagged out
     // above and configured later via completeAsyncConnect. Fire-and-forget here.
     if (!this._asyncConnectPending) void this.configureConnection();
-    this._nativeTypeMap = AbstractSQLite3Adapter._buildTypeMap();
+    this._nativeTypeMap = SQLite3Adapter._buildTypeMap();
   }
 
   /**
@@ -1228,7 +1228,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // INTEGER in SQLite can store up to 8 bytes; default _limit to 8 when none given.
   private static _buildTypeMap(): TypeMap {
     const map = new TypeMap();
-    AbstractSQLite3Adapter.initializeTypeMap(map);
+    SQLite3Adapter.initializeTypeMap(map);
     return map;
   }
 
@@ -1446,7 +1446,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    */
   get encoding(): string {
     if (this._encoding !== null) return this._encoding;
-    return AbstractSQLite3Adapter.parseEncoding(this.driver?.pragma("encoding"));
+    return SQLite3Adapter.parseEncoding(this.driver?.pragma("encoding"));
   }
 
   private _encoding: string | null = null;
@@ -1512,9 +1512,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   static newClient(
-    this: new (filename?: string, options?: SQLite3AdapterOptions) => AbstractSQLite3Adapter,
+    this: new (filename?: string, options?: SQLite3AdapterOptions) => SQLite3Adapter,
     config: { database?: string; readonly?: boolean },
-  ): AbstractSQLite3Adapter {
+  ): SQLite3Adapter {
     return new this(config.database ?? ":memory:", { readonly: config.readonly });
   }
 
@@ -2638,7 +2638,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   /** @internal */
   override buildStatementPool(): GenericStatementPool<SqliteStatement> {
     return new GenericStatementPool<SqliteStatement>(
-      AbstractSQLite3Adapter.typeCastConfigToInteger(this._statementLimit) as number,
+      SQLite3Adapter.typeCastConfigToInteger(this._statementLimit) as number,
     );
   }
 
@@ -2695,7 +2695,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       this._databaseVersion = new Version(vRow?.v ?? "0.0.0");
       // Pre-warm encoding too, so the sync `encoding` getter never touches the
       // driver directly (parity with _databaseVersion).
-      this._encoding = AbstractSQLite3Adapter.parseEncoding(syncConn.pragma("encoding"));
+      this._encoding = SQLite3Adapter.parseEncoding(syncConn.pragma("encoding"));
       this.driver = syncConn as SqliteConnection;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -2739,7 +2739,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       this._databaseVersion = new Version(vRow?.v ?? "0.0.0");
       // Memoize encoding while we can still await the async pragma, so the sync
       // `encoding` getter serves a cached value rather than a Promise.
-      this._encoding = AbstractSQLite3Adapter.parseEncoding(await conn.pragma("encoding"));
+      this._encoding = SQLite3Adapter.parseEncoding(await conn.pragma("encoding"));
       this.driver = conn;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -2813,10 +2813,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * has or can have.
    */
   static async openAsync(
-    this: new (filename?: string, options?: SQLite3AdapterOptions) => AbstractSQLite3Adapter,
+    this: new (filename?: string, options?: SQLite3AdapterOptions) => SQLite3Adapter,
     filename: string | ":memory:" = ":memory:",
     options: SQLite3AdapterOptions = {},
-  ): Promise<AbstractSQLite3Adapter> {
+  ): Promise<SQLite3Adapter> {
     const adapter = new this(filename, options);
     await adapter.completeAsyncConnect();
     return adapter;
@@ -2896,7 +2896,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       throw new ArgumentError("Cannot specify both timeout and retries arguments");
     }
     if (!isRubyTruthy(cfg.timeout)) return undefined;
-    const timeout = AbstractSQLite3Adapter.typeCastConfigToInteger(cfg.timeout);
+    const timeout = SQLite3Adapter.typeCastConfigToInteger(cfg.timeout);
     if (typeof timeout !== "number" || !Number.isInteger(timeout)) {
       throw new TypeError(`timeout must be integer, not ${String(timeout)}`);
     }
@@ -3123,7 +3123,7 @@ function translateException(
 // through the wired `execute`, as in Rails), and reads route through
 // `internalExecQuery` (never tripping the wrapper).
 dirtiesQueryCache(
-  AbstractSQLite3Adapter,
+  SQLite3Adapter,
   "execInsert",
   "rollbackDbTransaction",
   "rollbackToSavepoint",
@@ -3132,10 +3132,10 @@ dirtiesQueryCache(
 // Snapshot the unwrapped `execute` first: schema reflection routes through it
 // (via schemaQuery) so it never trips the dirtying wrapper, mirroring Rails'
 // `internal_exec_query`.
-captureUnwrappedExecute(AbstractSQLite3Adapter);
-dirtiesQueryCache(AbstractSQLite3Adapter, "execQuery", "execute");
+captureUnwrappedExecute(SQLite3Adapter);
+dirtiesQueryCache(SQLite3Adapter, "execQuery", "execute");
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, self)`
 // at the bottom of Rails' sqlite3_adapter.rb — lets railtie initializers
 // gate behavior on the sqlite3 adapter being loaded.
-runLoadHooks("active_record_sqlite3adapter", AbstractSQLite3Adapter);
+runLoadHooks("active_record_sqlite3adapter", SQLite3Adapter);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import type { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 
 // trails-only coverage for the SQLite `register_class_with_limit` convergence
@@ -13,7 +13,7 @@ import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 // (`fetchTypeMetadata` → `lookupCastTypeFromColumn`) carries the limit without
 // the reflective cast-type rebuild that previously stood in for it.
 describe("SQLite3Adapter type-map limit threading", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
   let tmpDir: string;
 
   beforeEach(() => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 
 describe("SQLite3Adapter schema introspection", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
   let tmpDir: string;
 
   beforeEach(() => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -4,7 +4,7 @@ import { BinaryData } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
-import { type AbstractSQLite3Adapter, SQLite3DateTime } from "../sqlite3-adapter.js";
+import { type SQLite3Adapter, SQLite3DateTime } from "../sqlite3-adapter.js";
 import { Date as DateType } from "../../type/date.js";
 import { Time as TimeType } from "../../type/time.js";
 import {
@@ -27,7 +27,7 @@ import {
 // prefix on times, and quotedBinary so binary self-dispatch reaches SQLite's
 // `x'..'` hex form, and the boolean pair so the inherited abstract boolean arm
 // self-dispatches back to SQLite's 1/0 — the same overrides
-// AbstractSQLite3Adapter supplies.
+// SQLite3Adapter supplies.
 const HOST = {
   quotedDate,
   quotedTime,
@@ -346,10 +346,10 @@ describe("SQLite3::Quoting", () => {
   });
 
   describeIfSqlite("SQLite microsecond round-trip — integration", () => {
-    let adapter: AbstractSQLite3Adapter;
+    let adapter: SQLite3Adapter;
 
     beforeEach(async () => {
-      adapter = Base.connection as AbstractSQLite3Adapter;
+      adapter = Base.connection as SQLite3Adapter;
       await adapter.exec(`DROP TABLE IF EXISTS "quoting_events"`);
       await adapter.exec(`CREATE TABLE "quoting_events" (
         "id" INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/activerecord/src/sqlite-adapter.test.ts
+++ b/packages/activerecord/src/sqlite-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
 import { NodeSQLiteAdapter } from "./connection-adapters/node-sqlite-adapter.js";
 import { ExpoSQLiteAdapter } from "./connection-adapters/expo-sqlite-adapter.js";
@@ -26,38 +26,38 @@ const asyncOnlyDriver = asyncDriver(openVia);
 describe("SQLite adapter driver binding", () => {
   it("BetterSQLite3Adapter binds its bundled driver and opens", () => {
     const adapter = new BetterSQLite3Adapter(":memory:");
-    expect(adapter).toBeInstanceOf(AbstractSQLite3Adapter);
+    expect(adapter).toBeInstanceOf(SQLite3Adapter);
     adapter.disconnectBang();
   });
 
   it("the abstract base has no bundled driver and cannot open directly", () => {
-    expect(() => new AbstractSQLite3Adapter(":memory:")).toThrow(/No SQLite driver configured/);
+    expect(() => new SQLite3Adapter(":memory:")).toThrow(/No SQLite driver configured/);
   });
 
   it("accepts an explicit SqliteDriver via config.driver", () => {
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: betterSqlite3Driver });
-    expect(adapter).toBeInstanceOf(AbstractSQLite3Adapter);
+    const adapter = new SQLite3Adapter(":memory:", { driver: betterSqlite3Driver });
+    expect(adapter).toBeInstanceOf(SQLite3Adapter);
     adapter.disconnectBang();
   });
 
   it("rejects an invalid driver object", () => {
-    expect(
-      () => new AbstractSQLite3Adapter(":memory:", { driver: { name: "x" } as never }),
-    ).toThrow(/config.driver must be a SqliteDriver/);
+    expect(() => new SQLite3Adapter(":memory:", { driver: { name: "x" } as never })).toThrow(
+      /config.driver must be a SqliteDriver/,
+    );
   });
 
-  it("NodeSQLiteAdapter and ExpoSQLiteAdapter are thin AbstractSQLite3Adapter subclasses", () => {
-    expect(Object.getPrototypeOf(NodeSQLiteAdapter)).toBe(AbstractSQLite3Adapter);
-    expect(Object.getPrototypeOf(ExpoSQLiteAdapter)).toBe(AbstractSQLite3Adapter);
+  it("NodeSQLiteAdapter and ExpoSQLiteAdapter are thin SQLite3Adapter subclasses", () => {
+    expect(Object.getPrototypeOf(NodeSQLiteAdapter)).toBe(SQLite3Adapter);
+    expect(Object.getPrototypeOf(ExpoSQLiteAdapter)).toBe(SQLite3Adapter);
   });
 
   it("defers connection for an async-only driver constructed synchronously", () => {
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
+    const adapter = new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
     expect(adapter.active).toBe(false);
   });
 
   it("opens an async-only driver via openAsync and round-trips a query", async () => {
-    const adapter = await AbstractSQLite3Adapter.openAsync(":memory:", { driver: asyncOnlyDriver });
+    const adapter = await SQLite3Adapter.openAsync(":memory:", { driver: asyncOnlyDriver });
     expect(adapter.active).toBe(true);
     await adapter.internalExecute(
       "CREATE TABLE async_t (id INTEGER PRIMARY KEY, name TEXT)",
@@ -82,7 +82,7 @@ describe("SQLite adapter driver binding", () => {
       seen = config as unknown as Record<string, unknown>;
       return openVia(config);
     });
-    const adapter = await AbstractSQLite3Adapter.openAsync(":memory:", {
+    const adapter = await SQLite3Adapter.openAsync(":memory:", {
       driver,
       timeout: 1234,
       driverOptions: { foo: "bar" },
@@ -98,7 +98,7 @@ describe("SQLite adapter driver binding", () => {
       if (++attempts === 1) throw new Error("boom");
       return openVia(config);
     });
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver });
+    const adapter = new SQLite3Adapter(":memory:", { driver });
     await expect(adapter.completeAsyncConnect()).rejects.toThrow();
     expect(adapter.active).toBe(false);
     await adapter.completeAsyncConnect();
@@ -112,7 +112,7 @@ describe("SQLite adapter driver binding", () => {
       opens++;
       return openVia(config);
     });
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver });
+    const adapter = new SQLite3Adapter(":memory:", { driver });
     await Promise.all([adapter.completeAsyncConnect(), adapter.completeAsyncConnect()]);
     expect(opens).toBe(1);
     expect(adapter.active).toBe(true);
@@ -120,7 +120,7 @@ describe("SQLite adapter driver binding", () => {
   });
 
   it("disconnectBang is safe before an async-only connection completes", () => {
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
+    const adapter = new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
     expect(() => adapter.disconnectBang()).not.toThrow();
   });
 
@@ -145,7 +145,7 @@ describe("SQLite adapter driver binding", () => {
         },
       });
     });
-    const adapter = await AbstractSQLite3Adapter.openAsync(":memory:", { driver });
+    const adapter = await SQLite3Adapter.openAsync(":memory:", { driver });
     adapter.disconnectBang();
     expect(closed).toBe(false);
     resolveClose!();
@@ -170,7 +170,7 @@ describe("SQLite adapter driver binding", () => {
         },
       });
     });
-    const adapter = await AbstractSQLite3Adapter.openAsync(":memory:", { driver });
+    const adapter = await SQLite3Adapter.openAsync(":memory:", { driver });
     adapter.disconnectBang();
     await expect(adapter.close()).resolves.toBeUndefined();
   });
@@ -179,7 +179,7 @@ describe("SQLite adapter driver binding", () => {
     // Mirrors what the synchronous pool checkout does: construct the adapter
     // without awaiting openAsync(), then issue the first query. The query must
     // transparently complete the deferred open rather than touch an unset handle.
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
+    const adapter = new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
     expect(adapter.active).toBe(false);
     await adapter.internalExecute(
       "CREATE TABLE sync_checkout (id INTEGER PRIMARY KEY, name TEXT)",
@@ -196,7 +196,7 @@ describe("SQLite adapter driver binding", () => {
   it("completes a deferred open when the first call is a schema introspection", async () => {
     // columns()/exec() must also drain the pending open: the first call after a
     // sync checkout is not always a SELECT.
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
+    const adapter = new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
     await adapter.exec("CREATE TABLE schema_first (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
     const cols = await adapter.columns("schema_first");
     expect(cols.map((c) => c.name)).toEqual(["id", "name"]);
@@ -210,7 +210,7 @@ describe("SQLite adapter driver binding", () => {
       opens++;
       return openVia(config);
     });
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver });
+    const adapter = new SQLite3Adapter(":memory:", { driver });
     // These are the FIRST operations — no prior query has cleared the pending
     // flag, so all three race into completeAsyncConnect() and must dedupe onto
     // the single in-flight open rather than each opening their own handle.
@@ -236,13 +236,13 @@ describe("SQLite adapter driver binding", () => {
       "default",
       {
         adapterFactory: () =>
-          new AbstractSQLite3Adapter(":memory:", {
+          new SQLite3Adapter(":memory:", {
             driver: asyncOnlyDriver,
           }) as unknown as DatabaseAdapter,
       },
     );
     const pool = new ConnectionPool(poolConfig);
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     expect(conn.active).toBe(false);
     await conn.internalExecute("CREATE TABLE pool_t (id INTEGER PRIMARY KEY, name TEXT)", "SCHEMA");
     expect(conn.active).toBe(true);
@@ -286,11 +286,11 @@ describe("SQLite adapter driver binding", () => {
       "default",
       {
         adapterFactory: () =>
-          new AbstractSQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
+          new SQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
       },
     );
     const pool = new ConnectionPool(poolConfig);
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     await conn.internalExecute("CREATE TABLE drain_t (id INTEGER PRIMARY KEY)", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS drain_t", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS drain_t", "SCHEMA");
@@ -313,13 +313,13 @@ describe("SQLite adapter driver binding", () => {
       "default",
       {
         adapterFactory: () =>
-          new AbstractSQLite3Adapter(":memory:", {
+          new SQLite3Adapter(":memory:", {
             driver: betterSqlite3Driver,
           }) as unknown as DatabaseAdapter,
       },
     );
     const pool = new ConnectionPool(poolConfig);
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     await conn.internalExecute("CREATE TABLE sync_drain_t (id INTEGER PRIMARY KEY)", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS sync_drain_t", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS sync_drain_t", "SCHEMA");
@@ -373,7 +373,7 @@ describe("SQLite adapter driver binding", () => {
     const { driver, release, isClosed } = gatedCloseDriver();
     const poolConfig = makePoolConfig(
       () =>
-        new Proxy(new AbstractSQLite3Adapter(":memory:", { driver }), {
+        new Proxy(new SQLite3Adapter(":memory:", { driver }), {
           get(target, prop, receiver) {
             // SQLite is a reload-requiring adapter in Rails; the abstract base
             // defaults to false, so force it true to exercise the reload seam.
@@ -383,7 +383,7 @@ describe("SQLite adapter driver binding", () => {
         }) as unknown as DatabaseAdapter,
     );
     const pool = new ConnectionPool(poolConfig);
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     await conn.internalExecute("CREATE TABLE reload_t (id INTEGER PRIMARY KEY)", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS reload_t", "SCHEMA");
     pool.checkin(conn as unknown as DatabaseAdapter);
@@ -399,10 +399,10 @@ describe("SQLite adapter driver binding", () => {
     const { driver, release, isClosed } = gatedCloseDriver();
     const pool = new ConnectionPool(
       makePoolConfig(
-        () => new AbstractSQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
+        () => new SQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
       ),
     );
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     await conn.internalExecute("CREATE TABLE flush_t (id INTEGER PRIMARY KEY)", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS flush_t", "SCHEMA");
     pool.checkin(conn as unknown as DatabaseAdapter);
@@ -418,10 +418,10 @@ describe("SQLite adapter driver binding", () => {
     const { driver, release, isClosed } = gatedCloseDriver();
     const pool = new ConnectionPool(
       makePoolConfig(
-        () => new AbstractSQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
+        () => new SQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
       ),
     );
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     await conn.internalExecute("CREATE TABLE discard_t (id INTEGER PRIMARY KEY)", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS discard_t", "SCHEMA");
     // Rails' discard! abandons the handle without closing; fire the async close
@@ -442,7 +442,7 @@ describe("SQLite adapter driver binding", () => {
     const pool = new ConnectionPool(
       makePoolConfig(
         () =>
-          new Proxy(new AbstractSQLite3Adapter(":memory:", { driver }), {
+          new Proxy(new SQLite3Adapter(":memory:", { driver }), {
             get(target, prop, receiver) {
               // checkout_and_verify runs clean!; throwing from it drives the
               // swap/checkout-failure discard path (pool.remove + disconnectBang).
@@ -455,7 +455,7 @@ describe("SQLite adapter driver binding", () => {
           }) as unknown as DatabaseAdapter,
       ),
     );
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     await conn.internalExecute("CREATE TABLE swap_t (id INTEGER PRIMARY KEY)", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS swap_t", "SCHEMA");
     pool.checkin(conn as unknown as DatabaseAdapter);
@@ -476,12 +476,12 @@ describe("SQLite adapter driver binding", () => {
     const pool = new ConnectionPool(
       makePoolConfig(
         () =>
-          new AbstractSQLite3Adapter(":memory:", {
+          new SQLite3Adapter(":memory:", {
             driver: betterSqlite3Driver,
           }) as unknown as DatabaseAdapter,
       ),
     );
-    const conn = (await pool.checkout()) as unknown as AbstractSQLite3Adapter;
+    const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
     await conn.internalExecute("CREATE TABLE sync_seam_t (id INTEGER PRIMARY KEY)", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS sync_seam_t", "SCHEMA");
     pool.checkin(conn as unknown as DatabaseAdapter);
@@ -492,7 +492,7 @@ describe("SQLite adapter driver binding", () => {
   });
 
   it("reconnects an async-only driver and reapplies pragmas", async () => {
-    const adapter = await AbstractSQLite3Adapter.openAsync(":memory:", { driver: asyncOnlyDriver });
+    const adapter = await SQLite3Adapter.openAsync(":memory:", { driver: asyncOnlyDriver });
     adapter.disconnectBang();
     expect(adapter.active).toBe(false);
     // Full lifecycle: reconnectBang() -> reconnect() (opens) -> configureConnection().
@@ -522,7 +522,7 @@ describe("SQLite adapter driver binding", () => {
   });
 
   it("encoding is memoized at connect for an async-only driver", async () => {
-    const adapter = await AbstractSQLite3Adapter.openAsync(":memory:", {
+    const adapter = await SQLite3Adapter.openAsync(":memory:", {
       driver: asyncPragmaDriver,
     });
     expect(adapter.encoding).toBe("UTF-8");
@@ -530,19 +530,19 @@ describe("SQLite adapter driver binding", () => {
   });
 
   it("encoding falls back to UTF-8 before a deferred async-only open completes", () => {
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: asyncPragmaDriver });
+    const adapter = new SQLite3Adapter(":memory:", { driver: asyncPragmaDriver });
     expect(adapter.active).toBe(false);
     expect(adapter.encoding).toBe("UTF-8");
   });
 
   it("encoding returns the database encoding for a sync driver", () => {
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: betterSqlite3Driver });
+    const adapter = new SQLite3Adapter(":memory:", { driver: betterSqlite3Driver });
     expect(adapter.encoding).toBe("UTF-8");
     adapter.disconnectBang();
   });
 
   it("isOpen and raw degrade gracefully before a deferred async-only open", () => {
-    const adapter = new AbstractSQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
+    const adapter = new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
     expect(adapter.isOpen).toBe(false);
     expect(adapter.raw).toBeUndefined();
   });

--- a/packages/activerecord/src/sqlite-adapter.ts
+++ b/packages/activerecord/src/sqlite-adapter.ts
@@ -72,7 +72,7 @@ export interface SqliteConnection {
  * Synchronous narrowing of `SqliteStatement` for `inProcessSync` drivers. The
  * sync constructor path binds to this via `openSync()`; async drivers can't be
  * wired here (they'd return Promises the sync path casts as concrete values)
- * and instead use the async `open()` path (`AbstractSQLite3Adapter.openAsync()`).
+ * and instead use the async `open()` path (`SQLite3Adapter.openAsync()`).
  */
 export interface SyncSqliteStatement {
   run(binds?: SqliteBinds): RunResult;
@@ -134,11 +134,11 @@ export interface SqliteDriver {
   open(config: SqliteOpenConfig): Promise<SqliteConnection>;
   /**
    * Sync open for `inProcessSync` drivers. Retained — NOT superseded by the
-   * async path: `AbstractSQLite3Adapter`'s constructor is synchronous, so
+   * async path: `SQLite3Adapter`'s constructor is synchronous, so
    * in-process drivers (better-sqlite3, node:sqlite) connect eagerly here,
    * keeping `new Adapter()` usable without `await`. Async-only drivers
    * (expo-sqlite, WASM/network) omit this hook and are opened via
-   * `AbstractSQLite3Adapter.openAsync()`, which awaits `open()`. Returns the
+   * `SQLite3Adapter.openAsync()`, which awaits `open()`. Returns the
    * narrowed `SyncSqliteConnection` so the type system rejects async drivers
    * wired here. @internal
    */

--- a/packages/activerecord/src/sqlite/libsql.test.ts
+++ b/packages/activerecord/src/sqlite/libsql.test.ts
@@ -202,7 +202,7 @@ describe("LibSQLAdapter — local-file smoke", () => {
     expect(rows.map((r) => (r as { name: string }).name)).toEqual(["apple", "banana"]);
   });
 
-  it("reflects schema ops via the shared AbstractSQLite3Adapter dialect", async () => {
+  it("reflects schema ops via the shared SQLite3Adapter dialect", async () => {
     const tables = await adapter.tables();
     expect(tables).toContain("items");
     const columns = await adapter.columns("items");

--- a/packages/activerecord/src/sqlite/libsql.ts
+++ b/packages/activerecord/src/sqlite/libsql.ts
@@ -164,7 +164,7 @@ const remoteCapabilities: SqliteDriverCapabilities = {
  * libsql driver for remote Turso connections (`libsql://`, `https://`, etc.).
  *
  * Remote handles are network-backed; they must go through the async-open path
- * (`AbstractSQLite3Adapter.openAsync()` / `completeAsyncConnect()`). The driver
+ * (`SQLite3Adapter.openAsync()` / `completeAsyncConnect()`). The driver
  * intentionally omits `openSync` so the abstract base defers to `connectAsync`.
  * `restoreFromPath` and `databaseExists` are omitted — remote databases have no
  * local-file counterpart.

--- a/packages/activerecord/src/sqlite/statement-reader.test.ts
+++ b/packages/activerecord/src/sqlite/statement-reader.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { SqliteConnection, SqliteDriver } from "../sqlite-adapter.js";
-import type { AbstractSQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { LibSQLAdapter } from "../connection-adapters/libsql-adapter.js";
 import { NodeSQLiteAdapter } from "../connection-adapters/node-sqlite-adapter.js";
@@ -56,7 +56,7 @@ describe.each(drivers)("SqliteStatement#reader — %s", (_name, driver, availabl
   });
 });
 
-const adapters: [string, () => AbstractSQLite3Adapter, boolean][] = [
+const adapters: [string, () => SQLite3Adapter, boolean][] = [
   ["better-sqlite3", () => new BetterSQLite3Adapter(":memory:"), true],
   ["libsql", () => new LibSQLAdapter(":memory:"), true],
   ["node-sqlite", () => new NodeSQLiteAdapter(":memory:"), isNodeSqliteAvailable],

--- a/packages/activerecord/src/support/ddl-profile.ts
+++ b/packages/activerecord/src/support/ddl-profile.ts
@@ -243,7 +243,7 @@ export async function install(): Promise<void> {
   if (!ddlProfileEnabled() || installed) return;
   installed = true;
 
-  const [{ PostgreSQLAdapter }, { Mysql2Adapter }, { AbstractSQLite3Adapter }] = await Promise.all([
+  const [{ PostgreSQLAdapter }, { Mysql2Adapter }, { SQLite3Adapter }] = await Promise.all([
     import("../connection-adapters/postgresql-adapter.js"),
     import("../connection-adapters/mysql2-adapter.js"),
     import("../connection-adapters/sqlite3-adapter.js"),
@@ -254,7 +254,7 @@ export async function install(): Promise<void> {
   // (abstract/mysql/sqlite), so wrapping it too would double-count batched
   // truncate/fixture DDL — and the leaf calls give better per-statement
   // attribution (real table names, real per-statement timing).
-  for (const klass of [PostgreSQLAdapter, Mysql2Adapter, AbstractSQLite3Adapter]) {
+  for (const klass of [PostgreSQLAdapter, Mysql2Adapter, SQLite3Adapter]) {
     const proto = klass.prototype as unknown as Record<string, unknown>;
     wrap(proto, "execute", 0);
     wrap(proto, "executeMutation", 0);

--- a/packages/activerecord/src/support/setup-adapter-suite.test.ts
+++ b/packages/activerecord/src/support/setup-adapter-suite.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterAll } from "vitest";
-import { AbstractSQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { setupAdapterSuite } from "./setup-adapter-suite.js";
 
@@ -9,7 +9,7 @@ interface RawAdapter {
 }
 
 describe("setupAdapterSuite — schema + transactional rollback", () => {
-  const setup = vi.fn(async (adapter: AbstractSQLite3Adapter) => {
+  const setup = vi.fn(async (adapter: SQLite3Adapter) => {
     await adapter.exec(`CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`);
   });
 

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -6,7 +6,7 @@ import {
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
 import { Base } from "../base.js";
-import { AbstractSQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { NullTransaction } from "../connection-adapters/abstract/transaction.js";
 import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
@@ -79,7 +79,7 @@ describe("withTransactionalFixtures", () => {
 // the DDL-touched tables after rollback (per-table, not a blanket clear) to
 // keep that in-memory reflection in sync with the rolled-back DB.
 describe("withTransactionalFixtures (schema-cache invalidation)", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
 
   beforeAll(async () => {
     adapter = new BetterSQLite3Adapter(":memory:");
@@ -121,7 +121,7 @@ describe("withTransactionalFixtures (schema-cache invalidation)", () => {
 // `transactionManager` lives on the adapter itself via AbstractAdapter, not
 // behind an `innerAdapter` wrapper.
 describe("withTransactionalFixtures (raw adapter)", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
   const exec = (sql: string) => adapter.exec(sql);
   const query = (sql: string) => adapter.execute(sql);
 
@@ -152,7 +152,7 @@ describe("withTransactionalFixtures (raw adapter)", () => {
 // shape), so a warmed entry for an untouched table survives into the next test
 // instead of being wiped by a blanket clear.
 describe("withTransactionalFixtures (per-table re-reflection preserves untouched entries)", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
 
   beforeAll(async () => {
     adapter = new BetterSQLite3Adapter(":memory:");
@@ -195,7 +195,7 @@ describe("withTransactionalFixtures (per-table re-reflection preserves untouched
 // re-reflection in afterEach. Cached column reflection survives across tests
 // — pay this cost only when the file does pure DML.
 describe("withTransactionalFixtures (invalidateSchemaCache: false)", () => {
-  let adapter: AbstractSQLite3Adapter;
+  let adapter: SQLite3Adapter;
 
   beforeAll(async () => {
     adapter = new BetterSQLite3Adapter(":memory:");

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -3,7 +3,7 @@ import { Trailtie, loadDefaults, type ActiveRecordConfig } from "./trailtie.js";
 import { Base } from "./base.js";
 import { Railtie as BaseRailtie, resetLoadHooks, runLoadHooks } from "@blazetrails/activesupport";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
-import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
 import { ExtendedDeterministicUniquenessValidator } from "./encryption/extended-deterministic-uniqueness-validator.js";
@@ -35,7 +35,7 @@ describe("RailtieTest", () => {
     savedTimeZoneAwareTypes = [...Base.timeZoneAwareTypes];
     savedUseSchemaCacheDump = SchemaReflection.useSchemaCacheDump;
     savedCheckSchemaCacheDumpVersion = SchemaReflection.checkSchemaCacheDumpVersion;
-    savedStrictStrings = AbstractSQLite3Adapter.strictStringsByDefault;
+    savedStrictStrings = SQLite3Adapter.strictStringsByDefault;
     savedDecodeDates = PostgreSQLAdapter.decodeDates;
     savedEncryptionSupportUnencryptedData = EncryptionConfigurable.config.supportUnencryptedData;
     savedPartialInserts = Base.partialInserts;
@@ -48,7 +48,7 @@ describe("RailtieTest", () => {
     resetLoadHooks();
     runLoadHooks("active_record", Base);
     runLoadHooks("active_record_postgresqladapter", PostgreSQLAdapter);
-    runLoadHooks("active_record_sqlite3adapter", AbstractSQLite3Adapter);
+    runLoadHooks("active_record_sqlite3adapter", SQLite3Adapter);
   });
 
   afterEach(() => {
@@ -59,7 +59,7 @@ describe("RailtieTest", () => {
     Base.timeZoneAwareTypes = savedTimeZoneAwareTypes;
     SchemaReflection.useSchemaCacheDump = savedUseSchemaCacheDump;
     SchemaReflection.checkSchemaCacheDumpVersion = savedCheckSchemaCacheDumpVersion;
-    AbstractSQLite3Adapter.strictStringsByDefault = savedStrictStrings;
+    SQLite3Adapter.strictStringsByDefault = savedStrictStrings;
     PostgreSQLAdapter.decodeDates = savedDecodeDates;
     EncryptionConfigurable.config.supportUnencryptedData = savedEncryptionSupportUnencryptedData;
     Base.partialInserts = savedPartialInserts;
@@ -127,7 +127,7 @@ describe("RailtieTest", () => {
     const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
     cfg.sqlite3AdapterStrictStringsByDefault = true;
     Trailtie.runInitializers();
-    expect(AbstractSQLite3Adapter.strictStringsByDefault).toBe(true);
+    expect(SQLite3Adapter.strictStringsByDefault).toBe(true);
   });
 
   it("runInitializers copies postgresql decode_dates flag onto PostgreSQLAdapter", () => {

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -29,7 +29,7 @@ import { Base } from "./base.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
 import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
-import type { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import type { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
 import { deprecator } from "./deprecator.js";
 import {
@@ -159,7 +159,7 @@ const installEncryptionExtendedQueries = (): void => {
   installExtendedQueriesIfConfigured();
 };
 
-const setSqlite3StrictStringsByDefault = (adapter: typeof AbstractSQLite3Adapter): void => {
+const setSqlite3StrictStringsByDefault = (adapter: typeof SQLite3Adapter): void => {
   adapter.strictStringsByDefault = true;
 };
 

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -16,7 +16,7 @@ import { fixtures } from "./test-fixtures.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import { WrongReply } from "./test-helpers/models/reply.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
 import { AbstractAdapter } from "./index.js";
 
@@ -43,7 +43,7 @@ interface AdapterTxView {
   currentTransaction?(): unknown;
 }
 
-const openAdapters: AbstractSQLite3Adapter[] = [];
+const openAdapters: SQLite3Adapter[] = [];
 
 async function makeSQLiteTopic() {
   const adp = new BetterSQLite3Adapter(":memory:");

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -185,7 +185,7 @@ new Mysql2Adapter({
 
 // SQLite3 defaults preparedStatements to true (matches Rails' abstract default).
 // BetterSQLite3Adapter is the concrete `sqlite3` adapter (subclass of
-// AbstractSQLite3Adapter, bound to the better-sqlite3 client library).
+// SQLite3Adapter, bound to the better-sqlite3 client library).
 new BetterSQLite3Adapter("db/app.sqlite3", { statementLimit: 200 });
 ```
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1546,10 +1546,21 @@ export function main() {
 
       // When multiple entities share a name, pick the best parent by
       // file path proximity (most shared directory segments).
-      const resolveParent = (name: string, childFile: string): ClassInfo | null => {
+      const resolveParent = (
+        name: string,
+        childFile: string,
+        declFile?: string,
+      ): ClassInfo | null => {
         const candidates = entitiesByName.get(name) || [];
         if (candidates.length === 0) return null;
         if (candidates.length === 1) return candidates[0];
+        // An include()/extend() edge knows the file its module was declared in;
+        // that beats filename proximity, which cannot separate same-named
+        // modules in sibling adapter directories.
+        if (declFile) {
+          const exact = candidates.find((c) => c.file === declFile);
+          if (exact) return exact;
+        }
         const childParts = (childFile || "").split("/");
         let best: ClassInfo | null = null;
         let bestScore = -1;
@@ -1590,7 +1601,7 @@ export function main() {
         }
 
         for (const ext of entity.extends || []) {
-          const parent = resolveParent(ext, entity.file || "");
+          const parent = resolveParent(ext, entity.file || "", entity.extendsFiles?.[ext]);
           if (parent) {
             for (const m of getInherited(parent, visited)) methods.add(m);
           }

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -931,6 +931,26 @@ describe("extractFromProgram — include() detection", () => {
     expect(info.classes["node.ts:Node"].extends).toContain("Math");
   });
 
+  it("records the mod's declaration file on host.extendsFiles", () => {
+    // Two modules share the short name `SchemaStatements` (abstract/ and
+    // postgresql/); only the declaration file separates them, so the edge
+    // carries it for the consumer that resolves the parent.
+    const info = extractFromFiles("/p", {
+      "abstract/schema-statements.ts": `export const SchemaStatements = { addColumn() {} };`,
+      "postgresql/schema-statements-class.ts": `export const SchemaStatements = { quoteSchemaName() {} };`,
+      "postgresql-adapter.ts": `export class PostgreSQLAdapter {}`,
+      "wire.ts": `
+        import { include } from "@blazetrails/activesupport";
+        import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+        import { SchemaStatements } from "./postgresql/schema-statements-class.js";
+        include(PostgreSQLAdapter, SchemaStatements);
+      `,
+    });
+    const host = info.classes["postgresql-adapter.ts:PostgreSQLAdapter"];
+    expect(host.extends).toContain("SchemaStatements");
+    expect(host.extendsFiles?.["SchemaStatements"]).toBe("postgresql/schema-statements-class.ts");
+  });
+
   it("follows import aliases (`Math as MathMixin`) to the original module name", () => {
     const info = extractFromFiles("/p", {
       "math.ts": `export const Math = { add() {} };`,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -166,6 +166,24 @@ if (!isMainThread && parentPort) {
 // extractPackage and posts the result back.
 const WORKER_BOOTSTRAP = path.join(SCRIPT_DIR, "extract-ts-api-worker.mjs");
 
+/**
+ * Record where an `include()`/`extend()` edge's module was declared, so a
+ * consumer resolving the bare short name is not left guessing between
+ * same-named modules in sibling adapter directories.
+ */
+function recordExtendsFile(
+  hostInfo: ClassInfo,
+  modName: string,
+  sym: ts.Symbol | undefined,
+  srcDir: string,
+): void {
+  const decl = sym?.valueDeclaration ?? sym?.declarations?.[0];
+  if (!decl) return;
+  const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
+  if (declFile.startsWith("..")) return;
+  hostInfo.extendsFiles = { ...(hostInfo.extendsFiles ?? {}), [modName]: declFile };
+}
+
 function extractInWorker(pkgName: string, srcDir: string): Promise<WorkerOutput> {
   return new Promise((resolve, reject) => {
     const worker = new Worker(WORKER_BOOTSTRAP, {
@@ -1085,6 +1103,7 @@ export function extractFromProgram(
         // (a): class / interface / module — push name for later resolution.
         const modName = sym?.name ?? modArg.text;
         if (!hostInfo.extends.includes(modName)) hostInfo.extends.push(modName);
+        recordExtendsFile(hostInfo, modName, sym, srcDir);
       }
     });
   }
@@ -1200,6 +1219,7 @@ export function extractFromProgram(
 
         const modName = sym?.name ?? modArg.text;
         if (!hostInfo.extends.includes(modName)) hostInfo.extends.push(modName);
+        recordExtendsFile(hostInfo, modName, sym, srcDir);
       }
     });
   }

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -120,7 +120,7 @@ export interface MethodInfo {
    * TS-side only (RFC 0083): the class/module this method forwards to when its
    * whole body is `return this.<accessor>().<sameName>(...)`. trails does not
    * mix a Rails module into its host class the way Ruby `include` does — the
-   * PostgreSQL schema-statements port lives in `PostgreSQLSchemaStatements` and
+   * PostgreSQL schema-statements port lives in `PostgreSQL::SchemaStatements` and
    * `PostgreSQLAdapter` reaches it through `this.pgSchemaStatements()`. The
    * target name is resolved from the accessor's RETURN TYPE via the checker,
    * never from filename proximity (sibling adapters would cross-credit each
@@ -136,6 +136,16 @@ export interface ClassInfo {
   reExportedFrom?: string;
   includes: string[];
   extends: string[];
+  /**
+   * TS-side only: for each `include()`/`extend()` edge recorded on `extends` by
+   * its bare short name, the src-relative file the symbol was declared in. Two
+   * different modules can share a short name (`SchemaStatements` exists under
+   * `connection-adapters/abstract/`, `postgresql/` and `sqlite3/`), and
+   * filename-proximity scoring cannot tell them apart from the host's path.
+   * Consumers resolving an edge should prefer the candidate whose `file`
+   * matches the entry here and fall back to proximity only when absent.
+   */
+  extendsFiles?: Record<string, string>;
   /**
    * TS-side only (RFC 0083): sorted union of every `MethodInfo.delegatesTo` on
    * this class — the accessor-forwarding counterpart of `includes`/`extends`,

--- a/scripts/mixin-declaration-drift.test.ts
+++ b/scripts/mixin-declaration-drift.test.ts
@@ -36,7 +36,7 @@ const PAIRS = [
   {
     label: "PostgreSQLAdapter / PostgreSQL::SchemaStatements",
     mixinFile: `${ADAPTERS}postgresql/schema-statements-class.ts`,
-    mixinClass: "PostgreSQLSchemaStatements",
+    mixinClass: "SchemaStatements",
     adapterFile: `${ADAPTERS}postgresql-adapter.ts`,
     adapterInterface: "PostgreSQLAdapter",
     witness: PostgreSQLAdapter,

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -3,7 +3,7 @@ import { mkdirSync, readdirSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { Base } from "@blazetrails/activerecord";
-import type { AbstractSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
+import type { SQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js";
 import { parseTestCompareFromLogs } from "./parse-test-compare.js";
 
@@ -406,7 +406,7 @@ class SyncLog extends Base {
 // Schema setup via the adapter schema DSL
 // ---------------------------------------------------------------------------
 
-async function tableExists(adapter: AbstractSQLite3Adapter, name: string): Promise<boolean> {
+async function tableExists(adapter: SQLite3Adapter, name: string): Promise<boolean> {
   const rows = await adapter.execute(
     `SELECT name FROM sqlite_master WHERE type='table' AND name=?`,
     [name],
@@ -415,7 +415,7 @@ async function tableExists(adapter: AbstractSQLite3Adapter, name: string): Promi
 }
 
 async function columnExists(
-  adapter: AbstractSQLite3Adapter,
+  adapter: SQLite3Adapter,
   table: string,
   column: string,
 ): Promise<boolean> {
@@ -424,7 +424,7 @@ async function columnExists(
   return cols.some((c) => c.name === column);
 }
 
-async function migrateDb(adapter: AbstractSQLite3Adapter) {
+async function migrateDb(adapter: SQLite3Adapter) {
   const hasExistingSchema = await tableExists(adapter, "sync_log");
 
   if (hasExistingSchema) {


### PR DESCRIPTION
Renames two adapter classes to the names Rails' layout demands.

1. `AbstractSQLite3Adapter` → `SQLite3Adapter` (Rails declares `SQLite3Adapter`
   in `sqlite3_adapter.rb:30`, and the whole sqlite3_adapter.rb port lives on
   this class, so it is a renamed port, not novel surface). **This is the
   single-mechanical-rename exception to the 500-LOC ceiling** — 197 references
   across 48 files; no behavior change.

2. `PostgreSQLSchemaStatements` → `SchemaStatements`, matching
   `PostgreSQL::SchemaStatements` and the unprefixed convention the rest of
   `connection-adapters/postgresql/` already follows.

The pg rename was previously attempted and reverted because it cost one matched
method (`quoteSchemaName`): `include(Host, X)` edges are recorded by the bare
short name, and `resolveParent` broke a duplicated short name by filename
proximity — with `SchemaStatements` under `abstract/`, `postgresql/` and
`sqlite3/` all scoring equally, the tie landed on the abstract class and dropped
the pg class's methods from `PostgreSQLAdapter`'s inherited set. Fixed at the
source: the extractor now records each include/extend edge's declaring file on
`ClassInfo.extendsFiles` (it has the symbol's declaration at extraction time),
and `resolveParent` prefers an exact file match, falling back to proximity when
absent.


## Test-name scope

The rename touches **16** describe/it strings — every one of them embeds the
renamed class name and would otherwise name a class that no longer exists:

- 2 `it()` strings (`sqlite-adapter.test.ts`, `sqlite/libsql.test.ts`) — e.g.
  "...are thin `AbstractSQLite3Adapter` subclasses".
- 14 `describe()` strings — 1 in `dbconsole-option-keys.test.ts` and 13 in the
  two `schema-statements-class` test files, all of the form
  `describe("PostgreSQLSchemaStatements#dropTable")`.

No Rails-matched `it()`/`test()` name was reworded. The 14 `describe()` strings
are trails-invented wrappers with no Rails counterpart (Rails has no
`PostgreSQLSchemaStatements`), and test-compare falls back to matching on the
test name alone when the describe path does not match
(`scripts/test-compare/test-compare.ts:10-12`), so the describe rename cannot
drop a match. Confirmed empirically below.

## Verification

- `pnpm api:compare` data layer: **7725/7816** (baseline 7724 — up one, not
  down).
- `pnpm api:extra --package activerecord`:
  `connection-adapters/sqlite3-adapter.ts` no longer reports the adapter class
  as novel; remaining novel names are `exec` / `executeMutation` (other
  stories) and `SQLite3IntegerType` / `SQLiteDateTimeType`, both owned by the
  pending `extra-surface-adapter-class-names` PR.
  `postgresql/schema-statements-class.ts` reports only `createRange` /
  `dropRange`.
- `pnpm test:compare`: **14879/22203** matched — unchanged by this branch.
- `pnpm typecheck` clean; scoped vitest on the sqlite3 adapter cluster, the pg
  schema-statements tests and the api-compare script tests pass (328 + 300).

Closes-story: adapter-class-name-renames-sqlite3-and-pg-schema-statements
