### PR TITLE
test(i18n): port backend/exceptions_test.rb

### DIFF
--- a/packages/i18n/src/backend/exceptions.test.ts
+++ b/packages/i18n/src/backend/exceptions.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Mirrors: i18n/test/backend/exceptions_test.rb
+ *
+ * Two cases stay measured as missing rather than being faked:
+ *
+ * - the `#localize` case, since `Backend::Base#localize`
+ *   (i18n/lib/i18n/backend/base.rb:78) lands with the `i18n-backend-localize`
+ *   story;
+ * - the `MissingInterpolationArgument` case, which passes the String `'key'`
+ *   and expects `key.inspect` to render `"key"`
+ *   (i18n/lib/i18n/exceptions.rb:102). Ruby Symbols have no JS analogue, so a
+ *   trails interpolation key is a plain string and the message renders it as a
+ *   Symbol — which is what the every-day path and
+ *   `i18n/test/i18n/exceptions_test.rb:59` (ported in
+ *   `../exceptions.trails.test.ts`) require. The two Rails cases cannot both
+ *   hold off one representation.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { MissingTranslationData } from "../exceptions.js";
+import { config, resetConfig, setBackend, t } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import { catchException } from "../throw-catch.js";
+import { Simple } from "./simple.js";
+
+describe("I18nBackendExceptionsTest", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    setBackend(new Simple());
+    config().enforceAvailableLocales = false;
+  });
+
+  it("throw message: MissingTranslation message from #translate includes the given scope and full key", () => {
+    const exception = catchException(() => t("baz.missing", { scope: "foo.bar", throw: true }));
+    expect((exception as Error).message).toBe("Translation missing: en.foo.bar.baz.missing");
+  });
+
+  it("exceptions: MissingTranslationData message from #translate includes the given scope and full key", () => {
+    let exception: MissingTranslationData | undefined;
+    try {
+      t("baz.missing", { scope: "foo.bar", raise: true });
+    } catch (error) {
+      if (!(error instanceof MissingTranslationData)) throw error;
+      exception = error;
+    }
+    expect(exception!.message).toBe("Translation missing: en.foo.bar.baz.missing");
+  });
+});

--- a/packages/i18n/src/backend/exceptions.test.ts
+++ b/packages/i18n/src/backend/exceptions.test.ts
@@ -1,27 +1,31 @@
 /**
  * Mirrors: i18n/test/backend/exceptions_test.rb
  *
- * Two cases stay measured as missing rather than being faked:
- *
- * - the `#localize` case, since `Backend::Base#localize`
- *   (i18n/lib/i18n/backend/base.rb:78) lands with the `i18n-backend-localize`
- *   story;
- * - the `MissingInterpolationArgument` case, which passes the String `'key'`
- *   and expects `key.inspect` to render `"key"`
- *   (i18n/lib/i18n/exceptions.rb:102). Ruby Symbols have no JS analogue, so a
- *   trails interpolation key is a plain string and the message renders it as a
- *   Symbol — which is what the every-day path and
- *   `i18n/test/i18n/exceptions_test.rb:59` (ported in
- *   `../exceptions.trails.test.ts`) require. The two Rails cases cannot both
- *   hold off one representation.
+ * The `MissingInterpolationArgument` case stays measured as missing rather
+ * than faked: it passes the String `'key'` and expects `key.inspect` to render
+ * `"key"` (i18n/lib/i18n/exceptions.rb:102), while the message renders every
+ * key as a Symbol (`:key`) — which is what `i18n/test/i18n/exceptions_test.rb:59`
+ * (ported in `../exceptions.trails.test.ts`) needs, since interpolation keys
+ * reach it as bare strings rather than the colon-prefixed spelling. Converging
+ * that representation is the `i18n-interpolation-key-symbol-spelling` story.
  */
-
 import { beforeEach, describe, expect, it } from "vitest";
 import { MissingTranslationData } from "../exceptions.js";
-import { config, resetConfig, setBackend, t } from "../i18n.js";
+import { config, l, resetConfig, setBackend, t } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { catchException } from "../throw-catch.js";
 import { Simple } from "./simple.js";
+
+/**
+ * Stands in for `Time.now`: `localize` duck-types its object off `strftime`
+ * and `sec`, and this case raises at the format lookup before `strftime` runs.
+ */
+const timeNow = {
+  sec: 0,
+  strftime(format: string): string {
+    return format;
+  },
+};
 
 describe("I18nBackendExceptionsTest", () => {
   beforeEach(() => {
@@ -45,5 +49,15 @@ describe("I18nBackendExceptionsTest", () => {
       exception = error;
     }
     expect(exception!.message).toBe("Translation missing: en.foo.bar.baz.missing");
+  });
+  it("exceptions: MissingTranslationData message from #localize includes the given scope and full key", () => {
+    let exception: MissingTranslationData | undefined;
+    try {
+      l(timeNow, { format: ":foo" });
+    } catch (error) {
+      if (!(error instanceof MissingTranslationData)) throw error;
+      exception = error;
+    }
+    expect(exception!.message).toBe("Translation missing: en.time.formats.foo");
   });
 });


### PR DESCRIPTION
Ports `i18n/test/backend/exceptions_test.rb` into `packages/i18n/src/backend/exceptions.test.ts` under verbatim Rails names: the `:throw => true` and `:raise => true` arms of `#translate`, and the `#localize` case (now portable — `Backend::Base#localize` landed on main).

The `MissingInterpolationArgument` case stays measured as missing (nothing added to `unported-files.ts`): it passes the String `'key'` and expects `key.inspect` → `"key"` (`i18n/lib/i18n/exceptions.rb:102`), while `exceptions.ts` colon-prefixes every key, which is what `i18n/test/i18n/exceptions_test.rb:59` needs today. Converging that to the settled colon-in-the-string Symbol spelling is filed as `i18n-interpolation-key-symbol-spelling`; the reason is recorded at the file header.

`test:compare --package i18n`: `backend/exceptions_test.rb` 0/4 → 3/4.

Closes-story: i18n-backend-exceptions-test-port