### PR TITLE
feat(i18n): port Backend::Base#localize and translate_localization_format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,16 @@ port a body:
 - **Bang methods** raise; the non-bang form returns falsy. Port both arms.
 - **Symbols vs strings.** Where Rails accepts a Symbol _or_ a String, port both
   arms — dropping the string arm is a common silent gap.
+- **A Ruby Symbol is a JS string, never a JS `Symbol`.** `:short` is `"short"`.
+  JS `Symbol` / `Symbol.for` is reserved for private keys and brands — using it
+  to model a Ruby Symbol value puts a type in the port that Rails devs don't
+  read as a Symbol and that no other package uses. Where a method's control
+  flow turns on `Symbol === x` (a Symbol meaning "look this up" against a
+  String meaning "use this literally" — `I18n::Backend::Base#localize`'s
+  `format`, a `:default` that names another key), keep the Symbol's leading
+  colon in the string: `":short"`, and `.slice(1)` for its name. The colon is
+  the discriminator Ruby gets from the type, and it is how the value already
+  renders through `inspect`.
 
 If you find a new instance, file it against the best-fit active RFC, else
 `0023-surfaced-deviations`. RFC `0082-ruby-ts-idiom-conversion-classes` in the

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -14,7 +14,7 @@
  *
  * Not ported here: `load_translations` / `load_file` / `load_rb` / `load_yml` /
  * `load_json` (file loading needs a YAML reader and async fs — its own story),
- * `localize` / `translate_localization_format`, and the `Transliterator` mixin.
+ * and the `Transliterator` mixin.
  */
 
 import {
@@ -22,13 +22,17 @@ import {
   InvalidLocale,
   InvalidPluralizationData,
   MissingTranslation,
+  MissingTranslationData,
   ReservedInterpolationKey,
+  inspect,
 } from "../exceptions.js";
 import {
   EMPTY_HASH,
   RESERVED_KEYS,
   config,
   reservedKeysPattern,
+  t,
+  tBang,
   type Locale,
   type TranslationKey,
 } from "../i18n.js";
@@ -49,6 +53,34 @@ function isHash(value: unknown): value is TranslationData {
 
 function symbolName(subject: symbol): string {
   return Symbol.keyFor(subject) ?? subject.description ?? "";
+}
+
+/** Ruby `#to_s`, for the values a format argument can hold. */
+function toS(subject: unknown): string {
+  if (subject == null) return "";
+  return typeof subject === "symbol" ? symbolName(subject) : String(subject);
+}
+
+/**
+ * Ruby `respond_to?`. A Ruby reader that returns a value is a property or a
+ * getter in JS, not a function, so membership — not callability — is the test.
+ */
+function respondTo(object: unknown, name: string): boolean {
+  return (
+    object != null && (typeof object === "object" || typeof object === "function") && name in object
+  );
+}
+
+/**
+ * The duck type `localize` accepts: the gem asks the object for `strftime`,
+ * `wday`, `mon`, `hour` and `sec` and nothing else.
+ */
+interface Localizable {
+  strftime(format: string): string;
+  wday: number;
+  mon: number;
+  hour?: number;
+  sec?: number;
 }
 
 export abstract class Base {
@@ -118,6 +150,37 @@ export abstract class Base {
     options: TranslateOptions = EMPTY_HASH,
   ): boolean {
     return this.lookup(locale, key, options.scope) != null;
+  }
+
+  /**
+   * Acts the same as `strftime`, but uses a localized version of the format
+   * string. Takes a key from the date/time formats translations as a format
+   * argument (*e.g.*, `short` in `date.formats`).
+   */
+  localize(
+    locale: Locale,
+    object: unknown,
+    format: unknown = Symbol.for("default"),
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    if (object == null && "default" in options) {
+      return options.default;
+    }
+    if (!respondTo(object, "strftime")) {
+      throw new ArgumentError(
+        `Object must be a Date, DateTime or Time object. ${inspect(object)} given.`,
+      );
+    }
+
+    if (typeof format === "symbol") {
+      const key = format;
+      const type = respondTo(object, "sec") ? "time" : "date";
+      options = { ...options, raise: true, object, locale };
+      format = t(`${type}.formats.${symbolName(key)}`, options);
+    }
+
+    format = this.translateLocalizationFormat(locale, object, format, options);
+    return (object as Localizable).strftime(format as string);
   }
 
   /**
@@ -279,6 +342,61 @@ export abstract class Base {
       return result;
     }
     return data;
+  }
+
+  protected translateLocalizationFormat(
+    locale: Locale,
+    object: unknown,
+    format: unknown,
+    _options: TranslateOptions,
+  ): string {
+    const o = object as Localizable;
+    try {
+      return toS(format).replace(/%(|\^)[aAbBpP]/g, (match) => {
+        switch (match) {
+          case "%a":
+            return (tBang("date.abbr_day_names", { locale, format }) as string[])[o.wday];
+          case "%^a":
+            return (tBang("date.abbr_day_names", { locale, format }) as string[])[
+              o.wday
+            ].toUpperCase();
+          case "%A":
+            return (tBang("date.day_names", { locale, format }) as string[])[o.wday];
+          case "%^A":
+            return (tBang("date.day_names", { locale, format }) as string[])[o.wday].toUpperCase();
+          case "%b":
+            return (tBang("date.abbr_month_names", { locale, format }) as string[])[o.mon];
+          case "%^b":
+            return (tBang("date.abbr_month_names", { locale, format }) as string[])[
+              o.mon
+            ].toUpperCase();
+          case "%B":
+            return (tBang("date.month_names", { locale, format }) as string[])[o.mon];
+          case "%^B":
+            return (tBang("date.month_names", { locale, format }) as string[])[o.mon].toUpperCase();
+          case "%p":
+            return (
+              tBang(`time.${(respondTo(object, "hour") ? o.hour! : 0) < 12 ? "am" : "pm"}`, {
+                locale,
+                format,
+              }) as string
+            ).toUpperCase();
+          case "%P":
+            return (
+              tBang(`time.${(respondTo(object, "hour") ? o.hour! : 0) < 12 ? "am" : "pm"}`, {
+                locale,
+                format,
+              }) as string
+            ).toLowerCase();
+          default:
+            // Ruby's `case` falls through to nil, which gsub substitutes as "".
+            return "";
+        }
+      });
+    } catch (e) {
+      if (e instanceof MissingTranslationData) return e.message;
+      throw e;
+    }
   }
 
   protected pluralizationKey(entry: TranslationData, count: unknown): string {

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -179,7 +179,7 @@ export abstract class Base {
       format = t(`${type}.formats.${symbolName(key)}`, options);
     }
 
-    format = this.translateLocalizationFormat(locale, object, format, options);
+    format = this.translateLocalizationFormat(locale, object as Localizable, format, options);
     return (object as Localizable).strftime(format as string);
   }
 
@@ -346,50 +346,52 @@ export abstract class Base {
 
   protected translateLocalizationFormat(
     locale: Locale,
-    object: unknown,
+    object: Localizable,
     format: unknown,
     _options: TranslateOptions,
   ): string {
-    const o = object as Localizable;
     try {
       return toS(format).replace(/%(|\^)[aAbBpP]/g, (match) => {
         switch (match) {
           case "%a":
-            return (tBang("date.abbr_day_names", { locale, format }) as string[])[o.wday];
+            return (tBang("date.abbr_day_names", { locale, format }) as string[])[object.wday];
           case "%^a":
             return (tBang("date.abbr_day_names", { locale, format }) as string[])[
-              o.wday
+              object.wday
             ].toUpperCase();
           case "%A":
-            return (tBang("date.day_names", { locale, format }) as string[])[o.wday];
+            return (tBang("date.day_names", { locale, format }) as string[])[object.wday];
           case "%^A":
-            return (tBang("date.day_names", { locale, format }) as string[])[o.wday].toUpperCase();
+            return (tBang("date.day_names", { locale, format }) as string[])[
+              object.wday
+            ].toUpperCase();
           case "%b":
-            return (tBang("date.abbr_month_names", { locale, format }) as string[])[o.mon];
+            return (tBang("date.abbr_month_names", { locale, format }) as string[])[object.mon];
           case "%^b":
             return (tBang("date.abbr_month_names", { locale, format }) as string[])[
-              o.mon
+              object.mon
             ].toUpperCase();
           case "%B":
-            return (tBang("date.month_names", { locale, format }) as string[])[o.mon];
+            return (tBang("date.month_names", { locale, format }) as string[])[object.mon];
           case "%^B":
-            return (tBang("date.month_names", { locale, format }) as string[])[o.mon].toUpperCase();
+            return (tBang("date.month_names", { locale, format }) as string[])[
+              object.mon
+            ].toUpperCase();
           case "%p":
             return (
-              tBang(`time.${(respondTo(object, "hour") ? o.hour! : 0) < 12 ? "am" : "pm"}`, {
+              tBang(`time.${(respondTo(object, "hour") ? object.hour! : 0) < 12 ? "am" : "pm"}`, {
                 locale,
                 format,
               }) as string
             ).toUpperCase();
           case "%P":
             return (
-              tBang(`time.${(respondTo(object, "hour") ? o.hour! : 0) < 12 ? "am" : "pm"}`, {
+              tBang(`time.${(respondTo(object, "hour") ? object.hour! : 0) < 12 ? "am" : "pm"}`, {
                 locale,
                 format,
               }) as string
             ).toLowerCase();
           default:
-            // Ruby's `case` falls through to nil, which gsub substitutes as "".
             return "";
         }
       });

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -7,10 +7,10 @@
  * `available_locales`) are `abstract` here — TypeScript's form of the same
  * contract.
  *
- * Ruby Symbols appear in two value positions this file cares about: a `default`
- * that names another translation key, and a translation entry that redirects
- * to one. Since a JS string is the analogue of a Ruby String, those use real JS
- * symbols — `Symbol.for("some.key")` is the analogue of `:"some.key"`.
+ * A Ruby Symbol value is a JS string that keeps its leading colon — `":short"`
+ * is `:short` — which is the discriminator Ruby gets from the type. `default`
+ * and `resolve` still spell theirs as real JS symbols; converging those two is
+ * story `i18n-symbol-values-are-colon-strings`.
  *
  * Not ported here: `load_translations` / `load_file` / `load_rb` / `load_yml` /
  * `load_json` (file loading needs a YAML reader and async fs — its own story),
@@ -55,10 +55,18 @@ function symbolName(subject: symbol): string {
   return Symbol.keyFor(subject) ?? subject.description ?? "";
 }
 
+/**
+ * Ruby `Symbol === x`. A Ruby Symbol is a JS string that keeps its leading
+ * colon (`":short"`), which is the discriminator Ruby gets from the type.
+ */
+function isSymbol(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(":");
+}
+
 /** Ruby `#to_s`, for the values a format argument can hold. */
 function toS(subject: unknown): string {
   if (subject == null) return "";
-  return typeof subject === "symbol" ? symbolName(subject) : String(subject);
+  return isSymbol(subject) ? subject.slice(1) : String(subject);
 }
 
 /**
@@ -160,7 +168,7 @@ export abstract class Base {
   localize(
     locale: Locale,
     object: unknown,
-    format: unknown = Symbol.for("default"),
+    format: unknown = ":default",
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
     if (object == null && "default" in options) {
@@ -172,11 +180,11 @@ export abstract class Base {
       );
     }
 
-    if (typeof format === "symbol") {
+    if (isSymbol(format)) {
       const key = format;
       const type = respondTo(object, "sec") ? "time" : "date";
       options = { ...options, raise: true, object, locale };
-      format = t(`${type}.formats.${symbolName(key)}`, options);
+      format = t(`${type}.formats.${key.slice(1)}`, options);
     }
 
     format = this.translateLocalizationFormat(locale, object as Localizable, format, options);

--- a/packages/i18n/src/backend/localization.test.ts
+++ b/packages/i18n/src/backend/localization.test.ts
@@ -151,15 +151,15 @@ describe("I18nSimpleBackendApiTest", () => {
   });
 
   it("localize Date: given the short format it uses it", () => {
-    expect(l(date, { format: Symbol.for("short"), locale: "de" })).toBe("01. Mär");
+    expect(l(date, { format: ":short", locale: "de" })).toBe("01. Mär");
   });
 
   it("localize Date: given the long format it uses it", () => {
-    expect(l(date, { format: Symbol.for("long"), locale: "de" })).toBe("01. März 2008");
+    expect(l(date, { format: ":long", locale: "de" })).toBe("01. März 2008");
   });
 
   it("localize Date: given the default format it uses it", () => {
-    expect(l(date, { format: Symbol.for("default"), locale: "de" })).toBe("01.03.2008");
+    expect(l(date, { format: ":default", locale: "de" })).toBe("01.03.2008");
   });
 
   it("localize Date: given a day name format it returns the correct day name", () => {
@@ -235,24 +235,22 @@ describe("I18nSimpleBackendApiTest", () => {
   });
 
   it("localize Date: given a format is missing it raises I18n::MissingTranslationData", () => {
-    expect(() => l(date, { format: Symbol.for("missing") })).toThrow(MissingTranslationData);
+    expect(() => l(date, { format: ":missing" })).toThrow(MissingTranslationData);
   });
 
   it("localize Date: it does not alter the format string", () => {
-    expect(l(new RubyDate(2009, 2, 1), { format: Symbol.for("long"), locale: "de" })).toBe(
-      "01. Februar 2009",
-    );
-    expect(l(new RubyDate(2009, 10, 1), { format: Symbol.for("long"), locale: "de" })).toBe(
+    expect(l(new RubyDate(2009, 2, 1), { format: ":long", locale: "de" })).toBe("01. Februar 2009");
+    expect(l(new RubyDate(2009, 10, 1), { format: ":long", locale: "de" })).toBe(
       "01. Oktober 2009",
     );
   });
 
   it("localize Time: given the short format it uses it", () => {
-    expect(l(time, { format: Symbol.for("short"), locale: "de" })).toBe("01. Mär 06:00");
+    expect(l(time, { format: ":short", locale: "de" })).toBe("01. Mär 06:00");
   });
 
   it("localize Time: given the long format it uses it", () => {
-    expect(l(time, { format: Symbol.for("long"), locale: "de" })).toBe("01. März 2008 06:00");
+    expect(l(time, { format: ":long", locale: "de" })).toBe("01. März 2008 06:00");
   });
 
   it("localize Time: given a day name format it returns the correct day name", () => {
@@ -314,6 +312,6 @@ describe("I18nSimpleBackendApiTest", () => {
   });
 
   it("localize Time: given a format is missing it raises I18n::MissingTranslationData", () => {
-    expect(() => l(time, { format: Symbol.for("missing") })).toThrow(MissingTranslationData);
+    expect(() => l(time, { format: ":missing" })).toThrow(MissingTranslationData);
   });
 });

--- a/packages/i18n/src/backend/localization.test.ts
+++ b/packages/i18n/src/backend/localization.test.ts
@@ -132,7 +132,7 @@ function setupTimeTranslations(backend: Simple): void {
   });
 }
 
-describe("I18nBackendSimpleLocalizationTest", () => {
+describe("I18nSimpleBackendApiTest", () => {
   let date: RubyDate;
   let time: RubyTime;
   let otherTime: RubyTime;

--- a/packages/i18n/src/backend/localization.test.ts
+++ b/packages/i18n/src/backend/localization.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Mirrors: i18n/lib/i18n/tests/localization/date.rb and
+ * i18n/lib/i18n/tests/localization/time.rb — the conformance mixins the gem
+ * runs against the Simple backend in i18n/test/api/simple_test.rb.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Simple } from "./simple.js";
+import { config, l, resetConfig } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import { ArgumentError, MissingTranslationData } from "../exceptions.js";
+
+/**
+ * Stands in for Ruby's `::Date` — `localize` duck-types its object, so what a
+ * test needs is `strftime`, `wday` and `mon`. The directives below are the
+ * ones the gem's format strings use; `%a`/`%A`/`%b`/`%B`/`%p`/`%P` never reach
+ * here, since `translate_localization_format` substitutes them first.
+ */
+class RubyDate {
+  readonly utc: Date;
+
+  constructor(year: number, month: number, day: number, hour = 0, min = 0, sec = 0) {
+    this.utc = new Date(Date.UTC(year, month - 1, day, hour, min, sec));
+  }
+
+  get wday(): number {
+    return this.utc.getUTCDay();
+  }
+
+  get mon(): number {
+    return this.utc.getUTCMonth() + 1;
+  }
+
+  strftime(format: string): string {
+    const pad = (value: number, width = 2) => String(value).padStart(width, "0");
+    return format.replace(/%(-?)([A-Za-z%])/g, (match, dash: string, directive: string) => {
+      switch (directive) {
+        case "d":
+          return dash ? String(this.utc.getUTCDate()) : pad(this.utc.getUTCDate());
+        case "m":
+          return dash ? String(this.mon) : pad(this.mon);
+        case "Y":
+          return String(this.utc.getUTCFullYear());
+        case "H":
+          return pad(this.utc.getUTCHours());
+        case "M":
+          return pad(this.utc.getUTCMinutes());
+        case "S":
+          return pad(this.utc.getUTCSeconds());
+        case "z":
+          return "+0000";
+        case "x":
+          return `${pad(this.mon)}/${pad(this.utc.getUTCDate())}/${pad(
+            this.utc.getUTCFullYear() % 100,
+          )}`;
+        case "%":
+          return "%";
+        default:
+          return match;
+      }
+    });
+  }
+}
+
+/** Ruby's `::Time` answers `hour` and `sec`, which is what routes a format
+ * lookup to `time.formats` and picks the meridian. */
+class RubyTime extends RubyDate {
+  get hour(): number {
+    return this.utc.getUTCHours();
+  }
+
+  get sec(): number {
+    return this.utc.getUTCSeconds();
+  }
+}
+
+function setupDateTranslations(backend: Simple): void {
+  backend.storeTranslations("de", {
+    date: {
+      formats: {
+        default: "%d.%m.%Y",
+        short: "%d. %b",
+        long: "%d. %B %Y",
+      },
+      day_names: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"],
+      abbr_day_names: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
+      month_names: [
+        null,
+        "Januar",
+        "Februar",
+        "März",
+        "April",
+        "Mai",
+        "Juni",
+        "Juli",
+        "August",
+        "September",
+        "Oktober",
+        "November",
+        "Dezember",
+      ],
+      abbr_month_names: [
+        null,
+        "Jan",
+        "Feb",
+        "Mär",
+        "Apr",
+        "Mai",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Okt",
+        "Nov",
+        "Dez",
+      ],
+    },
+  });
+}
+
+function setupTimeTranslations(backend: Simple): void {
+  backend.storeTranslations("de", {
+    time: {
+      formats: {
+        default: "%a, %d. %b %Y %H:%M:%S %z",
+        short: "%d. %b %H:%M",
+        long: "%d. %B %Y %H:%M",
+      },
+      am: "am",
+      pm: "pm",
+    },
+  });
+}
+
+describe("I18nBackendSimpleLocalizationTest", () => {
+  let date: RubyDate;
+  let time: RubyTime;
+  let otherTime: RubyTime;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    const backend = new Simple();
+    config().backend = backend;
+    config().enforceAvailableLocales = false;
+    setupDateTranslations(backend);
+    setupTimeTranslations(backend);
+    date = new RubyDate(2008, 3, 1);
+    time = new RubyTime(2008, 3, 1, 6, 0);
+    otherTime = new RubyTime(2008, 3, 1, 18, 0);
+  });
+
+  it("localize Date: given the short format it uses it", () => {
+    expect(l(date, { format: Symbol.for("short"), locale: "de" })).toBe("01. Mär");
+  });
+
+  it("localize Date: given the long format it uses it", () => {
+    expect(l(date, { format: Symbol.for("long"), locale: "de" })).toBe("01. März 2008");
+  });
+
+  it("localize Date: given the default format it uses it", () => {
+    expect(l(date, { format: Symbol.for("default"), locale: "de" })).toBe("01.03.2008");
+  });
+
+  it("localize Date: given a day name format it returns the correct day name", () => {
+    expect(l(date, { format: "%A", locale: "de" })).toBe("Samstag");
+  });
+
+  it("localize Date: given a uppercased day name format it returns the correct day name in upcase", () => {
+    expect(l(date, { format: "%^A", locale: "de" })).toBe("samstag".toUpperCase());
+  });
+
+  it("localize Date: given an abbreviated day name format it returns the correct abbreviated day name", () => {
+    expect(l(date, { format: "%a", locale: "de" })).toBe("Sa");
+  });
+
+  it("localize Date: given an meridian indicator format it returns the correct meridian indicator", () => {
+    expect(l(date, { format: "%p", locale: "de" })).toBe("AM");
+    expect(l(date, { format: "%P", locale: "de" })).toBe("am");
+  });
+
+  it("localize Date: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase", () => {
+    expect(l(date, { format: "%^a", locale: "de" })).toBe("sa".toUpperCase());
+  });
+
+  it("localize Date: given a month name format it returns the correct month name", () => {
+    expect(l(date, { format: "%B", locale: "de" })).toBe("März");
+  });
+
+  it("localize Date: given a uppercased month name format it returns the correct month name in upcase", () => {
+    expect(l(date, { format: "%^B", locale: "de" })).toBe("märz".toUpperCase());
+  });
+
+  it("localize Date: given an abbreviated month name format it returns the correct abbreviated month name", () => {
+    expect(l(date, { format: "%b", locale: "de" })).toBe("Mär");
+  });
+
+  it("localize Date: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase", () => {
+    expect(l(date, { format: "%^b", locale: "de" })).toBe("mär".toUpperCase());
+  });
+
+  it("localize Date: given a date format with the month name upcased it returns the correct value", () => {
+    expect(l(new RubyDate(2008, 2, 1), { format: "%-d. %^B %Y", locale: "de" })).toBe(
+      "1. FEBRUAR 2008",
+    );
+  });
+
+  it("localize Date: given missing translations it returns the correct error message", () => {
+    expect(l(date, { format: "%b", locale: "fr" })).toBe(
+      "Translation missing: fr.date.abbr_month_names",
+    );
+  });
+
+  it("localize Date: given an unknown format it does not fail", () => {
+    expect(() => l(date, { format: "%x" })).not.toThrow();
+  });
+
+  it("localize Date: does not modify the options hash", () => {
+    const options = { format: "%b", locale: "de" };
+    expect(l(date, options)).toBe("Mär");
+    expect(options).toEqual({ format: "%b", locale: "de" });
+    expect(() => l(date, Object.freeze({ format: "%b", locale: "de" }))).not.toThrow();
+  });
+
+  it("localize Date: given nil with default value it returns default", () => {
+    expect(l(null, { default: "default" })).toBe("default");
+  });
+
+  it("localize Date: given nil it raises I18n::ArgumentError", () => {
+    expect(() => l(null)).toThrow(ArgumentError);
+  });
+
+  it("localize Date: given a plain Object it raises I18n::ArgumentError", () => {
+    expect(() => l({})).toThrow(ArgumentError);
+  });
+
+  it("localize Date: given a format is missing it raises I18n::MissingTranslationData", () => {
+    expect(() => l(date, { format: Symbol.for("missing") })).toThrow(MissingTranslationData);
+  });
+
+  it("localize Date: it does not alter the format string", () => {
+    expect(l(new RubyDate(2009, 2, 1), { format: Symbol.for("long"), locale: "de" })).toBe(
+      "01. Februar 2009",
+    );
+    expect(l(new RubyDate(2009, 10, 1), { format: Symbol.for("long"), locale: "de" })).toBe(
+      "01. Oktober 2009",
+    );
+  });
+
+  it("localize Time: given the short format it uses it", () => {
+    expect(l(time, { format: Symbol.for("short"), locale: "de" })).toBe("01. Mär 06:00");
+  });
+
+  it("localize Time: given the long format it uses it", () => {
+    expect(l(time, { format: Symbol.for("long"), locale: "de" })).toBe("01. März 2008 06:00");
+  });
+
+  it("localize Time: given a day name format it returns the correct day name", () => {
+    expect(l(time, { format: "%A", locale: "de" })).toBe("Samstag");
+  });
+
+  it("localize Time: given a uppercased day name format it returns the correct day name in upcase", () => {
+    expect(l(time, { format: "%^A", locale: "de" })).toBe("samstag".toUpperCase());
+  });
+
+  it("localize Time: given an abbreviated day name format it returns the correct abbreviated day name", () => {
+    expect(l(time, { format: "%a", locale: "de" })).toBe("Sa");
+  });
+
+  it("localize Time: given an abbreviated and uppercased day name format it returns the correct abbreviated day name in upcase", () => {
+    expect(l(time, { format: "%^a", locale: "de" })).toBe("sa".toUpperCase());
+  });
+
+  it("localize Time: given a month name format it returns the correct month name", () => {
+    expect(l(time, { format: "%B", locale: "de" })).toBe("März");
+  });
+
+  it("localize Time: given a uppercased month name format it returns the correct month name in upcase", () => {
+    expect(l(time, { format: "%^B", locale: "de" })).toBe("märz".toUpperCase());
+  });
+
+  it("localize Time: given an abbreviated month name format it returns the correct abbreviated month name", () => {
+    expect(l(time, { format: "%b", locale: "de" })).toBe("Mär");
+  });
+
+  it("localize Time: given an abbreviated and uppercased month name format it returns the correct abbreviated month name in upcase", () => {
+    expect(l(time, { format: "%^b", locale: "de" })).toBe("mär".toUpperCase());
+  });
+
+  it("localize Time: given a date format with the month name upcased it returns the correct value", () => {
+    expect(l(new RubyTime(2008, 2, 1, 6, 0), { format: "%-d. %^B %Y", locale: "de" })).toBe(
+      "1. FEBRUAR 2008",
+    );
+  });
+
+  it("localize Time: given missing translations it returns the correct error message", () => {
+    expect(l(time, { format: "%b", locale: "fr" })).toBe(
+      "Translation missing: fr.date.abbr_month_names",
+    );
+  });
+
+  it("localize Time: given a meridian indicator format it returns the correct meridian indicator", () => {
+    expect(l(time, { format: "%p", locale: "de" })).toBe("AM");
+    expect(l(otherTime, { format: "%p", locale: "de" })).toBe("PM");
+  });
+
+  it("localize Time: given a meridian indicator format it returns the correct meridian indicator in upcase", () => {
+    expect(l(time, { format: "%P", locale: "de" })).toBe("am");
+    expect(l(otherTime, { format: "%P", locale: "de" })).toBe("pm");
+  });
+
+  it("localize Time: given an unknown format it does not fail", () => {
+    expect(() => l(time, { format: "%x" })).not.toThrow();
+  });
+
+  it("localize Time: given a format is missing it raises I18n::MissingTranslationData", () => {
+    expect(() => l(time, { format: Symbol.for("missing") })).toThrow(MissingTranslationData);
+  });
+});

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -21,6 +21,9 @@ class FakeBackend implements Backend {
   exists(): boolean {
     return false;
   }
+  localize(): unknown {
+    return null;
+  }
 }
 
 /**

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -13,8 +13,7 @@ export interface Backend {
   eagerLoadBang(): void;
   translate(locale: Locale, key: unknown, options?: Record<string, unknown>): unknown;
   exists(locale: Locale, key: TranslationKey, options?: Record<string, unknown>): boolean;
-  /** Optional until `Backend::Base#localize` lands (story `i18n-backend-localize`). */
-  localize?(
+  localize(
     locale: Locale,
     object: unknown,
     format: unknown,

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -55,7 +55,7 @@ describe("I18nTest", () => {
     const spy = vi.fn();
     (backend as unknown as { localize: unknown }).localize = spy;
     localize("whatever", { locale: "de" });
-    expect(spy).toHaveBeenCalledWith("de", "whatever", Symbol.for("default"), {});
+    expect(spy).toHaveBeenCalledWith("de", "whatever", ":default", {});
   });
 
   it("translate given no locale uses the current locale", () => {

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -55,7 +55,7 @@ describe("I18nTest", () => {
     const spy = vi.fn();
     (backend as unknown as { localize: unknown }).localize = spy;
     localize("whatever", { locale: "de" });
-    expect(spy).toHaveBeenCalledWith("de", "whatever", "default", {});
+    expect(spy).toHaveBeenCalledWith("de", "whatever", Symbol.for("default"), {});
   });
 
   it("translate given no locale uses the current locale", () => {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -253,7 +253,7 @@ export function localize(
   if (locale === false) throw new Disabled("l");
   enforceAvailableLocalesBang(locale as Locale);
 
-  if (!truthy(format)) format = Symbol.for("default");
+  if (!truthy(format)) format = ":default";
   return config().backend.localize(locale as Locale, object, format, options);
 }
 

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -244,9 +244,6 @@ export function exists(
 
 /**
  * Localizes certain objects, such as dates and numbers to local formatting.
- *
- * `Backend#localize` lands with the `i18n-backend-localize` story; until then
- * a backend that has not defined it fails here rather than silently no-op.
  */
 export function localize(
   object: unknown,
@@ -256,8 +253,8 @@ export function localize(
   if (locale === false) throw new Disabled("l");
   enforceAvailableLocalesBang(locale as Locale);
 
-  if (!truthy(format)) format = "default";
-  return config().backend.localize!(locale as Locale, object, format, options);
+  if (!truthy(format)) format = Symbol.for("default");
+  return config().backend.localize(locale as Locale, object, format, options);
 }
 
 export const l = localize;


### PR DESCRIPTION
Ports the last two members of `I18n::Backend::Base` — `localize`
(`vendor/i18n/lib/i18n/backend/base.rb:77-92`) and
`translate_localization_format` (`base.rb:289-306`).

- `localize` keeps the gem's branch order: `default` for a nil object, the
  `ArgumentError` ("Object must be a Date, DateTime or Time object. … given.")
  when the object has no `strftime`, then the Symbol-format arm that resolves
  `time.formats.*` vs `date.formats.*` off `respond_to?(:sec)` through
  `I18n.t` with `raise: true` (base.rb:83-86).
- `translate_localization_format` gsubs `/%(|\^)[aAbBpP]/` against
  `date.abbr_day_names` / `date.day_names` / `date.abbr_month_names` /
  `date.month_names` / `time.am` / `time.pm` via `I18n.t!`, and rescues
  `MissingTranslationData` by returning `e.message`.
- The object stays duck-typed (`strftime`, `wday`, `mon`, `hour`, `sec`), as
  in the gem — no activesupport dependency.
- Symbol values: a Ruby Symbol is a JS string that keeps its leading colon —
  `:short` is `":short"` — which is the discriminator `base.rb:82`'s
  `Symbol === format` gets from the type. `CLAUDE.md` now states that rule
  under "Ruby idioms that do not translate literally"; `base.ts`'s `default` /
  `resolve` still spell theirs as JS symbols, and story
  `i18n-symbol-values-are-colon-strings` converges them.
- Facade: `I18n.localize` defaulted `format` to `"default"`, which the arm
  above never treated as a key; it now passes `":default"` (the gem's
  `format ||= :default`), and `Config`'s `localize` is no longer optional.

Tests mirror `lib/i18n/tests/localization/date.rb` and `.../time.rb` — the
conformance mixins the gem runs against the Simple backend in
`test/api/simple_test.rb` — verbatim names, 37 cases covering
`%a %^a %A %^A %b %^b %B %^B %p %P`, the missing-translation message, and the
`MissingTranslationData` raise for a missing format key. `Date#strftime` has no
JS counterpart, so the test file carries a small stub standing in for Ruby's
`::Date` / `::Time`.

Closes-story: i18n-backend-localize
