### PR TITLE
refactor(activerecord): drop the zero-node join-dependency degrade branches

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2745,19 +2745,6 @@ export class Relation<T extends Base> {
 
     const jd = this._buildEagerJoinDependency(eagerAssociations);
 
-    // Nothing to JOIN (empty spec): load the base rows only.
-    if (jd.nodes.length === 0) {
-      const sql = this._toSql();
-      // selectAll (not execute) so the adapter-reported column_types cast
-      // extra/computed select columns, matching the JOIN and plain load paths.
-      const result = await this._conn().selectAll(sql, "SQL", this._lastSelectBinds);
-      this._records = this._instrumentInstantiation(
-        result.toArray(),
-        result.columnTypes as Record<string, { deserialize(value: unknown): unknown }>,
-      );
-      return;
-    }
-
     // For collection (non-limitable) eager loads with a LIMIT/OFFSET, Rails
     // (distinct_relation_for_primary_key) runs a separate DISTINCT-pk query to
     // materialize the limited parent IDs, then re-queries with `pk IN (ids)`.
@@ -3581,13 +3568,6 @@ export class Relation<T extends Base> {
 
       const basePk = (this._modelClass as any).primaryKey ?? "id";
       const jd = this._buildEagerJoinDependency(eagerSpecs);
-
-      // Nothing was joined (empty spec): degrade entirely to the base relation
-      // (limit/offset preserved), mirroring _executeEagerLoad's
-      // jd.nodes.length === 0 path.
-      if (jd.nodes.length === 0) {
-        return rel.pluck(...columns);
-      }
 
       const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
       if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
@@ -6583,12 +6563,7 @@ export class Relation<T extends Base> {
         const hasLimitOrOffset = this._limitValue !== null || (this._offsetValue ?? 0) > 0;
         const pk = (this._modelClass as { primaryKey?: string | string[] }).primaryKey ?? "id";
         const jd = this._buildEagerJoinDependency(eagerSpecs);
-        if (jd.nodes.length === 0) {
-          // Nothing was joined (empty spec): degrade entirely to the base
-          // relation (limit/offset preserved), mirroring _executeEagerLoad's
-          // jd.nodes.length === 0 path.
-          collection = rel;
-        } else if (
+        if (
           hasLimitOrOffset &&
           !this._applyJoinDependencyIsLimitable(eagerSpecs) &&
           !Array.isArray(pk)

--- a/packages/activerecord/src/relation/empty-eager-spec-join-dependency.trails.test.ts
+++ b/packages/activerecord/src/relation/empty-eager-spec-join-dependency.trails.test.ts
@@ -1,0 +1,57 @@
+/**
+ * A blank-but-present eager spec (`eagerLoad([])`, `eagerLoad({})`) makes
+ * `eager_loading?` true — `eager_load_values.any?` is true for `[[]]`
+ * (relation.rb:414, query_methods.rb:295) — while
+ * `JoinDependency.walk_tree` folds it to an empty tree, so the JoinDependency
+ * has zero nodes.
+ *
+ * Rails does not special-case that: `apply_join_dependency`
+ * (finder_methods.rb:457) builds the JoinDependency, joins it (contributing no
+ * JOINs), and runs the ordinary query. trails carried three
+ * `jd.nodes.length === 0` degrade branches — in `_executeEagerLoad`, the
+ * `pluck` eager path and the `cacheVersion` eager path — which were load-bearing
+ * only while the preload-fallback lane existed (deleted in #5968). This file
+ * covers the shape that reaches those sites, so the ordinary Rails-shaped flow
+ * stays correct without them.
+ *
+ * trails-only (hence `.trails.test.ts`): Rails has no test for a blank eager
+ * spec that is actually executed.
+ */
+import { describe, it, expect } from "vitest";
+import { Base } from "../index.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Topic } from "../test-helpers/models/topic.js";
+import { fixtures } from "../test-fixtures.js";
+
+describe("blank eager spec with a zero-node join dependency", () => {
+  fixtures(["posts", "comments", "topics"]);
+
+  it("loads the base records", async () => {
+    const posts = await Post.eagerLoad([]).order("id");
+    const plain = await Post.order("id");
+    expect(posts.map((p) => p.id)).toEqual(plain.map((p) => p.id));
+  });
+
+  it("loads the base records for a blank hash spec", async () => {
+    const posts = await Post.eagerLoad({}).order("id");
+    expect(posts.length).toBeGreaterThan(0);
+  });
+
+  it("plucks from the base relation", async () => {
+    const ids = await Post.eagerLoad([]).order("id").pluck("id");
+    const plain = await Post.order("id").pluck("id");
+    expect(ids).toEqual(plain);
+  });
+
+  it("computes a cache version from the base relation", async () => {
+    const original = Base.collectionCacheVersioning;
+    Base.collectionCacheVersioning = true;
+    try {
+      const version = await Topic.eagerLoad([]).cacheVersion();
+      const plain = await Topic.all().cacheVersion();
+      expect(version).toEqual(plain);
+    } finally {
+      Base.collectionCacheVersioning = original;
+    }
+  });
+});


### PR DESCRIPTION
Three eager-load call sites in `packages/activerecord/src/relation.ts` branched on `jd.nodes.length === 0` and degraded to the plain base relation: `_executeEagerLoad`, the `pluck` eager path, and the `cacheVersion` eager path.

They were load-bearing while the preload-fallback lane existed (a JD whose specs had all been rolled back into `fallbackAssocs` had zero nodes). PR #5968 deleted that lane, so the only remaining producer of a zero-node JD is a **blank-but-present** eager spec — `eagerLoad([])` / `eagerLoad({})`, which makes `eager_loading?` true (`eager_load_values.any?` is true for `[[]]`, query_methods.rb:295 / relation.rb:414) while `JoinDependency.walk_tree` folds the spec to an empty tree.

Rails does not special-case that shape: `apply_join_dependency` (`vendor/rails/activerecord/lib/active_record/relation/finder_methods.rb:457`) builds the JoinDependency, joins it (contributing no JOINs) and runs the ordinary query. So all three branches are deleted and the blank spec now flows through the same Rails-shaped path as any other eager load.

- No change to emitted SQL for any spec that already joins.
- No change to `_eagerLoadBypassesJoinDependency` (a separate, still-live degrade route).
- New `empty-eager-spec-join-dependency.trails.test.ts` covers load / pluck / cacheVersion over `eagerLoad([])` and `eagerLoad({})`. It passes on the baseline too (the deleted branches produced the same results) — it exists to pin the shape that reaches the now-single flow.

Closes-story: drop-zero-node-join-dependency-degrade-branches