### PR TITLE
refactor(activerecord): require a real adapter for schema creation and table definitions

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -11,6 +11,7 @@ import { adapterType } from "./test-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { itIfSupports } from "./support/supports.js";
 import { fixtures } from "./test-fixtures.js";
+import { schemaConn } from "./support/schema-conn.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -113,7 +114,7 @@ describe("ActiveRecordSchemaTest", () => {
 
   it("schema raises an error for invalid column type", () => {
     // TableDefinition doesn't have a method for an invalid type; calling a nonexistent method should throw
-    const td = new TableDefinition("test_invalid");
+    const td = new TableDefinition("test_invalid", { adapter: schemaConn("sqlite") });
     expect(() => (td as any).unknownType("col")).toThrow();
   });
 
@@ -148,7 +149,7 @@ describe("ActiveRecordSchemaTest", () => {
 
   it.skipIf(adapterType !== "postgres")("timestamps with and without zones", async () => {
     // TableDefinition timestamps creates created_at and updated_at as datetime
-    const td = new TableDefinition("tz_test");
+    const td = new TableDefinition("tz_test", { adapter: schemaConn("sqlite") });
     td.timestamps();
     const colNames = td.columns.map((c) => c.name);
     expect(colNames).toContain("created_at");
@@ -158,7 +159,7 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("timestamps with implicit default on create table", async () => {
-    const td = new TableDefinition("ts_default");
+    const td = new TableDefinition("ts_default", { adapter: schemaConn("sqlite") });
     td.timestamps();
     const createdAt = td.columns.find((c) => c.name === "created_at");
     // timestamps sets null: false by default
@@ -166,7 +167,7 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("timestamps with custom options on create table", async () => {
-    const td = new TableDefinition("ts_custom");
+    const td = new TableDefinition("ts_custom", { adapter: schemaConn("sqlite") });
     td.timestamps({ null: true, precision: 6 });
     const createdAt = td.columns.find((c) => c.name === "created_at");
     const updatedAt = td.columns.find((c) => c.name === "updated_at");

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -40,6 +40,7 @@ import {
   ARUNIT_DATABASE,
   ARUNIT2_DATABASE,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
+import { schemaConn } from "./support/schema-conn.js";
 
 // Drives Rails' AdapterTest casted/non-casted bind probes against the leased
 // connection and the canonical `events` table. The insert return value is
@@ -514,9 +515,9 @@ describe("AdapterTest", () => {
   });
 
   it("type_to_sql returns a String for unmapped types", () => {
-    expect(new SchemaCreation("sqlite").typeToSql("special_db_type" as any)).toBe(
-      "special_db_type",
-    );
+    expect(
+      new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql("special_db_type" as any),
+    ).toBe("special_db_type");
   });
 
   it("inspect does not show secrets", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -19,7 +19,6 @@ import { BigDecimal } from "@blazetrails/activesupport";
 import { Attribute as ModelAttribute, BinaryData, type Type } from "@blazetrails/activemodel";
 import type { TypeMap } from "../../type/type-map.js";
 import { NotImplementedError } from "../../errors.js";
-import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import {
   formatInstantForSql,
   formatPlainDateTimeForSql,
@@ -67,8 +66,8 @@ type TemporalDateLike =
 /**
  * ANSI double-quote identifier quoter (`""`-escaped). Not a Rails-layer
  * method — Rails' abstract `Quoting` has no `quote_identifier`. This is the
- * SQL-92 fallback used only by {@link ABSTRACT_SCHEMA_QUOTER} when DDL is
- * rendered without a live adapter; every real adapter quotes through its own
+ * SQL-92 fallback used only by the `ABSTRACT_QUOTER` crutch in
+ * `sanitization.ts`; every real adapter quotes through its own
  * dialect-specific helper.
  *
  * @internal
@@ -247,7 +246,7 @@ export interface QuotingHost {
  *
  * Rails can call `lookup_cast_type` unconditionally because every host of this
  * module is an adapter. This standalone version is also bound to adapter-less
- * hosts (`ABSTRACT_SCHEMA_QUOTER`, the MySQL schema quoter) that have no type
+ * hosts (the MySQL schema quoter) that have no type
  * map, so it keeps the guard and hands back the raw sql_type for them; the
  * adapter method (`AbstractAdapter#lookupCastTypeFromColumn`) is the
  * unconditional one-liner.
@@ -319,8 +318,8 @@ export function quoteDefaultExpression(
   // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
   // (abstract/quoting.rb:161). Rails dispatches `lookup_cast_type`
   // unconditionally; the optional call is for the adapter-free hosts this
-  // standalone version also serves (ABSTRACT_SCHEMA_QUOTER, the mysql schema
-  // quoter), which have no type map, so their values pass through unserialized.
+  // standalone version also serves (the mysql schema quoter), which has no type
+  // map, so its values pass through unserialized.
   let serialized: unknown = value;
   if (column != null) {
     const castType = this.lookupCastType?.(column.sqlType ?? null) as {
@@ -335,38 +334,9 @@ export function quoteDefaultExpression(
   // own dialect quoting, including the raw-view branches the abstract `quote`
   // deliberately lacks. Falling straight to the module `quote` here would bypass
   // the dialect entirely and raise `can't quote Uint8Array` on a binary default.
-  // Hosts without a `quote` (ABSTRACT_SCHEMA_QUOTER) keep the module helper.
+  // Hosts without a `quote` keep the module helper.
   return dispatchQuote(this, serialized);
 }
-
-/**
- * ANSI fallback quoter used only when a schema visitor or definition is built
- * without a live adapter (the standalone `schemaCreation()` convention helpers
- * and isolated unit tests). Every adapter-backed caller passes its own
- * `SchemaQuoter`, so this never quotes DDL for a real connection; it exists so
- * the abstract schema layer stays usable adapter-free rather than silently
- * routing through whatever dialect happens to import these freestanding
- * functions. Mirrors the `ABSTRACT_QUOTER` crutch in `sanitization.ts`.
- *
- * @noRailsEquivalent CONVERGEABLE (story:
- * converge-schema-creation-adapter-free-construction). Rails never builds a
- * schema visitor or definition without a connection — `SchemaCreation.new(conn)`
- * (`abstract/schema_creation.rb:6`) and `TableDefinition#initialize`
- * (`abstract/schema_definitions.rb:369`) both require one — so this fallback
- * exists only to serve trails' adapter-free construction paths.
- */
-export const ABSTRACT_SCHEMA_QUOTER: SchemaQuoter = {
-  quoteColumnName: quoteIdentifier,
-  // The adapter-free fallback renders schema-qualified names ANSI-style by
-  // quoting each dot-separated part. The public `quoteTableName` mirrors Rails
-  // (delegates to the throwing `quoteColumnName`), so it can't back this crutch.
-  quoteTableName: (name) =>
-    name
-      .split(".")
-      .map((part) => quoteIdentifier(part))
-      .join("."),
-  quoteDefaultExpression,
-};
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_true

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -1,66 +1,88 @@
 import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./schema-creation.js";
 import { CreateIndexDefinition, IndexDefinition } from "./schema-definitions.js";
+import { schemaConn } from "../../support/schema-conn.js";
 
 describe("SchemaCreation#typeToSql blank type guard", () => {
   it("throws a descriptive error for an empty custom type", () => {
-    expect(() => new SchemaCreation("sqlite").typeToSql("" as any)).toThrow(/empty or blank type/);
+    expect(() => new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql("" as any)).toThrow(
+      /empty or blank type/,
+    );
   });
 
   it("throws a descriptive error for a whitespace-only custom type", () => {
-    expect(() => new SchemaCreation("sqlite").typeToSql("   " as any)).toThrow(
-      /empty or blank type/,
-    );
+    expect(() =>
+      new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql("   " as any),
+    ).toThrow(/empty or blank type/);
   });
 });
 
 describe("SchemaCreation#typeToSql virtual / nil pass-through", () => {
   it("returns '' for a nil type (Rails type_to_sql: type.to_s of nil)", () => {
-    expect(new SchemaCreation("sqlite").typeToSql(undefined as any)).toBe("");
+    expect(new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql(undefined as any)).toBe("");
   });
 
   it("passes 'virtual' through verbatim, with no options.type/string fallback", () => {
     // Rails' type_to_sql has no :virtual case, so type_to_sql(:virtual) → "virtual".
     // The :virtual → options[:type] mapping is newColumnDefinition-only.
     expect(
-      new SchemaCreation("sqlite").typeToSql("virtual" as any, { type: "integer" } as any),
+      new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql(
+        "virtual" as any,
+        { type: "integer" } as any,
+      ),
     ).toBe("virtual");
   });
 });
 
 describe("SchemaCreation drop-constraint visitors", () => {
   it("visit_DropForeignKey emits DROP CONSTRAINT with a quoted name", () => {
-    const sc = new SchemaCreation("postgres") as any;
+    const sc = new SchemaCreation("postgres", schemaConn("postgres")) as any;
     expect(sc.visitDropForeignKey("fk_rails_abc")).toBe('DROP CONSTRAINT "fk_rails_abc"');
   });
 
   it("visit_DropCheckConstraint emits DROP CONSTRAINT with a quoted name", () => {
-    const sc = new SchemaCreation("postgres") as any;
+    const sc = new SchemaCreation("postgres", schemaConn("postgres")) as any;
     expect(sc.visitDropCheckConstraint("chk_rails_abc")).toBe('DROP CONSTRAINT "chk_rails_abc"');
   });
 });
 
 describe("SchemaCreation support predicates", () => {
   it("supports_indexes_in_create? is true only on MySQL", () => {
-    expect((new SchemaCreation("mysql") as any).supportsIndexesInCreate()).toBe(true);
-    expect((new SchemaCreation("postgres") as any).supportsIndexesInCreate()).toBe(false);
-    expect((new SchemaCreation("sqlite") as any).supportsIndexesInCreate()).toBe(false);
+    expect(
+      (new SchemaCreation("mysql", schemaConn("mysql")) as any).supportsIndexesInCreate(),
+    ).toBe(true);
+    expect(
+      (new SchemaCreation("postgres", schemaConn("postgres")) as any).supportsIndexesInCreate(),
+    ).toBe(false);
+    expect(
+      (new SchemaCreation("sqlite", schemaConn("sqlite")) as any).supportsIndexesInCreate(),
+    ).toBe(false);
   });
 
   it("supports_exclusion_constraints? is true only on PostgreSQL", () => {
-    expect((new SchemaCreation("postgres") as any).supportsExclusionConstraints()).toBe(true);
-    expect((new SchemaCreation("mysql") as any).supportsExclusionConstraints()).toBe(false);
+    expect(
+      (
+        new SchemaCreation("postgres", schemaConn("postgres")) as any
+      ).supportsExclusionConstraints(),
+    ).toBe(true);
+    expect(
+      (new SchemaCreation("mysql", schemaConn("mysql")) as any).supportsExclusionConstraints(),
+    ).toBe(false);
   });
 
   it("supports_unique_constraints? is true only on PostgreSQL", () => {
-    expect((new SchemaCreation("postgres") as any).supportsUniqueConstraints()).toBe(true);
-    expect((new SchemaCreation("mysql") as any).supportsUniqueConstraints()).toBe(false);
+    expect(
+      (new SchemaCreation("postgres", schemaConn("postgres")) as any).supportsUniqueConstraints(),
+    ).toBe(true);
+    expect(
+      (new SchemaCreation("mysql", schemaConn("mysql")) as any).supportsUniqueConstraints(),
+    ).toBe(false);
   });
 });
 
 describe("SchemaCreation quoting delegations", () => {
   it("quote_column_name / quote_table_name delegate to the quoter", () => {
-    const sc = new SchemaCreation("postgres") as any;
+    const sc = new SchemaCreation("postgres", schemaConn("postgres")) as any;
     expect(sc.quoteColumnName("title")).toBe('"title"');
     expect(sc.quoteTableName("posts")).toBe('"posts"');
   });
@@ -75,9 +97,9 @@ describe("SchemaCreation#quotedColumnsForIndex sub-part length gating", () => {
       const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
         lengths: { title: 10 },
       });
-      const sql = (new SchemaCreation(adapter) as any).visitCreateIndexDefinition(
-        new CreateIndexDefinition(idx, false),
-      );
+      const sql = (
+        new SchemaCreation(adapter, schemaConn(adapter)) as any
+      ).visitCreateIndexDefinition(new CreateIndexDefinition(idx, false));
       expect(sql).not.toContain("(10)");
       expect(sql).toContain('("title")');
     });
@@ -133,23 +155,28 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
 
 describe("SchemaCreation#typeToSql decimal precision/scale", () => {
   it("raises when a decimal scale is given without a precision", () => {
-    expect(() => new SchemaCreation("sqlite").typeToSql("decimal", { scale: 2 })).toThrow(
-      "Error adding decimal column: precision cannot be empty if scale is specified",
-    );
+    expect(() =>
+      new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql("decimal", { scale: 2 }),
+    ).toThrow("Error adding decimal column: precision cannot be empty if scale is specified");
   });
 
   it("honors precision and scale when both are given", () => {
-    expect(new SchemaCreation("sqlite").typeToSql("decimal", { precision: 8, scale: 2 })).toBe(
-      "decimal(8,2)",
-    );
+    expect(
+      new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql("decimal", {
+        precision: 8,
+        scale: 2,
+      }),
+    ).toBe("decimal(8,2)");
   });
 
   it("emits a bare decimal with no precision when none is given", () => {
     // Rails sources the default from native_database_types[:decimal], which
     // carries no :precision on SQLite/MySQL/PostgreSQL — so a precision-less
     // decimal dumps bare rather than defaulting to (10).
-    expect(new SchemaCreation("sqlite").typeToSql("decimal")).toBe("decimal");
-    expect(new SchemaCreation("mysql").typeToSql("decimal")).toBe("decimal");
-    expect(new SchemaCreation("postgres").typeToSql("decimal")).toBe("decimal");
+    expect(new SchemaCreation("sqlite", schemaConn("sqlite")).typeToSql("decimal")).toBe("decimal");
+    expect(new SchemaCreation("mysql", schemaConn("mysql")).typeToSql("decimal")).toBe("decimal");
+    expect(new SchemaCreation("postgres", schemaConn("postgres")).typeToSql("decimal")).toBe(
+      "decimal",
+    );
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -21,7 +21,6 @@ import {
   CheckConstraintDefinition,
   TableDefinition,
 } from "./schema-definitions.js";
-import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
 import {
   NATIVE_DATABASE_TYPES_BY_ADAPTER,
   type NativeDatabaseType,
@@ -40,15 +39,11 @@ type Definition =
   | CheckConstraintDefinition;
 
 export class SchemaCreation {
-  /** Quoter used for identifier/table/default-expression quoting. */
-  protected adapter: SchemaQuoter;
-
   constructor(
     protected adapterName: "sqlite" | "postgres" | "mysql",
-    adapter?: SchemaQuoter,
-  ) {
-    this.adapter = adapter ?? ABSTRACT_SCHEMA_QUOTER;
-  }
+    /** Quoter used for identifier/table/default-expression quoting. */
+    protected adapter: SchemaQuoter,
+  ) {}
 
   protected supportsPartialIndex(): boolean {
     return this.adapterName !== "mysql";

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -7,6 +7,7 @@ import {
   Table,
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
+import { schemaConn } from "../../support/schema-conn.js";
 
 describe("IndexDefinition#concise_options", () => {
   it("keeps hash when values differ", () => {
@@ -131,7 +132,9 @@ describe("ForeignKeyDefinition#defined_for?", () => {
   it("slices out lookup keys the definition does not store", () => {
     // Mirrors `options = options.slice(*self.options.keys)`: a key the FK never
     // carried is dropped before the generic compare, so it is ignored.
-    const fkDef = new TableDefinition("astronauts").newForeignKeyDefinition("rockets");
+    const fkDef = new TableDefinition("astronauts", {
+      adapter: schemaConn("sqlite"),
+    }).newForeignKeyDefinition("rockets");
     // primaryKey/onDelete/onUpdate/deferrable were not passed, so they are not
     // stored — a lookup on them is sliced out and matches.
     expect(fkDef.isDefinedFor({ primaryKey: "wrong" })).toBe(true);
@@ -143,7 +146,9 @@ describe("ForeignKeyDefinition#defined_for?", () => {
     expect(fkDef.isDefinedFor({ column: "rocket_id" })).toBe(true);
     expect(fkDef.isDefinedFor({ column: "wrong_id" })).toBe(false);
     // An explicitly-set key is stored and compared.
-    const withPk = new TableDefinition("astronauts").newForeignKeyDefinition("rockets", {
+    const withPk = new TableDefinition("astronauts", {
+      adapter: schemaConn("sqlite"),
+    }).newForeignKeyDefinition("rockets", {
       primaryKey: "uuid",
     });
     expect(withPk.isDefinedFor({ primaryKey: "uuid" })).toBe(true);
@@ -190,7 +195,9 @@ describe("ForeignKeyDefinition#defined_for?", () => {
 
 describe("TableDefinition#new_foreign_key_definition", () => {
   it("defaults the name to fk_rails_<hex>, not fk_<table>_<column>", () => {
-    const fk = new TableDefinition("astronauts").newForeignKeyDefinition("rockets");
+    const fk = new TableDefinition("astronauts", {
+      adapter: schemaConn("sqlite"),
+    }).newForeignKeyDefinition("rockets");
     expect(fk.column).toBe("rocket_id");
     expect(fk.name).toMatch(/^fk_rails_[0-9a-f]{10}$/);
   });
@@ -210,7 +217,9 @@ describe("TableDefinition#new_foreign_key_definition", () => {
   it("maps a composite primaryKey array to a composite column array (bare-adapter fallback)", () => {
     // Mirrors foreign_key_options' array branch: each PK column gets its own
     // singularized foreign-key column.
-    const fk = new TableDefinition("astronauts").newForeignKeyDefinition("rockets", {
+    const fk = new TableDefinition("astronauts", {
+      adapter: schemaConn("sqlite"),
+    }).newForeignKeyDefinition("rockets", {
       primaryKey: ["tenant_id", "id"],
     });
     expect(fk.column).toEqual(["rocket_tenant_id", "rocket_id"]);
@@ -220,10 +229,13 @@ describe("TableDefinition#new_foreign_key_definition", () => {
     // Mirrors foreign_key_options' arity guard (schema_statements.rb:1258-1266):
     // a composite primaryKey must be matched by an equal-arity column.
     expect(() =>
-      new TableDefinition("astronauts").newForeignKeyDefinition("rockets", {
-        column: "rocket_id",
-        primaryKey: ["tenant_id", "id"],
-      }),
+      new TableDefinition("astronauts", { adapter: schemaConn("sqlite") }).newForeignKeyDefinition(
+        "rockets",
+        {
+          column: "rocket_id",
+          primaryKey: ["tenant_id", "id"],
+        },
+      ),
     ).toThrow(":column must reference all the :primary_key columns");
   });
 
@@ -243,7 +255,9 @@ describe("TableDefinition#new_foreign_key_definition", () => {
 
 describe("TableDefinition#new_check_constraint_definition", () => {
   it("defaults the name to chk_rails_<hex> (bare-adapter fallback)", () => {
-    const chk = new TableDefinition("products").newCheckConstraintDefinition("price > 0");
+    const chk = new TableDefinition("products", {
+      adapter: schemaConn("sqlite"),
+    }).newCheckConstraintDefinition("price > 0");
     expect(chk.name).toMatch(/^chk_rails_[0-9a-f]{10}$/);
     expect(chk.validate).toBe(true);
   });
@@ -286,14 +300,14 @@ describe("TableDefinition#new_check_constraint_definition", () => {
 describe("ReferenceDefinition helpers", () => {
   it("addTo adds id column by default", () => {
     const ref = new ReferenceDefinition("user", { index: false });
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     expect(td.columns.map((c) => c.name)).toContain("user_id");
   });
 
   it("addTo adds type column when polymorphic", () => {
     const ref = new ReferenceDefinition("taggable", { polymorphic: true, index: false });
-    const td = new TableDefinition("taggings", { id: false });
+    const td = new TableDefinition("taggings", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     const names = td.columns.map((c) => c.name);
     expect(names).toContain("taggable_id");
@@ -302,14 +316,14 @@ describe("ReferenceDefinition helpers", () => {
 
   it("addTo adds index with polymorphic name", () => {
     const ref = new ReferenceDefinition("taggable", { polymorphic: true });
-    const td = new TableDefinition("taggings", { id: false });
+    const td = new TableDefinition("taggings", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     expect(td.indexes[0].name).toBe("index_taggings_on_taggable");
   });
 
   it("addTo adds foreign key when foreignKey: true", () => {
     const ref = new ReferenceDefinition("user", { foreignKey: true, index: false });
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     expect(td.foreignKeys).toHaveLength(1);
     expect(td.foreignKeys[0].toTable).toBe("users");
@@ -320,7 +334,7 @@ describe("ReferenceDefinition helpers", () => {
       foreignKey: { toTable: "accounts" },
       index: false,
     });
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     expect(td.foreignKeys[0].toTable).toBe("accounts");
   });
@@ -333,7 +347,7 @@ describe("ReferenceDefinition helpers", () => {
 
   it("polymorphic columns are ordered type before id", () => {
     const ref = new ReferenceDefinition("taggable", { polymorphic: true, index: false });
-    const td = new TableDefinition("taggings", { id: false });
+    const td = new TableDefinition("taggings", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     expect(td.columns[0].name).toBe("taggable_type");
     expect(td.columns[1].name).toBe("taggable_id");
@@ -342,17 +356,17 @@ describe("ReferenceDefinition helpers", () => {
 
 describe("TableDefinition#toSql blank type guard", () => {
   it("throws a descriptive error for an empty custom type", async () => {
-    const td = new TableDefinition("t", { id: false });
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), id: false });
     td.column("bad", "" as any);
-    await expect(new SchemaCreation("sqlite").accept(td)).rejects.toThrow(
+    await expect(new SchemaCreation("sqlite", schemaConn("sqlite")).accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
     );
   });
 
   it("throws a descriptive error for a whitespace-only custom type", async () => {
-    const td = new TableDefinition("t", { id: false });
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), id: false });
     td.column("bad", "   " as any);
-    await expect(new SchemaCreation("sqlite").accept(td)).rejects.toThrow(
+    await expect(new SchemaCreation("sqlite", schemaConn("sqlite")).accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
     );
   });
@@ -360,13 +374,13 @@ describe("TableDefinition#toSql blank type guard", () => {
 
 describe("TableDefinition#raise_on_duplicate_column", () => {
   it("raises when adding a duplicate non-pk column", () => {
-    const td = new TableDefinition("t", { id: false });
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), id: false });
     td.string("name");
     expect(() => td.string("name")).toThrow("already defined column");
   });
 
   it("raises with pk-specific message for primary key columns", () => {
-    const td = new TableDefinition("t");
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite") });
     expect(() => td.column("id", "integer", { primaryKey: true })).toThrow(
       "redefine the primary key",
     );
@@ -375,12 +389,12 @@ describe("TableDefinition#raise_on_duplicate_column", () => {
 
 describe("TableDefinition#primary_key option", () => {
   it("treats primaryKey: false same as id: false", () => {
-    const td = new TableDefinition("t", { primaryKey: false });
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), primaryKey: false });
     expect(td.columns.find((c) => c.options.primaryKey)).toBeUndefined();
   });
 
   it("treats primaryKey: 'uuid' as a custom PK column name", () => {
-    const td = new TableDefinition("t", { primaryKey: "uuid" });
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), primaryKey: "uuid" });
     const pk = td.columns.find((c) => c.options.primaryKey);
     expect(pk?.name).toBe("uuid");
   });
@@ -388,7 +402,7 @@ describe("TableDefinition#primary_key option", () => {
 
 describe("TableDefinition#integer_like_primary_key?", () => {
   it("newColumnDefinition preserves integer pk type in base class", () => {
-    const td = new TableDefinition("t", { id: false });
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), id: false });
     const col = td.newColumnDefinition("id", "integer", { primaryKey: true });
     expect(col.type).toBe("integer");
   });
@@ -396,7 +410,7 @@ describe("TableDefinition#integer_like_primary_key?", () => {
 
 describe("TableDefinition#aliased_types", () => {
   it("maps timestamp to datetime", () => {
-    const td = new TableDefinition("t", { id: false });
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), id: false });
     td.column("ts", "timestamp");
     expect(td.columns[0].type).toBe("datetime");
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./schema-definitions.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Base } from "../../base.js";
+import { schemaConn } from "../../support/schema-conn.js";
 
 const originalFkPattern = SchemaDumper.fkIgnorePattern;
 const originalChkPattern = SchemaDumper.chkIgnorePattern;
@@ -55,7 +56,7 @@ describe("CheckConstraintDefinition#export_name_on_schema_dump?", () => {
 
 describe("TableDefinition#remove_column", () => {
   const td = (): TableDefinition => {
-    const t = new TableDefinition("astronauts");
+    const t = new TableDefinition("astronauts", { adapter: schemaConn("sqlite") });
     t.string("name");
     t.integer("rocket_id");
     return t;
@@ -168,7 +169,7 @@ describe("ReferenceDefinition#foreign_table_name", () => {
   it("targets the singular table when Base.pluralizeTableNames is false", () => {
     Base.pluralizeTableNames = false;
     const ref = new ReferenceDefinition("user", { foreignKey: true, index: false });
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     expect(td.foreignKeys[0].toTable).toBe("user");
   });
@@ -179,7 +180,7 @@ describe("ReferenceDefinition#foreign_table_name", () => {
       foreignKey: { toTable: "accounts" },
       index: false,
     });
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     ref.addTo(td);
     expect(td.foreignKeys[0].toTable).toBe("accounts");
   });
@@ -187,7 +188,7 @@ describe("ReferenceDefinition#foreign_table_name", () => {
 
 describe("TableDefinition column methods", () => {
   it("defines one column per name, mirroring `names.each` in define_column_methods", () => {
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     td.string("goat", "sheep", { limit: 40 });
 
     expect(td.columns.map((c) => c.name)).toEqual(["goat", "sheep"]);
@@ -195,14 +196,14 @@ describe("TableDefinition column methods", () => {
   });
 
   it("defines a single column when no options are passed", () => {
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     td.integer("votes");
 
     expect(td.columns.map((c) => c.name)).toEqual(["votes"]);
   });
 
   it("raises when called with no column name", () => {
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
 
     expect(() => (td.timestamp as () => unknown)()).toThrow("Missing column name(s) for timestamp");
     expect(() => (td.string as (o: object) => unknown)({ limit: 40 })).toThrow(
@@ -213,7 +214,7 @@ describe("TableDefinition column methods", () => {
 
 describe("ColumnMethods#primary_key", () => {
   it("merges primary_key: true and honours the type argument on create_table", () => {
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     td.primaryKey("id", "uuid", { default: "gen_random_uuid()" });
 
     expect(td.columns.map((c) => c.name)).toEqual(["id"]);
@@ -223,7 +224,7 @@ describe("ColumnMethods#primary_key", () => {
   });
 
   it("defaults the type to primary_key", () => {
-    const td = new TableDefinition("posts", { id: false });
+    const td = new TableDefinition("posts", { adapter: schemaConn("sqlite"), id: false });
     td.primaryKey("id");
 
     expect(td.columns[0].type).toBe("primary_key");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,4 +1,3 @@
-import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import type { Column } from "../column.js";
 import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
@@ -90,8 +89,9 @@ export type ReferentialAction = "cascade" | "nullify" | "restrict";
  * The adapter surface {@link TableDefinition.newForeignKeyDefinition} reads
  * beyond {@link SchemaQuoter}: the table_name_prefix/suffix (Rails reads these
  * off `ActiveRecord::Base`) and the converged `foreign_key_options` that fills
- * the default column and SHA256 `fk_rails_<hex>` name. All optional — the bare
- * ABSTRACT_SCHEMA_QUOTER path exposes none and falls back locally.
+ * the default column and SHA256 `fk_rails_<hex>` name. All optional — a
+ * bare-{@link SchemaQuoter} host (the MySQL schema quoter) exposes none and
+ * falls back locally.
  * @internal
  */
 export interface ForeignKeyOptionsAdapter {
@@ -983,7 +983,7 @@ export class TableDefinition {
       id?: boolean | ColumnType | IdHashOptions;
       primaryKey?: string | string[] | false;
       adapterName?: "sqlite" | "postgres" | "mysql";
-      adapter?: SchemaQuoter;
+      adapter: SchemaQuoter;
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
@@ -993,11 +993,11 @@ export class TableDefinition {
       collation?: string;
       default?: unknown;
       autoIncrement?: boolean;
-    } = {},
+    },
   ) {
     this.tableName = tableName;
     this._adapterName = tdOptions.adapterName ?? "sqlite";
-    this._adapter = tdOptions.adapter ?? ABSTRACT_SCHEMA_QUOTER;
+    this._adapter = tdOptions.adapter;
     // Composite primaryKey implies id: false — Rails requires this and emitting both
     // an auto-id column AND a composite PK constraint is invalid DDL.
     const hasCompositePk = Array.isArray(tdOptions.primaryKey) && tdOptions.primaryKey.length > 0;
@@ -1243,10 +1243,10 @@ export class TableDefinition {
 
   /**
    * Delegate to the adapter's `foreignKeyOptions` (which fills the default
-   * column and SHA256 `fk_rails_<hex>` name) when available. The bare
-   * ABSTRACT_SCHEMA_QUOTER path (used in unit tests that construct a
-   * TableDefinition directly) lacks it, so fall back to the same
-   * derivation as SchemaStatements#foreignKeyOptions / foreignKeyName.
+   * column and SHA256 `fk_rails_<hex>` name) when available. A
+   * bare-{@link SchemaQuoter} host (the MySQL schema quoter) lacks it, so fall
+   * back to the same derivation as SchemaStatements#foreignKeyOptions /
+   * foreignKeyName.
    * @internal
    */
   private _foreignKeyOptions(

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../abstract/schema-definitions.js";
 import { TableDefinition as MyTd } from "./schema-definitions.js";
 import { Column } from "./column.js";
+import { schemaConn } from "../../support/schema-conn.js";
 
 describe("MySQL::SchemaCreation", () => {
   const sc = new SchemaCreation();
@@ -100,7 +101,7 @@ describe("MySQL::SchemaCreation", () => {
   });
 
   it("addTableOptionsBang appends charset and collation", async () => {
-    const td = new TableDefinition("users", { adapterName: "mysql" });
+    const td = new TableDefinition("users", { adapter: schemaConn("mysql"), adapterName: "mysql" });
     (td as any).charset = "utf8mb4";
     (td as any).collation = "utf8mb4_unicode_ci";
     const result = (sc as any).addTableOptionsBang("CREATE TABLE `users` ()", td);
@@ -185,7 +186,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   const toSql = (td: MyTd, host?: unknown) => new SchemaCreation(host as any).accept(td);
 
   it("emits bigint AUTO_INCREMENT PRIMARY KEY for default id column", async () => {
-    const td = new MyTd("users", {});
+    const td = new MyTd("users", { adapter: schemaConn("mysql") });
     td.string("name");
     expect(await toSql(td)).toBe(
       "CREATE TABLE `users` (`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(255))",
@@ -193,7 +194,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   });
 
   it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
-    const td = new MyTd("t", { id: false });
+    const td = new MyTd("t", { adapter: schemaConn("mysql"), id: false });
     td.column("full_name", "virtual" as any, { as: "CONCAT(a, b)" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
@@ -203,13 +204,17 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   });
 
   it("honors id: false (no primary key column)", async () => {
-    const td = new MyTd("logs", { id: false });
+    const td = new MyTd("logs", { adapter: schemaConn("mysql"), id: false });
     td.string("body");
     expect(await toSql(td)).toBe("CREATE TABLE `logs` (`body` varchar(255))");
   });
 
   it("appends DEFAULT CHARSET and COLLATE from table options", async () => {
-    const td = new MyTd("posts", { charset: "utf8mb4", collation: "utf8mb4_unicode_ci" });
+    const td = new MyTd("posts", {
+      adapter: schemaConn("mysql"),
+      charset: "utf8mb4",
+      collation: "utf8mb4_unicode_ci",
+    });
     td.string("title");
     const sql = await toSql(td);
     expect(sql).toContain("DEFAULT CHARSET=utf8mb4");
@@ -217,13 +222,21 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   });
 
   it("emits IF NOT EXISTS and TEMPORARY modifiers", async () => {
-    const td = new MyTd("tmp", { id: false, temporary: true, ifNotExists: true });
+    const td = new MyTd("tmp", {
+      adapter: schemaConn("mysql"),
+      id: false,
+      temporary: true,
+      ifNotExists: true,
+    });
     td.integer("n");
     expect(await toSql(td)).toBe("CREATE TEMPORARY TABLE IF NOT EXISTS `tmp` (`n` int)");
   });
 
   it("emits composite PRIMARY KEY clause", async () => {
-    const td = new MyTd("memberships", { primaryKey: ["user_id", "group_id"] });
+    const td = new MyTd("memberships", {
+      adapter: schemaConn("mysql"),
+      primaryKey: ["user_id", "group_id"],
+    });
     td.bigint("user_id", { null: false });
     td.bigint("group_id", { null: false });
     const sql = await toSql(td);
@@ -231,7 +244,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   });
 
   it("inlines indexes when supportsIndexesInCreate (MySQL)", async () => {
-    const td = new MyTd("users", {});
+    const td = new MyTd("users", { adapter: schemaConn("mysql") });
     td.string("email");
     td.index(["email"], { unique: true, name: "idx_users_email" });
     const sql = await toSql(td);
@@ -239,7 +252,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   });
 
   it("inlines FOREIGN KEY constraints", async () => {
-    const td = new MyTd("posts", {});
+    const td = new MyTd("posts", { adapter: schemaConn("mysql") });
     td.bigint("author_id");
     td.foreignKey("authors", { column: "author_id" });
     const sql = await toSql(td);
@@ -248,7 +261,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   });
 
   it("inlines CHECK constraints", async () => {
-    const td = new MyTd("products", {});
+    const td = new MyTd("products", { adapter: schemaConn("mysql") });
     td.integer("price");
     td.checkConstraint("price > 0", { name: "price_positive" });
     const sql = await toSql(td);
@@ -256,13 +269,13 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   });
 
   it("appends MySQL COMMENT on table option", async () => {
-    const td = new MyTd("notes", { comment: "user-supplied" });
+    const td = new MyTd("notes", { adapter: schemaConn("mysql"), comment: "user-supplied" });
     td.string("body");
     expect(await toSql(td)).toContain("COMMENT 'user-supplied'");
   });
 
   it("emits AS clause after table options for CTAS", async () => {
-    const td = new MyTd("snapshot", { id: false, as: "SELECT 1" });
+    const td = new MyTd("snapshot", { adapter: schemaConn("mysql"), id: false, as: "SELECT 1" });
     expect(await toSql(td)).toMatch(/CREATE TABLE `snapshot`.* AS SELECT 1$/);
   });
 
@@ -288,7 +301,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
 
 describe("MySQL::TableDefinition column methods", () => {
   it("defines one column per name, mirroring `names.each` in define_column_methods", () => {
-    const td = new MyTd("t", { id: false });
+    const td = new MyTd("t", { adapter: schemaConn("mysql"), id: false });
     td.longtext("body", "summary");
     td.unsignedInteger("hits", "misses");
 
@@ -302,7 +315,7 @@ describe("MySQL::TableDefinition column methods", () => {
   });
 
   it("applies the shared options and per-name sizing to every blob name", () => {
-    const td = new MyTd("t", { id: false });
+    const td = new MyTd("t", { adapter: schemaConn("mysql"), id: false });
     td.blob("thumb", "preview", { limit: 300 });
 
     expect(td.columns.map((c) => c.name)).toEqual(["thumb", "preview"]);
@@ -310,7 +323,7 @@ describe("MySQL::TableDefinition column methods", () => {
   });
 
   it("raises when called with no column name", () => {
-    const td = new MyTd("t", { id: false });
+    const td = new MyTd("t", { adapter: schemaConn("mysql"), id: false });
 
     expect(() => (td.blob as () => unknown)()).toThrow("Missing column name(s) for blob");
     expect(() => (td.tinytext as () => unknown)()).toThrow("Missing column name(s) for tinytext");

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -69,7 +69,7 @@ export function _pgGeneratedClause(
 export class SchemaCreation extends AbstractSchemaCreation {
   declare protected adapter: PgSchemaCreationHost;
 
-  constructor(adapter?: PgSchemaCreationHost) {
+  constructor(adapter: PgSchemaCreationHost) {
     super("postgres", adapter);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { SchemaDumper } from "../../schema-dumper.js";
 import {
   ExclusionConstraintDefinition,
@@ -9,6 +9,9 @@ import {
   type SchemaStatementsConstraintLike,
 } from "./schema-definitions.js";
 import { SchemaCreation as PgSchemaCreation } from "./schema-creation.js";
+import { schemaConn } from "../../support/schema-conn.js";
+import { describeIfPg, PG_TEST_URL } from "../../support/describe-if-pg.js";
+import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 
 describe("ExclusionConstraintDefinition", () => {
   it("exposes options as accessors", async () => {
@@ -131,7 +134,7 @@ describe("UniqueConstraintDefinition", () => {
 
 describe("TableDefinition", () => {
   it("accumulates exclusion constraints", () => {
-    const td = new TableDefinition("products");
+    const td = new TableDefinition("products", { adapter: schemaConn("postgres") });
     td.exclusionConstraint("price WITH =, range WITH &&", { name: "price_check", using: "gist" });
 
     expect(td.exclusionConstraints).toHaveLength(1);
@@ -142,7 +145,7 @@ describe("TableDefinition", () => {
   });
 
   it("accumulates unique constraints", () => {
-    const td = new TableDefinition("orders");
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres") });
     td.uniqueConstraint("position", { name: "unique_position", deferrable: "deferred" });
 
     expect(td.uniqueConstraints).toHaveLength(1);
@@ -153,17 +156,17 @@ describe("TableDefinition", () => {
   });
 
   it("defaults unlogged to false", () => {
-    const td = new TableDefinition("t");
+    const td = new TableDefinition("t", { adapter: schemaConn("postgres") });
     expect(td.unlogged).toBe(false);
   });
 
   it("accepts unlogged option", () => {
-    const td = new TableDefinition("t", { unlogged: true });
+    const td = new TableDefinition("t", { adapter: schemaConn("postgres"), unlogged: true });
     expect(td.unlogged).toBe(true);
   });
 
   it("newExclusionConstraintDefinition returns definition without pushing", () => {
-    const td = new TableDefinition("products");
+    const td = new TableDefinition("products", { adapter: schemaConn("postgres") });
     const defn = td.newExclusionConstraintDefinition("price WITH =", { name: "pc" });
     expect(defn).toBeInstanceOf(ExclusionConstraintDefinition);
     expect(defn.tableName).toBe("products");
@@ -171,7 +174,7 @@ describe("TableDefinition", () => {
   });
 
   it("newUniqueConstraintDefinition returns definition without pushing", () => {
-    const td = new TableDefinition("orders");
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres") });
     const defn = td.newUniqueConstraintDefinition("col", { name: "uc" });
     expect(defn).toBeInstanceOf(UniqueConstraintDefinition);
     expect(defn.tableName).toBe("orders");
@@ -216,7 +219,7 @@ describe("PostgreSQL::TableDefinition column methods", () => {
 
   it("defines one column per name", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { id: false });
+      const td = new TableDefinition("t", { adapter: schemaConn("postgres"), id: false });
       (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "b", "c");
       expect(td.columns.map((c) => c.name)).toEqual(["a", "b", "c"]);
     }
@@ -224,7 +227,7 @@ describe("PostgreSQL::TableDefinition column methods", () => {
 
   it("applies the trailing options to every name", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { id: false });
+      const td = new TableDefinition("t", { adapter: schemaConn("postgres"), id: false });
       (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "b", {
         null: false,
       });
@@ -237,7 +240,7 @@ describe("PostgreSQL::TableDefinition column methods", () => {
 
   it("raises when given no column name", () => {
     for (const [method, railsType] of types) {
-      const td = new TableDefinition("t", { id: false });
+      const td = new TableDefinition("t", { adapter: schemaConn("postgres"), id: false });
       expect(() =>
         (td as unknown as Record<string, (...args: unknown[]) => void>)[method](),
       ).toThrow(`Missing column name(s) for ${railsType}`);
@@ -249,7 +252,7 @@ describe("PostgreSQL::TableDefinition column methods", () => {
 
   it("creates an index for every name when index is passed", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { id: false });
+      const td = new TableDefinition("t", { adapter: schemaConn("postgres"), id: false });
       (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "b", {
         index: true,
       });
@@ -260,7 +263,7 @@ describe("PostgreSQL::TableDefinition column methods", () => {
 
   it("raises on a duplicate column name", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { id: false });
+      const td = new TableDefinition("t", { adapter: schemaConn("postgres"), id: false });
       expect(() =>
         (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "a"),
       ).toThrow("you can't define an already defined column 'a' on 't'.");
@@ -268,7 +271,7 @@ describe("PostgreSQL::TableDefinition column methods", () => {
   });
 
   it("keeps type-specific SQL types when defining multiple columns", () => {
-    const td = new TableDefinition("t", { id: false });
+    const td = new TableDefinition("t", { adapter: schemaConn("postgres"), id: false });
     td.bit("a", "b", { limit: 8 });
     td.bitVarying("c", { limit: 4 });
     td.bigserial("d", "e");
@@ -284,14 +287,14 @@ describe("PostgreSQL::TableDefinition column methods", () => {
 
 describe("AlterTable", () => {
   it("validateConstraint pushes to constraintValidations", () => {
-    const td = new TableDefinition("products");
+    const td = new TableDefinition("products", { adapter: schemaConn("postgres") });
     const at = new AlterTable(td);
     at.validateConstraint("price_check");
     expect(at.constraintValidations).toEqual(["price_check"]);
   });
 
   it("addExclusionConstraint pushes to exclusionConstraintAdds", () => {
-    const td = new TableDefinition("products");
+    const td = new TableDefinition("products", { adapter: schemaConn("postgres") });
     const at = new AlterTable(td);
     at.addExclusionConstraint("price WITH =", { name: "pc", using: "gist" });
     expect(at.exclusionConstraintAdds).toHaveLength(1);
@@ -299,7 +302,7 @@ describe("AlterTable", () => {
   });
 
   it("addUniqueConstraint pushes to uniqueConstraintAdds", () => {
-    const td = new TableDefinition("orders");
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres") });
     const at = new AlterTable(td);
     at.addUniqueConstraint("position", { name: "unique_position" });
     expect(at.uniqueConstraintAdds).toHaveLength(1);
@@ -316,20 +319,24 @@ describe("TableDefinition#toSql", () => {
   };
 
   it("emits UNLOGGED when unlogged: true", async () => {
-    const td = new TableDefinition("products", { id: false, unlogged: true });
+    const td = new TableDefinition("products", {
+      adapter: schemaConn("postgres"),
+      id: false,
+      unlogged: true,
+    });
     td.string("name");
     expect(await toSql(td)).toMatch(/^CREATE UNLOGGED TABLE/);
   });
 
   it("does not emit UNLOGGED by default", async () => {
-    const td = new TableDefinition("products", { id: false });
+    const td = new TableDefinition("products", { adapter: schemaConn("postgres"), id: false });
     td.string("name");
     expect(await toSql(td)).toMatch(/^CREATE TABLE/);
     expect(await toSql(td)).not.toContain("UNLOGGED");
   });
 
   it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
-    const td = new TableDefinition("articles", { id: false });
+    const td = new TableDefinition("articles", { adapter: schemaConn("postgres"), id: false });
     td.column("full_name", "virtual" as any, { as: "a || b", stored: true } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
@@ -339,7 +346,7 @@ describe("TableDefinition#toSql", () => {
   });
 
   it("emits exclusion constraint in CREATE TABLE", async () => {
-    const td = new TableDefinition("meetings", { id: false });
+    const td = new TableDefinition("meetings", { adapter: schemaConn("postgres"), id: false });
     td.exclusionConstraint("room WITH =, during WITH &&", { name: "no_overlap", using: "gist" });
     const sql = await toSql(td);
     expect(sql).toContain(
@@ -348,7 +355,7 @@ describe("TableDefinition#toSql", () => {
   });
 
   it("emits unique constraint in CREATE TABLE", async () => {
-    const td = new TableDefinition("orders", { id: false });
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres"), id: false });
     td.uniqueConstraint("position", { name: "unique_pos", deferrable: "deferred" });
     const sql = await toSql(td);
     expect(sql).toContain(
@@ -357,21 +364,21 @@ describe("TableDefinition#toSql", () => {
   });
 
   it("emits unique constraint with nulls not distinct", async () => {
-    const td = new TableDefinition("orders", { id: false });
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres"), id: false });
     td.uniqueConstraint("position", { name: "unique_pos", nullsNotDistinct: true });
     const sql = await toSql(td);
     expect(sql).toContain("NULLS NOT DISTINCT");
   });
 
   it("emits unique constraint using index", async () => {
-    const td = new TableDefinition("orders", { id: false });
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres"), id: false });
     td.uniqueConstraint("position", { name: "unique_pos", usingIndex: "orders_pos_idx" });
     const sql = await toSql(td);
     expect(sql).toContain('USING INDEX "orders_pos_idx"');
   });
 
   it("emits DEFERRABLE without INITIALLY clause when deferrable: true", async () => {
-    const td = new TableDefinition("orders", { id: false });
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres"), id: false });
     td.uniqueConstraint("position", { name: "unique_pos", deferrable: true });
     const sql = await toSql(td);
     expect(sql).toContain('CONSTRAINT "unique_pos" UNIQUE ("position") DEFERRABLE');
@@ -380,7 +387,7 @@ describe("TableDefinition#toSql", () => {
   });
 
   it("emits exclusion constraint without CONSTRAINT clause when name is omitted", async () => {
-    const td = new TableDefinition("meetings", { id: false });
+    const td = new TableDefinition("meetings", { adapter: schemaConn("postgres"), id: false });
     td.exclusionConstraint("room WITH =", { using: "gist" });
     const sql = await toSql(td);
     expect(sql).toContain("EXCLUDE USING gist (room WITH =)");
@@ -388,7 +395,7 @@ describe("TableDefinition#toSql", () => {
   });
 
   it("emits unique constraint without CONSTRAINT clause when name is omitted", async () => {
-    const td = new TableDefinition("orders", { id: false });
+    const td = new TableDefinition("orders", { adapter: schemaConn("postgres"), id: false });
     td.uniqueConstraint("position");
     const sql = await toSql(td);
     expect(sql).toContain('UNIQUE ("position")');
@@ -396,7 +403,7 @@ describe("TableDefinition#toSql", () => {
   });
 
   it("handles constraint-only table with no columns (id: false)", async () => {
-    const td = new TableDefinition("link_table", { id: false });
+    const td = new TableDefinition("link_table", { adapter: schemaConn("postgres"), id: false });
     td.uniqueConstraint("ref", { name: "unique_ref" });
     const sql = await toSql(td);
     expect(sql).not.toContain("(,");
@@ -405,6 +412,7 @@ describe("TableDefinition#toSql", () => {
 
   it("injects constraints before trailing table options clause", async () => {
     const td = new TableDefinition("logs", {
+      adapter: schemaConn("postgres"),
       id: false,
       options: "WITH (autovacuum_enabled = false)",
     });
@@ -420,6 +428,7 @@ describe("TableDefinition#toSql", () => {
 
   it("skips constraint injection for CREATE TABLE ... AS queries", async () => {
     const td = new TableDefinition("archived_orders", {
+      adapter: schemaConn("postgres"),
       id: false,
       as: "SELECT (1) AS id, amount FROM orders WHERE archived = true",
     });
@@ -434,7 +443,7 @@ describe("TableDefinition#toSql", () => {
     // whose default branch returns an unrecognized type verbatim (Rails parity:
     // `type.to_s` — it never uppercases). This matches the real-PostgreSQLAdapter
     // path, where typeToSql("cidr") also returns "cidr" via NATIVE_DATABASE_TYPES.
-    const td = new TableDefinition("widgets", { id: false });
+    const td = new TableDefinition("widgets", { adapter: schemaConn("postgres"), id: false });
     td.cidr("net");
     td.inet("addr");
     td.hstore("props");
@@ -487,12 +496,27 @@ describe("TableDefinition#toSql", () => {
     expect(sql).toContain('"doc" tsvector');
     expect(sql).toContain('"price" money');
   });
+});
+
+// Quoting a DEFAULT resolves the column's cast type through the server
+// (`lookup_cast_type`'s regtype query), so this one needs a live connection
+// where the rest of the file only renders SQL.
+describeIfPg("TableDefinition#toSql default quoting", () => {
+  let conn: PostgreSQLAdapter;
+
+  beforeAll(() => {
+    conn = new PostgreSQLAdapter(PG_TEST_URL);
+  });
+
+  afterAll(() => {
+    conn.disconnect();
+  });
 
   it("handles default values containing doubled single-quotes without mis-parsing", async () => {
-    const td = new TableDefinition("messages", { id: false });
+    const td = new TableDefinition("messages", { adapter: conn, id: false });
     td.string("body", { default: "Bob's" });
     td.uniqueConstraint("body", { name: "unique_body" });
-    const sql = await toSql(td);
+    const sql = await new PgSchemaCreation(conn).accept(td);
     expect(sql).toContain("Bob''s");
     expect(sql).toContain('CONSTRAINT "unique_body"');
   });
@@ -563,7 +587,7 @@ describe("Table delegation", () => {
 
 describe("TableDefinition#validColumnDefinitionOptions", () => {
   it("adds the PostgreSQL-specific option keys to the abstract set", () => {
-    const td = new TableDefinition("articles");
+    const td = new TableDefinition("articles", { adapter: schemaConn("postgres") });
     const opts = (td as any).validColumnDefinitionOptions() as string[];
     for (const key of ["array", "using", "castAs", "as", "type", "enumType", "stored"]) {
       expect(opts).toContain(key);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -498,9 +498,6 @@ describe("TableDefinition#toSql", () => {
   });
 });
 
-// Quoting a DEFAULT resolves the column's cast type through the server
-// (`lookup_cast_type`'s regtype query), so this one needs a live connection
-// where the rest of the file only renders SQL.
 describeIfPg("TableDefinition#toSql default quoting", () => {
   let conn: PostgreSQLAdapter;
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -206,8 +206,8 @@ export class TableDefinition extends AbstractTableDefinition {
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
-      adapter?: SchemaQuoter;
-    } = {},
+      adapter: SchemaQuoter;
+    },
   ) {
     super(tableName, { ...options, adapterName: "postgres" });
     this.unlogged = options.unlogged ?? false;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -769,6 +769,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     } = {},
   ): string {
     const { limit, array, enumType } = options;
+    // Rails switches on `type.to_s`, so a nil type falls through to the
+    // abstract `type_to_sql`, whose own `type.to_s` renders it as "".
+    type = type ?? "";
     let sql: string;
     switch (type) {
       case "binary":

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -769,8 +769,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     } = {},
   ): string {
     const { limit, array, enumType } = options;
-    // Rails switches on `type.to_s`, so a nil type falls through to the
-    // abstract `type_to_sql`, whose own `type.to_s` renders it as "".
     type = type ?? "";
     let sql: string;
     switch (type) {

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -13,6 +13,7 @@ import { newRawTestAdapter } from "../test-adapter.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { schemaConn } from "../support/schema-conn.js";
 
 function makeColumn(
   name: string,
@@ -730,7 +731,7 @@ class MockAdapter {
   quoteDefaultExpression = (_v: unknown) => "";
   supportsDatetimeWithPrecision = () => false;
   createTableDefinition = (n: string, opts: Record<string, unknown>) =>
-    new TableDefinition(n, { ...opts, adapterName: "sqlite" });
+    new TableDefinition(n, { adapter: schemaConn("sqlite"), ...opts, adapterName: "sqlite" });
 
   constructor(cache: SchemaCache) {
     this.schemaCache = BoundSchemaReflection.forLoneConnection(

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
@@ -5,9 +5,10 @@ import {
   TableDefinition,
   CreateIndexDefinition,
 } from "../abstract/schema-definitions.js";
+import { schemaConn } from "../../support/schema-conn.js";
 
 describe("SQLite3::SchemaCreation", () => {
-  const sc = new SchemaCreation("sqlite");
+  const sc = new SchemaCreation("sqlite", schemaConn("sqlite"));
 
   it("appends DEFERRABLE INITIALLY DEFERRED when deferrable is 'deferred'", async () => {
     const fk = new ForeignKeyDefinition(
@@ -35,19 +36,28 @@ describe("SQLite3::SchemaCreation", () => {
   });
 
   it("omits USING clause from CREATE INDEX (no index-using support)", async () => {
-    const td = new TableDefinition("articles", { adapterName: "sqlite" });
+    const td = new TableDefinition("articles", {
+      adapter: schemaConn("sqlite"),
+      adapterName: "sqlite",
+    });
     td.index(["title"], { using: "btree" });
     expect(await sc.accept(new CreateIndexDefinition(td.indexes[0]))).not.toContain("USING");
   });
 
   it("appends COLLATE clause when collation option is set", async () => {
-    const td = new TableDefinition("articles", { adapterName: "sqlite" });
+    const td = new TableDefinition("articles", {
+      adapter: schemaConn("sqlite"),
+      adapterName: "sqlite",
+    });
     td.column("title", "string", { collation: "BINARY" } as any);
     expect(await sc.accept(td)).toContain('COLLATE "BINARY"');
   });
 
   it("appends GENERATED ALWAYS AS VIRTUAL for virtual columns", async () => {
-    const td = new TableDefinition("articles", { adapterName: "sqlite" });
+    const td = new TableDefinition("articles", {
+      adapter: schemaConn("sqlite"),
+      adapterName: "sqlite",
+    });
     td.column("full_name", "string", { as: "first_name || ' ' || last_name" } as any);
     const sql = await sc.accept(td);
     expect(sql).toContain("GENERATED ALWAYS AS");
@@ -55,7 +65,10 @@ describe("SQLite3::SchemaCreation", () => {
   });
 
   it("appends STORED for stored virtual columns", async () => {
-    const td = new TableDefinition("articles", { adapterName: "sqlite" });
+    const td = new TableDefinition("articles", {
+      adapter: schemaConn("sqlite"),
+      adapterName: "sqlite",
+    });
     td.column("full_name", "string", { as: "first_name || ' ' || last_name", stored: true } as any);
     expect(await sc.accept(td)).toContain("STORED");
   });

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
@@ -1,36 +1,37 @@
 import { describe, it, expect } from "vitest";
 import { TableDefinition } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
+import { schemaConn } from "../../support/schema-conn.js";
 
 describe("SQLite3::TableDefinition", () => {
   it("forces type: integer for references", () => {
-    const td = new TableDefinition("orders");
+    const td = new TableDefinition("orders", { adapter: schemaConn("sqlite") });
     td.references("customer");
     const col = td.columns.find((c) => c.name === "customer_id");
     expect(col!.type).toBe("integer");
   });
 
   it("returns primary_key for integer primary key columns (integerLikePrimaryKeyType)", () => {
-    const td = new TableDefinition("orders", { id: false });
+    const td = new TableDefinition("orders", { adapter: schemaConn("sqlite"), id: false });
     td.column("order_id", "integer", { primaryKey: true });
     expect(td.columns.find((c) => c.name === "order_id")!.type).toBe("primary_key");
   });
 
   it("includes as, type, stored in validColumnDefinitionOptions", () => {
-    const td = new TableDefinition("t");
+    const td = new TableDefinition("t", { adapter: schemaConn("sqlite") });
     const opts = (td as any).validColumnDefinitionOptions() as string[];
     expect(opts).toContain("as");
     expect(opts).toContain("stored");
   });
 
   it("resolves virtual type to the actual type option", () => {
-    const td = new TableDefinition("articles");
+    const td = new TableDefinition("articles", { adapter: schemaConn("sqlite") });
     const col = td.newColumnDefinition("full_name", "virtual" as any, { type: "string" } as any);
     expect(col.type).toBe("string");
   });
 
   it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
-    const td = new TableDefinition("articles", { id: false });
+    const td = new TableDefinition("articles", { adapter: schemaConn("sqlite"), id: false });
     td.column("full_name", "virtual" as any, { as: "a || b" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
@@ -41,7 +42,7 @@ describe("SQLite3::TableDefinition", () => {
   });
 
   it("emits GENERATED ALWAYS AS ... STORED via visitor", async () => {
-    const td = new TableDefinition("items", { id: false });
+    const td = new TableDefinition("items", { adapter: schemaConn("sqlite"), id: false });
     td.column("x", "integer");
     td.column("expr", "integer", { as: "x + 1", stored: true } as any);
     const sql = await new SchemaCreation("sqlite", (td as any)._adapter).accept(td);

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -14,7 +14,7 @@ import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
 export class TableDefinition extends AbstractTableDefinition {
   constructor(
     tableName: string,
-    options: { id?: boolean | "uuid"; adapter?: SchemaQuoter; [key: string]: unknown } = {},
+    options: { id?: boolean | "uuid"; adapter: SchemaQuoter; [key: string]: unknown },
   ) {
     super(tableName, { ...options, adapterName: "sqlite" });
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
@@ -15,11 +15,12 @@ import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { Column } from "./column.js";
 import { SchemaCreation } from "./schema-creation.js";
 import { SchemaDumper } from "./schema-dumper.js";
+import { schemaConn } from "../../support/schema-conn.js";
 
 describe("SQLite3::SchemaStatements", () => {
   describe("schemaCreation", () => {
     it("returns a SQLite3 SchemaCreation instance", () => {
-      expect(schemaCreation()).toBeInstanceOf(SchemaCreation);
+      expect(schemaCreation(schemaConn("sqlite"))).toBeInstanceOf(SchemaCreation);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
@@ -20,7 +20,7 @@ import { schemaConn } from "../../support/schema-conn.js";
 describe("SQLite3::SchemaStatements", () => {
   describe("schemaCreation", () => {
     it("returns a SQLite3 SchemaCreation instance", () => {
-      expect(schemaCreation(schemaConn("sqlite"))).toBeInstanceOf(SchemaCreation);
+      expect(schemaCreation.call(schemaConn("sqlite"))).toBeInstanceOf(SchemaCreation);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -14,6 +14,7 @@ import type { CheckConstraintDefinition } from "../abstract/schema-definitions.j
 import { IndexDefinition } from "../abstract/schema-definitions.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { SchemaCreation } from "./schema-creation.js";
+import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
 import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 import { SchemaDumper } from "./schema-dumper.js";
@@ -192,8 +193,8 @@ export function createSchemaDumper(
   return SchemaDumper.create(source as Parameters<typeof SchemaDumper.create>[0], options);
 }
 
-export function schemaCreation(): SchemaCreation {
-  return new SchemaCreation("sqlite");
+export function schemaCreation(adapter: SchemaQuoter): SchemaCreation {
+  return new SchemaCreation("sqlite", adapter);
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -193,8 +193,8 @@ export function createSchemaDumper(
   return SchemaDumper.create(source as Parameters<typeof SchemaDumper.create>[0], options);
 }
 
-export function schemaCreation(adapter: SchemaQuoter): SchemaCreation {
-  return new SchemaCreation("sqlite", adapter);
+export function schemaCreation(this: SchemaQuoter): SchemaCreation {
+  return new SchemaCreation("sqlite", this);
 }
 
 /** @internal */

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -42,6 +42,7 @@ import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
 import { leaseMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
+import { schemaConn } from "./support/schema-conn.js";
 
 // The migration-on-`people` tests (Rails runs `add_column/remove_column
 // "people", "last_name"` through a `Migrator`) need the canonical `people`
@@ -246,7 +247,7 @@ describe("MigrationTest", () => {
   });
 
   it("decimal scale without precision should raise", async () => {
-    const td = new TableDefinition("products");
+    const td = new TableDefinition("products", { adapter: schemaConn("sqlite") });
     td.decimal("price", { scale: 2 });
     await expect(emitTableSql(td)).rejects.toThrow(
       "Error adding decimal column: precision cannot be empty if scale is specified",

--- a/packages/activerecord/src/support/schema-conn.ts
+++ b/packages/activerecord/src/support/schema-conn.ts
@@ -1,0 +1,30 @@
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";
+import type { SchemaQuoter } from "../connection-adapters/abstract/assert-schema-adapter.js";
+
+export type SchemaConnName = "sqlite" | "postgres" | "mysql";
+
+const conns = new Map<SchemaConnName, SchemaQuoter>();
+
+/**
+ * The `conn` argument for DDL-rendering unit tests. Rails' `SchemaCreation.new`
+ * and `TableDefinition#initialize` both require a connection, and its tests hand
+ * them `ActiveRecord::Base.lease_connection`. Tests that only render SQL cannot
+ * lease one for a dialect the lane isn't running, so they get a real adapter of
+ * that dialect that is constructed but never connected — quoting and type
+ * mapping are pure, so the rendered DDL is the adapter's own.
+ */
+export function schemaConn(name: SchemaConnName): SchemaQuoter {
+  let conn = conns.get(name);
+  if (!conn) {
+    conn =
+      name === "sqlite"
+        ? new BetterSQLite3Adapter(":memory:")
+        : name === "postgres"
+          ? new PostgreSQLAdapter("postgresql://localhost/trails_schema_conn")
+          : new Mysql2Adapter("mysql://localhost/trails_schema_conn");
+    conns.set(name, conn);
+  }
+  return conn;
+}


### PR DESCRIPTION
## Summary

`ABSTRACT_SCHEMA_QUOTER` was an ANSI `SchemaQuoter` used when a schema visitor
or table definition was built without a live adapter. Rails has no such object:
`SchemaCreation.new(conn)`
(`abstract/schema_creation.rb:6`) and `TableDefinition#initialize`
(`abstract/schema_definitions.rb:369`) both require the connection.

- `SchemaCreation`'s `adapter` and `TableDefinition`'s `adapter` option are now
  required, as are the PG/SQLite3 subclasses' equivalents.
- The standalone `sqlite3/schema-statements.ts#schemaCreation` takes the
  connection as its receiver (`this: SchemaQuoter`), keeping Rails' zero-arg
  `schema_creation`.
- `ABSTRACT_SCHEMA_QUOTER` is deleted (the comments that cited it now name the
  only remaining bare-quoter host, the MySQL schema quoter).
- DDL-rendering unit tests get a real adapter of the dialect under test via
  `support/schema-conn.ts`. Rails' equivalents pass
  `ActiveRecord::Base.lease_connection`; a test that renders SQL for a dialect
  the lane isn't running can't lease one, so it gets a real adapter of that
  dialect constructed but not connected — quoting and type mapping are pure.
- `PostgreSQL::SchemaStatements#typeToSql` now switches on `type ?? ""`,
  mirroring Rails' `case type.to_s`; routing through the real adapter surfaced
  that a nil type rendered as the string `undefined`.
- "handles default values containing doubled single-quotes without mis-parsing"
  moved under `describeIfPg` with a live connection: PG's
  `quote_default_expression` resolves the cast type with a `regtype` query, so
  it genuinely needs a server. Test name unchanged.

`api:compare` + `api:extra`: activerecord novel drops by one (the deleted
constant); `test:compare --gates --check` is clean.

## Note on the two deleted comments

The follow-up commit drops the two explanatory comments this PR had introduced
(above `type ?? ""` in `postgresql/schema-statements-class.ts` and above the
`describeIfPg` block in `postgresql/schema-definitions.test.ts`) because this PR
is required to add no new code comments to the diff. Both rationales are
recorded above instead: `type ?? ""` mirrors Rails' `case type.to_s`
(`postgresql/schema_statements.rb:832`), and the `describeIfPg` block needs a
server because `quote_default_expression` resolves the column's cast type with a
`regtype` query. No pre-existing comment was removed.

## Testing

`pnpm typecheck`, `eslint` on the touched files, and vitest over
`connection-adapters/**`, `migration.test.ts`, `active-record-schema.test.ts`,
`adapter.test.ts` (all green locally; the PG-gated test skips without a server).

Closes-story: converge-schema-creation-adapter-free-construction
