### PR TITLE
chore(activerecord): clear stale @noRailsEquivalent tags

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1401,13 +1401,6 @@ export class Base extends Model {
    * a getter can't await without wrapping instances in a `Proxy`.
    *
    * @internal
-   * @noRailsEquivalent PERMANENT No `def ensure_schema_loaded` exists anywhere
-   * in Rails: Ruby reflects lazily and synchronously from `method_missing` /
-   * `define_attribute_methods` around
-   * `vendor/rails/activerecord/lib/active_record/model_schema.rb:534`
-   * (`def load_schema`), where the blocking DB round-trip is invisible to the
-   * caller. Every trails DB call is a promise, so the lazy hook has to be an
-   * awaitable named entry point on the query/persistence path.
    */
   static ensureSchemaLoaded(this: typeof Base): Promise<void> {
     // A model whose declared attributes are all virtual (e.g. Rails'

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -252,11 +252,6 @@ export class ExecutorHooks {
    * at wire-up time to hand the pool a getter instead.
    *
    * @internal Wiring only; called exactly once, from `index.ts`.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
-   * Wiring hook. Ruby resolves the `ActiveRecord::Base`
-   * constant at call time; a TS import here would be a module cycle. See
-   * above.
    */
   static setConnectionHandlerResolver(resolver: () => ConnectionHandlerLike | null): void {
     ExecutorHooks._getConnectionHandler = resolver;
@@ -651,11 +646,6 @@ export class ConnectionPool implements ReapablePool {
    * is tracked by `connection-pool-pinned-sync-checkout-per-checkout-verify`.
    *
    * @internal
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
-   * Sync lease for callers mirroring Rails' synchronous
-   * `lease_connection` that cannot await, since trails' `leaseConnection`
-   * had to become async. See above.
    */
   leaseConnectionSync(): DatabaseAdapter {
     const lease = this.connectionLease();
@@ -1047,10 +1037,6 @@ export class ConnectionPool implements ReapablePool {
    * discarded. Not a Rails counterpart — Rails' `discard!` is fully synchronous.
    *
    * @internal
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
-   * Rails' `discard!` is fully synchronous and has no
-   * async closes to hand back. See above.
    */
   discardBangDraining(): Array<Promise<void>> {
     return this._discardBang();
@@ -1238,11 +1224,6 @@ export class ConnectionPool implements ReapablePool {
    * nothing is in flight (the sync-driver case).
    *
    * @internal
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-connection-pool-async-resolution-shims).
-   * Ruby's `driver.close` is synchronous, so Rails'
-   * discard paths complete the close before returning and need no drain
-   * bookkeeping. See above.
    */
   async drainPendingCloses(): Promise<void> {
     await Promise.all(this._pendingCloseDrains);

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -477,11 +477,6 @@ export class SchemaCache {
    * {@link takeTouchedTables} is called. Test-harness only.
    *
    * @internal
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
-   * Test-harness ledger. Rails re-reflects from a live
-   * blocking connection at fixture teardown and needs no record of what was
-   * cleared.
    */
   recordTouchedTables(): void {
     this._touchedTables = new Set();
@@ -492,10 +487,6 @@ export class SchemaCache {
    * close the recording window. Test-harness only.
    *
    * @internal
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
-   * Test-harness ledger, closing the window opened by
-   * `recordTouchedTables`. No Rails analogue, for the same reason.
    */
   takeTouchedTables(): Set<string> {
     const touched = this._touchedTables ?? new Set<string>();
@@ -561,11 +552,6 @@ export class SchemaCache {
    * Order-independent with {@link setColumns}: whichever lands second runs
    * {@link reconcilePrimaryKeyFlags}, so the authoritative key always wins over
    * a column-reflected flag.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-test-only-sync-writers).
-   * Test-harness seeding, no production caller: Rails'
-   * tests let the blocking `add` / `primary_keys` warm the map, the trails
-   * ports run pool-less. See above.
    */
   setPrimaryKeys(tableName: string, pk: string | string[] | null): void {
     this._primaryKeys.set(tableName, pk);
@@ -622,11 +608,6 @@ export class SchemaCache {
    * the trails ports run pool-less and seed it through this writer instead.
    * Production warming goes through {@link setColumns} (which sets `true` for a
    * table whose columns just came back) or the async `dataSourceExists` query.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-test-only-sync-writers).
-   * Test-harness seeding, no production caller: Rails'
-   * tests let the blocking `data_source_exists?` warm the map, the trails
-   * ports run pool-less. See above.
    */
   setDataSourceExists(tableName: string, exists: boolean): void {
     this._dataSourceExists.set(tableName, exists);
@@ -845,11 +826,6 @@ export class SchemaReflection {
    * this pairs the two so the eager-warm pool path has a single entry point
    * that also routes through the lone-connection `FakePool`. Don't grep Rails
    * for it.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
-   * trails-only composite of Rails'
-   * `SchemaReflection#load!` and `SchemaCache#add_all`; Rails has no
-   * `load_all!`. See above.
    */
   async loadAllBang(pool: unknown): Promise<this> {
     const cache = await this.cache(pool);
@@ -864,11 +840,6 @@ export class SchemaReflection {
    * so adapter-side consumers (AbstractAdapter.schemaCache) see the
    * preloaded data from a schema_cache.json without hitting the DB.
    * External callers should not mutate the returned cache.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
-   * Sync, non-loading peek. Rails' `SchemaReflection`
-   * needs none because every accessor can block on `cache(pool)`. See
-   * above.
    */
   get loadedCache(): SchemaCache | null {
     return this._cache;
@@ -880,10 +851,6 @@ export class SchemaReflection {
    * reader — the BoundSchemaReflection and the adapters' `internalSchemaCache`
    * alike. Assigning drops any in-flight disk load so it can't overwrite the
    * cache the caller just installed.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-schema-cache-sync-and-ledger-shims).
-   * Rails' PoolConfig owns `@schema_cache` outright; trails routes the slot
-   * here so there is a single instance. See above.
    */
   set loadedCache(cache: SchemaCache | null) {
     this._cache = cache;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2749,13 +2749,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   /**
    * Complete a deferred async connection. No-op when already connected
-   * synchronously. Invoked by `openAsync()` and `verifyBang()`. @internal
+   * synchronously. Invoked by `openAsync()` and `verifyBang()`.
    *
-   * @noRailsEquivalent PERMANENT — Rails' `connect` (sqlite3_adapter.rb:806)
-   * opens the handle synchronously inside `initialize`, so there is nothing
-   * left to finish afterwards. Drivers whose `open()` returns a Promise cannot
-   * be opened from a synchronous constructor or a synchronous pool checkout,
-   * so the deferred completion is a seam Ruby never needs.
+   * @internal
    */
   async completeAsyncConnect(): Promise<void> {
     if (!this._asyncConnectPending) return;


### PR DESCRIPTION
Clears the 12 STALE `@noRailsEquivalent` tags that were failing `pnpm api:extra` on `main`.

All 12 went stale for the same reason: each member carries an `@internal` tag, and extra-surface never counts internal declarations — so the `@noRailsEquivalent` tag on it is dead metadata. Verified member by member before deleting; no blanket delete, no allowlist. The surrounding prose in each doc comment already carries the Rails context the tag reason restated.

- `schema-cache.ts` — `recordTouchedTables`, `takeTouchedTables`, `setPrimaryKeys`, `setDataSourceExists`, `loadAllBang`, `loadedCache` (getter + setter)
- `abstract/connection-pool.ts` — `setConnectionHandlerResolver`, `leaseConnectionSync`, `discardBangDraining`, `drainPendingCloses`
- `sqlite3-adapter.ts` — `completeAsyncConnect`
- `base.ts` — `ensureSchemaLoaded`

One extra fix: `completeAsyncConnect` had its `@internal` sitting mid-line at the end of a prose sentence, where it still parses as a real tag. Moved onto its own line so the intent is not ambiguous to the next reader.

Non-stale tags in the same files (e.g. `ConnectionPool#adapterReady`, `#queryCacheDisabled`, `SchemaReflection.eagerLoadSchemaCache`) are untouched.

`pnpm api:extra` exits 0.

Closes-story: clear-stale-norailsequivalent-tags
