### PR TITLE
refactor(activerecord): classify has-one-through-association.ts's novel extras

### DIFF
--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -42,7 +42,8 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    *     owner's first `save`. This marker carries that deferral.
    *   - **Sync `build`/`create` on a persisted owner** — the `!save` half of the
    *     same arm, reached from non-awaitable builders that cannot `await` the
-   *     join-row reconcile; `persistThroughRecord` drains it inside the save.
+   *     join-row reconcile; `autosaveHasOne` drains it via `persistReplace`
+   *     inside the save.
    *
    * It is NOT a deferral for assignment to a persisted owner: `writer` runs
    * `persistReplace` inline (clearing the marker before it returns), mirroring
@@ -84,6 +85,15 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * against the now-loaded join row (update-existing / build-when-absent),
    * exactly as Rails' `create_through_record` does.
    *
+   * Extra surface, deliberately left counted: the name exists only because the
+   * base `HasOneAssociation` splits Rails' inline `build_#{name}` target load
+   * into a public `loadTargetForBuild` hook. It cannot be `protected` while
+   * `associations/builder/has-one.ts` drives it from outside the class, and it
+   * converges when the BASE hook does — see the
+   * `extra-surface-has-one-base-build-hooks-classify` story. No
+   * `@noRailsEquivalent` tag, because convergeable surface belongs on the novel
+   * count, not in the allowed set.
+   *
    * @internal
    */
   override loadTargetForBuild(): Promise<unknown> {
@@ -103,6 +113,13 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * nullify/destroy the previously-associated end record. Override to a no-op so
    * the `build#{name}` / `create#{name}` accessors leave displacement to the
    * through's own `createThroughRecord` / `persistReplace`.
+   *
+   * Extra surface, deliberately left counted, for the same reason as
+   * `loadTargetForBuild` above: Rails has no `remove_target!` hook of this
+   * shape at all, and this override only neutralizes the base class's. It
+   * cannot be `protected` while `nested-attributes.ts` calls it from outside,
+   * and it disappears when the base hook converges — see the
+   * `extra-surface-has-one-base-build-hooks-classify` story.
    *
    * @internal
    */
@@ -433,34 +450,29 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   /**
    * Persists ONLY the join-model side of the through — the deferred analog of
    * Rails' assignment-time `create_through_record`
-   * (has_one_through_association.rb:15-42): build/update/destroy the join row
-   * via `createThroughRecord`. It does NOT save the end record; that is the
-   * `record.save` arm of Rails' `save_has_one_association`
+   * (has_one_through_association.rb:15-42): runs `createThroughRecord`, which
+   * builds/updates/destroys the join row. It does NOT save the end record; that
+   * is the `record.save` arm of Rails' `save_has_one_association`
    * (autosave_association.rb:503), which `autosaveHasOne` runs separately after
    * calling this (skipping only the through's foreign-key write, per
    * autosave_association.rb:489).
    *
-   * `autosaveHasOne` calls this for every loaded through association during the
-   * owner's save, replacing the post-commit `flushPendingReplaces` deferral for
-   * the sync `build`/`create`-on-persisted-owner path: those queue
-   * `_pendingReplace` in `replace`/`constructThroughRecordInMemory` (no `await`
-   * is possible from the sync builder), and this flushes it inside the save. The
-   * awaitable `writer` already persists on assignment (clearing the marker), so
-   * this no-ops there; it also no-ops for a merely-cached target (no marker),
-   * matching Rails, which creates the join only on assignment.
-   */
-  async persistThroughRecord(): Promise<void> {
-    await this.persistReplace();
-  }
-
-  /**
-   * Mirrors: ActiveRecord::Associations::HasOneThroughAssociation — deferred DB flush.
+   * Reached two ways: the awaitable `writer` calls it inline on assignment to a
+   * persisted owner (immediate persist), and `autosaveHasOne` calls it for every
+   * loaded through association during the owner's save, which is what covers the
+   * sync `build`/`create`-on-persisted-owner path: those queue `_pendingReplace`
+   * in `replace`/`constructThroughRecordInMemory` and this flushes it inside the
+   * save. It no-ops when the marker is already consumed (an awaited `writer`) or
+   * absent (a merely-cached target), matching Rails, which creates the join only
+   * on assignment.
    *
-   * Runs `createThroughRecord`, which creates/updates/destroys the join-model
-   * record as needed. Reached two ways: the awaitable `writer` calls it inline
-   * on assignment to a persisted owner (immediate persist), and
-   * `persistThroughRecord` calls it from `autosaveHasOne` during the owner's
-   * save for the sync `build`/`create` path that could not `await`.
+   * @noRailsEquivalent PERMANENT Rails does this DB work inline inside
+   * `create_through_record`, reached from the SYNCHRONOUS `replace` /
+   * `build_#{name}` / `create_#{name}` entry points. In JS those entry points
+   * cannot `await`, so the DB half has to be a separately-callable method the
+   * async save path drains — a language-level split with no Ruby counterpart to
+   * name it after. Rails' own `create_through_record` is ported under that name
+   * (the in-memory half); this is the DB half it cannot inline.
    */
   async persistReplace(save = true): Promise<void> {
     const pending = this._pendingReplace;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -318,7 +318,7 @@ export function validOptions(): string[] {
 // of the duck-type below is `HasOneThroughAssociation`, which still defines
 // both `persistReplace` (has-one-through-association.ts) and `_pendingReplace`.
 // Its marker is normally consumed during the save (`autosaveHasOne` ->
-// `persistThroughRecord`, Rails' `save_has_one_association` through arm), so by
+// `persistReplace` from Rails' `save_has_one_association` through arm), so by
 // post-commit it is usually null and the loop no-ops — this is deliberately
 // kept as its safety net for a marker that survives the save, not dead code.
 export async function flushPendingReplaces(record: Base): Promise<void> {
@@ -496,6 +496,12 @@ async function _insertCollectionRecordFallback(
 
 async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
+  const ctor = record.constructor as typeof Base;
+  const reflection = (ctor as any)._reflectOnAssociation?.(assoc.name);
+  // Rails discriminates the through arms of `save_has_one_association` off the
+  // reflection (`reflection.through_reflection`, autosave_association.rb:489),
+  // not off the association object's shape.
+  const isThrough = !!reflection?.throughReflection;
 
   // Rails `save_has_one_association`'s `through_reflection` arm persists the
   // join side of a has_one *through* (build/update/destroy via
@@ -511,8 +517,8 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // body below — which, per Rails (autosave_association.rb:489), skips only the
   // foreign-key write for through, but still runs the end-record
   // `marked_for_destruction` and (autosave-gated) `record.save` arms.
-  if (typeof inst?.persistThroughRecord === "function") {
-    await inst.persistThroughRecord();
+  if (isThrough && typeof inst?.persistReplace === "function") {
+    await inst.persistReplace();
   }
 
   // A has_one *through* suppresses its through-proxy's independent autosave by
@@ -524,10 +530,10 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // would duplicate that row. A plain `HasOneAssociation` never sets
   // `_pendingReplace` itself (its displacement removal runs inline, via
   // `detachDisplacedTarget`), and the through association itself clears its marker
-  // inside `persistThroughRecord` above, so a truthy marker on an instance with
-  // no `persistThroughRecord` is unambiguously that suppression sentinel. Skip
+  // in the `persistReplace` above, so a truthy marker on a non-through
+  // association is unambiguously that suppression sentinel. Skip
   // the end-record persistence; the through owns the join row.
-  if (inst?._pendingReplace && typeof inst?.persistThroughRecord !== "function") {
+  if (inst?._pendingReplace && !isThrough) {
     return true;
   }
 
@@ -553,7 +559,7 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   const autosave = assoc.options.autosave;
 
   // NOTE: the join side of a has_one *through* was already persisted above by
-  // `persistThroughRecord` (which consumes the association's `_pendingReplace`),
+  // `persistReplace` (which consumes the association's `_pendingReplace`),
   // so control falls through here to run the shared end-record arms — the FK
   // write is skipped for through further down (Rails autosave_association.rb:489)
   // while `marked_for_destruction`/`record.save` still apply.
@@ -586,8 +592,6 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // returned above), so a NEW child persists whether or not autosave is set.
   // Rails:485-486 — `primary_key = Array(compute_primary_key(reflection, self))`
   // then `primary_key_value = primary_key.map { _read_attribute(_1) }`.
-  const ctor = record.constructor as typeof Base;
-  const reflection = (ctor as any)._reflectOnAssociation?.(assoc.name);
   const pkSpec = reflection ? computePrimaryKey(reflection, record) : (ctor.primaryKey ?? "id");
   const pkArr: string[] = Array.isArray(pkSpec) ? pkSpec : [pkSpec];
   const pkForChangeCheck = pkArr.map((k) => record._readAttribute(k));
@@ -602,7 +606,7 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
     // Rails save_has_one_association:489 — `unless reflection.through_reflection`.
     // A has_one *through* never writes a foreign key onto the end record (its
     // owner-linkage lives on the join row, persisted above via
-    // `persistThroughRecord`); it also skips `set_inverse_instance`. Both are
+    // `persistReplace`); it also skips `set_inverse_instance`. Both are
     // guarded here, while the `record.save` arm below still runs for through
     // (gated by the same `(autosave && changed) || _record_changed?` condition),
     // so an `autosave: true` through re-saves a mutated end record.

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -498,9 +498,8 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   const inst = _loadedAssociation(record, assoc.name);
   const ctor = record.constructor as typeof Base;
   const reflection = (ctor as any)._reflectOnAssociation?.(assoc.name);
-  // Rails discriminates the through arms of `save_has_one_association` off the
-  // reflection (`reflection.through_reflection`, autosave_association.rb:489),
-  // not off the association object's shape.
+  // Rails `save_has_one_association` reads `reflection.through_reflection`
+  // (autosave_association.rb:489).
   const isThrough = !!reflection?.throughReflection;
 
   // Rails `save_has_one_association`'s `through_reflection` arm persists the


### PR DESCRIPTION
Classifies the novel extra surface on
`packages/activerecord/src/associations/has-one-through-association.ts`.
`detachDisplacedRecord` was already gone (#5455), so four names were in scope,
not five.

## Classification

| name | category | action |
| --- | --- | --- |
| `persistThroughRecord` | (a) invention to delete | deleted |
| `persistReplace` | (b) faithful internal | `@noRailsEquivalent PERMANENT` at the declaration |
| `loadTargetForBuild` | convergeable, base-class root | left counted; story filed |
| `detachDisplacedTarget` | convergeable, base-class root | left counted; story filed |

### `persistThroughRecord` — deleted

Its whole body was `await this.persistReplace()`. It existed as a duck-type
*brand*: `autosaveHasOne` tested `typeof inst.persistThroughRecord === "function"`
to tell a has_one **through** from a plain has_one, in both the join-persist arm
and the through-proxy suppression guard. Rails does not discriminate on the
association object's shape — `save_has_one_association` reads
`reflection.through_reflection` (autosave_association.rb:489), which trails
already resolves (`reflection.throughReflection`, used two lines further down in
the same function). Converged both call sites onto the reflection and call
`persistReplace` directly.

### `persistReplace` — PERMANENT

Rails runs the join-row build/update/destroy inline inside
`create_through_record`, reached from the **synchronous** `replace` /
`build_#{name}` / `create_#{name}` entry points. Those entry points cannot
`await` in JS, so the DB half must be a separately-callable method the async
save path drains. Rails' `create_through_record` is ported under its own name
(the in-memory half); this is the DB half it cannot inline — a language-level
split with no Ruby `def` to name it after.

### `loadTargetForBuild` / `detachDisplacedTarget` — left counted

Both are overrides that exist only because the **base** `HasOneAssociation`
splits Rails' inline `build_#{name}` load and `remove_target!` call into public
hooks; they vanish when the base hooks converge. Neither can be made `protected`
today (the extractor honors visibility, not a member-level `@internal`) because
`associations/builder/has-one.ts` and `nested-attributes.ts` drive them from
outside the class. Per the fidelity-first policy, convergeable surface stays on
the novel count rather than being tagged into the allowed set — the reason is
recorded at each declaration, and the root is filed as
`extra-surface-has-one-base-build-hooks-classify` (which also covers the sibling
`has-one-association.ts` cluster: `detachDisplacedTarget`, `loadTargetForBuild`,
`needsTargetLoadForBuild`, `syncWrite`).

## Measurement

`pnpm api:compare && pnpm api:extra --package activerecord --novel-only`, after
a full `pnpm build` on both sides:

```text
before:  associations/has-one-through-association.ts — 4 novel, 0 moved
           detachDisplacedTarget  loadTargetForBuild  persistReplace  persistThroughRecord
after:   associations/has-one-through-association.ts — 2 novel, 0 moved
           detachDisplacedTarget  loadTargetForBuild
```

Pre-existing and unrelated: the run reports 1 STALE `@noRailsEquivalent` tag on
`base.ts equals`, untouched by this branch.

## Tests

`has-one-through-associations.test.ts`, `has-one-associations.test.ts`,
`autosave-association.test.ts`, `nested-attributes.test.ts`,
`has-one-set-accessor-sugar.trails.test.ts`,
`has-one-sync-build-displacement.trails.test.ts`,
`nested-attributes-displaced-removal-failure.trails.test.ts` — all pass, no test
renames.

Closes-story: extra-surface-has-one-through-classify
