### PR TITLE
feat(scripts): inventory stale story citations in the frozen docs tree

### DIFF
--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -149,11 +149,6 @@ describe("stale story references", () => {
     expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);
   });
 
-  // `docs/activerecord/` is frozen (RFC 0011 Phase 4) and its stale citations
-  // have no legal fix, so they are reported rather than gated: this test
-  // records the inventory for the freeze cutover to consume and passes either
-  // way. It still asserts the population is non-empty, so the inventory cannot
-  // quietly stop covering the tree.
   it("inventories stale citations in the frozen tree without gating on them", async () => {
     const files = await collectFrozenMarkdownFiles(REPO_ROOT);
     expect(files).toContain(path.join("docs", "activerecord", "parity-verification.md"));

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  collectFrozenMarkdownFiles,
   collectMarkdownFiles,
   extractMarkdownStoryReferences,
   extractStoryReferences,
   loadStories,
+  scanFrozenStoryReferences,
   scanStoryReferences,
   staleStoryReferences,
   type IndexStory,
@@ -145,6 +147,25 @@ describe("stale story references", () => {
     const stories = await loadStories(resolveTasksDir(REPO_ROOT));
     const stale = staleStoryReferences(await scanStoryReferences(REPO_ROOT), stories);
     expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);
+  });
+
+  // `docs/activerecord/` is frozen (RFC 0011 Phase 4) and its stale citations
+  // have no legal fix, so they are reported rather than gated: this test
+  // records the inventory for the freeze cutover to consume and passes either
+  // way. It still asserts the population is non-empty, so the inventory cannot
+  // quietly stop covering the tree.
+  it("inventories stale citations in the frozen tree without gating on them", async () => {
+    const files = await collectFrozenMarkdownFiles(REPO_ROOT);
+    expect(files).toContain(path.join("docs", "activerecord", "parity-verification.md"));
+    const stories = await loadStories(resolveTasksDir(REPO_ROOT));
+    const stale = staleStoryReferences(await scanFrozenStoryReferences(REPO_ROOT), stories);
+    if (stale.length > 0) {
+      console.warn(
+        `frozen-tree stale story citations (not gated):\n${stale
+          .map((ref) => `  ${ref.file}:${ref.line} ${ref.slug}`)
+          .join("\n")}`,
+      );
+    }
   });
 
   it("reads each story's status from its own frontmatter", async () => {

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -31,9 +31,6 @@ const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "vendor", "__snapshot
 const SOURCE_ROOTS = ["packages", "scripts", "eslint"];
 
 const MARKDOWN_SKIP_DIRS = new Set([...SKIP_DIRS, "tasks"]);
-// Frozen by RFC 0011 Phase 4: CI's `Docs ActiveRecord Freeze` job fails any PR
-// that edits a file here, so a stale citation in this tree has no legal fix and
-// cannot be gated. It is scanned as an inventory instead.
 const FROZEN_MARKDOWN_TREES = [path.join("docs", "activerecord")];
 
 // Its test states a stale promise verbatim as a fixture, and the line-based
@@ -194,10 +191,11 @@ export async function collectFrozenMarkdownFiles(root: string): Promise<string[]
 }
 
 /**
- * Every pending citation in the frozen trees. This is an inventory, not a gate:
- * the prose cannot legally be edited, so a finding here is a note for the
- * freeze cutover rather than a failure. Kept out of `scanStoryReferences` so
- * the hard gate stays scoped to the editable tree.
+ * Every pending citation in the frozen trees — `docs/activerecord/`, frozen by
+ * RFC 0011 Phase 4, whose prose CI's `Docs ActiveRecord Freeze` job forbids
+ * editing. This is an inventory, not a gate: a finding here has no legal fix,
+ * so it is a note for the freeze cutover rather than a failure. Kept out of
+ * `scanStoryReferences` so the hard gate stays scoped to the editable tree.
  */
 export async function scanFrozenStoryReferences(repoRoot: string): Promise<StoryReference[]> {
   const refs: StoryReference[] = [];

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -31,7 +31,10 @@ const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "vendor", "__snapshot
 const SOURCE_ROOTS = ["packages", "scripts", "eslint"];
 
 const MARKDOWN_SKIP_DIRS = new Set([...SKIP_DIRS, "tasks"]);
-const MARKDOWN_SKIP_TREES = [path.join("docs", "activerecord")];
+// Frozen by RFC 0011 Phase 4: CI's `Docs ActiveRecord Freeze` job fails any PR
+// that edits a file here, so a stale citation in this tree has no legal fix and
+// cannot be gated. It is scanned as an inventory instead.
+const FROZEN_MARKDOWN_TREES = [path.join("docs", "activerecord")];
 
 // Its test states a stale promise verbatim as a fixture, and the line-based
 // scan reads that template literal as a real comment.
@@ -150,9 +153,9 @@ export async function collectSourceFiles(
  * checkout of the tasks repo (a symlink in agent worktrees, so it is never
  * walked as a directory anyway; the name is excluded so a plain checkout
  * behaves the same way) whose story files legitimately cite landed stories as
- * dependencies and provenance. `docs/activerecord/` is frozen by RFC 0011 Phase
- * 4 — CI's `Docs ActiveRecord Freeze` job fails any PR that edits it, so a
- * finding there could not be resolved by correcting the prose.
+ * dependencies and provenance. The frozen trees are left to
+ * `collectFrozenMarkdownFiles` — a finding there could not be resolved by
+ * correcting the prose, so it is inventoried rather than gated.
  */
 export async function collectMarkdownFiles(
   root: string,
@@ -168,7 +171,7 @@ export async function collectMarkdownFiles(
   for (const entry of entries) {
     const abs = path.join(dir, entry.name);
     const rel = path.relative(root, abs);
-    if (MARKDOWN_SKIP_TREES.includes(rel)) continue;
+    if (FROZEN_MARKDOWN_TREES.includes(rel)) continue;
     if (entry.isDirectory()) {
       if (!MARKDOWN_SKIP_DIRS.has(entry.name)) await collectMarkdownFiles(root, abs, acc);
     } else if (entry.name.endsWith(".md")) {
@@ -176,6 +179,34 @@ export async function collectMarkdownFiles(
     }
   }
   return acc;
+}
+
+/**
+ * Repo-relative `.md` paths under the frozen trees `collectMarkdownFiles`
+ * leaves out — the population the inventory covers.
+ */
+export async function collectFrozenMarkdownFiles(root: string): Promise<string[]> {
+  const acc: string[] = [];
+  for (const tree of FROZEN_MARKDOWN_TREES) {
+    await collectMarkdownFiles(root, path.join(root, tree), acc);
+  }
+  return acc;
+}
+
+/**
+ * Every pending citation in the frozen trees. This is an inventory, not a gate:
+ * the prose cannot legally be edited, so a finding here is a note for the
+ * freeze cutover rather than a failure. Kept out of `scanStoryReferences` so
+ * the hard gate stays scoped to the editable tree.
+ */
+export async function scanFrozenStoryReferences(repoRoot: string): Promise<StoryReference[]> {
+  const refs: StoryReference[] = [];
+  for (const file of await collectFrozenMarkdownFiles(repoRoot)) {
+    refs.push(
+      ...extractMarkdownStoryReferences(await readFile(path.join(repoRoot, file), "utf8"), file),
+    );
+  }
+  return refs;
 }
 
 /** Every pending citation in the source roots this check covers. */


### PR DESCRIPTION
`scripts/stale-story-references.ts` excluded `docs/activerecord/` from the
markdown scan outright, so stale story citations there were unguarded forever.
The exclusion reason is real — the tree is frozen by RFC 0011 Phase 4 and CI's
`Docs ActiveRecord Freeze` job fails any PR that edits it, so a finding there
has no legal fix — but that argues against *gating* it, not against *seeing* it.

This routes the tree into a separate, non-failing inventory:

- `FROZEN_MARKDOWN_TREES` (was `MARKDOWN_SKIP_TREES`) now names the population
  the inventory covers as well as the one `collectMarkdownFiles` skips.
- `collectFrozenMarkdownFiles` / `scanFrozenStoryReferences` walk and scan just
  those trees, kept out of `scanStoryReferences` so the hard gate stays scoped
  to the editable tree — its behavior is unchanged.
- A test reports the inventory (warning, not assertion) and asserts only that
  the population is non-empty, so the inventory cannot quietly stop covering
  the tree.

The tree is clean today: 3 pending citations across the 4 files, none naming a
landed story.

`pnpm vitest run scripts/stale-story-references.test.ts` — 17 passed.

Closes-story: cover-frozen-docs-activerecord-in-stale-story-scan
