### PR TITLE
fix(activerecord): drop cached ping state from Mysql2Adapter#isConnected

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.connected-vs-active.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.connected-vs-active.trails.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+
+// Trails-specific guard (no Rails counterpart, because in Rails the split is
+// structural): Rails' Mysql2Adapter#connected? is
+// `!(@raw_connection.nil? || @raw_connection.closed?)` — handle presence only —
+// while #active? is `connected?` PLUS a live ping. A failed ping must therefore
+// leave `isConnected()` true and only flip `active` false.
+//
+// Runs offline: newClient is stubbed, so no real socket is opened.
+describe("Mysql2Adapter connected? vs active?", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubNewClient(ping: () => Promise<void>): void {
+    const fakeConn = {
+      end: () => Promise.resolve(),
+      query: () => Promise.resolve([[{ v: "8.0.28" }]]),
+      ping,
+    };
+    vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
+  }
+
+  it("keeps isConnected true after a failed ping while active goes false", async () => {
+    stubNewClient(() => Promise.reject(new Error("server has gone away")));
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    await adapter.connectBang();
+    expect(adapter.isConnected()).toBe(true);
+    expect(adapter.active).toBe(true);
+
+    expect(await adapter.activeAsync()).toBe(false);
+
+    expect(adapter.isConnected()).toBe(true);
+    expect(adapter.active).toBe(false);
+  });
+
+  it("restores active on a successful ping", async () => {
+    let fail = true;
+    stubNewClient(() => (fail ? Promise.reject(new Error("gone")) : Promise.resolve()));
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    await adapter.connectBang();
+    await adapter.activeAsync();
+    expect(adapter.active).toBe(false);
+
+    fail = false;
+    expect(await adapter.activeAsync()).toBe(true);
+    expect(adapter.isConnected()).toBe(true);
+    expect(adapter.active).toBe(true);
+  });
+
+  it("reports not connected when the raw handle is absent", async () => {
+    stubNewClient(() => Promise.resolve());
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    expect(adapter.isConnected()).toBe(false);
+    await adapter.connectBang();
+    adapter.disconnectBang();
+    expect(adapter.isConnected()).toBe(false);
+    expect(adapter.active).toBe(false);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -213,7 +213,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // stash). A never-connected/fake/closed adapter skips the ping and flows
   // straight through the base logic, exactly as before.
   override async verifyBang(): Promise<void> {
-    if (this._client !== null && !this._permanentlyClosed && !this._isFakeConnection) {
+    if (this.isConnected()) {
       await this.activeAsync();
     }
     await super.verifyBang();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -149,9 +149,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // `connected?` rather than re-deriving the guard, so this delegates to
   // `isConnected()` (trails' `connected?`) the same way. The sync getter can't
   // do the live `ping` half of Rails' active? (that's activeAsync);
-  // `_activeState` is the cached liveness that ping updates.
+  // `_activeState` is the cached liveness that ping updates, and it is the
+  // second term here rather than inside `connected?`.
   override get active(): boolean {
-    return this.isConnected();
+    return this.isConnected() && this._activeState;
   }
 
   /**
@@ -159,14 +160,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * persistent connection, lazily establishing it if needed. Updates the cached
    * `_activeState` so the sync `active` getter reflects the result.
    *
-   * @noRailsEquivalent PERMANENT — this is the async half of Rails' `active?`
+   * @noRailsEquivalent CONVERGEABLE — this is the async half of Rails' `active?`
    * (mysql2_adapter.rb:108), which pings the raw connection inline
    * (`@raw_connection&.ping`) because the Ruby mysql2 driver is blocking. The
    * node-mysql2 `ping()` returns a promise, so the ping cannot happen inside a
-   * sync predicate; trails splits `active?` into the sync `active` getter
-   * (Rails' `connected?` guard plus the cached liveness) and this awaitable
-   * probe. Rails has one method where trails needs two, so the second name has
-   * no counterpart to converge onto.
+   * sync predicate. Folding this back onto the Rails name `active` — accepting
+   * `Promise<boolean>` as the documented divergence, per the ConnectionPool
+   * `*Async`-twin precedent — is scoped as
+   * `converge-adapter-active-predicate-to-async` (RFC 0072): it touches 7
+   * `get active()` declarations and ~88 call sites.
+   */
    */
   async activeAsync(): Promise<boolean> {
     if (this._permanentlyClosed || this._isFakeConnection) {
@@ -188,16 +191,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // @raw_connection.closed?)` (mysql2_adapter.rb:104). `_client` is trails'
   // `@raw_connection`, so a never-connected / disconnected adapter (`_client
   // === null`) reports NOT connected. This also matches the base adapter's
-  // `isConnected()` (`_connection !== null`) and keeps `active ⟹ isConnected`,
-  // the invariant Rails guarantees by checking `connected?` first inside
-  // `active?`.
+  // `isConnected()` (`_connection !== null`). The cached ping result
+  // (`_activeState`) is deliberately NOT a term here: Rails' `connected?` asks
+  // only about the handle, and `active?` is `connected?` PLUS a live ping — so a
+  // failed ping leaves `connected?` true while `active?` goes false.
   override isConnected(): boolean {
-    return (
-      this._client !== null &&
-      !this._permanentlyClosed &&
-      !this._isFakeConnection &&
-      this._activeState
-    );
+    return this._client !== null && !this._permanentlyClosed && !this._isFakeConnection;
   }
 
   // Mirrors Rails' `verify!` (abstract_adapter.rb:759), which decides whether to

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -170,7 +170,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * `converge-adapter-active-predicate-to-async` (RFC 0072): it touches 7
    * `get active()` declarations and ~88 call sites.
    */
-   */
   async activeAsync(): Promise<boolean> {
     if (this._permanentlyClosed || this._isFakeConnection) {
       this._activeState = false;


### PR DESCRIPTION
Rails' `Mysql2Adapter#connected?` (`mysql2_adapter.rb:104`) is
`!(@raw_connection.nil? || @raw_connection.closed?)` — handle presence only —
while `#active?` (`:108`) is `connected?` **plus** a live `ping`. trails folded
the cached ping result (`_activeState`) into `isConnected()`, so after a failed
ping trails reported `isConnected() === false` where Rails' `connected?` still
reports true.

- `isConnected()` → `_client !== null && !_permanentlyClosed && !_isFakeConnection`
- `active` → `isConnected() && _activeState`

This keeps the `active ⟹ isConnected` invariant the in-file comment defends
(Rails guarantees it by checking `connected?` first inside `active?`).

New trails-only regression test verified red on baseline: with the pre-fix body,
`keeps isConnected true after a failed ping while active goes false` fails.

### `active` sync→async flip: decision

Recorded as **do it, but not here.** It follows the precedent already approved
for `ConnectionPool`'s `*Async` twins — fidelity is the Rails method NAME +
semantics, not the sync return type, so `Promise<boolean>` is an accepted
documented divergence. It touches 7 `get active()` declarations and ~88 call
sites, so it is scoped as its own story,
`converge-adapter-active-predicate-to-async` (RFC 0072), with the declarations
and the two sync consumers enumerated there. A pointer comment sits on
`activeAsync`.

`activeAsync` keeps its `@noRailsEquivalent` tag, with the reason retagged from
`PERMANENT` to `CONVERGEABLE` pointing at that story (the convergence path is now
known, so the tag can no longer claim permanence). `pnpm api:extra --package
activerecord` confirms `activeAsync` is still not flagged novel; the 12 STALE
tags it reports are pre-existing on `main` (schema-cache.ts, connection-pool.ts,
sqlite3-adapter.ts, base.ts) and untouched by this PR.

Rebased onto `main` after #5947 merged.

Closes-story: mysql2-connected-predicate-folds-in-cached-ping-state

