### PR TITLE
refactor(activerecord): converge adapter active? onto an async active() method

### DIFF
--- a/packages/activerecord/src/adapter-connection.trails.test.ts
+++ b/packages/activerecord/src/adapter-connection.trails.test.ts
@@ -41,7 +41,7 @@ class LifecycleTestAdapter extends AbstractAdapter {
     this._connected = false;
   }
 
-  override get active(): boolean {
+  override async active(): Promise<boolean> {
     return this._connected;
   }
 

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -188,8 +188,7 @@ async function killConnectionFromServer(
 // optimistic and only reflects an adapter-initiated disconnect
 // (postgresql-adapter.ts:2523 documents that it cannot run this async ping), so
 // the remote-disconnect cases drive the probe directly here. The raw ping has
-// no adapter-state side effects (unlike `activeAsync()`), matching Rails'
-// pure `active?` check.
+// no adapter-state side effects, matching Rails' pure `active?` check.
 async function activePredicate(conn: DatabaseAdapter): Promise<boolean> {
   if (adapterType === "postgres") {
     const raw = (
@@ -218,7 +217,7 @@ async function activePredicate(conn: DatabaseAdapter): Promise<boolean> {
     }
   }
   // SQLite (not reached: remote-disconnect cases are gated on remoteSupported).
-  return conn.active;
+  return conn.active();
 }
 
 // Faithful port of Rails' AdapterTest (adapter_test.rb). Rides the canonical
@@ -789,14 +788,14 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
 
   let connection: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     connection = Base.connection;
-    expect(connection.active).toBe(true);
+    expect(await connection.active()).toBe(true);
   });
 
   afterEach(async () => {
     await connection.reconnectBang();
-    expect(connection.active).toBe(true);
+    expect(await connection.active()).toBe(true);
     expect(connection.isTransactionOpen()).toBe(false);
     expect(await rawTransactionOpen(connection)).toBe(false);
   });
@@ -817,7 +816,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     connection.disconnectBang();
     expect(await activePredicate(connection)).toBe(false);
     await connection.reconnectBang();
-    expect(connection.active).toBe(true);
+    expect(await connection.active()).toBe(true);
   });
 
   it("materialized transaction state is reset after a reconnect", async () => {
@@ -887,13 +886,13 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
   it.skipIf(!remoteSupported)("verify! restores after remote disconnection", async () => {
     await remoteDisconnect(connection);
     await connection.verifyBang();
-    expect(connection.active).toBe(true);
+    expect(await connection.active()).toBe(true);
   });
 
   it.skipIf(!remoteSupported)("reconnect! restores after remote disconnection", async () => {
     await remoteDisconnect(connection);
     await connection.reconnectBang();
-    expect(connection.active).toBe(true);
+    expect(await connection.active()).toBe(true);
   });
 
   it.skipIf(!remoteSupported)(
@@ -915,7 +914,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
       // querying.
       await Post.deleteAll();
 
-      expect(connection.active).toBe(true);
+      expect(await connection.active()).toBe(true);
     },
   );
 
@@ -953,7 +952,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
 
       await Post.deleteAll();
 
-      expect(connection.active).toBe(true);
+      expect(await connection.active()).toBe(true);
     },
   );
 
@@ -969,7 +968,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
       ).rejects.toBeInstanceOf(ConnectionFailed);
 
       expect(await Post.first()).toBeTruthy(); // Verifying causes a reconnect and the query succeeds
-      expect(connection.active).toBe(true);
+      expect(await connection.active()).toBe(true);
     },
   );
 
@@ -981,12 +980,12 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
       await remoteDisconnect(connection);
 
       expect(await Post.first()).toBeTruthy();
-      expect(connection.active).toBe(true);
+      expect(await connection.active()).toBe(true);
 
       await remoteDisconnect(connection);
 
       expect(await Post.where({ id: [1, 2] }).first()).toBeTruthy();
-      expect(connection.active).toBe(true);
+      expect(await connection.active()).toBe(true);
     },
   );
 
@@ -998,12 +997,12 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
       await remoteDisconnect(connection);
 
       expect(await Post.find(1)).toBeTruthy();
-      expect(connection.active).toBe(true);
+      expect(await connection.active()).toBe(true);
 
       await remoteDisconnect(connection);
 
       expect(await Post.findBy({ title: "Welcome to the weblog" })).toBeTruthy();
-      expect(connection.active).toBe(true);
+      expect(await connection.active()).toBe(true);
     },
   );
 
@@ -1054,13 +1053,13 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     await Post.transaction(async () => {
       await Post.count();
     });
-    expect(connection.active).toBe(true);
+    expect(await connection.active()).toBe(true);
   });
 
   // Runs on every remote-capable adapter (PG + MySQL/MariaDB). #4935 closed the
   // two MySQL divergences that used to gate this to PG: (1) Mysql2Adapter now
   // overrides `verifyBang` to probe with a real `active?`-style ping
-  // (`activeAsync`) so it detects the server-side kill and reconnects, and
+  // (`active()`) so it detects the server-side kill and reconnects, and
   // (2) `isMysql2ConnectionError` now maps the mysql2 driver's "Can't add new
   // command when connection is in closed state" to `ConnectionFailed`.
   it.skipIf(!remoteSupported)(

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -64,10 +64,10 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         // must not land on the shared leased connection.
         const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
         try {
-          expect(await singleConn.activeAsync()).toBe(true);
           await singleConn.execute("SET SESSION wait_timeout=1");
+          expect(await singleConn.active()).toBe(true);
           await new Promise((r) => setTimeout(r, 2000));
-          expect(await singleConn.activeAsync()).toBe(false);
+          expect(await singleConn.active()).toBe(false);
         } finally {
           await singleConn.close();
         }
@@ -81,15 +81,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       // execute() — and the provoked disconnect must not hit the leased one.
       const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
       try {
-        expect(await singleConn.activeAsync()).toBe(true);
         await singleConn.execute("SET SESSION wait_timeout=1");
+        expect(await singleConn.active()).toBe(true);
         await new Promise((r) => setTimeout(r, 2000));
         // Rails' reconnect! is synchronous; trails' reconnectBang is async, so
-        // await it before reading the sync `active` getter — which now tracks
-        // real connection state (`_client !== null`), only re-established once
-        // reconnectBang's _ensureClient resolves.
+        // await it before probing `active()` — which only reports true once
+        // reconnectBang's _ensureClient has re-established the handle.
         await singleConn.reconnectBang();
-        expect(singleConn.active).toBe(true);
+        expect(await singleConn.active()).toBe(true);
         await expect(singleConn.execute("SELECT 1")).resolves.toBeDefined();
       } finally {
         await singleConn.close();
@@ -97,22 +96,20 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     }, 10_000);
     it("successful reconnection after timeout with verify", async () => {
       // Stays self-built: connectionLimit:1 so the session wait_timeout applies
-      // to the same connection that activeAsync() and verifyBang() will use, and
+      // to the same connection that active() and verifyBang() will use, and
       // the provoked server-side disconnect must not hit the leased one.
       const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
       try {
-        expect(await singleConn.activeAsync()).toBe(true);
         await singleConn.execute("SET SESSION wait_timeout=1");
+        expect(await singleConn.active()).toBe(true);
         await new Promise((r) => setTimeout(r, 2000));
         // With connectionLimit:1 the pool has no spare slot to create a fresh
         // connection, so getConnection() returns the dead socket and ping() fails.
-        // activeAsync() sets _activeState = false, making active return false.
-        await singleConn.activeAsync();
+        expect(await singleConn.active()).toBe(false);
         // active is false → verifyBang calls reconnectBang(). Await it (async in
-        // trails, unlike Rails' synchronous verify!) before reading the sync
-        // `active` getter, which now reflects `_client !== null`.
+        // trails, unlike Rails' synchronous verify!) before probing again.
         await singleConn.verifyBang();
-        expect(singleConn.active).toBe(true);
+        expect(await singleConn.active()).toBe(true);
         await expect(singleConn.execute("SELECT 1")).resolves.toBeDefined();
       } finally {
         await singleConn.close();
@@ -134,9 +131,9 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       // establish one here before disconnecting — the sync `active` getter now
       // tracks real connection state (`_client !== null`) like Rails' active?.
       await adapter.execute("SELECT 1");
-      expect(adapter.active).toBe(true);
+      expect(await adapter.active()).toBe(true);
       adapter.disconnectBang();
-      expect(adapter.active).toBe(false);
+      expect(await adapter.active()).toBe(false);
     });
 
     it("active after discard", async () => {
@@ -146,9 +143,9 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
           connection?: { stream?: { destroy?: () => void } };
         }
       )?.connection?.stream;
-      expect(adapter.active).toBe(true);
+      expect(await adapter.active()).toBe(true);
       adapter.discardBang();
-      expect(adapter.active).toBe(false);
+      expect(await adapter.active()).toBe(false);
       // discardBang abandons the socket without closing it; free the fd.
       socket?.destroy?.();
     });
@@ -171,7 +168,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         // Rails' discard! must not communicate with the server: the abandoned
         // handle is dropped without an end()/close() that would shut the socket.
         expect(endSpy).not.toHaveBeenCalled();
-        expect(adapter.active).toBe(false);
+        expect(await adapter.active()).toBe(false);
       } finally {
         socket?.destroy?.();
       }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -126,8 +126,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         expect(errors).toHaveLength(1);
         expect(errors[0]).toBeInstanceOf(Deadlocked);
 
-        expect(adapter.active).toBe(true);
-        expect(adapter2.active).toBe(true);
+        expect(await adapter.active()).toBe(true);
+        expect(await adapter2.active()).toBe(true);
       } finally {
         await adapter2.close();
       }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
@@ -14,20 +14,20 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("multi results", async () => {
       const rows = await Base.connection.selectRows("CALL ten();");
       expect(Number(rows[0][0])).toBe(10);
-      expect((Base.connection as Mysql2Adapter).active).toBe(true);
+      expect(await (Base.connection as Mysql2Adapter).active()).toBe(true);
     });
 
     it("multi results from select one", async () => {
       const row = await Base.connection.selectOne("CALL topics(1);");
       expect(row?.["author_name"]).toBe(topics("first").author_name);
-      expect((Base.connection as Mysql2Adapter).active).toBe(true);
+      expect(await (Base.connection as Mysql2Adapter).active()).toBe(true);
     });
 
     it("multi results from find by sql", async () => {
       const result = await Topic.findBySql("CALL topics(3);");
       expect(result.length).toBe(3);
       expect(result[0]["author_name"]).toBe(topics("first").author_name);
-      expect((Base.connection as Mysql2Adapter).active).toBe(true);
+      expect(await (Base.connection as Mysql2Adapter).active()).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -48,17 +48,17 @@ describe("Mysql2Adapter#translateException (fabricated errors)", () => {
     await adapter.close().catch(() => {});
   });
 
-  it("active is false for a never-connected / fake adapter", () => {
+  it("active is false for a never-connected / fake adapter", async () => {
     // Rails' Mysql2Adapter#active? is gated on connected? (raw_connection
     // non-nil). A fake or never-connected adapter has no _client, so the sync
     // getter — and isConnected() (Rails' connected?) — report inactive without
     // touching a real DB, preserving the `active ⟹ isConnected` invariant.
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
     expect(adapter.isConnected()).toBe(false);
     // Stays self-built: a *never-connected* adapter is exactly what this
     // asserts on — the leased connection is live by construction.
     const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
-    expect(fresh.active).toBe(false);
+    expect(await fresh.active()).toBe(false);
     expect(fresh.isConnected()).toBe(false);
   });
 
@@ -163,14 +163,14 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
       // is the assertion, and disconnectBang() must not hit the leased pool.
       const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
-        expect(fresh.active).toBe(false);
+        expect(await fresh.active()).toBe(false);
         expect(fresh.isConnected()).toBe(false);
         // First query still connects lazily (verifyBang's _ensureClient net).
         await fresh.execQuery("SELECT 1");
-        expect(fresh.active).toBe(true);
+        expect(await fresh.active()).toBe(true);
         expect(fresh.isConnected()).toBe(true);
         fresh.disconnectBang();
-        expect(fresh.active).toBe(false);
+        expect(await fresh.active()).toBe(false);
         expect(fresh.isConnected()).toBe(false);
       } finally {
         await fresh.close();

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -267,10 +267,10 @@ describeIfPg("PostgresqlConnectionTest", () => {
     await a.execute("SELECT 1");
     const conn = a._rawConnectionForTest();
     try {
-      expect(a.active).toBe(true);
+      expect(await a.active()).toBe(true);
       expect(a.isConnected()).toBe(true);
       a.disconnectBang();
-      expect(a.active).toBe(false);
+      expect(await a.active()).toBe(false);
       expect(a.isConnected()).toBe(false);
     } finally {
       // disconnectBang fires conn.end() fire-and-forget; await it here
@@ -290,9 +290,9 @@ describeIfPg("PostgresqlConnectionTest", () => {
     const socket = (conn as unknown as { connection?: { stream?: { destroy?: () => void } } })
       ?.connection?.stream;
     try {
-      expect(a.active).toBe(true);
+      expect(await a.active()).toBe(true);
       a.discardBang();
-      expect(a.active).toBe(false);
+      expect(await a.active()).toBe(false);
       expect(a.isConnected()).toBe(false);
       // Rails' discard! abandons the fd WITHOUT closing it (socket_io.reopen
       // (IO::NULL)); it must never communicate with the server. end() would
@@ -307,7 +307,7 @@ describeIfPg("PostgresqlConnectionTest", () => {
     const a = new PostgreSQLAdapter(PG_TEST_URL);
     try {
       await a.reconnect();
-      expect(a.active).toBe(true);
+      expect(await a.active()).toBe(true);
       const rows = await a.execute("SELECT 1 AS n");
       expect(rows[0]?.n).toBe(1);
     } finally {
@@ -319,9 +319,9 @@ describeIfPg("PostgresqlConnectionTest", () => {
     const a = new PostgreSQLAdapter(PG_TEST_URL);
     try {
       a.disconnectBang();
-      expect(a.active).toBe(false);
+      expect(await a.active()).toBe(false);
       await a.reconnect();
-      expect(a.active).toBe(true);
+      expect(await a.active()).toBe(true);
       const rows = await a.execute("SELECT 2 AS n");
       expect(rows[0]?.n).toBe(2);
     } finally {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1101,10 +1101,6 @@ export class AbstractAdapter implements Quoting {
     this._preparedStatements = value && !ActiveRecord.disablePreparedStatements;
   }
 
-  // Mirrors Rails' `active?` (abstract_adapter.rb). A method rather than a
-  // getter: PG/MySQL override it with a live probe (`query ";"` / `ping`) that
-  // can only be awaited, and a getter returning a Promise would let
-  // `if (adapter.active)` silently pass on every call site.
   async active(): Promise<boolean> {
     return this._connection !== null;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1101,7 +1101,11 @@ export class AbstractAdapter implements Quoting {
     this._preparedStatements = value && !ActiveRecord.disablePreparedStatements;
   }
 
-  get active(): boolean {
+  // Mirrors Rails' `active?` (abstract_adapter.rb). A method rather than a
+  // getter: PG/MySQL override it with a live probe (`query ";"` / `ping`) that
+  // can only be awaited, and a getter returning a Promise would let
+  // `if (adapter.active)` silently pass on every call site.
+  async active(): Promise<boolean> {
     return this._connection !== null;
   }
 
@@ -1322,7 +1326,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   async verifyBang(): Promise<void> {
-    if (!this.active) {
+    if (!(await this.active())) {
       // Mirrors Rails' `verify!` (abstract_adapter.rb): an unconfigured raw
       // connection (opened by the pool but never run through
       // configure_connection) is promoted here rather than reconnected. If

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -618,7 +618,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       await this.update("SET FOREIGN_KEY_CHECKS = 0");
       await fn();
     } finally {
-      if (this.active) await this.update(`SET FOREIGN_KEY_CHECKS = ${old}`);
+      if (await this.active()) await this.update(`SET FOREIGN_KEY_CHECKS = ${old}`);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -301,7 +301,7 @@ export type TransactionConnection = DatabaseAdapter & {
   supportsLazyTransactions?(): boolean;
   supportsRestartDbTransaction?(): boolean;
   addTransactionRecord?(record: unknown): void;
-  active?: boolean;
+  active?(): boolean | Promise<boolean>;
   currentTransaction?(): Transaction | NullTransaction;
   throwAwayBang?(): void;
 };
@@ -819,7 +819,7 @@ export class SavepointTransaction extends Transaction {
   override async rollback(): Promise<void> {
     if (!this.state.isInvalidated()) {
       const conn = this.connection;
-      if (this.isMaterialized() && conn.active !== false) {
+      if (this.isMaterialized() && (await conn.active?.()) !== false) {
         await conn.rollbackToSavepoint(this.savepointName);
       }
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -20,7 +20,11 @@ describe("Mysql2Adapter base _connection field", () => {
     const end = vi.fn(() => Promise.resolve());
     // The connect-once configure warms the server version (getFullVersion issues
     // SELECT VERSION() before checkVersion); hand it a row so the warm resolves.
-    const fakeConn = { end, query: () => Promise.resolve([[{ v: "8.0.28" }]]) };
+    const fakeConn = {
+      end,
+      ping: () => Promise.resolve(),
+      query: () => Promise.resolve([[{ v: "8.0.28" }]]),
+    };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
     return { end };
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -37,7 +37,7 @@ describe("Mysql2Adapter base _connection field", () => {
     await adapter.connectBang();
     expect(connectionOf(adapter)).not.toBeNull();
     expect(adapter.isConnected()).toBe(true);
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
   });
 
   it("nulls _connection on disconnectBang and repopulates it on the next connect", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.connected-vs-active.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.connected-vs-active.trails.test.ts
@@ -28,12 +28,10 @@ describe("Mysql2Adapter connected? vs active?", () => {
 
     await adapter.connectBang();
     expect(adapter.isConnected()).toBe(true);
-    expect(adapter.active).toBe(true);
 
-    expect(await adapter.activeAsync()).toBe(false);
+    expect(await adapter.active()).toBe(false);
 
     expect(adapter.isConnected()).toBe(true);
-    expect(adapter.active).toBe(false);
   });
 
   it("restores active on a successful ping", async () => {
@@ -42,13 +40,11 @@ describe("Mysql2Adapter connected? vs active?", () => {
     const adapter = new Mysql2Adapter({ host: "localhost" });
 
     await adapter.connectBang();
-    await adapter.activeAsync();
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
 
     fail = false;
-    expect(await adapter.activeAsync()).toBe(true);
+    expect(await adapter.active()).toBe(true);
     expect(adapter.isConnected()).toBe(true);
-    expect(adapter.active).toBe(true);
   });
 
   it("reports not connected when the raw handle is absent", async () => {
@@ -59,6 +55,6 @@ describe("Mysql2Adapter connected? vs active?", () => {
     await adapter.connectBang();
     adapter.disconnectBang();
     expect(adapter.isConnected()).toBe(false);
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -139,49 +139,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     m.registerType(/^set/i, Type.lookup("string", { adapter: "mysql" }));
   }
 
-  // Cached liveness state — true until a failure is observed (ping fail,
-  // disconnect, permanent close). Set false by disconnectBang(); restored to
-  // true by reconnectBang() and by successful activeAsync().
-  private _activeState = true;
-
   // Mirrors Rails' Mysql2Adapter#active? (mysql2_adapter.rb:108), whose body is
   // `if connected? ... @raw_connection&.ping ... end || false` — it *calls*
   // `connected?` rather than re-deriving the guard, so this delegates to
-  // `isConnected()` (trails' `connected?`) the same way. The sync getter can't
-  // do the live `ping` half of Rails' active? (that's activeAsync);
-  // `_activeState` is the cached liveness that ping updates, and it is the
-  // second term here rather than inside `connected?`.
-  override get active(): boolean {
-    return this.isConnected() && this._activeState;
-  }
-
-  /**
-   * Async liveness probe — checks socket health via a real `ping` call on the
-   * persistent connection, lazily establishing it if needed. Updates the cached
-   * `_activeState` so the sync `active` getter reflects the result.
-   *
-   * @noRailsEquivalent CONVERGEABLE — this is the async half of Rails' `active?`
-   * (mysql2_adapter.rb:108), which pings the raw connection inline
-   * (`@raw_connection&.ping`) because the Ruby mysql2 driver is blocking. The
-   * node-mysql2 `ping()` returns a promise, so the ping cannot happen inside a
-   * sync predicate. Folding this back onto the Rails name `active` — accepting
-   * `Promise<boolean>` as the documented divergence, per the ConnectionPool
-   * `*Async`-twin precedent — is scoped as
-   * `converge-adapter-active-predicate-to-async` (RFC 0072): it touches 7
-   * `get active()` declarations and ~88 call sites.
-   */
-  async activeAsync(): Promise<boolean> {
-    if (this._permanentlyClosed || this._isFakeConnection) {
-      this._activeState = false;
-      return false;
-    }
+  // `isConnected()` (trails' `connected?`) the same way. node-mysql2's `ping()`
+  // returns a promise, which is why the predicate is awaitable here where
+  // Rails' is not.
+  override async active(): Promise<boolean> {
+    if (!this.isConnected()) return false;
     try {
       const conn = await this._ensureClient();
       await conn.ping();
-      this._activeState = true;
       return true;
     } catch {
-      this._activeState = false;
       return false;
     }
   }
@@ -190,32 +160,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // @raw_connection.closed?)` (mysql2_adapter.rb:104). `_client` is trails'
   // `@raw_connection`, so a never-connected / disconnected adapter (`_client
   // === null`) reports NOT connected. This also matches the base adapter's
-  // `isConnected()` (`_connection !== null`). The cached ping result
-  // (`_activeState`) is deliberately NOT a term here: Rails' `connected?` asks
-  // only about the handle, and `active?` is `connected?` PLUS a live ping — so a
-  // failed ping leaves `connected?` true while `active?` goes false.
+  // `isConnected()` (`_connection !== null`). The ping result is deliberately
+  // NOT a term here: Rails' `connected?` asks only about the handle, and
+  // `active?` is `connected?` PLUS a live ping — so a failed ping leaves
+  // `connected?` true while `active?` goes false.
   override isConnected(): boolean {
     return this._client !== null && !this._permanentlyClosed && !this._isFakeConnection;
-  }
-
-  // Mirrors Rails' `verify!` (abstract_adapter.rb:759), which decides whether to
-  // reconnect by calling `active?` — a real `mysql_ping` on the raw connection.
-  // trails' sync `active` getter is optimistic (it reports the cached
-  // `_activeState`, unchanged by a remote disconnect the adapter hasn't yet
-  // observed), so the inherited base `verifyBang` — which gates on that sync
-  // getter — would no-op on a socket the server has already severed
-  // (`wait_timeout`, server-side `KILL`). Probe with the async ping first
-  // (`activeAsync`, the analogue of Rails' `active?`) so the cached state
-  // reflects reality, then delegate to the inherited flow: base `verifyBang`
-  // now sees `active === false` and drives `reconnectBang({ restoreTransactions:
-  // true })` (or the `_unconfiguredConnection` promotion for the fake-connection
-  // stash). A never-connected/fake/closed adapter skips the ping and flows
-  // straight through the base logic, exactly as before.
-  override async verifyBang(): Promise<void> {
-    if (this.isConnected()) {
-      await this.activeAsync();
-    }
-    await super.verifyBang();
   }
 
   // Single persistent connection — mirrors Rails' @raw_connection. Unified onto
@@ -460,7 +410,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       this._acceptDeprecatedRawConnection(config, deprecatedConfig);
       this._poolConfig = { flags: ["FOUND_ROWS"] };
       this._isFakeConnection = true;
-      this._activeState = false;
       return;
     }
     // Mirrors abstract_adapter.rb:135 — a config hash must be the only argument.
@@ -608,7 +557,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // constructor path: `new Mysql2Adapter(fake_conn, logger, nil, config)`).
     if (fake) {
       this._isFakeConnection = true;
-      this._activeState = false;
     }
     // Connection is created lazily on first _ensureClient() call.
   }
@@ -820,7 +768,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // on every withRawConnection call.
         this._client = conn;
         this._statementPool = null;
-        this._activeState = true;
         // Configure the freshly-opened socket exactly as Rails does on every
         // fresh connect (attempt_configure_connection via connect!/reconnect!).
         // trails' connectBang opens the raw socket directly (bypassing verify!),
@@ -848,7 +795,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       },
       (err) => {
         if (this._connectingPromiseGen === gen) this._connectingPromise = null;
-        this._activeState = false;
         // Mirrors Rails' Mysql2Adapter#connect: `rescue ConnectionNotEstablished
         // => ex; raise ex.set_pool(@pool)`. Attach the originating pool (a
         // NullPool for a standalone adapter) so `error.connection_pool` is set
@@ -1597,7 +1543,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   override async reconnect(): Promise<void> {
     if (this._permanentlyClosed) throw new Error("Mysql2Adapter: client is permanently closed");
-    this._activeState = false;
     this._connectGeneration++;
     // Mirror Rails' private `Mysql2Adapter#reconnect` (mysql2_adapter.rb:150):
     // `@raw_connection&.close; @raw_connection = nil; connect`. Crucially it does
@@ -1609,7 +1554,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // here — only the raw-handle teardown. `_closeRawHandle` ends the live
     // socket then nulls `_client`, which nulls the unified base `_connection`.
     this._closeRawHandle();
-    this._activeState = true;
     // Re-establish the connection eagerly and PROPAGATE any connect failure —
     // Rails' private `reconnect` calls `connect` synchronously, so a dead socket
     // raises out of `reconnect!` (mysql2_adapter.rb:150 → :144). Awaiting here
@@ -1626,7 +1570,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Mirrors Rails' `Mysql2Adapter#disconnect!`.
    */
   override disconnectBang(): void {
-    this._activeState = false;
     // Advance generation — _ensureClient() will bypass the stale
     // _connectingPromise (gen mismatch) and start a fresh attempt, while
     // close() can still await the old promise for clean teardown.
@@ -1673,7 +1616,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * `client.end()`, which would actively close it.
    */
   override discardBang(): void {
-    this._activeState = false;
     // If a connect is in flight, record its generation so that when it
     // resolves into the gen-mismatch branch it abandons the socket instead
     // of end()ing it (Rails discard! must not communicate with the server).
@@ -1759,7 +1701,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       throw new Error(
         this._permanentlyClosed
           ? "Mysql2Adapter: connection is permanently closed"
-          : "Mysql2Adapter: connection not yet established — call execute() or await activeAsync() first",
+          : "Mysql2Adapter: connection not yet established — call execute() or await active() first",
       );
     }
     return this._client;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -235,9 +235,11 @@ export class PostgreSQLAdapter
     return env;
   }
 
-  override get active(): boolean {
+  override async active(): Promise<boolean> {
     // Rails' active? starts with `return false unless @raw_connection`
-    // (postgresql_adapter.rb); the ping half can't run in a sync getter.
+    // (postgresql_adapter.rb) and then probes with `@raw_connection.query ";"`;
+    // trails still answers from handle state only — the probe half is tracked
+    // separately now that the predicate is awaitable.
     return this._rawConnection !== null && !this._closed && this._pgClientOptions != null;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -237,9 +237,7 @@ export class PostgreSQLAdapter
 
   override async active(): Promise<boolean> {
     // Rails' active? starts with `return false unless @raw_connection`
-    // (postgresql_adapter.rb) and then probes with `@raw_connection.query ";"`;
-    // trails still answers from handle state only — the probe half is tracked
-    // separately now that the predicate is awaitable.
+    // (postgresql_adapter.rb); the `query ";"` probe half is not ported yet.
     return this._rawConnection !== null && !this._closed && this._pgClientOptions != null;
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -285,7 +285,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * the handle is fully torn down. Sync drivers (better-sqlite3) leave this null.
    */
   private _closingDriver: Promise<void> | null = null;
-  override get active(): boolean {
+  override async active(): Promise<boolean> {
     return this.driver?.isOpen() ?? false;
   }
   /**
@@ -1404,7 +1404,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * @internal
    */
   override async reconnect(): Promise<void> {
-    if (this.active) {
+    if (await this.active()) {
       // Mirrors `@raw_connection.rollback rescue nil` — a ROLLBACK with no
       // active transaction raises, which we swallow like Rails does.
       try {

--- a/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
+++ b/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
@@ -35,13 +35,13 @@ describe("StandaloneConnectionTest", () => {
     // un-skip when that infrastructure lands.
   });
 
-  it("can throw away", () => {
+  it("can throw away", async () => {
     connection.throwAwayBang();
-    expect(connection.active).toBe(false);
+    expect(await connection.active()).toBe(false);
   });
 
   it("can close", async () => {
     await connection.close();
-    expect(connection.active).toBe(false);
+    expect(await connection.active()).toBe(false);
   });
 });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -67,7 +67,7 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
   // active and verify! returns without reconnecting). Backed by a mutable
   // field so a test can simulate the connection dying mid-session.
   activeFlag = true;
-  override get active(): boolean {
+  override async active(): Promise<boolean> {
     return this.activeFlag;
   }
   readonly inTransaction = false;
@@ -562,7 +562,7 @@ it("subsequent pinned checkout verifies and reconnects a connection that died mi
   expect(again).toBe(conn);
   expect(verify).toHaveBeenCalledTimes(2);
   expect(reconnect).toHaveBeenCalledWith({ restoreTransactions: true });
-  expect(again.active).toBe(true);
+  expect(await again.active()).toBe(true);
 
   verify.mockRestore();
   reconnect.mockRestore();

--- a/packages/activerecord/src/sqlite-adapter.test.ts
+++ b/packages/activerecord/src/sqlite-adapter.test.ts
@@ -51,14 +51,14 @@ describe("SQLite adapter driver binding", () => {
     expect(Object.getPrototypeOf(ExpoSQLiteAdapter)).toBe(SQLite3Adapter);
   });
 
-  it("defers connection for an async-only driver constructed synchronously", () => {
+  it("defers connection for an async-only driver constructed synchronously", async () => {
     const adapter = new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
   });
 
   it("opens an async-only driver via openAsync and round-trips a query", async () => {
     const adapter = await SQLite3Adapter.openAsync(":memory:", { driver: asyncOnlyDriver });
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
     await adapter.internalExecute(
       "CREATE TABLE async_t (id INTEGER PRIMARY KEY, name TEXT)",
       "SCHEMA",
@@ -72,7 +72,7 @@ describe("SQLite adapter driver binding", () => {
 
   it("openAsync also opens sync drivers (better-sqlite3)", async () => {
     const adapter = await BetterSQLite3Adapter.openAsync(":memory:");
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
     adapter.disconnectBang();
   });
 
@@ -100,9 +100,9 @@ describe("SQLite adapter driver binding", () => {
     });
     const adapter = new SQLite3Adapter(":memory:", { driver });
     await expect(adapter.completeAsyncConnect()).rejects.toThrow();
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
     await adapter.completeAsyncConnect();
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
     adapter.disconnectBang();
   });
 
@@ -115,7 +115,7 @@ describe("SQLite adapter driver binding", () => {
     const adapter = new SQLite3Adapter(":memory:", { driver });
     await Promise.all([adapter.completeAsyncConnect(), adapter.completeAsyncConnect()]);
     expect(opens).toBe(1);
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
     adapter.disconnectBang();
   });
 
@@ -180,12 +180,12 @@ describe("SQLite adapter driver binding", () => {
     // without awaiting openAsync(), then issue the first query. The query must
     // transparently complete the deferred open rather than touch an unset handle.
     const adapter = new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver });
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
     await adapter.internalExecute(
       "CREATE TABLE sync_checkout (id INTEGER PRIMARY KEY, name TEXT)",
       "SCHEMA",
     );
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
     await adapter.internalExecute("INSERT INTO sync_checkout (name) VALUES ('lazy')", "SQL");
     const rows = await adapter.execute("SELECT name FROM sync_checkout");
     expect(rows).toEqual([{ name: "lazy" }]);
@@ -214,7 +214,7 @@ describe("SQLite adapter driver binding", () => {
     // These are the FIRST operations — no prior query has cleared the pending
     // flag, so all three race into completeAsyncConnect() and must dedupe onto
     // the single in-flight open rather than each opening their own handle.
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
     await Promise.all([
       adapter.execute("SELECT 1 AS one"),
       adapter.execQuery("SELECT 2 AS two"),
@@ -243,9 +243,9 @@ describe("SQLite adapter driver binding", () => {
     );
     const pool = new ConnectionPool(poolConfig);
     const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
-    expect(conn.active).toBe(false);
+    expect(await conn.active()).toBe(false);
     await conn.internalExecute("CREATE TABLE pool_t (id INTEGER PRIMARY KEY, name TEXT)", "SCHEMA");
-    expect(conn.active).toBe(true);
+    expect(await conn.active()).toBe(true);
     await conn.internalExecute("INSERT INTO pool_t (name) VALUES ('pooled')", "SQL");
     const rows = await conn.execute("SELECT name FROM pool_t");
     expect(rows).toEqual([{ name: "pooled" }]);
@@ -324,7 +324,7 @@ describe("SQLite adapter driver binding", () => {
     await conn.internalExecute("DROP TABLE IF EXISTS sync_drain_t", "SCHEMA");
     await conn.internalExecute("DROP TABLE IF EXISTS sync_drain_t", "SCHEMA");
     await expect(pool.disconnect()).resolves.toBeUndefined();
-    expect(conn.active).toBe(false);
+    expect(await conn.active()).toBe(false);
   });
 
   // A driver whose connection's close() is gated on an external promise, so a
@@ -494,10 +494,10 @@ describe("SQLite adapter driver binding", () => {
   it("reconnects an async-only driver and reapplies pragmas", async () => {
     const adapter = await SQLite3Adapter.openAsync(":memory:", { driver: asyncOnlyDriver });
     adapter.disconnectBang();
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
     // Full lifecycle: reconnectBang() -> reconnect() (opens) -> configureConnection().
     await adapter.reconnectBang();
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
     // foreign_keys defaults OFF in SQLite; ON proves configure_connection ran.
     const rows = await adapter.execute("PRAGMA foreign_keys");
     expect(rows).toEqual([{ foreign_keys: 1 }]);
@@ -529,9 +529,9 @@ describe("SQLite adapter driver binding", () => {
     adapter.disconnectBang();
   });
 
-  it("encoding falls back to UTF-8 before a deferred async-only open completes", () => {
+  it("encoding falls back to UTF-8 before a deferred async-only open completes", async () => {
     const adapter = new SQLite3Adapter(":memory:", { driver: asyncPragmaDriver });
-    expect(adapter.active).toBe(false);
+    expect(await adapter.active()).toBe(false);
     expect(adapter.encoding).toBe("UTF-8");
   });
 

--- a/packages/activerecord/src/support/fake-adapter.test.ts
+++ b/packages/activerecord/src/support/fake-adapter.test.ts
@@ -43,7 +43,7 @@ describe("FakeActiveRecordAdapter", () => {
   it("data_source_exists? and active? are always true", async () => {
     const adapter = new FakeActiveRecordAdapter();
     expect(await adapter.dataSourceExists()).toBe(true);
-    expect(adapter.active).toBe(true);
+    expect(await adapter.active()).toBe(true);
   });
 
   it("shares the synthetic column list across instances", () => {

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -54,7 +54,7 @@ export class FakeActiveRecordAdapter extends AbstractAdapter {
     return true;
   }
 
-  get active(): boolean {
+  async active(): Promise<boolean> {
     return true;
   }
 

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1342,7 +1342,7 @@ describe.skipIf(inMemoryDb())("TransactionTest", () => {
       throw new Rollback();
     });
 
-    expect(connection.active).toBe(false);
+    expect(await connection.active()).toBe(false);
     expect(pool.connections.includes(connection)).toBe(false);
   });
 
@@ -1389,7 +1389,7 @@ describe.skipIf(inMemoryDb())("TransactionTest", () => {
       }),
     ).rejects.toThrow("rollback failed");
 
-    expect(connection.active).toBe(false);
+    expect(await connection.active()).toBe(false);
     expect(pool.connections.includes(connection)).toBe(false);
     expect((await topic.reload()).title).toBe("The Fifth Topic of the day");
   });
@@ -1404,7 +1404,7 @@ describe.skipIf(inMemoryDb())("TransactionTest", () => {
 
     await expect(Topic.transaction(async () => {})).rejects.toThrow("begin failed");
 
-    expect(connection.active).toBe(false);
+    expect(await connection.active()).toBe(false);
     expect(pool.connections.includes(connection)).toBe(false);
   });
 

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -152,7 +152,7 @@ describe("TransactionTest", () => {
         supportsLazyTransactions: () => false,
         supportsRestartDbTransaction: () => false,
         addTransactionRecord: vi.fn(),
-        active: true,
+        active: () => true,
       };
       const tm = new TransactionManager(conn as never);
       await expect(
@@ -184,7 +184,7 @@ describe("TransactionTest", () => {
         supportsLazyTransactions: () => false,
         supportsRestartDbTransaction: () => false,
         addTransactionRecord: vi.fn(),
-        active: true,
+        active: () => true,
       };
       const tm = new TransactionManager(conn as never);
       // Force inner frame to SavepointTransaction (not

--- a/packages/activerecord/src/unconnected.test.ts
+++ b/packages/activerecord/src/unconnected.test.ts
@@ -6,14 +6,14 @@ import { ConnectionNotDefined } from "./errors.js";
 class TestRecord extends Base {}
 
 describe("TestUnconnectedAdapter", () => {
-  let underlying: { active: boolean };
+  let underlying: { active(): Promise<boolean> };
   // Rails' `remove_connection` hands back the db_config the pool was opened
   // from, and teardown re-establishes it — the ambient `arunit` connection is
   // never named or rebuilt by hand here.
   let connectionName: DatabaseConfig | undefined;
 
   beforeEach(async () => {
-    underlying = (await Base.leaseConnection()) as unknown as { active: boolean };
+    underlying = (await Base.leaseConnection()) as unknown as { active(): Promise<boolean> };
     connectionName = Base.removeConnection();
   });
 
@@ -35,7 +35,7 @@ describe("TestUnconnectedAdapter", () => {
     expect((err as ConnectionNotDefined).message).toBe("No database connection defined.");
   });
 
-  it("underlying adapter no longer active", () => {
-    expect(underlying.active).toBe(false);
+  it("underlying adapter no longer active", async () => {
+    expect(await underlying.active()).toBe(false);
   });
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2-adapter.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "active?",
+    "call": "synchronize",
+    "reason": "@lock.synchronize has no counterpart: trails is single-threaded and ports no adapter mutex."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "discard!",
     "call": "synchronize",
     "reason": "Rails wraps discard! in @lock.synchronize (Ruby Mutex); trails' single-threaded async model has no lock to acquire, matching the existing disconnect!/reconnect! synchronize exclusions in this file."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -2,6 +2,20 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "active?",
+    "call": "query",
+    "reason": "The `query \";\"` liveness probe is registered separately as RFC 0072 story postgresql-active-issues-the-rails-liveness-query."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "active?",
+    "call": "synchronize",
+    "reason": "@lock.synchronize has no counterpart: trails is single-threaded and ports no adapter mutex."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "begin_isolated_db_transaction",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Converges trails' adapter liveness predicate onto the Rails name + semantics.

Rails' `active?` is a **live** probe on two of three adapters (PG issues
`@raw_connection.query ";"`, MySQL pings); trails degraded all three to a sync
`get active(): boolean` over handle/cached state and split the MySQL ping half
into a bespoke `activeAsync`. Per the decision recorded on #5966 (and the
RFC 0023 `ConnectionPool` `*Async`-twin precedent), fidelity here is the Rails
NAME + semantics — `Promise<boolean>` vs `boolean` is an accepted divergence.

- `get active(): boolean` → `async active(): Promise<boolean>` on all seven
  declarations (abstract, PG, SQLite3, Mysql2, `FakeAdapter`, two test doubles).
  A **method**, not a getter returning a Promise, so `if (adapter.active)`
  fails typecheck instead of silently passing at every call site.
- `Mysql2Adapter#activeAsync` is deleted; its `ping` body folds into `active`,
  gated on `isConnected()` exactly as Rails' `active?` calls `connected?` first.
- The cached `_activeState` field is gone — with a real ping in `active()` it
  had no remaining reader, so `isConnected()` is now handle presence only
  (`_client !== null`), matching Rails' `connected?`.
- `Mysql2Adapter#verifyBang` override deleted: it existed solely to pre-ping
  before the base gate read the optimistic sync getter. Rails has no such
  override; the base `verifyBang` now awaits the pinging `active()` directly.
- All call sites await (`verifyBang`, `sqlite3#reconnect`,
  `disableReferentialIntegrity`, savepoint `rollback`, and the tests).

Not in scope: PG's `active?` still answers from handle state rather than
issuing `query ";"` — now unblocked by the async flip, but it adds a query to
every verify, so it is registered as a separate story.

Closes-story: converge-adapter-active-predicate-to-async
