### PR TITLE
refactor(prism-codegen): drop score-cli's private listJsonFiles copy

### DIFF
--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -2,9 +2,8 @@ import * as fs from "fs/promises";
 import { readFileSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-// The wide exclude tree is api-compare's baseline, so its walker comes from
-// api-compare too rather than being re-homed into a shared scripts/ module —
-// prism-codegen already imports that surface (see naming.ts, catalog.ts).
+// The wide exclude tree is api-compare's baseline, so its walker stays there
+// rather than moving to a shared scripts/ module (as naming.ts/catalog.ts do).
 import { listJsonFiles } from "../api-compare/baseline-json.js";
 import { portMethodNames } from "./port-symbols.js";
 import { generateFromSource } from "./index.js";

--- a/scripts/prism-codegen/score-cli.ts
+++ b/scripts/prism-codegen/score-cli.ts
@@ -2,6 +2,10 @@ import * as fs from "fs/promises";
 import { readFileSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+// The wide exclude tree is api-compare's baseline, so its walker comes from
+// api-compare too rather than being re-homed into a shared scripts/ module —
+// prism-codegen already imports that surface (see naming.ts, catalog.ts).
+import { listJsonFiles } from "../api-compare/baseline-json.js";
 import { portMethodNames } from "./port-symbols.js";
 import { generateFromSource } from "./index.js";
 import { asyncMethodsForRailsFile, buildAsyncManifest } from "./async-source.js";
@@ -76,23 +80,6 @@ async function railsLibFiles(): Promise<{ path: string; source: string }[]> {
     }
   };
   await walk(root);
-  return out;
-}
-
-async function listJsonFiles(dir: string): Promise<string[]> {
-  const out: string[] = [];
-  let dirents;
-  try {
-    dirents = await fs.readdir(dir, { withFileTypes: true });
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") return out;
-    throw e;
-  }
-  for (const d of dirents) {
-    const full = path.join(dir, d.name);
-    if (d.isDirectory()) out.push(...(await listJsonFiles(full)));
-    else if (d.name.endsWith(".json")) out.push(full);
-  }
   return out;
 }
 


### PR DESCRIPTION
PR #5922 moved `listJsonFiles` into `scripts/api-compare/baseline-json.ts` so both split baseline trees are walked by one implementation. `scripts/prism-codegen/score-cli.ts` still carried a byte-identical private copy — the last of the three.

**Direction decided:** import across script dirs rather than re-homing the helper into a shared `scripts/` module. The wide exclude tree score-cli walks *is* api-compare's baseline (score-cli already points at it via the `API_COMPARE` path constant), and `prism-codegen` already imports that module surface (`naming.ts`, `catalog.ts` both import `../api-compare/conventions.js`). A one-line comment at the import records this so it isn't re-litigated.

Out of scope: `scripts/parity/{schema,query}/diff.ts` each have a *synchronous* `listJsonFiles` used from sync diff paths — a different helper with a different signature, not one of the three async copies #5922 consolidated. Converting those is a separate change.

`pnpm vitest run scripts/prism-codegen scripts/api-compare`: 48 files / 1137 tests green. `codegen:score` totals unchanged (15 catalogued, 7 signed off, 340 residue).

Closes-story: dedupe-list-json-files-in-prism-score-cli