### PR TITLE
fix(i18n): drop the duplicate storeTranslations Backend declaration

### DIFF
--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -8,9 +8,6 @@ import { resetConfig } from "./i18n.js";
 class FakeBackend implements Backend {
   reloaded = 0;
   constructor(private locales: string[] = ["en"]) {}
-  storeTranslations(): unknown {
-    return null;
-  }
   availableLocales(): string[] {
     return this.locales;
   }

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -9,7 +9,6 @@ import type { TranslationData } from "./utils.js";
 
 /** The slice of a backend `Config` hands out. */
 export interface Backend {
-  storeTranslations(locale: Locale, data: Record<string, unknown>, options?: unknown): unknown;
   availableLocales(): Locale[];
   reloadBang(): void;
   eagerLoadBang(): void;


### PR DESCRIPTION
Virtualized DX Type Tests is red on `main` @1144532a:

```
packages/i18n/src/config.trails.test.ts(11,3): error TS2393: Duplicate function implementation.
packages/i18n/src/config.trails.test.ts(21,3): error TS2393: Duplicate function implementation.
```

#6011 declared `storeTranslations` on the `Backend` interface in the position `I18n::Backend::Base` defines it (`vendor/i18n/lib/i18n/backend/base.rb:24`, immediately before `translate`) — but a stale, loosely-typed declaration (`data: Record<string, unknown>, options?: unknown`) was already sitting ahead of `availableLocales`. An interface tolerates the pair as overloads, so `pnpm typecheck` stayed green; `FakeBackend` in `config.trails.test.ts` then grew a second *implementation*, which is TS2393 under the virtualized DX tsconfig.

Keeps the Rails-positioned, `TranslationData`-typed declaration and deletes the stale one, plus the matching duplicate method on `FakeBackend`.

`pnpm test:types:virtualized` passes; `pnpm vitest run packages/i18n` 201/201.

Closes-story: red-1144532a