### PR TITLE
feat(i18n): enroll i18n in api:compare

### DIFF
--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -232,7 +232,7 @@ describe("rubyFileToTs", () => {
 describe("RUBY_FILE_TS_OVERRIDES", () => {
   it("keys every entry as <package>:<ruby path> and maps to a .ts file", () => {
     for (const [key, value] of Object.entries(RUBY_FILE_TS_OVERRIDES)) {
-      expect(key).toMatch(/^[a-z-]+:.+\.rb$/);
+      expect(key).toMatch(/^[a-z0-9-]+:.+\.rb$/);
       expect(value).toMatch(/\.ts$/);
     }
   });
@@ -247,6 +247,15 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
   it("returns the mapped TS file, or undefined when unmapped", () => {
     expect(rubyFileTsOverride("inflector/methods.rb", "activesupport")).toBe("inflector.ts");
     expect(rubyFileTsOverride("inflector/inflections.rb", "activesupport")).toBeUndefined();
+  });
+
+  it("maps i18n's umbrella and interpolate files into packages/i18n/src", () => {
+    // `lib/i18n.rb` is scanned one level above libPath, so the default rule
+    // would place it at `../i18n.ts`, outside src. `interpolate/ruby.rb`
+    // reopens `module I18n` — whose bucket `backend/cache.rb` owns — so
+    // without an override its methods are measured against an unported file.
+    expect(rubyFileToTs("../i18n.rb", "i18n")).toBe("i18n.ts");
+    expect(rubyFileToTs("interpolate/ruby.rb", "i18n")).toBe("interpolate/ruby.ts");
   });
 });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -75,6 +75,16 @@ export const PATH_SEGMENT_ALIASES: Record<string, string> = {
 export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   "activesupport:inflector/methods.rb": "inflector.ts",
   "activesupport:core_ext/string/inflections.rb": "inflector.ts",
+  // The i18n gem's umbrella file (`lib/i18n.rb`, scanned one level above
+  // libPath) is where `I18n::Base` itself is defined, so unlike Rails'
+  // umbrella files it owns real surface. trails ports it to `src/i18n.ts`;
+  // without this the default rule would expect `../i18n.ts`, outside src.
+  "i18n:../i18n.rb": "i18n.ts",
+  // `interpolate/ruby.rb` reopens `module I18n`, which `backend/cache.rb`
+  // defines first — so without an entry here its `interpolate` /
+  // `interpolate_hash` are measured against `backend/cache.ts` and, since
+  // cache.rb is unported, drop out of accounting entirely.
+  "i18n:interpolate/ruby.rb": "interpolate/ruby.ts",
 };
 
 /** The explicit TS mapping for `rubyFile` in `pkg`, or undefined when unmapped. */

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -1,6 +1,26 @@
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+
 import { describe, it, expect } from "vitest";
 
+import { resolvePath } from "../../vendor/sources.js";
 import { isSourceUnported, isTestFileUnported, UNPORTED_FILES } from "./unported-files.js";
+
+async function walkRb(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...(await walkRb(p)));
+    else if (e.name.endsWith(".rb")) out.push(p);
+  }
+  return out;
+}
 
 describe("isSourceUnported package scoping", () => {
   it("matches an unscoped pattern across every package", () => {
@@ -16,44 +36,36 @@ describe("isSourceUnported package scoping", () => {
     expect(isSourceUnported("core_ext/name_error.rb", "activesupport")).toBe(false);
   });
 
-  it("excludes i18n's deferrable gem surface without touching its ported core", () => {
-    for (const f of [
-      "backend/chain.rb",
-      "backend/fallbacks.rb",
-      "backend/key_value.rb",
-      "backend/cache.rb",
-      "backend/cache_file.rb",
-      "backend/cascade.rb",
-      "backend/gettext.rb",
-      "backend/interpolation_compiler.rb",
-      "backend/lazy_loadable.rb",
-      "backend/memoize.rb",
-      "backend/metadata.rb",
-      "backend/pluralization.rb",
-      "backend/transliterator.rb",
-      "gettext.rb",
-      "gettext/helpers.rb",
-      "gettext/po_parser.rb",
-      "locale/fallbacks.rb",
-      "locale/tag/rfc4646.rb",
-      "middleware.rb",
-      "version.rb",
-      "tests/basics.rb",
-    ]) {
-      expect(isSourceUnported(f, "i18n"), f).toBe(true);
-    }
-    for (const f of [
+  it("accounts for every file in the vendored i18n lib tree", async () => {
+    // RFC 0074 enrollment invariant: each i18n source file is either measured
+    // by api:compare or excluded here with a reason — nothing falls through
+    // unnoticed. Walking the real tree (rather than pinning a hand-written
+    // list) is what catches a file sitting BESIDE an excluded directory:
+    // `locale/` does not reach `locale.rb`, nor `tests/` reach `tests.rb`.
+    const root = resolvePath("i18n");
+    const files = (await walkRb(root)).map((f) => relative(root, f));
+    // Vendor not populated (bare checkout) — nothing to check.
+    if (files.length === 0) return;
+
+    // `lib/i18n.rb` is scanned one level above libPath, hence the `../`.
+    const inScope = new Set([
       "../i18n.rb",
+      "backend.rb",
+      "backend/base.rb",
+      "backend/flatten.rb",
+      "backend/simple.rb",
       "config.rb",
       "exceptions.rb",
-      "backend/base.rb",
-      "backend/simple.rb",
-      "backend/flatten.rb",
       "interpolate/ruby.rb",
       "utils.rb",
-    ]) {
-      expect(isSourceUnported(f, "i18n"), f).toBe(false);
-    }
+    ]);
+    const unaccounted = ["../i18n.rb", ...files].filter(
+      (f) => !inScope.has(f) && !isSourceUnported(f, "i18n"),
+    );
+    expect(unaccounted).toEqual([]);
+
+    // The other direction: an exclusion must never swallow the ported core.
+    for (const f of inScope) expect(isSourceUnported(f, "i18n"), f).toBe(false);
   });
 
   it("keeps i18n's exclusions from leaking into other packages", () => {

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -16,6 +16,53 @@ describe("isSourceUnported package scoping", () => {
     expect(isSourceUnported("core_ext/name_error.rb", "activesupport")).toBe(false);
   });
 
+  it("excludes i18n's deferrable gem surface without touching its ported core", () => {
+    for (const f of [
+      "backend/chain.rb",
+      "backend/fallbacks.rb",
+      "backend/key_value.rb",
+      "backend/cache.rb",
+      "backend/cache_file.rb",
+      "backend/cascade.rb",
+      "backend/gettext.rb",
+      "backend/interpolation_compiler.rb",
+      "backend/lazy_loadable.rb",
+      "backend/memoize.rb",
+      "backend/metadata.rb",
+      "backend/pluralization.rb",
+      "backend/transliterator.rb",
+      "gettext.rb",
+      "gettext/helpers.rb",
+      "gettext/po_parser.rb",
+      "locale/fallbacks.rb",
+      "locale/tag/rfc4646.rb",
+      "middleware.rb",
+      "version.rb",
+      "tests/basics.rb",
+    ]) {
+      expect(isSourceUnported(f, "i18n"), f).toBe(true);
+    }
+    for (const f of [
+      "../i18n.rb",
+      "config.rb",
+      "exceptions.rb",
+      "backend/base.rb",
+      "backend/simple.rb",
+      "backend/flatten.rb",
+      "interpolate/ruby.rb",
+      "utils.rb",
+    ]) {
+      expect(isSourceUnported(f, "i18n"), f).toBe(false);
+    }
+  });
+
+  it("keeps i18n's exclusions from leaking into other packages", () => {
+    // `middleware.rb`, `version.rb` and `gettext` all appear in other gems.
+    expect(isSourceUnported("middleware.rb", "actiondispatch")).toBe(false);
+    expect(isSourceUnported("version.rb", "activesupport")).toBe(false);
+    expect(isSourceUnported("gettext.rb", "activesupport")).toBe(false);
+  });
+
   it("treats an absent pkg argument as 'any package' to preserve legacy callers", () => {
     expect(isSourceUnported("core_ext/name_error.rb")).toBe(true);
   });

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1228,6 +1228,15 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Backend::Fallbacks, which is itself out of pre-1.0 scope.",
   },
   {
+    pattern: "locale.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: the `I18n::Locale` namespace's autoload shim — it declares " +
+      "nothing but `autoload :Fallbacks` / `autoload :Tag` for the `locale/` " +
+      "tree excluded above. Listed separately because the `locale/` pattern " +
+      "does not reach a file that sits beside the directory.",
+  },
+  {
     pattern: "middleware.rb",
     package: "i18n",
     reason:
@@ -1249,6 +1258,14 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "`lib/i18n/tests/*` are minitest mixins the gem ships so third-party " +
       "backends can run its conformance suite. Test-support scaffolding, not " +
       "library surface — trails' backend tests are vitest files instead.",
+  },
+  {
+    pattern: "tests.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: the `I18n::Tests` namespace's autoload shim for the `tests/` " +
+      "conformance mixins excluded above. Same beside-the-directory shape as " +
+      "`locale.rb`.",
   },
 ];
 

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1137,6 +1137,127 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Rails::TestUnit::Runner and invokes it with ARGV. vitest fills that role in " +
       "trails — no port intended.",
   },
+  // --- i18n: optional backend mixins layered on top of Simple ---
+  // The gem ships Simple as the only backend Rails boots with; everything
+  // else here is opt-in behavior a host application composes in
+  // (`I18n.backend = Chain.new(...)`, `Simple.include(Fallbacks)`, …).
+  // trails ports Base + Simple + the facade; these stay out of pre-1.0
+  // scope and are excluded per-file so the i18n parity number reflects
+  // the surface we committed to.
+  {
+    pattern: "backend/chain.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
+  },
+  {
+    pattern: "backend/fallbacks.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — locale fallback chain, built on the " +
+      "equally out-of-scope locale/fallbacks.rb.",
+  },
+  {
+    pattern: "backend/key_value.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
+  },
+  {
+    pattern: "backend/cache.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache.",
+  },
+  {
+    pattern: "backend/cache_file.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — caches parsed translation files on disk.",
+  },
+  {
+    pattern: "backend/cascade.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
+  },
+  {
+    pattern: "backend/gettext.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — loads gettext .po catalogues.",
+  },
+  {
+    pattern: "backend/interpolation_compiler.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — compiles interpolations into Ruby " +
+      "procs via `eval`/`instance_eval`, which has no trails counterpart.",
+  },
+  {
+    pattern: "backend/lazy_loadable.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup.",
+  },
+  {
+    pattern: "backend/memoize.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — memoizes lookups per locale.",
+  },
+  {
+    pattern: "backend/metadata.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — attaches lookup metadata onto the " +
+      "translated String's singleton class. JS strings take no per-instance state.",
+  },
+  {
+    pattern: "backend/pluralization.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data.",
+  },
+  {
+    pattern: "backend/transliterator.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: ASCII transliteration driven by per-locale rule tables and " +
+      "`$KCODE`-era String packing. JS has `String.prototype.normalize` and " +
+      "no locale rule data is shipped; not in pre-1.0 scope.",
+  },
+  {
+    pattern: "gettext",
+    package: "i18n",
+    reason:
+      "Pre-1.0: gettext .po support (parser + `_`/`n_`/`s_` helpers). A Ruby " +
+      "toolchain concern with no trails consumer — Rails' own I18n usage never " +
+      "touches it.",
+  },
+  {
+    pattern: "locale/",
+    package: "i18n",
+    reason:
+      "Pre-1.0: RFC 4646 locale-tag parsing and the fallback tag graph " +
+      "(`Locale::Tag::*`, `Locale::Fallbacks`). Only reachable through " +
+      "Backend::Fallbacks, which is itself out of pre-1.0 scope.",
+  },
+  {
+    pattern: "middleware.rb",
+    package: "i18n",
+    reason:
+      "Rack middleware that resets `I18n.locale` after each request. trails " +
+      "has no Rack request lifecycle wiring for i18n yet; resetting is done " +
+      "explicitly by callers.",
+  },
+  {
+    pattern: "version.rb",
+    package: "i18n",
+    reason:
+      "Gem version constant. trails carries the version in package.json — no " +
+      "TS counterpart by design.",
+  },
+  {
+    pattern: "tests/",
+    package: "i18n",
+    reason:
+      "`lib/i18n/tests/*` are minitest mixins the gem ships so third-party " +
+      "backends can run its conformance suite. Test-support scaffolding, not " +
+      "library surface — trails' backend tests are vitest files instead.",
+  },
 ];
 
 export function isSourceUnported(file: string, pkg?: string): boolean {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1137,13 +1137,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Rails::TestUnit::Runner and invokes it with ARGV. vitest fills that role in " +
       "trails — no port intended.",
   },
-  // --- i18n: optional backend mixins layered on top of Simple ---
-  // The gem ships Simple as the only backend Rails boots with; everything
-  // else here is opt-in behavior a host application composes in
-  // (`I18n.backend = Chain.new(...)`, `Simple.include(Fallbacks)`, …).
-  // trails ports Base + Simple + the facade; these stay out of pre-1.0
-  // scope and are excluded per-file so the i18n parity number reflects
-  // the surface we committed to.
+  // --- i18n: optional backend mixins composed on top of Simple ---
   {
     pattern: "backend/chain.rb",
     package: "i18n",
@@ -1175,11 +1169,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     pattern: "backend/cascade.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
-  },
-  {
-    pattern: "backend/gettext.rb",
-    package: "i18n",
-    reason: "Pre-1.0: optional backend mixin — loads gettext .po catalogues.",
   },
   {
     pattern: "backend/interpolation_compiler.rb",
@@ -1219,13 +1208,16 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "`$KCODE`-era String packing. JS has `String.prototype.normalize` and " +
       "no locale rule data is shipped; not in pre-1.0 scope.",
   },
+  // --- i18n: gem surface trails has no counterpart for ---
   {
+    // Deliberately broad: covers `gettext.rb`, `gettext/*` and the
+    // `backend/gettext.rb` mixin in one entry.
     pattern: "gettext",
     package: "i18n",
     reason:
-      "Pre-1.0: gettext .po support (parser + `_`/`n_`/`s_` helpers). A Ruby " +
-      "toolchain concern with no trails consumer — Rails' own I18n usage never " +
-      "touches it.",
+      "Pre-1.0: gettext .po support — the catalogue parser, the `_`/`n_`/`s_` " +
+      "helpers, and the backend mixin that loads .po files. A Ruby toolchain " +
+      "concern with no trails consumer; Rails' own I18n usage never touches it.",
   },
   {
     pattern: "locale/",

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -61,7 +61,7 @@ describe("vendor/sources.ts", () => {
     ]);
   });
 
-  it("declares the i18n source, vendored-only until packages/i18n exists", () => {
+  it("declares the i18n source, enrolled in api-compare but not test-compare", () => {
     const i18n = SOURCES.find((s) => s.name === "i18n");
     expect(i18n).toBeDefined();
     expect(i18n!.origin).toEqual({
@@ -74,12 +74,12 @@ describe("vendor/sources.ts", () => {
         name: "i18n",
         libPath: "lib/i18n",
         testPath: "test",
-        compareApi: false,
         compareTests: false,
       },
     ]);
-    expect(apiComparePackages()).not.toContain("i18n");
-    expect(Object.keys(libPathsManifest())).not.toContain("i18n");
+    expect(apiComparePackages()).toContain("i18n");
+    expect(Object.keys(libPathsManifest())).toContain("i18n");
+    // test-compare stays off until the gem's minitest suite is wired up.
     expect(Object.keys(testPathsManifest())).not.toContain("i18n");
     expect(resolvePath("i18n").endsWith("vendor/i18n/lib/i18n")).toBe(true);
     expect(resolvePath("i18n", "test").endsWith("vendor/i18n/test")).toBe(true);
@@ -196,6 +196,7 @@ describe("vendor/sources.ts", () => {
         "arel",
         "did-you-mean",
         "globalid",
+        "i18n",
         "rack",
         "trailties",
       ].sort(),

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -29,9 +29,9 @@ export interface PackageEntry {
    * Default true. Set to false to vendor the source (so test-compare or other
    * tooling can read it) without including it in the api-compare PACKAGES
    * derivation. Reserved for cases where the extractor can't yet handle a
-   * gem's idioms, or where no TS-side package dir exists yet to map onto
-   * (i18n today). Rack and globalid were wired into api-compare in wave 6
-   * (#1589).
+   * gem's idioms, or where no TS-side package dir exists yet to map onto.
+   * Rack and globalid were wired into api-compare in wave 6 (#1589), i18n
+   * once packages/i18n existed; today no source sets it.
    */
   compareApi?: boolean;
   /**
@@ -191,7 +191,6 @@ export const SOURCES: readonly UpstreamSource[] = [
         name: "i18n",
         libPath: "lib/i18n",
         testPath: "test",
-        compareApi: false,
         compareTests: false,
       },
     ],


### PR DESCRIPTION
Enrolls the i18n gem in `api:compare` (RFC 0074 Phase 1 follow-on to the
Config + exceptions scaffold in #5969).

## What changed

- `vendor/sources.ts`: drop `compareApi: false` from the i18n package
  entry, so `apiComparePackages()` includes `i18n` and it flows into
  `scripts/api-compare/config.ts` PACKAGES and `libPathsManifest()` →
  `extract-ruby-api.rb`. `compareTests` stays `false` — the gem's
  minitest suite isn't wired into test-compare yet.
- `scripts/api-compare/conventions.ts`: two `RUBY_FILE_TS_OVERRIDES`
  entries.
  - `i18n:../i18n.rb` → `i18n.ts`. Unlike Rails' umbrella files
    (`active_record.rb` etc., which only carry singleton config that gets
    attributed to `Base`), the i18n gem defines `I18n::Base` *in*
    `lib/i18n.rb`, so the umbrella scan owns real surface. The default
    rule would place it at `../i18n.ts`, outside `src`.
  - `i18n:interpolate/ruby.rb` → `interpolate/ruby.ts`. `interpolate/ruby.rb`
    reopens `module I18n`, whose bucket `backend/cache.rb` defines first —
    so without an override its `interpolate` / `interpolate_hash` are
    measured against `backend/cache.ts` and, since cache.rb is unported,
    vanish from accounting entirely. This is the second half of the
    documented `RUBY_FILE_TS_OVERRIDES` contract.
- `scripts/api-compare/unported-files.ts`: per-file exclusions with
  reasons, all scoped `package: "i18n"`, for the surface the RFC defers —
  the composable backend mixins (`chain`, `fallbacks`, `key_value`,
  `cache`, `cache_file`, `cascade`, `interpolation_compiler`,
  `lazy_loadable`, `memoize`, `metadata`, `pluralization`,
  `transliterator`), all gettext support (`gettext.rb`, `gettext/*` and
  `backend/gettext.rb` share one deliberately broad entry), `locale/*`,
  `middleware.rb`, `version.rb`, and `lib/i18n/tests/*` (minitest
  conformance mixins the gem ships for third-party backends —
  test-support scaffolding, not library surface), plus the `locale.rb`
  and `tests.rb` autoload shims that sit *beside* those directories and
  so are not reached by the `locale/` / `tests/` patterns.

Scoping matters here: `middleware.rb`, `version.rb` and `gettext.rb` all
exist in other packages, so unscoped patterns would silently drop ported
files elsewhere. There's a regression test for that.

The "no silent gaps" criterion is enforced rather than asserted by hand:
`unported-files.test.ts` walks the vendored i18n lib tree and requires
every file to be either in an explicit in-scope set or excluded with a
reason. `backend.rb` is deliberately in-scope — it's the autoload shim
for the ported `Backend::Base` / `Simple` / `Flatten` subtree, unlike
`locale.rb` and `tests.rb` whose whole subtrees are deferred.

## Parity after enrollment

```
i18n — 39/111 methods (35.1%) | files: 4/8 | inheritance: 2/2 (100%) | arity: 14/14 (100%)

  Ruby file              Expected TS file       Match   Miss    Tot    %
  ../i18n.rb             i18n.ts                    0      3      3    0%
  backend/base.rb        backend/base.ts            0     24     24    0% ✗
  backend/flatten.rb     backend/flatten.ts         0      8      8    0% ✗
  backend/simple.rb      backend/simple.ts          0     27     27    0% ✗
  config.rb              config.ts                 23      0     23  100% ✓
  exceptions.rb          exceptions.ts             16      3     19   84%
  interpolate/ruby.rb    interpolate/ruby.ts        0      2      2    0%
  utils.rb               utils.ts                   0      5      5    0% ✗
```

Every unported i18n file is now either measured or excluded with a
reason — no silent gaps. The remaining zeros are the ported-core files
subsequent RFC 0074 stories fill in (`interpolate/ruby.ts` currently
holds only the pattern constants; `i18n.ts` holds the facade helpers but
not `translate`/`localize` yet).

## Verification

- `pnpm api:compare` clean (exit 0), with an i18n section.
- Gates green locally: call-mismatches ratchet, wide call-mismatches
  ratchet + reseed-drift, arity excludes, missing-call reasons, detached
  JSDoc tags, body pins, dependency lint, conventions-doc `--check`.
- `pnpm vitest run vendor scripts/api-compare` — 988 passed.
- `pnpm typecheck`, eslint, prettier clean.
- Deprecation manifest `--check-deprecated` and the codegen convergence
  guard both unmoved.

Closes-story: i18n-api-compare-enrollment
