### PR TITLE
refactor(api-compare): resolve TS superclass short names by declaring file

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -13,6 +13,7 @@ import {
   MISPLACED_MIN_HITS,
   blazetrailsDepKeys,
   buildEntitiesByName,
+  resolveEntityByDeclaringFile,
   significantMissingCalls,
   resolvePortedWithArgsSigs,
   jsEnumerableAliases,
@@ -1078,7 +1079,99 @@ describe("flattenIncludedMethodInfos", () => {
   });
 });
 
+describe("resolveEntityByDeclaringFile", () => {
+  const entity = (file: string, name = "SchemaStatements"): ClassInfo => ({
+    name,
+    file,
+    includes: [],
+    extends: [],
+    instanceMethods: [],
+    classMethods: [],
+  });
+
+  it("returns the sole candidate without consulting the declaring file", () => {
+    const only = entity("connection-adapters/abstract/schema-statements.ts");
+    expect(resolveEntityByDeclaringFile([only], "connection-adapters/sqlite3/adapter.ts")).toBe(
+      only,
+    );
+  });
+
+  it("returns null when nothing shares the short name", () => {
+    expect(resolveEntityByDeclaringFile([], "a.ts", "b.ts")).toBeNull();
+  });
+
+  it("prefers the candidate whose file the extends clause resolved to", () => {
+    // Proximity alone picks the sibling under `postgresql/`; the recorded
+    // declaring file says the `extends` actually bound the abstract one.
+    const abstract = entity("connection-adapters/abstract/schema-statements.ts");
+    const postgresql = entity("connection-adapters/postgresql/schema-statements.ts");
+    expect(
+      resolveEntityByDeclaringFile(
+        [abstract, postgresql],
+        "connection-adapters/postgresql/adapter.ts",
+        "connection-adapters/abstract/schema-statements.ts",
+      ),
+    ).toBe(abstract);
+  });
+
+  it("falls back to path proximity when no declaring file was recorded", () => {
+    const abstract = entity("connection-adapters/abstract/schema-statements.ts");
+    const sqlite3 = entity("connection-adapters/sqlite3/schema-statements.ts");
+    expect(
+      resolveEntityByDeclaringFile([abstract, sqlite3], "connection-adapters/sqlite3/adapter.ts"),
+    ).toBe(sqlite3);
+  });
+
+  it("falls back to path proximity when the declaring file matches no candidate", () => {
+    const abstract = entity("connection-adapters/abstract/schema-statements.ts");
+    const sqlite3 = entity("connection-adapters/sqlite3/schema-statements.ts");
+    expect(
+      resolveEntityByDeclaringFile(
+        [abstract, sqlite3],
+        "connection-adapters/sqlite3/adapter.ts",
+        "some/other/package/schema-statements.ts",
+      ),
+    ).toBe(sqlite3);
+  });
+
+  it("skips the child's own file when scoring proximity", () => {
+    // A class and its same-named parent can't share a file, so a candidate at
+    // the child's path is the child itself — picking it would loop.
+    const self = entity("connection-adapters/sqlite3/adapter.ts");
+    const parent = entity("connection-adapters/abstract/adapter.ts");
+    expect(
+      resolveEntityByDeclaringFile([self, parent], "connection-adapters/sqlite3/adapter.ts"),
+    ).toBe(parent);
+  });
+});
+
 describe("resolveModuleName", () => {
+  it("disambiguates a duplicated short name by namespace, needing no declaring file", () => {
+    // The Ruby-side counterpart of `resolveEntityByDeclaringFile`: same
+    // `SchemaStatements` collision across sibling adapters, resolved by the
+    // enclosing namespace the way Ruby's own constant lookup does. This is why
+    // the include-graph walks (`buildModuleIncluderFqns`,
+    // `flattenIncludedMethodInfos`, extra-surface's `walkMixin`) don't take a
+    // declaring-file hint.
+    const byShort = new Map([
+      [
+        "SchemaStatements",
+        [
+          "AR::ConnectionAdapters::SchemaStatements",
+          "AR::ConnectionAdapters::PostgreSQL::SchemaStatements",
+          "AR::ConnectionAdapters::SQLite3::SchemaStatements",
+        ],
+      ],
+    ]);
+    expect(
+      resolveModuleName(
+        "SchemaStatements",
+        "AR::ConnectionAdapters::SQLite3::SQLite3Adapter",
+        byShort,
+      ),
+    ).toEqual("AR::ConnectionAdapters::SQLite3::SchemaStatements");
+  });
+
   it("returns the single candidate unchanged", () => {
     const byShort = new Map([["Quoting", ["AR::ConnectionAdapters::Quoting"]]]);
     expect(

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1028,6 +1028,14 @@ function nearestNamespaceMatch(
  * namespace walk — so dropping it moved no method counts. Same false-positive
  * shape PR #5344 removed from the includer graph, where 21 methods were
  * counting as implemented in files Ruby's lookup never reaches.
+ *
+ * This is the RUBY side, and it needs no declaring-file hint the way the TS
+ * superclass/mixin sites do (`resolveEntityByDeclaringFile`). A duplicated
+ * short name here is disambiguated by the enclosing namespace, which is
+ * exactly how Ruby itself binds it — `ConnectionAdapters::PostgreSQL::Quoting`
+ * beats `ConnectionAdapters::Quoting` for a context inside `PostgreSQL::`
+ * regardless of which `.rb` either lives in. The TS sites have no namespaces
+ * to walk, which is why they need the file.
  */
 export function resolveModuleName(
   incName: string,
@@ -1281,6 +1289,49 @@ export function buildEntitiesByName(pkg: string, ts: ApiManifest): Map<string, C
   for (const depKey of blazetrailsDepKeys(pkg)) addPkg(depKey);
 
   return map;
+}
+
+/**
+ * Pick the entity a superclass / include-edge short name refers to.
+ *
+ * TS records both by their BARE short name, and sibling adapter directories
+ * declare same-named entities (`SchemaStatements` lives under
+ * `connection-adapters/abstract/`, `postgresql/` and `sqlite3/`). The extractor
+ * therefore also records the file the name resolved to — `superclassFile` for
+ * an `extends` clause, `extendsFiles[name]` for an `include()`/`extend()` edge
+ * — and an exact match on it wins outright. `declFile` is absent only when the
+ * symbol resolved outside the package's `src` (a dep package, a mixin-factory
+ * call), and then we fall back to file-path proximity: most shared leading
+ * directory segments with the child, self excluded.
+ */
+export function resolveEntityByDeclaringFile(
+  candidates: ClassInfo[],
+  childFile: string,
+  declFile?: string,
+): ClassInfo | null {
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+  if (declFile) {
+    const exact = candidates.find((c) => c.file === declFile);
+    if (exact) return exact;
+  }
+  const childParts = (childFile || "").split("/");
+  let best: ClassInfo | null = null;
+  let bestScore = -1;
+  for (const c of candidates) {
+    if (c.file === childFile) continue; // skip self
+    const parts = (c.file || "").split("/");
+    let shared = 0;
+    for (let i = 0; i < Math.min(childParts.length, parts.length); i++) {
+      if (childParts[i] === parts[i]) shared++;
+      else break;
+    }
+    if (shared > bestScore) {
+      bestScore = shared;
+      best = c;
+    }
+  }
+  return best ?? candidates[0];
 }
 
 export function main() {
@@ -1544,41 +1595,8 @@ export function main() {
 
       const entityKey = (e: ClassInfo) => `${e.file}:${e.name}`;
 
-      // When multiple entities share a name, pick the best parent by
-      // file path proximity (most shared directory segments).
-      const resolveParent = (
-        name: string,
-        childFile: string,
-        declFile?: string,
-      ): ClassInfo | null => {
-        const candidates = entitiesByName.get(name) || [];
-        if (candidates.length === 0) return null;
-        if (candidates.length === 1) return candidates[0];
-        // An include()/extend() edge knows the file its module was declared in;
-        // that beats filename proximity, which cannot separate same-named
-        // modules in sibling adapter directories.
-        if (declFile) {
-          const exact = candidates.find((c) => c.file === declFile);
-          if (exact) return exact;
-        }
-        const childParts = (childFile || "").split("/");
-        let best: ClassInfo | null = null;
-        let bestScore = -1;
-        for (const c of candidates) {
-          if (c.file === childFile) continue; // skip self
-          const parts = (c.file || "").split("/");
-          let shared = 0;
-          for (let i = 0; i < Math.min(childParts.length, parts.length); i++) {
-            if (childParts[i] === parts[i]) shared++;
-            else break;
-          }
-          if (shared > bestScore) {
-            bestScore = shared;
-            best = c;
-          }
-        }
-        return best ?? candidates[0];
-      };
+      const resolveParent = (name: string, childFile: string, declFile?: string) =>
+        resolveEntityByDeclaringFile(entitiesByName.get(name) || [], childFile, declFile);
 
       const inheritedCache = new Map<string, Set<string>>();
       const getInherited = (entity: ClassInfo, visited: Set<string>): Set<string> => {
@@ -1594,7 +1612,7 @@ export function main() {
         }
 
         if (entity.superclass) {
-          const parent = resolveParent(entity.superclass, entity.file || "");
+          const parent = resolveParent(entity.superclass, entity.file || "", entity.superclassFile);
           if (parent) {
             for (const m of getInherited(parent, visited)) methods.add(m);
           }
@@ -2246,30 +2264,8 @@ export function main() {
         tsByShort.set(cls.name, list);
       }
 
-      // Resolve the most likely parent class among duplicates by file-path
-      // proximity, mirroring the `resolveParent` heuristic above.
-      const resolveAncestor = (name: string, childFile: string): ClassInfo | null => {
-        const candidates = tsByShort.get(name) || [];
-        if (candidates.length === 0) return null;
-        if (candidates.length === 1) return candidates[0];
-        const childParts = (childFile || "").split("/");
-        let best: ClassInfo | null = null;
-        let bestScore = -1;
-        for (const c of candidates) {
-          if (c.file === childFile && c.name === name) continue;
-          const parts = (c.file || "").split("/");
-          let shared = 0;
-          for (let i = 0; i < Math.min(childParts.length, parts.length); i++) {
-            if (childParts[i] === parts[i]) shared++;
-            else break;
-          }
-          if (shared > bestScore) {
-            bestScore = shared;
-            best = c;
-          }
-        }
-        return best ?? candidates[0];
-      };
+      const resolveAncestor = (name: string, childFile: string, declFile?: string) =>
+        resolveEntityByDeclaringFile(tsByShort.get(name) || [], childFile, declFile);
 
       const ancestorChain = (cls: ClassInfo): string[] => {
         const chain: string[] = [];
@@ -2282,7 +2278,7 @@ export function main() {
           const key = `${cursor.file}::${name}`;
           if (seen.has(key)) break;
           seen.add(key);
-          cursor = resolveAncestor(name, cursor.file || "");
+          cursor = resolveAncestor(name, cursor.file || "", cursor.superclassFile);
         }
         return chain;
       };

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -831,6 +831,13 @@ function collectAllowedNames(
     for (const c of candidates) allowed.add(c);
   };
 
+  // Ruby-side walk: `incName` is a Ruby constant, so a duplicated short name
+  // (`SchemaStatements` under three adapter namespaces) is disambiguated by the
+  // enclosing namespace inside `resolveModuleName`, exactly as Ruby's own
+  // constant lookup does. It needs no declaring-file hint — that is the TS side's
+  // problem, where short names have no namespace to walk and the extractor
+  // records `superclassFile` / `extendsFiles` instead (compare.ts
+  // `resolveEntityByDeclaringFile`).
   const walkMixin = (incName: string, contextFqn: string): void => {
     const fqn = resolveModuleName(incName, contextFqn, moduleFqnByShort);
     if (visited.has(fqn)) return;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -831,13 +831,9 @@ function collectAllowedNames(
     for (const c of candidates) allowed.add(c);
   };
 
-  // Ruby-side walk: `incName` is a Ruby constant, so a duplicated short name
-  // (`SchemaStatements` under three adapter namespaces) is disambiguated by the
-  // enclosing namespace inside `resolveModuleName`, exactly as Ruby's own
-  // constant lookup does. It needs no declaring-file hint — that is the TS side's
-  // problem, where short names have no namespace to walk and the extractor
-  // records `superclassFile` / `extendsFiles` instead (compare.ts
-  // `resolveEntityByDeclaringFile`).
+  // Ruby-side walk: a duplicated short name is disambiguated by the enclosing
+  // namespace inside `resolveModuleName`, so this needs no declaring-file hint
+  // the way the TS sites do (compare.ts `resolveEntityByDeclaringFile`).
   const walkMixin = (incName: string, contextFqn: string): void => {
     const fqn = resolveModuleName(incName, contextFqn, moduleFqnByShort);
     if (visited.has(fqn)) return;

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -951,6 +951,44 @@ describe("extractFromProgram — include() detection", () => {
     expect(host.extendsFiles?.["SchemaStatements"]).toBe("postgresql/schema-statements-class.ts");
   });
 
+  it("records the superclass's declaration file on superclassFile", () => {
+    // Same collision as extendsFiles, on the `extends` heritage clause: two
+    // classes named `SchemaStatements`, and the subclass's own path is no help
+    // in telling them apart.
+    const info = extractFromFiles("/p", {
+      "abstract/schema-statements.ts": `export class SchemaStatements { addColumn(): void {} }`,
+      "sqlite3/schema-statements.ts": `export class SchemaStatements { renameColumn(): void {} }`,
+      "sqlite3/adapter.ts": `
+        import { SchemaStatements } from "./schema-statements.js";
+        export class SQLite3Adapter extends SchemaStatements {}
+      `,
+    });
+    const cls = info.classes["sqlite3/adapter.ts:SQLite3Adapter"];
+    expect(cls.superclass).toBe("SchemaStatements");
+    expect(cls.superclassFile).toBe("sqlite3/schema-statements.ts");
+  });
+
+  it("omits superclassFile when the extends clause has no resolvable declaration", () => {
+    // A mixin-factory call (`extends Mixin(Base)`) has no symbol to locate, and
+    // a superclass imported from another package declares outside `srcDir`.
+    // Both fall back to the proximity heuristic rather than recording a file.
+    const info = extractFromFiles("/p", {
+      "mixin.ts": `export function Mixin(b: any): any { return b; }`,
+      "base.ts": `export class Base {}`,
+      "derived.ts": `
+        import { Mixin } from "./mixin.js";
+        import { Base } from "./base.js";
+        export class Derived extends Mixin(Base) {}
+      `,
+      "external.ts": `
+        import { Model } from "@blazetrails/activemodel";
+        export class Record extends Model {}
+      `,
+    });
+    expect(info.classes["derived.ts:Derived"].superclassFile).toBeUndefined();
+    expect(info.classes["external.ts:Record"].superclassFile).toBeUndefined();
+  });
+
   it("follows import aliases (`Math as MathMixin`) to the original module name", () => {
     const info = extractFromFiles("/p", {
       "math.ts": `export const Math = { add() {} };`,

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -968,6 +968,20 @@ describe("extractFromProgram — include() detection", () => {
     expect(cls.superclassFile).toBe("sqlite3/schema-statements.ts");
   });
 
+  it("records extendsFiles for an interface's extends clause", () => {
+    const info = extractFromFiles("/p", {
+      "abstract/quoting.ts": `export interface Quoting { quoteColumnName(n: string): string }`,
+      "sqlite3/quoting.ts": `export interface Quoting { quotedBinary(v: string): string }`,
+      "sqlite3/adapter.ts": `
+        import type { Quoting } from "./quoting.js";
+        export interface SQLite3Adapter extends Quoting {}
+      `,
+    });
+    const iface = info.modules["sqlite3/adapter.ts:SQLite3Adapter"];
+    expect(iface.extends).toContain("Quoting");
+    expect(iface.extendsFiles?.["Quoting"]).toBe("sqlite3/quoting.ts");
+  });
+
   it("omits superclassFile when the extends clause has no resolvable declaration", () => {
     // A mixin-factory call (`extends Mixin(Base)`) has no symbol to locate, and
     // a superclass imported from another package declares outside `srcDir`.

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -177,11 +177,28 @@ function recordExtendsFile(
   sym: ts.Symbol | undefined,
   srcDir: string,
 ): void {
-  const decl = sym?.valueDeclaration ?? sym?.declarations?.[0];
-  if (!decl) return;
-  const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
-  if (declFile.startsWith("..")) return;
+  const declFile = declaringFile(sym, srcDir);
+  if (!declFile) return;
   hostInfo.extendsFiles = { ...(hostInfo.extendsFiles ?? {}), [modName]: declFile };
+}
+
+/**
+ * src-relative file a symbol was declared in, POSIX-normalized so it can be
+ * compared against a manifest `ClassInfo.file`. Returns undefined for symbols
+ * declared outside `srcDir` (node_modules, other packages) — those can't be
+ * matched against this package's entities anyway.
+ */
+function declaringFile(sym: ts.Symbol | undefined, srcDir: string): string | undefined {
+  const decl = sym?.valueDeclaration ?? sym?.declarations?.[0];
+  if (!decl) return undefined;
+  const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
+  if (declFile.startsWith("..")) return undefined;
+  return declFile;
+}
+
+function resolveDeclarationSymbol(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | undefined {
+  const sym = checker.getSymbolAtLocation(node);
+  return sym && sym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym) : sym;
 }
 
 function extractInWorker(pkgName: string, srcDir: string): Promise<WorkerOutput> {
@@ -508,7 +525,7 @@ export function extractFromProgram(
     ts.forEachChild(sourceFile, (node) => {
       if (ts.isClassDeclaration(node) && node.name) {
         if (!isExported(node)) return;
-        const classInfo = extractClass(node, checker, relPath);
+        const classInfo = extractClass(node, checker, relPath, srcDir);
         if (classInfo) {
           const classKey = `${relPath}:${classInfo.name}`;
           info.classes[classKey] = classInfo;
@@ -1847,15 +1864,26 @@ export function extractClass(
   node: ts.ClassDeclaration,
   checker: ts.TypeChecker,
   file: string,
+  srcDir?: string,
 ): ClassInfo | null {
   const name = node.name?.text;
   if (!name) return null;
 
   let superclass: string | undefined;
+  let superclassFile: string | undefined;
   if (node.heritageClauses) {
     for (const clause of node.heritageClauses) {
       if (clause.token === ts.SyntaxKind.ExtendsKeyword) {
-        superclass = clause.types[0]?.expression.getText();
+        const expr = clause.types[0]?.expression;
+        if (!expr) continue;
+        superclass = expr.getText();
+        // Same rule as include()/extend() edges: the superclass is recorded by
+        // its bare short name, and sibling adapter directories declare classes
+        // that share one (`SchemaStatements`). Record where it was declared so
+        // the consumer doesn't have to guess from path proximity.
+        if (srcDir !== undefined) {
+          superclassFile = declaringFile(resolveDeclarationSymbol(checker, expr), srcDir);
+        }
       }
     }
   }
@@ -2028,6 +2056,7 @@ export function extractClass(
   return {
     name,
     superclass,
+    ...(superclassFile !== undefined ? { superclassFile } : {}),
     file,
     includes,
     extends: extendsArr,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -535,7 +535,7 @@ export function extractFromProgram(
         if (!isExported(node)) return;
         const name = node.name.text;
         const modKey = `${relPath}:${name}`;
-        const extracted = extractInterface(node, checker, relPath);
+        const extracted = extractInterface(node, checker, relPath, srcDir);
         const existing = info.modules[modKey];
         if (existing) {
           // Merge declaration-merged interfaces (same name, same file)
@@ -545,6 +545,9 @@ export function extractFromProgram(
           }
           for (const e of extracted.extends) {
             if (!existing.extends.includes(e)) existing.extends.push(e);
+          }
+          if (extracted.extendsFiles) {
+            existing.extendsFiles = { ...extracted.extendsFiles, ...(existing.extendsFiles ?? {}) };
           }
           // A declaration-merged interface only needs the tag on ONE of its
           // declarations; without this the reason is lost whenever the tagged
@@ -1860,6 +1863,15 @@ export function resolveRelModule(fromRel: string, spec: string): string | null {
   return path.posix.normalize(path.posix.join(fromDir, withoutExt)) + ".ts";
 }
 
+/**
+ * Extract one exported class into a `ClassInfo`.
+ *
+ * `srcDir` is what lets the `extends` clause be recorded as a declaring file
+ * (`superclassFile`) and not just a bare short name — sibling adapter
+ * directories declare same-named classes, and a consumer given only the name
+ * has to guess. Omit it (tests compiling a single virtual file) and the
+ * superclass is still recorded by name, without the file.
+ */
 export function extractClass(
   node: ts.ClassDeclaration,
   checker: ts.TypeChecker,
@@ -1877,10 +1889,6 @@ export function extractClass(
         const expr = clause.types[0]?.expression;
         if (!expr) continue;
         superclass = expr.getText();
-        // Same rule as include()/extend() edges: the superclass is recorded by
-        // its bare short name, and sibling adapter directories declare classes
-        // that share one (`SchemaStatements`). Record where it was declared so
-        // the consumer doesn't have to guess from path proximity.
         if (srcDir !== undefined) {
           superclassFile = declaringFile(resolveDeclarationSymbol(checker, expr), srcDir);
         }
@@ -2071,10 +2079,12 @@ function extractInterface(
   node: ts.InterfaceDeclaration,
   checker: ts.TypeChecker,
   file: string,
+  srcDir?: string,
 ): ClassInfo {
   const name = node.name.text;
   const instanceMethods: MethodInfo[] = [];
   const extendsArr: string[] = [];
+  let extendsFiles: Record<string, string> | undefined;
 
   if (node.heritageClauses) {
     for (const clause of node.heritageClauses) {
@@ -2082,6 +2092,13 @@ function extractInterface(
         for (const type of clause.types) {
           const exprText = type.expression.getText();
           extendsArr.push(exprText);
+          if (srcDir !== undefined) {
+            const declFile = declaringFile(
+              resolveDeclarationSymbol(checker, type.expression),
+              srcDir,
+            );
+            if (declFile) extendsFiles = { ...(extendsFiles ?? {}), [exprText]: declFile };
+          }
 
           // Resolve mapped/generic types (e.g. Included<typeof X>) via
           // the type checker so their computed properties appear as methods.
@@ -2142,6 +2159,7 @@ function extractInterface(
     file,
     includes: [],
     extends: extendsArr,
+    ...(extendsFiles !== undefined ? { extendsFiles } : {}),
     instanceMethods,
     classMethods: [],
     isInterface: true,

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -132,6 +132,15 @@ export interface MethodInfo {
 export interface ClassInfo {
   name: string;
   superclass?: string;
+  /**
+   * TS-side only: the src-relative file `superclass` was declared in. Same
+   * problem `extendsFiles` solves for include/extend edges — the superclass is
+   * recorded by its bare short name, and sibling adapter directories declare
+   * same-named classes, which filename proximity cannot separate. Absent when
+   * the superclass resolves outside the package's `src` (a dep package, a
+   * mixin-factory call expression); consumers fall back to proximity then.
+   */
+  superclassFile?: string;
   file?: string;
   reExportedFrom?: string;
   includes: string[];


### PR DESCRIPTION
## What

`extractClass` recorded a class's `superclass` by its **bare short name** only,
so `resolveParent` broke ties between same-named classes in sibling adapter
directories by counting shared leading path segments. That's the exact failure
#5929 fixed for `include()`/`extend()` edges (`ClassInfo.extendsFiles`) — and
with `SchemaStatements` now declared under `connection-adapters/abstract/`,
`postgresql/` and `sqlite3/`, the superclass path is one faithful rename away
from silently resolving to the wrong parent.

- The extractor now records `ClassInfo.superclassFile` from the
  checker-resolved `extends` clause (undefined when the symbol resolves outside
  the package `src` — a dep package, a mixin-factory call — so proximity still
  covers those).
- Interface heritage clauses (`extractInterface`) land on the same `extends`
  array `resolveParent` reads, and had the same ambiguity — they now record
  `extendsFiles` too (merged across declaration-merged halves).
- The two TS-side short-name resolvers, `resolveParent` and the inheritance
  check's `resolveAncestor`, were near-duplicate closures. They now share one
  exported `resolveEntityByDeclaringFile`: exact declaring-file match wins,
  proximity is the fallback.

## The sites left on `resolveModuleName`

`buildModuleIncluderFqns` (compare.ts), `flattenIncludedMethodInfos`
(compare.ts) and `walkMixin` (extra-surface.ts) are the **Ruby** side. They
resolve Ruby constants, where a duplicated short name is disambiguated by the
enclosing namespace — exactly how Ruby's own constant lookup binds it. There is
no declaring file to consume and no collision to fix; documented at all three
sites, with a test covering the three-way `SchemaStatements` namespace
collision.

## Verification

- New unit tests: extractor records/omits `superclassFile` and records an
  interface's `extendsFiles`;
  `resolveEntityByDeclaringFile` prefers the declaring file, falls back to
  proximity when it's absent or matches nothing, and skips the child's own file;
  `resolveModuleName` resolves the Ruby-side collision by namespace.
- `pnpm vitest run scripts/api-compare/` — 927 passed.
- `API_COMPARE_FORCE=1 pnpm api:compare` before/after: data layer
  **7725/7816 → 7725/7816**, files 409/409, inheritance 539/592 unchanged;
  arity 7541/7621 → 7542/7622 (one more pair now resolves and matches).

Closes-story: api-compare-resolve-superclass-and-mixin-shortnames-by-declaring-file
