### PR TITLE
refactor(activerecord): resolve MySQL max_allowed_packet from the server

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -12,6 +12,7 @@ import { inspectExplainOption } from "./abstract/database-statements.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
 import {
   isWriteQuery as mysqlIsWriteQuery,
+  maxAllowedPacket as mysqlMaxAllowedPacket,
   returningColumnValues as mysqlReturningColumnValues,
 } from "./mysql/database-statements.js";
 import { Result } from "../result.js";
@@ -1125,6 +1126,17 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       if (e instanceof StatementInvalid) return null;
       throw e;
     }
+  }
+
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#max_allowed_packet
+   * — `@max_allowed_packet ||= show_variable("max_allowed_packet")`.
+   */
+  declare _maxAllowedPacket?: number;
+
+  /** @internal */
+  async maxAllowedPacket(): Promise<number> {
+    return mysqlMaxAllowedPacket.call(this);
   }
 
   async primaryKeys(tableName: string): Promise<string[]> {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1128,13 +1128,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     }
   }
 
+  declare _maxAllowedPacket?: number;
+
   /**
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#max_allowed_packet
    * — `@max_allowed_packet ||= show_variable("max_allowed_packet")`.
+   * @internal
    */
-  declare _maxAllowedPacket?: number;
-
-  /** @internal */
   async maxAllowedPacket(): Promise<number> {
     return mysqlMaxAllowedPacket.call(this);
   }

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.trails.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  combineMultiStatements,
+  isMaxAllowedPacketReached,
+  maxAllowedPacket,
+  type MaxAllowedPacketHost,
+} from "./database-statements.js";
+
+function hostReporting(value: string | null): MaxAllowedPacketHost & { calls: number } {
+  const host = {
+    calls: 0,
+    async showVariable(name: string) {
+      expect(name).toBe("max_allowed_packet");
+      host.calls += 1;
+      return value;
+    },
+  };
+  return host;
+}
+
+describe("MySQL::DatabaseStatements max_allowed_packet", () => {
+  it("reads the ceiling from the server and memoizes it", async () => {
+    const host = hostReporting("1024");
+    expect(await maxAllowedPacket.call(host)).toBe(1024);
+    expect(await maxAllowedPacket.call(host)).toBe(1024);
+    expect(host.calls).toBe(1);
+  });
+
+  it("falls back to the MySQL default when the server does not answer", async () => {
+    const host = hostReporting(null);
+    expect(await maxAllowedPacket.call(host)).toBe(16_777_216);
+  });
+
+  it("splits statements against the server-reported ceiling", async () => {
+    const host = hostReporting("32");
+    const statements = ["SELECT 1234567890", "SELECT 1234567890"];
+    expect(await combineMultiStatements.call(host, statements)).toEqual(statements);
+  });
+
+  it("concatenates statements that fit under the server-reported ceiling", async () => {
+    const host = hostReporting("1024");
+    expect(await combineMultiStatements.call(host, ["SELECT 1", "SELECT 2"])).toEqual([
+      "SELECT 1;\nSELECT 2",
+    ]);
+  });
+
+  it("raises when a single statement exceeds the ceiling", async () => {
+    const host = hostReporting("8");
+    await expect(
+      isMaxAllowedPacketReached.call(host, "SELECT 1234567890", undefined),
+    ).rejects.toThrow(/Fixtures set is too large 17\./);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -148,6 +148,8 @@ export async function isMaxAllowedPacketReached(
   previousPacket: string | undefined,
 ): Promise<boolean> {
   const host = this ?? undefined;
+  // Rails resolves `max_allowed_packet` on self; the receiver only carries it
+  // once the module is mixed in, so a bare host falls back to the free function.
   const maxPacket = host?.maxAllowedPacket
     ? await host.maxAllowedPacket()
     : await maxAllowedPacket.call(host);

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -115,28 +115,42 @@ export function returningColumnValues(
   return undefined;
 }
 
-/** @internal */
-export function combineMultiStatements(totalSql: string[]): string[] {
-  // Rails reads max_allowed_packet lazily from the server; we use the MySQL default (16 MiB).
-  // Full wiring (async server query) is deferred to the adapter layer.
-  const maxPacket = 16_777_216;
-  return totalSql.reduce<string[]>((chunks, sql) => {
-    const prev = chunks[chunks.length - 1];
-    if (isMaxAllowedPacketReached(sql, prev, maxPacket)) {
-      chunks.push(sql);
-    } else {
-      chunks[chunks.length - 1] = `${prev};\n${sql}`;
-    }
-    return chunks;
-  }, []);
+export interface MaxAllowedPacketHost {
+  showVariable?(name: string): Promise<string | null>;
+  /** Mirrors Rails' `@max_allowed_packet` memo. */
+  _maxAllowedPacket?: number;
+  /** @internal */
+  maxAllowedPacket?(): Promise<number>;
 }
 
 /** @internal */
-export function isMaxAllowedPacketReached(
+export async function combineMultiStatements(
+  this: MaxAllowedPacketHost | void,
+  totalSql: string[],
+): Promise<string[]> {
+  const host = this ?? undefined;
+  const chunks: string[] = [];
+  for (const sql of totalSql) {
+    const previousPacket = chunks[chunks.length - 1];
+    if (await isMaxAllowedPacketReached.call(host, sql, previousPacket)) {
+      chunks.push(sql);
+    } else {
+      chunks[chunks.length - 1] = `${previousPacket};\n${sql}`;
+    }
+  }
+  return chunks;
+}
+
+/** @internal */
+export async function isMaxAllowedPacketReached(
+  this: MaxAllowedPacketHost | void,
   currentPacket: string,
   previousPacket: string | undefined,
-  maxPacket: number,
-): boolean {
+): Promise<boolean> {
+  const host = this ?? undefined;
+  const maxPacket = host?.maxAllowedPacket
+    ? await host.maxAllowedPacket()
+    : await maxAllowedPacket.call(host);
   const currentSize = Buffer.byteLength(currentPacket, "utf8");
   if (currentSize > maxPacket) {
     throw new Error(
@@ -148,14 +162,16 @@ export function isMaxAllowedPacketReached(
 }
 
 /** @internal */
-export async function maxAllowedPacket(
-  this: { showVariable?(name: string): Promise<string | null> } | void,
-): Promise<number> {
-  const raw = await (
-    this as { showVariable?(name: string): Promise<string | null> } | null
-  )?.showVariable?.("max_allowed_packet");
+export async function maxAllowedPacket(this: MaxAllowedPacketHost | void): Promise<number> {
+  const host = this ?? undefined;
+  if (host?._maxAllowedPacket !== undefined) return host._maxAllowedPacket;
+  const raw = await host?.showVariable?.("max_allowed_packet");
   const parsed = raw != null ? parseInt(raw, 10) : NaN;
-  return Number.isNaN(parsed) ? 16_777_216 : parsed;
+  // Rails has no fallback — `show_variable` always answers on a live MySQL
+  // connection. The default stands in for hosts without one (e.g. unit tests).
+  const resolved = Number.isNaN(parsed) ? 16_777_216 : parsed;
+  if (host) host._maxAllowedPacket = resolved;
+  return resolved;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -167,8 +167,8 @@ export async function maxAllowedPacket(this: MaxAllowedPacketHost | void): Promi
   if (host?._maxAllowedPacket !== undefined) return host._maxAllowedPacket;
   const raw = await host?.showVariable?.("max_allowed_packet");
   const parsed = raw != null ? parseInt(raw, 10) : NaN;
-  // Rails has no fallback — `show_variable` always answers on a live MySQL
-  // connection. The default stands in for hosts without one (e.g. unit tests).
+  // Rails needs no fallback: `show_variable` always answers on a live MySQL
+  // connection. The MySQL default stands in for a host without one.
   const resolved = Number.isNaN(parsed) ? 16_777_216 : parsed;
   if (host) host._maxAllowedPacket = resolved;
   return resolved;

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -8,7 +8,7 @@ import type { Type } from "@blazetrails/activemodel";
 import type mysql from "mysql2/promise";
 import { NotImplementedError } from "../../errors.js";
 import { Result, type ColumnTypes } from "../../result.js";
-import { combineMultiStatements } from "../mysql/database-statements.js";
+import { combineMultiStatements, type MaxAllowedPacketHost } from "../mysql/database-statements.js";
 
 export interface DatabaseStatementsHost {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
@@ -158,11 +158,11 @@ export async function selectAll(
  * @internal
  */
 export async function executeBatch(
-  this: { execute(sql: string, name?: string | null): Promise<unknown> },
+  this: MaxAllowedPacketHost & { execute(sql: string, name?: string | null): Promise<unknown> },
   statements: string[],
   name?: string | null,
 ): Promise<void> {
-  for (const statement of combineMultiStatements(statements)) {
+  for (const statement of await combineMultiStatements.call(this, statements)) {
     await this.execute(statement, name);
   }
 }

--- a/scripts/api-compare/arity-exclude.json
+++ b/scripts/api-compare/arity-exclude.json
@@ -1,12 +1,6 @@
 [
   {
     "package": "activerecord",
-    "rubyFile": "connection_adapters/mysql/database_statements.rb",
-    "rubyName": "max_allowed_packet_reached?",
-    "reason": "Rails reads the packet ceiling from `max_allowed_packet`, which memoizes an async `SHOW VARIABLES` round-trip. `combineMultiStatements` is synchronous in trails and hands the limit down as `maxPacket` (currently the 16 MiB MySQL default), so the third param cannot be dropped until that caller chain becomes async."
-  },
-  {
-    "package": "activerecord",
     "rubyFile": "database_configurations/url_config.rb",
     "rubyName": "build_url_hash",
     "reason": "Ruby reads `@url`, but the TS port must run BEFORE `super(...)` in the UrlConfig constructor — its result is merged into the configuration hash passed up to HashConfig, and `this` is unavailable before `super`. The url therefore has to be threaded in as a parameter."


### PR DESCRIPTION
## What

MySQL's `combine_multi_statements` sizes each multi-statement chunk against
`max_allowed_packet`, which memoizes a `SHOW VARIABLES` round-trip
(`mysql/database_statements.rb:66-90`). The trails port hardcoded the 16 MiB
MySQL default and threaded it down as a third `maxPacket` parameter, so a server
configured below 16 MiB built an over-long multi-statement and failed at
execution instead of splitting.

- `combineMultiStatements` and `isMaxAllowedPacketReached` are now async and
  read the ceiling off the receiver. `isMaxAllowedPacketReached` matches Rails'
  `(current_packet, previous_packet)` arity.
- `maxAllowedPacket` memoizes into `_maxAllowedPacket`, mirroring Rails'
  `@max_allowed_packet ||=`, and `AbstractMysqlAdapter` gains the accessor so
  the lookup resolves through the live `showVariable`.
- `mysql2`'s `executeBatch` awaits the combine, closing the async chain end to
  end.
- Drops the `max_allowed_packet_reached?` entry from `arity-exclude.json`
  (added in #5340).

The 16 MiB constant survives only as the fallback for a host with no live
connection (the unit-test doubles) — Rails needs none because `show_variable`
always answers on a real MySQL connection.

## Testing

`packages/activerecord/src/connection-adapters/mysql/database-statements.trails.test.ts`
covers memoization, the server-reported split, the concat path, and the
too-large raise. The split test fails on baseline (the hardcoded 16 MiB never
splits a 32-byte ceiling).

Parity deltas are non-negative: `test:compare` unchanged at 14879/22203;
`api:compare` arity mismatches unchanged with one fewer exclusion (4 → 3).

`arity-exclude.json` is rewritten through `serializeBaseline` so it stays in the
canonical baseline form `scripts/api-compare/baseline-json.test.ts` enforces.

Closes-story: mysql-max-allowed-packet-async-lookup
