### PR TITLE
test(i18n): enroll i18n in test:compare and port the core suites

### DIFF
--- a/packages/i18n/src/api/simple.test.ts
+++ b/packages/i18n/src/api/simple.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Mirrors: i18n/test/api/simple_test.rb. The `I18n::Tests::*` conformance
+ * mixins the Ruby class includes are minitest scaffolding the gem ships for
+ * third-party backends (see the `tests/` entry in unported-files.ts); trails'
+ * equivalent coverage is backend/simple.test.ts.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Simple } from "../backend/simple.js";
+import { resetClassConfig } from "../config.js";
+import { config, resetConfig } from "../i18n.js";
+
+describe("I18nSimpleBackendApiTest", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    config().backend = new Simple();
+  });
+
+  it("make sure we use the Simple backend", () => {
+    expect(config().backend.constructor).toBe(Simple);
+  });
+});

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -387,11 +387,6 @@ describe("I18nTest", () => {
     expect(localeAvailable("de")).toBe(true);
   });
 
-  it("I18n.locale_available? returns true when the passed locale is a string and is available", () => {
-    config().availableLocales = ["en", "de"];
-    expect(localeAvailable("de")).toBe(true);
-  });
-
   it("I18n.locale_available? returns false when the passed locale is unavailable", () => {
     expect(localeAvailable("klingon")).toBe(false);
   });

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -3,19 +3,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ArgumentError, Disabled, InvalidLocale } from "./exceptions.js";
 import {
+  RESERVED_KEYS,
   config,
   defaultLocale,
+  defaultSeparator,
+  enforceAvailableLocalesBang,
   exists,
   interpolationKeys,
   locale,
+  localeAvailable,
   localize,
+  normalizeKeys,
+  reserveKey,
   resetConfig,
+  setAvailableLocales,
+  setDefaultLocale,
+  setDefaultSeparator,
   setExceptionHandler,
+  setLocale,
   t,
   translate,
   withLocale,
 } from "./i18n.js";
-import { resetClassConfig } from "./config.js";
+import { Config, resetClassConfig } from "./config.js";
 import { Simple } from "./backend/simple.js";
 import type { TranslationData } from "./utils.js";
 import type { TranslationKey } from "./i18n.js";
@@ -248,5 +258,148 @@ describe("I18nTest", () => {
       }),
     ).toThrow(ArgumentError);
     expect(locale()).toBe(defaultLocale());
+  });
+
+  it("uses :en as a default_locale by default", () => {
+    expect(defaultLocale()).toBe("en");
+  });
+
+  it("can set the default locale", () => {
+    expect(() => setDefaultLocale("de")).not.toThrow();
+    expect(defaultLocale()).toBe("de");
+  });
+
+  it("raises an I18n::InvalidLocale exception when setting an unavailable default locale", () => {
+    config().enforceAvailableLocales = true;
+    expect(() => setDefaultLocale("klingon")).toThrow(InvalidLocale);
+  });
+
+  it("uses the default locale as a locale by default", () => {
+    expect(locale()).toBe(defaultLocale());
+  });
+
+  it("raises an I18n::InvalidLocale exception when setting an unavailable locale", () => {
+    config().enforceAvailableLocales = true;
+    expect(() => setLocale("klingon")).toThrow(InvalidLocale);
+  });
+
+  it("locale is not shared between configurations", () => {
+    const a = new Config();
+    const b = new Config();
+    a.locale = "fr";
+    b.locale = "es";
+    expect(a.locale).toBe("fr");
+    expect(b.locale).toBe("es");
+    expect(locale()).toBe("en");
+  });
+
+  it("other options are shared between configurations", () => {
+    const a = new Config();
+    const b = new Config();
+    a.defaultLocale = "fr";
+    b.defaultLocale = "es";
+    expect(a.defaultLocale).toBe("es");
+    expect(b.defaultLocale).toBe("es");
+    expect(defaultLocale()).toBe("es");
+  });
+
+  it("uses a dot as a default_separator by default", () => {
+    expect(defaultSeparator()).toBe(".");
+  });
+
+  it("can set the default_separator", () => {
+    expect(() => setDefaultSeparator("\u0001")).not.toThrow();
+  });
+
+  it("normalize_keys normalizes given locale, keys and scope to an array of single-key symbols", () => {
+    expect(normalizeKeys("en", "bar", "foo")).toEqual(["en", "foo", "bar"]);
+    expect(normalizeKeys("en", "baz.buz", "foo.bar")).toEqual(["en", "foo", "bar", "baz", "buz"]);
+    expect(normalizeKeys("en", ["baz", "buz"], ["foo", "bar"])).toEqual([
+      "en",
+      "foo",
+      "bar",
+      "baz",
+      "buz",
+    ]);
+  });
+
+  it("normalize_keys discards empty keys", () => {
+    expect(normalizeKeys("en", "baz..buz", "foo..bar")).toEqual(["en", "foo", "bar", "baz", "buz"]);
+    expect(normalizeKeys("en", "baz......buz", "foo......bar")).toEqual([
+      "en",
+      "foo",
+      "bar",
+      "baz",
+      "buz",
+    ]);
+    expect(normalizeKeys("en", ["baz", null, "", "buz"], ["foo", null, "", "bar"])).toEqual([
+      "en",
+      "foo",
+      "bar",
+      "baz",
+      "buz",
+    ]);
+  });
+
+  it("normalize_keys uses a given separator", () => {
+    expect(normalizeKeys("en", "baz|buz", "foo|bar", "|")).toEqual([
+      "en",
+      "foo",
+      "bar",
+      "baz",
+      "buz",
+    ]);
+  });
+
+  it("normalize_keys normalizes given locale with separator", () => {
+    expect(normalizeKeys("en.foo", "baz", "bar")).toEqual(["en", "foo", "bar", "baz"]);
+  });
+
+  it("available_locales_set should return a set", () => {
+    expect(config().availableLocalesSet).toBeInstanceOf(Set);
+    expect(config().availableLocalesSet.size).toBe(config().availableLocales.length);
+  });
+
+  it("I18n.locale_available? returns true when the passed locale is available", () => {
+    setAvailableLocales(["en", "de"]);
+    expect(localeAvailable("de")).toBe(true);
+  });
+
+  it("I18n.locale_available? returns true when the passed locale is a string and is available", () => {
+    setAvailableLocales(["en", "de"]);
+    expect(localeAvailable("de")).toBe(true);
+  });
+
+  it("I18n.locale_available? returns false when the passed locale is unavailable", () => {
+    expect(localeAvailable("klingon")).toBe(false);
+  });
+
+  it("I18n.enforce_available_locales! raises an I18n::InvalidLocale when the passed locale is unavailable", () => {
+    config().enforceAvailableLocales = true;
+    expect(() => enforceAvailableLocalesBang("klingon")).toThrow(InvalidLocale);
+  });
+
+  it("I18n.enforce_available_locales! does nothing when the passed locale is available", () => {
+    setAvailableLocales(["en", "de"]);
+    config().enforceAvailableLocales = true;
+    expect(() => enforceAvailableLocalesBang("en")).not.toThrow();
+  });
+
+  it("I18n.enforce_available_locales config can be set to false", () => {
+    config().enforceAvailableLocales = false;
+    expect(config().enforceAvailableLocales).toBe(false);
+  });
+
+  it("can reserve a key", () => {
+    const originalKeys = [...RESERVED_KEYS];
+    try {
+      reserveKey("foo");
+      reserveKey("bar");
+
+      expect(RESERVED_KEYS).toContain("foo");
+      expect(RESERVED_KEYS).toContain("bar");
+    } finally {
+      RESERVED_KEYS.splice(0, RESERVED_KEYS.length, ...originalKeys);
+    }
   });
 });

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ArgumentError, Disabled, InvalidLocale } from "./exceptions.js";
 import {
   RESERVED_KEYS,
+  availableLocales,
   config,
   defaultLocale,
   defaultSeparator,
@@ -14,9 +15,11 @@ import {
   localeAvailable,
   localize,
   normalizeKeys,
+  reloadBang,
   reserveKey,
   resetConfig,
   setAvailableLocales,
+  setBackend,
   setDefaultLocale,
   setDefaultSeparator,
   setExceptionHandler,
@@ -111,6 +114,10 @@ describe("I18nTest", () => {
 
   it("translate given an empty string as a key raises an I18n::ArgumentError", () => {
     expect(() => t("")).toThrow(ArgumentError);
+  });
+
+  it("translate given an empty symbol as a key raises an I18n::ArgumentError", () => {
+    expect(() => t(Symbol.for(""))).toThrow(ArgumentError);
   });
 
   it("translate given an array with empty string as a key raises an I18n::ArgumentError", () => {
@@ -260,6 +267,16 @@ describe("I18nTest", () => {
     expect(locale()).toBe(defaultLocale());
   });
 
+  it("uses the simple backend by default", () => {
+    expect(config().backend).toBeInstanceOf(Simple);
+  });
+
+  it("can set the backend", () => {
+    const other = new Simple();
+    expect(() => setBackend(other)).not.toThrow();
+    expect(config().backend).toBe(other);
+  });
+
   it("uses :en as a default_locale by default", () => {
     expect(defaultLocale()).toBe("en");
   });
@@ -393,6 +410,57 @@ describe("I18nTest", () => {
   it("I18n.enforce_available_locales config can be set to false", () => {
     config().enforceAvailableLocales = false;
     expect(config().enforceAvailableLocales).toBe(false);
+  });
+
+  it("can set the exception_handler", () => {
+    const customExceptionHandler = vi.fn();
+    expect(() => setExceptionHandler(customExceptionHandler)).not.toThrow();
+  });
+
+  it("uses a custom exception handler set to I18n.exception_handler", () => {
+    const customExceptionHandler = vi.fn();
+    setExceptionHandler(customExceptionHandler);
+    translate("bogus");
+    expect(customExceptionHandler).toHaveBeenCalled();
+  });
+
+  it("available_locales can be replaced at runtime", () => {
+    config().enforceAvailableLocales = true;
+    expect(() => t("foo", { locale: "klingon" })).toThrow(InvalidLocale);
+    setAvailableLocales(["klingon"]);
+    t("foo", { locale: "klingon" });
+  });
+
+  it("I18n.reload! reloads the set of locales that are enforced", () => {
+    backend = new Simple();
+    setBackend(backend);
+
+    expect(availableLocales()).not.toContain("de");
+
+    config().enforceAvailableLocales = true;
+
+    expect(() => setDefaultLocale("de")).toThrow(InvalidLocale);
+    expect(() => setLocale("de")).toThrow(InvalidLocale);
+
+    storeTranslations("de", { foo: "Foo in :de" });
+
+    expect(() => setDefaultLocale("de")).toThrow(InvalidLocale);
+    expect(() => setLocale("de")).toThrow(InvalidLocale);
+
+    reloadBang();
+
+    storeTranslations("en", { foo: "Foo in :en" });
+    storeTranslations("de", { foo: "Foo in :de" });
+    storeTranslations("pl", { foo: "Foo in :pl" });
+
+    expect(availableLocales()).toContain("de");
+    expect(availableLocales()).toContain("en");
+    expect(availableLocales()).toContain("pl");
+
+    expect(() => {
+      setDefaultLocale("en");
+      setLocale("en");
+    }).not.toThrow();
   });
 
   it("can reserve a key", () => {

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -370,6 +370,11 @@ describe("I18nTest", () => {
     expect(localeAvailable("de")).toBe(true);
   });
 
+  it("I18n.locale_available? returns true when the passed locale is a string and is available", () => {
+    config().availableLocales = ["en", "de"];
+    expect(localeAvailable("de")).toBe(true);
+  });
+
   it("I18n.locale_available? returns false when the passed locale is unavailable", () => {
     expect(localeAvailable("klingon")).toBe(false);
   });

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -18,6 +18,7 @@ import {
   reloadBang,
   reserveKey,
   resetConfig,
+  setConfig,
   setAvailableLocales,
   setBackend,
   setDefaultLocale,
@@ -298,6 +299,16 @@ describe("I18nTest", () => {
   it("raises an I18n::InvalidLocale exception when setting an unavailable locale", () => {
     config().enforceAvailableLocales = true;
     expect(() => setLocale("klingon")).toThrow(InvalidLocale);
+  });
+
+  it("can set the configuration object", () => {
+    // Rails' second assertion reads the object back off
+    // `Thread.current.thread_variable_get(:i18n_config)`; trails keeps one
+    // process-wide config (see `config` in i18n.ts), so there is no
+    // thread-local copy to check.
+    const other = new Config();
+    setConfig(other);
+    expect(config()).toBe(other);
   });
 
   it("locale is not shared between configurations", () => {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -76,6 +76,11 @@ export function config(): Config {
   return currentConfig;
 }
 
+/** Sets I18n configuration object. */
+export function setConfig(value: Config): void {
+  currentConfig = value;
+}
+
 /** @internal Test seam — drops the process-wide config so a case starts clean. */
 export function resetConfig(): void {
   currentConfig = undefined;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -47,6 +47,7 @@ export {
   reloadBang,
   reserveKey,
   reservedKeysPattern,
+  setConfig,
   setAvailableLocales,
   setBackend,
   setDefaultLocale,

--- a/packages/i18n/src/utils.test.ts
+++ b/packages/i18n/src/utils.test.ts
@@ -1,0 +1,33 @@
+/** Mirrors: i18n/test/utils_test.rb */
+
+import { describe, expect, it } from "vitest";
+
+import { deepMergeBang, deepSymbolizeKeys, except } from "./utils.js";
+
+describe("I18nUtilsTest", () => {
+  it(".deep_symbolize_keys", () => {
+    const hash = { foo: { bar: { baz: "bar" } } };
+    const expected = { foo: { bar: { baz: "bar" } } };
+    expect(deepSymbolizeKeys(hash)).toEqual(expected);
+  });
+
+  it("#deep_symbolize_keys with numeric keys", () => {
+    const hash = { 1: { 2: { 3: "bar" } } };
+    const expected = { 1: { 2: { 3: "bar" } } };
+    expect(deepSymbolizeKeys(hash)).toEqual(expected);
+  });
+
+  it("#except", () => {
+    const hash = { foo: "bar", baz: "bar" };
+    const expected = { foo: "bar" };
+    expect(except(hash, "baz")).toEqual(expected);
+  });
+
+  it("#deep_merge!", () => {
+    const hash = { foo: { bar: { baz: "bar" } }, baz: "bar" };
+    deepMergeBang(hash, { foo: { bar: { baz: "foo" } } });
+
+    const expected = { foo: { bar: { baz: "foo" } }, baz: "bar" };
+    expect(hash).toEqual(expected);
+  });
+});

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1235,16 +1235,64 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "lookup — the mixin is excluded above.",
   },
   {
-    testFile: "api/",
+    testFile: "api/all_features_test.rb",
     package: "i18n",
     reason:
-      "The `test/api/*` suites are shells: each one picks a backend and includes " +
-      "the `I18n::Tests::*` conformance mixins, which are themselves excluded " +
-      "(`tests/` below) as minitest scaffolding rather than library surface. " +
-      "trails' equivalent coverage lives in the per-backend vitest files. " +
-      "`api/override_test.rb` is excluded with them: it reopens `I18n.dup` and " +
-      "`extend`s modules over `translate`, Ruby singleton-class semantics with " +
-      "no JS analogue.",
+      "Stacks every optional backend mixin (Cascade, Chain, Fallbacks, Memoize, " +
+      "Pluralization, …) onto Simple at once; each mixin is excluded above, so " +
+      "the composition has nothing to run against. `api/simple_test.rb` is NOT " +
+      "excluded — the Simple backend is ported and its API suite is compared.",
+  },
+  {
+    testFile: "api/override_test.rb",
+    package: "i18n",
+    reason:
+      "Reopens `I18n.dup` and `extend`s modules over `translate` to check that a " +
+      "host app can override the facade. Ruby singleton-class semantics with no " +
+      "JS analogue — a TS module's exported function can't be swapped per-copy.",
+  },
+  {
+    testFile: "i18n_test.rb",
+    className: "I18nTest",
+    tests: ["exposes its VERSION constant"],
+    reason:
+      "Asserts the `I18n::VERSION` constant, whose `version.rb` is excluded above " +
+      "— trails carries the version in package.json.",
+  },
+  {
+    testFile: "i18n_test.rb",
+    className: "I18nTest",
+    tests: [
+      "sets the current locale to Thread.current",
+      "I18n.locale is preserved in Fiber context",
+    ],
+    reason:
+      "Both assert the config lives in a Thread/Fiber-local " +
+      "(`Thread.current.thread_variable_get(:i18n_config)`, i18n/lib/i18n/config.rb). " +
+      "JS is single-threaded and trails' `I18n.config` is a process singleton, so " +
+      "there is no per-thread copy to observe.",
+  },
+  {
+    testFile: "i18n_test.rb",
+    className: "I18nTest",
+    tests: ["default_locale= doesn't ignore junk", "locale= doesn't ignore junk"],
+    reason:
+      "Assert `NoMethodError` from Ruby calling `#to_sym` on a Class object " +
+      "(i18n/lib/i18n/config.rb `locale=`). Locales are strings in TS with no " +
+      "symbolization step, so there is no junk-coercion failure to raise.",
+  },
+  {
+    testFile: "i18n_test.rb",
+    className: "I18nTest",
+    tests: [
+      "I18n.transliterate handles I18n::ArgumentError exception",
+      "I18n.transliterate raises I18n::ArgumentError exception",
+      "transliterate given an unavailable locale rases an I18n::InvalidLocale",
+      "transliterate non-ASCII chars not in map with default replacement char",
+    ],
+    reason:
+      "Facade cases for `I18n.transliterate`, whose `backend/transliterator.rb` is " +
+      "excluded above.",
   },
   // --- i18n: gem surface trails has no counterpart for ---
   {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1140,11 +1140,13 @@ export const UNPORTED_FILES: UnportedFile[] = [
   // --- i18n: optional backend mixins composed on top of Simple ---
   {
     pattern: "backend/chain.rb",
+    testFile: "chain_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
   },
   {
     pattern: "backend/fallbacks.rb",
+    testFile: "fallbacks_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — locale fallback chain, built on the " +
@@ -1152,26 +1154,31 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/key_value.rb",
+    testFile: "key_value_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
   },
   {
     pattern: "backend/cache.rb",
+    testFile: "cache_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache.",
   },
   {
     pattern: "backend/cache_file.rb",
+    testFile: "cache_file_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches parsed translation files on disk.",
   },
   {
     pattern: "backend/cascade.rb",
+    testFile: "cascade_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
   },
   {
     pattern: "backend/interpolation_compiler.rb",
+    testFile: "interpolation_compiler_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — compiles interpolations into Ruby " +
@@ -1179,16 +1186,19 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/lazy_loadable.rb",
+    testFile: "lazy_loadable_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup.",
   },
   {
     pattern: "backend/memoize.rb",
+    testFile: "memoize_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — memoizes lookups per locale.",
   },
   {
     pattern: "backend/metadata.rb",
+    testFile: "metadata_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — attaches lookup metadata onto the " +
@@ -1196,23 +1206,52 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/pluralization.rb",
+    testFile: "pluralization_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data.",
   },
   {
     pattern: "backend/transliterator.rb",
+    testFile: "transliterator_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: ASCII transliteration driven by per-locale rule tables and " +
       "`$KCODE`-era String packing. JS has `String.prototype.normalize` and " +
       "no locale rule data is shipped; not in pre-1.0 scope.",
   },
+  {
+    testFile: "pluralization_fallback_test.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: exercises Backend::Pluralization stacked on Backend::Fallbacks — " +
+      "both mixins are excluded above, so the combination has no trails counterpart.",
+  },
+  {
+    testFile: "pluralization_scope_test.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: scoped pluralization rules, i.e. Backend::Pluralization data " +
+      "lookup — the mixin is excluded above.",
+  },
+  {
+    testFile: "api/",
+    package: "i18n",
+    reason:
+      "The `test/api/*` suites are shells: each one picks a backend and includes " +
+      "the `I18n::Tests::*` conformance mixins, which are themselves excluded " +
+      "(`tests/` below) as minitest scaffolding rather than library surface. " +
+      "trails' equivalent coverage lives in the per-backend vitest files. " +
+      "`api/override_test.rb` is excluded with them: it reopens `I18n.dup` and " +
+      "`extend`s modules over `translate`, Ruby singleton-class semantics with " +
+      "no JS analogue.",
+  },
   // --- i18n: gem surface trails has no counterpart for ---
   {
     // Deliberately broad: covers `gettext.rb`, `gettext/*` and the
     // `backend/gettext.rb` mixin in one entry.
     pattern: "gettext",
+    testFile: "gettext",
     package: "i18n",
     reason:
       "Pre-1.0: gettext .po support — the catalogue parser, the `_`/`n_`/`s_` " +
@@ -1221,6 +1260,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "locale/",
+    testFile: "locale/",
     package: "i18n",
     reason:
       "Pre-1.0: RFC 4646 locale-tag parsing and the fallback tag graph " +
@@ -1238,6 +1278,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "middleware.rb",
+    testFile: "middleware_test.rb",
     package: "i18n",
     reason:
       "Rack middleware that resets `I18n.locale` after each request. trails " +

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1140,13 +1140,11 @@ export const UNPORTED_FILES: UnportedFile[] = [
   // --- i18n: optional backend mixins composed on top of Simple ---
   {
     pattern: "backend/chain.rb",
-    testFile: "chain_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
   },
   {
     pattern: "backend/fallbacks.rb",
-    testFile: "fallbacks_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — locale fallback chain, built on the " +
@@ -1154,31 +1152,26 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/key_value.rb",
-    testFile: "key_value_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
   },
   {
     pattern: "backend/cache.rb",
-    testFile: "cache_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache.",
   },
   {
     pattern: "backend/cache_file.rb",
-    testFile: "cache_file_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches parsed translation files on disk.",
   },
   {
     pattern: "backend/cascade.rb",
-    testFile: "cascade_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
   },
   {
     pattern: "backend/interpolation_compiler.rb",
-    testFile: "interpolation_compiler_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — compiles interpolations into Ruby " +
@@ -1186,19 +1179,16 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/lazy_loadable.rb",
-    testFile: "lazy_loadable_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup.",
   },
   {
     pattern: "backend/memoize.rb",
-    testFile: "memoize_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — memoizes lookups per locale.",
   },
   {
     pattern: "backend/metadata.rb",
-    testFile: "metadata_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — attaches lookup metadata onto the " +
@@ -1206,100 +1196,23 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/pluralization.rb",
-    testFile: "pluralization_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data.",
   },
   {
     pattern: "backend/transliterator.rb",
-    testFile: "transliterator_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: ASCII transliteration driven by per-locale rule tables and " +
       "`$KCODE`-era String packing. JS has `String.prototype.normalize` and " +
       "no locale rule data is shipped; not in pre-1.0 scope.",
   },
-  {
-    testFile: "pluralization_fallback_test.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: exercises Backend::Pluralization stacked on Backend::Fallbacks — " +
-      "both mixins are excluded above, so the combination has no trails counterpart.",
-  },
-  {
-    testFile: "pluralization_scope_test.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: scoped pluralization rules, i.e. Backend::Pluralization data " +
-      "lookup — the mixin is excluded above.",
-  },
-  {
-    testFile: "api/all_features_test.rb",
-    package: "i18n",
-    reason:
-      "Stacks every optional backend mixin (Cascade, Chain, Fallbacks, Memoize, " +
-      "Pluralization, …) onto Simple at once; each mixin is excluded above, so " +
-      "the composition has nothing to run against. `api/simple_test.rb` is NOT " +
-      "excluded — the Simple backend is ported and its API suite is compared.",
-  },
-  {
-    testFile: "api/override_test.rb",
-    package: "i18n",
-    reason:
-      "Reopens `I18n.dup` and `extend`s modules over `translate` to check that a " +
-      "host app can override the facade. Ruby singleton-class semantics with no " +
-      "JS analogue — a TS module's exported function can't be swapped per-copy.",
-  },
-  {
-    testFile: "i18n_test.rb",
-    className: "I18nTest",
-    tests: ["exposes its VERSION constant"],
-    reason:
-      "Asserts the `I18n::VERSION` constant, whose `version.rb` is excluded above " +
-      "— trails carries the version in package.json.",
-  },
-  {
-    testFile: "i18n_test.rb",
-    className: "I18nTest",
-    tests: [
-      "sets the current locale to Thread.current",
-      "I18n.locale is preserved in Fiber context",
-    ],
-    reason:
-      "Both assert the config lives in a Thread/Fiber-local " +
-      "(`Thread.current.thread_variable_get(:i18n_config)`, i18n/lib/i18n/config.rb). " +
-      "JS is single-threaded and trails' `I18n.config` is a process singleton, so " +
-      "there is no per-thread copy to observe.",
-  },
-  {
-    testFile: "i18n_test.rb",
-    className: "I18nTest",
-    tests: ["default_locale= doesn't ignore junk", "locale= doesn't ignore junk"],
-    reason:
-      "Assert `NoMethodError` from Ruby calling `#to_sym` on a Class object " +
-      "(i18n/lib/i18n/config.rb `locale=`). Locales are strings in TS with no " +
-      "symbolization step, so there is no junk-coercion failure to raise.",
-  },
-  {
-    testFile: "i18n_test.rb",
-    className: "I18nTest",
-    tests: [
-      "I18n.transliterate handles I18n::ArgumentError exception",
-      "I18n.transliterate raises I18n::ArgumentError exception",
-      "transliterate given an unavailable locale rases an I18n::InvalidLocale",
-      "transliterate non-ASCII chars not in map with default replacement char",
-    ],
-    reason:
-      "Facade cases for `I18n.transliterate`, whose `backend/transliterator.rb` is " +
-      "excluded above.",
-  },
   // --- i18n: gem surface trails has no counterpart for ---
   {
     // Deliberately broad: covers `gettext.rb`, `gettext/*` and the
     // `backend/gettext.rb` mixin in one entry.
     pattern: "gettext",
-    testFile: "gettext",
     package: "i18n",
     reason:
       "Pre-1.0: gettext .po support — the catalogue parser, the `_`/`n_`/`s_` " +
@@ -1308,7 +1221,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "locale/",
-    testFile: "locale/",
     package: "i18n",
     reason:
       "Pre-1.0: RFC 4646 locale-tag parsing and the fallback tag graph " +
@@ -1326,7 +1238,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "middleware.rb",
-    testFile: "middleware_test.rb",
     package: "i18n",
     reason:
       "Rack middleware that resets `I18n.locale` after each request. trails " +

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -50,6 +50,11 @@
       "kind": 0,
       "value": 0
     },
+    "i18n": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
     "rack": {
       "assertionCount": 0,
       "kind": 0,

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -21,6 +21,7 @@ function getPackageTestFiles(): Record<string, string[]> {
     "trailties",
     "globalid",
     "did-you-mean",
+    "i18n",
   ];
   const packageAliases: Record<string, string> = {};
   const result: Record<string, string[]> = {};

--- a/scripts/test-compare/test-compare.test.ts
+++ b/scripts/test-compare/test-compare.test.ts
@@ -134,6 +134,16 @@ describe("rubyToConventionTs", () => {
     );
   });
 
+  it("strips the i18n gem's test/i18n directory, which mirrors its lib/i18n root", () => {
+    expect(rubyToConventionTs("i18n/exceptions_test.rb", "i18n")).toBe("exceptions.test.ts");
+    expect(rubyToConventionTs("i18n_test.rb", "i18n")).toBe("i18n.test.ts");
+    expect(rubyToConventionTs("backend/simple_test.rb", "i18n")).toBe("backend/simple.test.ts");
+    // Only scoped to the i18n package — activesupport has its own i18n/ tests.
+    expect(rubyToConventionTs("i18n/exceptions_test.rb", "activesupport")).toBe(
+      "i18n/exceptions.test.ts",
+    );
+  });
+
   it("leaves unaliased paths unchanged apart from kebab-casing", () => {
     expect(rubyToConventionTs("relation/where_test.rb", "activerecord")).toBe(
       "relation/where.test.ts",

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -112,6 +112,12 @@ function enforceGateZero(results: { package: string; totalGateMismatch: number }
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Maps a Ruby test path to the TS test path our conventions put it at. The
+ * i18n gem's lib root is `lib/i18n` while its test root is `test`, so a test
+ * mirroring `lib/i18n/<x>.rb` sits at `test/i18n/<x>_test.rb`; that leading
+ * segment is dropped so both sides land on `packages/i18n/src/<x>`.
+ */
 export function rubyToConventionTs(rubyFile: string, pkg: string): string {
   if (pkg === "rack") {
     const dir = path.dirname(rubyFile);
@@ -121,9 +127,6 @@ export function rubyToConventionTs(rubyFile: string, pkg: string): string {
     return dir === "." ? tsFile : path.join(dir, tsFile);
   }
 
-  // The i18n gem's lib root is `lib/i18n` but its test root is `test`, so
-  // every test mirroring `lib/i18n/<x>.rb` sits at `test/i18n/<x>_test.rb`.
-  // Drop that leading segment so both sides land on `packages/i18n/src/<x>`.
   if (pkg === "i18n" && rubyFile.startsWith("i18n/")) {
     rubyFile = rubyFile.slice("i18n/".length);
   }

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -121,6 +121,13 @@ export function rubyToConventionTs(rubyFile: string, pkg: string): string {
     return dir === "." ? tsFile : path.join(dir, tsFile);
   }
 
+  // The i18n gem's lib root is `lib/i18n` but its test root is `test`, so
+  // every test mirroring `lib/i18n/<x>.rb` sits at `test/i18n/<x>_test.rb`.
+  // Drop that leading segment so both sides land on `packages/i18n/src/<x>`.
+  if (pkg === "i18n" && rubyFile.startsWith("i18n/")) {
+    rubyFile = rubyFile.slice("i18n/".length);
+  }
+
   const dir = path.dirname(rubyFile);
   const rawBase = path.basename(rubyFile, ".rb").replace(/_test$/, "");
   // Trails renames `railtie`/`railties` path segments to `trailtie`/`trailties`
@@ -1246,6 +1253,7 @@ function extractRelativeTsPath(fullPath: string, pkg: string): string {
     trailties: "packages/trailties/src/",
     globalid: "packages/globalid/src/",
     "did-you-mean": "packages/did-you-mean/src/",
+    i18n: "packages/i18n/src/",
   };
 
   const prefix = pkgDirs[pkg];

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -61,7 +61,7 @@ describe("vendor/sources.ts", () => {
     ]);
   });
 
-  it("declares the i18n source, enrolled in api-compare but not test-compare", () => {
+  it("declares the i18n source, enrolled in both api-compare and test-compare", () => {
     const i18n = SOURCES.find((s) => s.name === "i18n");
     expect(i18n).toBeDefined();
     expect(i18n!.origin).toEqual({
@@ -74,13 +74,11 @@ describe("vendor/sources.ts", () => {
         name: "i18n",
         libPath: "lib/i18n",
         testPath: "test",
-        compareTests: false,
       },
     ]);
     expect(apiComparePackages()).toContain("i18n");
     expect(Object.keys(libPathsManifest())).toContain("i18n");
-    // test-compare stays off until the gem's minitest suite is wired up.
-    expect(Object.keys(testPathsManifest())).not.toContain("i18n");
+    expect(Object.keys(testPathsManifest())).toContain("i18n");
     expect(resolvePath("i18n").endsWith("vendor/i18n/lib/i18n")).toBe(true);
     expect(resolvePath("i18n", "test").endsWith("vendor/i18n/test")).toBe(true);
     expect(vendoredRoot("i18n").endsWith("vendor/i18n")).toBe(true);

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -226,6 +226,7 @@ describe("vendor/sources.ts", () => {
         "arel",
         "did-you-mean",
         "globalid",
+        "i18n",
         "rack",
         "trailties",
       ].sort(),

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -191,7 +191,6 @@ export const SOURCES: readonly UpstreamSource[] = [
         name: "i18n",
         libPath: "lib/i18n",
         testPath: "test",
-        compareTests: false,
       },
     ],
   },


### PR DESCRIPTION
Flips `compareTests` on the i18n source (`vendor/sources.ts`) so
`vendor/i18n/test` reaches `testPathsManifest()` and `extract-ruby-tests.rb`,
registers `i18n` on the TS side (`extract-ts-tests.ts` package list,
`extractRelativeTsPath` dir map), and ports the core suites.

## Path convention

The gem's lib root is `lib/i18n` but its test root is `test`, so every test
mirroring `lib/i18n/<x>.rb` sits at `test/i18n/<x>_test.rb`.
`rubyToConventionTs` strips that leading segment for the `i18n` package only
(activesupport has its own `i18n/` test dir and is untouched) — covered by a
new unit test.

## Ports

- `utils_test.rb` → `utils.test.ts` — 4/4, complete.
- `api/simple_test.rb` → `api/simple.test.ts` — 1/1, complete.
- `i18n_test.rb` → `i18n.test.ts` — the facade port landed on main while this
  was in review, so this adds the configuration, `normalize_keys`,
  available-locale, backend-accessor, exception-handler, `config=` and
  `reload!` cases on top of it: 69/82.

Test names are verbatim from the Ruby; no existing trails test was renamed or
moved.

## Nothing is excluded

`scripts/api-compare/unported-files.ts` is untouched. Every unported i18n suite
— the optional backend mixins, gettext, `locale/`, middleware, the remaining
`api/*` shells — is measured as missing in `test:compare` rather than hidden
behind a `testFile` entry, so the gap stays on the ledger.

`I18n.config=` (`i18n/lib/i18n.rb:63`) was the one gap that was neither Ruby-
specific nor blocked on unported backend source, so `setConfig` is ported here
(the `set*` writer spelling the surrounding delegators already use) along with
its test. Its Thread-local assertion is dropped with the reason at the call
site.

## Result

`pnpm test:compare --package i18n`: 101/440 (23%), 5/38 files mapped. No other
package moved.

Still missing in `i18n_test.rb` (13 of 82), all measured, none excluded:

- `localize given nil|nil and default|an Object|an unavailable locale` (4) —
  every one of them raises from `Backend::Base#localize`
  (`i18n/lib/i18n/backend/base.rb`), which is unported: the facade's `localize`
  already delegates (`packages/i18n/src/i18n.ts`) and main's
  `delegates localize calls to the backend` case stubs the backend method. The
  `i18n-backend-localize` story ports it; implementing it here would be a
  second story in one PR.
- `I18n.transliterate …` (4) — `backend/transliterator.rb` is excluded on main
  as pre-1.0 (`scripts/api-compare/unported-files.ts`); the facade cases can't
  run without it.
- `exposes its VERSION constant` — `version.rb` has no TS counterpart
  (package.json carries the version).
- `sets the current locale to Thread.current`, `I18n.locale is preserved in
  Fiber context` — the gem keeps the config in a Thread/Fiber-local; trails'
  `config()` is a process singleton.
- `default_locale= / locale= doesn't ignore junk` (2) — assert `NoMethodError`
  from Ruby calling `#to_sym` on a Class; locales are strings in TS.
The four Ruby-runtime cases (Thread/Fiber, the two junk-coercion ones) will
never port; they stay visible as missing rather than being written into an
allowlist.

Known-not-fixed: 3 tests in `exceptions.trails.test.ts` report as misplaced
because they reuse Rails test names while asserting the ported classes
directly rather than through `I18n.translate` (the path Rails' versions take).
Moving them into `exceptions.test.ts` would claim parity for a path that isn't
ported yet, so they stay put.

Closes-story: i18n-test-compare-enrollment
