### PR TITLE
fix(activerecord): defer nested parameter hashes in assignAttributes

### DIFF
--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -158,3 +158,44 @@ describe("nested attributes save wrapper argument forwarding (trails-only)", () 
     expect((await Pirate.find(readAttr(pirate, "id"))).catchphrase).toBe("");
   });
 });
+
+describe("nested attributes assignment ordering (trails-only)", () => {
+  fixtures({
+    pirates: [Pirate, {}],
+    ships: [Ship, {}],
+  });
+
+  // `_assign_attributes` (attribute_assignment.rb:6-22) buckets every
+  // Hash-valued key out of the main loop and assigns it only after the scalar
+  // pass (:21), so a nested writer's `reject_if` observes an owner whose own
+  // attributes are already set — even when the nested key sits first in the
+  // literal.
+  it("assigns nested parameter hashes after the base attributes", () => {
+    const config = (
+      Pirate as unknown as {
+        _nestedAttributeConfigs: {
+          associationName: string;
+          options: { rejectIf?: unknown };
+        }[];
+      }
+    )._nestedAttributeConfigs.find((c) => c.associationName === "ship")!;
+    const originalRejectIf = config.options.rejectIf;
+    const observed: unknown[] = [];
+    config.options.rejectIf = (_attrs: Record<string, unknown>, record: Base) => {
+      observed.push((record as Pirate).catchphrase);
+      return false;
+    };
+
+    try {
+      const pirate = new Pirate();
+      pirate.assignAttributes({
+        shipAttributes: { name: "The Black Rock" },
+        catchphrase: "Aye",
+      });
+    } finally {
+      config.options.rejectIf = originalRejectIf;
+    }
+
+    expect(observed).toEqual(["Aye"]);
+  });
+});

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -27,7 +27,6 @@ import {
   UnknownAttributeError,
 } from "./errors.js";
 import {
-  hasMultiparameterKeys,
   extractMultiparameterCallstack,
   executeMultiparameterAssignment,
 } from "./multiparameter-attribute-assignment.js";
@@ -1049,12 +1048,58 @@ export function _reapplyNestedAttrSetters(
 }
 
 /**
- * Mirrors: ActiveRecord::AttributeAssignment#assign_attributes. Rails'
- * version lets setter exceptions propagate raw; ours additionally wraps
- * them in AttributeAssignmentError with the offending key/value for
- * debugging. (That wrapping is stricter than Rails but longstanding —
- * preserved by this extraction; revisiting the Rails-fidelity gap can
- * happen in a follow-up.)
+ * Mirrors Rails' `_assign_attribute` (ActiveModel
+ * attribute_assignment.rb:67-75): dispatch through the public setter when one
+ * exists (store accessors write to the store hash, not a standalone attribute
+ * slot). Falls back to writeAttribute for plain columns and unknown keys.
+ *
+ * Rails lets setter exceptions propagate raw; ours additionally wraps them in
+ * AttributeAssignmentError with the offending key/value for debugging. (That
+ * wrapping is stricter than Rails but longstanding.)
+ */
+function _assignAttribute(self: AttributeIO, key: string, value: unknown): void {
+  try {
+    if (
+      assignAssociationIfMatch(
+        self as { constructor?: unknown; association?: (name: string) => unknown },
+        key,
+        value,
+      )
+    ) {
+      // Routed to the association proxy writer (constructor-form collection /
+      // singular) — Rails reaches these through `public_send("#{k}=")` too.
+      return;
+    }
+    const setter = findPrototypeSetter(self, key);
+    if (setter) {
+      setter.call(self, value);
+    } else {
+      self.writeAttribute(key, value);
+    }
+  } catch (e) {
+    let repr: string;
+    try {
+      repr = JSON.stringify(value);
+    } catch {
+      repr = String(value);
+    }
+    throw new AttributeAssignmentError(
+      `error on assignment ${repr} to ${key} (${e instanceof Error ? e.message : String(e)})`,
+      e instanceof Error ? e : undefined,
+      key,
+    );
+  }
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeAssignment#_assign_attributes
+ * (attribute_assignment.rb:6-22), reached through
+ * ActiveModel's `assign_attributes` (:32-35).
+ *
+ * Rails buckets multiparameter keys AND Hash values out of the main loop and
+ * assigns the nested hashes only after the scalar pass (:21), so a nested
+ * writer's `reject_if` / the built record's callbacks observe an owner whose
+ * own attributes are already set. Nested runs before multiparameter (:21-22).
  */
 export function assignAttributes(this: AttributeIO, attrs: Record<string, unknown>): void {
   assertHashAttributes(attrs);
@@ -1064,77 +1109,49 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
   if (Object.keys(attrs).length === 0) return;
   attrs = sanitizeForMassAssignment(attrs);
 
-  if (hasMultiparameterKeys(attrs)) {
-    const { multiparams, regular } = extractMultiparameterCallstack(attrs);
-    // Assign regular attributes first (with existing error wrapping)
-    for (const [key, value] of Object.entries(regular)) {
-      try {
-        if (
-          assignAssociationIfMatch(
-            this as { constructor?: unknown; association?: (name: string) => unknown },
-            key,
-            value,
-          )
-        )
-          continue;
-        const setter = findPrototypeSetter(this, key);
-        if (setter) {
-          setter.call(this, value);
-        } else {
-          this.writeAttribute(key, value);
-        }
-      } catch (e) {
-        let repr: string;
-        try {
-          repr = JSON.stringify(value);
-        } catch {
-          repr = String(value);
-        }
-        throw new AttributeAssignmentError(
-          `error on assignment ${repr} to ${key} (${e instanceof Error ? e.message : String(e)})`,
-          e instanceof Error ? e : undefined,
-          key,
-        );
-      }
-    }
-    // Then assign multiparameter attributes (throws MultiparameterAssignmentErrors)
-    executeMultiparameterAssignment(this as any, multiparams);
-    return;
-  }
+  let multiParameterAttributes: Record<string, unknown> | null = null;
+  let nestedParameterAttributes: Record<string, unknown> | null = null;
 
   for (const [key, value] of Object.entries(attrs)) {
-    try {
-      if (
-        assignAssociationIfMatch(
-          this as { constructor?: unknown; association?: (name: string) => unknown },
-          key,
-          value,
-        )
-      )
-        continue;
-      // Mirrors Rails' _assign_attribute: dispatch through the public setter
-      // when one exists (store accessors write to the store hash, not a
-      // standalone attribute slot). Falls back to writeAttribute for plain
-      // columns and unknown keys.
-      const setter = findPrototypeSetter(this, key);
-      if (setter) {
-        setter.call(this, value);
-      } else {
-        this.writeAttribute(key, value);
-      }
-    } catch (e) {
-      let repr: string;
-      try {
-        repr = JSON.stringify(value);
-      } catch {
-        repr = String(value);
-      }
-      throw new AttributeAssignmentError(
-        `error on assignment ${repr} to ${key} (${e instanceof Error ? e.message : String(e)})`,
-        e instanceof Error ? e : undefined,
-        key,
-      );
+    if (key.includes("(")) {
+      (multiParameterAttributes ??= {})[key] = value;
+    } else if (isNestedParameterHash(value)) {
+      (nestedParameterAttributes ??= {})[key] = value;
+    } else {
+      _assignAttribute(this, key, value);
     }
+  }
+
+  if (nestedParameterAttributes) {
+    assignNestedParameterAttributes(this, nestedParameterAttributes);
+  }
+  if (multiParameterAttributes) {
+    // Rails' assign_multiparameter_attributes → extract/execute callstack.
+    executeMultiparameterAssignment(
+      this as any,
+      extractMultiparameterCallstack(multiParameterAttributes).multiparams,
+    );
+  }
+}
+
+/**
+ * Ruby `v.is_a?(Hash)`. A Date/Temporal/model value is `typeof "object"` in JS
+ * but is not a Hash in Ruby, so only plain objects may be deferred.
+ */
+function isNestedParameterHash(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeAssignment#assign_nested_parameter_attributes
+ * (attribute_assignment.rb:26-28) — assign any deferred nested attributes after
+ * the base attributes have been set.
+ */
+function assignNestedParameterAttributes(self: AttributeIO, pairs: Record<string, unknown>): void {
+  for (const [k, v] of Object.entries(pairs)) {
+    _assignAttribute(self, k, v);
   }
 }
 

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1126,7 +1126,6 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
     assignNestedParameterAttributes(this, nestedParameterAttributes);
   }
   if (multiParameterAttributes) {
-    // Rails' assign_multiparameter_attributes → extract/execute callstack.
     executeMultiparameterAssignment(
       this as any,
       extractMultiparameterCallstack(multiParameterAttributes).multiparams,


### PR DESCRIPTION
## Summary

`Base#assignAttributes` — the trails stand-in for
`ActiveRecord::AttributeAssignment#_assign_attributes`
(`vendor/rails/activerecord/lib/active_record/attribute_assignment.rb:6-22`) —
assigned in a single pass in raw hash order. Rails buckets every Hash-valued key
into `nested_parameter_attributes` and assigns those only after the scalar pass
(:21), via `assign_nested_parameter_attributes` (:26-28), so a nested writer's
`reject_if`, the built record's callbacks, and the association's
`initialize_attributes` all observe an owner whose own attributes are already
set. PR #5997 ported that ordering into the `#update` path only.

This ports it into `assignAttributes`:

- Single Rails-shaped loop that buckets `(`-keys into
  `multiParameterAttributes` and Hash values into `nestedParameterAttributes`,
  then runs `assign_nested_parameter_attributes` **before**
  `assign_multiparameter_attributes` (:21-22). The two duplicated loops (the
  early-returning `hasMultiparameterKeys` branch and the plain one) collapse
  into one, so the nested pass can no longer be skipped when multiparameter
  keys are also present.
- The per-key `public_send("#{k}=")` stand-in — association dispatch, prototype
  setter, `writeAttribute` fallback, plus the longstanding
  `AttributeAssignmentError` wrap — is extracted into a module-local
  `_assignAttribute` matching ActiveModel's
  `attribute_assignment.rb:67-75`, shared by the scalar pass and the deferred
  nested pass.
- `isNestedParameterHash` restricts the deferral to plain objects: Ruby's
  `v.is_a?(Hash)` excludes Date/Temporal/model values that are `typeof
  "object"` in JS.

## Test

`nested attributes assignment ordering (trails-only)` — a `reject_if` on
`Pirate`'s `ship` nested writer records the owner's `catchphrase` while
`shipAttributes` sits *first* in the literal. Fails on baseline (`[null]`),
passes here (`["Aye"]`).

## Gates

- `pnpm typecheck`, `pnpm lint` clean
- `pnpm api:calls` OK · `pnpm api:calls:wide` OK · `pnpm api:extra --package
  activerecord` unchanged (the one novel name in `persistence.ts` is the
  pre-existing `deleteRow`)
- `pnpm api:compare` / `pnpm test:compare` deltas non-negative
- 133 insertions / 75 deletions across 2 files

Closes-story: assign-attributes-defers-nested-parameter-hashes
