### PR TITLE
fix(i18n): converge resolve's :object handling onto Hash#delete semantics

### DIFF
--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -68,6 +68,29 @@ describe("I18n::Backend::Base", () => {
     expect(translate("alias")).toBe("Target");
   });
 
+  it("deletes the object option from the options passed to a Proc entry", () => {
+    let seen: TranslateOptions | undefined;
+    const options: TranslateOptions = { object: "subject", other: 1 };
+    backend.storeTranslations("en", {
+      proc_entry: (value: unknown, opts: TranslateOptions) => {
+        seen = opts;
+        return value;
+      },
+    });
+
+    expect(translate("proc_entry", options)).toBe("subject");
+    expect(seen).not.toHaveProperty("object");
+    expect(options).not.toHaveProperty("object");
+  });
+
+  it("falls through to the object argument when the object option is false", () => {
+    backend.storeTranslations("en", {
+      proc_entry: (value: unknown) => value,
+    });
+
+    expect(translate("proc_entry", { object: false })).toBe("proc_entry");
+  });
+
   it("raises InvalidPluralizationData when the pluralization key is missing", () => {
     backend.storeTranslations("en", { stars: { one: "one star" } });
     expect(() => translate("stars", { count: 2 })).toThrow(InvalidPluralizationData);

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -199,12 +199,15 @@ export abstract class Base {
         });
       }
       if (typeof subject === "function") {
-        const dateOrTime = options.object ?? object;
-        const rest = except(options, "object");
+        // `Hash#delete` strips `:object` from the hash the caller still holds,
+        // so later reads in the same `translate` call no longer see it.
+        const deleted = options.object;
+        delete options.object;
+        const dateOrTime = deleted != null && deleted !== false ? deleted : object;
         return this.resolve(
           locale,
           object,
-          (subject as (value: unknown, options: TranslateOptions) => unknown)(dateOrTime, rest),
+          (subject as (value: unknown, options: TranslateOptions) => unknown)(dateOrTime, options),
         );
       }
       return subject;

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -199,11 +199,9 @@ export abstract class Base {
         });
       }
       if (typeof subject === "function") {
-        // `Hash#delete` strips `:object` from the hash the caller still holds,
-        // so later reads in the same `translate` call no longer see it.
-        const deleted = options.object;
+        const dateOrTime =
+          options.object != null && options.object !== false ? options.object : object;
         delete options.object;
-        const dateOrTime = deleted != null && deleted !== false ? deleted : object;
         return this.resolve(
           locale,
           object,


### PR DESCRIPTION
Converges `Base#resolve`'s Proc branch onto Rails' `Hash#delete` semantics
(`vendor/i18n/lib/i18n/backend/base.rb:158-160`).

- `options.delete(:object)` mutates the caller's hash, so later reads in the
  same `translate` call no longer see `:object`. We now `delete options.object`
  and forward `options` itself instead of building an `except()` copy.
- Ruby's `||` falls through on `false`; `??` does not. The fallback now reads
  `deleted != null && deleted !== false ? deleted : object`.

Tests cover both arms: the Proc sees options without `object` (and the caller's
hash is mutated), and `object: false` falls through to the `object` argument.

Closes-story: i18n-resolve-object-delete-mutation
