### PR TITLE
fix(api-compare): pin Integer core_ext bucket to the activesupport barrel

### DIFF
--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -249,6 +249,10 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
     expect(rubyFileTsOverride("inflector/inflections.rb", "activesupport")).toBeUndefined();
   });
 
+  it("pins the Integer core_ext bucket to the package barrel", () => {
+    expect(rubyFileTsOverride("core_ext/integer/inflections.rb", "activesupport")).toBe("index.ts");
+  });
+
   it("maps i18n's umbrella and interpolate files into packages/i18n/src", () => {
     // `lib/i18n.rb` is scanned one level above libPath, so the default rule
     // would place it at `../i18n.ts`, outside src. `interpolate/ruby.rb`

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -75,16 +75,11 @@ export const PATH_SEGMENT_ALIASES: Record<string, string> = {
 export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   "activesupport:inflector/methods.rb": "inflector.ts",
   "activesupport:core_ext/string/inflections.rb": "inflector.ts",
-  // Same reopening shape, one level worse: `core_ext/integer/inflections.rb` is
-  // where Ruby first reopens `class Integer`, so its bucket owns the whole
-  // Integer core_ext surface — `ordinalize`/`ordinal` from this file, plus
-  // `multiple_of?` (multiple.rb) and `months`/`years` (time.rb). trails spreads
-  // those across `inflector.ts` and `duration.ts`, so no single implementation
-  // file is the home; the package barrel is. Left to the misplaced-file
-  // heuristic the bucket resolved to `index.ts` only by luck and lost it the
-  // moment a 4-hit rival (`time-with-zone.ts`, which has its own
-  // `month`/`months`/`year`/`years`) tied the barrel and tripped the separation
-  // threshold.
+  // Same reopening shape: this file reopens `class Integer` first, so its
+  // bucket owns all of Integer's core_ext surface — `ordinalize`/`ordinal` here
+  // plus `multiple_of?` (multiple.rb) and `months`/`years` (time.rb). trails
+  // splits those across `inflector.ts` and `duration.ts`, so the barrel is the
+  // only file that holds the whole bucket.
   "activesupport:core_ext/integer/inflections.rb": "index.ts",
   // The i18n gem's umbrella file (`lib/i18n.rb`, scanned one level above
   // libPath) is where `I18n::Base` itself is defined, so unlike Rails'

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -75,6 +75,17 @@ export const PATH_SEGMENT_ALIASES: Record<string, string> = {
 export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   "activesupport:inflector/methods.rb": "inflector.ts",
   "activesupport:core_ext/string/inflections.rb": "inflector.ts",
+  // Same reopening shape, one level worse: `core_ext/integer/inflections.rb` is
+  // where Ruby first reopens `class Integer`, so its bucket owns the whole
+  // Integer core_ext surface — `ordinalize`/`ordinal` from this file, plus
+  // `multiple_of?` (multiple.rb) and `months`/`years` (time.rb). trails spreads
+  // those across `inflector.ts` and `duration.ts`, so no single implementation
+  // file is the home; the package barrel is. Left to the misplaced-file
+  // heuristic the bucket resolved to `index.ts` only by luck and lost it the
+  // moment a 4-hit rival (`time-with-zone.ts`, which has its own
+  // `month`/`months`/`year`/`years`) tied the barrel and tripped the separation
+  // threshold.
+  "activesupport:core_ext/integer/inflections.rb": "index.ts",
   // The i18n gem's umbrella file (`lib/i18n.rb`, scanned one level above
   // libPath) is where `I18n::Base` itself is defined, so unlike Rails'
   // umbrella files it owns real surface. trails ports it to `src/i18n.ts`;


### PR DESCRIPTION
`core_ext/integer/inflections.rb` is where Ruby first reopens `class Integer`,
so api:compare buckets the whole Integer core_ext surface there: `ordinalize` /
`ordinal` from this file, plus `multiple_of?` (`multiple.rb`) and
`months` / `years` (`time.rb`) — 7 expected members.

trails spreads those across `inflector.ts` and `duration.ts`, so no single
implementation file is the home; the package barrel is. Left to the
misplaced-file heuristic, the tally was:

```
inflector.ts 2   duration.ts 2   time-with-zone.ts 4   index.ts 4
```

`index.ts` won only by iteration luck, and #5977 (interface property signatures
entering the compared surface) gave `time-with-zone.ts` — which has its own
`month`/`months`/`year`/`years` — a tying 4th hit. The separation threshold
(`bestCount >= secondCount * 2`) then correctly declined to guess, and the file
went `4 3 7 57% ↦ index.ts` → `0 7 7 0% ✗`.

Fix: pin it in `RUBY_FILE_TS_OVERRIDES` rather than lean on the heuristic. This
is the same reopening shape the two existing activesupport entries
(`inflector/methods.rb`, `core_ext/string/inflections.rb`) already cover; the
only difference is that the target is the barrel.

The separation threshold is untouched, so the `deprecator.rb ↦ migration.ts`
false positive that `compare.test.ts` pins stays blocked.

## Measurement

Re-measured on top of `origin/main` @ 3b14289a8 (branch head ef6f98a5a) — the raw totals moved with sibling
merges #5972/#5980; the delta this PR contributes is unchanged at +1 file.

Re-measured on top of `origin/main` @ 3b14289a8 (branch head ef6f98a5a) (the raw numbers moved with sibling
merges #5972/#5980; the delta this PR contributes is unchanged at +1 file).

| | before | after |
| --- | --- | --- |
| overall `files:` | 787/1037 | **788/1037** |
| activesupport `files:` | 87/176 | **88/176** |
| overall methods | 11963/17647 | 11967/17647 |

Closes-story: misplaced-file-redirect-lost-to-barrel-reexport-rival


