### PR TITLE
fix(api-compare): honor @internal JSDoc on class members

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1489,8 +1489,10 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
     expect(fns.find((f) => f.name === "performSecondBang")!.internal).toBe(true);
     expect(fns.find((f) => f.name === "secondBang")!.internal).toBeUndefined();
   });
+});
 
-  it("tags an @internal-tagged public class member and leaves its untagged sibling public", () => {
+describe("extractFromProgram — @internal JSDoc on class members", () => {
+  it("tags an @internal-tagged public method and leaves its untagged sibling public", () => {
     const info = extractFromFiles("/p", {
       "abstract-adapter.ts": `
         export class AbstractAdapter {
@@ -1508,6 +1510,42 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
     expect(cls.instanceMethods.find((m) => m.name === "columnMethodNames")!.internal).toBe(true);
     expect(cls.classMethods.find((m) => m.name === "seamHook")!.internal).toBe(true);
     expect(cls.instanceMethods.find((m) => m.name === "quoteTableName")!.internal).toBeUndefined();
+  });
+
+  it("tags an @internal-tagged member of a synthesized __mixin class", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new () => object) {
+          class M extends Base {
+            /** @internal */
+            loadAttributes(): void {}
+            readAttribute(): void {}
+          }
+          return M;
+        }
+      `,
+    });
+    const mixin = info.modules["attributes.ts:Attributes__mixin"];
+    expect(mixin.instanceMethods.find((m) => m.name === "loadAttributes")!.internal).toBe(true);
+    expect(mixin.instanceMethods.find((m) => m.name === "readAttribute")!.internal).toBeUndefined();
+  });
+
+  it("tags an @internal-tagged constructor of a synthesized __mixin class", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new (...a: any[]) => object) {
+          class M extends Base {
+            /** @internal */
+            constructor(...a: any[]) { super(...a); }
+          }
+          return M;
+        }
+      `,
+    });
+    const ctor = info.modules["attributes.ts:Attributes__mixin"].instanceMethods.find(
+      (m) => m.name === "constructor",
+    )!;
+    expect(ctor.internal).toBe(true);
   });
 });
 

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1489,6 +1489,26 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
     expect(fns.find((f) => f.name === "performSecondBang")!.internal).toBe(true);
     expect(fns.find((f) => f.name === "secondBang")!.internal).toBeUndefined();
   });
+
+  it("tags an @internal-tagged public class member and leaves its untagged sibling public", () => {
+    const info = extractFromFiles("/p", {
+      "abstract-adapter.ts": `
+        export class AbstractAdapter {
+          /** @internal */
+          columnMethodNames(): string[] { return []; }
+
+          /** @internal */
+          static seamHook(): void {}
+
+          quoteTableName(name: string): string { return name; }
+        }
+      `,
+    });
+    const cls = info.classes["abstract-adapter.ts:AbstractAdapter"];
+    expect(cls.instanceMethods.find((m) => m.name === "columnMethodNames")!.internal).toBe(true);
+    expect(cls.classMethods.find((m) => m.name === "seamHook")!.internal).toBe(true);
+    expect(cls.instanceMethods.find((m) => m.name === "quoteTableName")!.internal).toBeUndefined();
+  });
 });
 
 describe("extractFromProgram — re-export attribution", () => {
@@ -1595,7 +1615,7 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     const info = extractFromSource(`
       class Foo {
         /**
-         * Registry hook — public by design; @internal would be a lie.
+         * Registry hook — public by design; an internal tag would be a lie.
          *
          * @noRailsEquivalent trails-only model registry seam
          */

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -782,7 +782,7 @@ export function extractFromProgram(
         const hasProtectedMod = hasModifier(decl, ts.SyntaxKind.ProtectedKeyword);
         const visibility: "public" | "private" | "protected" =
           isPrivateField || hasPrivateMod ? "private" : hasProtectedMod ? "protected" : "public";
-        const internal = visibility !== "public";
+        const internal = visibility !== "public" || hasInternalJsDocTag(decl);
         const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
         const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
         // Only a member DECLARED in this file carries its tag into the mixin
@@ -835,7 +835,10 @@ export function extractFromProgram(
           ...(ctorDeclFile !== undefined && ctorDeclFile !== relPath
             ? { declaredIn: ctorDeclFile }
             : {}),
-          ...(ctorVisibility !== "public" ? { internal: true } : {}),
+          ...(ctorVisibility !== "public" ||
+          (ctorDecl !== undefined && hasInternalJsDocTag(ctorDecl))
+            ? { internal: true }
+            : {}),
           ...(ctorReason !== undefined ? { noRailsEquivalent: ctorReason } : {}),
         });
       }
@@ -1961,9 +1964,6 @@ export function extractClass(
   for (const member of node.members) {
     const memberName = getMemberName(member);
     const visibility = memberVisibility(member);
-    // A public class member can still be a wiring seam: `@internal` is the
-    // same marker exported functions, interface members and object-literal
-    // module members already honor, so it must not depend on declaration kind.
     const internal = visibility !== "public" || hasInternalJsDocTag(member);
     const noRailsEquivalent = noRailsEquivalentReason(member);
     const memberMissingRailsCalls = missingRailsCallTags(member);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1961,7 +1961,10 @@ export function extractClass(
   for (const member of node.members) {
     const memberName = getMemberName(member);
     const visibility = memberVisibility(member);
-    const internal = visibility !== "public";
+    // A public class member can still be a wiring seam: `@internal` is the
+    // same marker exported functions, interface members and object-literal
+    // module members already honor, so it must not depend on declaration kind.
+    const internal = visibility !== "public" || hasInternalJsDocTag(member);
     const noRailsEquivalent = noRailsEquivalentReason(member);
     const memberMissingRailsCalls = missingRailsCallTags(member);
     const tagged = {


### PR DESCRIPTION
The class walker in `extract-ts-api.ts` derived `internal` from
`memberVisibility(member)` alone (`private` / `protected` / `#`-field), so a
public class member tagged `/** @internal */` stayed fully scored on the
compared surface. Exported file functions, interface members and
object-literal module members already honor the tag — the marker should not
disagree by declaration kind. The `@internal` JSDoc already sprinkled across
`abstract-adapter.ts` class bodies was silently inert.

The second commit closes the same gap on the two synthesized `__mixin`
walkers (mixin members and the mixin constructor). No mixin member carries the
tag today, so totals do not move there; it only keeps the rule uniform.

Also rewords one `@noRailsEquivalent` test fixture whose prose contained a
literal `@internal` mid-line — TS's JSDoc parser reads that as a real tag, so
the fixture would otherwise have flipped to `internal: true`.

## `pnpm api:extra` delta (measured on a fresh `pnpm build`)

Extra-surface total drops **4262 → 4092 (−170)**, all in packages whose class
bodies already carry `@internal`:

| Package | before | after | delta |
| --- | ---: | ---: | ---: |
| activerecord | 1778 | 1671 | −107 |
| activemodel | 307 | 288 | −19 |
| actionview | 130 | 113 | −17 |
| actiondispatch | 383 | 372 | −11 |
| trailties | 285 | 278 | −7 |
| actioncontroller | 148 | 144 | −4 |
| arel | 247 | 245 | −2 |
| rack | 111 | 109 | −2 |
| globalid | 22 | 21 | −1 |

`pnpm api:compare` parity is unchanged (11822/17536, 67.4%) — the
newly-internal members matched no Rails method. The `@noRailsEquivalent`
matched count moves 99 → 87: twelve members carry both tags, and `@internal`
now removes them from the surface before their tag can match. No generated
manifest changed.

Closes-story: extract-ts-api-honor-internal-jsdoc-on-class-members
