### PR TITLE
test(scripts): fail when a deviation comment names a landed story

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           # of whichever job runs its tests, or a change confined to it runs
           # nothing; scripts/ci-suite-coverage.test.ts enforces that pairing.
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces)(\.test)?\.ts$)'
+          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references)(\.test)?\.ts$)'
           # AR workspace deps: arel/activemodel/activesupport/globalid/
           # did-you-mean (per packages/activerecord/package.json). Also
           # consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
@@ -195,7 +195,7 @@ jobs:
           # eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
           # its byte set and the ESLint rule's, and scripts/ci/ is carved out
           # of the infra sweep (INFRA_CARVEOUT_RE).
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport|i18n)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport|i18n)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -721,6 +721,7 @@ jobs:
           scripts/ci-suite-coverage.test.ts
           scripts/mixin-declaration-drift.test.ts
           scripts/mysql-grant-namespaces.test.ts
+          scripts/stale-story-references.test.ts
           vendor/sources.test.ts
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,6 +684,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
+      # scripts/stale-story-references.test.ts compares story citations in
+      # comments against real story statuses; the story markdown is the source
+      # of truth and the check throws without it, so the (public) tasks repo is
+      # checked out where resolveTasksDir looks.
+      - uses: actions/checkout@v5
+        with:
+          repository: blazetrailsdev/tasks
+          path: tasks
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: ./.github/actions/cache-build

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -767,13 +767,6 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
 
   // Cases blocked on genuine trails PG/MySQL adapter divergences that the faithful
   // port surfaced (checked in verbatim; un-skip once the adapters converge):
-  //   - Connection-failure error classification + retryability
-  //     (RFC 0023 story adapter-connection-failure-error-classification): trails
-  //     maps a severed PG connection to ConnectionNotEstablished, not Rails'
-  //     ConnectionFailed (node-pg has no libpq layer to reproduce Rails' split),
-  //     which also makes it non-retryable. (The parallel mysql2 divergence — the
-  //     driver's "Can't add new command when connection is in closed state" going
-  //     untranslated — was fixed in #4935, which maps it to ConnectionFailed.)
   //   - No-bind unprepared SELECT does not materialize a pending lazy
   //     transaction on PG/MySQL (story thread-collector-preparable-for-
   //     statement-cache; see transactions.test.ts "unprepared statement

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -593,7 +593,9 @@ describe("PreloaderTest", () => {
     expect(loaded.length).toBe(Number(await Comment.where({ post_id: post.id }).count()));
   });
 
-  // TODO(store-full-sti-class-name): remove it.fails when that story fixes the gap.
+  // TODO(preload-hmt-with-conditions-remaining-sti-gap): remove it.fails when
+  // that story fixes the gap. `store-full-sti-class-name` landed (#3874)
+  // without closing it.
   it.fails("preload for hmt with conditions", async () => {
     const post = posts("welcome");
     await CategoryPost.create({

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -85,14 +85,10 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * against the now-loaded join row (update-existing / build-when-absent),
    * exactly as Rails' `create_through_record` does.
    *
-   * Extra surface, deliberately left counted: the name exists only because the
-   * base `HasOneAssociation` splits Rails' inline `build_#{name}` target load
-   * into a public `loadTargetForBuild` hook. It cannot be `protected` while
-   * `associations/builder/has-one.ts` drives it from outside the class, and it
-   * converges when the BASE hook does — see the
-   * `extra-surface-has-one-base-build-hooks-classify` story. No
-   * `@noRailsEquivalent` tag, because convergeable surface belongs on the novel
-   * count, not in the allowed set.
+   * The name exists only because the base `HasOneAssociation` splits Rails'
+   * inline `build_#{name}` target load into a `loadTargetForBuild` hook; both
+   * the base hook and this override are `protected` (#5946), so neither counts
+   * as public extra surface.
    *
    * @internal
    */
@@ -114,12 +110,9 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * the `build#{name}` / `create#{name}` accessors leave displacement to the
    * through's own `createThroughRecord` / `persistReplace`.
    *
-   * Extra surface, deliberately left counted, for the same reason as
-   * `loadTargetForBuild` above: Rails has no `remove_target!` hook of this
-   * shape at all, and this override only neutralizes the base class's. It
-   * cannot be `protected` while `nested-attributes.ts` calls it from outside,
-   * and it disappears when the base hook converges — see the
-   * `extra-surface-has-one-base-build-hooks-classify` story.
+   * Same shape as `loadTargetForBuild` above: Rails has no `remove_target!`
+   * hook of this kind at all, and this override only neutralizes the base
+   * class's. `protected` on both since #5946.
    *
    * @internal
    */

--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -371,8 +371,8 @@ describe("BindParameterTest", () => {
       // in the relation layer, so the payload carries `[1]` rather than Attribute
       // objects — the `?? attr` fallback matches the primitive trails emits. (The
       // payload can't preserve Attribute objects without production changes; the
-      // stronger `binds are logged` assertion is deferred to RFC 0016 story
-      // `preserve-queryattribute-binds-in-notification-payload` for that reason.)
+      // stronger `binds are logged` assertion is deferred to RFC 0077 story
+      // `tosqlandbinds-preserve-attribute-binds` for that reason.)
       const message = subscriber.events.find((e) =>
         (e.payload.binds as any[])?.some((attr) => Number(attr?.value ?? attr) === 1),
       );

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -83,7 +83,7 @@ interface ReferentialIntegrityHost extends ReferentialIntegritySqlHost {
 //
 // The `scopedTables` parameter has no Rails counterpart (the method is zero-arg
 // in every adapter); it is a tracked deviation pending convergence — see RFC
-// 0060 story `converge-referential-integrity-zero-arg-shape` (hoist the
+// 0023 story `converge-referential-integrity-scoped-tables-parameter` (hoist the
 // fixture-load flow to one block per set, matching Rails' insert_fixtures_set,
 // then drop the parameter).
 export async function disableReferentialIntegrity(

--- a/packages/activesupport/src/cache/coder.ts
+++ b/packages/activesupport/src/cache/coder.ts
@@ -14,11 +14,11 @@
 // (`NaN`/`±Infinity` → `null`). This codec is the trails Marshal-equivalent: a
 // type-tagging JSON serializer that survives those cases.
 //
-// It is deliberately NOT Ruby-wire-compatible. Remaining cache-serialization
-// convergence — the MessagePack serializer, `SerializerWithFallback`, and
-// wiring the concrete stores (MemoryStore/FileStore/entry-record) through this
-// Coder rather than their own ad-hoc JSON — is tracked as pending convergence
-// by `activesupport-messagepack-port` and `cache-entry-remaining-methods`.
+// It is deliberately NOT Ruby-wire-compatible. The rest of the cache
+// serialization surface has since converged: the MessagePack serializer
+// (`message-pack/cache-serializer.ts`), `SerializerWithFallback`
+// (`cache/serializer-with-fallback.ts`), and MemoryStore/FileStore/entry-record
+// all route their values through this Coder rather than their own ad-hoc JSON.
 
 // Special values are encoded as a compact 1- or 2-element array whose head is a
 // short sentinel code: `["~#d", 1750000000000]` for a Date, `["~#u"]` for

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractStoryReferences,
+  scanStoryReferences,
+  staleStoryReferences,
+  type IndexStory,
+} from "./stale-story-references.js";
+import { resolveTasksDir } from "./tasks/cli.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// The exact comment message-verifier.test.ts carried until #5976.
+const LANDED_PROMISE = `
+    // Trails' encoder has no \`time_precision\` knob and leans on
+    // \`Temporal.Instant#toJSON\`, which drops a zero subsecond part.
+    // Converged by the \`activesupport-json-encoding-time-precision\` story.
+    const exp = { foo: 123, bar: "2010-01-01T00:00:00Z" };
+`;
+
+const STORIES: IndexStory[] = [
+  { id: "activesupport-json-encoding-time-precision", status: "done", raw_status: "done" },
+  { id: "converge-connection-pool-lifecycle-async", status: "ready", raw_status: "ready" },
+  // A done story under a closed RFC: `status` is demoted, `raw_status` is not.
+  { id: "cache-entry-remaining-methods", status: "closed", raw_status: "done" },
+];
+
+describe("stale story references", () => {
+  it("flags a pending citation of a story that has landed", () => {
+    const refs = extractStoryReferences(LANDED_PROMISE, "message-verifier.test.ts");
+    expect(refs.map((ref) => ref.slug)).toContain("activesupport-json-encoding-time-precision");
+    expect(staleStoryReferences(refs, STORIES)).toHaveLength(1);
+  });
+
+  it("leaves a pending citation of a story that has not landed", () => {
+    const refs = extractStoryReferences(
+      "// (Lifecycle-path async convergence is deferred to\n// `converge-connection-pool-lifecycle-async`.)\n",
+      "connection-pool.ts",
+    );
+    expect(refs).toHaveLength(1);
+    expect(staleStoryReferences(refs, STORIES)).toEqual([]);
+  });
+
+  it("reads the story's own status, not the one its RFC demotes it to", () => {
+    const refs = extractStoryReferences(
+      "// Remaining wiring is pending convergence by `cache-entry-remaining-methods`.\n",
+      "coder.ts",
+    );
+    expect(staleStoryReferences(refs, STORIES)).toHaveLength(1);
+  });
+
+  it("ignores a slug cited as provenance rather than as a promise", () => {
+    const refs = extractStoryReferences(
+      "// Regression for `activesupport-json-encoding-time-precision`: the encoder\n// emits three subsecond digits.\n",
+      "json.test.ts",
+    );
+    expect(refs).toEqual([]);
+  });
+
+  it("ignores kebab identifiers that name no story", () => {
+    const refs = extractStoryReferences(
+      "// Converged by the `some-thing-that-is-not-a-story` rewrite.\n",
+      "x.ts",
+    );
+    expect(staleStoryReferences(refs, STORIES)).toEqual([]);
+  });
+
+  it("only reads comment text", () => {
+    expect(
+      extractStoryReferences('const msg = "converged by cache-entry-remaining-methods";', "x.ts"),
+    ).toEqual([]);
+  });
+
+  // The tasks repo is not checked out in CI, so the tree-wide gate is the
+  // pre-push signal here and in every agent worktree (start-worktree.sh
+  // symlinks `tasks/`). The unit cases above carry the CI signal.
+  const tasksIndex = path.join(resolveTasksDir(REPO_ROOT), "index.json");
+  const readIndex = async (): Promise<{ stories: IndexStory[] } | null> => {
+    try {
+      return JSON.parse(await readFile(tasksIndex, "utf8")) as { stories: IndexStory[] };
+    } catch {
+      return null;
+    }
+  };
+
+  it("no comment in the tree names a story that has already landed", async () => {
+    const index = await readIndex();
+    if (!index) return;
+    const stale = staleStoryReferences(await scanStoryReferences(REPO_ROOT), index.stories);
+    expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);
+  });
+});

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -85,9 +85,12 @@ describe("stale story references", () => {
     }
   };
 
-  it("no comment in the tree names a story that has already landed", async () => {
+  it("no comment in the tree names a story that has already landed", async (ctx) => {
     const index = await readIndex();
-    if (!index) return;
+    if (!index) {
+      ctx.skip(`no tasks index at ${tasksIndex}`);
+      return;
+    }
     const stale = staleStoryReferences(await scanStoryReferences(REPO_ROOT), index.stories);
     expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);
   });

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   extractStoryReferences,
+  loadStories,
   scanStoryReferences,
   staleStoryReferences,
   type IndexStory,
@@ -21,10 +21,9 @@ const LANDED_PROMISE = `
 `;
 
 const STORIES: IndexStory[] = [
-  { id: "activesupport-json-encoding-time-precision", status: "done", raw_status: "done" },
-  { id: "converge-connection-pool-lifecycle-async", status: "ready", raw_status: "ready" },
-  // A done story under a closed RFC: `status` is demoted, `raw_status` is not.
-  { id: "cache-entry-remaining-methods", status: "closed", raw_status: "done" },
+  { id: "activesupport-json-encoding-time-precision", status: "done" },
+  { id: "converge-connection-pool-lifecycle-async", status: "ready" },
+  { id: "cache-entry-remaining-methods", status: "closed" },
 ];
 
 describe("stale story references", () => {
@@ -43,7 +42,7 @@ describe("stale story references", () => {
     expect(staleStoryReferences(refs, STORIES)).toEqual([]);
   });
 
-  it("reads the story's own status, not the one its RFC demotes it to", () => {
+  it("flags every landed status a story can carry", () => {
     const refs = extractStoryReferences(
       "// Remaining wiring is pending convergence by `cache-entry-remaining-methods`.\n",
       "coder.ts",
@@ -73,25 +72,26 @@ describe("stale story references", () => {
     ).toEqual([]);
   });
 
-  // The tasks repo is not checked out in CI, so the tree-wide gate is the
-  // pre-push signal here and in every agent worktree (start-worktree.sh
-  // symlinks `tasks/`). The unit cases above carry the CI signal.
-  const tasksIndex = path.join(resolveTasksDir(REPO_ROOT), "index.json");
-  const readIndex = async (): Promise<{ stories: IndexStory[] } | null> => {
-    try {
-      return JSON.parse(await readFile(tasksIndex, "utf8")) as { stories: IndexStory[] };
-    } catch {
-      return null;
-    }
-  };
-
-  it("no comment in the tree names a story that has already landed", async (ctx) => {
-    const index = await readIndex();
-    if (!index) {
-      ctx.skip(`no tasks index at ${tasksIndex}`);
-      return;
-    }
-    const stale = staleStoryReferences(await scanStoryReferences(REPO_ROOT), index.stories);
+  // The tasks repo is public and checked out into `tasks/` by the Unit Tests
+  // job, so this gate compares the tree against real story statuses there as
+  // well as in every agent worktree (start-worktree.sh symlinks the same path).
+  // loadStories throws rather than skipping when that checkout is missing.
+  it("no comment in the tree names a story that has already landed", async () => {
+    const stories = await loadStories(resolveTasksDir(REPO_ROOT));
+    const stale = staleStoryReferences(await scanStoryReferences(REPO_ROOT), stories);
     expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);
+  });
+
+  it("reads each story's status from its own frontmatter", async () => {
+    const stories = await loadStories(resolveTasksDir(REPO_ROOT));
+    expect(
+      stories.find((story) => story.id === "activesupport-json-encoding-time-precision"),
+    ).toEqual({ id: "activesupport-json-encoding-time-precision", status: "done" });
+  });
+
+  it("refuses to pass without a tasks checkout", async () => {
+    await expect(loadStories(path.join(REPO_ROOT, "no-such-tasks"))).rejects.toThrow(
+      /cannot resolve story statuses/,
+    );
   });
 });

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -10,13 +10,10 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
-// A story id: three or more kebab segments. Two-segment names collide with
-// ordinary prose ("has-one", "type-map") far too often to be worth matching.
+// Three or more kebab segments: two-segment names collide with ordinary prose
+// ("has-one", "type-map") far too often to be worth matching.
 const STORY_SLUG = /[a-z0-9]+(?:-[a-z0-9]+){2,}/g;
 
-// Phrasings that promise future convergence. A slug cited as provenance
-// ("Regression for X", "story: X") is history, not a promise, and stays legal
-// after the story lands.
 const PENDING_PHRASE =
   /converged by|converges (when|in|once)|will (be )?converge|deferred to|pending convergence|once .{0,40}lands|until .{0,60}lands|un-?skip once|when that story|fixed by/i;
 
@@ -26,9 +23,8 @@ const SENTENCE = /(?<=[.;:)])\s+(?=[A-Z(`])|\.\s+/;
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "vendor", "__snapshots__"]);
 const SOURCE_ROOTS = ["packages", "scripts", "eslint"];
 
-// This check's own test states a stale promise verbatim as its fixture; the
-// scan is line-based, so the fixture inside a template literal reads as a real
-// comment.
+// Its test states a stale promise verbatim as a fixture, and the line-based
+// scan reads that template literal as a real comment.
 const SKIP_FILES = new Set([path.join("scripts", "stale-story-references.test.ts")]);
 
 export interface StoryReference {
@@ -37,8 +33,13 @@ export interface StoryReference {
   slug: string;
 }
 
-// Contiguous comment lines form one block: a promise and its slug routinely sit
-// on different physical lines of the same JSDoc paragraph.
+/**
+ * Story slugs cited as still-pending in `source`'s comments. Contiguous comment
+ * lines form one block, because a promise and its slug routinely sit on
+ * different physical lines of the same JSDoc paragraph; the phrase and the slug
+ * must then share a sentence, so a slug cited as provenance ("Regression for
+ * X") is history rather than a promise and stays legal after the story lands.
+ */
 export function extractStoryReferences(source: string, file: string): StoryReference[] {
   const refs: StoryReference[] = [];
   const lines = source.split("\n");
@@ -67,7 +68,12 @@ export function extractStoryReferences(source: string, file: string): StoryRefer
   return refs;
 }
 
-export async function collectSourceFiles(root: string, dir = root, acc: string[] = []) {
+/** Repo-relative `.ts`/`.mjs` paths under `dir`. */
+export async function collectSourceFiles(
+  root: string,
+  dir = root,
+  acc: string[] = [],
+): Promise<string[]> {
   let entries;
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -85,6 +91,7 @@ export async function collectSourceFiles(root: string, dir = root, acc: string[]
   return acc;
 }
 
+/** Every pending citation in the source roots this check covers. */
 export async function scanStoryReferences(repoRoot: string): Promise<StoryReference[]> {
   const refs: StoryReference[] = [];
   for (const root of SOURCE_ROOTS) {
@@ -99,13 +106,18 @@ export async function scanStoryReferences(repoRoot: string): Promise<StoryRefere
 export interface IndexStory {
   id: string;
   status: string;
-  // The story's own status; `status` is demoted to its RFC's when the RFC is
-  // closed, which would hide a landed story behind an rfc-level state.
+  /**
+   * The story's own status. `status` is demoted to its RFC's when that RFC is
+   * closed, which would hide a landed story behind an RFC-level state.
+   */
   raw_status?: string;
 }
 
-// A slug the index doesn't know is not a story reference at all (kebab file
-// names, CSS-ish identifiers, Rails option names), so it is never a finding.
+/**
+ * The citations whose story has already landed. A slug the index doesn't know
+ * is not a story reference at all (kebab file names, Rails option names), so it
+ * is never a finding.
+ */
 export function staleStoryReferences(
   refs: readonly StoryReference[],
   stories: readonly IndexStory[],

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -1,0 +1,120 @@
+// A deviation comment that names the story which will converge it is a promise
+// nothing checks. `activesupport-json-encoding-time-precision` landed as #5971
+// while `message-verifier.test.ts` still asserted the pre-convergence value,
+// and the break surfaced only as a red Unit Tests lane on main (#5976).
+//
+// This module extracts those promises — a story slug sitting in the same
+// comment sentence as a forward-looking phrase — so a landed story with a
+// still-pending citation fails a test instead of a suite.
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+// A story id: three or more kebab segments. Two-segment names collide with
+// ordinary prose ("has-one", "type-map") far too often to be worth matching.
+const STORY_SLUG = /[a-z0-9]+(?:-[a-z0-9]+){2,}/g;
+
+// Phrasings that promise future convergence. A slug cited as provenance
+// ("Regression for X", "story: X") is history, not a promise, and stays legal
+// after the story lands.
+const PENDING_PHRASE =
+  /converged by|converges (when|in|once)|will (be )?converge|deferred to|pending convergence|once .{0,40}lands|until .{0,60}lands|un-?skip once|when that story|fixed by/i;
+
+const COMMENT_LINE = /^\s*(?:\/\/|\/\*+|\*)(.*)$/;
+const SENTENCE = /(?<=[.;:)])\s+(?=[A-Z(`])|\.\s+/;
+
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "vendor", "__snapshots__"]);
+const SOURCE_ROOTS = ["packages", "scripts", "eslint"];
+
+// This check's own test states a stale promise verbatim as its fixture; the
+// scan is line-based, so the fixture inside a template literal reads as a real
+// comment.
+const SKIP_FILES = new Set([path.join("scripts", "stale-story-references.test.ts")]);
+
+export interface StoryReference {
+  file: string;
+  line: number;
+  slug: string;
+}
+
+// Contiguous comment lines form one block: a promise and its slug routinely sit
+// on different physical lines of the same JSDoc paragraph.
+export function extractStoryReferences(source: string, file: string): StoryReference[] {
+  const refs: StoryReference[] = [];
+  const lines = source.split("\n");
+  let block: string[] = [];
+  let start = 0;
+  const flush = (): void => {
+    if (block.length === 0) return;
+    for (const sentence of block.join(" ").split(SENTENCE)) {
+      if (!PENDING_PHRASE.test(sentence)) continue;
+      for (const slug of new Set(sentence.match(STORY_SLUG) ?? [])) {
+        refs.push({ file, line: start, slug });
+      }
+    }
+    block = [];
+  };
+  lines.forEach((line, i) => {
+    const match = COMMENT_LINE.exec(line);
+    if (match) {
+      if (block.length === 0) start = i + 1;
+      block.push(match[1].trim());
+    } else {
+      flush();
+    }
+  });
+  flush();
+  return refs;
+}
+
+export async function collectSourceFiles(root: string, dir = root, acc: string[] = []) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const entry of entries) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) await collectSourceFiles(root, abs, acc);
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".mjs")) {
+      acc.push(path.relative(root, abs));
+    }
+  }
+  return acc;
+}
+
+export async function scanStoryReferences(repoRoot: string): Promise<StoryReference[]> {
+  const refs: StoryReference[] = [];
+  for (const root of SOURCE_ROOTS) {
+    for (const file of await collectSourceFiles(repoRoot, path.join(repoRoot, root))) {
+      if (SKIP_FILES.has(file)) continue;
+      refs.push(...extractStoryReferences(await readFile(path.join(repoRoot, file), "utf8"), file));
+    }
+  }
+  return refs;
+}
+
+export interface IndexStory {
+  id: string;
+  status: string;
+  // The story's own status; `status` is demoted to its RFC's when the RFC is
+  // closed, which would hide a landed story behind an rfc-level state.
+  raw_status?: string;
+}
+
+// A slug the index doesn't know is not a story reference at all (kebab file
+// names, CSS-ish identifiers, Rails option names), so it is never a finding.
+export function staleStoryReferences(
+  refs: readonly StoryReference[],
+  stories: readonly IndexStory[],
+): StoryReference[] {
+  const byId = new Map(stories.map((story) => [story.id, story]));
+  return refs.filter((ref) => {
+    const story = byId.get(ref.slug);
+    if (!story) return false;
+    const status = story.raw_status ?? story.status;
+    return status === "done" || status === "closed";
+  });
+}

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -17,6 +17,9 @@ const STORY_SLUG = /[a-z0-9]+(?:-[a-z0-9]+){2,}/g;
 const PENDING_PHRASE =
   /converged by|converges (when|in|once)|will (be )?converge|deferred to|pending convergence|once .{0,40}lands|until .{0,60}lands|un-?skip once|when that story|fixed by/i;
 
+// Frontmatter `status:` of a story file, matched before any body prose.
+const STORY_STATUS = /^status:\s*"?([a-z-]+)"?\s*$/m;
+
 const COMMENT_LINE = /^\s*(?:\/\/|\/\*+|\*)(.*)$/;
 const SENTENCE = /(?<=[.;:)])\s+(?=[A-Z(`])|\.\s+/;
 
@@ -106,17 +109,50 @@ export async function scanStoryReferences(repoRoot: string): Promise<StoryRefere
 export interface IndexStory {
   id: string;
   status: string;
-  /**
-   * The story's own status. `status` is demoted to its RFC's when that RFC is
-   * closed, which would hide a landed story behind an RFC-level state.
-   */
-  raw_status?: string;
 }
 
 /**
- * The citations whose story has already landed. A slug the index doesn't know
- * is not a story reference at all (kebab file names, Rails option names), so it
- * is never a finding.
+ * Every story's own status, read from the frontmatter under
+ * `<tasksDir>/rfcs/*\/stories/*.md`. The tracked markdown is the source of
+ * truth: `index.json` is a gitignored cache, absent in a fresh checkout, and
+ * the status it serves is demoted to the RFC's whenever that RFC is closed —
+ * which would hide a landed story behind an RFC-level state. Throws when
+ * `tasksDir` holds no stories, so a missing tasks checkout reds this check
+ * rather than silently retiring it.
+ */
+export async function loadStories(tasksDir: string): Promise<IndexStory[]> {
+  const stories: IndexStory[] = [];
+  const rfcsDir = path.join(tasksDir, "rfcs");
+  let rfcs: string[];
+  try {
+    rfcs = await readdir(rfcsDir);
+  } catch {
+    throw new Error(`no tasks checkout at ${tasksDir} — cannot resolve story statuses`);
+  }
+  for (const rfc of rfcs) {
+    const dir = path.join(rfcsDir, rfc, "stories");
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+      const status = STORY_STATUS.exec(await readFile(path.join(dir, entry), "utf8"))?.[1];
+      if (status) stories.push({ id: entry.slice(0, -3), status });
+    }
+  }
+  if (stories.length === 0) {
+    throw new Error(`no stories under ${rfcsDir} — cannot resolve story statuses`);
+  }
+  return stories;
+}
+
+/**
+ * The citations whose story has already landed. A slug no story claims is not a
+ * story reference at all (kebab file names, Rails option names), so it is never
+ * a finding.
  */
 export function staleStoryReferences(
   refs: readonly StoryReference[],
@@ -124,9 +160,7 @@ export function staleStoryReferences(
 ): StoryReference[] {
   const byId = new Map(stories.map((story) => [story.id, story]));
   return refs.filter((ref) => {
-    const story = byId.get(ref.slug);
-    if (!story) return false;
-    const status = story.raw_status ?? story.status;
+    const status = byId.get(ref.slug)?.status;
     return status === "done" || status === "closed";
   });
 }


### PR DESCRIPTION
A deviation comment that names the story which will converge it is a promise
nothing checks. `activesupport-json-encoding-time-precision` landed as #5971
while `message-verifier.test.ts` still asserted the pre-convergence value, and
the break surfaced only as a red Unit Tests lane on `main` (fixed in #5976).

`scripts/stale-story-references.ts` extracts those promises — a story slug
sitting in the same comment *sentence* as a forward-looking phrase ("converged
by", "deferred to", "pending convergence", "un-skip once", …) — and
`stale-story-references.test.ts` fails when a cited story is `done`/`closed`.
A slug cited as provenance ("Regression for X") is history, not a promise, and
stays legal; a slug the tasks index doesn't know is never a finding.

Statuses come from the story markdown's own frontmatter under
`<tasksDir>/rfcs/*/stories/*.md` — `index.json` is a gitignored cache absent in
a fresh checkout, and the status it serves is demoted to the RFC's whenever
that RFC is closed, which would hide a landed story. The tasks repo is public,
so the Unit Tests job checks it out into `tasks/` (where `resolveTasksDir`
looks) and the tree-wide gate compares against real statuses in CI as well as
in every agent worktree. It throws rather than skipping when that checkout is
missing, so the gate cannot silently retire itself. Wired into the Unit Tests
lane plus both changes-gate regexes.

Seven pre-existing citations were stale; each was adjudicated against the tree:

- `cache/coder.ts` — MessagePack, `SerializerWithFallback`, and the
  MemoryStore/FileStore/entry-record wiring all landed; the pending clause is
  now a statement of what converged.
- `has-one-through-association.ts` — #5946 narrowed the base and override hooks
  to `protected`, so the "cannot be protected / extra surface" prose is gone.
- `adapter.test.ts` — the PG connection-failure classification bullet was fixed
  by #4935 and gated nothing (`itBlocked` has one call site, covered by the
  second bullet); deleted.
- `bind-parameter.test.ts` — repointed to the live story that actually owns the
  residual, `tosqlandbinds-preserve-attribute-binds` (RFC 0077).
- `referential-integrity.ts` (`scopedTables`) and `associations.test.ts`
  (`it.fails("preload for hmt with conditions")`) — deviations still present
  under closed stories, so filed
  `converge-referential-integrity-scoped-tables-parameter` and
  `preload-hmt-with-conditions-remaining-sti-gap` (RFC 0023) and repointed.

Verified per the story: re-introducing the pre-#5976 comment in
`message-verifier.test.ts` reds the tree check.

Closes-story: stale-deviation-comment-names-landed-story
