### PR TITLE
refactor(activerecord): resolve mysql2 adapter per-file novel surface

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -360,13 +360,13 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
     // default timezone flipped to :local, executing a statement re-syncs the
     // connection's database_timezone from :utc to :local.
     await adapter.execute("SELECT 1");
-    expect(adapter.databaseTimezone).toBe("utc");
+    expect(adapter._databaseTimezone).toBe("utc");
     await withTimezoneConfig({ default: "local" }, async () => {
       await adapter.execute("SELECT 1");
-      expect(adapter.databaseTimezone).toBe("local");
+      expect(adapter._databaseTimezone).toBe("local");
     });
     await adapter.execute("SELECT 1");
-    expect(adapter.databaseTimezone).toBe("utc");
+    expect(adapter._databaseTimezone).toBe("utc");
   });
 
   it("warnings do not change returned value of exec update", async () => {

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -269,23 +269,23 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
     // mirror only checks execute(); here we guard that every perform-query path
     // (execQuery / executeMutation / exec / explain) re-syncs the timezone too.
     await adapter.execute("SELECT 1");
-    expect(adapter.databaseTimezone).toBe("utc");
+    expect(adapter._databaseTimezone).toBe("utc");
     await withTimezoneConfig({ default: "local" }, async () => {
-      adapter.databaseTimezone = "utc";
+      adapter._databaseTimezone = "utc";
       await adapter.execQuery("SELECT 1");
-      expect(adapter.databaseTimezone).toBe("local");
-      adapter.databaseTimezone = "utc";
+      expect(adapter._databaseTimezone).toBe("local");
+      adapter._databaseTimezone = "utc";
       await adapter.executeMutation("DO 1");
-      expect(adapter.databaseTimezone).toBe("local");
-      adapter.databaseTimezone = "utc";
+      expect(adapter._databaseTimezone).toBe("local");
+      adapter._databaseTimezone = "utc";
       await adapter.exec("DO 1");
-      expect(adapter.databaseTimezone).toBe("local");
-      adapter.databaseTimezone = "utc";
+      expect(adapter._databaseTimezone).toBe("local");
+      adapter._databaseTimezone = "utc";
       await adapter.explain("SELECT 1");
-      expect(adapter.databaseTimezone).toBe("local");
+      expect(adapter._databaseTimezone).toBe("local");
     });
     await adapter.execute("SELECT 1");
-    expect(adapter.databaseTimezone).toBe("utc");
+    expect(adapter._databaseTimezone).toBe("utc");
   });
 
   it("configure connection seeds database timezone from default", async () => {
@@ -293,14 +293,14 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
     // `@raw_connection.query_options[:database_timezone] = default_timezone`
     // up front. Asserts the seed lands immediately — the per-query re-sync
     // is covered by the mirror's timezone test.
-    adapter.databaseTimezone = "utc";
+    adapter._databaseTimezone = "utc";
     await withTimezoneConfig({ default: "local" }, async () => {
       await adapter.configureConnection();
-      expect(adapter.databaseTimezone).toBe("local");
+      expect(adapter._databaseTimezone).toBe("local");
     });
     await withTimezoneConfig({ default: "utc" }, async () => {
       await adapter.configureConnection();
-      expect(adapter.databaseTimezone).toBe("utc");
+      expect(adapter._databaseTimezone).toBe("utc");
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -162,8 +162,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   /**
    * Async liveness probe — checks socket health via a real `ping` call on the
    * persistent connection, lazily establishing it if needed. Updates the cached
-   * `_activeState` so the sync `active` getter reflects the result. Mirrors
-   * Rails' `active?` which calls `mysql_ping` on the raw connection.
+   * `_activeState` so the sync `active` getter reflects the result.
+   *
+   * @noRailsEquivalent PERMANENT — this is the async half of Rails' `active?`
+   * (mysql2_adapter.rb:108), which pings the raw connection inline
+   * (`@raw_connection&.ping`) because the Ruby mysql2 driver is blocking. The
+   * node-mysql2 `ping()` returns a promise, so the ping cannot happen inside a
+   * sync predicate; trails splits `active?` into the sync `active` getter
+   * (Rails' `connected?` guard plus the cached liveness) and this awaitable
+   * probe. Rails has one method where trails needs two, so the second name has
+   * no counterpart to converge onto.
    */
   async activeAsync(): Promise<boolean> {
     if (this._permanentlyClosed || this._isFakeConnection) {
@@ -274,15 +282,17 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private _statementPool: Mysql2StatementPool | null = null;
 
   /**
-   * The timezone applied to result rows for the most recent query. Mirrors
-   * the Ruby mysql2 driver's `query_options[:database_timezone]`, which
-   * Rails' `Mysql2Adapter#perform_query` re-syncs to
-   * `ActiveRecord.default_timezone` before each query so a runtime change to
-   * the global default takes effect on the next statement (no reconnect).
+   * The timezone applied to result rows for the most recent query. Rails-private
+   * (`_` prefix) because Rails exposes no reader for it: the value lives inside
+   * the Ruby driver as `@raw_connection.query_options[:database_timezone]`,
+   * which `Mysql2Adapter#configure_connection` assigns from `default_timezone`
+   * (mysql2_adapter.rb:160). node-mysql2 has no `query_options` hash, so trails
+   * holds the same state in a field — there is no Rails method name to map it
+   * onto, only a driver ivar.
    *
    * Updated by {@link _syncDatabaseTimezone} from the perform-query path.
    */
-  databaseTimezone: "utc" | "local" = "utc";
+  _databaseTimezone: "utc" | "local" = "utc";
 
   /**
    * Rows affected by the most recent write, recorded by {@link _performQuery}.
@@ -292,14 +302,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   _affectedRowsBeforeWarnings = 0;
 
   /**
-   * Refresh {@link databaseTimezone} from the global default. Called from
+   * Refresh {@link _databaseTimezone} from the global default. Called from
    * the perform-query path so a `withTimezoneConfig({ default: "local" })`
    * block is observable on the very next query — matching Rails'
    * `raw_connection.query_options[:database_timezone] = default_timezone`
    * line in `Mysql2Adapter#perform_query`.
    */
   private _syncDatabaseTimezone(): void {
-    this.databaseTimezone = ActiveRecord.defaultTimezone;
+    this._databaseTimezone = ActiveRecord.defaultTimezone;
   }
 
   protected override _onStatementLimitChanged(value: number): void {
@@ -1484,9 +1494,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   async tableExists(name: string): Promise<boolean> {
     // Rails' table_exists?(nil) / "" returns false; a null/empty name has no
-    // schema to parse, so short-circuit before parseMysqlName (which trims).
+    // schema to parse, so short-circuit before mysqlParseName (which trims).
     if (!name) return false;
-    const { schema, table } = this.parseMysqlName(name);
+    const { schema, table } = mysqlParseName(name);
     // Use `schema_placeholder OR database()` via COALESCE so the same
     // query shape serves qualified + unqualified callers.
     const rows = await this.schemaQuery(
@@ -1507,7 +1517,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * emits in `abstract_mysql_adapter#primary_keys`.
    */
   async primaryKey(tableName: string): Promise<string | string[] | null> {
-    const { schema, table } = this.parseMysqlName(tableName);
+    const { schema, table } = mysqlParseName(tableName);
     const rows = (await this.schemaQuery(
       `SELECT column_name AS name FROM information_schema.statistics
          WHERE index_name = 'PRIMARY'
@@ -1532,11 +1542,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       },
       tableName,
     );
-  }
-
-  /** Delegates to {@link mysqlParseName} in `mysql/schema-statements.ts`. */
-  parseMysqlName(name: string): { schema?: string; table: string } {
-    return mysqlParseName(name);
   }
 
   supportsAdvisoryLocks(): boolean {
@@ -1772,7 +1777,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // database_timezone on the single raw connection. We have a single
     // persistent connection here too; mysql2's typeCast handles temporal
     // fields and results are returned as objects (not arrays).
-    // The database_timezone equivalent ({@link databaseTimezone}) is seeded
+    // The database_timezone equivalent ({@link _databaseTimezone}) is seeded
     // from the global default here and re-synced per-query in perform_query,
     // mirroring Rails' `query_options[:database_timezone] = default_timezone`.
     // This reseed is UNGATED: Rails reassigns database_timezone on every

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -144,19 +144,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // true by reconnectBang() and by successful activeAsync().
   private _activeState = true;
 
-  // Mirrors Rails' Mysql2Adapter#active? (mysql2_adapter.rb:108) whose first
-  // guard is `connected?` — `!(@raw_connection.nil? || @raw_connection.closed?)`.
-  // A never-connected adapter (`_client === null`) therefore reports inactive:
-  // trails connects lazily, so `_client` stands in for `@raw_connection`. The
-  // sync getter can't do the live `ping` half of Rails' active? (that's
-  // activeAsync); `_activeState` is the cached liveness that ping updates.
+  // Mirrors Rails' Mysql2Adapter#active? (mysql2_adapter.rb:108), whose body is
+  // `if connected? ... @raw_connection&.ping ... end || false` — it *calls*
+  // `connected?` rather than re-deriving the guard, so this delegates to
+  // `isConnected()` (trails' `connected?`) the same way. The sync getter can't
+  // do the live `ping` half of Rails' active? (that's activeAsync);
+  // `_activeState` is the cached liveness that ping updates.
   override get active(): boolean {
-    return (
-      this._client !== null &&
-      !this._permanentlyClosed &&
-      !this._isFakeConnection &&
-      this._activeState
-    );
+    return this.isConnected();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -285,10 +285,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * The timezone applied to result rows for the most recent query. Rails-private
    * (`_` prefix) because Rails exposes no reader for it: the value lives inside
    * the Ruby driver as `@raw_connection.query_options[:database_timezone]`,
-   * which `Mysql2Adapter#configure_connection` assigns from `default_timezone`
-   * (mysql2_adapter.rb:160). node-mysql2 has no `query_options` hash, so trails
-   * holds the same state in a field — there is no Rails method name to map it
-   * onto, only a driver ivar.
+   * seeded by `Mysql2Adapter#configure_connection` (mysql2_adapter.rb:160) and
+   * re-synced to `default_timezone` on every statement by
+   * `Mysql2::DatabaseStatements#perform_query` (mysql2/database_statements.rb:49).
+   * node-mysql2 has no `query_options` hash, so trails holds the same state in a
+   * field — there is no Rails method name to map it onto, only a driver ivar.
    *
    * Updated by {@link _syncDatabaseTimezone} from the perform-query path.
    */


### PR DESCRIPTION
Resolves the per-file novel surface on the two concrete adapter files named by
the story. The libsql half needed no work — `LibSQLReplicaAdapter` and
`syncReplica` already carry `@noRailsEquivalent PERMANENT` tags anchored to
`sqlite3_adapter.rb:30`, and `api:extra` no longer reports
`connection-adapters/libsql-replica-adapter.ts` at all. So all the decisions
here are on `mysql2-adapter.ts`.

## Decisions

| Name | Decision | Anchor |
| --- | --- | --- |
| `parseMysqlName` | **deleted** — it was a bare delegation to `parseMysqlName` in `mysql/schema-statements.ts`; the three in-file call sites now call the module function directly (already imported as `mysqlParseName`). | Rails splits qualified names in `AbstractMysqlAdapter#extract_schema_qualified_name`, not in `mysql2_adapter.rb` — there was never a method here to converge onto. |
| `databaseTimezone` | **made Rails-private** (`_databaseTimezone`). Rails exposes no reader: the value lives inside the Ruby driver as `@raw_connection.query_options[:database_timezone]`, seeded by `configure_connection` and re-synced per statement by `perform_query`. node-mysql2 has no `query_options` hash, so trails holds the same state in a field — a driver ivar, not a method name. | `mysql2_adapter.rb:160`, `mysql2/database_statements.rb:49` |
| `activeAsync` | **`@noRailsEquivalent PERMANENT`** — the async half of Rails' `active?`, which pings the raw connection inline (`@raw_connection&.ping`) because the Ruby mysql2 driver blocks. node-mysql2's `ping()` returns a promise, so the ping cannot live in a sync predicate; trails splits `active?` into the sync `active` getter (Rails' `connected?` guard + cached liveness) and this awaitable probe. One Rails method, two trails names. | `mysql2_adapter.rb:108` |

Justifications are all at the declaration site, not only here.

Follow-up commit `d874e2296`: `active` and `isConnected()` had **byte-identical
bodies**, while Rails' `active?` *calls* `connected?` (`mysql2_adapter.rb:108`
→ `:104`) rather than re-deriving the guard inline. `active` now delegates to
`isConnected()`, matching that call structure. Pure dedup, zero behavior change.

## Per-file novel: before → after

| File | Before | After |
| --- | --- | --- |
| `connection-adapters/mysql2-adapter.ts` | 5 (`activeAsync`, `databaseTimezone`, `exec`, `executeMutation`, `parseMysqlName`) | 2 (`exec`, `executeMutation`) |
| `connection-adapters/libsql-replica-adapter.ts` | 0 (already resolved) | 0 |

Package total novel: 544 → 541. The residue (`exec` / `executeMutation`) is owned
by `extra-surface-adapter-cross-file-recurring-names`, per this story's scope.

`pnpm api:extra` reports **no new STALE entries**. It does report one
pre-existing stale tag (`base.ts` `equals`), byte-identical in the before and
after runs and untouched by this diff — it belongs to whoever owns the
`declare`-kind exemption, not to this story.

## Verification

- `pnpm typecheck` clean; `pnpm eslint` clean on the touched files.
- `pnpm vitest run` on `mysql/schema-statements.test.ts` — 48 passed.
- The two mysql2 test files need a running MySQL server, unavailable in this
  worktree, so they skipped locally — **CI's MySQL lane is green**, which covers
  them. The only change in them is the `adapter.databaseTimezone` →
  `adapter._databaseTimezone` rename.

## Can these be renamed to the Rails names exactly?

Checked; neither can today, and the blockers are recorded as stories rather than
papered over.

- **`_databaseTimezone`** has no Rails method to rename *to* — Rails never defines
  one, it assigns the mysql2 gem's `query_options[:database_timezone]` hash key.
  Naming the field `queryOptions` would match the *driver* API, not Rails source,
  so it would still count as novel with no fidelity gain. `_`-private is the
  terminal answer.
- **`activeAsync` → `active`** would require making `active` awaitable across all
  7 `get active()` declarations (`abstract-adapter.ts:1104`,
  `postgresql-adapter.ts:238`, `sqlite3-adapter.ts:288`, `mysql2-adapter.ts:153`,
  `support/fake-adapter.ts:57`, two test doubles). Non-test call sites are only
  four and all already sit inside `async` functions, so the flip is more tractable
  than it first looks; the bulk is ~68 `.active` references across `*.test.ts`.
  The sharp edge is `abstract/transaction.ts:822` — `conn.active !== false` is
  truthiness-sensitive, and an un-awaited promise there would pass the guard
  unconditionally rather than fail loudly. Filed as
  `collapse-adapter-active-onto-the-rails-active-name` (RFC 0072), including the
  open question of whether the flip is worth an `await` on every liveness check.

Also surfaced and filed, not smuggled in here: `isConnected()` folds in
`_activeState`, which Rails' `connected?` does not — it asks only whether the raw
handle exists and is open, so after a failed ping trails reports not-connected
where Rails still reports connected. That is a **behavior** change needing a
regression test on the MySQL lane, filed as
`mysql2-connected-predicate-folds-in-cached-ping-state` (RFC 0072). It also gates
the rename story above, since it settles what `active` should return.

Closes-story: extra-surface-mysql2-and-libsql-per-file-singletons
