### PR TITLE
feat(i18n): scaffold packages/i18n and port Config + exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           # dependency is activesupport.
           RACK_PKGS_RE='^packages/(rack|activesupport)/'
           # unit_tests_affected gates the bundled vitest run for the small
-          # leaf packages (arel/activemodel/activesupport) and the
+          # leaf packages (arel/activemodel/activesupport/i18n) and the
           # scripts/guides-typecheck self-test. Rack is excluded here — it
           # runs in the leaf-tests job.
           # scripts/tasks/ and scripts/guides-typecheck/ also ride on this gate
@@ -191,7 +191,7 @@ jobs:
           # eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
           # its byte set and the ESLint rule's, and scripts/ci/ is carved out
           # of the infra sweep (INFRA_CARVEOUT_RE).
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport|i18n)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -699,6 +699,7 @@ jobs:
           packages/arel
           packages/activemodel
           packages/activesupport
+          packages/i18n
           scripts/guides-typecheck
           scripts/tasks
           scripts/api-compare
@@ -829,6 +830,7 @@ jobs:
           packages/activesupport
           packages/did-you-mean
           packages/globalid
+          packages/i18n
           packages/nokogiri
           packages/html-sanitizer
           packages/rack

--- a/packages/i18n/NOTICE
+++ b/packages/i18n/NOTICE
@@ -1,0 +1,31 @@
+@blazetrails/i18n
+=================
+
+This package is a TypeScript port of the Ruby i18n gem
+(https://github.com/ruby-i18n/i18n), licensed under the MIT License.
+
+Original copyright:
+
+  i18n — Copyright (c) 2008 The Ruby I18n team, MIT License.
+
+MIT License (i18n)
+------------------
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@blazetrails/i18n",
+  "version": "0.1.0",
+  "description": "Port of the Ruby i18n gem: Config, exceptions",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { Config, registerDefaultBackend, resetClassConfig, type Backend } from "./config.js";
+import { ExceptionHandler, InvalidLocale, MissingInterpolationArgument } from "./exceptions.js";
+import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
+import { resetConfig } from "./i18n.js";
+
+class FakeBackend implements Backend {
+  reloaded = 0;
+  constructor(private locales: string[] = ["en"]) {}
+  availableLocales(): string[] {
+    return this.locales;
+  }
+  reload(): void {
+    this.reloaded += 1;
+  }
+}
+
+// Trails-only: the gem has no config_test.rb — Config is covered indirectly by
+// test/i18n_test.rb through the translate API, which is not ported yet.
+describe("Config", () => {
+  let config: Config;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    config = new Config();
+    registerDefaultBackend(() => new FakeBackend());
+  });
+
+  it("locale defaults to the default locale and is per-instance", () => {
+    expect(config.locale).toBe("en");
+    config.enforceAvailableLocales = false;
+    config.locale = "de";
+    expect(config.locale).toBe("de");
+    expect(new Config().locale).toBe("en");
+  });
+
+  it("locale= enforces available locales", () => {
+    expect(() => (config.locale = "klingon")).toThrow(InvalidLocale);
+    config.availableLocales = ["en", "de"];
+    config.locale = "de";
+    expect(config.locale).toBe("de");
+  });
+
+  it("defaultLocale= enforces available locales and is shared across instances", () => {
+    expect(() => (config.defaultLocale = "klingon")).toThrow(InvalidLocale);
+    config.availableLocales = ["en", "de"];
+    config.defaultLocale = "de";
+    expect(new Config().defaultLocale).toBe("de");
+  });
+
+  it("backend defaults to the registered default and is settable", () => {
+    expect(config.backend).toBeInstanceOf(FakeBackend);
+    const backend = new FakeBackend(["fr"]);
+    config.backend = backend;
+    expect(new Config().backend).toBe(backend);
+  });
+
+  it("backend raises when no default backend is registered", () => {
+    resetClassConfig();
+    expect(() => config.backend).toThrow(/no backend/);
+  });
+
+  it("availableLocales delegates to the backend until set", () => {
+    config.backend = new FakeBackend(["en", "fr"]);
+    expect(config.availableLocales).toEqual(["en", "fr"]);
+    expect(config.availableLocalesInitialized).toBe(false);
+
+    config.availableLocales = ["de"];
+    expect(config.availableLocales).toEqual(["de"]);
+    expect(config.availableLocalesInitialized).toBe(true);
+  });
+
+  it("availableLocales= wraps a single locale and clears back to the backend when empty", () => {
+    config.availableLocales = "de";
+    expect(config.availableLocales).toEqual(["de"]);
+    config.availableLocales = [];
+    expect(config.availableLocalesInitialized).toBe(false);
+  });
+
+  it("availableLocalesSet is memoized and cleared by clearAvailableLocalesSet", () => {
+    config.availableLocales = ["en", "de"];
+    const set = config.availableLocalesSet;
+    expect(set.has("de")).toBe(true);
+    expect(config.availableLocalesSet).toBe(set);
+
+    config.clearAvailableLocalesSet();
+    expect(config.availableLocalesSet).not.toBe(set);
+  });
+
+  it("defaultSeparator defaults to a dot", () => {
+    expect(config.defaultSeparator).toBe(".");
+    config.defaultSeparator = "|";
+    expect(new Config().defaultSeparator).toBe("|");
+  });
+
+  it("exceptionHandler defaults to an ExceptionHandler", () => {
+    expect(config.exceptionHandler).toBeInstanceOf(ExceptionHandler);
+    const handler = { call: () => "handled" };
+    config.exceptionHandler = handler;
+    expect(config.exceptionHandler).toBe(handler);
+  });
+
+  it("missingInterpolationArgumentHandler raises MissingInterpolationArgument by default", () => {
+    expect(() => config.missingInterpolationArgumentHandler("bar", { baz: 1 }, "%{bar}")).toThrow(
+      MissingInterpolationArgument,
+    );
+    config.missingInterpolationArgumentHandler = (key) => `${key} is missing`;
+    expect(config.missingInterpolationArgumentHandler("bar", {}, "%{bar}")).toBe("bar is missing");
+  });
+
+  it("loadPath defaults to an empty array and reloads the backend when assigned", () => {
+    expect(config.loadPath).toEqual([]);
+    config.loadPath.push("a.yml");
+    expect(new Config().loadPath).toEqual(["a.yml"]);
+
+    const backend = new FakeBackend();
+    config.backend = backend;
+    config.availableLocales = ["en"];
+    config.loadPath = ["b.yml"];
+    expect(backend.reloaded).toBe(1);
+    expect(config.availableLocalesInitialized).toBe(true);
+    expect(config.availableLocalesSet.has("en")).toBe(true);
+  });
+
+  it("enforceAvailableLocales defaults to true", () => {
+    expect(config.enforceAvailableLocales).toBe(true);
+    config.enforceAvailableLocales = false;
+    expect(new Config().enforceAvailableLocales).toBe(false);
+  });
+
+  it("interpolationPatterns defaults to a copy of DEFAULT_INTERPOLATION_PATTERNS", () => {
+    expect(config.interpolationPatterns).toEqual([...DEFAULT_INTERPOLATION_PATTERNS]);
+    config.interpolationPatterns.push(/\{\{(\w+)\}\}/);
+    expect(config.interpolationPatterns).toHaveLength(DEFAULT_INTERPOLATION_PATTERNS.length + 1);
+    expect(DEFAULT_INTERPOLATION_PATTERNS).toHaveLength(3);
+  });
+});

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -16,8 +16,10 @@ class FakeBackend implements Backend {
   }
 }
 
-// Trails-only: the gem has no config_test.rb — Config is covered indirectly by
-// test/i18n_test.rb through the translate API, which is not ported yet.
+/**
+ * Trails-only: the gem has no config_test.rb — Config is covered indirectly by
+ * test/i18n_test.rb through the translate API, which is not ported yet.
+ */
 describe("Config", () => {
   let config: Config;
 

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -22,9 +22,11 @@ export type MissingInterpolationArgumentHandler = (
   string: string,
 ) => unknown;
 
-// Ruby's `@@`-scoped config lives on the class and is shared by every Config
-// instance (and subclass); module-level bindings are the JS equivalent. Only
-// `locale` is per-instance, exactly as in the gem.
+/**
+ * Ruby's `@@`-scoped config lives on the class and is shared by every `Config`
+ * instance (and subclass); these module-level bindings are the JS equivalent.
+ * Only `locale` is per-instance, exactly as in the gem.
+ */
 let backend: Backend | undefined;
 let defaultLocale: Locale | undefined;
 let availableLocales: Locale[] | undefined;
@@ -94,16 +96,16 @@ export class Config {
     return availableLocales ?? this.backend.availableLocales();
   }
 
-  set availableLocales(locales: Locale | Locale[] | null | undefined) {
-    const list = locales === null || locales === undefined ? [] : [locales].flat();
-    availableLocales = list.length === 0 ? undefined : list;
-    availableLocalesSet = undefined;
-  }
-
   /** Cached as a Set for faster available-locales enforce checks. */
   get availableLocalesSet(): Set<Locale> {
     availableLocalesSet ??= new Set(this.availableLocales);
     return availableLocalesSet;
+  }
+
+  set availableLocales(locales: Locale | Locale[] | null | undefined) {
+    const list = locales === null || locales === undefined ? [] : [locales].flat();
+    availableLocales = list.length === 0 ? undefined : list;
+    availableLocalesSet = undefined;
   }
 
   /** Returns true if the available locales have been initialized. */

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -1,0 +1,196 @@
+/**
+ * Mirrors: i18n/lib/i18n/config.rb
+ */
+
+import { enforceAvailableLocales, type Locale, type TranslationKey } from "./i18n.js";
+import { ExceptionHandler, MissingInterpolationArgument } from "./exceptions.js";
+import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
+
+/** The slice of a backend `Config` itself calls. */
+export interface Backend {
+  availableLocales(): Locale[];
+  reload(): void;
+}
+
+export type ExceptionHandlerLike = {
+  call(exception: Error, locale: Locale, key: TranslationKey, options: unknown): unknown;
+};
+
+export type MissingInterpolationArgumentHandler = (
+  missingKey: string,
+  providedHash: Record<string, unknown>,
+  string: string,
+) => unknown;
+
+// Ruby's `@@`-scoped config lives on the class and is shared by every Config
+// instance (and subclass); module-level bindings are the JS equivalent. Only
+// `locale` is per-instance, exactly as in the gem.
+let backend: Backend | undefined;
+let defaultLocale: Locale | undefined;
+let availableLocales: Locale[] | undefined;
+let availableLocalesSet: Set<Locale> | undefined;
+let defaultSeparator: string | undefined;
+let exceptionHandler: ExceptionHandlerLike | undefined;
+let missingInterpolationArgumentHandler: MissingInterpolationArgumentHandler | undefined;
+let loadPath: string[] | undefined;
+let enforceAvailableLocalesFlag = true;
+let interpolationPatterns: RegExp[] | undefined;
+
+let defaultBackendFactory: (() => Backend) | undefined;
+
+/**
+ * Ruby's `Config#backend` defaults to `Backend::Simple.new`, resolved through
+ * `autoload`. `backend/simple.ts` is not ported yet, so it registers itself
+ * here when it lands; until then `config.backend` raises rather than handing
+ * back a half-built default.
+ */
+export function registerDefaultBackend(factory: () => Backend): void {
+  defaultBackendFactory = factory;
+}
+
+export class Config {
+  private localeValue?: Locale;
+
+  /** Not global/thread-scoped like the rest; defaults to `defaultLocale`. */
+  get locale(): Locale {
+    return this.localeValue ?? this.defaultLocale;
+  }
+
+  set locale(locale: Locale) {
+    enforceAvailableLocales(locale);
+    this.localeValue = locale;
+  }
+
+  /** Returns the current backend. Defaults to `Backend::Simple`. */
+  get backend(): Backend {
+    if (!backend) {
+      if (!defaultBackendFactory) {
+        throw new Error(
+          "I18n has no backend: set `I18n.config.backend`, or port I18n::Backend::Simple and register it with registerDefaultBackend().",
+        );
+      }
+      backend = defaultBackendFactory();
+    }
+    return backend;
+  }
+
+  set backend(value: Backend) {
+    backend = value;
+  }
+
+  /** Returns the current default locale. Defaults to `en`. */
+  get defaultLocale(): Locale {
+    defaultLocale ??= "en";
+    return defaultLocale;
+  }
+
+  set defaultLocale(locale: Locale) {
+    enforceAvailableLocales(locale);
+    defaultLocale = locale;
+  }
+
+  /** Locales with translations; delegated to the backend unless set. */
+  get availableLocales(): Locale[] {
+    return availableLocales ?? this.backend.availableLocales();
+  }
+
+  set availableLocales(locales: Locale | Locale[] | null | undefined) {
+    const list = locales === null || locales === undefined ? [] : [locales].flat();
+    availableLocales = list.length === 0 ? undefined : list;
+    availableLocalesSet = undefined;
+  }
+
+  /** Cached as a Set for faster available-locales enforce checks. */
+  get availableLocalesSet(): Set<Locale> {
+    availableLocalesSet ??= new Set(this.availableLocales);
+    return availableLocalesSet;
+  }
+
+  /** Returns true if the available locales have been initialized. */
+  get availableLocalesInitialized(): boolean {
+    return availableLocales !== undefined;
+  }
+
+  /** Clears the set so it is recomputed after I18n gets reloaded. */
+  clearAvailableLocalesSet(): void {
+    availableLocalesSet = undefined;
+  }
+
+  /** Returns the current default scope separator. Defaults to `.` */
+  get defaultSeparator(): string {
+    defaultSeparator ??= ".";
+    return defaultSeparator;
+  }
+
+  set defaultSeparator(separator: string) {
+    defaultSeparator = separator;
+  }
+
+  /** Returns the current exception handler. Defaults to an `ExceptionHandler`. */
+  get exceptionHandler(): ExceptionHandlerLike {
+    exceptionHandler ??= new ExceptionHandler();
+    return exceptionHandler;
+  }
+
+  set exceptionHandler(handler: ExceptionHandlerLike) {
+    exceptionHandler = handler;
+  }
+
+  /** Handler for a missing interpolation argument; raises by default. */
+  get missingInterpolationArgumentHandler(): MissingInterpolationArgumentHandler {
+    missingInterpolationArgumentHandler ??= (missingKey, providedHash, string) => {
+      throw new MissingInterpolationArgument(missingKey, providedHash, string);
+    };
+    return missingInterpolationArgumentHandler;
+  }
+
+  set missingInterpolationArgumentHandler(handler: MissingInterpolationArgumentHandler) {
+    missingInterpolationArgumentHandler = handler;
+  }
+
+  /** Paths providing translation data sources; the backend defines what it accepts. */
+  get loadPath(): string[] {
+    loadPath ??= [];
+    return loadPath;
+  }
+
+  set loadPath(value: string[]) {
+    loadPath = value;
+    availableLocalesSet = undefined;
+    this.backend.reload();
+  }
+
+  /** Whether to verify locales are in the available list. Defaults to true. */
+  get enforceAvailableLocales(): boolean {
+    return enforceAvailableLocalesFlag;
+  }
+
+  set enforceAvailableLocales(value: boolean) {
+    enforceAvailableLocalesFlag = value;
+  }
+
+  /** Defaults to a copy of `DEFAULT_INTERPOLATION_PATTERNS`. */
+  get interpolationPatterns(): RegExp[] {
+    interpolationPatterns ??= [...DEFAULT_INTERPOLATION_PATTERNS];
+    return interpolationPatterns;
+  }
+
+  set interpolationPatterns(patterns: RegExp[]) {
+    interpolationPatterns = patterns;
+  }
+}
+
+/** @internal Test seam — restores every class-level slot to its gem default. */
+export function resetClassConfig(): void {
+  backend = undefined;
+  defaultLocale = undefined;
+  availableLocales = undefined;
+  availableLocalesSet = undefined;
+  defaultSeparator = undefined;
+  exceptionHandler = undefined;
+  missingInterpolationArgumentHandler = undefined;
+  loadPath = undefined;
+  enforceAvailableLocalesFlag = true;
+  interpolationPatterns = undefined;
+  defaultBackendFactory = undefined;
+}

--- a/packages/i18n/src/exceptions.test.ts
+++ b/packages/i18n/src/exceptions.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+
+import { MissingTranslation, MissingTranslationData } from "./exceptions.js";
+
+// Ported from i18n/test/i18n/exceptions_test.rb. Only the two cases that do
+// not route through `I18n.translate` are here; the rest exercise the backend
+// and land with the translate story. Trails-only coverage of the message and
+// accessor shapes lives in exceptions.trails.test.ts.
+describe("I18nExceptionsTest", () => {
+  it("MissingTranslation can be initialized without options", () => {
+    const exception = new MissingTranslation("en", "foo");
+    expect(exception.options).toEqual({});
+  });
+
+  it("MissingTranslationData#new can be initialized with just two arguments", () => {
+    expect(new MissingTranslationData("en", "key")).toBeTruthy();
+  });
+});

--- a/packages/i18n/src/exceptions.test.ts
+++ b/packages/i18n/src/exceptions.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 
 import { MissingTranslation, MissingTranslationData } from "./exceptions.js";
 
-// Ported from i18n/test/i18n/exceptions_test.rb. Only the two cases that do
-// not route through `I18n.translate` are here; the rest exercise the backend
-// and land with the translate story. Trails-only coverage of the message and
-// accessor shapes lives in exceptions.trails.test.ts.
+/**
+ * Ported from i18n/test/i18n/exceptions_test.rb. Only the two cases that do not
+ * route through `I18n.translate` are here; the rest exercise the backend and
+ * land with the translate story. Trails-only coverage of the message and
+ * accessor shapes lives in exceptions.trails.test.ts.
+ */
 describe("I18nExceptionsTest", () => {
   it("MissingTranslation can be initialized without options", () => {
     const exception = new MissingTranslation("en", "foo");

--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  ArgumentError,
+  Disabled,
+  ExceptionHandler,
+  InvalidLocale,
+  InvalidLocaleData,
+  InvalidPluralizationData,
+  MissingInterpolationArgument,
+  MissingTranslation,
+  MissingTranslationData,
+  ReservedInterpolationKey,
+  UnknownFileType,
+} from "./exceptions.js";
+import { resetClassConfig } from "./config.js";
+import { resetConfig } from "./i18n.js";
+
+// Trails-only: i18n/test/i18n/exceptions_test.rb drives every message
+// assertion through `I18n.translate`, which is not ported yet (and whose
+// default ExceptionHandler swallows MissingTranslation, leaving those cases
+// vacuous upstream). These assert the ported classes directly.
+describe("exceptions", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+  });
+
+  it("roots every error at I18n::ArgumentError", () => {
+    const errors = [
+      new Disabled("t"),
+      new InvalidLocale("de"),
+      new InvalidLocaleData("en.yml", "boom"),
+      new MissingTranslation("de", "foo"),
+      new MissingTranslationData("de", "foo"),
+      new InvalidPluralizationData({ other: "bar" }, 1, "one"),
+      new MissingInterpolationArgument("bar", { baz: "baz" }, "%{bar}"),
+      new ReservedInterpolationKey("scope", "%{scope}"),
+      new UnknownFileType("xml", "en.xml"),
+    ];
+    for (const e of errors) expect(e).toBeInstanceOf(ArgumentError);
+  });
+
+  it("InvalidLocale stores the locale and inspects it in the message", () => {
+    const exception = new InvalidLocale(null);
+    expect(exception.locale).toBeNull();
+    expect(exception.message).toBe("nil is not a valid locale");
+    expect(new InvalidLocale("klingon").message).toBe(":klingon is not a valid locale");
+  });
+
+  it("InvalidLocaleData stores the filename", () => {
+    const exception = new InvalidLocaleData("en.yml", "syntax error");
+    expect(exception.filename).toBe("en.yml");
+    expect(exception.message).toBe("can not load translations from en.yml: syntax error");
+  });
+
+  it("UnknownFileType stores type and filename", () => {
+    const exception = new UnknownFileType("xml", "en.xml");
+    expect(exception.type).toBe("xml");
+    expect(exception.message).toBe(
+      "can not load translations from en.xml, the file type xml is not known",
+    );
+  });
+
+  it("Disabled names the disabled method", () => {
+    expect(new Disabled("t").message).toContain("I18n.t is currently disabled");
+  });
+
+  it("MissingTranslationData stores locale, key and permitted options", () => {
+    const exception = new MissingTranslationData("de", "foo", { scope: "bar", count: 1 });
+    expect(exception.locale).toBe("de");
+    expect(exception.key).toBe("foo");
+    expect(exception.options).toEqual({ scope: "bar" });
+  });
+
+  it("MissingTranslation inspects Proc options", () => {
+    const exception = new MissingTranslation("de", "foo", { default: () => "x" });
+    expect(exception.options["default"]).toBe("#<Proc>");
+  });
+
+  it("MissingTranslation message contains the locale and scoped key", () => {
+    const exception = new MissingTranslationData("de", "foo", { scope: "bar" });
+    expect(exception.message).toBe("Translation missing: de.bar.foo");
+    expect(exception.toString()).toBe(exception.message);
+    expect(exception.keys()).toEqual(["de", "bar", "foo"]);
+    expect(new MissingTranslation("de", "").keys()).toEqual(["de", "no key"]);
+  });
+
+  it("MissingTranslation message lists the options considered for an array default", () => {
+    const exception = new MissingTranslation("de", "foo", { default: ["bar", "baz"] });
+    expect(exception.message).toBe(
+      "Translation missing. Options considered were:\n- de.foo\n- de.bar\n- de.baz",
+    );
+  });
+
+  it("MissingTranslation#toException returns MissingTranslationData", () => {
+    const exception = new MissingTranslation("de", "foo", { scope: "bar" });
+    const converted = exception.toException();
+    expect(converted).toBeInstanceOf(MissingTranslationData);
+    expect(converted.message).toBe("Translation missing: de.bar.foo");
+  });
+
+  it("InvalidPluralizationData stores entry, count and key", () => {
+    const exception = new InvalidPluralizationData({ other: "bar" }, 1, "one");
+    expect(exception.entry).toEqual({ other: "bar" });
+    expect(exception.count).toBe(1);
+    expect(exception.key).toBe("one");
+    expect(exception.message).toBe(
+      `translation data {other: "bar"} can not be used with :count => 1. key 'one' is missing.`,
+    );
+  });
+
+  it("MissingInterpolationArgument message contains the missing and given arguments", () => {
+    const exception = new MissingInterpolationArgument("bar", { baz: "baz" }, "%{bar}");
+    expect(exception.key).toBe("bar");
+    expect(exception.string).toBe("%{bar}");
+    expect(exception.message).toBe(
+      `missing interpolation argument :bar in "%{bar}" ({baz: "baz"} given)`,
+    );
+  });
+
+  it("ReservedInterpolationKey message contains the reserved key", () => {
+    const exception = new ReservedInterpolationKey("scope", "%{scope}");
+    expect(exception.key).toBe("scope");
+    expect(exception.message).toBe(`reserved key :scope used in "%{scope}"`);
+  });
+
+  it("ExceptionHandler returns the message for MissingTranslation and re-raises otherwise", () => {
+    const handler = new ExceptionHandler();
+    const missing = new MissingTranslation("de", "foo");
+    expect(handler.call(missing, "de", "foo", {})).toBe("Translation missing: de.foo");
+
+    const other = new InvalidLocale("de");
+    expect(() => handler.call(other, "de", "foo", {})).toThrow(other);
+    // MissingTranslationData is a sibling of MissingTranslation in Ruby, not a
+    // subclass, so the handler re-raises it.
+    const data = new MissingTranslationData("de", "foo");
+    expect(() => handler.call(data, "de", "foo", {})).toThrow(data);
+  });
+});

--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -16,10 +16,12 @@ import {
 import { resetClassConfig } from "./config.js";
 import { resetConfig } from "./i18n.js";
 
-// Trails-only: i18n/test/i18n/exceptions_test.rb drives every message
-// assertion through `I18n.translate`, which is not ported yet (and whose
-// default ExceptionHandler swallows MissingTranslation, leaving those cases
-// vacuous upstream). These assert the ported classes directly.
+/**
+ * Trails-only: i18n/test/i18n/exceptions_test.rb drives every message assertion
+ * through `I18n.translate`, which is not ported yet (and whose default
+ * ExceptionHandler swallows MissingTranslation, leaving those cases vacuous
+ * upstream). These assert the ported classes directly.
+ */
 describe("exceptions", () => {
   beforeEach(() => {
     resetConfig();
@@ -125,15 +127,13 @@ describe("exceptions", () => {
     expect(exception.message).toBe(`reserved key :scope used in "%{scope}"`);
   });
 
-  it("ExceptionHandler returns the message for MissingTranslation and re-raises otherwise", () => {
+  it("ExceptionHandler returns the message for MissingTranslation and re-raises everything else, MissingTranslationData included", () => {
     const handler = new ExceptionHandler();
     const missing = new MissingTranslation("de", "foo");
     expect(handler.call(missing, "de", "foo", {})).toBe("Translation missing: de.foo");
 
     const other = new InvalidLocale("de");
     expect(() => handler.call(other, "de", "foo", {})).toThrow(other);
-    // MissingTranslationData is a sibling of MissingTranslation in Ruby, not a
-    // subclass, so the handler re-raises it.
     const data = new MissingTranslationData("de", "foo");
     expect(() => handler.call(data, "de", "foo", {})).toThrow(data);
   });

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -1,0 +1,222 @@
+/**
+ * Mirrors: i18n/lib/i18n/exceptions.rb
+ *
+ * Ruby Symbols have no JS analogue, so every symbol-typed value here (locale,
+ * translation key, interpolation key) is a plain string. Messages that embed
+ * one through `#inspect` therefore render it the way Ruby renders a Symbol
+ * (`:en`) via `inspectSymbol`; everything else goes through `inspect`.
+ */
+
+import { normalizeKeys } from "./i18n.js";
+import type { Locale, TranslationKey } from "./i18n.js";
+
+function inspect(value: unknown): string {
+  if (value === null || value === undefined) return "nil";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "function") return "#<Proc>";
+  if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
+  if (typeof value === "object") {
+    const pairs = Object.entries(value as Record<string, unknown>).map(
+      ([k, v]) => `${k}: ${inspect(v)}`,
+    );
+    return `{${pairs.join(", ")}}`;
+  }
+  return String(value);
+}
+
+function inspectSymbol(value: unknown): string {
+  return typeof value === "string" ? `:${value}` : inspect(value);
+}
+
+export class ArgumentError extends Error {
+  constructor(message?: string) {
+    // Passing `message` straight through (rather than defaulting to "") keeps
+    // `Error` from installing an own `message` property when it is undefined —
+    // an own property would shadow `MissingTranslation`'s computed getter.
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
+export class Disabled extends ArgumentError {
+  constructor(method: string) {
+    super(
+      `I18n.${method} is currently disabled, likely because your application is still in its loading phase.\n` +
+        `\n` +
+        `This method is meant to display text in the user locale, so calling it before the user locale has\n` +
+        `been set is likely to display text from the wrong locale to some users.\n` +
+        `\n` +
+        `If you have a legitimate reason to access i18n data outside of the user flow, you can do so by passing\n` +
+        `the desired locale explicitly with the \`locale\` argument, e.g. \`I18n.${method}(..., locale: :en)\`\n`,
+    );
+    this.name = "Disabled";
+  }
+}
+
+export class InvalidLocale extends ArgumentError {
+  readonly locale: unknown;
+
+  constructor(locale: unknown) {
+    super(`${inspectSymbol(locale)} is not a valid locale`);
+    this.name = "InvalidLocale";
+    this.locale = locale;
+  }
+}
+
+export class InvalidLocaleData extends ArgumentError {
+  readonly filename: string;
+
+  constructor(filename: string, exceptionMessage: string) {
+    super(`can not load translations from ${filename}: ${exceptionMessage}`);
+    this.name = "InvalidLocaleData";
+    this.filename = filename;
+  }
+}
+
+export interface MissingTranslationOptions {
+  scope?: TranslationKey | TranslationKey[];
+  default?: unknown;
+  [key: string]: unknown;
+}
+
+const PERMITTED_KEYS = ["scope", "default"] as const;
+
+/**
+ * Mirrors: I18n::MissingTranslation::Base. Ruby mixes this module into both
+ * `MissingTranslation` and `MissingTranslationData`; here it is their shared
+ * superclass, which puts the same methods on both.
+ */
+export class Base extends ArgumentError {
+  readonly locale: Locale;
+  readonly key: TranslationKey;
+  readonly options: MissingTranslationOptions;
+  private keysCache?: (string | number | boolean)[];
+
+  constructor(locale: Locale, key: TranslationKey, options: MissingTranslationOptions = {}) {
+    super();
+    this.name = "MissingTranslation";
+    this.locale = locale;
+    this.key = key;
+    this.options = {};
+    const slice = this.options as Record<string, unknown>;
+    for (const permitted of PERMITTED_KEYS) {
+      if (permitted in options) slice[permitted] = options[permitted];
+    }
+    // Ruby copies Proc-valued entries in verbatim, permitted or not.
+    for (const [k, v] of Object.entries(options)) {
+      if (typeof v === "function") slice[k] = inspect(v);
+    }
+  }
+
+  keys(): (string | number | boolean)[] {
+    if (!this.keysCache) {
+      const keys = normalizeKeys(this.locale, this.key, this.options.scope);
+      if (keys.length < 2) keys.push("no key");
+      this.keysCache = keys;
+    }
+    return this.keysCache;
+  }
+
+  override get message(): string {
+    const fallbacks = this.options.default;
+    if (Array.isArray(fallbacks) && fallbacks.length > 0) {
+      const otherOptions = [this.key, ...fallbacks]
+        .map((k) => `- ${this.normalizedOption(k as TranslationKey)}`)
+        .join("\n");
+      return `Translation missing. Options considered were:\n${otherOptions}`;
+    }
+    return `Translation missing: ${this.keys().join(".")}`;
+  }
+
+  normalizedOption(key: TranslationKey): string {
+    return normalizeKeys(this.locale, key, this.options.scope).join(".");
+  }
+
+  override toString(): string {
+    return this.message;
+  }
+
+  toException(): MissingTranslationData {
+    return new MissingTranslationData(this.locale, this.key, this.options);
+  }
+}
+
+export class MissingTranslation extends Base {
+  static readonly Base = Base;
+}
+
+export class MissingTranslationData extends Base {
+  constructor(locale: Locale, key: TranslationKey, options: MissingTranslationOptions = {}) {
+    super(locale, key, options);
+    this.name = "MissingTranslationData";
+  }
+}
+
+export class InvalidPluralizationData extends ArgumentError {
+  readonly entry: unknown;
+  readonly count: unknown;
+  readonly key: TranslationKey;
+
+  constructor(entry: unknown, count: unknown, key: TranslationKey) {
+    super(
+      `translation data ${inspect(entry)} can not be used with :count => ${count}. key '${key}' is missing.`,
+    );
+    this.name = "InvalidPluralizationData";
+    this.entry = entry;
+    this.count = count;
+    this.key = key;
+  }
+}
+
+export class MissingInterpolationArgument extends ArgumentError {
+  readonly key: string;
+  readonly values: Record<string, unknown>;
+  readonly string: string;
+
+  constructor(key: string, values: Record<string, unknown>, string: string) {
+    super(
+      `missing interpolation argument ${inspectSymbol(key)} in ${inspect(string)} (${inspect(values)} given)`,
+    );
+    this.name = "MissingInterpolationArgument";
+    this.key = key;
+    this.values = values;
+    this.string = string;
+  }
+}
+
+export class ReservedInterpolationKey extends ArgumentError {
+  readonly key: string;
+  readonly string: string;
+
+  constructor(key: string, string: string) {
+    super(`reserved key ${inspectSymbol(key)} used in ${inspect(string)}`);
+    this.name = "ReservedInterpolationKey";
+    this.key = key;
+    this.string = string;
+  }
+}
+
+export class UnknownFileType extends ArgumentError {
+  readonly type: string;
+  readonly filename: string;
+
+  constructor(type: string, filename: string) {
+    super(`can not load translations from ${filename}, the file type ${type} is not known`);
+    this.name = "UnknownFileType";
+    this.type = type;
+    this.filename = filename;
+  }
+}
+
+/**
+ * Mirrors: I18n::ExceptionHandler. Returns the message for a missing
+ * translation and re-raises anything else.
+ */
+export class ExceptionHandler {
+  call(exception: Error, _locale: Locale, _key: TranslationKey, _options: unknown): string {
+    if (exception instanceof MissingTranslation) {
+      return exception.message;
+    }
+    throw exception;
+  }
+}

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -7,7 +7,7 @@
  * (`:en`) via `inspectSymbol`; everything else goes through `inspect`.
  */
 
-import { normalizeKeys } from "./i18n.js";
+import { EMPTY_HASH, normalizeKeys } from "./i18n.js";
 import type { Locale, TranslationKey } from "./i18n.js";
 
 function inspect(value: unknown): string {
@@ -97,7 +97,11 @@ export class Base extends ArgumentError {
   readonly options: MissingTranslationOptions;
   private keysCache?: TranslationKey[];
 
-  constructor(locale: Locale, key: TranslationKey, options: MissingTranslationOptions = {}) {
+  constructor(
+    locale: Locale,
+    key: TranslationKey,
+    options: MissingTranslationOptions = EMPTY_HASH,
+  ) {
     super();
     this.name = "MissingTranslation";
     this.locale = locale;
@@ -150,7 +154,11 @@ export class MissingTranslation extends Base {
 }
 
 export class MissingTranslationData extends Base {
-  constructor(locale: Locale, key: TranslationKey, options: MissingTranslationOptions = {}) {
+  constructor(
+    locale: Locale,
+    key: TranslationKey,
+    options: MissingTranslationOptions = EMPTY_HASH,
+  ) {
     super(locale, key, options);
     this.name = "MissingTranslationData";
   }

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -28,11 +28,15 @@ function inspectSymbol(value: unknown): string {
   return typeof value === "string" ? `:${value}` : inspect(value);
 }
 
+/**
+ * Mirrors: I18n::ArgumentError, the root of every error in this file.
+ *
+ * `message` is passed straight through rather than defaulting to `""`, so
+ * `Error` installs no own `message` property when it is undefined — an own
+ * property would shadow `MissingTranslation`'s computed getter.
+ */
 export class ArgumentError extends Error {
   constructor(message?: string) {
-    // Passing `message` straight through (rather than defaulting to "") keeps
-    // `Error` from installing an own `message` property when it is undefined —
-    // an own property would shadow `MissingTranslation`'s computed getter.
     super(message);
     this.name = "ArgumentError";
   }
@@ -40,15 +44,14 @@ export class ArgumentError extends Error {
 
 export class Disabled extends ArgumentError {
   constructor(method: string) {
-    super(
-      `I18n.${method} is currently disabled, likely because your application is still in its loading phase.\n` +
-        `\n` +
-        `This method is meant to display text in the user locale, so calling it before the user locale has\n` +
-        `been set is likely to display text from the wrong locale to some users.\n` +
-        `\n` +
-        `If you have a legitimate reason to access i18n data outside of the user flow, you can do so by passing\n` +
-        `the desired locale explicitly with the \`locale\` argument, e.g. \`I18n.${method}(..., locale: :en)\`\n`,
-    );
+    super(`I18n.${method} is currently disabled, likely because your application is still in its loading phase.
+
+This method is meant to display text in the user locale, so calling it before the user locale has
+been set is likely to display text from the wrong locale to some users.
+
+If you have a legitimate reason to access i18n data outside of the user flow, you can do so by passing
+the desired locale explicitly with the \`locale\` argument, e.g. \`I18n.${method}(..., locale: :en)\`
+`);
     this.name = "Disabled";
   }
 }
@@ -84,13 +87,15 @@ const PERMITTED_KEYS = ["scope", "default"] as const;
 /**
  * Mirrors: I18n::MissingTranslation::Base. Ruby mixes this module into both
  * `MissingTranslation` and `MissingTranslationData`; here it is their shared
- * superclass, which puts the same methods on both.
+ * superclass, which puts the same methods on both. The constructor keeps only
+ * the permitted options, plus every Proc-valued entry (permitted or not) in
+ * its inspected form, as Ruby does.
  */
 export class Base extends ArgumentError {
   readonly locale: Locale;
   readonly key: TranslationKey;
   readonly options: MissingTranslationOptions;
-  private keysCache?: (string | number | boolean)[];
+  private keysCache?: TranslationKey[];
 
   constructor(locale: Locale, key: TranslationKey, options: MissingTranslationOptions = {}) {
     super();
@@ -102,13 +107,12 @@ export class Base extends ArgumentError {
     for (const permitted of PERMITTED_KEYS) {
       if (permitted in options) slice[permitted] = options[permitted];
     }
-    // Ruby copies Proc-valued entries in verbatim, permitted or not.
     for (const [k, v] of Object.entries(options)) {
       if (typeof v === "function") slice[k] = inspect(v);
     }
   }
 
-  keys(): (string | number | boolean)[] {
+  keys(): TranslationKey[] {
     if (!this.keysCache) {
       const keys = normalizeKeys(this.locale, this.key, this.options.scope);
       if (keys.length < 2) keys.push("no key");

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -58,16 +58,14 @@ export function normalizeKeys(
  * Mirrors: I18n.locale_available?. Returns true when the passed locale is in
  * the list of available locales.
  */
-export function localeAvailable(locale: Locale): boolean {
-  return config().availableLocalesSet.has(locale);
+export function localeAvailable(locale: Locale | null | undefined): boolean {
+  return config().availableLocalesSet.has(locale as Locale);
 }
 
 /** Mirrors: I18n.enforce_available_locales! */
 export function enforceAvailableLocales(locale: Locale | false | null | undefined): void {
   if (locale !== false && config().enforceAvailableLocales) {
-    if (locale === null || locale === undefined || !localeAvailable(locale)) {
-      throw new InvalidLocale(locale);
-    }
+    if (!localeAvailable(locale)) throw new InvalidLocale(locale);
   }
 }
 

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -1,0 +1,77 @@
+/**
+ * Mirrors: i18n/lib/i18n.rb — partially. Only the members `config.ts` and
+ * `exceptions.ts` reach for are ported here; the translate/interpolate surface
+ * lands with its own story (RFC 0074).
+ */
+
+import { Config } from "./config.js";
+import { InvalidLocale } from "./exceptions.js";
+
+/** Ruby models locales as Symbols; the JS analogue is a plain string. */
+export type Locale = string;
+/** A translation key: a dotted string, or a normalized key segment. */
+export type TranslationKey = string | number | boolean;
+
+export const EMPTY_HASH: Readonly<Record<string, never>> = Object.freeze({});
+
+let currentConfig: Config | undefined;
+
+/**
+ * Mirrors: I18n::Base#config. Ruby scopes the config to `Thread.current`; JS
+ * has no threads, so the singleton below is the whole-process equivalent.
+ */
+export function config(): Config {
+  currentConfig ??= new Config();
+  return currentConfig;
+}
+
+/** @internal Test seam — drops the process-wide config so a case starts clean. */
+export function resetConfig(): void {
+  currentConfig = undefined;
+}
+
+function normalizeKey(key: unknown, separator: string): TranslationKey[] {
+  if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
+  if (key === null || key === undefined) return [];
+  const keys = String(key)
+    .split(separator)
+    .filter((k) => k !== "");
+  return keys.map((k) => {
+    if (/^[-+]?([1-9]\d*|0)$/.test(k)) return Number(k);
+    if (k === "true") return true;
+    if (k === "false") return false;
+    return k;
+  });
+}
+
+export function normalizeKeys(
+  locale: Locale | null | undefined,
+  key: unknown,
+  scope: unknown,
+  separator?: string,
+): TranslationKey[] {
+  const sep = separator ?? config().defaultSeparator;
+  return [...normalizeKey(locale, sep), ...normalizeKey(scope, sep), ...normalizeKey(key, sep)];
+}
+
+/**
+ * Mirrors: I18n.locale_available?. Returns true when the passed locale is in
+ * the list of available locales.
+ */
+export function localeAvailable(locale: Locale): boolean {
+  return config().availableLocalesSet.has(locale);
+}
+
+/** Mirrors: I18n.enforce_available_locales! */
+export function enforceAvailableLocales(locale: Locale | false | null | undefined): void {
+  if (locale !== false && config().enforceAvailableLocales) {
+    if (locale === null || locale === undefined || !localeAvailable(locale)) {
+      throw new InvalidLocale(locale);
+    }
+  }
+}
+
+/** Mirrors: I18n.available_locales_initialized? */
+export function availableLocalesInitialized(): boolean {
+  return config().availableLocalesInitialized;
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,0 +1,17 @@
+export { Config, registerDefaultBackend } from "./config.js";
+export type {
+  Backend,
+  ExceptionHandlerLike,
+  MissingInterpolationArgumentHandler,
+} from "./config.js";
+export * from "./exceptions.js";
+export { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
+export {
+  EMPTY_HASH,
+  availableLocalesInitialized,
+  config,
+  enforceAvailableLocales,
+  localeAvailable,
+  normalizeKeys,
+} from "./i18n.js";
+export type { Locale, TranslationKey } from "./i18n.js";

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -4,7 +4,20 @@ export type {
   ExceptionHandlerLike,
   MissingInterpolationArgumentHandler,
 } from "./config.js";
-export * from "./exceptions.js";
+export {
+  ArgumentError,
+  Disabled,
+  ExceptionHandler,
+  InvalidLocale,
+  InvalidLocaleData,
+  InvalidPluralizationData,
+  MissingInterpolationArgument,
+  MissingTranslation,
+  MissingTranslationData,
+  ReservedInterpolationKey,
+  UnknownFileType,
+} from "./exceptions.js";
+export type { MissingTranslationOptions } from "./exceptions.js";
 export { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
 export {
   EMPTY_HASH,

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -1,0 +1,16 @@
+/**
+ * Mirrors: i18n/lib/i18n/interpolate/ruby.rb
+ *
+ * Only the pattern list is ported here — `Config#interpolation_patterns`
+ * defaults to a copy of it. `I18n.interpolate` itself lands with the
+ * interpolation story.
+ *
+ * The Ruby patterns are anchored on Ruby's `%{}` / `%<>` sprintf syntax and
+ * carry no flags; the JS equivalents keep the same source, with the capture
+ * groups in the same positions.
+ */
+export const DEFAULT_INTERPOLATION_PATTERNS: readonly RegExp[] = Object.freeze([
+  /%%/,
+  /%\{([\w|]+)\}/,
+  /%<(\w+)>([^\d]*?\d*\.?\d*[bBdiouxXeEfgGcps])/,
+]);

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,8 @@ importers:
         specifier: ^2.13.0
         version: 2.16.1
 
+  packages/i18n: {}
+
   packages/nokogiri:
     dependencies:
       libxml2-wasm:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     { "path": "packages/trailties" },
     { "path": "packages/globalid" },
     { "path": "packages/did-you-mean" },
+    { "path": "packages/i18n" },
     { "path": "packages/html-sanitizer" },
     { "path": "packages/nokogiri" },
     { "path": "packages/activerecord-cli" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -229,6 +229,7 @@ const alias = {
   "@blazetrails/globalid": path.resolve(__dirname, "packages/globalid/src/index.ts"),
   "@blazetrails/trails-tsc": path.resolve(__dirname, "packages/trails-tsc/src/index.ts"),
   "@blazetrails/did-you-mean": path.resolve(__dirname, "packages/did-you-mean/src/index.ts"),
+  "@blazetrails/i18n": path.resolve(__dirname, "packages/i18n/src/index.ts"),
   "@blazetrails/nokogiri": path.resolve(__dirname, "packages/nokogiri/src/index.ts"),
 };
 


### PR DESCRIPTION
Scaffolds the `@blazetrails/i18n` workspace package — the missing TS home for
the vendored i18n gem — and ports the first two files into it.

## What's here

- **Package scaffold** (`packages/i18n`), wired the same way
  `packages/did-you-mean` is: root `tsconfig.json` project reference, the
  `vitest.config.ts` alias map, `UNIT_TESTS_PKGS_RE` + the Unit Tests vitest
  invocation, and the (non-gating) Coverage job's package list.
- **`src/config.ts`** — `vendor/i18n/lib/i18n/config.rb` method-for-method:
  `locale`, `backend`, `defaultLocale`, `availableLocales(Set)`,
  `availableLocalesInitialized`, `clearAvailableLocalesSet`,
  `defaultSeparator`, `exceptionHandler`,
  `missingInterpolationArgumentHandler`, `loadPath`, `enforceAvailableLocales`,
  `interpolationPatterns`. Ruby's `@@`-scoped class variables become
  module-level bindings (shared by every instance, as in the gem); only
  `locale` is per-instance.
- **`src/exceptions.ts`** — `vendor/i18n/lib/i18n/exceptions.rb`:
  `ExceptionHandler`, `ArgumentError`, `Disabled`, `InvalidLocale`,
  `InvalidLocaleData`, `MissingTranslation(.Base)`, `MissingTranslationData`,
  `InvalidPluralizationData`, `MissingInterpolationArgument`,
  `ReservedInterpolationKey`, `UnknownFileType`. `MissingTranslation::Base` is
  a shared superclass rather than a mixin, which puts the same methods on both
  including classes; `MissingTranslationData` stays a *sibling* of
  `MissingTranslation`, so `ExceptionHandler` re-raises it exactly as Ruby does.
- **Seams the two files reach for**: a partial `src/i18n.ts` (`config`,
  `normalizeKeys`, `localeAvailable`, `enforceAvailableLocales`, `EMPTY_HASH`)
  and `src/interpolate/ruby.ts` (`DEFAULT_INTERPOLATION_PATTERNS`). The rest of
  `i18n.rb` lands with the translate story.

## Notes for review

- **`Config#backend` has no default yet.** Ruby autoloads
  `Backend::Simple.new`; that file is not ported, so `registerDefaultBackend()`
  is the seam it will use, and until then reading `config.backend` without a
  backend set raises with an explicit message rather than handing back a
  half-built default.
- **Symbols.** Locales and translation keys are plain strings. Messages that
  embed one through `#inspect` render it Ruby-style (`:en`) via
  `inspectSymbol`; everything else goes through `inspect`.
- **Tests.** `exceptions.test.ts` ports the only two cases in
  `test/i18n/exceptions_test.rb` that do not route through `I18n.translate`
  (unported). The rest of that file is vacuous upstream — its assertions live
  inside blocks that only run if `translate` raises, and the default
  `ExceptionHandler` swallows `MissingTranslation` — so the equivalent coverage
  is in `*.trails.test.ts` against the classes directly.
- Existing `activesupport`/`activemodel` i18n shims are untouched
  (consolidation is a later story), and the `vendor/sources.ts` compare flags
  stay off (enrollment is its own story).
- `packages/i18n/NOTICE` carries the i18n gem's MIT attribution, matching
  `packages/did-you-mean`.
- **Over the 500-LOC ceiling (~920).** The story bundles scaffolding plus two
  gem files, and they are not separable: `config.rb` raises `InvalidLocale` and
  builds `ExceptionHandler` / `MissingInterpolationArgument`, while
  `exceptions.rb`'s `MissingTranslation#keys` normalizes through
  `config.defaultSeparator`. Splitting would leave one half unable to compile.
  Roughly 560 is source (the ported gem doc comments included), 290 tests, 30
  the NOTICE, 45 package scaffolding and CI wiring.

Closes-story: i18n-package-scaffold-config-exceptions
