### PR TITLE
feat(scripts): extend the stale-story-reference scan to markdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,8 +279,9 @@ catches a class of drift a reviewer would otherwise spend a cycle on.
 
    **Converged something?** The wide baseline is **only-shrink**: fixing a real
    divergence makes its baseline row stale and turns the gate red. Delete that
-   one row by hand. Do **not** `--write`/reseed — a reseed reorders and re-emits
-   entries for untouched packages and produces an unreviewable diff.
+   one row by hand. Do **not** `--write`/reseed — a reseed rewrites the whole
+   exclude tree and buries the one row you meant to retire in an unreviewable
+   diff.
 
 3. **Did you add any public TS name?** `pnpm api:extra --package <pkg>` — it
    lists every public TS method, getter, class, and top-level function in a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,9 +110,12 @@ entry stale and turns the gate red — e.g. #5027 added the `String` arm to
 and made the baselined "omits quote_column_name" entry stale. **The fix is to
 delete the now-stale entry from the `call-mismatches-wide-exclude/` baseline,
 NOT to `--write`/reseed.** Reseeding (`pnpm api:calls:wide:reseed` /
-`lint-call-mismatches-wide.ts --write`) reorders and re-emits entries for
-untouched packages, producing an unreviewable diff — this churn hazard is
-tracked in the `wide-calls-exclude-reseed-reorders-untouched-packages` story.
+`lint-call-mismatches-wide.ts --write`) rewrites the whole
+`call-mismatches-wide-exclude/` tree, so it buries the one entry you meant to
+retire in a diff nobody can review; the hand deletion is the whole change. (The
+cross-package reordering that used to make this worse is fixed — #5183 pinned
+emission to the code-unit `compareKeys` order, so a reseed now leaves untouched
+packages byte-identical.)
 
 Any PR that converges a visitor or method body toward Rails can trip this, so
 run the wide ratchet locally whenever you change a ported method body.

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  collectMarkdownFiles,
+  extractMarkdownStoryReferences,
   extractStoryReferences,
   loadStories,
   scanStoryReferences,
@@ -104,11 +106,42 @@ describe("stale story references", () => {
     ).toEqual([]);
   });
 
+  it("flags a pending citation in markdown prose", () => {
+    const refs = extractMarkdownStoryReferences(
+      "Trails drops the subsecond part; the encoder is converged by\n`activesupport-json-encoding-time-precision`.\n",
+      "docs/activesupport.md",
+    );
+    expect(staleStoryReferences(refs, STORIES)).toHaveLength(1);
+  });
+
+  it("ends a markdown block at a blank line", () => {
+    const refs = extractMarkdownStoryReferences(
+      "The encoder is converged by a later phase.\n\n`activesupport-json-encoding-time-precision` is the story id.\n",
+      "docs/activesupport.md",
+    );
+    expect(refs).toEqual([]);
+  });
+
+  it("ignores a promise quoted inside a fenced code block", () => {
+    const refs = extractMarkdownStoryReferences(
+      "Example:\n\n```ts\n// Converged by `cache-entry-remaining-methods`.\n```\n",
+      "docs/index.md",
+    );
+    expect(refs).toEqual([]);
+  });
+
+  it("scans no markdown outside the trails tree", async () => {
+    const files = await collectMarkdownFiles(REPO_ROOT);
+    expect(files).toContain(path.join("docs", "index.md"));
+    expect(files.filter((file) => file.startsWith(`tasks${path.sep}`))).toEqual([]);
+    expect(files.filter((file) => file.startsWith(path.join("docs", "activerecord")))).toEqual([]);
+  });
+
   // The tasks repo is public and checked out into `tasks/` by the Unit Tests
   // job, so this gate compares the tree against real story statuses there as
   // well as in every agent worktree (start-worktree.sh symlinks the same path).
   // loadStories throws rather than skipping when that checkout is missing.
-  it("no comment in the tree names a story that has already landed", async () => {
+  it("no comment or markdown paragraph in the tree names a story that has already landed", async () => {
     const stories = await loadStories(resolveTasksDir(REPO_ROOT));
     const stale = staleStoryReferences(await scanStoryReferences(REPO_ROOT), stories);
     expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -30,11 +30,6 @@ const CODE_FENCE = /^\s*(?:```|~~~)/;
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "vendor", "__snapshots__"]);
 const SOURCE_ROOTS = ["packages", "scripts", "eslint"];
 
-// The trails tree only: `tasks/` is a checkout of the tasks repo (a symlink in
-// agent worktrees) whose story files legitimately cite landed stories as
-// dependencies and provenance, and `docs/activerecord/` is frozen by RFC 0011
-// Phase 4 — CI's `Docs ActiveRecord Freeze` job fails any PR that edits it, so
-// a finding there could not be resolved by correcting the prose.
 const MARKDOWN_SKIP_DIRS = new Set([...SKIP_DIRS, "tasks"]);
 const MARKDOWN_SKIP_TREES = [path.join("docs", "activerecord")];
 
@@ -46,6 +41,11 @@ export interface StoryReference {
   file: string;
   line: number;
   slug: string;
+}
+
+interface Block {
+  line: number;
+  text: string[];
 }
 
 /**
@@ -103,11 +103,6 @@ export function extractMarkdownStoryReferences(source: string, file: string): St
   return blockReferences(blocks, file);
 }
 
-interface Block {
-  line: number;
-  text: string[];
-}
-
 /**
  * The pending citations in each block: the promise is matched over the whole
  * block, and a `PROVENANCE_PHRASE` sentence is then vetoed per sentence.
@@ -151,10 +146,13 @@ export async function collectSourceFiles(
 }
 
 /**
- * Repo-relative `.md` paths under `dir`, minus the trees whose findings are not
- * ours to fix (see `MARKDOWN_SKIP_DIRS` / `MARKDOWN_SKIP_TREES`). `tasks/` is a
- * symlink in agent worktrees, so it is never walked as a directory anyway; the
- * name is excluded so a plain checkout behaves the same way.
+ * Repo-relative `.md` paths under `dir` — the trails tree only. `tasks/` is a
+ * checkout of the tasks repo (a symlink in agent worktrees, so it is never
+ * walked as a directory anyway; the name is excluded so a plain checkout
+ * behaves the same way) whose story files legitimately cite landed stories as
+ * dependencies and provenance. `docs/activerecord/` is frozen by RFC 0011 Phase
+ * 4 — CI's `Docs ActiveRecord Freeze` job fails any PR that edits it, so a
+ * finding there could not be resolved by correcting the prose.
  */
 export async function collectMarkdownFiles(
   root: string,

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -5,7 +5,8 @@
 //
 // This module extracts those promises — a story slug sitting in the same
 // comment sentence as a forward-looking phrase — so a landed story with a
-// still-pending citation fails a test instead of a suite.
+// still-pending citation fails a test instead of a suite. Markdown prose names
+// landed stories the same way, so `.md` under the trails tree is scanned too.
 
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -24,9 +25,18 @@ const STORY_STATUS = /^status:\s*"?([a-z-]+)"?\s*$/m;
 
 const COMMENT_LINE = /^\s*(?:\/\/|\/\*+|\*)(.*)$/;
 const SENTENCE = /(?<=[.;:)])\s+(?=[A-Z(`])|\.\s+/;
+const CODE_FENCE = /^\s*(?:```|~~~)/;
 
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "vendor", "__snapshots__"]);
 const SOURCE_ROOTS = ["packages", "scripts", "eslint"];
+
+// The trails tree only: `tasks/` is a checkout of the tasks repo (a symlink in
+// agent worktrees) whose story files legitimately cite landed stories as
+// dependencies and provenance, and `docs/activerecord/` is frozen by RFC 0011
+// Phase 4 — CI's `Docs ActiveRecord Freeze` job fails any PR that edits it, so
+// a finding there could not be resolved by correcting the prose.
+const MARKDOWN_SKIP_DIRS = new Set([...SKIP_DIRS, "tasks"]);
+const MARKDOWN_SKIP_TREES = [path.join("docs", "activerecord")];
 
 // Its test states a stale promise verbatim as a fixture, and the line-based
 // scan reads that template literal as a real comment.
@@ -53,33 +63,67 @@ export interface StoryReference {
  * without closing it") from reading as the promise it disclaims.
  */
 export function extractStoryReferences(source: string, file: string): StoryReference[] {
+  const blocks: Block[] = [];
+  let block: Block | undefined;
+  source.split("\n").forEach((line, i) => {
+    const match = COMMENT_LINE.exec(line);
+    if (!match) {
+      block = undefined;
+      return;
+    }
+    if (!block) blocks.push((block = { line: i + 1, text: [] }));
+    block.text.push(match[1].trim());
+  });
+  return blockReferences(blocks, file);
+}
+
+/**
+ * The same promises in markdown prose. Every line is prose, so a block is a
+ * paragraph — blank-line separated — rather than a run of comment lines, and
+ * fenced code is skipped so an example comment quoted in a fence is not read
+ * as a real promise.
+ */
+export function extractMarkdownStoryReferences(source: string, file: string): StoryReference[] {
+  const blocks: Block[] = [];
+  let block: Block | undefined;
+  let fenced = false;
+  source.split("\n").forEach((line, i) => {
+    if (CODE_FENCE.test(line)) {
+      fenced = !fenced;
+      block = undefined;
+      return;
+    }
+    if (fenced || line.trim() === "") {
+      block = undefined;
+      return;
+    }
+    if (!block) blocks.push((block = { line: i + 1, text: [] }));
+    block.text.push(line.trim());
+  });
+  return blockReferences(blocks, file);
+}
+
+interface Block {
+  line: number;
+  text: string[];
+}
+
+/**
+ * The pending citations in each block: the promise is matched over the whole
+ * block, and a `PROVENANCE_PHRASE` sentence is then vetoed per sentence.
+ */
+function blockReferences(blocks: readonly Block[], file: string): StoryReference[] {
   const refs: StoryReference[] = [];
-  const lines = source.split("\n");
-  let block: string[] = [];
-  let start = 0;
-  const flush = (): void => {
-    if (block.length === 0) return;
-    const text = block.join(" ");
-    if (PENDING_PHRASE.test(text)) {
-      for (const sentence of text.split(SENTENCE)) {
-        if (PROVENANCE_PHRASE.test(sentence)) continue;
-        for (const slug of new Set(sentence.match(STORY_SLUG) ?? [])) {
-          refs.push({ file, line: start, slug });
-        }
+  for (const block of blocks) {
+    const text = block.text.join(" ");
+    if (!PENDING_PHRASE.test(text)) continue;
+    for (const sentence of text.split(SENTENCE)) {
+      if (PROVENANCE_PHRASE.test(sentence)) continue;
+      for (const slug of new Set(sentence.match(STORY_SLUG) ?? [])) {
+        refs.push({ file, line: block.line, slug });
       }
     }
-    block = [];
-  };
-  lines.forEach((line, i) => {
-    const match = COMMENT_LINE.exec(line);
-    if (match) {
-      if (block.length === 0) start = i + 1;
-      block.push(match[1].trim());
-    } else {
-      flush();
-    }
-  });
-  flush();
+  }
   return refs;
 }
 
@@ -106,6 +150,36 @@ export async function collectSourceFiles(
   return acc;
 }
 
+/**
+ * Repo-relative `.md` paths under `dir`, minus the trees whose findings are not
+ * ours to fix (see `MARKDOWN_SKIP_DIRS` / `MARKDOWN_SKIP_TREES`). `tasks/` is a
+ * symlink in agent worktrees, so it is never walked as a directory anyway; the
+ * name is excluded so a plain checkout behaves the same way.
+ */
+export async function collectMarkdownFiles(
+  root: string,
+  dir = root,
+  acc: string[] = [],
+): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const entry of entries) {
+    const abs = path.join(dir, entry.name);
+    const rel = path.relative(root, abs);
+    if (MARKDOWN_SKIP_TREES.includes(rel)) continue;
+    if (entry.isDirectory()) {
+      if (!MARKDOWN_SKIP_DIRS.has(entry.name)) await collectMarkdownFiles(root, abs, acc);
+    } else if (entry.name.endsWith(".md")) {
+      acc.push(rel);
+    }
+  }
+  return acc;
+}
+
 /** Every pending citation in the source roots this check covers. */
 export async function scanStoryReferences(repoRoot: string): Promise<StoryReference[]> {
   const refs: StoryReference[] = [];
@@ -114,6 +188,11 @@ export async function scanStoryReferences(repoRoot: string): Promise<StoryRefere
       if (SKIP_FILES.has(file)) continue;
       refs.push(...extractStoryReferences(await readFile(path.join(repoRoot, file), "utf8"), file));
     }
+  }
+  for (const file of await collectMarkdownFiles(repoRoot)) {
+    refs.push(
+      ...extractMarkdownStoryReferences(await readFile(path.join(repoRoot, file), "utf8"), file),
+    );
   }
   return refs;
 }


### PR DESCRIPTION
`scripts/stale-story-references.ts` only scanned `.ts`/`.mjs` comments. Markdown
prose names landed stories the same way — `docs/` bodies and plan files that cite
a story as their tracker — and none of it was guarded.

## What changed

- `extractMarkdownStoryReferences` reuses the existing block/sentence machinery
  through a shared `blockReferences`, with **paragraph-scoped blocks**
  (blank-line separated, since in markdown every line is prose so `COMMENT_LINE`
  has nothing to key off) and **fenced code skipped**, so an example comment
  quoted in a fence is not read as a real promise.
- `collectMarkdownFiles` walks the trails tree for `.md`, deliberately excluding:
  - `tasks/` — the tasks repo checkout (a symlink in agent worktrees); its story
    files legitimately cite landed stories as deps and provenance, so scanning it
    would be almost all false positives.
  - `docs/activerecord/` — frozen by RFC 0011 Phase 4; CI's
    `Docs ActiveRecord Freeze` job fails any PR that edits it, so a finding there
    could not be resolved by correcting the prose.

## Audit

The widened scan surfaces **no stale citation**. Across the 51 markdown files it
now covers, exactly one pending-phrase sentence contains a kebab slug —
`docs/actionpack-100-percent.md:99` naming the gem `rails-dom-testing`, which is
not a story id and so is never a finding. Nothing to converge or repoint.

`pnpm vitest run scripts/stale-story-references.test.ts` — 13 passed.

Closes-story: extend-stale-story-reference-scan-to-markdown


## Rebase note

Rebased onto `main` after it widened the matcher to block-scoped `PENDING_PHRASE`
with a sentence-scoped `PROVENANCE_PHRASE` veto; the resolution keeps those
semantics in the shared `blockReferences`, so the markdown path inherits them.

That widened phrase set surfaced one real markdown finding, audited and fixed
here: `CONTRIBUTING.md` cited `wide-calls-exclude-reseed-reorders-untouched-packages`
as a live tracker, but that story landed as #5183 — emission is pinned to the
code-unit `compareKeys` order (`lint-call-mismatches-wide.ts:51-52,247`), so a
reseed leaves untouched packages byte-identical. The prose (and the matching
claim in `CLAUDE.md`) now rests on the diff-size argument instead.

The transient prettier emphasis corruption in that paragraph
(`quote*column_name`, `\_reordering*`) was fixed in the amended commit that is
currently pushed; `CONTRIBUTING.md` on HEAD contains neither string.
