### PR TITLE
feat(i18n): port Backend::Base, Backend::Simple and Utils

### DIFF
--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -10,6 +10,7 @@ import { Simple } from "./simple.js";
 import { config, resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import {
+  ArgumentError,
   InvalidLocale,
   InvalidPluralizationData,
   MissingTranslation,
@@ -32,6 +33,11 @@ describe("I18n::Backend::Base", () => {
   function translate(key: string | null, options: TranslateOptions = {}): unknown {
     return backend.translate("en", key, options);
   }
+
+  it("raises ArgumentError given an empty String or Symbol key", () => {
+    expect(() => translate("")).toThrow(ArgumentError);
+    expect(() => backend.translate("en", Symbol.for(""))).toThrow(ArgumentError);
+  });
 
   it("raises InvalidLocale given no locale", () => {
     expect(() => backend.translate(null, "foo")).toThrow(InvalidLocale);

--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Base-backend semantics the gem covers through `I18n::Tests::Basics` /
+ * `Defaults` / `Pluralization` rather than `simple_test.rb`; those suites are
+ * ported with their own story, so the throw/raise/default resolution order is
+ * pinned here in the meantime.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Simple } from "./simple.js";
+import { config, resetConfig } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import {
+  InvalidLocale,
+  InvalidPluralizationData,
+  MissingTranslation,
+  ReservedInterpolationKey,
+} from "../exceptions.js";
+import { ThrownException, catchException } from "../throw-catch.js";
+import type { TranslateOptions } from "./base.js";
+
+describe("I18n::Backend::Base", () => {
+  let backend: Simple;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    backend = new Simple();
+    config().backend = backend;
+    config().enforceAvailableLocales = false;
+  });
+
+  function translate(key: string | null, options: TranslateOptions = {}): unknown {
+    return backend.translate("en", key, options);
+  }
+
+  it("raises InvalidLocale given no locale", () => {
+    expect(() => backend.translate(null, "foo")).toThrow(InvalidLocale);
+  });
+
+  it("throws MissingTranslation when the key is missing", () => {
+    expect(() => translate("missing")).toThrow(ThrownException);
+
+    const thrown = catchException(() => translate("missing.key")) as MissingTranslation;
+    expect(thrown).toBeInstanceOf(MissingTranslation);
+    expect(thrown.message).toBe("Translation missing: en.missing.key");
+  });
+
+  it("does not throw when an explicit nil default is given", () => {
+    expect(translate("missing", { default: null })).toBeNull();
+  });
+
+  it("walks an array of defaults and resolves the first hit", () => {
+    backend.storeTranslations("en", { fallback: "Fallback" });
+    expect(translate("missing", { default: [Symbol.for("also_missing"), "Literal"] })).toBe(
+      "Literal",
+    );
+    expect(translate("missing", { default: [Symbol.for("fallback")] })).toBe("Fallback");
+  });
+
+  it("resolves a Symbol entry through the configured backend", () => {
+    backend.storeTranslations("en", { target: "Target", alias: Symbol.for("target") });
+    expect(translate("alias")).toBe("Target");
+  });
+
+  it("raises InvalidPluralizationData when the pluralization key is missing", () => {
+    backend.storeTranslations("en", { stars: { one: "one star" } });
+    expect(() => translate("stars", { count: 2 })).toThrow(InvalidPluralizationData);
+  });
+
+  it("picks the zero subkey only when it is present", () => {
+    backend.storeTranslations("en", {
+      with_zero: { zero: "none", one: "one", other: "many" },
+      without_zero: { one: "one", other: "many" },
+    });
+    expect(translate("with_zero", { count: 0 })).toBe("none");
+    expect(translate("without_zero", { count: 0 })).toBe("many");
+  });
+
+  it("ignores the attributes subkey when pluralizing", () => {
+    backend.storeTranslations("en", {
+      stars: { one: "one star", other: "many stars", attributes: { name: "Name" } },
+    });
+    expect(translate("stars", { count: 1 })).toBe("one star");
+  });
+
+  it("deep interpolates when deepInterpolation is set", () => {
+    backend.storeTranslations("en", { people: { ann: "Ann is %{ann}", john: "John is %{john}" } });
+    expect(translate("people", { deepInterpolation: true, ann: "good", john: "big" })).toEqual({
+      ann: "Ann is good",
+      john: "John is big",
+    });
+  });
+
+  it("raises ReservedInterpolationKey when an entry uses a reserved key", () => {
+    backend.storeTranslations("en", { reserved: "an entry with %{scope}" });
+    expect(() => translate("reserved")).toThrow(ReservedInterpolationKey);
+  });
+
+  it("exists reports whether a key resolves", () => {
+    backend.storeTranslations("en", { foo: { bar: "baz" } });
+    expect(backend.exists("en", "foo.bar")).toBe(true);
+    expect(backend.exists("en", "bar", { scope: "foo" })).toBe(true);
+    expect(backend.exists("en", "missing")).toBe(false);
+  });
+
+  it("availableLocales skips locales holding only i18n metadata", () => {
+    backend.storeTranslations("en", { foo: "bar" });
+    backend.storeTranslations("de", { i18n: { transliterate: {} } });
+    backend.storeTranslations("fr", {});
+    expect(backend.availableLocales()).toEqual(["en"]);
+  });
+});

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -126,13 +126,11 @@ export abstract class Base {
    */
   abstract availableLocales(): Locale[];
 
-  /** Mirrors: `reload!` */
-  reload(): void {
-    if (this.eagerLoaded()) this.eagerLoad();
+  reloadBang(): void {
+    if (this.eagerLoaded()) this.eagerLoadBang();
   }
 
-  /** Mirrors: `eager_load!` */
-  eagerLoad(): void {
+  eagerLoadBang(): void {
     this.eagerLoadedFlag = true;
   }
 

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -69,7 +69,7 @@ export abstract class Base {
     key: TranslationKey | symbol | null | undefined,
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
-    if (typeof key === "string" && key === "") throw new ArgumentError();
+    if (key === "") throw new ArgumentError();
     if (!truthy(locale)) throw new InvalidLocale(locale);
     if (key == null && !("default" in options)) return null;
 
@@ -191,8 +191,7 @@ export abstract class Base {
         // The gem goes through `I18n.translate`, which — with `throw: true` —
         // hands a MissingTranslation straight back to this `catch`, exactly as
         // calling the backend does. The `I18n.t` facade is not ported yet.
-        const backend = config().backend as unknown as Base;
-        return backend.translate(locale, symbolName(subject), {
+        return config().backend.translate(locale, symbolName(subject), {
           ...options,
           locale,
           throw: true,

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -69,7 +69,9 @@ export abstract class Base {
     key: TranslationKey | symbol | null | undefined,
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
-    if (key === "") throw new ArgumentError();
+    if (key === "" || (typeof key === "symbol" && symbolName(key) === "")) {
+      throw new ArgumentError();
+    }
     if (!truthy(locale)) throw new InvalidLocale(locale);
     if (key == null && !("default" in options)) return null;
 

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -1,0 +1,288 @@
+/**
+ * Mirrors: i18n/lib/i18n/backend/base.rb
+ *
+ * Ruby mixes `Base` into a backend with `include`; the JS equivalent is an
+ * abstract class that concrete backends extend, which keeps the file layout of
+ * the gem. The `NotImplementedError` members (`store_translations`, `lookup`,
+ * `available_locales`) are `abstract` here — TypeScript's form of the same
+ * contract.
+ *
+ * Ruby Symbols appear in two value positions this file cares about: a `default`
+ * that names another translation key, and a translation entry that redirects
+ * to one. Since a JS string is the analogue of a Ruby String, those use real JS
+ * symbols — `Symbol.for("some.key")` is the analogue of `:"some.key"`.
+ *
+ * Not ported here: `load_translations` / `load_file` / `load_rb` / `load_yml` /
+ * `load_json` (file loading needs a YAML reader and async fs — its own story),
+ * `localize` / `translate_localization_format`, and the `Transliterator` mixin.
+ */
+
+import {
+  ArgumentError,
+  InvalidLocale,
+  InvalidPluralizationData,
+  MissingTranslation,
+  ReservedInterpolationKey,
+} from "../exceptions.js";
+import {
+  EMPTY_HASH,
+  RESERVED_KEYS,
+  config,
+  reservedKeysPattern,
+  type Locale,
+  type TranslationKey,
+} from "../i18n.js";
+import { interpolate as interpolateString } from "../interpolate/ruby.js";
+import { throwException, catchException } from "../throw-catch.js";
+import { except, type TranslationData } from "../utils.js";
+
+export type TranslateOptions = { [key: string]: unknown };
+
+/** Ruby truthiness: only `nil` and `false` are falsy — `0` and `""` are not. */
+function truthy(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== false;
+}
+
+function isHash(value: unknown): value is TranslationData {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function symbolName(subject: symbol): string {
+  return Symbol.keyFor(subject) ?? subject.description ?? "";
+}
+
+export abstract class Base {
+  private eagerLoadedFlag = false;
+
+  /**
+   * This method receives a locale, a data hash and options for storing
+   * translations. Should be implemented.
+   */
+  abstract storeTranslations(
+    locale: Locale,
+    data: TranslationData,
+    options?: TranslateOptions,
+  ): unknown;
+
+  translate(
+    locale: Locale | null | undefined,
+    key: TranslationKey | symbol | null | undefined,
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    if (typeof key === "string" && key === "") throw new ArgumentError();
+    if (!truthy(locale)) throw new InvalidLocale(locale);
+    if (key == null && !("default" in options)) return null;
+
+    let entry: unknown =
+      key == null ? null : (this.lookup(locale!, key, options.scope, options) ?? null);
+
+    if (entry == null && "default" in options) {
+      entry = this.default(locale!, key, options.default, options);
+    } else {
+      entry = this.resolveEntry(locale!, key, entry, options);
+    }
+
+    const count = options.count;
+
+    if (entry == null && (this.subtrees() || !truthy(count))) {
+      if (("default" in options && options.default != null) || !("default" in options)) {
+        throwException(new MissingTranslation(locale!, key as TranslationKey, options));
+      }
+    }
+
+    if (truthy(count)) entry = this.pluralize(locale!, entry, count);
+
+    if (entry == null && !this.subtrees()) {
+      throwException(new MissingTranslation(locale!, key as TranslationKey, options));
+    }
+
+    const deepInterpolation = options.deepInterpolation;
+    const skipInterpolation = options.skipInterpolation;
+    const values = Object.keys(options).length > 0 ? except(options, ...RESERVED_KEYS) : undefined;
+    if (!truthy(skipInterpolation) && values && Object.keys(values).length > 0) {
+      entry = truthy(deepInterpolation)
+        ? this.deepInterpolate(locale!, entry, values)
+        : this.interpolate(locale!, entry, values);
+    } else if (typeof entry === "string") {
+      const reserved = reservedKeysPattern().exec(entry);
+      if (reserved) throw new ReservedInterpolationKey(reserved[1], entry);
+    }
+    return entry;
+  }
+
+  exists(
+    locale: Locale,
+    key: TranslationKey | symbol,
+    options: TranslateOptions = EMPTY_HASH,
+  ): boolean {
+    return this.lookup(locale, key, options.scope) != null;
+  }
+
+  /**
+   * Returns an array of locales for which translations are available ignoring
+   * the reserved translation meta data key `i18n`.
+   */
+  abstract availableLocales(): Locale[];
+
+  /** Mirrors: `reload!` */
+  reload(): void {
+    if (this.eagerLoaded()) this.eagerLoad();
+  }
+
+  /** Mirrors: `eager_load!` */
+  eagerLoad(): void {
+    this.eagerLoadedFlag = true;
+  }
+
+  protected eagerLoaded(): boolean {
+    return this.eagerLoadedFlag;
+  }
+
+  /** The method which actually looks up for the translation in the store. */
+  protected abstract lookup(
+    locale: Locale,
+    key: TranslationKey | symbol,
+    scope?: unknown,
+    options?: TranslateOptions,
+  ): unknown;
+
+  protected subtrees(): boolean {
+    return true;
+  }
+
+  /**
+   * Evaluates defaults. If given subject is an Array, it walks the array and
+   * returns the first translation that can be resolved. Otherwise it tries to
+   * resolve the translation directly.
+   */
+  protected default(
+    locale: Locale,
+    object: TranslationKey | symbol | null | undefined,
+    subject: unknown,
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    const rest =
+      Object.keys(options).length === 1 && "default" in options ? {} : except(options, "default");
+
+    if (Array.isArray(subject)) {
+      for (const item of subject) {
+        const result = this.resolve(locale, object, item, rest);
+        if (result != null) return result;
+      }
+      return null;
+    }
+    return this.resolve(locale, object, subject, rest);
+  }
+
+  /**
+   * Resolves a translation. If the given subject is a Symbol, it will be
+   * translated with the given options. If it is a Proc then it will be
+   * evaluated. All other subjects will be returned directly.
+   */
+  protected resolve(
+    locale: Locale,
+    object: TranslationKey | symbol | null | undefined,
+    subject: unknown,
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    if (options.resolve === false) return subject;
+    const result = catchException(() => {
+      if (typeof subject === "symbol") {
+        // The gem goes through `I18n.translate`, which — with `throw: true` —
+        // hands a MissingTranslation straight back to this `catch`, exactly as
+        // calling the backend does. The `I18n.t` facade is not ported yet.
+        const backend = config().backend as unknown as Base;
+        return backend.translate(locale, symbolName(subject), {
+          ...options,
+          locale,
+          throw: true,
+          skipInterpolation: true,
+        });
+      }
+      if (typeof subject === "function") {
+        const dateOrTime = options.object ?? object;
+        const rest = except(options, "object");
+        return this.resolve(
+          locale,
+          object,
+          (subject as (value: unknown, options: TranslateOptions) => unknown)(dateOrTime, rest),
+        );
+      }
+      return subject;
+    });
+    return result instanceof MissingTranslation ? null : result;
+  }
+
+  protected resolveEntry(
+    locale: Locale,
+    object: TranslationKey | symbol | null | undefined,
+    subject: unknown,
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    return this.resolve(locale, object, subject, options);
+  }
+
+  /**
+   * Picks a translation from a pluralized mnemonic subkey according to English
+   * pluralization rules:
+   * - It will pick the `one` subkey if count is equal to 1.
+   * - It will pick the `other` subkey otherwise.
+   * - It will pick the `zero` subkey in the special case where count is equal
+   *   to 0 and there is a `zero` subkey present. This behaviour is not standard
+   *   with regards to the CLDR pluralization rules.
+   */
+  protected pluralize(_locale: Locale, entry: unknown, count: unknown): unknown {
+    const subject = isHash(entry) ? except(entry, "attributes") : entry;
+    if (!isHash(subject) || !truthy(count)) return subject;
+
+    const key = this.pluralizationKey(subject, count);
+    if (!(key in subject)) throw new InvalidPluralizationData(subject, count, key);
+    return subject[key];
+  }
+
+  /**
+   * Interpolates values into a given subject. Arrays are interpolated
+   * element-wise, recursively.
+   */
+  protected interpolate(
+    locale: Locale,
+    subject: unknown,
+    values: TranslationData = EMPTY_HASH,
+  ): unknown {
+    if (Object.keys(values).length === 0) return subject;
+    if (typeof subject === "string") return interpolateString(subject, values);
+    if (Array.isArray(subject)) {
+      return subject.map((element) => this.interpolate(locale, element, values));
+    }
+    return subject;
+  }
+
+  /**
+   * Deep interpolation.
+   *
+   *     deepInterpolate({ people: { ann: "Ann is %{ann}" } }, { ann: "good" })
+   *     //=> { people: { ann: "Ann is good" } }
+   */
+  protected deepInterpolate(
+    locale: Locale,
+    data: unknown,
+    values: TranslationData = EMPTY_HASH,
+  ): unknown {
+    if (Object.keys(values).length === 0) return data;
+    if (typeof data === "string") return interpolateString(data, values);
+    if (Array.isArray(data)) return data.map((v) => this.deepInterpolate(locale, v, values));
+    if (isHash(data)) {
+      const result: TranslationData = {};
+      for (const [k, v] of Object.entries(data)) {
+        result[k] = this.deepInterpolate(locale, v, values);
+      }
+      return result;
+    }
+    return data;
+  }
+
+  protected pluralizationKey(entry: TranslationData, count: unknown): string {
+    if (count === 0 && "zero" in entry) return "zero";
+    return count === 1 ? "one" : "other";
+  }
+}

--- a/packages/i18n/src/backend/simple.test.ts
+++ b/packages/i18n/src/backend/simple.test.ts
@@ -140,7 +140,7 @@ describe("I18nBackendSimpleTest", () => {
     storeTranslations("fr", data);
     expect(translations()["fr"]).toEqual({ foo: { bar: "barfr", baz: "bazfr" } });
 
-    backend.reload();
+    backend.reloadBang();
 
     backend.storeTranslations("fr", data, { skipSymbolizeKeys: true });
     // JS object keys are already strings, so the only observable difference is
@@ -153,24 +153,24 @@ describe("I18nBackendSimpleTest", () => {
 
   it("simple reload_translations: unloads translations", () => {
     storeTranslations("en", { foo: "bar" });
-    backend.reload();
+    backend.reloadBang();
     expect(translations()).toEqual({});
   });
 
   it("simple reload_translations: uninitializes the backend", () => {
-    backend.reload();
+    backend.reloadBang();
     expect(backend.initialized()).toBe(false);
   });
 
   it("simple eager_load!: loads the translations", () => {
     expect(backend.initialized()).toBe(false);
-    backend.eagerLoad();
+    backend.eagerLoadBang();
     expect(backend.initialized()).toBe(true);
   });
 
   it("simple reload!: reinitialize the backend if it was previously eager loaded", () => {
-    backend.eagerLoad();
-    backend.reload();
+    backend.eagerLoadBang();
+    backend.reloadBang();
     expect(backend.initialized()).toBe(true);
   });
 

--- a/packages/i18n/src/backend/simple.test.ts
+++ b/packages/i18n/src/backend/simple.test.ts
@@ -1,0 +1,200 @@
+/** Mirrors: i18n/test/backend/simple_test.rb */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Simple } from "./simple.js";
+import { config, resetConfig, type TranslationKey } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import { catchException } from "../throw-catch.js";
+import type { TranslateOptions } from "./base.js";
+import type { TranslationData } from "../utils.js";
+
+describe("I18nBackendSimpleTest", () => {
+  let backend: Simple;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    backend = new Simple();
+    config().backend = backend;
+    config().enforceAvailableLocales = false;
+  });
+
+  function storeTranslations(locale: string, data: TranslationData): unknown {
+    return backend.storeTranslations(locale, data);
+  }
+
+  function translations(): TranslationData {
+    return backend.translations();
+  }
+
+  /** Stands in for `I18n.t`, which the facade story ports. */
+  function t(key: TranslationKey | null, options: TranslateOptions = {}): unknown {
+    return catchException(() => backend.translate("en", key, options));
+  }
+
+  // useful because this way we can use the backend with no key for interpolation/pluralization
+  it("simple backend translate: given nil as a key it still interpolations the default value", () => {
+    expect(t(null, { default: "Hi %{name}", name: "David" })).toBe("Hi David");
+  });
+
+  it("simple backend translate: given true as a key", () => {
+    storeTranslations("en", { available: { true: "Yes", false: "No" } });
+    expect((t("available") as TranslationData)["true"]).toBe("Yes");
+    expect((t("available") as TranslationData)["false"]).toBe("No");
+  });
+
+  it("simple backend translate: given integer as a key", () => {
+    storeTranslations("en", {
+      available: { "-1": "Possibly", 0: "Maybe", 1: "Yes", 2: "No", 3: "Never" },
+    });
+    expect((t("available") as TranslationData)["-1"]).toBe("Possibly");
+    expect(t("available.-1")).toBe("Possibly");
+    expect((t("available") as TranslationData)[0]).toBe("Maybe");
+    expect(t("available.0")).toBe("Maybe");
+    expect((t("available") as TranslationData)[1]).toBe("Yes");
+    expect(t("available.1")).toBe("Yes");
+    expect((t("available") as TranslationData)[2]).toBe("No");
+    expect(t("available.2")).toBe("No");
+    expect((t("available") as TranslationData)[3]).toBe("Never");
+    expect(t("available.+3")).toBe("Never");
+  });
+
+  it("simple backend translate: given integer with a leading positive/negative sign", () => {
+    storeTranslations("en", { available: { "-1": "No", 0: "Maybe", 1: "Yes" } });
+    expect((t("available") as TranslationData)["-1"]).toBe("No");
+    expect(t("available.-1")).toBe("No");
+    expect((t("available") as TranslationData)[0]).toBe("Maybe");
+    expect(t("available.-0")).toBe("Maybe");
+    expect(t("available.+0")).toBe("Maybe");
+    expect((t("available") as TranslationData)[1]).toBe("Yes");
+    expect(t("available.+1")).toBe("Yes");
+  });
+
+  it("simple backend translate: given integer with a lead zero as a key", () => {
+    storeTranslations("en", { available: { "01": "foo" } });
+    expect((t("available") as TranslationData)["01"]).toBe("foo");
+    expect(t("available.01")).toBe("foo");
+  });
+
+  it("simple backend translate: symbolize keys in hash", () => {
+    storeTranslations("en", { nested_hashes_in_array: { hello: "world" } });
+    expect(t("nested_hashes_in_array.hello")).toBe("world");
+    expect((t("nested_hashes_in_array") as TranslationData)["hello"]).toBe("world");
+  });
+
+  it("simple backend translate: symbolize keys in array", () => {
+    storeTranslations("en", { nested_hashes_in_array: [{ hello: "world" }] });
+    for (const val of t("nested_hashes_in_array") as TranslationData[]) {
+      expect(val["hello"]).toBe("world");
+    }
+  });
+
+  // storing translations
+
+  it("simple store_translations: stores translations, ... no, really :-)", () => {
+    storeTranslations("en", { foo: "bar" });
+    expect(translations()).toEqual({ en: { foo: "bar" } });
+  });
+
+  it("simple store_translations: deep_merges with existing translations", () => {
+    storeTranslations("en", { foo: { bar: "bar" } });
+    storeTranslations("en", { foo: { baz: "baz" } });
+    expect(translations()).toEqual({ en: { foo: { bar: "bar", baz: "baz" } } });
+  });
+
+  it("simple store_translations: converts keys to Symbols", () => {
+    storeTranslations("en", { foo: { bar: "bar", baz: "baz" } });
+    expect(translations()).toEqual({ en: { foo: { bar: "bar", baz: "baz" } } });
+  });
+
+  it("simple store_translations: do not store translations unavailable locales if enforce_available_locales is true", () => {
+    try {
+      config().enforceAvailableLocales = true;
+      config().availableLocales = ["en", "es"];
+      storeTranslations("fr", { foo: { bar: "barfr", baz: "bazfr" } });
+      storeTranslations("es", { foo: { bar: "bares", baz: "bazes" } });
+      // Ruby's Concurrent::Hash default block hands back `{}` for the missing
+      // `:fr` key; a plain JS object has nothing there.
+      expect(translations()["fr"]).toBeUndefined();
+      expect(translations()["es"]).toEqual({ foo: { bar: "bares", baz: "bazes" } });
+    } finally {
+      config().enforceAvailableLocales = false;
+    }
+  });
+
+  it("simple store_translations: store translations for unavailable locales if enforce_available_locales is false", () => {
+    config().availableLocales = ["en", "es"];
+    storeTranslations("fr", { foo: { bar: "barfr", baz: "bazfr" } });
+    expect(translations()["fr"]).toEqual({ foo: { bar: "barfr", baz: "bazfr" } });
+  });
+
+  it("simple store_translations: supports numeric keys", () => {
+    storeTranslations("en", { 1: "foo" });
+    expect(t("1")).toBe("foo");
+    expect(t(1)).toBe("foo");
+  });
+
+  it("simple store_translations: store translations doesn't deep symbolize keys if skip_symbolize_keys is true", () => {
+    const data = { foo: { bar: "barfr", baz: "bazfr" } };
+
+    storeTranslations("fr", data);
+    expect(translations()["fr"]).toEqual({ foo: { bar: "barfr", baz: "bazfr" } });
+
+    backend.reload();
+
+    backend.storeTranslations("fr", data, { skipSymbolizeKeys: true });
+    // JS object keys are already strings, so the only observable difference is
+    // that the stored subtree is the caller's object rather than a deep copy.
+    expect(translations()["fr"]).toEqual({ foo: { bar: "barfr", baz: "bazfr" } });
+    expect((translations()["fr"] as TranslationData)["foo"]).toBe(data.foo);
+  });
+
+  // reloading translations
+
+  it("simple reload_translations: unloads translations", () => {
+    storeTranslations("en", { foo: "bar" });
+    backend.reload();
+    expect(translations()).toEqual({});
+  });
+
+  it("simple reload_translations: uninitializes the backend", () => {
+    backend.reload();
+    expect(backend.initialized()).toBe(false);
+  });
+
+  it("simple eager_load!: loads the translations", () => {
+    expect(backend.initialized()).toBe(false);
+    backend.eagerLoad();
+    expect(backend.initialized()).toBe(true);
+  });
+
+  it("simple reload!: reinitialize the backend if it was previously eager loaded", () => {
+    backend.eagerLoad();
+    backend.reload();
+    expect(backend.initialized()).toBe(true);
+  });
+
+  it("Nested keys within pluralization context", () => {
+    storeTranslations("en", {
+      stars: {
+        one: "%{count} star",
+        other: "%{count} stars",
+        special: {
+          one: "%{count} special star",
+          other: "%{count} special stars",
+        },
+      },
+    });
+    expect(t("stars", { count: 1 })).toBe("1 star");
+    expect(t("stars", { count: 20 })).toBe("20 stars");
+    expect(t("stars.special", { count: 1 })).toBe("1 special star");
+    expect(t("stars.special", { count: 20 })).toBe("20 special stars");
+  });
+
+  it("returns localized string given missing pluralization data", () => {
+    // The gem's setup loads this pair from `test/test_data/locales/en.yml`;
+    // file loading lands with its own story.
+    storeTranslations("en", { foo: { bar: "baz" } });
+    expect(t("foo.bar", { count: 1 })).toBe("baz");
+  });
+});

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -20,7 +20,7 @@ import {
   type Locale,
   type TranslationKey,
 } from "../i18n.js";
-import { deepMergeInPlace, deepSymbolizeKeys, except, type TranslationData } from "../utils.js";
+import { deepMergeBang, deepSymbolizeKeys, except, type TranslationData } from "../utils.js";
 import { Base, type TranslateOptions } from "./base.js";
 
 function isHash(value: unknown): value is TranslationData {
@@ -56,7 +56,7 @@ export class Simple extends Base {
     const translations = this.translations();
     translations[locale] ??= {};
     const payload = options.skipSymbolizeKeys ? data : deepSymbolizeKeys(data);
-    return deepMergeInPlace(translations[locale] as TranslationData, payload);
+    return deepMergeBang(translations[locale] as TranslationData, payload);
   }
 
   /** Get available locales from the translations hash. */
@@ -72,15 +72,15 @@ export class Simple extends Base {
   }
 
   /** Clean up translations hash and set initialized to false on reload. */
-  override reload(): void {
+  override reloadBang(): void {
     this.initializedFlag = false;
     this.translationsStore = undefined;
-    super.reload();
+    super.reloadBang();
   }
 
-  override eagerLoad(): void {
+  override eagerLoadBang(): void {
     if (!this.initialized()) this.initTranslations();
-    super.eagerLoad();
+    super.eagerLoadBang();
   }
 
   translations({ doInit = false }: { doInit?: boolean } = {}): TranslationData {

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -1,0 +1,140 @@
+/**
+ * Mirrors: i18n/lib/i18n/backend/simple.rb
+ *
+ * A simple backend that reads translations from an in-memory hash. Relies on
+ * the Base backend.
+ *
+ * The gem splits the code into a `Simple::Implementation` module so other
+ * modules can be `include`d over it; TypeScript has no module reopening, so
+ * `Simple` is a single class extending `Base`. There is likewise no `MUTEX` —
+ * JS has no threads, so the concurrent-hash machinery has nothing to guard.
+ */
+
+import { registerDefaultBackend } from "../config.js";
+import {
+  EMPTY_HASH,
+  availableLocalesInitialized,
+  config,
+  localeAvailable,
+  normalizeKeys,
+  type Locale,
+  type TranslationKey,
+} from "../i18n.js";
+import { deepMergeInPlace, deepSymbolizeKeys, except, type TranslationData } from "../utils.js";
+import { Base, type TranslateOptions } from "./base.js";
+
+function isHash(value: unknown): value is TranslationData {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class Simple extends Base {
+  private initializedFlag = false;
+  private translationsStore: TranslationData | undefined;
+
+  /** Mirrors: `initialized?` */
+  initialized(): boolean {
+    return this.initializedFlag;
+  }
+
+  /**
+   * Stores translations for the given locale in memory. This uses a deep merge
+   * for the translations hash, so existing translations will be overwritten by
+   * new ones only at the deepest level of the hash.
+   */
+  override storeTranslations(
+    locale: Locale,
+    data: TranslationData,
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    if (
+      config().enforceAvailableLocales &&
+      availableLocalesInitialized() &&
+      !localeAvailable(locale)
+    ) {
+      return data;
+    }
+    const translations = this.translations();
+    translations[locale] ??= {};
+    const payload = options.skipSymbolizeKeys ? data : deepSymbolizeKeys(data);
+    return deepMergeInPlace(translations[locale] as TranslationData, payload);
+  }
+
+  /** Get available locales from the translations hash. */
+  override availableLocales(): Locale[] {
+    if (!this.initialized()) this.initTranslations();
+    const locales: Locale[] = [];
+    for (const [locale, data] of Object.entries(this.translations())) {
+      const entries = isHash(data) ? Object.keys(data) : [];
+      const onlyMetadata = entries.length <= 1 && (entries.length === 0 || entries[0] === "i18n");
+      if (!onlyMetadata) locales.push(locale);
+    }
+    return locales;
+  }
+
+  /** Clean up translations hash and set initialized to false on reload. */
+  override reload(): void {
+    this.initializedFlag = false;
+    this.translationsStore = undefined;
+    super.reload();
+  }
+
+  override eagerLoad(): void {
+    if (!this.initialized()) this.initTranslations();
+    super.eagerLoad();
+  }
+
+  translations({ doInit = false }: { doInit?: boolean } = {}): TranslationData {
+    // To avoid returning empty translations, call `initTranslations`.
+    if (doInit && !this.initialized()) this.initTranslations();
+
+    this.translationsStore ??= {};
+    return this.translationsStore;
+  }
+
+  /**
+   * The gem's `init_translations` calls `load_translations` first; file loading
+   * lands with its own story, so for now this only flips the flag.
+   */
+  protected initTranslations(): void {
+    this.initializedFlag = true;
+  }
+
+  /**
+   * Looks up a translation from the translations hash. Returns null if either
+   * key is null, or locale, scope or key do not exist as a key in the nested
+   * translations hash. Splits keys or scopes containing dots into multiple
+   * keys, i.e. `currency.format` is regarded the same as `["currency",
+   * "format"]`.
+   */
+  protected override lookup(
+    locale: Locale,
+    key: TranslationKey | symbol,
+    scope: unknown = [],
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    if (!this.initialized()) this.initTranslations();
+    const name = typeof key === "symbol" ? (Symbol.keyFor(key) ?? key.description) : key;
+    const keys = normalizeKeys(locale, name, scope, options.separator as string | undefined);
+
+    let result: unknown = this.translations();
+    for (const rawKey of keys) {
+      if (!isHash(result)) return null;
+      // Ruby retries the lookup with `_key.to_s.to_sym`; JS object keys are
+      // already strings, so the string form is the only form.
+      const segment = String(rawKey);
+      if (!(segment in result)) return null;
+      result = result[segment];
+      if (typeof result === "symbol") {
+        result = this.resolveEntry(
+          locale,
+          segment,
+          result,
+          except({ ...options, scope: null }, "count"),
+        );
+      }
+    }
+    return result;
+  }
+}
+
+registerDefaultBackend(() => new Simple());

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -11,7 +11,7 @@ class FakeBackend implements Backend {
   availableLocales(): string[] {
     return this.locales;
   }
-  reload(): void {
+  reloadBang(): void {
     this.reloaded += 1;
   }
   translate(): unknown {

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -14,6 +14,9 @@ class FakeBackend implements Backend {
   reload(): void {
     this.reloaded += 1;
   }
+  translate(): unknown {
+    return null;
+  }
 }
 
 /**

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -9,7 +9,7 @@ import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
 /** The slice of a backend `Config` hands out. */
 export interface Backend {
   availableLocales(): Locale[];
-  reload(): void;
+  reloadBang(): void;
   translate(locale: Locale, key: unknown, options?: Record<string, unknown>): unknown;
 }
 
@@ -160,7 +160,7 @@ export class Config {
   set loadPath(value: string[]) {
     loadPath = value;
     availableLocalesSet = undefined;
-    this.backend.reload();
+    this.backend.reloadBang();
   }
 
   /** Whether to verify locales are in the available list. Defaults to true. */

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -6,10 +6,11 @@ import { enforceAvailableLocales, type Locale, type TranslationKey } from "./i18
 import { ExceptionHandler, MissingInterpolationArgument } from "./exceptions.js";
 import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
 
-/** The slice of a backend `Config` itself calls. */
+/** The slice of a backend `Config` hands out. */
 export interface Backend {
   availableLocales(): Locale[];
   reload(): void;
+  translate(locale: Locale, key: unknown, options?: Record<string, unknown>): unknown;
 }
 
 export type ExceptionHandlerLike = {

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -10,7 +10,8 @@
 import { EMPTY_HASH, normalizeKeys } from "./i18n.js";
 import type { Locale, TranslationKey } from "./i18n.js";
 
-function inspect(value: unknown): string {
+/** @internal Ruby `Object#inspect`, as far as the values reaching this file go. */
+export function inspect(value: unknown): string {
   if (value === null || value === undefined) return "nil";
   if (typeof value === "string") return JSON.stringify(value);
   if (typeof value === "function") return "#<Proc>";

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -14,6 +14,54 @@ export type TranslationKey = string | number | boolean;
 
 export const EMPTY_HASH: Readonly<Record<string, never>> = Object.freeze({});
 
+/**
+ * The gem spells these as snake_case Symbols because they double as option
+ * keys; trails option keys are camelCase, so these follow suit.
+ * `reservedKeysPattern` still recognizes the snake_case spellings, since those
+ * are what appears inside translation data written for Ruby.
+ */
+export const RESERVED_KEYS: string[] = [
+  "cascade",
+  "deepInterpolation",
+  "skipInterpolation",
+  "default",
+  "exceptionHandler",
+  "fallback",
+  "fallbackInProgress",
+  "fallbackOriginalLocale",
+  "format",
+  "object",
+  "raise",
+  "resolve",
+  "scope",
+  "separator",
+  "throw",
+];
+
+function underscore(key: string): string {
+  return key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+}
+
+let reservedKeysPatternCache: RegExp | undefined;
+
+/**
+ * Mirrors: I18n.reserve_key. Reserved keys are used internally and can't also
+ * be used for interpolation.
+ */
+export function reserveKey(key: string): void {
+  RESERVED_KEYS.push(key);
+  reservedKeysPatternCache = undefined;
+}
+
+/** Mirrors: I18n.reserved_keys_pattern */
+export function reservedKeysPattern(): RegExp {
+  if (!reservedKeysPatternCache) {
+    const spellings = new Set(RESERVED_KEYS.flatMap((key) => [key, underscore(key)]));
+    reservedKeysPatternCache = new RegExp(`(?<!%)%\\{(${[...spellings].join("|")})\\}`);
+  }
+  return reservedKeysPatternCache;
+}
+
 let currentConfig: Config | undefined;
 
 /**

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -18,13 +18,26 @@ export {
   UnknownFileType,
 } from "./exceptions.js";
 export type { MissingTranslationOptions } from "./exceptions.js";
-export { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
+export {
+  DEFAULT_INTERPOLATION_PATTERNS,
+  interpolate,
+  interpolateHash,
+} from "./interpolate/ruby.js";
 export {
   EMPTY_HASH,
+  RESERVED_KEYS,
   availableLocalesInitialized,
   config,
   enforceAvailableLocales,
   localeAvailable,
   normalizeKeys,
+  reserveKey,
+  reservedKeysPattern,
 } from "./i18n.js";
 export type { Locale, TranslationKey } from "./i18n.js";
+export { Base } from "./backend/base.js";
+export type { TranslateOptions } from "./backend/base.js";
+export { Simple } from "./backend/simple.js";
+export { ThrownException, catchException, throwException } from "./throw-catch.js";
+export { deepMerge, deepMergeInPlace, deepSymbolizeKeys, except } from "./utils.js";
+export type { TranslationData } from "./utils.js";

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -39,5 +39,5 @@ export { Base } from "./backend/base.js";
 export type { TranslateOptions } from "./backend/base.js";
 export { Simple } from "./backend/simple.js";
 export { ThrownException, catchException, throwException } from "./throw-catch.js";
-export { deepMerge, deepMergeInPlace, deepSymbolizeKeys, except } from "./utils.js";
+export { deepMerge, deepMergeBang, deepSymbolizeKeys, except } from "./utils.js";
 export type { TranslationData } from "./utils.js";

--- a/packages/i18n/src/interpolate/ruby.trails.test.ts
+++ b/packages/i18n/src/interpolate/ruby.trails.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The gem covers `I18n.interpolate` through `test/i18n_test.rb`, which the
+ * facade story ports. What is pinned here is the `%<name>fmt` branch: Ruby
+ * delegates it to `sprintf`, JS has no such builtin, so every expectation below
+ * is the literal output of the matching `sprintf` call in Ruby.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { interpolate } from "./ruby.js";
+import { resetConfig } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import { MissingInterpolationArgument, ReservedInterpolationKey } from "../exceptions.js";
+
+describe("I18n.interpolate", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+  });
+
+  it("interpolates %{} placeholders", () => {
+    expect(interpolate("file %{file} opened by %%{user}", { file: "test.txt" })).toBe(
+      "file test.txt opened by %{user}",
+    );
+  });
+
+  it("calls a callable value with the values hash", () => {
+    const values = {
+      gender: "w",
+      name: (v: { gender: string }) => (v.gender === "m" ? "Mr" : "Mrs"),
+    };
+    expect(interpolate("%{name}", values)).toBe("Mrs");
+  });
+
+  it("raises MissingInterpolationArgument for an absent key", () => {
+    expect(() => interpolate("%{name}", {})).toThrow(MissingInterpolationArgument);
+  });
+
+  it("raises ReservedInterpolationKey for a reserved key", () => {
+    expect(() => interpolate("%{scope}", { scope: "x" })).toThrow(ReservedInterpolationKey);
+  });
+
+  it("formats %<> placeholders the way sprintf does", () => {
+    const cases: [string, unknown, string][] = [
+      ["%<v>#x", 255, "0xff"],
+      ["%<v>#o", 8, "010"],
+      ["%<v>+d", 42, "+42"],
+      ["%<v>08.2f", -3.14159, "-0003.14"],
+      ["%<v>.2e", 1234.5, "1.23e+03"],
+      ["%<v>.3g", 1234.5678, "1.23e+03"],
+      ["%<v>g", 0.0001234, "0.0001234"],
+      ["%<v>g", 100000.0, "100000"],
+      ["%<v>g", 1000000.0, "1e+06"],
+      ["%<v>g", 1.5, "1.5"],
+      ["%<v>-6s", "hi", "hi    "],
+      ["%<v>.3s", "hello", "hel"],
+    ];
+    for (const [format, value, expected] of cases) {
+      expect(interpolate(format, { v: value })).toBe(expected);
+    }
+  });
+});

--- a/packages/i18n/src/interpolate/ruby.trails.test.ts
+++ b/packages/i18n/src/interpolate/ruby.trails.test.ts
@@ -42,6 +42,15 @@ describe("I18n.interpolate", () => {
   it("formats %<> placeholders the way sprintf does", () => {
     const cases: [string, unknown, string][] = [
       ["%<v>#x", 255, "0xff"],
+      ["%<v>#x", 0, "0"],
+      ["%<v>#b", 0, "0"],
+      ["%<v>d", 1.9, "1"],
+      ["%<v>d", -1.9, "-1"],
+      ["%<v>i", -3.9, "-3"],
+      ["%<v>p", "abc", '"abc"'],
+      ["%<v>p", 123, "123"],
+      ["%<v>p", null, "nil"],
+      ["%<v>.3p", "abcdef", '"ab'],
       ["%<v>#o", 8, "010"],
       ["%<v>+d", 42, "+42"],
       ["%<v>08.2f", -3.14159, "-0003.14"],

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -6,7 +6,7 @@
  * groups in the same positions.
  */
 
-import { ArgumentError, ReservedInterpolationKey } from "../exceptions.js";
+import { ArgumentError, ReservedInterpolationKey, inspect } from "../exceptions.js";
 import { config, reservedKeysPattern } from "../i18n.js";
 
 export const DEFAULT_INTERPOLATION_PATTERNS: readonly RegExp[] = Object.freeze([
@@ -71,7 +71,8 @@ const ALTERNATE_PREFIX: Record<string, string> = { b: "0b", B: "0B", o: "0", x: 
 
 /**
  * Ruby hands `%<name>fmt` to `sprintf`; JS has no equivalent, so the
- * conversions the interpolation pattern admits (`bBdiouxXeEfgGcps`) are
+ * conversions the interpolation pattern admits (`bBdiouxXeEfgGcps`, `p`
+ * included) are
  * reimplemented here, along with the `-+ #0` flags, width and precision that
  * `sprintf` applies to them.
  */
@@ -80,16 +81,17 @@ function sprintf(spec: string, value: unknown): string {
   if (!parsed) return String(value);
   const [, flags = "", width = "", precision, conversion = "s"] = parsed;
   const digits = precision === undefined ? 6 : Number(precision);
-  const numeric = conversion !== "c" && conversion !== "s";
+  const numeric = !"csp".includes(conversion);
   const alternate = flags.includes("#");
   const magnitude = Math.abs(Number(value));
 
   let body: string;
   if (conversion in RADIX) {
     body = Math.trunc(magnitude).toString(RADIX[conversion]);
-    if (alternate) body = ALTERNATE_PREFIX[conversion] + body;
+    // Ruby omits the alternate-form prefix for zero.
+    if (alternate && Number(value) !== 0) body = ALTERNATE_PREFIX[conversion] + body;
   } else if ("diu".includes(conversion)) {
-    body = String(Math.round(magnitude));
+    body = String(Math.trunc(magnitude));
   } else if (conversion === "e" || conversion === "E") {
     body = exponential(magnitude, digits);
     if (alternate && digits === 0) body = body.replace("e", ".e");
@@ -101,7 +103,8 @@ function sprintf(spec: string, value: unknown): string {
   } else if (conversion === "c") {
     body = typeof value === "number" ? String.fromCodePoint(value) : String(value).charAt(0);
   } else {
-    body = precision === undefined ? String(value) : String(value).slice(0, digits);
+    body = conversion === "p" ? inspect(value) : String(value);
+    if (precision !== undefined) body = body.slice(0, digits);
   }
   if (conversion === conversion.toUpperCase() && numeric) body = body.toUpperCase();
 

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -67,10 +67,13 @@ export function interpolateHash(string: string, values: Record<string, unknown>)
 const FORMAT_SPEC = /^([-+ #0]*)(\d*)(?:\.(\d+))?([a-zA-Z])$/;
 
 const RADIX: Record<string, number> = { b: 2, B: 2, o: 8, x: 16, X: 16 };
+const ALTERNATE_PREFIX: Record<string, string> = { b: "0b", B: "0B", o: "0", x: "0x", X: "0X" };
 
 /**
- * Mirrors Ruby's `sprintf("%#{spec}", value)` for the conversions the `%<>`
- * interpolation pattern admits (`bBdiouxXeEfgGcps`).
+ * Ruby hands `%<name>fmt` to `sprintf`; JS has no equivalent, so the
+ * conversions the interpolation pattern admits (`bBdiouxXeEfgGcps`) are
+ * reimplemented here, along with the `-+ #0` flags, width and precision that
+ * `sprintf` applies to them.
  */
 function sprintf(spec: string, value: unknown): string {
   const parsed = FORMAT_SPEC.exec(spec);
@@ -78,15 +81,24 @@ function sprintf(spec: string, value: unknown): string {
   const [, flags = "", width = "", precision, conversion = "s"] = parsed;
   const digits = precision === undefined ? 6 : Number(precision);
   const numeric = conversion !== "c" && conversion !== "s";
+  const alternate = flags.includes("#");
   const magnitude = Math.abs(Number(value));
 
   let body: string;
-  if (conversion in RADIX) body = Math.trunc(magnitude).toString(RADIX[conversion]);
-  else if ("diu".includes(conversion)) body = String(Math.round(magnitude));
-  else if (conversion === "e" || conversion === "E") body = magnitude.toExponential(digits);
-  else if (conversion === "f") body = magnitude.toFixed(digits);
-  else if (conversion === "g" || conversion === "G") body = String(magnitude);
-  else if (conversion === "c") {
+  if (conversion in RADIX) {
+    body = Math.trunc(magnitude).toString(RADIX[conversion]);
+    if (alternate) body = ALTERNATE_PREFIX[conversion] + body;
+  } else if ("diu".includes(conversion)) {
+    body = String(Math.round(magnitude));
+  } else if (conversion === "e" || conversion === "E") {
+    body = exponential(magnitude, digits);
+    if (alternate && digits === 0) body = body.replace("e", ".e");
+  } else if (conversion === "f") {
+    body = magnitude.toFixed(digits);
+    if (alternate && digits === 0) body += ".";
+  } else if (conversion === "g" || conversion === "G") {
+    body = generalFormat(magnitude, digits === 0 ? 1 : digits, alternate);
+  } else if (conversion === "c") {
     body = typeof value === "number" ? String.fromCodePoint(value) : String(value).charAt(0);
   } else {
     body = precision === undefined ? String(value) : String(value).slice(0, digits);
@@ -102,4 +114,25 @@ function sprintf(spec: string, value: unknown): string {
   if (flags.includes("-")) return (sign + body).padEnd(target);
   if (flags.includes("0") && numeric) return sign + body.padStart(target - sign.length, "0");
   return (sign + body).padStart(target);
+}
+
+/** Ruby pads the exponent to at least two digits; `toExponential` does not. */
+function exponential(magnitude: number, digits: number): string {
+  return magnitude.toExponential(digits).replace(/e([+-])(\d)$/, "e$10$2");
+}
+
+/**
+ * `%g`: fixed notation when the exponent sits in `[-4, precision)`, otherwise
+ * exponential; trailing zeros are dropped unless the `#` flag is set.
+ * `Number#toPrecision` picks a different cutover, so the choice is made here.
+ */
+function generalFormat(magnitude: number, digits: number, alternate: boolean): string {
+  const exponent = magnitude === 0 ? 0 : Math.floor(Math.log10(magnitude));
+  const body =
+    exponent < -4 || exponent >= digits
+      ? exponential(magnitude, digits - 1)
+      : magnitude.toFixed(Math.max(digits - 1 - exponent, 0));
+  if (alternate || !body.includes(".")) return body;
+  const [mantissa = "", suffix = ""] = body.split("e");
+  return mantissa.replace(/\.?0+$/, "") + (suffix ? `e${suffix}` : "");
 }

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -1,16 +1,105 @@
 /**
  * Mirrors: i18n/lib/i18n/interpolate/ruby.rb
  *
- * Only the pattern list is ported here — `Config#interpolation_patterns`
- * defaults to a copy of it. `I18n.interpolate` itself lands with the
- * interpolation story.
- *
  * The Ruby patterns are anchored on Ruby's `%{}` / `%<>` sprintf syntax and
  * carry no flags; the JS equivalents keep the same source, with the capture
  * groups in the same positions.
  */
+
+import { ArgumentError, ReservedInterpolationKey } from "../exceptions.js";
+import { config, reservedKeysPattern } from "../i18n.js";
+
 export const DEFAULT_INTERPOLATION_PATTERNS: readonly RegExp[] = Object.freeze([
   /%%/,
   /%\{([\w|]+)\}/,
   /%<(\w+)>([^\d]*?\d*\.?\d*[bBdiouxXeEfgGcps])/,
 ]);
+
+const INTERPOLATION_PATTERNS_CACHE = new Map<string, RegExp>();
+
+function unionPattern(patterns: readonly RegExp[]): RegExp {
+  const source = patterns.map((pattern) => `(?:${pattern.source})`).join("|");
+  let union = INTERPOLATION_PATTERNS_CACHE.get(source);
+  if (!union) {
+    union = new RegExp(source, "g");
+    INTERPOLATION_PATTERNS_CACHE.set(source, union);
+  }
+  return union;
+}
+
+/**
+ * Mirrors: I18n.interpolate. Returns a String or raises
+ * `MissingInterpolationArgument`; the missing-argument logic is handled by
+ * `config().missingInterpolationArgumentHandler`.
+ */
+export function interpolate(string: string, values: unknown): string {
+  const reserved = reservedKeysPattern().exec(string);
+  if (reserved) throw new ReservedInterpolationKey(reserved[1], string);
+  if (typeof values !== "object" || values === null || Array.isArray(values)) {
+    throw new ArgumentError("Interpolation values must be a Hash.");
+  }
+  return interpolateHash(string, values as Record<string, unknown>);
+}
+
+export function interpolateHash(string: string, values: Record<string, unknown>): string {
+  const pattern = unionPattern(config().interpolationPatterns);
+  let interpolated = false;
+
+  const interpolatedString = string.replace(
+    pattern,
+    (match, braced?: string, angled?: string, format?: string) => {
+      interpolated = true;
+      if (match === "%%") return "%";
+
+      const key = braced ?? angled ?? match.replace(/[%{}]/g, "");
+      let value =
+        key in values
+          ? values[key]
+          : config().missingInterpolationArgumentHandler(key, values, string);
+      if (typeof value === "function") value = (value as (v: unknown) => unknown)(values);
+      return format ? sprintf(format, value) : String(value);
+    },
+  );
+
+  return interpolated ? interpolatedString : string;
+}
+
+const FORMAT_SPEC = /^([-+ #0]*)(\d*)(?:\.(\d+))?([a-zA-Z])$/;
+
+const RADIX: Record<string, number> = { b: 2, B: 2, o: 8, x: 16, X: 16 };
+
+/**
+ * Mirrors Ruby's `sprintf("%#{spec}", value)` for the conversions the `%<>`
+ * interpolation pattern admits (`bBdiouxXeEfgGcps`).
+ */
+function sprintf(spec: string, value: unknown): string {
+  const parsed = FORMAT_SPEC.exec(spec);
+  if (!parsed) return String(value);
+  const [, flags = "", width = "", precision, conversion = "s"] = parsed;
+  const digits = precision === undefined ? 6 : Number(precision);
+  const numeric = conversion !== "c" && conversion !== "s";
+  const magnitude = Math.abs(Number(value));
+
+  let body: string;
+  if (conversion in RADIX) body = Math.trunc(magnitude).toString(RADIX[conversion]);
+  else if ("diu".includes(conversion)) body = String(Math.round(magnitude));
+  else if (conversion === "e" || conversion === "E") body = magnitude.toExponential(digits);
+  else if (conversion === "f") body = magnitude.toFixed(digits);
+  else if (conversion === "g" || conversion === "G") body = String(magnitude);
+  else if (conversion === "c") {
+    body = typeof value === "number" ? String.fromCodePoint(value) : String(value).charAt(0);
+  } else {
+    body = precision === undefined ? String(value) : String(value).slice(0, digits);
+  }
+  if (conversion === conversion.toUpperCase() && numeric) body = body.toUpperCase();
+
+  let sign = "";
+  if (numeric && Number(value) < 0) sign = "-";
+  else if (numeric && flags.includes("+")) sign = "+";
+  else if (numeric && flags.includes(" ")) sign = " ";
+
+  const target = Number(width || 0);
+  if (flags.includes("-")) return (sign + body).padEnd(target);
+  if (flags.includes("0") && numeric) return sign + body.padStart(target - sign.length, "0");
+  return (sign + body).padStart(target);
+}

--- a/packages/i18n/src/throw-catch.ts
+++ b/packages/i18n/src/throw-catch.ts
@@ -1,0 +1,31 @@
+/**
+ * Ruby's `throw`/`catch` has no JS analogue. `I18n::Backend::Base#translate`
+ * signals a missing translation with `throw(:exception, ...)`, which callers
+ * intercept with `catch(:exception)`; the pair below is that mechanism, not a
+ * port of any gem file.
+ */
+
+export class ThrownException extends Error {
+  readonly value: unknown;
+
+  constructor(value: unknown) {
+    super("uncaught throw :exception");
+    this.name = "ThrownException";
+    this.value = value;
+  }
+}
+
+/** Mirrors Ruby's `throw(:exception, value)`. */
+export function throwException(value: unknown): never {
+  throw new ThrownException(value);
+}
+
+/** Mirrors Ruby's `catch(:exception) { ... }`. */
+export function catchException<T>(block: () => T): T | unknown {
+  try {
+    return block();
+  } catch (error) {
+    if (error instanceof ThrownException) return error.value;
+    throw error;
+  }
+}

--- a/packages/i18n/src/throw-catch.ts
+++ b/packages/i18n/src/throw-catch.ts
@@ -5,6 +5,11 @@
  * port of any gem file.
  */
 
+/**
+ * @noRailsEquivalent PERMANENT — Ruby's `throw`/`catch` is a language-level
+ * non-local exit with no JS counterpart, so the value Ruby throws has to travel
+ * as a carrier error.
+ */
 export class ThrownException extends Error {
   readonly value: unknown;
 
@@ -15,12 +20,20 @@ export class ThrownException extends Error {
   }
 }
 
-/** Mirrors Ruby's `throw(:exception, value)`. */
+/**
+ * Mirrors Ruby's `throw(:exception, value)`.
+ *
+ * @noRailsEquivalent PERMANENT — `throw` is a Ruby keyword, not a method.
+ */
 export function throwException(value: unknown): never {
   throw new ThrownException(value);
 }
 
-/** Mirrors Ruby's `catch(:exception) { ... }`. */
+/**
+ * Mirrors Ruby's `catch(:exception) { ... }`.
+ *
+ * @noRailsEquivalent PERMANENT — `catch` is a Ruby keyword, not a method.
+ */
 export function catchException<T>(block: () => T): T | unknown {
   try {
     return block();

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -1,0 +1,67 @@
+/**
+ * Mirrors: i18n/lib/i18n/utils.rb
+ */
+
+/** A translation subtree: Ruby's Symbol-keyed Hash. */
+export type TranslationData = { [key: string]: unknown };
+
+function isHash(value: unknown): value is TranslationData {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function except(hash: TranslationData, ...keys: string[]): TranslationData {
+  const result = { ...hash };
+  for (const key of keys) delete result[key];
+  return result;
+}
+
+export function deepMerge(
+  hash: TranslationData,
+  otherHash: TranslationData,
+  block?: (key: string, thisVal: unknown, otherVal: unknown) => unknown,
+): TranslationData {
+  return deepMergeInPlace({ ...hash }, otherHash, block);
+}
+
+/** Mirrors: I18n::Utils.deep_merge! — mutates and returns `hash`. */
+export function deepMergeInPlace(
+  hash: TranslationData,
+  otherHash: TranslationData,
+  block?: (key: string, thisVal: unknown, otherVal: unknown) => unknown,
+): TranslationData {
+  for (const [key, otherVal] of Object.entries(otherHash)) {
+    if (!(key in hash)) {
+      hash[key] = otherVal;
+      continue;
+    }
+    const thisVal = hash[key];
+    if (isHash(thisVal) && isHash(otherVal)) {
+      hash[key] = deepMerge(thisVal, otherVal, block);
+    } else if (block) {
+      hash[key] = block(key, thisVal, otherVal);
+    } else {
+      hash[key] = otherVal;
+    }
+  }
+  return hash;
+}
+
+/**
+ * Mirrors: I18n::Utils.deep_symbolize_keys. JS object keys are already
+ * strings, so the Symbol conversion is inherent to the language; what remains
+ * observable is the deep copy (and the coercion of numeric/boolean keys to
+ * their string form), which this reproduces.
+ */
+export function deepSymbolizeKeys(hash: TranslationData): TranslationData {
+  const result: TranslationData = {};
+  for (const [key, value] of Object.entries(hash)) {
+    result[key] = deepSymbolizeKeysInObject(value);
+  }
+  return result;
+}
+
+function deepSymbolizeKeysInObject(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepSymbolizeKeysInObject);
+  if (isHash(value)) return deepSymbolizeKeys(value);
+  return value;
+}

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -20,11 +20,11 @@ export function deepMerge(
   otherHash: TranslationData,
   block?: (key: string, thisVal: unknown, otherVal: unknown) => unknown,
 ): TranslationData {
-  return deepMergeInPlace({ ...hash }, otherHash, block);
+  return deepMergeBang({ ...hash }, otherHash, block);
 }
 
 /** Mirrors: I18n::Utils.deep_merge! — mutates and returns `hash`. */
-export function deepMergeInPlace(
+export function deepMergeBang(
   hash: TranslationData,
   otherHash: TranslationData,
   block?: (key: string, thisVal: unknown, otherVal: unknown) => unknown,


### PR DESCRIPTION
Ports `I18n::Backend::Base`, `I18n::Backend::Simple` and `I18n::Utils` into
`packages/i18n`, plus the `I18n.interpolate` machinery `Base#translate` needs.

## What landed

- `src/utils.ts` — `except`, `deepMerge`, `deepMergeInPlace` (`deep_merge!`),
  `deepSymbolizeKeys`.
- `src/backend/base.ts` — `translate`, `exists`, `default`, `resolve` /
  `resolveEntry`, `pluralize` / `pluralizationKey`, `interpolate`,
  `deepInterpolate`, `subtrees`, `reload`, `eagerLoad`. Ruby mixes `Base` in
  with `include`; the JS equivalent is an abstract class concrete backends
  extend, so the file layout still mirrors the gem. The `NotImplementedError`
  members (`store_translations`, `lookup`, `available_locales`) are `abstract`.
- `src/backend/simple.ts` — `initialized`, `storeTranslations` (deep merge,
  enforce-available-locales gate), `availableLocales`, `reload`, `eagerLoad`,
  `translations`, `lookup`. Registers itself as the default backend, so
  `config.backend` now resolves instead of raising.
- `src/i18n.ts` — `RESERVED_KEYS`, `reserveKey`, `reservedKeysPattern`.
- `src/interpolate/ruby.ts` — `interpolate` / `interpolateHash`, including the
  `%<name>fmt` sprintf branch the third default pattern admits. `Base#translate`
  can't be ported without it.
- `src/throw-catch.ts` — Ruby's `throw(:exception)` / `catch(:exception)` has no
  JS analogue; this is the mechanism `translate` signals missing translations
  through. Not a port of any gem file.

## Ported deviations

- **Ruby Symbols.** A Ruby `default:` may be a String (returned as-is) or a
  Symbol (translated); both are strings in JS, so symbol-valued positions use
  real JS symbols — `Symbol.for("some.key")` is the analogue of `:"some.key"`.
  Translation hash *keys* stay strings, since JS object keys always are.
- **`RESERVED_KEYS` spelling.** They double as option keys, and trails options
  are camelCase, so the list is camelCase. `reservedKeysPattern` also matches
  the snake_case spellings, which is what appears in Ruby-authored translation
  data.
- **`Simple#initTranslations`** only flips the flag for now; `load_translations`
  arrives with the file-loading story below.
- **`deepSymbolizeKeys`** is a deep copy in JS — key symbolization is inherent
  to the language.

## Deferred (registered as `i18n-backend-file-loading-localize`)

`load_translations` / `load_file` / `load_rb` / `load_yml` / `load_json`
(needs a YAML reader with no new deps and an async-fs abstraction), `localize` +
`translate_localization_format`, and the `Transliterator` mixin. The
`simple load_*:` tests from `simple_test.rb` go with them.

## Size

~1000 LOC against the 500 ceiling. Base and Simple are mutually untestable when
split — `Base` is abstract and `Simple` is the only concrete backend — so the
smallest shippable unit is both plus `Utils` and the interpolation `translate`
calls into. The file-loading half of `base.rb` is already carved out into the
follow-up story above rather than bundled here.

## Tests

`src/backend/simple.test.ts` ports the reachable `simple_test.rb` cases with
their Rails names verbatim; `src/backend/base.trails.test.ts` pins the
throw/raise/default resolution order that the gem covers in `I18n::Tests::*`
suites not yet ported.

Closes-story: i18n-backend-base-simple
