### PR TITLE
refactor(activerecord): retire the nested-attributes sync setter's deferred displacement

### DIFF
--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -369,6 +369,36 @@ export class DeleteRestrictionError extends ActiveRecordError {
 }
 
 /**
+ * Thrown when a one-to-one `#{name}_attributes=` nested-attributes assignment
+ * would *displace* an existing associated record — build a replacement over a
+ * record the association already holds, or over one that only exists in the DB.
+ *
+ * The sibling of {@link HasOnePersistedAssignmentError}, for the same reason:
+ * Rails' `build_#{name}` → `set_new_record` → `replace(record, false)` runs
+ * `load_target` (has_one_association.rb:59) and `remove_target!` (:69) inline
+ * before `self.target = record` (:84), and neither the SELECT nor the
+ * nullify/destroy save can be awaited from a JS property setter. Deferring them
+ * to the owner's next `save()` is what RFC 0068 exists to kill, so the
+ * synchronous setter refuses and names the awaitable writer instead. Nested
+ * assignments that displace nothing — a fresh association, an `id`-matched
+ * update, a reused unsaved build — stay on the synchronous setter.
+ */
+export class NestedAttributesDisplacementError extends ActiveRecordError {
+  readonly association: string;
+
+  constructor(association: string) {
+    const cap = association.charAt(0).toUpperCase() + association.slice(1);
+    super(
+      `Cannot replace the existing \`${association}\` with \`${association}Attributes = ` +
+        `{...}\`: Rails removes the displaced record at assignment time, which ` +
+        `requires \`await\` in JS. Use \`await owner.set${cap}Attributes({...})\`.`,
+    );
+    this.name = "NestedAttributesDisplacementError";
+    this.association = association;
+  }
+}
+
+/**
  * Thrown when a `has_one` association is assigned with the native `=` setter
  * (or a mass-assignment key) on a *persisted* owner. This is a deliberate
  * trails-only deviation with no Rails counterpart: Rails'

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -382,6 +382,12 @@ export class DeleteRestrictionError extends ActiveRecordError {
  * synchronous setter refuses and names the awaitable writer instead. Nested
  * assignments that displace nothing — a fresh association, an `id`-matched
  * update, a reused unsaved build — stay on the synchronous setter.
+ *
+ * @noRailsEquivalent Rails has no such error because `ship_attributes=` does
+ * the displacement inline; a JS property setter's value expression cannot be
+ * awaited by any caller syntax, so the write is unimplementable there and the
+ * refusal is the honest port. Sibling of `HasOnePersistedAssignmentError` /
+ * `CollectionPersistedAssignmentError` (RFC 0068 Design §2, §6).
  */
 export class NestedAttributesDisplacementError extends ActiveRecordError {
   readonly association: string;

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -484,11 +484,10 @@ export class HasOneAssociation extends SingularAssociation {
    * record` (:84) is never reached when `remove_target!` raises (e.g. a failed
    * nullify save, has_one_association.rb:102-108).
    *
-   * The one synchronous caller — the nested-attributes property setter, which
-   * cannot await — starts the removal here and *then* builds. That is safe
-   * because `removeTargetBang` reads `this.target` on entry, before its first
-   * `await`: the build's swap lands in the same synchronous slice and cannot
-   * disturb the in-flight removal.
+   * There is no synchronous caller: the Rails-named `#{name}_attributes=`
+   * setter refuses a displacing assignment outright
+   * ({@link NestedAttributesDisplacementError}) rather than starting a removal
+   * it cannot await, so every caller here runs Rails' order intact.
    *
    * No `isPersisted` pre-screen: Rails' `remove_target!` gates on persistence
    * only inside its `:destroy` and nullify arms; the `:delete` arm calls
@@ -500,7 +499,7 @@ export class HasOneAssociation extends SingularAssociation {
    * surface — Rails' `remove_target!` is private too. The nested-attributes
    * writer lives outside the class hierarchy and reaches it through its
    * duck-typed `OneToOneAssociation` handle, exactly as it does the sibling
-   * `prepareDetachDisplacedForSyncBuild`.
+   * `displacementNeedsAwait`.
    *
    * @internal
    */
@@ -512,78 +511,30 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   /**
-   * The unloaded half of the nested-attributes writer's `remove_target!`.
+   * Whether a nested-attributes build over this association would reach DB I/O
+   * — the question the *synchronous* `#{name}_attributes=` setter has to answer
+   * before it starts, because it can await neither half of the `load_target`
+   * (has_one_association.rb:59) / `remove_target!` (:69) pair Rails runs inline.
    *
-   * Rails' `set_new_record` -> `replace(record, false)` opens with `load_target`
-   * (has_one_association.rb:59-62) on EVERY build, so a build over a *never
-   * loaded* has_one on a persisted owner still discovers the existing row and
-   * removes it. `detachDisplacedTarget` only covers what the caller already had
-   * in memory; this covers the row that only ever existed in the DB.
-   *
-   * The synchronous writer (`pirate.shipAttributes = {...}`) cannot await the
-   * SELECT, so it parks the promise on the owner and drains it in the `save`
-   * wrapper exactly like `detachDisplacedTarget`'s. Null when Rails would issue
-   * no query at all (`findTargetNeeded`) or when the target is already loaded,
-   * which keeps the writer synchronous on those paths.
-   *
-   * Returns a *thunk* rather than the promise: Rails reaches `load_target` from
-   * `set_new_record`, i.e. after `build_record`, so a build that raises issues
-   * no query. The gate (`find_target?`) stops being observable once
-   * `setNewRecord` marks the association loaded, so the writer takes the
-   * decision here, before `buildRecord`, and invokes the thunk after
-   * `setNewRecord`.
-   *
-   * The writer invokes the thunk only when `buildRecord` returns normally,
-   * which would suppress a query for a throw from the `set_new_record` half —
-   * Rails reaches everything past has_one_association.rb:62 with `load_target`
-   * already run. That half is unreachable on this path: `raise_on_type_mismatch!`
-   * (:60) is the sole pre-`load_target` raise and cannot fire for a record the
-   * association built from its own reflection, and the remainder is
-   * `setNewRecord`'s in-memory foreign-key/inverse writes.
+   * True on both displacing arms: an already-loaded record to remove, and an
+   * unloaded association whose `find_target?` (`findTargetNeeded`) says Rails
+   * would query for one — the guard is `return target unless load_target ||
+   * record`, and Ruby always evaluates the left operand, so a never-loaded
+   * has_one on a persisted owner still discovers (and removes) the row. False
+   * when the build displaces nothing, which keeps the synchronous setter
+   * working for every non-displacing assignment.
    *
    * `protected` because this is association-internal bookkeeping, not API
-   * surface. The writer lives outside the class hierarchy and reaches it
-   * through its duck-typed handle.
-   *
-   * The find deliberately goes through `doAsyncFindTarget` rather than
-   * `loadTargetForBuild`: by the time it resolves, the build has already
-   * installed the replacement as `this.target`, and `load_target`'s writeback
-   * would clobber it. We need only the displaced record, never the cache.
+   * surface. The nested-attributes writer lives outside the class hierarchy and
+   * reaches it through its duck-typed handle, as it does `detachDisplacedTarget`.
    *
    * @internal
    */
-  protected prepareDetachDisplacedForSyncBuild(): (() => Promise<void>) | null {
-    if (this.loaded) return null;
-    if (!this.findTargetNeeded()) return null;
-    return () => this.findThenDetachDisplaced();
-  }
-
-  private async findThenDetachDisplaced(): Promise<void> {
-    // The synchronous build installed the replacement while the find was in
-    // flight, so run Rails' `replace` tail in order only now: `load_target`
-    // (just awaited) → `remove_target!` → `self.target = record`. Both writes
-    // below sit in one synchronous slice — `removeTargetBang` reads
-    // `this.target` before its first `await` — so nothing can observe the
-    // association caching the displaced record.
-    //
-    // The accepted deviation (RFC 0068 Design §6) is the *pair* of writes:
-    // Rails' target only ever
-    // moves forward, because `load_target` runs before `self.target = record`
-    // rather than after it. It cannot be removed while the Rails-named writer
-    // is a synchronous property setter (`pirate.shipAttributes = {...}`) that
-    // must install the replacement before returning; the awaitable
-    // `setShipAttributes` needs no swap, and retiring the sync setter's
-    // displacement contract is what deletes this method. Read the replacement
-    // *after* the await so the restore writes back whatever the association
-    // caches now — a capture taken before the find would resurrect a target a
-    // later assignment has already superseded.
-    const displaced = await this.doAsyncFindTarget();
-    const replacement = this.target;
-    if (!displaced || sameRecord(displaced, replacement)) return;
-    this.target = displaced;
-    const removal = this.detachDisplacedTarget();
-    this.target = replacement;
-    await removal;
+  protected displacementNeedsAwait(): boolean {
+    if (!this.loaded) return this.findTargetNeeded();
+    const displaced = this.target;
+    if (!displaced) return false;
+    return (displaced as { isDestroyed?: () => boolean }).isDestroyed?.() !== true;
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {
@@ -666,8 +617,8 @@ export class HasOneAssociation extends SingularAssociation {
    * an `await` this synchronous method cannot issue, so every caller that can
    * displace a persisted record issues it itself — `detachDisplacedTarget` from
    * the `build#{name}` / `create#{name}` accessors (builder/has-one.ts,
-   * `_createRecord`), and the same method from the nested-attributes writer
-   * (nested-attributes.ts, `detachDisplacedAtAssignment`). Nothing is queued
+   * `_createRecord`), and the same method from the awaitable nested-attributes
+   * writer (nested-attributes.ts, `detachDisplacedThenSetNewRecord`). Nothing is queued
    * here: a queue drained at the owner's `save` would defer a write Rails makes
    * at assignment, and would double-remove records the awaiting callers have
    * already detached.

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -145,46 +145,6 @@ describe("has_one displacement via the synchronous build path", () => {
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
   });
 
-  it("restores the current replacement when the unloaded displacement resolves", async () => {
-    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
-    const displaced = (await Ship.create({
-      name: "Nights Dirty Lightning",
-      pirate_id: (pirate as unknown as { id: number }).id,
-    })) as Base;
-
-    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
-    const assoc = refetched.association("ship") as unknown as {
-      doAsyncFindTarget(): Promise<Base | null>;
-      target: Base | null;
-    };
-    // Hold the displacement query open so a second build lands while it is in
-    // flight — the window in which the association caches a target the query's
-    // caller never saw.
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => (release = resolve));
-    const findTarget = assoc.doAsyncFindTarget.bind(assoc);
-    assoc.doAsyncFindTarget = async () => {
-      await gate;
-      return findTarget();
-    };
-
-    (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
-      name: "Davy Jones Gold Dagger",
-    };
-    const latest = await (
-      refetched as unknown as { buildShip(a: object): Promise<Base> }
-    ).buildShip({ name: "Black Pearl" });
-    release();
-    await refetched.save();
-
-    // Rails' target only moves forward, so the removal's restore must write the
-    // record the association caches *now*, not the one it cached when the query
-    // was issued.
-    expect(assoc.target).toBe(latest);
-    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
-    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
-  });
-
   it("nullifies the displaced row when association(name).build replaces a loaded child", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
     const displaced = (await Ship.create({

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -7,13 +7,14 @@
  * persisted nullify `target.save` at :108. A synchronous JS builder cannot
  * await that write, so `setNewRecord` performs only the in-memory half; every
  * caller that can displace a persisted record issues the DB half itself. The
- * `build#{Name}` / `create#{Name}` accessors use `detachDisplacedTarget`. For
- * `assoc.build()`, which nested attributes calls directly, the nested-attributes
- * writer calls the same method — starting the removal inline at
- * assignment and awaiting it in its `save` wrapper before the replacement is
- * inserted. A *direct* `record.association(name).build(...)` has no such
- * wrapper, so `HasOneAssociation#build` runs the removal itself and returns the
- * record wrapped in that promise for the caller to `await`.
+ * `build#{Name}` / `create#{Name}` accessors use `detachDisplacedTarget`. The
+ * nested-attributes writer calls the same method from its *awaitable* half
+ * (`await owner.set#{Name}Attributes({...})`), in Rails' order; the Rails-named
+ * synchronous setter refuses a displacing assignment outright
+ * (`NestedAttributesDisplacementError`) rather than deferring the write to the
+ * owner's next `save()`. A *direct* `record.association(name).build(...)` runs
+ * the removal itself and returns the record wrapped in that promise for the
+ * caller to `await`.
  *
  * Rails' own `test_should_replace_an_existing_record_if_there_is_no_id`
  * (nested_attributes_test.rb:288) asserts only in-memory state and never saves
@@ -21,7 +22,12 @@
  * guard rather than a change to the mirrored test.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, RecordNotSaved, type Base } from "../index.js";
+import {
+  registerModel,
+  NestedAttributesDisplacementError,
+  RecordNotSaved,
+  type Base,
+} from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { Pirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
@@ -47,32 +53,78 @@ describe("has_one displacement via the synchronous build path", () => {
     // the case where Rails' `remove_target!` has a row to nullify.
     await (pirate as unknown as { ship: Promise<Base | null> }).ship;
 
-    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+    await (pirate as unknown as { setShipAttributes(a: object): Promise<void> }).setShipAttributes({
       name: "Davy Jones Gold Dagger",
-    };
-    await pirate.save();
+    });
 
     const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
   });
 
-  it("nullifies the displaced row when nested attributes replace an unloaded child", async () => {
+  it("refuses a displacing assignment through the synchronous setter", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    // Rails' `replace` removes the displaced row inline at the assignment
+    // expression; a property setter can neither await that nor defer it without
+    // reopening the two-row window, so it raises and names the awaitable writer.
+    expect(() => {
+      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+        name: "Davy Jones Gold Dagger",
+      };
+    }).toThrow(NestedAttributesDisplacementError);
+
+    // Nothing partial landed: the displaced record is still cached and attached.
+    expect((pirate.association("ship").target as unknown as { id: number }).id).toBe(
+      (displaced as unknown as { id: number }).id,
+    );
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
+      (pirate as unknown as { id: number }).id,
+    );
+  });
+
+  it("refuses a displacing assignment over an unloaded child through the synchronous setter", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
     const displaced = (await Ship.create({
       name: "Nights Dirty Lightning",
       pirate_id: (pirate as unknown as { id: number }).id,
     })) as Base;
 
-    // Never load the association: Rails' `build_#{name}` runs `load_target`
-    // regardless, so the writer must discover and detach the row itself.
+    // Never loaded: Rails' `replace` guard is `return target unless load_target
+    // || record`, whose left operand always runs, so the assignment still owes a
+    // SELECT — which is exactly what the synchronous setter cannot await.
     const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
-    (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
-      name: "Davy Jones Gold Dagger",
-    };
-    await refetched.save();
+    expect(() => {
+      (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
+        name: "Davy Jones Gold Dagger",
+      };
+    }).toThrow(NestedAttributesDisplacementError);
 
     const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
-    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
+      (pirate as unknown as { id: number }).id,
+    );
+  });
+
+  it("keeps the synchronous setter working when the assignment displaces nothing", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    // A loaded, empty association owes no load and has nothing to remove, so
+    // Rails' `replace` reduces to `self.target = record` — in-memory work a
+    // property setter can do.
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+    await pirate.save();
+
+    const ship = (await (pirate as unknown as { ship: Promise<Base | null> }).ship) as Base;
+    expect((ship as unknown as { name: string }).name).toBe("Davy Jones Gold Dagger");
   });
 
   it("awaits the unloaded displacement removal from the awaitable writer", async () => {
@@ -204,8 +256,8 @@ describe("has_one displacement via the synchronous build path", () => {
     // because the production path has no reachable raise left to provoke —
     // `assertNestedAttributesAreKnown` pre-empts the unknown-attribute one, and
     // the post-`build_record` raises Rails *does* query before are unreachable
-    // here (see `prepareDetachDisplacedForSyncBuild`). It pins that the query is
-    // issued downstream of the construction, so a future raise added to
+    // here (the displacement raise sits after `build_record`). It pins that the
+    // query is issued downstream of the construction, so a future raise added to
     // `build_record` cannot regress the order.
     assoc.buildRecord = () => {
       throw new Error("build exploded");
@@ -218,11 +270,8 @@ describe("has_one displacement via the synchronous build path", () => {
     }).toThrow("build exploded");
 
     // Rails is `build_record(...)` then `set_new_record` → `load_target`, so a
-    // raising build leaves the row untouched and nothing parked to drain.
-    expect(
-      (refetched as unknown as { _pendingDisplacedRemovals?: unknown[] })
-        ._pendingDisplacedRemovals ?? [],
-    ).toHaveLength(0);
+    // raising build leaves the row untouched — the construction error surfaces,
+    // not the displacement refusal that would follow it.
     const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
       (pirate as unknown as { id: number }).id,

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -195,14 +195,15 @@ export class HasOneThroughAssociation extends HasOneAssociation {
 
   /**
    * No load and no removal, for the same reason as `loadDisplacedForBuild`
-   * above: a through `replace` has no `load_target`, so the nested-attributes
-   * writer must not issue a target SELECT (nor detach a displaced *end* record)
-   * for a has_one_through.
+   * above: a through `replace` has no `load_target`, so a nested-attributes
+   * build issues no target SELECT and detaches no displaced *end* record for a
+   * has_one_through — there is nothing for the synchronous writer to await, and
+   * so nothing for it to refuse.
    *
    * @internal
    */
-  protected override prepareDetachDisplacedForSyncBuild(): (() => Promise<void>) | null {
-    return null;
+  protected override displacementNeedsAwait(): boolean {
+    return false;
   }
 
   /**

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -249,6 +249,7 @@ export {
   EagerLoadPolymorphicError,
   DeleteRestrictionError,
   HasOnePersistedAssignmentError,
+  NestedAttributesDisplacementError,
   CollectionPersistedAssignmentError,
   CollectionIdsAssignmentError,
 } from "./associations/errors.js";

--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -7,25 +7,22 @@
  * (vendor/rails/activerecord/lib/active_record/associations/has_one_association.rb:95-115),
  * so `pirate.ship_attributes = {...}` surfaces the failure at the assignment
  * expression whether or not the owner is ever saved. A synchronous JS property
- * setter cannot raise on an async write, so trails splits that guarantee: the
- * awaitable `set#{Name}Attributes` writer raises at the assignment point, and the
- * synchronous setter's failure is parked on the owner permanently — every later
- * drain rethrows it, so an owner that is never saved never loses it.
+ * setter cannot raise on an async write — so it does not start one: the
+ * awaitable `set#{Name}Attributes` writer runs the load, the removal and the
+ * target install in Rails' order and raises at the assignment point, while the
+ * Rails-named setter refuses a displacing assignment up front
+ * (`NestedAttributesDisplacementError`) instead of parking a write that would
+ * fail later.
  *
  * No Rails test covers a *failing* displacement removal, hence a trails-only
  * guard rather than a mirrored test.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, type Base } from "./index.js";
+import { registerModel, NestedAttributesDisplacementError, type Base } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import { Pirate } from "./test-helpers/models/pirate.js";
 import { Ship } from "./test-helpers/models/ship.js";
 import { Bird } from "./test-helpers/models/bird.js";
-
-interface RemovalHost {
-  _pendingDisplacedRemovals?: Promise<unknown>[];
-  _displacedRemovalFailure?: unknown;
-}
 
 /**
  * A pirate with a loaded, persisted ship whose displacement removal is rigged
@@ -43,22 +40,6 @@ async function pirateWithFailingRemoval(): Promise<Base> {
   const assoc = pirate.association("ship") as unknown as {
     detachDisplacedTarget: () => Promise<void>;
   };
-  assoc.detachDisplacedTarget = () => Promise.reject(new Error("removal exploded"));
-  return pirate;
-}
-
-async function pirateWithFailingUnloadedRemoval(): Promise<Base> {
-  const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
-  await Ship.create({
-    name: "Nights Dirty Lightning",
-    pirate_id: (pirate as unknown as { id: number }).id,
-  });
-
-  const assoc = pirate.association("ship") as unknown as {
-    detachDisplacedTarget: () => Promise<void>;
-    isLoaded(): boolean;
-  };
-  expect(assoc.isLoaded()).toBe(false);
   assoc.detachDisplacedTarget = () => Promise.reject(new Error("removal exploded"));
   return pirate;
 }
@@ -100,61 +81,52 @@ describe("nested-attributes displacement removal failure", () => {
     ).rejects.toThrow("removal exploded");
   });
 
-  it("keeps the failure on the owner once it has been raised", async () => {
+  it("leaves the displaced record cached when the removal fails", async () => {
     const pirate = await pirateWithFailingRemoval();
+    const displaced = pirate.association("ship").target;
 
-    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-      name: "Davy Jones Gold Dagger",
-    };
+    await expect(
+      (pirate as unknown as { setShipAttributes: (a: unknown) => Promise<void> }).setShipAttributes(
+        { name: "Davy Jones Gold Dagger" },
+      ),
+    ).rejects.toThrow("removal exploded");
 
-    // Every drain rethrows: the first observation does not consume the failure,
-    // so an owner saved (or re-assigned) later cannot silently succeed.
-    await expect(pirate.save()).rejects.toThrow("removal exploded");
-    await expect(pirate.save()).rejects.toThrow("removal exploded");
-    expect((pirate as unknown as RemovalHost)._displacedRemovalFailure).toBeInstanceOf(Error);
+    // Rails reaches `self.target = record` (:84) only after `remove_target!`
+    // (:69), so a raising removal leaves the OLD record cached — the ordering
+    // the retired target swap could not express.
+    expect(pirate.association("ship").target).toBe(displaced);
   });
 
-  it("surfaces the failure through an unrelated association's awaitable writer", async () => {
+  it("parks no removal for a synchronous displacing assignment to fail later", async () => {
     const pirate = await pirateWithFailingRemoval();
 
-    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-      name: "Davy Jones Gold Dagger",
-    };
+    // The setter refuses instead of starting a write it cannot await, so there
+    // is no deferred failure to surface at `save()` — and nothing that could
+    // become an unhandled rejection if the owner is never saved.
+    expect(() => {
+      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+        name: "Davy Jones Gold Dagger",
+      };
+    }).toThrow(NestedAttributesDisplacementError);
 
-    // The pending list and the sticky failure are per-owner, so the collection
-    // writer rethrows the has_one's failure even though the crew assignment
-    // itself succeeded: the owner instance is poisoned, and an awaitable write
-    // to it must not proceed toward a `save()` that would persist two rows.
+    await expect(pirate.save()).resolves.toBe(true);
+  });
+
+  it("leaves an unrelated association's awaitable writer unaffected", async () => {
+    const pirate = await pirateWithFailingRemoval();
+
+    expect(() => {
+      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+        name: "Davy Jones Gold Dagger",
+      };
+    }).toThrow(NestedAttributesDisplacementError);
+
+    // With no parked removal, there is no owner-wide sticky failure left for an
+    // unrelated writer to inherit: the refusal was terminal at its own call site.
     await expect(
       (
         pirate as unknown as { setBirdsAttributes: (a: unknown) => Promise<void> }
       ).setBirdsAttributes([{ name: "Posideons Killer" }]),
-    ).rejects.toThrow("removal exploded");
-  });
-
-  it("does not leave a floating rejection when the removal is never drained", async () => {
-    const pirate = await pirateWithFailingRemoval();
-
-    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-      name: "Davy Jones Gold Dagger",
-    };
-
-    // The captured promise resolves *to* the error rather than rejecting, so a
-    // never-drained removal cannot surface as an unhandled rejection.
-    const pending = (pirate as unknown as RemovalHost)._pendingDisplacedRemovals ?? [];
-    expect(pending).toHaveLength(1);
-    await expect(pending[0]).resolves.toBeInstanceOf(Error);
-  });
-
-  it("does not leave a floating rejection when an unloaded removal is never drained", async () => {
-    const pirate = await pirateWithFailingUnloadedRemoval();
-
-    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-      name: "Davy Jones Gold Dagger",
-    };
-
-    const pending = (pirate as unknown as RemovalHost)._pendingDisplacedRemovals ?? [];
-    expect(pending).toHaveLength(1);
-    await expect(pending[0]).resolves.toBeInstanceOf(Error);
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -205,8 +205,10 @@ describe("TestNestedAttributesInGeneral", () => {
     await pirate.saveBang();
     expect(Number(await Ship.count())).toBe(before); // not persisted → rejected
 
-    // pirate is now persisted, so reject_empty_ships_on_create returns false
-    (pirate as any).shipAttributes = { name: "Red Pearl", _reject_me_if_new: true };
+    // pirate is now persisted, so reject_empty_ships_on_create returns false.
+    // The awaitable writer, because a persisted owner's unloaded has_one still
+    // owes Rails' leading `load_target` (has_one_association.rb:59).
+    await (pirate as any).setShipAttributes({ name: "Red Pearl", _reject_me_if_new: true });
     before = Number(await Ship.count());
     await pirate.saveBang();
     expect(Number(await Ship.count())).toBe(before + 1);
@@ -278,7 +280,9 @@ describe("TestNestedAttributesInGeneral", () => {
     const pirate = await Pirate.createBang({
       catchphrase: "Don' botharrr talkin' like one, savvy?",
     });
-    (pirate.association("ship") as any).build();
+    // `build` on a persisted owner's unloaded has_one returns Rails' leading
+    // `load_target` for the caller to await.
+    await (pirate.association("ship") as any).build();
     (pirate as any).shipAttributes = { name: "Ship 1", pirate_id: Number(pirate.id) + 1 };
     expect(Number((pirate.association("ship") as any).target.pirate_id)).toBe(Number(pirate.id));
     resetShipConfig();
@@ -407,7 +411,10 @@ describe("TestNestedAttributesOnAHasOneAssociation", () => {
     const { pirate, ship } = await setup();
     await ship.destroy();
     const p = await Pirate.find(pirate.id);
-    (p as any).shipAttributes = { name: "Davy Jones Gold Dagger" };
+    // The awaitable writer: a persisted owner's unloaded has_one owes Rails'
+    // leading `load_target` (has_one_association.rb:59) even when it finds
+    // nothing, which the synchronous setter cannot await.
+    await (p as any).setShipAttributes({ name: "Davy Jones Gold Dagger" });
     const target = (p.association("ship") as any).target as Ship;
     expect(target.isPersisted()).toBe(false);
     expect(target.name).toBe("Davy Jones Gold Dagger");
@@ -433,7 +440,9 @@ describe("TestNestedAttributesOnAHasOneAssociation", () => {
     const { pirate, ship } = await setup();
     const p = await Pirate.find(pirate.id);
     await shipOf(p);
-    (p as any).shipAttributes = { name: "Davy Jones Gold Dagger" };
+    // The awaitable writer: replacing a loaded record runs Rails'
+    // `remove_target!` (has_one_association.rb:69) inline at the assignment.
+    await (p as any).setShipAttributes({ name: "Davy Jones Gold Dagger" });
     const target = (p.association("ship") as any).target as Ship;
     expect(target.isPersisted()).toBe(false);
     expect(target.name).toBe("Davy Jones Gold Dagger");

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -148,6 +148,27 @@ describe("nested attributes save wrapper argument forwarding (trails-only)", () 
   // ordinary save), so it must be argument-transparent: dropping its options
   // silently re-enabled validations for every model that accepts nested
   // attributes.
+  // Rails buckets Hash-valued keys into `nested_parameter_attributes` and
+  // assigns them only after the scalar pass (attribute_assignment.rb:7-25), so
+  // `reject_if` sees the owner attributes the same `update` call assigned. A
+  // single-pass loop leaves that to hash key order.
+  it("assigns scalar attributes before nested ones within one update", async () => {
+    Pirate.acceptsNestedAttributesFor("ship", {
+      rejectIf: (_attrs, record) => cols(record).catchphrase !== "Aye",
+    });
+
+    const pirate = await Pirate.createBang({ catchphrase: "Arr" });
+    await pirate.update({
+      shipAttributes: { name: "Black Pearl" },
+      catchphrase: "Aye",
+    });
+
+    const ship = await Ship.where({ pirate_id: readAttr(pirate, "id") }).first();
+    expect(cols(ship as Base).name).toBe("Black Pearl");
+
+    Pirate.acceptsNestedAttributesFor("ship");
+  });
+
   it("forwards save options through the nested-attributes save wrapper", async () => {
     Pirate.acceptsNestedAttributesFor("ship");
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -6,6 +6,7 @@ import {
   association as collectionProxyFor,
 } from "./associations.js";
 import { ActiveRecordError, UnknownAttributeError, RecordNotFound } from "./errors.js";
+import { NestedAttributesDisplacementError } from "./associations/errors.js";
 import { singularize, camelize, underscore, isBlank } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
 import {
@@ -177,11 +178,10 @@ export function acceptsNestedAttributesFor(
       this: Base,
       options?: { validate?: boolean; touch?: boolean },
     ): Promise<boolean> {
-      // Finish the displaced-record removals a nested-attributes assignment
-      // started (Rails runs them inline inside `replace`), before the parent
-      // save's has_one autosave inserts the replacement — so the nullify lands
-      // first, as it does in Rails.
-      await awaitPendingDisplacedRemovals(this);
+      // Finish the reader load a nested-attributes assignment could not await
+      // (Rails' `send(association_name)` is synchronous), so the parent is never
+      // saved against a half-assigned graph.
+      await awaitPendingNestedReaderLoads(this);
       const result = await originalSave.call(this, options);
       if (!result) return false;
 
@@ -568,7 +568,7 @@ function generateAssociationWriter(
     (modelClass as any)._nestedAttributeSetterKeys = new Set<string>();
   }
   (modelClass as any)._nestedAttributeSetterKeys.add(attrName);
-  const assign: (record: Base, name: string, value: any) => void =
+  const assign: (record: Base, name: string, value: any, awaitable?: boolean) => unknown =
     type === "collection"
       ? assignNestedAttributesForCollectionAssociation
       : assignNestedAttributesForOneToOneAssociation;
@@ -580,22 +580,15 @@ function generateAssociationWriter(
   });
 
   // The awaitable counterpart of the Rails-named `#{name}_attributes=` setter.
-  // Rails' writer removes the displaced record inline and raises at the
-  // assignment expression; a JS property setter cannot await, so this is the
-  // surface that reproduces that timing (RFC 0068's `set#{Name}` sugar, applied
-  // to nested attributes). See `detachDisplacedAtAssignment` for the contract.
-  // Collections get it too, for one uniform awaitable writer per association. A
-  // collection assignment never queues a removal of its own, but the drain is
-  // NOT a no-op there: the pending list and the sticky failure are per-*owner*,
-  // so `await pirate.setBirdsAttributes(...)` rethrows an undrained
-  // `pirate.shipAttributes = ...` failure. That is the contract, not a leak —
-  // the failure poisons the owner instance (see `detachDisplacedAtAssignment`),
-  // and an awaitable write to a poisoned owner must not silently proceed toward
-  // a `save()` that would persist the two-row state.
+  // Rails' writer loads, removes the displaced record and installs the
+  // replacement inline, raising at the assignment expression; a JS property
+  // setter cannot await, so this is the surface that reproduces that timing
+  // (RFC 0068's `set#{Name}` sugar, applied to nested attributes) — and the one
+  // the synchronous setter names when it refuses a displacing assignment.
+  // Collections get it too, for one uniform awaitable writer per association.
   Object.defineProperty(modelClass.prototype, `set${camelize(attrName, true)}`, {
     async value(this: Base, value: any): Promise<void> {
-      assign(this, associationName, value);
-      await awaitPendingDisplacedRemovals(this);
+      await assign(this, associationName, value, true);
     },
     writable: true,
     configurable: true,
@@ -687,120 +680,80 @@ interface OneToOneAssociation {
   // Rails' `send(association_name)` — `SingularAssociation#reader`, which is
   // where trails raises strict-loading violations (singular-association.ts:210).
   readonly reader?: Base | null | Promise<Base | null>;
+  // Rails' leading `load_target` (has_one_association.rb:59) and its
+  // `remove_target!` (:69), plus the predicate that says whether either would do
+  // any work — see `detachDisplacedThenSetNewRecord`.
+  loadDisplacedForBuild?(): Promise<unknown> | null;
   detachDisplacedTarget?(): Promise<void>;
-  prepareDetachDisplacedForSyncBuild?(): (() => Promise<void>) | null;
+  displacementNeedsAwait?(): boolean;
 }
 
 /**
- * Start Rails' `remove_target!` for the record a nested-attributes `build`
- * displaced, at the moment of assignment.
+ * Rails' `HasOneAssociation#replace` tail, in Rails' order: `load_target`
+ * (has_one_association.rb:59) → `remove_target!` (:69) → `self.target = record`
+ * (:84).
  *
- * Rails runs the removal inline inside `HasOneAssociation#replace`
- * (has_one_association.rb:69) — the nested-attributes writer is a synchronous
- * property setter (`pirate.shipAttributes = {...}`), so it cannot `await` the
- * nullify save. It CAN issue it: `detachDisplacedTarget` is kicked off here,
- * inline at assignment exactly as in Rails — and, crucially, *before* the build
- * swaps the replacement into `assoc.target`, so the removal binds to the
- * displaced record with no parked state. Only its *completion* is deferred — to
- * the nested-attributes `save` wrapper, which drains the parked list before the
- * parent (and its autosaved new target) is persisted. That keeps
- * Rails' write ordering (displaced row nullified before the replacement is
- * inserted) and, like Rails, removes the displaced record even if the owner is
- * never saved.
- *
- * The rejection is captured rather than left floating: a never-drained removal
- * must not surface as an unhandled rejection, and a drained one must rethrow.
- *
- * ## The contract for a removal that fails
- *
- * Rails raises `RecordNotSaved` at the assignment expression itself, so the
- * failure is observable whether or not the owner is ever saved. A synchronous
- * property setter cannot do that, so trails splits the guarantee in two, and a
- * failure is **retained on the owner forever** rather than consumed by whoever
- * happens to drain first:
- *
- * - `await owner.set#{Name}Attributes({...})` — the awaitable nested-attributes
- *   writer (the analogue of RFC 0068's `set#{Name}`) assigns and then awaits the
- *   removal, so it raises at the assignment point exactly as Rails does. This is
- *   the sanctioned surface when the failure matters.
- * - `owner.#{name}Attributes = {...}` — the Rails-named synchronous setter still
- *   works, and its failure is *sticky*: {@link recordDisplacedRemovalFailure}
- *   parks the first error on the owner, and **every** subsequent drain
- *   (`save()`, an awaitable writer, another assignment's drain) rethrows it. An
- *   owner that is never saved therefore still carries the failure; nothing
- *   silently discards it.
- *
- * The sticky failure is deliberately terminal for that instance: the in-memory
- * replacement landed while the displaced row did not detach, so persisting the
- * owner would produce exactly the two-FK-matching-rows state RFC 0068 exists to
- * eliminate. Recovery is a fresh load of the owner, not a retry on the poisoned
- * instance.
+ * The record was already constructed by `build_record`
+ * (singular_association.rb:29-31), which is why the caller passes it in: Rails
+ * reaches `load_target` only from `set_new_record`, i.e. *after* the
+ * construction, so a build that raises queries nothing. Running the three steps
+ * forward means a raising `remove_target!` leaves the OLD record cached,
+ * exactly as Rails' `self.target = record` after the transaction block does.
  * @internal
  */
-function detachDisplacedAtAssignment(assoc: OneToOneAssociation): Promise<void> | null {
-  if (assoc.isLoaded?.() === false) return null;
-  if (!assoc.target) return null;
-  if (typeof assoc.detachDisplacedTarget !== "function") return null;
-  // Started BEFORE the build: `removeTargetBang` reads `this.target` on entry,
-  // before its first `await`, so the removal binds to the displaced record even
-  // though the synchronous build swaps in the replacement immediately after.
-  return assoc.detachDisplacedTarget();
+async function detachDisplacedThenSetNewRecord(
+  assoc: OneToOneAssociation,
+  built: Base | null,
+): Promise<void> {
+  await assoc.loadDisplacedForBuild?.();
+  await assoc.detachDisplacedTarget?.();
+  if (built) assoc.setNewRecord(built);
 }
 
 /**
- * Park an in-flight removal on the owner: capture its rejection so a
- * never-drained removal cannot surface as an unhandled rejection, and queue it
- * for the drain that rethrows. See {@link detachDisplacedAtAssignment} for the
- * full contract.
+ * Park the async re-entry of {@link assignNestedAttributesForOneToOneAssociation}
+ * on the owner: capture its rejection so a never-drained load cannot surface as
+ * an unhandled rejection, and queue it for the drain that rethrows.
+ *
+ * Rails reads the existing record with `send(association_name)`
+ * (nested_attributes.rb:434), a plain synchronous call; ours is a promise for an
+ * unloaded association, which the Rails-named setter cannot await. Unlike the
+ * displacement removal — which now refuses rather than defers
+ * ({@link NestedAttributesDisplacementError}) — this deferral is a *read*, so no
+ * DB state is in flight to race an interim insert.
  * @internal
  */
-function parkDisplacedRemoval(record: Base, removal: Promise<void>): void {
-  const settled = removal.then(
+function parkNestedReaderLoad(record: Base, load: Promise<void>): void {
+  const settled = load.then(
     () => null,
-    (error: unknown) => error ?? new Error("displaced record removal failed"),
+    (error: unknown) => error ?? new Error("nested attributes reader load failed"),
   );
-  const host = record as unknown as DisplacedRemovalHost;
-  (host._pendingDisplacedRemovals ??= []).push(settled);
+  const host = record as unknown as NestedReaderLoadHost;
+  (host._pendingNestedReaderLoads ??= []).push(settled);
 }
 
 /**
- * The owner-side state {@link detachDisplacedAtAssignment} parks: the in-flight
- * removals plus the sticky first failure among them.
+ * The owner-side state {@link parkNestedReaderLoad} parks.
  * @internal
  */
-interface DisplacedRemovalHost {
-  _pendingDisplacedRemovals?: Promise<unknown>[];
-  _displacedRemovalFailure?: unknown;
+interface NestedReaderLoadHost {
+  _pendingNestedReaderLoads?: Promise<unknown>[];
 }
 
 /**
- * Park a displacement-removal failure on the owner permanently. Draining
- * consumes the *promise*, never the error — see the contract on
- * {@link detachDisplacedAtAssignment}.
+ * Await the re-entries parked by {@link parkNestedReaderLoad}, rethrowing the
+ * first failure, so the owner is never saved against a half-assigned graph.
  * @internal
  */
-function recordDisplacedRemovalFailure(host: DisplacedRemovalHost, error: unknown): void {
-  host._displacedRemovalFailure ??= error;
-}
-
-/**
- * Await the removals started by `detachDisplacedAtAssignment`, rethrowing the
- * first failure — the deferred half of Rails' inline `remove_target!`. A failure
- * already parked by an earlier drain is rethrown before anything is awaited, so
- * it cannot be observed once and then forgotten.
- * @internal
- */
-async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
-  const host = record as unknown as DisplacedRemovalHost;
-  const pending = host._pendingDisplacedRemovals;
-  if (pending?.length) {
-    host._pendingDisplacedRemovals = [];
-    for (const settled of pending) {
-      const error = await settled;
-      if (error) recordDisplacedRemovalFailure(host, error);
-    }
+async function awaitPendingNestedReaderLoads(record: Base): Promise<void> {
+  const host = record as unknown as NestedReaderLoadHost;
+  const pending = host._pendingNestedReaderLoads;
+  if (!pending?.length) return;
+  host._pendingNestedReaderLoads = [];
+  for (const settled of pending) {
+    const error = await settled;
+    if (error) throw error;
   }
-  if (host._displacedRemovalFailure !== undefined) throw host._displacedRemovalFailure;
 }
 
 /** @internal */
@@ -847,7 +800,12 @@ export function assignNestedAttributesForOneToOneAssociation(
   record: Base,
   associationName: string,
   attributes: Record<string, unknown>,
-): void {
+  // Whether the caller can `await` the result: true for the awaitable
+  // `set#{Name}Attributes` writer, false for the Rails-named
+  // `#{name}_attributes=` property setter, which refuses the assignments that
+  // need I/O rather than deferring them (RFC 0068 Design §6).
+  awaitable = false,
+): Promise<void> | void {
   if (typeof attributes !== "object" || attributes === null || Array.isArray(attributes)) {
     throw new Error(
       `Hash expected for \`${associationName}\` attributes, got ${nestedTypeName(attributes)}`,
@@ -868,12 +826,16 @@ export function assignNestedAttributesForOneToOneAssociation(
   if ((hasId || updateOnly) && assoc.isLoaded?.() === false && "reader" in assoc) {
     const read = assoc.reader;
     if (read instanceof Promise) {
-      parkDisplacedRemoval(
-        record,
-        read.then(() =>
-          assignNestedAttributesForOneToOneAssociation(record, associationName, attributes),
+      const reentry = read.then(() =>
+        assignNestedAttributesForOneToOneAssociation(
+          record,
+          associationName,
+          attributes,
+          awaitable,
         ),
       );
+      if (awaitable) return reentry;
+      parkNestedReaderLoad(record, reentry);
       return;
     }
   }
@@ -928,35 +890,26 @@ export function assignNestedAttributesForOneToOneAssociation(
           );
         }
       } else {
-        // Rails' `build_#{name}` → `set_new_record` → `replace(record, false)`
-        // removes the displaced target inline (has_one_association.rb:69).
-        // Rails' `replace` opens with `load_target`, so an association that was
-        // never loaded still discovers the row in the DB and removes it. That
-        // SELECT is issued just AFTER the build, where Rails reaches
-        // `load_target` — from `set_new_record`, i.e. after `build_record` — so
-        // a build that raises queries nothing. Only its completion is deferred
-        // to the same drain; see
-        // `HasOneAssociation#prepareDetachDisplacedForSyncBuild`. The decision
-        // to issue it has to be taken here, before the build, because `build`
-        // marks the association loaded and so falsifies its `find_target?` gate.
-        const startUnloadedRemoval = assoc.prepareDetachDisplacedForSyncBuild?.() ?? null;
         // Rails' `SingularAssociation#build` is `build_record` then
         // `set_new_record` (singular_association.rb:29-31), and only the second
-        // reaches `remove_target!` (has_one_association.rb:59-69). `build`
-        // fuses the two, which would let a raising `build_record` (an invalid
-        // STI `type`, `SubclassNotFound`) detach a record Rails never touches,
-        // so run the two halves separately and keep the removal between them.
+        // reaches `load_target` / `remove_target!`
+        // (has_one_association.rb:59-69). Run the two halves separately and keep
+        // the displacement between them, so a raising `build_record` (an invalid
+        // STI `type`, `SubclassNotFound`) neither queries nor detaches a record
+        // Rails never touches.
         const built = assoc.buildRecord(assignable);
-        // `remove_target!` on the still-cached displaced record.
-        // `removeTargetBang` binds `this.target` on entry, before its first
-        // `await`, so `setNewRecord` below may swap in the replacement while
-        // the removal is in flight. See `detachDisplacedAtAssignment`.
-        const loadedRemoval = detachDisplacedAtAssignment(assoc);
-        // Rails' `self.target = record` (:84), in memory — the DB half is the
-        // two removals parked below.
+        if (assoc.displacementNeedsAwait?.() === true) {
+          // DB I/O Rails runs inline before `self.target = record` (:84) — a
+          // SELECT for a never-loaded association, then `remove_target!`'s
+          // nullify/destroy save. A property setter can neither await it nor
+          // defer it without reopening the order-undefined two-row window RFC
+          // 0068 exists to close, so it refuses and names the awaitable writer.
+          if (!awaitable) throw new NestedAttributesDisplacementError(associationName);
+          return detachDisplacedThenSetNewRecord(assoc, built);
+        }
+        // Nothing to displace: Rails' `self.target = record` (:84) is all that
+        // remains of `replace`, and it is in-memory work.
         if (built) assoc.setNewRecord(built);
-        if (startUnloadedRemoval) parkDisplacedRemoval(record, startUnloadedRemoval());
-        if (loadedRemoval) parkDisplacedRemoval(record, loadedRemoval);
       }
     }
   }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -615,12 +615,33 @@ async function assignUpdateAttributes(self: any, attrs: Record<string, unknown>)
   if (isMassAssignmentEmpty(attrs)) return;
   const sanitized = sanitizeForMassAssignment(attrs);
   assertLockingColumnNotExplicitly(self, sanitized);
+  // Rails buckets every Hash-valued key into `nested_parameter_attributes` and
+  // runs `assign_nested_parameter_attributes` only after the scalar pass
+  // (attribute_assignment.rb:7-22) — "Assign any deferred nested attributes
+  // after the base attributes have been set" (:25). So a nested writer's
+  // `reject_if`, the built record's callbacks, and the association's
+  // `initialize_attributes` all observe an owner whose own attributes are
+  // already assigned. `assign_nested_parameter_attributes` then assigns them in
+  // order, one at a time (:27).
+  let nestedParameterAttributes: [string, unknown][] | undefined;
   const pending: Promise<void>[] = [];
   for (const [key, value] of Object.entries(sanitized)) {
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value) &&
+      (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
+    ) {
+      (nestedParameterAttributes ??= []).push([key, value]);
+      continue;
+    }
     const p = assignUpdateAttribute(self, key, value);
     if (p) pending.push(p);
   }
   if (pending.length) await Promise.all(pending);
+  for (const [key, value] of nestedParameterAttributes ?? []) {
+    await assignUpdateAttribute(self, key, value);
+  }
 }
 
 function collectionWriterPromise(

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -6,7 +6,7 @@
  */
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { singularize } from "@blazetrails/activesupport";
+import { camelize, singularize } from "@blazetrails/activesupport";
 import { reflectOnAllAssociations } from "./reflection.js";
 import type { Base } from "./base.js";
 import {
@@ -647,8 +647,12 @@ function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<
     | { associationName: string }[]
     | undefined;
   if (configs?.some((c) => `${c.associationName}Attributes` === key)) {
-    self[key] = value;
-    return;
+    // The awaitable writer, for the same reason `#{singular}Ids` goes through
+    // `idsWriter` below: Rails' `#{name}_attributes=` runs `load_target` and
+    // `remove_target!` inline (has_one_association.rb:59-69), and `#update` is
+    // async, so it can await what the property setter refuses
+    // (`NestedAttributesDisplacementError`).
+    return self[`set${camelize(key, true)}`](value) as Promise<void>;
   }
   // Rails' #update → assign_attributes dispatches `id` through `public_send("id=")`,
   // which for a composite-PK model distributes the value across the key columns.


### PR DESCRIPTION
Converges the deviation RFC 0068 Design §6 ratified on 2026-08-03.

## The deviation

`HasOneAssociation#findThenDetachDisplaced` installed the *displaced* record on
`this.target` for the duration of `remove_target!` and then restored the
replacement — a write Rails never makes. Rails' `replace`
(`vendor/rails/activerecord/lib/active_record/associations/has_one_association.rb:59-84`)
runs `load_target` (:59) → `remove_target!` (:69) → `self.target = record` (:84)
in one forward pass; its target only ever moves forward. The swap existed solely
because the synchronous `#{name}_attributes=` property setter had to install the
replacement before returning, while the displacing SELECT was still in flight.

## The contract now

Design §2's call, scoped to the assignments that actually need I/O:

- **Non-displacing assignments stay on the synchronous setter** — a fresh
  association, an `id`-matched update, a reused unsaved build, a
  `has_one_through` (whose `replace` has no `load_target`/`remove_target!` at
  all), and every `belongs_to` nested assignment reduce to Rails' in-memory
  `self.target = record`. The blast radius §6 feared is confined to the
  displacing case: **four** call sites across the Rails-ported nested-attributes
  and autosave suites.
- **A displacing assignment raises `NestedAttributesDisplacementError`**, naming
  `await owner.set#{Name}Attributes({...})`. "Displacing" is
  `HasOneAssociation#displacementNeedsAwait`: an already-loaded record to remove,
  or an unloaded association whose `find_target?` says Rails would query for one
  (`return target unless load_target || record` always evaluates its left
  operand). The raise sits *after* `build_record` (singular_association.rb:29-31),
  so a construction error still surfaces first, as in Rails.
- **The awaitable writer runs Rails' order intact** —
  `detachDisplacedThenSetNewRecord` is `load_target` → `remove_target!` →
  `self.target = record`, forward only. A raising `remove_target!` leaves the OLD
  record cached for free, which is what Rails' `self.target = record` sitting
  after the transaction block gives you.
- **`#update` routes nested-attribute keys through the awaitable writer**, as it
  already does `#{singular}Ids` (`collectionWriterPromise`): it is async, so it
  can await what the property setter refuses. This is why the ported
  `update(irisAttributes: ...)` autosave tests need no change.

## Deleted

`findThenDetachDisplaced` + its target swap, `prepareDetachDisplacedForSyncBuild`
(and the `has_one_through` override), `detachDisplacedAtAssignment`,
`recordDisplacedRemovalFailure`, and `_displacedRemovalFailure` — with no
deferred write left, there is no failure to make sticky.

## Why `_pendingDisplacedRemovals` survives (renamed)

It becomes `_pendingNestedReaderLoads`. Rails reads the existing record with
`send(association_name)` (nested_attributes.rb:434), a plain synchronous call;
ours is a promise for an unloaded association on the `id` / `update_only` arm,
which the synchronous setter cannot await, so the body re-enters when it lands
and `save()` drains it. That deferral is a **read** — no DB state in flight, so
nothing can race an interim insert, which is the property the displacement
deferral lacked. The awaitable writer returns the re-entry directly instead.

## Verification

- `nested-attributes.test.ts` (163), `autosave-association.test.ts`,
  `persistence.test.ts`, the whole `associations/` tree (98 files, 2325 tests) —
  green.
- `has-one-sync-build-displacement.trails.test.ts` and
  `nested-attributes-displaced-removal-failure.trails.test.ts` rewritten to the
  new contract: the refusal, the non-displacing setter path that still works, the
  awaitable writer's Rails ordering, and the old-record-stays-cached guarantee.
- `pnpm api:calls` OK (14 baselined), `pnpm api:calls:wide` OK, `pnpm lint`
  clean, `pnpm test:compare` 14904/22203 (unchanged).
- RFC 0068 Design §6 rewritten to record the reversal (tasks branch
  `tasks-retire-nested-attributes-sync-setter-displacement-4492`).

## Size

603 LOC changed (288+ / 311−), over the 500 ceiling. It does not split: the four
deleted members and the two dedicated trails tests that cover them are one
contract, and a partial removal would leave the swap reachable. Roughly half the
diff is JSDoc describing the retired machinery.

Closes-story: retire-nested-attributes-sync-setter-displacement
