### PR TITLE
feat(i18n): port the I18n.config= writer

### DIFF
--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -10,12 +10,13 @@ import {
   locale,
   localize,
   resetConfig,
+  setConfig,
   setExceptionHandler,
   t,
   translate,
   withLocale,
 } from "./i18n.js";
-import { resetClassConfig } from "./config.js";
+import { Config, resetClassConfig } from "./config.js";
 import { Simple } from "./backend/simple.js";
 import type { TranslationData } from "./utils.js";
 import type { TranslationKey } from "./i18n.js";
@@ -37,6 +38,19 @@ describe("I18nTest", () => {
     storeTranslations("en", { currency: { format: { separator: ".", delimiter: "," } } });
     storeTranslations("nl", { currency: { format: { separator: ",", delimiter: "." } } });
     storeTranslations("en", { true: "Yes", false: "No" });
+  });
+
+  // Rails also asserts the object is visible at
+  // `Thread.current.thread_variable_get(:i18n_config)`; JS has no threads, so
+  // `config()` is a process singleton and only the round-trip arm ports.
+  it("can set the configuration object", () => {
+    const value = new Config();
+    try {
+      setConfig(value);
+      expect(config()).toBe(value);
+    } finally {
+      setConfig(new Config());
+    }
   });
 
   it("uses a custom exception handler passed as an option", () => {

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -43,10 +43,12 @@ describe("I18nTest", () => {
   /**
    * Rails also asserts the object is visible at
    * `Thread.current.thread_variable_get(:i18n_config)`; JS has no threads, so
-   * `config()` is a process singleton and only the round-trip arm ports.
+   * `config()` is a process singleton and only the round-trip arm ports. Rails
+   * assigns `self` — an arbitrary duck-typed object, not an `I18n::Config` —
+   * so the value below is cast rather than constructed.
    */
   it("can set the configuration object", () => {
-    const value = new Config();
+    const value = {} as Config;
     try {
       setConfig(value);
       expect(config()).toBe(value);

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -40,9 +40,11 @@ describe("I18nTest", () => {
     storeTranslations("en", { true: "Yes", false: "No" });
   });
 
-  // Rails also asserts the object is visible at
-  // `Thread.current.thread_variable_get(:i18n_config)`; JS has no threads, so
-  // `config()` is a process singleton and only the round-trip arm ports.
+  /**
+   * Rails also asserts the object is visible at
+   * `Thread.current.thread_variable_get(:i18n_config)`; JS has no threads, so
+   * `config()` is a process singleton and only the round-trip arm ports.
+   */
   it("can set the configuration object", () => {
     const value = new Config();
     try {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -76,6 +76,11 @@ export function config(): Config {
   return currentConfig;
 }
 
+/** Sets I18n configuration object. */
+export function setConfig(value: Config): void {
+  currentConfig = value;
+}
+
 /** @internal Test seam — drops the process-wide config so a case starts clean. */
 export function resetConfig(): void {
   currentConfig = undefined;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -49,6 +49,7 @@ export {
   reservedKeysPattern,
   setAvailableLocales,
   setBackend,
+  setConfig,
   setDefaultLocale,
   setDefaultSeparator,
   setEnforceAvailableLocales,


### PR DESCRIPTION
Ports `I18n.config=` (`i18n/lib/i18n.rb:63`) as `setConfig`, following the `set*` writer spelling the surrounding delegators use, and exports it from `index.ts`.

Also ports `i18n/test/i18n_test.rb:79` — `test "can set the configuration object"` — under its verbatim Rails name. Rails' second assertion (`Thread.current.thread_variable_get(:i18n_config)`) has no JS analogue since `config()` is a process singleton here; the reason is at the call site.

## Review response: the `Config` parameter type

The body already matches `i18n/lib/i18n.rb:63-65` exactly — one assignment, no class guard, no coercion. The static type is not a guard: it erases at runtime, so `setConfig` stores whatever it is handed, exactly as Ruby does.

Widening the parameter to an arbitrary object is not portable in isolation. `currentConfig` backs `config()`, which is declared `config(): Config` (`packages/i18n/src/i18n.ts:74`) and is what all eighteen delegators (`locale()`, `setBackend()`, …) read through. A setter typed looser than its own getter would either force `config()` to return an untyped value — dropping type checking from every delegator and every caller in the package — or leave the store deliberately unsound. TypeScript has no duck-typed dynamic slot that keeps the reader typed; that is the language shortcoming, and the settled trails workaround (`setX()` for an async/typed Ruby writer) is what is used here.

The Rails behavior the comment is protecting — that an arbitrary non-`Config` object round-trips — is now covered directly: the test assigns `{} as Config`, the nearest analogue of Rails' `self`, so the assertion fails if `setConfig` ever grows a guard or a copy.

## Acceptance-criteria note

The i18n gem is not currently one of `test:compare`'s extracted packages (`pnpm test:compare --package i18n` reports 0/0 and the gem appears in neither extraction summary), so the story's 69/82 number can't be observed on this branch. The i18n unit tests pass (41/41).

Closes-story: i18n-config-writer
