### PR TITLE
fix(activerecord): restore the current target after the unloaded displacement removal

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -566,7 +566,8 @@ export class HasOneAssociation extends SingularAssociation {
     // `this.target` before its first `await` — so nothing can observe the
     // association caching the displaced record.
     //
-    // The accepted deviation is the *pair* of writes: Rails' target only ever
+    // The accepted deviation (RFC 0068 Design §6) is the *pair* of writes:
+    // Rails' target only ever
     // moves forward, because `load_target` runs before `self.target = record`
     // rather than after it. It cannot be removed while the Rails-named writer
     // is a synchronous property setter (`pirate.shipAttributes = {...}`) that

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -565,8 +565,19 @@ export class HasOneAssociation extends SingularAssociation {
     // below sit in one synchronous slice — `removeTargetBang` reads
     // `this.target` before its first `await` — so nothing can observe the
     // association caching the displaced record.
-    const replacement = this.target;
+    //
+    // The accepted deviation is the *pair* of writes: Rails' target only ever
+    // moves forward, because `load_target` runs before `self.target = record`
+    // rather than after it. It cannot be removed while the Rails-named writer
+    // is a synchronous property setter (`pirate.shipAttributes = {...}`) that
+    // must install the replacement before returning; the awaitable
+    // `setShipAttributes` needs no swap, and retiring the sync setter's
+    // displacement contract is what deletes this method. Read the replacement
+    // *after* the await so the restore writes back whatever the association
+    // caches now — a capture taken before the find would resurrect a target a
+    // later assignment has already superseded.
     const displaced = await this.doAsyncFindTarget();
+    const replacement = this.target;
     if (!displaced || sameRecord(displaced, replacement)) return;
     this.target = displaced;
     const removal = this.detachDisplacedTarget();

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -93,6 +93,46 @@ describe("has_one displacement via the synchronous build path", () => {
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
   });
 
+  it("restores the current replacement when the unloaded displacement resolves", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+
+    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
+    const assoc = refetched.association("ship") as unknown as {
+      doAsyncFindTarget(): Promise<Base | null>;
+      target: Base | null;
+    };
+    // Hold the displacement query open so a second build lands while it is in
+    // flight — the window in which the association caches a target the query's
+    // caller never saw.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const findTarget = assoc.doAsyncFindTarget.bind(assoc);
+    assoc.doAsyncFindTarget = async () => {
+      await gate;
+      return findTarget();
+    };
+
+    (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+    const latest = await (
+      refetched as unknown as { buildShip(a: object): Promise<Base> }
+    ).buildShip({ name: "Black Pearl" });
+    release();
+    await refetched.save();
+
+    // Rails' target only moves forward, so the removal's restore must write the
+    // record the association caches *now*, not the one it cached when the query
+    // was issued.
+    expect(assoc.target).toBe(latest);
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
   it("nullifies the displaced row when association(name).build replaces a loaded child", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
     const displaced = (await Ship.create({


### PR DESCRIPTION
## The RFC record (acceptance criterion 1) — already landed

RFCs are not versioned in this repo; there is no `rfcs/` tree here. They live in
`blazetrailsdev/tasks`, which is why this PR touches no
`rfcs/0068-awaitable-has-one-setter` file and never could. The decision is
recorded there as **RFC 0068 Design §6, "The nested-attributes
`#{name}_attributes=` setter keeps its deferred displacement"** —
`blazetrailsdev/tasks@0566520`, merged to `main` before this PR was opened,
with a matching Changelog entry. It cites
`has_one_association.rb:59-84` for Rails' one-pass
`load_target` -> `remove_target!` -> `self.target = record`, names the swap as
the accepted deviation, and names its exit path: the follow-up story
`retire-nested-attributes-sync-setter-displacement`
(`tasks/rfcs/0068-awaitable-has-one-setter/stories/`), which is what actually
deletes `findThenDetachDisplaced` and `prepareDetachDisplacedForSyncBuild`'s
thunk. The inline comment at `has-one-association.ts:569` is the call-site half
of that record, not a substitute for it.

## Why the deferral stays

Design §2 makes `owner.account = x` throw on a persisted owner because
`await owner.setAccount(x)` is a drop-in replacement for one assignment.
`pirate.ship_attributes = {...}` is not that case: it is reached from
`assign_attributes` / `update` / `create` with a hash of mixed keys, so throwing
rewrites every mass-assignment site containing a nested key, including the
Rails-ported nested-attributes tests. That blast radius is its own story, filed
above.

## The fix

Reviewing the swap surfaced a real defect. `findThenDetachDisplaced` captured
`this.target` **before** awaiting the displacing SELECT and wrote that capture
back after `remove_target!`, so a build landing while the query is in flight is
undone — the restore resurrects the superseded target. Reading `this.target`
after the find resolves makes the restore write back whatever the association
caches at that moment. Rails' target only ever moves forward
(`has_one_association.rb:59-84`, reached from `singular_association.rb:29-32`);
with the read moved, the restore writes the value the association already holds,
so the intermediate target is unobservable by construction rather than by
argument.

Regression test in `has-one-sync-build-displacement.trails.test.ts` gates the
displacing SELECT open, builds a second ship over the pending one, and asserts
the association still caches the latest record. It fails on baseline (restores
"Davy Jones Gold Dagger" over "Black Pearl").

## Verification

- `has-one-sync-build-displacement.trails.test.ts`,
  `nested-attributes-displaced-removal-failure.trails.test.ts`,
  `nested-attributes.test.ts`, `has-one-associations.test.ts` — pass.
- `pnpm api:calls` OK (14 baselined), `pnpm api:calls:wide` OK (2218 baselined)
  — both unchanged; `pnpm api:extra --package activerecord` adds no novel name.

Closes-story: eliminate-sync-build-displacement-target-swap
