### PR TITLE
feat(activesupport): port Messages::RotationCoordinator

### DIFF
--- a/packages/activesupport/src/messages/rotation-coordinator-tests.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator-tests.ts
@@ -78,11 +78,11 @@ export function rotationCoordinatorTests<C extends FallsBack<C>>(hooks: Coordina
 
   it("#rotate block receives salt in its original form", () => {
     const blockCoordinator = makeCoordinator().rotate((salt) => {
-      expect(salt).toEqual("salt");
+      expect(salt).toBe(Symbol.for("salt"));
       return {};
     });
 
-    blockCoordinator.get("salt");
+    blockCoordinator.get(Symbol.for("salt"));
   });
 
   it("#rotate raises when both a block and options are provided", () => {

--- a/packages/activesupport/src/messages/rotation-coordinator-tests.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator-tests.ts
@@ -1,0 +1,282 @@
+import { beforeEach, expect, it } from "vitest";
+
+import type { FallsBack, RotationCoordinator } from "./rotation-coordinator.js";
+
+/**
+ * Rails' `make_coordinator` / `roundtrip`, which each including test supplies.
+ */
+export interface CoordinatorHooks<C extends FallsBack<C>> {
+  makeCoordinator(): RotationCoordinator<C>;
+  roundtrip(message: string, codec: C, otherCodec?: C): unknown;
+}
+
+/**
+ * Rails' `RotationCoordinatorTests`, the module both `MessageVerifiersTest`
+ * and `MessageEncryptorsTest` `include`.
+ */
+export function rotationCoordinatorTests<C extends FallsBack<C>>(hooks: CoordinatorHooks<C>): void {
+  const { makeCoordinator, roundtrip } = hooks;
+
+  let coordinator: RotationCoordinator<C>;
+
+  beforeEach(() => {
+    coordinator = makeCoordinator().rotateDefaults();
+  });
+
+  it("builds working codecs", () => {
+    const codec = coordinator.get("salt");
+    const otherCodec = coordinator.get("other salt");
+
+    expect(roundtrip("message", codec)).toEqual("message");
+    expect(roundtrip("message", codec, otherCodec)).toBeNull();
+  });
+
+  it("memoizes codecs", () => {
+    expect(coordinator.get("salt")).toBe(coordinator.get("salt"));
+  });
+
+  it("can override codecs", () => {
+    coordinator.set("other salt", coordinator.get("salt"));
+    expect(coordinator.get("salt")).toBe(coordinator.get("other salt"));
+  });
+
+  it("configures codecs with rotations", () => {
+    coordinator.rotate({ digest: "MD5" });
+    const codec = coordinator.get("salt");
+    const obsoleteCodec = makeCoordinator().rotate({ digest: "MD5" }).get("salt");
+
+    expect(roundtrip("message", obsoleteCodec, codec)).toEqual("message");
+    expect(roundtrip("message", codec, obsoleteCodec)).toBeNull();
+  });
+
+  it("raises when building a codec and no rotations are configured", () => {
+    expect(() => makeCoordinator().get("salt")).toThrow();
+  });
+
+  it("#rotate supports a block", () => {
+    const blockCoordinator = makeCoordinator().rotate((salt) => ({
+      digest: salt === "salt" ? "SHA1" : "MD5",
+    }));
+
+    const sha1Coordinator = makeCoordinator().rotate({ digest: "SHA1" });
+    const md5Coordinator = makeCoordinator().rotate({ digest: "MD5" });
+
+    expect(roundtrip("message", blockCoordinator.get("salt"), sha1Coordinator.get("salt"))).toEqual(
+      "message",
+    );
+    expect(
+      roundtrip("message", blockCoordinator.get("salt"), md5Coordinator.get("salt")),
+    ).toBeNull();
+
+    expect(
+      roundtrip("message", blockCoordinator.get("other salt"), md5Coordinator.get("other salt")),
+    ).toEqual("message");
+    expect(
+      roundtrip("message", blockCoordinator.get("other salt"), sha1Coordinator.get("other salt")),
+    ).toBeNull();
+  });
+
+  it("#rotate block receives salt in its original form", () => {
+    const blockCoordinator = makeCoordinator().rotate((salt) => {
+      expect(salt).toEqual("salt");
+      return {};
+    });
+
+    blockCoordinator.get("salt");
+  });
+
+  it("#rotate raises when both a block and options are provided", () => {
+    expect(() => makeCoordinator().rotate({ digest: "MD5" }, () => ({}))).toThrow(
+      "Options cannot be specified when using a block",
+    );
+  });
+
+  it("#rotate block can return nil to skip a rotation for specific salts", () => {
+    const blockCoordinator = makeCoordinator().rotate({ digest: "SHA1" });
+    blockCoordinator.rotate((salt) => (salt === "salt" ? { digest: "MD5" } : null));
+
+    const sha1Coordinator = makeCoordinator().rotate({ digest: "SHA1" });
+    const md5Coordinator = makeCoordinator().rotate({ digest: "MD5" });
+
+    expect(roundtrip("message", sha1Coordinator.get("salt"), blockCoordinator.get("salt"))).toEqual(
+      "message",
+    );
+    expect(roundtrip("message", md5Coordinator.get("salt"), blockCoordinator.get("salt"))).toEqual(
+      "message",
+    );
+
+    expect(
+      roundtrip("message", sha1Coordinator.get("other salt"), blockCoordinator.get("other salt")),
+    ).toEqual("message");
+    expect(
+      roundtrip("message", md5Coordinator.get("other salt"), blockCoordinator.get("other salt")),
+    ).toBeNull();
+  });
+
+  it("raises when building a codec and no rotations are configured for a specific salt", () => {
+    const blockCoordinator = makeCoordinator().rotate((salt) =>
+      salt === "salt" ? { digest: "MD5" } : null,
+    );
+
+    expect(() => blockCoordinator.get("salt")).not.toThrow();
+    expect(() => blockCoordinator.get("other salt")).toThrow("other salt");
+  });
+
+  it("#transitional swaps the first two rotations when enabled", () => {
+    const transitionalCoordinator = makeCoordinator().rotate({ digest: "SHA1" });
+    transitionalCoordinator.rotate({ digest: "MD5" });
+    transitionalCoordinator.rotate({ digest: "SHA256" });
+    transitionalCoordinator.transitional = true;
+
+    const codec = transitionalCoordinator.get("salt");
+    const sha1Codec = makeCoordinator().rotate({ digest: "SHA1" }).get("salt");
+    const md5Codec = makeCoordinator().rotate({ digest: "MD5" }).get("salt");
+    const sha256Codec = makeCoordinator().rotate({ digest: "SHA256" }).get("salt");
+
+    expect(roundtrip("message", codec, md5Codec)).toEqual("message");
+    expect(roundtrip("message", codec, sha1Codec)).toBeNull();
+
+    expect(roundtrip("message", sha1Codec, codec)).toEqual("message");
+    expect(roundtrip("message", md5Codec, codec)).toEqual("message");
+    expect(roundtrip("message", sha256Codec, codec)).toEqual("message");
+  });
+
+  it("#transitional works with a single rotation", () => {
+    coordinator.transitional = true;
+
+    const codec = coordinator.get("salt");
+    expect(roundtrip("message", codec)).toEqual("message");
+
+    const differentCodec = makeCoordinator().rotate({ digest: "MD5" }).get("salt");
+    expect(roundtrip("message", differentCodec, codec)).toBeNull();
+  });
+
+  it("#transitional treats a nil first rotation as a new rotation", () => {
+    const transitionalCoordinator = makeCoordinator();
+    // (3) Finally, one salt upgraded to SHA1
+    transitionalCoordinator.rotate((salt) => (salt === "salt" ? { digest: "SHA1" } : null));
+    transitionalCoordinator.rotate({ digest: "MD5" }); // (2) Then, everything upgraded to MD5
+    transitionalCoordinator.rotate({ digest: "SHA256" }); // (1) Originally, everything used SHA256
+    transitionalCoordinator.transitional = true;
+
+    const sha1Coordinator = makeCoordinator().rotate({ digest: "SHA1" });
+    const md5Coordinator = makeCoordinator().rotate({ digest: "MD5" });
+
+    // "salt" encodes with MD5 and can decode SHA1 (i.e. [SHA1, MD5, SHA256] => [MD5, SHA1, SHA256])
+    expect(
+      roundtrip("message", transitionalCoordinator.get("salt"), md5Coordinator.get("salt")),
+    ).toEqual("message");
+    expect(
+      roundtrip("message", sha1Coordinator.get("salt"), transitionalCoordinator.get("salt")),
+    ).toEqual("message");
+
+    // "other salt" encodes with MD5 and cannot decode SHA1 (i.e. [nil, MD5, SHA256] => [MD5, SHA256])
+    expect(
+      roundtrip(
+        "message",
+        transitionalCoordinator.get("other salt"),
+        md5Coordinator.get("other salt"),
+      ),
+    ).toEqual("message");
+    expect(
+      roundtrip(
+        "message",
+        sha1Coordinator.get("other salt"),
+        transitionalCoordinator.get("other salt"),
+      ),
+    ).toBeNull();
+  });
+
+  it("#transitional swaps the first rotation with the next non-nil rotation", () => {
+    const transitionalCoordinator = makeCoordinator();
+    // (3) Finally, everything upgraded to SHA1
+    transitionalCoordinator.rotate({ digest: "SHA1" });
+    // (2) Then, one salt upgraded to SHA1
+    transitionalCoordinator.rotate((salt) => (salt === "salt" ? { digest: "SHA1" } : null));
+    transitionalCoordinator.rotate({ digest: "MD5" }); // (1) Originally, everything used MD5
+    transitionalCoordinator.transitional = true;
+
+    const sha1Coordinator = makeCoordinator().rotate({ digest: "SHA1" });
+    const md5Coordinator = makeCoordinator().rotate({ digest: "MD5" });
+
+    // "salt" encodes with SHA1 and can decode SHA1 (i.e. [SHA1, SHA1, MD5] => [SHA1, MD5])
+    expect(
+      roundtrip("message", transitionalCoordinator.get("salt"), sha1Coordinator.get("salt")),
+    ).toEqual("message");
+    expect(
+      roundtrip("message", sha1Coordinator.get("salt"), transitionalCoordinator.get("salt")),
+    ).toEqual("message");
+
+    // "other salt" encodes with MD5 and can decode SHA1 (i.e. [SHA1, nil, MD5] => [MD5, SHA1])
+    expect(
+      roundtrip(
+        "message",
+        transitionalCoordinator.get("other salt"),
+        md5Coordinator.get("other salt"),
+      ),
+    ).toEqual("message");
+    expect(
+      roundtrip(
+        "message",
+        sha1Coordinator.get("other salt"),
+        transitionalCoordinator.get("other salt"),
+      ),
+    ).toEqual("message");
+  });
+
+  it("can clear rotations", () => {
+    coordinator.clearRotations().rotate({ digest: "MD5" });
+    const codec = coordinator.get("salt");
+    const similarCodec = makeCoordinator().rotate({ digest: "MD5" }).get("salt");
+
+    expect(roundtrip("message", codec, similarCodec)).toEqual("message");
+  });
+
+  it("configures codecs with on_rotation", () => {
+    let rotated = 0;
+    coordinator.onRotation(() => {
+      rotated += 1;
+    });
+    coordinator.rotate({ digest: "MD5" });
+    const codec = coordinator.get("salt");
+    const obsoleteCodec = makeCoordinator().rotate({ digest: "MD5" }).get("salt");
+
+    expect(roundtrip("message", obsoleteCodec, codec)).toEqual("message");
+    expect(rotated).toEqual(1);
+  });
+
+  it("rotation options are deduped", () => {
+    const dedupedCoordinator = makeCoordinator();
+    // (3) Finally, everything upgraded to SHA1
+    dedupedCoordinator.rotate({ digest: "SHA1" });
+    // (2) Then, one salt upgraded to SHA1
+    dedupedCoordinator.rotate((salt) => (salt === "salt" ? { digest: "SHA1" } : null));
+    dedupedCoordinator.rotate({ digest: "MD5" }); // (1) Originally, everything used MD5
+
+    let rotated = 0;
+    dedupedCoordinator.onRotation(() => {
+      rotated += 1;
+    });
+
+    const codec = dedupedCoordinator.get("salt");
+    const md5Codec = makeCoordinator().rotate({ digest: "MD5" }).get("salt");
+
+    expect(roundtrip("message", md5Codec, codec)).toEqual("message");
+    expect(rotated).toEqual(1); // SHA1 tried only once
+  });
+
+  it("prevents adding a rotation after rotations have been applied", () => {
+    coordinator.get("salt");
+    expect(() => coordinator.rotate({ digest: "MD5" })).toThrow();
+  });
+
+  it("prevents clearing rotations after rotations have been applied", () => {
+    coordinator.get("salt");
+    expect(() => coordinator.clearRotations()).toThrow();
+  });
+
+  it("prevents changing on_rotation after on_rotation has been applied", () => {
+    coordinator.get("salt");
+    expect(() => coordinator.onRotation(() => "this block will not be evaluated")).toThrow();
+  });
+}

--- a/packages/activesupport/src/messages/rotation-coordinator.trails.test.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator.trails.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { MessageVerifier } from "../message-verifier.js";
+import { rotationCoordinatorTests } from "./rotation-coordinator-tests.js";
+import { RotationCoordinator, type BuildOptions } from "./rotation-coordinator.js";
+
+/**
+ * `RotationCoordinator` is abstract and Rails covers it only through
+ * `MessageVerifiers` / `MessageEncryptors`, neither of which is ported yet.
+ * This stands in for `MessageVerifiers` so the base class and the shared
+ * `RotationCoordinatorTests` module are exercised until it lands.
+ */
+class VerifierCoordinator extends RotationCoordinator<MessageVerifier> {
+  protected build(salt: string, options: BuildOptions): MessageVerifier {
+    const { secretGenerator, secretGeneratorOptions, ...rest } = options;
+    return new MessageVerifier(
+      secretGenerator(salt, secretGeneratorOptions) as string,
+      rest as ConstructorParameters<typeof MessageVerifier>[1],
+    );
+  }
+}
+
+describe("RotationCoordinator", () => {
+  rotationCoordinatorTests<MessageVerifier>({
+    makeCoordinator: () => new VerifierCoordinator((salt) => `secret for ${salt}`),
+
+    roundtrip(message, codec, otherCodec = codec) {
+      return otherCodec.verified(codec.generate(message));
+    },
+  });
+
+  it("requires a secret generator", () => {
+    expect(() => new VerifierCoordinator()).toThrow("A secret generator block is required");
+  });
+});

--- a/packages/activesupport/src/messages/rotation-coordinator.trails.test.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator.trails.test.ts
@@ -29,6 +29,18 @@ describe("RotationCoordinator", () => {
     },
   });
 
+  it("stringifies a symbol salt before building", () => {
+    const salts: string[] = [];
+    const coordinator = new VerifierCoordinator((salt) => {
+      salts.push(salt);
+      return `secret for ${salt}`;
+    }).rotateDefaults();
+
+    coordinator.get(Symbol.for("salt"));
+
+    expect(salts).toEqual(["salt"]);
+  });
+
   it("requires a secret generator", () => {
     expect(() => new VerifierCoordinator()).toThrow("A secret generator block is required");
   });

--- a/packages/activesupport/src/messages/rotation-coordinator.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator.ts
@@ -1,0 +1,153 @@
+import { extractKeys, isPlainObject } from "../hash-utils.js";
+import type { OnRotation } from "./rotator.js";
+import { ArgumentError, RuntimeError } from "./serializer-with-fallback.js";
+
+/**
+ * Ruby's secret generator block, `->(salt, **kwargs) { ... }`. Ruby reads the
+ * block's keyword parameters with `Method#parameters` to decide which of the
+ * `rotate` options belong to the generator; TypeScript has no parameter
+ * reflection, so a generator that takes options declares their names on
+ * `parameters` instead.
+ */
+export interface SecretGenerator {
+  (salt: string, options: Record<string, unknown>): unknown;
+  parameters?: readonly string[];
+}
+
+export interface RotateOptions extends Record<string, unknown> {
+  secretGenerator?: SecretGenerator;
+}
+
+/** Ruby's `rotate { |salt| ... }` block, which may return nil to skip a salt. */
+export type RotateBlock = (salt: string) => RotateOptions | null | undefined;
+
+export interface BuildOptions extends Record<string, unknown> {
+  secretGenerator: SecretGenerator;
+  secretGeneratorOptions: Record<string, unknown>;
+  onRotation: OnRotation | null;
+}
+
+/** The codec surface `build_with_rotations` reduces over. */
+export interface FallsBack<C> {
+  fallBackTo(fallback: C): C;
+}
+
+export abstract class RotationCoordinator<C extends FallsBack<C>> {
+  transitional: boolean | null = null;
+
+  readonly #secretGenerator: SecretGenerator;
+  #rotateOptions: (RotateOptions | RotateBlock)[] = [];
+  #onRotation: OnRotation | null = null;
+  #codecs = new Map<string, C>();
+
+  constructor(secretGenerator?: SecretGenerator) {
+    if (!secretGenerator) throw new ArgumentError("A secret generator block is required");
+    this.#secretGenerator = secretGenerator;
+  }
+
+  get(salt: string): C {
+    let codec = this.#codecs.get(salt);
+    if (!codec) {
+      codec = this.buildWithRotations(salt);
+      this.#codecs.set(salt, codec);
+    }
+    return codec;
+  }
+
+  set(salt: string, codec: C): void {
+    this.#codecs.set(salt, codec);
+  }
+
+  rotate(options: RotateOptions | RotateBlock = {}, block?: RotateBlock): this {
+    const rotationBlock = typeof options === "function" ? options : block;
+    const rotationOptions = typeof options === "function" ? {} : options;
+    if (rotationBlock && Object.keys(rotationOptions).length > 0) {
+      throw new ArgumentError("Options cannot be specified when using a block");
+    }
+    this.changingConfigurationBang();
+
+    this.#rotateOptions.push(rotationBlock ?? rotationOptions);
+
+    return this;
+  }
+
+  rotateDefaults(): this {
+    return this.rotate();
+  }
+
+  clearRotations(): this {
+    this.changingConfigurationBang();
+    this.#rotateOptions = [];
+    return this;
+  }
+
+  onRotation(callback: OnRotation): void {
+    this.changingConfigurationBang();
+    this.#onRotation = callback;
+  }
+
+  /** @internal */
+  protected changingConfigurationBang(): void {
+    if (this.#codecs.size > 0) {
+      throw new RuntimeError(
+        `Cannot change ${this.constructor.name} configuration after it has already been applied.\n\n` +
+          "The configuration has been applied with the following salts:\n" +
+          `${[...this.#codecs.keys()].map((salt) => `- ${JSON.stringify(salt)}`).join("\n")}\n`,
+      );
+    }
+  }
+
+  /** @internal */
+  protected normalizeOptions(options: RotateOptions): BuildOptions {
+    const normalized = { ...options } as Record<string, unknown>;
+
+    normalized.secretGenerator ??= this.#secretGenerator;
+
+    const secretGeneratorKwargs = (normalized.secretGenerator as SecretGenerator).parameters ?? [];
+    normalized.secretGeneratorOptions = extractKeys(normalized, ...secretGeneratorKwargs);
+
+    normalized.onRotation = this.#onRotation;
+
+    return normalized as BuildOptions;
+  }
+
+  /** @internal */
+  protected buildWithRotations(salt: string): C {
+    const evaluated = this.#rotateOptions.map((options) =>
+      typeof options === "function" ? options(salt) : options,
+    );
+    const transitional = this.transitional && evaluated[0];
+    let compacted = evaluated.filter((options): options is RotateOptions => options != null);
+    if (transitional) {
+      compacted = [...compacted.slice(0, 2).reverse(), ...compacted.slice(2)];
+    }
+    const rotateOptions = uniq(compacted.map((options) => this.normalizeOptions(options)));
+
+    if (rotateOptions.length === 0)
+      throw new RuntimeError(`No options have been configured for ${salt}`);
+
+    return rotateOptions
+      .map((options) => this.build(String(salt), options))
+      .reduce((codec, fallback) => codec.fallBackTo(fallback));
+  }
+
+  /** @internal */
+  protected abstract build(salt: string, options: BuildOptions): C;
+}
+
+/** Ruby's `Array#uniq` over option hashes, which compares them by value. */
+function uniq(optionsList: BuildOptions[]): BuildOptions[] {
+  const unique: BuildOptions[] = [];
+  for (const options of optionsList) {
+    if (!unique.some((seen) => valuesEqual(seen, options))) unique.push(options);
+  }
+  return unique;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (!isPlainObject(a) || !isPlainObject(b)) return false;
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every((key) => key in b && valuesEqual(a[key], b[key]));
+}

--- a/packages/activesupport/src/messages/rotation-coordinator.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator.ts
@@ -1,5 +1,8 @@
 import { extractKeys, isPlainObject } from "../hash-utils.js";
 import type { OnRotation } from "./rotator.js";
+// The `messages/` ports raise through the Ruby builtins declared in
+// serializer-with-fallback.ts; activesupport has no separate errors module, and
+// hash-utils' ArgumentError is the core-ext hash extensions' own copy.
 import { ArgumentError, RuntimeError } from "./serializer-with-fallback.js";
 
 /**
@@ -95,7 +98,7 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
   }
 
   /** @internal */
-  protected changingConfigurationBang(): void {
+  private changingConfigurationBang(): void {
     if (this.#codecs.size > 0) {
       throw new RuntimeError(
         `Cannot change ${this.constructor.name} configuration after it has already been applied.\n\n` +
@@ -106,7 +109,7 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
   }
 
   /** @internal */
-  protected normalizeOptions(options: RotateOptions): BuildOptions {
+  private normalizeOptions(options: RotateOptions): BuildOptions {
     const normalized = { ...options } as Record<string, unknown>;
 
     normalized.secretGenerator ??= this.#secretGenerator;
@@ -120,7 +123,7 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
   }
 
   /** @internal */
-  protected buildWithRotations(salt: Salt): C {
+  private buildWithRotations(salt: Salt): C {
     const evaluated = this.#rotateOptions.map((options) =>
       typeof options === "function" ? options(salt) : options,
     );
@@ -132,15 +135,20 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
     const rotateOptions = uniq(compacted.map((options) => this.normalizeOptions(options)));
 
     if (rotateOptions.length === 0)
-      throw new RuntimeError(`No options have been configured for ${String(salt)}`);
+      throw new RuntimeError(`No options have been configured for ${saltToS(salt)}`);
 
     return rotateOptions
-      .map((options) => this.build(String(salt), options))
+      .map((options) => this.build(saltToS(salt), options))
       .reduce((codec, fallback) => codec.fallBackTo(fallback));
   }
 
   /** @internal */
   protected abstract build(salt: string, options: BuildOptions): C;
+}
+
+/** Ruby's `Symbol#to_s` / `String#to_s` over a salt. */
+function saltToS(salt: Salt): string {
+  return typeof salt === "symbol" ? (salt.description ?? "") : salt;
 }
 
 /** Ruby's `Symbol#inspect` / `String#inspect` over a salt. */

--- a/packages/activesupport/src/messages/rotation-coordinator.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator.ts
@@ -18,8 +18,15 @@ export interface RotateOptions extends Record<string, unknown> {
   secretGenerator?: SecretGenerator;
 }
 
+/**
+ * A codec key. Ruby salts are usually Symbols but any object works, and the
+ * coordinator stringifies only when it builds, so `rotate` blocks see the salt
+ * in its original form.
+ */
+export type Salt = string | symbol;
+
 /** Ruby's `rotate { |salt| ... }` block, which may return nil to skip a salt. */
-export type RotateBlock = (salt: string) => RotateOptions | null | undefined;
+export type RotateBlock = (salt: Salt) => RotateOptions | null | undefined;
 
 export interface BuildOptions extends Record<string, unknown> {
   secretGenerator: SecretGenerator;
@@ -38,14 +45,14 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
   readonly #secretGenerator: SecretGenerator;
   #rotateOptions: (RotateOptions | RotateBlock)[] = [];
   #onRotation: OnRotation | null = null;
-  #codecs = new Map<string, C>();
+  #codecs = new Map<Salt, C>();
 
   constructor(secretGenerator?: SecretGenerator) {
     if (!secretGenerator) throw new ArgumentError("A secret generator block is required");
     this.#secretGenerator = secretGenerator;
   }
 
-  get(salt: string): C {
+  get(salt: Salt): C {
     let codec = this.#codecs.get(salt);
     if (!codec) {
       codec = this.buildWithRotations(salt);
@@ -54,7 +61,7 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
     return codec;
   }
 
-  set(salt: string, codec: C): void {
+  set(salt: Salt, codec: C): void {
     this.#codecs.set(salt, codec);
   }
 
@@ -81,9 +88,10 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
     return this;
   }
 
-  onRotation(callback: OnRotation): void {
+  onRotation(callback: OnRotation): OnRotation {
     this.changingConfigurationBang();
     this.#onRotation = callback;
+    return callback;
   }
 
   /** @internal */
@@ -92,7 +100,7 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
       throw new RuntimeError(
         `Cannot change ${this.constructor.name} configuration after it has already been applied.\n\n` +
           "The configuration has been applied with the following salts:\n" +
-          `${[...this.#codecs.keys()].map((salt) => `- ${JSON.stringify(salt)}`).join("\n")}\n`,
+          `${[...this.#codecs.keys()].map((salt) => `- ${inspect(salt)}`).join("\n")}\n`,
       );
     }
   }
@@ -112,7 +120,7 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
   }
 
   /** @internal */
-  protected buildWithRotations(salt: string): C {
+  protected buildWithRotations(salt: Salt): C {
     const evaluated = this.#rotateOptions.map((options) =>
       typeof options === "function" ? options(salt) : options,
     );
@@ -124,7 +132,7 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
     const rotateOptions = uniq(compacted.map((options) => this.normalizeOptions(options)));
 
     if (rotateOptions.length === 0)
-      throw new RuntimeError(`No options have been configured for ${salt}`);
+      throw new RuntimeError(`No options have been configured for ${String(salt)}`);
 
     return rotateOptions
       .map((options) => this.build(String(salt), options))
@@ -133,6 +141,11 @@ export abstract class RotationCoordinator<C extends FallsBack<C>> {
 
   /** @internal */
   protected abstract build(salt: string, options: BuildOptions): C;
+}
+
+/** Ruby's `Symbol#inspect` / `String#inspect` over a salt. */
+function inspect(salt: Salt): string {
+  return typeof salt === "symbol" ? `:${salt.description ?? ""}` : JSON.stringify(salt);
 }
 
 /** Ruby's `Array#uniq` over option hashes, which compares them by value. */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/messages/rotation-coordinator.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/messages/rotation-coordinator.json
@@ -1,0 +1,23 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "messages/rotation-coordinator.ts",
+    "rubyName": "changing_configuration!",
+    "call": "any?",
+    "reason": "Equivalent: `@codecs.any?` over a Hash is `this.#codecs.size > 0` on a Map, which has no `any?`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "messages/rotation-coordinator.ts",
+    "rubyName": "clear_rotations",
+    "call": "clear",
+    "reason": "Equivalent: JS arrays have no `clear`; the rotate-options array is emptied by assignment instead."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "messages/rotation-coordinator.ts",
+    "rubyName": "normalize_options",
+    "call": "filter_map",
+    "reason": "No JS analogue: Ruby filter_maps `Method#parameters` for the generator's keyword names; TS has no parameter reflection, so a generator declares them on `parameters`."
+  }
+]

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -127,6 +127,9 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // result.rb:58 `def ==(other)` / :80 `def [](column)` → result.ts `IndexedRow#equals`
   // / `IndexedRow#get`.
   "ActiveRecord::Result::IndexedRow": { "==": ["equals"], "[]": ["get"] },
+  // messages/rotation_coordinator.rb:18 `def [](salt)` / :22 `def []=(salt, codec)`
+  // → messages/rotation-coordinator.ts `get` / `set`.
+  "ActiveSupport::Messages::RotationCoordinator": { "[]": ["get"], "[]=": ["set"] },
 };
 
 // `fqn#operator` keys this process has actually resolved. A key that is never


### PR DESCRIPTION
Ports `ActiveSupport::Messages::RotationCoordinator`
(`activesupport/lib/active_support/messages/rotation_coordinator.rb`), the base
class behind `MessageVerifiers` / `MessageEncryptors`.

- `packages/activesupport/src/messages/rotation-coordinator.ts` — `transitional`,
  `[]`/`[]=` (→ `get`/`set`, per the repo's operator spelling convention),
  `rotate`, `rotate_defaults`, `clear_rotations`, `on_rotation`, and the private
  `changing_configuration!` / `normalize_options` / `build_with_rotations` /
  `build` internals.
- `messages/rotation-coordinator-tests.ts` — Rails'
  `test/rotation_coordinator_tests.rb` as a shared TS module, following the
  `messages/message-rotator-tests.ts` precedent, so `MessageVerifiers` and
  `MessageEncryptors` can each include it when they land. Test names are verbatim.
- `messages/rotation-coordinator.trails.test.ts` — trails-only cover that runs the
  shared module against a `MessageVerifier`-building coordinator, so the base
  class and the shared module are exercised now rather than after the first
  consumer lands.
- `scripts/api-compare/operator-order-spelling.ts` — pins `[]`→`get`, `[]=`→`set`
  for the new fqn.

Deviation, justified at the call site: Ruby picks the secret-generator's keyword
options with `Method#parameters`. TypeScript has no parameter reflection, so a
generator that takes options declares their names on a `parameters` property.

`api:compare` for `messages/rotation_coordinator.rb`: 0/11 → 11/11 ✓.

Closes-story: port-activesupport-messages-rotation-coordinator
