### PR TITLE
refactor(activerecord): route order!/reorder! through preprocessOrderArgs

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -361,7 +361,7 @@ export class Relation<T extends Base> {
   private _modelClass: typeof Base;
   /** @internal */
   _whereClause: WhereClause = WhereClause.empty();
-  private _orderClauses: Array<string | [string, "asc" | "desc"] | Nodes.Node> = [];
+  private _orderClauses: Array<string | Nodes.Node> = [];
   private _rawOrderClauses: string[] = [];
   // Tri-state (Rails `@values.fetch(:reordering, nil)`): `undefined` = unset,
   // distinct from an explicit `false`. Mirrors `_isStrictLoading` below.
@@ -4258,7 +4258,7 @@ export class Relation<T extends Base> {
    * directly (like Rails), so no on-read normalization or fresh allocation is
    * needed.
    */
-  get orderValues(): Array<string | [string, "asc" | "desc"] | Nodes.Node> {
+  get orderValues(): Array<string | Nodes.Node> {
     return this._orderClauses;
   }
 
@@ -4698,8 +4698,8 @@ export class Relation<T extends Base> {
           await ensureValidOptions();
           for (const batchRows of loadedBatches) {
             const batchRel = self._clone();
-            batchRel._orderClauses = batchOrders.map(
-              ([col, dir]) => [col, dir] as [string, "asc" | "desc"],
+            batchRel._orderClauses = batchOrders.map(([col, dir]) =>
+              dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
             );
             (batchRel as any)._records = batchRows;
             (batchRel as any)._loaded = true;
@@ -4728,8 +4728,8 @@ export class Relation<T extends Base> {
           },
         )) {
           const batchRel = self._clone();
-          batchRel._orderClauses = batchOrders.map(
-            ([col, dir]) => [col, dir] as [string, "asc" | "desc"],
+          batchRel._orderClauses = batchOrders.map(([col, dir]) =>
+            dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
           );
           const tuples = batchRows.map((r) => cursorArr.map((c) => r.readAttribute(c)));
           if (batchUseRanges && !load && cursorArr.length === 1 && tuples.length > 0) {
@@ -5261,7 +5261,7 @@ export class Relation<T extends Base> {
     // relation `_applyEagerJoinDependency` yields.
     this._withEagerJoinDependency(jd)._applyJoinsToManager(idSubquery);
     this._applyWheresToManager(idSubquery, table);
-    this._applyOrderToManager(idSubquery, table);
+    this._applyOrderToManager(idSubquery);
     if (this._limitValue !== null) idSubquery.take(this._limitValue);
     if (this._offsetValue !== null) idSubquery.skip(this._offsetValue);
     return idSubquery;
@@ -5401,7 +5401,7 @@ export class Relation<T extends Base> {
     this._applyJoinsToManager(manager, aliases);
 
     this._applyWheresToManager(manager, table);
-    this._applyOrderToManager(manager, table);
+    this._applyOrderToManager(manager);
 
     if (this._isDistinct) manager.distinct();
     if (this._limitValue !== null) manager.take(this._limitValue);
@@ -5653,13 +5653,15 @@ export class Relation<T extends Base> {
       return;
     }
     // `orderArgs` runs Rails' order/reorder normalization: raise-on-blank, then
-    // `flatten!` + `compact_blank!` (query_methods.rb:656-660/752-756) — except a
-    // trails bind-array `[Arel.sql("x = ?"), ...binds]` is preserved so orderBang
-    // can interpolate it. So `order([nil])` / `reorder([{}])` flatten then compact
-    // to empty (no-op), matching Rails, instead of reaching orderBang as arrays.
+    // the `sanitize_order_arguments(args)` block, then `flatten!` +
+    // `compact_blank!` (query_methods.rb:656-660/752-756). Sanitizing first is
+    // what collapses a bind array `[Arel.sql("x = ?"), ...binds]` into a single
+    // interpolated SqlLiteral, so the subsequent flatten can't scatter its binds.
+    // `order([nil])` / `reorder([{}])` flatten then compact to empty (no-op).
     if (options?.orderArgs) {
       raiseIfBlank();
-      const flat = _qm.flattenedOrderArgs(args).filter((a) => !_qm.isBlankArgument(a));
+      const sanitized = _qm.sanitizeOrderArguments.call(this as any, args);
+      const flat = _qm.flattenedOrderArgs(sanitized).filter((a) => !_qm.isBlankArgument(a));
       args.length = 0;
       args.push(...flat);
       return;
@@ -5752,41 +5754,18 @@ export class Relation<T extends Base> {
     return `"${name.replace(/"/g, '""')}"`;
   }
 
-  private _applyOrderToManager(manager: SelectManager, table: Table): void {
-    // Raw order clauses (from inOrderOf)
+  /**
+   * Mirrors: ActiveRecord::QueryMethods#build_order — `order_values` already
+   * holds fully-resolved terms (preprocess_order_args ran at `order!` time), so
+   * this only drops blanks and hands them to the manager. The `_rawOrderClauses`
+   * prefix is the trails-side carrier for `inOrderOf`'s generated SQL, which
+   * Rails keeps inside order_values as an Arel CASE node.
+   */
+  private _applyOrderToManager(manager: SelectManager): void {
     for (const rawClause of this._rawOrderClauses) {
       manager.order(new Nodes.SqlLiteral(rawClause));
     }
-    for (const clause of this._orderClauses) {
-      if (clause instanceof Nodes.Node) {
-        // Arel order nodes (Ascending/Descending/Attribute/...) preserved by
-        // orderBang — emit directly so identity survives to the SQL manager.
-        manager.order(clause);
-        continue;
-      }
-      if (typeof clause === "string") {
-        // Rails leaves a string order arg bare: `order("name ASC")` /
-        // `order("name")` pass through as an unquoted `Arel::Nodes::SqlLiteral`,
-        // never qualified to the table or column-quoted. Only Symbol and Hash
-        // order args route through column resolution (the tuple branch below).
-        // See Relation#preprocess_order_args (query_methods.rb): the `else`
-        // branch returns the string unchanged.
-        manager.order(new Nodes.SqlLiteral(clause.trim()));
-      } else if (Array.isArray(clause)) {
-        const [col, dir] = clause;
-        // Function expressions, quoted identifiers, and dotted names must be
-        // emitted as raw SQL — table.get() would double-quote them incorrectly.
-        if (/[()"`]|::/.test(col) || /^[\w$]+(\.[\w$]+)+$/.test(col)) {
-          const lit = new Nodes.SqlLiteral(col);
-          manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
-        } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(col)) {
-          const lit = this.orderColumn(col) as Nodes.Node;
-          manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
-        } else {
-          manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
-        }
-      }
-    }
+    this.buildOrder(manager);
   }
 
   private _qualifiedCol(table: Table, key: string): { tbl: string; col: string } {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5755,11 +5755,9 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirrors: ActiveRecord::QueryMethods#build_order — `order_values` already
-   * holds fully-resolved terms (preprocess_order_args ran at `order!` time), so
-   * this only drops blanks and hands them to the manager. The `_rawOrderClauses`
-   * prefix is the trails-side carrier for `inOrderOf`'s generated SQL, which
-   * Rails keeps inside order_values as an Arel CASE node.
+   * Mirrors: ActiveRecord::QueryMethods#build_order. `_rawOrderClauses` is the
+   * trails-side carrier for `inOrderOf`'s generated SQL, which Rails keeps
+   * inside order_values as an Arel CASE node.
    */
   private _applyOrderToManager(manager: SelectManager): void {
     for (const rawClause of this._rawOrderClauses) {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -100,7 +100,7 @@ interface CalculationRelation {
   /** @internal Rails `apply_join_dependency`; see Relation. */
   applyJoinDependency(eagerLoading?: boolean): CalculationRelation;
   _applyWheresToManager(manager: any, table: any): void;
-  _applyOrderToManager(manager: any, table: any): void;
+  _applyOrderToManager(manager: any): void;
   _buildFromNode(): Nodes.Node | string | undefined;
   _checkEagerLoadable(): void;
   toArray(): Promise<any[]>;
@@ -548,7 +548,7 @@ async function groupedAggregate(
   // Rails `execute_grouped_calculation` runs `select_all` on the relation's own
   // arel, which retains order_values — without the ORDER BY, LIMIT/OFFSET pick
   // arbitrary groups on PG/MySQL.
-  rel._applyOrderToManager(manager, table);
+  rel._applyOrderToManager(manager);
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);
@@ -686,7 +686,7 @@ async function groupedCompositeAssoc(
   // runs `select_all` on the relation's own arel, so order_values ride along
   // for composite FKs too. Without the ORDER BY, LIMIT/OFFSET pick arbitrary
   // groups on PG/MySQL.
-  rel._applyOrderToManager(manager, table);
+  rel._applyOrderToManager(manager);
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);
@@ -831,7 +831,7 @@ export async function performCount(
           // the relation's `order_values` so the LIMIT/OFFSET selects a
           // deterministic, Rails-ordered top-n set of primary keys before the
           // re-count — otherwise an arbitrary limited id set can diverge.
-          this._applyOrderToManager(idSubquery, table);
+          this._applyOrderToManager(idSubquery);
           // Rails builds the DISTINCT select via `columns_for_distinct(pk,
           // order_values)`: PG/MySQL reject `SELECT DISTINCT id ... ORDER BY
           // <non-selected>`, so those adapters prepend the (aliased) order
@@ -927,7 +927,7 @@ export async function performCount(
             idSubquery.distinct();
             eagerJoined()._applyJoinsToManager(idSubquery);
             this._applyWheresToManager(idSubquery, table);
-            this._applyOrderToManager(idSubquery, table);
+            this._applyOrderToManager(idSubquery);
             // Rails `distinct_relation_for_primary_key` builds the DISTINCT
             // select via `columns_for_distinct(primary_key_columns,
             // order_values)`: PG/MySQL reject `SELECT DISTINCT id ... ORDER BY

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -284,7 +284,7 @@ interface FinderRelation {
   _isEmptyRelation(): boolean;
   _limitValue: number | null;
   _offsetValue: number | null;
-  _orderClauses: any[];
+  _orderClauses: unknown[];
   _rawOrderClauses: string[];
   _createWithAttrs: Record<string, unknown>;
   _scopeAttributes(): Record<string, unknown>;
@@ -967,11 +967,8 @@ export function orderedRelation(rel: FinderRelation): any {
   if (!hasOrder(rel) && (implicitOrder || constraintsList != null || pk)) {
     const cols = _orderColumns(rel);
     if (cols.length > 0) {
-      // Use hash-form { col: "asc" } so _orderClauses stores ["col", "asc"] tuples.
-      // Tuple form is what reverseOrderBang expects — Arel node form pre-renders to
-      // a SqlLiteral('"tbl"."col" ASC') which the chained-replace in reverseOrderBang
-      // would undo (ASC→DESC→ASC). This matches Rails: table[column].asc nodes are
-      // rendered by the visitor at SQL-build time, not at order-storage time.
+      // Hash-form { col: "asc" } so preprocess_order_args resolves each column
+      // against the model's table, matching Rails' ordered_relation.
       return (rel as any).order(...cols.map((col: string) => ({ [col]: "asc" as const })));
     }
   }

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -204,9 +204,6 @@ export class Merger {
       const m = bareColumn(clause);
       return m ? asNode(m[1], m[2] ?? "asc") : clause;
     }
-    if (Array.isArray(clause) && typeof clause[0] === "string" && !clause[0].includes(".")) {
-      return asNode(clause[0], String(clause[1] ?? "asc"));
-    }
     return clause;
   }
 

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -14,7 +14,6 @@ import { describe, it, expect } from "vitest";
 import "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
-import { UnknownAttributeReference } from "../errors.js";
 
 fixtures([]);
 /** Fresh relation per test — the trails analogue of Rails' `Relation.new(FakeKlass)`. */
@@ -243,14 +242,5 @@ describe("RelationMutationTest", () => {
   it("uniq! with no argument is a no-op", () => {
     const rel: any = Post.group("title");
     expect(() => rel.uniqBang()).not.toThrow();
-  });
-
-  it("order with empty string does not emit ORDER BY", () => {
-    // Rails compact_blank!s order args in `order` (check_if_method_has_arguments!),
-    // not in `order!` — `order!("")` reaches preprocess_order_args and raises from
-    // disallow_raw_sql!, so the blank-swallowing must be asserted on `order`.
-    const rel: any = Post.all().order("");
-    expect(rel.toSql()).not.toContain("ORDER BY");
-    expect(() => Post.all().orderBang("")).toThrow(UnknownAttributeReference);
   });
 });

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from "vitest";
 import "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
+import { UnknownAttributeReference } from "../errors.js";
 
 fixtures([]);
 /** Fresh relation per test — the trails analogue of Rails' `Relation.new(FakeKlass)`. */
@@ -141,7 +142,7 @@ describe("RelationMutationTest", () => {
     const rel: any = Post.order("title ASC", "comments_count DESC");
     // String order args stay bare (matching Rails), so reversing them keeps them
     // as SqlLiteral strings with the trailing direction flipped — never
-    // re-qualified to `[col, dir]` tuples.
+    // re-qualified against the table.
     const litValues = (): string[] => rel._orderClauses.map((c: any) => String(c.value));
     rel.reverseOrderBang();
     expect(litValues()).toEqual(["title DESC", "comments_count ASC"]);
@@ -244,10 +245,12 @@ describe("RelationMutationTest", () => {
     expect(() => rel.uniqBang()).not.toThrow();
   });
 
-  it("order! with empty string does not emit ORDER BY", () => {
-    // Test the bang method directly — order() delegates to orderBang() on a clone.
-    const rel: any = Post.all();
-    rel.orderBang("");
+  it("order with empty string does not emit ORDER BY", () => {
+    // Rails compact_blank!s order args in `order` (check_if_method_has_arguments!),
+    // not in `order!` — `order!("")` reaches preprocess_order_args and raises from
+    // disallow_raw_sql!, so the blank-swallowing must be asserted on `order`.
+    const rel: any = Post.all().order("");
     expect(rel.toSql()).not.toContain("ORDER BY");
+    expect(() => Post.all().orderBang("")).toThrow(UnknownAttributeReference);
   });
 });

--- a/packages/activerecord/src/relation/order-blank-arg-compaction.trails.test.ts
+++ b/packages/activerecord/src/relation/order-blank-arg-compaction.trails.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import { UnknownAttributeReference } from "../errors.js";
+
+/**
+ * Locks where blank order args are compacted.
+ *
+ * Rails runs `compact_blank!` inside `order` / `reorder`'s
+ * `check_if_method_has_arguments!` (query_methods.rb:656-660/752-756), NOT
+ * inside `order!`. So `order("")` is a no-op, while `order!("")` reaches
+ * `preprocess_order_args` and raises from `disallow_raw_sql!` — the blank
+ * string never matches the column-name-with-order matcher.
+ *
+ * trails previously swallowed the blank inside `orderBang`, which made the bang
+ * method silently lenient where Rails raises.
+ */
+describe("order blank arg compaction", () => {
+  fixtures([]);
+
+  it("compacts a blank order arg in order", () => {
+    expect(Post.all().order("").toSql()).not.toContain("ORDER BY");
+  });
+
+  it("raises from the bang method, which does not compact", () => {
+    // orderBang is mixed onto the relation, so it is not on Relation's public type.
+    const rel = Post.all() as unknown as { orderBang(arg: string): unknown };
+    expect(() => rel.orderBang("")).toThrow(UnknownAttributeReference);
+  });
+});

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -593,9 +593,9 @@ function reorderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
 // mirrors Rails' `self.order_values |= args` and reorderBang its `args.uniq!` —
 // both dedupe by value (query_methods.rb order!/reorder!).
 //
-// Ruby compares Arel nodes structurally (Arel::Nodes::Node#eql?), so build a
-// structural key rather than JSON-stringifying: an Attribute holds a back
-// reference to its Arel::Table, which JSON.stringify cannot serialize.
+// Ruby compares Arel nodes structurally (Arel::Nodes::Node#eql?), so the key is
+// structural: an Attribute holds a back reference to its Arel::Table, which
+// JSON.stringify cannot serialize.
 let orderClauseIdentity = 0;
 const orderClauseIdentities = new WeakMap<object, number>();
 
@@ -1598,8 +1598,6 @@ const VALID_DIRECTIONS = new Set(["asc", "desc"]);
 /** @internal */
 export function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
   for (const arg of args) {
-    // A Map stands in for Rails' Arel-node-keyed order hash; its values are
-    // directions and validate the same way.
     if (arg instanceof Map) {
       for (const [, value] of arg) {
         if (!VALID_DIRECTIONS.has(String(value).toLowerCase())) {
@@ -1966,8 +1964,8 @@ function buildOrderNode(clause: unknown): unknown {
 
 /** @internal */
 export function buildOrder(this: QueryMethodsHost, arel: any): void {
-  // Rails' `order_values.compact_blank`: an Arel::Nodes::SqlLiteral is a String
-  // subclass, so a blank one is blank? too and gets dropped along with nil and "".
+  // An Arel::Nodes::SqlLiteral is a String subclass in Ruby, so compact_blank
+  // drops a blank one along with nil and "".
   const orders = ((this as any)._orderClauses ?? [])
     .filter((o: unknown) => {
       if (o === null || o === undefined) return false;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1835,9 +1835,13 @@ export function columnReferences(orderArgs: unknown[]): string[] {
         refs.push(relationName(expr.relation.name));
       }
     } else if (arg instanceof Map) {
-      for (const key of arg.keys()) {
-        if (key instanceof Nodes.Attribute) refs.push(relationName(key.relation.name));
-        else if (typeof key === "string" || typeof key === "symbol") {
+      // Rails' Hash arm extracts a table only from String/Symbol keys; an Arel
+      // key with a scalar direction falls through to nil, so `order(node => dir)`
+      // never promotes an includes to eager_load.
+      for (const [key, value] of arg) {
+        if (isPlainObject(value)) {
+          refs.push(String(key));
+        } else if (typeof key === "string" || typeof key === "symbol") {
           const t = extractTableNameFrom(typeof key === "symbol" ? symbolToName(key) : key);
           if (t) refs.push(t);
         }
@@ -1940,40 +1944,16 @@ export function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]
   orderArgs.push(...mapped);
 }
 
-function buildOrderNode(clause: unknown): unknown {
-  if (clause instanceof Nodes.Node) return clause;
-  if (typeof clause === "string") return new Nodes.SqlLiteral(clause);
-  if (typeof clause === "symbol") return new Nodes.SqlLiteral(symbolToName(clause));
-  if (Array.isArray(clause) && clause.length === 2) {
-    const [col, dir] = clause;
-    if (col instanceof Nodes.Node) {
-      return String(dir).toLowerCase() === "desc"
-        ? new Nodes.Descending(col)
-        : new Nodes.Ascending(col);
-    }
-    if (typeof col === "string" || typeof col === "symbol") {
-      const expr = new Nodes.SqlLiteral(typeof col === "symbol" ? symbolToName(col) : col);
-      return String(dir).toLowerCase() === "desc"
-        ? new Nodes.Descending(expr)
-        : new Nodes.Ascending(expr);
-    }
-    throw argumentError(`Unsupported order column type: ${Object.prototype.toString.call(col)}`);
-  }
-  throw argumentError(`Unsupported order clause type: ${Object.prototype.toString.call(clause)}`);
-}
-
 /** @internal */
 export function buildOrder(this: QueryMethodsHost, arel: any): void {
   // An Arel::Nodes::SqlLiteral is a String subclass in Ruby, so compact_blank
   // drops a blank one along with nil and "".
-  const orders = ((this as any)._orderClauses ?? [])
-    .filter((o: unknown) => {
-      if (o === null || o === undefined) return false;
-      if (typeof o === "string") return o.trim() !== "";
-      if (o instanceof Nodes.SqlLiteral) return String((o as any).value ?? "").trim() !== "";
-      return true;
-    })
-    .map(buildOrderNode);
+  const orders = ((this as any)._orderClauses ?? []).filter((o: unknown) => {
+    if (o === null || o === undefined) return false;
+    if (typeof o === "string") return o.trim() !== "";
+    if (o instanceof Nodes.SqlLiteral) return String((o as any).value ?? "").trim() !== "";
+    return true;
+  });
   if (orders.length > 0) arel.order?.(...orders);
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -169,7 +169,7 @@ interface QueryMethodsHost {
   /** Rails `delegate :primary_key, to: :model` (delegation.rb:106). */
   primaryKey: string | string[];
   _whereClause: WhereClause;
-  _orderClauses: Array<string | [string, "asc" | "desc"] | Nodes.Node>;
+  _orderClauses: Array<string | Nodes.Node>;
   _rawOrderClauses: string[];
   _reordering: boolean | undefined;
   _limitValue: number | null;
@@ -572,204 +572,57 @@ function regroupBang(
   return this;
 }
 
-/**
- * Resolve one entry of a node-keyed order Map into a stored order clause.
- * Arel node keys become Ascending/Descending nodes (preserving identity for
- * reverseOrder); string keys become validated `[col, dir]` tuples.
- * @internal
- */
-function orderHashEntry(
-  host: QueryMethodsHost,
-  key: unknown,
-  dir: unknown,
-): Nodes.Node | [string, "asc" | "desc"] {
-  if (!/^(asc|desc)$/i.test(String(dir))) {
-    throw argumentError(
-      `Direction "${dir}" is invalid. Valid directions are: [:asc, :desc, :ASC, :DESC, "asc", "desc", "ASC", "DESC"]`,
-    );
-  }
-  const direction = String(dir).toLowerCase() as "asc" | "desc";
-  if (key instanceof Nodes.Node) {
-    return direction === "desc" ? (key as any).desc() : (key as any).asc();
-  }
-  disallowRawSqlBang([String(key)], resolveOrderMatcher(host.model));
-  return [String(key), direction];
-}
-
-// Expand an order hash into clauses. Flat `{ col: "asc" }` yields
-// `["col", "asc"]`; nested `{ table: { col: "asc" } }` mirrors Rails'
-// preprocess_order_args, expanding to a `table.col` qualified order.
-function expandOrderHash(
-  host: QueryMethodsHost,
-  arg: Record<string, unknown>,
-): Array<Nodes.Node | [string, "asc" | "desc"]> {
-  const clauses: Array<Nodes.Node | [string, "asc" | "desc"]> = [];
-  for (const [key, value] of Object.entries(arg)) {
-    if (value !== null && typeof value === "object" && !(value instanceof Nodes.Node)) {
-      for (const [col, dir] of Object.entries(value as Record<string, unknown>)) {
-        clauses.push(orderHashEntry(host, `${key}.${col}`, dir));
-      }
-    } else {
-      clauses.push(orderHashEntry(host, key, value));
-    }
-  }
-  return clauses;
-}
-
 function orderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
-  // Mirrors Rails' preprocess_order_args adding column_references to
-  // references_values, so `includes(:author).order("authors.name")` (or the
-  // hash/Arel forms) promotes the include to eager_load.
-  const refs = columnReferences(args as unknown[]);
-  if (refs.length > 0) referencesBang.call(this, ...refs);
-  let i = 0;
-  while (i < args.length) {
-    const arg = args[i];
-    if (Array.isArray(arg)) {
-      const [first, ...rest] = arg as unknown[];
-      if (first instanceof Nodes.Node) {
-        // Bind array: [Arel.sql("col = ?"), bind1, ...] — Arel bypasses check.
-        // Store as a SqlLiteral so _applyOrderToManager emits it verbatim.
-        const rawSql = (first as any).value ?? connectionFor(this._modelClass).toSql(first);
-        const interpolated =
-          rest.length > 0 ? this._modelClass.sanitizeSqlArray(rawSql, ...rest) : rawSql;
-        if (interpolated.trim() !== "")
-          this._orderClauses.push(new Nodes.SqlLiteral(String(interpolated)));
-      } else {
-        // Plain string array: all elements must be strings; validate each immediately.
-        if (!(arg as unknown[]).every((e) => typeof e === "string")) {
-          throw argumentError("Order arguments passed as an array must contain only strings");
-        }
-        disallowRawSqlBang(arg as string[], resolveOrderMatcher(this.model));
-        for (const elem of arg as string[]) {
-          if (elem.trim() !== "") this._orderClauses.push(elem);
-        }
-      }
-    } else if (arg instanceof Map) {
-      // Hash form with Arel node keys: order(arelTable.get("id") => "desc").
-      // JS object keys can't be Arel nodes, so a Map is the faithful analog of
-      // Rails' `order(node => :desc)`.
-      for (const [key, dir] of arg) {
-        this._orderClauses.push(orderHashEntry(this, key, dir));
-      }
-    } else if (arg instanceof Nodes.Node) {
-      // Preserve the Arel node identity (Ascending/Descending/Attribute/...) so
-      // reverseOrderBang can flip it via .reverse()/.desc(), mirroring Rails'
-      // reverse_sql_order. _applyOrderToManager emits the node directly. Skip blank
-      // SQL literals — Rails build_order's compact_blank drops them (SqlLiteral is
-      // a blank? String subclass).
-      const blankLiteral =
-        arg instanceof Nodes.SqlLiteral && String((arg as any).value ?? "").trim() === "";
-      if (!blankLiteral) this._orderClauses.push(arg);
-    } else if (typeof arg === "symbol") {
-      // Rails qualifies a Symbol order arg (`order(:name)` → `"table"."name"
-      // ASC`), unlike a string, which stays bare. Store as a `[col, "asc"]`
-      // tuple so `_applyOrderToManager` routes it through column resolution.
-      const name = symbolToName(arg);
-      disallowRawSqlBang([name], resolveOrderMatcher(this.model));
-      this._orderClauses.push([name, "asc"]);
-    } else if (typeof arg === "string") {
-      // Rails maps each String order arg through unchanged (preprocess_order_args'
-      // `else` branch) and compact_blanks blank strings away. A string never pairs
-      // with a following "asc"/"desc" arg nor qualifies — it stays a bare
-      // SqlLiteral (see _applyOrderToManager). Validate immediately, mirroring
-      // Rails raising on order("invalid") at call time.
-      if (arg.trim() !== "") {
-        disallowRawSqlBang([arg], resolveOrderMatcher(this.model));
-        this._orderClauses.push(arg);
-      }
-    } else if (arg !== null && typeof arg === "object") {
-      // Hash form { col: "asc"|"desc" } — and nested { table: { col: "asc" } },
-      // which Rails expands to a `table.col dir` qualified order.
-      for (const clause of expandOrderHash(this, arg as Record<string, unknown>)) {
-        this._orderClauses.push(clause);
-      }
-    } else {
-      const argType = arg === null ? "null" : typeof arg;
-      throw argumentError(`Unsupported order argument: ${argType}`);
-    }
-    i++;
-  }
-  // Mirror Rails' `self.order_values |= args`: union dedupes repeated terms.
-  this._orderClauses = dedupeOrderClauses(this._orderClauses);
+  if (args.length > 0) preprocessOrderArgs.call(this, args as unknown[]);
+  // Mirrors Rails' `self.order_values |= args`: union dedupes repeated terms.
+  this._orderClauses = dedupeOrderClauses([
+    ...this._orderClauses,
+    ...(args as unknown[]),
+  ]) as typeof this._orderClauses;
   return this;
 }
 
 function reorderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
-  this._orderClauses = [];
+  preprocessOrderArgs.call(this, args as unknown[]);
   this._rawOrderClauses = [];
   this._reordering = true;
-  const refs = columnReferences(args as unknown[]);
-  if (refs.length > 0) referencesBang.call(this, ...refs);
-  let i = 0;
-  while (i < args.length) {
-    const arg = args[i];
-    if (Array.isArray(arg)) {
-      const [first, ...rest] = arg as unknown[];
-      if (first instanceof Nodes.Node) {
-        const rawSql = (first as any).value ?? connectionFor(this._modelClass).toSql(first);
-        const interpolated =
-          rest.length > 0 ? this._modelClass.sanitizeSqlArray(rawSql, ...rest) : rawSql;
-        if (interpolated.trim() !== "")
-          this._orderClauses.push(new Nodes.SqlLiteral(String(interpolated)));
-      } else {
-        if (!(arg as unknown[]).every((e) => typeof e === "string")) {
-          throw argumentError("Order arguments passed as an array must contain only strings");
-        }
-        disallowRawSqlBang(arg as string[], resolveOrderMatcher(this.model));
-        for (const elem of arg as string[]) {
-          if (elem.trim() !== "") this._orderClauses.push(elem);
-        }
-      }
-    } else if (arg instanceof Map) {
-      for (const [key, dir] of arg) {
-        this._orderClauses.push(orderHashEntry(this, key, dir));
-      }
-    } else if (arg instanceof Nodes.Node) {
-      // Preserve the Arel node identity (Ascending/Descending/Attribute/...) so
-      // reverseOrderBang can flip it via .reverse()/.desc(), mirroring Rails'
-      // reverse_sql_order. _applyOrderToManager emits the node directly. Skip blank
-      // SQL literals — Rails build_order's compact_blank drops them (SqlLiteral is
-      // a blank? String subclass).
-      const blankLiteral =
-        arg instanceof Nodes.SqlLiteral && String((arg as any).value ?? "").trim() === "";
-      if (!blankLiteral) this._orderClauses.push(arg);
-    } else if (typeof arg === "symbol") {
-      // Rails qualifies a Symbol order arg (`order(:name)` → `"table"."name"
-      // ASC`), unlike a string, which stays bare. Store as a `[col, "asc"]`
-      // tuple so `_applyOrderToManager` routes it through column resolution.
-      const name = symbolToName(arg);
-      disallowRawSqlBang([name], resolveOrderMatcher(this.model));
-      this._orderClauses.push([name, "asc"]);
-    } else if (typeof arg === "string") {
-      // Each String order arg maps through unchanged and stays bare (see the
-      // orderBang string branch); blanks are compact_blank'd away. No pairing
-      // with a following "asc"/"desc" arg, no qualification.
-      if (arg.trim() !== "") {
-        disallowRawSqlBang([arg], resolveOrderMatcher(this.model));
-        this._orderClauses.push(arg);
-      }
-    } else if (arg !== null && typeof arg === "object") {
-      for (const clause of expandOrderHash(this, arg as Record<string, unknown>)) {
-        this._orderClauses.push(clause);
-      }
-    } else {
-      const argType = arg === null ? "null" : typeof arg;
-      throw argumentError(`Unsupported order argument: ${argType}`);
-    }
-    i++;
-  }
-  this._orderClauses = dedupeOrderClauses(this._orderClauses);
+  this._orderClauses = dedupeOrderClauses(args as unknown[]) as typeof this._orderClauses;
   return this;
 }
-
 // Remove duplicate order terms while preserving first-seen order. orderBang
 // mirrors Rails' `self.order_values |= args` and reorderBang its `args.uniq!` —
 // both dedupe by value (query_methods.rb order!/reorder!).
+//
+// Ruby compares Arel nodes structurally (Arel::Nodes::Node#eql?), so build a
+// structural key rather than JSON-stringifying: an Attribute holds a back
+// reference to its Arel::Table, which JSON.stringify cannot serialize.
+let orderClauseIdentity = 0;
+const orderClauseIdentities = new WeakMap<object, number>();
+
+function orderClauseKey(clause: unknown): string {
+  if (typeof clause === "string") return `s:${clause}`;
+  if (clause instanceof Nodes.SqlLiteral) return `s:${String((clause as any).value ?? "")}`;
+  if (clause instanceof Nodes.Attribute) {
+    return `a:${relationName((clause as any).relation?.name)}.${(clause as any).name}`;
+  }
+  if (clause instanceof Nodes.Node && "expr" in (clause as any)) {
+    return `${clause.constructor.name}(${orderClauseKey((clause as any).expr)})`;
+  }
+  if (clause !== null && typeof clause === "object") {
+    let id = orderClauseIdentities.get(clause);
+    if (id === undefined) {
+      id = ++orderClauseIdentity;
+      orderClauseIdentities.set(clause, id);
+    }
+    return `o:${id}`;
+  }
+  return `v:${String(clause)}`;
+}
+
 function dedupeOrderClauses<T>(clauses: T[]): T[] {
   const seen = new Set<string>();
   return clauses.filter((c) => {
-    const key = JSON.stringify(c);
+    const key = orderClauseKey(c);
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
@@ -1499,7 +1352,7 @@ function reverseOrderBang(this: QueryMethodsHost): any {
   // substitute here: it reports a key-less object as blank, but Ruby's blank? is
   // false for an Arel node (it has no #empty?), so routing clauses through it
   // would drop every Ordering. Only nil/blank-string clauses are blank in this
-  // list; nodes and [col, dir] tuples never are.
+  // list; Arel nodes never are.
   const clauses = this._orderClauses.filter(
     (clause) => clause != null && !(typeof clause === "string" && /^\s*$/.test(clause)),
   );
@@ -1538,19 +1391,14 @@ function reverseOrderBang(this: QueryMethodsHost): any {
       if (typeof (clause as any).desc === "function") return (clause as any).desc();
       return clause;
     }
-    if (typeof clause === "string") {
-      // A string order arg stays a bare SqlLiteral (see _applyOrderToManager),
-      // so reversing it mirrors Rails' reverse_sql_order String branch: split on
-      // comma and flip each term's trailing ASC↔DESC (appending DESC when
-      // unmarked), keeping the result a bare SqlLiteral rather than re-qualifying
-      // it to a `[col, dir]` tuple. reverseSqlOrder runs isDoesNotSupportReverse
-      // (the faithful port of does_not_support_reverse?), so unbalanced-paren
-      // sections and "nulls first/last" still raise.
-      const reversed = reverseSqlOrder.call(this, [clause]) as string[];
-      return new Nodes.SqlLiteral(reversed.join(", "));
-    }
-    const [col, dir] = clause;
-    return [col, dir === "asc" ? "desc" : "asc"] as [string, "asc" | "desc"];
+    // A string order arg stays bare (Rails leaves String args unchanged in
+    // order_values), so reversing it mirrors reverse_sql_order's String branch:
+    // split on comma and flip each term's trailing ASC↔DESC (appending DESC when
+    // unmarked). reverseSqlOrder runs isDoesNotSupportReverse (the faithful port
+    // of does_not_support_reverse?), so unbalanced-paren sections and
+    // "nulls first/last" still raise.
+    const reversed = reverseSqlOrder.call(this, [clause]) as string[];
+    return new Nodes.SqlLiteral(reversed.join(", "));
   });
   return this;
 }
@@ -1740,20 +1588,9 @@ export function flattenedArgs(args: unknown[]): unknown[] {
 export function flattenedOrderArgs(args: unknown[]): unknown[] {
   // order/reorder mirror Rails' `args.flatten!` (query_methods.rb:659/755) so a
   // nested blank array like `order([nil])` collapses and compact_blanks away.
-  // The one exception is trails' bind-array form `[Arel.sql("x = ?"), ...binds]`
-  // — an array led by an Arel node — which orderBang consumes structurally to
-  // interpolate the binds; flattening it would split the SQL from its binds.
-  const out: unknown[] = [];
-  for (const e of args) {
-    if (Array.isArray(e) && !(e[0] instanceof Nodes.Node)) {
-      out.push(...flattenedOrderArgs(e));
-    } else {
-      // A bind-array (Arel-node-led) or scalar is pushed as one element; using a
-      // loop (not flatMap) keeps the preserved bind-array from being spread.
-      out.push(e);
-    }
-  }
-  return out;
+  // A bind array `[Arel.sql("x = ?"), ...binds]` has already been collapsed into
+  // one SqlLiteral by sanitize_order_arguments, which runs first.
+  return args.flatMap((e) => (Array.isArray(e) ? flattenedOrderArgs(e) : e));
 }
 
 const VALID_DIRECTIONS = new Set(["asc", "desc"]);
@@ -1761,6 +1598,18 @@ const VALID_DIRECTIONS = new Set(["asc", "desc"]);
 /** @internal */
 export function validateOrderArgs(this: QueryMethodsHost, args: unknown[]): void {
   for (const arg of args) {
+    // A Map stands in for Rails' Arel-node-keyed order hash; its values are
+    // directions and validate the same way.
+    if (arg instanceof Map) {
+      for (const [, value] of arg) {
+        if (!VALID_DIRECTIONS.has(String(value).toLowerCase())) {
+          throw argumentError(
+            `Direction "${value}" is invalid. Valid directions are: [:asc, :desc, :ASC, :DESC, "asc", "desc", "ASC", "DESC"]`,
+          );
+        }
+      }
+      continue;
+    }
     if (!isPlainObject(arg)) continue;
     for (const [, value] of Object.entries(arg)) {
       if (isPlainObject(value)) {
@@ -1987,6 +1836,14 @@ export function columnReferences(orderArgs: unknown[]): string[] {
       if (expr instanceof Nodes.Attribute) {
         refs.push(relationName(expr.relation.name));
       }
+    } else if (arg instanceof Map) {
+      for (const key of arg.keys()) {
+        if (key instanceof Nodes.Attribute) refs.push(relationName(key.relation.name));
+        else if (typeof key === "string" || typeof key === "symbol") {
+          const t = extractTableNameFrom(typeof key === "symbol" ? symbolToName(key) : key);
+          if (t) refs.push(t);
+        }
+      }
     } else if (isPlainObject(arg)) {
       for (const [key, value] of Object.entries(arg)) {
         if (isPlainObject(value)) {
@@ -2016,6 +1873,10 @@ function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): (string | symbo
       result.push(arg);
     } else if (arg instanceof Nodes.Node) {
       // Arel nodes (SqlLiteral, Attribute, Ordering, …) are pre-sanitized; skip them.
+    } else if (arg instanceof Map) {
+      for (const key of arg.keys()) {
+        if (typeof key === "string" || typeof key === "symbol") result.push(key);
+      }
     } else if (isPlainObject(arg)) {
       for (const [key, value] of Object.entries(arg)) {
         result.push(key);
@@ -2046,11 +1907,21 @@ export function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]
     const existing: string[] = (this as any)._referencesValues ?? [];
     (this as any)._referencesValues = [...new Set([...existing, ...refs])];
   }
-  // Rails maps Symbol args to Ascending nodes and Hash args to directional nodes.
   const mapped: unknown[] = [];
   for (const arg of orderArgs) {
     if (typeof arg === "symbol") {
       mapped.push(new Nodes.Ascending(orderColumn.call(this, symbolToName(arg))));
+    } else if (arg instanceof Map) {
+      // JS object keys can't be Arel nodes, so a Map is the analogue of Rails'
+      // `order(node => :desc)` — the `when Arel::Nodes::Node` branch, which
+      // sends the direction to the key itself instead of resolving it.
+      for (const [key, value] of arg) {
+        mapped.push(
+          key instanceof Nodes.Node
+            ? orderedNode(key, value)
+            : orderedNode(orderColumn.call(this, String(key)), value),
+        );
+      }
     } else if (isPlainObject(arg)) {
       for (const rawKey of Reflect.ownKeys(arg)) {
         const key = typeof rawKey === "symbol" ? symbolToName(rawKey) : rawKey;
@@ -2095,8 +1966,15 @@ function buildOrderNode(clause: unknown): unknown {
 
 /** @internal */
 export function buildOrder(this: QueryMethodsHost, arel: any): void {
+  // Rails' `order_values.compact_blank`: an Arel::Nodes::SqlLiteral is a String
+  // subclass, so a blank one is blank? too and gets dropped along with nil and "".
   const orders = ((this as any)._orderClauses ?? [])
-    .filter((o: unknown) => o !== null && o !== undefined && o !== "")
+    .filter((o: unknown) => {
+      if (o === null || o === undefined) return false;
+      if (typeof o === "string") return o.trim() !== "";
+      if (o instanceof Nodes.SqlLiteral) return String((o as any).value ?? "").trim() !== "";
+      return true;
+    })
     .map(buildOrderNode);
   if (orders.length > 0) arel.order?.(...orders);
 }

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -497,7 +497,11 @@ describe("RelationTest", () => {
   });
 
   it("reverse arel assoc order with function", async () => {
-    const topicsRel = Topic.order({ [arelSql("lower(title)").toSql()]: "asc" }).reverseOrder();
+    // Rails: `Topic.order(Arel.sql("lower(title)") => :asc)`. JS object keys
+    // can't be Arel nodes, so a Map is the faithful analog of a node-keyed
+    // order hash — preprocessOrderArgs sends the direction to the node itself
+    // rather than resolving it as a column name.
+    const topicsRel = Topic.order(new Map([[arelSql("lower(title)"), "asc"]])).reverseOrder();
     expect((await topicsRel.first())!.title).toBe(topics("third").title);
   });
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -772,13 +772,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "order",
-    "call": "sanitize_order_arguments",
-    "reason": "Deferred (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `orderBang`/`reorderBang` inline `disallowRawSqlBang` in a restructured body, leaving `sanitizeOrderArguments` and `checkIfMethodHasArgumentsBang` dead. Routing them is a real convergence but a whole-body restructure of the order/reorder path — its own story, not part of this sweep."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "pick",
     "call": "all_attributes?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -845,13 +838,6 @@
     "rubyName": "references_eager_loaded_tables?",
     "call": "references_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "reorder",
-    "call": "sanitize_order_arguments",
-    "reason": "Deferred (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `orderBang`/`reorderBang` inline `disallowRawSqlBang` in a restructured body, leaving `sanitizeOrderArguments` and `checkIfMethodHasArgumentsBang` dead. Routing them is a real convergence but a whole-body restructure of the order/reorder path — its own story, not part of this sweep."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
`preprocessOrderArgs` mirrored Rails' `preprocess_order_args`
(`query_methods.rb:2081-2116`) but had **no callers**. The live path was
`orderBang` / `reorderBang`, which stored order args as raw strings,
`[col, dir]` tuples, or Arel nodes via `expandOrderHash` / `orderHashEntry`
and resolved them later in `_applyOrderToManager` with a bespoke regex
dispatch (a raw-SQL character regex, `_isKnownColumn`, direct `table.get(col)`).

Rails has no such split: `order!` calls `preprocess_order_args`, `order_values`
holds fully-resolved terms, and `build_order` just filters blanks.

Rebased on #5932, which converged `preprocessOrderArgs`' own symbol/hash arms
onto `orderColumn`. This PR is the other half — giving that function its
callers and deleting the parallel path it was shadowed by.

## What changed

- **`orderBang` / `reorderBang`** are now Rails' three-liners over
  `preprocessOrderArgs` (`order_values |= args` / `uniq!` + `reordering_value`),
  so `_orderClauses` holds resolved terms and narrows to
  `Array<string | Nodes.Node>`.
- **`preprocessOrderArgs`** gains the `Map` arm — the analogue of Rails'
  Arel-node-keyed order hash (`when Arel::Nodes::SqlLiteral, Node, Attribute`
  sends the direction to the key itself). JS object keys can't be Arel nodes,
  so a `Map` is the faithful stand-in. `validateOrderArgs` / `columnReferences`
  / the raw-SQL key scan learned `Map` to match. The symbol/hash arms are
  #5932's, reused as-is via its `orderedNode` helper.
- **Deleted**: `expandOrderHash`, `orderHashEntry`, the `[col, dir]` tuple
  dispatch in `_applyOrderToManager` (now just `buildOrder`), the dead tuple
  arms in `reverseOrderBang` and `Merger#qualifyOrderForOther`, and the
  invented `"Order arguments passed as an array must contain only strings"`
  error.
- **`order` / `reorder`** run `sanitizeOrderArguments` inside
  `check_if_method_has_arguments!`, where Rails runs it. That is where a bind
  array `[Arel.sql("x = ?"), ...binds]` collapses into one interpolated
  SqlLiteral, so `flattenedOrderArgs` no longer needs to special-case
  Arel-led arrays and becomes a plain `flatten!`.
- **Blank compaction** moves to `buildOrder` (Rails' `compact_blank`, which
  drops blank `SqlLiteral`s since they're `String` subclasses).

Net −146 LOC.

## Behavior deltas, both toward Rails

- `order!("")` now raises `UnknownAttributeReference` from `disallow_raw_sql!`,
  as Rails does — `compact_blank!` lives in `order`, not `order!`.
  `order("")` still compacts to a no-op. `mutation.test.ts`'s trails-only
  `order! with empty string...` (no Rails counterpart) is retargeted at `order`
  and additionally pins the bang raise.
- `relations_test`'s `reverse arel assoc order with function` passed Rails'
  `Arel.sql("lower(title)")` hash key through `.toSql()`, degrading it to a
  string key that only worked because of the deleted regex dispatch. It now
  uses the `Map` form that Rails' node key maps to. Test name unchanged.

The string-arg-stays-bare behavior locked by
`order-string-arg-stays-bare.trails.test.ts` is preserved — Rails leaves
String args untouched in `order_values`.

## Verification

`pnpm typecheck` / `pnpm lint` clean.

Compare deltas measured against a built worktree at the merge-base
(`2cce072dc`, i.e. after #5932/#5933/#5934) — **both exactly 0**:

| | merge-base | this PR |
|---|---|---|
| api:compare activerecord | 6084/6148 | 6084/6148 |
| api:compare Data layer | 7725/7816 | 7725/7816 |
| api:compare Overall | 11790/17536 | 11790/17536 |
| test:compare Overall | 14879/22203 (4027 extra) | 14879/22203 (4027 extra) |

Suites: `relation`, `scoping`, `associations`, `batches`, `relations`,
`finder`, `calculations`, `merging`, `unsafe-raw-sql`, `sanitize` — all green.

## Review round 1

All three findings fixed; no justification-only replies.

1. **Test rename** — resolved by deletion rather than reword. The old assertion
   (`order!("")` swallows the blank) is genuinely superseded: Rails raises
   there, since `compact_blank!` lives in `order`, not `order!`. It is removed
   from `mutation.test.ts` outright — that file mirrors `mutation_test.rb`,
   which has no such test, so a trails invention never belonged in it — and the
   coverage moves to a new trails sidecar,
   `order-blank-arg-compaction.trails.test.ts`, pinning both halves (`order("")`
   compacts, `orderBang("")` raises). `mutation.test.ts` is now a pure deletion,
   so no test name is reworded in place.
2. **`columnReferences` Map arm** — confirmed a real deviation and fixed. Rails'
   `when Arel::Attribute` is a sibling of `when Hash` in the outer `case arg`,
   not a case inside the Hash arm; a node key with a scalar direction falls
   through to `nil` (query_methods.rb:2129-2137). Verified empirically:
   `Post.includes("author").order(new Map([[authors.get("name"), "desc"]]))`
   produced `references_values == ["authors"]` before the fix and `[]` after,
   with no eager join in the SQL. The Map arm now mirrors Rails' Hash arm
   exactly — String/Symbol key extraction, plus the nested-hash `key.to_s` case.
3. **Dead code in `buildOrderNode`** — deleted entirely, not just the tuple
   branch. trails' `SelectManager#order` (`packages/arel/src/select-manager.ts:329-340`)
   already performs the same String/Symbol → `SqlLiteral` coercion as Rails'
   Arel (`select_manager.rb:172-178`), so `build_order` needs no mapping at all.
   `buildOrder` is now Rails' two lines: `compact_blank` then `arel.order(*orders)`.

Closes-story: converge-order-bang-through-preprocess-order-args
