### PR TITLE
refactor(activerecord): classify the residual invented SCREAMING_CASE constants

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1282,7 +1282,7 @@ async function _buildDisableJoinsScopeRelation(
   // DJAS.scope() now returns a sync deferred-chain Relation — the
   // async chain walk runs on first toArray(). No more Promise<{relation}>
   // boxing to unwrap.
-  let rel: unknown = DisableJoinsAssociationScope.INSTANCE.scope({
+  let rel: unknown = DisableJoinsAssociationScope.create().scope({
     owner: record,
     reflection: reflection as never,
     klass,

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -609,14 +609,6 @@ describe("AssociationScope", () => {
     expect(sql).not.toMatch(/["`]id["`]\s*=/);
   });
 
-  it("static scope() routes through this.INSTANCE (subclass dispatch)", async () => {
-    const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
-    expect(DisableJoinsAssociationScope.INSTANCE).toBeInstanceOf(DisableJoinsAssociationScope);
-    // Subclass INSTANCE shadows the parent's so polymorphic
-    // this.INSTANCE in `static scope` resolves to the subclass instance.
-    expect(DisableJoinsAssociationScope.INSTANCE).not.toBe(AssociationScope.INSTANCE);
-  });
-
   it("through chain merges scope on the through reflection (chain.reverse_each)", () => {
     // Rails' add_constraints walks chain.reverse_each over each
     // reflection's constraints and merges WHERE/ORDER predicates from

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -205,16 +205,19 @@ export class AssociationScope {
 
   /**
    * Entry point. Build the Relation that loads (or filters) the given
-   * association's records for its owner. Polymorphic via `this.INSTANCE`
-   * so a subclass with its own `static INSTANCE` (e.g.
-   * `DisableJoinsAssociationScope`) routes through that subclass'
-   * instance — matching Rails' `AssociationScope.scope(association)` /
-   * `INSTANCE` lookup chain.
+   * association's records for its owner.
+   *
+   * `INSTANCE` is read off `AssociationScope` rather than `this`: Ruby
+   * resolves the constant lexically, so `DisableJoinsAssociationScope.scope`
+   * (association.rb:303) reaches `AssociationScope::INSTANCE` too — a
+   * subclass never gets an INSTANCE of its own. The disable-joins path that
+   * does want subclass behaviour goes through
+   * `DisableJoinsAssociationScope.create` (association.rb:109).
    *
    * Mirrors: ActiveRecord::Associations::AssociationScope.scope
    */
-  static scope(this: typeof AssociationScope, association: AssociationScopeable): unknown {
-    return this.INSTANCE.scope(association);
+  static scope(association: AssociationScopeable): unknown {
+    return AssociationScope.INSTANCE.scope(association);
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1742,7 +1742,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Box the DJAR so awaiting this helper doesn't unwrap it via
     // `Relation.then` (which resolves to the records array). Callers
     // read `.djar` off the resolved value.
-    const djar = DisableJoinsAssociationScope.INSTANCE.scope({
+    const djar = DisableJoinsAssociationScope.create().scope({
       owner: this._record,
       reflection: reflection as any,
       klass,

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -86,10 +86,6 @@ describe("DisableJoinsAssociationScope", () => {
     Notifications.unsubscribeAll();
   });
 
-  it("INSTANCE is a DisableJoinsAssociationScope", () => {
-    expect(DisableJoinsAssociationScope.INSTANCE).toBeInstanceOf(DisableJoinsAssociationScope);
-  });
-
   it("scope(association) returns a sync Relation loadable via toArray", async () => {
     const author = await DjsAuthor.create({ name: "A" });
     const post = await DjsPost.create({ djs_author_id: author.id, title: "p" });
@@ -97,7 +93,7 @@ describe("DisableJoinsAssociationScope", () => {
     await DjsComment.create({ djs_post_id: post.id, body: "c2" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
-    const built = DisableJoinsAssociationScope.INSTANCE.scope({
+    const built = DisableJoinsAssociationScope.create().scope({
       owner: author,
       reflection,
       klass: reflection.klass,
@@ -114,7 +110,7 @@ describe("DisableJoinsAssociationScope", () => {
     await DjsComment.create({ djs_post_id: post.id, body: "c1" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
-    const built = DisableJoinsAssociationScope.INSTANCE.scope({
+    const built = DisableJoinsAssociationScope.create().scope({
       owner: author,
       reflection,
       klass: reflection.klass,
@@ -144,7 +140,7 @@ describe("DisableJoinsAssociationScope", () => {
     await DjsComment.create({ djs_post_id: post.id, body: "exclude-me" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
-    const built = DisableJoinsAssociationScope.INSTANCE.scope({
+    const built = DisableJoinsAssociationScope.create().scope({
       owner: author,
       reflection,
       klass: reflection.klass,
@@ -172,7 +168,7 @@ describe("DisableJoinsAssociationScope", () => {
     await DjsComment.create({ djs_post_id: postA.id, body: "from-a" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsCommentsViaOrderedPosts");
-    const built = DisableJoinsAssociationScope.INSTANCE.scope({
+    const built = DisableJoinsAssociationScope.create().scope({
       owner: author,
       reflection,
       klass: reflection.klass,
@@ -190,7 +186,7 @@ describe("DisableJoinsAssociationScope", () => {
     await DjsComment.create({ djs_post_id: postA.id, body: "from-a" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsCommentsViaOrderedPosts");
-    const built = DisableJoinsAssociationScope.INSTANCE.scope({
+    const built = DisableJoinsAssociationScope.create().scope({
       owner: author,
       reflection,
       klass: reflection.klass,

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -95,9 +95,6 @@ function resolveJoinPrimaryKey(reflection: unknown, klass?: typeof Base): string
  * Mirrors: ActiveRecord::Associations::DisableJoinsAssociationScope
  */
 export class DisableJoinsAssociationScope extends AssociationScope {
-  static override readonly INSTANCE: DisableJoinsAssociationScope =
-    DisableJoinsAssociationScope.create();
-
   constructor(valueTransformation: ValueTransformation = (v) => v) {
     super(valueTransformation);
   }
@@ -378,5 +375,5 @@ function addConstraints(
 }
 
 setDjasScopeBuilder((assoc) =>
-  DisableJoinsAssociationScope.INSTANCE.scope(assoc as AssociationScopeable),
+  DisableJoinsAssociationScope.create().scope(assoc as AssociationScopeable),
 );

--- a/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
@@ -26,7 +26,7 @@ function djasScope(owner: Base, assocName: string): any {
   const reflection = (ctor as any)._reflectOnAssociation?.(assocName);
   if (!reflection) throw new Error(`No reflection found for ${assocName}`);
   const klass = reflection.klass;
-  return DisableJoinsAssociationScope.INSTANCE.scope({
+  return DisableJoinsAssociationScope.create().scope({
     owner,
     reflection,
     klass,

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -347,6 +347,13 @@ export function quoteDefaultExpression(
  * the abstract schema layer stays usable adapter-free rather than silently
  * routing through whatever dialect happens to import these freestanding
  * functions. Mirrors the `ABSTRACT_QUOTER` crutch in `sanitization.ts`.
+ *
+ * @noRailsEquivalent CONVERGEABLE (story:
+ * converge-schema-creation-adapter-free-construction). Rails never builds a
+ * schema visitor or definition without a connection — `SchemaCreation.new(conn)`
+ * (`abstract/schema_creation.rb:6`) and `TableDefinition#initialize`
+ * (`abstract/schema_definitions.rb:369`) both require one — so this fallback
+ * exists only to serve trails' adapter-free construction paths.
  */
 export const ABSTRACT_SCHEMA_QUOTER: SchemaQuoter = {
   quoteColumnName: quoteIdentifier,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -74,7 +74,6 @@ import {
 import * as _qm from "./relation/query-methods.js";
 import { seedJoinClauseAliases } from "./relation/merged-join-alias-tracker.js";
 import {
-  Batches,
   ensureValidOptionsForBatchingBang as _ensureValidOptionsForBatchingBang,
   applyLimits as _applyLimits,
   applyStartLimit as _applyStartLimit,
@@ -4567,7 +4566,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#find_in_batches
    */
   async *findInBatches({
-    batchSize = Batches.DEFAULT_BATCH_SIZE,
+    batchSize = 1000,
     start,
     finish,
     order,
@@ -4600,7 +4599,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#find_each
    */
   async *findEach({
-    batchSize = Batches.DEFAULT_BATCH_SIZE,
+    batchSize = 1000,
     start,
     finish,
     order,
@@ -4637,7 +4636,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Batches#in_batches
    */
   inBatches({
-    batchSize = Batches.DEFAULT_BATCH_SIZE,
+    batchSize = 1000,
     start,
     finish,
     order,

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -8,8 +8,6 @@ import { ActiveRecord } from "../ar-config.js";
 export class Batches {
   static readonly ORDER_IGNORE_MESSAGE =
     "Scoped order is ignored, use :cursor with :order to configure custom order." as const;
-
-  static readonly DEFAULT_BATCH_SIZE = 1000;
 }
 
 /** @internal */

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1498,6 +1498,25 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(fns.find((f) => f.name === "hasMany")!.noRailsEquivalent).toBeUndefined();
   });
 
+  it("records the reason on a tagged object-literal module", () => {
+    const info = extractFromFiles("/p", {
+      "quoting.ts": `
+        /** @noRailsEquivalent PERMANENT adapter-free quoting crutch */
+        export const ABSTRACT_SCHEMA_QUOTER = {
+          quoteColumnName(name: string): string { return name; },
+        };
+
+        export const OTHER_QUOTER = {
+          quoteColumnName(name: string): string { return name; },
+        };
+      `,
+    });
+    expect(info.modules["quoting.ts:ABSTRACT_SCHEMA_QUOTER"].noRailsEquivalent).toBe(
+      "PERMANENT adapter-free quoting crutch",
+    );
+    expect(info.modules["quoting.ts:OTHER_QUOTER"].noRailsEquivalent).toBeUndefined();
+  });
+
   it("drops the reason on a renamed export of a tagged declaration", () => {
     const info = extractFromFiles("/p", {
       "routes-helpers.ts": `

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -661,6 +661,7 @@ export function extractFromProgram(
           if (methods.length === 0) continue;
           const modKey = `${relPath}:${decl.name.text}`;
           if (info.modules[modKey] || info.classes[modKey]) continue;
+          const modReason = noRailsEquivalentReason(decl) ?? noRailsEquivalentReason(node);
           info.modules[modKey] = {
             name: decl.name.text,
             file: relPath,
@@ -668,6 +669,7 @@ export function extractFromProgram(
             extends: [],
             instanceMethods: methods,
             classMethods: [],
+            ...(modReason !== undefined ? { noRailsEquivalent: modReason } : {}),
           };
           fileHasClassOrModule = true;
         }


### PR DESCRIPTION
Per-name verdicts for the residual invented SCREAMING_CASE constants flagged by
the `extra-surface-activerecord-top-files-inventory` spike.

## Verdicts on the story's named set

Every name the story listed had already been resolved by the time this was
claimed — re-measured against a fresh `api:compare`, none of them flags as
extra surface any more:

| Name | Verdict |
| --- | --- |
| `INSTANCE` (`associations/association-scope.ts`) | Genuine port — `vendor/rails/activerecord/lib/active_record/associations/association_scope.rb:19` (`INSTANCE = create`). Scores allowed. |
| `NULL_CONFIG` (`connection-adapters/abstract/connection-pool.ts`) | Genuine port — `.../connection_adapters/abstract/connection_pool.rb:22`. Scores allowed. |
| `NULL_TRANSACTION` (`transaction.ts`, `connection-adapters/abstract/transaction.ts`) | Genuine port — `.../transaction.rb:130` and `.../connection_adapters/abstract/transaction.rb:666`. Both score allowed. |
| `TYPE` (`connection-adapters/postgresql-adapter.ts`) | Genuine port — `.../connection_adapters/postgresql_adapter.rb:1159` (`MoneyDecoder::TYPE`). Scores allowed. |
| `CLIENT_NOT_CONNECTED_RE` | Not in Rails, and no longer present in trails either — already deleted. |
| `ER_TABLE_EXISTS` | Not in Rails, and no longer present in trails either — already deleted. |

## What this PR actually changes

The residue after that re-measure was two names, both handled here.

**`Batches.DEFAULT_BATCH_SIZE` — invention, deleted.** Rails writes the literal
`1000` in each signature (`relation/batches.rb:85`, `:161`, and `in_batches`'s
`of: 1000`); it declares no constant. The three `relation.ts` defaults now
inline `1000`.

**`INSTANCE` override on `DisableJoinsAssociationScope` — invention, deleted.**
It scored as *moved*, not novel: Rails declares `INSTANCE` only on
`AssociationScope`. Ruby resolves the constant lexically, so
`AssociationScope.scope`'s `INSTANCE` reaches `AssociationScope::INSTANCE` even
when called as `DisableJoinsAssociationScope.scope` (`associations/association.rb:303`);
a subclass never gets its own. The disable-joins path that does want subclass
behaviour goes through `DisableJoinsAssociationScope.create`
(`associations/association.rb:109`), so the three trails call sites now do
that — behaviourally identical, since `create()` with no block is the same
identity-lambda instance the override held. `AssociationScope.scope` reads
`AssociationScope.INSTANCE` rather than `this.INSTANCE` to match the lexical
lookup. Two trails-only tests whose entire subject was the override are
deleted; the rest switch to `create()`.

**`ABSTRACT_SCHEMA_QUOTER` — invention, tagged `CONVERGEABLE`.** Rails never
builds a schema visitor or definition without a connection
(`abstract/schema_creation.rb:6`, `abstract/schema_definitions.rb:369`), so this
ANSI fallback exists only to serve trails' adapter-free construction paths.
Removing it is a real refactor of every `SchemaCreation` / `TableDefinition`
call site, so it is filed as
`converge-schema-creation-adapter-free-construction` and cited in the tag.

Tagging it needed an extractor fix: the object-literal-module path in
`extract-ts-api.ts` never read `@noRailsEquivalent`, so a tag on an
`export const X = { ... }` was silently dropped and the module's own name could
never score as allowed. The tag is now read off the `export const` statement
(where JSDoc lands), with a unit test.

## Novel delta

activerecord, measured on a warm build either side:

- before: 557 novel / 1237 moved / 1794 extras / 73 allowed
- after: 555 novel / 1236 moved / 1791 extras / 74 allowed

No SCREAMING_CASE novel names remain in activerecord. The two that still show
as *moved* (`Migration.VERSION`, `SchemaDumper.DEFAULT_DATETIME_PRECISION`) are
genuine Rails names living in a different `.rb`, not inventions. The remaining
SCREAMING_CASE novel names are in activesupport (`logger.ts` levels) and
actiondispatch (`http/mime-type.ts`), outside this story.

## Note

`pnpm api:extra` reports one stale `@noRailsEquivalent` tag (`activerecord
base.ts equals`). It reproduces on a clean `origin/main` with the same warm
build, so it is pre-existing and untouched here.

Closes-story: extra-surface-classify-invented-adapter-constants
