### PR TITLE
test(i18n): port interpolate_test.rb onto interpolate.test.ts

### DIFF
--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -18,9 +18,6 @@ class FakeBackend implements Backend {
     this.reloaded += 1;
   }
   eagerLoadBang(): void {}
-  storeTranslations(): unknown {
-    return null;
-  }
   translate(): unknown {
     return null;
   }

--- a/packages/i18n/src/interpolate.test.ts
+++ b/packages/i18n/src/interpolate.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Mirrors: i18n/test/i18n/interpolate_test.rb
+ *
+ * The two `RailsSafeBuffer` cases are not ported: they turn on a Ruby `String`
+ * subclass that redefines `gsub`, and on `assert_same` identity for that
+ * object. JS strings are primitives with no subclass hook, so there is nothing
+ * for the cases to exercise.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ArgumentError, MissingInterpolationArgument, inspect } from "./exceptions.js";
+import { config, resetConfig } from "./i18n.js";
+import { resetClassConfig } from "./config.js";
+import type { MissingInterpolationArgumentHandler } from "./config.js";
+import { interpolate } from "./interpolate/ruby.js";
+
+describe("I18nInterpolateTest", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+  });
+
+  it("String interpolates a hash argument w/ named placeholders", () => {
+    expect(interpolate("%{first} %{last}", { first: "Masao", last: "Mutoh" })).toBe("Masao Mutoh");
+  });
+
+  it("String interpolates a hash argument w/ named placeholders (reverse order)", () => {
+    expect(interpolate("%{last}, %{first}", { first: "Masao", last: "Mutoh" })).toBe(
+      "Mutoh, Masao",
+    );
+  });
+
+  it("String interpolates named placeholders with sprintf syntax", () => {
+    expect(interpolate("%<integer>d, %<float>.1f", { integer: 10, float: 43.4 })).toBe("10, 43.4");
+  });
+
+  it("String interpolates named placeholders with sprintf syntax, does not recurse", () => {
+    expect(
+      interpolate("%{msg}", { msg: "%<not_translated>s", not_translated: "should not happen" }),
+    ).toBe("%<not_translated>s");
+  });
+
+  it("String interpolation does not replace anything when no placeholders are given", () => {
+    expect(interpolate("aaa", { num: 1 })).toBe("aaa");
+  });
+
+  it("String interpolation sprintf behaviour equals Ruby 1.9 behaviour", () => {
+    expect(interpolate("%<num>d", { num: 1 })).toBe("1");
+    expect(interpolate("%<num>#b", { num: 1 })).toBe("0b1");
+    expect(interpolate("%<msg>s", { msg: "foo" })).toBe("foo");
+    expect(interpolate("%<num>f", { num: 1.0 })).toBe("1.000000");
+    expect(interpolate("%<num>3.0f", { num: 1.0 })).toBe("  1");
+    expect(interpolate("%<num>2.2f", { num: 100.0 })).toBe("100.00");
+    expect(interpolate("%<num>#x", { num: 100.0 })).toBe("0x64");
+    expect(() => interpolate("%<num>,d", { num: 100 })).toThrow(ArgumentError);
+    expect(() => interpolate("%<num>/d", { num: 100 })).toThrow(ArgumentError);
+  });
+
+  it("String interpolation raises an I18n::MissingInterpolationArgument when the string has extra placeholders", () => {
+    expect(() => interpolate("%{first} %{last}", { first: "Masao" })).toThrow(
+      MissingInterpolationArgument,
+    );
+  });
+
+  it("String interpolation does not raise when extra values were passed", () => {
+    expect(
+      interpolate("%{first} %{last}", { first: "Masao", last: "Mutoh", salutation: "Mr." }),
+    ).toBe("Masao Mutoh");
+  });
+
+  it("% acts as escape character in String interpolation", () => {
+    expect(interpolate("%%{first}", { first: "Masao" })).toBe("%{first}");
+    expect(interpolate("%% %<num>d", { num: 1.0 })).toBe("% 1");
+    expect(interpolate("%%{num} %%<num>d", { num: 1 })).toBe("%{num} %<num>d");
+  });
+
+  it("sprintf mix unformatted and formatted named placeholders", () => {
+    expect(interpolate("%{name} %<num>f", { name: "foo", num: 1.0 })).toBe("foo 1.000000");
+  });
+});
+
+describe("I18nMissingInterpolationCustomHandlerTest", () => {
+  let oldHandler: MissingInterpolationArgumentHandler;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    oldHandler = config().missingInterpolationArgumentHandler;
+    config().missingInterpolationArgumentHandler = (key, values, string) =>
+      `missing key is ${key}, values are ${inspect(values)}, given string is '${string}'`;
+  });
+
+  afterEach(() => {
+    config().missingInterpolationArgumentHandler = oldHandler;
+  });
+
+  it("String interpolation can use custom missing interpolation handler", () => {
+    expect(interpolate("%{first} %{last}", { first: "Masao" })).toBe(
+      `Masao missing key is last, values are ${inspect({ first: "Masao" })}, given string is '%{first} %{last}'`,
+    );
+  });
+});
+
+describe("I18nCustomInterpolationPatternTest", () => {
+  let oldInterpolationPatterns: RegExp[];
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    oldInterpolationPatterns = config().interpolationPatterns;
+    config().interpolationPatterns.push(/\{\{(\w+)\}\}/);
+  });
+
+  afterEach(() => {
+    config().interpolationPatterns = oldInterpolationPatterns;
+  });
+
+  it("String interpolation can use custom interpolation pattern", () => {
+    expect(interpolate("{{first}} {{last}}", { first: "Masao", last: "Mutoh" })).toBe(
+      "Masao Mutoh",
+    );
+  });
+});

--- a/packages/i18n/src/interpolate.test.ts
+++ b/packages/i18n/src/interpolate.test.ts
@@ -8,11 +8,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ArgumentError, MissingInterpolationArgument, inspect } from "./exceptions.js";
-import { config, resetConfig } from "./i18n.js";
+import * as I18n from "./index.js";
+import { ArgumentError, MissingInterpolationArgument, config } from "./index.js";
+import type { MissingInterpolationArgumentHandler } from "./index.js";
+
+import { inspect } from "./exceptions.js";
+import { resetConfig } from "./i18n.js";
 import { resetClassConfig } from "./config.js";
-import type { MissingInterpolationArgumentHandler } from "./config.js";
-import { interpolate } from "./interpolate/ruby.js";
 
 describe("I18nInterpolateTest", () => {
   beforeEach(() => {
@@ -21,61 +23,68 @@ describe("I18nInterpolateTest", () => {
   });
 
   it("String interpolates a hash argument w/ named placeholders", () => {
-    expect(interpolate("%{first} %{last}", { first: "Masao", last: "Mutoh" })).toBe("Masao Mutoh");
+    expect(I18n.interpolate("%{first} %{last}", { first: "Masao", last: "Mutoh" })).toBe(
+      "Masao Mutoh",
+    );
   });
 
   it("String interpolates a hash argument w/ named placeholders (reverse order)", () => {
-    expect(interpolate("%{last}, %{first}", { first: "Masao", last: "Mutoh" })).toBe(
+    expect(I18n.interpolate("%{last}, %{first}", { first: "Masao", last: "Mutoh" })).toBe(
       "Mutoh, Masao",
     );
   });
 
   it("String interpolates named placeholders with sprintf syntax", () => {
-    expect(interpolate("%<integer>d, %<float>.1f", { integer: 10, float: 43.4 })).toBe("10, 43.4");
+    expect(I18n.interpolate("%<integer>d, %<float>.1f", { integer: 10, float: 43.4 })).toBe(
+      "10, 43.4",
+    );
   });
 
   it("String interpolates named placeholders with sprintf syntax, does not recurse", () => {
     expect(
-      interpolate("%{msg}", { msg: "%<not_translated>s", not_translated: "should not happen" }),
+      I18n.interpolate("%{msg}", {
+        msg: "%<not_translated>s",
+        not_translated: "should not happen",
+      }),
     ).toBe("%<not_translated>s");
   });
 
   it("String interpolation does not replace anything when no placeholders are given", () => {
-    expect(interpolate("aaa", { num: 1 })).toBe("aaa");
+    expect(I18n.interpolate("aaa", { num: 1 })).toBe("aaa");
   });
 
   it("String interpolation sprintf behaviour equals Ruby 1.9 behaviour", () => {
-    expect(interpolate("%<num>d", { num: 1 })).toBe("1");
-    expect(interpolate("%<num>#b", { num: 1 })).toBe("0b1");
-    expect(interpolate("%<msg>s", { msg: "foo" })).toBe("foo");
-    expect(interpolate("%<num>f", { num: 1.0 })).toBe("1.000000");
-    expect(interpolate("%<num>3.0f", { num: 1.0 })).toBe("  1");
-    expect(interpolate("%<num>2.2f", { num: 100.0 })).toBe("100.00");
-    expect(interpolate("%<num>#x", { num: 100.0 })).toBe("0x64");
-    expect(() => interpolate("%<num>,d", { num: 100 })).toThrow(ArgumentError);
-    expect(() => interpolate("%<num>/d", { num: 100 })).toThrow(ArgumentError);
+    expect(I18n.interpolate("%<num>d", { num: 1 })).toBe("1");
+    expect(I18n.interpolate("%<num>#b", { num: 1 })).toBe("0b1");
+    expect(I18n.interpolate("%<msg>s", { msg: "foo" })).toBe("foo");
+    expect(I18n.interpolate("%<num>f", { num: 1.0 })).toBe("1.000000");
+    expect(I18n.interpolate("%<num>3.0f", { num: 1.0 })).toBe("  1");
+    expect(I18n.interpolate("%<num>2.2f", { num: 100.0 })).toBe("100.00");
+    expect(I18n.interpolate("%<num>#x", { num: 100.0 })).toBe("0x64");
+    expect(() => I18n.interpolate("%<num>,d", { num: 100 })).toThrow(ArgumentError);
+    expect(() => I18n.interpolate("%<num>/d", { num: 100 })).toThrow(ArgumentError);
   });
 
   it("String interpolation raises an I18n::MissingInterpolationArgument when the string has extra placeholders", () => {
-    expect(() => interpolate("%{first} %{last}", { first: "Masao" })).toThrow(
+    expect(() => I18n.interpolate("%{first} %{last}", { first: "Masao" })).toThrow(
       MissingInterpolationArgument,
     );
   });
 
   it("String interpolation does not raise when extra values were passed", () => {
     expect(
-      interpolate("%{first} %{last}", { first: "Masao", last: "Mutoh", salutation: "Mr." }),
+      I18n.interpolate("%{first} %{last}", { first: "Masao", last: "Mutoh", salutation: "Mr." }),
     ).toBe("Masao Mutoh");
   });
 
   it("% acts as escape character in String interpolation", () => {
-    expect(interpolate("%%{first}", { first: "Masao" })).toBe("%{first}");
-    expect(interpolate("%% %<num>d", { num: 1.0 })).toBe("% 1");
-    expect(interpolate("%%{num} %%<num>d", { num: 1 })).toBe("%{num} %<num>d");
+    expect(I18n.interpolate("%%{first}", { first: "Masao" })).toBe("%{first}");
+    expect(I18n.interpolate("%% %<num>d", { num: 1.0 })).toBe("% 1");
+    expect(I18n.interpolate("%%{num} %%<num>d", { num: 1 })).toBe("%{num} %<num>d");
   });
 
   it("sprintf mix unformatted and formatted named placeholders", () => {
-    expect(interpolate("%{name} %<num>f", { name: "foo", num: 1.0 })).toBe("foo 1.000000");
+    expect(I18n.interpolate("%{name} %<num>f", { name: "foo", num: 1.0 })).toBe("foo 1.000000");
   });
 });
 
@@ -95,7 +104,7 @@ describe("I18nMissingInterpolationCustomHandlerTest", () => {
   });
 
   it("String interpolation can use custom missing interpolation handler", () => {
-    expect(interpolate("%{first} %{last}", { first: "Masao" })).toBe(
+    expect(I18n.interpolate("%{first} %{last}", { first: "Masao" })).toBe(
       `Masao missing key is last, values are ${inspect({ first: "Masao" })}, given string is '%{first} %{last}'`,
     );
   });
@@ -116,7 +125,7 @@ describe("I18nCustomInterpolationPatternTest", () => {
   });
 
   it("String interpolation can use custom interpolation pattern", () => {
-    expect(interpolate("{{first}} {{last}}", { first: "Masao", last: "Mutoh" })).toBe(
+    expect(I18n.interpolate("{{first}} {{last}}", { first: "Masao", last: "Mutoh" })).toBe(
       "Masao Mutoh",
     );
   });

--- a/packages/i18n/src/interpolate/ruby.trails.test.ts
+++ b/packages/i18n/src/interpolate/ruby.trails.test.ts
@@ -1,6 +1,6 @@
 /**
- * The gem covers `I18n.interpolate` through `test/i18n_test.rb`, which the
- * facade story ports. What is pinned here is the `%<name>fmt` branch: Ruby
+ * The gem covers `I18n.interpolate` through `test/i18n/interpolate_test.rb`, which
+ * `interpolate.test.ts` now ports. What is pinned here is the `%<name>fmt` branch: Ruby
  * delegates it to `sprintf`, JS has no such builtin, so every expectation below
  * is the literal output of the matching `sprintf` call in Ruby.
  */
@@ -9,18 +9,12 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { interpolate } from "./ruby.js";
 import { resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
-import { MissingInterpolationArgument, ReservedInterpolationKey } from "../exceptions.js";
+import { ReservedInterpolationKey } from "../exceptions.js";
 
 describe("I18n.interpolate", () => {
   beforeEach(() => {
     resetConfig();
     resetClassConfig();
-  });
-
-  it("interpolates %{} placeholders", () => {
-    expect(interpolate("file %{file} opened by %%{user}", { file: "test.txt" })).toBe(
-      "file test.txt opened by %{user}",
-    );
   });
 
   it("calls a callable value with the values hash", () => {
@@ -29,10 +23,6 @@ describe("I18n.interpolate", () => {
       name: (v: { gender: string }) => (v.gender === "m" ? "Mr" : "Mrs"),
     };
     expect(interpolate("%{name}", values)).toBe("Mrs");
-  });
-
-  it("raises MissingInterpolationArgument for an absent key", () => {
-    expect(() => interpolate("%{name}", {})).toThrow(MissingInterpolationArgument);
   });
 
   it("raises ReservedInterpolationKey for a reserved key", () => {

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -83,7 +83,8 @@ const ALTERNATE_PREFIX: Record<string, string> = { b: "0b", B: "0B", o: "0", x: 
  */
 function sprintf(spec: string, value: unknown): string {
   const parsed = FORMAT_SPEC.exec(spec);
-  if (!parsed) return String(value);
+  // Ruby's sprintf raises on a spec it cannot parse, e.g. `%<num>,d`.
+  if (!parsed) throw new ArgumentError(`malformed format string - %${spec}`);
   const [, flags = "", width = "", precision, conversion = "s"] = parsed;
   const digits = precision === undefined ? 6 : Number(precision);
   const numeric = !"csp".includes(conversion);

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -79,12 +79,12 @@ const ALTERNATE_PREFIX: Record<string, string> = { b: "0b", B: "0B", o: "0", x: 
  * conversions the interpolation pattern admits (`bBdiouxXeEfgGcps`, `p`
  * included) are
  * reimplemented here, along with the `-+ #0` flags, width and precision that
- * `sprintf` applies to them.
+ * `sprintf` applies to them. A spec outside that grammar raises `ArgumentError`
+ * with `sprintf`'s message, as Ruby's does for `%<num>,d`.
  */
 function sprintf(spec: string, value: unknown): string {
   const parsed = FORMAT_SPEC.exec(spec);
-  // Ruby's sprintf raises on a spec it cannot parse, e.g. `%<num>,d`.
-  if (!parsed) throw new ArgumentError(`malformed format string - %${spec}`);
+  if (!parsed) throw new ArgumentError(`malformed format string - %${spec.charAt(0)}`);
   const [, flags = "", width = "", precision, conversion = "s"] = parsed;
   const digits = precision === undefined ? 6 : Number(precision);
   const numeric = !"csp".includes(conversion);


### PR DESCRIPTION
Ports `i18n/test/i18n/interpolate_test.rb` onto
`packages/i18n/src/interpolate.test.ts` (the convention target — the gem's
source is `lib/i18n/interpolate/ruby.rb` but its test sits at
`test/i18n/interpolate_test.rb`).

`test:compare --package i18n`: `i18n/interpolate_test.rb` goes 0/14 → 12/14,
overall 109/440 → 121/440.

The two unported cases are the `RailsSafeBuffer` ones
(`interpolate_test.rb:59-73`): both turn on a Ruby `String` subclass that
redefines `gsub`, plus `assert_same` object identity for it. JS strings are
primitives with no subclass hook, so there is nothing to exercise. Left
measured as missing, not excluded.

Two implementation changes:

- `sprintf` in `interpolate/ruby.ts` now raises `ArgumentError` on a spec it
  cannot parse instead of falling back to `String(value)` — Ruby's `sprintf`
  raises, which is what `interpolate_test.rb:35-36` asserts for `%<num>,d` and
  `%<num>/d`.
- Drive-by: `config.trails.test.ts` had a duplicate `storeTranslations` on
  `FakeBackend` from #6011, failing `tsc --build` on `main` (and blocking every
  local commit via husky). Removed the duplicate.

Redundant trails-only cases deleted from `interpolate/ruby.trails.test.ts`
(the plain `%{}` interpolation and the missing-argument raise); the
`sprintf`-table and callable-value cases stay.

Closes-story: i18n-interpolate-test-port
