### PR TITLE
feat(activesupport): port MessageVerifiers and Messages::RotationCoordinator

### DIFF
--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/message-verifier.d.ts",
       "default": "./dist/message-verifier.js"
     },
+    "./message-verifiers": {
+      "types": "./dist/message-verifiers.d.ts",
+      "default": "./dist/message-verifiers.js"
+    },
     "./message-encryptor": {
       "types": "./dist/message-encryptor.d.ts",
       "default": "./dist/message-encryptor.js"

--- a/packages/activesupport/src/message-verifiers.test.ts
+++ b/packages/activesupport/src/message-verifiers.test.ts
@@ -1,9 +1,48 @@
-import { describe, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { MessageVerifier } from "./message-verifier.js";
+import { MessageVerifiers } from "./message-verifiers.js";
+import type { SecretGenerator } from "./messages/rotation-coordinator.js";
 
 describe("MessageVerifiersTest", () => {
-  it.skip("can override secret generator");
+  const makeCoordinator = (): MessageVerifiers => new MessageVerifiers((salt) => salt.repeat(10));
 
-  it.skip("supports arbitrary secret generator kwargs");
+  const roundtrip = (
+    message: string,
+    signer: MessageVerifier,
+    verifier: MessageVerifier = signer,
+  ): unknown => verifier.verified(signer.generate(message));
 
-  it.skip("supports arbitrary secret generator kwargs when using #rotate block");
+  const kwargSecretGenerator = (): SecretGenerator =>
+    Object.assign(
+      (_salt: string, { foo, bar }: Record<string, unknown>) => `${foo as string}${bar as string}`,
+      { parameters: ["foo", "bar"] as const },
+    );
+
+  let coordinator: MessageVerifiers;
+
+  beforeEach(() => {
+    coordinator = makeCoordinator().rotateDefaults();
+  });
+
+  it("can override secret generator", () => {
+    const secretGenerator: SecretGenerator = (salt) => `${salt}!`;
+    const other = makeCoordinator().rotate({ secretGenerator });
+
+    expect(roundtrip("message", other.get("salt"))).toEqual("message");
+    expect(roundtrip("message", coordinator.get("salt"), other.get("salt"))).toBeNull();
+  });
+
+  it("supports arbitrary secret generator kwargs", () => {
+    const other = new MessageVerifiers(kwargSecretGenerator());
+    other.rotate({ foo: "foo", bar: "bar" });
+
+    expect(roundtrip("message", other.get("salt"))).toEqual("message");
+  });
+
+  it("supports arbitrary secret generator kwargs when using #rotate block", () => {
+    const other = new MessageVerifiers(kwargSecretGenerator());
+    other.rotate(() => ({ foo: "foo", bar: "bar" }));
+
+    expect(roundtrip("message", other.get("salt"))).toEqual("message");
+  });
 });

--- a/packages/activesupport/src/message-verifiers.ts
+++ b/packages/activesupport/src/message-verifiers.ts
@@ -1,0 +1,13 @@
+import { MessageVerifier } from "./message-verifier.js";
+import { RotationCoordinator, type BuildOptions } from "./messages/rotation-coordinator.js";
+
+export class MessageVerifiers extends RotationCoordinator<MessageVerifier> {
+  /** @internal */
+  protected build(salt: string, options: BuildOptions): MessageVerifier {
+    const { secretGenerator, secretGeneratorOptions, ...rest } = options;
+    return new MessageVerifier(
+      secretGenerator(salt, secretGeneratorOptions) as string | Buffer,
+      rest,
+    );
+  }
+}


### PR DESCRIPTION
Ports `ActiveSupport::MessageVerifiers` (`message_verifiers.rb`) — a
`Messages::RotationCoordinator` subclass supplying `build` — and replaces the 3
bodyless `it.skip` placeholders in `message-verifiers.test.ts` with the real
Rails tests (`test/message_verifiers_test.rb`, names verbatim).

Rebased onto the merged `RotationCoordinator` port (#5974); this PR now carries
only the subclass, its subpath export, and the tests.

`api:compare` `message_verifiers.rb` 1/1; `test:compare`
`message_verifiers_test.rb` 3/3 (was 0/3, 3 skipped).

The shared `rotation_coordinator_tests.rb` module is not ported here — it stays
with the `port-activesupport-messages-rotation-coordinator` line of work. The
3 tests reconstruct that module's `setup` (`@coordinator =
make_coordinator.rotate_defaults`) as a local `beforeEach`, matching what the
Ruby test file sees.

Closes-story: port-activesupport-message-verifiers
