### PR TITLE
feat(i18n): converge handle_exception's Symbol handler arm

### DIFF
--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -25,8 +25,9 @@ export interface Backend {
  * Ruby's handler is a Symbol naming a method on `I18n`, a Proc, or any object
  * responding to `#call`; a JS function carries `Function#call`, whose first
  * argument is a receiver, so the latter two arms stay distinct here and
- * `handle_exception` dispatches on all three. The Symbol arm is a string, since
- * it has to name a member of the `I18n` module for `send` to reach.
+ * `handle_exception` dispatches on all three. The Symbol arm is a string that
+ * keeps its leading colon (`":customExceptionHandler"`), naming the member of
+ * the `I18n` module `send` reaches.
  */
 export type ExceptionHandlerLike =
   | string

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -22,11 +22,14 @@ export interface Backend {
 }
 
 /**
- * Ruby's handler is a Proc or any object responding to `#call`; a JS function
- * carries `Function#call`, whose first argument is a receiver, so the two arms
- * stay distinct here and `handle_exception` dispatches on them.
+ * Ruby's handler is a Symbol naming a method on `I18n`, a Proc, or any object
+ * responding to `#call`; a JS function carries `Function#call`, whose first
+ * argument is a receiver, so the latter two arms stay distinct here and
+ * `handle_exception` dispatches on all three. The Symbol arm is a string, since
+ * it has to name a member of the `I18n` module for `send` to reach.
  */
 export type ExceptionHandlerLike =
+  | string
   | ((exception: Error, locale: Locale, key: TranslationKey, options: unknown) => unknown)
   | { call(exception: Error, locale: Locale, key: TranslationKey, options: unknown): unknown };
 

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -43,20 +43,12 @@ describe("I18nTest", () => {
     backend.storeTranslations(locale, data);
   }
 
-  /**
-   * Mocha's `I18n.expects(:custom_exception_handler)` defines the method on the
-   * `I18n` singleton for the duration of the test; the module namespace is what
-   * `handleException` sends to, so this defines it there.
-   */
+  /** Mocha's `I18n.expects(:custom_exception_handler)`: defines the method on `I18n`. */
   function expectsCustomExceptionHandler(): ReturnType<typeof vi.fn> {
     const customExceptionHandler = vi.fn();
     (I18n as unknown as Record<string, unknown>).customExceptionHandler = customExceptionHandler;
     return customExceptionHandler;
   }
-
-  afterEach(() => {
-    delete (I18n as unknown as Record<string, unknown>).customExceptionHandler;
-  });
 
   beforeEach(() => {
     resetConfig();
@@ -70,10 +62,14 @@ describe("I18nTest", () => {
     storeTranslations("en", { true: "Yes", false: "No" });
   });
 
+  afterEach(() => {
+    delete (I18n as unknown as Record<string, unknown>).customExceptionHandler;
+  });
+
   it("can set the exception_handler", () => {
     const previousExceptionHandler = exceptionHandler();
     try {
-      expect(() => setExceptionHandler("customExceptionHandler")).not.toThrow();
+      expect(() => setExceptionHandler(":customExceptionHandler")).not.toThrow();
     } finally {
       setExceptionHandler(previousExceptionHandler);
     }
@@ -82,7 +78,7 @@ describe("I18nTest", () => {
   it("uses a custom exception handler set to I18n.exception_handler", () => {
     const previousExceptionHandler = exceptionHandler();
     try {
-      setExceptionHandler("customExceptionHandler");
+      setExceptionHandler(":customExceptionHandler");
       const customExceptionHandler = expectsCustomExceptionHandler();
       translate("bogus");
       expect(customExceptionHandler).toHaveBeenCalled();
@@ -93,7 +89,7 @@ describe("I18nTest", () => {
 
   it("uses a custom exception handler passed as an option", () => {
     const customExceptionHandler = expectsCustomExceptionHandler();
-    translate("bogus", { exceptionHandler: "customExceptionHandler" });
+    translate("bogus", { exceptionHandler: ":customExceptionHandler" });
     expect(customExceptionHandler).toHaveBeenCalled();
   });
 

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -43,7 +43,12 @@ describe("I18nTest", () => {
     backend.storeTranslations(locale, data);
   }
 
-  /** Mocha's `I18n.expects(:custom_exception_handler)`: defines the method on `I18n`. */
+  /**
+   * Mocha's `I18n.expects(:custom_exception_handler)`: defines the method on
+   * `I18n` for the duration of the test. Vitest's module namespace is
+   * extensible, so the method installs on the same object `handleException`
+   * sends to.
+   */
   function expectsCustomExceptionHandler(): ReturnType<typeof vi.fn> {
     const customExceptionHandler = vi.fn();
     (I18n as unknown as Record<string, unknown>).customExceptionHandler = customExceptionHandler;
@@ -450,18 +455,6 @@ describe("I18nTest", () => {
   it("I18n.enforce_available_locales config can be set to false", () => {
     config().enforceAvailableLocales = false;
     expect(config().enforceAvailableLocales).toBe(false);
-  });
-
-  it("can set the exception_handler", () => {
-    const customExceptionHandler = vi.fn();
-    expect(() => setExceptionHandler(customExceptionHandler)).not.toThrow();
-  });
-
-  it("uses a custom exception handler set to I18n.exception_handler", () => {
-    const customExceptionHandler = vi.fn();
-    setExceptionHandler(customExceptionHandler);
-    translate("bogus");
-    expect(customExceptionHandler).toHaveBeenCalled();
   });
 
   it("available_locales can be replaced at runtime", () => {

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -45,9 +45,9 @@ describe("I18nTest", () => {
 
   /**
    * Mocha's `I18n.expects(:custom_exception_handler)`: defines the method on
-   * `I18n` for the duration of the test. Vitest's module namespace is
-   * extensible, so the method installs on the same object `handleException`
-   * sends to.
+   * `I18n` for the duration of the test. A native module namespace is
+   * non-extensible; Vitest's transformed one is not, so the method installs on
+   * the same object `handleException` sends to.
    */
   function expectsCustomExceptionHandler(): ReturnType<typeof vi.fn> {
     const customExceptionHandler = vi.fn();

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -1,7 +1,8 @@
 /** Mirrors: i18n/test/i18n_test.rb */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ArgumentError, Disabled, InvalidLocale } from "./exceptions.js";
+import * as I18n from "./i18n.js";
 import {
   RESERVED_KEYS,
   availableLocales,
@@ -9,6 +10,7 @@ import {
   defaultLocale,
   defaultSeparator,
   enforceAvailableLocalesBang,
+  exceptionHandler,
   exists,
   interpolationKeys,
   locale,
@@ -41,6 +43,21 @@ describe("I18nTest", () => {
     backend.storeTranslations(locale, data);
   }
 
+  /**
+   * Mocha's `I18n.expects(:custom_exception_handler)` defines the method on the
+   * `I18n` singleton for the duration of the test; the module namespace is what
+   * `handleException` sends to, so this defines it there.
+   */
+  function expectsCustomExceptionHandler(): ReturnType<typeof vi.fn> {
+    const customExceptionHandler = vi.fn();
+    (I18n as unknown as Record<string, unknown>).customExceptionHandler = customExceptionHandler;
+    return customExceptionHandler;
+  }
+
+  afterEach(() => {
+    delete (I18n as unknown as Record<string, unknown>).customExceptionHandler;
+  });
+
   beforeEach(() => {
     resetConfig();
     resetClassConfig();
@@ -53,9 +70,30 @@ describe("I18nTest", () => {
     storeTranslations("en", { true: "Yes", false: "No" });
   });
 
+  it("can set the exception_handler", () => {
+    const previousExceptionHandler = exceptionHandler();
+    try {
+      expect(() => setExceptionHandler("customExceptionHandler")).not.toThrow();
+    } finally {
+      setExceptionHandler(previousExceptionHandler);
+    }
+  });
+
+  it("uses a custom exception handler set to I18n.exception_handler", () => {
+    const previousExceptionHandler = exceptionHandler();
+    try {
+      setExceptionHandler("customExceptionHandler");
+      const customExceptionHandler = expectsCustomExceptionHandler();
+      translate("bogus");
+      expect(customExceptionHandler).toHaveBeenCalled();
+    } finally {
+      setExceptionHandler(previousExceptionHandler);
+    }
+  });
+
   it("uses a custom exception handler passed as an option", () => {
-    const customExceptionHandler = vi.fn();
-    translate("bogus", { exceptionHandler: customExceptionHandler });
+    const customExceptionHandler = expectsCustomExceptionHandler();
+    translate("bogus", { exceptionHandler: "customExceptionHandler" });
     expect(customExceptionHandler).toHaveBeenCalled();
   });
 

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -371,7 +371,7 @@ function translateKey(
  *
  * Examples:
  *
- *   I18n.setExceptionHandler("customExceptionHandler")
+ *   I18n.setExceptionHandler(":customExceptionHandler")
  *   I18n.customExceptionHandler(exception, locale, key, options)  // will be called like this
  *
  *   I18n.setExceptionHandler((...args) => { ... })                // a lambda
@@ -396,17 +396,15 @@ function handleException(
       const handler = truthy(options.exceptionHandler)
         ? (options.exceptionHandler as ExceptionHandlerLike)
         : config().exceptionHandler;
-      if (typeof handler === "string") {
-        return (I18n as unknown as Record<string, (...args: unknown[]) => unknown>)[handler](
-          exception,
-          locale,
-          key as TranslationKey,
-          options,
-        );
+      if (typeof handler === "string" && handler.startsWith(":")) {
+        return (I18n as unknown as Record<string, (...args: unknown[]) => unknown>)[
+          handler.slice(1)
+        ](exception, locale, key as TranslationKey, options);
       }
-      return typeof handler === "function"
-        ? handler(exception, locale, key as TranslationKey, options)
-        : handler.call(exception, locale, key as TranslationKey, options);
+      const callable = handler as Exclude<ExceptionHandlerLike, string>;
+      return typeof callable === "function"
+        ? callable(exception, locale, key as TranslationKey, options)
+        : callable.call(exception, locale, key as TranslationKey, options);
     }
   }
 }

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -4,6 +4,11 @@
  * cache; both land with their own stories (RFC 0074).
  */
 
+/**
+ * Ruby's `send(handler, ...)` in `handle_exception` dispatches on the `I18n`
+ * module itself; this self-import is that receiver.
+ */
+import * as I18n from "./i18n.js";
 import type { Backend, ExceptionHandlerLike } from "./config.js";
 import { Config } from "./config.js";
 import { ArgumentError, Disabled, InvalidLocale, MissingTranslation } from "./exceptions.js";
@@ -357,12 +362,23 @@ function translateKey(
 
 /**
  * Any exceptions thrown in translate will be sent to the exception_handler
- * which can be a Proc or any other Object unless they're forced to be raised
- * or thrown (MissingTranslation).
+ * which can be a Symbol, a Proc or any other Object unless they're forced to
+ * be raised or thrown (MissingTranslation).
  *
- * @missingRailsCall send — Ruby's `Symbol` handler arm sends the handler name
- * to `I18n`; `config.exceptionHandler` is typed as a callable here, so the
- * name-of-a-method form has no representable value.
+ * If exception_handler is a Symbol then it will simply be sent to I18n as
+ * a method call. A Proc will simply be called. In any other case the
+ * method #call will be called on the exception_handler object.
+ *
+ * Examples:
+ *
+ *   I18n.setExceptionHandler("customExceptionHandler")
+ *   I18n.customExceptionHandler(exception, locale, key, options)  // will be called like this
+ *
+ *   I18n.setExceptionHandler((...args) => { ... })                // a lambda
+ *   I18n.exceptionHandler()(exception, locale, key, options)      // will be called like this
+ *
+ *   I18n.setExceptionHandler(new I18nExceptionHandler())          // an object
+ *   I18n.exceptionHandler().call(exception, locale, key, options) // will be called like this
  */
 function handleException(
   handling: "raise" | "throw" | false,
@@ -380,6 +396,14 @@ function handleException(
       const handler = truthy(options.exceptionHandler)
         ? (options.exceptionHandler as ExceptionHandlerLike)
         : config().exceptionHandler;
+      if (typeof handler === "string") {
+        return (I18n as unknown as Record<string, (...args: unknown[]) => unknown>)[handler](
+          exception,
+          locale,
+          key as TranslationKey,
+          options,
+        );
+      }
       return typeof handler === "function"
         ? handler(exception, locale, key as TranslationKey, options)
         : handler.call(exception, locale, key as TranslationKey, options);

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -9,6 +9,12 @@
  * module itself; this self-import is that receiver. A Symbol handler therefore
  * names an export of this module, which is what `I18n.custom_exception_handler`
  * is in the gem (i18n.rb:415-416).
+ *
+ * A Ruby module is open and a module namespace object is not: ECMA-262 makes it
+ * a non-extensible exotic object, so a handler method installed after load —
+ * Ruby's `module I18n; def self.custom_exception_handler` reopening, or mocha's
+ * `I18n.expects` — has no representable form outside a test transform. Every
+ * handler that names a real export dispatches exactly as the gem's does.
  */
 import * as I18n from "./i18n.js";
 import type { Backend, ExceptionHandlerLike } from "./config.js";

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -6,7 +6,9 @@
 
 /**
  * Ruby's `send(handler, ...)` in `handle_exception` dispatches on the `I18n`
- * module itself; this self-import is that receiver.
+ * module itself; this self-import is that receiver. A Symbol handler therefore
+ * names an export of this module, which is what `I18n.custom_exception_handler`
+ * is in the gem (i18n.rb:415-416).
  */
 import * as I18n from "./i18n.js";
 import type { Backend, ExceptionHandlerLike } from "./config.js";


### PR DESCRIPTION
Ports the `Symbol` arm of `handle_exception` (`vendor/i18n/lib/i18n.rb:423-437`),
which #6000 dropped behind a `@missingRailsCall send` tag.

- `ExceptionHandlerLike` (`config.ts`) gains the Symbol arm: a Ruby Symbol
  spelled as a colon-prefixed string (`":customExceptionHandler"`, the
  convention already used for `format` in `backend/base.ts`), naming a method on
  the `I18n` module — alongside the callable and `#call`-object arms.
- `handleException` dispatches all three in the gem's branch order: Symbol
  first, then the `else` arm's callable / `#call` split. `send`'s receiver is
  the `I18n` module itself, so the module self-imports its own namespace. The
  `@missingRailsCall send` tag is deleted, and the doc comment now mirrors
  `i18n.rb:405-422`. A String handler (no leading colon) still falls to the
  `else` arm, as it does in Ruby.
- Tests: "can set the exception_handler" and "uses a custom exception handler set
  to I18n.exception_handler" land verbatim from `i18n_test.rb:147-165`, and
  "uses a custom exception handler passed as an option" (`i18n_test.rb:167-170`)
  moves from the callable form to the Symbol form the gem test uses. The
  callable and `#call` arms stay covered by the two existing "can use a lambda /
  an object responding to #call as an exception handler" tests.
  `expectsCustomExceptionHandler` is the local analogue of mocha's
  `I18n.expects(:custom_exception_handler)`, which defines the method on the
  `I18n` singleton for the duration of a test.

Gates: `api:calls` OK (14 baselined, unchanged), `api:calls:wide` OK, no new
public surface, `packages/i18n` suite green (184 tests).

Closes-story: i18n-exception-handler-symbol-arm

## Review round 1

- **Duplicate cases (fixed).** `main` had picked up callable-form copies of
  "can set the exception_handler" and "uses a custom exception handler set to
  I18n.exception_handler"; `i18n_test.rb:147-165` has one of each, in the
  Symbol form. Both copies are deleted, leaving the verbatim Symbol-form pair.
  The callable and `#call` arms remain covered by "can use a lambda as an
  exception handler" / "can use an object responding to #call as an exception
  handler".
- **`send` receiver (no change; justification).** A Symbol handler in the gem
  names a method *defined on* `I18n` — `I18n.custom_exception_handler`
  (`i18n.rb:415-416`) — and the module namespace holds exactly those exports,
  in every runtime. Installing a method at runtime is a test affordance
  (mocha's `expects`); Vitest's module namespace is extensible, verified by the
  two passing cases, so `expectsCustomExceptionHandler` installs on the same
  object `handleException` sends to. The alternative — a bespoke mutable method
  registry — is surface the gem does not have.

## Review round 2

- **`send` receiver — reproduced, and held with a receipt.** Importing
  `packages/i18n/dist/i18n.js` under Node does report
  `Object.isExtensible(I18n) === false` and throws on assignment; the finding is
  accurate. It is also a language-level fact, not a porting shortcut: ECMA-262
  makes a module namespace a non-extensible exotic object, whereas a Ruby module
  is open. So the half of the analogue that survives is the half that matters at
  runtime — a Symbol handler naming a real export of `I18n`, which is what the
  gem documents (`i18n.rb:415-416`) and what production code writes. Only
  after-load installation (Ruby reopening the module, or mocha's `expects`) has
  no representable form, and that is a test affordance Vitest's transformed
  namespace supplies. The receipt now sits at the self-import in `i18n.ts` and
  at `expectsCustomExceptionHandler`. The alternative — routing `send` through a
  bespoke mutable method table so a name can be installed at runtime — is
  indirection the gem does not have, and `api:extra` would count it.
