### PR TITLE
refactor(associations): drop the JoinDependency preload-fallback lane

### DIFF
--- a/packages/activerecord/src/associations/eager-load-unjoinable-raises.trails.test.ts
+++ b/packages/activerecord/src/associations/eager-load-unjoinable-raises.trails.test.ts
@@ -1,0 +1,54 @@
+/**
+ * An eager-load spec JoinDependency can't resolve raises on EVERY path, not
+ * just the record-loading one.
+ *
+ * `JoinDependency#build` used to accept a `fallbackAssociations` out-parameter:
+ * a top-level spec whose segment couldn't be JOINed was rolled back and handed
+ * to the preloader, so a load could silently degrade while
+ * `count`/`sum`/`exists?` — which validate through `Relation#_checkEagerLoadable`
+ * rather than building the tree — raised. Rails has no such mode
+ * (`join_dependency.rb:228` only ever raises via `find_reflection`), and the
+ * lane is gone; these cover that the loading and calculation/exists paths now
+ * agree on raising.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Comment } from "../test-helpers/models/comment.js";
+import type { Base } from "../index.js";
+
+describe("eager_load with an unresolvable association", () => {
+  fixtures(["posts", "comments"]);
+
+  beforeAll(() => {
+    [Post, Comment].forEach((m) => registerModel(m as unknown as typeof Base));
+  });
+
+  const expected = /Can't join 'Post' to association named 'monkeys'; perhaps you misspelled it\?/;
+
+  it("raises on the record-loading path", async () => {
+    await expect(Post.all().eagerLoad("monkeys").toArray()).rejects.toThrow(expected);
+  });
+
+  it("raises on a nested spec's inner segment", async () => {
+    await expect(Post.all().eagerLoad({ comments: "monkeys" }).toArray()).rejects.toThrow(
+      /Can't join 'Comment' to association named 'monkeys'/,
+    );
+  });
+
+  it("raises on the calculation path", async () => {
+    await expect(Post.all().eagerLoad("monkeys").count()).rejects.toThrow(expected);
+    await expect(Post.all().eagerLoad("monkeys").sum("legacyCommentsCount")).rejects.toThrow(
+      expected,
+    );
+  });
+
+  it("raises on the exists? path", async () => {
+    await expect(Post.all().eagerLoad("monkeys").exists()).rejects.toThrow(expected);
+  });
+
+  it("raises on the pluck path", async () => {
+    await expect(Post.all().eagerLoad("monkeys").pluck("title")).rejects.toThrow(expected);
+  });
+});

--- a/packages/activerecord/src/associations/join-dependency-spec.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-spec.test.ts
@@ -1,9 +1,8 @@
 /**
  * Covers JoinDependency#build — the recursive tree construction the constructor
  * runs, which routes nested eager_load specs (hashes, dotted strings, arrays)
- * into the JOIN tree instead of degrading them to preload. Verifies
- * shared-prefix deduplication and all-or-nothing rollback on unjoinable
- * segments (the latter a trails-only fallback lane; Rails raises).
+ * into the JOIN tree. Verifies shared-prefix deduplication and that an
+ * unresolvable segment raises, as Rails' `find_reflection` does.
  *
  * Mirrors: ActiveRecord::Associations::JoinDependency#build (recursive tree
  * construction from the eager_load values hash).
@@ -62,40 +61,37 @@ describe("JoinDependency#build", () => {
 
   const paths = (jd: JoinDependency) => jd.nodes.map((n) => n.assocName).sort();
 
-  /** Build the way the eager-load paths do: un-joinable specs land in `fallback`. */
-  const buildEager = (spec: AssociationSpec | AssociationSpec[]) => {
-    const fallback: AssociationSpec[] = [];
-    const jd = new JoinDependency(Post, null, spec, Nodes.OuterJoin, fallback);
-    return { jd, fallback };
-  };
+  /** Build the way the eager-load paths do — Rails' four-argument constructor. */
+  const buildEager = (spec: AssociationSpec | AssociationSpec[]) =>
+    new JoinDependency(Post, null, spec, Nodes.OuterJoin);
 
   it("joins a nested hash spec instead of falling back to preload", () => {
-    const { jd, fallback } = buildEager({ comments: "author" });
-    expect(fallback).toEqual([]);
-    expect(paths(jd)).toEqual(["comments", "comments.author"]);
+    expect(paths(buildEager({ comments: "author" }))).toEqual(["comments", "comments.author"]);
   });
 
   it("joins a dotted-string spec", () => {
-    const { jd, fallback } = buildEager("comments.author");
-    expect(fallback).toEqual([]);
-    expect(paths(jd)).toEqual(["comments", "comments.author"]);
+    expect(paths(buildEager("comments.author"))).toEqual(["comments", "comments.author"]);
   });
 
   it("deduplicates shared prefixes across hash array values", () => {
-    const { jd, fallback } = buildEager({ comments: ["author", "tags"] });
-    expect(fallback).toEqual([]);
-    expect(paths(jd)).toEqual(["comments", "comments.author", "comments.tags"]);
+    expect(paths(buildEager({ comments: ["author", "tags"] }))).toEqual([
+      "comments",
+      "comments.author",
+      "comments.tags",
+    ]);
   });
 
   it("deduplicates shared prefixes across separate spec calls", () => {
-    const { jd } = buildEager(["comments.author", "comments.tags"]);
-    expect(paths(jd)).toEqual(["comments", "comments.author", "comments.tags"]);
+    expect(paths(buildEager(["comments.author", "comments.tags"]))).toEqual([
+      "comments",
+      "comments.author",
+      "comments.tags",
+    ]);
   });
 
-  it("rolls back the whole spec when a segment can't be joined", () => {
-    const spec = { comments: "nonExisting" };
-    const { jd, fallback } = buildEager(spec);
-    expect(fallback).toEqual([spec]);
-    expect(jd.nodes).toHaveLength(0);
+  it("raises when a segment can't be joined", () => {
+    expect(() => buildEager({ comments: "nonExisting" })).toThrow(
+      /Can't join 'Comment' to association named 'nonExisting'; perhaps you misspelled it\?/,
+    );
   });
 });

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -184,29 +184,14 @@ export class JoinDependency {
     { aliased: TableRef; effectiveName: string; terminated: boolean }
   > = new Map();
   /**
-   * When set, `build` degrades an un-joinable spec to preloading (pushing it
-   * here) instead of raising. See the constructor's deviation note.
-   * @internal
-   */
-  private _fallbackAssociations: AssociationSpec[] | undefined;
-  /**
    * Mirrors: ActiveRecord::Associations::JoinDependency#initialize
    * (join_dependency.rb:71) — `(base, table, associations, join_type)`.
-   *
-   * Deviation: the trailing `fallbackAssociations` out-parameter. Rails JOINs
-   * every association it is handed, so `build` only ever raises; trails still
-   * has join capability gaps (composite keys, through associations it can't
-   * alias), and the eager-load paths degrade those specs to preloading instead
-   * of failing. Passing an array selects that lenient mode and collects the
-   * specs that were rolled back; omitting it raises, as Rails does. Either way
-   * the tree is built here and never mutated afterwards.
    */
   constructor(
     baseModel: typeof Base,
     table: TableRef | null,
     associations: AssociationSpec | AssociationSpec[] | null,
     joinType: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin | null,
-    fallbackAssociations?: AssociationSpec[],
   ) {
     this._baseModel = baseModel;
     const baseTable = table ?? (baseModel as any).arelTable;
@@ -217,24 +202,11 @@ export class JoinDependency {
     );
     this._joinRoot = new JoinBase(baseModel, baseTable);
     this._joinType = joinType ?? Nodes.OuterJoin;
-    this._fallbackAssociations = fallbackAssociations;
 
     const specs =
       associations == null ? [] : Array.isArray(associations) ? associations : [associations];
     for (const spec of specs) {
-      const tree = JoinDependency.makeTree(spec);
-      if (!fallbackAssociations) {
-        this.build(tree, baseModel, this._baseAlias, "");
-        continue;
-      }
-      // Each top-level spec is all-or-nothing: a later segment proving
-      // un-joinable must not leave half a JOIN chain (and half an alias claim)
-      // behind for the caller that degrades the whole spec to preloading.
-      const snapshot = this._capture();
-      if (!this.build(tree, baseModel, this._baseAlias, "")) {
-        this._rollback(snapshot);
-        fallbackAssociations.push(spec);
-      }
+      this.build(JoinDependency.makeTree(spec), baseModel, this._baseAlias, "");
     }
   }
 
@@ -378,9 +350,9 @@ export class JoinDependency {
 
     if (assocDef.type === "belongsTo") {
       // Rails raises for polymorphic eager loads — the join target table is
-      // not known statically (join_dependency.rb#build). This is distinct from
-      // the capability-gap fallbacks below (CPK / unjoinable through), which
-      // return null so the caller degrades to preloading.
+      // not known statically (join_dependency.rb#build). This is a dedicated
+      // error rather than the generic `build` raise the null returns below
+      // surface.
       if (assocDef.options.polymorphic) {
         throw new EagerLoadPolymorphicError(assocName);
       }
@@ -536,14 +508,11 @@ export class JoinDependency {
    * errors `construct_join_dependency` does before any SQL is built —
    * `ConfigurationError` for a misspelled/unknown name (via `findReflection`,
    * mirroring Rails `find_reflection`) and `EagerLoadPolymorphicError` for a
-   * polymorphic association. Valid-but-unjoinable specs (composite-key
-   * belongsTo, through associations trails can't alias) do NOT raise — Rails
-   * joins them and trails degrades them to preloading separately.
+   * polymorphic association.
    *
    * Used by the calculation/exists paths (`Relation#_checkEagerLoadable`), which
    * never build the real join tree but must still surface these errors. Unlike
-   * `build` this only validates — it doesn't mutate the tree — so there's
-   * nothing to roll back.
+   * `build` this only validates — it doesn't mutate the tree.
    *
    * Mirrors: ActiveRecord::Associations::JoinDependency#build.
    */
@@ -573,10 +542,8 @@ export class JoinDependency {
    * `tableAlias` here would emit ON clauses referencing e.g. "t1" against SQL
    * that names the real table.
    *
-   * Called once per top-level spec, from the constructor. Returns false on the
-   * first un-joinable segment in lenient mode so the constructor can roll the
-   * spec back and hand it to the preloader; in Rails-faithful mode it raises
-   * instead.
+   * Called once per top-level spec, from the constructor. Like Rails, an
+   * association that can't be JOINed raises — there is no lenient mode.
    *
    * Mirrors: ActiveRecord::Associations::JoinDependency#build
    * (join_dependency.rb:228).
@@ -587,41 +554,27 @@ export class JoinDependency {
     model: typeof Base,
     alias: string,
     parentPath: string,
-  ): boolean {
+  ): void {
     for (const key of Reflect.ownKeys(hash)) {
       const name = typeof key === "symbol" ? (key.description ?? String(key)) : String(key);
       const node = this._addOrReuse(name, model, alias, parentPath);
       if (!node) {
-        if (this._fallbackAssociations) return false;
+        // Rails' `find_reflection` (join_dependency.rb:236) raises
+        // ConfigurationError for a name that doesn't resolve — the only case
+        // observed here. Getting past it means the reflection resolved but the
+        // JOIN still couldn't be built, which has no Rails analogue: surface it
+        // loudly rather than silently degrading the spec to a preload.
         this.findReflection(model, name);
-        this._raiseUnjoinable(name, model);
+        throw new Error(
+          `Could not build a JOIN for association '${name}' on ${(model as any).name}`,
+        );
       }
       const child = hash[key];
       const childPath = parentPath ? `${parentPath}.${name}` : name;
-      if (
-        child != null &&
-        Reflect.ownKeys(child).length > 0 &&
-        !this.build(child, node.baseKlass, node.effectiveSqlName, childPath)
-      ) {
-        return false;
+      if (child != null && Reflect.ownKeys(child).length > 0) {
+        this.build(child, node.baseKlass, node.effectiveSqlName, childPath);
       }
     }
-    return true;
-  }
-
-  /**
-   * A null node for an association `findReflection` resolved is a trails join
-   * capability gap (composite keys, unaliasable through) rather than Rails'
-   * misspelled-name case, which `find_reflection` has already raised on.
-   * @internal
-   */
-  private _raiseUnjoinable(assocName: string, fromModelClass: any): never {
-    const onModel = fromModelClass?.name ?? (this._baseModel as any).name ?? "model";
-    const err = new Error(
-      `Association named '${assocName}' was not found on ${onModel}; perhaps you misspelled it?`,
-    );
-    err.name = "ArgumentError";
-    throw err;
   }
 
   /**
@@ -659,43 +612,6 @@ export class JoinDependency {
       node = child;
     }
     return node;
-  }
-
-  /**
-   * Snapshot the alias bookkeeping + current tree nodes so an all-or-nothing
-   * spec build can be rolled back when a later segment proves un-joinable.
-   * @internal
-   */
-  private _capture(): {
-    nodes: Set<JoinPart>;
-    tracker: Map<string, number>;
-  } {
-    const nodes = new Set<JoinPart>();
-    this._joinRoot.each((p) => {
-      if (p !== this._joinRoot) nodes.add(p);
-    });
-    return {
-      nodes,
-      tracker: new Map(this._aliasTracker.aliases),
-    };
-  }
-
-  /** @internal */
-  private _rollback(snapshot: { nodes: Set<JoinPart>; tracker: Map<string, number> }): void {
-    const prune = (parent: JoinPart): void => {
-      for (let i = parent.children.length - 1; i >= 0; i--) {
-        const child = parent.children[i];
-        if (snapshot.nodes.has(child)) {
-          prune(child);
-        } else {
-          parent.children.splice(i, 1);
-        }
-      }
-    };
-    prune(this._joinRoot);
-    this._aliasesCache = undefined;
-    this._aliasTracker.aliases.clear();
-    for (const [k, v] of snapshot.tracker) this._aliasTracker.aliases.set(k, v);
   }
 
   private _buildSelectArelNodes(): Nodes.As[] {
@@ -1470,7 +1386,7 @@ export class JoinDependency {
    * column names and Arel table. Replaces the index-keyed `_aliases`/`_arelTablesByIndex`.
    *
    * Memoized like Rails' `@aliases ||=`; the cache is cleared on any tree
-   * mutation (`_insertTreeNode` / `_rollback`) so it can never go stale.
+   * mutation (`_insertTreeNode`) so it can never go stale.
    * @internal
    */
   private aliases(): Aliases {

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -351,8 +351,8 @@ export class JoinDependency {
     if (assocDef.type === "belongsTo") {
       // Rails raises for polymorphic eager loads — the join target table is
       // not known statically (join_dependency.rb#build). This is a dedicated
-      // error rather than the generic `build` raise the null returns below
-      // surface.
+      // error rather than the ConfigurationError `build` raises for the null
+      // returns below.
       if (assocDef.options.polymorphic) {
         throw new EagerLoadPolymorphicError(assocName);
       }
@@ -543,7 +543,10 @@ export class JoinDependency {
    * that names the real table.
    *
    * Called once per top-level spec, from the constructor. Like Rails, an
-   * association that can't be JOINed raises — there is no lenient mode.
+   * association that can't be JOINed raises `ConfigurationError` — either from
+   * `findReflection` (a name that doesn't resolve, Rails' `find_reflection`) or,
+   * with no Rails analogue, because the reflection resolved but trails still
+   * couldn't build the JOIN. There is no lenient mode.
    *
    * Mirrors: ActiveRecord::Associations::JoinDependency#build
    * (join_dependency.rb:228).
@@ -559,14 +562,9 @@ export class JoinDependency {
       const name = typeof key === "symbol" ? (key.description ?? String(key)) : String(key);
       const node = this._addOrReuse(name, model, alias, parentPath);
       if (!node) {
-        // Rails' `find_reflection` (join_dependency.rb:236) raises
-        // ConfigurationError for a name that doesn't resolve — the only case
-        // observed here. Getting past it means the reflection resolved but the
-        // JOIN still couldn't be built, which has no Rails analogue: surface it
-        // loudly rather than silently degrading the spec to a preload.
         this.findReflection(model, name);
-        throw new Error(
-          `Could not build a JOIN for association '${name}' on ${(model as any).name}`,
+        throw new ConfigurationError(
+          `Can't join '${(model as any).name}' to association named '${name}'`,
         );
       }
       const child = hash[key];

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2747,10 +2747,8 @@ export class Relation<T extends Base> {
    * Builds the eager-load JoinDependency in one shot, mirroring Rails'
    * `construct_join_dependency(eager_load_values, ...)` — nested hashes and
    * dotted paths become recursive JOINs. Polymorphic specs raise
-   * `EagerLoadPolymorphicError` out of the constructor (matching Rails), so
-   * they never reach the fallback list. Capability-gap specs (composite key,
-   * unjoinable through) are rolled back into `fallbackAssocs` for preload
-   * fallback — a trails deviation Rails has no need for.
+   * `EagerLoadPolymorphicError` out of the constructor (matching Rails), and an
+   * association that can't be JOINed raises rather than degrading to a preload.
    *
    * Alias resolution and `references` re-aliasing (`authors AS author`) are
    * deferred to emit-time: the eager JD is folded into the single
@@ -2760,19 +2758,8 @@ export class Relation<T extends Base> {
    * filter to compute.
    * @internal
    */
-  private _buildEagerJoinDependency(specs: AssociationSpec[]): {
-    jd: JoinDependency;
-    fallbackAssocs: AssociationSpec[];
-  } {
-    const fallbackAssocs: AssociationSpec[] = [];
-    const jd = new JoinDependency(
-      this._modelClass,
-      this.table,
-      specs,
-      Nodes.OuterJoin,
-      fallbackAssocs,
-    );
-    return { jd, fallbackAssocs };
+  private _buildEagerJoinDependency(specs: AssociationSpec[]): JoinDependency {
+    return new JoinDependency(this._modelClass, this.table, specs, Nodes.OuterJoin);
   }
 
   private async _executeEagerLoad(eagerAssocs?: AssociationSpec[]): Promise<void> {
@@ -2791,7 +2778,7 @@ export class Relation<T extends Base> {
       return;
     }
 
-    const { jd, fallbackAssocs } = this._buildEagerJoinDependency(eagerAssociations);
+    const jd = this._buildEagerJoinDependency(eagerAssociations);
 
     // If no associations could be JOINed, fall back entirely to preload
     if (jd.nodes.length === 0) {
@@ -2803,9 +2790,6 @@ export class Relation<T extends Base> {
         result.toArray(),
         result.columnTypes as Record<string, { deserialize(value: unknown): unknown }>,
       );
-      if (fallbackAssocs.length > 0) {
-        await this.preloadAssociations(this._records, fallbackAssocs);
-      }
       return;
     }
 
@@ -2895,14 +2879,10 @@ export class Relation<T extends Base> {
     // the block otherwise runs). The bypass / degrade-to-preload sub-paths above
     // already instantiate through `_instrumentInstantiation`, so firing here only
     // — not in `_toArrayInner` — keeps the block once-per-record like Rails'
-    // `instantiate_records(rows, &block)`. Runs before the residual preload below
-    // (and the `_toArrayInner` preload), matching Rails' ordering.
+    // `instantiate_records(rows, &block)`. Runs before the `_toArrayInner`
+    // preload, matching Rails' ordering.
     const block = this._instantiateBlock;
     if (block) for (const record of this._records) block(record);
-
-    if (fallbackAssocs.length > 0 && this._records.length > 0) {
-      await this.preloadAssociations(this._records, fallbackAssocs);
-    }
   }
 
   /**
@@ -3637,66 +3617,17 @@ export class Relation<T extends Base> {
       rel._includesAssociations = [];
 
       const basePk = (this._modelClass as any).primaryKey ?? "id";
-      const { jd, fallbackAssocs } = this._buildEagerJoinDependency(eagerSpecs);
-      // Rails joins every eager spec; trails can't join capability-gap
-      // reflections (composite-key collections, unjoinable through), so
-      // `_buildEagerJoinDependency` returns them as `fallbackAssocs` to
-      // preload. JOIN only the joinable remainder — replaying the full
-      // `eagerSpecs` through `leftOuterJoins` would re-enter JoinDependency
-      // construction and throw for the unjoinable spec. pluck reads columns only
-      // from the base and joined tables, so the preloaded fallbacks contribute
-      // nothing and are simply omitted (no preload needed).
-      const joinableSpecs = eagerSpecs.filter((s) => !fallbackAssocs.includes(s));
+      const jd = this._buildEagerJoinDependency(eagerSpecs);
 
-      // A pluck column may reference a degraded (unjoinable) association's own
-      // table (e.g. `pluck("cpk_chapters.title")`). Rails JOINs that table;
-      // trails cannot (composite-key capability gap), and silently preloading it
-      // would emit SQL against an unjoined table. The degraded query can only
-      // project the base table, the relation's manual joins, and the joinable
-      // eager specs' tables, so treat a column referencing any OTHER table as
-      // reaching for an unjoinable fallback — covering nested hash/array
-      // fallback shapes that `_resolveAssocTables` (string-spec only) can't
-      // resolve directly. Route those back through the full-spec join, which
-      // raises the explicit capability-gap error rather than degrade into
-      // broken SQL.
-      if (fallbackAssocs.length > 0) {
-        const safeTables = this._joinedTableNames();
-        // `_joinedTableNames` / `_resolveAssocTables` only resolve string specs.
-        // Resolve hash/array manual-join and joinable-eager specs to their
-        // tables through a JoinDependency (which handles every spec shape) so a
-        // pluck column reaching a joined table of any shape is recognized as
-        // servable rather than misclassified as an unjoinable fallback.
-        const namedSpecs: AssociationSpec[] = [];
-        for (const spec of [
-          ...this._namedInnerJoins,
-          ...this._leftOuterJoinsValues,
-          ...joinableSpecs,
-        ]) {
-          if (spec instanceof JoinDependency) {
-            for (const node of spec.nodes) safeTables.add(node.tableName.toLowerCase());
-            continue;
-          }
-          namedSpecs.push(spec);
-        }
-        const { jd: joinedJd } = this._buildEagerJoinDependency(namedSpecs);
-        for (const node of joinedJd.nodes) safeTables.add(node.tableName.toLowerCase());
-        const referencesUnservableTable = columns.some((c) => {
-          const text = typeof c === "string" ? c : c instanceof Nodes.SqlLiteral ? c.value : "";
-          return this.tablesInString(text).some((t) => !safeTables.has(t));
-        });
-        if (referencesUnservableTable) {
-          return rel.leftOuterJoins(eagerSpecs).pluck(...columns);
-        }
-      }
-
-      // No spec is joinable: degrade entirely to the base relation (limit/offset
-      // preserved), mirroring _executeEagerLoad's jd.nodes.length === 0 fallback.
+      // Nothing was joined (empty spec): degrade entirely to the base relation
+      // (limit/offset preserved), mirroring _executeEagerLoad's
+      // jd.nodes.length === 0 path.
       if (jd.nodes.length === 0) {
         return rel.pluck(...columns);
       }
 
       const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-      if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(joinableSpecs)) {
+      if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
         // A composite base PK can't be materialized here — `_materializeLimitedIds`
         // (Rails' zip/transpose over `Array(primary_key)`) has no composite
         // support, so it would emit a wrong single-column `"col1,col2"` predicate.
@@ -3711,14 +3642,14 @@ export class Relation<T extends Base> {
         // limit/offset. Limiting the joined rows directly would be wrong under
         // fan-out (it limits associated rows, not parents).
         const limitedIds = await this._materializeLimitedIds(jd, basePk);
-        const limited = rel.leftOuterJoins(joinableSpecs).where({
+        const limited = rel.leftOuterJoins(eagerSpecs).where({
           [basePk]: limitedIds,
         });
         limited._limitValue = null;
         limited._offsetValue = null;
         return limited.pluck(...columns);
       }
-      return rel.leftOuterJoins(joinableSpecs).pluck(...columns);
+      return rel.leftOuterJoins(eagerSpecs).pluck(...columns);
     }
 
     // Reflect the schema before casting results so the model's attribute
@@ -4866,7 +4797,7 @@ export class Relation<T extends Base> {
    */
   private _eagerReflectionsAreLimitable(specs: AssociationSpec[]): boolean {
     if (specs.length === 0) return true;
-    const { jd } = this._buildEagerJoinDependency(specs);
+    const jd = this._buildEagerJoinDependency(specs);
     return this.usingLimitableReflections(jd.reflections);
   }
 
@@ -4910,7 +4841,7 @@ export class Relation<T extends Base> {
       }
       namedSpecs.push(spec);
     }
-    const { jd } = this._buildEagerJoinDependency(namedSpecs);
+    const jd = this._buildEagerJoinDependency(namedSpecs);
     return this.usingLimitableReflections([...jd.reflections, ...mergedReflections] as never);
   }
 
@@ -4963,7 +4894,7 @@ export class Relation<T extends Base> {
    */
   _buildDeferredDistinctPkInlineSubquery(): SelectManager {
     const basePk = (this._modelClass as any).primaryKey ?? "id";
-    const { jd } = this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs());
+    const jd = this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs());
     return this._buildEagerIdSubquery(jd, basePk);
   }
 
@@ -4976,7 +4907,7 @@ export class Relation<T extends Base> {
    */
   async _materializeDistinctPkIds(): Promise<unknown[]> {
     const basePk = (this._modelClass as any).primaryKey ?? "id";
-    const { jd } = this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs());
+    const jd = this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs());
     if (jd.nodes.length === 0) return [];
     return this._withQueryConnection(() => this._materializeLimitedIds(jd, basePk));
   }
@@ -5368,7 +5299,7 @@ export class Relation<T extends Base> {
 
     const basePk = (this._modelClass as any).primaryKey ?? "id";
 
-    const { jd } = this._buildEagerJoinDependency(allEager);
+    const jd = this._buildEagerJoinDependency(allEager);
     if (jd.nodes.length === 0) return null;
 
     const eagerRelation = this._applyEagerJoinDependency(jd, basePk);
@@ -6688,21 +6619,15 @@ export class Relation<T extends Base> {
         rel._includesAssociations = [];
         const hasLimitOrOffset = this._limitValue !== null || (this._offsetValue ?? 0) > 0;
         const pk = (this._modelClass as { primaryKey?: string | string[] }).primaryKey ?? "id";
-        const { jd, fallbackAssocs } = this._buildEagerJoinDependency(eagerSpecs);
-        // JOIN only the joinable remainder; capability-gap reflections
-        // (composite-key collections, unjoinable through) come back as
-        // `fallbackAssocs` and would throw if replayed through `leftOuterJoins`.
-        // cache_version reads size/timestamp from the base + joined tables, so
-        // the preloaded fallbacks contribute nothing and are simply omitted.
-        const joinableSpecs = eagerSpecs.filter((s) => !fallbackAssocs.includes(s));
+        const jd = this._buildEagerJoinDependency(eagerSpecs);
         if (jd.nodes.length === 0) {
-          // No spec is joinable: degrade entirely to the base relation
-          // (limit/offset preserved), mirroring _executeEagerLoad's
-          // jd.nodes.length === 0 preload fallback.
+          // Nothing was joined (empty spec): degrade entirely to the base
+          // relation (limit/offset preserved), mirroring _executeEagerLoad's
+          // jd.nodes.length === 0 path.
           collection = rel;
         } else if (
           hasLimitOrOffset &&
-          !this._applyJoinDependencyIsLimitable(joinableSpecs) &&
+          !this._applyJoinDependencyIsLimitable(eagerSpecs) &&
           !Array.isArray(pk)
         ) {
           // Rails' distinct_relation_for_primary_key (finder_methods.rb:463):
@@ -6715,16 +6640,16 @@ export class Relation<T extends Base> {
           // unsupported combination as an explicit NotImplementedError rather
           // than emitting a wrong single-column `"col1,col2"` predicate.
           const limitedIds = await this._materializeLimitedIds(jd, pk);
-          collection = rel.leftOuterJoins(joinableSpecs).where({ [pk]: limitedIds });
+          collection = rel.leftOuterJoins(eagerSpecs).where({ [pk]: limitedIds });
           collection._limitValue = null;
           collection._offsetValue = null;
-        } else if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(joinableSpecs)) {
+        } else if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
           // Composite-PK, non-limitable eager limit/offset: unsupported here —
           // surfaces NotImplementedError rather than a wrong predicate. Tracked
           // by 0023-surfaced-deviations/composite-pk-distinct-relation-materialization.
           collection = this.applyJoinDependency();
         } else {
-          collection = rel.leftOuterJoins(joinableSpecs);
+          collection = rel.leftOuterJoins(eagerSpecs);
         }
       }
       const tsColumn = this.table.get(timestampColumn);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2686,41 +2686,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Table names reachable from the relation's manual joins plus the base table,
-   * used by the pluck eager-degrade guard to tell a servable column from one
-   * reaching for an unjoinable fallback association. Mirrors the joined-table
-   * extraction in `referencesEagerLoadedTables` (Rails `build_joins([])`,
-   * relation.rb:1474-1488); kept as a sibling rather than a shared callee so the
-   * ported `references_eager_loaded_tables?` body retains its Arel/StringJoin
-   * usage for the api-compare dependency + call-set parity gates.
-   * @internal
-   */
-  private _joinedTableNames(): Set<string> {
-    const leftOuterTables = this._resolveAssocTables(this._leftOuterJoinsValues);
-    const namedInnerTables = this._resolveAssocTables(this._namedInnerJoins);
-    return new Set<string>([
-      ...this._joinClauses.map((j) => j.table.toLowerCase()),
-      ...leftOuterTables,
-      ...namedInnerTables,
-      ...this._joinValues.flatMap((v) => {
-        if (typeof v === "string") {
-          const join = new Nodes.StringJoin(new Nodes.SqlLiteral(v));
-          const sqlText = join.left instanceof Nodes.SqlLiteral ? join.left.value : v;
-          return this.tablesInString(sqlText);
-        }
-        if (v instanceof Nodes.StringJoin) {
-          const sqlText = v.left instanceof Nodes.SqlLiteral ? v.left.value : v.toSql();
-          return this.tablesInString(sqlText);
-        }
-        const leftName = (v.left as any)?.name;
-        if (typeof leftName === "string") return [leftName.toLowerCase()];
-        return this.tablesInString(v.toSql());
-      }),
-      String((this._modelClass as unknown as { tableName?: string }).tableName ?? "").toLowerCase(),
-    ]);
-  }
-
-  /**
    * Extracts table-like identifiers from a raw SQL string (e.g. a JOIN fragment).
    *
    * Mirrors: ActiveRecord::Relation#tables_in_string
@@ -2780,7 +2745,7 @@ export class Relation<T extends Base> {
 
     const jd = this._buildEagerJoinDependency(eagerAssociations);
 
-    // If no associations could be JOINed, fall back entirely to preload
+    // Nothing to JOIN (empty spec): load the base rows only.
     if (jd.nodes.length === 0) {
       const sql = this._toSql();
       // selectAll (not execute) so the adapter-reported column_types cast


### PR DESCRIPTION
## What

`JoinDependency`'s constructor took a trails-only fifth argument,
`fallbackAssociations`, which selected a lenient build mode: a top-level spec
whose segment couldn't be JOINed was rolled back and pushed to that array so
the caller degraded it to preloading. Rails has no such concept — `build`
(`vendor/rails/activerecord/lib/active_record/associations/join_dependency.rb:228`)
raises and never returns a failure value.

## Measurement

Instrumented sweep over every AR test file that can reach eager loading
(every `*.test.ts` under `packages/activerecord/src` mentioning `eagerLoad` or
`includes(` — 85 files, 80 with tests, 4534 tests), not just `associations/`
and `relation/`. Zero legitimate degradations: the only spec that ever reached
the fallback was the deliberately-misspelled one from
`join-dependency-spec.test.ts`, which Rails' `find_reflection` raises on
anyway. The residual through arm (`_addThroughViaJoinAssociation` returning
null) was never reached.

## Changes

All five deviations collapse together:

- the fifth constructor argument, restoring Rails' arity of 4
  (`initialize(base, table, associations, join_type)`, `join_dependency.rb:71`)
- `build` returning `boolean` → `void`, raising like Rails
- `_capture` / `_rollback`, which existed only to undo a partial build
- `_raiseUnjoinable`'s `ArgumentError` arm, which reported "perhaps you
  misspelled it" for a name `findReflection` had already resolved. A null node
  past `findReflection` now throws a plain invariant error naming the spec —
  loud rather than silently preloading
- `Relation#_buildEagerJoinDependency` collapses to a direct
  `new JoinDependency(...)`, and its callers drop the
  `fallbackAssocs.includes(...)` filtering (plus the whole dead
  unservable-table detour in the `pluck` path, and with it the trails-only
  `_joinedTableNames` helper that existed solely to serve it)

Join SQL is unchanged for everything that already joins — no construction path
was touched, only the rollback/degrade wrapper around it.

## Behavior change

A spec that silently preloaded now raises. Covered on the record-loading,
nested-inner-segment, calculation (`count`/`sum`), `exists?` and `pluck` paths
in `associations/eager-load-unjoinable-raises.trails.test.ts` — the
calculation/exists paths reach this through `Relation#_checkEagerLoadable`,
which already raised, so all paths now agree.

Closes-story: drop-join-dependency-preload-fallback-lane
