### PR TITLE
feat(activesupport): answer mon on TimeWithZone for the I18n localize duck type

### DIFF
--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -82,6 +82,12 @@ describe("TimeWithZoneTest", () => {
     expect(twz.wday).toBe(1); // Monday
   });
 
+  it("returns mon (alias of month)", () => {
+    const twz = eastern.local(2024, 2, 1, 12, 0, 0);
+    expect(twz.mon).toBe(2);
+    expect(twz.mon).toBe(twz.month);
+  });
+
   it("returns yday (day of year)", () => {
     const twz = eastern.local(2024, 2, 1, 12, 0, 0);
     expect(twz.yday).toBe(32); // Jan has 31 days, so Feb 1 = 32

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -213,6 +213,11 @@ export class TimeWithZone {
   }
 
   /** 1-12 */
+  get mon(): number {
+    return this._local().month;
+  }
+
+  /** 1-12 */
   get month(): number {
     return this._local().month;
   }


### PR DESCRIPTION
`I18n::Backend::Base#localize` (`packages/i18n/src/backend/base.ts:168`) duck-types
its argument on `strftime`, `wday`, `mon`, `hour` and `sec`. `TimeWithZone` answered
all of those except `mon` — it spelled it `month` only — so `%b` / `%B` resolved
against `undefined`.

Rails delegates `year mon month day mday wday yday hour min sec usec nsec to_date`
to the wrapped `time`
(`vendor/rails/activesupport/lib/active_support/time_with_zone.rb:440`); `mon` is
added in that list's position, immediately before `month`.

### Scope

The story's second acceptance criterion — porting the nine localization cases from
`vendor/rails/activesupport/test/i18n_test.rb:13-48` over `I18n.localize` and a
`TimeWithZone` — is blocked here and is **not** in this PR. Those cases live in
`packages/activesupport/src/i18n.test.ts` and today run against the activesupport
facade (`packages/activesupport/src/i18n.ts:428`), which takes a JS `Date` and its
own `strftime`. Driving them over the shared backend needs activesupport to import
`I18n` from `@blazetrails/i18n`, which is the deliverable of the sibling story
`i18n-consolidate-activesupport-shim` (claimed, unmerged) — rewriting the same nine
cases in the same file now would conflict head-on with that PR.

Filed as `as-i18n-localization-tests-over-shared-i18n` (RFC 0074) with the full
context and Rails citations.

Closes-story: as-i18n-localization-tests
