### PR TITLE
feat(i18n): port I18n.transliterate and the Transliterator mixin

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -13,8 +13,7 @@
  * story `i18n-symbol-values-are-colon-strings`.
  *
  * Not ported here: `load_rb` (it `eval`s Ruby source, which trails has none of
- * — see the `SCOPED_SKIP_GROUPS` entry in `scripts/api-compare/conventions.ts`),
- * and the `Transliterator` mixin.
+ * — see the `SCOPED_SKIP_GROUPS` entry in `scripts/api-compare/conventions.ts`).
  */
 
 import {
@@ -40,6 +39,11 @@ import {
 } from "../i18n.js";
 import { interpolate as interpolateString } from "../interpolate/ruby.js";
 import { throwException, catchException } from "../throw-catch.js";
+import {
+  transliterate,
+  type HashTransliterator,
+  type ProcTransliterator,
+} from "./transliterator.js";
 import { except, type TranslationData } from "../utils.js";
 import { parseYaml } from "../yaml.js";
 
@@ -132,6 +136,11 @@ interface Localizable {
 }
 
 export abstract class Base {
+  /** Mirrors: `include I18n::Backend::Transliterator` (base.rb:9). */
+  transliterate = transliterate;
+  /** @internal Ruby's `@transliterators` ivar, which has no public reader. */
+  transliterators?: Record<Locale, HashTransliterator | ProcTransliterator>;
+
   private eagerLoadedFlag = false;
   /**
    * Whether `I18n.load_path` has actually been read. The gem needs no such

--- a/packages/i18n/src/backend/transliterator.ts
+++ b/packages/i18n/src/backend/transliterator.ts
@@ -1,0 +1,299 @@
+/**
+ * Mirrors: i18n/lib/i18n/backend/transliterator.rb
+ *
+ * Ruby mixes `Transliterator` into `Backend::Base` with `include`; the JS
+ * equivalent is the `this`-typed `transliterate` below, assigned to `Base` so
+ * the code stays in the file that matches the gem's layout.
+ */
+
+import { ArgumentError } from "../exceptions.js";
+import { t, type Locale } from "../i18n.js";
+import type { Base } from "./base.js";
+
+export const DEFAULT_REPLACEMENT_CHAR = "?";
+
+/**
+ * Given a locale and a UTF-8 string, return the locale's ASCII
+ * approximation for the string.
+ */
+export function transliterate(
+  this: Base,
+  locale: Locale,
+  string: string,
+  replacement: string | null = null,
+): string {
+  this.transliterators ??= {};
+  this.transliterators[locale] ??= get(
+    t("i18n.transliterate.rule", { locale, resolve: false, default: {} }),
+  );
+  return this.transliterators[locale].transliterate(string, replacement);
+}
+
+/** Get a transliterator instance. */
+export function get(rule: unknown = null): HashTransliterator | ProcTransliterator {
+  if (rule == null || rule === false || isHash(rule)) {
+    return new HashTransliterator(rule as Record<string, unknown> | null);
+  } else if (typeof rule === "function") {
+    return new ProcTransliterator(rule as (string: string) => string);
+  } else {
+    throw new ArgumentError("Transliteration rule must be a proc or a hash.");
+  }
+}
+
+function isHash(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A transliterator which accepts a Proc as its transliteration rule. */
+export class ProcTransliterator {
+  private rule: (string: string) => string;
+
+  constructor(rule: (string: string) => string) {
+    this.rule = rule;
+  }
+
+  /**
+   * @missingRailsCall call — Ruby invokes a Proc with `Proc#call`; the JS
+   * analogue of a Proc is a function, which is invoked by application. There is
+   * no `call` to make (JS `Function#call` takes a receiver and means something
+   * else).
+   */
+  transliterate(string: string, _replacement: string | null = null): string {
+    return this.rule(string);
+  }
+}
+
+/**
+ * A transliterator which accepts a Hash of characters as its translation
+ * rule.
+ */
+export class HashTransliterator {
+  static DEFAULT_APPROXIMATIONS: Readonly<Record<string, string>> = Object.freeze({
+    À: "A",
+    Á: "A",
+    Â: "A",
+    Ã: "A",
+    Ä: "A",
+    Å: "A",
+    Æ: "AE",
+    Ç: "C",
+    È: "E",
+    É: "E",
+    Ê: "E",
+    Ë: "E",
+    Ì: "I",
+    Í: "I",
+    Î: "I",
+    Ï: "I",
+    Ð: "D",
+    Ñ: "N",
+    Ò: "O",
+    Ó: "O",
+    Ô: "O",
+    Õ: "O",
+    Ö: "O",
+    "×": "x",
+    Ø: "O",
+    Ù: "U",
+    Ú: "U",
+    Û: "U",
+    Ü: "U",
+    Ý: "Y",
+    Þ: "Th",
+    ß: "ss",
+    ẞ: "SS",
+    à: "a",
+    á: "a",
+    â: "a",
+    ã: "a",
+    ä: "a",
+    å: "a",
+    æ: "ae",
+    ç: "c",
+    è: "e",
+    é: "e",
+    ê: "e",
+    ë: "e",
+    ì: "i",
+    í: "i",
+    î: "i",
+    ï: "i",
+    ð: "d",
+    ñ: "n",
+    ò: "o",
+    ó: "o",
+    ô: "o",
+    õ: "o",
+    ö: "o",
+    ø: "o",
+    ù: "u",
+    ú: "u",
+    û: "u",
+    ü: "u",
+    ý: "y",
+    þ: "th",
+    ÿ: "y",
+    Ā: "A",
+    ā: "a",
+    Ă: "A",
+    ă: "a",
+    Ą: "A",
+    ą: "a",
+    Ć: "C",
+    ć: "c",
+    Ĉ: "C",
+    ĉ: "c",
+    Ċ: "C",
+    ċ: "c",
+    Č: "C",
+    č: "c",
+    Ď: "D",
+    ď: "d",
+    Đ: "D",
+    đ: "d",
+    Ē: "E",
+    ē: "e",
+    Ĕ: "E",
+    ĕ: "e",
+    Ė: "E",
+    ė: "e",
+    Ę: "E",
+    ę: "e",
+    Ě: "E",
+    ě: "e",
+    Ĝ: "G",
+    ĝ: "g",
+    Ğ: "G",
+    ğ: "g",
+    Ġ: "G",
+    ġ: "g",
+    Ģ: "G",
+    ģ: "g",
+    Ĥ: "H",
+    ĥ: "h",
+    Ħ: "H",
+    ħ: "h",
+    Ĩ: "I",
+    ĩ: "i",
+    Ī: "I",
+    ī: "i",
+    Ĭ: "I",
+    ĭ: "i",
+    Į: "I",
+    į: "i",
+    İ: "I",
+    ı: "i",
+    Ĳ: "IJ",
+    ĳ: "ij",
+    Ĵ: "J",
+    ĵ: "j",
+    Ķ: "K",
+    ķ: "k",
+    ĸ: "k",
+    Ĺ: "L",
+    ĺ: "l",
+    Ļ: "L",
+    ļ: "l",
+    Ľ: "L",
+    ľ: "l",
+    Ŀ: "L",
+    ŀ: "l",
+    Ł: "L",
+    ł: "l",
+    Ń: "N",
+    ń: "n",
+    Ņ: "N",
+    ņ: "n",
+    Ň: "N",
+    ň: "n",
+    ŉ: "'n",
+    Ŋ: "NG",
+    ŋ: "ng",
+    Ō: "O",
+    ō: "o",
+    Ŏ: "O",
+    ŏ: "o",
+    Ő: "O",
+    ő: "o",
+    Œ: "OE",
+    œ: "oe",
+    Ŕ: "R",
+    ŕ: "r",
+    Ŗ: "R",
+    ŗ: "r",
+    Ř: "R",
+    ř: "r",
+    Ś: "S",
+    ś: "s",
+    Ŝ: "S",
+    ŝ: "s",
+    Ş: "S",
+    ş: "s",
+    Š: "S",
+    š: "s",
+    Ţ: "T",
+    ţ: "t",
+    Ť: "T",
+    ť: "t",
+    Ŧ: "T",
+    ŧ: "t",
+    Ũ: "U",
+    ũ: "u",
+    Ū: "U",
+    ū: "u",
+    Ŭ: "U",
+    ŭ: "u",
+    Ů: "U",
+    ů: "u",
+    Ű: "U",
+    ű: "u",
+    Ų: "U",
+    ų: "u",
+    Ŵ: "W",
+    ŵ: "w",
+    Ŷ: "Y",
+    ŷ: "y",
+    Ÿ: "Y",
+    Ź: "Z",
+    ź: "z",
+    Ż: "Z",
+    ż: "z",
+    Ž: "Z",
+    ž: "z",
+  });
+
+  private rule: Record<string, unknown> | null;
+  private approximationsMemo?: Record<string, string>;
+
+  constructor(rule: Record<string, unknown> | null = null) {
+    this.rule = rule;
+    this.addDefaultApproximations();
+    if (this.rule != null) this.add(this.rule);
+  }
+
+  transliterate(string: string, replacement: string | null = null): string {
+    if (replacement == null) replacement = DEFAULT_REPLACEMENT_CHAR;
+    return string.replace(
+      // eslint-disable-next-line no-control-regex -- mirrors the gem's `/[^\x00-\x7f]/u`
+      /[^\x00-\x7f]/gu,
+      (char) => this.approximations()[char] ?? replacement,
+    );
+  }
+
+  private approximations(): Record<string, string> {
+    return (this.approximationsMemo ??= {});
+  }
+
+  private addDefaultApproximations(): void {
+    for (const [key, value] of Object.entries(HashTransliterator.DEFAULT_APPROXIMATIONS)) {
+      this.approximations()[key] = value;
+    }
+  }
+
+  /** Add transliteration rules to the approximations hash. */
+  private add(hash: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(hash)) {
+      this.approximations()[String(key)] = String(value);
+    }
+  }
+}

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -18,9 +18,6 @@ class FakeBackend implements Backend {
     this.reloaded += 1;
   }
   eagerLoadBang(): void {}
-  storeTranslations(): unknown {
-    return null;
-  }
   translate(): unknown {
     return null;
   }

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -30,6 +30,9 @@ class FakeBackend implements Backend {
   localize(): unknown {
     return null;
   }
+  transliterate(): string {
+    return "";
+  }
 }
 
 /**

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -9,15 +9,14 @@ import type { TranslationData } from "./utils.js";
 
 /** The slice of a backend `Config` hands out. */
 export interface Backend {
-  storeTranslations(locale: Locale, data: Record<string, unknown>, options?: unknown): unknown;
-  availableLocales(): Locale[];
-  reloadBang(): void;
-  eagerLoadBang(): void;
   storeTranslations(
     locale: Locale,
     data: TranslationData,
     options?: Record<string, unknown>,
   ): unknown;
+  availableLocales(): Locale[];
+  reloadBang(): void;
+  eagerLoadBang(): void;
   translate(locale: Locale, key: unknown, options?: Record<string, unknown>): unknown;
   exists(locale: Locale, key: TranslationKey, options?: Record<string, unknown>): boolean;
   localize(

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -26,6 +26,7 @@ export interface Backend {
     format: unknown,
     options?: Record<string, unknown>,
   ): unknown;
+  transliterate(locale: Locale, string: string, replacement?: string | null): string;
 }
 
 /**

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -29,6 +29,7 @@ import {
   setLocale,
   t,
   translate,
+  transliterate,
   withLocale,
 } from "./i18n.js";
 import { Config, resetClassConfig } from "./config.js";
@@ -302,6 +303,44 @@ describe("I18nTest", () => {
       }),
     ).toThrow(ArgumentError);
     expect(locale()).toBe(defaultLocale());
+  });
+
+  /**
+   * The gem stubs `I18n::Backend::Transliterator.get` to raise; ESM exports
+   * can't be stubbed in place, so these two store a rule that is neither a
+   * Proc nor a Hash, which is what makes `get` raise (transliterator.rb:26).
+   */
+  it("I18n.transliterate handles I18n::ArgumentError exception", () => {
+    storeTranslations("en", { i18n: { transliterate: { rule: "not a rule" } } });
+    const exceptionHandler = vi.fn(() => {
+      throw new ArgumentError();
+    });
+    setExceptionHandler(exceptionHandler);
+
+    expect(() => transliterate("ąćó")).toThrow(ArgumentError);
+    expect(exceptionHandler).toHaveBeenCalled();
+  });
+
+  it("I18n.transliterate raises I18n::ArgumentError exception", () => {
+    storeTranslations("en", { i18n: { transliterate: { rule: "not a rule" } } });
+    const exceptionHandler = vi.fn();
+    setExceptionHandler(exceptionHandler);
+
+    expect(() => transliterate("ąćó", { raise: true })).toThrow(ArgumentError);
+    expect(exceptionHandler).not.toHaveBeenCalled();
+  });
+
+  it("transliterate given an unavailable locale rases an I18n::InvalidLocale", () => {
+    try {
+      config().enforceAvailableLocales = true;
+      expect(() => transliterate("string", { locale: "klingon" })).toThrow(InvalidLocale);
+    } finally {
+      config().enforceAvailableLocales = false;
+    }
+  });
+
+  it("transliterate non-ASCII chars not in map with default replacement char", () => {
+    expect(transliterate("日本語")).toBe("???");
   });
 
   it("uses the simple backend by default", () => {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -1,7 +1,6 @@
 /**
- * Mirrors: i18n/lib/i18n.rb — partially. `transliterate` waits on the
- * `Transliterator` mixin, and `new_double_nested_cache` on the normalize-key
- * cache; both land with their own stories (RFC 0074).
+ * Mirrors: i18n/lib/i18n.rb — partially. `new_double_nested_cache` waits on the
+ * normalize-key cache; it lands with its own story (RFC 0074).
  */
 
 /**
@@ -261,6 +260,41 @@ export function exists(
 }
 
 /**
+ * Transliterates UTF-8 characters to ASCII.
+ *
+ * Ruby takes `throw:`, `raise:`, `locale:` and `replacement:` as keyword
+ * arguments alongside `**options`; the destructured rest below is that split.
+ * `throw` can't be a binding name in JS, so the local reads `throwOption`.
+ */
+export function transliterate(
+  key: string,
+  {
+    throw: throwOption = false,
+    raise = false,
+    locale = null,
+    replacement = null,
+    ...options
+  }: TranslateOptions = EMPTY_HASH,
+): unknown {
+  if (locale == null || locale === false) locale = config().locale;
+  if (locale === false) throw new Disabled("transliterate");
+  enforceAvailableLocalesBang(locale as Locale);
+
+  try {
+    return config().backend.transliterate(locale as Locale, key, replacement as string | null);
+  } catch (exception) {
+    if (!(exception instanceof ArgumentError)) throw exception;
+    return handleException(
+      truthy(throwOption) ? "throw" : truthy(raise) ? "raise" : false,
+      exception,
+      locale as Locale,
+      key,
+      options,
+    );
+  }
+}
+
+/**
  * Localizes certain objects, such as dates and numbers to local formatting.
  */
 export function localize(
@@ -390,14 +424,14 @@ function translateKey(
  */
 function handleException(
   handling: "raise" | "throw" | false,
-  exception: MissingTranslation,
+  exception: MissingTranslation | ArgumentError,
   locale: Locale,
   key: TranslateKey,
   options: TranslateOptions,
 ): unknown {
   switch (handling) {
     case "raise":
-      throw exception.toException();
+      throw exception instanceof MissingTranslation ? exception.toException() : exception;
     case "throw":
       return throwException(exception);
     default: {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -276,11 +276,11 @@ export function transliterate(
     ...options
   }: TranslateOptions = EMPTY_HASH,
 ): unknown {
-  if (locale == null || locale === false) locale = config().locale;
-  if (locale === false) throw new Disabled("transliterate");
-  enforceAvailableLocalesBang(locale as Locale);
-
   try {
+    if (locale == null || locale === false) locale = config().locale;
+    if (locale === false) throw new Disabled("transliterate");
+    enforceAvailableLocalesBang(locale as Locale);
+
     return config().backend.transliterate(locale as Locale, key, replacement as string | null);
   } catch (exception) {
     if (!(exception instanceof ArgumentError)) throw exception;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -60,6 +60,7 @@ export {
   tBang,
   translate,
   translateBang,
+  transliterate,
   withLocale,
 } from "./i18n.js";
 export type { Locale, TranslateKey, TranslationKey } from "./i18n.js";

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -54,6 +54,7 @@ describe("isSourceUnported package scoping", () => {
       "backend/base.rb",
       "backend/flatten.rb",
       "backend/simple.rb",
+      "backend/transliterator.rb",
       "config.rb",
       "exceptions.rb",
       "interpolate/ruby.rb",

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1200,14 +1200,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason:
       "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data.",
   },
-  {
-    pattern: "backend/transliterator.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: ASCII transliteration driven by per-locale rule tables and " +
-      "`$KCODE`-era String packing. JS has `String.prototype.normalize` and " +
-      "no locale rule data is shipped; not in pre-1.0 scope.",
-  },
   // --- i18n: gem surface trails has no counterpart for ---
   {
     // Deliberately broad: covers `gettext.rb`, `gettext/*` and the


### PR DESCRIPTION
Ports `I18n.transliterate` and the machinery it needs.

- **`packages/i18n/src/backend/transliterator.ts`** (new) mirrors
  `i18n/lib/i18n/backend/transliterator.rb`: `DEFAULT_REPLACEMENT_CHAR`, the
  `transliterate` mixin method, `get`, `ProcTransliterator`, and
  `HashTransliterator` with `DEFAULT_APPROXIMATIONS` (all 191 pairs, generated
  from the gem's table), in the gem's member order.
- **`backend/base.ts`** picks up the mixin the way the gem does with
  `include I18n::Backend::Transliterator` (base.rb:9) — a `this`-typed function
  assigned to `Base`, plus the `@transliterators` memo.
- **`i18n.ts`** gains `transliterate`, mirroring i18n.rb:325-333. The `rescue
  I18n::ArgumentError` is a method-level rescue, so it covers the `Disabled`
  raise and `enforce_available_locales!` too — both raise `I18n::ArgumentError`
  subclasses (exceptions.rb:16, :30) — and the whole body sits inside the `try`
  for that reason.
- `handleException`'s raise arm now mirrors i18n.rb:426's
  `respond_to?(:to_exception)` check — an `ArgumentError` does not answer it, so
  it is re-raised as-is.
- `backend/transliterator.rb` leaves `unported-files.ts`.

Also fixes the duplicate `storeTranslations` member `#6011` left in
`config.ts` / `config.trails.test.ts`, which reds Build, Unit Tests and
Rails API/Test Comparison on `main` and on every branch rebased onto it
(story `red-1144532a`).

Tests: the four `i18n_test.rb` cases land verbatim. The gem stubs
`I18n::Backend::Transliterator.get` to raise; ESM exports cannot be stubbed in
place, so the two exception cases store a rule that is neither a Proc nor a
Hash, which is exactly what makes `get` raise (transliterator.rb:26). The gem's
own `test/backend/transliterator_test.rb` is out of this story's scope and is
filed as `i18n-backend-transliterator-tests`.

Deviations, both cited at the call site: a `@missingRailsCall call` on
`ProcTransliterator#transliterate` (Ruby's `Proc#call` is function application
in JS, and `Function#call` means something else), and an `eslint-disable
no-control-regex` on the gem's verbatim `/[^\x00-\x7f]/u`.

Gates: `api:calls` OK, `api:calls:wide` OK, `api:extra --package i18n` shows no
new novel surface, `api:compare` +6 methods / +1 file, `test:compare` +4 tests.

Closes-story: i18n-facade-transliterate
