### PR TITLE
refactor(i18n): type Config#backend as Backend::Base

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -59,7 +59,6 @@ let fileReader: FileReader | undefined;
  * `YAML.load_file` (base.rb:246) and `JSON.load_file` (base.rb:262). JS has no
  * filesystem in the language, and `packages/i18n` imports nothing from `node:*`
  * so it stays usable off a server, so the host registers the reader instead.
- * Mirrors the `registerDefaultBackend` seam in `config.ts`.
  */
 export function registerFileReader(reader: FileReader): void {
   fileReader = reader;

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -10,7 +10,6 @@
  * JS has no threads, so the concurrent-hash machinery has nothing to guard.
  */
 
-import { registerDefaultBackend } from "../config.js";
 import {
   EMPTY_HASH,
   availableLocalesInitialized,
@@ -169,5 +168,3 @@ export class Simple extends Base {
     return result;
   }
 }
-
-registerDefaultBackend(() => new Simple());

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -1,34 +1,28 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { Config, registerDefaultBackend, resetClassConfig, type Backend } from "./config.js";
+import { Config, resetClassConfig } from "./config.js";
 import { ExceptionHandler, InvalidLocale, MissingInterpolationArgument } from "./exceptions.js";
 import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
 import { resetConfig } from "./i18n.js";
+import { Base } from "./backend/base.js";
+import { Simple } from "./backend/simple.js";
 
-class FakeBackend implements Backend {
+class FakeBackend extends Base {
   reloaded = 0;
-  constructor(private locales: string[] = ["en"]) {}
+  constructor(private locales: string[] = ["en"]) {
+    super();
+  }
   storeTranslations(): unknown {
     return null;
   }
   availableLocales(): string[] {
     return this.locales;
   }
-  reloadBang(): void {
+  override reloadBang(): void {
     this.reloaded += 1;
   }
-  eagerLoadBang(): void {}
-  translate(): unknown {
+  protected lookup(): unknown {
     return null;
-  }
-  exists(): boolean {
-    return false;
-  }
-  localize(): unknown {
-    return null;
-  }
-  transliterate(): string {
-    return "";
   }
 }
 
@@ -43,7 +37,6 @@ describe("Config", () => {
     resetConfig();
     resetClassConfig();
     config = new Config();
-    registerDefaultBackend(() => new FakeBackend());
   });
 
   it("locale defaults to the default locale and is per-instance", () => {
@@ -68,16 +61,11 @@ describe("Config", () => {
     expect(new Config().defaultLocale).toBe("de");
   });
 
-  it("backend defaults to the registered default and is settable", () => {
-    expect(config.backend).toBeInstanceOf(FakeBackend);
+  it("backend defaults to Backend::Simple and is settable", () => {
+    expect(config.backend).toBeInstanceOf(Simple);
     const backend = new FakeBackend(["fr"]);
     config.backend = backend;
     expect(new Config().backend).toBe(backend);
-  });
-
-  it("backend raises when no default backend is registered", () => {
-    resetClassConfig();
-    expect(() => config.backend).toThrow(/no backend/);
   });
 
   it("availableLocales delegates to the backend until set", () => {

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -5,28 +5,8 @@
 import { enforceAvailableLocalesBang, type Locale, type TranslationKey } from "./i18n.js";
 import { ExceptionHandler, MissingInterpolationArgument } from "./exceptions.js";
 import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
-import type { TranslationData } from "./utils.js";
-
-/** The slice of a backend `Config` hands out. */
-export interface Backend {
-  storeTranslations(
-    locale: Locale,
-    data: TranslationData,
-    options?: Record<string, unknown>,
-  ): unknown;
-  availableLocales(): Locale[];
-  reloadBang(): void;
-  eagerLoadBang(): void;
-  translate(locale: Locale, key: unknown, options?: Record<string, unknown>): unknown;
-  exists(locale: Locale, key: TranslationKey, options?: Record<string, unknown>): boolean;
-  localize(
-    locale: Locale,
-    object: unknown,
-    format: unknown,
-    options?: Record<string, unknown>,
-  ): unknown;
-  transliterate(locale: Locale, string: string, replacement?: string | null): string;
-}
+import type { Base } from "./backend/base.js";
+import { Simple } from "./backend/simple.js";
 
 /**
  * Ruby's handler is a Symbol naming a method on `I18n`, a Proc, or any object
@@ -52,7 +32,7 @@ export type MissingInterpolationArgumentHandler = (
  * instance (and subclass); these module-level bindings are the JS equivalent.
  * Only `locale` is per-instance, exactly as in the gem.
  */
-let backend: Backend | undefined;
+let backend: Base | undefined;
 let defaultLocale: Locale | undefined;
 let availableLocales: Locale[] | undefined;
 let availableLocalesSet: Set<Locale> | undefined;
@@ -62,18 +42,6 @@ let missingInterpolationArgumentHandler: MissingInterpolationArgumentHandler | u
 let loadPath: string[] | undefined;
 let enforceAvailableLocalesFlag = true;
 let interpolationPatterns: RegExp[] | undefined;
-
-let defaultBackendFactory: (() => Backend) | undefined;
-
-/**
- * Ruby's `Config#backend` defaults to `Backend::Simple.new`, resolved through
- * `autoload`. `backend/simple.ts` is not ported yet, so it registers itself
- * here when it lands; until then `config.backend` raises rather than handing
- * back a half-built default.
- */
-export function registerDefaultBackend(factory: () => Backend): void {
-  defaultBackendFactory = factory;
-}
 
 export class Config {
   private localeValue?: Locale | false;
@@ -89,19 +57,12 @@ export class Config {
   }
 
   /** Returns the current backend. Defaults to `Backend::Simple`. */
-  get backend(): Backend {
-    if (!backend) {
-      if (!defaultBackendFactory) {
-        throw new Error(
-          "I18n has no backend: set `I18n.config.backend`, or port I18n::Backend::Simple and register it with registerDefaultBackend().",
-        );
-      }
-      backend = defaultBackendFactory();
-    }
+  get backend(): Base {
+    backend ??= new Simple();
     return backend;
   }
 
-  set backend(value: Backend) {
+  set backend(value: Base) {
     backend = value;
   }
 
@@ -219,5 +180,4 @@ export function resetClassConfig(): void {
   loadPath = undefined;
   enforceAvailableLocalesFlag = true;
   interpolationPatterns = undefined;
-  defaultBackendFactory = undefined;
 }

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -16,7 +16,8 @@
  * handler that names a real export dispatches exactly as the gem's does.
  */
 import * as I18n from "./i18n.js";
-import type { Backend, ExceptionHandlerLike } from "./config.js";
+import type { ExceptionHandlerLike } from "./config.js";
+import type { Base } from "./backend/base.js";
 import { Config } from "./config.js";
 import { ArgumentError, Disabled, InvalidLocale, MissingTranslation } from "./exceptions.js";
 import type { TranslateOptions } from "./backend/base.js";
@@ -111,11 +112,11 @@ export function setLocale(value: Locale | false): void {
   config().locale = value;
 }
 
-export function backend(): Backend {
+export function backend(): Base {
   return config().backend;
 }
 
-export function setBackend(value: Backend): void {
+export function setBackend(value: Base): void {
   config().backend = value;
 }
 
@@ -384,7 +385,7 @@ function translateKey(
   throwOption: unknown,
   raise: unknown,
   locale: Locale,
-  backend: Backend,
+  backend: Base,
   options: TranslateOptions,
 ): unknown {
   const result = catchException(() => backend.translate(locale, key, options));

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,9 +1,5 @@
-export { Config, registerDefaultBackend } from "./config.js";
-export type {
-  Backend,
-  ExceptionHandlerLike,
-  MissingInterpolationArgumentHandler,
-} from "./config.js";
+export { Config } from "./config.js";
+export type { ExceptionHandlerLike, MissingInterpolationArgumentHandler } from "./config.js";
 export {
   ArgumentError,
   Disabled,


### PR DESCRIPTION
Types `Config#backend` as the `Base` abstract class instead of a hand-written
interface slice.

The gem has no such type: `I18n::Config#backend` (`vendor/i18n/lib/i18n/config.rb:26-28`)
returns `@@backend ||= Backend::Simple.new`, i.e. a `Backend::Base` including
object. The members the deleted `Backend` interface enumerated are exactly
`I18n::Backend::Base`'s, and every one of them was added as a bug report from a
caller that could not typecheck (`storeTranslations` was #6011).

- Delete `export interface Backend` from `packages/i18n/src/config.ts`; the
  reader and writer are typed `Base` (`packages/i18n/src/backend/base.ts`, the
  port of `I18n::Backend::Base`).
- With a concrete `Simple` reachable, the default resolves the way
  `config.rb:27` writes it — `backend ??= new Simple()` — so
  `registerDefaultBackend` and its "no backend registered" raise go away.
  `api:extra --package i18n` novel count for `config.ts`: 1 → 0 (the file no
  longer appears in the per-file detail at all).
- `i18n.ts` / `index.ts` follow the type through; `backend/simple.ts` loses its
  self-registration call.
- `FakeBackend` in `config.trails.test.ts` extends `Base`. The
  "backend raises when no default backend is registered" trails-only test is
  removed with the behavior it covered.

The `config.ts` → `simple.ts` edge is a value import, closing the
`base.ts` → `i18n.ts` → `config.ts` cycle; nothing in `config.ts` touches
`Simple` at module-eval time, so the cycle is inert — verified by the suite.

`pnpm vitest run packages/i18n/src` green (222). `pnpm api:calls` and
`pnpm api:calls:wide` OK.

Closes-story: i18n-config-backend-typed-as-base
