### PR TITLE
chore(api-compare): drop the stale @noRailsEquivalent tag on Base#equals

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4399,11 +4399,6 @@ export class Base extends Model {
    * Compare two records for equality based on class and primary key.
    *
    * Mirrors: ActiveRecord::Core#==
-   *
-   * @noRailsEquivalent PERMANENT This is `def ==` at
-   * `vendor/rails/activerecord/lib/active_record/core.rb:631`. TS cannot name a
-   * method `==` and cannot overload the operator, so the ported body needs a
-   * spelled-out identifier; there is no `def is_equal` in Rails to match it.
    */
   declare equals: (other: unknown) => boolean;
 


### PR DESCRIPTION
`pnpm api:extra --package activerecord` exits non-zero on `main` with 1 STALE
`@noRailsEquivalent` tag: `activerecord  base.ts  equals`. Every extra-surface
story inherits that red run.

Cause: the tag's reason claims there is no Rails counterpart because TS cannot
name a method `==`. But `extra-surface.ts`'s `MIRROR_CANDIDATE_OVERRIDES` maps
`"==" -> ["equals"]`, and `OPERATOR_SPELLING_BY_FQN` pins
`ActiveRecord::Core` `"==" -> ["equals"]`, so `def ==` at
`vendor/rails/activerecord/lib/active_record/core.rb:631` (aliased `eql?` at
:637) now resolves `equals` into base.ts's allowed set. The name no longer
flags as extra surface, which is exactly the tool's "Rails gained the method"
case — so the tag is deleted, per the tool's own instruction. The reason prose
was not truncated by a bare `@tag`; the `Mirrors: ActiveRecord::Core#==` line
stays.

Verified after `pnpm build && pnpm api:compare`:
- `pnpm api:extra --package activerecord` exits 0, 0 STALE
- `pnpm api:extra` (all packages) exits 0
- `pnpm api:compare` exits 0
- `pnpm test:compare` exits 0 — 14879/22203 tests, totals unchanged

Closes-story: clear-stale-no-rails-equivalent-tag-on-base-equals