### PR TITLE
refactor(activerecord): mark columnMethodNames internal instead of tagging it

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1308,10 +1308,10 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 });
 
-describe("PostgreSQLAdapter#columnMethodNames", () => {
+describe("PostgreSQLAdapter#_columnMethodNames", () => {
   it("appends PG ColumnMethods shorthands to the abstract list", () => {
     const adapter = Object.create(PostgreSQLAdapter.prototype) as PostgreSQLAdapter;
-    const names = adapter.columnMethodNames();
+    const names = adapter._columnMethodNames();
     for (const name of [
       "serial",
       "bigserial",

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -46,10 +46,10 @@ describe("AbstractAdapter#returnValueAfterInsert", () => {
   });
 });
 
-describe("AbstractAdapter#columnMethodNames", () => {
+describe("AbstractAdapter#_columnMethodNames", () => {
   it("mirrors the abstract ColumnMethods list (define_column_methods + blob/numeric aliases)", () => {
     const adapter = new TestAdapter();
-    expect(adapter.columnMethodNames()).toEqual([
+    expect(adapter._columnMethodNames()).toEqual([
       "bigint",
       "binary",
       "boolean",
@@ -71,7 +71,7 @@ describe("AbstractAdapter#columnMethodNames", () => {
 
   it("does not surface native-types-only `primary_key`", () => {
     const adapter = new TestAdapter();
-    expect(adapter.columnMethodNames()).not.toContain("primary_key");
+    expect(adapter._columnMethodNames()).not.toContain("primary_key");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -724,7 +724,7 @@ export const RAW_CONNECTION_DEPRECATION_MESSAGE =
  * The base `ColumnMethods` shorthands every adapter's `change_table` proxy
  * exposes, mirroring `abstract/schema_definitions.rb:324` (`define_column_methods`
  * plus the `:blob`/`:numeric` aliases). Adapter-specific names are appended in
- * each adapter's `columnMethodNames()` override.
+ * each adapter's `_columnMethodNames()` override.
  */
 export const ABSTRACT_COLUMN_METHOD_NAMES: readonly string[] = [
   "bigint",
@@ -1425,17 +1425,16 @@ export class AbstractAdapter implements Quoting {
    * `blob`/`numeric` aliases) — NOT `Object.keys(nativeDatabaseTypes())`, which
    * is only an approximation (it surfaces `primary_key` and omits `virtual`).
    * Adapters whose `ColumnMethods` list adds more (MySQL, PostgreSQL) override
-   * this and append their own names to `super.columnMethodNames()`.
+   * this and append their own names to `super._columnMethodNames()`.
    *
-   * @noRailsEquivalent CONVERGEABLE (story: mark-column-method-names-internal).
-   * Rails spells this list as the `ColumnMethods` modules'
-   *   `define_column_methods` metaprogramming
-   *   (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a
-   *   `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so
-   *   trails reifies the list; each adapter appends to `super.columnMethodNames()` exactly where
-   *   Rails' adapter-specific ColumnMethods module extends the abstract one.
+   * @internal Rails spells this list as the `ColumnMethods` modules'
+   * `define_column_methods` metaprogramming
+   * (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as public
+   * API. TypeScript has no `define_method`, so trails reifies the list; each adapter appends to
+   * `super._columnMethodNames()` exactly where Rails' adapter-specific ColumnMethods module extends
+   * the abstract one.
    */
-  columnMethodNames(): string[] {
+  _columnMethodNames(): string[] {
     return [...ABSTRACT_COLUMN_METHOD_NAMES];
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -46,11 +46,11 @@ describe("AbstractMysqlAdapter#returnValueAfterInsert", () => {
   });
 });
 
-describe("AbstractMysqlAdapter#columnMethodNames", () => {
+describe("AbstractMysqlAdapter#_columnMethodNames", () => {
   it("appends MySQL ColumnMethods shorthands to the abstract list", async () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
-    const names = adapter.columnMethodNames();
+    const names = adapter._columnMethodNames();
     for (const name of [
       "tinyblob",
       "mediumblob",

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -576,17 +576,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   // `:blob` is in the Rails MySQL list too, but it's already surfaced via the
   // abstract `blob`/`binary` alias, so we don't repeat it here.
   /**
-   * @noRailsEquivalent CONVERGEABLE (story: mark-column-method-names-internal).
-   * Rails spells this list as the `ColumnMethods` modules'
-   *   `define_column_methods` metaprogramming
-   *   (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a
-   *   `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so
-   *   trails reifies the list; each adapter appends to `super.columnMethodNames()` exactly where
-   *   Rails' adapter-specific ColumnMethods module extends the abstract one.
+   * @internal Reification of Rails' MySQL `ColumnMethods` module, which extends the abstract
+   * `define_column_methods` list (abstract/schema_definitions.rb:324) rather than exposing public
+   * API.
    */
-  override columnMethodNames(): string[] {
+  override _columnMethodNames(): string[] {
     return [
-      ...super.columnMethodNames(),
+      ...super._columnMethodNames(),
       "tinyblob",
       "mediumblob",
       "longblob",

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2554,17 +2554,13 @@ export class PostgreSQLAdapter
   // exposed as `change_table` shorthands. Multi-word names use the camelCase form of
   // the trails TableDefinition method (e.g. `bit_varying` -> `bitVarying`).
   /**
-   * @noRailsEquivalent CONVERGEABLE (story: mark-column-method-names-internal).
-   * Rails spells this list as the `ColumnMethods` modules'
-   *   `define_column_methods` metaprogramming
-   *   (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a
-   *   `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so
-   *   trails reifies the list; each adapter appends to `super.columnMethodNames()` exactly where
-   *   Rails' adapter-specific ColumnMethods module extends the abstract one.
+   * @internal Reification of Rails' PostgreSQL `ColumnMethods` module, which extends the abstract
+   * `define_column_methods` list (abstract/schema_definitions.rb:324) rather than exposing public
+   * API.
    */
-  override columnMethodNames(): string[] {
+  override _columnMethodNames(): string[] {
     return [
-      ...super.columnMethodNames(),
+      ...super._columnMethodNames(),
       "bigserial",
       "bit",
       "bitVarying",

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1428,7 +1428,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   // --- Database info ---
 
   // SQLite has no adapter-specific `ColumnMethods` module (sqlite3/schema_definitions.rb
-  // defines none), so it inherits the abstract `columnMethodNames()` list unchanged —
+  // defines none), so it inherits the abstract `_columnMethodNames()` list unchanged —
   // no override here is intentional.
 
   nativeDatabaseTypes(): NativeDatabaseTypes {

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -529,7 +529,7 @@ describe("CommandRecorder", () => {
   describe("change_table surfaces adapter ColumnMethods shorthands (serial/bigserial)", () => {
     // Mirrors Rails: the PG `ColumnMethods` mixin exposes `t.serial` /
     // `t.bigserial` (SERIAL/BIGSERIAL) inside change_table — shorthands the
-    // adapter advertises via columnMethodNames() beyond NATIVE_DATABASE_TYPES.
+    // adapter advertises via _columnMethodNames() beyond NATIVE_DATABASE_TYPES.
     const pgLike = pgDelegate;
 
     it("records addColumn for t.serial and t.bigserial (up adds)", async () => {
@@ -583,7 +583,7 @@ describe("CommandRecorder", () => {
   describe("change_table surfaces adapter ColumnMethods shorthands (MySQL unsigned/blob)", () => {
     // Mirrors Rails: the MySQL `ColumnMethods` mixin exposes `t.unsignedInteger`,
     // `t.mediumtext`, `t.longblob`, ... inside change_table — shorthands the
-    // adapter advertises via columnMethodNames() beyond NATIVE_DATABASE_TYPES.
+    // adapter advertises via _columnMethodNames() beyond NATIVE_DATABASE_TYPES.
     //
     // The proxy normalizes the camelCase method name back to the snake symbol
     // Rails' `define_column_methods` records (`unsignedInteger` ->


### PR DESCRIPTION
`columnMethodNames` was tagged `@noRailsEquivalent` in three places (abstract, MySQL, PostgreSQL adapters). Rails spells this list as `define_column_methods` metaprogramming plus the per-adapter `ColumnMethods` modules (`abstract/schema_definitions.rb:324`) — there is no public Ruby method with this name, so the tag was blessing invented public API.

TypeScript genuinely needs the reified list (no `define_method`), so the member stays. It is now marked internal via the leading-underscore marker `extra-surface.ts` honors (the class-member extractor derives `internal` from TS visibility modifiers, not from an `@internal` JSDoc tag, so the tag alone would not have removed it from the compared surface), and the `@noRailsEquivalent` tags are deleted.

- Override chain unchanged: MySQL and PG still append to `super._columnMethodNames()`.
- No external package imports it; all call sites are inside `activerecord`.
- `pnpm api:extra --package activerecord` reports no stale tags.

Closes-story: mark-column-method-names-internal