### PR TITLE
fix(eslint): order mixin object literals in rails-file-structure-method-order

### DIFF
--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -230,8 +230,10 @@ function isOrderableObjectMember(node) {
  *
  * Reordering properties is safe for the same reason class members are: the
  * literal is one expression and nothing in it observes their relative order —
- * EXCEPT under a duplicate key, where the last definition wins and a reorder
- * would change which one that is. Such a literal is skipped.
+ * except where a later definition OVERRIDES an earlier one, which a reorder
+ * would invert. Two shapes do that, and both skip the literal: a duplicate
+ * key, and a spread (`{ foo() {}, ...base, bar() {} }`, where moving a member
+ * across the spread flips whether it or `base`'s same-named key wins).
  */
 function collectObjectContainers(programNode) {
   const candidates = [];
@@ -245,6 +247,7 @@ function collectObjectContainers(programNode) {
     if (!decl) continue;
     for (const d of decl.declarations) {
       if (d.id?.type !== "Identifier" || d.init?.type !== "ObjectExpression") continue;
+      if (d.init.properties.some((p) => p.type === "SpreadElement")) continue;
       const members = d.init.properties.filter(isOrderableObjectMember);
       if (members.length < 2) continue;
       const declaredKeys = new Set();
@@ -551,8 +554,12 @@ const rule = {
           });
         }
 
-        // Two unresolved literals competing for one `functions` bucket is
-        // ambiguous; guessing would impose an unrelated Rails order.
+        // The `functions` bucket has ONE claimant. Top-level functions take it
+        // when the file has them — they are the primary port shape for a Ruby
+        // module, and an object literal alongside them is as likely to be an
+        // unrelated const table as a mixin. A literal claims it only when it is
+        // the sole candidate: two competing literals are ambiguous, and guessing
+        // would impose an unrelated Rails order on the wrong one.
         const freeObjects = objectCandidates.filter((c) => !c.expectedOrder);
         if (!functionsConsumed && functionOrder.length > 0 && freeObjects.length === 1) {
           freeObjects[0].expectedOrder = functionOrder;

--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -11,6 +11,8 @@
  * Scope per file:
  *   - Class instance + static methods (one container per ClassBody).
  *   - Top-level FunctionDeclaration (incl. `export function …`).
+ *   - Top-level mixin object literals (`export const Math = { add(…) {} }`),
+ *     the CLAUDE.md port shape for a Ruby module of methods.
  *
  * The manifest keys expected order per container: `classes[Name]` for
  * each class body (matched by the class's declared name) and `functions`
@@ -172,6 +174,10 @@ function memberName(node) {
   if (node.type === "FunctionDeclaration" || node.type === "TSDeclareFunction") {
     return node.id?.name ?? null;
   }
+  // Method of a mixin object literal (`export const Math = { add(…) {} }`).
+  if (node.type === "Property") {
+    return node.key?.type === "Identifier" && !node.computed ? node.key.name : null;
+  }
   if (
     node.type === "ExportNamedDeclaration" &&
     (node.declaration?.type === "FunctionDeclaration" ||
@@ -207,6 +213,50 @@ function isOrderableClassMember(node) {
   if (node.type !== "MethodDefinition") return false;
   if (node.key?.type !== "Identifier") return false;
   return true;
+}
+
+// A Ruby module ported as a mixin OBJECT (CLAUDE.md "Module mixins" —
+// `export const Math = { add(…) {}, … }` in packages/arel/src/math.ts) is
+// neither a ClassBody nor a top-level FunctionDeclaration, so without this it
+// matched no container and its manifest bucket was silently dropped.
+// Only plain function-valued members are orderable; spreads, computed keys and
+// value properties are left alone.
+function isOrderableObjectMember(node) {
+  if (node.type !== "Property") return false;
+  if (node.computed || node.key?.type !== "Identifier") return false;
+  return (
+    node.value?.type === "FunctionExpression" || node.value?.type === "ArrowFunctionExpression"
+  );
+}
+
+// Top-level `const Name = { … }` / `export const Name = { … }` object literals,
+// as `{ name, members, declaredKeys }` candidates. Reordering properties of an
+// object literal is safe for the same reason class members are: the properties
+// are evaluated as one expression and nothing inside can observe their relative
+// declaration order.
+function collectObjectContainers(programNode) {
+  const candidates = [];
+  for (const stmt of programNode.body) {
+    const decl =
+      stmt.type === "VariableDeclaration"
+        ? stmt
+        : stmt.type === "ExportNamedDeclaration" && stmt.declaration?.type === "VariableDeclaration"
+          ? stmt.declaration
+          : null;
+    if (!decl) continue;
+    for (const d of decl.declarations) {
+      if (d.id?.type !== "Identifier" || d.init?.type !== "ObjectExpression") continue;
+      const members = d.init.properties.filter(isOrderableObjectMember);
+      if (members.length < 2) continue;
+      const declaredKeys = new Set();
+      for (const p of d.init.properties) {
+        const n = memberName(p);
+        if (n) declaredKeys.add(n);
+      }
+      candidates.push({ name: d.id.name, members, declaredKeys });
+    }
+  }
+  return candidates;
 }
 
 function isOrderableTopLevel(node) {
@@ -448,6 +498,20 @@ const rule = {
             usedBucket.add(cand.name);
           }
         }
+        // Mixin object literals compete for the same buckets as class bodies:
+        // a `Foo::ClassMethods`-style mixin lands in `classes[Foo]`, while a
+        // standalone Ruby module lands in `functions` (see
+        // scripts/build-rails-file-structure-manifest.ts). Take an exact
+        // classes-bucket name match first; whatever is left is a candidate for
+        // the `functions` bucket below.
+        const objectCandidates = collectObjectContainers(programNode);
+        for (const cand of objectCandidates) {
+          if (!usedBucket.has(cand.name) && (classOrders[cand.name]?.length ?? 0) > 0) {
+            cand.expectedOrder = classOrders[cand.name];
+            usedBucket.add(cand.name);
+          }
+        }
+
         const unresolved = classCandidates.filter((c) => !c.expectedOrder);
         const freeBuckets = bucketKeys.filter((k) => !usedBucket.has(k));
         if (unresolved.length === 1 && freeBuckets.length === 1) {
@@ -476,7 +540,7 @@ const rule = {
         }
 
         const topLevel = programNode.body.filter(isOrderableTopLevel);
-        const functionsConsumed = topLevel.length >= 2 && functionOrder.length > 0;
+        let functionsConsumed = topLevel.length >= 2 && functionOrder.length > 0;
         if (functionsConsumed) {
           containers.push({
             container: programNode,
@@ -485,6 +549,25 @@ const rule = {
             // Top-level functions have no staticness; every name is "instance".
             declaredKeys: new Set(topLevel.map(memberName).filter(Boolean)),
           });
+        }
+
+        // A mixin object literal takes the `functions` bucket when the file has
+        // no top-level function container to claim it and exactly ONE object
+        // literal is still unresolved — more than one is ambiguous, and guessing
+        // would impose an unrelated Rails order on the wrong object.
+        const freeObjects = objectCandidates.filter((c) => !c.expectedOrder);
+        if (!functionsConsumed && functionOrder.length > 0 && freeObjects.length === 1) {
+          freeObjects[0].expectedOrder = functionOrder;
+          functionsConsumed = true;
+        }
+        for (const cand of objectCandidates) {
+          if (cand.expectedOrder) {
+            containers.push({
+              members: cand.members,
+              expectedOrder: cand.expectedOrder,
+              declaredKeys: cand.declaredKeys,
+            });
+          }
         }
 
         if (coverageReport) {

--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -174,7 +174,6 @@ function memberName(node) {
   if (node.type === "FunctionDeclaration" || node.type === "TSDeclareFunction") {
     return node.id?.name ?? null;
   }
-  // Method of a mixin object literal (`export const Math = { add(…) {} }`).
   if (node.type === "Property") {
     return node.key?.type === "Identifier" && !node.computed ? node.key.name : null;
   }
@@ -215,12 +214,6 @@ function isOrderableClassMember(node) {
   return true;
 }
 
-// A Ruby module ported as a mixin OBJECT (CLAUDE.md "Module mixins" —
-// `export const Math = { add(…) {}, … }` in packages/arel/src/math.ts) is
-// neither a ClassBody nor a top-level FunctionDeclaration, so without this it
-// matched no container and its manifest bucket was silently dropped.
-// Only plain function-valued members are orderable; spreads, computed keys and
-// value properties are left alone.
 function isOrderableObjectMember(node) {
   if (node.type !== "Property") return false;
   if (node.computed || node.key?.type !== "Identifier") return false;
@@ -229,11 +222,17 @@ function isOrderableObjectMember(node) {
   );
 }
 
-// Top-level `const Name = { … }` / `export const Name = { … }` object literals,
-// as `{ name, members, declaredKeys }` candidates. Reordering properties of an
-// object literal is safe for the same reason class members are: the properties
-// are evaluated as one expression and nothing inside can observe their relative
-// declaration order.
+/**
+ * Top-level `const Name = { … }` / `export const Name = { … }` mixin object
+ * literals as orderable containers — the CLAUDE.md "Module mixins" port shape
+ * for a Ruby module of methods (`packages/arel/src/math.ts`), which is neither
+ * a ClassBody nor a FunctionDeclaration and so matched nothing before.
+ *
+ * Reordering properties is safe for the same reason class members are: the
+ * literal is one expression and nothing in it observes their relative order —
+ * EXCEPT under a duplicate key, where the last definition wins and a reorder
+ * would change which one that is. Such a literal is skipped.
+ */
 function collectObjectContainers(programNode) {
   const candidates = [];
   for (const stmt of programNode.body) {
@@ -249,10 +248,14 @@ function collectObjectContainers(programNode) {
       const members = d.init.properties.filter(isOrderableObjectMember);
       if (members.length < 2) continue;
       const declaredKeys = new Set();
+      let duplicate = false;
       for (const p of d.init.properties) {
         const n = memberName(p);
-        if (n) declaredKeys.add(n);
+        if (!n) continue;
+        if (declaredKeys.has(n) && p.kind === "init") duplicate = true;
+        declaredKeys.add(n);
       }
+      if (duplicate) continue;
       candidates.push({ name: d.id.name, members, declaredKeys });
     }
   }
@@ -498,12 +501,9 @@ const rule = {
             usedBucket.add(cand.name);
           }
         }
-        // Mixin object literals compete for the same buckets as class bodies:
-        // a `Foo::ClassMethods`-style mixin lands in `classes[Foo]`, while a
-        // standalone Ruby module lands in `functions` (see
-        // scripts/build-rails-file-structure-manifest.ts). Take an exact
-        // classes-bucket name match first; whatever is left is a candidate for
-        // the `functions` bucket below.
+        // A mixin object flattened from `Foo::ClassMethods` lands in
+        // `classes[Foo]`; a standalone Ruby module lands in `functions` (see
+        // scripts/build-rails-file-structure-manifest.ts), claimed below.
         const objectCandidates = collectObjectContainers(programNode);
         for (const cand of objectCandidates) {
           if (!usedBucket.has(cand.name) && (classOrders[cand.name]?.length ?? 0) > 0) {
@@ -551,10 +551,8 @@ const rule = {
           });
         }
 
-        // A mixin object literal takes the `functions` bucket when the file has
-        // no top-level function container to claim it and exactly ONE object
-        // literal is still unresolved — more than one is ambiguous, and guessing
-        // would impose an unrelated Rails order on the wrong object.
+        // Two unresolved literals competing for one `functions` bucket is
+        // ambiguous; guessing would impose an unrelated Rails order.
         const freeObjects = objectCandidates.filter((c) => !c.expectedOrder);
         if (!functionsConsumed && functionOrder.length > 0 && freeObjects.length === 1) {
           freeObjects[0].expectedOrder = functionOrder;

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -169,6 +169,12 @@ try {
         filename: mixinFile,
         code: `export const Math = {\n  alpha() {},\n  beta() {},\n  gamma() {},\n};\n`,
       },
+      // Duplicate key: the LAST definition wins at runtime, so a reorder would
+      // change which one that is. The literal is skipped.
+      {
+        filename: mixinFile,
+        code: `export const Math = {\n  gamma() {},\n  alpha() {},\n  gamma() {},\n};\n`,
+      },
       // Two object literals, one `functions` bucket — ambiguous, left alone.
       {
         filename: mixin2File,

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -34,6 +34,25 @@ const fixture = {
       classes: {},
       functions: ["alpha", "beta", "gamma"],
     },
+    // A Ruby module ported as a mixin OBJECT literal (`export const Math =
+    // { … }`, packages/arel/src/math.ts). Standalone modules bucket into
+    // `functions`, so the object literal claims that bucket.
+    "packages/arel/src/fixture-mixin.ts": {
+      classes: {},
+      functions: ["alpha", "beta", "gamma"],
+    },
+    // A mixin object whose name matches a CLASS bucket (the flattened
+    // `Foo::ClassMethods` shape) resolves by exact name, like a class body.
+    "packages/arel/src/fixture-mixinclass.ts": {
+      classes: { M: sharedClassOrder },
+      functions: [],
+    },
+    // Two unresolved object literals competing for one `functions` bucket →
+    // ambiguous, so neither is ordered.
+    "packages/arel/src/fixture-mixin2.ts": {
+      classes: {},
+      functions: ["alpha", "beta", "gamma"],
+    },
     "packages/arel/src/fixture-multi.ts": {
       classes: { Casted: ["before", "database"], Quoted: ["database", "before"] },
       functions: [],
@@ -102,6 +121,9 @@ process.on("exit", restoreManifest);
 const classFile = path.join(REPO_ROOT, "packages/arel/src/fixture-class.ts");
 const fnFile = path.join(REPO_ROOT, "packages/arel/src/fixture-fns.ts");
 const unlistedFile = path.join(REPO_ROOT, "packages/arel/src/fixture-unlisted.ts");
+const mixinFile = path.join(REPO_ROOT, "packages/arel/src/fixture-mixin.ts");
+const mixinClassFile = path.join(REPO_ROOT, "packages/arel/src/fixture-mixinclass.ts");
+const mixin2File = path.join(REPO_ROOT, "packages/arel/src/fixture-mixin2.ts");
 const multiFile = path.join(REPO_ROOT, "packages/arel/src/fixture-multi.ts");
 const renameFile = path.join(REPO_ROOT, "packages/arel/src/fixture-rename.ts");
 const ambiguousFile = path.join(REPO_ROOT, "packages/arel/src/fixture-ambiguous.ts");
@@ -141,6 +163,18 @@ try {
       {
         filename: fnFile,
         code: `export function alpha() {}\nexport function beta() {}\nexport function gamma() {}\n`,
+      },
+      // Mixin object literal already in expected order.
+      {
+        filename: mixinFile,
+        code: `export const Math = {\n  alpha() {},\n  beta() {},\n  gamma() {},\n};\n`,
+      },
+      // Two object literals, one `functions` bucket — ambiguous, left alone.
+      {
+        filename: mixin2File,
+        code:
+          `export const A = {\n  gamma() {},\n  alpha() {},\n};\n` +
+          `export const B = {\n  beta() {},\n  alpha() {},\n};\n`,
       },
       // Single member — nothing to reorder.
       {
@@ -267,6 +301,35 @@ try {
           `export function beta(x: number): number;\n` +
           `export function beta(x: any): any { return x; }\n` +
           `export function gamma(): void {}\n`,
+      },
+      // Mixin object literal out of order (packages/arel/src/math.ts). Its
+      // members are properties, not FunctionDeclarations, so before this the
+      // whole `functions` bucket was dropped and no order was enforced.
+      {
+        filename: mixinFile,
+        code:
+          `export const Math = {\n` +
+          `  gamma() {},\n` +
+          `  /** doc for alpha */\n` +
+          `  alpha() {},\n` +
+          `  beta() {},\n` +
+          `};\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output:
+          `export const Math = {\n` +
+          `  /** doc for alpha */\n` +
+          `  alpha() {},\n` +
+          `  beta() {},\n` +
+          `  gamma() {},\n` +
+          `};\n`,
+      },
+      // Mixin object matched to a CLASS bucket by exact name; a non-function
+      // property is not orderable and keeps its place.
+      {
+        filename: mixinClassFile,
+        code: `const M = {\n` + `  second() {},\n` + `  value: 1,\n` + `  first() {},\n` + `};\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output: `const M = {\n` + `  first() {},\n` + `  value: 1,\n` + `  second() {},\n` + `};\n`,
       },
       // Class methods out of order.
       {

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -175,6 +175,12 @@ try {
         filename: mixinFile,
         code: `export const Math = {\n  gamma() {},\n  alpha() {},\n  gamma() {},\n};\n`,
       },
+      // A spread can define the same keys, so moving a member across it flips
+      // which definition wins. The literal is skipped.
+      {
+        filename: mixinFile,
+        code: `export const Math = {\n  gamma() {},\n  ...base,\n  alpha() {},\n};\n`,
+      },
       // Two object literals, one `functions` bucket — ambiguous, left alone.
       {
         filename: mixin2File,
@@ -328,6 +334,20 @@ try {
           `  beta() {},\n` +
           `  gamma() {},\n` +
           `};\n`,
+      },
+      // Top-level functions and an object literal both compete for the single
+      // `functions` bucket: the functions take it and the literal is left as-is.
+      {
+        filename: fnFile,
+        code:
+          `export function gamma() {}\n` +
+          `export function alpha() {}\n` +
+          `export const M = {\n  gamma() {},\n  alpha() {},\n};\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output:
+          `export function alpha() {}\n` +
+          `export function gamma() {}\n` +
+          `export const M = {\n  gamma() {},\n  alpha() {},\n};\n`,
       },
       // Mixin object matched to a CLASS bucket by exact name; a non-function
       // property is not orderable and keeps its place.

--- a/packages/arel/src/math.ts
+++ b/packages/arel/src/math.ts
@@ -30,14 +30,14 @@ import type { NodeOrValue } from "./nodes/binary.js";
  * a caller that cannot produce a `NodeOrValue` is a finding, not a widen.
  */
 export const Math = {
+  multiply(this: Node, other: NodeOrValue): Multiplication {
+    return new Multiplication(this, other);
+  },
   add(this: Node, other: NodeOrValue): Grouping {
     return new Grouping(new Addition(this, other));
   },
   subtract(this: Node, other: NodeOrValue): Grouping {
     return new Grouping(new Subtraction(this, other));
-  },
-  multiply(this: Node, other: NodeOrValue): Multiplication {
-    return new Multiplication(this, other);
   },
   divide(this: Node, other: NodeOrValue): Division {
     return new Division(this, other);


### PR DESCRIPTION
`eslint/rails-file-structure-method-order.mjs` only built containers from class bodies and top-level `FunctionDeclaration`s, so a Ruby module ported as a mixin OBJECT literal (CLAUDE.md "Module mixins": `export const Math = { add(…) {}, … }` in `packages/arel/src/math.ts`) matched nothing and its manifest bucket was silently dropped — visible only under `RAILS_STRUCTURE_REPORT=1` as `packages/arel/src/math.ts — functions (no top-level fns)`.

- Top-level `const Name = { … }` / `export const Name = { … }` object literals with ≥2 function-valued members are now orderable containers. Resolution mirrors class bodies: exact `classes[Name]` match first (the flattened `Foo::ClassMethods` shape), otherwise the file's `functions` bucket when no top-level function container claimed it and exactly one literal is unresolved (more is ambiguous → left unordered). Non-function, computed and spread properties stay put.
- A literal with a duplicate key is skipped entirely: the last definition wins at runtime, so a reorder would change which one that is.
- `packages/arel/src/math.ts` reordered to `math.rb`'s order (`*`:5, `+`:9, `-`:13, `/`:17, …) — only `multiply` moves.
- Rule unit tests cover the in-order literal, the out-of-order autofix (with attached JSDoc), the classes-bucket-by-name match, the two-literal ambiguity, and the duplicate-key guard.

Verified against the real `math.ts` with a synthetic manifest: clean in the new order, and a shuffled copy autofixes back to it. (The `Arel::Math` operator pin itself lands in the sibling `module-level-operator-spellings-unpinned` PR.)

Closes-story: method-order-rule-blind-to-mixin-objects
