### PR TITLE
chore(api-compare): drop converged inflector ordinal translate wide-call rows

### DIFF
--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/inflector.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/inflector.json
@@ -2,20 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "inflector.ts",
-    "rubyName": "ordinal",
-    "call": "translate",
-    "reason": "Divergence, not equivalence (story inflector-ordinal-via-i18n-translate): Rails' `ordinal` is `I18n.translate(\"number.nth.ordinals\", number:)`; trails hardcodes the English st/nd/rd/th rules because activesupport has no I18n backend yet. Surfaced by the inflector/methods.rb file-manifest fix, not by a code change."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "inflector.ts",
-    "rubyName": "ordinalize",
-    "call": "translate",
-    "reason": "Divergence, not equivalence (story inflector-ordinal-via-i18n-translate): reaches `translate` through `ordinal`, which trails hardcodes for English — see the `ordinal` entry above. Surfaced by the inflector/methods.rb file-manifest fix, not by a code change."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "inflector.ts",
     "rubyName": "safe_constantize",
     "call": "match?",
     "reason": "Rails' `match?` here is in the `rescue LoadError` arm, matching the \"Unable to autoload constant\" message. trails has no Ruby autoload and `constantize` never raises LoadError, so the arm — and its `match?` — has no analogue."


### PR DESCRIPTION
Fixes the red `Rails API/Test Comparison` job on main @c6ab09123 (run 30811712696, step **Wide call-mismatches ratchet**).

bc34f83e5 (#5954) routed `Inflector#ordinal` through `I18n.translate`, which converged the two wide call-mismatch rows for `ordinal` / `ordinalize` omitting `translate`. The ratchet fails on STALE baseline rows, so main went red one commit later.

Reseeded via `pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write`; both dropped rows are genuine convergences, not a widened gate.

Closes-story: red-c6ab0912
