### PR TITLE
fix(ci): unred main — guides-typecheck i18n dep and MessageVerifier time precision

### DIFF
--- a/packages/activesupport/src/message-verifier.test.ts
+++ b/packages/activesupport/src/message-verifier.test.ts
@@ -117,12 +117,7 @@ describe("MessageVerifierTest", () => {
         foo: 123,
         bar: Temporal.Instant.from("2010-01-01T00:00:00Z"),
       });
-      // Rails' `exp` reads "2010-01-01T00:00:00.000Z": its JSON encoder emits
-      // times at `ActiveSupport::JSON::Encoding.time_precision` (3) digits.
-      // Trails' encoder has no `time_precision` knob and leans on
-      // `Temporal.Instant#toJSON`, which drops a zero subsecond part.
-      // Converged by the `activesupport-json-encoding-time-precision` story.
-      const exp = { foo: 123, bar: "2010-01-01T00:00:00Z" };
+      const exp = { foo: 123, bar: "2010-01-01T00:00:00.000Z" };
       expect(jsonVerifier.verified(message)).toEqual(exp);
       expect(jsonVerifier.verify(message)).toEqual(exp);
     } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,9 @@ importers:
       '@blazetrails/html-sanitizer':
         specifier: workspace:*
         version: link:../../packages/html-sanitizer
+      '@blazetrails/i18n':
+        specifier: workspace:*
+        version: link:../../packages/i18n
       '@blazetrails/nokogiri':
         specifier: workspace:*
         version: link:../../packages/nokogiri

--- a/scripts/guides-typecheck/package.json
+++ b/scripts/guides-typecheck/package.json
@@ -17,6 +17,7 @@
     "@blazetrails/did-you-mean": "workspace:*",
     "@blazetrails/globalid": "workspace:*",
     "@blazetrails/html-sanitizer": "workspace:*",
+    "@blazetrails/i18n": "workspace:*",
     "@blazetrails/trails-tsc": "workspace:*",
     "@blazetrails/tse-compiler": "workspace:*",
     "@blazetrails/nokogiri": "workspace:*"


### PR DESCRIPTION
Two reds on `main`, both from packages that landed in the last few commits.

**1. Guides Code Type Check** — #5969 added `packages/i18n` to the workspace but not to `scripts/guides-typecheck/package.json`. The runner asserts every workspace package is declared as a dependency so guide code blocks can import it, so it fails fast:

```
✗ scripts/guides-typecheck/package.json is missing workspace deps for:
  @blazetrails/i18n
```

Fixed by adding the `workspace:*` entry (+ lockfile). Verified: `✓ All 17 code blocks type-check cleanly.`

**2. Unit Tests** — #5971 landed the JSON `Encoding.timePrecision` knob, so trails' encoder now emits three subsecond digits like Rails. `MessageVerifierTest > alternative serialization method` still asserted the pre-convergence value (`2010-01-01T00:00:00Z`) plus a deviation comment saying the story that shipped in #5971 would converge it:

```
AssertionError: expected { foo: 123, …(1) } to deeply equal { foo: 123, …(1) }
```

Now asserts Rails' value verbatim — `vendor/rails/activesupport/test/message_verifier_test.rb:109` reads `"bar" => "2010-01-01T00:00:00.000Z"` — and the stale comment is gone. Verified: 10 passed | 1 skipped.

Closes-story: red-4c7ff086
