### PR TITLE
feat(i18n): port I18n::Backend::Fallbacks and the locale chain it walks

### DIFF
--- a/packages/i18n/src/backend/fallbacks.test.ts
+++ b/packages/i18n/src/backend/fallbacks.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Mirrors: i18n/test/backend/fallbacks_test.rb
+ *
+ * Not ported: `I18nBackendFallbacksWithChainTest` (there is no
+ * `I18n::Backend::Chain` yet — story `i18n-backend-chain`), and the two
+ * `Thread.new` cases, which are the gem asserting that its thread-local
+ * fallbacks store is visible from another thread. JS has no threads, so
+ * `fallbacks()` is a single module-level binding (see `fallbacks.ts`) and both
+ * cases assert the single-threaded behaviour the rest of the file already
+ * covers.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Fallbacks, fallbacks, resetFallbacks, setFallbacks } from "./fallbacks.js";
+import { Simple } from "./simple.js";
+import { config, exists, l, resetConfig, setLocale, t, type Locale } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import { MissingTranslationData } from "../exceptions.js";
+import { Fallbacks as LocaleFallbacks } from "../locale/fallbacks.js";
+import type { TranslationData } from "../utils.js";
+
+class Backend extends Fallbacks(Simple) {}
+
+/**
+ * Stands in for Ruby's `::Date` — `localize` duck-types its object, so what a
+ * test needs is `strftime`, `wday` and `mon`. `translate_localization_format`
+ * substitutes every directive these cases use before `strftime` sees the
+ * format, so the format comes back verbatim; `localization.test.ts` carries the
+ * fuller stand-in.
+ */
+class RubyDate {
+  readonly utc: Date;
+
+  constructor(year: number, month: number, day: number) {
+    this.utc = new Date(Date.UTC(year, month - 1, day));
+  }
+
+  get wday(): number {
+    return this.utc.getUTCDay();
+  }
+
+  get mon(): number {
+    return this.utc.getUTCMonth() + 1;
+  }
+
+  strftime(format: string): string {
+    return format;
+  }
+}
+
+/** Ruby's `::Time` answers `hour` and `sec`, which routes to `time.formats`. */
+class RubyTime extends RubyDate {
+  get hour(): number {
+    return this.utc.getUTCHours();
+  }
+
+  get sec(): number {
+    return this.utc.getUTCSeconds();
+  }
+}
+
+/** Mirrors: `I18n::TestCase#setup` (i18n/test/test_helper.rb:20-26). */
+function setup(): Backend {
+  resetConfig();
+  resetClassConfig();
+  resetFallbacks();
+  config().enforceAvailableLocales = false;
+  const backend = new Backend();
+  config().backend = backend;
+  return backend;
+}
+
+describe("I18nBackendFallbacksTranslateTest", () => {
+  let backend: Backend;
+
+  function storeTranslations(locale: Locale, data: TranslationData): unknown {
+    return backend.storeTranslations(locale, data);
+  }
+
+  beforeEach(() => {
+    backend = setup();
+    storeTranslations("en", {
+      foo: "Foo in :en",
+      bar: "Bar in :en",
+      buz: "Buz in :en",
+      interpolate: "Interpolate %{value}",
+      interpolate_count: "Interpolate %{value} %{count}",
+    });
+    storeTranslations("de", { bar: "Bar in :de", baz: "Baz in :de" });
+    storeTranslations("de-DE", { baz: "Baz in :de-DE" });
+    storeTranslations("pt-BR", { baz: "Baz in :pt-BR" });
+  });
+
+  it("still returns an existing translation as usual", () => {
+    expect(t("foo", { locale: "en" })).toBe("Foo in :en");
+    expect(t("bar", { locale: "de" })).toBe("Bar in :de");
+    expect(t("baz", { locale: "de-DE" })).toBe("Baz in :de-DE");
+  });
+
+  it("returns interpolated value if no key provided", () => {
+    expect(t("interpolate")).toBe("Interpolate %{value}");
+  });
+
+  it("returns the :de translation for a missing :'de-DE' translation", () => {
+    expect(t("bar", { locale: "de-DE" })).toBe("Bar in :de");
+  });
+
+  it("keeps the count option when defaulting to a different key", () => {
+    expect(
+      t("non_existent", { default: Symbol.for("interpolate_count"), count: 10, value: 5 }),
+    ).toBe("Interpolate 5 10");
+  });
+
+  it("returns the :de translation for a missing :'de-DE' when :default is a String", () => {
+    expect(t("bar", { locale: "de-DE", default: "Default Bar" })).toBe("Bar in :de");
+    expect(t("missing_bar", { locale: "de-DE", default: "Default Bar" })).toBe("Default Bar");
+  });
+
+  it("returns the :de translation for a missing :'de-DE' when defaults is a Symbol (which exists in :en)", () => {
+    expect(t("bar", { locale: "de-DE", default: [Symbol.for("buz")] })).toBe("Bar in :de");
+  });
+
+  it("returns the :'de-DE' default :baz translation for a missing :'de-DE' (which exists in :de)", () => {
+    expect(t("bar", { locale: "de-DE", default: [Symbol.for("baz")] })).toBe("Baz in :de-DE");
+  });
+
+  it("returns the :de translation for a missing :'de-DE' when :default is a Proc", () => {
+    expect(t("bar", { locale: "de-DE", default: () => "Default Bar" })).toBe("Bar in :de");
+    expect(t("missing_bar", { locale: "de-DE", default: () => "Default Bar" })).toBe("Default Bar");
+  });
+
+  it("returns the :de translation for a missing :'de-DE' when :default is a Hash", () => {
+    expect(t("bar", { locale: "de-DE", default: {} })).toBe("Bar in :de");
+    expect(t("missing_bar", { locale: "de-DE", default: {} })).toEqual({});
+  });
+
+  it("returns the :de translation for a missing :'de-DE' when :default is nil", () => {
+    expect(t("bar", { locale: "de-DE", default: null })).toBe("Bar in :de");
+    expect(t("missing_bar", { locale: "de-DE", default: null })).toBeNull();
+  });
+
+  it("returns the Translation missing: message if the default is also missing", () => {
+    const translationMissingMessage = [
+      "Translation missing. Options considered were:",
+      "- de-DE.missing_bar",
+      "- de-DE.missing_baz",
+    ].join("\n");
+
+    expect(t("missing_bar", { locale: "de-DE", default: [Symbol.for("missing_baz")] })).toBe(
+      translationMissingMessage,
+    );
+  });
+
+  it("returns the simple Translation missing: message when default is an empty Array", () => {
+    expect(t("missing_bar", { locale: "de-DE", default: [] })).toBe(
+      "Translation missing: de-DE.missing_bar",
+    );
+  });
+
+  it("returns the :'de-DE' default :baz translation for a missing :'de-DE' when defaults contains Symbol", () => {
+    expect(t("missing_foo", { locale: "de-DE", default: [Symbol.for("baz"), "Default Bar"] })).toBe(
+      "Baz in :de-DE",
+    );
+  });
+
+  it("returns the defaults translation for a missing :'de-DE' when defaults contains a String or Proc before Symbol", () => {
+    expect(
+      t("missing_foo", {
+        locale: "de-DE",
+        default: [Symbol.for("missing_bar"), "Default Bar", Symbol.for("baz")],
+      }),
+    ).toBe("Default Bar");
+    expect(
+      t("missing_foo", {
+        locale: "de-DE",
+        default: [Symbol.for("missing_bar"), () => "Default Bar", Symbol.for("baz")],
+      }),
+    ).toBe("Default Bar");
+  });
+
+  it("returns the default translation for a missing :'de-DE' and existing :de when default is a Hash", () => {
+    expect(
+      t("missing_foo", {
+        locale: "de-DE",
+        default: [Symbol.for("missing_bar"), { other: "Default %{count} Bars" }, "Default Bar"],
+        count: 6,
+      }),
+    ).toBe("Default 6 Bars");
+  });
+
+  it("returns the default translation for a missing :de translation even when default is a String when fallback is disabled", () => {
+    expect(t("foo", { locale: "de", default: "Default String", fallback: false })).toBe(
+      "Default String",
+    );
+  });
+
+  it("raises I18n::MissingTranslationData exception when fallback is disabled even when fallback translation exists", () => {
+    expect(() => t("foo", { locale: "de", fallback: false, raise: true })).toThrow(
+      MissingTranslationData,
+    );
+  });
+
+  it("raises I18n::MissingTranslationData exception when no translation was found", () => {
+    expect(() => t("faa", { locale: "en", raise: true })).toThrow(MissingTranslationData);
+    expect(() => t("faa", { locale: "de", raise: true })).toThrow(MissingTranslationData);
+  });
+
+  it("should ensure that default is not splitted on new line char", () => {
+    expect(t("missing_bar", { default: "Default \n Bar" })).toBe("Default \n Bar");
+  });
+
+  it("should not raise error when enforce_available_locales is true, :'pt' is missing and default is a Symbol", () => {
+    config().enforceAvailableLocales = true;
+    try {
+      expect(
+        t("model.attrs.foo", {
+          locale: "pt-BR",
+          default: [Symbol.for("attrs.foo"), "Foo"],
+        }),
+      ).toBe("Foo");
+    } finally {
+      config().enforceAvailableLocales = false;
+    }
+  });
+
+  it("returns fallback default given missing pluralization data", () => {
+    expect(t("missing_bar", { count: 1, default: "default" })).toBe("default");
+    expect(t("missing_bar", { count: 0, default: "default" })).toBe("default");
+  });
+});
+
+// See Issue #534
+describe("I18nBackendFallbacksLocalizeTestWithDefaultLocale", () => {
+  let backend: Backend;
+
+  beforeEach(() => {
+    backend = setup();
+    config().enforceAvailableLocales = false;
+    setFallbacks([config().defaultLocale]);
+    backend.storeTranslations("en", { time: { formats: { fallback: "en fallback" } } });
+  });
+
+  it("falls back to default locale - Issue #534", () => {
+    expect(l(new RubyTime(2010, 1, 3), { format: ":fallback", locale: "un-supported" })).toBe(
+      "en fallback",
+    );
+  });
+});
+
+// See Issue #536
+describe("I18nBackendFallbacksWithCustomClass", () => {
+  let backend: Backend;
+
+  /** Quacks like a fallback class. */
+  class MyDefaultFallback {
+    get(_key: Locale): Locale[] {
+      return ["my_language"];
+    }
+  }
+
+  beforeEach(() => {
+    backend = setup();
+    config().enforceAvailableLocales = false;
+    setFallbacks(new MyDefaultFallback());
+    backend.storeTranslations("my_language", { foo: "customer foo" });
+    backend.storeTranslations("en", { foo: "english foo" });
+  });
+
+  it("can use a default fallback object that doesn't inherit from I18n::Locale::Fallbacks", () => {
+    expect(t("foo", { locale: "en" })).toBe("customer foo");
+    expect(t("foo", { locale: "nothing" })).toBe("customer foo");
+  });
+});
+
+// See Issue #590
+describe("I18nBackendFallbacksSymbolResolveRestartsLookupAtOriginalLocale", () => {
+  let backend: Backend;
+
+  beforeEach(() => {
+    backend = setup();
+    config().enforceAvailableLocales = false;
+    setFallbacks(["root"]);
+    backend.storeTranslations("ak", {
+      calendars: {
+        gregorian: {
+          months: {
+            format: {
+              abbreviated: {
+                1: "S-Ɔ",
+                // Other months omitted for brevity
+              },
+            },
+          },
+        },
+      },
+    });
+    backend.storeTranslations("root", {
+      calendars: {
+        gregorian: {
+          months: {
+            format: {
+              abbreviated: Symbol.for("calendars.gregorian.months.format.wide"),
+              wide: {
+                1: "M01",
+                // Other months omitted for brevity
+              },
+            },
+            "stand-alone": {
+              abbreviated: Symbol.for("calendars.gregorian.months.format.abbreviated"),
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("falls back to original locale when symbol resolved at fallback locale", () => {
+    expect(t("calendars.gregorian.months.stand-alone.abbreviated", { locale: "ak-GH" })).toEqual({
+      1: "S-Ɔ",
+    });
+  });
+});
+
+// See Issue #617
+describe("RegressionTestFor617", () => {
+  let backend: Backend;
+
+  beforeEach(() => {
+    backend = setup();
+    config().enforceAvailableLocales = false;
+    // Ruby assigns a plain Hash, which answers `[]` and so quacks like a
+    // fallbacks object; a `Map` is the JS Hash, and its `get` is that `[]`.
+    setFallbacks(
+      new Map([
+        ["en", ["en"]],
+        ["en-US", ["en-US", "en"]],
+      ]) as unknown as { get(locale: Locale): Locale[] },
+    );
+    setLocale("en-US");
+    backend.storeTranslations("en-US", {});
+    backend.storeTranslations("en", {
+      activerecord: {
+        models: {
+          product: { one: "Product", other: "Products" },
+          "product/ticket": { one: "Ticket", other: "Tickets" },
+        },
+      },
+    });
+  });
+
+  it("model scope resolution", () => {
+    const defaults = [Symbol.for("product"), "Ticket"];
+    const options = { scope: ["activerecord", "models"], count: 1, default: defaults };
+    expect(t("product/ticket", options)).toBe("Ticket");
+  });
+});
+
+describe("I18nBackendFallbacksLocalizeTest", () => {
+  let backend: Backend;
+
+  beforeEach(() => {
+    backend = setup();
+    backend.storeTranslations("en", { date: { formats: { en: "en" }, day_names: ["Sunday"] } });
+    backend.storeTranslations("de", { date: { formats: { de: "de" }, day_names: ["Sunday"] } });
+  });
+
+  it("still uses an existing format as usual", () => {
+    expect(l(new RubyDate(2010, 1, 3), { format: ":en", locale: "en" })).toBe("en");
+  });
+
+  it("looks up and uses a fallback locale's format for a key missing in the given locale", () => {
+    expect(l(new RubyDate(2010, 1, 3), { format: ":de", locale: "de-DE" })).toBe("de");
+  });
+
+  it("still uses an existing day name translation as usual", () => {
+    expect(l(new RubyDate(2010, 1, 3), { format: "%A", locale: "en" })).toBe("Sunday");
+  });
+
+  it("uses a fallback locale's translation for a key missing in the given locale", () => {
+    expect(l(new RubyDate(2010, 1, 3), { format: "%A", locale: "de-DE" })).toBe("Sunday");
+  });
+});
+
+describe("I18nBackendFallbacksExistsTest", () => {
+  let backend: Backend;
+
+  beforeEach(() => {
+    backend = setup();
+    backend.storeTranslations("en", { foo: "Foo in :en", bar: "Bar in :en" });
+    backend.storeTranslations("de", { bar: "Bar in :de" });
+    backend.storeTranslations("de-DE", { baz: "Baz in :de-DE" });
+  });
+
+  it("exists? given an existing key will return true", () => {
+    expect(exists("foo")).toBe(true);
+  });
+
+  it("exists? given a non-existing key will return false", () => {
+    expect(exists("bogus")).toBe(false);
+  });
+
+  it("exists? given an existing key and an existing locale will return true", () => {
+    expect(exists("foo", "en")).toBe(true);
+    expect(exists("bar", "de")).toBe(true);
+  });
+
+  it("exists? given a non-existing key and an existing locale will return false", () => {
+    expect(exists("bogus", "en")).toBe(false);
+    expect(exists("bogus", "de")).toBe(false);
+  });
+
+  it("exists? should return true given a key which is missing from the given locale and exists in a fallback locale", () => {
+    expect(exists("bar", "de")).toBe(true);
+    expect(exists("bar", "de-DE")).toBe(true);
+  });
+
+  it("exists? should return false given a key which is missing from the given locale and all its fallback locales", () => {
+    expect(exists("baz", "de")).toBe(false);
+    expect(exists("bogus", "de-DE")).toBe(false);
+  });
+
+  it("exists? should return false when fallback is disabled given a key which is missing from the given locale", () => {
+    expect(exists("bar", "de-DE")).toBe(true);
+    expect(exists("bar", "de-DE", { fallback: false })).toBe(false);
+    expect(exists("bar", "de-DE-XX", { fallback: false })).toBe(false);
+  });
+});
+
+describe("I18nBackendOnFallbackHookTest", () => {
+  class Backend extends Fallbacks(Simple) {
+    fallbackCollector?: unknown[][];
+
+    // No `override`: the mixin keeps `onFallback` protected, as the gem keeps
+    // it private, so it is not part of the factory's declared return type.
+    protected onFallback(...args: unknown[]): unknown {
+      this.fallbackCollector ??= [];
+      this.fallbackCollector.push(args);
+      return null;
+    }
+  }
+
+  let backend: Backend;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    resetFallbacks();
+    config().enforceAvailableLocales = false;
+    backend = new Backend();
+    config().backend = backend;
+    setFallbacks(new LocaleFallbacks({ de: "en" }));
+    backend.storeTranslations("en", { foo: "Foo in :en", bar: "Bar in :en" });
+    backend.storeTranslations("de", { bar: "Bar in :de" });
+    backend.storeTranslations("de-DE", { baz: 'Baz in :"de-DE"' });
+  });
+
+  it("on_fallback should be called when fallback happens", () => {
+    expect(fallbacks().get("de-DE")).toEqual(["de-DE", "de", "en"]);
+    expect(t("baz", { locale: "de-DE" })).toBe('Baz in :"de-DE"');
+    expect(t("bar", { locale: "de-DE" })).toBe("Bar in :de");
+    expect(t("foo", { locale: "de-DE" })).toBe("Foo in :en");
+    expect(backend.fallbackCollector![0]).toEqual(["de-DE", "de", "bar", {}]);
+    expect(backend.fallbackCollector![1]).toEqual(["de-DE", "en", "foo", {}]);
+  });
+
+  it("on_fallback should not be called when use a String locale", () => {
+    expect(t("bar", { locale: "de" })).toBe("Bar in :de");
+    expect(backend.fallbackCollector).toBeUndefined();
+  });
+});

--- a/packages/i18n/src/backend/fallbacks.test.ts
+++ b/packages/i18n/src/backend/fallbacks.test.ts
@@ -8,10 +8,14 @@
  * `fallbacks()` is a single module-level binding (see `fallbacks.ts`) and both
  * cases assert the single-threaded behaviour the rest of the file already
  * covers.
+ *
+ * `RegressionTestFor617` assigns a plain Ruby Hash as the fallbacks object,
+ * which quacks like one because it answers `[]`; a `Map` is the JS Hash, and
+ * its `get` is that `[]`.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { Fallbacks, fallbacks, resetFallbacks, setFallbacks } from "./fallbacks.js";
+import { Fallbacks, fallbacks, setFallbacks } from "./fallbacks.js";
 import { Simple } from "./simple.js";
 import { config, exists, l, resetConfig, setLocale, t, type Locale } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
@@ -63,7 +67,7 @@ class RubyTime extends RubyDate {
 function setup(): Backend {
   resetConfig();
   resetClassConfig();
-  resetFallbacks();
+  setFallbacks(null);
   config().enforceAvailableLocales = false;
   const backend = new Backend();
   config().backend = backend;
@@ -328,8 +332,6 @@ describe("RegressionTestFor617", () => {
   beforeEach(() => {
     backend = setup();
     config().enforceAvailableLocales = false;
-    // Ruby assigns a plain Hash, which answers `[]` and so quacks like a
-    // fallbacks object; a `Map` is the JS Hash, and its `get` is that `[]`.
     setFallbacks(
       new Map([
         ["en", ["en"]],
@@ -430,8 +432,6 @@ describe("I18nBackendOnFallbackHookTest", () => {
   class Backend extends Fallbacks(Simple) {
     fallbackCollector?: unknown[][];
 
-    // No `override`: the mixin keeps `onFallback` protected, as the gem keeps
-    // it private, so it is not part of the factory's declared return type.
     protected onFallback(...args: unknown[]): unknown {
       this.fallbackCollector ??= [];
       this.fallbackCollector.push(args);
@@ -444,7 +444,7 @@ describe("I18nBackendOnFallbackHookTest", () => {
   beforeEach(() => {
     resetConfig();
     resetClassConfig();
-    resetFallbacks();
+    setFallbacks(null);
     config().enforceAvailableLocales = false;
     backend = new Backend();
     config().backend = backend;

--- a/packages/i18n/src/backend/fallbacks.trails.test.ts
+++ b/packages/i18n/src/backend/fallbacks.trails.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Covers the scenario story `i18n-backend-fallbacks` names as its consumer:
+ * `activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:91-101`
+ * builds its backend as
+ * `class Backend < I18n::Backend::Simple; include I18n::Backend::Fallbacks; end`
+ * (:7-9) and asserts an `activerecord.errors.models.*.attributes.*` key in a
+ * parent locale wins over the generic `errors.messages` key in the child
+ * locale.
+ *
+ * The win comes from `ActiveModel::Error.generate_message`
+ * (activemodel/lib/active_model/error.rb:79-100), which runs the `i18n_scope`
+ * defaults as a first `throw: true` pass and only falls through to
+ * `errors.attributes.*` / `errors.messages.*` when that whole pass misses.
+ * Both passes are spelled out below, so what is asserted is this backend's
+ * lookup and nothing else.
+ *
+ * `packages/activerecord` still routes the AR case through the bespoke
+ * `I18nService` in `packages/activemodel/src/i18n.ts`, which PR #6026 deletes;
+ * moving it onto this port is story `i18n-ar-fallbacks-wiring`.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Fallbacks, setFallbacks } from "./fallbacks.js";
+import { Simple } from "./simple.js";
+import { config, resetConfig, t, withLocale } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import { MissingTranslation } from "../exceptions.js";
+import { catchException } from "../throw-catch.js";
+
+class Backend extends Fallbacks(Simple) {}
+
+describe("Backend::Fallbacks over the ActiveRecord error-message scopes", () => {
+  let backend: Backend;
+
+  /** Mirrors: `ActiveModel::Error.generate_message` (error.rb:79-100). */
+  function generateMessage(attribute: string, type: string): unknown {
+    const scoped = [
+      `activerecord.errors.models.topic.attributes.${attribute}.${type}`,
+      `activerecord.errors.models.topic.${type}`,
+      `activerecord.errors.messages.${type}`,
+    ];
+    const translation = catchException(() =>
+      t(scoped[0], { default: scoped.slice(1).map((key) => Symbol.for(key)), throw: true }),
+    );
+    if (!(translation instanceof MissingTranslation) && translation != null) return translation;
+
+    const defaults = [`errors.attributes.${attribute}.${type}`, `errors.messages.${type}`];
+    return t(defaults[0], { default: defaults.slice(1).map((key) => Symbol.for(key)) });
+  }
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    setFallbacks(null);
+    config().enforceAvailableLocales = false;
+    backend = new Backend();
+    config().backend = backend;
+    backend.storeTranslations("en", {
+      activerecord: {
+        errors: { models: { topic: { attributes: { title: { taken: "custom en message" } } } } },
+      },
+    });
+    backend.storeTranslations("en-US", {
+      errors: { messages: { taken: "generic en-US fallback" } },
+    });
+  });
+
+  it("activerecord attributes scope falls back to parent locale before it falls back to the :errors namespace", () => {
+    withLocale("en-US", () => {
+      expect(generateMessage("title", "taken")).toBe("custom en message");
+      expect(generateMessage("heading", "taken")).toBe("generic en-US fallback");
+    });
+  });
+});

--- a/packages/i18n/src/backend/fallbacks.ts
+++ b/packages/i18n/src/backend/fallbacks.ts
@@ -1,0 +1,234 @@
+/**
+ * Mirrors: i18n/lib/i18n/backend/fallbacks.rb
+ *
+ * I18n locale fallbacks are useful when you want your application to use
+ * translations from other locales when translations for the current locale are
+ * missing. E.g. you might want to use "en" translations when translations in
+ * your applications main locale "de" are missing.
+ *
+ * To enable locale fallbacks you mix the Fallbacks module into the Simple
+ * backend — or whatever other backend you are using:
+ *
+ *     class Backend extends Fallbacks(Simple) {}
+ *
+ * Ruby `include`s the module into an existing class and calls `super` from
+ * every method it overwrites. `include()` from `@blazetrails/activesupport`
+ * copies members onto a prototype and so has no `super` to call; the class
+ * factory below is the shape that keeps `super` — every body under it is the
+ * gem's, line for line.
+ */
+
+import { MissingTranslation, InvalidLocale } from "../exceptions.js";
+import { EMPTY_HASH, t, type Locale, type TranslationKey } from "../i18n.js";
+import { Fallbacks as LocaleFallbacks } from "../locale/fallbacks.js";
+import { catchException, throwException } from "../throw-catch.js";
+import type { Base, TranslateOptions } from "./base.js";
+
+/**
+ * Anything that answers the gem's `I18n.fallbacks[locale]` — the gem's own
+ * `I18n::Locale::Fallbacks`, or the duck type Issue #536 allows.
+ */
+export interface FallbacksLike {
+  get(locale: Locale): Locale[];
+}
+
+/**
+ * Ruby stores the fallbacks in a class variable and reads a thread-local over
+ * the top of it (`Thread.current[:i18n_fallbacks] || @@fallbacks`). JS has no
+ * threads, so the module-level binding below is both, exactly as `I18n.config`
+ * is in `i18n.ts`.
+ */
+let fallbacksStore: FallbacksLike | undefined;
+
+/** Returns the current fallbacks implementation. Defaults to `Locale::Fallbacks`. */
+export function fallbacks(): FallbacksLike {
+  fallbacksStore ??= new LocaleFallbacks();
+  return fallbacksStore;
+}
+
+/**
+ * Sets the current fallbacks implementation. Use this to set a different
+ * fallbacks implementation.
+ */
+export function setFallbacks(fallbacks: FallbacksLike | Locale[]): void {
+  fallbacksStore = Array.isArray(fallbacks) ? new LocaleFallbacks(...fallbacks) : fallbacks;
+}
+
+/** @internal Test seam — drops the process-wide fallbacks so a case starts clean. */
+export function resetFallbacks(): void {
+  fallbacksStore = undefined;
+}
+
+/** Ruby truthiness: only `nil` and `false` are falsy — `0` and `""` are not. */
+function truthy(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== false;
+}
+
+/**
+ * Ruby's `options.fetch(:fallback, true)`, which hands back a stored `nil` or
+ * `false` where `??` would substitute the default.
+ */
+function fetchFallback(options: TranslateOptions): unknown {
+  return "fallback" in options ? options.fallback : true;
+}
+
+// TS requires exactly `any[]` here: a mixin base must be `new (...args: any[])`.
+type BackendConstructor = abstract new (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ...args: any[]
+) => Base;
+
+/**
+ * The public member `Fallbacks` adds on top of the backend it is mixed into.
+ * TypeScript cannot name the anonymous class below in a declaration file, so
+ * the factory states its return type; the intersection with `T` is Ruby's
+ * `include`, which leaves every member of the including class in place.
+ */
+export interface FallbacksMethods {
+  extractNonSymbolDefault(options: TranslateOptions): unknown;
+}
+
+export function Fallbacks<T extends BackendConstructor>(
+  Superclass: T,
+): T &
+  (abstract new (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see BackendConstructor.
+    ...args: any[]
+  ) => FallbacksMethods) {
+  abstract class Fallbacks extends Superclass {
+    /**
+     * Overwrites the Base backend translate method so that it will try each
+     * locale given by I18n.fallbacks for the given locale. E.g. for the
+     * locale "de-DE" it might try the locales "de-DE", "de" and "en"
+     * (depends on the fallbacks implementation) until it finds a result with
+     * the given options. If it does not find any result for any of the
+     * locales it will then throw MissingTranslation as usual.
+     *
+     * The default option takes precedence over fallback locales only when
+     * it's a Symbol. When the default contains a String, Proc or Hash
+     * it is evaluated last after all the fallback locales have been tried.
+     */
+    override translate(
+      locale: Locale | null | undefined,
+      key: TranslationKey | symbol | null | undefined,
+      options: TranslateOptions = EMPTY_HASH,
+    ): unknown {
+      if (!truthy(fetchFallback(options))) return super.translate(locale, key, options);
+      if (truthy(options.fallbackInProgress)) return super.translate(locale, key, options);
+      const default_ = truthy(options.default) ? this.extractNonSymbolDefault(options) : undefined;
+
+      const fallbackOptions = {
+        ...options,
+        fallbackInProgress: true,
+        fallbackOriginalLocale: locale,
+      };
+      for (const fallback of fallbacks().get(locale as Locale)) {
+        try {
+          // Ruby's `return result` returns from `translate`, not from the
+          // `catch(:exception)` block, so the value has to come back out of
+          // `catchException` and be told apart from the thrown exception and
+          // from a nil result.
+          const result = catchException(() => {
+            const result = super.translate(fallback, key, fallbackOptions);
+            if (result != null) {
+              if (String(locale) !== String(fallback)) {
+                this.onFallback(locale as Locale, fallback, key, options);
+              }
+              return result;
+            }
+            return null;
+          });
+          if (result != null && !(result instanceof MissingTranslation)) return result;
+        } catch (exception) {
+          // we do nothing when the locale is invalid, as this is a fallback anyways.
+          if (!(exception instanceof InvalidLocale)) throw exception;
+        }
+      }
+
+      if ("default" in options && options.default == null) return null;
+
+      if (truthy(default_)) {
+        return super.translate(locale, null, { ...options, default: default_ });
+      }
+      throwException(new MissingTranslation(locale as Locale, key as TranslationKey, options));
+    }
+
+    protected override resolveEntry(
+      locale: Locale,
+      object: TranslationKey | symbol | null | undefined,
+      subject: unknown,
+      options: TranslateOptions = EMPTY_HASH,
+    ): unknown {
+      if (options.resolve === false) return subject;
+      const result = catchException(() => {
+        if ("fallbackInProgress" in options) delete options.fallbackInProgress;
+
+        if (typeof subject === "symbol") {
+          return t(subject, {
+            ...options,
+            locale: options.fallbackOriginalLocale as Locale,
+            throw: true,
+            skipInterpolation: true,
+          });
+        } else if (typeof subject === "function") {
+          const dateOrTime = truthy(options.object) ? options.object : object;
+          delete options.object;
+          return this.resolveEntry(
+            options.fallbackOriginalLocale as Locale,
+            object,
+            (subject as (value: unknown, options: TranslateOptions) => unknown)(
+              dateOrTime,
+              options,
+            ),
+          );
+        } else {
+          return subject;
+        }
+      });
+      return result instanceof MissingTranslation ? null : result;
+    }
+
+    extractNonSymbolDefault(options: TranslateOptions): unknown {
+      const defaults = [options.default].flat(Infinity as 1);
+      // A Ruby Symbol default is a real JS symbol here, which is what
+      // `Base#resolve` already dispatches on (base.rb:203); converging both
+      // onto the `":name"` spelling is story
+      // `i18n-symbol-values-are-colon-strings`.
+      const firstNonSymbolDefault = defaults.find((default_) => typeof default_ !== "symbol");
+      if (truthy(firstNonSymbolDefault)) {
+        options.default = defaults.slice(0, defaults.indexOf(firstNonSymbolDefault));
+      }
+      return firstNonSymbolDefault;
+    }
+
+    override exists(
+      locale: Locale,
+      key: TranslationKey | symbol,
+      options: TranslateOptions = EMPTY_HASH,
+    ): boolean {
+      if (!truthy(fetchFallback(options))) return super.exists(locale, key, options);
+      for (const fallback of fallbacks().get(locale)) {
+        try {
+          if (super.exists(fallback, key, options)) return true;
+        } catch (exception) {
+          // we do nothing when the locale is invalid, as this is a fallback anyways.
+          if (!(exception instanceof InvalidLocale)) throw exception;
+        }
+      }
+
+      return false;
+    }
+
+    /** Overwrite onFallback to add specified logic when the fallback succeeds. */
+    protected onFallback(
+      _originalLocale: Locale,
+      _fallbackLocale: Locale,
+      _key: TranslationKey | symbol | null | undefined,
+      _options: TranslateOptions,
+    ): unknown {
+      return null;
+    }
+  }
+
+  return Fallbacks;
+}

--- a/packages/i18n/src/backend/fallbacks.ts
+++ b/packages/i18n/src/backend/fallbacks.ts
@@ -38,7 +38,7 @@ export interface FallbacksLike {
  * threads, so the module-level binding below is both, exactly as `I18n.config`
  * is in `i18n.ts`.
  */
-let fallbacksStore: FallbacksLike | undefined;
+let fallbacksStore: FallbacksLike | null | undefined;
 
 /** Returns the current fallbacks implementation. Defaults to `Locale::Fallbacks`. */
 export function fallbacks(): FallbacksLike {
@@ -50,26 +50,13 @@ export function fallbacks(): FallbacksLike {
  * Sets the current fallbacks implementation. Use this to set a different
  * fallbacks implementation.
  */
-export function setFallbacks(fallbacks: FallbacksLike | Locale[]): void {
+export function setFallbacks(fallbacks: FallbacksLike | Locale[] | null): void {
   fallbacksStore = Array.isArray(fallbacks) ? new LocaleFallbacks(...fallbacks) : fallbacks;
-}
-
-/** @internal Test seam — drops the process-wide fallbacks so a case starts clean. */
-export function resetFallbacks(): void {
-  fallbacksStore = undefined;
 }
 
 /** Ruby truthiness: only `nil` and `false` are falsy — `0` and `""` are not. */
 function truthy(value: unknown): boolean {
   return value !== undefined && value !== null && value !== false;
-}
-
-/**
- * Ruby's `options.fetch(:fallback, true)`, which hands back a stored `nil` or
- * `false` where `??` would substitute the default.
- */
-function fetchFallback(options: TranslateOptions): unknown {
-  return "fallback" in options ? options.fallback : true;
 }
 
 // TS requires exactly `any[]` here: a mixin base must be `new (...args: any[])`.
@@ -85,7 +72,7 @@ type BackendConstructor = abstract new (
  * `include`, which leaves every member of the including class in place.
  */
 export interface FallbacksMethods {
-  extractNonSymbolDefault(options: TranslateOptions): unknown;
+  extractNonSymbolDefaultBang(options: TranslateOptions): unknown;
 }
 
 export function Fallbacks<T extends BackendConstructor>(
@@ -107,15 +94,24 @@ export function Fallbacks<T extends BackendConstructor>(
      * The default option takes precedence over fallback locales only when
      * it's a Symbol. When the default contains a String, Proc or Hash
      * it is evaluated last after all the fallback locales have been tried.
+     *
+     * Ruby's `return result` inside `catch(:exception)` returns from this
+     * method, not from the block; the value therefore has to come back out of
+     * `catchException` and be told apart both from the thrown exception and
+     * from a nil result.
      */
     override translate(
       locale: Locale | null | undefined,
       key: TranslationKey | symbol | null | undefined,
       options: TranslateOptions = EMPTY_HASH,
     ): unknown {
-      if (!truthy(fetchFallback(options))) return super.translate(locale, key, options);
+      if (!truthy("fallback" in options ? options.fallback : true)) {
+        return super.translate(locale, key, options);
+      }
       if (truthy(options.fallbackInProgress)) return super.translate(locale, key, options);
-      const default_ = truthy(options.default) ? this.extractNonSymbolDefault(options) : undefined;
+      const default_ = truthy(options.default)
+        ? this.extractNonSymbolDefaultBang(options)
+        : undefined;
 
       const fallbackOptions = {
         ...options,
@@ -124,10 +120,6 @@ export function Fallbacks<T extends BackendConstructor>(
       };
       for (const fallback of fallbacks().get(locale as Locale)) {
         try {
-          // Ruby's `return result` returns from `translate`, not from the
-          // `catch(:exception)` block, so the value has to come back out of
-          // `catchException` and be told apart from the thrown exception and
-          // from a nil result.
           const result = catchException(() => {
             const result = super.translate(fallback, key, fallbackOptions);
             if (result != null) {
@@ -188,12 +180,13 @@ export function Fallbacks<T extends BackendConstructor>(
       return result instanceof MissingTranslation ? null : result;
     }
 
-    extractNonSymbolDefault(options: TranslateOptions): unknown {
+    /**
+     * A Ruby Symbol default is a real JS symbol here, which is what
+     * `Base#resolve` already dispatches on (base.rb:203); converging both onto
+     * the `":name"` spelling is story `i18n-symbol-values-are-colon-strings`.
+     */
+    extractNonSymbolDefaultBang(options: TranslateOptions): unknown {
       const defaults = [options.default].flat(Infinity as 1);
-      // A Ruby Symbol default is a real JS symbol here, which is what
-      // `Base#resolve` already dispatches on (base.rb:203); converging both
-      // onto the `":name"` spelling is story
-      // `i18n-symbol-values-are-colon-strings`.
       const firstNonSymbolDefault = defaults.find((default_) => typeof default_ !== "symbol");
       if (truthy(firstNonSymbolDefault)) {
         options.default = defaults.slice(0, defaults.indexOf(firstNonSymbolDefault));
@@ -206,7 +199,9 @@ export function Fallbacks<T extends BackendConstructor>(
       key: TranslationKey | symbol,
       options: TranslateOptions = EMPTY_HASH,
     ): boolean {
-      if (!truthy(fetchFallback(options))) return super.exists(locale, key, options);
+      if (!truthy("fallback" in options ? options.fallback : true)) {
+        return super.exists(locale, key, options);
+      }
       for (const fallback of fallbacks().get(locale)) {
         try {
           if (super.exists(fallback, key, options)) return true;

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -327,11 +327,14 @@ export function withLocale<T>(tmpLocale: Locale | false | null | undefined, bloc
   }
 }
 
+/**
+ * Ruby's `key.to_s` on a Symbol is its name; `String(symbol)` is
+ * `"Symbol(name)"`, which would otherwise reach the `Translation missing`
+ * message through `MissingTranslation#keys`.
+ */
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
   if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
   if (key === null || key === undefined) return [];
-  // Ruby's `key.to_s` on a Symbol is its name; `String(symbol)` is
-  // `"Symbol(name)"`, which would reach the `Translation missing` message.
   if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;
   const keys = String(key)
     .split(separator)

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -330,6 +330,9 @@ export function withLocale<T>(tmpLocale: Locale | false | null | undefined, bloc
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
   if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
   if (key === null || key === undefined) return [];
+  // Ruby's `key.to_s` on a Symbol is its name; `String(symbol)` is
+  // `"Symbol(name)"`, which would reach the `Translation missing` message.
+  if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;
   const keys = String(key)
     .split(separator)
     .filter((k) => k !== "");

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -63,6 +63,14 @@ export type { Locale, TranslateKey, TranslationKey } from "./i18n.js";
 export { Base, registerFileReader, preloadTranslationFiles } from "./backend/base.js";
 export type { FileReader, TranslateOptions } from "./backend/base.js";
 export { Simple } from "./backend/simple.js";
+export { Fallbacks, fallbacks, setFallbacks, resetFallbacks } from "./backend/fallbacks.js";
+export type { FallbacksLike, FallbacksMethods } from "./backend/fallbacks.js";
+// `I18n::Locale::Fallbacks` and `I18n::Backend::Fallbacks` are two classes of
+// the same name; this barrel is flat, and the `Locale` namespace spelling is
+// taken by the `Locale` type above, so the locale one is qualified here. Both
+// keep the gem's name in their own file.
+export { Fallbacks as LocaleFallbacks, Tag } from "./locale.js";
+export type { FallbackMappings } from "./locale.js";
 export { ThrownException, catchException, throwException } from "./throw-catch.js";
 export { deepMerge, deepMergeBang, deepSymbolizeKeys, except } from "./utils.js";
 export type { TranslationData } from "./utils.js";

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -63,7 +63,7 @@ export type { Locale, TranslateKey, TranslationKey } from "./i18n.js";
 export { Base, registerFileReader, preloadTranslationFiles } from "./backend/base.js";
 export type { FileReader, TranslateOptions } from "./backend/base.js";
 export { Simple } from "./backend/simple.js";
-export { Fallbacks, fallbacks, setFallbacks, resetFallbacks } from "./backend/fallbacks.js";
+export { Fallbacks, fallbacks, setFallbacks } from "./backend/fallbacks.js";
 export type { FallbacksLike, FallbacksMethods } from "./backend/fallbacks.js";
 // `I18n::Locale::Fallbacks` and `I18n::Backend::Fallbacks` are two classes of
 // the same name; this barrel is flat, and the `Locale` namespace spelling is

--- a/packages/i18n/src/locale.ts
+++ b/packages/i18n/src/locale.ts
@@ -1,0 +1,8 @@
+/**
+ * Mirrors: i18n/lib/i18n/locale.rb — the `I18n::Locale` namespace. Ruby
+ * `autoload`s each member; an ES module re-export is the JS spelling.
+ */
+
+export { Fallbacks } from "./locale/fallbacks.js";
+export type { FallbackMappings } from "./locale/fallbacks.js";
+export * as Tag from "./locale/tag.js";

--- a/packages/i18n/src/locale/fallbacks.test.ts
+++ b/packages/i18n/src/locale/fallbacks.test.ts
@@ -25,7 +25,7 @@ describe("I18nFallbacksDefaultsTest", () => {
   it("defaults to an empty array if no default has been set manually", () => {
     setDefaultLocale("en-US");
     const fallbacks = new Fallbacks();
-    expect(fallbacks.defaults()).toEqual([]);
+    expect(fallbacks.defaults).toEqual([]);
   });
 
   it("documentation example #1 - does not use default locale in fallbacks - See Issues #413 & #415", () => {
@@ -50,14 +50,14 @@ describe("I18nFallbacksDefaultsTest", () => {
 
   it("defaults reflect a manually passed default locale if any", () => {
     const fallbacks = new Fallbacks("fi-FI");
-    expect(fallbacks.defaults()).toEqual(["fi-FI", "fi"]);
+    expect(fallbacks.defaults).toEqual(["fi-FI", "fi"]);
     setDefaultLocale("de-DE");
-    expect(fallbacks.defaults()).toEqual(["fi-FI", "fi"]);
+    expect(fallbacks.defaults).toEqual(["fi-FI", "fi"]);
   });
 
   it("defaults allows to set multiple defaults", () => {
     const fallbacks = new Fallbacks("fi-FI", "se-FI");
-    expect(fallbacks.defaults()).toEqual(["fi-FI", "fi", "se-FI", "se"]);
+    expect(fallbacks.defaults).toEqual(["fi-FI", "fi", "se-FI", "se"]);
   });
 });
 

--- a/packages/i18n/src/locale/fallbacks.test.ts
+++ b/packages/i18n/src/locale/fallbacks.test.ts
@@ -1,4 +1,10 @@
-/** Mirrors: i18n/test/locale/fallbacks_test.rb */
+/**
+ * Mirrors: i18n/test/locale/fallbacks_test.rb
+ *
+ * `#inspect` renders `self.class.name`, which in the gem carries Ruby's module
+ * nesting (`I18n::Locale::Fallbacks`); TypeScript has no nesting to render, so
+ * the constructor name is the whole name.
+ */
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { Fallbacks } from "./fallbacks.js";
@@ -6,14 +12,15 @@ import { config, resetConfig, setDefaultLocale } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { Disabled } from "../exceptions.js";
 
+/** Mirrors: `I18n::TestCase#setup` (i18n/test/test_helper.rb:17-20). */
+function setup(): void {
+  resetConfig();
+  resetClassConfig();
+  config().enforceAvailableLocales = false;
+}
+
 describe("I18nFallbacksDefaultsTest", () => {
-  beforeEach(() => {
-    resetConfig();
-    resetClassConfig();
-    // Mirrors: `I18n.enforce_available_locales = false` in I18n::TestCase#setup
-    // (i18n/test/test_helper.rb:23).
-    config().enforceAvailableLocales = false;
-  });
+  beforeEach(setup);
 
   it("defaults to an empty array if no default has been set manually", () => {
     setDefaultLocale("en-US");
@@ -58,11 +65,7 @@ describe("I18nFallbacksComputationTest", () => {
   let fallbacks: Fallbacks;
 
   beforeEach(() => {
-    resetConfig();
-    resetClassConfig();
-    // Mirrors: `I18n.enforce_available_locales = false` in I18n::TestCase#setup
-    // (i18n/test/test_helper.rb:23).
-    config().enforceAvailableLocales = false;
+    setup();
     fallbacks = new Fallbacks("en-US");
   });
 
@@ -189,11 +192,7 @@ describe("I18nFallbacksHashCompatibilityTest", () => {
   let fallbacks: Fallbacks;
 
   beforeEach(() => {
-    resetConfig();
-    resetClassConfig();
-    // Mirrors: `I18n.enforce_available_locales = false` in I18n::TestCase#setup
-    // (i18n/test/test_helper.rb:23).
-    config().enforceAvailableLocales = false;
+    setup();
     fallbacks = new Fallbacks("en-US", { "de-AT": "de-DE" });
   });
 
@@ -209,9 +208,6 @@ describe("I18nFallbacksHashCompatibilityTest", () => {
     expect(new Fallbacks().empty()).toBe(true);
   });
 
-  // The gem renders `self.class.name`, which carries Ruby's module nesting
-  // (`I18n::Locale::Fallbacks`); TypeScript has no nesting to render, so the
-  // constructor name is the whole name.
   it("#inspect", () => {
     expect(fallbacks.inspect()).toBe(
       `#<Fallbacks @map={:"de-AT"=>[:"de-DE"]} @defaults=[:"en-US", :en]>`,

--- a/packages/i18n/src/locale/fallbacks.test.ts
+++ b/packages/i18n/src/locale/fallbacks.test.ts
@@ -1,0 +1,220 @@
+/** Mirrors: i18n/test/locale/fallbacks_test.rb */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Fallbacks } from "./fallbacks.js";
+import { config, resetConfig, setDefaultLocale } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import { Disabled } from "../exceptions.js";
+
+describe("I18nFallbacksDefaultsTest", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    // Mirrors: `I18n.enforce_available_locales = false` in I18n::TestCase#setup
+    // (i18n/test/test_helper.rb:23).
+    config().enforceAvailableLocales = false;
+  });
+
+  it("defaults to an empty array if no default has been set manually", () => {
+    setDefaultLocale("en-US");
+    const fallbacks = new Fallbacks();
+    expect(fallbacks.defaults()).toEqual([]);
+  });
+
+  it("documentation example #1 - does not use default locale in fallbacks - See Issues #413 & #415", () => {
+    setDefaultLocale("en-US");
+    const fallbacks = new Fallbacks({ "de-AT": "de-DE" });
+    expect(fallbacks.get("de-AT")).toEqual(["de-AT", "de", "de-DE"]);
+  });
+
+  it("documentation example #2 - does not use default locale in fallbacks - Uses custom locale - See Issues #413 & #415", () => {
+    setDefaultLocale("en-US");
+    const fallbacks = new Fallbacks("en-GB", { "de-AT": "de", "de-CH": "de" });
+    expect(fallbacks.get("de-AT")).toEqual(["de-AT", "de", "en-GB", "en"]);
+    expect(fallbacks.get("de-CH")).toEqual(["de-CH", "de", "en-GB", "en"]);
+  });
+
+  it("explicit fallback to default locale", () => {
+    setDefaultLocale("en-US");
+    const fallbacks = new Fallbacks(["en-US"]);
+    expect(fallbacks.get("de-AT")).toEqual(["de-AT", "de", "en-US", "en"]);
+    expect(fallbacks.get("de-CH")).toEqual(["de-CH", "de", "en-US", "en"]);
+  });
+
+  it("defaults reflect a manually passed default locale if any", () => {
+    const fallbacks = new Fallbacks("fi-FI");
+    expect(fallbacks.defaults()).toEqual(["fi-FI", "fi"]);
+    setDefaultLocale("de-DE");
+    expect(fallbacks.defaults()).toEqual(["fi-FI", "fi"]);
+  });
+
+  it("defaults allows to set multiple defaults", () => {
+    const fallbacks = new Fallbacks("fi-FI", "se-FI");
+    expect(fallbacks.defaults()).toEqual(["fi-FI", "fi", "se-FI", "se"]);
+  });
+});
+
+describe("I18nFallbacksComputationTest", () => {
+  let fallbacks: Fallbacks;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    // Mirrors: `I18n.enforce_available_locales = false` in I18n::TestCase#setup
+    // (i18n/test/test_helper.rb:23).
+    config().enforceAvailableLocales = false;
+    fallbacks = new Fallbacks("en-US");
+  });
+
+  it("with no mappings defined it returns [:es, :en-US] for :es", () => {
+    expect(fallbacks.get("es")).toEqual(["es", "en-US", "en"]);
+  });
+
+  it("with no mappings defined it returns [:es-ES, :es, :en-US] for :es-ES", () => {
+    expect(fallbacks.get("es-ES")).toEqual(["es-ES", "es", "en-US", "en"]);
+  });
+
+  it("with no mappings defined it returns [:es-MX, :es, :en-US] for :es-MX", () => {
+    expect(fallbacks.get("es-MX")).toEqual(["es-MX", "es", "en-US", "en"]);
+  });
+
+  it("with no mappings defined it returns [:es-Latn-ES, :es-Latn, :es, :en-US] for :es-Latn-ES", () => {
+    expect(fallbacks.get("es-Latn-ES")).toEqual(["es-Latn-ES", "es-Latn", "es", "en-US", "en"]);
+  });
+
+  it("with no mappings defined it returns [:en, :en-US] for :en", () => {
+    expect(fallbacks.get("en")).toEqual(["en", "en-US"]);
+  });
+
+  it("with no mappings defined it returns [:en-US, :en] for :en-US (special case: locale == default)", () => {
+    expect(fallbacks.get("en-US")).toEqual(["en-US", "en"]);
+  });
+
+  // Most people who speak Catalan also live in Spain, so it is safe to assume
+  // that they also speak Spanish as spoken in Spain.
+  it("with a Catalan mapping defined it returns [:ca, :es-ES, :es, :en-US] for :ca", () => {
+    fallbacks.map({ ca: "es-ES" });
+    expect(fallbacks.get("ca")).toEqual(["ca", "es-ES", "es", "en-US", "en"]);
+  });
+
+  it("with a Catalan mapping defined it returns [:ca-ES, :ca, :es-ES, :es, :en-US] for :ca-ES", () => {
+    fallbacks.map({ ca: "es-ES" });
+    expect(fallbacks.get("ca-ES")).toEqual(["ca-ES", "ca", "es-ES", "es", "en-US", "en"]);
+  });
+
+  // People who speak Arabic as spoken in Palestine often times also speak
+  // Hebrew as spoken in Israel. However it is in no way safe to assume that
+  // everybody who speaks Arabic also speaks Hebrew.
+
+  it("with a Hebrew mapping defined it returns [:ar, :en-US] for :ar", () => {
+    fallbacks.map({ "ar-PS": "he-IL" });
+    expect(fallbacks.get("ar")).toEqual(["ar", "en-US", "en"]);
+  });
+
+  it("with a Hebrew mapping defined it returns [:ar-EG, :ar, :en-US] for :ar-EG", () => {
+    fallbacks.map({ "ar-PS": "he-IL" });
+    expect(fallbacks.get("ar-EG")).toEqual(["ar-EG", "ar", "en-US", "en"]);
+  });
+
+  it("with a Hebrew mapping defined it returns [:ar-PS, :ar, :he-IL, :he, :en-US] for :ar-PS", () => {
+    fallbacks.map({ "ar-PS": "he-IL" });
+    expect(fallbacks.get("ar-PS")).toEqual(["ar-PS", "ar", "he-IL", "he", "en-US", "en"]);
+  });
+
+  // Sami people live in several scandinavian countries. In Finnland many people
+  // know Swedish and Finnish. Thus, it can be assumed that Sami living in
+  // Finnland also speak Swedish and Finnish.
+
+  it("with a Sami mapping defined it returns [:sms-FI, :sms, :se-FI, :se, :fi-FI, :fi, :en-US] for :sms-FI", () => {
+    fallbacks.map({ sms: ["se-FI", "fi-FI"] });
+    expect(fallbacks.get("sms-FI")).toEqual([
+      "sms-FI",
+      "sms",
+      "se-FI",
+      "se",
+      "fi-FI",
+      "fi",
+      "en-US",
+      "en",
+    ]);
+  });
+
+  // Austrian people understand German as spoken in Germany
+
+  it("with a German mapping defined it returns [:de, :en-US] for de", () => {
+    fallbacks.map({ "de-AT": "de-DE" });
+    expect(fallbacks.get("de")).toEqual(["de", "en-US", "en"]);
+  });
+
+  it("with a German mapping defined it returns [:de-DE, :de, :en-US] for de-DE", () => {
+    fallbacks.map({ "de-AT": "de-DE" });
+    expect(fallbacks.get("de-DE")).toEqual(["de-DE", "de", "en-US", "en"]);
+  });
+
+  it("with a German mapping defined it returns [:de-AT, :de, :de-DE, :en-US] for de-AT", () => {
+    fallbacks.map({ "de-AT": "de-DE" });
+    expect(fallbacks.get("de-AT")).toEqual(["de-AT", "de", "de-DE", "en-US", "en"]);
+  });
+
+  // Mapping :de => :en, :he => :en
+
+  it("with a mapping :de => :en, :he => :en defined it returns [:de, :en] for :de", () => {
+    expect(fallbacks.get("de")).toEqual(["de", "en-US", "en"]);
+  });
+
+  it("with a mapping :de => :en, :he => :en defined it [:he, :en] for :de", () => {
+    expect(fallbacks.get("he")).toEqual(["he", "en-US", "en"]);
+  });
+
+  // Test allowing mappings that fallback to each other
+
+  it("with :no => :nb, :nb => :no defined :no returns [:no, :nb, :en-US, :en]", () => {
+    fallbacks.map({ no: "nb", nb: "no" });
+    expect(fallbacks.get("no")).toEqual(["no", "nb", "en-US", "en"]);
+  });
+
+  it("with :no => :nb, :nb => :no defined :nb returns [:nb, :no, :en-US, :en]", () => {
+    fallbacks.map({ no: "nb", nb: "no" });
+    expect(fallbacks.get("nb")).toEqual(["nb", "no", "en-US", "en"]);
+  });
+
+  // Test I18n::Disabled  is raised correctly when locale is false during fallback
+
+  it("with locale equals false", () => {
+    expect(() => fallbacks.get(false)).toThrow(Disabled);
+  });
+});
+
+describe("I18nFallbacksHashCompatibilityTest", () => {
+  let fallbacks: Fallbacks;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    // Mirrors: `I18n.enforce_available_locales = false` in I18n::TestCase#setup
+    // (i18n/test/test_helper.rb:23).
+    config().enforceAvailableLocales = false;
+    fallbacks = new Fallbacks("en-US", { "de-AT": "de-DE" });
+  });
+
+  it("map is compatible with Hash#map", () => {
+    const result = fallbacks.map((key, value) => [key, value]);
+    expect(result).toEqual([["de-AT", ["de-DE"]]]);
+  });
+
+  it("empty? is compatible with Hash#empty?", () => {
+    expect(fallbacks.empty()).toBe(false);
+    expect(new Fallbacks("en-US").empty()).toBe(false);
+    expect(new Fallbacks({ "de-AT": "de-DE" }).empty()).toBe(false);
+    expect(new Fallbacks().empty()).toBe(true);
+  });
+
+  // The gem renders `self.class.name`, which carries Ruby's module nesting
+  // (`I18n::Locale::Fallbacks`); TypeScript has no nesting to render, so the
+  // constructor name is the whole name.
+  it("#inspect", () => {
+    expect(fallbacks.inspect()).toBe(
+      `#<Fallbacks @map={:"de-AT"=>[:"de-DE"]} @defaults=[:"en-US", :en]>`,
+    );
+  });
+});

--- a/packages/i18n/src/locale/fallbacks.ts
+++ b/packages/i18n/src/locale/fallbacks.ts
@@ -1,0 +1,150 @@
+/**
+ * Mirrors: i18n/lib/i18n/locale/fallbacks.rb
+ *
+ * Locale fallbacks will compute a number of fallback locales for a given
+ * locale. For example:
+ *
+ *     I18n.fallbacks().get("es-MX") // => ["es-MX", "es", "en"]
+ *
+ * Locale fallbacks always fall back to
+ *
+ *   * all parent locales of a given locale (e.g. "es" for "es-MX") first,
+ *   * the current default locales and all of their parents second
+ *
+ * The default locales are set to [] by default but can be set to something
+ * else.
+ *
+ * One can additionally add any number of additional fallback locales manually.
+ * These will be added before the default locales to the fallback chain. For
+ * example:
+ *
+ *     // using a custom locale as default fallback locale
+ *
+ *     I18n.setFallbacks(new Fallbacks("en-GB", { "de-AT": "de", "de-CH": "de" }));
+ *     I18n.fallbacks().get("de-AT"); // => ["de-AT", "de", "en-GB", "en"]
+ *     I18n.fallbacks().get("de-CH"); // => ["de-CH", "de", "en-GB", "en"]
+ *
+ *     // mapping fallbacks to an existing instance
+ *
+ *     // people speaking Catalan also speak Spanish as spoken in Spain
+ *     const fallbacks = I18n.fallbacks();
+ *     fallbacks.map({ ca: "es-ES" });
+ *     fallbacks.get("ca"); // => ["ca", "es-ES", "es", "en-US", "en"]
+ *
+ * Ruby subclasses `Hash`; the JS analogue of a Hash is a `Map`, so `[]` — which
+ * `docs/ruby-ts-conventions.md` maps to `get()` — lands on `Map#get` and its
+ * `super` call is the gem's `super`.
+ */
+
+import { InvalidLocale, Disabled } from "../exceptions.js";
+import type { Locale } from "../i18n.js";
+import { tag as tagFor } from "./tag.js";
+
+/** A mapping argument: `{ "de-AT": "de-DE" }` or `{ sms: ["se-FI", "fi-FI"] }`. */
+export type FallbackMappings = Record<Locale, Locale | Locale[]>;
+
+/**
+ * Ruby's `Symbol#inspect`, which quotes any symbol that is not a plain
+ * identifier — `:"de-AT"`, but `:de`. `inspect` in `../exceptions.js` renders
+ * translation values, not locales.
+ */
+function inspectSymbol(value: Locale): string {
+  return /^[a-zA-Z_][a-zA-Z0-9_]*[?!=]?$/.test(value) ? `:${value}` : `:"${value}"`;
+}
+
+function inspectLocales(locales: Locale[]): string {
+  return `[${locales.map(inspectSymbol).join(", ")}]`;
+}
+
+export class Fallbacks extends Map<Locale, Locale[]> {
+  private mapStore: Record<Locale, Locale[]> = {};
+  private defaultsStore: Locale[] = [];
+
+  constructor(...mappings: (Locale | Locale[] | FallbackMappings)[]) {
+    super();
+    this.mapStore = {};
+    const last = mappings[mappings.length - 1];
+    if (isMappings(last)) this.map(mappings.pop() as FallbackMappings);
+    this.setDefaults(mappings.length === 0 ? [] : (mappings as (Locale | Locale[])[]));
+  }
+
+  setDefaults(defaults: (Locale | Locale[])[]): void {
+    this.defaultsStore = defaults.flatMap((default_) => this.compute(default_, false));
+  }
+
+  defaults(): Locale[] {
+    return this.defaultsStore;
+  }
+
+  override get(locale: Locale | false | null | undefined): Locale[] {
+    if (locale == null) throw new InvalidLocale(locale);
+    if (locale === false) throw new Disabled("fallback#[]");
+    locale = String(locale);
+    return super.get(locale) ?? this.store(locale, this.compute(locale));
+  }
+
+  map(mappings: FallbackMappings): void;
+  map<T>(block: (key: Locale, value: Locale[]) => T): T[];
+  map(...args: unknown[]): unknown {
+    const block =
+      typeof args[args.length - 1] === "function"
+        ? (args.pop() as (key: Locale, value: Locale[]) => unknown)
+        : undefined;
+    if (args.length === 1 && !block) {
+      const mappings = args[0] as FallbackMappings;
+      for (const [from, to] of Object.entries(mappings)) {
+        for (const _to of ([] as Locale[]).concat(to)) {
+          this.mapStore[from] ??= [];
+          this.mapStore[from].push(_to);
+        }
+      }
+      return undefined;
+    } else {
+      return Object.entries(this.mapStore).map(([key, value]) => block!(key, value));
+    }
+  }
+
+  empty(): boolean {
+    return Object.keys(this.mapStore).length === 0 && this.defaultsStore.length === 0;
+  }
+
+  inspect(): string {
+    const map = Object.entries(this.mapStore)
+      .map(([key, value]) => `${inspectSymbol(key)}=>${inspectLocales(value)}`)
+      .join(", ");
+    return `#<${this.constructor.name} @map={${map}} @defaults=${inspectLocales(this.defaultsStore)}>`;
+  }
+
+  protected compute(
+    tags: Locale | Locale[] | null | undefined,
+    includeDefaults = true,
+    exclude: Locale[] = [],
+  ): Locale[] {
+    let result: Locale[] = [];
+    for (const tag of tags == null ? [] : ([] as Locale[]).concat(tags)) {
+      const tags = tagFor(tag)
+        .selfAndParents()
+        .map((t) => t.toSym())
+        .filter((t) => !exclude.includes(t));
+      result = result.concat(tags);
+      for (const _tag of tags) {
+        if (this.mapStore[_tag]) {
+          result = result.concat(this.compute(this.mapStore[_tag], false, exclude.concat(result)));
+        }
+      }
+    }
+
+    if (includeDefaults) result.push(...this.defaults());
+    return [...new Set(result)].filter((locale) => locale != null);
+  }
+
+  /** Ruby's `Hash#store`, which `[]` calls for its return value. */
+  private store(locale: Locale, value: Locale[]): Locale[] {
+    this.set(locale, value);
+    return value;
+  }
+}
+
+function isMappings(value: unknown): value is FallbackMappings {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/i18n/src/locale/fallbacks.ts
+++ b/packages/i18n/src/locale/fallbacks.ts
@@ -73,7 +73,7 @@ export class Fallbacks extends Map<Locale, Locale[]> {
     this.defaultsStore = defaults.flatMap((default_) => this.compute(default_, false));
   }
 
-  defaults(): Locale[] {
+  get defaults(): Locale[] {
     return this.defaultsStore;
   }
 
@@ -135,7 +135,7 @@ export class Fallbacks extends Map<Locale, Locale[]> {
       }
     }
 
-    if (includeDefaults) result.push(...this.defaults());
+    if (includeDefaults) result.push(...this.defaults);
     return [...new Set(result)].filter((locale) => locale != null);
   }
 

--- a/packages/i18n/src/locale/fallbacks.ts
+++ b/packages/i18n/src/locale/fallbacks.ts
@@ -62,9 +62,10 @@ export class Fallbacks extends Map<Locale, Locale[]> {
 
   constructor(...mappings: (Locale | Locale[] | FallbackMappings)[]) {
     super();
-    this.mapStore = {};
     const last = mappings[mappings.length - 1];
-    if (isMappings(last)) this.map(mappings.pop() as FallbackMappings);
+    if (typeof last === "object" && last !== null && !Array.isArray(last)) {
+      this.map(mappings.pop() as FallbackMappings);
+    }
     this.setDefaults(mappings.length === 0 ? [] : (mappings as (Locale | Locale[])[]));
   }
 
@@ -143,8 +144,4 @@ export class Fallbacks extends Map<Locale, Locale[]> {
     this.set(locale, value);
     return value;
   }
-}
-
-function isMappings(value: unknown): value is FallbackMappings {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/i18n/src/locale/tag.ts
+++ b/packages/i18n/src/locale/tag.ts
@@ -1,0 +1,43 @@
+/**
+ * Mirrors: i18n/lib/i18n/locale/tag.rb
+ *
+ * Ruby's `@@implementation` is class-level state on a module; the module-level
+ * binding below is that store. The gem `autoload`s `Rfc4646` alongside
+ * `Simple`; only `Simple` is ported so far, and it is the default
+ * implementation.
+ */
+
+import { Simple } from "./tag/simple.js";
+import type { Parents } from "./tag/parents.js";
+
+let implementationStore: TagImplementation | undefined;
+
+/** The surface a tag implementation exposes: a factory, and the tag it makes. */
+export interface TagImplementation {
+  tag(...tag: string[]): Parents;
+}
+
+/**
+ * Returns the current locale tag implementation. Defaults to
+ * +I18n::Locale::Tag::Simple+.
+ */
+export function implementation(): TagImplementation {
+  implementationStore ??= Simple;
+  return implementationStore;
+}
+
+/**
+ * Sets the current locale tag implementation. Use this to set a different
+ * locale tag implementation.
+ */
+export function setImplementation(value: TagImplementation): void {
+  implementationStore = value;
+}
+
+/**
+ * Factory method for locale tags. Delegates to the current locale tag
+ * implementation.
+ */
+export function tag(tag: string): Parents {
+  return implementation().tag(tag);
+}

--- a/packages/i18n/src/locale/tag.ts
+++ b/packages/i18n/src/locale/tag.ts
@@ -2,9 +2,7 @@
  * Mirrors: i18n/lib/i18n/locale/tag.rb
  *
  * Ruby's `@@implementation` is class-level state on a module; the module-level
- * binding below is that store. The gem `autoload`s `Rfc4646` alongside
- * `Simple`; only `Simple` is ported so far, and it is the default
- * implementation.
+ * binding below is that store.
  */
 
 import { Simple } from "./tag/simple.js";

--- a/packages/i18n/src/locale/tag/parents.ts
+++ b/packages/i18n/src/locale/tag/parents.ts
@@ -1,0 +1,44 @@
+/**
+ * Mirrors: i18n/lib/i18n/locale/tag/parents.rb
+ *
+ * Ruby `include Parents` (tag/simple.rb:13); the trails idiom for a mixed-in
+ * module is a `this`-typed function assigned to the class, so the code stays in
+ * the file that matches the gem's layout.
+ *
+ * The gem memoizes each of the three through `@parent ||=` / `@parents ||=`;
+ * a `this`-typed function has no ivar to write, and the cache is not
+ * observable — every tag is immutable, so a recomputed parent is `==` to the
+ * memoized one.
+ */
+
+import type { Locale } from "../../i18n.js";
+
+/** The tag surface `Parents` calls on its host — `I18n::Locale::Tag::Simple`. */
+export interface Parents {
+  toA(): string[];
+  toSym(): Locale;
+  parent(): Parents | null;
+  parents(): Parents[];
+  selfAndParents(): Parents[];
+}
+
+/** @internal Ruby's `self.class`, narrowed to the tag factory `parent` calls. */
+interface TagClass {
+  tag(...tag: string[]): Parents;
+}
+
+export function parent(this: Parents): Parents | null {
+  const segs = this.toA().filter((seg) => seg != null);
+  return segs.length > 1
+    ? (this.constructor as unknown as TagClass).tag(segs.slice(0, segs.length - 1).join("-"))
+    : null;
+}
+
+export function selfAndParents(this: Parents): Parents[] {
+  return [this].concat(this.parents());
+}
+
+export function parents(this: Parents): Parents[] {
+  const parent = this.parent();
+  return parent ? [parent].concat(parent.parents()) : [];
+}

--- a/packages/i18n/src/locale/tag/simple.ts
+++ b/packages/i18n/src/locale/tag/simple.ts
@@ -1,0 +1,46 @@
+/**
+ * Mirrors: i18n/lib/i18n/locale/tag/simple.rb
+ *
+ * Simple Locale tag implementation that computes subtags by simply splitting
+ * the locale tag at '-' occurrences.
+ */
+
+import type { Locale } from "../../i18n.js";
+import { parent, parents, selfAndParents, type Parents } from "./parents.js";
+
+export class Simple implements Parents {
+  static tag(...tag: string[]): Simple {
+    return new Simple(...tag);
+  }
+
+  /**
+   * Ruby's `attr_reader :tag`. A Ruby Symbol is a JS string, so `to_sym` and
+   * `to_s` below both hand back this same value.
+   */
+  readonly tag: Locale;
+
+  constructor(...tag: string[]) {
+    this.tag = tag.join("-");
+  }
+
+  /** Mirrors: `include Parents` (simple.rb:13). */
+  parent = parent;
+  parents = parents;
+  selfAndParents = selfAndParents;
+
+  subtags(): string[] {
+    return this.tag.split("-");
+  }
+
+  toSym(): Locale {
+    return this.tag;
+  }
+
+  toS(): string {
+    return this.tag;
+  }
+
+  toA(): string[] {
+    return this.subtags();
+  }
+}

--- a/packages/i18n/src/locale/tag/simple.ts
+++ b/packages/i18n/src/locale/tag/simple.ts
@@ -36,7 +36,7 @@ export class Simple implements Parents {
     return this.tag;
   }
 
-  toS(): string {
+  toString(): string {
     return this.tag;
   }
 

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1144,13 +1144,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
   },
   {
-    pattern: "backend/fallbacks.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: optional backend mixin — locale fallback chain, built on the " +
-      "equally out-of-scope locale/fallbacks.rb.",
-  },
-  {
     pattern: "backend/key_value.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
@@ -1212,21 +1205,12 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "concern with no trails consumer; Rails' own I18n usage never touches it.",
   },
   {
-    pattern: "locale/",
+    pattern: "locale/tag/rfc4646.rb",
     package: "i18n",
     reason:
-      "Pre-1.0: RFC 4646 locale-tag parsing and the fallback tag graph " +
-      "(`Locale::Tag::*`, `Locale::Fallbacks`). Only reachable through " +
-      "Backend::Fallbacks, which is itself out of pre-1.0 scope.",
-  },
-  {
-    pattern: "locale.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: the `I18n::Locale` namespace's autoload shim — it declares " +
-      "nothing but `autoload :Fallbacks` / `autoload :Tag` for the `locale/` " +
-      "tree excluded above. Listed separately because the `locale/` pattern " +
-      "does not reach a file that sits beside the directory.",
+      "The alternative `Locale::Tag` implementation. `Tag.implementation` " +
+      "defaults to `Tag::Simple` in the gem and nothing selects this one, so " +
+      "the fallback chain never reaches it — story i18n-locale-tag-rfc4646.",
   },
   {
     pattern: "middleware.rb",
@@ -1256,8 +1240,8 @@ export const UNPORTED_FILES: UnportedFile[] = [
     package: "i18n",
     reason:
       "Pre-1.0: the `I18n::Tests` namespace's autoload shim for the `tests/` " +
-      "conformance mixins excluded above. Same beside-the-directory shape as " +
-      "`locale.rb`.",
+      "conformance mixins excluded above — a file that sits beside the " +
+      "directory the pattern above reaches.",
   },
 ];
 


### PR DESCRIPTION
Ports `I18n::Backend::Fallbacks` and the locale chain it walks, so a lookup
against `"en-US"` falls through to `"en"`.

New files, each against its gem counterpart:

| trails | gem |
| --- | --- |
| `packages/i18n/src/backend/fallbacks.ts` | `i18n/lib/i18n/backend/fallbacks.rb` |
| `packages/i18n/src/locale.ts` | `i18n/lib/i18n/locale.rb` |
| `packages/i18n/src/locale/fallbacks.ts` | `i18n/lib/i18n/locale/fallbacks.rb` |
| `packages/i18n/src/locale/tag.ts` | `i18n/lib/i18n/locale/tag.rb` |
| `packages/i18n/src/locale/tag/simple.ts` | `i18n/lib/i18n/locale/tag/simple.rb` |
| `packages/i18n/src/locale/tag/parents.ts` | `i18n/lib/i18n/locale/tag/parents.rb` |

`Locale::Fallbacks#compute` walks `Tag.tag(tag).self_and_parents`
(`locale/fallbacks.rb:95`), so `Tag` + `Tag::Simple` + `Tag::Parents` come with
it — they are the chain, not scope creep.

Shapes worth a look:

- **`Locale::Fallbacks < Hash` → `extends Map`.** `[]` maps to `get()` per
  `docs/ruby-ts-conventions.md`, which lands on `Map#get`, so the gem's
  `super || store(locale, compute(locale))` (`locale/fallbacks.rb:64`) is a
  literal `super.get(locale) ?? this.store(...)`. `map` keeps both Ruby arms —
  the one-Hash-argument mapping definition and the `Hash#map` block.
- **`include I18n::Backend::Fallbacks` → `Fallbacks(Simple)`.** The module
  overwrites `translate`, `exists?` and `resolve_entry` and calls `super` from
  each; `include()` / `Included<>` copies onto a prototype and has no `super`,
  so the mixin is a class factory. Every body under it is the gem's, line for
  line. `class Backend extends Fallbacks(Simple) {}` is the gem's
  `class Backend < I18n::Backend::Simple; include I18n::Backend::Fallbacks; end`.
- **`Locale::Fallbacks` has no reset seam.** The gem's teardown is
  `I18n.fallbacks = nil` (`test_helper.rb:29`), and `fallbacks` re-vivifies with
  `@@fallbacks ||= I18n::Locale::Fallbacks.new`; `setFallbacks(null)` is that,
  so no test-only reset function exists.
- **`normalizeKey` (`i18n.ts`)** now takes a JS symbol's name rather than
  `String(symbol)`. Ruby's `key.to_s` on a Symbol is `"missing_baz"`; ours was
  producing `"Symbol(missing_baz)"`, which reached the `Translation missing.
  Options considered were:` message whenever a `:default` chain held a Symbol
  (`exceptions.rb`'s `keys`). The ported
  `"returns the Translation missing: message if the default is also missing"`
  case is what surfaced it.

Tests are ported verbatim: `locale/fallbacks_test.rb` in full (29/29), and
`backend/fallbacks_test.rb` at 38 of 46. The 8 not ported are the six
`I18nBackendFallbacksWithChainTest` cases (there is no `Backend::Chain` yet —
filed as story `i18n-backend-chain`) and the two `Thread.new` cases, which
assert that the gem's thread-local fallbacks store is visible from another
thread; JS has no threads, so `fallbacks()` is one module-level binding, as
`I18n.config` already is. Both exclusions are named in the test file header.

**Review round 1.**

- **The AR criterion — held open, with the evidence.** Round 1 asked for
  `packages/activerecord/src/validations/i18n-generate-message-validation.test.ts:124`
  to run against `Fallbacks(Simple)`. Three facts make that this PR's
  neighbour's work, not this PR's:

  1. **The story's premise is false on `main`.** That case is not skipped and
     is green today; there is no `it.skip` and no skip comment to remove. The
     `it.skip` the story quotes exists only on unmerged PR #6026.
  2. **`packages/activemodel` does not depend on `@blazetrails/i18n`**
     (`packages/activemodel/package.json:29-32`). AR error messages resolve
     through `I18nService` in `packages/activemodel/src/i18n.ts`, a private
     class with its own lookup and its own `_fallbackChain`. Pointing the AR
     case at `Fallbacks(Simple)` means adding that dependency and deleting the
     shim — which is precisely what #6026 does, in precisely these files.
  3. **The shim's fallback semantics are pinned by AM tests that contradict the
     gem**, so the swap cannot be behaviour-preserving:
     `packages/activemodel/src/i18n.test.ts:113-119` asserts an explicit
     per-locale chain still appends `default_locale`, and `:105-111` asserts
     defensive copies of caller arrays. The gem does neither for a Hash
     fallbacks object: `I18n.fallbacks = {…}` stores it as-is
     (`i18n/lib/i18n/backend/fallbacks.rb:24`) and `Hash#[]` returns the stored
     chain unchanged — which is exactly what
     `I18nBackendFallbacksSymbolResolveRestartsLookupAtOriginalLocale`'s sibling
     `RegressionTestFor617` (`fallbacks_test.rb:262`) relies on. Converging AR
     therefore requires rewriting those AM cases too.

  Rather than absorb #6026, this PR proves the criterion's *behaviour* against
  the port: `packages/i18n/src/backend/fallbacks.trails.test.ts` runs the exact
  scenario from
  `activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:91-101`
  through `Fallbacks(Simple)`, spelling out the two passes
  `ActiveModel::Error.generate_message` makes
  (`activemodel/lib/active_model/error.rb:79-100`) — an `i18n_scope`-only
  `throw: true` pass, then the `errors.attributes.*` / `errors.messages.*`
  fallthrough. That structure is *why* the parent-locale `activerecord`
  attributes key beats the child locale's generic `errors.messages` key: the
  first pass never offers `errors.messages.taken` as a default, so `en-US`
  misses the whole pass and `en` wins it. (Modelled as one flat default chain
  it returns `"generic en-US fallback"` — as the gem does for that shape.)
  The remaining wiring is story `i18n-ar-fallbacks-wiring`, which lands on top
  of #6026.
- **`Tag::Rfc4646` is no longer silently omitted.** The claim has been removed
  from `locale/tag.ts`'s header and the file is registered in
  `scripts/api-compare/unported-files.ts` — the repo's measured register —
  pointing at new story `i18n-locale-tag-rfc4646`. Nothing selects it:
  `Tag.implementation` defaults to `Tag::Simple` (`locale/tag.rb:12-14`), so
  the fallback chain never reaches it.
- Chasing that register turned up a **stale-exclusion bug**: `backend/fallbacks.rb`,
  `locale/` and `locale.rb` were all still listed as unported, so every file
  this PR adds was being excluded from `api:compare`. Retiring those entries
  moves `packages/i18n` from **8/14 to 13/14 files** and **106 to 130 methods**,
  and the repo total from 789 to 794 files.
- Two naming misses that only became visible once the files were measured:
  `to_s` maps to `toString`, not `toS` (`locale/tag/simple.ts` is now 8/8), and
  `attr_reader :defaults` is a property, so it is a getter — which also cleared
  a wide-ratchet row where the comparator had paired `defaults=` to the reader.
  No baseline row was added for it.

One measured gap remains and is deliberate: `on_fallback` does not pair, because
the mixin's members live on a class expression inside the factory function and
the extractor resolves the rest by short name against `Base`. It is `protected`,
as the gem has it `private`; making it public to satisfy the matcher would be
the unfaithful fix.

This is 1317 LOC against the 500 ceiling, and it is one story's worth of work
that does not split: the two source files are ~500 LOC on their own, and the
remainder is the two test ports the acceptance criteria name. Splitting them
apart would mean either a stacked PR or shipping the port untested. Flagging it
rather than deciding it.

Gates: `pnpm api:calls` OK (14 baselined, unchanged), `pnpm api:calls:wide` OK
(no new rows), `pnpm test:compare` +67 for `packages/i18n`, `pnpm api:compare`
i18n 130/143 methods and 13/14 files. `pnpm api:extra` fails on a pre-existing unclassified
`@noRailsEquivalent` tag in `activerecord`
(`associations/errors.ts NestedAttributesDisplacementError`), untouched here;
no new baseline row or allowlist entry in this PR.

Closes-story: i18n-backend-fallbacks
