### PR TITLE
docs: make Rails fidelity a stated rule and add pre-PR drift gates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,25 @@
 
 ## What this project is
 
-A TypeScript monorepo that mirrors the Ruby on Rails API. Class names, method names, and call signatures should match Rails as closely as TypeScript allows. Someone reading the Rails API docs should be able to use these packages with near-identical intent and naming.
+A TypeScript monorepo that mirrors the Ruby on Rails API. Someone reading the Rails API docs should be able to use these packages with near-identical intent and naming.
+
+## Fidelity is the standard
+
+This is a re-implementation of Rails, not a library inspired by it. When code has a Rails counterpart, it should be as close to the Ruby as TypeScript allows. The bar is **"would a Rails dev recognize this as the same method"**, not "does it pass the tests". Mirror:
+
+- **Names** — method, class, module, constant, and field names, translated by the rules in [docs/ruby-ts-conventions.md](../docs/ruby-ts-conventions.md).
+- **Locals and parameters** — a Rails local `stmt` stays `stmt`, not `statement`; `klass` stays `klass`. Same for parameter order and defaults.
+- **Control flow** — same branches, same order, same guards and early returns. Collapsing, reordering, or inverting them is a finding.
+- **Decomposition** — if Rails extracts a private helper, so should we, at the Rails name. One Rails method is one TS method.
+- **Member order within the file**, and the file layout itself.
+- **Errors** — same class, same message, same raise site.
+- **No extra abstraction** — no helper, wrapper, indirection layer, or "cleaner" rewrite Rails doesn't have. `pnpm api:extra` measures this; `@noRailsEquivalent <reason>` is the only sanctioned exception.
+
+Only a genuine TypeScript language shortcoming justifies a deviation, and only after the settled workaround is ruled out (`setX()` where a Ruby `x=` setter must be async, `include()`/`Included<>` and `this`-typed functions for Ruby `include`). "Cleaner in TS", "more idiomatic", and "the tests pass either way" are not language shortcomings.
+
+**Converge, never ratify.** An existing deviation — a `call-mismatches-*-exclude` baseline row, an `arity-exclude.json` entry, a `SKIP_GROUPS` name, a `@noRailsEquivalent` / `@missingRailsCall` tag, a story under `0023-surfaced-deviations` — is debt, not permission. It is never a reason to match the shape, extend it, or add a sibling row. A diff that _adds_ one is recording a new deviation: review its `reason` at least as hard as the code, and treat a seeded placeholder or a reason that only restates the code as a finding.
+
+The full standard, and the pre-PR gates that detect drift, are in [CLAUDE.md](../CLAUDE.md) — "Fidelity is the job" and "Before you open the PR".
 
 ## Project structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,9 @@ port a body:
 
 - **Truthiness.** Ruby's `if x` is false only for `nil`/`false`. `Boolean(x)`
   and `if (x)` are also false for `0`, `""`, and `NaN`. Port `if x` as
-  `x != null`, never as a bare truthiness test, unless you have checked the
-  value can't be `0`/`""`.
+  `x != null && x !== false` — or just `x != null` once you have checked the
+  value can't be a boolean — never as a bare truthiness test unless you have
+  checked it can't be `0`/`""` either.
 - **`fetch` vs `??`.** `h.fetch(:k, default)` returns the _stored_ value
   whenever the key exists — including a stored `nil` or `false`. `h.k ?? default`
   substitutes the default for `null`/`undefined`. They differ, and Rails
@@ -251,14 +252,23 @@ catches a class of drift a reviewer would otherwise spend a cycle on.
    an invented shortcut.
 
    ```bash
-   API_COMPARE_FORCE=1 pnpm api:compare --wide-calls   # regenerate BOTH artifacts
-   pnpm api:calls                                      # narrow ratchet (RFC 0044)
-   pnpm api:calls:wide                                 # wide ratchet (RFC 0047)
+   pnpm api:calls        # narrow ratchet (RFC 0044)
+   pnpm api:calls:wide   # wide ratchet (RFC 0047)
    ```
 
-   The regeneration is not optional: both lints read an artifact on disk, and
-   gating a stale one reports movement that never happened. A warm cache
-   under-reports, which is why the force flag is there.
+   Each lint reads an artifact on disk and regenerates its own first, so a
+   plain gating run is enough — gating a stale artifact reports movement that
+   never happened, which is how a sibling PR's deleted method surfaces as a
+   STALE row on a branch that never touched it. The two artifacts are
+   **separate**: `compare.ts` writes `call-mismatches.json` on a normal run and
+   `call-mismatches-wide.json` only under `--wide-calls`, so one compare run
+   never refreshes both. If you need to force past a warm cache (it
+   under-reports vs CI), do it per artifact:
+
+   ```bash
+   API_COMPARE_FORCE=1 pnpm api:compare                # narrow
+   API_COMPARE_FORCE=1 pnpm api:compare --wide-calls   # wide
+   ```
 
    **New mismatch?** The right fix is almost always to make the TS body call
    what Rails calls. Baselining is the fallback, and it costs a reviewed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,116 @@ measure progress — see [CONTRIBUTING.md](CONTRIBUTING.md). For project overvie
 package list, and the `declare` / associations / enums / schema reference, see
 [README.md](README.md).
 
+## Fidelity is the job
+
+trails is a re-implementation of Rails, not a library inspired by it. When a
+file has a Rails counterpart, write it as close to the Ruby as TypeScript
+allows. The bar is **"would a Rails dev recognize this as the same method"** —
+not "does it pass the tests."
+
+Mirror, method by method and line by line:
+
+- **Names.** Method, class, module, constant, and field names come from Rails,
+  translated by the rules in
+  [docs/ruby-ts-conventions.md](docs/ruby-ts-conventions.md) — that file is
+  generated from `scripts/api-compare/conventions.ts` and is what `api:compare`
+  actually matches on, so read it _before_ you pick a name, not after CI
+  disagrees. It also covers file paths (`PATH_SEGMENT_ALIASES`,
+  `RUBY_FILE_TS_OVERRIDES`). If your name isn't the one that table produces
+  from the Ruby name, you have a bug, not a preference.
+- **Locals and parameters.** A local or parameter keeps the Rails identifier,
+  camelCased — Ruby `stmt` is `stmt`, not `statement`; `klass` is `klass`, not
+  `modelClass`. Same for parameter _order_ and defaults. This is free fidelity
+  and it is most of what makes a body readable next to the Ruby.
+- **Control flow.** Same branches, in the same order, with the same guards and
+  early returns. Do not collapse two Rails branches into one, invert a guard,
+  reorder side-effect-free calls, or drop a check you believe is unreachable.
+- **Decomposition.** If Rails extracts a private helper, extract it, with the
+  Rails name. If Rails inlines something, inline it. One Rails method is one TS
+  method.
+- **No extra abstraction.** Do not add a helper, wrapper, indirection layer, or
+  "cleaner" rewrite that Rails does not have. Extra surface is measured —
+  `pnpm api:extra` reports every public TS name with no Ruby counterpart. If
+  you genuinely need one, declare it with a `@noRailsEquivalent <reason>` JSDoc
+  tag; that tag is the only sanctioned exception and the reason is reviewed.
+- **Errors.** Same error class, same message string, same raise site.
+
+**Only a genuine TypeScript language shortcoming can justify a deviation** —
+and even then, converge the shape as far as the language allows and keep the
+Rails name. There is almost always a way around:
+
+- Ruby `x=` that must be async → keep the Rails name in a `setX()` method
+  rather than renaming the concept (a TS `set` accessor can't be awaited).
+- Ruby `include SomeModule` → `include()` / `Included<>` from
+  `@blazetrails/activesupport`, or `this`-typed functions assigned to the class
+  (see "Module mixins" below), so the code still lives in the Rails file at the
+  Rails name.
+- Ruby kwargs, blocks, and `method_missing` each have a settled trails idiom.
+  Find it and use it; don't invent a new shape.
+
+"TypeScript can't do this" is a claim you have to actually try to disprove
+first. Deviation from Rails is almost always wrong; matching Rails is almost
+always right. Every deviation you do ship is justified **at the call site**,
+not in the PR body.
+
+### A documented deviation is debt, not permission
+
+Convergence is the goal. Every deviation register in this repo — the
+`call-mismatches-exclude` baselines, `arity-exclude.json`, `@noRailsEquivalent`,
+`@missingRailsCall`, `SKIP_GROUPS`, and every story under
+`0023-surfaced-deviations` — is a **burndown ledger**, not a settled decision. A
+row in one of them says "we know this is wrong and haven't fixed it yet." It is
+never a licence to leave it, to copy the pattern into new code, or to add a
+sibling row next to it.
+
+So:
+
+- **Finding an existing deviation next to your work is a reason to converge it,
+  not to match it.** If it's out of scope for your PR, file it
+  (`pnpm tasks new <rfc> <slug> --body-file <path>`) with the Rails `file:line`
+  you already have in front of you. Do not silently propagate the shape.
+- **A deviation-convergence story always converges.** Do not close one by
+  writing a better justification for the deviation, by broadening a baseline
+  reason, or by moving it to a different register. If it genuinely cannot
+  converge, `pnpm tasks block` it with the specific blocker — but that is rare,
+  and "it would be a bigger diff" is not one.
+- **Never widen an allowlist to cover new work.** Baselines are only-shrink by
+  construction; adding a row for code you are writing right now inverts the
+  entire mechanism.
+- **Only a genuine TypeScript language shortcoming is ratifiable**, and only
+  after you have tried the settled workaround above. "Cleaner in TS", "more
+  idiomatic", "the tests pass either way", and "this is how the rest of the file
+  does it" are not language shortcomings.
+
+### Ruby idioms that do not translate literally
+
+These are the recurring silent-divergence traps. Check each one whenever you
+port a body:
+
+- **Truthiness.** Ruby's `if x` is false only for `nil`/`false`. `Boolean(x)`
+  and `if (x)` are also false for `0`, `""`, and `NaN`. Port `if x` as
+  `x != null`, never as a bare truthiness test, unless you have checked the
+  value can't be `0`/`""`.
+- **`fetch` vs `??`.** `h.fetch(:k, default)` returns the _stored_ value
+  whenever the key exists — including a stored `nil` or `false`. `h.k ?? default`
+  substitutes the default for `null`/`undefined`. They differ, and Rails
+  relation readers depend on the difference.
+- **`present?` / `blank?` / `presence`.** Use the ActiveSupport analogues, not
+  `!!x` or `x?.length`. `" "` is blank in Ruby and truthy in JS.
+- **kwargs.** A TS default parameter swallows an explicitly-passed `undefined`,
+  so a caller forwarding an absent kwarg silently gets the default where Ruby
+  would have seen `nil`. Match Ruby's kwarg semantics explicitly when it matters.
+- **Predicates.** A Ruby predicate returns a value, not necessarily a boolean;
+  a value-returning predicate ported as a `boolean` breaks every call site that
+  used the value.
+- **Bang methods** raise; the non-bang form returns falsy. Port both arms.
+- **Symbols vs strings.** Where Rails accepts a Symbol _or_ a String, port both
+  arms — dropping the string arm is a common silent gap.
+
+If you find a new instance, file it against the best-fit active RFC, else
+`0023-surfaced-deviations`. RFC `0082-ruby-ts-idiom-conversion-classes` in the
+tasks repo enumerates these as convergence classes.
+
 ## Working in this repo
 
 - Do use worktrees for any changes; leave the default worktree for the user.
@@ -29,6 +139,15 @@ package list, and the `declare` / associations / enums / schema reference, see
   `file:line` instead of hand-grepping, run `pnpm rails:find <query>` — it
   reuses the test-compare / api-compare manifests and falls back to a scoped
   grep of `vendor/rails/activerecord/`, tagging each result with the mode.
+- Two reference tables answer "what do I call this?" without guessing, and both
+  are CI-verified current:
+  **[docs/ruby-ts-conventions.md](docs/ruby-ts-conventions.md)** for the
+  Ruby→TS name and file-path translations `api:compare` matches on (generated
+  from `scripts/api-compare/conventions.ts` — change the rule there, never
+  hand-edit the doc), and `SKIP_GROUPS` / `SCOPED_SKIP_GROUPS` in that same
+  source file for the members deliberately not mirrored, each with its reason.
+  If you think a Ruby name has no reasonable TS spelling, check `SKIP_GROUPS`
+  before inventing one.
 - Do NOT use subagents unless explicitly requested.
 - **AR work tracking lives in the `tasks` repo, not in docs.** Pick work via
   `pnpm tasks` (`ready` / `next-bundle` / `claim`) — never by hand-editing an
@@ -117,6 +236,56 @@ package list, and the `declare` / associations / enums / schema reference, see
   schema lacks, add it to the canonical schema — do not reach for a bespoke
   schema. (`defineSchema` is the retired trails invention being removed by RFC
   0059; don't reach for it in new tests.)
+
+## Before you open the PR
+
+Run these in order. All of them are fast next to a review round, and each one
+catches a class of drift a reviewer would otherwise spend a cycle on.
+
+1. **Size.**
+   `git diff --shortstat origin/main...HEAD -- ':!**/pnpm-lock.yaml' ':!**/__snapshots__/**' ':!**/*.md'`
+   — 500 LOC ceiling (see Conventions).
+2. **Did you touch a ported method body?** If yes, run the call-parity gates.
+   They detect the highest-frequency fidelity miss in this repo: a TS body that
+   omits a call the Rails body makes — a dropped delegation, an inlined helper,
+   an invented shortcut.
+
+   ```bash
+   API_COMPARE_FORCE=1 pnpm api:compare --wide-calls   # regenerate BOTH artifacts
+   pnpm api:calls                                      # narrow ratchet (RFC 0044)
+   pnpm api:calls:wide                                 # wide ratchet (RFC 0047)
+   ```
+
+   The regeneration is not optional: both lints read an artifact on disk, and
+   gating a stale one reports movement that never happened. A warm cache
+   under-reports, which is why the force flag is there.
+
+   **New mismatch?** The right fix is almost always to make the TS body call
+   what Rails calls. Baselining is the fallback, and it costs a reviewed
+   one-line `reason` — never leave the seeded placeholder (RFC 0083 ratchets the
+   count of unreviewed reasons; leaving placeholders reds the gate for whoever
+   comes next). A single justified omission can also carry a `@missingRailsCall`
+   JSDoc tag at the call site instead.
+
+   **Converged something?** The wide baseline is **only-shrink**: fixing a real
+   divergence makes its baseline row stale and turns the gate red. Delete that
+   one row by hand. Do **not** `--write`/reseed — a reseed reorders and re-emits
+   entries for untouched packages and produces an unreviewable diff.
+
+3. **Did you add any public TS name?** `pnpm api:extra --package <pkg>` — it
+   lists every public TS method, getter, class, and top-level function in a
+   Rails-matched file with no Ruby counterpart. Anything you added and can't
+   trace to a Ruby method is invented surface: delete it, fold it into the
+   ported method, or tag it `@noRailsEquivalent <reason>`. Do **not** reach for
+   a baseline allowlist to defer it. The tag is a receipt, not absolution — it
+   says "known extra surface, not yet removed", and someone will come back for
+   it.
+4. **Working in `arel` or `activemodel`?** `pnpm lint --fix` after step 2 —
+   `blazetrails/rails-file-structure-method-order` enforces Rails source order
+   for class members and top-level functions and is autofixable, but it needs
+   the manifest `pnpm api:compare` builds. Without a compare run it silently
+   passes everything, then fails in the `Rails API/Test Comparison` CI job.
+5. **`pnpm api:compare` / `pnpm test:compare`** deltas must be non-negative.
 
 ## Module mixins (Ruby `include` → TypeScript)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,13 @@ the `declare` / associations / enums / schema reference live in
   `isPersisted()`, `readAttribute()`, `writeAttribute()`) — not ad-hoc state.
   Handle composite primary keys (`primaryKey` can be `string | string[]`).
   Delegate to existing infrastructure; don't reimplement it.
-- **Ship behavior, not signatures.** Never commit a method that matches a
-  Rails API surface but returns null/undefined or only mutates in-memory
-  state when Rails hits the DB. A missing method is better than a misleading
-  one. `api:compare` coverage is a side effect of correct implementation.
+- **Ship behavior _and_ signatures.** Never commit a method that matches a
+  Rails API surface but returns null/undefined or only mutates in-memory state
+  when Rails hits the DB — a missing method is better than a misleading one.
+  The converse is equally true: correct behavior under a name, signature, or
+  structure Rails doesn't have is also a defect, because the next agent to port
+  a caller won't find it. `api:compare` coverage is a floor, not a goal; see
+  CLAUDE.md "Fidelity is the job" for the standard.
 - **Use the package ecosystem like Rails does.** In `activerecord`, build
   queries with `@blazetrails/arel` (Table, SelectManager, Nodes, Attribute) —
   never raw SQL strings. Use `@blazetrails/activemodel` for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,11 +89,19 @@ ratchet is a separate CI step (`.github/workflows/ci.yml`, jobs "API comparison
 **not** run: `api:compare` runs only the narrow call ratchet. Because the wide
 step runs only in CI, a PR that passes every local check can still fail the
 `rails-comparison` job (this happened in #5027). `pnpm api:calls:wide` runs the
-wide lint locally, but it lints an artifact that
-`scripts/api-compare/compare.ts --wide-calls` must regenerate first — so run
-`pnpm api:compare --wide-calls` (or `API_COMPARE_FORCE=1 pnpm api:compare
---wide-calls` to bypass the cache) before it, or the lint checks a stale
-artifact.
+wide lint locally, and since RFC 0083 a plain gating run **regenerates
+`output/call-mismatches-wide.json` itself** before linting
+(`lint-call-mismatches-wide.ts:68-78`, via `run.sh` so the extraction manifests
+compare.ts reads are refreshed first) — so the bare command is enough. It opts
+out of that regeneration under `--no-regen`, `API_COMPARE_SKIP_WIDE_REGEN=1`, or
+any CI value, and only then does it gate whatever artifact is on disk. Reach for
+`API_COMPARE_FORCE=1 pnpm api:compare --wide-calls` beforehand when you need to
+bypass a warm cache (it under-reports vs CI), remembering that the narrow and
+wide artifacts are separate: `compare.ts` writes `call-mismatches.json` on a
+normal run and `call-mismatches-wide.json` only under `--wide-calls`
+(`compare.ts:2543`), so one compare run never refreshes both. The pre-PR
+checklist in [CLAUDE.md](CLAUDE.md) is the authoritative workflow; this section
+explains the machinery behind it.
 
 The wide baseline is **only-shrink**: it fails not just on a _new_ mismatch but
 on a _converged_ one. Fixing a real divergence makes the corresponding baseline


### PR DESCRIPTION
Docs-only. Implements the CLAUDE.md / CONTRIBUTING.md / copilot-instructions.md
slice of the fidelity-instructions audit
(`~/.btwhooks/data/github/blazetrailsdev/trails/audits/fidelity-instructions-20260803T134718Z.md`).
The `messages.json` slice of that audit is already applied and live.

## Why

**CLAUDE.md contained no fidelity rule.** Its only fidelity content was about
test names (L104-107) and canonical tables (L108-119); nothing in any
implementer-facing doc said that method names, constant names, locals, control
flow, branch order, method decomposition, or file layout must mirror Rails.

The standard already existed — in the **reviewer's** prompt:

> "Go method by method, line by line, against the Rails source: method names,
> argument order and defaults, control flow, branch conditions, early returns,
> error/exception behavior, and edge-case handling should all mirror Rails.
> ANY deviation … is a finding. The bar is 'would a Rails dev recognize this as
> the same method,' not 'does it pass the tests.'"

The implementer never read it, so every fidelity finding cost a review round to
teach a rule we had already written down.

Evidence, from 15,925 reviews across 5,405 PRs plus 1,054 stories under
`0023-surfaced-deviations` (counts are strict/loose bounds — see the audit for
method): invented abstraction 112-564 PRs, Ruby-idiom mistranslation 142-300,
control flow / branch order 26-197, name fidelity 16-292.

Two supporting gaps this closes:

- `api:calls` and `api:extra` appeared **0 times** in CLAUDE.md and
  copilot-instructions.md; `api:calls:wide` only in CONTRIBUTING under
  "Measuring progress", framed as a CI gate you might trip rather than a drift
  detector you should run. These are the direct detectors for invented surface
  and dropped delegation.
- Nothing said that a documented deviation must still be converged. Six
  deviation registers plus 1,054 stories, all built as burndown ledgers, and no
  doc says so — a baselined row with a plausible `reason` reads to a fresh agent
  as a settled decision, so the deviation gets matched and extended instead of
  converged once.

## What changed

**CLAUDE.md** — three new sections:

- **"Fidelity is the job"** (placed first): the mirroring standard — names,
  locals and parameters, control flow, decomposition, no extra abstraction,
  errors. Only a genuine TypeScript language shortcoming justifies a deviation,
  and the settled workarounds are named (`setX()` where a Ruby `x=` setter must
  be async, `include()`/`Included<>` and `this`-typed functions for Ruby
  `include`), so "TypeScript can't do this" is a claim you have to try to
  disprove first.
- **"A documented deviation is debt, not permission"**: converge, never ratify.
  A convergence story always converges; never widen an allowlist to cover new
  work; finding an existing deviation next to your work is a reason to converge
  it, not to match it.
- **"Ruby idioms that do not translate literally"**: the recurring
  silent-divergence traps — truthiness, `fetch` vs `??`, `present?`/`blank?`,
  kwargs via TS default params, value-returning predicates, bang arms,
  symbol-vs-string.
- **"Before you open the PR"**: a numbered checklist wiring `api:calls`,
  `api:calls:wide` and `api:extra` into the standard workflow, with the
  regeneration prerequisite, the only-shrink trap, and the
  `rails-file-structure-method-order` manifest dependency stated.
- Reference pointer to `docs/ruby-ts-conventions.md` and `SKIP_GROUPS`.

**CONTRIBUTING.md** — "Ship behavior, not signatures" was the one sentence in
either doc pointing away from surface fidelity ("`api:compare` coverage is a
side effect of correct implementation"). Retargeted: correct behavior under a
name or structure Rails doesn't have is also a defect.

**.github/copilot-instructions.md** — the reviewer seed tells reviewers to read
this file in full and treat it as binding, and its entire fidelity statement was
one sentence about class/method names and signatures. Expanded to the same
standard, including locals, decomposition, member order, and the converge-never-
ratify rule (with baseline/tag additions flagged as reviewable by default).

## Notes

- Docs-only, so exempt from the 500 LOC ceiling: `git diff --shortstat` against
  the non-`.md` pathspec is empty.
- No code, no CI changes. Every drift class here already has a detector
  (`api:calls`, `api:calls:wide`, `api:extra`, `body-pins`,
  `rails-file-structure-method-order`); the gap was that agents were never told
  to run them.
- Not a story PR — this came out of an audit task.
- Deliberately out of scope, from the same audit: the reviewer-seed changes
  (add locals/decomposition/constants/member-order to the seed's check list;
  constrain what counts as `justified`; treat baseline/tag additions as findings
  by default). Those live in btwhooks `webhook/handler.go`, not this repo. Note
  that a per-repo `reviewer_prompt` key is **not** a safe vehicle for them: it
  replaces the whole hardcoded seed and would drop the
  `<!-- comments: N; open: M -->` sentinel btwhooks parses for cycle counting.
