### PR TITLE
fix(activerecord): keep arunit2 siblings under their own run token

### DIFF
--- a/packages/activerecord/src/support/arunit2-config.test.ts
+++ b/packages/activerecord/src/support/arunit2-config.test.ts
@@ -18,4 +18,14 @@ describe("arunit2-config", () => {
       "activerecord_unittest2_32",
     );
   });
+
+  it("keeps the run token whole when the primary database is stamped", () => {
+    expect(arunitDatabaseNames("activerecord_unittest_rabc000001_3")).toEqual({
+      arunit: "activerecord_unittest_rabc000001_3",
+      arunit2: "activerecord_unittest2_rabc000001_3",
+    });
+    expect(arunitDatabaseNames("activerecord_unittest_rabc000001_32").arunit2).toBe(
+      "activerecord_unittest2_rabc000001_32",
+    );
+  });
 });

--- a/packages/activerecord/src/support/arunit2-config.ts
+++ b/packages/activerecord/src/support/arunit2-config.ts
@@ -27,11 +27,7 @@
  * @internal
  */
 
-/**
- * The `_N` worker-isolation slot `support/config.ts`'s `applySlot` appends to
- * the primary database name (slot 1 gets none).
- */
-const SLOT_SUFFIX = /_\d+$/;
+import { splitRunDatabaseName } from "./run-token.js";
 
 /**
  * The config-derived `arunit` / `arunit2` database names for a primary
@@ -41,11 +37,18 @@ const SLOT_SUFFIX = /_\d+$/;
  * `arunit2` is spelled the way `expand_config` spells it — the primary name
  * plus a literal `"2"` (`test/support/config.rb:28`) — so at slot 1 (local
  * runs and every un-sharded lane) it is Rails' own `activerecord_unittest2`.
- * The `"2"` goes *before* the slot suffix rather than after it, which is the
+ * The `"2"` goes *before* the per-run suffix rather than after it, which is the
  * one unavoidable deviation: appending it to slot 3's
  * `activerecord_unittest_3` would yield `activerecord_unittest_32`, i.e. slot
  * 32's own database. Written this way slot 3 gets `activerecord_unittest2_3`,
  * which no slot can collide with, since primary names never carry the `2`.
+ *
+ * The per-run suffix is `_<runToken>_<slot>`, not just `_<slot>`: a stamped
+ * primary is `activerecord_unittest_<token>_<slot>`, so the `"2"` has to land
+ * ahead of the *token* — `activerecord_unittest2_<token>_<slot>`. Placing it
+ * after the token instead left `runTokenOfDatabase` reading the sibling's
+ * token as `<token>2`, which both hid it from its own run's teardown and
+ * exposed it to a concurrent run's stale sweep (`run-token.ts`).
  *
  * `arunit` is the primary database itself, as `expand_config` defaults it
  * (`activerecord_unittest`). Rails' only consumer of these two names — the
@@ -58,7 +61,6 @@ export function arunitDatabaseNames(primaryDatabase: string): {
   arunit: string;
   arunit2: string;
 } {
-  const slot = SLOT_SUFFIX.exec(primaryDatabase)?.[0] ?? "";
-  const base = slot === "" ? primaryDatabase : primaryDatabase.slice(0, -slot.length);
-  return { arunit: primaryDatabase, arunit2: `${base}2${slot}` };
+  const { base, suffix } = splitRunDatabaseName(primaryDatabase);
+  return { arunit: primaryDatabase, arunit2: `${base}2${suffix}` };
 }

--- a/packages/activerecord/src/support/run-token.test.ts
+++ b/packages/activerecord/src/support/run-token.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { arunitDatabaseNames } from "./arunit2-config.js";
 import {
   STALE_DB_AGE_MS,
   mysqlAdvisoryLockName,
@@ -47,9 +48,7 @@ describe("slot database names", () => {
 
   it("reads the run token back off a stamped name", () => {
     expect(runTokenOfDatabase(BASE, "activerecord_unittest_rabc000001_2")).toBe("rabc000001");
-    expect(runTokenOfDatabase(BASE, "activerecord_unittest_rabc000001_2_arunit2")).toBe(
-      "rabc000001",
-    );
+    expect(runTokenOfDatabase(BASE, "activerecord_unittest2_rabc000001_2")).toBe("rabc000001");
     expect(runTokenOfDatabase(BASE, "activerecord_unittest_rabc000001_template")).toBe(
       "rabc000001",
     );
@@ -70,7 +69,7 @@ describe("drop targets", () => {
       "activerecord_unittest_2",
       slotDatabaseName(BASE, mine, 1),
       slotDatabaseName(BASE, mine, 2),
-      `${slotDatabaseName(BASE, mine, 2)}_arunit2`,
+      arunitDatabaseNames(slotDatabaseName(BASE, mine, 2)).arunit2,
       slotDatabaseName(BASE, theirs, 1),
       slotDatabaseName(BASE, theirs, 2),
       "postgres",
@@ -80,8 +79,36 @@ describe("drop targets", () => {
     expect(ownRunDatabases(BASE, mine, names)).toEqual([
       "activerecord_unittest_raaa000001_1",
       "activerecord_unittest_raaa000001_2",
-      "activerecord_unittest_raaa000001_2_arunit2",
+      "activerecord_unittest2_raaa000001_2",
     ]);
+  });
+
+  // The arunit2 sibling carries the run's token like every other database the
+  // run mints, but with a `2` on the base. An earlier spelling put the `2` on
+  // the token instead (`<base>_<token>2_<slot>`), so the sibling read as
+  // belonging to token `<token>2`: invisible to its own run's teardown, and
+  // droppable by a concurrent run's stale sweep once `<token>2` aged out.
+  it("keeps the arunit2 sibling of a slot database under its own run token", () => {
+    const mine = newRunToken();
+    const theirs = newRunToken();
+    for (let slot = 1; slot <= 40; slot++) {
+      const sibling = arunitDatabaseNames(slotDatabaseName(BASE, mine, slot)).arunit2;
+      expect(runTokenOfDatabase(BASE, sibling)).toBe(mine);
+      expect(ownRunDatabases(BASE, mine, [sibling])).toEqual([sibling]);
+      expect(ownRunDatabases(BASE, theirs, [sibling])).toEqual([]);
+      expect(staleRunDatabases(BASE, theirs, [sibling])).toEqual([]);
+    }
+  });
+
+  it("reads back exactly the token that minted the name", () => {
+    for (const token of [newRunToken(), `${newRunToken()}2`, "r2222222222"]) {
+      for (let slot = 1; slot <= 40; slot++) {
+        const slotDb = slotDatabaseName(BASE, token, slot);
+        for (const name of [slotDb, arunitDatabaseNames(slotDb).arunit2]) {
+          expect(runTokenOfDatabase(BASE, name)).toBe(token);
+        }
+      }
+    }
   });
 });
 

--- a/packages/activerecord/src/support/run-token.ts
+++ b/packages/activerecord/src/support/run-token.ts
@@ -17,10 +17,11 @@
  * the same name from it.
  *
  * Naming: `<base>_<runToken>_<slot>` for a slot database, plus
- * `<base>_<runToken>_template` for the PG clone template, and whatever a suite
- * appends to a slot name (`_arunit2`, via `arunit2-config.ts`). Every database
- * a run creates therefore starts with `<base>_<runToken>_`, which is what makes
- * "drop only my own" expressible as a prefix test.
+ * `<base>_<runToken>_template` for the PG clone template, and the `arunit2`
+ * sibling of a slot database, `<base>2_<runToken>_<slot>` (via
+ * `arunit2-config.ts`). Every database a run creates therefore starts with
+ * `<base>_<runToken>_` or `<base>2_<runToken>_`, which is what makes "drop only
+ * my own" expressible as a prefix test.
  *
  * Hard rules (RFC 0023): no `node:*` imports, no `process.*`, async fs only —
  * none of which this module needs.
@@ -89,9 +90,32 @@ export function slotDatabaseName(base: string, runToken: string, slot: number): 
   return `${runDatabasePrefix(base, runToken)}${slot}`;
 }
 
-/** The run token a database name carries, or `null` if it carries none. */
+/**
+ * Splits a database name into the part a run derives its names from and the
+ * `_<runToken>_<slot>` suffix a run appends to it (either half may be absent:
+ * an unstamped name carries no token, and a name may carry no slot).
+ *
+ * `arunit2-config.ts` needs this to place its literal `"2"` on the base rather
+ * than inside the suffix — `<base>2_<token>_<slot>` — so the token stays a
+ * whole segment. Appending the `"2"` to the token instead made
+ * `runTokenOfDatabase` read a sibling's token as `<token>2`: not this run's
+ * token (so teardown leaked it), and a plausible *foreign* token (so a
+ * concurrent run's stale sweep could DROP it while it was live).
+ */
+export function splitRunDatabaseName(name: string): { base: string; suffix: string } {
+  const suffix = new RegExp(`(_${TOKEN_PATTERN})?(_\\d+)?$`).exec(name)?.[0] ?? "";
+  return { base: suffix === "" ? name : name.slice(0, -suffix.length), suffix };
+}
+
+/**
+ * The run token a database name carries, or `null` if it carries none.
+ *
+ * The optional `2` is the `arunit2` sibling's marker (`arunit2-config.ts`): it
+ * sits on the base, ahead of the token, so the capture is the minting run's
+ * token whether or not it is there.
+ */
 export function runTokenOfDatabase(base: string, name: string): string | null {
-  const match = new RegExp(`^${escapeRegExp(base)}_(${TOKEN_PATTERN})_`).exec(name);
+  const match = new RegExp(`^${escapeRegExp(base)}2?_(${TOKEN_PATTERN})_`).exec(name);
   return match?.[1] ?? null;
 }
 


### PR DESCRIPTION
`7a9100e2` stamps a run token into every database a run creates, and
`ownRunDatabases` is the filter deciding what teardown and the stale sweep may
DROP. The arunit2 siblings escaped it: `arunitDatabaseNames` inserted the
literal `2` ahead of the slot suffix, so a stamped sibling was
`activerecord_unittest_<token>2_<slot>` and `runTokenOfDatabase` read its token
as `<token>2`.

Two consequences, both fixed here:

1. `ownRunDatabases` never returned the siblings — PG and MySQL teardown leaked
   one arunit2 database per slot, per run, despite the comment at
   `template-global-setup.ts:229-231` claiming one filtered sweep reclaims them.
2. `staleRunDatabases` saw `<token>2` as a *foreign* token, so once it parsed as
   older than `STALE_DB_AGE_MS` a concurrent run could DROP a live run's arunit2
   database — the exact cross-run collision the run token exists to eliminate.

The fix moves the `2` onto the base rather than into the run suffix:
`<base>2_<token>_<slot>`. The token stays a whole segment, `runTokenOfDatabase`
learns the optional marker (`^<base>2?_(<token>)_`), and the capture is the
minting run's token with or without it. Slot 1 unstamped still spells Rails'
own `activerecord_unittest2` (`test/support/config.rb:28`) and the documented
slot-3-vs-slot-32 collision constraint still holds, since primary names never
carry the `2`.

Tests: property-style coverage over (token, slot) triples in
`run-token.test.ts` — every name a run mints reads back exactly the token that
minted it, siblings included, and a sibling is never own/stale for a different
token — plus the previously untested stamped-input case in
`arunit2-config.test.ts`.

Closes-story: arunit2-siblings-escape-run-token-ownership
