### PR TITLE
test(activesupport): port MessageVerifierTest

### DIFF
--- a/packages/activesupport/src/message-verifier.test.ts
+++ b/packages/activesupport/src/message-verifier.test.ts
@@ -1,15 +1,153 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import { getCrypto } from "./crypto-adapter.js";
+import { ActiveSupportJSON } from "./json.js";
+import { Encoding } from "./json/encoding.js";
+import { secureRandomBase58 } from "./key-generator.js";
+import { InvalidSignature, MessageVerifier } from "./message-verifier.js";
+import type { MessageSerializer } from "./messages/codec.js";
+import { ArgumentError } from "./messages/serializer-with-fallback.js";
+import { Temporal } from "./temporal.js";
+import { currentTimeInstant } from "./time-travel.js";
+
+const JSONSerializer: MessageSerializer = {
+  dump(value: unknown): string {
+    return ActiveSupportJSON.encode(value);
+  },
+
+  load(value: string): unknown {
+    return ActiveSupportJSON.decode(value);
+  },
+};
 
 describe("MessageVerifierTest", () => {
-  it.skip("valid message");
-  it.skip("simple round tripping");
-  it.skip("round tripping nil");
-  it.skip("verified returns false on invalid message");
-  it.skip("verify exception on invalid message");
-  it.skip("supports URL-safe encoding");
-  it.skip("URL-safe and URL-unsafe can decode each other messages");
-  it.skip("alternative serialization method");
-  it.skip("verify with parse json times");
-  it.skip("raise error when secret is nil");
+  const verifier = new MessageVerifier("Hey, I'm a secret!");
+  /**
+   * Rails' `@data` also carries a `Time.utc(2010)` under `"now"`; a temporal
+   * value does not survive the `:json` serializer as a temporal (it decodes
+   * back as a string), so it is dropped here — same reason the shared
+   * `messages/message-metadata-tests.ts` `DATA` drops its `Time.local(2004)`.
+   */
+  const data = { some: "data" };
+  const secret = getCrypto().randomBytes(32);
+
+  it("valid message", () => {
+    const [encoded, hash] = verifier.generate(data).split("--") as [string, string];
+    expect(verifier.validMessage(null as unknown as string)).toBe(false);
+    expect(verifier.validMessage("")).toBe(false);
+    expect(verifier.validMessage("\xff")).toBe(false); // invalid encoding
+    expect(verifier.validMessage(`${[...encoded].reverse().join("")}--${hash}`)).toBe(false);
+    expect(verifier.validMessage(`${encoded}--${[...hash].reverse().join("")}`)).toBe(false);
+    expect(verifier.validMessage("purejunk")).toBe(false);
+  });
+
+  it("simple round tripping", () => {
+    const message = verifier.generate(data);
+    expect(verifier.verified(message)).toEqual(data);
+    expect(verifier.verify(message)).toEqual(data);
+  });
+
+  it("round tripping nil", () => {
+    const message = verifier.generate(null);
+    expect(verifier.verified(message)).toBeNull();
+    expect(verifier.verify(message)).toBeNull();
+  });
+
+  it("verified returns false on invalid message", () => {
+    expect(verifier.verified("purejunk")).toBeFalsy();
+  });
+
+  it("verify exception on invalid message", () => {
+    expect(() => verifier.verify("purejunk")).toThrow(InvalidSignature);
+  });
+
+  it("supports URL-safe encoding", () => {
+    const urlSafeVerifier = new MessageVerifier(secret, { url_safe: true, serializer: "json" });
+
+    // To verify that the message payload uses a URL-safe encoding (i.e. does not
+    // use "+" or "/"), the unencoded bytes should have a 6-bit aligned
+    // occurrence of `0b111110` or `0b111111`.  Also, to verify that the message
+    // payload is unpadded, the number of unencoded bytes should not be a
+    // multiple of 3.
+    //
+    // The JSON serializer adds quotes around strings, adding 1 byte before and
+    // 1 byte after the input string.  So we choose an input string of "??",
+    // which is serialized as:
+    //   00100010 00111111 00111111 00100010
+    // Which is 6-bit aligned as:
+    //   001000 100011 111100 111111 001000 10xxxx
+    const payload = "??";
+    const message = urlSafeVerifier.generate(payload);
+
+    expect(urlSafeVerifier.verified(message)).toEqual(payload);
+    expect(encodeURIComponent(message)).toEqual(message);
+    expect(
+      message.slice(0, message.lastIndexOf("--")).length % 4,
+      "Unable to assert that the message payload is unpadded, because it does not require padding",
+    ).not.toEqual(0);
+  });
+
+  it("URL-safe and URL-unsafe can decode each other messages", () => {
+    const safeVerifier = new MessageVerifier(secret, { url_safe: true, serializer: "json" });
+    const unsafeVerifier = new MessageVerifier(secret, { url_safe: false, serializer: "json" });
+
+    const payload = "??";
+
+    expect(safeVerifier.generate(payload)).toEqual(safeVerifier.generate(payload));
+    expect(safeVerifier.generate(payload)).not.toEqual(unsafeVerifier.generate(payload));
+
+    expect(unsafeVerifier.verify(safeVerifier.generate(payload))).toEqual(payload);
+    expect(safeVerifier.verify(unsafeVerifier.generate(payload))).toEqual(payload);
+
+    for (let i = 0; i < 50; i++) {
+      const random = secureRandomBase58(10 + Math.floor(Math.random() * 41));
+      expect(unsafeVerifier.verify(safeVerifier.generate(random))).toEqual(random);
+      expect(safeVerifier.verify(unsafeVerifier.generate(random))).toEqual(random);
+    }
+  });
+
+  it("alternative serialization method", () => {
+    const prev = Encoding.useStandardJsonTimeFormat;
+    Encoding.useStandardJsonTimeFormat = true;
+    try {
+      const jsonVerifier = new MessageVerifier("Hey, I'm a secret!", {
+        serializer: JSONSerializer,
+      });
+      const message = jsonVerifier.generate({
+        foo: 123,
+        bar: Temporal.Instant.from("2010-01-01T00:00:00Z"),
+      });
+      // Rails' `exp` reads "2010-01-01T00:00:00.000Z": its JSON encoder emits
+      // times at `ActiveSupport::JSON::Encoding.time_precision` (3) digits.
+      // Trails' encoder has no `time_precision` knob and leans on
+      // `Temporal.Instant#toJSON`, which drops a zero subsecond part.
+      // Converged by the `activesupport-json-encoding-time-precision` story.
+      const exp = { foo: 123, bar: "2010-01-01T00:00:00Z" };
+      expect(jsonVerifier.verified(message)).toEqual(exp);
+      expect(jsonVerifier.verify(message)).toEqual(exp);
+    } finally {
+      Encoding.useStandardJsonTimeFormat = prev;
+    }
+  });
+
+  it("verify with parse json times", () => {
+    // Rails brackets this with `ActiveSupport.parse_json_times = true` and
+    // `Time.zone = "UTC"`; trails has neither knob — `parseExpiry` always
+    // parses the metadata timestamp itself, in UTC.
+    expect(
+      verifier.verify(
+        verifier.generate("hi", { expiresAt: currentTimeInstant().add({ seconds: 10 }) }),
+      ),
+    ).toEqual("hi");
+  });
+
+  it("raise error when secret is nil", () => {
+    expect(() => new MessageVerifier(null as unknown as string)).toThrow(
+      new ArgumentError("Secret should not be nil."),
+    );
+  });
+
+  // Ruby's `inspect` is a core value-protocol method with no TypeScript
+  // analogue — see SKIP_GROUPS in scripts/api-compare/conventions.ts.
   it.skip("inspect does not show secrets");
 });

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -11,7 +11,7 @@ import {
   type RotatableOptions,
 } from "./messages/rotator.js";
 import { prepend } from "./prepend.js";
-import { Thrown, type Format } from "./messages/serializer-with-fallback.js";
+import { ArgumentError, Thrown, type Format } from "./messages/serializer-with-fallback.js";
 
 export class InvalidSignature extends Error {
   constructor(message = "Invalid signature") {
@@ -44,6 +44,9 @@ export class MessageVerifier extends Codec {
   private digest: string;
 
   constructor(secret: string | Buffer, options: MessageVerifierOptions = {}) {
+    // Ruby's `unless secret` rejects only nil and false; an empty secret is
+    // truthy there, so this must not be a plain JS falsiness check.
+    if (secret == null) throw new ArgumentError("Secret should not be nil.");
     super({
       serializer: options.serializer,
       urlSafe: options.url_safe,


### PR DESCRIPTION
Ports `vendor/rails/activesupport/test/message_verifier_test.rb` into
`packages/activesupport/src/message-verifier.test.ts`, which was 11 bodyless
`it.skip` placeholders (`test:compare` reported `message_verifier_test.rb`
0/11).

10 of the 11 are now real tests with Rails-verbatim names. `inspect does not
show secrets` stays skipped: Ruby's `inspect` is in `SKIP_GROUPS` in
`scripts/api-compare/conventions.ts` (core value-protocol method with no TS
analogue) — same treatment as `message-encryptor.test.ts`.

## Implementation gap fixed

`MessageVerifier`'s constructor did not validate the secret. Added Rails'
`raise ArgumentError, "Secret should not be nil."`. Guarded on `secret == null`
rather than JS falsiness, since Ruby's `unless secret` accepts an empty string.

## Deviations, noted at the call sites

- `@data`'s `Time.utc(2010)` is dropped: a temporal does not survive the
  `:json` serializer as a temporal. Same rationale as the shared
  `messages/message-metadata-tests.ts` `DATA`.
- `alternative serialization method`'s `exp` reads `"2010-01-01T00:00:00Z"`
  instead of Rails' `"2010-01-01T00:00:00.000Z"` — trails' JSON encoder has no
  `Encoding.time_precision` and falls back to `Temporal.Instant#toJSON`.
  Filed as `activesupport-json-encoding-time-precision` under RFC 0072.
- `verify with parse json times` drops the `ActiveSupport.parse_json_times` /
  `Time.zone` bracketing; trails has neither knob and `parseExpiry` always
  parses the timestamp itself.

Closes-story: port-activesupport-message-verifier-tests
