### PR TITLE
refactor(activesupport): route Inflector#ordinal through I18n.translate

### DIFF
--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -1,6 +1,18 @@
 import { deepMergeInPlace } from "./hash-utils.js";
+import { ordinal } from "./inflector.js";
 
-type TranslationValue = string | number | boolean | (string | null)[] | null | TranslationHash;
+/** A stored Proc entry, resolved with (key, options) at lookup time — i18n's
+ * `Backend::Base#resolve_entry` (i18n/lib/i18n/backend/base.rb:169-180). */
+type TranslationProc = (key: string, options: TranslateOptions) => TranslationValue;
+
+type TranslationValue =
+  | string
+  | number
+  | boolean
+  | (string | null)[]
+  | null
+  | TranslationProc
+  | TranslationHash;
 interface TranslationHash {
   [key: string]: TranslationValue;
 }
@@ -15,6 +27,15 @@ function dig(obj: TranslationHash, keys: string[]): TranslationValue | undefined
     if (current === undefined) return undefined;
   }
   return current;
+}
+
+function resolveEntry(
+  key: string,
+  value: TranslationValue | undefined,
+  options: TranslateOptions,
+): TranslationValue | undefined {
+  if (typeof value === "function") return resolveEntry(key, value(key, options), options);
+  return value;
 }
 
 const I18N_RESERVED_KEYS = new Set(["locale", "default", "raise", "scope", "separator"]);
@@ -310,13 +331,55 @@ class I18nModule {
           last_word_connector: ", and ",
         },
       },
+      // active_support/locale/en.rb — the Proc-valued half of the default
+      // English locale, which Rails loads alongside en.yml.
+      number: {
+        nth: {
+          ordinals: (_key, options) => {
+            const number = Number(options.number);
+            switch (number) {
+              case 1:
+                return "st";
+              case 2:
+                return "nd";
+              case 3:
+                return "rd";
+              case 4:
+              case 5:
+              case 6:
+              case 7:
+              case 8:
+              case 9:
+              case 10:
+              case 11:
+              case 12:
+              case 13:
+                return "th";
+            }
+            let numModulo = Math.abs(Math.trunc(number)) % 100;
+            if (numModulo > 13) numModulo %= 10;
+            switch (numModulo) {
+              case 1:
+                return "st";
+              case 2:
+                return "nd";
+              case 3:
+                return "rd";
+              default:
+                return "th";
+            }
+          },
+
+          ordinalized: (_key, options) => `${options.number}${ordinal(Number(options.number))}`,
+        },
+      },
     });
   }
 
   translate(key: string | symbol, options: TranslateOptions = {}): TranslationValue {
     const locale = options.locale ?? this.locale;
     const keyStr = this._scopedKey(symbolToString(key), options.scope);
-    const result = this.backend.lookup(locale, keyStr);
+    const result = resolveEntry(keyStr, this.backend.lookup(locale, keyStr), options);
     if (result !== undefined) return interpolate(this._pluralize(result, options.count), options);
     // `default` is a chain (i18n/lib/i18n/backend/base.rb:124-145): #default
     // wraps its subject with Array(), so a lone default is a one-entry chain.
@@ -338,7 +401,7 @@ class I18nModule {
       }
       const defaultKey = this._scopedKey(symbolToString(entry), options.scope);
       consideredKeys.push(defaultKey);
-      const found = this.backend.lookup(locale, defaultKey);
+      const found = resolveEntry(defaultKey, this.backend.lookup(locale, defaultKey), options);
       if (found !== undefined) return interpolate(this._pluralize(found, options.count), options);
     }
     // An explicit `default: nil` is a resolved nil fallback, not a miss: i18n

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -1,8 +1,6 @@
 import { deepMergeInPlace } from "./hash-utils.js";
 import { ordinal } from "./inflector.js";
 
-/** A stored Proc entry, resolved with (key, options) at lookup time — i18n's
- * `Backend::Base#resolve_entry` (i18n/lib/i18n/backend/base.rb:169-180). */
 type TranslationProc = (key: string, options: TranslateOptions) => TranslationValue;
 
 type TranslationValue =
@@ -331,8 +329,6 @@ class I18nModule {
           last_word_connector: ", and ",
         },
       },
-      // active_support/locale/en.rb — the Proc-valued half of the default
-      // English locale, which Rails loads alongside en.yml.
       number: {
         nth: {
           ordinals: (_key, options) => {

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -30,9 +30,9 @@ function dig(obj: TranslationHash, keys: string[]): TranslationValue | undefined
 function resolveEntry(
   key: string,
   value: TranslationValue | undefined,
-  options: TranslateOptions,
+  options: TranslateOptions = {},
 ): TranslationValue | undefined {
-  if (typeof value === "function") return resolveEntry(key, value(key, options), options);
+  if (typeof value === "function") return resolveEntry(key, value(key, options));
   return value;
 }
 

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -5,6 +5,7 @@
 
 import { Inflections } from "./inflector/inflections.js";
 import { NameError } from "./core-ext/name-error.js";
+import { I18n } from "./i18n.js";
 
 /** @internal */
 function applyInflections(word: string, rules: { rule: RegExp; replacement: string }[]): string {
@@ -342,25 +343,9 @@ export function parameterize(
 }
 
 export function ordinal(number: number): string {
-  const abs = Math.abs(number);
-  const mod100 = abs % 100;
-
-  if (mod100 === 11 || mod100 === 12 || mod100 === 13) {
-    return "th";
-  }
-
-  switch (abs % 10) {
-    case 1:
-      return "st";
-    case 2:
-      return "nd";
-    case 3:
-      return "rd";
-    default:
-      return "th";
-  }
+  return String(I18n.translate("number.nth.ordinals", { number }));
 }
 
 export function ordinalize(number: number): string {
-  return `${number}${ordinal(number)}`;
+  return String(I18n.translate("number.nth.ordinalized", { number }));
 }


### PR DESCRIPTION
Rails delegates `ordinal`/`ordinalize` to I18n (`inflector/methods.rb:334,348`) and keeps the English suffix rules as Procs in the default locale data (`active_support/locale/en.rb`). trails hardcoded the st/nd/rd/th rules in `inflector.ts` instead.

- The I18n backend now resolves Proc-valued entries at lookup time (i18n's `Backend::Base#resolve_entry`), for both the primary key and `default:` chain entries.
- `number.nth.ordinals` / `number.nth.ordinalized` ported verbatim from `en.rb` into the default "en" data; `ordinalized` still delegates to `Inflector.ordinal`.
- `ordinal`/`ordinalize` are now one-line `I18n.translate` calls.

No baseline entries to drop: `call-mismatches-wide-exclude/activesupport/inflector.json` does not exist on main (the referenced `translate` entries were never seeded there).

Existing inflector + i18n tests pass unchanged.

Closes-story: inflector-ordinal-via-i18n-translate


---

**Review notes**

- Nested-proc recursion now drops `options`, matching the 3-arg `resolve(locale, object, subject.call(...))` at `vendor/i18n/lib/i18n/backend/base.rb:165`.
- Proc first positional arg: passing `key` is correct, not a latent divergence. `Base#translate` calls `resolve_entry(locale, key, entry, options)` (base.rb:38), so `object` **is** the key on the translate path; the `Proc` arm's `date_or_time = options.delete(:object) || object` falls through to that same key absent an `:object` override (which trails does not support).
- `ordinalize` follows `methods.rb:352` (`I18n.translate("number.nth.ordinalized", ...)`) rather than the story's "delegates to ordinal" phrasing; delegation to `Inflector.ordinal` happens inside the `ordinalized` proc, as in `en.rb:26-29`.
