### PR TITLE
fix(activesupport): converge EncryptedFile cipher to aes-128-gcm

### DIFF
--- a/packages/activesupport/src/encrypted-file.trails.test.ts
+++ b/packages/activesupport/src/encrypted-file.trails.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EncryptedFile } from "./encrypted-file.js";
+import { getFsAsync, getPathAsync } from "./fs-adapter.js";
+import { getOsAsync } from "./os-adapter.js";
+
+// Trails-only coverage for the aes-128-gcm cipher constant
+// (`vendor/rails/activesupport/lib/active_support/encrypted_file.rb:29`):
+// Rails has no equivalent test because its cipher never changed.
+describe("EncryptedFile cipher", () => {
+  let tmpdir: string;
+  let contentPath: string;
+  let keyPath: string;
+
+  beforeEach(async () => {
+    const fs = await getFsAsync();
+    const path = await getPathAsync();
+    const os = await getOsAsync();
+    tmpdir = await fs.mkdtemp!(`${os.tmpdir()}${path.sep}encrypted-file-cipher-test-`);
+    contentPath = path.join(tmpdir, "content.txt.enc");
+    keyPath = path.join(tmpdir, "content.txt.key");
+  });
+
+  afterEach(async () => {
+    const fs = await getFsAsync();
+    try {
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+    } catch {
+      /* */
+    }
+  });
+
+  it("generates a 16-byte key, hex-encoded", () => {
+    expect(EncryptedFile.generateKey()).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("expects a 32-character key", () => {
+    expect(EncryptedFile.expectedKeyLength()).toBe(32);
+  });
+
+  it("round-trips content under aes-128-gcm", async () => {
+    const fs = await getFsAsync();
+    await fs.writeFile!(keyPath, EncryptedFile.generateKey());
+    const ef = new EncryptedFile({
+      contentPath,
+      keyPath,
+      envKey: "CONTENT_KEY",
+      raiseIfMissingKey: true,
+    });
+    await ef.write("One little fox jumped over the hedge");
+    expect(await ef.read()).toBe("One little fox jumped over the hedge");
+  });
+});

--- a/packages/activesupport/src/encrypted-file.ts
+++ b/packages/activesupport/src/encrypted-file.ts
@@ -12,11 +12,6 @@
  *
  * - **Async API.** Rails is sync; the async surface is required for
  *   trailties' "async fs only" rule and for browser hosts without sync fs.
- * - **Default cipher = `aes-256-cbc`.** Rails uses `aes-128-gcm`.
- *   `MessageEncryptor` handles GCM auth tags now, so the remaining blocker is
- *   the migration: the cipher sets the key length, so flipping it invalidates
- *   every existing key file. Story
- *   `converge-encrypted-file-cipher-to-aes-128-gcm` (RFC 0072).
  * - **Default serializer = `NullSerializer`** (raw string in/out). Rails
  *   uses `Marshal`; we have no Marshal port. The higher-level
  *   `EncryptedConfiguration` parses contents itself.
@@ -28,7 +23,7 @@ import { getFsAsync, getPathAsync } from "./fs-adapter.js";
 import { MessageEncryptor, NullSerializer } from "./message-encryptor.js";
 import { env as processEnv } from "./process-adapter.js";
 
-const CIPHER = "aes-256-cbc";
+const CIPHER = "aes-128-gcm";
 
 export class MissingContentError extends Error {
   constructor(contentPath: string) {


### PR DESCRIPTION
`packages/activesupport/src/encrypted-file.ts` declared
`const CIPHER = "aes-256-cbc"`. Rails'
`vendor/rails/activesupport/lib/active_support/encrypted_file.rb:29` declares
`CIPHER = "aes-128-gcm"` — different algorithm, different key size, and
authenticated rather than unauthenticated. This flips the constant and drops
the divergence note from the file header.

The prerequisite landed already: `MessageEncryptor` handles AEAD (GCM auth
tag) mode, and `MessageEncryptor.keyLen("aes-128-gcm")` returns 16, so
`generateKey()` (`encrypted_file.rb:31-32`) and `expectedKeyLength()`
(`encrypted_file.rb:35-37`) both derive the Rails values with no other change.

## Key-length migration impact

**This invalidates every existing key file.** `expectedKeyLength()` derives
from `generateKey().length`, so the accepted key length goes from 64 hex chars
(32 bytes) to Rails' 32 hex chars (16 bytes). Existing `config/master.key` /
`*.key` files written under the old cipher are now rejected by
`checkKeyLength` with `InvalidKeyLengthError`, and existing `.enc` payloads —
CBC ciphertext with a trailing HMAC — cannot be decrypted under GCM. Anyone
holding a trails-encrypted file must regenerate the key and re-encrypt the
contents. There are no committed key files or fixtures in this repo, and every
in-repo caller (`encrypted-file-editor.ts`, the `master-key`,
`encryption-key-file`, `credentials` and `encrypted-file` generators) sources
its key from `EncryptedFile.generateKey()`, so nothing in-tree hardcodes the
old length.

## Serializer

The story asked whether `serializer: NullSerializer` vs Rails'
`serializer: Marshal` (`encrypted_file.rb:113`) is related. It is not — it is
independent of the cipher and blocked on there being no Marshal port. The
existing header note stays as the record of that separate deviation.

## Tests

Rails has no test for the cipher constant (its cipher never changed), so the
new coverage goes in a `.trails.test.ts` sibling: key shape (32 hex chars),
`expectedKeyLength() === 32`, and a write/read round trip under GCM. The ported
`encrypted-file.test.ts` is unchanged and still passes — it sources its key
from `generateKey()` throughout.

Verified: `encrypted-file.test.ts`, `encrypted-file.trails.test.ts`,
`encrypted-configuration.test.ts`, `trailties/encrypted-file-editor.test.ts`
and the four key-file generator tests all pass; `tsc --build` +
`scripts/typecheck.mjs` and eslint clean.

Closes-story: converge-encrypted-file-cipher-to-aes-128-gcm
