### PR TITLE
refactor(associations): drop JoinDependency#validateEagerLoadSpec

### DIFF
--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -504,36 +504,6 @@ export class JoinDependency {
   }
 
   /**
-   * Rails-faithful eager-load validation: walk the spec tree and raise the same
-   * errors `construct_join_dependency` does before any SQL is built —
-   * `ConfigurationError` for a misspelled/unknown name (via `findReflection`,
-   * mirroring Rails `find_reflection`) and `EagerLoadPolymorphicError` for a
-   * polymorphic association.
-   *
-   * Used by the calculation/exists paths (`Relation#_checkEagerLoadable`), which
-   * never build the real join tree but must still surface these errors. Unlike
-   * `build` this only validates — it doesn't mutate the tree.
-   *
-   * Mirrors: ActiveRecord::Associations::JoinDependency#build.
-   */
-  validateEagerLoadSpec(spec: AssociationSpec): void {
-    const walk = (associations: Record<PropertyKey, any>, baseKlass: typeof Base): void => {
-      if (!associations || typeof associations !== "object") return;
-      for (const key of Reflect.ownKeys(associations)) {
-        const name = typeof key === "symbol" ? (key.description ?? String(key)) : String(key);
-        const reflection = this.findReflection(baseKlass, name);
-        reflection.checkValidityBang?.();
-        reflection.checkEagerLoadableBang?.();
-        if (reflection.isPolymorphic?.()) {
-          throw new EagerLoadPolymorphicError(name);
-        }
-        walk(associations[key], reflection.klass);
-      }
-    };
-    walk(JoinDependency.makeTree(spec), this._baseModel);
-  }
-
-  /**
    * Build the join tree from a normalized make_tree-style hash (dotted strings
    * already split into nested keys by `walkTree`). Each key becomes a JOIN via
    * `_addOrReuse`; children recurse under the joined node's model and effective

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3176,9 +3176,8 @@ export class Relation<T extends Base> {
    * over `eager_load_values | includes_values` and which raises (via
    * `construct_join_dependency` → `build`) for both misspelled names
    * (`ConfigurationError`) and polymorphic associations
-   * (`EagerLoadPolymorphicError`). Capability-gap specs that Rails joins fine
-   * (composite-key belongsTo, unjoinable through) do NOT raise — trails degrades
-   * them to preloading, so the calculation paths stay silent like `toArray`.
+   * (`EagerLoadPolymorphicError`). Building the JoinDependency and discarding it
+   * is the whole check — like Rails, the errors are a side effect of `build`.
    *
    * Skips entirely when the query bypasses the JoinDependency (CTEs, set ops,
    * FROM overrides, composite PK): there `toArray` degrades to preloading
@@ -3201,8 +3200,7 @@ export class Relation<T extends Base> {
       ...new Set([...this._eagerLoadAssociations, ...this._includesToPromoteFromReferences()]),
     ];
     if (specs.length === 0) return;
-    const jd = new JoinDependency(this._modelClass, this.table, null, Nodes.OuterJoin);
-    for (const spec of specs) jd.validateEagerLoadSpec(spec);
+    new JoinDependency(this._modelClass, this.table, specs, Nodes.OuterJoin);
   }
 
   /**


### PR DESCRIPTION
Deletes `JoinDependency#validateEagerLoadSpec` — a trails invention with no
Rails counterpart — and routes `Relation#_checkEagerLoadable` through
constructing a `JoinDependency` with the real specs and discarding it, as Rails'
`apply_join_dependency` does. `build`
(`join_dependency.rb:228-238`) already raises `ConfigurationError` (via
`find_reflection`) for a misspelled name and `EagerLoadPolymorphicError` for a
polymorphic one as a side effect of building, so the separate recursive walk was
pure duplication.

**Route taken:** the dependency route. `drop-join-dependency-preload-fallback-lane`
landed in #5968, so nothing degrades to preloading any more and the
lenient/strict difference for valid-but-unjoinable specs has vanished — no
`fallbackAssociations` array needed.

`pnpm api:extra` now reports 4 novel names in `associations/join-dependency.ts`
(`columnsForNode`, `instantiateFromRows`, `nodes`, `selectArel`), down from 5.

Verified green locally: `join-model.test.ts`,
`eager-load-unjoinable-raises.trails.test.ts`, `eager.test.ts`, `errors.test.ts`,
`calculations.test.ts`, `finder.test.ts`.

Closes-story: converge-check-eager-loadable-onto-join-dependency-build
