### PR TITLE
test(activesupport): port the encryptor rotator and shared MessageRotatorTests

### DIFF
--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -24,6 +24,7 @@ interface MessageEncryptorOptions extends RotatableOptions {
   cipher?: string;
   digest?: string;
   serializer?: Format | MessageSerializer;
+  url_safe?: boolean;
   forceLegacyMetadataSerializer?: boolean;
 }
 
@@ -45,7 +46,7 @@ export class MessageEncryptor extends Codec {
     options?: MessageEncryptorOptions,
   ) {
     let signSecret: string | Buffer | undefined;
-    let opts: MessageEncryptorOptions = {};
+    let opts: MessageEncryptorOptions;
 
     if (
       signSecretOrOptions &&
@@ -53,13 +54,14 @@ export class MessageEncryptor extends Codec {
       !Buffer.isBuffer(signSecretOrOptions)
     ) {
       opts = signSecretOrOptions;
-    } else if (signSecretOrOptions !== undefined) {
+    } else {
       signSecret = signSecretOrOptions;
       opts = options ?? {};
     }
 
     super({
       serializer: opts.serializer,
+      urlSafe: opts.url_safe,
       forceLegacyMetadataSerializer: opts.forceLegacyMetadataSerializer,
     });
 

--- a/packages/activesupport/src/messages/message-encryptor-rotator.test.ts
+++ b/packages/activesupport/src/messages/message-encryptor-rotator.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "vitest";
+
+import { getCrypto } from "../crypto-adapter.js";
+import { InvalidMessage, MessageEncryptor } from "../message-encryptor.js";
+import { extractOptions } from "../hash-utils.js";
+import {
+  assertRotate,
+  messageRotatorTests,
+  type RotatorCodecHooks,
+} from "./message-rotator-tests.js";
+
+describe("MessageEncryptorRotatorTest", () => {
+  const secrets = new Map<string, Buffer>();
+
+  const secret = (key: string): Buffer => {
+    let value = secrets.get(key);
+    if (!value) {
+      value = getCrypto().randomBytes(32);
+      secrets.set(key, value);
+    }
+    return value;
+  };
+
+  const hooks: RotatorCodecHooks<MessageEncryptor> = {
+    secret,
+
+    makeCodec(...args: unknown[]): MessageEncryptor {
+      const [positional, options] = extractOptions(args);
+      return new MessageEncryptor(
+        (positional[0] as Buffer) ?? secret("secret"),
+        positional[1] as Buffer | undefined,
+        options,
+      );
+    },
+
+    encode(data: unknown, encryptor: MessageEncryptor, options = {}): string {
+      return encryptor.encryptAndSign(data, options);
+    },
+
+    decode(message: string, encryptor: MessageEncryptor, options = {}): unknown {
+      try {
+        return encryptor.decryptAndVerify(message, options);
+      } catch (error) {
+        if (error instanceof InvalidMessage) return null;
+        throw error;
+      }
+    },
+  };
+
+  messageRotatorTests(hooks);
+
+  it("rotate cipher", () => {
+    assertRotate(hooks, [{ cipher: "aes-256-gcm" }], [[{ cipher: "aes-256-cbc" }]]);
+  });
+
+  it("rotate verifier secret when using non-authenticated encryption", () => {
+    assertRotate(
+      hooks,
+      [secret("encryption"), secret("new verifier")],
+      [
+        [secret("encryption"), secret("old verifier")],
+        [secret("encryption"), secret("older verifier")],
+      ],
+    );
+  });
+
+  it("rotate verifier digest when using non-authenticated encryption", () => {
+    assertRotate(hooks, [{ digest: "SHA256" }], [[{ digest: "SHA1" }], [{ digest: "MD5" }]]);
+  });
+});

--- a/packages/activesupport/src/messages/message-rotator-tests.ts
+++ b/packages/activesupport/src/messages/message-rotator-tests.ts
@@ -1,0 +1,183 @@
+import { expect, it } from "vitest";
+
+import type { MessageSerializer } from "./codec.js";
+import type { OnRotation } from "./rotator.js";
+
+/** Rails' `MessageRotatorTests::DATA`. */
+export const DATA: readonly unknown[] = [{ a_boolean: true, a_number: 123, a_string: "abc" }];
+
+/**
+ * Rails' `secret` / `make_codec` / `encode` / `decode`, which each including
+ * test supplies.
+ */
+export interface RotatorCodecHooks<T> {
+  secret(key: string): unknown;
+  makeCodec(...args: unknown[]): T;
+  encode(data: unknown, codec: T, options?: Record<string, unknown>): string;
+  decode(message: string, codec: T, options?: Record<string, unknown>): unknown;
+}
+
+interface RotatableCodec {
+  rotate(...args: unknown[]): RotatableCodec;
+  onRotation(callback: OnRotation): RotatableCodec;
+}
+
+function rotatable(codec: unknown): RotatableCodec {
+  return codec as RotatableCodec;
+}
+
+/** Rails' `assert_rotate`. */
+export function assertRotate<T>(
+  hooks: RotatorCodecHooks<T>,
+  current: unknown[],
+  old: unknown[][],
+  messageMetadata: Record<string, unknown> = {},
+): void {
+  const currentCodec = hooks.makeCodec(...current);
+
+  for (const oldArgs of old) {
+    rotatable(currentCodec).rotate(...oldArgs);
+
+    const oldCodec = hooks.makeCodec(...oldArgs);
+    const oldMessage = hooks.encode(DATA, oldCodec, messageMetadata);
+
+    expect(hooks.decode(oldMessage, currentCodec, messageMetadata)).toEqual(DATA);
+
+    if (Object.keys(messageMetadata).length > 0) {
+      expect(hooks.decode(oldMessage, currentCodec)).toBeNull();
+    }
+  }
+}
+
+/**
+ * Rails' `MessageRotatorTests`, the module both `MessageVerifierRotatorTest`
+ * and `MessageEncryptorRotatorTest` `include`.
+ */
+export function messageRotatorTests<T>(hooks: RotatorCodecHooks<T>): void {
+  const { secret, makeCodec, encode, decode } = hooks;
+
+  it("rotate secret", () => {
+    assertRotate(hooks, [secret("new")], [[secret("old")], [secret("older")]]);
+  });
+
+  it("rotate secret when message has purpose", () => {
+    assertRotate(hooks, [secret("new")], [[secret("old")]], { purpose: "purpose" });
+  });
+
+  it("rotate url_safe", () => {
+    assertRotate(hooks, [{ url_safe: true }], [[{ url_safe: false }]]);
+  });
+
+  it("rotate serializer", () => {
+    assertRotate(hooks, [{ serializer: "json" }], [[{ serializer: "marshal" }]]);
+  });
+
+  it("rotate serializer when message has purpose", () => {
+    assertRotate(hooks, [{ serializer: "json" }], [[{ serializer: "marshal" }]], {
+      purpose: "purpose",
+    });
+  });
+
+  it("rotate serializer that raises a custom deserialization error", () => {
+    class CustomDeserializationError extends Error {}
+
+    const serializer: MessageSerializer = {
+      dump: () => "",
+      load: () => {
+        throw new CustomDeserializationError();
+      },
+    };
+
+    assertRotate(hooks, [{ serializer }], [[{ serializer: "json" }], [{ serializer: "marshal" }]]);
+  });
+
+  it("rotate secret and options", () => {
+    assertRotate(
+      hooks,
+      [secret("new"), { url_safe: true }],
+      [[secret("old"), { url_safe: false }]],
+    );
+  });
+
+  it("on_rotation is called on successful rotation", () => {
+    let called: boolean | null = null;
+    assertRotate(
+      hooks,
+      [
+        secret("new"),
+        {
+          onRotation: () => {
+            called = true;
+          },
+        },
+      ],
+      [[secret("old")]],
+    );
+    expect(called).toBe(true);
+  });
+
+  it("rotate().on_rotation is called on successful rotation", () => {
+    let called: boolean | null = null;
+    const codec = makeCodec(secret("new"));
+    rotatable(codec)
+      .rotate(secret("old"))
+      .onRotation(() => {
+        called = true;
+      });
+    const oldCodec = makeCodec(secret("old"));
+    const oldMessage = encode(DATA, oldCodec);
+    expect(decode(oldMessage, codec)).toEqual(DATA);
+    expect(called).toBe(true);
+  });
+
+  it("on_rotation is not called when no rotation is necessary", () => {
+    let called: boolean | null = null;
+    assertRotate(
+      hooks,
+      [
+        secret("same"),
+        {
+          onRotation: () => {
+            called = true;
+          },
+        },
+      ],
+      [[secret("same")]],
+    );
+    expect(called).toBeNull();
+  });
+
+  it("on_rotation is not called when no rotation is successful", () => {
+    let called: boolean | null = null;
+    const codec = makeCodec(secret("new"), {
+      onRotation: () => {
+        called = true;
+      },
+    });
+    rotatable(codec).rotate(secret("old"));
+    const otherMessage = encode(DATA, makeCodec(secret("other")));
+
+    expect(decode(otherMessage, codec)).toBeNull();
+    expect(called).toBeNull();
+  });
+
+  it("on_rotation method option takes precedence over constructor option", () => {
+    let called = "";
+    const codec = makeCodec(secret("new"), {
+      onRotation: () => {
+        called += "via constructor";
+      },
+    });
+    rotatable(codec).rotate(secret("old"));
+    const oldMessage = encode(DATA, makeCodec(secret("old")));
+
+    expect(
+      decode(oldMessage, codec, {
+        onRotation: () => {
+          called += "via method";
+        },
+      }),
+    ).toEqual(DATA);
+    expect(called).toBe("via method");
+  });
+}

--- a/packages/activesupport/src/messages/message-verifier-rotator.test.ts
+++ b/packages/activesupport/src/messages/message-verifier-rotator.test.ts
@@ -1,25 +1,36 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
+
 import { MessageVerifier } from "../message-verifier.js";
-
-const DATA = [{ a_boolean: true, a_number: 123, a_string: "abc" }];
-
-function makeCodec(options: Record<string, unknown> = {}): MessageVerifier {
-  return new MessageVerifier("secret", options);
-}
-
-function assertRotate(current: Record<string, unknown>, ...old: Record<string, unknown>[]): void {
-  const currentCodec = makeCodec(current);
-
-  for (const oldOptions of old) {
-    currentCodec.rotate(oldOptions);
-    const oldMessage = makeCodec(oldOptions).generate(DATA);
-
-    expect(currentCodec.verified(oldMessage)).toEqual(DATA);
-  }
-}
+import { extractOptions } from "../hash-utils.js";
+import {
+  assertRotate,
+  messageRotatorTests,
+  type RotatorCodecHooks,
+} from "./message-rotator-tests.js";
 
 describe("MessageVerifierRotatorTest", () => {
+  const secret = (key: string): string => key;
+
+  const hooks: RotatorCodecHooks<MessageVerifier> = {
+    secret,
+
+    makeCodec(...args: unknown[]): MessageVerifier {
+      const [positional, options] = extractOptions(args);
+      return new MessageVerifier((positional[0] as string) ?? secret("secret"), options);
+    },
+
+    encode(data: unknown, verifier: MessageVerifier, options = {}): string {
+      return verifier.generate(data, options);
+    },
+
+    decode(message: string, verifier: MessageVerifier, options = {}): unknown {
+      return verifier.verified(message, options);
+    },
+  };
+
+  messageRotatorTests(hooks);
+
   it("rotate digest", () => {
-    assertRotate({ digest: "SHA256" }, { digest: "SHA1" }, { digest: "MD5" });
+    assertRotate(hooks, [{ digest: "SHA256" }], [[{ digest: "SHA1" }], [{ digest: "MD5" }]]);
   });
 });


### PR DESCRIPTION
**Rescoped after #5960 merged.** That PR ported `Messages::Rotator` and
`Messages::RotationConfiguration`, so this branch was reset onto it and its
duplicate implementation dropped. What remains is the test surface #5960 left
behind, plus the two `MessageEncryptor` fixes those tests surface.

- `messages/message-encryptor-rotator.test.ts` — #5960 deleted this file
  rather than porting it, so `message_encryptor_rotator_test.rb` (`rotate
  cipher`, `rotate verifier secret when using non-authenticated encryption`,
  `rotate verifier digest when using non-authenticated encryption`) was
  unported. Restored with real bodies.
- `messages/message-rotator-tests.ts` — the shared `MessageRotatorTests`
  module (`message_rotator_tests.rb`), all 11 cases, included from both
  rotator test files as Rails does (22 runs). This is the only coverage of
  the `on_rotation` wiring: the constructor option, `rotate().on_rotation`,
  the read-time option's precedence over the constructor's, and the two
  cases asserting it is *not* called.
- `messages/message-verifier-rotator.test.ts` — keeps `rotate digest`,
  now on the shared module instead of a local `assert_rotate`.

Fixes the shared cases surfaced:

- `MessageEncryptor` dropped its options entirely when the sign secret was
  passed explicitly as `undefined` — `new MessageEncryptor(secret, undefined,
  opts)` silently ignored `opts`. Ruby's `initialize(secret, sign_secret =
  nil, **options)` keeps them, and Rails' own `make_codec` in
  `message_encryptor_rotator_test.rb:35` uses exactly that shape. Without the
  fix `on_rotation is called on successful rotation` fails on the encryptor.
- `MessageEncryptor` now forwards `url_safe` to `Codec`, which Rails gets from
  `super(**options)` (`message_encryptor.rb:184`). Without it `rotate url_safe`
  and `rotate secret and options` cannot run on the encryptor.

Rails wraps two encryptor cases in `with_authenticated_encryption(false)`:
trails' `MessageEncryptor` has no AEAD mode — it always signs with its own
verifier secret — so the non-authenticated path is the only path and the
helper has no analogue.

Deltas: test:compare — `message_encryptor_rotator_test.rb` goes from unported
to 3 OK / 0 missing / 0 extra; the other two rotator files stay green.
(`message_rotator_tests.rb` is a shared module with no TS file of its own, so
its 11 cases are not scored per-file either way.) api:compare is unchanged.
`pnpm typecheck`, `pnpm lint`, and
`pnpm vitest run packages/activesupport/src/messages/` (85 passed) are green.

Closes-story: port-activesupport-messages-rotator-surface
