### PR TITLE
ci: run scripts/test-deps guards on activerecord-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
           # packages/activerecord/, is deliberately NOT on this gate — pulling
           # every AR PR into the leaf-package suites costs more than it catches;
           # the label-gated query-parity-trails job covers that direction.)
+          # NO packages/activerecord/ path feeds this gate. scripts/test-deps/
+          # imports AR source, so sqlite-tests (activerecord_affected) re-runs
+          # that suite as its own step — see the comment there.
           # The compare tooling's suites run in that same invocation and are
           # ALL in INFRA_CARVEOUT_RE, so without naming them here a change
           # confined to one of them would run none of its own tests.
@@ -877,6 +880,15 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
+      # scripts/test-deps/ holds the import-graph regression guards
+      # (adapter-graph-import-tdz, base-import-cycle) — both read
+      # packages/activerecord/src, but they are bundled into the unit-tests
+      # job, which is gated on unit_tests_affected and so never runs on an
+      # AR-only PR. That is how the `_arConfig` TDZ reached main red (#5647).
+      # Running them here, as a separate vitest invocation from the AR suite,
+      # keeps them in the `other` project: no AR setupFiles preload the adapter
+      # graph, which is what makes the entry order reproduce the crash.
+      - run: pnpm vitest run scripts/test-deps
       - run: pnpm vitest run packages/activerecord/
       - run: pnpm vitest run packages/activerecord-cli
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,10 @@ jobs:
           # packages/activerecord/, is deliberately NOT on this gate — pulling
           # every AR PR into the leaf-package suites costs more than it catches;
           # the label-gated query-parity-trails job covers that direction.)
-          # NO packages/activerecord/ path feeds this gate. scripts/test-deps/
-          # imports AR source, so sqlite-tests (activerecord_affected) re-runs
-          # that suite as its own step — see the comment there.
+          # NO packages/activerecord/ path feeds this gate. The two suites here
+          # that import AR — scripts/test-deps/ and scripts/parity/query/node/ —
+          # are re-run by sqlite-tests (activerecord_affected) instead; see the
+          # comment there.
           # The compare tooling's suites run in that same invocation and are
           # ALL in INFRA_CARVEOUT_RE, so without naming them here a change
           # confined to one of them would run none of its own tests.
@@ -880,13 +881,14 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
-      # The scripts/test-deps import guards read packages/activerecord/src but
-      # ride the unit_tests_affected gate, which the AR tree is off — so this is
-      # the only job that runs them on an AR-only PR. Separate invocation from
-      # the AR suite on purpose: it keeps them in the `other` vitest project,
-      # whose lack of AR setupFiles is what reproduces the entry order.
+      # Both suites below import activerecord — scripts/test-deps from src,
+      # scripts/parity/query/node through the dump runners it spawns — yet ride
+      # the unit_tests_affected gate, which the AR tree is off. This is the only
+      # job that runs them on an AR-only PR. Separate invocation from the AR
+      # suite on purpose: it keeps them in the `other` vitest project, whose
+      # lack of AR setupFiles is what reproduces the TDZ entry order.
       # (Guard: scripts/ci-suite-coverage.test.ts.)
-      - run: pnpm vitest run scripts/test-deps
+      - run: pnpm vitest run scripts/test-deps scripts/parity/query/node
       - run: pnpm vitest run packages/activerecord/
       - run: pnpm vitest run packages/activerecord-cli
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -880,14 +880,12 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
-      # scripts/test-deps/ holds the import-graph regression guards
-      # (adapter-graph-import-tdz, base-import-cycle) — both read
-      # packages/activerecord/src, but they are bundled into the unit-tests
-      # job, which is gated on unit_tests_affected and so never runs on an
-      # AR-only PR. That is how the `_arConfig` TDZ reached main red (#5647).
-      # Running them here, as a separate vitest invocation from the AR suite,
-      # keeps them in the `other` project: no AR setupFiles preload the adapter
-      # graph, which is what makes the entry order reproduce the crash.
+      # The scripts/test-deps import guards read packages/activerecord/src but
+      # ride the unit_tests_affected gate, which the AR tree is off — so this is
+      # the only job that runs them on an AR-only PR. Separate invocation from
+      # the AR suite on purpose: it keeps them in the `other` vitest project,
+      # whose lack of AR setupFiles is what reproduces the entry order.
+      # (Guard: scripts/ci-suite-coverage.test.ts.)
       - run: pnpm vitest run scripts/test-deps
       - run: pnpm vitest run packages/activerecord/
       - run: pnpm vitest run packages/activerecord-cli

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -299,6 +299,24 @@ describe("CI runs every tooling test suite", () => {
     expect(filter.run.length).toBeLessThan(20_500);
   });
 
+  // scripts/test-deps/ imports packages/activerecord/src (the adapter-graph
+  // TDZ guard enters the graph from outside the AR vitest project by design),
+  // but it is bundled into unit-tests, which is gated on unit_tests_affected —
+  // and packages/activerecord/ is deliberately off that gate for cost reasons.
+  // So the suite has to ALSO run from a job gated on activerecord_affected, or
+  // an AR-only PR reports green and the break lands on the next push to main.
+  // That is how the `_arConfig` TDZ reached main red (#5647).
+  it("runs the scripts/test-deps import guards from an activerecord-gated job", async () => {
+    const wf = parseYaml(await readFile(CI_YML, "utf8"));
+    const jobs: { if?: string; steps?: { run?: string }[] }[] = Object.values(wf.jobs);
+    const covering = jobs.filter(
+      (job) =>
+        String(job.if ?? "").includes("activerecord_affected") &&
+        job.steps?.some((step) => /vitest run[\s\S]*scripts\/test-deps/.test(step.run ?? "")),
+    );
+    expect(covering.length).toBeGreaterThan(0);
+  });
+
   it("keeps the draft deferral, its two jobs and the ci aggregate in agreement", async () => {
     const wf = parseYaml(await readFile(CI_YML, "utf8"));
     const gateOf = (job: string): string => wf.jobs[job].if.replace(/\s+/g, " ").trim();

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -299,20 +299,23 @@ describe("CI runs every tooling test suite", () => {
     expect(filter.run.length).toBeLessThan(20_500);
   });
 
-  // scripts/test-deps/ imports packages/activerecord/src (the adapter-graph
-  // TDZ guard enters the graph from outside the AR vitest project by design),
-  // but it is bundled into unit-tests, which is gated on unit_tests_affected —
-  // and packages/activerecord/ is deliberately off that gate for cost reasons.
-  // So the suite has to ALSO run from a job gated on activerecord_affected, or
-  // an AR-only PR reports green and the break lands on the next push to main.
+  // These two suites import activerecord — scripts/test-deps from src (the
+  // adapter-graph TDZ guard enters the graph from outside the AR vitest project
+  // by design), scripts/parity/query/node through the dump runners it spawns —
+  // but they are bundled into unit-tests, gated on unit_tests_affected, and
+  // packages/activerecord/ is deliberately off that gate for cost reasons. So
+  // each has to ALSO run from a job gated on activerecord_affected, or an
+  // AR-only PR reports green and the break lands on the next push to main.
   // That is how the `_arConfig` TDZ reached main red (#5647).
-  it("runs the scripts/test-deps import guards from an activerecord-gated job", async () => {
+  const AR_IMPORTING_SUITES = ["scripts/test-deps", "scripts/parity/query/node"];
+
+  it.each(AR_IMPORTING_SUITES)("runs %s from an activerecord-gated job", async (suite) => {
     const wf = parseYaml(await readFile(CI_YML, "utf8"));
     const jobs: { if?: string; steps?: { run?: string }[] }[] = Object.values(wf.jobs);
     const covering = jobs.filter(
       (job) =>
         String(job.if ?? "").includes("activerecord_affected") &&
-        job.steps?.some((step) => /vitest run[\s\S]*scripts\/test-deps/.test(step.run ?? "")),
+        job.steps?.some((step) => new RegExp(`vitest run[\\s\\S]*${suite}`).test(step.run ?? "")),
     );
     expect(covering.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
`Unit Tests` is gated on `unit_tests_affected`, which deliberately excludes
`packages/activerecord/`. But `scripts/test-deps/adapter-graph-import-tdz.test.ts`
imports AR source directly — so an AR-only change can break that guard while the
PR reports green, and the break only surfaces on the next push to `main`. That is
exactly how the `_arConfig` TDZ reached main red (fixed in #5647, whose own PR
runs all showed `Unit Tests: skipped`).

Fix: run `pnpm vitest run scripts/test-deps` as a step of `sqlite-tests`, which is
gated on `activerecord_affected`. It stays a separate vitest invocation from the
AR suite, so the files remain in the `other` project — no AR `setupFiles` preload
the adapter graph, which is what makes the entry order reproduce the crash.
`scripts/base-import-cycle` rides along for the same reason.

The AR tree is NOT added to `unit_tests_affected`; the cost carve-out at
ci.yml:175 is preserved, and its rationale comment now states that no
`packages/activerecord/` path feeds the gate and where the AR-side coverage lives.

Verification: a deliberate local re-break (module-level
`include(AbstractAdapter, SchemaStatements)` plus restoring the value-import cycle
from `schema-statements.ts`) fails the guard at collection time with the TDZ
`ReferenceError`; reverted, `pnpm vitest run scripts/test-deps` is green (11 tests).

`scripts/ci-suite-coverage.test.ts` gains a guard asserting some
`activerecord_affected`-gated job runs `scripts/test-deps`, so the wiring can't be
dropped again silently; it fails against `origin/main`.

Closes-story: unit-tests-gate-misses-activerecord-importers
