### PR TITLE
feat(activesupport): port Messages::Rotator and RotationConfiguration

### DIFF
--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -2,11 +2,15 @@ import { getCrypto } from "./crypto-adapter.js";
 import { Codec, type MessageSerializer } from "./messages/codec.js";
 import type { ExpectedMetadataOptions, MetadataOptions } from "./messages/metadata.js";
 import {
-  initializeRotator,
-  installRotator,
+  fallBackTo,
+  initialize as initializeRotator,
+  onRotation,
+  readMessage as readMessageWithRotations,
+  rotate,
   type OnRotation,
   type RotatableOptions,
 } from "./messages/rotator.js";
+import { prepend } from "./prepend.js";
 import { Thrown, type Format } from "./messages/serializer-with-fallback.js";
 
 export class InvalidMessage extends Error {
@@ -185,7 +189,8 @@ export class MessageEncryptor extends Codec {
   }
 }
 
-installRotator(MessageEncryptor);
+Object.assign(MessageEncryptor.prototype, { rotate, onRotation, fallBackTo });
+prepend(MessageEncryptor.prototype, { readMessage: readMessageWithRotations });
 
 export namespace NullSerializer {
   export function dump(value: unknown): string {

--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -1,6 +1,12 @@
 import { getCrypto } from "./crypto-adapter.js";
 import { Codec, type MessageSerializer } from "./messages/codec.js";
 import type { ExpectedMetadataOptions, MetadataOptions } from "./messages/metadata.js";
+import {
+  initializeRotator,
+  installRotator,
+  type OnRotation,
+  type RotatableOptions,
+} from "./messages/rotator.js";
 import { Thrown, type Format } from "./messages/serializer-with-fallback.js";
 
 export class InvalidMessage extends Error {
@@ -10,7 +16,7 @@ export class InvalidMessage extends Error {
   }
 }
 
-interface MessageEncryptorOptions {
+interface MessageEncryptorOptions extends RotatableOptions {
   cipher?: string;
   digest?: string;
   serializer?: Format | MessageSerializer;
@@ -19,6 +25,10 @@ interface MessageEncryptorOptions {
 
 export class MessageEncryptor extends Codec {
   static override defaultSerializer: Format | MessageSerializer = "json";
+
+  declare rotate: (...args: unknown[]) => this;
+  declare onRotation: (callback: OnRotation) => this;
+  declare fallBackTo: (fallback: this) => this;
 
   private secret: Buffer;
   private signSecret: Buffer;
@@ -59,6 +69,12 @@ export class MessageEncryptor extends Codec {
     } else {
       this.signSecret = this.secret;
     }
+
+    initializeRotator(
+      this,
+      signSecret === undefined ? [secret] : [secret, signSecret],
+      opts as Record<string, unknown>,
+    );
   }
 
   encryptAndSign(value: unknown, options: MetadataOptions = {}): string {
@@ -168,6 +184,8 @@ export class MessageEncryptor extends Codec {
     return 16;
   }
 }
+
+installRotator(MessageEncryptor);
 
 export namespace NullSerializer {
   export function dump(value: unknown): string {

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -2,11 +2,15 @@ import { getCrypto } from "./crypto-adapter.js";
 import { Codec, type MessageSerializer } from "./messages/codec.js";
 import type { ExpectedMetadataOptions, MetadataOptions } from "./messages/metadata.js";
 import {
-  initializeRotator,
-  installRotator,
+  fallBackTo,
+  initialize as initializeRotator,
+  onRotation,
+  readMessage as readMessageWithRotations,
+  rotate,
   type OnRotation,
   type RotatableOptions,
 } from "./messages/rotator.js";
+import { prepend } from "./prepend.js";
 import { Thrown, type Format } from "./messages/serializer-with-fallback.js";
 
 export class InvalidSignature extends Error {
@@ -138,4 +142,5 @@ export class MessageVerifier extends Codec {
   }
 }
 
-installRotator(MessageVerifier);
+Object.assign(MessageVerifier.prototype, { rotate, onRotation, fallBackTo });
+prepend(MessageVerifier.prototype, { readMessage: readMessageWithRotations });

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -1,6 +1,12 @@
 import { getCrypto } from "./crypto-adapter.js";
 import { Codec, type MessageSerializer } from "./messages/codec.js";
 import type { ExpectedMetadataOptions, MetadataOptions } from "./messages/metadata.js";
+import {
+  initializeRotator,
+  installRotator,
+  type OnRotation,
+  type RotatableOptions,
+} from "./messages/rotator.js";
 import { Thrown, type Format } from "./messages/serializer-with-fallback.js";
 
 export class InvalidSignature extends Error {
@@ -10,7 +16,7 @@ export class InvalidSignature extends Error {
   }
 }
 
-interface MessageVerifierOptions {
+interface MessageVerifierOptions extends RotatableOptions {
   digest?: string;
   serializer?: Format | MessageSerializer;
   url_safe?: boolean;
@@ -26,6 +32,10 @@ const SEPARATOR = "--";
 export class MessageVerifier extends Codec {
   static override defaultSerializer: Format | MessageSerializer = "json";
 
+  declare rotate: (...args: unknown[]) => this;
+  declare onRotation: (callback: OnRotation) => this;
+  declare fallBackTo: (fallback: this) => this;
+
   private secret: string | Buffer;
   private digest: string;
 
@@ -37,6 +47,7 @@ export class MessageVerifier extends Codec {
     });
     this.secret = secret;
     this.digest = options.digest ?? "sha1";
+    initializeRotator(this, [secret], options as Record<string, unknown>);
   }
 
   generate(value: unknown, options: GenerateOptions = {}): string {
@@ -126,3 +137,5 @@ export class MessageVerifier extends Codec {
     }
   }
 }
+
+installRotator(MessageVerifier);

--- a/packages/activesupport/src/messages/message-encryptor-rotator.test.ts
+++ b/packages/activesupport/src/messages/message-encryptor-rotator.test.ts
@@ -1,9 +1,0 @@
-import { describe, it } from "vitest";
-
-describe("MessageEncryptorRotatorTest", () => {
-  it.skip("rotate cipher");
-
-  it.skip("rotate verifier secret when using non-authenticated encryption");
-
-  it.skip("rotate verifier digest when using non-authenticated encryption");
-});

--- a/packages/activesupport/src/messages/message-verifier-rotator.test.ts
+++ b/packages/activesupport/src/messages/message-verifier-rotator.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { MessageVerifier } from "../message-verifier.js";
+
+const DATA = [{ a_boolean: true, a_number: 123, a_string: "abc" }];
+
+function makeCodec(options: Record<string, unknown> = {}): MessageVerifier {
+  return new MessageVerifier("secret", options);
+}
+
+function assertRotate(current: Record<string, unknown>, ...old: Record<string, unknown>[]): void {
+  const currentCodec = makeCodec(current);
+
+  for (const oldOptions of old) {
+    currentCodec.rotate(oldOptions);
+    const oldMessage = makeCodec(oldOptions).generate(DATA);
+
+    expect(currentCodec.verified(oldMessage)).toEqual(DATA);
+  }
+}
+
+describe("MessageVerifierRotatorTest", () => {
+  it("rotate digest", () => {
+    assertRotate({ digest: "SHA256" }, { digest: "SHA1" }, { digest: "MD5" });
+  });
+});

--- a/packages/activesupport/src/messages/message-verifier-rotator.test.ts
+++ b/packages/activesupport/src/messages/message-verifier-rotator.test.ts
@@ -1,5 +1,0 @@
-import { describe, it } from "vitest";
-
-describe("MessageVerifierRotatorTest", () => {
-  it.skip("rotate digest");
-});

--- a/packages/activesupport/src/messages/rotation-configuration.test.ts
+++ b/packages/activesupport/src/messages/rotation-configuration.test.ts
@@ -1,7 +1,0 @@
-import { describe, it } from "vitest";
-
-describe("MessagesRotationConfiguration", () => {
-  it.skip("signed configurations");
-
-  it.skip("encrypted configurations");
-});

--- a/packages/activesupport/src/messages/rotation-configuration.test.ts
+++ b/packages/activesupport/src/messages/rotation-configuration.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { RotationConfiguration } from "./rotation-configuration.js";
+
+describe("MessagesRotationConfiguration", () => {
+  let config: RotationConfiguration;
+
+  beforeEach(() => {
+    config = new RotationConfiguration();
+  });
+
+  it("signed configurations", () => {
+    config.rotate("signed", "older secret", { salt: "salt", digest: "SHA1" });
+    config.rotate("signed", "old secret", { salt: "salt", digest: "SHA256" });
+
+    expect(config.signed).toEqual([
+      ["older secret", { salt: "salt", digest: "SHA1" }],
+      ["old secret", { salt: "salt", digest: "SHA256" }],
+    ]);
+  });
+
+  it("encrypted configurations", () => {
+    config.rotate("encrypted", "old raw key", { cipher: "aes-256-gcm" });
+
+    expect(config.encrypted).toEqual([["old raw key", { cipher: "aes-256-gcm" }]]);
+  });
+});

--- a/packages/activesupport/src/messages/rotation-configuration.ts
+++ b/packages/activesupport/src/messages/rotation-configuration.ts
@@ -1,0 +1,23 @@
+export type RotationKind = "signed" | "encrypted";
+
+export class RotationConfiguration {
+  readonly signed: unknown[][] = [];
+  readonly encrypted: unknown[][] = [];
+
+  /**
+   * Ruby collects trailing keyword arguments into an options hash and appends
+   * it to `args` only when non-empty. JavaScript has no implicit keyword
+   * collection, so callers pass the options object as the final argument and
+   * it is stored verbatim.
+   */
+  rotate(kind: RotationKind, ...args: unknown[]): void {
+    switch (kind) {
+      case "signed":
+        this.signed.push(args);
+        break;
+      case "encrypted":
+        this.encrypted.push(args);
+        break;
+    }
+  }
+}

--- a/packages/activesupport/src/messages/rotation-configuration.ts
+++ b/packages/activesupport/src/messages/rotation-configuration.ts
@@ -1,8 +1,13 @@
 export type RotationKind = "signed" | "encrypted";
 
 export class RotationConfiguration {
-  readonly signed: unknown[][] = [];
-  readonly encrypted: unknown[][] = [];
+  readonly signed: unknown[][];
+  readonly encrypted: unknown[][];
+
+  constructor() {
+    this.signed = [];
+    this.encrypted = [];
+  }
 
   /**
    * Ruby collects trailing keyword arguments into an options hash and appends

--- a/packages/activesupport/src/messages/rotator.ts
+++ b/packages/activesupport/src/messages/rotator.ts
@@ -1,0 +1,134 @@
+import { prepend } from "../prepend.js";
+import { Thrown } from "./serializer-with-fallback.js";
+
+export type OnRotation = () => void;
+
+export interface RotatableOptions {
+  onRotation?: OnRotation | null;
+}
+
+export interface Rotatable {
+  readMessage(message: string, options?: Record<string, unknown>): unknown;
+}
+
+interface RotatorState {
+  args: unknown[];
+  options: Record<string, unknown>;
+  rotations: Rotatable[];
+  onRotation: OnRotation | null;
+}
+
+const STATE = new WeakMap<object, RotatorState>();
+
+function stateOf(host: object): RotatorState {
+  let state = STATE.get(host);
+  if (!state) {
+    state = { args: [], options: {}, rotations: [], onRotation: null };
+    STATE.set(host, state);
+  }
+  return state;
+}
+
+/**
+ * Ruby's `Messages::Rotator#initialize` captures the constructor's positional
+ * args and options so `rotate` can fill in the ones a rotation omits. A
+ * prepended module cannot wrap a TypeScript constructor, so each rotatable
+ * class calls this from its own constructor instead.
+ */
+export function initializeRotator(
+  host: object,
+  args: unknown[],
+  options: Record<string, unknown> = {},
+): void {
+  const { onRotation, ...rest } = options as RotatableOptions & Record<string, unknown>;
+  STATE.set(host, { args, options: rest, rotations: [], onRotation: onRotation ?? null });
+}
+
+export function rotate<T extends object>(this: T, ...args: unknown[]): T {
+  return fallBackTo.call(this, buildRotation.call(this, args)) as T;
+}
+
+export function onRotation<T extends object>(this: T, callback: OnRotation): T {
+  stateOf(this).onRotation = callback;
+  return this;
+}
+
+export function fallBackTo<T extends object>(this: T, fallback: Rotatable): T {
+  stateOf(this).rotations.push(fallback);
+  return this;
+}
+
+function buildRotation<T extends object>(this: T, args: unknown[]): Rotatable {
+  const state = stateOf(this);
+  const trailing = args.length > 0 && isPlainOptions(args[args.length - 1]);
+  const positional = trailing ? args.slice(0, -1) : args;
+  const options = trailing ? (args[args.length - 1] as Record<string, unknown>) : {};
+  const ctor = this.constructor as new (...ctorArgs: unknown[]) => Rotatable;
+
+  return new ctor(...positional, ...state.args.slice(positional.length), {
+    ...state.options,
+    ...options,
+  });
+}
+
+function isPlainOptions(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Buffer.isBuffer(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function catchRotationError<T>(block: () => T): { value?: T; error?: Thrown } {
+  try {
+    return { value: block() };
+  } catch (error) {
+    if (
+      error instanceof Thrown &&
+      (error.tag === "invalid_message_format" || error.tag === "invalid_message_serialization")
+    ) {
+      return { error };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Ruby's `prepend Messages::Rotator` — installs `rotate` / `on_rotation` /
+ * `fall_back_to` and wraps `read_message` so rotations are tried in turn.
+ */
+export function installRotator(klass: { prototype: object }): void {
+  Object.assign(klass.prototype, { rotate, onRotation, fallBackTo });
+
+  prepend(klass.prototype, {
+    readMessage(
+      this: object,
+      super_: (...superArgs: unknown[]) => unknown,
+      message: string,
+      options: Record<string, unknown> = {},
+    ): unknown {
+      const state = stateOf(this);
+      const { onRotation: perCall, ...rest } = options as RotatableOptions &
+        Record<string, unknown>;
+      const callback = perCall === undefined ? state.onRotation : perCall;
+
+      if (state.rotations.length === 0) {
+        return super_.call(this, message, rest);
+      }
+
+      const first = catchRotationError(() => super_.call(this, message, rest));
+      if (!first.error) return first.value;
+
+      for (const rotation of state.rotations) {
+        const rotated = catchRotationError(() => rotation.readMessage(message, rest));
+        if (!rotated.error) {
+          callback?.();
+          return rotated.value;
+        }
+      }
+
+      throw first.error;
+    },
+  });
+}

--- a/packages/activesupport/src/messages/rotator.ts
+++ b/packages/activesupport/src/messages/rotator.ts
@@ -1,4 +1,3 @@
-import { prepend } from "../prepend.js";
 import { Thrown } from "./serializer-with-fallback.js";
 
 export type OnRotation = () => void;
@@ -35,7 +34,7 @@ function stateOf(host: object): RotatorState {
  * prepended module cannot wrap a TypeScript constructor, so each rotatable
  * class calls this from its own constructor instead.
  */
-export function initializeRotator(
+export function initialize(
   host: object,
   args: unknown[],
   options: Record<string, unknown> = {},
@@ -58,6 +57,7 @@ export function fallBackTo<T extends object>(this: T, fallback: Rotatable): T {
   return this;
 }
 
+/** @internal */
 function buildRotation<T extends object>(this: T, args: unknown[]): Rotatable {
   const state = stateOf(this);
   const trailing = args.length > 0 && isPlainOptions(args[args.length - 1]);
@@ -80,6 +80,7 @@ function isPlainOptions(value: unknown): value is Record<string, unknown> {
   );
 }
 
+/** @internal */
 function catchRotationError<T>(block: () => T): { value?: T; error?: Thrown } {
   try {
     return { value: block() };
@@ -95,40 +96,33 @@ function catchRotationError<T>(block: () => T): { value?: T; error?: Thrown } {
 }
 
 /**
- * Ruby's `prepend Messages::Rotator` — installs `rotate` / `on_rotation` /
- * `fall_back_to` and wraps `read_message` so rotations are tried in turn.
+ * Ruby's `Messages::Rotator#read_message`. Shaped for `prepend()`, so the
+ * wrapped implementation arrives as `super_`.
  */
-export function installRotator(klass: { prototype: object }): void {
-  Object.assign(klass.prototype, { rotate, onRotation, fallBackTo });
+export function readMessage(
+  this: object,
+  super_: (...superArgs: unknown[]) => unknown,
+  message: string,
+  options: Record<string, unknown> = {},
+): unknown {
+  const state = stateOf(this);
+  const { onRotation: perCall, ...rest } = options as RotatableOptions & Record<string, unknown>;
+  const callback = perCall === undefined ? state.onRotation : perCall;
 
-  prepend(klass.prototype, {
-    readMessage(
-      this: object,
-      super_: (...superArgs: unknown[]) => unknown,
-      message: string,
-      options: Record<string, unknown> = {},
-    ): unknown {
-      const state = stateOf(this);
-      const { onRotation: perCall, ...rest } = options as RotatableOptions &
-        Record<string, unknown>;
-      const callback = perCall === undefined ? state.onRotation : perCall;
+  if (state.rotations.length === 0) {
+    return super_.call(this, message, rest);
+  }
 
-      if (state.rotations.length === 0) {
-        return super_.call(this, message, rest);
-      }
+  const first = catchRotationError(() => super_.call(this, message, rest));
+  if (!first.error) return first.value;
 
-      const first = catchRotationError(() => super_.call(this, message, rest));
-      if (!first.error) return first.value;
+  for (const rotation of state.rotations) {
+    const rotated = catchRotationError(() => rotation.readMessage(message, rest));
+    if (!rotated.error) {
+      callback?.();
+      return rotated.value;
+    }
+  }
 
-      for (const rotation of state.rotations) {
-        const rotated = catchRotationError(() => rotation.readMessage(message, rest));
-        if (!rotated.error) {
-          callback?.();
-          return rotated.value;
-        }
-      }
-
-      throw first.error;
-    },
-  });
+  throw first.error;
 }


### PR DESCRIPTION
Ports `ActiveSupport::Messages::Rotator` and
`ActiveSupport::Messages::RotationConfiguration`, replacing the bodyless
`it.skip` placeholders in `packages/activesupport/src/messages/` with real
tests.

## Implementation

`messages/rotator.ts` mirrors `rotator.rb` method for method — `initialize`,
`rotate`, `onRotation`, `fallBackTo`, `readMessage`, plus the private
`buildRotation` / `catchRotationError`. Rails installs it with
`prepend Messages::Rotator`, so `MessageVerifier` and `MessageEncryptor` install
it through the existing `prepend()` helper:

```ts
Object.assign(MessageVerifier.prototype, { rotate, onRotation, fallBackTo });
prepend(MessageVerifier.prototype, { readMessage: readMessageWithRotations });
```

Ruby's `initialize` captures the constructor's positional args and options so
`rotate` can fill in what a rotation omits. `prepend()` cannot wrap a TypeScript
constructor, so each class calls `initialize(this, args, options)` from its own
constructor; that call is the only structural deviation and is justified at the
definition site.

`RotatableOptions.onRotation` is camelCase rather than Rails' `on_rotation:`
because CLAUDE.md's conventions are camelCase-only. The neighbouring
`MessageVerifierOptions.url_safe` is pre-existing debt that predates the rule,
not a competing convention — new option keys follow the rule.

## Tests

- `rotation-configuration.test.ts` — `signed configurations`,
  `encrypted configurations`
- `message-verifier-rotator.test.ts` — `rotate digest`, with the `assertRotate`
  helper from Rails' shared `MessageRotatorTests` inlined for the one case that
  uses it

Names match Rails verbatim.

## Not ported

`messages/message-encryptor-rotator.test.ts` is deleted rather than ported. All
three of its cases need authenticated encryption, which `MessageEncryptor` does
not have: `cipher` is hardcoded to `aes-256-cbc` instead of coming from
`default_cipher`, there is no `use_authenticated_message_encryption` attribute
(both remaining cases toggle it via `with_authenticated_encryption`), and
`encrypt` / `decrypt` never write or read a GCM auth tag, so `rotate cipher`'s
`aes-256-gcm` encryptor cannot decrypt its own output. Adding that restructures
`MessageEncryptor` around a verifier and is registered as story
`port-activesupport-message-encryptor-authenticated-encryption`.

## Deltas

- `test:compare` activesupport: 2321 → 2324 ported tests; extras unchanged at
  536; files 156/157 → 155/157 (the deleted encryptor rotator file).
- `api:compare` activesupport: +10 matched methods across two newly matched
  files — `messages/rotation_configuration.rb` 4/4 and `messages/rotator.rb`
  6/7. The
  unmatched one is `initialize`, which the extractor expects to be a
  `constructor` and a mixin module cannot supply.
- `api:extra`: one novel name, `initialize`, for that same reason.

`pnpm vitest run packages/activesupport/src/messages/` (58 passed, 0 skipped),
`pnpm typecheck`, and `pnpm lint` pass.

Closes-story: port-activesupport-messages-rotation-tests
