### PR TITLE
feat(i18n): add storeTranslations to the Config backend interface

### DIFF
--- a/packages/i18n/src/backend/localization.test.ts
+++ b/packages/i18n/src/backend/localization.test.ts
@@ -74,8 +74,8 @@ class RubyTime extends RubyDate {
   }
 }
 
-function setupDateTranslations(backend: Simple): void {
-  backend.storeTranslations("de", {
+function setupDateTranslations(): void {
+  config().backend.storeTranslations("de", {
     date: {
       formats: {
         default: "%d.%m.%Y",
@@ -118,8 +118,8 @@ function setupDateTranslations(backend: Simple): void {
   });
 }
 
-function setupTimeTranslations(backend: Simple): void {
-  backend.storeTranslations("de", {
+function setupTimeTranslations(): void {
+  config().backend.storeTranslations("de", {
     time: {
       formats: {
         default: "%a, %d. %b %Y %H:%M:%S %z",
@@ -140,11 +140,10 @@ describe("I18nSimpleBackendApiTest", () => {
   beforeEach(() => {
     resetConfig();
     resetClassConfig();
-    const backend = new Simple();
-    config().backend = backend;
+    config().backend = new Simple();
     config().enforceAvailableLocales = false;
-    setupDateTranslations(backend);
-    setupTimeTranslations(backend);
+    setupDateTranslations();
+    setupTimeTranslations();
     date = new RubyDate(2008, 3, 1);
     time = new RubyTime(2008, 3, 1, 6, 0);
     otherTime = new RubyTime(2008, 3, 1, 18, 0);

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -15,6 +15,9 @@ class FakeBackend implements Backend {
     this.reloaded += 1;
   }
   eagerLoadBang(): void {}
+  storeTranslations(): unknown {
+    return null;
+  }
   translate(): unknown {
     return null;
   }

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -5,12 +5,18 @@
 import { enforceAvailableLocalesBang, type Locale, type TranslationKey } from "./i18n.js";
 import { ExceptionHandler, MissingInterpolationArgument } from "./exceptions.js";
 import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
+import type { TranslationData } from "./utils.js";
 
 /** The slice of a backend `Config` hands out. */
 export interface Backend {
   availableLocales(): Locale[];
   reloadBang(): void;
   eagerLoadBang(): void;
+  storeTranslations(
+    locale: Locale,
+    data: TranslationData,
+    options?: Record<string, unknown>,
+  ): unknown;
   translate(locale: Locale, key: unknown, options?: Record<string, unknown>): unknown;
   exists(locale: Locale, key: TranslationKey, options?: Record<string, unknown>): boolean;
   localize(

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -35,17 +35,14 @@ import type { TranslationData } from "./utils.js";
 import type { TranslationKey } from "./i18n.js";
 
 describe("I18nTest", () => {
-  let backend: Simple;
-
   function storeTranslations(locale: string, data: TranslationData): void {
-    backend.storeTranslations(locale, data);
+    config().backend.storeTranslations(locale, data);
   }
 
   beforeEach(() => {
     resetConfig();
     resetClassConfig();
-    backend = new Simple();
-    config().backend = backend;
+    config().backend = new Simple();
     config().enforceAvailableLocales = false;
 
     storeTranslations("en", { currency: { format: { separator: ".", delimiter: "," } } });
@@ -60,20 +57,20 @@ describe("I18nTest", () => {
   });
 
   it("delegates translate calls to the backend", () => {
-    const spy = vi.spyOn(backend, "translate");
+    const spy = vi.spyOn(config().backend, "translate");
     translate("foo", { locale: "de" });
     expect(spy).toHaveBeenCalledWith("de", "foo", {});
   });
 
   it("delegates localize calls to the backend", () => {
     const spy = vi.fn();
-    (backend as unknown as { localize: unknown }).localize = spy;
+    config().backend.localize = spy;
     localize("whatever", { locale: "de" });
     expect(spy).toHaveBeenCalledWith("de", "whatever", ":default", {});
   });
 
   it("translate given no locale uses the current locale", () => {
-    const spy = vi.spyOn(backend, "translate");
+    const spy = vi.spyOn(config().backend, "translate");
     translate("foo");
     expect(spy).toHaveBeenCalledWith("en", "foo", {});
   });
@@ -438,8 +435,7 @@ describe("I18nTest", () => {
   });
 
   it("I18n.reload! reloads the set of locales that are enforced", () => {
-    backend = new Simple();
-    setBackend(backend);
+    setBackend(new Simple());
 
     expect(availableLocales()).not.toContain("de");
 


### PR DESCRIPTION
Declares `storeTranslations` on the `Backend` interface `Config#backend` hands out.

The gem has no backend slice: `I18n.backend` is a backend, and `store_translations` is part of `I18n::Backend::Base` (`vendor/i18n/lib/i18n/backend/base.rb:22-25`) alongside `translate`, `exists?` and `localize`. The declaration goes in the position `Base` defines it, before `translate`.

With it, the test setup reaches translations through `config().backend` the way the gem tests call `I18n.backend.store_translations(...)`, so `localization.test.ts` and `i18n.test.ts` no longer hold a separate `Simple` reference.

Closes-story: i18n-backend-interface-store-translations
