### PR TITLE
test(i18n): restore the four date localization cases

### DIFF
--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -11,15 +11,96 @@ function reloadTranslations(): void {
   I18n.backend().storeTranslations("en", en);
 }
 
+/** Ruby's `Date::MONTHNAMES` / `Date::ABBR_MONTHNAMES`, which `strftime`'s
+ * `%B` / `%b` render from. Both are 1-indexed with a leading `nil`. */
+const MONTHNAMES = [
+  null,
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+const ABBR_MONTHNAMES = [
+  null,
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+/**
+ * Stands in for Ruby's `::Date`, which the setup builds with
+ * `Date.parse("2008-7-2")`. `I18n::Backend::Base#localize` duck-types its
+ * object (i18n/lib/i18n/backend/base.rb:78-92), and a `Date` answers
+ * `strftime`, `wday` and `mon` but *not* `sec` — which is what routes the
+ * format lookup to `date.formats` rather than `time.formats` (base.rb:82).
+ * `TimeWithZone` answers `sec`, so it cannot stand in here. Mirrors the same
+ * stand-in in i18n/src/backend/localization.test.ts.
+ */
+class RubyDate {
+  readonly utc: Date;
+
+  constructor(year: number, month: number, day: number) {
+    this.utc = new Date(Date.UTC(year, month - 1, day));
+  }
+
+  get wday(): number {
+    return this.utc.getUTCDay();
+  }
+
+  get mon(): number {
+    return this.utc.getUTCMonth() + 1;
+  }
+
+  strftime(format: string): string {
+    return format.replace(/%([A-Za-z%])/g, (match, directive: string) => {
+      switch (directive) {
+        case "Y":
+          return String(this.utc.getUTCFullYear());
+        case "m":
+          return String(this.mon).padStart(2, "0");
+        case "d":
+          return String(this.utc.getUTCDate()).padStart(2, "0");
+        case "b":
+          return ABBR_MONTHNAMES[this.mon]!;
+        case "B":
+          return MONTHNAMES[this.mon]!;
+        case "%":
+          return "%";
+        default:
+          return match;
+      }
+    });
+  }
+}
+
 // Rails' activesupport/test/abstract_unit.rb:35 turns the check off for the
 // whole suite.
 I18n.setEnforceAvailableLocales(false);
 
 describe("I18nTest", () => {
+  let date: RubyDate;
   let time: TimeWithZone;
 
   beforeEach(() => {
     reloadTranslations();
+    date = new RubyDate(2008, 7, 2);
     time = TimeZone.find("UTC").local(2008, 7, 2, 16, 47, 1);
   });
 
@@ -30,6 +111,22 @@ describe("I18nTest", () => {
   it("time zone localization with default format", () => {
     const now = TimeZone.find("UTC").local(2000, 1, 1);
     expect(I18n.localize(now)).toBe(now.strftime("%a, %d %b %Y %H:%M:%S %z"));
+  });
+
+  it("date localization should use default format", () => {
+    expect(I18n.localize(date)).toBe(date.strftime("%Y-%m-%d"));
+  });
+
+  it("date localization with default format", () => {
+    expect(I18n.localize(date, { format: ":default" })).toBe(date.strftime("%Y-%m-%d"));
+  });
+
+  it("date localization with short format", () => {
+    expect(I18n.localize(date, { format: ":short" })).toBe(date.strftime("%b %d"));
+  });
+
+  it("date localization with long format", () => {
+    expect(I18n.localize(date, { format: ":long" })).toBe(date.strftime("%B %d, %Y"));
   });
 
   it("time localization should use default format", () => {

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -11,8 +11,6 @@ function reloadTranslations(): void {
   I18n.backend().storeTranslations("en", en);
 }
 
-/** Ruby's `Date::MONTHNAMES` / `Date::ABBR_MONTHNAMES`, which `strftime`'s
- * `%B` / `%b` render from. Both are 1-indexed with a leading `nil`. */
 const MONTHNAMES = [
   null,
   "January",
@@ -45,13 +43,12 @@ const ABBR_MONTHNAMES = [
 ];
 
 /**
- * Stands in for Ruby's `::Date`, which the setup builds with
- * `Date.parse("2008-7-2")`. `I18n::Backend::Base#localize` duck-types its
- * object (i18n/lib/i18n/backend/base.rb:78-92), and a `Date` answers
- * `strftime`, `wday` and `mon` but *not* `sec` — which is what routes the
- * format lookup to `date.formats` rather than `time.formats` (base.rb:82).
- * `TimeWithZone` answers `sec`, so it cannot stand in here. Mirrors the same
- * stand-in in i18n/src/backend/localization.test.ts.
+ * Stands in for Ruby's `::Date` (`Date.parse("2008-7-2")` in `setup`), which
+ * trails has no analogue of. `localize` duck-types its object
+ * (i18n/lib/i18n/backend/base.rb:78-92): `Date` answers `strftime`, `wday` and
+ * `mon` but not `sec`, which is what selects `date.formats` over
+ * `time.formats` (base.rb:82). Mirrors the stand-in in
+ * i18n/src/backend/localization.test.ts.
  */
 class RubyDate {
   readonly utc: Date;


### PR DESCRIPTION
Restores the four `test_date_localization_*` cases from
`vendor/rails/activesupport/test/i18n_test.rb:18-32`, dropped when #6008
ported the `TimeWithZone` cases.

Rails localizes a bare `Date.parse("2008-7-2")`, which selects the
`date.formats` scope precisely because it does not answer `sec`
(`vendor/rails/i18n/lib/i18n/backend/base.rb:82`; ours at
`packages/i18n/src/backend/base.ts:256`). trails has no `Date` analogue that
answers `strftime`/`wday`/`mon` without also answering `sec`, so the test
uses a date-only stand-in, mirroring the same `RubyDate` stand-in already in
`packages/i18n/src/backend/localization.test.ts`. `format` is passed as a Ruby
Symbol string (`":default"`, `":short"`, `":long"`).

Test-file-only change; no runtime surface added.

Closes-story: as-i18n-date-localization-tests
