### PR TITLE
fix(api-compare): give mapped reopening Ruby files their own bucket

### DIFF
--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/inflector.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/inflector.json
@@ -1,0 +1,30 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "inflector.ts",
+    "rubyName": "ordinal",
+    "call": "translate",
+    "reason": "Divergence, not equivalence (story inflector-ordinal-via-i18n-translate): Rails' `ordinal` is `I18n.translate(\"number.nth.ordinals\", number:)`; trails hardcodes the English st/nd/rd/th rules because activesupport has no I18n backend yet. Surfaced by the inflector/methods.rb file-manifest fix, not by a code change."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "inflector.ts",
+    "rubyName": "ordinalize",
+    "call": "translate",
+    "reason": "Divergence, not equivalence (story inflector-ordinal-via-i18n-translate): reaches `translate` through `ordinal`, which trails hardcodes for English — see the `ordinal` entry above. Surfaced by the inflector/methods.rb file-manifest fix, not by a code change."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "inflector.ts",
+    "rubyName": "safe_constantize",
+    "call": "match?",
+    "reason": "Rails' `match?` here is in the `rescue LoadError` arm, matching the \"Unable to autoload constant\" message. trails has no Ruby autoload and `constantize` never raises LoadError, so the arm — and its `match?` — has no analogue."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "inflector.ts",
+    "rubyName": "underscore",
+    "call": "match?",
+    "reason": "Ruby `Regexp#match?` spells as `RegExp#test` in JS: `/[A-Z-]|::/.match?(word)` ports verbatim to `/[A-Z-]|::/.test(camelCasedWord)` (inflector.ts:71)."
+  }
+]

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -27,6 +27,7 @@ import {
   reachedSameFileMethods,
   narrowCallsApplies,
   callTagKey,
+  splitOverriddenFileBuckets,
   staleCallTags,
   suppressTaggedCalls,
 } from "./compare.js";
@@ -1473,5 +1474,73 @@ describe("staleCallTags", () => {
     expect(staleCallTags(twoFiles, used)).toEqual([
       { tsFile: "core.ts", tsName: "load", call: "synchronize" },
     ]);
+  });
+});
+
+describe("splitOverriddenFileBuckets", () => {
+  function m(name: string, file: string): MethodInfo {
+    return { name, visibility: "public", params: [], file };
+  }
+  // ActiveSupport::Inflector's shape: the extractor stamps the entity with the
+  // file that defined its FIRST method (inflector/inflections.rb), so every
+  // method Ruby adds when it reopens the module in inflector/methods.rb carries
+  // its own file but would otherwise be measured against inflections.ts.
+  const inflector: ClassInfo = {
+    name: "Inflector",
+    file: "inflector/inflections.rb",
+    includes: ["Comparable"],
+    extends: [],
+    instanceMethods: [
+      m("inflections", "inflector/inflections.rb"),
+      m("deconstantize", "inflector/methods.rb"),
+      m("constantize", "inflector/methods.rb"),
+      m("transliterate", "inflector/transliterate.rb"),
+    ],
+    classMethods: [],
+  };
+
+  it("moves a mapped reopening file's methods into a bucket of their own", () => {
+    const out = splitOverriddenFileBuckets(
+      { fqn: "ActiveSupport::Inflector", info: inflector },
+      "activesupport",
+    );
+    expect(out.map((e) => e.info.file)).toEqual([
+      "inflector/inflections.rb",
+      "inflector/methods.rb",
+    ]);
+    expect(out[0].info.instanceMethods.map((im) => im.name)).toEqual([
+      "inflections",
+      "transliterate",
+    ]);
+    expect(out[1].info.instanceMethods.map((im) => im.name)).toEqual([
+      "deconstantize",
+      "constantize",
+    ]);
+  });
+
+  it("keeps the fqn but drops includes/extends on the split bucket", () => {
+    const out = splitOverriddenFileBuckets(
+      { fqn: "ActiveSupport::Inflector", info: inflector },
+      "activesupport",
+    );
+    // The include-flattened surface belongs to the home bucket only —
+    // duplicating it would report Comparable's methods missing twice.
+    expect(out[1].fqn).toBe("ActiveSupport::Inflector");
+    expect(out[1].info.includes).toEqual([]);
+    expect(out[0].info.includes).toEqual(["Comparable"]);
+  });
+
+  it("returns the entity untouched when no reopening file is mapped", () => {
+    const entity = { fqn: "ActiveSupport::Inflector", info: inflector };
+    // Same entity, different package: the override table is package-scoped.
+    expect(splitOverriddenFileBuckets(entity, "activerecord")).toEqual([entity]);
+  });
+
+  it("does not split the entity's own home file", () => {
+    const entity = {
+      fqn: "ActiveSupport::Inflector",
+      info: { ...inflector, file: "inflector/methods.rb" },
+    };
+    expect(splitOverriddenFileBuckets(entity, "activesupport")).toEqual([entity]);
   });
 });

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1481,10 +1481,6 @@ describe("splitOverriddenFileBuckets", () => {
   function m(name: string, file: string): MethodInfo {
     return { name, visibility: "public", params: [], file };
   }
-  // ActiveSupport::Inflector's shape: the extractor stamps the entity with the
-  // file that defined its FIRST method (inflector/inflections.rb), so every
-  // method Ruby adds when it reopens the module in inflector/methods.rb carries
-  // its own file but would otherwise be measured against inflections.ts.
   const inflector: ClassInfo = {
     name: "Inflector",
     file: "inflector/inflections.rb",
@@ -1523,16 +1519,13 @@ describe("splitOverriddenFileBuckets", () => {
       { fqn: "ActiveSupport::Inflector", info: inflector },
       "activesupport",
     );
-    // The include-flattened surface belongs to the home bucket only —
-    // duplicating it would report Comparable's methods missing twice.
     expect(out[1].fqn).toBe("ActiveSupport::Inflector");
     expect(out[1].info.includes).toEqual([]);
     expect(out[0].info.includes).toEqual(["Comparable"]);
   });
 
-  it("returns the entity untouched when no reopening file is mapped", () => {
+  it("returns the entity untouched when no reopening file is mapped in this package", () => {
     const entity = { fqn: "ActiveSupport::Inflector", info: inflector };
-    // Same entity, different package: the override table is package-scoped.
     expect(splitOverriddenFileBuckets(entity, "activerecord")).toEqual([entity]);
   });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -82,7 +82,13 @@ import {
   packageSrcDir,
 } from "./config.js";
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
-import { isArityOverridden, isScopedSkip, rubyFileToTs, rubyMethodToTs } from "./conventions.js";
+import {
+  hasRubyFileTsOverride,
+  isArityOverridden,
+  isScopedSkip,
+  rubyFileToTs,
+  rubyMethodToTs,
+} from "./conventions.js";
 import {
   isForwardingRubyEntry,
   matchArityAgainst,
@@ -1107,6 +1113,59 @@ export function buildModuleIncluderFqns(
  * `resolveModuleName`): `AbstractAdapter` including `"Quoting"` resolves
  * only to `ConnectionAdapters::Quoting`, not to adapter-specific siblings.
  */
+/**
+ * Split an entity's methods out of its home-file bucket for every reopening
+ * file that carries an explicit TS mapping (RUBY_FILE_TS_OVERRIDES).
+ *
+ * Ruby reopens a class/module across many files, but the extractor stamps ONE
+ * `file` on the entity — where its first method was defined — so by default
+ * every later file's methods are measured against that file's TS counterpart.
+ * For `ActiveSupport::Inflector` that means `inflector/methods.rb`'s 20 methods
+ * are looked for in `inflector/inflections.ts` and reported missing forever.
+ * A mapped file gets its own bucket instead, holding only the methods it
+ * defines. Splits carry no `includes`/`extends`: the include-flattened methods
+ * belong to the home bucket, not to every file the entity is reopened in.
+ */
+export function splitOverriddenFileBuckets(
+  entity: { fqn: string; info: ClassInfo },
+  pkg: string,
+): { fqn: string; info: ClassInfo }[] {
+  const home = entity.info.file || "unknown.rb";
+  const allMethods = [...entity.info.instanceMethods, ...entity.info.classMethods];
+  const splitFiles = new Set(
+    allMethods
+      .map((m) => m.file)
+      .filter((f): f is string => f !== undefined && f !== home && hasRubyFileTsOverride(f, pkg)),
+  );
+  if (splitFiles.size === 0) return [entity];
+
+  const inSplit = (m: MethodInfo) => m.file !== undefined && splitFiles.has(m.file);
+  const out: { fqn: string; info: ClassInfo }[] = [
+    {
+      fqn: entity.fqn,
+      info: {
+        ...entity.info,
+        instanceMethods: entity.info.instanceMethods.filter((m) => !inSplit(m)),
+        classMethods: entity.info.classMethods.filter((m) => !inSplit(m)),
+      },
+    },
+  ];
+  for (const file of splitFiles) {
+    out.push({
+      fqn: entity.fqn,
+      info: {
+        ...entity.info,
+        file,
+        includes: [],
+        extends: [],
+        instanceMethods: entity.info.instanceMethods.filter((m) => m.file === file),
+        classMethods: entity.info.classMethods.filter((m) => m.file === file),
+      },
+    });
+  }
+  return out;
+}
+
 export function flattenIncludedMethodInfos(
   entity: ClassInfo,
   entityFqn: string,
@@ -1746,15 +1805,17 @@ export function main() {
     // Group by Ruby file
     const byFile = new Map<string, typeof allRuby>();
     const excludedFiles = new Set<string>();
-    for (const item of allRuby) {
-      const file = item.info.file || "unknown.rb";
-      if (isSourceUnported(file, pkg)) {
-        excludedFiles.add(file);
-        continue;
+    for (const entity of allRuby) {
+      for (const item of splitOverriddenFileBuckets(entity, pkg)) {
+        const file = item.info.file || "unknown.rb";
+        if (isSourceUnported(file, pkg)) {
+          excludedFiles.add(file);
+          continue;
+        }
+        const list = byFile.get(file) || [];
+        list.push(item);
+        byFile.set(file, list);
       }
-      const list = byFile.get(file) || [];
-      list.push(item);
-      byFile.set(file, list);
     }
 
     // Resolve package src directory for file existence checks

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1113,59 +1113,6 @@ export function buildModuleIncluderFqns(
  * `resolveModuleName`): `AbstractAdapter` including `"Quoting"` resolves
  * only to `ConnectionAdapters::Quoting`, not to adapter-specific siblings.
  */
-/**
- * Split an entity's methods out of its home-file bucket for every reopening
- * file that carries an explicit TS mapping (RUBY_FILE_TS_OVERRIDES).
- *
- * Ruby reopens a class/module across many files, but the extractor stamps ONE
- * `file` on the entity — where its first method was defined — so by default
- * every later file's methods are measured against that file's TS counterpart.
- * For `ActiveSupport::Inflector` that means `inflector/methods.rb`'s 20 methods
- * are looked for in `inflector/inflections.ts` and reported missing forever.
- * A mapped file gets its own bucket instead, holding only the methods it
- * defines. Splits carry no `includes`/`extends`: the include-flattened methods
- * belong to the home bucket, not to every file the entity is reopened in.
- */
-export function splitOverriddenFileBuckets(
-  entity: { fqn: string; info: ClassInfo },
-  pkg: string,
-): { fqn: string; info: ClassInfo }[] {
-  const home = entity.info.file || "unknown.rb";
-  const allMethods = [...entity.info.instanceMethods, ...entity.info.classMethods];
-  const splitFiles = new Set(
-    allMethods
-      .map((m) => m.file)
-      .filter((f): f is string => f !== undefined && f !== home && hasRubyFileTsOverride(f, pkg)),
-  );
-  if (splitFiles.size === 0) return [entity];
-
-  const inSplit = (m: MethodInfo) => m.file !== undefined && splitFiles.has(m.file);
-  const out: { fqn: string; info: ClassInfo }[] = [
-    {
-      fqn: entity.fqn,
-      info: {
-        ...entity.info,
-        instanceMethods: entity.info.instanceMethods.filter((m) => !inSplit(m)),
-        classMethods: entity.info.classMethods.filter((m) => !inSplit(m)),
-      },
-    },
-  ];
-  for (const file of splitFiles) {
-    out.push({
-      fqn: entity.fqn,
-      info: {
-        ...entity.info,
-        file,
-        includes: [],
-        extends: [],
-        instanceMethods: entity.info.instanceMethods.filter((m) => m.file === file),
-        classMethods: entity.info.classMethods.filter((m) => m.file === file),
-      },
-    });
-  }
-  return out;
-}
-
 export function flattenIncludedMethodInfos(
   entity: ClassInfo,
   entityFqn: string,
@@ -1197,6 +1144,62 @@ export function flattenIncludedMethodInfos(
   for (const inc of entity.includes ?? []) walk(inc, false, entityFqn);
   for (const ext of entity.extends ?? []) walk(ext, true, entityFqn);
   return { instance, klass };
+}
+
+/** A Ruby class or module, paired with the fully-qualified name it was found under. */
+export interface RubyEntity {
+  fqn: string;
+  info: ClassInfo;
+}
+
+/**
+ * Split an entity's methods out of its home-file bucket for every reopening
+ * file that carries an explicit TS mapping (RUBY_FILE_TS_OVERRIDES).
+ *
+ * Ruby reopens a class/module across many files, but the extractor stamps ONE
+ * `file` on the entity — where its first method was defined — so by default
+ * every later file's methods are measured against that file's TS counterpart.
+ * For `ActiveSupport::Inflector` that means `inflector/methods.rb`'s 20 methods
+ * are looked for in `inflector/inflections.ts` and reported missing forever.
+ * A mapped file gets its own bucket instead, holding only the methods it
+ * defines. Splits carry no `includes`/`extends`: the include-flattened methods
+ * belong to the home bucket, not to every file the entity is reopened in.
+ */
+export function splitOverriddenFileBuckets(entity: RubyEntity, pkg: string): RubyEntity[] {
+  const home = entity.info.file || "unknown.rb";
+  const allMethods = [...entity.info.instanceMethods, ...entity.info.classMethods];
+  const splitFiles = new Set(
+    allMethods
+      .map((m) => m.file)
+      .filter((f): f is string => f !== undefined && f !== home && hasRubyFileTsOverride(f, pkg)),
+  );
+  if (splitFiles.size === 0) return [entity];
+
+  const inSplit = (m: MethodInfo) => m.file !== undefined && splitFiles.has(m.file);
+  const out: RubyEntity[] = [
+    {
+      fqn: entity.fqn,
+      info: {
+        ...entity.info,
+        instanceMethods: entity.info.instanceMethods.filter((m) => !inSplit(m)),
+        classMethods: entity.info.classMethods.filter((m) => !inSplit(m)),
+      },
+    },
+  ];
+  for (const file of splitFiles) {
+    out.push({
+      fqn: entity.fqn,
+      info: {
+        ...entity.info,
+        file,
+        includes: [],
+        extends: [],
+        instanceMethods: entity.info.instanceMethods.filter((m) => m.file === file),
+        classMethods: entity.info.classMethods.filter((m) => m.file === file),
+      },
+    });
+  }
+  return out;
 }
 
 /**
@@ -1682,10 +1685,7 @@ export function main() {
     }
 
     // Collect all Ruby classes and modules with their methods
-    const allRuby: {
-      fqn: string;
-      info: ClassInfo;
-    }[] = [];
+    const allRuby: RubyEntity[] = [];
 
     // Skip nested classes that share a file with a shorter-named parent.
     // e.g., Preloader::Association::LoaderQuery in preloader/association.rb

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -5,6 +5,8 @@ import {
   rubyMethodToTsIgnoringSkip,
   SKIP_TS_MIRROR_IS_DRIFT,
   rubyFileToTs,
+  RUBY_FILE_TS_OVERRIDES,
+  hasRubyFileTsOverride,
   SKIP,
   SKIP_GROUPS,
   ARITY_OVERRIDE_GROUPS,
@@ -211,6 +213,34 @@ describe("rubyFileToTs", () => {
     // The alias is global, not per-package — any framework's railties/
     // subdir maps to trailties/ uniformly.
     expect(rubyFileToTs("railties/some_file.rb", "actiondispatch")).toBe("trailties/some-file.ts");
+  });
+
+  it("prefers an explicit per-package override over the kebab-case rule", () => {
+    // Rails splits the Inflector across inflector/methods.rb and the String
+    // delegators; trails ports both onto the one inflector.ts.
+    expect(rubyFileToTs("inflector/methods.rb", "activesupport")).toBe("inflector.ts");
+    expect(rubyFileToTs("core_ext/string/inflections.rb", "activesupport")).toBe("inflector.ts");
+  });
+
+  it("scopes overrides to their package", () => {
+    expect(rubyFileToTs("inflector/methods.rb", "activerecord")).toBe("inflector/methods.ts");
+    expect(rubyFileToTs("inflector/methods.rb")).toBe("inflector/methods.ts");
+  });
+});
+
+describe("RUBY_FILE_TS_OVERRIDES", () => {
+  it("keys every entry as <package>:<ruby path> and maps to a .ts file", () => {
+    for (const [key, value] of Object.entries(RUBY_FILE_TS_OVERRIDES)) {
+      expect(key).toMatch(/^[a-z-]+:.+\.rb$/);
+      expect(value).toMatch(/\.ts$/);
+    }
+  });
+
+  it("reports override membership only for the owning package", () => {
+    expect(hasRubyFileTsOverride("inflector/methods.rb", "activesupport")).toBe(true);
+    expect(hasRubyFileTsOverride("inflector/methods.rb", "activerecord")).toBe(false);
+    expect(hasRubyFileTsOverride("inflector/methods.rb")).toBe(false);
+    expect(hasRubyFileTsOverride("inflector/inflections.rb", "activesupport")).toBe(false);
   });
 });
 

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -7,6 +7,7 @@ import {
   rubyFileToTs,
   RUBY_FILE_TS_OVERRIDES,
   hasRubyFileTsOverride,
+  rubyFileTsOverride,
   SKIP,
   SKIP_GROUPS,
   ARITY_OVERRIDE_GROUPS,
@@ -241,6 +242,11 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
     expect(hasRubyFileTsOverride("inflector/methods.rb", "activerecord")).toBe(false);
     expect(hasRubyFileTsOverride("inflector/methods.rb")).toBe(false);
     expect(hasRubyFileTsOverride("inflector/inflections.rb", "activesupport")).toBe(false);
+  });
+
+  it("returns the mapped TS file, or undefined when unmapped", () => {
+    expect(rubyFileTsOverride("inflector/methods.rb", "activesupport")).toBe("inflector.ts");
+    expect(rubyFileTsOverride("inflector/inflections.rb", "activesupport")).toBeUndefined();
   });
 });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -77,9 +77,16 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   "activesupport:core_ext/string/inflections.rb": "inflector.ts",
 };
 
+/** The explicit TS mapping for `rubyFile` in `pkg`, or undefined when unmapped. */
+export function rubyFileTsOverride(rubyFile: string, pkg?: string): string | undefined {
+  if (pkg === undefined) return undefined;
+  const key = `${pkg}:${rubyFile}`;
+  return Object.hasOwn(RUBY_FILE_TS_OVERRIDES, key) ? RUBY_FILE_TS_OVERRIDES[key] : undefined;
+}
+
 /** True when `rubyFile` has an explicit TS mapping in this package. */
 export function hasRubyFileTsOverride(rubyFile: string, pkg?: string): boolean {
-  return pkg !== undefined && `${pkg}:${rubyFile}` in RUBY_FILE_TS_OVERRIDES;
+  return rubyFileTsOverride(rubyFile, pkg) !== undefined;
 }
 
 /**
@@ -91,8 +98,8 @@ export function hasRubyFileTsOverride(rubyFile: string, pkg?: string): boolean {
  * on Windows.
  */
 export function rubyFileToTs(rubyFile: string, pkg?: string): string {
-  const override = pkg !== undefined ? RUBY_FILE_TS_OVERRIDES[`${pkg}:${rubyFile}`] : undefined;
-  if (override) return override;
+  const override = rubyFileTsOverride(rubyFile, pkg);
+  if (override !== undefined) return override;
   const dir = path.posix.dirname(rubyFile);
   const base = path.posix.basename(rubyFile, ".rb");
   const aliasedBase = PATH_SEGMENT_ALIASES[base] ?? base;

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -58,6 +58,31 @@ export const PATH_SEGMENT_ALIASES: Record<string, string> = {
 };
 
 /**
+ * Ruby files whose TS counterpart does NOT follow the kebab-case path rule,
+ * keyed by `<package>:<ruby path>`.
+ *
+ * An entry here does two things: it names the TS file the Ruby file's methods
+ * are measured against, and it makes the Ruby file own a comparison bucket even
+ * when Ruby reopens the class/module elsewhere. The second half matters —
+ * api:compare buckets an entity's whole method set under the ONE file that
+ * first defined a method on it, so a reopening file's methods are otherwise
+ * measured against the DEFINING file's TS counterpart and report missing
+ * forever no matter what is ported. `inflector/methods.rb` (folded into
+ * `inflector/inflections.rb`) and `core_ext/string/inflections.rb` (folded into
+ * `core_ext/object/blank.rb`, where `String` is first reopened) are both that
+ * shape; trails ports both onto the single `inflector.ts`.
+ */
+export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
+  "activesupport:inflector/methods.rb": "inflector.ts",
+  "activesupport:core_ext/string/inflections.rb": "inflector.ts",
+};
+
+/** True when `rubyFile` has an explicit TS mapping in this package. */
+export function hasRubyFileTsOverride(rubyFile: string, pkg?: string): boolean {
+  return pkg !== undefined && `${pkg}:${rubyFile}` in RUBY_FILE_TS_OVERRIDES;
+}
+
+/**
  * Ruby file path → expected TS file path (kebab-case, .ts extension).
  *
  * Uses `path.posix.*` so the mapping stays cross-platform stable —
@@ -65,7 +90,9 @@ export const PATH_SEGMENT_ALIASES: Record<string, string> = {
  * POSIX paths, and the default `path.join` would return backslashes
  * on Windows.
  */
-export function rubyFileToTs(rubyFile: string, _pkg?: string): string {
+export function rubyFileToTs(rubyFile: string, pkg?: string): string {
+  const override = pkg !== undefined ? RUBY_FILE_TS_OVERRIDES[`${pkg}:${rubyFile}`] : undefined;
+  if (override) return override;
   const dir = path.posix.dirname(rubyFile);
   const base = path.posix.basename(rubyFile, ".rb");
   const aliasedBase = PATH_SEGMENT_ALIASES[base] ?? base;


### PR DESCRIPTION
## Problem

api:compare stamps a single `file` on each Ruby entity — the file that defined
its **first** method (`extract-ruby-api.rb:670`, `maybe_update_module_file`).
Ruby reopens classes and modules across many files, so every method a *later*
file adds gets measured against the **defining** file's TS counterpart and is
reported missing forever, no matter what is ported. The reopening file never
gets a summary row at all.

`ActiveSupport::Inflector` is the clearest case: its entity file is
`inflector/inflections.rb`, so `inflector/methods.rb`'s 20 methods were looked
for in `inflector/inflections.ts`. `deconstantize` has shipped at
`packages/activesupport/src/inflector.ts:160` for ages and was still listed as
missing; `constantize` / `safeConstantize` (PR #5471) landed in the same dead
bucket. `core_ext/string/inflections.rb`'s 19 `String#` delegators have the same
shape, folded into `core_ext/object/blank.rb` where `String` is first reopened.

## Fix

- `RUBY_FILE_TS_OVERRIDES` (conventions.ts): a package-scoped
  `<package>:<ruby path>` → TS file table, consulted by `rubyFileToTs`. Two
  entries, both mapping onto trails' single `inflector.ts`.
- `splitOverriddenFileBuckets` (compare.ts): an entry in that table also makes
  the Ruby file **own a bucket**, holding only the methods it defines. Splits
  carry no `includes`/`extends` — the include-flattened surface belongs to the
  home bucket, not to every file the entity is reopened in.

## Measurement delta (this is a measurement fix, not new porting work)

Nothing was ported in this PR. activesupport moves **754 → 786 ported methods
(32.4% → 33.7%)**, files 82/174 → 84/176. The +32 is entirely already-shipped
code that the folding was hiding:

| bucket | matched | still missing |
| --- | --- | --- |
| `inflector/methods.rb` → `inflector.ts` | 17/20 (85%) | `upcase_first`, `downcase_first`, `const_regexp` |
| `core_ext/string/inflections.rb` → `inflector.ts` | 15/19 (79%) | `camelcase`, `titlecase`, `upcase_first`, `downcase_first` |
| `inflector/inflections.rb` → `inflector/inflections.ts` | 16/21 (76%) | was 16/41 |
| `core_ext/object/blank.rb` | 2/162 | was 2/181 |

`deconstantize`, `constantize`, `safe_constantize` and the rest of the ported
inflector surface no longer appear in `missingMethods`. The remaining misses
above are real gaps.

## Gates

Newly matched pairs surfaced 4 wide call-mismatch entries, now baselined with
real reasons in `call-mismatches-wide-exclude/activesupport/inflector.json`
(none left on the seeded default):

- `underscore` / `match?` — Ruby `Regexp#match?` spells as `RegExp#test`.
- `safe_constantize` / `match?` — Rails' call is in the `rescue LoadError` arm;
  trails has no Ruby autoload, so the arm has no analogue.
- `ordinal` / `ordinalize` / `translate` — a **real divergence**, not an
  equivalence: Rails is `I18n.translate("number.nth.ordinals")`, trails
  hardcodes the English suffixes. Registered as story
  `inflector-ordinal-via-i18n-translate`.

`api:calls`, `api:calls:wide`, `api:arity`, `api:pins`, `api:extra` all clean;
`scripts/api-compare/` suite 926 tests green.

## The wider gap

The `tsFile: null` signature quoted in the story is a red herring — `FileResult`
has no `tsFile` field (it carries `expectedTsFile`), so `f["tsFile"] is None`
holds for every bucket, including 100%-ported ones. The real signature is a Ruby
file that appears as a `MethodInfo.file` but is no entity's `ClassInfo.file`.
**75 such files exist; 73 remain after this PR** — 65 in activesupport (362
methods, led by `core_ext/time/calculations.rb` at 57 and the
`date`/`date_time` calculations pair at 72), plus `globalid/global_id.rb` (22),
`activerecord/encryption/cipher.rb` (6), `activemodel/validations/validates.rb`
(4) and a handful of `version.rb`. Registered with the full enumeration query as
story `api-compare-orphan-reopened-file-buckets`.

Closes-story: inflector-methods-rb-unmapped-in-file-manifest
