### PR TITLE
refactor(associations): narrow has_one's four novel build/write hooks to protected

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -64,10 +64,7 @@ export class HasOne extends SingularAssociation {
         // error surfaces as a rejected Promise instead, an unavoidable
         // consequence of awaiting `load_target` in JS (Rails' `replace` is
         // fully synchronous, so it raises inline regardless of persistence).
-        if (
-          typeof assoc.needsTargetLoadForBuild === "function" &&
-          assoc.needsTargetLoadForBuild()
-        ) {
+        if (typeof assoc.findTargetNeeded === "function" && assoc.findTargetNeeded()) {
           // `loadTargetForBuild` caches the direct-FK target for a plain
           // has_one, but a has_one_through overrides it to load the *through*
           // proxy — Rails' has_one_through `replace` runs no

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -300,8 +300,8 @@ export class HasOneAssociation extends SingularAssociation {
    * (has_one_association.rb:59-62): the guard is `return target unless
    * load_target || record`, and Ruby always evaluates the left operand, so
    * EVERY build queries for an existing target before deciding whether to
-   * displace it — a never-loaded association included. `needsTargetLoadForBuild`
-   * is Rails' `find_target?`, so the query runs exactly when Rails' would (a
+   * displace it — a never-loaded association included. `findTargetNeeded` is
+   * Rails' `find_target?`, so the query runs exactly when Rails' would (a
    * persisted / FK-present owner whose target isn't loaded), and returning it
    * here is what makes `association(name).build(...)` awaitable on that path.
    *
@@ -309,7 +309,7 @@ export class HasOneAssociation extends SingularAssociation {
    */
   protected override loadDisplacedForBuild(): Promise<unknown> | null {
     if (this.buildDisplacementOwnedByCaller) return null;
-    if (!this.needsTargetLoadForBuild()) return null;
+    if (!this.findTargetNeeded()) return null;
     return this.loadTargetForBuild();
   }
 
@@ -353,31 +353,9 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   /**
-   * Whether a `build#{name}` accessor call must first run Rails'
-   * `load_target` — mirrors `HasOneAssociation#set_new_record` →
-   * `replace(record, false)`, whose leading `load_target`
-   * (has_one_association.rb:59) materializes the current target before the
-   * freshly-built record displaces it. Both drivers of that load consult this
-   * gate — `SingularAssociation#build` via `loadDisplacedForBuild`, and the
-   * generated `build#{name}` accessor (builder/has-one.ts) — so the SELECT
-   * runs exactly when Rails' `find_target?` would: a persisted / FK-present
-   * owner whose target isn't loaded. `findTargetNeeded()` already returns
-   * false when the target is loaded (association.ts, `if (this.loaded) return
-   * false`), so it is the whole gate.
-   *
-   * `protected` because it is association-internal bookkeeping, not API
-   * surface. The generated accessor lives outside the class hierarchy and
-   * reaches it through its duck-typed handle.
-   *
-   * @internal
-   */
-  protected needsTargetLoadForBuild(): boolean {
-    return this.findTargetNeeded();
-  }
-
-  /**
-   * The load run before the new record is constructed, gated by
-   * `needsTargetLoadForBuild`. A direct-FK has_one loads its own target —
+   * The load run before the new record is constructed, gated by Rails'
+   * `find_target?` (`findTargetNeeded`). A direct-FK has_one loads its own
+   * target —
    * Rails' `set_new_record` → `replace(record, false)` runs `load_target`
    * (has_one_association.rb:59). A has_one_through overrides this: Rails'
    * `HasOneThroughAssociation#replace` has NO `load_target`; its
@@ -387,7 +365,7 @@ export class HasOneAssociation extends SingularAssociation {
    *
    * `protected`: association-internal bookkeeping, not API surface. The
    * generated `build#{name}` accessor reaches it through its duck-typed
-   * handle, as it does `needsTargetLoadForBuild`.
+   * handle, as it does `findTargetNeeded`.
    *
    * @internal
    */
@@ -460,7 +438,7 @@ export class HasOneAssociation extends SingularAssociation {
    * The record `create#{name}` displaces: Rails' `replace` opens with
    * `load_target` (has_one_association.rb:59), so `remove_target!` detaches a row
    * that only ever existed in the DB. Routed through `loadTargetForBuild` — gated
-   * by `needsTargetLoadForBuild` (Rails' `find_target?`) so the SELECT runs only
+   * by `findTargetNeeded` (Rails' `find_target?`) so the SELECT runs only
    * when Rails' would, and overridden by has_one_through to load the *through*
    * proxy, since Rails' through `replace` issues no target load.
    *
@@ -480,7 +458,7 @@ export class HasOneAssociation extends SingularAssociation {
    * @internal
    */
   private async loadDisplacedTargetForCreate(): Promise<unknown> {
-    if (!this.needsTargetLoadForBuild()) return null;
+    if (!this.findTargetNeeded()) return null;
     try {
       await this.loadTargetForBuild();
       return null;
@@ -545,7 +523,7 @@ export class HasOneAssociation extends SingularAssociation {
    * The synchronous writer (`pirate.shipAttributes = {...}`) cannot await the
    * SELECT, so it parks the promise on the owner and drains it in the `save`
    * wrapper exactly like `detachDisplacedTarget`'s. Null when Rails would issue
-   * no query at all (`find_target?`) or when the target is already loaded,
+   * no query at all (`findTargetNeeded`) or when the target is already loaded,
    * which keeps the writer synchronous on those paths.
    *
    * Returns a *thunk* rather than the promise: Rails reaches `load_target` from
@@ -576,7 +554,7 @@ export class HasOneAssociation extends SingularAssociation {
    */
   protected prepareDetachDisplacedForSyncBuild(): (() => Promise<void>) | null {
     if (this.loaded) return null;
-    if (!this.needsTargetLoadForBuild()) return null;
+    if (!this.findTargetNeeded()) return null;
     return () => this.findThenDetachDisplaced();
   }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -40,8 +40,15 @@ export class HasOneAssociation extends SingularAssociation {
    *   name the awaitable replacement (`await owner.set#{Name}(x)`). See RFC
    *   0068-awaitable-has-one-setter ("Why 'loud' beats 'deferred'") for the
    *   ergonomic-tradeoff decision to deviate loudly from Rails' legal syntax.
+   *
+   * `protected`: the generated `#{name}=` property setter (builder/has-one.ts
+   * `defineWriters`) is the sole caller, and it reaches the association through
+   * a structural handle rather than the class type. The Rails-named surface is
+   * `writer` / `set#{Name}`.
+   *
+   * @internal
    */
-  syncWrite(record: Base | null): void {
+  protected syncWrite(record: Base | null): void {
     // Rails' `replace` raises a class mismatch as its very first statement
     // (has_one_association.rb:59-60), before any load/removal/persist — and so
     // before the persisted-owner deviation below. That guard is synchronous, so
@@ -350,32 +357,41 @@ export class HasOneAssociation extends SingularAssociation {
    * `load_target` — mirrors `HasOneAssociation#set_new_record` →
    * `replace(record, false)`, whose leading `load_target`
    * (has_one_association.rb:59) materializes the current target before the
-   * freshly-built record displaces it. The sync `build` / nested-attributes
-   * paths can't await, so the awaitable accessor (builder/has-one.ts) consults
-   * this and issues the SELECT only when a query would actually run
-   * (`find_target?`): a persisted / FK-present owner whose target isn't loaded.
-   * `findTargetNeeded()` already returns false when the target is loaded
-   * (association.ts, `if (this.loaded) return false`), so it is the whole gate.
+   * freshly-built record displaces it. Both drivers of that load consult this
+   * gate — `SingularAssociation#build` via `loadDisplacedForBuild`, and the
+   * generated `build#{name}` accessor (builder/has-one.ts) — so the SELECT
+   * runs exactly when Rails' `find_target?` would: a persisted / FK-present
+   * owner whose target isn't loaded. `findTargetNeeded()` already returns
+   * false when the target is loaded (association.ts, `if (this.loaded) return
+   * false`), so it is the whole gate.
+   *
+   * `protected` because it is association-internal bookkeeping, not API
+   * surface. The generated accessor lives outside the class hierarchy and
+   * reaches it through its duck-typed handle.
    *
    * @internal
    */
-  needsTargetLoadForBuild(): boolean {
+  protected needsTargetLoadForBuild(): boolean {
     return this.findTargetNeeded();
   }
 
   /**
-   * The load the `build#{name}` accessor awaits before constructing the new
-   * record. A direct-FK has_one loads its own target — Rails'
-   * `set_new_record` → `replace(record, false)` runs `load_target`
+   * The load run before the new record is constructed, gated by
+   * `needsTargetLoadForBuild`. A direct-FK has_one loads its own target —
+   * Rails' `set_new_record` → `replace(record, false)` runs `load_target`
    * (has_one_association.rb:59). A has_one_through overrides this: Rails'
    * `HasOneThroughAssociation#replace` has NO `load_target`; its
    * `create_through_record` loads the *through* proxy instead
    * (has_one_through_association.rb:15-19), so the through must issue the
    * join-model SELECT here, never a target SELECT.
    *
+   * `protected`: association-internal bookkeeping, not API surface. The
+   * generated `build#{name}` accessor reaches it through its duck-typed
+   * handle, as it does `needsTargetLoadForBuild`.
+   *
    * @internal
    */
-  loadTargetForBuild(): Promise<unknown> {
+  protected loadTargetForBuild(): Promise<unknown> {
     return this.loadTarget();
   }
 
@@ -502,9 +518,15 @@ export class HasOneAssociation extends SingularAssociation {
    * record destroyed and freezes it when the row does not exist
    * (persistence.rb:439-444). Let `removeTargetBang`'s arms make that call.
    *
+   * `protected` because this is association-internal bookkeeping, not API
+   * surface — Rails' `remove_target!` is private too. The nested-attributes
+   * writer lives outside the class hierarchy and reaches it through its
+   * duck-typed `OneToOneAssociation` handle, exactly as it does the sibling
+   * `prepareDetachDisplacedForSyncBuild`.
+   *
    * @internal
    */
-  async detachDisplacedTarget(): Promise<void> {
+  protected async detachDisplacedTarget(): Promise<void> {
     const displaced = this.target;
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -79,7 +79,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * `HasOneAssociation` loads its own target for `build#{name}`, which for a
    * through would issue a `clubs` SELECT Rails never runs while skipping the
    * `memberships` SELECT it does. Override so the `build#{name}` accessor's
-   * pre-build load (gated by the inherited `needsTargetLoadForBuild`) reads
+   * pre-build load (gated by Rails' `find_target?`, `findTargetNeeded`) reads
    * the through proxy, then `constructThroughRecordInMemory` reconciles
    * against the now-loaded join row (update-existing / build-when-absent),
    * exactly as Rails' `create_through_record` does.

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -86,7 +86,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    *
    * @internal
    */
-  override loadTargetForBuild(): Promise<unknown> {
+  protected override loadTargetForBuild(): Promise<unknown> {
     const throughProxy = throughAssociation(this) as {
       loadTarget?: () => unknown;
     } | null;
@@ -106,7 +106,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    *
    * @internal
    */
-  override async detachDisplacedTarget(): Promise<void> {
+  protected override async detachDisplacedTarget(): Promise<void> {
     // no-op — see JSDoc
   }
 
@@ -173,7 +173,9 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * from `create_through_record` (:15-19), which our `build#{name}` accessor
    * drives via `loadTargetForBuild`. Building through `association(name).build`
    * must not issue that join-model SELECT here, so return null and keep the
-   * synchronous return the through builders expect.
+   * synchronous return the through builders expect — Rails'
+   * `association(:club).build` is synchronous
+   * (has_one_through_associations_test.rb:60-70).
    *
    * @internal
    */


### PR DESCRIPTION
Classifies the four novel extras `pnpm api:extra --package activerecord
--novel-only` reported on `associations/has-one-association.ts`.

## Classification

One is a redundant alias for a method we already carry under its Rails
name, and is deleted. The other three are the trails split of Rails'
inline, *synchronous* `build_#{name}` / `create_#{name}` / `#{name}=`
bodies into separately callable hooks the async JS accessors can drive —
each load-bearing on a path Rails runs inline, and none with a Rails name
to relocate onto. Those land in bucket (b): **faithful internals, narrowed
to `protected`**.

| name | verdict |
| --- | --- |
| `needsTargetLoadForBuild` | **(a) deleted** — a zero-value alias. Its whole body was `return this.findTargetNeeded()`, with no override anywhere, and `findTargetNeeded` (association.ts:688) is already the faithful port of `find_target?` (association.rb:320). The four call sites now name Rails' gate directly |
| `loadTargetForBuild` | (b) `protected` — that `load_target` itself; has_one_through redirects it at the *through* proxy (`create_through_record`, has_one_through_association.rb:15-19) |
| `detachDisplacedTarget` | (b) `protected` — the awaitable wrapper around `remove_target!` (:69), which is `private` in Rails too. `removeTargetBang` already carries the Rails name |
| `syncWrite` | (b) `protected` — the in-memory half of `writer`, reached only from the generated `#{name}=` property setter. The Rails-named surface is `writer` / `set#{Name}` |

### Why the remaining three are not renamed

Renaming them onto Rails names would be *worse* fidelity, not better — a
Rails name that doesn't map to the real Rails method is the failure mode
the naming rules exist to prevent:

- `loadTargetForBuild` — the base body is `this.loadTarget()`, but
  has_one_through **overrides** it to load the *through* proxy. Rails has
  no single method both classes define: `HasOneAssociation#replace` calls
  `load_target` inline, while `HasOneThroughAssociation#replace` never
  does (`create_through_record` loads the through instead,
  has_one_through_association.rb:15-19). The polymorphic seam is genuinely
  invented, and it cannot be folded into `loadTarget` — that name has real
  Rails semantics the reader path depends on.
- `detachDisplacedTarget` — Rails' name `remove_target!` is already taken
  by the faithful port (`removeTargetBang`, `private`). This is the nullary
  guard wrapper (`target && !target.destroyed?`, has_one_association.rb:69)
  *and* the seam has_one_through no-ops.
- `syncWrite` — Rails' name is `#{name}=` / `writer`, both of which already
  exist here with the awaitable semantics. There is no third Rails name.

The three out-of-hierarchy drivers — the generated `build#{name}`
accessor, the generated `#{name}=` setter, and the nested-attributes
writer — all already reach the association through *duck-typed structural
handles*, exactly as the nested-attributes writer already reaches the
sibling `prepareDetachDisplacedForSyncBuild` (itself `protected`). So
narrowing needed no call-site rewrites and changes no behaviour.

Nothing is tagged `@noRailsEquivalent CONVERGEABLE`.

Three files, +38/−39 — net-negative, and every added line is either a
`protected` keyword or JSDoc.

## What was considered and rejected

`SingularAssociation#build` already drives `loadDisplacedForBuild()` /
`detachDisplacedOnBuild()` (singular-association.ts:88-106), and
`HasOneAssociation#loadDisplacedForBuild` is exactly
`findTargetNeeded() ? loadTargetForBuild() : null` — so the
`build#{name}` accessor override in `builder/has-one.ts` looks redundant
and deletable outright. It is not: `HasOneThroughAssociation` overrides
`loadDisplacedForBuild` to `null` because Rails'
`association(:club).build` is **synchronous**
(has_one_through_associations_test.rb:60-70), so the through's join-model
load has to run one level up, in the accessor. Deleting the override
turned 8 has_one_through tests red, so the accessor stays untouched — the
finding is recorded here and in the through's `loadDisplacedForBuild`
JSDoc, which now cites the Rails test that pins the synchronous shape.

## Before / after

`pnpm build && pnpm api:compare && pnpm api:extra --package activerecord --novel-only`:

| file | before | after |
| --- | --- | --- |
| `associations/has-one-association.ts` | 4 novel (`detachDisplacedTarget`, `loadTargetForBuild`, `needsTargetLoadForBuild`, `syncWrite`) | **0** (off the report) |
| `associations/has-one-through-association.ts` | 4 novel (`detachDisplacedTarget`, `loadTargetForBuild`, `persistReplace`, `persistThroughRecord`) | **2** (`persistReplace`, `persistThroughRecord`) |

−6 novel extras: `needsTargetLoadForBuild` by deletion, the rest by
narrowing. The through's two matching overrides drop with the base hooks,
as the story predicted; its residual `persistReplace` /
`persistThroughRecord` are a separate pair, out of scope here.

## Tests

No test renames, no test changes at all. Green locally:

- 93 files — all 91 under `packages/activerecord/src/associations/`, plus
  `nested-attributes.test.ts` and `autosave-association.test.ts` — 2339
  passed, 12 skipped, 1 todo
- `pnpm typecheck` clean
- CI green

Closes-story: extra-surface-has-one-base-build-hooks-classify

