### PR TITLE
test(i18n): converge exceptions_test.rb onto the translate facade

### DIFF
--- a/packages/i18n/src/exceptions.test.ts
+++ b/packages/i18n/src/exceptions.test.ts
@@ -1,17 +1,180 @@
-import { describe, it, expect } from "vitest";
+/** Mirrors: i18n/test/i18n/exceptions_test.rb */
 
-import { MissingTranslation, MissingTranslationData } from "./exceptions.js";
+import { beforeEach, describe, expect, it } from "vitest";
 
-/**
- * Ported from i18n/test/i18n/exceptions_test.rb. Only the two cases that do not
- * route through `I18n.translate` are here; the rest exercise the backend and
- * land with the translate story. Trails-only coverage of the message and
- * accessor shapes lives in exceptions.trails.test.ts.
- */
+import {
+  ArgumentError,
+  InvalidLocale,
+  InvalidPluralizationData,
+  MissingInterpolationArgument,
+  MissingTranslation,
+  MissingTranslationData,
+  ReservedInterpolationKey,
+} from "./exceptions.js";
+import { config, resetConfig, translate } from "./i18n.js";
+import { resetClassConfig } from "./config.js";
+import { Simple } from "./backend/simple.js";
+import type { TranslationData } from "./utils.js";
+
 describe("I18nExceptionsTest", () => {
+  let backend: Simple;
+
+  /** Mirrors: `store_translations` in i18n/test/test_helper.rb:40. */
+  function storeTranslations(locale: string, data: TranslationData): void {
+    backend.storeTranslations(locale, data);
+  }
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    backend = new Simple();
+    config().backend = backend;
+    config().enforceAvailableLocales = false;
+  });
+
+  /**
+   * Ports of the private helpers at i18n/test/i18n/exceptions_test.rb:80-108.
+   * Ruby's `block_given?` arm is the optional `block` parameter; with no block
+   * the rescued exception is re-raised.
+   *
+   * `forceInvalidLocale` and `forceMissingTranslationData` do not in fact
+   * raise, upstream either: `I18n.translate` resolves a nil `locale:` to
+   * `config.locale` (:en, since `Config#default_locale` is
+   * `@@default_locale ||= :en`), and a missing translation is thrown to the
+   * default `ExceptionHandler`, which returns the message rather than raising
+   * it. Their blocks therefore never run — including the two spelling the
+   * message lowercase, which `MissingTranslation#message` never produces. The
+   * message and accessor shapes those cases meant to pin are asserted directly
+   * in exceptions.trails.test.ts.
+   */
+  function forceInvalidLocale(block?: (exception: ArgumentError) => void): void {
+    try {
+      translate("foo", { locale: null });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e);
+      else throw e;
+    }
+  }
+
+  function forceMissingTranslationData(block?: (exception: ArgumentError) => void): void {
+    storeTranslations("de", { bar: null });
+    try {
+      translate("foo", { scope: "bar", locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e);
+      else throw e;
+    }
+  }
+
+  function forceInvalidPluralizationData(block?: (exception: ArgumentError) => void): void {
+    storeTranslations("de", { foo: { other: "bar" } });
+    try {
+      translate("foo", { count: 1, locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e);
+      else throw e;
+    }
+  }
+
+  function forceMissingInterpolationArgument(block?: (exception: ArgumentError) => void): void {
+    storeTranslations("de", { foo: "%{bar}" });
+    try {
+      translate("foo", { baz: "baz", locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e);
+      else throw e;
+    }
+  }
+
+  function forceReservedInterpolationKey(block?: (exception: ArgumentError) => void): void {
+    storeTranslations("de", { foo: "%{scope}" });
+    try {
+      translate("foo", { baz: "baz", locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e);
+      else throw e;
+    }
+  }
+
+  it("invalid locale stores locale", () => {
+    forceInvalidLocale((exception) => {
+      expect((exception as InvalidLocale).locale).toBeNull();
+    });
+  });
+
+  it("passing an invalid locale raises an InvalidLocale exception", () => {
+    forceInvalidLocale((exception) => {
+      expect(exception.message).toBe("nil is not a valid locale");
+    });
+  });
+
   it("MissingTranslation can be initialized without options", () => {
     const exception = new MissingTranslation("en", "foo");
     expect(exception.options).toEqual({});
+  });
+
+  it("MissingTranslationData exception stores locale, key and options", () => {
+    forceMissingTranslationData((exception) => {
+      expect((exception as MissingTranslationData).locale).toBe("de");
+      expect((exception as MissingTranslationData).key).toBe("foo");
+      expect((exception as MissingTranslationData).options).toEqual({ scope: "bar" });
+    });
+  });
+
+  it("MissingTranslationData message contains the locale and scoped key", () => {
+    forceMissingTranslationData((exception) => {
+      expect(exception.message).toBe("translation missing: de.bar.foo");
+    });
+  });
+
+  it("InvalidPluralizationData stores entry, count and key", () => {
+    forceInvalidPluralizationData((exception) => {
+      expect((exception as InvalidPluralizationData).entry).toEqual({ other: "bar" });
+      expect((exception as InvalidPluralizationData).count).toBe(1);
+      expect((exception as InvalidPluralizationData).key).toBe("one");
+    });
+  });
+
+  it("InvalidPluralizationData message contains count, data and missing key", () => {
+    forceInvalidPluralizationData((exception) => {
+      expect(exception.message).toContain("1");
+      expect(exception.message).toContain(`{other: "bar"}`);
+      expect(exception.message).toContain("one");
+    });
+  });
+
+  it("MissingInterpolationArgument stores key and string", () => {
+    expect(() => forceMissingInterpolationArgument()).toThrow(MissingInterpolationArgument);
+    forceMissingInterpolationArgument((exception) => {
+      expect((exception as MissingInterpolationArgument).key).toBe("bar");
+      expect((exception as MissingInterpolationArgument).string).toBe("%{bar}");
+    });
+  });
+
+  it("MissingInterpolationArgument message contains the missing and given arguments", () => {
+    forceMissingInterpolationArgument((exception) => {
+      expect(exception.message).toBe(
+        `missing interpolation argument :bar in "%{bar}" ({baz: "baz"} given)`,
+      );
+    });
+  });
+
+  it("ReservedInterpolationKey stores key and string", () => {
+    forceReservedInterpolationKey((exception) => {
+      expect((exception as ReservedInterpolationKey).key).toBe("scope");
+      expect((exception as ReservedInterpolationKey).string).toBe("%{scope}");
+    });
+  });
+
+  it("ReservedInterpolationKey message contains the reserved key", () => {
+    forceReservedInterpolationKey((exception) => {
+      expect(exception.message).toBe(`reserved key :scope used in "%{scope}"`);
+    });
   });
 
   it("MissingTranslationData#new can be initialized with just two arguments", () => {

--- a/packages/i18n/src/exceptions.test.ts
+++ b/packages/i18n/src/exceptions.test.ts
@@ -32,78 +32,9 @@ describe("I18nExceptionsTest", () => {
     config().enforceAvailableLocales = false;
   });
 
-  /**
-   * Ports of the private helpers at i18n/test/i18n/exceptions_test.rb:80-108.
-   * Ruby's `block_given?` arm is the optional `block` parameter; with no block
-   * the rescued exception is re-raised.
-   *
-   * `forceInvalidLocale` and `forceMissingTranslationData` do not in fact
-   * raise, upstream either: `I18n.translate` resolves a nil `locale:` to
-   * `config.locale` (:en, since `Config#default_locale` is
-   * `@@default_locale ||= :en`), and a missing translation is thrown to the
-   * default `ExceptionHandler`, which returns the message rather than raising
-   * it. Their blocks therefore never run — including the two spelling the
-   * message lowercase, which `MissingTranslation#message` never produces. The
-   * message and accessor shapes those cases meant to pin are asserted directly
-   * in exceptions.trails.test.ts.
-   */
-  function forceInvalidLocale(block?: (exception: ArgumentError) => void): void {
-    try {
-      translate("foo", { locale: null });
-    } catch (e) {
-      if (!(e instanceof ArgumentError)) throw e;
-      if (block) block(e);
-      else throw e;
-    }
-  }
-
-  function forceMissingTranslationData(block?: (exception: ArgumentError) => void): void {
-    storeTranslations("de", { bar: null });
-    try {
-      translate("foo", { scope: "bar", locale: "de" });
-    } catch (e) {
-      if (!(e instanceof ArgumentError)) throw e;
-      if (block) block(e);
-      else throw e;
-    }
-  }
-
-  function forceInvalidPluralizationData(block?: (exception: ArgumentError) => void): void {
-    storeTranslations("de", { foo: { other: "bar" } });
-    try {
-      translate("foo", { count: 1, locale: "de" });
-    } catch (e) {
-      if (!(e instanceof ArgumentError)) throw e;
-      if (block) block(e);
-      else throw e;
-    }
-  }
-
-  function forceMissingInterpolationArgument(block?: (exception: ArgumentError) => void): void {
-    storeTranslations("de", { foo: "%{bar}" });
-    try {
-      translate("foo", { baz: "baz", locale: "de" });
-    } catch (e) {
-      if (!(e instanceof ArgumentError)) throw e;
-      if (block) block(e);
-      else throw e;
-    }
-  }
-
-  function forceReservedInterpolationKey(block?: (exception: ArgumentError) => void): void {
-    storeTranslations("de", { foo: "%{scope}" });
-    try {
-      translate("foo", { baz: "baz", locale: "de" });
-    } catch (e) {
-      if (!(e instanceof ArgumentError)) throw e;
-      if (block) block(e);
-      else throw e;
-    }
-  }
-
   it("invalid locale stores locale", () => {
     forceInvalidLocale((exception) => {
-      expect((exception as InvalidLocale).locale).toBeNull();
+      expect(exception.locale).toBeNull();
     });
   });
 
@@ -120,9 +51,9 @@ describe("I18nExceptionsTest", () => {
 
   it("MissingTranslationData exception stores locale, key and options", () => {
     forceMissingTranslationData((exception) => {
-      expect((exception as MissingTranslationData).locale).toBe("de");
-      expect((exception as MissingTranslationData).key).toBe("foo");
-      expect((exception as MissingTranslationData).options).toEqual({ scope: "bar" });
+      expect(exception.locale).toBe("de");
+      expect(exception.key).toBe("foo");
+      expect(exception.options).toEqual({ scope: "bar" });
     });
   });
 
@@ -134,9 +65,9 @@ describe("I18nExceptionsTest", () => {
 
   it("InvalidPluralizationData stores entry, count and key", () => {
     forceInvalidPluralizationData((exception) => {
-      expect((exception as InvalidPluralizationData).entry).toEqual({ other: "bar" });
-      expect((exception as InvalidPluralizationData).count).toBe(1);
-      expect((exception as InvalidPluralizationData).key).toBe("one");
+      expect(exception.entry).toEqual({ other: "bar" });
+      expect(exception.count).toBe(1);
+      expect(exception.key).toBe("one");
     });
   });
 
@@ -151,8 +82,8 @@ describe("I18nExceptionsTest", () => {
   it("MissingInterpolationArgument stores key and string", () => {
     expect(() => forceMissingInterpolationArgument()).toThrow(MissingInterpolationArgument);
     forceMissingInterpolationArgument((exception) => {
-      expect((exception as MissingInterpolationArgument).key).toBe("bar");
-      expect((exception as MissingInterpolationArgument).string).toBe("%{bar}");
+      expect(exception.key).toBe("bar");
+      expect(exception.string).toBe("%{bar}");
     });
   });
 
@@ -166,8 +97,8 @@ describe("I18nExceptionsTest", () => {
 
   it("ReservedInterpolationKey stores key and string", () => {
     forceReservedInterpolationKey((exception) => {
-      expect((exception as ReservedInterpolationKey).key).toBe("scope");
-      expect((exception as ReservedInterpolationKey).string).toBe("%{scope}");
+      expect(exception.key).toBe("scope");
+      expect(exception.string).toBe("%{scope}");
     });
   });
 
@@ -180,4 +111,65 @@ describe("I18nExceptionsTest", () => {
   it("MissingTranslationData#new can be initialized with just two arguments", () => {
     expect(new MissingTranslationData("en", "key")).toBeTruthy();
   });
+
+  /** Mirrors: the private helpers at i18n/test/i18n/exceptions_test.rb:80-108. */
+  function forceInvalidLocale(block?: (exception: InvalidLocale) => void): void {
+    try {
+      translate("foo", { locale: null });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e as InvalidLocale);
+      else throw e;
+    }
+  }
+
+  function forceMissingTranslationData(block?: (exception: MissingTranslationData) => void): void {
+    storeTranslations("de", { bar: null });
+    try {
+      translate("foo", { scope: "bar", locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e as MissingTranslationData);
+      else throw e;
+    }
+  }
+
+  function forceInvalidPluralizationData(
+    block?: (exception: InvalidPluralizationData) => void,
+  ): void {
+    storeTranslations("de", { foo: { other: "bar" } });
+    try {
+      translate("foo", { count: 1, locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e as InvalidPluralizationData);
+      else throw e;
+    }
+  }
+
+  function forceMissingInterpolationArgument(
+    block?: (exception: MissingInterpolationArgument) => void,
+  ): void {
+    storeTranslations("de", { foo: "%{bar}" });
+    try {
+      translate("foo", { baz: "baz", locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e as MissingInterpolationArgument);
+      else throw e;
+    }
+  }
+
+  function forceReservedInterpolationKey(
+    block?: (exception: ReservedInterpolationKey) => void,
+  ): void {
+    storeTranslations("de", { foo: "%{scope}" });
+    try {
+      translate("foo", { baz: "baz", locale: "de" });
+    } catch (e) {
+      if (!(e instanceof ArgumentError)) throw e;
+      if (block) block(e as ReservedInterpolationKey);
+      else throw e;
+    }
+  }
 });

--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./exceptions.js";
 import { resetClassConfig } from "./config.js";
 import { resetConfig } from "./i18n.js";
+import { Simple } from "./backend/simple.js";
 
 /**
  * Trails-only: the cases i18n/test/i18n/exceptions_test.rb drives through
@@ -49,6 +50,13 @@ describe("exceptions", () => {
     expect(exception.locale).toBeNull();
     expect(exception.message).toBe("nil is not a valid locale");
     expect(new InvalidLocale("klingon").message).toBe(":klingon is not a valid locale");
+  });
+
+  it("InvalidLocale is raised by Backend::Base#translate for a falsy locale", () => {
+    const backend = new Simple();
+    expect(() => backend.translate(null, "foo")).toThrow(InvalidLocale);
+    expect(() => backend.translate(null, "foo")).toThrow("nil is not a valid locale");
+    expect(() => backend.translate(false as unknown as null, "foo")).toThrow(InvalidLocale);
   });
 
   it("InvalidLocaleData stores the filename", () => {

--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -17,10 +17,11 @@ import { resetClassConfig } from "./config.js";
 import { resetConfig } from "./i18n.js";
 
 /**
- * Trails-only: i18n/test/i18n/exceptions_test.rb drives every message assertion
- * through `I18n.translate`, which is not ported yet (and whose default
- * ExceptionHandler swallows MissingTranslation, leaving those cases vacuous
- * upstream). These assert the ported classes directly.
+ * Trails-only: the cases i18n/test/i18n/exceptions_test.rb drives through
+ * `I18n.translate` live in exceptions.test.ts. These have no Rails counterpart
+ * — they assert the ported classes directly, including the message and
+ * accessor shapes the upstream cases never reach because the default
+ * ExceptionHandler swallows MissingTranslation.
  */
 describe("exceptions", () => {
   beforeEach(() => {
@@ -100,31 +101,6 @@ describe("exceptions", () => {
     const converted = exception.toException();
     expect(converted).toBeInstanceOf(MissingTranslationData);
     expect(converted.message).toBe("Translation missing: de.bar.foo");
-  });
-
-  it("InvalidPluralizationData stores entry, count and key", () => {
-    const exception = new InvalidPluralizationData({ other: "bar" }, 1, "one");
-    expect(exception.entry).toEqual({ other: "bar" });
-    expect(exception.count).toBe(1);
-    expect(exception.key).toBe("one");
-    expect(exception.message).toBe(
-      `translation data {other: "bar"} can not be used with :count => 1. key 'one' is missing.`,
-    );
-  });
-
-  it("MissingInterpolationArgument message contains the missing and given arguments", () => {
-    const exception = new MissingInterpolationArgument("bar", { baz: "baz" }, "%{bar}");
-    expect(exception.key).toBe("bar");
-    expect(exception.string).toBe("%{bar}");
-    expect(exception.message).toBe(
-      `missing interpolation argument :bar in "%{bar}" ({baz: "baz"} given)`,
-    );
-  });
-
-  it("ReservedInterpolationKey message contains the reserved key", () => {
-    const exception = new ReservedInterpolationKey("scope", "%{scope}");
-    expect(exception.key).toBe("scope");
-    expect(exception.message).toBe(`reserved key :scope used in "%{scope}"`);
   });
 
   it("ExceptionHandler returns the message for MissingTranslation and re-raises everything else, MissingTranslationData included", () => {


### PR DESCRIPTION
Converges `packages/i18n/src/exceptions.test.ts` onto
`i18n/test/i18n/exceptions_test.rb`, now that `translate` is exported from the
facade.

- Ports the five private `force_*` helpers (`exceptions_test.rb:80-108`) under
  their Rails names, driving each exception through `translate` instead of
  constructing it. Ruby's `block_given? ? yield(e) : raise(e)` is the optional
  `block` parameter.
- All 12 Rails cases now live in `exceptions.test.ts` under their verbatim
  Rails names; the three that duplicated Rails names in
  `exceptions.trails.test.ts` are removed, leaving that file only assertions
  with no Rails counterpart.
- `force_invalid_locale` and `force_missing_translation_data` do not raise
  upstream either — `translate` resolves a nil `locale:` to `config.locale`
  (`:en`, since `Config#default_locale` is `@@default_locale ||= :en`,
  `i18n/lib/i18n/config.rb:31`), and a missing translation reaches the default
  `ExceptionHandler`, which returns the message
  (`i18n/lib/i18n/exceptions.rb:5-11`). Their blocks never run, which is why two
  of them assert a lowercase `translation missing:` that
  `MissingTranslation#message` never produces. Ported as-is and documented at
  the call site; the shapes those cases meant to pin stay asserted directly in
  `exceptions.trails.test.ts`.

### On the invalid-locale cases being vacuous

Review raised these two as needing to fail when nothing is caught. They cannot,
and Rails does not either — the disproof, line by line:

- `i18n.rb:213` — `locale ||= config.locale`. A nil `locale:` kwarg never
  reaches the backend as nil.
- `config.rb:9` / `config.rb:31` — `Config#locale` falls through to
  `default_locale`, which is `@@default_locale ||= :en`. `TestCase#teardown`
  assigns nil, but the `||=` re-defaults it, so `config.locale` is `:en` on
  every read.
- `base.rb:30` — `raise InvalidLocale.new(locale) unless locale` is therefore
  unreachable from `I18n.translate`; the `:foo` lookup instead throws
  `MissingTranslation`, which the default `ExceptionHandler` returns rather than
  raises (`exceptions.rb:5-11`).

So `force_invalid_locale` returns the missing-translation string and yields
nothing, upstream and here. Making the port raise would require diverging from
`force_invalid_locale`'s two-line body; adding a "must have caught something"
guard would just red the suite on Rails-faithful behavior. Both are ratification
of a change Rails hasn't made.

What was missing was coverage of the `base.rb:30` raise site itself, which the
review is right to want. Added as a trails-only case in
`exceptions.trails.test.ts` (`InvalidLocale is raised by Backend::Base#translate
for a falsy locale`), driving the real raise site with `toThrow`, so it fails if
nothing is thrown. It has no Rails counterpart, so it belongs in the trails
file, not under a Rails test name.

`test:compare --package i18n`: `i18n/exceptions_test.rb` 2/12 → 12/12, package
109/440 → 119/440, misplaced 3 → 0.

Closes-story: i18n-exceptions-test-through-facade
