### PR TITLE
fix(api-compare): hoist tag-order allowlist above the worker dispatch

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2026,11 +2026,6 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     ).toThrow(/truncated by a bare `@internal`.*seams\.ts/s);
   });
 
-  // A worker thread runs the whole extraction from the `!isMainThread` block
-  // during module evaluation, so any module-level `const` the extraction reads
-  // must be initialized above that block — otherwise the read lands in the
-  // temporal dead zone and a tag-order violation aborts `api:compare` with a
-  // `ReferenceError` naming the constant instead of the diagnostic above.
   it("initializes TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT before the worker dispatch", () => {
     const src = fs.readFileSync(path.join(import.meta.dirname, "extract-ts-api.ts"), "utf8");
     const constAt = src.indexOf("const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT");

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2010,6 +2010,36 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     ).toThrow(/truncated by a bare `@internal`.*move it above `@noRailsEquivalent`/s);
   });
 
+  it("reports the offending interface member instead of crashing on the tag order", () => {
+    expect(() =>
+      extractFromFiles("/p", {
+        "seams.ts": `
+          export interface Quoting {
+            /**
+             * @noRailsEquivalent wiring seam; the member is real Rails-facing
+             * @internal is the wrong tool here because callers depend on it.
+             */
+            quoteBound(): string;
+          }
+        `,
+      }),
+    ).toThrow(/truncated by a bare `@internal`.*seams\.ts/s);
+  });
+
+  // A worker thread runs the whole extraction from the `!isMainThread` block
+  // during module evaluation, so any module-level `const` the extraction reads
+  // must be initialized above that block — otherwise the read lands in the
+  // temporal dead zone and a tag-order violation aborts `api:compare` with a
+  // `ReferenceError` naming the constant instead of the diagnostic above.
+  it("initializes TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT before the worker dispatch", () => {
+    const src = fs.readFileSync(path.join(import.meta.dirname, "extract-ts-api.ts"), "utf8");
+    const constAt = src.indexOf("const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT");
+    const dispatchAt = src.indexOf("if (!isMainThread && parentPort)");
+    expect(constAt).toBeGreaterThan(-1);
+    expect(dispatchAt).toBeGreaterThan(-1);
+    expect(constAt).toBeLessThan(dispatchAt);
+  });
+
   it("accepts a deliberate @internal placed above @noRailsEquivalent", () => {
     const foo = extractFromSource(`
       class Foo {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -159,12 +159,10 @@ const fileHasMissingRailsCallTag = new WeakMap<ts.SourceFile, boolean>();
  * conventionally trail the description. Every other tag name after the reason
  * is prose that TypeScript mis-parsed — see `proseTagAfter`.
  *
- * Declared with the imports, above the `!isMainThread` block below, for the
- * same reason as `fileHasMissingRailsCallTag`: a worker thread runs the whole
- * extraction during module evaluation, so a `const` declared next to its
- * reader further down the file is still in its temporal dead zone when the
- * reader runs — a tag-order violation would abort the run with a
- * `ReferenceError` naming this constant instead of the intended diagnostic.
+ * Declared with the imports, above the `!isMainThread` block, for the same
+ * reason as `fileHasMissingRailsCallTag`: a worker runs the whole extraction
+ * during module evaluation, so a `const` declared next to its reader further
+ * down the file is still in its temporal dead zone when that reader runs.
  */
 const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT = new Set([
   "param",

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -153,6 +153,34 @@ interface WorkerOutput {
 }
 const fileHasMissingRailsCallTag = new WeakMap<ts.SourceFile, boolean>();
 
+/**
+ * Tags a deliberate JSDoc block may legitimately carry *after*
+ * `@noRailsEquivalent`: the structural ones that document the signature and
+ * conventionally trail the description. Every other tag name after the reason
+ * is prose that TypeScript mis-parsed — see `proseTagAfter`.
+ *
+ * Declared with the imports, above the `!isMainThread` block below, for the
+ * same reason as `fileHasMissingRailsCallTag`: a worker thread runs the whole
+ * extraction during module evaluation, so a `const` declared next to its
+ * reader further down the file is still in its temporal dead zone when the
+ * reader runs — a tag-order violation would abort the run with a
+ * `ReferenceError` naming this constant instead of the intended diagnostic.
+ */
+const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT = new Set([
+  "param",
+  "returns",
+  "return",
+  "throws",
+  "example",
+  "see",
+  "template",
+  "typeParam",
+  "yields",
+  "defaultValue",
+  "remarks",
+  "deprecated",
+]);
+
 if (!isMainThread && parentPort) {
   const { package: pkgName, srcDir } = workerData as WorkerInput;
   const out: WorkerOutput = extractPackage(pkgName, srcDir);
@@ -1588,27 +1616,6 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
   }
   return undefined;
 }
-
-/**
- * Tags a deliberate JSDoc block may legitimately carry *after*
- * `@noRailsEquivalent`: the structural ones that document the signature and
- * conventionally trail the description. Every other tag name after the reason
- * is prose that TypeScript mis-parsed — see `proseTagAfter`.
- */
-const TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT = new Set([
-  "param",
-  "returns",
-  "return",
-  "throws",
-  "example",
-  "see",
-  "template",
-  "typeParam",
-  "yields",
-  "defaultValue",
-  "remarks",
-  "deprecated",
-]);
 
 /**
  * The first JSDoc tag that follows `tag` in the same comment and is a bare


### PR DESCRIPTION
A tag-order violation (`@noRailsEquivalent` reason followed by a line-leading `@internal`) aborted `pnpm api:compare` with:

```
ReferenceError: Cannot access 'TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT' before initialization
```

instead of the intended diagnostic naming the file and declaration.

Cause: a worker thread runs the whole extraction from the `!isMainThread` block during module evaluation, so `TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT` — declared next to its reader `proseTagAfter`, far below that block — was still in its temporal dead zone. Same hazard `fileHasMissingRailsCallTag` already documents.

Fix: hoist the const to the imports region, above the worker dispatch. No change to the tag-order rule itself.

Covers: an interface-member violation now pins the diagnostic (the path from the reported stack trace), plus a source-order cover that fails on the pre-fix layout.

Closes-story: tag-order-violation-crashes-extractor-with-tdz-referenceerror
