### PR TITLE
feat(scripts): match stale story promises at comment-block scope

### DIFF
--- a/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
+++ b/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
@@ -28,14 +28,8 @@ describe("MassAssignmentEmptyParametersTest", () => {
     // The guard must NOT count the wrapper's own instance fields: a non-empty
     // Parameters reports `empty === false`, so construction proceeds past the
     // empty-bag short-circuit into sanitize_for_mass_assignment (contrast the
-    // empty no-op above). We assert only that it does NOT silently no-op — it
-    // throws — not the specific error class: an unpermitted Parameters SHOULD
-    // raise ForbiddenAttributesError, but real Parameters exposes `permitted`
-    // as a boolean getter (not a method), so sanitize currently misreads it as
-    // a plain hash and raises on its private fields instead. That
-    // permitted-getter divergence is tracked separately in
-    // `sanitize-mass-assignment-permitted-getter`; either way the guard is
-    // proven to proceed rather than skip.
+    // empty no-op above), where an unpermitted Parameters raises
+    // ForbiddenAttributesError.
     expect(new Parameters({ name: "Bob" }).empty).toBe(false);
     expect(
       () => new Account(new Parameters({ name: "Bob" }) as unknown as Record<string, unknown>),

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -121,18 +121,8 @@ describe("CustomPropertiesTest", () => {
   });
 
   it("overloaded properties with limit", () => {
-    // Rails asserts the cast type carries the declared limit (50) vs the schema
-    // limit (255); trails never threads `limit` into the cast type, so assert
-    // retention on the reflected column instead. Known gap, tracked by RFC 0043
-    // thread-column-limit-into-cast-type (a dependent of this story).
-    expect(
-      (OverloadedType.columnsHash() as Record<string, { limit?: number }>)
-        .overloaded_string_with_limit.limit,
-    ).toBe(255);
-    expect(
-      (UnoverloadedType.columnsHash() as Record<string, { limit?: number }>)
-        .overloaded_string_with_limit.limit,
-    ).toBe(255);
+    expect(OverloadedType.typeForAttribute("overloaded_string_with_limit").limit).toBe(50);
+    expect(UnoverloadedType.typeForAttribute("overloaded_string_with_limit").limit).toBe(255);
   });
 
   it("overloaded default but keeping its own type", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -648,7 +648,7 @@ export class ConnectionPool implements ReapablePool {
    * `leaseConnection`. NOT part of the Rails surface — do not use on
    * production/query paths; those go through async `leaseConnection` /
    * `withConnection`. The lost self-heal on the deprecated `.connection` getter
-   * is tracked by `connection-pool-pinned-sync-checkout-per-checkout-verify`.
+   * is tracked by `converge-sync-connection-lease-per-checkout-verify`.
    *
    * @internal
    *
@@ -1689,7 +1689,7 @@ function checkoutForExclusiveAccess(pool: Pool, checkoutTimeout: number): Databa
     // tests). The sweep only reaches here when connections are busy, so
     // acquisition raises `ConnectionTimeoutError` (converted below).
     // (Lifecycle-path async convergence is tracked by
-    // `converge-connection-pool-lifecycle-async`.)
+    // `converge-connection-pool-lifecycle-exclusive-access-async`.)
     return pool._acquireConnection();
   } catch (err) {
     if (err instanceof ConnectionTimeoutError) {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -2157,7 +2157,7 @@ export function combineMultiStatements(totalSql: string[]): string {
  * effectively false and the guard can never fire. Wiring it before then would
  * be dead code that fakes a feature we don't have. Tracked to land alongside
  * the `load_async` port — see story
- * `wire-tablenotspecified-async-error-throw-sites` (RFC 0023).
+ * `wire-asynchronous-query-inside-transaction-error-with-load-async` (RFC 0023).
  * @internal
  */
 export async function select(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1185,7 +1185,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // schema_creation.accept(AlterTable + ForeignKeyDefinition). We replicate
     // that abstract body here (rather than delegating to our own `super`, which
     // would recurse through the self-delegation guard — tracked by
-    // abstract-add-foreign-key-converge-to-foreign-key-options). The PG
+    // pg-add-foreign-key-delegate-to-abstract-body). The PG
     // schema_creation (visitAlterTable/visitForeignKeyDefinition) emits the
     // deferrable / NOT VALID / action / schema-qualified-name decoration, so no
     // bespoke inline SQL is needed here.

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -504,7 +504,7 @@ export function connection(this: typeof Base): DatabaseAdapter {
     // establishes a first lease exactly as before, but WITHOUT the async
     // per-checkout verify/self-heal. That lost self-heal on the deprecated sync
     // path is the documented residual tracked by
-    // `connection-pool-pinned-sync-checkout-per-checkout-verify`; the async
+    // `converge-sync-connection-lease-per-checkout-verify`; the async
     // Rails-named path (`withConnection`/`leaseConnection`) keeps full parity.
     return pool.leaseConnectionSync();
   }

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -8,12 +8,8 @@
  * Test names mirror the Ruby method names verbatim (minus the `test_` prefix,
  * underscores rendered as spaces) so scripts/test-compare can match them.
  *
- * Many Rails tests here depend on features trails has not ported yet — they are
- * left `it.skip` with a BLOCKED tag and tracked by RFC 0030 follow-up stories:
- *   - insert_all/upsert_all returning an ActiveRecord::Result (RETURNING
- *     extraction) — d2-insert-all-returning-result
- *   - SQL logging assertions, db-warnings, has_many_through guards,
- *     partitioned indexes, Speedometer no-DB-key — d2-insert-all-canonical-models
+ * The remaining `it.skipIf` guards are adapter conditionals mirroring Rails'
+ * own `current_adapter?` / `supports_*` gates, not unported features.
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { UnknownAttributeError, RecordNotUnique } from "./errors.js";

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3596,7 +3596,7 @@ export class Relation<T extends Base> {
         // support, so it would emit a wrong single-column `"col1,col2"` predicate.
         // Surface the same explicit NotImplementedError the cache_version path
         // raises for this shape (tracked by
-        // 0023-surfaced-deviations/composite-pk-distinct-relation-materialization).
+        // 0023-surfaced-deviations/converge-composite-pk-distinct-relation-materialization).
         if (Array.isArray(basePk)) this.applyJoinDependency();
         // Rails apply_join_dependency, for a limit/offset over a collection
         // reflection, replaces the relation via distinct_relation_for_primary_key
@@ -4728,7 +4728,7 @@ export class Relation<T extends Base> {
     // pure-SQL approximation (DISTINCT+LIMIT subquery) diverges from Rails'
     // materialized-ID shape and ordered-distinct handling — so rather than
     // claim parity we reject this combination explicitly. Tracked by the
-    // `relation-handler-distinct-pk-materialization` continuation story.
+    // `converge-relation-subquery-distinct-pk-materialization` continuation story.
     const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
     const isLimitable =
       this.usingLimitableReflections(joinDependency.reflections as never) &&
@@ -6609,7 +6609,7 @@ export class Relation<T extends Base> {
         } else if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
           // Composite-PK, non-limitable eager limit/offset: unsupported here —
           // surfaces NotImplementedError rather than a wrong predicate. Tracked
-          // by 0023-surfaced-deviations/composite-pk-distinct-relation-materialization.
+          // by 0023-surfaced-deviations/converge-composite-pk-distinct-relation-materialization.
           collection = this.applyJoinDependency();
         } else {
           collection = rel.leftOuterJoins(eagerSpecs);

--- a/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
@@ -20,7 +20,7 @@
  *   - A limit/offset over the joined collection needs the composite-PK
  *     `distinct_relation_for_primary_key` materialization, which trails can't do
  *     yet — it surfaces an explicit NotImplementedError
- *     (0023-surfaced-deviations/composite-pk-distinct-relation-materialization).
+ *     (0023-surfaced-deviations/converge-composite-pk-distinct-relation-materialization).
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
@@ -129,7 +129,7 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
     // (distinct_relation_for_primary_key) before joining; trails has no
     // composite-PK materialization yet, so it surfaces the explicit error
     // rather than emitting a wrong single-column predicate. Tracked by
-    // 0023-surfaced-deviations/composite-pk-distinct-relation-materialization.
+    // 0023-surfaced-deviations/converge-composite-pk-distinct-relation-materialization.
     await expect(
       CpkBook.eagerLoad("chapters")
         .order("cpk_books.author_id", "cpk_books.id")

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -101,7 +101,7 @@ describe("Arel::Nodes.build_quoted", () => {
   // rb:760's `add_bind(o.value)` land the same payload), but the AST shape does
   // not, for callers that inspect the node.
   //
-  // Tracked by story `arel-build-quoted-passes-model-attribute-unwrapped`,
+  // Tracked by story `converge-arel-build-quoted-model-attribute-unwrapped`,
   // which owns the convergence to Rails' unwrapped shape. This test pins
   // today's shape so that change is visible in the diff — it records the
   // deviation, it does not endorse it.

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -55,7 +55,7 @@ export abstract class Node {
    * `to_sql` is synchronous at all 600+ call sites, so this takes the sync
    * `engine.connection` lease. Same visitor and connection; it skips only the
    * async per-checkout verify, the residual tracked by
-   * `connection-pool-pinned-sync-checkout-per-checkout-verify`.
+   * `converge-sync-connection-lease-per-checkout-verify`.
    */
   toSql(engine: ArelEngine | null = _engine.current): string {
     if (!engine) {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -610,7 +610,7 @@ describe("the to_sql visitor", () => {
         // duck-typed (`value.respond_to?(:unboundable?) && value.unboundable?`,
         // to_sql.rb:905-907) and a Float answers it false, so Rails reaches
         // visit_Float and raises. Tracked by story
-        // arel-unboundable-sign-duck-types-like-rails; converging it is out of
+        // converge-arel-unboundable-sign-duck-typing; converging it is out of
         // scope here (it also changes Quoted(INFINITY), which Rails renders as
         // `= Infinity`).
         const v = new Visitors.ToSql(testConnection);

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -50,6 +50,38 @@ describe("stale story references", () => {
     expect(staleStoryReferences(refs, STORIES)).toHaveLength(1);
   });
 
+  it("flags a promise whose slug sits in a later sentence than its phrase", () => {
+    const refs = extractStoryReferences(
+      "// Until the connection is threaded into `create` it falls back to the\n" +
+        "// owner's pool. Tracked by `cache-entry-remaining-methods`.\n",
+      "association-scope.ts",
+    );
+    expect(staleStoryReferences(refs, STORIES)).toHaveLength(1);
+  });
+
+  it("flags the tracked-by family and a TODO tag", () => {
+    for (const comment of [
+      "// Known gap, tracked to `cache-entry-remaining-methods`.\n",
+      "// This is tracked separately in `cache-entry-remaining-methods`.\n",
+      "// TODO(cache-entry-remaining-methods): drop the shim.\n",
+    ]) {
+      expect(staleStoryReferences(extractStoryReferences(comment, "x.ts"), STORIES)).toHaveLength(
+        1,
+      );
+    }
+  });
+
+  it("ignores a landed-story citation in a block that promises a different story", () => {
+    const refs = extractStoryReferences(
+      "// TODO(converge-connection-pool-lifecycle-async): remove it.fails when\n" +
+        "// that story fixes the gap. `cache-entry-remaining-methods` landed\n" +
+        "// (#3874) without closing it.\n",
+      "associations.test.ts",
+    );
+    expect(refs.map((ref) => ref.slug)).toEqual(["converge-connection-pool-lifecycle-async"]);
+    expect(staleStoryReferences(refs, STORIES)).toEqual([]);
+  });
+
   it("ignores a slug cited as provenance rather than as a promise", () => {
     const refs = extractStoryReferences(
       "// Regression for `activesupport-json-encoding-time-precision`: the encoder\n// emits three subsecond digits.\n",

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -15,7 +15,14 @@ import path from "node:path";
 const STORY_SLUG = /[a-z0-9]+(?:-[a-z0-9]+){2,}/g;
 
 const PENDING_PHRASE =
-  /converged by|converges (when|in|once)|will (be )?converge|deferred to|pending convergence|once .{0,40}lands|until .{0,60}lands|un-?skip once|when that story|fixed by/i;
+  /converged by|converges (when|in|once)|will (be )?converge|deferred to|pending convergence|once .{0,40}lands|until .{0,60}lands|un-?skip once|when that story|fixed by|tracked (by|to|in|here|separately)|known gap|TODO\(/i;
+
+// A slug in a sentence that reports history rather than a promise. The pending
+// phrase is matched over the whole comment block (below), so this is what keeps
+// "Regression for X" legal in a block whose *other* sentence makes a promise —
+// and what keeps a citation of the story that already landed ("`X` landed
+// (#3874) without closing it") from reading as the promise it disclaims.
+const PROVENANCE_PHRASE = /regression for|\blanded\b|added by|introduced by|ported in/i;
 
 // Frontmatter `status:` of a story file, matched before any body prose.
 const STORY_STATUS = /^status:\s*"?([a-z-]+)"?\s*$/m;
@@ -38,10 +45,14 @@ export interface StoryReference {
 
 /**
  * Story slugs cited as still-pending in `source`'s comments. Contiguous comment
- * lines form one block, because a promise and its slug routinely sit on
- * different physical lines of the same JSDoc paragraph; the phrase and the slug
- * must then share a sentence, so a slug cited as provenance ("Regression for
- * X") is history rather than a promise and stays legal after the story lands.
+ * lines form one block, and the promise is matched over the whole block: a
+ * paragraph routinely states the gap in one sentence and names its story in the
+ * next ("… it falls back. Tracked by `X`."), which a sentence-scoped match
+ * misses entirely.
+ *
+ * Provenance is then vetoed per sentence rather than per block, so a block that
+ * makes a promise does not drag its own history citations in with it — the
+ * match is block-scoped, the exemption stays sentence-scoped.
  */
 export function extractStoryReferences(source: string, file: string): StoryReference[] {
   const refs: StoryReference[] = [];
@@ -50,10 +61,13 @@ export function extractStoryReferences(source: string, file: string): StoryRefer
   let start = 0;
   const flush = (): void => {
     if (block.length === 0) return;
-    for (const sentence of block.join(" ").split(SENTENCE)) {
-      if (!PENDING_PHRASE.test(sentence)) continue;
-      for (const slug of new Set(sentence.match(STORY_SLUG) ?? [])) {
-        refs.push({ file, line: start, slug });
+    const text = block.join(" ");
+    if (PENDING_PHRASE.test(text)) {
+      for (const sentence of text.split(SENTENCE)) {
+        if (PROVENANCE_PHRASE.test(sentence)) continue;
+        for (const slug of new Set(sentence.match(STORY_SLUG) ?? [])) {
+          refs.push({ file, line: start, slug });
+        }
       }
     }
     block = [];

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -17,11 +17,6 @@ const STORY_SLUG = /[a-z0-9]+(?:-[a-z0-9]+){2,}/g;
 const PENDING_PHRASE =
   /converged by|converges (when|in|once)|will (be )?converge|deferred to|pending convergence|once .{0,40}lands|until .{0,60}lands|un-?skip once|when that story|fixed by|tracked (by|to|in|here|separately)|known gap|TODO\(/i;
 
-// A slug in a sentence that reports history rather than a promise. The pending
-// phrase is matched over the whole comment block (below), so this is what keeps
-// "Regression for X" legal in a block whose *other* sentence makes a promise —
-// and what keeps a citation of the story that already landed ("`X` landed
-// (#3874) without closing it") from reading as the promise it disclaims.
 const PROVENANCE_PHRASE = /regression for|\blanded\b|added by|introduced by|ported in/i;
 
 // Frontmatter `status:` of a story file, matched before any body prose.
@@ -50,9 +45,12 @@ export interface StoryReference {
  * next ("… it falls back. Tracked by `X`."), which a sentence-scoped match
  * misses entirely.
  *
- * Provenance is then vetoed per sentence rather than per block, so a block that
- * makes a promise does not drag its own history citations in with it — the
- * match is block-scoped, the exemption stays sentence-scoped.
+ * A `PROVENANCE_PHRASE` sentence is then vetoed per sentence rather than per
+ * block, so a block that makes a promise does not drag its own history
+ * citations in with it: the match is block-scoped, the exemption stays
+ * sentence-scoped. That keeps "Regression for X" legal alongside a promise, and
+ * keeps a citation of the story that already landed ("`X` landed (#3874)
+ * without closing it") from reading as the promise it disclaims.
  */
 export function extractStoryReferences(source: string, file: string): StoryReference[] {
   const refs: StoryReference[] = [];


### PR DESCRIPTION
## What

`scripts/stale-story-references.ts` (added in #5984) only caught a promise when
the forward-looking phrase and the story slug landed in the **same sentence**.
A JSDoc paragraph that states the gap in one sentence and names its story in the
next — the common spelling — slipped through entirely.

- **Block scope.** `PENDING_PHRASE` now matches over the whole contiguous comment
  block, not one sentence.
- **Provenance stays sentence-scoped.** A new `PROVENANCE_PHRASE`
  (`regression for`, `landed`, `added by`, `introduced by`, `ported in`) vetoes
  per sentence, so a block that makes a promise no longer drags its own history
  citations in with it. `"Regression for X"` stays legal.
- **Phrase list.** Added the `tracked by/to/in/here/separately`, `known gap`, and
  `TODO(<slug>)` family.

## Audit

The widened matcher surfaced 17 citations of landed stories. All are resolved:

**Converged**
- `attributes.test.ts` "overloaded properties with limit" now asserts Rails'
  `type_for_attribute(...).limit` (attributes_test.rb:62-65) instead of the
  `columnsHash()` workaround — `thread-column-limit-into-cast-type` (#4668)
  landed the type-level limit threading.

**Prose corrected (gap is gone)**
- `mass-assignment-empty.test.ts` — the permitted-getter divergence it described
  was fixed by #4972; `sanitizeForMassAssignment`'s `readPermitted` handles the
  boolean getter.
- `insert-all.test.ts` header — the RFC 0030 `it.skip` BLOCKED blocks it
  documents were removed by #3446/#3447; only adapter conditionals remain.
- `associations.test.ts:596` needed no edit: its `store-full-sti-class-name`
  mention is explicitly provenance ("landed (#3874) without closing it"), which
  the new `PROVENANCE_PHRASE` correctly exempts. The live `TODO(...)` there
  names an open story.

**Repointed at fresh convergence stories** (RFC 0023, each filed with the
trails/Rails `file:line` this audit surfaced)

| Sites | New story |
| --- | --- |
| `connection-pool.ts:651`, `connection-handling.ts:507`, `arel/nodes/node.ts:58` | `converge-sync-connection-lease-per-checkout-verify` |
| `connection-pool.ts:1691` | `converge-connection-pool-lifecycle-exclusive-access-async` |
| `pg/schema-statements-class.ts:1187` | `pg-add-foreign-key-delegate-to-abstract-body` |
| `relation.ts:3598`, `relation.ts:6611`, `cpk-eager-pluck-...trails.test.ts:131` | `converge-composite-pk-distinct-relation-materialization` |
| `relation.ts:4724` | `converge-relation-subquery-distinct-pk-materialization` |
| `arel/nodes/casted.test.ts:104` | `converge-arel-build-quoted-model-attribute-unwrapped` |
| `arel/visitors/to-sql.test.ts:612` | `converge-arel-unboundable-sign-duck-typing` |
| `abstract/database-statements.ts:2160` | `wire-asynchronous-query-inside-transaction-error-with-load-async` |

Each of the eight is a real residual verified against the tree, not a
re-justification: e.g. the PG `add_foreign_key` duplication cited a
self-delegation guard that #3803 removed, and
`composite-pk-distinct-relation-materialization` was **closed without a PR**
under a now-closed RFC.

## Notes

- `.md` under `docs/` and RFC prose is still out of the scan's roots. That
  widening needs paragraph-scoped blocks, fence skipping, and a decision about
  the frozen `docs/activerecord/` tree, so it is filed as
  `extend-stale-story-reference-scan-to-markdown` (RFC 0061) rather than bolted
  on here.
- Three new tests cover block-scope matching, the `tracked-by`/`TODO()` family,
  and the provenance veto inside a promising block.

Closes-story: widen-stale-story-reference-matcher-and-audit
