### PR TITLE
fix(i18n): render Hash inspect Ruby-style in error messages

### DIFF
--- a/packages/i18n/src/exceptions.test.ts
+++ b/packages/i18n/src/exceptions.test.ts
@@ -74,7 +74,7 @@ describe("I18nExceptionsTest", () => {
   it("InvalidPluralizationData message contains count, data and missing key", () => {
     forceInvalidPluralizationData((exception) => {
       expect(exception.message).toContain("1");
-      expect(exception.message).toContain(`{other: "bar"}`);
+      expect(exception.message).toContain(`{:other=>"bar"}`);
       expect(exception.message).toContain("one");
     });
   });
@@ -90,7 +90,7 @@ describe("I18nExceptionsTest", () => {
   it("MissingInterpolationArgument message contains the missing and given arguments", () => {
     forceMissingInterpolationArgument((exception) => {
       expect(exception.message).toBe(
-        `missing interpolation argument :bar in "%{bar}" ({baz: "baz"} given)`,
+        `missing interpolation argument :bar in "%{bar}" ({:baz=>"baz"} given)`,
       );
     });
   });

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -18,7 +18,7 @@ export function inspect(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
   if (typeof value === "object") {
     const pairs = Object.entries(value as Record<string, unknown>).map(
-      ([k, v]) => `${k}: ${inspect(v)}`,
+      ([k, v]) => `${inspectSymbol(k)}=>${inspect(v)}`,
     );
     return `{${pairs.join(", ")}}`;
   }

--- a/packages/i18n/src/interpolate.test.ts
+++ b/packages/i18n/src/interpolate.test.ts
@@ -105,7 +105,7 @@ describe("I18nMissingInterpolationCustomHandlerTest", () => {
 
   it("String interpolation can use custom missing interpolation handler", () => {
     expect(I18n.interpolate("%{first} %{last}", { first: "Masao" })).toBe(
-      `Masao missing key is last, values are ${inspect({ first: "Masao" })}, given string is '%{first} %{last}'`,
+      `Masao missing key is last, values are {:first=>"Masao"}, given string is '%{first} %{last}'`,
     );
   });
 });


### PR DESCRIPTION
`inspect` in `packages/i18n/src/exceptions.ts` rendered a Hash JS-style —
`{first: "Masao"}` — where Ruby's `Hash#inspect` renders `{:first=>"Masao"}`.
It stands in for Ruby `#inspect` throughout `exceptions.ts`, so the divergence
was baked into every I18n error message
(`vendor/i18n/lib/i18n/exceptions.rb:44` `MissingInterpolationArgument`,
`:89` `InvalidPluralizationData`).

Hash keys now go through `inspectSymbol` (already the Symbol rendering used
for interpolation keys and locales) and pairs join with `=>`.

Expectations updated to the gem's literal strings:

- `interpolate.test.ts` "String interpolation can use custom missing
  interpolation handler" — `vendor/i18n/test/i18n/interpolate_test.rb:93`
  asserts `values are {:first=>"Masao"}`; the ported case now spells that
  literal instead of routing through `inspect`.
- `exceptions.test.ts` — `exceptions_test.rb:46` (`{:other=>"bar"}`) and
  `:61` (`({:baz=>"baz"} given)`).

Closes-story: i18n-inspect-hash-ruby-rendering
