### PR TITLE
refactor(i18n): converge Simple's lazy init onto the gem's load-then-initialize order

### DIFF
--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -5,13 +5,13 @@
  * Rails appends `locale/en.yml` and `locale/en.rb` to `I18n.load_path`
  * (active_support/i18n.rb:16-17) and `Simple#init_translations` reads the path
  * back on first use and after every `I18n.reload!`
- * (i18n/lib/i18n/backend/simple.rb:83-86). Neither `load_path` end is ported:
- * `Backend::Base#load_translations` / `load_file` / `load_rb` need async fs and
- * a YAML reader, and `Simple#initTranslations` only flips its flag until they
- * land (story `i18n-backend-file-loading-localize`). Registering a path here
- * would therefore store nothing at all, so the data goes into the backend
- * directly — with the one behavioural difference that `I18n.reloadBang()` drops
- * it instead of re-reading it. Move this to `I18n.setLoadPath` when the loader
+ * (i18n/lib/i18n/backend/simple.rb:83-86). `Simple#initTranslations` now reads
+ * the path back exactly as the gem does, but the read itself is async — the
+ * host awaits `I18n.preloadTranslationFiles()` once at boot — and Active
+ * Support has no boot hook of its own to await from (`run_load_hooks(:i18n)`
+ * has no port). So the data goes into the backend directly, with the one
+ * behavioural difference that `I18n.reloadBang()` drops it instead of
+ * re-reading it. Move this to `I18n.load_path` + a preload once the load hook
  * lands; nothing else about this file changes.
  *
  * `run_load_hooks(:i18n)` and `i18n/backend/fallbacks` have no port yet.

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -66,6 +66,19 @@ describe("I18n::Backend::Base file loading", () => {
     expect(backend.initialized()).toBe(true);
   });
 
+  it("re-reads I18n.load_path when the preload is re-run before reloadBang", async () => {
+    let body = "en:\n  foo:\n    bar: baz\n";
+    registerFileReader(() => Promise.resolve(body));
+    config().loadPath = ["mutable.yml"];
+    await preloadTranslationFiles();
+    expect(backend.translate("en", "foo.bar")).toBe("baz");
+
+    body = "en:\n  foo:\n    bar: qux\n";
+    await preloadTranslationFiles();
+    backend.reloadBang();
+    expect(backend.translate("en", "foo.bar")).toBe("qux");
+  });
+
   it("leaves the lazy-init guard armed when the load path holds an invalid file", () => {
     config().loadPath = [`${localesDir()}/invalid/syntax.yml`];
     expect(() => backend.translate("en", "foo.bar")).toThrow(InvalidLocaleData);

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -9,7 +9,7 @@ import { Simple } from "./simple.js";
 import { config, resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { InvalidLocaleData } from "../exceptions.js";
-import { registerFileReader } from "./base.js";
+import { preloadTranslationFiles, registerFileReader } from "./base.js";
 import { parseYaml } from "../yaml.js";
 
 function localesDir(): string {
@@ -19,50 +19,56 @@ function localesDir(): string {
 describe("I18n::Backend::Base file loading", () => {
   let backend: Simple;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetConfig();
     resetClassConfig();
     registerFileReader((filename) => readFile(filename, "utf8"));
+    await preloadTranslationFiles(
+      ["en.yml", "fr.yml", "invalid/empty.yml", "invalid/syntax.yml"].map(
+        (name) => `${localesDir()}/${name}`,
+      ),
+    );
     backend = new Simple();
     config().backend = backend;
     config().enforceAvailableLocales = false;
   });
 
-  it("raises InvalidLocaleData given a YAML file that is empty", async () => {
-    await expect(
-      backend.loadTranslations(`${localesDir()}/invalid/empty.yml`),
-    ).rejects.toBeInstanceOf(InvalidLocaleData);
+  it("raises InvalidLocaleData given a YAML file that is empty", () => {
+    expect(() => backend.loadTranslations(`${localesDir()}/invalid/empty.yml`)).toThrow(
+      InvalidLocaleData,
+    );
   });
 
-  it("raises InvalidLocaleData naming the file given a YAML syntax error", async () => {
+  it("raises InvalidLocaleData naming the file given a YAML syntax error", () => {
     const filename = `${localesDir()}/invalid/syntax.yml`;
-    await expect(backend.loadTranslations(filename)).rejects.toThrow(
+    expect(() => backend.loadTranslations(filename)).toThrow(
       new RegExp(`^can not load translations from ${filename}: `),
     );
   });
 
-  it("yields each filename and its data to the block", async () => {
+  it("yields each filename and its data to the block", () => {
     const yielded: unknown[] = [];
     const fr = `${localesDir()}/fr.yml`;
-    await backend.loadTranslations(fr, (...args: unknown[]) => yielded.push(args));
+    backend.loadTranslations(fr, (...args: unknown[]) => yielded.push(args));
     expect(yielded).toEqual([[fr, { fr: { animal: { dog: "chien" } } }]]);
   });
 
   it("refuses a lazy lookup while I18n.load_path is unread", () => {
-    config().loadPath = [`${localesDir()}/en.yml`];
-    expect(() => backend.translate("en", "foo.bar")).toThrow(/await backend.loadTranslations/);
+    config().loadPath = [`${localesDir()}/never-preloaded.yml`];
+    expect(() => backend.translate("en", "foo.bar")).toThrow(
+      /await I18n.preloadTranslationFiles\(\)/,
+    );
   });
 
-  it("serves lookups after an awaited preload of I18n.load_path", async () => {
+  it("serves lookups after an awaited preload of I18n.load_path", () => {
     config().loadPath = [`${localesDir()}/en.yml`];
-    await backend.loadTranslations();
     expect(backend.translate("en", "foo.bar")).toBe("baz");
+    expect(backend.initialized()).toBe(true);
   });
 
-  it("leaves the lazy-init guard armed when the preload rejects", async () => {
+  it("leaves the lazy-init guard armed when the load path holds an invalid file", () => {
     config().loadPath = [`${localesDir()}/invalid/syntax.yml`];
-    await expect(backend.loadTranslations()).rejects.toBeInstanceOf(InvalidLocaleData);
-    expect(() => backend.translate("en", "foo.bar")).toThrow(/await backend.loadTranslations/);
+    expect(() => backend.translate("en", "foo.bar")).toThrow(InvalidLocaleData);
     expect(backend.initialized()).toBe(false);
   });
 

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -53,6 +53,7 @@ export type TranslateOptions = { [key: string]: unknown };
 export type FileReader = (filename: string) => Promise<string>;
 
 let fileReader: FileReader | undefined;
+const fileContents = new Map<string, string>();
 
 /**
  * @noRailsEquivalent PERMANENT — the gem reads translation files with Ruby core —
@@ -65,13 +66,44 @@ export function registerFileReader(reader: FileReader): void {
   fileReader = reader;
 }
 
-function readFile(filename: string): Promise<string> {
+/**
+ * Reads every file in `I18n.load_path` into memory, so that the gem's loading
+ * chain — `load_translations` / `load_file` / `load_yml` / `load_json`, and
+ * `Simple#init_translations` above them — can stay synchronous exactly as the
+ * gem writes it.
+ *
+ * @noRailsEquivalent PERMANENT — the gem has no preload because Ruby reads
+ * files synchronously, so `init_translations` can read at its four lazy call
+ * sites (simple.rb:83-86). Here the read is a Promise and those sites are
+ * synchronous in Rails all the way up through `Error#message`,
+ * `Naming#human` and `NumberConverter#format`; making them async would push a
+ * deviation through five packages to remove one from this file. Awaiting the
+ * I/O once at boot keeps the async fs and leaves every ported body verbatim.
+ */
+export async function preloadTranslationFiles(...filenames: (string | string[])[]): Promise<void> {
+  const paths = filenames.length === 0 ? config().loadPath : filenames;
+  for (const filename of paths.flat()) {
+    fileContents.set(filename, await readTranslationFile(filename));
+  }
+}
+
+function readTranslationFile(filename: string): Promise<string> {
   if (!fileReader) {
     throw new Error(
       "I18n cannot read translation files: register a reader with registerFileReader().",
     );
   }
   return fileReader(filename);
+}
+
+function readFile(filename: string): string {
+  const contents = fileContents.get(filename);
+  if (contents === undefined) {
+    throw new Error(
+      `I18n cannot read ${filename}: reading translation files is async, so await I18n.preloadTranslationFiles() after setting I18n.load_path.`,
+    );
+  }
+  return contents;
 }
 
 /** Mirrors: Ruby's `File.extname`, down to the leading dot. */
@@ -142,36 +174,22 @@ export abstract class Base {
   transliterators?: Record<Locale, HashTransliterator | ProcTransliterator>;
 
   private eagerLoadedFlag = false;
-  /**
-   * Whether `I18n.load_path` has actually been read. The gem needs no such
-   * flag: `load_translations` is synchronous there, so a lazy-init call site
-   * can just run it. Here the read is async and has to happen up front, and
-   * `Simple#markInitialized` consults this to tell "nothing to load" apart
-   * from "not loaded yet".
-   */
-  protected loadPathRead = false;
 
   /**
    * Accepts a list of paths to translation files. Loads translations from YAML
    * files (*.yml) or JSON files (*.json). See #loadYml and #loadJson for
    * details. Ruby's optional block is the trailing argument here.
-   *
-   * A no-arg call records that `I18n.load_path` was read, but only once every
-   * file has loaded: a rejected preload must leave `Simple`'s lazy-init guard
-   * armed rather than let a later lookup initialize against partial data.
    */
-  async loadTranslations(...filenames: unknown[]): Promise<void> {
+  loadTranslations(...filenames: unknown[]): void {
     const block =
       typeof filenames[filenames.length - 1] === "function"
         ? (filenames.pop() as (filename: string, loadedTranslations: TranslationData) => void)
         : undefined;
-    const fromLoadPath = filenames.length === 0;
-    if (fromLoadPath) filenames = config().loadPath;
+    if (filenames.length === 0) filenames = config().loadPath;
     for (const filename of (filenames as (string | string[])[]).flat()) {
-      const loadedTranslations = await this.loadFile(filename);
+      const loadedTranslations = this.loadFile(filename);
       if (block) block(filename, loadedTranslations);
     }
-    if (fromLoadPath) this.loadPathRead = true;
   }
 
   /**
@@ -278,7 +296,6 @@ export abstract class Base {
   abstract availableLocales(): Locale[];
 
   reloadBang(): void {
-    this.loadPathRead = false;
     if (this.eagerLoaded()) this.eagerLoadBang();
   }
 
@@ -496,14 +513,14 @@ export abstract class Base {
    * existing translations. Raises I18n::UnknownFileType for all other file
    * extensions.
    */
-  protected async loadFile(filename: string): Promise<TranslationData> {
+  protected loadFile(filename: string): TranslationData {
     const type = extname(filename).replaceAll(".", "").toLowerCase();
     const loader = (this as unknown as Record<string, unknown>)[
       `load${type.charAt(0).toUpperCase()}${type.slice(1)}`
     ];
     if (typeof loader !== "function") throw new UnknownFileType(type, filename);
-    const [data, keysSymbolized] = await (
-      loader as (this: Base, filename: string) => Promise<[unknown, boolean]>
+    const [data, keysSymbolized] = (
+      loader as (this: Base, filename: string) => [unknown, boolean]
     ).call(this, filename);
     if (!isHash(data)) {
       throw new InvalidLocaleData(filename, "expects it to return a hash, but does not");
@@ -523,12 +540,12 @@ export abstract class Base {
    * `parseYaml` neither symbolizes nor freezes, so `keys_symbolized` is false.
    *
    * @missingRailsCall load_file — Ruby's `YAML.load_file` (base.rb:246) reads
-   * and parses in one call; JS has neither, so the read goes through the
-   * registered reader and the parse through `parseYaml`.
+   * and parses in one call; JS has neither, so the read is served from the
+   * preload (`preloadTranslationFiles`) and the parse goes through `parseYaml`.
    */
-  protected async loadYml(filename: string): Promise<[unknown, boolean]> {
+  protected loadYml(filename: string): [unknown, boolean] {
     try {
-      return [parseYaml(await readFile(filename)), false];
+      return [parseYaml(readFile(filename)), false];
     } catch (e) {
       throw new InvalidLocaleData(filename, inspectError(e));
     }
@@ -543,12 +560,12 @@ export abstract class Base {
    * (:load_file)` probe that neither symbolizes nor freezes exists here.
    *
    * @missingRailsCall load_file — Ruby's `JSON.load_file` (base.rb:262) reads
-   * and parses in one call; `JSON.parse` only parses, so the read goes through
-   * the registered reader.
+   * and parses in one call; `JSON.parse` only parses, so the read is served
+   * from the preload (`preloadTranslationFiles`).
    */
-  protected async loadJson(filename: string): Promise<[unknown, boolean]> {
+  protected loadJson(filename: string): [unknown, boolean] {
     try {
-      return [JSON.parse(await readFile(filename)), false];
+      return [JSON.parse(readFile(filename)), false];
     } catch (e) {
       throw new InvalidLocaleData(filename, inspectError(e));
     }

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -79,6 +79,12 @@ export function registerFileReader(reader: FileReader): void {
  * `Naming#human` and `NumberConverter#format`; making them async would push a
  * deviation through five packages to remove one from this file. Awaiting the
  * I/O once at boot keeps the async fs and leaves every ported body verbatim.
+ *
+ * One behavioural consequence, and the only one: `I18n.reload!` re-parses these
+ * bytes rather than re-reading the files, so it does not pick up an edit on
+ * disk the way `reload!` does in the gem. Re-running this preload before
+ * `I18n.reloadBang()` restores that; a synchronous re-read here is exactly what
+ * the language does not allow.
  */
 export async function preloadTranslationFiles(...filenames: (string | string[])[]): Promise<void> {
   const paths = filenames.length === 0 ? config().loadPath : filenames;

--- a/packages/i18n/src/backend/simple.test.ts
+++ b/packages/i18n/src/backend/simple.test.ts
@@ -7,7 +7,7 @@ import { config, resetConfig, type TranslationKey } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { UnknownFileType } from "../exceptions.js";
 import { catchException } from "../throw-catch.js";
-import { registerFileReader, type TranslateOptions } from "./base.js";
+import { preloadTranslationFiles, registerFileReader, type TranslateOptions } from "./base.js";
 import type { TranslationData } from "../utils.js";
 
 /** Mirrors: `locales_dir` in i18n/test/test_helper.rb:44. */
@@ -18,10 +18,17 @@ function localesDir(): string {
 describe("I18nBackendSimpleTest", () => {
   let backend: Simple;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetConfig();
     resetClassConfig();
     registerFileReader((filename) => readFile(filename, "utf8"));
+    // The gem reads files synchronously inside `load_translations`; here the
+    // I/O is awaited up front so every ported body below stays synchronous.
+    await preloadTranslationFiles(
+      ["en.yml", "en.yaml", "en.json", "fr.yml", "invalid/empty.yml", "invalid/syntax.yml"].map(
+        (name) => `${localesDir()}/${name}`,
+      ),
+    );
     backend = new Simple();
     config().backend = backend;
     config().enforceAvailableLocales = false;
@@ -32,10 +39,10 @@ describe("I18nBackendSimpleTest", () => {
     target: Simple,
     name: "loadYml" | "loadJson",
     filename: string,
-  ): Promise<[unknown, boolean]> {
-    return (target as unknown as Record<typeof name, (f: string) => Promise<[unknown, boolean]>>)[
-      name
-    ](filename);
+  ): [unknown, boolean] {
+    return (target as unknown as Record<typeof name, (f: string) => [unknown, boolean]>)[name](
+      filename,
+    );
   }
 
   function storeTranslations(locale: string, data: TranslationData): unknown {
@@ -110,48 +117,46 @@ describe("I18nBackendSimpleTest", () => {
 
   // loading translations
 
-  it("simple load_translations: given an unknown file type it raises I18n::UnknownFileType", async () => {
-    await expect(backend.loadTranslations(`${localesDir()}/en.xml`)).rejects.toBeInstanceOf(
-      UnknownFileType,
-    );
+  it("simple load_translations: given an unknown file type it raises I18n::UnknownFileType", () => {
+    expect(() => backend.loadTranslations(`${localesDir()}/en.xml`)).toThrow(UnknownFileType);
   });
 
-  it("simple load_translations: given a YAML file name with yaml extension does not raise anything", async () => {
-    await expect(backend.loadTranslations(`${localesDir()}/en.yaml`)).resolves.toBeUndefined();
+  it("simple load_translations: given a YAML file name with yaml extension does not raise anything", () => {
+    expect(() => backend.loadTranslations(`${localesDir()}/en.yaml`)).not.toThrow();
   });
 
-  it("simple load_translations: given a JSON file name with yaml extension does not raise anything", async () => {
-    await expect(backend.loadTranslations(`${localesDir()}/en.json`)).resolves.toBeUndefined();
+  it("simple load_translations: given a JSON file name with yaml extension does not raise anything", () => {
+    expect(() => backend.loadTranslations(`${localesDir()}/en.json`)).not.toThrow();
   });
 
-  it("simple load_translations: given no argument, it uses I18n.load_path", async () => {
+  it("simple load_translations: given no argument, it uses I18n.load_path", () => {
     config().loadPath = [`${localesDir()}/en.yml`];
-    await backend.loadTranslations();
+    backend.loadTranslations();
     expect(translations()).toEqual({ en: { foo: { bar: "baz" } } });
   });
 
-  it("simple load_yml: loads data from a YAML file", async () => {
-    const [data] = await send(backend, "loadYml", `${localesDir()}/en.yml`);
+  it("simple load_yml: loads data from a YAML file", () => {
+    const [data] = send(backend, "loadYml", `${localesDir()}/en.yml`);
     expect(data).toEqual({ en: { foo: { bar: "baz" } } });
   });
 
-  it("simple load_json: loads data from a JSON file", async () => {
-    const [data] = await send(backend, "loadJson", `${localesDir()}/en.json`);
+  it("simple load_json: loads data from a JSON file", () => {
+    const [data] = send(backend, "loadJson", `${localesDir()}/en.json`);
     expect(data).toEqual({ en: { foo: { bar: "baz" } } });
   });
 
-  it("simple load_translations: loads data from known file formats", async () => {
+  it("simple load_translations: loads data from known file formats", () => {
     backend = new Simple();
     config().backend = backend;
-    await backend.loadTranslations(`${localesDir()}/fr.yml`, `${localesDir()}/en.yml`);
+    backend.loadTranslations(`${localesDir()}/fr.yml`, `${localesDir()}/en.yml`);
     const expected = { fr: { animal: { dog: "chien" } }, en: { foo: { bar: "baz" } } };
     expect(translations()).toEqual(expected);
   });
 
-  it("simple load_translations: given file names as array it does not raise anything", async () => {
-    await expect(
+  it("simple load_translations: given file names as array it does not raise anything", () => {
+    expect(() =>
       backend.loadTranslations([`${localesDir()}/fr.yml`, `${localesDir()}/en.yml`]),
-    ).resolves.toBeUndefined();
+    ).not.toThrow();
   });
 
   // storing translations
@@ -254,9 +259,9 @@ describe("I18nBackendSimpleTest", () => {
     expect(t("stars.special", { count: 20 })).toBe("20 special stars");
   });
 
-  it("returns localized string given missing pluralization data", async () => {
+  it("returns localized string given missing pluralization data", () => {
     config().loadPath = [`${localesDir()}/en.yml`];
-    await backend.loadTranslations();
+    backend.loadTranslations();
     expect(t("foo.bar", { count: 1 })).toBe("baz");
   });
 });

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -61,7 +61,7 @@ export class Simple extends Base {
 
   /** Get available locales from the translations hash. */
   override availableLocales(): Locale[] {
-    if (!this.initialized()) this.markInitialized();
+    if (!this.initialized()) this.initTranslations();
     const locales: Locale[] = [];
     for (const [locale, data] of Object.entries(this.translations())) {
       const entries = isHash(data) ? Object.keys(data) : [];
@@ -79,13 +79,13 @@ export class Simple extends Base {
   }
 
   override eagerLoadBang(): void {
-    if (!this.initialized()) this.markInitialized();
+    if (!this.initialized()) this.initTranslations();
     super.eagerLoadBang();
   }
 
   translations({ doInit = false }: { doInit?: boolean } = {}): TranslationData {
     // To avoid returning empty translations, call `initTranslations`.
-    if (doInit && !this.initialized()) this.markInitialized();
+    if (doInit && !this.initialized()) this.initTranslations();
 
     // Ruby's default block writes `h[k] = Concurrent::Hash.new` on a missing-key
     // read, and that is observable through the public reader — Rails asserts
@@ -102,33 +102,8 @@ export class Simple extends Base {
     return this.translationsStore;
   }
 
-  /**
-   * Loads `I18n.load_path` and marks the backend initialized.
-   *
-   * Reading files is async here (`packages/i18n` imports nothing from `node:*`
-   * and only does async fs), so this cannot run from the gem's synchronous
-   * lazy-init call sites in `lookup` / `available_locales` / `translations` /
-   * `eager_load!`. A host with a populated `I18n.load_path` awaits this once at
-   * boot; those four sites go through `markInitialized`, which refuses to mark
-   * a backend initialized while its load path is still unread rather than
-   * silently answering from an empty store.
-   */
-  protected async initTranslations(): Promise<void> {
-    await this.loadTranslations();
-    this.initializedFlag = true;
-  }
-
-  /**
-   * @internal The synchronous half of `init_translations` — see there. With an
-   * empty `I18n.load_path` this is the whole of the gem's method, since
-   * `load_translations` then loads nothing.
-   */
-  private markInitialized(): void {
-    if (config().loadPath.length > 0 && !this.loadPathRead) {
-      throw new Error(
-        "I18n.load_path is set but was never read: reading translation files is async, so await backend.loadTranslations() before the first lookup.",
-      );
-    }
+  protected initTranslations(): void {
+    this.loadTranslations();
     this.initializedFlag = true;
   }
 
@@ -145,7 +120,7 @@ export class Simple extends Base {
     scope: unknown = [],
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
-    if (!this.initialized()) this.markInitialized();
+    if (!this.initialized()) this.initTranslations();
     const name = typeof key === "symbol" ? (Symbol.keyFor(key) ?? key.description) : key;
     const keys = normalizeKeys(locale, name, scope, options.separator as string | undefined);
 

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -64,7 +64,7 @@ export {
   withLocale,
 } from "./i18n.js";
 export type { Locale, TranslateKey, TranslationKey } from "./i18n.js";
-export { Base, registerFileReader } from "./backend/base.js";
+export { Base, registerFileReader, preloadTranslationFiles } from "./backend/base.js";
 export type { FileReader, TranslateOptions } from "./backend/base.js";
 export { Simple } from "./backend/simple.js";
 export { ThrownException, catchException, throwException } from "./throw-catch.js";


### PR DESCRIPTION
Converges `Simple`'s lazy init onto the gem's load-then-initialize order
(`i18n/lib/i18n/backend/simple.rb:83-86`). `initTranslations` is now the gem's
body verbatim —

```ts
protected initTranslations(): void {
  this.loadTranslations();
  this.initializedFlag = true;
}
```

— and all four lazy-init sites (`lookup`, `availableLocales`,
`translations(doInit:)`, `eagerLoadBang`) call it, as they do at
`simple.rb:49-55`, `:64-85`, `:93-95`. `markInitialized`, its raise, and the
`loadPathRead` flag it consulted are gone, and `Base#reloadBang` is back to the
gem's two-line body (`base.rb:101-103`).

## Where the async went

The story offered two routes. The async conversion of `lookup` / `translate` /
`availableLocales` was measured and rejected: `I18n.translate` has 12 direct
caller files across `actionpack`, `actionview`, `activemodel`, `activerecord`
and `activesupport`, and every one of them is a method Rails defines as
synchronous — `Error#message` / `#fullMessage`, `Naming#human`,
`Inflector#ordinal`, `NumberConverter#format`, `HtmlSafeTranslation.translate`.
Making them async removes one deviation from this file by pushing a new one
through five packages, well past the LOC ceiling.

Instead the async boundary moves **up**, out of the gem's call chain: the host
awaits `I18n.preloadTranslationFiles()` once after setting `I18n.load_path`,
which reads every file into memory. `loadTranslations` / `loadFile` / `loadYml`
/ `loadJson` then port verbatim and synchronously, and so does everything above
them. The fs stays async and `packages/i18n` still imports nothing from
`node:*` — the read is the host's registered `FileReader`, unchanged and still
`Promise`-returning.

Net effect on fidelity: five method bodies converge onto the gem, and the
deviation shrinks to one seam function next to the `registerFileReader` seam
that was already there, tagged `@noRailsEquivalent PERMANENT` with the same
reasoning.

## Behaviour change worth a look

A parse error in a load-path file used to surface from the awaited
`loadTranslations()`; it now surfaces from the first lazy lookup, which is where
the gem raises it too. A file in `load_path` that was never preloaded raises
naming `preloadTranslationFiles()`, replacing `markInitialized`'s raise.

The one consequence of caching bytes: `I18n.reload!` re-parses them rather than
re-reading the files, so it does not pick up an on-disk edit the way the gem's
`reload!` does. Re-running the preload before `reloadBang()` restores that, and
a test covers it. A synchronous re-read is the part the language forbids.

Falling out of deleting `loadPathRead`: `Base#reloadBang` is back to the gem's
two-line body (`base.rb:101-103`).

Tests keep their Rails names; the loading cases lost their `await` and preload
in `beforeEach` instead.

Closes-story: i18n-backend-async-read-path
