### PR TITLE
fix(i18n): tag the Ruby-object-model call omissions in Simple and interpolate

### DIFF
--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -40,6 +40,10 @@ export class Simple extends Base {
    * Stores translations for the given locale in memory. This uses a deep merge
    * for the translations hash, so existing translations will be overwritten by
    * new ones only at the deepest level of the hash.
+   *
+   * @missingRailsCall new — `Concurrent::Hash.new` guards concurrent loading
+   * across threads; JS is single-threaded, so the per-locale hash is a plain
+   * object literal.
    */
   override storeTranslations(
     locale: Locale,
@@ -83,6 +87,11 @@ export class Simple extends Base {
     super.eagerLoadBang();
   }
 
+  /**
+   * @missingRailsCall new — `Concurrent::Hash.new` with a MUTEX-synchronized
+   * default block guards concurrent loading across threads; JS is
+   * single-threaded, so the store is a plain object literal.
+   */
   translations({ doInit = false }: { doInit?: boolean } = {}): TranslationData {
     // To avoid returning empty translations, call `initTranslations`.
     if (doInit && !this.initialized()) this.initTranslations();

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -41,6 +41,11 @@ export function interpolate(string: string, values: unknown): string {
   return interpolateHash(string, values as Record<string, unknown>);
 }
 
+/**
+ * @missingRailsCall call — Ruby's `value.call(values)` on a `respond_to?(:call)`
+ * value is plain invocation in JS; `Function#call` there takes a receiver, not
+ * the argument list.
+ */
 export function interpolateHash(string: string, values: Record<string, unknown>): string {
   const pattern = unionPattern(config().interpolationPatterns);
   let interpolated = false;


### PR DESCRIPTION
The i18n port (#5980) landed three wide call-mismatches, which reds the `Rails API/Test Comparison` job on `main` @3b14289a (`Wide call-mismatches ratchet` step):

```
+ i18n  backend/simple.ts      store_translations  new
+ i18n  backend/simple.ts      translations        new
+ i18n  interpolate/ruby.ts    interpolate_hash    call
```

All three are Ruby object-model constructs with no TS call expression:

- `i18n/lib/i18n/backend/simple.rb:40,71` — `Concurrent::Hash.new` (and its MUTEX-synchronized default block) exists to make concurrent translation loading thread-safe. JS is single-threaded, so the store is a plain object literal and there is no `new`.
- `i18n/lib/i18n/interpolate/ruby.rb:42` — `value.call(values)` on a `respond_to?(:call)` value is plain invocation in JS; `Function#call` takes a receiver, not the argument list.

Recorded with `@missingRailsCall` at each call site rather than in the wide baseline, per CLAUDE.md ("justified at the call site"). No behavior change.

Verified: `pnpm api:calls:wide` → OK, `pnpm api:calls` → OK.

Closes-story: red-3b14289a
