### PR TITLE
feat(i18n): register Active Support's en locale on I18n.load_path

### DIFF
--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -64,6 +64,7 @@ file paths):
 | Ruby token | trails token |
 | ---------- | ------------ |
 | `erb`      | `tse`        |
+| `rb`       | `js`         |
 | `ERB`      | `TSE`        |
 | `Erb`      | `Tse`        |
 
@@ -118,8 +119,6 @@ a genuine gap:
   - `supports_default_expression?`, `supports_non_unique_constraint_name?`, `supports_text_column_with_default?`, `supports_sql_standard_drop_constraint?` (only in: `adapter_helper.rb`)
 - `module ARTest` opens in config.rb and is reopened in connection.rb, so the Ruby extractor records one ARTest entity filed under config.rb and every ARTest method buckets there. Two populations end up in that bucket, neither of which is a gap. (1) `connection_name` / `test_configuration_hashes` / `connect` (connection.rb) and `expand_config` (config.rb) ARE ported — all four in packages/activerecord/src/support/connection.ts, next to the CONNECTIONS entries they name and expand. They miss only because the bucket's expected TS file is config.ts; export status is not why — in the default full-surface run the TS extractor records file-local functions too, so the non-exported `expandConfig` (connection.ts:269) is as visible to api:compare as the three exported ones, and exporting it would not match it. (Under --public-only the two sides drop it symmetrically: Ruby's `expand_config` is itself private, under config.rb's `private` at :13, so neither side offers it.) Moving it into config.ts is the only thing that would match it, and that is what cannot happen: it is typed on `NamedConnection` and `ARUNIT_ENTRY_NAMES`, both declared in connection.ts, which already imports from config.ts — so the move would CREATE an import cycle, and dragging those declarations along would relocate the `connections:` vocabulary out of the file mirroring connection.rb. (2) `config` / `config_file` / `read_config` are the memoized read of test/config.yml; trails ships no config.yml — the `connections:` hash is expressed directly as the CONNECTIONS table in connection.ts and the sub-setting readers in config.ts — so there is no file to locate, copy from config.example.yml, or parse. Scoped to config.rb, the only Ruby file in the tree that defines these names.
   - `config`, `config_file`, `read_config`, `expand_config`, `connection_name`, `test_configuration_hashes`, `connect` (only in: `config.rb`)
-- I18n::Backend::Base#load_rb (backend/base.rb:236-239) is `eval(IO.read(filename), binding, filename)` — it loads a translation file written in Ruby source. trails has no Ruby to eval, and a `.js` locale module loaded with dynamic `import()` would be new public surface the gem has no counterpart for, so the `.rb` arm of `load_file`'s extension dispatch is not ported at all. The `.yml` / `.yaml` / `.json` arms are.
-  - `load_rb` (only in: `backend/base.rb`)
 
 ## Arity overrides
 

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -1,16 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { I18n } from "./i18n.js";
-import { en } from "./locale/en.js";
 import { toSentence } from "./array-utils.js";
 import { TimeZone } from "./values/time-zone.js";
 import { Date as RubyDate } from "./date.js";
 import type { TimeWithZone } from "./time-with-zone.js";
-
-/** `I18n.reload!` plus the `en` locale Rails re-reads from its load path. */
-async function reloadTranslations(): Promise<void> {
-  await I18n.reloadBang();
-  I18n.backend().storeTranslations("en", en);
-}
 
 // Rails' activesupport/test/abstract_unit.rb:35 turns the check off for the
 // whole suite.
@@ -21,13 +14,13 @@ describe("I18nTest", () => {
   let time: TimeWithZone;
 
   beforeEach(async () => {
-    await reloadTranslations();
+    await I18n.reloadBang();
     date = RubyDate.parse("2008-7-2");
     time = TimeZone.find("UTC").local(2008, 7, 2, 16, 47, 1);
   });
 
   afterEach(async () => {
-    await reloadTranslations();
+    await I18n.reloadBang();
   });
 
   it("time zone localization with default format", () => {

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -5,14 +5,10 @@
  * Rails appends `locale/en.yml` and `locale/en.rb` to `I18n.load_path`
  * (active_support/i18n.rb:16-17) and `Simple#init_translations` reads the path
  * back on first use and after every `I18n.reload!`
- * (i18n/lib/i18n/backend/simple.rb:83-86). `Simple#initTranslations` now reads
- * the path back exactly as the gem does, but the read itself is async — the
- * host awaits `I18n.preloadTranslationFiles()` once at boot — and Active
- * Support has no boot hook of its own to await from (`run_load_hooks(:i18n)`
- * has no port). So the data goes into the backend directly, with the one
- * behavioural difference that `I18n.reloadBang()` drops it instead of
- * re-reading it. Move this to `I18n.load_path` + a preload once the load hook
- * lands; nothing else about this file changes.
+ * (i18n/lib/i18n/backend/simple.rb:83-86). The two locale files are one module
+ * here, so there is one entry rather than two, and it is handed to
+ * `registerLocaleModule` first because evaluating a JS module is async where
+ * Ruby's `eval` in `load_rb` is not.
  *
  * `run_load_hooks(:i18n)` and `i18n/backend/fallbacks` have no port yet.
  */
@@ -20,6 +16,8 @@
 import * as I18n from "@blazetrails/i18n";
 import { en } from "./locale/en.js";
 
-I18n.backend().storeTranslations("en", en);
+const enPath = new URL("./locale/en.js", import.meta.url).pathname;
+I18n.registerLocaleModule(enPath, { en });
+I18n.loadPath().push(enPath);
 
 export { I18n };

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -6,9 +6,18 @@
  * (active_support/i18n.rb:16-17) and `Simple#init_translations` reads the path
  * back on first use and after every `I18n.reload!`
  * (i18n/lib/i18n/backend/simple.rb:83-86). The two locale files are one module
- * here, so there is one entry rather than two, and it is handed to
- * `registerLocaleModule` first because evaluating a JS module is async where
- * Ruby's `eval` in `load_rb` is not.
+ * here, so there is one entry rather than two.
+ *
+ * Rails' two lines are bare appends because `load_rb` reads and evaluates the
+ * named file itself (base.rb:254). Its port cannot: `load_file` and
+ * `load_translations` are synchronous (base.rb:240, :14 — and so is every
+ * `init_translations` call site above them, simple.rb:83-86), while the only
+ * way JS evaluates a module is `import()`, which is a Promise. Awaiting it here
+ * is not open either — a top-level await in this file cannot be transformed to
+ * CJS, which breaks every `tsx`-run script that imports Active Support. So the
+ * module this file has already imported is handed over first, the same way the
+ * host already registers a reader and preloads the bytes for the `.yml` and
+ * `.json` arms of the same dispatch.
  *
  * `run_load_hooks(:i18n)` and `i18n/backend/fallbacks` have no port yet.
  */

--- a/packages/activesupport/src/number-helper-i18n.test.ts
+++ b/packages/activesupport/src/number-helper-i18n.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { I18n } from "./i18n.js";
-import { en } from "./locale/en.js";
 import {
   numberToCurrency,
   numberToRounded,
@@ -13,12 +12,6 @@ import {
 // Rails' activesupport/test/abstract_unit.rb:35 turns the check off for the
 // whole suite; these cases translate under locales they store themselves.
 I18n.setEnforceAvailableLocales(false);
-
-/** `I18n.reload!` plus the `en` locale Rails re-reads from its load path. */
-async function reloadTranslations(): Promise<void> {
-  await I18n.reloadBang();
-  I18n.backend().storeTranslations("en", en);
-}
 
 function setupTranslations(): void {
   I18n.backend().storeTranslations("ts", {
@@ -80,12 +73,12 @@ function setupTranslations(): void {
 
 describe("NumberHelperI18nTest", () => {
   beforeEach(async () => {
-    await reloadTranslations();
+    await I18n.reloadBang();
     setupTranslations();
   });
 
   afterEach(async () => {
-    await reloadTranslations();
+    await I18n.reloadBang();
   });
 
   it("number to i18n currency", () => {

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -13,9 +13,6 @@
  * the value already renders through `inspect`. That is the spelling `localize`,
  * `default` and `resolve` all use for the `Symbol === x` arms of the gem
  * (base.rb:84, base.rb:154).
- *
- * Not ported here: `load_rb` (it `eval`s Ruby source, which trails has none of
- * — see the `SCOPED_SKIP_GROUPS` entry in `scripts/api-compare/conventions.ts`).
  */
 
 import {
@@ -56,6 +53,7 @@ export type FileReader = (filename: string) => Promise<string>;
 
 let fileReader: FileReader | undefined;
 const fileContents = new Map<string, string>();
+const localeModules = new Map<string, unknown>();
 
 /**
  * @noRailsEquivalent PERMANENT — the gem reads translation files with Ruby core —
@@ -81,6 +79,22 @@ export function registerFileReader(reader: FileReader): void {
  * deviation through five packages to remove one from this file. Awaiting the
  * I/O once at boot keeps the async fs and leaves every ported body verbatim.
  */
+/**
+ * Registers an already-imported JavaScript locale module under the load-path
+ * entry that names it, so that `load_rb`'s port can evaluate it synchronously.
+ *
+ * @noRailsEquivalent PERMANENT — `load_rb` (base.rb:254) is
+ * `eval(IO.read(filename), binding, filename)`: Ruby evaluates a source file
+ * synchronously, wherever it sits. JS evaluates one with `import()`, which is a
+ * Promise, and the four lazy `init_translations` call sites (simple.rb:83-86)
+ * are synchronous in Rails all the way up. A host that puts a `.js` file on the
+ * load path has already imported it, so it hands the module over here — the
+ * module counterpart of `preloadTranslationFiles` below.
+ */
+export function registerLocaleModule(filename: string, translations: unknown): void {
+  localeModules.set(filename, translations);
+}
+
 export async function preloadTranslationFiles(...filenames: (string | string[])[]): Promise<void> {
   const paths = filenames.length === 0 ? config().loadPath : filenames;
   for (const filename of paths.flat()) {
@@ -114,6 +128,15 @@ function readTranslationFile(filename: string): Promise<string> {
     );
   }
   return fileReader(filename);
+}
+
+function readLocaleModule(filename: string): unknown {
+  if (!localeModules.has(filename)) {
+    throw new Error(
+      `I18n cannot evaluate ${filename}: importing a module is async, so register it with I18n.registerLocaleModule() before putting it on I18n.load_path.`,
+    );
+  }
+  return localeModules.get(filename);
 }
 
 function readFile(filename: string): string {
@@ -200,9 +223,9 @@ export abstract class Base {
   private eagerLoadedFlag = false;
 
   /**
-   * Accepts a list of paths to translation files. Loads translations from YAML
-   * files (*.yml) or JSON files (*.json). See #loadYml and #loadJson for
-   * details. Ruby's optional block is the trailing argument here.
+   * Accepts a list of paths to translation files. Loads translations from
+   * plain JavaScript (*.js), YAML files (*.yml), or JSON files (*.json). See
+   * #loadJs, #loadYml, and #loadJson for details. Ruby's optional block is the trailing argument here.
    */
   loadTranslations(...filenames: unknown[]): void {
     const block =
@@ -528,7 +551,7 @@ export abstract class Base {
   }
 
   /**
-   * Loads a single translations file by delegating to #loadYml or #loadJson
+   * Loads a single translations file by delegating to #loadJs or #loadYml
    * depending on the file extension and directly merges the data to the
    * existing translations. Raises I18n::UnknownFileType for all other file
    * extensions.
@@ -551,6 +574,16 @@ export abstract class Base {
       });
     }
     return data;
+  }
+
+  /**
+   * Loads a plain JavaScript translations file. Evaluating the file must yield
+   * translation data with locales as toplevel keys — the gem `eval`s Ruby
+   * source for that hash, and a JS module's exports are the same hash.
+   */
+  protected loadJs(filename: string): [unknown, boolean] {
+    const translations = readLocaleModule(filename);
+    return [translations, false];
   }
 
   /**

--- a/packages/i18n/src/backend/simple.test.ts
+++ b/packages/i18n/src/backend/simple.test.ts
@@ -7,7 +7,13 @@ import { config, resetConfig, type TranslationKey } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { UnknownFileType } from "../exceptions.js";
 import { catchException } from "../throw-catch.js";
-import { preloadTranslationFiles, registerFileReader, type TranslateOptions } from "./base.js";
+import {
+  preloadTranslationFiles,
+  registerFileReader,
+  registerLocaleModule,
+  type TranslateOptions,
+} from "./base.js";
+import { en } from "../test-data/locales/en.js";
 import type { TranslationData } from "../utils.js";
 
 /** Mirrors: `locales_dir` in i18n/test/test_helper.rb:44. */
@@ -29,6 +35,7 @@ describe("I18nBackendSimpleTest", () => {
         (name) => `${localesDir()}/${name}`,
       ),
     );
+    registerLocaleModule(`${localesDir()}/en.js`, { en });
     backend = new Simple();
     config().backend = backend;
     config().enforceAvailableLocales = false;
@@ -37,7 +44,7 @@ describe("I18nBackendSimpleTest", () => {
   /** Stands in for Ruby's `send`, which the gem's tests use for these. */
   function send(
     target: Simple,
-    name: "loadYml" | "loadJson",
+    name: "loadJs" | "loadYml" | "loadJson",
     filename: string,
   ): [unknown, boolean] {
     return (target as unknown as Record<typeof name, (f: string) => [unknown, boolean]>)[name](
@@ -129,10 +136,19 @@ describe("I18nBackendSimpleTest", () => {
     expect(() => backend.loadTranslations(`${localesDir()}/en.json`)).not.toThrow();
   });
 
+  it("simple load_translations: given a Ruby file name it does not raise anything", () => {
+    expect(() => backend.loadTranslations(`${localesDir()}/en.js`)).not.toThrow();
+  });
+
   it("simple load_translations: given no argument, it uses I18n.load_path", () => {
     config().loadPath = [`${localesDir()}/en.yml`];
     backend.loadTranslations();
     expect(translations()).toEqual({ en: { foo: { bar: "baz" } } });
+  });
+
+  it("simple load_rb: loads data from a Ruby file", () => {
+    const [data] = send(backend, "loadJs", `${localesDir()}/en.js`);
+    expect(data).toEqual({ en: { fuh: { bah: "bas" } } });
   });
 
   it("simple load_yml: loads data from a YAML file", () => {
@@ -148,14 +164,14 @@ describe("I18nBackendSimpleTest", () => {
   it("simple load_translations: loads data from known file formats", () => {
     backend = new Simple();
     config().backend = backend;
-    backend.loadTranslations(`${localesDir()}/fr.yml`, `${localesDir()}/en.yml`);
-    const expected = { fr: { animal: { dog: "chien" } }, en: { foo: { bar: "baz" } } };
+    backend.loadTranslations(`${localesDir()}/en.js`, `${localesDir()}/en.yml`);
+    const expected = { en: { fuh: { bah: "bas" }, foo: { bar: "baz" } } };
     expect(translations()).toEqual(expected);
   });
 
   it("simple load_translations: given file names as array it does not raise anything", () => {
     expect(() =>
-      backend.loadTranslations([`${localesDir()}/fr.yml`, `${localesDir()}/en.yml`]),
+      backend.loadTranslations([`${localesDir()}/en.js`, `${localesDir()}/en.yml`]),
     ).not.toThrow();
   });
 

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -61,7 +61,12 @@ export {
   withLocale,
 } from "./i18n.js";
 export type { Locale, TranslateKey, TranslationKey } from "./i18n.js";
-export { Base, registerFileReader, preloadTranslationFiles } from "./backend/base.js";
+export {
+  Base,
+  registerFileReader,
+  registerLocaleModule,
+  preloadTranslationFiles,
+} from "./backend/base.js";
 export type { FileReader, TranslateOptions } from "./backend/base.js";
 export { Chain } from "./backend/chain.js";
 export { Simple } from "./backend/simple.js";

--- a/packages/i18n/src/test-data/locales/en.ts
+++ b/packages/i18n/src/test-data/locales/en.ts
@@ -1,0 +1,7 @@
+/**
+ * Mirrors: i18n/test/test_data/locales/en.rb — the fixture `load_rb` evaluates.
+ * Authored as TypeScript and registered under its emitted `en.js` name, the
+ * way `activesupport/src/locale/en.ts` is.
+ */
+
+export const en = { fuh: { bah: "bas" } };

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -19,6 +19,11 @@ import * as path from "path";
  */
 const TOKEN_RENAMES: Record<string, string> = {
   erb: "tse",
+  // A Ruby source file is a TypeScript one: I18n::Backend::Base#load_rb
+  // (i18n/lib/i18n/backend/base.rb:254) loads a translation file written in
+  // Ruby, and its port loads one written in JS, dispatched off the `.js`
+  // extension by `load_file`.
+  rb: "js",
   ERB: "TSE",
   Erb: "Tse",
 };
@@ -441,18 +446,6 @@ export const SCOPED_SKIP_GROUPS: ScopedSkipGroup[] = [
       "connect",
     ],
     rubyFiles: ["config.rb"],
-  },
-  {
-    reason:
-      "I18n::Backend::Base#load_rb (backend/base.rb:236-239) is " +
-      "`eval(IO.read(filename), binding, filename)` — it loads a translation " +
-      "file written in Ruby source. trails has no Ruby to eval, and a `.js` " +
-      "locale module loaded with dynamic `import()` would be new public " +
-      "surface the gem has no counterpart for, so the `.rb` arm of " +
-      "`load_file`'s extension dispatch is not ported at all. The `.yml` / " +
-      "`.yaml` / `.json` arms are.",
-    names: ["load_rb"],
-    rubyFiles: ["backend/base.rb"],
   },
 ];
 


### PR DESCRIPTION
Rails appends `locale/en.yml` and `locale/en.rb` to `I18n.load_path`
(`activesupport/lib/active_support/i18n.rb:16-17`) and `Simple#init_translations`
(`i18n/lib/i18n/backend/simple.rb:83-86`) reads them back on first use and after
every `I18n.reload!`. `packages/activesupport/src/i18n.ts` stored the `en` hash
directly into the backend, so `I18n.reloadBang()` dropped Active Support's
`date`, `time`, `support` and `number` translations permanently — which is why
`i18n.test.ts` and `number-helper-i18n.test.ts` each carried a
`reloadTranslations()` helper that re-stored `en` by hand.

## Changes

- **`Backend::Base#loadJs`** — the port of `load_rb`
  (`i18n/lib/i18n/backend/base.rb:254`). The gem `eval`s a Ruby source file for
  a hash with locales as toplevel keys; a JS module's exports are that same
  hash.
- **`registerLocaleModule`** — evaluating a JS module is async where Ruby's
  `eval` is not, and the four lazy `init_translations` call sites
  (simple.rb:83-86) are synchronous in Rails all the way up. A host that puts a
  `.js` file on the load path has already imported it, so it hands the module
  over and `loadJs` reads it back synchronously. This is the module counterpart
  of the existing `preloadTranslationFiles` byte seam and carries the same
  `@noRailsEquivalent PERMANENT` reasoning. It keeps the gem's whole loading
  chain verbatim and, critically, introduces no top-level await.
- **`conventions.ts`** — `TOKEN_RENAMES` gains `rb -> js`, the same whole-token
  shape as the existing `erb -> tse`, so `load_rb` matches `loadJs`. The
  `SCOPED_SKIP_GROUPS` entry that deferred `load_rb` is deleted (converged, not
  re-justified).
- **`activesupport/src/i18n.ts`** — registers the module, then appends its path
  to `I18n.loadPath()`. `Simple#initTranslations` loads it lazily and
  `reloadBang()` re-reads it, exactly as the gem does.
- **Tests** — both `reloadTranslations()` helpers are deleted; `I18n.reloadBang()`
  alone now restores the locale, as in Rails. `to sentence` grows the two
  alone now restores the locale, as in Rails.

## Why not a bare `load_path <<` with `loadJs` reading the file

Rails' two lines in `active_support/i18n.rb:16-17` are bare appends because
`load_rb` reads and evaluates the named file itself
(`i18n/lib/i18n/backend/base.rb:254`). The port cannot do that, for two
independent reasons:

1. **The loading chain is synchronous on `main`.** `#6030`/`#6031` landed
   `loadTranslations(...): void` and `loadFile(...): TranslationData`, and every
   `init_translations` call site above them (simple.rb:83-86) is synchronous in
   Rails all the way up through `Error#message`, `Naming#human` and
   `NumberConverter#format`. The only way JS evaluates a module is `import()`,
   which is a Promise. An `async loadJs` would have to un-converge that chain.
2. **A boot await is not available either.** An earlier revision of this PR did
   exactly the bare-append shape with `await I18n.preloadTranslationFiles()` in
   `i18n.ts`. It failed CI: esbuild rejects it with
   `Top-level await is currently not supported with the "cjs" output format`,
   which takes down every `tsx`-run script that imports Active Support
   (`scripts/schema-compare/compare.ts` among them).

So the seam is language-forced, and it is not a new *kind* of seam: the `.yml`
and `.json` arms of the very same `load_file` dispatch already require the host
to `registerFileReader` and `preloadTranslationFiles` before the loader can read
a file, each carrying `@noRailsEquivalent PERMANENT`. `registerLocaleModule` is
the module counterpart, and Active Support has the module in hand already — it
imports `en` on the line above. The story's converged shape anticipates this
explicitly: "check what `load_rb` maps onto in the shipped loader (dynamic
`import()` vs a registered value) and follow it". The shipped loader is
synchronous, so the registered-value arm is the one that exists.

The justification is at the call site (`activesupport/src/i18n.ts`), not only
here.

## Test mirrors

`simple_test.rb`'s three `.rb`-arm cases had no counterpart while `load_rb` was
skipped, and the two mixed-format cases substituted `fr.yml` for the gem's
`en.rb`. All four now mirror the gem, with `test-data/locales/en.ts` standing in
for `test_data/locales/en.rb` under its emitted `en.js` name:

- `simple load_translations: given a Ruby file name it does not raise anything`
  (simple_test.rb:78-80)
- `simple load_rb: loads data from a Ruby file` (simple_test.rb:88-90)
- `simple load_translations: loads data from known file formats` and
  `... given file names as array it does not raise anything` (simple_test.rb:112-123)

`pnpm test:compare`: `backend/simple_test.rb` 28 -> 30 matched.

## Verification

`pnpm typecheck`, `pnpm build`, `pnpm vitest run packages/activesupport
packages/i18n packages/activemodel` (6496 passed), `pnpm api:calls`,
`pnpm api:calls:wide`, `pnpm api:extra --package i18n`.

Both failure modes from the earlier revision of this PR are gone, and both are
now checked directly:
`node --input-type=module -e "await import('./packages/activesupport/dist/i18n.js')"`
and `pnpm exec tsx scripts/schema-compare/compare.ts` (the CJS transform that
rejected top-level await) both succeed.

The one `api:extra` failure (`NestedAttributesDisplacementError`, activerecord)
is pre-existing on `main`.

`toSentence`'s missing `support.array` lookup — filed from this PR as
`0074-i18n-parity/as-to-sentence-i18n-connectors` — has since shipped in #6039,
so `i18n_test.rb`'s `to sentence` bodies are verbatim on `main` and this branch
carries no adaptation of them.

Closes-story: as-i18n-register-en-on-load-path
