### PR TITLE
feat(api-compare): add a file-level @noRailsEquivalent tag with a checked claim

### DIFF
--- a/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
@@ -3,10 +3,9 @@
  * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream. Written file-level: every name this
- * file declares belongs to that one driver binding.
+ * clients, so trails keeps the sqlite3_adapter.rb port on the shared base and
+ * binds each client in its own thin subclass — every name this file declares
+ * belongs to that one binding, and none has anything to converge onto.
  */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { betterSqlite3Driver } from "../sqlite/better-sqlite3.js";

--- a/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/better-sqlite3-adapter.ts
@@ -1,3 +1,13 @@
+/**
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream. Written file-level: every name this
+ * file declares belongs to that one driver binding.
+ */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { betterSqlite3Driver } from "../sqlite/better-sqlite3.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
@@ -10,14 +20,6 @@ import { SQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
- *
- * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
- * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
- * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream.
  */
 export class BetterSQLite3Adapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
@@ -1,3 +1,13 @@
+/**
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream. Written file-level: every name this
+ * file declares belongs to that one driver binding.
+ */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { expoSqliteDriver } from "../sqlite/expo-sqlite.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
@@ -9,14 +19,6 @@ import { SQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
- *
- * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
- * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
- * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream.
  */
 export class ExpoSQLiteAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/expo-sqlite-adapter.ts
@@ -3,10 +3,9 @@
  * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream. Written file-level: every name this
- * file declares belongs to that one driver binding.
+ * clients, so trails keeps the sqlite3_adapter.rb port on the shared base and
+ * binds each client in its own thin subclass — every name this file declares
+ * belongs to that one binding, and none has anything to converge onto.
  */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { expoSqliteDriver } from "../sqlite/expo-sqlite.js";

--- a/packages/activerecord/src/connection-adapters/libsql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-adapter.ts
@@ -1,3 +1,13 @@
+/**
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream. Written file-level: every name this
+ * file declares belongs to that one driver binding.
+ */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { libsqlDriver } from "../sqlite/libsql.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
@@ -9,14 +19,6 @@ import { SQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
- *
- * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
- * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
- * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream.
  */
 export class LibSQLAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/libsql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-adapter.ts
@@ -3,10 +3,9 @@
  * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream. Written file-level: every name this
- * file declares belongs to that one driver binding.
+ * clients, so trails keeps the sqlite3_adapter.rb port on the shared base and
+ * binds each client in its own thin subclass — every name this file declares
+ * belongs to that one binding, and none has anything to converge onto.
  */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { libsqlDriver } from "../sqlite/libsql.js";

--- a/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
@@ -1,3 +1,13 @@
+/**
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream. Written file-level: every name this
+ * file declares belongs to that one driver binding.
+ */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { libsqlRemoteDriver } from "../sqlite/libsql.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
@@ -14,14 +24,6 @@ import { SQLite3Adapter } from "./sqlite3-adapter.js";
  *
  * Thin subclass of `SQLite3Adapter`: all SQLite dialect, quoting, and
  * schema logic lives in the abstract base.
- *
- * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
- * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
- * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream.
  */
 export class LibSQLRemoteAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-remote-adapter.ts
@@ -3,10 +3,9 @@
  * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream. Written file-level: every name this
- * file declares belongs to that one driver binding.
+ * clients, so trails keeps the sqlite3_adapter.rb port on the shared base and
+ * binds each client in its own thin subclass — every name this file declares
+ * belongs to that one binding, and none has anything to converge onto.
  */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { libsqlRemoteDriver } from "../sqlite/libsql.js";

--- a/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
@@ -1,3 +1,13 @@
+/**
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream. Written file-level: every name this
+ * file declares belongs to that one driver binding.
+ */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { ConfigurationError } from "../errors.js";
 import { libsqlReplicaDriver, type SyncableSqliteConnection } from "../sqlite/libsql.js";
@@ -26,14 +36,6 @@ import { SQLite3Adapter } from "./sqlite3-adapter.js";
  * default — without it the replica is caller-driven only — and the loop lives
  * in the libsql handle, so it stops on `disconnect`/`close`; there is no
  * adapter-owned JS timer to clear.
- *
- * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
- * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
- * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream.
  */
 export class LibSQLReplicaAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {
@@ -44,11 +46,8 @@ export class LibSQLReplicaAdapter extends SQLite3Adapter {
    * Pull the latest changes from the remote primary into the local replica.
    * Caller-driven — there is no background sync. Reaches the libsql connection's
    * `sync()` escape hatch (not part of the core `SqliteConnection` interface).
-   *
-   * @noRailsEquivalent PERMANENT — a member of a driver-variant class Rails has
-   * no counterpart for (see the class tag above): Rails' only SQLite class is
-   * `SQLite3Adapter` (sqlite3_adapter.rb:30), bound to the sqlite3 gem, which
-   * has no embedded-replica mode and so nothing to name this after.
+   * Covered by the file-level `@noRailsEquivalent` above: Rails' only SQLite
+   * class is bound to the sqlite3 gem, which has no embedded-replica mode.
    */
   async syncReplica(): Promise<void> {
     const conn = (await this.sqliteConnection()) as Partial<SyncableSqliteConnection>;

--- a/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/libsql-replica-adapter.ts
@@ -3,10 +3,9 @@
  * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream. Written file-level: every name this
- * file declares belongs to that one driver binding.
+ * clients, so trails keeps the sqlite3_adapter.rb port on the shared base and
+ * binds each client in its own thin subclass — every name this file declares
+ * belongs to that one binding, and none has anything to converge onto.
  */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { ConfigurationError } from "../errors.js";

--- a/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
@@ -3,10 +3,9 @@
  * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
  * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
  * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream. Written file-level: every name this
- * file declares belongs to that one driver binding.
+ * clients, so trails keeps the sqlite3_adapter.rb port on the shared base and
+ * binds each client in its own thin subclass — every name this file declares
+ * belongs to that one binding, and none has anything to converge onto.
  */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { nodeSqliteDriver } from "../sqlite/node-sqlite.js";

--- a/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/node-sqlite-adapter.ts
@@ -1,3 +1,13 @@
+/**
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
+ * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
+ * per-driver subclass onto. The JS ecosystem has several interchangeable
+ * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
+ * base and binds each client in its own thin subclass; there is nothing to
+ * converge these names onto upstream. Written file-level: every name this
+ * file declares belongs to that one driver binding.
+ */
 import type { SqliteDriver } from "../sqlite-adapter.js";
 import { nodeSqliteDriver } from "../sqlite/node-sqlite.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
@@ -9,14 +19,6 @@ import { SQLite3Adapter } from "./sqlite3-adapter.js";
  * schema logic lives in the abstract base. This class only binds the base to a
  * concrete client library, mirroring how Rails' `Mysql2Adapter` /
  * `TrilogyAdapter` subclass `AbstractMysqlAdapter`.
- *
- * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
- * (`gem "sqlite3"`, sqlite3_adapter.rb:14), so Rails declares a single
- * `SQLite3Adapter` (sqlite3_adapter.rb:30) and has no class to map a
- * per-driver subclass onto. The JS ecosystem has several interchangeable
- * SQLite clients, so trails keeps the sqlite3_adapter.rb port on the shared
- * base and binds each client in its own thin subclass; there is nothing to
- * converge these names onto upstream.
  */
 export class NodeSQLiteAdapter extends SQLite3Adapter {
   protected override defaultSqliteDriver(): SqliteDriver {

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -2162,8 +2162,6 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(report.packages[0].totalNovel).toBe(0);
   });
 
-  // The file-level form (RFC 0072): one reason at the top of a file no Rails
-  // file maps onto, in place of the same reason on every declaration in it.
   const DRIVER_ADAPTER = `
     /**
      * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver, so
@@ -2208,14 +2206,28 @@ describe("@noRailsEquivalent — extractor to report", () => {
     const report = reportFor(railsWithout(), {
       "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER,
     });
-    // Both the class DECLARATION name and its member are absorbed by the one
-    // reason — the six driver adapters used to repeat it per declaration.
     expect(report.packages[0].totalAllowlisted).toBe(2);
     expect(report.packages[0].totalNovel).toBe(0);
     expect(report.packages[0].extraFiles).toEqual([]);
     expect(report.tagged).toMatchObject({ total: 1, matched: 1, stale: [] });
     expect(report.fileTagRejections).toEqual([]);
     expect(report.tagged.classification.permanent).toBe(1);
+  });
+
+  it("covers top-level functions and the synthesized file module too", () => {
+    const report = reportFor(railsWithout(), {
+      "sqlite/libsql.ts": `
+        /** @noRailsEquivalent PERMANENT — a driver binding Rails has no file for. */
+        import type { SqliteDriver } from "../sqlite-adapter.js";
+
+        export function libsqlDriver(): SqliteDriver | undefined { return undefined; }
+        export function libsqlRemoteDriver(): SqliteDriver | undefined { return undefined; }
+      `,
+      "sqlite-adapter.ts": `export interface SqliteDriver { open(): void }`,
+    });
+    expect(report.packages[0].totalAllowlisted).toBe(3);
+    expect(report.packages[0].extraFiles.map((f) => f.tsFile)).not.toContain("sqlite/libsql.ts");
+    expect(report.fileTagRejections).toEqual([]);
   });
 
   it("fails a file-level reason that states no permanence claim", () => {
@@ -2231,9 +2243,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
     );
   });
 
-  it("rejects a file-level tag when a name in the file scores as moved", () => {
-    // The postgresql/schema-statements-class.ts shape: no counterpart FILE, but
-    // the names exist in Rails elsewhere, so a rename may be owed.
+  it("rejects a file-level tag when a name in the file scores as moved (a rename may be owed)", () => {
     const report = reportFor(railsWithout([method("sync_replica")]), {
       "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER,
     });
@@ -2245,7 +2255,6 @@ describe("@noRailsEquivalent — extractor to report", () => {
         movedNames: ["syncReplica"],
       },
     ]);
-    // Nothing is absorbed: the names stay counted, and the tag reads as stale.
     expect(report.packages[0].totalAllowlisted).toBe(0);
     expect(report.packages[0].extraFiles[0].extras.map((e) => [e.name, e.kind])).toEqual([
       ["LibSQLReplicaAdapter", "novel"],
@@ -2306,8 +2315,6 @@ describe("@noRailsEquivalent — extractor to report", () => {
         }
       `,
     });
-    // Every name is already justified per declaration, so the file-level tag
-    // absorbs nothing — it is a tag anyone can delete, i.e. stale.
     expect(report.fileTagRejections).toEqual([]);
     expect(report.tagged.stale.map((e) => [e.tsFile, e.fileLevel])).toEqual([
       ["connection-adapters/libsql-replica-adapter.ts", true],

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -2312,7 +2312,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(report.tagged.stale.map((e) => [e.tsFile, e.fileLevel])).toEqual([
       ["connection-adapters/libsql-replica-adapter.ts", true],
     ]);
-    expect(gateStale(report.tagged)).toContain("file-level tag");
+    expect(gateStale(report.tagged)).toContain("(file-level tag)");
   });
 });
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -12,6 +12,7 @@ import {
   printClassificationBlock,
   gateUnclassified,
   gateStale,
+  gateFileTagRejections,
 } from "./extra-surface.js";
 import type { TaggedEntry, TaggedSummary } from "./extra-surface.js";
 import { extractFromProgram } from "./extract-ts-api.js";
@@ -2159,6 +2160,146 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(report.tagged).toMatchObject({ total: 1, matched: 1, inheritedMatched: 0, stale: [] });
     expect(report.packages[0].totalAllowlisted).toBe(1);
     expect(report.packages[0].totalNovel).toBe(0);
+  });
+
+  // The file-level form (RFC 0072): one reason at the top of a file no Rails
+  // file maps onto, in place of the same reason on every declaration in it.
+  const DRIVER_ADAPTER = `
+    /**
+     * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver, so
+     * Rails has no class to map a per-driver subclass onto.
+     */
+    import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+    export class LibSQLReplicaAdapter extends SQLite3Adapter {
+      syncReplica(): void {}
+    }
+  `;
+
+  /** Rails declares `base.rb` only, so nothing maps onto the adapter file. */
+  function railsWithout(extraInstance: MethodInfo[] = []): ApiManifest {
+    return {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            "ActiveRecord::Base": rubyClass({
+              name: "Base",
+              file: "base.rb",
+              instance: [method("foo"), ...extraInstance],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+  }
+
+  function reportFor(ruby: ApiManifest, files: Record<string, string>) {
+    return buildReport(
+      ruby,
+      { source: "typescript", generatedAt: "", packages: { activerecord: extract(files) } },
+      { filterPkg: null, excludeGlobs: [], novelOnly: false, topN: 50 },
+    );
+  }
+
+  it("covers every name in a file with no Rails counterpart from one file-level tag", () => {
+    const report = reportFor(railsWithout(), {
+      "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER,
+    });
+    // Both the class DECLARATION name and its member are absorbed by the one
+    // reason — the six driver adapters used to repeat it per declaration.
+    expect(report.packages[0].totalAllowlisted).toBe(2);
+    expect(report.packages[0].totalNovel).toBe(0);
+    expect(report.packages[0].extraFiles).toEqual([]);
+    expect(report.tagged).toMatchObject({ total: 1, matched: 1, stale: [] });
+    expect(report.fileTagRejections).toEqual([]);
+    expect(report.tagged.classification.permanent).toBe(1);
+  });
+
+  it("rejects a file-level tag when a name in the file scores as moved", () => {
+    // The postgresql/schema-statements-class.ts shape: no counterpart FILE, but
+    // the names exist in Rails elsewhere, so a rename may be owed.
+    const report = reportFor(railsWithout([method("sync_replica")]), {
+      "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER,
+    });
+    expect(report.fileTagRejections).toEqual([
+      {
+        package: "activerecord",
+        tsFile: "connection-adapters/libsql-replica-adapter.ts",
+        cause: "moved-names",
+        movedNames: ["syncReplica"],
+      },
+    ]);
+    // Nothing is absorbed: the names stay counted, and the tag reads as stale.
+    expect(report.packages[0].totalAllowlisted).toBe(0);
+    expect(report.packages[0].extraFiles[0].extras.map((e) => [e.name, e.kind])).toEqual([
+      ["LibSQLReplicaAdapter", "novel"],
+      ["syncReplica", "moved"],
+    ]);
+    expect(report.tagged.stale.map((e) => e.tsFile)).toEqual([
+      "connection-adapters/libsql-replica-adapter.ts",
+    ]);
+    expect(gateFileTagRejections(report.fileTagRejections)).toContain("moved name(s)");
+  });
+
+  it("rejects a file-level tag when a Rails file maps onto the file", () => {
+    const ruby = railsWithout();
+    ruby.packages.activerecord.classes["ActiveRecord::ConnectionAdapters::SQLite3Adapter"] =
+      rubyClass({
+        name: "SQLite3Adapter",
+        file: "connection_adapters/sqlite3_adapter.rb",
+        instance: [method("supports_ddl_transactions?")],
+      });
+    const report = reportFor(ruby, {
+      "connection-adapters/sqlite3-adapter.ts": `
+        /**
+         * @noRailsEquivalent PERMANENT — claims a counterpart-free file, wrongly.
+         */
+        import { AbstractAdapter } from "./abstract-adapter.js";
+
+        export class SQLite3Adapter extends AbstractAdapter {
+          reconnect(): void {}
+        }
+      `,
+    });
+    expect(report.fileTagRejections).toEqual([
+      {
+        package: "activerecord",
+        tsFile: "connection-adapters/sqlite3-adapter.ts",
+        cause: "counterpart-file",
+        rubyFile: "connection_adapters/sqlite3_adapter.rb",
+      },
+    ]);
+    expect(report.packages[0].totalAllowlisted).toBe(0);
+    expect(gateFileTagRejections(report.fileTagRejections)).toContain(
+      "connection_adapters/sqlite3_adapter.rb",
+    );
+  });
+
+  it("reports a file-level tag with nothing left to cover as stale", () => {
+    const report = reportFor(railsWithout(), {
+      "connection-adapters/libsql-replica-adapter.ts": `
+        /**
+         * @noRailsEquivalent PERMANENT — nothing in this file is public.
+         */
+        import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+        /** @noRailsEquivalent PERMANENT — the declaration, tagged itself. */
+        export class LibSQLReplicaAdapter extends SQLite3Adapter {
+          /** @noRailsEquivalent PERMANENT — the one member, tagged itself. */
+          syncReplica(): void {}
+        }
+      `,
+    });
+    // Every name is already justified per declaration, so the file-level tag
+    // absorbs nothing — it is a tag anyone can delete, i.e. stale.
+    expect(report.fileTagRejections).toEqual([]);
+    expect(report.tagged.stale.map((e) => [e.tsFile, e.fileLevel])).toEqual([
+      ["connection-adapters/libsql-replica-adapter.ts", true],
+    ]);
+    expect(gateStale(report.tagged)).toContain("file-level tag");
   });
 });
 

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -2218,6 +2218,19 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(report.tagged.classification.permanent).toBe(1);
   });
 
+  it("fails a file-level reason that states no permanence claim", () => {
+    const report = reportFor(railsWithout(), {
+      "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER.replace(
+        "PERMANENT — Ruby",
+        "Ruby",
+      ),
+    });
+    expect(report.tagged.classification.unclassified).toBe(1);
+    expect(gateUnclassified(report.tagged)).toContain(
+      "connection-adapters/libsql-replica-adapter.ts",
+    );
+  });
+
   it("rejects a file-level tag when a name in the file scores as moved", () => {
     // The postgresql/schema-statements-class.ts shape: no counterpart FILE, but
     // the names exist in Rails elsewhere, so a rename may be owed.

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -49,7 +49,9 @@
  *      its members do — the declaration name is scored surface (step 3), so
  *      such a tag matches and goes stale like any other. On an `interface` the
  *      declaration tag additionally covers every member — see
- *      `collectTaggedEntries`.
+ *      `collectTaggedEntries`. A FILE-level tag (a leading JSDoc block above
+ *      the imports) covers every extra in its file, but only where the blanket
+ *      is sound — see `fileTagVerdict`.
  *   6. Classify each written tag's permanence claim — see `classifyReason`.
  *      Advisory only: the count of tags that never state one is reported so a
  *      batch of new tags is visible, but it does not affect the exit code.
@@ -292,6 +294,62 @@ export interface TaggedEntry {
    * flag as extra is not a stale tag anyone can delete.
    */
   inherited?: boolean;
+  /**
+   * True when the entry is a FILE-level tag (`name` is `FILE_TAG_NAME`): one
+   * reason written at the top of a file that no Rails file maps onto, covering
+   * every otherwise-extra name in it. See `fileTagVerdict` for the two claims
+   * it is NOT allowed to make.
+   */
+  fileLevel?: boolean;
+}
+
+/**
+ * The `name` slot of a file-level tag's key. Not a legal TS identifier, so it
+ * can never collide with a declaration's key in the shared key space.
+ */
+export const FILE_TAG_NAME = "*";
+
+/** Why a file-level tag was refused — see `fileTagVerdict`. */
+export type FileTagRejectionCause = "counterpart-file" | "moved-names";
+
+export interface FileTagRejection {
+  package: string;
+  tsFile: string;
+  cause: FileTagRejectionCause;
+  /** The Rails file that maps onto this TS file (`counterpart-file` only). */
+  rubyFile?: string;
+  /** The names scoring `moved` (`moved-names` only). */
+  movedNames?: string[];
+}
+
+/**
+ * Whether a file-level tag may absorb this file's extras, and why not when it
+ * may not.
+ *
+ * A file-level tag is a blanket by construction, so it is confined to the one
+ * population where a blanket is sound: files no `.rb` maps onto AND whose extra
+ * names appear nowhere in Rails-land. Member inheritance from a tagged CLASS is
+ * refused for the same reason (see `collectTaggedEntries`) — a tagged container
+ * usually has members that DO have Ruby counterparts, so inheriting there would
+ * mask real drift.
+ *
+ * `postgresql/schema-statements-class.ts` is the counterexample that fixes the
+ * shape of this check: it has no counterpart `.rb`, yet its
+ * `PostgreSQLSchemaStatements` is a renamed port of
+ * `PostgreSQL::SchemaStatements` and ~80 of its names score `moved`. "No
+ * counterpart FILE" is not the claim "no counterpart NAME", and `moved` — the
+ * name exists in Rails, just in another `.rb` — is exactly the marker that a
+ * rename may be owed. Refusing on either signal is a hard failure naming the
+ * file, never a silent no-op: a blanket that quietly stops applying would leave
+ * the surface it was absorbing uncounted.
+ */
+export function fileTagVerdict(
+  rubyFile: string | null,
+  extras: readonly ExtraName[],
+): FileTagRejectionCause | null {
+  if (rubyFile !== null) return "counterpart-file";
+  if (extras.some((e) => e.kind === "moved")) return "moved-names";
+  return null;
 }
 
 /**
@@ -413,6 +471,23 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
     for (const [file, fns] of Object.entries(tsPkg.fileFunctions ?? {})) {
       for (const fn of fns) pushMethod(pkg, file, fn);
     }
+    // File-level tags: one written reason per file, keyed on a name no
+    // declaration can occupy, so it neither shadows nor is shadowed by the
+    // per-declaration form. It counts as a written tag like any other — the
+    // permanence gate and the staleness gate both apply to it unchanged.
+    for (const [file, reason] of Object.entries(tsPkg.fileNoRailsEquivalent ?? {})) {
+      const entry: TaggedEntry = {
+        package: pkg,
+        tsFile: file,
+        name: FILE_TAG_NAME,
+        reason,
+        fileLevel: true,
+      };
+      const key = allowKeyOf(entry);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(entry);
+    }
   }
   return out;
 }
@@ -497,6 +572,8 @@ interface Report {
   topN: ExtraFile[];
   /** `@noRailsEquivalent` tags found in the TS manifest. */
   tagged: TaggedSummary;
+  /** File-level tags whose claim the report refuted — see `fileTagVerdict`. */
+  fileTagRejections: FileTagRejection[];
 }
 
 const HELP = `extra-surface — TS files with public API exceeding their Rails counterpart
@@ -531,6 +608,12 @@ Reasoned exceptions: an extra is allowed by tagging its TS declaration
 novel/moved counts and reported as an "Allowed" total; a tag on a name that no
 longer flags is STALE and fails the run. A reason opening with PERMANENT or
 CONVERGEABLE states its permanence claim; a tag stating neither fails the run.
+
+A whole file with no Rails counterpart can carry ONE reason instead: write
+\`@noRailsEquivalent <reason>\` in a JSDoc block at the top of the file, above the
+imports. It covers every otherwise-extra name in that file. The claim is checked,
+not trusted — if a Rails file maps onto it, or any name in it scores as moved
+(the name exists in Rails, just elsewhere), the tag is refused and the run fails.
 
 Requires: pnpm api:compare must have run first to produce
   scripts/api-compare/output/{rails-api.json,ts-api.json}.
@@ -1040,6 +1123,7 @@ function buildPackageReport(
   novelOnly: boolean,
   tagKeys: Set<string>,
   matchedTagKeys: Set<string>,
+  fileTagRejections: FileTagRejection[],
 ): PackageTotals {
   const rubyPkg = ruby.packages[pkg];
   const tsPkg = ts.packages[pkg];
@@ -1100,6 +1184,7 @@ function buildPackageReport(
     pushTo(tsModulesByFile, m.file, m);
   }
   const tsFileFunctions = tsPkg.fileFunctions ?? {};
+  const fileTags = tsPkg.fileNoRailsEquivalent ?? {};
 
   // A Ruby file can declare file-level constants and no class/module at all
   // (rails/engine/commands.rb:3-9 is `Rails::Command::…` constants only), so it
@@ -1149,9 +1234,7 @@ function buildPackageReport(
             Object.keys(rubyPkg.fileConstants?.[rubyFile] ?? {}),
           );
 
-    const extras: ExtraName[] = [];
-    let novelCount = 0;
-    let movedCount = 0;
+    const scored: ExtraName[] = [];
     let allowlistedCount = 0;
     let interfaceExemptCount = 0;
     for (const name of tsNames) {
@@ -1171,9 +1254,39 @@ function buildPackageReport(
         interfaceExemptCount++;
         continue;
       }
-      if (novelOnly && kind !== "novel") continue;
-      extras.push({ name, kind });
-      if (kind === "novel") novelCount++;
+      scored.push({ name, kind });
+    }
+
+    // The file-level form is judged on the FULL scored set, `--novel-only`
+    // notwithstanding: a moved name refutes the claim whether or not this run
+    // is reporting moved names.
+    const fileReason = fileTags[expectedTs];
+    if (fileReason !== undefined) {
+      const cause = fileTagVerdict(rubyFile, scored);
+      if (cause === null) {
+        if (scored.length > 0) {
+          matchedTagKeys.add(allowKeyOf({ package: pkg, tsFile: expectedTs, name: FILE_TAG_NAME }));
+          allowlistedCount += scored.length;
+          scored.length = 0;
+        }
+      } else {
+        fileTagRejections.push({
+          package: pkg,
+          tsFile: expectedTs,
+          cause,
+          ...(rubyFile !== null ? { rubyFile } : {}),
+          ...(cause === "moved-names"
+            ? { movedNames: scored.filter((e) => e.kind === "moved").map((e) => e.name) }
+            : {}),
+        });
+      }
+    }
+
+    const extras = novelOnly ? scored.filter((e) => e.kind === "novel") : scored;
+    let novelCount = 0;
+    let movedCount = 0;
+    for (const e of extras) {
+      if (e.kind === "novel") novelCount++;
       else movedCount++;
     }
     result.totalAllowlisted += allowlistedCount;
@@ -1401,6 +1514,7 @@ export function buildReport(
     buildCrossPackageModules(ruby);
 
   const packages: PackageTotals[] = [];
+  const fileTagRejections: FileTagRejection[] = [];
   const scannedPkgs = new Set<string>();
   for (const pkg of Object.keys(ruby.packages)) {
     if (opts.filterPkg && pkg !== opts.filterPkg) continue;
@@ -1418,6 +1532,7 @@ export function buildReport(
         opts.novelOnly,
         tagKeys,
         matchedTagKeys,
+        fileTagRejections,
       ),
     );
   }
@@ -1468,7 +1583,36 @@ export function buildReport(
     packages,
     topN: allExtras.slice(0, opts.topN),
     tagged: taggedSummary,
+    fileTagRejections,
   };
+}
+
+/**
+ * The file-level claim gate: a `@noRailsEquivalent` written at the top of a
+ * file the report can see a Rails counterpart for. Separate from `gateStale`
+ * (which the same tag also trips, having absorbed nothing) because the fix is
+ * different: a stale tag is deleted, a refuted one is the signal that the file
+ * needs per-name reasons — or renames — instead of a blanket.
+ * Returns the failure message, or `null` when the run passes.
+ */
+export function gateFileTagRejections(rejections: readonly FileTagRejection[]): string | null {
+  if (rejections.length === 0) return null;
+  const lines = rejections.map((r) =>
+    r.cause === "counterpart-file"
+      ? `  - ${r.package}  ${r.tsFile} — Rails counterpart file ${r.rubyFile}`
+      : `  - ${r.package}  ${r.tsFile} — ${r.movedNames?.length ?? 0} moved name(s): ` +
+        (r.movedNames ?? []).slice(0, 8).join(", "),
+  );
+  return (
+    `\nextra-surface: ${rejections.length} file-level @noRailsEquivalent tag(s) claim a ` +
+    "file has no Rails counterpart, but the report finds one. A file-level tag is a " +
+    "blanket, so it is confined to files no `.rb` maps onto whose extra names appear " +
+    "nowhere in Rails-land; a `moved` name means the name DOES exist in Rails, just in " +
+    "another file — a rename may be owed, and the blanket would hide it. Tag the names " +
+    "individually, or converge them:\n" +
+    lines.join("\n") +
+    "\n"
+  );
 }
 
 /**
@@ -1485,7 +1629,12 @@ export function gateStale(tagged: TaggedSummary): string | null {
     "the reason and was parsed as a real JSDoc tag, or the tag covers a moved " +
     "(misplaced) port that belongs in its Rails-layout file. Delete the tag " +
     "next to the code:\n" +
-    tagged.stale.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
+    tagged.stale
+      .map(
+        (e) =>
+          `  - ${e.package}  ${e.tsFile}  ${e.fileLevel ? "(file-level tag — nothing left to cover)" : e.name}`,
+      )
+      .join("\n") +
     "\n"
   );
 }
@@ -1564,6 +1713,8 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   }
   const unclassifiedMessage = gateUnclassified(report.tagged);
   if (unclassifiedMessage) failures.push(unclassifiedMessage);
+  const rejectedMessage = gateFileTagRejections(report.fileTagRejections);
+  if (rejectedMessage) failures.push(rejectedMessage);
 
   if (failures.length === 0) return;
   for (const failure of failures) console.error(failure);

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -304,8 +304,10 @@ export interface TaggedEntry {
 }
 
 /**
- * The `name` slot of a file-level tag's key. Not a legal TS identifier, so it
- * can never collide with a declaration's key in the shared key space.
+ * The `name` slot of a file-level tag's key. Not a legal TS identifier, so a
+ * file-level tag neither shadows nor is shadowed by a per-declaration one in
+ * the shared key space, and it counts as a written tag like any other — the
+ * permanence gate and the staleness gate both apply to it unchanged.
  */
 export const FILE_TAG_NAME = "*";
 
@@ -342,6 +344,9 @@ export interface FileTagRejection {
  * rename may be owed. Refusing on either signal is a hard failure naming the
  * file, never a silent no-op: a blanket that quietly stops applying would leave
  * the surface it was absorbing uncounted.
+ *
+ * `extras` is the FULL scored set, `--novel-only` notwithstanding: a moved name
+ * refutes the claim whether or not this run is reporting moved names.
  */
 export function fileTagVerdict(
   rubyFile: string | null,
@@ -471,10 +476,6 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
     for (const [file, fns] of Object.entries(tsPkg.fileFunctions ?? {})) {
       for (const fn of fns) pushMethod(pkg, file, fn);
     }
-    // File-level tags: one written reason per file, keyed on a name no
-    // declaration can occupy, so it neither shadows nor is shadowed by the
-    // per-declaration form. It counts as a written tag like any other — the
-    // permanence gate and the staleness gate both apply to it unchanged.
     for (const [file, reason] of Object.entries(tsPkg.fileNoRailsEquivalent ?? {})) {
       const entry: TaggedEntry = {
         package: pkg,
@@ -1257,11 +1258,7 @@ function buildPackageReport(
       scored.push({ name, kind });
     }
 
-    // The file-level form is judged on the FULL scored set, `--novel-only`
-    // notwithstanding: a moved name refutes the claim whether or not this run
-    // is reporting moved names.
-    const fileReason = fileTags[expectedTs];
-    if (fileReason !== undefined) {
+    if (fileTags[expectedTs] !== undefined) {
       const cause = fileTagVerdict(rubyFile, scored);
       if (cause === null) {
         if (scored.length > 0) {
@@ -1269,7 +1266,7 @@ function buildPackageReport(
           allowlistedCount += scored.length;
           scored.length = 0;
         }
-      } else {
+      } else if (!fileTagRejections.some((r) => r.package === pkg && r.tsFile === expectedTs)) {
         fileTagRejections.push({
           package: pkg,
           tsFile: expectedTs,

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -331,9 +331,7 @@ export interface FileTagRejection {
  * A file-level tag is a blanket by construction, so it is confined to the one
  * population where a blanket is sound: files no `.rb` maps onto AND whose extra
  * names appear nowhere in Rails-land. Member inheritance from a tagged CLASS is
- * refused for the same reason (see `collectTaggedEntries`) — a tagged container
- * usually has members that DO have Ruby counterparts, so inheriting there would
- * mask real drift.
+ * refused for the same reason (see `collectTaggedEntries`).
  *
  * `postgresql/schema-statements-class.ts` is the counterexample that fixes the
  * shape of this check: it has no counterpart `.rb`, yet its
@@ -341,9 +339,9 @@ export interface FileTagRejection {
  * `PostgreSQL::SchemaStatements` and ~80 of its names score `moved`. "No
  * counterpart FILE" is not the claim "no counterpart NAME", and `moved` — the
  * name exists in Rails, just in another `.rb` — is exactly the marker that a
- * rename may be owed. Refusing on either signal is a hard failure naming the
- * file, never a silent no-op: a blanket that quietly stops applying would leave
- * the surface it was absorbing uncounted.
+ * rename may be owed. Refusing is a hard failure naming the file, never a
+ * silent no-op: a blanket that quietly stopped applying would leave the surface
+ * it was absorbing uncounted.
  *
  * `extras` is the FULL scored set, `--novel-only` notwithstanding: a moved name
  * refutes the claim whether or not this run is reporting moved names.
@@ -1602,11 +1600,9 @@ export function gateFileTagRejections(rejections: readonly FileTagRejection[]): 
   );
   return (
     `\nextra-surface: ${rejections.length} file-level @noRailsEquivalent tag(s) claim a ` +
-    "file has no Rails counterpart, but the report finds one. A file-level tag is a " +
-    "blanket, so it is confined to files no `.rb` maps onto whose extra names appear " +
-    "nowhere in Rails-land; a `moved` name means the name DOES exist in Rails, just in " +
-    "another file — a rename may be owed, and the blanket would hide it. Tag the names " +
-    "individually, or converge them:\n" +
+    "file has no Rails counterpart, but the report finds one. A `moved` name means the " +
+    "name DOES exist in Rails, just in another file — a rename may be owed, and the " +
+    "blanket would hide it. Tag the names individually, or converge them:\n" +
     lines.join("\n") +
     "\n"
   );

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1596,7 +1596,8 @@ export function gateFileTagRejections(rejections: readonly FileTagRejection[]): 
     r.cause === "counterpart-file"
       ? `  - ${r.package}  ${r.tsFile} — Rails counterpart file ${r.rubyFile}`
       : `  - ${r.package}  ${r.tsFile} — ${r.movedNames?.length ?? 0} moved name(s): ` +
-        (r.movedNames ?? []).slice(0, 8).join(", "),
+        (r.movedNames ?? []).slice(0, 8).join(", ") +
+        ((r.movedNames?.length ?? 0) > 8 ? ", …" : ""),
   );
   return (
     `\nextra-surface: ${rejections.length} file-level @noRailsEquivalent tag(s) claim a ` +

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -296,9 +296,9 @@ export interface TaggedEntry {
   inherited?: boolean;
   /**
    * True when the entry is a FILE-level tag (`name` is `FILE_TAG_NAME`): one
-   * reason written at the top of a file that no Rails file maps onto, covering
-   * every otherwise-extra name in it. See `fileTagVerdict` for the two claims
-   * it is NOT allowed to make.
+   * reason at the top of a file that no Rails file maps onto, covering every
+   * otherwise-extra name in it. See `fileTagVerdict` for the claims it may not
+   * make.
    */
   fileLevel?: boolean;
 }
@@ -475,17 +475,10 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
       for (const fn of fns) pushMethod(pkg, file, fn);
     }
     for (const [file, reason] of Object.entries(tsPkg.fileNoRailsEquivalent ?? {})) {
-      const entry: TaggedEntry = {
-        package: pkg,
-        tsFile: file,
-        name: FILE_TAG_NAME,
-        reason,
-        fileLevel: true,
-      };
-      const key = allowKeyOf(entry);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(entry);
+      const entry: TaggedEntry = { package: pkg, tsFile: file, name: FILE_TAG_NAME, reason };
+      if (seen.has(allowKeyOf(entry))) continue;
+      seen.add(allowKeyOf(entry));
+      out.push({ ...entry, fileLevel: true });
     }
   }
   return out;
@@ -1624,10 +1617,7 @@ export function gateStale(tagged: TaggedSummary): string | null {
     "(misplaced) port that belongs in its Rails-layout file. Delete the tag " +
     "next to the code:\n" +
     tagged.stale
-      .map(
-        (e) =>
-          `  - ${e.package}  ${e.tsFile}  ${e.fileLevel ? "(file-level tag — nothing left to cover)" : e.name}`,
-      )
+      .map((e) => `  - ${e.package}  ${e.tsFile}  ${e.fileLevel ? "(file-level tag)" : e.name}`)
       .join("\n") +
     "\n"
   );

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1464,6 +1464,81 @@ describe("extractFromProgram — re-export attribution", () => {
   });
 });
 
+function classOf(info: PackageInfo, name: string): ClassInfo {
+  return Object.values(info.classes).find((c) => c.name === name)!;
+}
+
+describe("extractFromProgram — file-level @noRailsEquivalent JSDoc", () => {
+  it("records a reason written above the imports against the file", () => {
+    const info = extractFromFiles("/p", {
+      "libsql-adapter.ts": `
+        /**
+         * SQLite adapter backed by the \`libsql\` client.
+         *
+         * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver,
+         * so Rails has no class to map a per-driver subclass onto.
+         */
+        import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+        export class LibSQLAdapter extends SQLite3Adapter {}
+      `,
+      "sqlite3-adapter.ts": `export class SQLite3Adapter {}`,
+    });
+    expect(info.fileNoRailsEquivalent).toEqual({
+      "libsql-adapter.ts":
+        "PERMANENT — Ruby binds exactly one SQLite driver, so Rails has no class to " +
+        "map a per-driver subclass onto.",
+    });
+  });
+
+  it("leaves a declaration's own leading block as a declaration tag", () => {
+    // No imports, so the top block is what TypeScript binds to the class —
+    // reading it as file-level too would widen every such tag into a blanket.
+    const info = extractFromFiles("/p", {
+      "connection-pool.ts": `
+        /** @noRailsEquivalent PERMANENT — Rails nests this class inside NullPool */
+        export class NullConfig {}
+      `,
+    });
+    expect(info.fileNoRailsEquivalent).toEqual({});
+    expect(classOf(info, "NullConfig").noRailsEquivalent).toBe(
+      "PERMANENT — Rails nests this class inside NullPool",
+    );
+  });
+
+  it("ignores a tag written below the imports", () => {
+    const info = extractFromFiles("/p", {
+      "libsql-adapter.ts": `
+        import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+        /** @noRailsEquivalent PERMANENT — bound to the class, not to the file */
+        export class LibSQLAdapter extends SQLite3Adapter {}
+      `,
+      "sqlite3-adapter.ts": `export class SQLite3Adapter {}`,
+    });
+    expect(info.fileNoRailsEquivalent).toEqual({});
+    expect(classOf(info, "LibSQLAdapter").noRailsEquivalent).toBe(
+      "PERMANENT — bound to the class, not to the file",
+    );
+  });
+
+  it("rejects a file-level tag with no reason", () => {
+    expect(() =>
+      extractFromFiles("/p", {
+        "libsql-adapter.ts": `
+          /**
+           * @noRailsEquivalent
+           */
+          import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+          export class LibSQLAdapter extends SQLite3Adapter {}
+        `,
+        "sqlite3-adapter.ts": `export class SQLite3Adapter {}`,
+      }),
+    ).toThrow(/@noRailsEquivalent needs a reason/);
+  });
+});
+
 describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
   it("records the reason on a tagged class member and leaves its sibling bare", () => {
     const info = extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1491,9 +1491,7 @@ describe("extractFromProgram — file-level @noRailsEquivalent JSDoc", () => {
     });
   });
 
-  it("leaves a declaration's own leading block as a declaration tag", () => {
-    // No imports, so the top block is what TypeScript binds to the class —
-    // reading it as file-level too would widen every such tag into a blanket.
+  it("leaves the leading block of an import-less file as its declaration's tag", () => {
     const info = extractFromFiles("/p", {
       "connection-pool.ts": `
         /** @noRailsEquivalent PERMANENT — Rails nests this class inside NullPool */

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1521,22 +1521,6 @@ describe("extractFromProgram — file-level @noRailsEquivalent JSDoc", () => {
       "PERMANENT — bound to the class, not to the file",
     );
   });
-
-  it("rejects a file-level tag with no reason", () => {
-    expect(() =>
-      extractFromFiles("/p", {
-        "libsql-adapter.ts": `
-          /**
-           * @noRailsEquivalent
-           */
-          import { SQLite3Adapter } from "./sqlite3-adapter.js";
-
-          export class LibSQLAdapter extends SQLite3Adapter {}
-        `,
-        "sqlite3-adapter.ts": `export class SQLite3Adapter {}`,
-      }),
-    ).toThrow(/@noRailsEquivalent needs a reason/);
-  });
 });
 
 describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1506,6 +1506,23 @@ describe("extractFromProgram — file-level @noRailsEquivalent JSDoc", () => {
     );
   });
 
+  it("rejects a file-level reason truncated by a bare @word in its prose", () => {
+    expect(() =>
+      extractFromFiles("/p", {
+        "libsql-adapter.ts": `
+          /**
+           * @noRailsEquivalent PERMANENT — trails binds each client in its own
+           * subclass, the way @deprecated APIs are kept apart.
+           */
+          import { SQLite3Adapter } from "./sqlite3-adapter.js";
+
+          export class LibSQLAdapter extends SQLite3Adapter {}
+        `,
+        "sqlite3-adapter.ts": `export class SQLite3Adapter {}`,
+      }),
+    ).toThrow(/truncated by a bare `@deprecated`/);
+  });
+
   it("ignores a tag written below the imports", () => {
     const info = extractFromFiles("/p", {
       "libsql-adapter.ts": `

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1638,38 +1638,16 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
  * too would silently widen every such tag into a blanket. So a file with no
  * imports has no file-level form — it uses the per-declaration one.
  *
- * The prose runs to the next line-leading `@tag` or the end of the block, and
- * an empty reason is the same hard error it is on a declaration.
+ * The block is read through `noRailsEquivalentReason` — TypeScript binds a
+ * file's leading block to that first import, so the file-level form goes
+ * through the SAME parse as the declaration-level one and inherits both of its
+ * hard errors: an empty reason, and a reason truncated by a bare `@word` in its
+ * prose. A checked claim that could be silently cut short would be neither.
  */
 export function fileLevelNoRailsEquivalentReason(sourceFile: ts.SourceFile): string | undefined {
   const first = sourceFile.statements[0];
   if (first === undefined || !ts.isImportDeclaration(first)) return undefined;
-  const text = sourceFile.getFullText();
-  const ranges = ts.getLeadingCommentRanges(text, 0) ?? [];
-  const block = ranges.find(
-    (r) => r.kind === ts.SyntaxKind.MultiLineCommentTrivia && text.startsWith("/**", r.pos),
-  );
-  if (block === undefined) return undefined;
-  const lines = text
-    .slice(block.pos + 3, block.end - 2)
-    .split("\n")
-    .map((line) => line.replace(/^\s*\*?/, "").trim());
-  const start = lines.findIndex((line) => /^@noRailsEquivalent\b/.test(line));
-  if (start === -1) return undefined;
-  const prose = [lines[start].replace(/^@noRailsEquivalent\b/, "")];
-  for (const line of lines.slice(start + 1)) {
-    if (/^@\w/.test(line)) break;
-    prose.push(line);
-  }
-  const reason = prose.join(" ").replace(/\s+/g, " ").trim();
-  if (reason === "") {
-    const line = sourceFile.getLineAndCharacterOfPosition(block.pos).line + start + 1;
-    throw new Error(
-      `@noRailsEquivalent needs a reason: ${sourceFile.fileName}:${line} — ` +
-        "state why this file has no Rails counterpart.",
-    );
-  }
-  return reason;
+  return noRailsEquivalentReason(first);
 }
 
 /**

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1630,19 +1630,17 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
  * one gem — and writing the same reason on every declaration in them is pure
  * repetition (RFC 0072). The file-level form states it once.
  *
- * It is read from the first JSDoc block in the file, and only when that block
- * sits above the IMPORTS — the one placement where it documents the file rather
- * than a declaration. A block at the top of a file whose first statement is a
- * declaration is that declaration's own doc block (TypeScript binds it there,
- * and `noRailsEquivalentReason` already reads it); treating it as file-level
- * too would silently widen every such tag into a blanket. So a file with no
- * imports has no file-level form — it uses the per-declaration one.
+ * It is read only from a block above the IMPORTS — the one placement where it
+ * documents the file rather than a declaration. A block at the top of a file
+ * whose first statement is a declaration is that declaration's own doc block
+ * (TypeScript binds it there, and `noRailsEquivalentReason` already reads it);
+ * treating it as file-level too would silently widen every such tag into a
+ * blanket. So a file with no imports has no file-level form.
  *
- * The block is read through `noRailsEquivalentReason` — TypeScript binds a
- * file's leading block to that first import, so the file-level form goes
- * through the SAME parse as the declaration-level one and inherits both of its
- * hard errors: an empty reason, and a reason truncated by a bare `@word` in its
- * prose. A checked claim that could be silently cut short would be neither.
+ * TypeScript binds a file's leading block to that first import, so the reason
+ * goes through the SAME parse as the declaration-level one and inherits both of
+ * its hard errors: an empty reason, and a reason truncated by a bare `@word` in
+ * its prose. A claim that could be silently cut short would not be a checked one.
  */
 export function fileLevelNoRailsEquivalentReason(sourceFile: ts.SourceFile): string | undefined {
   const first = sourceFile.statements[0];

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -502,11 +502,13 @@ export function extractFromProgram(
   // files reach it through the container's own imports even though the entry
   // list already skipped them — filter here too or the de-overlap is a no-op.
   const excludePrefixes = excludeDirs.map((dir) => dir.replace(/\\/g, "/") + "/");
-  const info: PackageInfo & Required<Pick<PackageInfo, "fileFunctions" | "fileConstants">> = {
+  const info: PackageInfo &
+    Required<Pick<PackageInfo, "fileFunctions" | "fileConstants" | "fileNoRailsEquivalent">> = {
     classes: {},
     modules: {},
     fileFunctions: {},
     fileConstants: {},
+    fileNoRailsEquivalent: {},
   };
   const pendingReExports: PendingReExport[] = [];
   const checker = program.getTypeChecker();
@@ -929,6 +931,9 @@ export function extractFromProgram(
 
     const fileConstants = extractFileConstants(sourceFile);
     if (Object.keys(fileConstants).length > 0) info.fileConstants[relPath] = fileConstants;
+
+    const fileReason = fileLevelNoRailsEquivalentReason(sourceFile);
+    if (fileReason !== undefined) info.fileNoRailsEquivalent[relPath] = fileReason;
 
     // If a file has exported functions but no class/interface/namespace,
     // also create a module entry from the file name for backward compat.
@@ -1613,6 +1618,58 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
     return reason;
   }
   return undefined;
+}
+
+/**
+ * Reason prose of a FILE-level `@noRailsEquivalent` tag, or undefined when the
+ * file carries none.
+ *
+ * The declaration-level tag answers "this NAME has no Rails counterpart". Some
+ * whole files are in that position — `better-sqlite3-adapter.ts` exists because
+ * the JS ecosystem has several interchangeable SQLite clients where Ruby binds
+ * one gem — and writing the same reason on every declaration in them is pure
+ * repetition (RFC 0072). The file-level form states it once.
+ *
+ * It is read from the first JSDoc block in the file, and only when that block
+ * sits above the IMPORTS — the one placement where it documents the file rather
+ * than a declaration. A block at the top of a file whose first statement is a
+ * declaration is that declaration's own doc block (TypeScript binds it there,
+ * and `noRailsEquivalentReason` already reads it); treating it as file-level
+ * too would silently widen every such tag into a blanket. So a file with no
+ * imports has no file-level form — it uses the per-declaration one.
+ *
+ * The prose runs to the next line-leading `@tag` or the end of the block, and
+ * an empty reason is the same hard error it is on a declaration.
+ */
+export function fileLevelNoRailsEquivalentReason(sourceFile: ts.SourceFile): string | undefined {
+  const first = sourceFile.statements[0];
+  if (first === undefined || !ts.isImportDeclaration(first)) return undefined;
+  const text = sourceFile.getFullText();
+  const ranges = ts.getLeadingCommentRanges(text, 0) ?? [];
+  const block = ranges.find(
+    (r) => r.kind === ts.SyntaxKind.MultiLineCommentTrivia && text.startsWith("/**", r.pos),
+  );
+  if (block === undefined) return undefined;
+  const lines = text
+    .slice(block.pos + 3, block.end - 2)
+    .split("\n")
+    .map((line) => line.replace(/^\s*\*?/, "").trim());
+  const start = lines.findIndex((line) => /^@noRailsEquivalent\b/.test(line));
+  if (start === -1) return undefined;
+  const prose = [lines[start].replace(/^@noRailsEquivalent\b/, "")];
+  for (const line of lines.slice(start + 1)) {
+    if (/^@\w/.test(line)) break;
+    prose.push(line);
+  }
+  const reason = prose.join(" ").replace(/\s+/g, " ").trim();
+  if (reason === "") {
+    const line = sourceFile.getLineAndCharacterOfPosition(block.pos).line + start + 1;
+    throw new Error(
+      `@noRailsEquivalent needs a reason: ${sourceFile.fileName}:${line} — ` +
+        "state why this file has no Rails counterpart.",
+    );
+  }
+  return reason;
 }
 
 /**

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -197,6 +197,15 @@ export interface PackageInfo {
   modules: Record<string, ClassInfo>;
   fileFunctions?: Record<string, MethodInfo[]>;
   fileConstants?: Record<string, Record<string, LiteralValue>>; // file → NAME → literal value
+  /**
+   * TS-side only: file → reason prose of a FILE-level `@noRailsEquivalent`
+   * tag, written in a JSDoc block at the very top of the file (above the
+   * imports) rather than on any one declaration. It claims the whole file has
+   * no Rails counterpart, so extra-surface.ts lets one reason cover every
+   * otherwise-novel name in it — see `collectFileTags` there, which also
+   * rejects the claim when the file DOES have a counterpart.
+   */
+  fileNoRailsEquivalent?: Record<string, string>;
 }
 
 export interface ApiManifest {

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -202,8 +202,8 @@ export interface PackageInfo {
    * tag, written in a JSDoc block at the very top of the file (above the
    * imports) rather than on any one declaration. It claims the whole file has
    * no Rails counterpart, so extra-surface.ts lets one reason cover every
-   * otherwise-novel name in it — see `collectFileTags` there, which also
-   * rejects the claim when the file DOES have a counterpart.
+   * otherwise-novel name in it — see `fileTagVerdict` there, which refuses the
+   * claim when the file DOES have a counterpart.
    */
   fileNoRailsEquivalent?: Record<string, string>;
 }


### PR DESCRIPTION
## What

Adds a **file-level** `@noRailsEquivalent` form: one reason in a JSDoc block at
the top of a file (above the imports) covering every otherwise-extra name in it.
Before this, a whole file with no Rails counterpart had to repeat the same reason
on every declaration — ~50 of PR #5927's 66 added lines were one eight-line
reason duplicated across six SQLite driver-variant adapters. Those six now state
it once.

## The claim is checked, not trusted

A file-level tag is a blanket, so it is confined to the population where a
blanket is sound. `fileTagVerdict` refuses it — a hard failure naming the file,
never a silent no-op — when:

- **a Rails counterpart `.rb` maps onto the file**, or
- **any name in the file scores as `moved`** — the name exists in Rails, just in
  another `.rb`, which is precisely the marker that a rename may be owed.

`connection-adapters/postgresql/schema-statements-class.ts` is why the second arm
exists: `rubyFile === null`, yet `PostgreSQLSchemaStatements` is a renamed port of
`PostgreSQL::SchemaStatements` and ~80 of its names score `moved`. "No counterpart
FILE" is not the claim "no counterpart NAME". A refused tag absorbs nothing, so it
also lands in the STALE list, and the permanence gate (`PERMANENT` /
`CONVERGEABLE`) applies to it unchanged.

The form is read only when the block sits above the **imports**. A block at the
top of a file whose first statement is a declaration is that declaration's own
doc block — TypeScript binds it there and `noRailsEquivalentReason` already reads
it — so treating it as file-level too would silently widen every such tag into a
blanket.

## Totals

`pnpm api:extra --package activerecord`, before and after the conversion:
Novel **542**, Allowed **82** — net-zero, as required. The written-tag count drops
110 → 109 (six files' 7 declaration tags become 6 file tags).

## Not in scope

`sqlite/libsql.ts` (11 novel), `abstract/temporal-wire.ts` (10),
`abstract/sql-datetime.ts` (12) are now taggable this way, but each needs its own
justification prose and would *change* the totals; that is separate work, not part
of the mechanism.

## Review round 1

- The `fileNoRailsEquivalent` doc pointed at a `collectFileTags` that does not
  exist; it now points at `fileTagVerdict`.
- The hand-rolled file-level JSDoc parser is gone. TypeScript binds a file's
  leading block to its first import, so `fileLevelNoRailsEquivalentReason` now
  just calls `noRailsEquivalentReason` on that import — the file-level form goes
  through the SAME parse as the declaration-level one and inherits both hard
  errors, including the `proseTagAfter` truncation guard the reviewer flagged as
  missing. Covered by a new test (a bare `@deprecated` in file-level prose
  raises rather than silently truncating the reason). Net −20 LOC.

## Size

**539 LOC** (477 + 62), 8% over the 500 ceiling. Trajectory: 557 at open → 534
after two trimming rounds → 539 once the file-function-shape test was added
(that test covers `sqlite/libsql.ts`'s shape, the mechanism's next real user, and
is worth its 5 lines).

Owner decision: accept as-is. The mechanism and its first user are not separable
— the acceptance criterion is that converting the six driver files is net-zero on
Novel and Allowed, which can only be shown with both halves in one tree — so
there is no deferrable remainder for `tasks new` to carry. Splitting would land a
checker with zero real users and demonstrate net-zero only from synthetic
fixtures.

## Rebase

Rebased onto `origin/main` after #5949 ("hoist tag-order allowlist above the
worker dispatch") landed: that TDZ fix moved `TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT`
to the top of `extract-ts-api.ts`, and this branch had inserted
`fileLevelNoRailsEquivalentReason` into the spot it vacated. Resolved by keeping
the hoist and dropping the copy this branch still carried at the old location —
reinstating it would have reintroduced the crash #5949 fixed. One definition
remains, at line 167.

## Tests

`pnpm vitest run scripts/api-compare` — 922 pass, including the accept arm and
both reject arms. `pnpm api:detached` and `pnpm api:reasons` clean.

Closes-story: file-level-no-rails-equivalent-tag
