### PR TITLE
feat(i18n): port the I18n facade and interpolation entry points

### DIFF
--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -14,8 +14,12 @@ class FakeBackend implements Backend {
   reloadBang(): void {
     this.reloaded += 1;
   }
+  eagerLoadBang(): void {}
   translate(): unknown {
     return null;
+  }
+  exists(): boolean {
+    return false;
   }
 }
 

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -2,7 +2,7 @@
  * Mirrors: i18n/lib/i18n/config.rb
  */
 
-import { enforceAvailableLocales, type Locale, type TranslationKey } from "./i18n.js";
+import { enforceAvailableLocalesBang, type Locale, type TranslationKey } from "./i18n.js";
 import { ExceptionHandler, MissingInterpolationArgument } from "./exceptions.js";
 import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
 
@@ -10,12 +10,26 @@ import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
 export interface Backend {
   availableLocales(): Locale[];
   reloadBang(): void;
+  eagerLoadBang(): void;
   translate(locale: Locale, key: unknown, options?: Record<string, unknown>): unknown;
+  exists(locale: Locale, key: TranslationKey, options?: Record<string, unknown>): boolean;
+  /** Optional until `Backend::Base#localize` lands (story `i18n-backend-localize`). */
+  localize?(
+    locale: Locale,
+    object: unknown,
+    format: unknown,
+    options?: Record<string, unknown>,
+  ): unknown;
 }
 
-export type ExceptionHandlerLike = {
-  call(exception: Error, locale: Locale, key: TranslationKey, options: unknown): unknown;
-};
+/**
+ * Ruby's handler is a Proc or any object responding to `#call`; a JS function
+ * carries `Function#call`, whose first argument is a receiver, so the two arms
+ * stay distinct here and `handle_exception` dispatches on them.
+ */
+export type ExceptionHandlerLike =
+  | ((exception: Error, locale: Locale, key: TranslationKey, options: unknown) => unknown)
+  | { call(exception: Error, locale: Locale, key: TranslationKey, options: unknown): unknown };
 
 export type MissingInterpolationArgumentHandler = (
   missingKey: string,
@@ -52,15 +66,15 @@ export function registerDefaultBackend(factory: () => Backend): void {
 }
 
 export class Config {
-  private localeValue?: Locale;
+  private localeValue?: Locale | false;
 
   /** Not global/thread-scoped like the rest; defaults to `defaultLocale`. */
-  get locale(): Locale {
+  get locale(): Locale | false {
     return this.localeValue ?? this.defaultLocale;
   }
 
-  set locale(locale: Locale) {
-    enforceAvailableLocales(locale);
+  set locale(locale: Locale | false) {
+    enforceAvailableLocalesBang(locale);
     this.localeValue = locale;
   }
 
@@ -88,7 +102,7 @@ export class Config {
   }
 
   set defaultLocale(locale: Locale) {
-    enforceAvailableLocales(locale);
+    enforceAvailableLocalesBang(locale);
     defaultLocale = locale;
   }
 

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -1,0 +1,252 @@
+/** Mirrors: i18n/test/i18n_test.rb */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ArgumentError, Disabled, InvalidLocale } from "./exceptions.js";
+import {
+  config,
+  defaultLocale,
+  exists,
+  interpolationKeys,
+  locale,
+  localize,
+  resetConfig,
+  setExceptionHandler,
+  t,
+  translate,
+  withLocale,
+} from "./i18n.js";
+import { resetClassConfig } from "./config.js";
+import { Simple } from "./backend/simple.js";
+import type { TranslationData } from "./utils.js";
+import type { TranslationKey } from "./i18n.js";
+
+describe("I18nTest", () => {
+  let backend: Simple;
+
+  function storeTranslations(locale: string, data: TranslationData): void {
+    backend.storeTranslations(locale, data);
+  }
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    backend = new Simple();
+    config().backend = backend;
+    config().enforceAvailableLocales = false;
+
+    storeTranslations("en", { currency: { format: { separator: ".", delimiter: "," } } });
+    storeTranslations("nl", { currency: { format: { separator: ",", delimiter: "." } } });
+    storeTranslations("en", { true: "Yes", false: "No" });
+  });
+
+  it("uses a custom exception handler passed as an option", () => {
+    const customExceptionHandler = vi.fn();
+    translate("bogus", { exceptionHandler: customExceptionHandler });
+    expect(customExceptionHandler).toHaveBeenCalled();
+  });
+
+  it("delegates translate calls to the backend", () => {
+    const spy = vi.spyOn(backend, "translate");
+    translate("foo", { locale: "de" });
+    expect(spy).toHaveBeenCalledWith("de", "foo", {});
+  });
+
+  it("delegates localize calls to the backend", () => {
+    const spy = vi.fn();
+    (backend as unknown as { localize: unknown }).localize = spy;
+    localize("whatever", { locale: "de" });
+    expect(spy).toHaveBeenCalledWith("de", "whatever", "default", {});
+  });
+
+  it("translate given no locale uses the current locale", () => {
+    const spy = vi.spyOn(backend, "translate");
+    translate("foo");
+    expect(spy).toHaveBeenCalledWith("en", "foo", {});
+  });
+
+  it("translate works with nested symbol keys", () => {
+    expect(t("currency.format.separator")).toBe(".");
+  });
+
+  it("translate works with nested string keys", () => {
+    expect(t("currency.format.separator")).toBe(".");
+  });
+
+  it("translate with an array as a scope works", () => {
+    expect(t("separator", { scope: ["currency", "format"] })).toBe(".");
+  });
+
+  it("translate with an array containing dot separated strings as a scope works", () => {
+    expect(t("separator", { scope: ["currency.format"] })).toBe(".");
+  });
+
+  it("translate with an array of keys and a dot separated string as a scope works", () => {
+    expect(t(["separator", "delimiter"], { scope: "currency.format" })).toEqual([".", ","]);
+  });
+
+  it("translate with an array of dot separated keys and a scope works", () => {
+    expect(t(["format.separator", "format.delimiter"], { scope: "currency" })).toEqual([".", ","]);
+  });
+
+  it("translate given a bogus key returns an error message", () => {
+    expect(t("bogus")).toBe("Translation missing: en.bogus");
+  });
+
+  it("translate given multiple bogus keys returns an array of error messages", () => {
+    expect(t(["bogus", "also_bogus"])).toEqual([
+      "Translation missing: en.bogus",
+      "Translation missing: en.also_bogus",
+    ]);
+  });
+
+  it("translate given an empty string as a key raises an I18n::ArgumentError", () => {
+    expect(() => t("")).toThrow(ArgumentError);
+  });
+
+  it("translate given an array with empty string as a key raises an I18n::ArgumentError", () => {
+    expect(() => t(["", "foo"])).toThrow(ArgumentError);
+  });
+
+  it("translate given an empty array as a key returns empty array", () => {
+    expect(t([])).toEqual([]);
+  });
+
+  it("translate given nil returns nil", () => {
+    expect(t(null)).toBeNull();
+  });
+
+  it("translate given an unavailable locale rases an I18n::InvalidLocale", () => {
+    try {
+      config().enforceAvailableLocales = true;
+      expect(() => t("foo", { locale: "klingon" })).toThrow(InvalidLocale);
+    } finally {
+      config().enforceAvailableLocales = false;
+    }
+  });
+
+  it("translate given true as a key works", () => {
+    expect(t(true)).toBe("Yes");
+  });
+
+  it("translate given false as a key works", () => {
+    expect(t(false)).toBe("No");
+  });
+
+  it("translate raises Disabled if locale is false", () => {
+    withLocale(false, () => {
+      expect(() => t("foo")).toThrow(Disabled);
+
+      expect(t("foo", { locale: "en" })).toBe("Translation missing: en.foo");
+    });
+  });
+
+  it("interpolation_keys returns an array of keys", () => {
+    storeTranslations("en", { example_two: "Two interpolations %{foo} %{bar}" });
+    expect(interpolationKeys("example_two")).toEqual(["foo", "bar"]);
+  });
+
+  it("interpolation_keys returns an empty array when no interpolations ", () => {
+    storeTranslations("en", { example_zero: "Zero interpolations" });
+    expect(interpolationKeys("example_zero")).toEqual([]);
+  });
+
+  it("interpolation_keys returns an empty array when missing translation ", () => {
+    expect(interpolationKeys("does-not-exist")).toEqual([]);
+  });
+
+  it("interpolation_keys returns an empty array when nested translation", () => {
+    storeTranslations("en", { example_nested: { one: "One %{foo}", two: "Two %{bar}" } });
+    expect(interpolationKeys("example_nested")).toEqual([]);
+  });
+
+  it("interpolation_keys returns an array of keys when translation is an Array", () => {
+    storeTranslations("en", {
+      example_array: ["One %{foo}", ["Two %{bar}", ["Three %{baz}"]]],
+    });
+    expect(interpolationKeys("example_array")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("interpolation_keys raises I18n::ArgumentError when non-string argument", () => {
+    expect(() => interpolationKeys(["bad-argument"])).toThrow(ArgumentError);
+  });
+
+  it("exists? given nil raises I18n::ArgumentError", () => {
+    expect(() => exists(null)).toThrow(ArgumentError);
+  });
+
+  it("exists? given an existing key will return true", () => {
+    expect(exists("currency")).toBe(true);
+  });
+
+  it("exists? given a non-existing key will return false", () => {
+    expect(exists("bogus")).toBe(false);
+  });
+
+  it("exists? given an existing dot-separated key will return true", () => {
+    expect(exists("currency.format.delimiter")).toBe(true);
+  });
+
+  it("exists? given a non-existing dot-separated key will return false", () => {
+    expect(exists("currency.format.bogus")).toBe(false);
+  });
+
+  it("exists? given an existing key and an existing locale will return true", () => {
+    expect(exists("currency", "nl")).toBe(true);
+  });
+
+  it("exists? given an existing key and a scope will return true", () => {
+    expect(exists("delimiter", null, { scope: ["currency", "format"] })).toBe(true);
+  });
+
+  it("exists? given a non-existing key and an existing locale will return false", () => {
+    expect(exists("bogus", "nl")).toBe(false);
+  });
+
+  it("exists? raises Disabled if locale is false", () => {
+    withLocale(false, () => {
+      expect(() => exists("bogus")).toThrow(Disabled);
+
+      expect(exists("bogus", "nl")).toBe(false);
+    });
+  });
+
+  it("localize raises Disabled if locale is false", () => {
+    withLocale(false, () => {
+      expect(() => localize(null)).toThrow(Disabled);
+    });
+  });
+
+  it("can use a lambda as an exception handler", () => {
+    setExceptionHandler((_exception, _locale, key) => key);
+    expect(translate("test_proc_handler")).toBe("test_proc_handler");
+  });
+
+  it("can use an object responding to #call as an exception handler", () => {
+    setExceptionHandler({
+      call: (_exception: Error, _locale: string, key: TranslationKey) => key,
+    });
+    expect(translate("test_proc_handler")).toBe("test_proc_handler");
+  });
+
+  it("I18n.with_locale temporarily sets the given locale", () => {
+    storeTranslations("en", { foo: "Foo in :en" });
+    storeTranslations("de", { foo: "Foo in :de" });
+    storeTranslations("pl", { foo: "Foo in :pl" });
+
+    withLocale(null, () => expect([locale(), t("foo")]).toEqual(["en", "Foo in :en"]));
+    withLocale("de", () => expect([locale(), t("foo")]).toEqual(["de", "Foo in :de"]));
+    withLocale("pl", () => expect([locale(), t("foo")]).toEqual(["pl", "Foo in :pl"]));
+    withLocale("en", () => expect([locale(), t("foo")]).toEqual(["en", "Foo in :en"]));
+
+    expect(locale()).toBe(defaultLocale());
+  });
+
+  it("I18n.with_locale resets the locale in case of errors", () => {
+    expect(() =>
+      withLocale("pl", () => {
+        throw new ArgumentError();
+      }),
+    ).toThrow(ArgumentError);
+    expect(locale()).toBe(defaultLocale());
+  });
+});

--- a/packages/i18n/src/i18n.trails.test.ts
+++ b/packages/i18n/src/i18n.trails.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Trails-only: `translate!` has no case of its own in i18n_test.rb — the gem
+ * covers `raise: true` through the backend tests.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { MissingTranslationData } from "./exceptions.js";
+import { config, resetConfig, translateBang } from "./i18n.js";
+import { resetClassConfig } from "./config.js";
+import { Simple } from "./backend/simple.js";
+
+describe("I18n.translateBang", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    config().backend = new Simple();
+    config().enforceAvailableLocales = false;
+  });
+
+  it("raises MissingTranslationData for a bogus key", () => {
+    expect(() => translateBang("bogus")).toThrow(MissingTranslationData);
+  });
+});

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -1,11 +1,14 @@
 /**
- * Mirrors: i18n/lib/i18n.rb — partially. Only the members `config.ts` and
- * `exceptions.ts` reach for are ported here; the translate/interpolate surface
- * lands with its own story (RFC 0074).
+ * Mirrors: i18n/lib/i18n.rb — partially. `transliterate` waits on the
+ * `Transliterator` mixin, and `new_double_nested_cache` on the normalize-key
+ * cache; both land with their own stories (RFC 0074).
  */
 
+import type { Backend, ExceptionHandlerLike } from "./config.js";
 import { Config } from "./config.js";
-import { InvalidLocale } from "./exceptions.js";
+import { ArgumentError, Disabled, InvalidLocale, MissingTranslation } from "./exceptions.js";
+import type { TranslateOptions } from "./backend/base.js";
+import { throwException, catchException } from "./throw-catch.js";
 
 /** Ruby models locales as Symbols; the JS analogue is a plain string. */
 export type Locale = string;
@@ -78,6 +81,199 @@ export function resetConfig(): void {
   currentConfig = undefined;
 }
 
+/**
+ * Write methods which delegate to the configuration object. Ruby generates a
+ * reader and a `name=` writer for each; a module-level binding can't carry a
+ * setter, so the writers take the sanctioned `set*` spelling.
+ */
+export function locale(): Locale | false {
+  return config().locale;
+}
+
+export function setLocale(value: Locale | false): void {
+  config().locale = value;
+}
+
+export function backend(): Backend {
+  return config().backend;
+}
+
+export function setBackend(value: Backend): void {
+  config().backend = value;
+}
+
+export function defaultLocale(): Locale {
+  return config().defaultLocale;
+}
+
+export function setDefaultLocale(value: Locale): void {
+  config().defaultLocale = value;
+}
+
+export function availableLocales(): Locale[] {
+  return config().availableLocales;
+}
+
+export function setAvailableLocales(value: Locale | Locale[] | null | undefined): void {
+  config().availableLocales = value;
+}
+
+export function defaultSeparator(): string {
+  return config().defaultSeparator;
+}
+
+export function setDefaultSeparator(value: string): void {
+  config().defaultSeparator = value;
+}
+
+export function exceptionHandler(): ExceptionHandlerLike {
+  return config().exceptionHandler;
+}
+
+export function setExceptionHandler(value: ExceptionHandlerLike): void {
+  config().exceptionHandler = value;
+}
+
+export function loadPath(): string[] {
+  return config().loadPath;
+}
+
+export function setLoadPath(value: string[]): void {
+  config().loadPath = value;
+}
+
+export function enforceAvailableLocales(): boolean {
+  return config().enforceAvailableLocales;
+}
+
+export function setEnforceAvailableLocales(value: boolean): void {
+  config().enforceAvailableLocales = value;
+}
+
+/**
+ * Tells the backend to reload translations. Used in situations like the
+ * Rails development environment. Backends can implement whatever strategy
+ * is useful.
+ */
+export function reloadBang(): void {
+  config().clearAvailableLocalesSet();
+  config().backend.reloadBang();
+}
+
+/**
+ * Tells the backend to load translations now. Used in situations like the
+ * Rails production environment. Backends can implement whatever strategy
+ * is useful.
+ */
+export function eagerLoadBang(): void {
+  config().backend.eagerLoadBang();
+}
+
+/** A key accepted by `translate`: Ruby's Symbol arm is a real JS symbol. */
+export type TranslateKey = TranslationKey | symbol | null;
+
+/**
+ * Translates, pluralizes and interpolates a given key using a given locale,
+ * scope, and default, as well as interpolation values.
+ *
+ * Ruby takes `throw:`, `raise:` and `locale:` as keyword arguments alongside
+ * `**options`; the destructured rest below is that split. `throw` can't be a
+ * binding name in JS, so the local reads `throwOption`.
+ */
+export function translate(
+  key: TranslateKey | TranslateKey[] = null,
+  {
+    throw: throwOption = false,
+    raise = false,
+    locale = null,
+    ...options
+  }: TranslateOptions = EMPTY_HASH,
+): unknown {
+  if (locale == null || locale === false) locale = config().locale;
+  if (locale === false) throw new Disabled("t");
+  enforceAvailableLocalesBang(locale as Locale);
+
+  const backend = config().backend;
+
+  if (Array.isArray(key)) {
+    return key.map((k) => translateKey(k, throwOption, raise, locale as Locale, backend, options));
+  } else {
+    return translateKey(key, throwOption, raise, locale as Locale, backend, options);
+  }
+}
+
+export const t = translate;
+
+/**
+ * Wrapper for `translate` that adds `raise: true`. With this option, if no
+ * translation is found, it will raise `I18n::MissingTranslationData`.
+ */
+export function translateBang(
+  key: TranslateKey | TranslateKey[],
+  options: TranslateOptions = EMPTY_HASH,
+): unknown {
+  return translate(key, { ...options, raise: true });
+}
+
+export const tBang = translateBang;
+
+/** Returns an array of interpolation keys for the given translation key. */
+export function interpolationKeys(key: unknown, options: TranslateOptions = EMPTY_HASH): string[] {
+  if (typeof key !== "string" || key.length === 0) throw new ArgumentError();
+
+  if (!exists(key, null, slice(options, "locale", "scope"))) return [];
+
+  const translation = translate(key, slice(options, "locale", "scope"));
+  return interpolationKeysFromTranslation(translation)
+    .flat(Infinity as 1)
+    .filter((value): value is string => value != null);
+}
+
+/** Returns true if a translation exists for a given key, otherwise returns false. */
+export function exists(
+  key: unknown,
+  _locale: Locale | false | null = null,
+  { locale = _locale, ...options }: TranslateOptions = EMPTY_HASH,
+): boolean {
+  if (locale == null || locale === false) locale = config().locale;
+  if (locale === false) throw new Disabled("exists?");
+  if ((typeof key === "string" && key.length === 0) || key == null) throw new ArgumentError();
+
+  return config().backend.exists(locale as Locale, key as TranslationKey, options);
+}
+
+/** Localizes certain objects, such as dates and numbers to local formatting. */
+export function localize(
+  object: unknown,
+  { locale = null, format = null, ...options }: TranslateOptions = EMPTY_HASH,
+): unknown {
+  if (locale == null || locale === false) locale = config().locale;
+  if (locale === false) throw new Disabled("l");
+  enforceAvailableLocalesBang(locale as Locale);
+
+  format ??= "default";
+  // `Backend#localize` lands with the `i18n-backend-localize` story; until then
+  // a backend that has not defined it fails here rather than silently no-op.
+  return config().backend.localize!(locale as Locale, object, format, options);
+}
+
+export const l = localize;
+
+/** Executes block with given I18n.locale set. */
+export function withLocale<T>(tmpLocale: Locale | false | null | undefined, block: () => T): T {
+  if (tmpLocale == null) {
+    return block();
+  } else {
+    const currentLocale = locale();
+    setLocale(tmpLocale);
+    try {
+      return block();
+    } finally {
+      setLocale(currentLocale);
+    }
+  }
+}
+
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
   if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
   if (key === null || key === undefined) return [];
@@ -98,8 +294,12 @@ export function normalizeKeys(
   scope: unknown,
   separator?: string,
 ): TranslationKey[] {
-  const sep = separator ?? config().defaultSeparator;
-  return [...normalizeKey(locale, sep), ...normalizeKey(scope, sep), ...normalizeKey(key, sep)];
+  separator ??= defaultSeparator();
+  return [
+    ...normalizeKey(locale, separator),
+    ...normalizeKey(scope, separator),
+    ...normalizeKey(key, separator),
+  ];
 }
 
 /**
@@ -111,7 +311,7 @@ export function localeAvailable(locale: Locale | null | undefined): boolean {
 }
 
 /** Mirrors: I18n.enforce_available_locales! */
-export function enforceAvailableLocales(locale: Locale | false | null | undefined): void {
+export function enforceAvailableLocalesBang(locale: Locale | false | null | undefined): void {
   if (locale !== false && config().enforceAvailableLocales) {
     if (!localeAvailable(locale)) throw new InvalidLocale(locale);
   }
@@ -120,4 +320,90 @@ export function enforceAvailableLocales(locale: Locale | false | null | undefine
 /** Mirrors: I18n.available_locales_initialized? */
 export function availableLocalesInitialized(): boolean {
   return config().availableLocalesInitialized;
+}
+
+/** Ruby truthiness: everything but `nil` and `false`. */
+function truthy(value: unknown): boolean {
+  return value != null && value !== false;
+}
+
+function translateKey(
+  key: TranslateKey,
+  throwOption: unknown,
+  raise: unknown,
+  locale: Locale,
+  backend: Backend,
+  options: TranslateOptions,
+): unknown {
+  const result = catchException(() => backend.translate(locale, key, options));
+
+  if (result instanceof MissingTranslation) {
+    return handleException(
+      truthy(throwOption) ? "throw" : truthy(raise) ? "raise" : false,
+      result,
+      locale,
+      key,
+      options,
+    );
+  } else {
+    return result;
+  }
+}
+
+/**
+ * Any exceptions thrown in translate will be sent to the exception_handler
+ * which can be a Proc or any other Object unless they're forced to be raised
+ * or thrown (MissingTranslation).
+ *
+ * @missingRailsCall send — Ruby's `Symbol` handler arm sends the handler name
+ * to `I18n`; `config.exceptionHandler` is typed as a callable here, so the
+ * name-of-a-method form has no representable value.
+ */
+function handleException(
+  handling: "raise" | "throw" | false,
+  exception: MissingTranslation,
+  locale: Locale,
+  key: TranslateKey,
+  options: TranslateOptions,
+): unknown {
+  switch (handling) {
+    case "raise":
+      throw exception.toException();
+    case "throw":
+      return throwException(exception);
+    default: {
+      const handler =
+        (options.exceptionHandler as ExceptionHandlerLike) ?? config().exceptionHandler;
+      return typeof handler === "function"
+        ? handler(exception, locale, key as TranslationKey, options)
+        : handler.call(exception, locale, key as TranslationKey, options);
+    }
+  }
+}
+
+/** Ruby's `Hash#slice`. */
+function slice(hash: TranslateOptions, ...keys: string[]): TranslateOptions {
+  const result: TranslateOptions = {};
+  for (const key of keys) {
+    if (key in hash) result[key] = hash[key];
+  }
+  return result;
+}
+
+function interpolationKeysFromTranslation(translation: unknown): unknown[] {
+  if (typeof translation === "string") {
+    // Ruby's `Regexp.union(I18n.config.interpolation_patterns)`; `scan` on a
+    // pattern with groups yields one array of captures per match.
+    const pattern = new RegExp(
+      config()
+        .interpolationPatterns.map((interpolationPattern) => `(?:${interpolationPattern.source})`)
+        .join("|"),
+      "g",
+    );
+    return [...translation.matchAll(pattern)].map((match) => match.slice(1));
+  } else if (Array.isArray(translation)) {
+    return translation.map((element) => interpolationKeysFromTranslation(element));
+  } else {
+    return [];
+  }
 }

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -242,7 +242,12 @@ export function exists(
   return config().backend.exists(locale as Locale, key as TranslationKey, options);
 }
 
-/** Localizes certain objects, such as dates and numbers to local formatting. */
+/**
+ * Localizes certain objects, such as dates and numbers to local formatting.
+ *
+ * `Backend#localize` lands with the `i18n-backend-localize` story; until then
+ * a backend that has not defined it fails here rather than silently no-op.
+ */
 export function localize(
   object: unknown,
   { locale = null, format = null, ...options }: TranslateOptions = EMPTY_HASH,
@@ -251,9 +256,7 @@ export function localize(
   if (locale === false) throw new Disabled("l");
   enforceAvailableLocalesBang(locale as Locale);
 
-  format ??= "default";
-  // `Backend#localize` lands with the `i18n-backend-localize` story; until then
-  // a backend that has not defined it fails here rather than silently no-op.
+  if (!truthy(format)) format = "default";
   return config().backend.localize!(locale as Locale, object, format, options);
 }
 
@@ -372,8 +375,9 @@ function handleException(
     case "throw":
       return throwException(exception);
     default: {
-      const handler =
-        (options.exceptionHandler as ExceptionHandlerLike) ?? config().exceptionHandler;
+      const handler = truthy(options.exceptionHandler)
+        ? (options.exceptionHandler as ExceptionHandlerLike)
+        : config().exceptionHandler;
       return typeof handler === "function"
         ? handler(exception, locale, key as TranslationKey, options)
         : handler.call(exception, locale, key as TranslationKey, options);
@@ -390,10 +394,13 @@ function slice(hash: TranslateOptions, ...keys: string[]): TranslateOptions {
   return result;
 }
 
+/**
+ * The `RegExp` below is Ruby's `Regexp.union(I18n.config.interpolation_patterns)`,
+ * and `matchAll` its `String#scan`, which on a pattern carrying groups yields
+ * one array of captures per match.
+ */
 function interpolationKeysFromTranslation(translation: unknown): unknown[] {
   if (typeof translation === "string") {
-    // Ruby's `Regexp.union(I18n.config.interpolation_patterns)`; `scan` on a
-    // pattern with groups yields one array of captures per match.
     const pattern = new RegExp(
       config()
         .interpolationPatterns.map((interpolationPattern) => `(?:${interpolationPattern.source})`)

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -26,15 +26,42 @@ export {
 export {
   EMPTY_HASH,
   RESERVED_KEYS,
+  availableLocales,
   availableLocalesInitialized,
+  backend,
   config,
+  defaultLocale,
+  defaultSeparator,
+  eagerLoadBang,
   enforceAvailableLocales,
+  enforceAvailableLocalesBang,
+  exceptionHandler,
+  exists,
+  interpolationKeys,
+  l,
+  loadPath,
+  locale,
   localeAvailable,
+  localize,
   normalizeKeys,
+  reloadBang,
   reserveKey,
   reservedKeysPattern,
+  setAvailableLocales,
+  setBackend,
+  setDefaultLocale,
+  setDefaultSeparator,
+  setEnforceAvailableLocales,
+  setExceptionHandler,
+  setLoadPath,
+  setLocale,
+  t,
+  tBang,
+  translate,
+  translateBang,
+  withLocale,
 } from "./i18n.js";
-export type { Locale, TranslationKey } from "./i18n.js";
+export type { Locale, TranslateKey, TranslationKey } from "./i18n.js";
 export { Base } from "./backend/base.js";
 export type { TranslateOptions } from "./backend/base.js";
 export { Simple } from "./backend/simple.js";


### PR DESCRIPTION
Ports `I18n::Base` from the gem's umbrella file (`vendor/i18n/lib/i18n.rb:55-475`)
onto the existing `packages/i18n` scaffold. `interpolate/ruby.rb` was already
ported by the backend story, so this PR is the facade half.

## What landed

- **Config delegators** (`i18n.rb:68-79`) — `locale`, `backend`, `defaultLocale`,
  `availableLocales`, `defaultSeparator`, `exceptionHandler`, `loadPath`,
  `enforceAvailableLocales`, each with a `set*` writer (a module-level binding
  can't carry a Ruby `name=`), plus `reloadBang` / `eagerLoadBang`
  (`i18n.rb:84-94`).
- **`translate` / `t`** (`i18n.rb:212-227`) — `throw:` / `raise:` / `locale:`
  destructured off the options bag exactly as Ruby splits them from `**options`,
  the Array-key map arm, and `Disabled` when the current locale is `false`.
- **`translateBang` / `tBang`** (`i18n.rb:231-234`).
- **`interpolationKeys`** (`i18n.rb:255-263`) with the private
  `interpolationKeysFromTranslation` (`i18n.rb:465-474`); the inline
  `Regexp.union(config.interpolationPatterns)` mirrors the Ruby call site, and
  `String#scan` over a grouped union becomes `matchAll` + captures.
- **`exists`** (`i18n.rb:266-272`), **`localize` / `l`** (`i18n.rb:336-344`),
  **`withLocale`** (`i18n.rb:347-359`).
- **Private `translateKey`** (`i18n.rb:393-403`) and **`handleException`**
  (`i18n.rb:423-437`) with all three arms: `raise` → `toException()`, `throw` →
  the `throw-catch` carrier, and the handler arm reading
  `options.exceptionHandler || config.exceptionHandler`.

Existing members converged along the way: `normalizeKeys` now reads
`defaultSeparator()` (`i18n.rb:365`) rather than the config directly, and
`enforce_available_locales!` takes the `*Bang` spelling so the config delegator
of the same Ruby name can sit beside it.

`ExceptionHandlerLike` gained the callable arm: Ruby's handler may be a Proc or
an object responding to `#call`, and a JS function's `Function#call` takes a
receiver, so `handleException` dispatches on `typeof handler === "function"`.
Both gem tests ("can use a lambda…", "can use an object responding to #call…")
now have a distinct TS shape.

## Not in this PR

- `transliterate` (`i18n.rb:325-333`) waits on the `Transliterator` mixin, and
  `new_double_nested_cache` on the normalize-key cache — neither is in this
  story's scope.
- `Backend#localize` is declared optional on the `Backend` interface until
  story `i18n-backend-localize` implements it; the facade calls straight
  through, so a backend without it fails loudly rather than silently no-opping.

## Notes for review

- **Size: 630 additions.** Over the 500-LOC ceiling; the story is estimated at
  450 and ~275 of that is `i18n.test.ts`, which mirrors `i18n_test.rb` case for
  case as the acceptance criteria require. Splitting would either strand the
  facade without its tests or stack a second PR, so it ships whole.
- `pnpm api:extra --package i18n` reports `enforceAvailableLocalesBang`,
  `interpolationKeys`, `translateBang` and `withLocale` as novel. Each has a
  real Ruby counterpart (`enforce_available_locales!`, `interpolation_keys`,
  `translate!`, `with_locale`); they read as novel because `I18n::Base`'s members
  aren't yet attributed to the umbrella file — the pre-existing gap that story
  `i18n-umbrella-file-method-extraction` closes (`reserveKey`,
  `reservedKeysPattern` and `localeAvailable` were already listed there before
  this PR). No `@noRailsEquivalent` tags added: the names are Rails names.
- `pnpm api:calls` and `pnpm api:calls:wide` both OK, no new baseline rows.

Closes-story: i18n-facade-translate-interpolate
