### PR TITLE
feat(api-compare): pin Arel::Math operator spellings for method order

### DIFF
--- a/scripts/api-compare/operator-order-spelling.test.ts
+++ b/scripts/api-compare/operator-order-spelling.test.ts
@@ -43,6 +43,31 @@ describe("operatorSpelling", () => {
     expect(operatorSpelling("ActiveRecord::Result", "[]")).toEqual(["at"]);
   });
 
+  it("resolves every Arel::Math operator to its named mixin spelling", () => {
+    expect(operatorSpelling("Arel::Math", "*")).toEqual(["multiply"]);
+    expect(operatorSpelling("Arel::Math", "+")).toEqual(["add"]);
+    expect(operatorSpelling("Arel::Math", "-")).toEqual(["subtract"]);
+    expect(operatorSpelling("Arel::Math", "/")).toEqual(["divide"]);
+    expect(operatorSpelling("Arel::Math", "&")).toEqual(["bitwiseAnd"]);
+    expect(operatorSpelling("Arel::Math", "|")).toEqual(["bitwiseOr"]);
+    expect(operatorSpelling("Arel::Math", "^")).toEqual(["bitwiseXor"]);
+    expect(operatorSpelling("Arel::Math", "<<")).toEqual(["bitwiseShiftLeft"]);
+    expect(operatorSpelling("Arel::Math", ">>")).toEqual(["bitwiseShiftRight"]);
+    expect(operatorSpelling("Arel::Math", "~@")).toEqual(["bitwiseNot"]);
+  });
+
+  it("leaves module operators with no TS counterpart unmapped", () => {
+    // attribute_methods.rb:415/428, relation/delegation.rb:101 and
+    // core_ext/range/compare_range.rb:16 have no TS member in the container
+    // their bucket maps to, so they stay unmapped rather than being pinned to
+    // a spelling that does not exist (a pin would be dead weight).
+    expect(operatorSpelling("ActiveRecord::AttributeMethods", "[]")).toBeUndefined();
+    expect(operatorSpelling("ActiveRecord::AttributeMethods", "[]=")).toBeUndefined();
+    expect(operatorSpelling("ActiveRecord::Delegation", "[]")).toBeUndefined();
+    expect(operatorSpelling("ActiveRecord::Delegation", "+")).toBeUndefined();
+    expect(operatorSpelling("ActiveSupport::CompareWithRange", "===")).toBeUndefined();
+  });
+
   it("returns undefined for an unlisted class (stays unmapped)", () => {
     expect(operatorSpelling("Arel::Nodes::Casted", "[]")).toBeUndefined();
     expect(operatorSpelling("Arel::Table", "==")).toBeUndefined();

--- a/scripts/api-compare/operator-order-spelling.test.ts
+++ b/scripts/api-compare/operator-order-spelling.test.ts
@@ -57,10 +57,6 @@ describe("operatorSpelling", () => {
   });
 
   it("leaves module operators with no TS counterpart unmapped", () => {
-    // attribute_methods.rb:415/428, relation/delegation.rb:101 and
-    // core_ext/range/compare_range.rb:16 have no TS member in the container
-    // their bucket maps to, so they stay unmapped rather than being pinned to
-    // a spelling that does not exist (a pin would be dead weight).
     expect(operatorSpelling("ActiveRecord::AttributeMethods", "[]")).toBeUndefined();
     expect(operatorSpelling("ActiveRecord::AttributeMethods", "[]=")).toBeUndefined();
     expect(operatorSpelling("ActiveRecord::Delegation", "[]")).toBeUndefined();

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -27,6 +27,26 @@ import { OPERATORS } from "./conventions.js";
 // `rubyMethodToTs`'s multi-name shape: the rule filters to spellings actually
 // present in the container, so listing more than one is a safe no-op.
 export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> = {
+  // arel/math.rb:5-41 — the arithmetic/bitwise mixin. Every operator has a
+  // named counterpart on math.ts's `Math` mixin object, one per Ruby `def`:
+  // `*`:5 `+`:9 `-`:13 `/`:17 `&`:21 `|`:25 `^`:29 `<<`:33 `>>`:37 `~@`:41.
+  // The spellings are verified, but math.ts ports the mixin as an object
+  // literal (`export const Math = {…}`), and the ORDER rule only reads
+  // top-level function declarations — so the bucket is reported as dropped
+  // until the rule learns to consume mixin objects. The pin is still the
+  // right data: it is what makes that drop visible instead of silent.
+  "Arel::Math": {
+    "*": ["multiply"],
+    "+": ["add"],
+    "-": ["subtract"],
+    "/": ["divide"],
+    "&": ["bitwiseAnd"],
+    "|": ["bitwiseOr"],
+    "^": ["bitwiseXor"],
+    "<<": ["bitwiseShiftLeft"],
+    ">>": ["bitwiseShiftRight"],
+    "~@": ["bitwiseNot"],
+  },
   // arel/table.rb:82 `def [](name, table = self)` → table.ts `get`.
   "Arel::Table": { "[]": ["get"] },
   // active_model/errors.rb:229 `def [](attribute)` → errors.ts `get`.

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -30,11 +30,9 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // arel/math.rb:5-41 — the arithmetic/bitwise mixin. Every operator has a
   // named counterpart on math.ts's `Math` mixin object, one per Ruby `def`:
   // `*`:5 `+`:9 `-`:13 `/`:17 `&`:21 `|`:25 `^`:29 `<<`:33 `>>`:37 `~@`:41.
-  // The spellings are verified, but math.ts ports the mixin as an object
-  // literal (`export const Math = {…}`), and the ORDER rule only reads
-  // top-level function declarations — so the bucket is reported as dropped
-  // until the rule learns to consume mixin objects. The pin is still the
-  // right data: it is what makes that drop visible instead of silent.
+  // math.ts ports the mixin as an object literal, which the ORDER rule (it
+  // reads top-level function declarations only) reports as a dropped bucket —
+  // the pin is what makes that drop visible rather than silent, so keep it.
   "Arel::Math": {
     "*": ["multiply"],
     "+": ["add"],


### PR DESCRIPTION
PR #5915 taught the standalone-module branch of
`build-rails-file-structure-manifest.ts` to consult `operatorSpelling`, which
made `OPERATOR_SPELLING_BY_FQN` entries for Ruby *modules* live for the first
time. This pins the module-level operators that are actually pinnable.

## What's pinned

`Arel::Math` (arel/math.rb:5-41) — all ten operators, each verified against a
named member of math.ts's `Math` mixin object:

| Ruby | line | TS |
| --- | --- | --- |
| `*` | 5 | `multiply` |
| `+` | 9 | `add` |
| `-` | 13 | `subtract` |
| `/` | 17 | `divide` |
| `&` | 21 | `bitwiseAnd` |
| `\|` | 25 | `bitwiseOr` |
| `^` | 29 | `bitwiseXor` |
| `<<` | 33 | `bitwiseShiftLeft` |
| `>>` | 37 | `bitwiseShiftRight` |
| `~@` | 41 | `bitwiseNot` |

The story listed eight; enumerating `rails-api.json` against the full
`OPERATORS` set turns up `>>` and `~@` as well.

## What's deliberately NOT pinned

The table only accepts spellings verified against a real TS member — a pin with
no member is dead weight. These have none in the container their manifest
bucket maps to, so each is filed as its own port story instead:

- `ActiveRecord::AttributeMethods` `[]` / `[]=` (attribute_methods.rb:415/428) —
  attribute-methods.ts has `readAttribute` / `writeAttribute` but no bracket
  accessor port → `port-attribute-methods-bracket-accessors`
- `ActiveRecord::Delegation` `[]`, `&`, `|`, `+`, `-` (relation/delegation.rb:101)
  — present only as strings in `DELEGATED_ARRAY_METHODS`, not as declared
  members of delegation.ts → `port-delegation-record-operators`
- `ActiveSupport::CompareWithRange` `===` (core_ext/range/compare_range.rb:16) —
  `packages/activesupport/src/core-ext/range/` does not exist at all →
  `port-compare-with-range`

## Known limitation surfaced by the pin

`rails-file-structure-method-order` builds its `functions` container from
top-level function declarations only, so math.ts's object-literal mixin matches
no container and the new bucket is reported as dropped under
`RAILS_STRUCTURE_REPORT=1`. The pin is still the right data — it is what makes
that drop visible instead of silent — and the rule fix (plus math.ts's actual
order, which does not match Rails) is filed as
`method-order-rule-blind-to-mixin-objects`.

## Verification

- `pnpm api:compare` green; manifest rebuild reports no dead entry and emits
  the ten names into `packages/arel/src/math.ts`.
- `pnpm vitest run scripts/api-compare/operator-order-spelling.test.ts` — 12
  passed.

Closes-story: module-level-operator-spellings-unpinned
