### PR TITLE
refactor(activerecord): drop the dead standalone sqlite3 schemaCreation helper

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import {
-  schemaCreation,
   createSchemaDumper,
   virtualTableExists,
   _extractValueFromDefault,
@@ -13,17 +12,9 @@ import {
 } from "./schema-statements.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { Column } from "./column.js";
-import { SchemaCreation } from "./schema-creation.js";
 import { SchemaDumper } from "./schema-dumper.js";
-import { schemaConn } from "../../support/schema-conn.js";
 
 describe("SQLite3::SchemaStatements", () => {
-  describe("schemaCreation", () => {
-    it("returns a SQLite3 SchemaCreation instance", () => {
-      expect(schemaCreation.call(schemaConn("sqlite"))).toBeInstanceOf(SchemaCreation);
-    });
-  });
-
   describe("createSchemaDumper", () => {
     it("returns a SchemaDumper instance", () => {
       const fakeAdapter = { adapterName: "sqlite" } as any;

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -13,8 +13,6 @@ import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js"
 import type { CheckConstraintDefinition } from "../abstract/schema-definitions.js";
 import { IndexDefinition } from "../abstract/schema-definitions.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
-import { SchemaCreation } from "./schema-creation.js";
-import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
 import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 import { SchemaDumper } from "./schema-dumper.js";
@@ -191,10 +189,6 @@ export function createSchemaDumper(
   options: Record<string, unknown> = {},
 ): AbstractSchemaDumper {
   return SchemaDumper.create(source as Parameters<typeof SchemaDumper.create>[0], options);
-}
-
-export function schemaCreation(this: SchemaQuoter): SchemaCreation {
-  return new SchemaCreation("sqlite", this);
 }
 
 /** @internal */


### PR DESCRIPTION
Removes the standalone `schemaCreation` function from
`connection-adapters/sqlite3/schema-statements.ts`. It had no production
caller — the live path is `SQLite3Adapter#schemaCreation`
(`connection-adapters/sqlite3-adapter.ts:213`), which is what mirrors Rails'
`SQLite3::SchemaStatements#schema_creation`. The module function was a second
spelling invoked only by its own test.

Verified with `pnpm api:compare` before and after (both on a fresh `pnpm build`):
`connection_adapters/sqlite3/schema_statements.rb` stays at 18/18 100% ✓ and
activerecord stays at 6084/6148 (99%) — the adapter getter carries the
`schema_creation` match.

Closes-story: drop-dead-standalone-sqlite3-schema-creation-helper
