### PR TITLE
fix(i18n): render String inspect with Ruby escapes in error messages

### DIFF
--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -12,6 +12,7 @@ import {
   MissingTranslationData,
   ReservedInterpolationKey,
   UnknownFileType,
+  inspect,
 } from "./exceptions.js";
 import { resetClassConfig } from "./config.js";
 import { resetConfig } from "./i18n.js";
@@ -120,5 +121,21 @@ describe("exceptions", () => {
     expect(() => handler.call(other, "de", "foo", {})).toThrow(other);
     const data = new MissingTranslationData("de", "foo");
     expect(() => handler.call(data, "de", "foo", {})).toThrow(data);
+  });
+
+  it("inspects a String the way Ruby's String#inspect does", () => {
+    // Expectations taken from MRI: `ruby -e 'puts s.inspect'`.
+    expect(inspect("foo")).toBe('"foo"');
+    expect(inspect('he said "hi"')).toBe('"he said \\"hi\\""');
+    expect(inspect("a\\b")).toBe('"a\\\\b"');
+    expect(inspect("a\x1b\tb")).toBe('"a\\e\\tb"');
+    expect(inspect("\x07\b\v\f\r\n")).toBe('"\\a\\b\\v\\f\\r\\n"');
+    expect(inspect("\x00\x1f\x7f\x85")).toBe('"\\u0000\\u001F\\u007F\\u0085"');
+    expect(inspect("#{x}")).toBe('"\\#{x}"');
+    expect(inspect("a#$g")).toBe('"a\\#$g"');
+    expect(inspect("a#@g")).toBe('"a\\#@g"');
+    expect(inspect("a#b")).toBe('"a#b"');
+    expect(inspect("café 😀")).toBe('"café 😀"');
+    expect(inspect("a\ud800b")).toBe('"a\\xED\\xA0\\x80b"');
   });
 });

--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -124,7 +124,6 @@ describe("exceptions", () => {
   });
 
   it("inspects a String the way Ruby's String#inspect does", () => {
-    // Expectations taken from MRI: `ruby -e 'puts s.inspect'`.
     expect(inspect("foo")).toBe('"foo"');
     expect(inspect('he said "hi"')).toBe('"he said \\"hi\\""');
     expect(inspect("a\\b")).toBe('"a\\\\b"');

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -13,7 +13,7 @@ import type { Locale, TranslationKey } from "./i18n.js";
 /** @internal Ruby `Object#inspect`, as far as the values reaching this file go. */
 export function inspect(value: unknown): string {
   if (value === null || value === undefined) return "nil";
-  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "string") return inspectString(value);
   if (typeof value === "function") return "#<Proc>";
   if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
   if (typeof value === "object") {
@@ -23,6 +23,51 @@ export function inspect(value: unknown): string {
     return `{${pairs.join(", ")}}`;
   }
   return String(value);
+}
+
+/** Ruby's `String#inspect` escapes (MRI `string.c`, `rb_str_inspect`). */
+const RUBY_ESCAPES: Record<string, string> = {
+  "\n": "\\n",
+  "\r": "\\r",
+  "\t": "\\t",
+  "\f": "\\f",
+  "\v": "\\v",
+  "\b": "\\b",
+  "\x07": "\\a",
+  "\x1b": "\\e",
+};
+
+/**
+ * Ruby `String#inspect` (MRI `string.c`, `rb_str_inspect`). `JSON.stringify`
+ * is not a stand-in: Ruby renders ESC as `\e`, escapes `#` before `{`, `$` and
+ * `@` so the result re-parses as the same string, prints printable non-ASCII
+ * literally, and renders bytes that are not valid UTF-8 as `\xNN`.
+ */
+function inspectString(value: string): string {
+  const chars = Array.from(value);
+  let result = '"';
+  for (let i = 0; i < chars.length; i++) {
+    const char = chars[i];
+    const code = char.codePointAt(0)!;
+    if (char === '"' || char === "\\") {
+      result += `\\${char}`;
+    } else if (char === "#" && ["{", "$", "@"].includes(chars[i + 1] ?? "")) {
+      result += "\\#";
+    } else if (char in RUBY_ESCAPES) {
+      result += RUBY_ESCAPES[char];
+    } else if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
+      result += `\\u${code.toString(16).toUpperCase().padStart(4, "0")}`;
+    } else if (code >= 0xd800 && code <= 0xdfff) {
+      // A lone surrogate is not valid UTF-8; Ruby inspects such a string byte
+      // by byte, so emit the three bytes its UTF-8 encoding would have had.
+      for (const byte of [0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f)]) {
+        result += `\\x${byte.toString(16).toUpperCase()}`;
+      }
+    } else {
+      result += char;
+    }
+  }
+  return `${result}"`;
 }
 
 function inspectSymbol(value: unknown): string {

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -25,7 +25,6 @@ export function inspect(value: unknown): string {
   return String(value);
 }
 
-/** Ruby's `String#inspect` escapes (MRI `string.c`, `rb_str_inspect`). */
 const RUBY_ESCAPES: Record<string, string> = {
   "\n": "\\n",
   "\r": "\\r",
@@ -41,7 +40,8 @@ const RUBY_ESCAPES: Record<string, string> = {
  * Ruby `String#inspect` (MRI `string.c`, `rb_str_inspect`). `JSON.stringify`
  * is not a stand-in: Ruby renders ESC as `\e`, escapes `#` before `{`, `$` and
  * `@` so the result re-parses as the same string, prints printable non-ASCII
- * literally, and renders bytes that are not valid UTF-8 as `\xNN`.
+ * literally, and renders bytes that are not valid UTF-8 — here, a lone
+ * surrogate — as the `\xNN` bytes of their encoding.
  */
 function inspectString(value: string): string {
   const chars = Array.from(value);
@@ -58,8 +58,6 @@ function inspectString(value: string): string {
     } else if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
       result += `\\u${code.toString(16).toUpperCase().padStart(4, "0")}`;
     } else if (code >= 0xd800 && code <= 0xdfff) {
-      // A lone surrogate is not valid UTF-8; Ruby inspects such a string byte
-      // by byte, so emit the three bytes its UTF-8 encoding would have had.
       for (const byte of [0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f)]) {
         result += `\\x${byte.toString(16).toUpperCase()}`;
       }


### PR DESCRIPTION
`inspect` (`packages/i18n/src/exceptions.ts`) rendered a String with
`JSON.stringify`, which agrees with Ruby on plain ASCII but diverges on
escapes. The values reaching it are interpolation values, translation entries
and the interpolated string itself (`i18n/lib/i18n/exceptions.rb:92`
`InvalidPluralizationData`, `:99` `MissingInterpolationArgument`, `:106`
`ReservedInterpolationKey`), so a user-supplied string with a control character
produced a message the gem would not.

Adds `inspectString`, a port of MRI's `rb_str_inspect` (`string.c`) covering
what those values can hold: double quotes and backslash escaped; `#` escaped
when it precedes `{`, `$` or `@`; the Ruby escapes `\n \t \r \f \v \b \a \e`;
non-printable code points as `\uXXXX`; printable UTF-8 (including astral
planes) passed through literally; and a lone surrogate — not valid UTF-8 —
rendered as the `\xNN` bytes Ruby prints for an invalid-encoding string.

One deviation from the story's stated shape: it called for `\xNN` for control
bytes, but MRI only uses `\xNN` for BINARY / invalid-encoding strings. For a
UTF-8 string MRI renders control characters in the `\uXXXX` form instead, so
that is what this produces. Every expectation in the new test was taken from
`ruby -e 'puts s.inspect'` rather than derived by hand.

Existing `exceptions.test.ts` / `interpolate.test.ts` expectations are
unchanged and pass.

Closes-story: i18n-inspect-string-ruby-escapes
