### PR TITLE
fix(i18n): re-read load_path from disk on I18n.reload!

### DIFF
--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -6,8 +6,8 @@ import { TimeZone } from "./values/time-zone.js";
 import type { TimeWithZone } from "./time-with-zone.js";
 
 /** `I18n.reload!` plus the `en` locale Rails re-reads from its load path. */
-function reloadTranslations(): void {
-  I18n.reloadBang();
+async function reloadTranslations(): Promise<void> {
+  await I18n.reloadBang();
   I18n.backend().storeTranslations("en", en);
 }
 
@@ -95,14 +95,14 @@ describe("I18nTest", () => {
   let date: RubyDate;
   let time: TimeWithZone;
 
-  beforeEach(() => {
-    reloadTranslations();
+  beforeEach(async () => {
+    await reloadTranslations();
     date = new RubyDate(2008, 7, 2);
     time = TimeZone.find("UTC").local(2008, 7, 2, 16, 47, 1);
   });
 
-  afterEach(() => {
-    reloadTranslations();
+  afterEach(async () => {
+    await reloadTranslations();
   });
 
   it("time zone localization with default format", () => {

--- a/packages/activesupport/src/number-helper-i18n.test.ts
+++ b/packages/activesupport/src/number-helper-i18n.test.ts
@@ -15,8 +15,8 @@ import {
 I18n.setEnforceAvailableLocales(false);
 
 /** `I18n.reload!` plus the `en` locale Rails re-reads from its load path. */
-function reloadTranslations(): void {
-  I18n.reloadBang();
+async function reloadTranslations(): Promise<void> {
+  await I18n.reloadBang();
   I18n.backend().storeTranslations("en", en);
 }
 
@@ -79,13 +79,13 @@ function setupTranslations(): void {
 }
 
 describe("NumberHelperI18nTest", () => {
-  beforeEach(() => {
-    reloadTranslations();
+  beforeEach(async () => {
+    await reloadTranslations();
     setupTranslations();
   });
 
-  afterEach(() => {
-    reloadTranslations();
+  afterEach(async () => {
+    await reloadTranslations();
   });
 
   it("number to i18n currency", () => {

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -78,6 +78,20 @@ describe("I18n::Backend::Base file loading", () => {
     expect(backend.translate("en", "foo.bar")).toBe("qux");
   });
 
+  it("re-reads I18n.load_path on reloadBang with an eager loaded backend", async () => {
+    let body = "en:\n  foo:\n    bar: baz\n";
+    registerFileReader(() => Promise.resolve(body));
+    config().loadPath = ["mutable.yml"];
+    await preloadTranslationFiles();
+    backend.eagerLoadBang();
+    expect(backend.translate("en", "foo.bar")).toBe("baz");
+
+    body = "en:\n  foo:\n    bar: qux\n";
+    await reloadBang();
+    expect(backend.initialized()).toBe(true);
+    expect(backend.translate("en", "foo.bar")).toBe("qux");
+  });
+
   it("leaves the lazy-init guard armed when the load path holds an invalid file", () => {
     config().loadPath = [`${localesDir()}/invalid/syntax.yml`];
     expect(() => backend.translate("en", "foo.bar")).toThrow(InvalidLocaleData);

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -6,7 +6,7 @@
 import { readFile } from "node:fs/promises";
 import { beforeEach, describe, expect, it } from "vitest";
 import { Simple } from "./simple.js";
-import { config, resetConfig } from "../i18n.js";
+import { config, reloadBang, resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { InvalidLocaleData } from "../exceptions.js";
 import { preloadTranslationFiles, registerFileReader } from "./base.js";
@@ -66,7 +66,7 @@ describe("I18n::Backend::Base file loading", () => {
     expect(backend.initialized()).toBe(true);
   });
 
-  it("re-reads I18n.load_path when the preload is re-run before reloadBang", async () => {
+  it("re-reads I18n.load_path on reloadBang", async () => {
     let body = "en:\n  foo:\n    bar: baz\n";
     registerFileReader(() => Promise.resolve(body));
     config().loadPath = ["mutable.yml"];
@@ -74,8 +74,7 @@ describe("I18n::Backend::Base file loading", () => {
     expect(backend.translate("en", "foo.bar")).toBe("baz");
 
     body = "en:\n  foo:\n    bar: qux\n";
-    await preloadTranslationFiles();
-    backend.reloadBang();
+    await reloadBang();
     expect(backend.translate("en", "foo.bar")).toBe("qux");
   });
 

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -78,18 +78,27 @@ export function registerFileReader(reader: FileReader): void {
  * `Naming#human` and `NumberConverter#format`; making them async would push a
  * deviation through five packages to remove one from this file. Awaiting the
  * I/O once at boot keeps the async fs and leaves every ported body verbatim.
- *
- * One behavioural consequence, and the only one: `I18n.reload!` re-parses these
- * bytes rather than re-reading the files, so it does not pick up an edit on
- * disk the way `reload!` does in the gem. Re-running this preload before
- * `I18n.reloadBang()` restores that; a synchronous re-read here is exactly what
- * the language does not allow.
  */
 export async function preloadTranslationFiles(...filenames: (string | string[])[]): Promise<void> {
   const paths = filenames.length === 0 ? config().loadPath : filenames;
   for (const filename of paths.flat()) {
     fileContents.set(filename, await readTranslationFile(filename));
   }
+}
+
+/**
+ * Drops the preloaded bytes and re-reads `I18n.load_path`, so that the
+ * `load_translations` the next lazy `init_translations` runs sees what is on
+ * disk now — which is what `YAML.load_file` (base.rb:246) does on every
+ * `I18n.reload!` in the gem. A host that never registered a reader has no
+ * files to re-read, and `I18n.reload!` there is only the in-memory clear.
+ *
+ * @internal
+ */
+export async function reloadTranslationFiles(): Promise<void> {
+  if (!fileReader) return;
+  fileContents.clear();
+  await preloadTranslationFiles();
 }
 
 function readTranslationFile(filename: string): Promise<string> {

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -93,7 +93,11 @@ export async function preloadTranslationFiles(...filenames: (string | string[])[
  * `I18n.reload!` in the gem. A host that never registered a reader has no
  * files to re-read, and `I18n.reload!` there is only the in-memory clear.
  *
- * @internal
+ * @noRailsEquivalent PERMANENT — the counterpart of `preloadTranslationFiles`
+ * above: the gem's re-read is a synchronous `YAML.load_file` inside
+ * `init_translations`, and the four call sites that reach it are synchronous in
+ * Rails all the way up. Awaiting the re-read at `I18n.reload!` — the one seam
+ * the gem also treats as a whole-backend reset — is what the language leaves.
  */
 export async function reloadTranslationFiles(): Promise<void> {
   if (!fileReader) return;

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -500,7 +500,7 @@ describe("I18nTest", () => {
     t("foo", { locale: "klingon" });
   });
 
-  it("I18n.reload! reloads the set of locales that are enforced", () => {
+  it("I18n.reload! reloads the set of locales that are enforced", async () => {
     setBackend(new Simple());
 
     expect(availableLocales()).not.toContain("de");
@@ -515,7 +515,7 @@ describe("I18nTest", () => {
     expect(() => setDefaultLocale("de")).toThrow(InvalidLocale);
     expect(() => setLocale("de")).toThrow(InvalidLocale);
 
-    reloadBang();
+    await reloadBang();
 
     storeTranslations("en", { foo: "Foo in :en" });
     storeTranslations("de", { foo: "Foo in :de" });

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -181,11 +181,16 @@ export function setEnforceAvailableLocales(value: boolean): void {
  * this one seam and awaited: `reload!` is the only method that becomes async,
  * and every ported body below it — including the four lazy call sites — stays
  * verbatim and synchronous.
+ *
+ * It precedes `backend.reload!` because that is not always lazy: `Base#reload!`
+ * re-runs `eager_load!` on an eager-loaded backend (base.rb:101), which reaches
+ * `init_translations` / `load_translations` during the reload itself
+ * (simple.rb:83, base.rb:14).
  */
 export async function reloadBang(): Promise<void> {
   config().clearAvailableLocalesSet();
-  config().backend.reloadBang();
   await reloadTranslationFiles();
+  config().backend.reloadBang();
 }
 
 /**

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -21,6 +21,7 @@ import type { Base } from "./backend/base.js";
 import { Config } from "./config.js";
 import { ArgumentError, Disabled, InvalidLocale, MissingTranslation } from "./exceptions.js";
 import type { TranslateOptions } from "./backend/base.js";
+import { reloadTranslationFiles } from "./backend/base.js";
 import { throwException, catchException } from "./throw-catch.js";
 
 /** Ruby models locales as Symbols; the JS analogue is a plain string. */
@@ -172,9 +173,18 @@ export function setEnforceAvailableLocales(value: boolean): void {
  * Tells the backend to reload translations. Used in situations like the
  * Rails development environment. Backends can implement whatever strategy
  * is useful.
+ *
+ * The gem's `reload!` is synchronous because `Simple#reload!` only clears
+ * `@initialized` / `@translations` (simple.rb:57-62) and the re-read of
+ * `I18n.load_path` happens later, inside the next lazy `init_translations`
+ * (simple.rb:83-86). Here that read is a Promise, so it is pulled forward to
+ * this one seam and awaited: `reload!` is the only method that becomes async,
+ * and every ported body below it — including the four lazy call sites — stays
+ * verbatim and synchronous.
  */
-export function reloadBang(): void {
+export async function reloadBang(): Promise<void> {
   config().clearAvailableLocalesSet();
+  await reloadTranslationFiles();
   config().backend.reloadBang();
 }
 

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -184,8 +184,8 @@ export function setEnforceAvailableLocales(value: boolean): void {
  */
 export async function reloadBang(): Promise<void> {
   config().clearAvailableLocalesSet();
-  await reloadTranslationFiles();
   config().backend.reloadBang();
+  await reloadTranslationFiles();
 }
 
 /**


### PR DESCRIPTION
`I18n.reload!` did not pick up an on-disk edit to a translation file.

In the gem, `Simple#reload!` clears `@initialized` / `@translations`
(`vendor/i18n/lib/i18n/backend/simple.rb:57-62`), so the next lazy call site
re-enters `init_translations` (`simple.rb:83-86`) → `load_translations`
(`base.rb:15-20`), which re-reads every file in `I18n.load_path` from disk via
`YAML.load_file` (`base.rb:246`) / `JSON.load_file` (`base.rb:262`).

#6021 made that chain synchronous so it could port verbatim, by moving the
async read up into `preloadTranslationFiles()`, which fills a module-level
`fileContents` Map. So `reloadBang()` re-parsed the *cached bytes* rather than
re-reading the files.

## Shape

The read is pulled forward to the one seam that can await it: the top-level
`I18n.reloadBang()` (`i18n.rb:84-87`) drops the preloaded bytes and re-reads
`I18n.load_path` before delegating to the backend. `reload!` is the only method
that becomes async — `Backend::Base#reload!`, `Simple#reload!`, and the four
lazy `init_translations` call sites in `simple.ts` stay synchronous and
verbatim, so no ported body below the seam changes. `Config#loadPath=`, which
also calls `backend.reloadBang()`, is untouched and still synchronous.

A host that never registered a `FileReader` has no files to re-read, and
`reload!` there is still just the in-memory clear.

The `@noRailsEquivalent PERMANENT` block on `preloadTranslationFiles` loses its
"one behavioural consequence" paragraph — the consequence is gone.

## Tests

`base.file-loading.trails.test.ts` — "re-reads I18n.load_path when the preload
is re-run before reloadBang" becomes "re-reads I18n.load_path on reloadBang":
the caller no longer re-runs the preload. Verified failing on baseline.

Closes-story: i18n-reload-rereads-load-path
