### PR TITLE
feat(activesupport): honour JSON Encoding.timePrecision for temporals

### DIFF
--- a/packages/activesupport/src/json.ts
+++ b/packages/activesupport/src/json.ts
@@ -111,9 +111,11 @@ function temporalAsJson(value: unknown): string | undefined {
 
   if (value instanceof Temporal.ZonedDateTime) {
     if (Encoding.useStandardJsonTimeFormat) {
-      return value.toString({ fractionalSecondDigits: digits, timeZoneName: "never" });
+      const formatted = value.toString({ fractionalSecondDigits: digits, timeZoneName: "never" });
+      // `xmlschema` renders a zero offset as "Z" (formatted_offset(true, 'Z')).
+      return value.offsetNanoseconds === 0 ? `${formatted.slice(0, -6)}Z` : formatted;
     }
-    return slashFormat(value, value.offset.replace(":", ""));
+    return slashFormat(value, value.offset.replaceAll(":", ""));
   }
 
   if (value instanceof Temporal.PlainDateTime) {

--- a/packages/activesupport/src/json.ts
+++ b/packages/activesupport/src/json.ts
@@ -7,6 +7,9 @@
  * since the behavior is equivalent for all standard types.
  */
 
+import { Temporal } from "./temporal.js";
+import { Encoding } from "./json/encoding.js";
+
 /**
  * Serialization options threaded through `as_json` — only the subset Rails'
  * `ActiveSupport::JSON.encode(value, options)` forwards to collections. `only`
@@ -43,6 +46,9 @@ function asJsonValue(value: unknown, options: NormalizedOptions): unknown {
 
   const asJson = (value as { asJson?: (o?: unknown) => unknown }).asJson;
   if (typeof asJson === "function") return asJson.call(value, options);
+
+  const temporal = temporalAsJson(value);
+  if (temporal !== undefined) return temporal;
 
   if (Array.isArray(value)) return value.map((v) => asJsonValue(v, options));
 
@@ -84,6 +90,63 @@ function asJsonValue(value: unknown, options: NormalizedOptions): unknown {
   }
 
   return value;
+}
+
+// Rails' `Time#as_json` / `DateTime#as_json` / `Date#as_json`
+// (core_ext/object/json.rb:200-228). Our Time analogues are the Temporal types,
+// which have no `asJson` of their own, so the dispatch lives here. Without this
+// arm `JSON.stringify` falls through to `Temporal#toJSON`, which drops a zero
+// subsecond part and so ignores `Encoding.timePrecision` entirely.
+function temporalAsJson(value: unknown): string | undefined {
+  const digits =
+    Encoding.timePrecision as Temporal.ToStringPrecisionOptions["fractionalSecondDigits"];
+
+  if (value instanceof Temporal.Instant) {
+    if (Encoding.useStandardJsonTimeFormat)
+      return value.toString({ fractionalSecondDigits: digits });
+    // An Instant carries no local zone, so the non-standard form — Ruby's local
+    // `strftime` plus `formatted_offset(false)` — renders in UTC.
+    return slashFormat(value.toZonedDateTimeISO("UTC"), "+0000");
+  }
+
+  if (value instanceof Temporal.ZonedDateTime) {
+    if (Encoding.useStandardJsonTimeFormat) {
+      return value.toString({ fractionalSecondDigits: digits, timeZoneName: "never" });
+    }
+    return slashFormat(value, value.offset.replace(":", ""));
+  }
+
+  if (value instanceof Temporal.PlainDateTime) {
+    // Ruby's DateTime defaults to a +00:00 offset, which `xmlschema` emits;
+    // a zoneless PlainDateTime is its analogue, so spell that offset out.
+    if (Encoding.useStandardJsonTimeFormat) {
+      return `${value.toString({ fractionalSecondDigits: digits })}+00:00`;
+    }
+    return slashFormat(value, "+0000");
+  }
+
+  if (value instanceof Temporal.PlainDate) {
+    return Encoding.useStandardJsonTimeFormat
+      ? value.toString()
+      : `${value.year}/${pad2(value.month)}/${pad2(value.day)}`;
+  }
+
+  return undefined;
+}
+
+// Ruby's `%Y/%m/%d %H:%M:%S` followed by a colon-less offset.
+function slashFormat(
+  value: Temporal.ZonedDateTime | Temporal.PlainDateTime,
+  offset: string,
+): string {
+  return (
+    `${value.year}/${pad2(value.month)}/${pad2(value.day)} ` +
+    `${pad2(value.hour)}:${pad2(value.minute)}:${pad2(value.second)} ${offset}`
+  );
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
 }
 
 // A Hash-shaped object: a bare object literal (`Object.prototype` or null

--- a/packages/activesupport/src/json.ts
+++ b/packages/activesupport/src/json.ts
@@ -92,11 +92,13 @@ function asJsonValue(value: unknown, options: NormalizedOptions): unknown {
   return value;
 }
 
-// Rails' `Time#as_json` / `DateTime#as_json` / `Date#as_json`
-// (core_ext/object/json.rb:200-228). Our Time analogues are the Temporal types,
-// which have no `asJson` of their own, so the dispatch lives here. Without this
-// arm `JSON.stringify` falls through to `Temporal#toJSON`, which drops a zero
-// subsecond part and so ignores `Encoding.timePrecision` entirely.
+/**
+ * Rails' `Time#as_json` / `DateTime#as_json` / `Date#as_json`
+ * (core_ext/object/json.rb:200-228), dispatched over our Temporal analogues:
+ * `Instant`/`ZonedDateTime` for `Time`, `PlainDateTime` for the zoneless
+ * `DateTime` (whose `xmlschema` carries Ruby's default `+00:00` offset), and
+ * `PlainDate` for `Date`.
+ */
 function temporalAsJson(value: unknown): string | undefined {
   const digits =
     Encoding.timePrecision as Temporal.ToStringPrecisionOptions["fractionalSecondDigits"];
@@ -104,8 +106,6 @@ function temporalAsJson(value: unknown): string | undefined {
   if (value instanceof Temporal.Instant) {
     if (Encoding.useStandardJsonTimeFormat)
       return value.toString({ fractionalSecondDigits: digits });
-    // An Instant carries no local zone, so the non-standard form — Ruby's local
-    // `strftime` plus `formatted_offset(false)` — renders in UTC.
     return slashFormat(value.toZonedDateTimeISO("UTC"), "+0000");
   }
 
@@ -117,8 +117,6 @@ function temporalAsJson(value: unknown): string | undefined {
   }
 
   if (value instanceof Temporal.PlainDateTime) {
-    // Ruby's DateTime defaults to a +00:00 offset, which `xmlschema` emits;
-    // a zoneless PlainDateTime is its analogue, so spell that offset out.
     if (Encoding.useStandardJsonTimeFormat) {
       return `${value.toString({ fractionalSecondDigits: digits })}+00:00`;
     }
@@ -134,7 +132,6 @@ function temporalAsJson(value: unknown): string | undefined {
   return undefined;
 }
 
-// Ruby's `%Y/%m/%d %H:%M:%S` followed by a colon-less offset.
 function slashFormat(
   value: Temporal.ZonedDateTime | Temporal.PlainDateTime,
   offset: string,

--- a/packages/activesupport/src/json/encoding.test.ts
+++ b/packages/activesupport/src/json/encoding.test.ts
@@ -218,7 +218,6 @@ describe("TestJSONEncoding", () => {
   it("datetime to json with custom time precision", () => {
     withStandardJsonTimeFormat(true, () => {
       withTimePrecision(0, () => {
-        // Ruby's DateTime — zoneless, with a +00:00 offset — is PlainDateTime here.
         const datetime = Temporal.PlainDateTime.from("2000-01-01T00:00:00");
         expect(ActiveSupportJSON.encode(datetime)).toBe('"2000-01-01T00:00:00+00:00"');
       });

--- a/packages/activesupport/src/json/encoding.test.ts
+++ b/packages/activesupport/src/json/encoding.test.ts
@@ -1,6 +1,31 @@
 import { describe, it, expect } from "vitest";
 
 import { slice, except } from "../hash-utils.js";
+import { ActiveSupportJSON } from "../json.js";
+import { Temporal } from "../temporal.js";
+import { TimeWithZone } from "../time-with-zone.js";
+import { TimeZone } from "../values/time-zone.js";
+import { Encoding } from "./encoding.js";
+
+function withStandardJsonTimeFormat(value: boolean, block: () => void): void {
+  const old = Encoding.useStandardJsonTimeFormat;
+  Encoding.useStandardJsonTimeFormat = value;
+  try {
+    block();
+  } finally {
+    Encoding.useStandardJsonTimeFormat = old;
+  }
+}
+
+function withTimePrecision(value: number, block: () => void): void {
+  const old = Encoding.timePrecision;
+  Encoding.timePrecision = value;
+  try {
+    block();
+  } finally {
+    Encoding.timePrecision = old;
+  }
+}
 
 describe("TestJSONEncoding", () => {
   it.skip("process status");
@@ -155,23 +180,51 @@ describe("TestJSONEncoding", () => {
   it.skip("json gem dump by passing active support encoder");
   it.skip("json gem generate by passing active support encoder");
   it.skip("json gem pretty generate by passing active support encoder");
-  it.skip("twz to json with use standard json time format config set to false");
-  it.skip("twz to json with use standard json time format config set to true");
-  it.skip("twz to json with custom time precision");
+  it("twz to json with use standard json time format config set to false", () => {
+    withStandardJsonTimeFormat(false, () => {
+      const zone = TimeZone.find("Eastern Time (US & Canada)");
+      const time = new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00Z"), zone);
+      expect(ActiveSupportJSON.encode(time)).toBe('"1999/12/31 19:00:00 -0500"');
+    });
+  });
+
+  it("twz to json with use standard json time format config set to true", () => {
+    withStandardJsonTimeFormat(true, () => {
+      const zone = TimeZone.find("Eastern Time (US & Canada)");
+      const time = new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00Z"), zone);
+      expect(ActiveSupportJSON.encode(time)).toBe('"1999-12-31T19:00:00.000-05:00"');
+    });
+  });
+
+  it("twz to json with custom time precision", () => {
+    withStandardJsonTimeFormat(true, () => {
+      withTimePrecision(0, () => {
+        const zone = TimeZone.find("Eastern Time (US & Canada)");
+        const time = new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00Z"), zone);
+        expect(ActiveSupportJSON.encode(time)).toBe('"1999-12-31T19:00:00-05:00"');
+      });
+    });
+  });
+
   it("time to json with custom time precision", () => {
-    // toISOString always includes milliseconds; verify standard format
-    const d = new Date("2023-01-15T10:30:00.123Z");
-    const json = JSON.stringify(d);
-    expect(json).toContain("2023-01-15");
-    expect(json).toContain("10:30:00");
+    withStandardJsonTimeFormat(true, () => {
+      withTimePrecision(0, () => {
+        const time = Temporal.Instant.from("2000-01-01T00:00:00Z");
+        expect(ActiveSupportJSON.encode(time)).toBe('"2000-01-01T00:00:00Z"');
+      });
+    });
   });
+
   it("datetime to json with custom time precision", () => {
-    const d = new Date("2023-06-01T12:00:00.456Z");
-    const isoStr = d.toISOString();
-    // Custom precision: strip milliseconds
-    const noMs = isoStr.replace(/\.\d{3}Z$/, "Z");
-    expect(noMs).toBe("2023-06-01T12:00:00Z");
+    withStandardJsonTimeFormat(true, () => {
+      withTimePrecision(0, () => {
+        // Ruby's DateTime — zoneless, with a +00:00 offset — is PlainDateTime here.
+        const datetime = Temporal.PlainDateTime.from("2000-01-01T00:00:00");
+        expect(ActiveSupportJSON.encode(datetime)).toBe('"2000-01-01T00:00:00+00:00"');
+      });
+    });
   });
+
   it.skip("twz to json when wrapping a date time");
 
   it("exception to json", () => {

--- a/packages/activesupport/src/json/encoding.trails.test.ts
+++ b/packages/activesupport/src/json/encoding.trails.test.ts
@@ -4,9 +4,6 @@ import { ActiveSupportJSON } from "../json.js";
 import { Temporal } from "../temporal.js";
 import { Encoding } from "./encoding.js";
 
-// trails-only coverage: Rails exercises the default `time_precision` (3) through
-// `Time#as_json`, a core_ext with no home in our port — the Temporal dispatch
-// lives in `ActiveSupportJSON.encode` instead, so pin its default here.
 describe("JSON Encoding default time precision (trails)", () => {
   it("encodes an Instant at the default precision of 3", () => {
     expect(Encoding.timePrecision).toBe(3);

--- a/packages/activesupport/src/json/encoding.trails.test.ts
+++ b/packages/activesupport/src/json/encoding.trails.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+
+import { ActiveSupportJSON } from "../json.js";
+import { Temporal } from "../temporal.js";
+import { Encoding } from "./encoding.js";
+
+// trails-only coverage: Rails exercises the default `time_precision` (3) through
+// `Time#as_json`, a core_ext with no home in our port — the Temporal dispatch
+// lives in `ActiveSupportJSON.encode` instead, so pin its default here.
+describe("JSON Encoding default time precision (trails)", () => {
+  it("encodes an Instant at the default precision of 3", () => {
+    expect(Encoding.timePrecision).toBe(3);
+    const time = Temporal.Instant.from("2010-01-01T00:00:00Z");
+    expect(ActiveSupportJSON.encode(time)).toBe('"2010-01-01T00:00:00.000Z"');
+  });
+
+  it("encodes a PlainDate without a time part", () => {
+    expect(ActiveSupportJSON.encode(Temporal.PlainDate.from("2005-02-01"))).toBe('"2005-02-01"');
+  });
+
+  it("encodes a PlainDate as %Y/%m/%d when the standard time format is off", () => {
+    const old = Encoding.useStandardJsonTimeFormat;
+    Encoding.useStandardJsonTimeFormat = false;
+    try {
+      expect(ActiveSupportJSON.encode(Temporal.PlainDate.from("2005-02-01"))).toBe('"2005/02/01"');
+    } finally {
+      Encoding.useStandardJsonTimeFormat = old;
+    }
+  });
+});

--- a/packages/activesupport/src/json/encoding.trails.test.ts
+++ b/packages/activesupport/src/json/encoding.trails.test.ts
@@ -11,6 +11,16 @@ describe("JSON Encoding default time precision (trails)", () => {
     expect(ActiveSupportJSON.encode(time)).toBe('"2010-01-01T00:00:00.000Z"');
   });
 
+  it("encodes a UTC ZonedDateTime with a Z offset", () => {
+    const time = Temporal.ZonedDateTime.from("2010-01-01T00:00:00[UTC]");
+    expect(ActiveSupportJSON.encode(time)).toBe('"2010-01-01T00:00:00.000Z"');
+  });
+
+  it("encodes an offset ZonedDateTime with its numeric offset", () => {
+    const time = Temporal.ZonedDateTime.from("2010-01-01T00:00:00[-05:00]");
+    expect(ActiveSupportJSON.encode(time)).toBe('"2010-01-01T00:00:00.000-05:00"');
+  });
+
   it("encodes a PlainDate without a time part", () => {
     expect(ActiveSupportJSON.encode(Temporal.PlainDate.from("2005-02-01"))).toBe('"2005-02-01"');
   });

--- a/packages/activesupport/src/json/encoding.ts
+++ b/packages/activesupport/src/json/encoding.ts
@@ -1,3 +1,4 @@
 export const Encoding = {
   useStandardJsonTimeFormat: true,
+  timePrecision: 3,
 };

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -451,7 +451,7 @@ export class TimeWithZone {
       base += frac;
     }
 
-    base += this.formattedOffset();
+    base += this.formattedOffset(true, "Z");
     return base;
   }
 

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -10,6 +10,7 @@ import { Duration } from "./duration.js";
 import { currentTime } from "./time-travel.js";
 import { getZone } from "./time-zone-config.js";
 import { Temporal, instantFrom } from "./temporal.js";
+import { Encoding } from "./json/encoding.js";
 
 /**
  * Options for the change() method.
@@ -525,7 +526,15 @@ export class TimeWithZone {
 
   /** JSON representation — ISO 8601 in UTC */
   asJson(): string {
-    return this.xmlschema(3);
+    if (Encoding.useStandardJsonTimeFormat) {
+      return this.xmlschema(Encoding.timePrecision);
+    }
+    const l = this._local();
+    return (
+      `${l.year}/${pad2(l.month)}/${pad2(l.day)} ` +
+      `${pad2(l.hour)}:${pad2(l.minute)}:${pad2(l.second)} ` +
+      `${this.formattedOffset(false)}`
+    );
   }
 
   toJSON(): string {


### PR DESCRIPTION
Rails' JSON encoder emits times with `ActiveSupport::JSON::Encoding.time_precision`
(default 3) fractional digits (`core_ext/object/json.rb:200-228`). Trails carried
only `useStandardJsonTimeFormat`, and `ActiveSupportJSON.encode` had no `as_json`
arm for temporals, so a `Temporal.Instant` fell through to `Instant#toJSON` and
dropped a zero subsecond part.

- `Encoding.timePrecision` added, defaulting to 3.
- `json.ts` gains the `Time` / `DateTime` / `Date` `as_json` dispatch for our
  Temporal analogues (`Instant`, `ZonedDateTime`, `PlainDateTime`, `PlainDate`),
  honouring both `timePrecision` and `useStandardJsonTimeFormat`.
- `TimeWithZone#asJson` stops hardcoding 3 and grows the
  `use_standard_json_time_format = false` branch (`time_with_zone.rb:166-172`).
- The three `twz to json ...` tests and the two `... with custom time precision`
  tests in `json/encoding.test.ts` are now faithful ports of
  `test/json/encoding_test.rb:409-450` (previously skipped or asserting against
  `JSON.stringify` on a JS `Date`).

Note on the second acceptance criterion: `message-verifier.test.ts`'s
`alternative serialization method` is still `it.skip` on main — the port that
carried the deviation note has not landed — so there is nothing to converge
there; whoever ports it now gets the Rails-exact `"2010-01-01T00:00:00.000Z"`.

Closes-story: activesupport-json-encoding-time-precision
