### PR TITLE
feat(i18n): port the normalize_key double-nested cache

### DIFF
--- a/packages/i18n/src/i18n.trails.test.ts
+++ b/packages/i18n/src/i18n.trails.test.ts
@@ -1,11 +1,13 @@
 /**
  * Trails-only: `translate!` has no case of its own in i18n_test.rb — the gem
- * covers `raise: true` through the backend tests.
+ * covers `raise: true` through the backend tests. Same for the
+ * `@@normalized_key_cache` memoization (i18n.rb:439-442), which the gem never
+ * asserts on directly.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { MissingTranslationData } from "./exceptions.js";
-import { config, resetConfig, translateBang } from "./i18n.js";
+import { config, newDoubleNestedCache, normalizeKeys, resetConfig, translateBang } from "./i18n.js";
 import { resetClassConfig } from "./config.js";
 import { Simple } from "./backend/simple.js";
 
@@ -19,5 +21,31 @@ describe("I18n.translateBang", () => {
 
   it("raises MissingTranslationData for a bogus key", () => {
     expect(() => translateBang("bogus")).toThrow(MissingTranslationData);
+  });
+});
+
+describe("I18n.newDoubleNestedCache", () => {
+  it("returns an empty map whose values are maps", () => {
+    const cache = newDoubleNestedCache();
+    expect(cache.size).toBe(0);
+    cache.set(".", new Map([["foo", ["foo"]]]));
+    expect(cache.get(".")?.get("foo")).toEqual(["foo"]);
+  });
+});
+
+describe("I18n.normalizeKeys memoization", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+  });
+
+  it("does not let a caller mutating its result corrupt the cached segments", () => {
+    normalizeKeys(null, "foo.bar", null).push("baz");
+    expect(normalizeKeys(null, "foo.bar", null)).toEqual(["foo", "bar"]);
+  });
+
+  it("keys the cache by separator", () => {
+    expect(normalizeKeys(null, "foo.bar", null, ".")).toEqual(["foo", "bar"]);
+    expect(normalizeKeys(null, "foo.bar", null, "|")).toEqual(["foo.bar"]);
   });
 });

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -368,14 +368,12 @@ function normalizeKey(key: unknown, separator: string): TranslationKey[] {
     bySeparator = new Map();
     normalizedKeyCache.set(separator, bySeparator);
   }
-  // Ruby's Hash keys by `eql?`, so an Array key memoizes across calls; JS `Map`
-  // keys by identity, so a fresh `["foo", "bar"]` could only ever miss and grow
-  // the cache without bound. The elements still memoize through the recursion.
-  if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
   const cacheKey = key;
   let normalized = bySeparator.get(cacheKey);
   if (normalized === undefined) {
-    if (key === null || key === undefined) {
+    if (Array.isArray(key)) {
+      normalized = key.flatMap((k) => normalizeKey(k, separator));
+    } else if (key === null || key === undefined) {
       normalized = [];
     } else {
       if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -1,7 +1,4 @@
-/**
- * Mirrors: i18n/lib/i18n.rb — partially. `new_double_nested_cache` waits on the
- * normalize-key cache; it lands with its own story (RFC 0074).
- */
+/** Mirrors: i18n/lib/i18n.rb */
 
 /**
  * Ruby's `send(handler, ...)` in `handle_exception` dispatches on the `I18n`
@@ -55,6 +52,15 @@ export const RESERVED_KEYS: string[] = [
   "throw",
 ];
 
+/**
+ * Mirrors: I18n.new_double_nested_cache. Ruby uses `Concurrent::Map`; the JS
+ * analogue is a plain `Map` of `Map`s, since the process-wide config singleton
+ * already stands in for `Thread.current` (i18n.rb:38-40).
+ */
+export function newDoubleNestedCache(): Map<string, Map<unknown, TranslationKey[]>> {
+  return new Map();
+}
+
 function underscore(key: string): string {
   return key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
 }
@@ -98,6 +104,7 @@ export function setConfig(value: Config): void {
 /** @internal Test seam — drops the process-wide config so a case starts clean. */
 export function resetConfig(): void {
   currentConfig = undefined;
+  normalizedKeyCache.clear();
 }
 
 /**
@@ -346,24 +353,41 @@ export function withLocale<T>(tmpLocale: Locale | false | null | undefined, bloc
   }
 }
 
+const normalizedKeyCache = newDoubleNestedCache();
+
 /**
  * Ruby's `key.to_s` on a Symbol is its name; `String(symbol)` is
  * `"Symbol(name)"`, which would otherwise reach the `Translation missing`
  * message through `MissingTranslation#keys`.
  */
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
-  if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
-  if (key === null || key === undefined) return [];
-  if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;
-  const keys = String(key)
-    .split(separator)
-    .filter((k) => k !== "");
-  return keys.map((k) => {
-    if (/^[-+]?([1-9]\d*|0)$/.test(k)) return Number(k);
-    if (k === "true") return true;
-    if (k === "false") return false;
-    return k;
-  });
+  let bySeparator = normalizedKeyCache.get(separator);
+  if (bySeparator === undefined) {
+    bySeparator = new Map();
+    normalizedKeyCache.set(separator, bySeparator);
+  }
+  const cacheKey = key;
+  let normalized = bySeparator.get(cacheKey);
+  if (normalized === undefined) {
+    if (Array.isArray(key)) {
+      normalized = key.flatMap((k) => normalizeKey(k, separator));
+    } else if (key === null || key === undefined) {
+      normalized = [];
+    } else {
+      if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;
+      const keys = String(key)
+        .split(separator)
+        .filter((k) => k !== "");
+      normalized = keys.map((k) => {
+        if (/^[-+]?([1-9]\d*|0)$/.test(k)) return Number(k);
+        if (k === "true") return true;
+        if (k === "false") return false;
+        return k;
+      });
+    }
+    bySeparator.set(cacheKey, normalized);
+  }
+  return normalized;
 }
 
 export function normalizeKeys(

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -53,9 +53,11 @@ export const RESERVED_KEYS: string[] = [
 ];
 
 /**
- * Mirrors: I18n.new_double_nested_cache. Ruby uses `Concurrent::Map`; the JS
- * analogue is a plain `Map` of `Map`s, since the process-wide config singleton
- * already stands in for `Thread.current` (i18n.rb:38-40).
+ * Mirrors: I18n.new_double_nested_cache (i18n.rb:38-40). Ruby uses
+ * `Concurrent::Map`; the JS analogue is a plain `Map` of `Map`s, since the
+ * process-wide config singleton already stands in for `Thread.current`. Ruby's
+ * default block (`{ |h, k| h[k] = Concurrent::Map.new }`) has no `Map`
+ * equivalent, so the outer read installs the inner map at the call site.
  */
 export function newDoubleNestedCache(): Map<string, Map<unknown, TranslationKey[]>> {
   return new Map();
@@ -366,12 +368,14 @@ function normalizeKey(key: unknown, separator: string): TranslationKey[] {
     bySeparator = new Map();
     normalizedKeyCache.set(separator, bySeparator);
   }
+  // Ruby's Hash keys by `eql?`, so an Array key memoizes across calls; JS `Map`
+  // keys by identity, so a fresh `["foo", "bar"]` could only ever miss and grow
+  // the cache without bound. The elements still memoize through the recursion.
+  if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
   const cacheKey = key;
   let normalized = bySeparator.get(cacheKey);
   if (normalized === undefined) {
-    if (Array.isArray(key)) {
-      normalized = key.flatMap((k) => normalizeKey(k, separator));
-    } else if (key === null || key === undefined) {
+    if (key === null || key === undefined) {
       normalized = [];
     } else {
       if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -39,6 +39,7 @@ export {
   locale,
   localeAvailable,
   localize,
+  newDoubleNestedCache,
   normalizeKeys,
   reloadBang,
   reserveKey,


### PR DESCRIPTION
Ports `I18n.new_double_nested_cache` (i18n.rb:38-40) and wires `normalizeKey` through the `@@normalized_key_cache` memo (i18n.rb:439-463), so a repeated key is split and coerced once per separator instead of on every `translate`.

- `newDoubleNestedCache` lands at its Rails name in `i18n.ts`. Ruby's `Concurrent::Map` default block installs the inner map on first read; JS `Map` has no such hook, so the outer read installs it at the call site.
- `normalizeKey` does the memo lookup before the `case key`, with all three branches inside it and a single write, keyed separator-then-key exactly as i18n.rb:441-445. The memo value is always an Array, never falsy, so an `undefined` probe is the faithful `||=` miss test.
- `resetConfig()` clears the cache so it cannot leak across test files.

The gem has no case for either method, so the new tests live in `i18n.trails.test.ts`.

Closes-story: i18n-normalize-key-cache
