### PR TITLE
refactor(activerecord): route the last relation arelTable reads through Relation#table

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3735,8 +3735,6 @@ export class Relation<T extends Base> {
       disallowRawSqlBang(stringColumns, resolveColumnNameMatcher(this._conn()));
     }
 
-    // Rails arel_column reads the `table` attr_reader, so an aliased relation
-    // qualifies to the alias rather than the model's own arel_table.
     const table = this.table;
     // Rails columns_hash.key? — qualify a bare known column to the base table.
     const knownColumns = new Set(this._modelClass.attributeNames());

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3735,7 +3735,9 @@ export class Relation<T extends Base> {
       disallowRawSqlBang(stringColumns, resolveColumnNameMatcher(this._conn()));
     }
 
-    const table = this._modelClass.arelTable;
+    // Rails arel_column reads the `table` attr_reader, so an aliased relation
+    // qualifies to the alias rather than the model's own arel_table.
+    const table = this.table;
     // Rails columns_hash.key? — qualify a bare known column to the base table.
     const knownColumns = new Set(this._modelClass.attributeNames());
     const isKnownColumn = (name: string): boolean => knownColumns.has(name);
@@ -5195,7 +5197,7 @@ export class Relation<T extends Base> {
     const hasLimit = this._limitValue !== null || this._offsetValue !== null;
     if (hasLimit && !this._eagerJoinDependencyIsLimitable(jd)) {
       const ids = limitedIds ?? this._buildEagerIdSubquery(jd, basePk);
-      rel = rel.where(this._modelClass.arelTable.get(basePk).in(ids as never));
+      rel = rel.where(this.table.get(basePk).in(ids as never));
       rel._limitValue = null;
       rel._offsetValue = null;
     }
@@ -5258,11 +5260,13 @@ export class Relation<T extends Base> {
     basePk: string,
     distinctSelectSql?: string,
   ): SelectManager {
-    const table = this._modelClass.arelTable;
-    const idSubquery =
-      distinctSelectSql !== undefined
-        ? table.project(new Nodes.SqlLiteral(distinctSelectSql))
-        : table.project(table.get(basePk));
+    const table = this.table;
+    // `table` may be a TableAlias (an aliased relation), which has no
+    // `project` — seed the manager from it instead, as Rails does by spawning
+    // the relation itself (`relation.reselect(values).distinct!`).
+    const idSubquery = new SelectManager(table).project(
+      distinctSelectSql !== undefined ? new Nodes.SqlLiteral(distinctSelectSql) : table.get(basePk),
+    );
     idSubquery.distinct();
     // This subquery is its own `build_joins` statement: fold the eager JD into
     // `stashedJoins` so it emits through the single `emitJoinPlan` port with one
@@ -5317,7 +5321,7 @@ export class Relation<T extends Base> {
    * SQL.
    */
   private _distinctSelectForLimitedIds(basePk: string): string {
-    const table = this._modelClass.arelTable;
+    const table = this.table;
     // Bind-free column ref — compile straight through the visitor (no bind
     // inlining needed) and hand the rendered text to the adapter's string
     // `columns_for_distinct`.

--- a/packages/activerecord/src/relation/aliased-table-attr-reader.trails.test.ts
+++ b/packages/activerecord/src/relation/aliased-table-attr-reader.trails.test.ts
@@ -5,6 +5,7 @@ import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { registerModel } from "../associations.js";
 import { escapeRegExp, quoteTableName } from "../support/quote-regex.js";
+import { assertQueriesMatch } from "../testing/query-assertions.js";
 
 registerModel(Post);
 registerModel(Comment);
@@ -49,5 +50,44 @@ describe("Relation on an aliased table", () => {
     const sql = aliased().joins("comments").toSql();
     expect(sql).toContain(`${aliasQ}.${idQ}`);
     expect(sql).not.toContain(`= ${baseQ}.${idQ}`);
+  });
+
+  it("qualifies plucked columns against the alias", async () => {
+    await assertQueriesMatch(
+      new RegExp(escapeRegExp(`${aliasQ}.${idQ}`)),
+      undefined,
+      false,
+      async () => {
+        await aliased().pluck("id");
+      },
+    );
+  });
+
+  it("roots the limited-id subquery on the alias", () => {
+    const sql = aliased().eagerLoad("comments").limit(1).toSql();
+    expect(sql).toContain(`${aliasQ}.${idQ}`);
+    expect(sql).not.toMatch(new RegExp(`SELECT DISTINCT ${escapeRegExp(`${baseQ}.${idQ}`)}`));
+  });
+
+  it("roots the materialized limited-id query on the alias", async () => {
+    await assertQueriesMatch(
+      new RegExp(`SELECT DISTINCT ${escapeRegExp(`${aliasQ}.${idQ}`)}`),
+      undefined,
+      false,
+      // The outer eager-load query still projects the JoinDependency's columns
+      // off the model's own arel_table (`"posts"."id" AS t0_r0`, a separate
+      // divergence outside this file's scope), so it errors on an aliased
+      // relation. The materialization query under test runs first; swallow the
+      // outer failure.
+      () =>
+        aliased()
+          .eagerLoad("comments")
+          .limit(1)
+          .toArray()
+          .then(
+            () => {},
+            () => {},
+          ),
+    );
   });
 });


### PR DESCRIPTION
Remainder from #5903: the four `this._modelClass.arelTable` reads in
`relation.ts` that #5903 left alone rather than guessing. Each was checked
against its nearest Rails body, and all four counterparts read the relation's
`table` attr_reader, so all four are routed through `this.table`:

- `_pluckInner` — `arel_column` (`query_methods.rb:1990`) qualifies a
  `columns_hash` hit as `table[field]`.
- `_applyEagerJoinDependency`'s `pk IN (ids)` rewrite — `apply_join_dependency`
  (`finder_methods.rb:456`) delegates to `distinct_relation_for_primary_key`,
  which does `relation.where!(relation.primary_key => ids)` on the relation.
- `_buildEagerIdSubquery` — same body: `relation.reselect(values).distinct!`
  builds off the relation, not the model's `arel_table`. Since the relation's
  table may be a `TableAlias` (no `project`), the manager is now seeded via
  `new SelectManager(table)`.
- `_distinctSelectForLimitedIds` — `distinct_relation_for_primary_key`
  (`schema_statements.rb:1431`) compiles `relation.table[column]`.

Regression coverage lands in the existing
`relation/aliased-table-attr-reader.trails.test.ts`; the three new tests fail on
baseline.

One gap found and filed separately (story
`eager-join-dependency-base-projections-use-relation-table`): the outer
eager-load query still projects the JoinDependency's base-node columns off
`model.arelTable` (`SELECT "posts"."id" AS t0_r0 … FROM "posts" "omg_posts"`),
so it errors on an aliased relation. The async test swallows that outer failure
and documents why at the call site.

Closes-story: converge-remaining-relation-arel-table-reads
