### PR TITLE
fix(i18n): carry the Symbol spelling on interpolation keys

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -227,7 +227,7 @@ export abstract class Base {
         : this.interpolate(locale!, entry, values);
     } else if (typeof entry === "string") {
       const reserved = reservedKeysPattern().exec(entry);
-      if (reserved) throw new ReservedInterpolationKey(reserved[1], entry);
+      if (reserved) throw new ReservedInterpolationKey(`:${reserved[1]}`, entry);
     }
     return entry;
   }

--- a/packages/i18n/src/backend/exceptions.test.ts
+++ b/packages/i18n/src/backend/exceptions.test.ts
@@ -1,16 +1,8 @@
 /**
  * Mirrors: i18n/test/backend/exceptions_test.rb
- *
- * The `MissingInterpolationArgument` case stays measured as missing rather
- * than faked: it passes the String `'key'` and expects `key.inspect` to render
- * `"key"` (i18n/lib/i18n/exceptions.rb:102), while the message renders every
- * key as a Symbol (`:key`) — which is what `i18n/test/i18n/exceptions_test.rb:59`
- * (ported in `../exceptions.trails.test.ts`) needs, since interpolation keys
- * reach it as bare strings rather than the colon-prefixed spelling. Converging
- * that representation is the `i18n-interpolation-key-symbol-spelling` story.
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { MissingTranslationData } from "../exceptions.js";
+import { MissingInterpolationArgument, MissingTranslationData } from "../exceptions.js";
 import { config, l, resetConfig, setBackend, t } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { catchException } from "../throw-catch.js";
@@ -59,5 +51,12 @@ describe("I18nBackendExceptionsTest", () => {
       exception = error;
     }
     expect(exception!.message).toBe("Translation missing: en.time.formats.foo");
+  });
+
+  it("exceptions: MissingInterpolationArgument message includes missing key, provided keys and full string", () => {
+    const exception = new MissingInterpolationArgument("key", { this: "was given" }, "string");
+    expect(exception.message).toBe(
+      `missing interpolation argument "key" in "string" ({this: "was given"} given)`,
+    );
   });
 });

--- a/packages/i18n/src/exceptions.test.ts
+++ b/packages/i18n/src/exceptions.test.ts
@@ -82,7 +82,7 @@ describe("I18nExceptionsTest", () => {
   it("MissingInterpolationArgument stores key and string", () => {
     expect(() => forceMissingInterpolationArgument()).toThrow(MissingInterpolationArgument);
     forceMissingInterpolationArgument((exception) => {
-      expect(exception.key).toBe("bar");
+      expect(exception.key).toBe(":bar");
       expect(exception.string).toBe("%{bar}");
     });
   });
@@ -97,7 +97,7 @@ describe("I18nExceptionsTest", () => {
 
   it("ReservedInterpolationKey stores key and string", () => {
     forceReservedInterpolationKey((exception) => {
-      expect(exception.key).toBe("scope");
+      expect(exception.key).toBe(":scope");
       expect(exception.string).toBe("%{scope}");
     });
   });

--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -38,8 +38,8 @@ describe("exceptions", () => {
       new MissingTranslation("de", "foo"),
       new MissingTranslationData("de", "foo"),
       new InvalidPluralizationData({ other: "bar" }, 1, "one"),
-      new MissingInterpolationArgument("bar", { baz: "baz" }, "%{bar}"),
-      new ReservedInterpolationKey("scope", "%{scope}"),
+      new MissingInterpolationArgument(":bar", { baz: "baz" }, "%{bar}"),
+      new ReservedInterpolationKey(":scope", "%{scope}"),
       new UnknownFileType("xml", "en.xml"),
     ];
     for (const e of errors) expect(e).toBeInstanceOf(ArgumentError);

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -2,11 +2,12 @@
  * Mirrors: i18n/lib/i18n/exceptions.rb
  *
  * Ruby Symbols have no JS analogue, so every symbol-typed value here (locale,
- * translation key, interpolation key) is a plain string. A value whose Ruby
- * type is what a message's `#inspect` turns on keeps the Symbol's leading
- * colon in that string (`":bar"`), so `inspect` renders it as Ruby does and
- * the String arm — `"bar"` — stays reachable. Where the Symbol spelling is not
- * carried, `inspectSymbol` puts the colon back.
+ * translation key, interpolation key) is a plain string. A Symbol whose
+ * message renders it through `#inspect` alongside a String keeps the leading
+ * colon in that string (`":bar"`), so `inspectSymbolOrString` can tell the two
+ * apart the way Ruby's types do; `inspect` itself stays Ruby's `Object#inspect`
+ * and quotes every String. Where the Symbol spelling is not carried,
+ * `inspectSymbol` puts the colon back.
  */
 
 import { EMPTY_HASH, normalizeKeys } from "./i18n.js";
@@ -15,7 +16,7 @@ import type { Locale, TranslationKey } from "./i18n.js";
 /** @internal Ruby `Object#inspect`, as far as the values reaching this file go. */
 export function inspect(value: unknown): string {
   if (value === null || value === undefined) return "nil";
-  if (typeof value === "string") return value.startsWith(":") ? value : JSON.stringify(value);
+  if (typeof value === "string") return JSON.stringify(value);
   if (typeof value === "function") return "#<Proc>";
   if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
   if (typeof value === "object") {
@@ -29,6 +30,15 @@ export function inspect(value: unknown): string {
 
 function inspectSymbol(value: unknown): string {
   return typeof value === "string" ? `:${value}` : inspect(value);
+}
+
+/**
+ * `#inspect` for a value Rails types as `Symbol | String`, where the two
+ * render differently (`:bar` against `"key"`). The Symbol arm is the string
+ * carrying the Symbol's leading colon, which is what Ruby gets from the type.
+ */
+function inspectSymbolOrString(value: string): string {
+  return value.startsWith(":") ? value : inspect(value);
 }
 
 /**
@@ -190,7 +200,7 @@ export class MissingInterpolationArgument extends ArgumentError {
 
   constructor(key: string, values: Record<string, unknown>, string: string) {
     super(
-      `missing interpolation argument ${inspect(key)} in ${inspect(string)} (${inspect(values)} given)`,
+      `missing interpolation argument ${inspectSymbolOrString(key)} in ${inspect(string)} (${inspect(values)} given)`,
     );
     this.name = "MissingInterpolationArgument";
     this.key = key;
@@ -204,7 +214,7 @@ export class ReservedInterpolationKey extends ArgumentError {
   readonly string: string;
 
   constructor(key: string, string: string) {
-    super(`reserved key ${inspect(key)} used in ${inspect(string)}`);
+    super(`reserved key ${inspectSymbolOrString(key)} used in ${inspect(string)}`);
     this.name = "ReservedInterpolationKey";
     this.key = key;
     this.string = string;

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -2,9 +2,11 @@
  * Mirrors: i18n/lib/i18n/exceptions.rb
  *
  * Ruby Symbols have no JS analogue, so every symbol-typed value here (locale,
- * translation key, interpolation key) is a plain string. Messages that embed
- * one through `#inspect` therefore render it the way Ruby renders a Symbol
- * (`:en`) via `inspectSymbol`; everything else goes through `inspect`.
+ * translation key, interpolation key) is a plain string. A value whose Ruby
+ * type is what a message's `#inspect` turns on keeps the Symbol's leading
+ * colon in that string (`":bar"`), so `inspect` renders it as Ruby does and
+ * the String arm — `"bar"` — stays reachable. Where the Symbol spelling is not
+ * carried, `inspectSymbol` puts the colon back.
  */
 
 import { EMPTY_HASH, normalizeKeys } from "./i18n.js";
@@ -13,7 +15,7 @@ import type { Locale, TranslationKey } from "./i18n.js";
 /** @internal Ruby `Object#inspect`, as far as the values reaching this file go. */
 export function inspect(value: unknown): string {
   if (value === null || value === undefined) return "nil";
-  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "string") return value.startsWith(":") ? value : JSON.stringify(value);
   if (typeof value === "function") return "#<Proc>";
   if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
   if (typeof value === "object") {
@@ -188,7 +190,7 @@ export class MissingInterpolationArgument extends ArgumentError {
 
   constructor(key: string, values: Record<string, unknown>, string: string) {
     super(
-      `missing interpolation argument ${inspectSymbol(key)} in ${inspect(string)} (${inspect(values)} given)`,
+      `missing interpolation argument ${inspect(key)} in ${inspect(string)} (${inspect(values)} given)`,
     );
     this.name = "MissingInterpolationArgument";
     this.key = key;
@@ -202,7 +204,7 @@ export class ReservedInterpolationKey extends ArgumentError {
   readonly string: string;
 
   constructor(key: string, string: string) {
-    super(`reserved key ${inspectSymbol(key)} used in ${inspect(string)}`);
+    super(`reserved key ${inspect(key)} used in ${inspect(string)}`);
     this.name = "ReservedInterpolationKey";
     this.key = key;
     this.string = string;

--- a/packages/i18n/src/interpolate.test.ts
+++ b/packages/i18n/src/interpolate.test.ts
@@ -95,8 +95,6 @@ describe("I18nMissingInterpolationCustomHandlerTest", () => {
     resetConfig();
     resetClassConfig();
     oldHandler = config().missingInterpolationArgumentHandler;
-    // Ruby's `#{key}` calls `Symbol#to_s`, which drops the leading colon the
-    // Symbol spelling carries here.
     config().missingInterpolationArgumentHandler = (key, values, string) =>
       `missing key is ${key.slice(1)}, values are ${inspect(values)}, given string is '${string}'`;
   });

--- a/packages/i18n/src/interpolate.test.ts
+++ b/packages/i18n/src/interpolate.test.ts
@@ -95,8 +95,10 @@ describe("I18nMissingInterpolationCustomHandlerTest", () => {
     resetConfig();
     resetClassConfig();
     oldHandler = config().missingInterpolationArgumentHandler;
+    // Ruby's `#{key}` calls `Symbol#to_s`, which drops the leading colon the
+    // Symbol spelling carries here.
     config().missingInterpolationArgumentHandler = (key, values, string) =>
-      `missing key is ${key}, values are ${inspect(values)}, given string is '${string}'`;
+      `missing key is ${key.slice(1)}, values are ${inspect(values)}, given string is '${string}'`;
   });
 
   afterEach(() => {

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -34,7 +34,7 @@ function unionPattern(patterns: readonly RegExp[]): RegExp {
  */
 export function interpolate(string: string, values: unknown): string {
   const reserved = reservedKeysPattern().exec(string);
-  if (reserved) throw new ReservedInterpolationKey(reserved[1], string);
+  if (reserved) throw new ReservedInterpolationKey(`:${reserved[1]}`, string);
   if (typeof values !== "object" || values === null || Array.isArray(values)) {
     throw new ArgumentError("Interpolation values must be a Hash.");
   }
@@ -56,10 +56,10 @@ export function interpolateHash(string: string, values: Record<string, unknown>)
       interpolated = true;
       if (match === "%%") return "%";
 
-      const key = braced ?? angled ?? match.replace(/[%{}]/g, "");
+      const key = `:${braced ?? angled ?? match.replace(/[%{}]/g, "")}`;
       let value =
-        key in values
-          ? values[key]
+        key.slice(1) in values
+          ? values[key.slice(1)]
           : config().missingInterpolationArgumentHandler(key, values, string);
       if (typeof value === "function") value = (value as (v: unknown) => unknown)(values);
       return format ? sprintf(format, value) : String(value);


### PR DESCRIPTION
Interpolation keys reaching `MissingInterpolationArgument` / `ReservedInterpolationKey` now carry the Ruby Symbol spelling (`":bar"`), and both messages are built with `inspect` rather than the `inspectSymbol` helper that prefixed a colon onto every string and left the String arm unreachable (`i18n/lib/i18n/exceptions.rb:102`, `:108`).

Producers updated to the Symbol spelling, matching the `to_sym` in the Ruby: `interpolate/ruby.rb:24` and `:40`, `backend/base.rb:66`. In `interpolateHash` the key keeps the colon and `slice(1)` recovers the name for the values lookup, per the CLAUDE.md convention.

Ports `i18n/test/backend/exceptions_test.rb:32` ("MissingInterpolationArgument message includes missing key, provided keys and full string") into `packages/i18n/src/backend/exceptions.test.ts`; `i18n/test/i18n/exceptions_test.rb:59` still passes, now asserting `:bar` / `:scope` as Rails does.

`pnpm test:compare --package i18n`: 138/440 → 139/440.

Closes-story: i18n-interpolation-key-symbol-spelling