### PR TITLE
refactor(globalid): make SignedGlobalID inherit from GlobalID

### DIFF
--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -1,11 +1,9 @@
 import { getApp } from "./config.js";
 import { GID, validateApp, type GidComponents } from "./uri/gid.js";
-// TYPE-ONLY on purpose: `global-id` must stay a leaf of the
-// global-id ↔ signed-global-id ↔ locator cycle. `class SignedGlobalID extends
-// GlobalID` reads the `GlobalID` binding at class-body evaluation time, so any
-// runtime edge out of this module that loops back here would evaluate
-// signed-global-id while `GlobalID` is still in TDZ (native ESM throws
-// ReferenceError). `find` therefore reaches Locator through a dynamic import.
+// TYPE-ONLY on purpose: a runtime edge from here back into the
+// global-id ↔ signed-global-id ↔ locator cycle would evaluate
+// `class SignedGlobalID extends GlobalID` while `GlobalID` is still in TDZ.
+// `find` therefore reaches Locator through a dynamic import.
 import type { LocateOptions, LocatorModel } from "./locator.js";
 import { constantize } from "@blazetrails/activesupport";
 
@@ -38,20 +36,9 @@ export interface GlobalIDOptions {
   [key: string]: unknown;
 }
 
-/**
- * @internal Constructor shape behind the `new this(...)` in `create` / `parse`,
- * mirroring Ruby's polymorphic `new`: `SignedGlobalID.create` runs the
- * inherited `GlobalID.create` body and gets a SignedGlobalID back.
- */
-export type GlobalIDConstructor<T extends GlobalID, O extends GlobalIDOptions> = new (
-  gid: string | GID,
-  options?: O,
-) => T;
-
 export class GlobalID {
   readonly uri: string;
-  /** @internal Snapshot of the parsed `URI::GID`; Rails delegates to `@uri`. */
-  protected readonly _components: GidComponents;
+  private readonly _components: GidComponents;
 
   /** Mirrors: GlobalID#initialize(gid, options) */
   constructor(gid: string | GID, _options: GlobalIDOptions = {}) {
@@ -73,9 +60,13 @@ export class GlobalID {
     return this._components.params;
   }
 
-  /** Mirrors: GlobalID.create */
+  /**
+   * Mirrors: GlobalID.create — the `this` constructor type carries Ruby's
+   * polymorphic `new`, so `SignedGlobalID.create` runs this body and hands
+   * back a SignedGlobalID.
+   */
   static create<T extends GlobalID, O extends GlobalIDOptions>(
-    this: GlobalIDConstructor<T, O>,
+    this: new (gid: string | GID, options?: O) => T,
     model: GlobalIDModel,
     options?: O,
   ): T {
@@ -87,7 +78,7 @@ export class GlobalID {
       );
     }
     // Rails: `options.except(:app, :verifier, :for)` — every other key,
-    // including SignedGlobalID's :expires_in / :expires_at, becomes a URI param.
+    // including SignedGlobalID's expiration options, becomes a URI param.
     const { app: _a, verifier: _v, for: _f, ...rest } = opts;
     const filteredParams: Record<string, string> = {};
     for (const [k, v] of Object.entries(rest)) {

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -1,13 +1,13 @@
 import { getApp } from "./config.js";
 import { GID, validateApp, type GidComponents } from "./uri/gid.js";
-import { Locator, type LocateOptions, type LocatorModel } from "./locator.js";
+// TYPE-ONLY on purpose: `global-id` must stay a leaf of the
+// global-id ↔ signed-global-id ↔ locator cycle. `class SignedGlobalID extends
+// GlobalID` reads the `GlobalID` binding at class-body evaluation time, so any
+// runtime edge out of this module that loops back here would evaluate
+// signed-global-id while `GlobalID` is still in TDZ (native ESM throws
+// ReferenceError). `find` therefore reaches Locator through a dynamic import.
+import type { LocateOptions, LocatorModel } from "./locator.js";
 import { constantize } from "@blazetrails/activesupport";
-// LAZY-IMPORT CYCLE: global-id ↔ signed-global-id ↔ locator. Safe because
-// every cross-module reference below happens inside a method body (runtime),
-// not at class-body init time. Do NOT add module-level `const X = SignedGlobalID.foo`
-// or similar — native ESM throws ReferenceError (TDZ) for an uninitialized
-// imported binding accessed during the initial circular evaluation.
-import { SignedGlobalID } from "./signed-global-id.js";
 
 /**
  * @internal Mirrors Ruby's `model <= GlobalID` — matches the identity
@@ -38,18 +38,26 @@ export interface GlobalIDOptions {
   [key: string]: unknown;
 }
 
+/**
+ * @internal Constructor shape behind the `new this(...)` in `create` / `parse`,
+ * mirroring Ruby's polymorphic `new`: `SignedGlobalID.create` runs the
+ * inherited `GlobalID.create` body and gets a SignedGlobalID back.
+ */
+export type GlobalIDConstructor<T extends GlobalID, O extends GlobalIDOptions> = new (
+  gid: string | GID,
+  options?: O,
+) => T;
+
 export class GlobalID {
   readonly uri: string;
-  private readonly _components: GidComponents;
+  /** @internal Snapshot of the parsed `URI::GID`; Rails delegates to `@uri`. */
+  protected readonly _components: GidComponents;
 
-  /**
-   * Rails' `GlobalID#initialize` stores the `URI::GID` and delegates
-   * app/model_name/model_id/params/to_s to it; we snapshot its components
-   * instead, so every entry point goes through a parsed GID.
-   */
-  private constructor(gid: GID) {
-    this.uri = gid.toString();
-    this._components = gid.deconstructKeys();
+  /** Mirrors: GlobalID#initialize(gid, options) */
+  constructor(gid: string | GID, _options: GlobalIDOptions = {}) {
+    const parsed = gid instanceof GID ? gid : GID.parse(gid);
+    this.uri = parsed.toString();
+    this._components = parsed.deconstructKeys();
   }
 
   get app(): string {
@@ -66,33 +74,41 @@ export class GlobalID {
   }
 
   /** Mirrors: GlobalID.create */
-  static create(model: GlobalIDModel, options: GlobalIDOptions = {}): GlobalID {
-    const app = options.app ?? getApp();
+  static create<T extends GlobalID, O extends GlobalIDOptions>(
+    this: GlobalIDConstructor<T, O>,
+    model: GlobalIDModel,
+    options?: O,
+  ): T {
+    const opts: GlobalIDOptions = options ?? {};
+    const app = opts.app ?? getApp();
     if (!app) {
       throw new Error(
         "An app is required to create a GlobalID. Pass the :app option or set the default GlobalID.app via setApp().",
       );
     }
-    const { app: _a, verifier: _v, for: _f, ...rest } = options as Record<string, unknown>;
+    // Rails: `options.except(:app, :verifier, :for)` — every other key,
+    // including SignedGlobalID's :expires_in / :expires_at, becomes a URI param.
+    const { app: _a, verifier: _v, for: _f, ...rest } = opts;
     const filteredParams: Record<string, string> = {};
     for (const [k, v] of Object.entries(rest)) {
       if (v != null) filteredParams[k] = String(v);
     }
     const modelName = model.constructor.name;
     const params = Object.keys(filteredParams).length ? filteredParams : null;
-    return new GlobalID(GID.build({ app, modelName, modelId: model.id, params }));
+    return new this(GID.build({ app, modelName, modelId: model.id, params }), options);
   }
 
   /** Mirrors: GlobalID.parse — falls back to base64-decoded form. */
-  static parse(gid: string | GlobalID, _options: GlobalIDOptions = {}): GlobalID | null {
-    if (gid instanceof GlobalID) return gid;
+  static parse(gid: string | GlobalID, options: GlobalIDOptions = {}): GlobalID | null {
+    if (gid instanceof this) return gid;
+    const str = String(gid);
     try {
-      return new GlobalID(GID.parse(gid));
+      return new this(GID.parse(str), options);
     } catch {
       try {
-        const b64 = gid.replace(/-/g, "+").replace(/_/g, "/");
+        const b64 = str.replace(/-/g, "+").replace(/_/g, "/");
         const decoded = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
-        return new GlobalID(GID.parse(decoded));
+        return new this(GID.parse(decoded), options);
       } catch {
         return null;
       }
@@ -108,14 +124,19 @@ export class GlobalID {
     return this.uri;
   }
 
-  /** Mirrors: GlobalID#as_json — `JSON.stringify(gid)` produces `"gid://..."`. */
+  /**
+   * Mirrors: GlobalID#as_json — `JSON.stringify(gid)` produces `"gid://..."`.
+   * Rails' `as_json` calls `to_s`, so a SignedGlobalID serializes to its
+   * signed token rather than the bare URI; route through `toString()` to
+   * keep that polymorphism.
+   */
   toJSON(): string {
-    return this.uri;
+    return this.toString();
   }
 
   /** @internal */
   [Symbol.toPrimitive](_hint: string): string {
-    return this.uri;
+    return this.toString();
   }
 
   /** Mirrors: GlobalID#== */
@@ -131,13 +152,12 @@ export class GlobalID {
   /**
    * Mirrors: GlobalID#model_class — `model_name.constantize`. Raises if the
    * resolved class is GlobalID / SignedGlobalID (Rails has the same guard
-   * against recursive `model_class` lookup).
+   * against recursive `model_class` lookup); `SignedGlobalID < GlobalID`, so
+   * the single `model <= GlobalID` check covers both.
    */
   get modelClass(): LocatorModel {
     const klass = constantize(this.modelName) as LocatorModel;
-    // Rails' `if model <= GlobalID` covers SGID too because SGID < GID in
-    // Ruby. In TS they're peers, so both branches are needed.
-    if (isOrExtends(klass, GlobalID) || isOrExtends(klass, SignedGlobalID)) {
+    if (isOrExtends(klass, GlobalID)) {
       throw new Error("GlobalID and SignedGlobalID cannot be used as model_class.");
     }
     return klass;
@@ -148,7 +168,8 @@ export class GlobalID {
    *
    * Mirrors: GlobalID#find — delegates to `Locator.locate(self, options)`.
    */
-  find(options?: LocateOptions): Promise<unknown | null> {
+  async find(options?: LocateOptions): Promise<unknown | null> {
+    const { Locator } = await import("./locator.js");
     return Locator.locate(this, options);
   }
 }

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -7,11 +7,7 @@ export { SignedGlobalID, ExpiredMessage } from "./signed-global-id.js";
 export { Verifier } from "./verifier.js";
 /** @internal */
 export { _resetSignedGlobalIDClassConfig } from "./signed-global-id.js";
-export type {
-  SignedGlobalIDOptions,
-  ParseOptions,
-  SignedGlobalIDInitOptions,
-} from "./signed-global-id.js";
+export type { SignedGlobalIDOptions, ParseOptions } from "./signed-global-id.js";
 export { validateApp, GID, MissingModelIdError, InvalidModelIdError } from "./uri/gid.js";
 export type { GidComponents } from "./uri/gid.js";
 export { Locator, BaseLocator, UnscopedLocator, BlockLocator } from "./locator.js";

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -1,30 +1,11 @@
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { getApp } from "./config.js";
-import { GID, type GidComponents } from "./uri/gid.js";
-// LAZY-IMPORT CYCLE: signed-global-id ↔ global-id ↔ locator. The `GlobalID`
-// and `isOrExtends` runtime values are only referenced inside method bodies
-// below; don't promote those references to module level — native ESM throws
-// ReferenceError (TDZ) for an uninitialized imported binding accessed during
-// the initial circular evaluation.
-import { GlobalID, isOrExtends, type GlobalIDModel } from "./global-id.js";
-import { type LocatorModel } from "./locator.js";
-import { constantize } from "@blazetrails/activesupport";
+import { GID } from "./uri/gid.js";
+import { GlobalID, type GlobalIDModel, type GlobalIDOptions } from "./global-id.js";
 
 export type { GlobalIDModel };
 
 const DEFAULT_PURPOSE = "default";
-
-/**
- * Option keys that are NOT forwarded as GID URI params.
- * Mirrors GlobalID.create's `options.except(:app, :verifier, :for)` plus
- * the SGID-specific expiration options. Any other key — including
- * `purpose` — flows through to URI params, matching Rails: SGID does
- * not reserve `purpose` as an option, only as the internal `purpose`
- * attr set via pick_purpose(:for).
- * @internal
- */
-const KNOWN_SGID_KEYS = new Set(["app", "for", "expiresIn", "expiresAt", "verifier"]);
 
 /** Monotonic counter for stable inspect() ids; mirrors Ruby's object_id. @internal */
 let _nextObjectId = 0;
@@ -33,8 +14,7 @@ let _nextObjectId = 0;
 let _classVerifier: MessageVerifier | undefined;
 let _classExpiresIn: number | null | undefined;
 
-export interface SignedGlobalIDOptions {
-  app?: string;
+export interface SignedGlobalIDOptions extends GlobalIDOptions {
   /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
   for?: string | null;
   /** Number of seconds until expiration. `null` explicitly disables expiration (Rails: `expires_in: nil`). */
@@ -47,20 +27,7 @@ export interface SignedGlobalIDOptions {
   [key: string]: unknown;
 }
 
-/**
- * Options accepted by the {@link SignedGlobalID} constructor — a narrower
- * slice of {@link SignedGlobalIDOptions} holding only the knobs that affect
- * verification and the SGID instance fields, since the constructor takes a
- * pre-built URI and can't embed `app` or arbitrary extra URI params.
- */
-export interface SignedGlobalIDInitOptions {
-  for?: string | null;
-  expiresIn?: number | null;
-  expiresAt?: Temporal.Instant | null;
-  verifier?: MessageVerifier;
-}
-
-export interface ParseOptions {
+export interface ParseOptions extends GlobalIDOptions {
   /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
   for?: string | null;
   /** Optional — falls back to `SignedGlobalID.verifier` when omitted. */
@@ -77,79 +44,26 @@ interface SgidPayload {
   expires_at: string | null;
 }
 
-export class SignedGlobalID {
-  /**
-   * The raw GID URI string, e.g. `gid://MyApp/User/1`
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
-   * Inherited from GlobalID in Ruby (`attr_reader :uri`);
-   * re-declared because the TS classes are peers, not a hierarchy. See the
-   * `create` entry for this file.
-   */
-  readonly uri: string;
+export class SignedGlobalID extends GlobalID {
   readonly purpose: string | null;
   readonly expiresAt: Temporal.Instant | undefined;
 
   private readonly verifier: MessageVerifier;
   private _cached: string | undefined;
-  private readonly _components: GidComponents;
   /** Stable per-instance hex id used by inspect(). Rails uses object_id. */
   private readonly _objectId: string;
 
   /**
-   * Mirrors: SignedGlobalID#initialize(gid, options) — the URI-first entry
-   * point the Rails test `new accepts a :for` exercises. Use
-   * {@link SignedGlobalID.create} for the model-first form. Only
-   * verifier/purpose/expiration are read; `app` and extra URI params can't
-   * be threaded into an already-built URI string.
+   * Mirrors: SignedGlobalID#initialize(gid, options) — `super` parses the GID
+   * (Rails' URI::GID.parse, which raises on a malformed URI), then the
+   * verifier/purpose/expiration are picked off the same options hash.
    */
-  constructor(uri: string, options: SignedGlobalIDInitOptions = {}) {
-    // Rails' SignedGlobalID#initialize delegates to URI::GID.parse, which
-    // raises on malformed URIs. Match that invariant here so callers get
-    // an early error rather than deferred failures from modelId/modelName
-    // getters reading garbage components.
-    this._components = GID.parse(uri).deconstructKeys();
-    this.uri = uri;
+  constructor(gid: string | GID, options: SignedGlobalIDOptions = {}) {
+    super(gid, options);
     this.verifier = SignedGlobalID.pickVerifier(options);
     this.purpose = SignedGlobalID.pickPurpose(options);
     this.expiresAt = pickExpiration(options);
     this._objectId = (_nextObjectId++).toString(16).padStart(12, "0");
-  }
-
-  /**
-   * Create a SignedGlobalID for a model instance.
-   *
-   * Mirrors: GlobalID.create
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
-   * Rails' `SignedGlobalID < GlobalID` inherits
-   * `GlobalID.create` (polymorphic `new`). In TS the two are peer classes —
-   * SignedGlobalID's fields (verifier/purpose/expiresAt) come from options its
-   * base has no notion of — so `create` is re-declared here. Unifying them
-   * under real inheritance is tracked by the globalid-sgid-inherits-globalid
-   * story.
-   */
-  static create(model: GlobalIDModel, options: SignedGlobalIDOptions = {}): SignedGlobalID {
-    const app = options.app ?? getApp();
-    if (!app) {
-      throw new Error(
-        "An app is required to create a SignedGlobalID. Pass the :app option or call setApp() from @blazetrails/globalid.",
-      );
-    }
-    const modelName = model.constructor.name;
-    // Rails: arbitrary options beyond the known SGID keys become GID URI params.
-    const filteredParams: Record<string, string> = {};
-    for (const [k, v] of Object.entries(options)) {
-      if (!KNOWN_SGID_KEYS.has(k) && v != null) filteredParams[k] = String(v);
-    }
-    const gid = GID.build({
-      app,
-      modelName,
-      modelId: model.id,
-      params: Object.keys(filteredParams).length ? filteredParams : null,
-    });
-
-    return new SignedGlobalID(gid.toString(), options);
   }
 
   /**
@@ -168,7 +82,7 @@ export class SignedGlobalID {
     if (verified === null) return null;
     // The token's own expiry wins over any class-level default: an explicit
     // null tells pickExpiration "no expiration" (Rails: `expires_at: nil`).
-    return new SignedGlobalID(verified.uri, { ...options, expiresAt: verified.expiresAt ?? null });
+    return new this(verified.uri, { ...options, expiresAt: verified.expiresAt ?? null });
   }
 
   // ─── Class-level config (Rails: attr_accessor :verifier, :expires_in) ─────
@@ -293,62 +207,6 @@ export class SignedGlobalID {
 
   toParam(): string {
     return this.toString();
-  }
-
-  /**
-   * Mirrors: GlobalID#model_id
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
-   * Inherited from GlobalID in Ruby (`delegate :model_id, to: :uri`);
-   * re-declared because the TS classes are peers, not a hierarchy. See the
-   * `create` entry for this file.
-   */
-  get modelId(): string | string[] {
-    return this._components.modelId;
-  }
-
-  /**
-   * Mirrors: GlobalID#model_name
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
-   * Inherited from GlobalID in Ruby (`delegate :model_name, to: :uri`);
-   * re-declared because the TS classes are peers, not a hierarchy. See the
-   * `create` entry for this file.
-   */
-  get modelName(): string {
-    return this._components.modelName;
-  }
-
-  /**
-   * Mirrors: GlobalID#params
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
-   * Inherited from GlobalID in Ruby (`delegate :params, to: :uri`);
-   * re-declared because the TS classes are peers, not a hierarchy. See the
-   * `create` entry for this file.
-   */
-  get params(): Record<string, string> {
-    return this._components.params;
-  }
-
-  /**
-   * Mirrors: GlobalID#model_class
-   *
-   * In Ruby SGID inherits the `model <= GlobalID` guard from GID; in TS
-   * the peer class repeats it so a misregistered constant can't slip
-   * either identity through.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: globalid-sgid-inherits-globalid).
-   * Inherited from GlobalID in Ruby; re-declared because the
-   * TS classes are peers, not a hierarchy. See the `create` entry for this
-   * file.
-   */
-  get modelClass(): LocatorModel {
-    const klass = constantize(this.modelName) as LocatorModel;
-    if (isOrExtends(klass, GlobalID) || isOrExtends(klass, SignedGlobalID)) {
-      throw new Error("GlobalID and SignedGlobalID cannot be used as model_class.");
-    }
-    return klass;
   }
 
   /**


### PR DESCRIPTION
Makes `SignedGlobalID < GlobalID` real, matching
`vendor/globalid/lib/global_id/signed_global_id.rb:4`, and retires the six
`@noRailsEquivalent CONVERGEABLE` tags that documented the peer-class
workaround (`uri`, `create`, `modelClass`, `modelId`, `modelName`, `params`).

## What changed

- `GlobalID`'s constructor takes Rails' `(gid, options)` shape and is public;
  `create` / `parse` build through `new this(...)`, so `SignedGlobalID.create`
  runs the inherited body and returns a SignedGlobalID (Ruby's polymorphic
  `new`).
- `SignedGlobalID extends GlobalID` and keeps only the genuine Rails
  overrides: `parse`, `initialize`, `to_s`, `==`, `inspect` (plus `to_param`,
  which Rails aliases to `to_s`).
- Param filtering converges on Rails: `options.except(:app, :verifier, :for)`.
  `KNOWN_SGID_KEYS` is gone, so `expires_in` / `expires_at` land in the GID
  URI query exactly as they do in Ruby.
- `global-id.ts` drops its runtime imports of `SignedGlobalID` and `Locator`,
  making it a leaf of the `global-id ↔ signed-global-id ↔ locator` cycle.
  `class SignedGlobalID extends GlobalID` reads the base binding at class-body
  evaluation time, so any runtime edge looping back into `global-id` would
  evaluate the subclass while `GlobalID` is still in TDZ. `find` now reaches
  `Locator` through a dynamic import.
- `modelClass`'s guard collapses to the single Ruby `model <= GlobalID` check.
- `as_json` routes through `to_s`, so a SignedGlobalID serializes to its
  signed token like Rails instead of the bare URI.
- `SignedGlobalIDInitOptions` (a type describing the peer-class constructor)
  is deleted along with its barrel export.

## Verification

- `pnpm api:extra --package globalid` — exit 0, 0 unreconciled entries;
  `signed-global-id.ts` no longer appears in the per-file detail.
- `pnpm api:compare` — globalid 63/63 methods (100%), arity 54/54, files 5/5;
  the two inheritance mismatches are pre-existing and unrelated.
- `pnpm vitest run packages/globalid/src` — 184 passed. Test names unchanged.
- `pnpm typecheck` clean.

Closes-story: globalid-sgid-inherits-globalid
