### PR TITLE
ci: use if/continue form in all aggregate skip arms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1963,10 +1963,14 @@ jobs:
                   ;;
                 actionpack-tests)
                   # Actionpack test skip is legitimate when no actionpack-affecting paths changed.
-                  [ "$AP_AFFECTED" = "false" ] && continue
+                  if [ "$AP_AFFECTED" = "false" ]; then
+                    continue
+                  fi
                   ;;
                 trailties-tests)
-                  [ "$TRAILTIES_AFFECTED" = "false" ] && continue
+                  if [ "$TRAILTIES_AFFECTED" = "false" ]; then
+                    continue
+                  fi
                   ;;
                 leaf-tests)
                   # Consolidated rack/actionview/tse-compiler/dx-type job.
@@ -1981,7 +1985,9 @@ jobs:
                   fi
                   ;;
                 unit-tests)
-                  [ "$UNIT_TESTS_AFFECTED" = "false" ] && continue
+                  if [ "$UNIT_TESTS_AFFECTED" = "false" ]; then
+                    continue
+                  fi
                   ;;
                 guides-typecheck)
                   if [ "$GUIDES_AFFECTED" = "false" ] || \
@@ -1994,7 +2000,9 @@ jobs:
                   # (no packages/**, scripts/{api,test,fixtures,schema}-compare/**,
                   # comparison-consumed manifest builders, vendor/**, or
                   # cross-cutting infra — see COMPARISON_RE).
-                  [ "$COMPARISON_AFFECTED" = "false" ] && continue
+                  if [ "$COMPARISON_AFFECTED" = "false" ]; then
+                    continue
+                  fi
                   ;;
                 website)
                   # Legitimate skip when website_affected is false AND no
@@ -2018,7 +2026,9 @@ jobs:
                 schema-parity-rails|schema-parity-trails|schema-parity-diff|\
                 query-parity-frozen-at|query-parity-rails|query-parity-trails|query-parity-diff)
                   # Parity skip is legitimate when no parity gate is on.
-                  [ "$any_parity" = "false" ] && continue
+                  if [ "$any_parity" = "false" ]; then
+                    continue
+                  fi
                   ;;
               esac
               echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED comparison_affected=$COMPARISON_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL db_adapters_draft_deferred=$DB_ADAPTERS_DRAFT_DEFERRED guides_unlabelled=$GUIDES_UNLABELLED)"


### PR DESCRIPTION
The `ci` aggregate's skip-diagnostic loop runs under `set -euo pipefail`. Arms
ending in `[ "$X" = "false" ] && continue` return 1 as the arm's last command
when the test is false — exactly the unexpected-skip case the loop exists to
report — so `set -e` kills the step before `echo "Unexpectedly skipped job:
..."` runs. The run fails correctly but says nothing about which job or gate
misfired.

PR #5749 converted `sqlite-tests` and `postgres-tests|maria-tests` to the
`if ... then continue; fi` form. This converts the rest: `actionpack-tests`,
`trailties-tests`, `unit-tests`, `rails-comparison`, and the parity arm.
(`guides-typecheck` already used the safe form.) No `&& continue` remains in
the loop.

Verified by simulating the loop with `set -euo pipefail` and a gate forced
true (i.e. the skip is unexpected): the diagnostic prints and `unexpected=1`
is set. Legitimate-skip and all-green paths are unchanged — the conditions
are identical, only the shell form differs.

Closes-story: ci-aggregate-skip-arms-suppress-diagnostic-under-errexit
