### PR TITLE
refactor(activerecord): root eager join dependency on the relation's table

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2787,7 +2787,7 @@ export class Relation<T extends Base> {
       return;
     }
 
-    const jd = new JoinDependency(this._modelClass);
+    const jd = new JoinDependency(this._modelClass, this.table);
     const fallbackAssocs = this._addEagerSpecsToJoinDependency(jd, eagerAssociations);
 
     // If no associations could be JOINed, fall back entirely to preload
@@ -3253,7 +3253,7 @@ export class Relation<T extends Base> {
       ...new Set([...this._eagerLoadAssociations, ...this._includesToPromoteFromReferences()]),
     ];
     if (specs.length === 0) return;
-    const jd = new JoinDependency(this._modelClass);
+    const jd = new JoinDependency(this._modelClass, this.table);
     for (const spec of specs) jd.validateEagerLoadSpec(spec);
   }
 
@@ -3634,7 +3634,7 @@ export class Relation<T extends Base> {
       rel._includesAssociations = [];
 
       const basePk = (this._modelClass as any).primaryKey ?? "id";
-      const jd = new JoinDependency(this._modelClass);
+      const jd = new JoinDependency(this._modelClass, this.table);
       const fallbackAssocs = this._addEagerSpecsToJoinDependency(jd, eagerSpecs);
       // Rails joins every eager spec; trails can't join capability-gap
       // reflections (composite-key collections, unjoinable through), so
@@ -3664,7 +3664,7 @@ export class Relation<T extends Base> {
         // tables through a JoinDependency (which handles every spec shape) so a
         // pluck column reaching a joined table of any shape is recognized as
         // servable rather than misclassified as an unjoinable fallback.
-        const joinedJd = new JoinDependency(this._modelClass);
+        const joinedJd = new JoinDependency(this._modelClass, this.table);
         for (const spec of [
           ...this._namedInnerJoins,
           ...this._leftOuterJoinsValues,
@@ -4863,7 +4863,7 @@ export class Relation<T extends Base> {
    */
   private _eagerReflectionsAreLimitable(specs: AssociationSpec[]): boolean {
     if (specs.length === 0) return true;
-    const jd = new JoinDependency(this._modelClass);
+    const jd = new JoinDependency(this._modelClass, this.table);
     for (const spec of specs) jd.addAssociationSpec(spec);
     return this.usingLimitableReflections(jd.reflections);
   }
@@ -4899,7 +4899,7 @@ export class Relation<T extends Base> {
   private _joinsReflectionsAreLimitable(): boolean {
     const specs = [...this._namedInnerJoins, ...this._leftOuterJoinsValues];
     if (specs.length === 0) return true;
-    const jd = new JoinDependency(this._modelClass);
+    const jd = new JoinDependency(this._modelClass, this.table);
     const mergedReflections: unknown[] = [];
     for (const spec of specs) {
       if (spec instanceof JoinDependency) {
@@ -4960,7 +4960,7 @@ export class Relation<T extends Base> {
    */
   _buildDeferredDistinctPkInlineSubquery(): SelectManager {
     const basePk = (this._modelClass as any).primaryKey ?? "id";
-    const jd = new JoinDependency(this._modelClass);
+    const jd = new JoinDependency(this._modelClass, this.table);
     this._addEagerSpecsToJoinDependency(jd, this._deferredDistinctPkEagerSpecs());
     return this._buildEagerIdSubquery(jd, basePk);
   }
@@ -4974,7 +4974,7 @@ export class Relation<T extends Base> {
    */
   async _materializeDistinctPkIds(): Promise<unknown[]> {
     const basePk = (this._modelClass as any).primaryKey ?? "id";
-    const jd = new JoinDependency(this._modelClass);
+    const jd = new JoinDependency(this._modelClass, this.table);
     this._addEagerSpecsToJoinDependency(jd, this._deferredDistinctPkEagerSpecs());
     if (jd.nodes.length === 0) return [];
     return this._withQueryConnection(() => this._materializeLimitedIds(jd, basePk));
@@ -5367,7 +5367,7 @@ export class Relation<T extends Base> {
 
     const basePk = (this._modelClass as any).primaryKey ?? "id";
 
-    const jd = new JoinDependency(this._modelClass);
+    const jd = new JoinDependency(this._modelClass, this.table);
     this._addEagerSpecsToJoinDependency(jd, allEager);
     if (jd.nodes.length === 0) return null;
 
@@ -6711,7 +6711,7 @@ export class Relation<T extends Base> {
         rel._includesAssociations = [];
         const hasLimitOrOffset = this._limitValue !== null || (this._offsetValue ?? 0) > 0;
         const pk = (this._modelClass as { primaryKey?: string | string[] }).primaryKey ?? "id";
-        const jd = new JoinDependency(this._modelClass);
+        const jd = new JoinDependency(this._modelClass, this.table);
         const fallbackAssocs = this._addEagerSpecsToJoinDependency(jd, eagerSpecs);
         // JOIN only the joinable remainder; capability-gap reflections
         // (composite-key collections, unjoinable through) come back as

--- a/packages/activerecord/src/relation/aliased-table-attr-reader.trails.test.ts
+++ b/packages/activerecord/src/relation/aliased-table-attr-reader.trails.test.ts
@@ -74,20 +74,15 @@ describe("Relation on an aliased table", () => {
       new RegExp(`SELECT DISTINCT ${escapeRegExp(`${aliasQ}.${idQ}`)}`),
       undefined,
       false,
-      // The outer eager-load query still projects the JoinDependency's columns
-      // off the model's own arel_table (`"posts"."id" AS t0_r0`, a separate
-      // divergence outside this file's scope), so it errors on an aliased
-      // relation. The materialization query under test runs first; swallow the
-      // outer failure.
-      () =>
-        aliased()
-          .eagerLoad("comments")
-          .limit(1)
-          .toArray()
-          .then(
-            () => {},
-            () => {},
-          ),
+      async () => {
+        await aliased().eagerLoad("comments").limit(1);
+      },
     );
+  });
+
+  it("projects the eager load's base columns off the alias", async () => {
+    const posts = await aliased().eagerLoad("comments").limit(1);
+    expect(posts.length).toBe(1);
+    expect(posts[0].id).toBeDefined();
   });
 });


### PR DESCRIPTION
Rails' `construct_join_dependency` builds `JoinDependency.new(model, table, …)`
off the relation's own `table` (query_methods.rb:1598-1602). `relation.ts` built
every JoinDependency from `model.arelTable`, so a relation created on a table
alias (`new Relation(Post, Post.arelTable.alias("omg_posts"))`) projected the
base node's eager columns off `posts` while FROM/JOIN used the alias —
`no such column: posts.id` on SQLite.

Passes `this.table` to the ten `new JoinDependency(this._modelClass)`
constructions in `relation.ts` (`constructJoinDependency` in
`relation/query-methods.ts` already passed it). Rebased onto #5933, which landed
the sibling DISTINCT-pk subquery and `pk IN (ids)` alias fixes, so this PR is
now just the JoinDependency threading plus the test.

`aliased-table-attr-reader.trails.test.ts` drops the swallow in "roots the
materialized limited-id query on the alias" and adds a case asserting the outer
eager-load query executes on an aliased relation.

Closes-story: eager-join-dependency-base-projections-use-relation-table
