### PR TITLE
ci: defer the guides type check out of the pre-ready phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
     #                         only main / the weekly sweep / workflow_dispatch).
     #                         Opting in also gates the merge on it: the job is
     #                         in the `ci` aggregator's `needs:`.
+    #   run-guides          — the Guides Code Type Check (otherwise only
+    #                         main / the weekly sweep / workflow_dispatch).
+    #                         Opting in also gates the merge on it: the job is
+    #                         in the `ci` aggregator's `needs:`.
     #   run-db-adapters     — force the PostgreSQL + MariaDB AR suites on a
     #                         draft PR that doesn't touch adapter paths; they
     #                         run unconditionally once it is ready for review.
@@ -625,11 +629,14 @@ jobs:
           fi
           echo "No forbidden Claude attribution found in commit messages."
 
-  # Draft-deferred like the PG/MariaDB suites: this is a documentation-drift
-  # merge gate (guide snippets vs. the public type surface), not review signal,
-  # and GUIDES_PKGS_RE spans every AR-adjacent package so it fired on nearly
-  # every source PR. `ready_for_review` is in the workflow's `on:` types, so a
-  # PR can't reach ready with no event left to start it.
+  # Off on PRs entirely. This is a documentation-drift gate — guide snippets vs.
+  # the public type surface — not review signal, and GUIDES_PKGS_RE spans every
+  # AR-adjacent package, so it fired on nearly every source PR to tell nobody
+  # anything. It runs on `main`, on the Monday sweep (where `changes` forces
+  # every gate true), on `workflow_dispatch`, and on a PR labelled
+  # `run-guides`. It is in the `ci` aggregator's `needs:`, so whenever it does
+  # run a failure blocks the merge; drift introduced by a PR is caught by the
+  # push-to-main run and the weekly sweep instead of by that PR.
   guides-typecheck:
     name: Guides Code Type Check
     needs: changes
@@ -637,7 +644,7 @@ jobs:
       needs.changes.outputs.docs_only != 'true' &&
       needs.changes.outputs.guides_affected == 'true' &&
       (github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false)
+       contains(github.event.pull_request.labels.*.name, 'run-guides'))
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
@@ -1872,7 +1879,7 @@ jobs:
           SQLITE_MEM_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-sqlite-mem') }}
           MYSQL_PREPARED_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-mysql-prepared') }}
           DB_ADAPTERS_DRAFT_DEFERRED: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && needs.changes.outputs.db_adapter_affected != 'true' && !contains(github.event.pull_request.labels.*.name, 'run-db-adapters') }}
-          GUIDES_DRAFT_DEFERRED: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
+          GUIDES_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-guides') }}
         run: |
           set -euo pipefail
           echo "$NEEDS_JSON"
@@ -1964,7 +1971,7 @@ jobs:
                   ;;
                 guides-typecheck)
                   if [ "$GUIDES_AFFECTED" = "false" ] || \
-                     [ "$GUIDES_DRAFT_DEFERRED" = "true" ]; then
+                     [ "$GUIDES_UNLABELLED" = "true" ]; then
                     continue
                   fi
                   ;;
@@ -2000,7 +2007,7 @@ jobs:
                   [ "$any_parity" = "false" ] && continue
                   ;;
               esac
-              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED comparison_affected=$COMPARISON_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL db_adapters_draft_deferred=$DB_ADAPTERS_DRAFT_DEFERRED guides_draft_deferred=$GUIDES_DRAFT_DEFERRED)"
+              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED comparison_affected=$COMPARISON_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL db_adapters_draft_deferred=$DB_ADAPTERS_DRAFT_DEFERRED guides_unlabelled=$GUIDES_UNLABELLED)"
               unexpected=1
             done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,12 +625,23 @@ jobs:
           fi
           echo "No forbidden Claude attribution found in commit messages."
 
+  # Draft-deferred, same shape as the PG/MariaDB suites. This compiles the
+  # fenced TS blocks in packages/website/docs/guides/** against the public type
+  # surface — a documentation-drift merge gate, not review signal: a reviewer
+  # of a packages/**/src diff never acts on its result, and the fix (adjust the
+  # guide snippet) is identical at ready-for-review time. Its gate
+  # (GUIDES_PKGS_RE) spans every AR-adjacent package, so pre-ready it fired on
+  # nearly every source PR for ~40-80s of runner time nobody read.
+  # `ready_for_review` is in the workflow's `on:` types, so a PR can't reach
+  # ready without an event left to start this.
   guides-typecheck:
     name: Guides Code Type Check
     needs: changes
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.guides_affected == 'true'
+      needs.changes.outputs.guides_affected == 'true' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
@@ -1865,6 +1876,7 @@ jobs:
           SQLITE_MEM_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-sqlite-mem') }}
           MYSQL_PREPARED_UNLABELLED: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-mysql-prepared') }}
           DB_ADAPTERS_DRAFT_DEFERRED: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && needs.changes.outputs.db_adapter_affected != 'true' && !contains(github.event.pull_request.labels.*.name, 'run-db-adapters') }}
+          GUIDES_DRAFT_DEFERRED: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
         run: |
           set -euo pipefail
           echo "$NEEDS_JSON"
@@ -1955,7 +1967,10 @@ jobs:
                   [ "$UNIT_TESTS_AFFECTED" = "false" ] && continue
                   ;;
                 guides-typecheck)
-                  [ "$GUIDES_AFFECTED" = "false" ] && continue
+                  if [ "$GUIDES_AFFECTED" = "false" ] || \
+                     [ "$GUIDES_DRAFT_DEFERRED" = "true" ]; then
+                    continue
+                  fi
                   ;;
                 rails-comparison)
                   # Legitimate skip when no comparison-relevant path changed
@@ -1989,7 +2004,7 @@ jobs:
                   [ "$any_parity" = "false" ] && continue
                   ;;
               esac
-              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED comparison_affected=$COMPARISON_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL db_adapters_draft_deferred=$DB_ADAPTERS_DRAFT_DEFERRED)"
+              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED comparison_affected=$COMPARISON_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL db_adapters_draft_deferred=$DB_ADAPTERS_DRAFT_DEFERRED guides_draft_deferred=$GUIDES_DRAFT_DEFERRED)"
               unexpected=1
             done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,15 +625,11 @@ jobs:
           fi
           echo "No forbidden Claude attribution found in commit messages."
 
-  # Draft-deferred, same shape as the PG/MariaDB suites. This compiles the
-  # fenced TS blocks in packages/website/docs/guides/** against the public type
-  # surface — a documentation-drift merge gate, not review signal: a reviewer
-  # of a packages/**/src diff never acts on its result, and the fix (adjust the
-  # guide snippet) is identical at ready-for-review time. Its gate
-  # (GUIDES_PKGS_RE) spans every AR-adjacent package, so pre-ready it fired on
-  # nearly every source PR for ~40-80s of runner time nobody read.
-  # `ready_for_review` is in the workflow's `on:` types, so a PR can't reach
-  # ready without an event left to start this.
+  # Draft-deferred like the PG/MariaDB suites: this is a documentation-drift
+  # merge gate (guide snippets vs. the public type surface), not review signal,
+  # and GUIDES_PKGS_RE spans every AR-adjacent package so it fired on nearly
+  # every source PR. `ready_for_review` is in the workflow's `on:` types, so a
+  # PR can't reach ready with no event left to start it.
   guides-typecheck:
     name: Guides Code Type Check
     needs: changes

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -345,9 +345,6 @@ describe("CI runs every tooling test suite", () => {
     const wf = parseYaml(await readFile(CI_YML, "utf8"));
     const optIn = wf.jobs["guides-typecheck"].if.replace(/\s+/g, " ").trim();
 
-    // Without the ready flip in `on:` a PR reaches ready with no event left to
-    // start the deferred job. (Also asserted for the DB pair above; repeated
-    // here so removing that test can't silently unpin this one.)
     expect(wf.on.pull_request.types).toContain("ready_for_review");
 
     const deferred = wf.jobs.ci.steps[0].env.GUIDES_DRAFT_DEFERRED.replace(/\s+/g, " ");
@@ -359,9 +356,8 @@ describe("CI runs every tooling test suite", () => {
       expect(deferred).toContain(aggregateClause);
     }
 
-    // The gate that decides whether the job is relevant at all must survive
-    // alongside the deferral — dropping it would run the job on every draft-
-    // less PR regardless of whether anything it compiles changed.
+    // The relevance gate has to survive alongside the deferral, or the job
+    // runs on every non-draft PR whether or not its inputs changed.
     expect(optIn).toContain("needs.changes.outputs.guides_affected == 'true'");
   });
 

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -337,28 +337,40 @@ describe("CI runs every tooling test suite", () => {
     }
   });
 
-  // guides-typecheck is draft-deferred with no opt-in of its own, so the job
-  // gate and the aggregate's skip allow-list are a two-clause pair rather than
-  // the four-clause one above. A narrower aggregate wedges every draft PR on
-  // "unexpectedly skipped"; a wider one passes a guides break that never ran.
-  it("keeps the guides-typecheck draft deferral and the ci aggregate in agreement", async () => {
+  // guides-typecheck is off on PRs unless labelled, so its skip is the norm
+  // rather than the exception: a too-narrow aggregate clause wedges EVERY
+  // unlabelled PR on "unexpectedly skipped", and a too-wide one swallows a
+  // genuine failure on the labelled runs and on main. Job and aggregate are
+  // written at opposite polarity, so each clause is pinned on both sides.
+  it("keeps the guides-typecheck label opt-in and the ci aggregate in agreement", async () => {
     const wf = parseYaml(await readFile(CI_YML, "utf8"));
     const optIn = wf.jobs["guides-typecheck"].if.replace(/\s+/g, " ").trim();
+    const unlabelled = wf.jobs.ci.steps[0].env.GUIDES_UNLABELLED.replace(/\s+/g, " ");
 
-    expect(wf.on.pull_request.types).toContain("ready_for_review");
-
-    const deferred = wf.jobs.ci.steps[0].env.GUIDES_DRAFT_DEFERRED.replace(/\s+/g, " ");
     for (const [jobClause, aggregateClause] of [
       ["github.event_name != 'pull_request'", "github.event_name == 'pull_request'"],
-      ["github.event.pull_request.draft == false", "github.event.pull_request.draft"],
+      [
+        "contains(github.event.pull_request.labels.*.name, 'run-guides')",
+        "!contains(github.event.pull_request.labels.*.name, 'run-guides')",
+      ],
     ]) {
       expect(optIn).toContain(jobClause);
-      expect(deferred).toContain(aggregateClause);
+      expect(unlabelled).toContain(aggregateClause);
     }
 
-    // The relevance gate has to survive alongside the deferral, or the job
-    // runs on every non-draft PR whether or not its inputs changed.
+    // `labeled` is what starts the run when the label goes on an open PR;
+    // without it the opt-in needs a fresh push to take effect.
+    expect(wf.on.pull_request.types).toContain("labeled");
+
+    // The relevance gate has to survive alongside the opt-in, or a labelled PR
+    // runs the job whether or not anything it compiles changed.
     expect(optIn).toContain("needs.changes.outputs.guides_affected == 'true'");
+
+    // main / the Monday sweep / workflow_dispatch are the standing coverage
+    // that replaces the per-PR run — `changes` forces guides_affected true on
+    // all three, so the schedule trigger must stay for drift to be caught.
+    expect(Object.keys(wf.on)).toContain("schedule");
+    expect(wf.on.push.branches).toContain("main");
   });
 
   it("keeps comparison_affected off for website-only changes", async () => {

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -337,6 +337,34 @@ describe("CI runs every tooling test suite", () => {
     }
   });
 
+  // guides-typecheck is draft-deferred with no opt-in of its own, so the job
+  // gate and the aggregate's skip allow-list are a two-clause pair rather than
+  // the four-clause one above. A narrower aggregate wedges every draft PR on
+  // "unexpectedly skipped"; a wider one passes a guides break that never ran.
+  it("keeps the guides-typecheck draft deferral and the ci aggregate in agreement", async () => {
+    const wf = parseYaml(await readFile(CI_YML, "utf8"));
+    const optIn = wf.jobs["guides-typecheck"].if.replace(/\s+/g, " ").trim();
+
+    // Without the ready flip in `on:` a PR reaches ready with no event left to
+    // start the deferred job. (Also asserted for the DB pair above; repeated
+    // here so removing that test can't silently unpin this one.)
+    expect(wf.on.pull_request.types).toContain("ready_for_review");
+
+    const deferred = wf.jobs.ci.steps[0].env.GUIDES_DRAFT_DEFERRED.replace(/\s+/g, " ");
+    for (const [jobClause, aggregateClause] of [
+      ["github.event_name != 'pull_request'", "github.event_name == 'pull_request'"],
+      ["github.event.pull_request.draft == false", "github.event.pull_request.draft"],
+    ]) {
+      expect(optIn).toContain(jobClause);
+      expect(deferred).toContain(aggregateClause);
+    }
+
+    // The gate that decides whether the job is relevant at all must survive
+    // alongside the deferral — dropping it would run the job on every draft-
+    // less PR regardless of whether anything it compiles changed.
+    expect(optIn).toContain("needs.changes.outputs.guides_affected == 'true'");
+  });
+
   it("keeps comparison_affected off for website-only changes", async () => {
     const runGate = await gateRunner(await readFile(CI_YML, "utf8"));
     expect((await runGate("packages/website/src/app.ts")).comparison_affected).toBe("false");


### PR DESCRIPTION
Story: `0028-ci-cost-optimization/defer-more-jobs-out-of-pre-ready`

An audit of all 31 jobs in `ci.yml` found `guides-typecheck` to be the one
unambiguous cut left in the PR pipeline. This takes it off PRs entirely.

The audit report is the story's primary deliverable and was filed via the
`audit-report` skill, which writes outside the repo — so it is deliberately not
part of this diff:
`~/.btwhooks/data/github/blazetrailsdev/trails/audits/pre-ready-ci-deferral-20260802T231228Z.md`.

**Mechanism note.** The story originally specified a `ready_for_review`
deferral, and that shipped first (`bf90da94b`). The owner then redirected to a
label opt-in, because draft-gating still ran the job on every PR that reaches
merge. The story's acceptance criteria have been rewritten to the shipped
mechanism (`tasks` commit `ad331b80a`) rather than left contradicting it.

## What changes

`guides-typecheck` (`ci.yml:640-648`) compiles the fenced TS blocks in
`packages/website/docs/guides/**` against the public type surface. That is
documentation-drift detection, not review signal — but its gate
`GUIDES_PKGS_RE` (`ci.yml:203`) spans `activerecord`, `activemodel`,
`activesupport`, `arel`, `globalid`, `did-you-mean` and `trails-tsc`, so it
fired on nearly every source PR at **39-83s measured** per push.

It now runs exactly where `sqlite-mem-tests` does:

- push to `main`
- the Monday `schedule` sweep (`changes` forces every gate true there)
- `workflow_dispatch`
- a PR carrying the new **`run-guides`** label

The label is created on the repo and documented in the `on.pull_request` label
block (`ci.yml:20-23`). `labeled` is already in `on.pull_request.types`, so
applying it starts a run without needing a fresh push. The job stays in the `ci`
aggregator's `needs:`, so a labelled run — or a red `main` — still blocks merges.

The `ci` aggregate learns the new skip condition via `GUIDES_UNLABELLED`
(`ci.yml:1882`, arm at `ci.yml:1973-1977`), mirroring `SQLITE_MEM_UNLABELLED` two
arms up, so an unlabelled PR doesn't fail on "Unexpectedly skipped job".

## Tradeoff

A guide snippet that stops compiling is caught by the push-to-main run and the
weekly sweep rather than by the PR that broke it, so the fix lands as a
follow-up commit on `main` instead of inside the offending PR. That is the
deliberate trade: guides drift is cheap to fix late and expensive to check
early.

## Test

`scripts/ci-suite-coverage.test.ts` pins the job gate and the aggregate clause
at opposite polarity (the pattern the DB-deferral test uses), plus `labeled` in
`on.pull_request.types`, the retained `guides_affected` relevance gate, and the
`schedule` + push-to-`main` triggers that are now the standing coverage. It
fails on baseline — `GUIDES_UNLABELLED` doesn't exist there.

## Not in scope (see the audit report)

The largest remaining pre-ready cost is the `db_adapter_affected` carve-out that
opts drafts back into PG + MariaDB — 4 matrix legs, ~34 runner-minutes, fired on
5/30 recent merged PRs. Filed NEEDS-DISCUSSION rather than changed here. Same
for `virtualized-dx-type-tests` (real type signal, ~1 billed min) and for
scoping `pnpm lint` to changed files (~150s/push — an optimization, not a
deferral). `sqlite-tests` (~575s, 41% of pre-ready cost) stays: it is the
review signal.
