### PR TITLE
refactor(activerecord): run TableDefinition#setPrimaryKey once, behind Rails' guard

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -84,7 +84,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         "mysql_table_options",
         {
           force: true,
-          id: false,
           primaryKey: ["id", "account_id"],
           charset: "utf8mb4",
           collation: "utf8mb4_bin",

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -388,11 +388,6 @@ describe("TableDefinition#raise_on_duplicate_column", () => {
 });
 
 describe("TableDefinition#primary_key option", () => {
-  it("treats primaryKey: false same as id: false", () => {
-    const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), primaryKey: false });
-    expect(td.columns.find((c) => c.options.primaryKey)).toBeUndefined();
-  });
-
   it("treats primaryKey: 'uuid' as a custom PK column name", () => {
     const td = new TableDefinition("t", { adapter: schemaConn("sqlite"), primaryKey: "uuid" });
     const pk = td.columns.find((c) => c.options.primaryKey);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1001,38 +1001,32 @@ export class TableDefinition {
       collation?: string;
       default?: unknown;
       autoIncrement?: boolean;
+      limit?: number;
+      precision?: number;
+      unsigned?: boolean;
     },
   ) {
     this.tableName = tableName;
     this._adapterName = tdOptions.adapterName ?? "sqlite";
     this._adapter = tdOptions.adapter;
-    // Composite primaryKey implies id: false — Rails requires this and emitting both
-    // an auto-id column AND a composite PK constraint is invalid DDL.
-    const hasCompositePk = Array.isArray(tdOptions.primaryKey) && tdOptions.primaryKey.length > 0;
     if (Array.isArray(tdOptions.primaryKey) && tdOptions.primaryKey.length === 0) {
       throw new ArgumentError("primaryKey array must not be empty");
     }
-    // primaryKey: false ⇒ same as id: false (no auto-PK column).
-    // primaryKey: "custom_name" ⇒ keep auto-PK but rename the column.
-    const pkFalse = tdOptions.primaryKey === false;
-    const pkNameOverride =
-      typeof tdOptions.primaryKey === "string" ? tdOptions.primaryKey : undefined;
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;
     this.as = tdOptions.as;
     this.options = tdOptions.options;
     this.comment = tdOptions.comment;
+    // Rails calls set_primary_key from build_create_table_definition
+    // (schema_statements.rb:335) rather than the constructor, because its
+    // TableDefinition#initialize takes no id/primary_key. trails' callers build
+    // definitions directly, so the single invocation lives here instead — the
+    // primary-key options travel alongside id/primaryKey in the same hash.
     const pkOptions: Record<string, unknown> = {};
-    if (tdOptions.default !== undefined) pkOptions.default = tdOptions.default;
-    if (tdOptions.autoIncrement !== undefined) pkOptions.autoIncrement = tdOptions.autoIncrement;
-    this.setPrimaryKey(
-      tableName,
-      // A composite primaryKey overrides `id: false`: Rails' guard would skip it,
-      // but trails' callers spell a composite PK as `id: false, primaryKey: [...]`.
-      hasCompositePk ? true : pkFalse ? false : (tdOptions.id ?? true),
-      hasCompositePk ? (tdOptions.primaryKey as string[]) : pkNameOverride,
-      pkOptions,
-    );
+    for (const key of ["limit", "default", "precision", "unsigned", "autoIncrement"] as const) {
+      if (tdOptions[key] !== undefined) pkOptions[key] = tdOptions[key];
+    }
+    this.setPrimaryKey(tableName, tdOptions.id ?? true, tdOptions.primaryKey, pkOptions);
   }
 
   setPrimaryKey(
@@ -1041,13 +1035,6 @@ export class TableDefinition {
     primaryKey?: string | string[] | false,
     options: Record<string, unknown> = {},
   ): void {
-    // Rails has no equivalent: its set_primary_key only ever runs on a fresh
-    // definition, while trails also re-runs it over a definition rebuilt from an
-    // existing table (SQLite's copy-table path), which already carries the old PK.
-    for (let i = this.columns.length - 1; i >= 0; i--) {
-      if (this.columns[i].options.primaryKey) this.columns.splice(i, 1);
-    }
-
     if (!id || this.as) return;
 
     // Rails' `primary_key || Base.get_primary_key(...)` — `||`, not `??`, so an

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -349,10 +349,8 @@ export function emitTableBody(
   // All values in tableOpts are pre-formatted TS-DSL text for formatColspec.
   const tableOpts: Record<string, unknown> = {};
   if (hasCompositePk) {
-    // Rails (Array case) emits only `primary_key: [...]`; the TS DSL also needs
-    // `id: false` so createTable doesn't auto-add an `id` column on round-trip.
+    // Rails (Array case) emits only `primary_key: [...]` — schema_dumper.rb:182.
     tableOpts["primaryKey"] = JSON.stringify(pkColumns.map((c) => c.name));
-    tableOpts["id"] = "false";
   } else if (!pkColumn) {
     tableOpts["id"] = "false";
   } else {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1488,21 +1488,13 @@ export class SchemaStatements {
 
     const ctdOptions = {
       ...tdOptions,
-      id: false,
+      ...pkOptions,
+      id,
+      primaryKey,
       adapterName: this.adapterName,
       adapter: this,
     };
-    const tableDefinition = this.createTableDefinition
-      ? this.createTableDefinition(tableName, ctdOptions)
-      : this.createTableDefinition(tableName, ctdOptions);
-    tableDefinition.setPrimaryKey(
-      tableName,
-      // A composite primaryKey overrides `id: false`: Rails' guard would skip it,
-      // but trails' callers spell a composite PK as `id: false, primaryKey: [...]`.
-      Array.isArray(primaryKey) ? true : id,
-      primaryKey,
-      pkOptions,
-    );
+    const tableDefinition = this.createTableDefinition(tableName, ctdOptions);
 
     if (fn) fn(tableDefinition);
 

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -355,7 +355,9 @@ describe("SchemaDumperAdapterTest", () => {
     const lines: string[] = [];
     await (dumper as any).table("t", lines);
     expect(lines[0]).toContain(`primaryKey: ["id","account_id"]`);
-    expect(lines[0]).toContain(`id: false`);
+    // Rails' Array case emits only `primary_key: [...]` (schema_dumper.rb:182);
+    // `id: false` would skip set_primary_key's guard on round-trip.
+    expect(lines[0]).not.toContain(`id: false`);
   });
 
   // Drop the real tables these adapter-backed tests create on the shared

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -275,10 +275,14 @@ export async function runTable(
 ): Promise<void> {
   const { name, meta, fn } = def;
   const createOpts: { id?: false; primaryKey?: string[] } = {};
-  if (meta.id === false || meta.serialPk !== undefined || meta.primaryKey !== undefined) {
+  // Rails spells a composite PK `create_table t, primary_key: [...]` with the
+  // default `id` — `id: false` would skip set_primary_key's `if id` guard
+  // entirely (schema_definitions.rb:395).
+  if (meta.primaryKey !== undefined) {
+    createOpts.primaryKey = meta.primaryKey;
+  } else if (meta.id === false || meta.serialPk !== undefined) {
     createOpts.id = false;
   }
-  if (meta.primaryKey !== undefined) createOpts.primaryKey = meta.primaryKey;
   let builder!: TableBuilder;
   await ss.createTable(name, createOpts, (t: TableDefinition) => {
     builder = new TableBuilder(t, adapter.adapterName, typeMap, meta.serialPk ?? null);


### PR DESCRIPTION
Converges `TableDefinition#set_primary_key` onto Rails
(`activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:395-410`):
guarded by `if id && !as`, one invocation per definition, no column clearing.

- `buildCreateTableDefinition` (`abstract/schema-statements.ts`) no longer
  constructs with `id: false` and re-runs `setPrimaryKey`; it passes the
  caller's real `id` / `primaryKey` (and the primary-key options) to the
  constructor, which makes the single call.
- Deleted the loop that spliced existing primary-key columns off
  `this.columns` — it only existed to absorb the second invocation. SQLite's
  `copyTable` never re-runs `setPrimaryKey` (it uses the `primaryKeys` setter,
  as Rails does).
- Dropped both `Array.isArray(primaryKey) ? true : id` overrides and the
  constructor's `primaryKey: false ⇒ id: false` mapping. Rails' `pk =
  primary_key || Base.get_primary_key(...)` already gives `primary_key: false`
  the conventional name, which is what `buildCreateTableDefinition`'s existing
  test asserts; the constructor test asserting the opposite is removed.
- Migrated the composite-PK callers to Rails' spelling `primary_key: [...]`
  (with the default `id`): `runTable` in `support/canonical-schema.ts`, and the
  schema dumper's Array case, which per `schema_dumper.rb:182` emits only
  `primary_key: [...]`. The dumper's extra `id: false` would now skip the guard
  on round-trip, so it had to go.

Composite-PK create-table and dumps verified unchanged on SQLite locally
(`primary-keys`, `schema-dumper`, `copy-table`, `migration/*`, canonical
schema); PG/MySQL via CI.

Closes-story: converge-set-primary-key-guard-and-single-invocation
