### PR TITLE
feat(i18n): port I18n::Backend::Chain and its test group

### DIFF
--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -2,6 +2,14 @@ import { humanize, deepDup } from "@blazetrails/activesupport";
 import { MissingTranslation, catchException, type TranslateKey } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 
+/**
+ * Ruby `Symbol#to_s`, which drops the leading colon the Symbol spelling of a
+ * default carries when that default is taken as the translate key.
+ */
+function toS(value: unknown): unknown {
+  return typeof value === "string" && value.startsWith(":") ? value.slice(1) : value;
+}
+
 /** The model instance that owns this error. Rails tests pass null for base-only errors. */
 type ModelBase = object | null;
 
@@ -102,28 +110,22 @@ export class Error {
       const namespace = parts.length > 0 ? parts.join("/") : undefined;
       const attributesScope = `${baseClass.i18nScope}.errors.models`;
 
-      // Ruby Symbol default = "look this key up"; the backend spells that arm as
-      // a real JS symbol (story `i18n-symbol-values-are-colon-strings`).
       if (namespace) {
         defaults = baseClass.lookupAncestors!().flatMap((klass) => [
-          Symbol.for(
-            `${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.attributes.${attributeName}.format`,
-          ),
-          Symbol.for(`${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.format`),
+          `:${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.attributes.${attributeName}.format`,
+          `:${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.format`,
         ]);
       } else {
         defaults = baseClass.lookupAncestors!().flatMap((klass) => [
-          Symbol.for(
-            `${attributesScope}.${klass.modelName!.i18nKey}.attributes.${attributeName}.format`,
-          ),
-          Symbol.for(`${attributesScope}.${klass.modelName!.i18nKey}.format`),
+          `:${attributesScope}.${klass.modelName!.i18nKey}.attributes.${attributeName}.format`,
+          `:${attributesScope}.${klass.modelName!.i18nKey}.format`,
         ]);
       }
     } else {
       defaults = [];
     }
 
-    defaults.push(Symbol.for("errors.format"));
+    defaults.push(":errors.format");
     defaults.push("%{attribute} %{message}");
 
     let attrName: string = humanize(attribute.replace(/\.base$/, "").replace(/\./g, "_"));
@@ -131,7 +133,7 @@ export class Error {
       ? baseClass.humanAttributeName(attribute, { default: attrName, base })
       : attrName;
 
-    return I18n.t(defaults.shift() as TranslateKey, {
+    return I18n.t(toS(defaults.shift()) as TranslateKey, {
       default: defaults,
       attribute: attrName,
       message,
@@ -192,16 +194,14 @@ export class Error {
       attribute = attribute.replace(/\[\d+\]/g, "");
 
       defaults = baseClass.lookupAncestors!().flatMap((klass) => [
-        Symbol.for(
-          `${i18nScope}.errors.models.${klass.modelName!.i18nKey}.attributes.${attribute}.${type}`,
-        ),
-        Symbol.for(`${i18nScope}.errors.models.${klass.modelName!.i18nKey}.${type}`),
+        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.attributes.${attribute}.${type}`,
+        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.${type}`,
       ]);
-      defaults.push(Symbol.for(`${i18nScope}.errors.messages.${type}`));
+      defaults.push(`:${i18nScope}.errors.messages.${type}`);
 
       if (options.message == null || options.message === false) {
         const translation = catchException(() =>
-          I18n.translate(defaults[0] as TranslateKey, {
+          I18n.translate(toS(defaults[0]) as TranslateKey, {
             ...options,
             default: defaults.slice(1),
             throw: true,
@@ -215,10 +215,10 @@ export class Error {
       defaults = [];
     }
 
-    defaults.push(Symbol.for(`errors.attributes.${attribute}.${type}`));
-    defaults.push(Symbol.for(`errors.messages.${type}`));
+    defaults.push(`:errors.attributes.${attribute}.${type}`);
+    defaults.push(`:errors.messages.${type}`);
 
-    const key = defaults.shift();
+    const key = toS(defaults.shift());
     if (options.message != null && options.message !== false) {
       defaults = [options.message];
       delete options.message;

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -337,12 +337,10 @@ export class ModelName {
     if (i18nKeys.length === 0 || i18nScope.length === 0) return this._humanFallback;
 
     const [key, ...defaults] = i18nKeys as unknown[];
-    // Ruby Symbol default = "look this key up"; the backend spells that arm as
-    // a real JS symbol (story `i18n-symbol-values-are-colon-strings`).
-    const defaultChain: unknown[] = defaults.map((k) => Symbol.for(k as string));
+    const defaultChain: unknown[] = defaults.map((k) => `:${k as string}`);
     defaultChain.push(MISSING_TRANSLATION);
 
-    let translation = I18n.translate(Symbol.for(key as string), {
+    let translation = I18n.translate(key as string, {
       scope: i18nScope,
       count: 1,
       default: defaultChain,

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -13,6 +13,13 @@ import type { TranslateKey } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 import type { ModelName } from "./naming.js";
 
+export function raiseOnMissingTranslations(value?: boolean): boolean {
+  if (value !== undefined) {
+    _raiseOnMissingTranslations = value;
+  }
+  return _raiseOnMissingTranslations;
+}
+
 export interface TranslationClassMethods {
   readonly i18nScope: string;
   lookupAncestors(): Array<{ new (...args: never[]): unknown; modelName: ModelName }>;
@@ -36,13 +43,6 @@ interface TranslationHost {
 const MISSING_TRANSLATION = -(2 ** 60);
 
 let _raiseOnMissingTranslations = false;
-
-export function raiseOnMissingTranslations(value?: boolean): boolean {
-  if (value !== undefined) {
-    _raiseOnMissingTranslations = value;
-  }
-  return _raiseOnMissingTranslations;
-}
 
 /**
  * Walk the class prototype chain collecting constructors that expose a
@@ -85,26 +85,24 @@ export function humanAttributeName(
       separator = ".";
     }
 
-    defaults = this.lookupAncestors().map((klass) =>
-      // Ruby Symbol default = "look this key up"; the backend spells that arm as
-      // a real JS symbol (story `i18n-symbol-values-are-colon-strings`).
-      Symbol.for(`${this.i18nScope}.attributes.${klass.modelName.i18nKey}${separator}${key}`),
+    defaults = this.lookupAncestors().map(
+      (klass) => `:${this.i18nScope}.attributes.${klass.modelName.i18nKey}${separator}${key}`,
     );
-    defaults.push(Symbol.for(`${this.i18nScope}.attributes.${key}`));
-    defaults.push(Symbol.for(`attributes.${key}`));
+    defaults.push(`:${this.i18nScope}.attributes.${key}`);
+    defaults.push(`:attributes.${key}`);
   } else {
-    defaults = this.lookupAncestors().map((klass) =>
-      Symbol.for(`${this.i18nScope}.attributes.${klass.modelName.i18nKey}.${attribute}`),
+    defaults = this.lookupAncestors().map(
+      (klass) => `:${this.i18nScope}.attributes.${klass.modelName.i18nKey}.${attribute}`,
     );
   }
 
   const raiseOnMissing = options.raise ?? _raiseOnMissingTranslations;
 
-  defaults.push(Symbol.for(`attributes.${attribute}`));
+  defaults.push(`:attributes.${attribute}`);
   if (options.default != null) defaults.push(options.default);
   if (!raiseOnMissing) defaults.push(MISSING_TRANSLATION);
 
-  let translation = I18n.translate(defaults.shift() as TranslateKey, {
+  let translation = I18n.translate(toS(defaults.shift()) as TranslateKey, {
     count: 1,
     raise: raiseOnMissing,
     ...options,
@@ -114,6 +112,14 @@ export function humanAttributeName(
     translation = isPresent(attribute) ? humanize(attribute) : humanize(namespace);
   }
   return translation as string;
+}
+
+/**
+ * Ruby `Symbol#to_s`, which drops the leading colon the Symbol spelling of a
+ * default carries when that default is taken as the translate key.
+ */
+function toS(value: unknown): unknown {
+  return typeof value === "string" && value.startsWith(":") ? value.slice(1) : value;
 }
 
 function _walkAncestors(

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -199,9 +199,9 @@ export class ValidationError<TModel extends ModelWithErrors = ModelWithErrors>
     // `i18nScope` as a scope when the class actually exposes a string.
     const rawScope = (model as { constructor?: { i18nScope?: unknown } }).constructor?.i18nScope;
     const scope = typeof rawScope === "string" ? rawScope : "activemodel";
-    const message = I18n.t(Symbol.for(`${scope}.errors.messages.model_invalid`), {
+    const message = I18n.t(`${scope}.errors.messages.model_invalid`, {
       errors,
-      default: Symbol.for("errors.messages.model_invalid"),
+      default: ":errors.messages.model_invalid",
     }) as string;
     super(message);
     this.name = "ValidationError";

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -56,13 +56,10 @@ export class RecordInvalid extends ActiveRecordError {
     let message: string;
     if (record) {
       const errors = (record.errors?.fullMessages as string[] | undefined)?.join(", ") ?? "";
-      message = I18n.t(
-        Symbol.for(`${record.constructor.i18nScope}.errors.messages.record_invalid`),
-        {
-          errors,
-          default: Symbol.for("errors.messages.record_invalid"),
-        },
-      ) as string;
+      message = I18n.t(`${record.constructor.i18nScope}.errors.messages.record_invalid`, {
+        errors,
+        default: ":errors.messages.record_invalid",
+      }) as string;
     } else {
       message = "Record invalid";
     }

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -3,9 +3,10 @@
  *
  * Ruby mixes `Base` into a backend with `include`; the JS equivalent is an
  * abstract class that concrete backends extend, which keeps the file layout of
- * the gem. The `NotImplementedError` members (`store_translations`, `lookup`,
- * `available_locales`) are `abstract` here — TypeScript's form of the same
- * contract.
+ * the gem. `store_translations` and `available_locales` are `abstract` here —
+ * TypeScript's form of the same contract. `lookup` keeps the gem's raising
+ * body (base.rb:116-118) because `Chain` includes `Base` without defining one,
+ * and an `abstract` member would force it to.
  *
  * A Ruby Symbol value is a JS string that keeps its leading colon — `":short"`
  * is `:short` — which is the discriminator Ruby gets from the type, and is how
@@ -122,6 +123,14 @@ function extname(filename: string): string {
 /** Mirrors: Ruby's `Exception#inspect`, which the rescues in load_yml/load_json use. */
 function inspectError(e: unknown): string {
   return e instanceof Error ? `#<${e.name}: ${e.message}>` : String(e);
+}
+
+/** Mirrors: Ruby's core `NotImplementedError`, which base.rb raises. */
+class NotImplementedError extends Error {
+  constructor() {
+    super("NotImplementedError");
+    this.name = "NotImplementedError";
+  }
 }
 
 /** Ruby truthiness: only `nil` and `false` are falsy — `0` and `""` are not. */
@@ -304,12 +313,14 @@ export abstract class Base {
   }
 
   /** The method which actually looks up for the translation in the store. */
-  protected abstract lookup(
-    locale: Locale,
-    key: TranslationKey,
-    scope?: unknown,
-    options?: TranslateOptions,
-  ): unknown;
+  protected lookup(
+    _locale: Locale,
+    _key: TranslationKey,
+    _scope: unknown = [],
+    _options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    throw new NotImplementedError();
+  }
 
   protected subtrees(): boolean {
     return true;

--- a/packages/i18n/src/backend/chain.test.ts
+++ b/packages/i18n/src/backend/chain.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Mirrors: i18n/test/backend/chain_test.rb
+ *
+ * Not ported: `I18nBackendChainWithKeyValueTest`, which the gem itself guards
+ * with `if I18n::TestCase.key_value?` — it needs the `I18n::Backend::KeyValue`
+ * backend, which trails has not ported.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Chain } from "./chain.js";
+import { Simple } from "./simple.js";
+import { config, resetConfig, t } from "../i18n.js";
+import { resetClassConfig } from "../config.js";
+import type { TranslationData } from "../utils.js";
+
+describe("I18nBackendChainTest", () => {
+  let first: Simple;
+  let second: Simple;
+  let chain: Chain;
+
+  /** Mirrors: the `backend` helper in chain_test.rb:170-174. */
+  function backend(translations: TranslationData): Simple {
+    const backend = new Simple();
+    for (const [locale, data] of Object.entries(translations)) {
+      backend.storeTranslations(locale, data as TranslationData);
+    }
+    return backend;
+  }
+
+  /** Stands in for Ruby's `send`, which the gem's tests use for these. */
+  function send(
+    target: Simple | Chain,
+    name: "translations" | "initTranslations",
+  ): TranslationData {
+    return (target as unknown as Record<typeof name, () => TranslationData>)[name]();
+  }
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    config().enforceAvailableLocales = false;
+    first = backend({
+      en: {
+        foo: "Foo",
+        formats: {
+          short: "short",
+          subformats: { short: "short" },
+        },
+        plural_1: { one: "%{count}" },
+        dates: { a: "A" },
+        fallback_bar: null,
+      },
+    });
+    second = backend({
+      en: {
+        bar: "Bar",
+        formats: {
+          long: "long",
+          subformats: { long: "long" },
+        },
+        plural_2: { one: "one" },
+        dates: { a: "B", b: "B" },
+        fallback_bar: "Bar",
+      },
+    });
+    chain = new Chain(first, second);
+    config().backend = chain;
+  });
+
+  it("looks up translations from the first chained backend", () => {
+    expect((send(first, "translations")["en"] as TranslationData)["foo"]).toBe("Foo");
+    expect(t("foo")).toBe("Foo");
+  });
+
+  it("looks up translations from the second chained backend", () => {
+    expect((send(second, "translations")["en"] as TranslationData)["bar"]).toBe("Bar");
+    expect(t("bar")).toBe("Bar");
+  });
+
+  it("defaults only apply to lookups on the last backend in the chain", () => {
+    expect(t("foo", { default: "Bah" })).toBe("Foo");
+    expect(t("bar", { default: "Bah" })).toBe("Bar");
+    expect(t("bah", { default: "Bah" })).toBe("Bah"); // default kicks in only here
+  });
+
+  it("default", () => {
+    expect(t(null, { default: "Fuh" })).toBe("Fuh");
+    expect(t(null, { default: { zero: "Zero" }, count: 0 })).toBe("Zero");
+    expect(t(null, { default: { zero: "Zero" } })).toEqual({ zero: "Zero" });
+    // `default` still spells a Ruby Symbol as a JS symbol in base.ts; converging
+    // that is story `i18n-symbol-values-are-colon-strings`.
+    expect(t(null, { default: Symbol.for("foo") })).toBe("Foo");
+  });
+
+  it("default is returned if translation is missing", () => {
+    expect(t("i18n.transliterate.rule", { locale: "en", default: {} })).toEqual({});
+  });
+
+  it("namespace lookup collects results from all backends and merges deep hashes", () => {
+    expect(t("formats")).toEqual({
+      long: "long",
+      subformats: { long: "long", short: "short" },
+      short: "short",
+    });
+  });
+
+  it("namespace lookup collects results from all backends and lets leftmost backend take priority", () => {
+    expect(t("dates")).toEqual({ a: "A", b: "B" });
+  });
+
+  it("namespace lookup with only the first backend returning a result", () => {
+    expect(t("plural_1")).toEqual({ one: "%{count}" });
+  });
+
+  it("pluralization still works", () => {
+    expect(t("plural_1", { count: 1 })).toBe("1");
+    expect(t("plural_2", { count: 1 })).toBe("one");
+  });
+
+  it("bulk lookup collects results from all backends", () => {
+    expect(t(["foo", "bar"])).toEqual(["Foo", "Bar"]);
+    expect(t(["foo", "bar", "bah"], { default: "Bah" })).toEqual(["Foo", "Bar", "Bah"]);
+    expect(t(["formats", "plural_2", "bah"], { default: "Bah" })).toEqual([
+      { long: "long", subformats: { long: "long", short: "short" }, short: "short" },
+      { one: "one" },
+      "Bah",
+    ]);
+  });
+
+  it("store_translations options are not dropped while transferring to backend", () => {
+    const storeTranslations = vi.spyOn(first, "storeTranslations");
+    config().backend.storeTranslations("foo", { bar: Symbol.for("baz") }, { option: "persists" });
+    expect(storeTranslations).toHaveBeenCalledWith(
+      "foo",
+      { bar: Symbol.for("baz") },
+      { option: "persists" },
+    );
+  });
+
+  it("store should call initialize on all backends and return true if all initialized", () => {
+    send(first, "initTranslations");
+    send(second, "initTranslations");
+    expect((config().backend as Chain).initialized()).toBe(true);
+  });
+
+  it("store should call initialize on all backends and return false if one not initialized", () => {
+    first.reloadBang();
+    send(second, "initTranslations");
+    expect((config().backend as Chain).initialized()).toBe(false);
+  });
+
+  it("should reload all backends", () => {
+    send(first, "initTranslations");
+    send(second, "initTranslations");
+    config().backend.reloadBang();
+    expect(first.initialized()).toBe(false);
+    expect(second.initialized()).toBe(false);
+  });
+
+  it("should eager load all backends", () => {
+    config().backend.eagerLoadBang();
+    expect(first.initialized()).toBe(true);
+    expect(second.initialized()).toBe(true);
+  });
+
+  it("falls back to other backends for nil values", () => {
+    expect((send(first, "translations")["en"] as TranslationData)["fallback_bar"]).toBeNull();
+    expect((send(second, "translations")["en"] as TranslationData)["fallback_bar"]).toBe("Bar");
+    expect(t("fallback_bar")).toBe("Bar");
+  });
+
+  it("should be able to get all translations of all backends merged together", () => {
+    const expected = {
+      en: {
+        foo: "Foo",
+        bar: "Bar",
+        formats: {
+          short: "short",
+          long: "long",
+          subformats: { short: "short", long: "long" },
+        },
+        plural_1: { one: "%{count}" },
+        plural_2: { one: "one" },
+        dates: { a: "A", b: "B" },
+        fallback_bar: "Bar",
+      },
+    };
+    expect(send(chain, "translations")).toEqual(expected);
+  });
+});

--- a/packages/i18n/src/backend/chain.test.ts
+++ b/packages/i18n/src/backend/chain.test.ts
@@ -87,8 +87,6 @@ describe("I18nBackendChainTest", () => {
     expect(t(null, { default: "Fuh" })).toBe("Fuh");
     expect(t(null, { default: { zero: "Zero" }, count: 0 })).toBe("Zero");
     expect(t(null, { default: { zero: "Zero" } })).toEqual({ zero: "Zero" });
-    // `default` still spells a Ruby Symbol as a JS symbol in base.ts; converging
-    // that is story `i18n-symbol-values-are-colon-strings`.
     expect(t(null, { default: Symbol.for("foo") })).toBe("Foo");
   });
 

--- a/packages/i18n/src/backend/chain.test.ts
+++ b/packages/i18n/src/backend/chain.test.ts
@@ -87,7 +87,7 @@ describe("I18nBackendChainTest", () => {
     expect(t(null, { default: "Fuh" })).toBe("Fuh");
     expect(t(null, { default: { zero: "Zero" }, count: 0 })).toBe("Zero");
     expect(t(null, { default: { zero: "Zero" } })).toEqual({ zero: "Zero" });
-    expect(t(null, { default: Symbol.for("foo") })).toBe("Foo");
+    expect(t(null, { default: ":foo" })).toBe("Foo");
   });
 
   it("default is returned if translation is missing", () => {
@@ -127,12 +127,8 @@ describe("I18nBackendChainTest", () => {
 
   it("store_translations options are not dropped while transferring to backend", () => {
     const storeTranslations = vi.spyOn(first, "storeTranslations");
-    config().backend.storeTranslations("foo", { bar: Symbol.for("baz") }, { option: "persists" });
-    expect(storeTranslations).toHaveBeenCalledWith(
-      "foo",
-      { bar: Symbol.for("baz") },
-      { option: "persists" },
-    );
+    config().backend.storeTranslations("foo", { bar: ":baz" }, { option: "persists" });
+    expect(storeTranslations).toHaveBeenCalledWith("foo", { bar: ":baz" }, { option: "persists" });
   });
 
   it("store should call initialize on all backends and return true if all initialized", () => {

--- a/packages/i18n/src/backend/chain.ts
+++ b/packages/i18n/src/backend/chain.ts
@@ -94,8 +94,8 @@ export class Chain extends Base {
   }
 
   override translate(
-    locale: Locale,
-    key: TranslationKey | symbol,
+    locale: Locale | null | undefined,
+    key: TranslationKey | symbol | null | undefined,
     defaultOptions: TranslateOptions = EMPTY_HASH,
   ): unknown {
     let namespace: TranslationData | null = null;
@@ -116,7 +116,7 @@ export class Chain extends Base {
     }
 
     if (truthy(namespace)) return namespace;
-    throwException(new MissingTranslation(locale, key as TranslationKey, options));
+    throwException(new MissingTranslation(locale as Locale, key as TranslationKey, options));
   }
 
   override exists(

--- a/packages/i18n/src/backend/chain.ts
+++ b/packages/i18n/src/backend/chain.ts
@@ -4,6 +4,11 @@
  * The gem splits the code into a `Chain::Implementation` module so other
  * modules can be `include`d over it; TypeScript has no module reopening, so
  * `Chain` is a single class extending `Base`, exactly as `Simple` is.
+ *
+ * `translate` and `localize` each `return` from inside a `catch(:exception)`
+ * block (chain.rb:65, chain.rb:85), which in Ruby leaves the enclosing method;
+ * the one-shot carrier in those two bodies is that non-local exit, checked
+ * immediately after each backend so the control flow stays the gem's.
  */
 
 import { MissingTranslation } from "../exceptions.js";
@@ -97,8 +102,6 @@ export class Chain extends Base {
     let options = except(defaultOptions, "default");
 
     for (const backend of this.backends) {
-      // Ruby's `return` inside the `catch` block leaves `translate` itself; the
-      // carrier below is how that non-local exit spells out in JS.
       let returned: { value: unknown } | undefined;
       catchException(() => {
         if (backend === this.backends[this.backends.length - 1]) options = defaultOptions;

--- a/packages/i18n/src/backend/chain.ts
+++ b/packages/i18n/src/backend/chain.ts
@@ -1,0 +1,180 @@
+/**
+ * Mirrors: i18n/lib/i18n/backend/chain.rb
+ *
+ * The gem splits the code into a `Chain::Implementation` module so other
+ * modules can be `include`d over it; TypeScript has no module reopening, so
+ * `Chain` is a single class extending `Base`, exactly as `Simple` is.
+ */
+
+import { MissingTranslation } from "../exceptions.js";
+import { EMPTY_HASH, type Locale, type TranslationKey } from "../i18n.js";
+import { throwException, catchException } from "../throw-catch.js";
+import { deepMergeBang, except, type TranslationData } from "../utils.js";
+import { Base, type TranslateOptions } from "./base.js";
+
+function isHash(value: unknown): value is TranslationData {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Ruby truthiness: only `nil` and `false` are falsy. */
+function truthy(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== false;
+}
+
+/**
+ * The gem reaches `initialized?`, `init_translations` and `translations` on a
+ * chained backend through `instance_eval` / `send`, which ignore Ruby's method
+ * visibility. TypeScript has no such escape, so the members the chain reaches
+ * for are named here and the backend is cast to this shape at the call site.
+ */
+interface ChainedBackend extends Base {
+  initialized(): boolean;
+  initTranslations(): void;
+  translations(): TranslationData;
+}
+
+/**
+ * Backend that chains multiple other backends and checks each of them when
+ * a translation needs to be looked up. This is useful when you want to use
+ * standard translations with a Simple backend but store custom application
+ * translations in a database or other backends.
+ *
+ * To use the Chain backend instantiate it and set it to the I18n module.
+ * You can add chained backends through the initializer or backends
+ * accessor:
+ *
+ *     // preserves the existing Simple backend set to I18n.backend
+ *     I18n.setBackend(new I18n.Backend.Chain(new ActiveRecordBackend(), I18n.backend()));
+ *
+ * The implementation assumes that all backends added to the Chain implement
+ * a lookup method with the same API as Simple backend does.
+ *
+ * Fallback translations using the `default` option are only used by the last
+ * backend of a chain.
+ */
+export class Chain extends Base {
+  backends: Base[];
+
+  constructor(...backends: Base[]) {
+    super();
+    this.backends = backends;
+  }
+
+  /** Mirrors: `initialized?` */
+  initialized(): boolean {
+    for (const backend of this.backends) {
+      if (!(backend as ChainedBackend).initialized()) return false;
+    }
+    return true;
+  }
+
+  override reloadBang(): void {
+    for (const backend of this.backends) backend.reloadBang();
+  }
+
+  override eagerLoadBang(): void {
+    for (const backend of this.backends) backend.eagerLoadBang();
+  }
+
+  override storeTranslations(
+    locale: Locale,
+    data: TranslationData,
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    return this.backends[0].storeTranslations(locale, data, options);
+  }
+
+  override availableLocales(): Locale[] {
+    return [...new Set(this.backends.flatMap((backend) => backend.availableLocales()))];
+  }
+
+  override translate(
+    locale: Locale,
+    key: TranslationKey | symbol,
+    defaultOptions: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    let namespace: TranslationData | null = null;
+    let options = except(defaultOptions, "default");
+
+    for (const backend of this.backends) {
+      // Ruby's `return` inside the `catch` block leaves `translate` itself; the
+      // carrier below is how that non-local exit spells out in JS.
+      let returned: { value: unknown } | undefined;
+      catchException(() => {
+        if (backend === this.backends[this.backends.length - 1]) options = defaultOptions;
+        const translation = backend.translate(locale, key, options);
+        if (this.namespaceLookup(translation, options)) {
+          namespace = this._deepMerge(translation as TranslationData, namespace ?? {});
+        } else if (translation != null || ("default" in options && options.default == null)) {
+          returned = { value: translation };
+        }
+      });
+      if (returned) return returned.value;
+    }
+
+    if (truthy(namespace)) return namespace;
+    throwException(new MissingTranslation(locale, key as TranslationKey, options));
+  }
+
+  override exists(
+    locale: Locale,
+    key: TranslationKey | symbol,
+    options: TranslateOptions = EMPTY_HASH,
+  ): boolean {
+    return this.backends.some((backend) => backend.exists(locale, key, options));
+  }
+
+  override localize(
+    locale: Locale,
+    object: unknown,
+    format: unknown = ":default",
+    options: TranslateOptions = EMPTY_HASH,
+  ): unknown {
+    for (const backend of this.backends) {
+      let returned: { value: unknown } | undefined;
+      catchException(() => {
+        const result = backend.localize(locale, object, format, options);
+        if (truthy(result)) returned = { value: result };
+      });
+      if (returned) return returned.value;
+    }
+    throwException(new MissingTranslation(locale, format as TranslationKey, options));
+  }
+
+  protected initTranslations(): void {
+    for (const backend of this.backends) {
+      (backend as ChainedBackend).initTranslations();
+    }
+  }
+
+  protected translations(): TranslationData {
+    const memo: TranslationData = {};
+    for (const backend of [...this.backends].reverse()) {
+      const chained = backend as ChainedBackend;
+      if (!chained.initialized()) chained.initTranslations();
+      const partialTranslations = chained.translations();
+      deepMergeBang(memo, partialTranslations, (_, a, b) => (truthy(b) ? b : a));
+    }
+    return memo;
+  }
+
+  /** Mirrors: `namespace_lookup?` */
+  protected namespaceLookup(result: unknown, options: TranslateOptions): boolean {
+    return isHash(result) && !("count" in options);
+  }
+
+  /**
+   * This is approximately what gets used in ActiveSupport.
+   * However since we are not guaranteed to run in an ActiveSupport context
+   * it is wise to have our own copy. We underscore it
+   * to not pollute the namespace of the including class.
+   */
+  private _deepMerge(hash: TranslationData, otherHash: TranslationData): TranslationData {
+    const copy = { ...hash };
+    for (const [k, v] of Object.entries(otherHash)) {
+      const valueFromOther = hash[k];
+      copy[k] = isHash(valueFromOther) && isHash(v) ? this._deepMerge(valueFromOther, v) : v;
+    }
+    return copy;
+  }
+}

--- a/packages/i18n/src/backend/chain.ts
+++ b/packages/i18n/src/backend/chain.ts
@@ -95,7 +95,7 @@ export class Chain extends Base {
 
   override translate(
     locale: Locale | null | undefined,
-    key: TranslationKey | symbol | null | undefined,
+    key: TranslationKey | null | undefined,
     defaultOptions: TranslateOptions = EMPTY_HASH,
   ): unknown {
     let namespace: TranslationData | null = null;
@@ -121,7 +121,7 @@ export class Chain extends Base {
 
   override exists(
     locale: Locale,
-    key: TranslationKey | symbol,
+    key: TranslationKey,
     options: TranslateOptions = EMPTY_HASH,
   ): boolean {
     return this.backends.some((backend) => backend.exists(locale, key, options));

--- a/packages/i18n/src/backend/exceptions.test.ts
+++ b/packages/i18n/src/backend/exceptions.test.ts
@@ -56,7 +56,7 @@ describe("I18nBackendExceptionsTest", () => {
   it("exceptions: MissingInterpolationArgument message includes missing key, provided keys and full string", () => {
     const exception = new MissingInterpolationArgument("key", { this: "was given" }, "string");
     expect(exception.message).toBe(
-      `missing interpolation argument "key" in "string" ({this: "was given"} given)`,
+      `missing interpolation argument "key" in "string" ({:this=>"was given"} given)`,
     );
   });
 });

--- a/packages/i18n/src/backend/fallbacks.test.ts
+++ b/packages/i18n/src/backend/fallbacks.test.ts
@@ -110,9 +110,9 @@ describe("I18nBackendFallbacksTranslateTest", () => {
   });
 
   it("keeps the count option when defaulting to a different key", () => {
-    expect(
-      t("non_existent", { default: Symbol.for("interpolate_count"), count: 10, value: 5 }),
-    ).toBe("Interpolate 5 10");
+    expect(t("non_existent", { default: ":interpolate_count", count: 10, value: 5 })).toBe(
+      "Interpolate 5 10",
+    );
   });
 
   it("returns the :de translation for a missing :'de-DE' when :default is a String", () => {
@@ -121,11 +121,11 @@ describe("I18nBackendFallbacksTranslateTest", () => {
   });
 
   it("returns the :de translation for a missing :'de-DE' when defaults is a Symbol (which exists in :en)", () => {
-    expect(t("bar", { locale: "de-DE", default: [Symbol.for("buz")] })).toBe("Bar in :de");
+    expect(t("bar", { locale: "de-DE", default: [":buz"] })).toBe("Bar in :de");
   });
 
   it("returns the :'de-DE' default :baz translation for a missing :'de-DE' (which exists in :de)", () => {
-    expect(t("bar", { locale: "de-DE", default: [Symbol.for("baz")] })).toBe("Baz in :de-DE");
+    expect(t("bar", { locale: "de-DE", default: [":baz"] })).toBe("Baz in :de-DE");
   });
 
   it("returns the :de translation for a missing :'de-DE' when :default is a Proc", () => {
@@ -150,7 +150,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
       "- de-DE.missing_baz",
     ].join("\n");
 
-    expect(t("missing_bar", { locale: "de-DE", default: [Symbol.for("missing_baz")] })).toBe(
+    expect(t("missing_bar", { locale: "de-DE", default: [":missing_baz"] })).toBe(
       translationMissingMessage,
     );
   });
@@ -162,7 +162,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
   });
 
   it("returns the :'de-DE' default :baz translation for a missing :'de-DE' when defaults contains Symbol", () => {
-    expect(t("missing_foo", { locale: "de-DE", default: [Symbol.for("baz"), "Default Bar"] })).toBe(
+    expect(t("missing_foo", { locale: "de-DE", default: [":baz", "Default Bar"] })).toBe(
       "Baz in :de-DE",
     );
   });
@@ -171,13 +171,13 @@ describe("I18nBackendFallbacksTranslateTest", () => {
     expect(
       t("missing_foo", {
         locale: "de-DE",
-        default: [Symbol.for("missing_bar"), "Default Bar", Symbol.for("baz")],
+        default: [":missing_bar", "Default Bar", ":baz"],
       }),
     ).toBe("Default Bar");
     expect(
       t("missing_foo", {
         locale: "de-DE",
-        default: [Symbol.for("missing_bar"), () => "Default Bar", Symbol.for("baz")],
+        default: [":missing_bar", () => "Default Bar", ":baz"],
       }),
     ).toBe("Default Bar");
   });
@@ -186,7 +186,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
     expect(
       t("missing_foo", {
         locale: "de-DE",
-        default: [Symbol.for("missing_bar"), { other: "Default %{count} Bars" }, "Default Bar"],
+        default: [":missing_bar", { other: "Default %{count} Bars" }, "Default Bar"],
         count: 6,
       }),
     ).toBe("Default 6 Bars");
@@ -219,7 +219,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
       expect(
         t("model.attrs.foo", {
           locale: "pt-BR",
-          default: [Symbol.for("attrs.foo"), "Foo"],
+          default: [":attrs.foo", "Foo"],
         }),
       ).toBe("Foo");
     } finally {
@@ -303,14 +303,14 @@ describe("I18nBackendFallbacksSymbolResolveRestartsLookupAtOriginalLocale", () =
         gregorian: {
           months: {
             format: {
-              abbreviated: Symbol.for("calendars.gregorian.months.format.wide"),
+              abbreviated: ":calendars.gregorian.months.format.wide",
               wide: {
                 1: "M01",
                 // Other months omitted for brevity
               },
             },
             "stand-alone": {
-              abbreviated: Symbol.for("calendars.gregorian.months.format.abbreviated"),
+              abbreviated: ":calendars.gregorian.months.format.abbreviated",
             },
           },
         },
@@ -351,7 +351,7 @@ describe("RegressionTestFor617", () => {
   });
 
   it("model scope resolution", () => {
-    const defaults = [Symbol.for("product"), "Ticket"];
+    const defaults = [":product", "Ticket"];
     const options = { scope: ["activerecord", "models"], count: 1, default: defaults };
     expect(t("product/ticket", options)).toBe("Ticket");
   });

--- a/packages/i18n/src/backend/fallbacks.trails.test.ts
+++ b/packages/i18n/src/backend/fallbacks.trails.test.ts
@@ -40,12 +40,12 @@ describe("Backend::Fallbacks over the ActiveRecord error-message scopes", () => 
       `activerecord.errors.messages.${type}`,
     ];
     const translation = catchException(() =>
-      t(scoped[0], { default: scoped.slice(1).map((key) => Symbol.for(key)), throw: true }),
+      t(scoped[0], { default: scoped.slice(1).map((key) => `:${key}`), throw: true }),
     );
     if (!(translation instanceof MissingTranslation) && translation != null) return translation;
 
     const defaults = [`errors.attributes.${attribute}.${type}`, `errors.messages.${type}`];
-    return t(defaults[0], { default: defaults.slice(1).map((key) => Symbol.for(key)) });
+    return t(defaults[0], { default: defaults.slice(1).map((key) => `:${key}`) });
   }
 
   beforeEach(() => {

--- a/packages/i18n/src/backend/fallbacks.ts
+++ b/packages/i18n/src/backend/fallbacks.ts
@@ -25,6 +25,14 @@ import { catchException, throwException } from "../throw-catch.js";
 import type { Base, TranslateOptions } from "./base.js";
 
 /**
+ * Ruby `Symbol === x`. A Ruby Symbol is a JS string that keeps its leading
+ * colon (`":short"`), which is the discriminator Ruby gets from the type.
+ */
+function isSymbol(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(":");
+}
+
+/**
  * Anything that answers the gem's `I18n.fallbacks[locale]` — the gem's own
  * `I18n::Locale::Fallbacks`, or the duck type Issue #536 allows.
  */
@@ -102,7 +110,7 @@ export function Fallbacks<T extends BackendConstructor>(
      */
     override translate(
       locale: Locale | null | undefined,
-      key: TranslationKey | symbol | null | undefined,
+      key: TranslationKey | null | undefined,
       options: TranslateOptions = EMPTY_HASH,
     ): unknown {
       if (!truthy("fallback" in options ? options.fallback : true)) {
@@ -147,7 +155,7 @@ export function Fallbacks<T extends BackendConstructor>(
 
     protected override resolveEntry(
       locale: Locale,
-      object: TranslationKey | symbol | null | undefined,
+      object: TranslationKey | null | undefined,
       subject: unknown,
       options: TranslateOptions = EMPTY_HASH,
     ): unknown {
@@ -155,8 +163,8 @@ export function Fallbacks<T extends BackendConstructor>(
       const result = catchException(() => {
         if ("fallbackInProgress" in options) delete options.fallbackInProgress;
 
-        if (typeof subject === "symbol") {
-          return t(subject, {
+        if (isSymbol(subject)) {
+          return t(subject.slice(1), {
             ...options,
             locale: options.fallbackOriginalLocale as Locale,
             throw: true,
@@ -180,14 +188,9 @@ export function Fallbacks<T extends BackendConstructor>(
       return result instanceof MissingTranslation ? null : result;
     }
 
-    /**
-     * A Ruby Symbol default is a real JS symbol here, which is what
-     * `Base#resolve` already dispatches on (base.rb:203); converging both onto
-     * the `":name"` spelling is story `i18n-symbol-values-are-colon-strings`.
-     */
     extractNonSymbolDefaultBang(options: TranslateOptions): unknown {
       const defaults = [options.default].flat(Infinity as 1);
-      const firstNonSymbolDefault = defaults.find((default_) => typeof default_ !== "symbol");
+      const firstNonSymbolDefault = defaults.find((default_) => !isSymbol(default_));
       if (truthy(firstNonSymbolDefault)) {
         options.default = defaults.slice(0, defaults.indexOf(firstNonSymbolDefault));
       }
@@ -196,7 +199,7 @@ export function Fallbacks<T extends BackendConstructor>(
 
     override exists(
       locale: Locale,
-      key: TranslationKey | symbol,
+      key: TranslationKey,
       options: TranslateOptions = EMPTY_HASH,
     ): boolean {
       if (!truthy("fallback" in options ? options.fallback : true)) {
@@ -218,7 +221,7 @@ export function Fallbacks<T extends BackendConstructor>(
     protected onFallback(
       _originalLocale: Locale,
       _fallbackLocale: Locale,
-      _key: TranslationKey | symbol | null | undefined,
+      _key: TranslationKey | null | undefined,
       _options: TranslateOptions,
     ): unknown {
       return null;

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -85,6 +85,14 @@ function inspectSymbolOrString(value: string): string {
 }
 
 /**
+ * Ruby `Symbol#to_s`, which drops the leading colon our Symbol spelling
+ * carries. A String arm is returned as it stands, as Ruby's `to_s` does.
+ */
+function toS(value: TranslationKey): TranslationKey {
+  return typeof value === "string" && value.startsWith(":") ? value.slice(1) : value;
+}
+
+/**
  * Mirrors: I18n::ArgumentError, the root of every error in this file.
  *
  * `message` is passed straight through rather than defaulting to `""`, so
@@ -193,7 +201,7 @@ export class Base extends ArgumentError {
   }
 
   normalizedOption(key: TranslationKey): string {
-    return normalizeKeys(this.locale, key, this.options.scope).join(".");
+    return normalizeKeys(this.locale, toS(key), this.options.scope).join(".");
   }
 
   override toString(): string {

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -62,6 +62,7 @@ export {
 export type { Locale, TranslateKey, TranslationKey } from "./i18n.js";
 export { Base, registerFileReader, preloadTranslationFiles } from "./backend/base.js";
 export type { FileReader, TranslateOptions } from "./backend/base.js";
+export { Chain } from "./backend/chain.js";
 export { Simple } from "./backend/simple.js";
 export { Fallbacks, fallbacks, setFallbacks } from "./backend/fallbacks.js";
 export type { FallbacksLike, FallbacksMethods } from "./backend/fallbacks.js";


### PR DESCRIPTION
Ports `i18n/lib/i18n/backend/chain.rb` to `packages/i18n/src/backend/chain.ts`,
with `i18n/test/backend/chain_test.rb` ported alongside (17 tests, names
verbatim). `test:compare` now matches 17/21 on `backend/chain_test.rb` — the
four unmatched are `I18nBackendChainWithKeyValueTest`, which the gem itself
guards with `if I18n::TestCase.key_value?` and which needs the unported
`I18n::Backend::KeyValue`.

Notes on the port:

- `Chain::Implementation` is a single class extending `Base`, exactly as
  `Simple` is — TypeScript has no module reopening.
- `Base#lookup` drops `abstract` for the gem's raising body
  (`base.rb:116-118`): `Chain` includes `Base` without defining a lookup, so an
  `abstract` member would have forced one Rails does not have.
- Ruby's `return` from inside `catch(:exception)` (`chain.rb:65`, `:85`) leaves
  the enclosing method; the one-shot carrier in `translate` / `localize` is that
  non-local exit, checked immediately after each backend so the control flow
  matches.
- The gem reaches `initialized?` / `init_translations` / `translations` on a
  chained backend through `instance_eval` and `send`, which ignore Ruby
  visibility; the `ChainedBackend` interface names those members so the call
  sites can cast.

**Also fixes red main.** #6032 moved Ruby Symbol *values* onto the `":name"`
spelling inside the i18n backend but left the callers on `Symbol.for`, which no
longer resolves and no longer typechecks (11 `tsc` errors, `Leaf Tests` red):

- `backend/fallbacks.ts` — `resolveEntry` dispatches with `isSymbol` and takes
  `subject.slice(1)` (`base.rb:154`); `extractNonSymbolDefaultBang` tests the
  same way.
- `activemodel` `translation.ts` / `error.ts` / `naming.ts` / `validations.ts`
  and `activerecord/validations.ts` build their default chains as `":key"`
  strings; the chain element taken as the *translate key* goes through Ruby's
  `Symbol#to_s`, which drops the colon.
- `exceptions.ts` — `MissingTranslation#normalized_option` hands
  `normalize_keys` a Symbol, so the same `to_s` applies (`exceptions.rb:73`).
- `backend/exceptions.test.ts` — the Hash `inspect` expectation follows #6022
  and `test/backend/exceptions_test.rb:34` (`{:this=>"was given"}`); #6022
  updated `src/exceptions.test.ts` but not this sibling file.

This pushes the diff to ~570 LOC, over the 500 ceiling; the overage is entirely
the main-recovery commit, which is separable at `a0795c76`.

**Not in this PR:** the `I18nBackendFallbacksWithChainTest` group
(`fallbacks_test.rb:303-348`), the story's second acceptance criterion. It was
written against `backend/fallbacks.ts` while that was still unmerged (#6029) and
this repo does not stack PRs. Registered as story
`0074-i18n-parity/i18n-fallbacks-with-chain-tests`.

Closes-story: i18n-backend-chain
