### PR TITLE
refactor(i18n): spell Ruby Symbol values as colon-prefixed strings

### DIFF
--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -35,8 +35,9 @@ describe("I18n::Backend::Base", () => {
   }
 
   it("raises ArgumentError given an empty String or Symbol key", () => {
+    // A Ruby Symbol key is a JS string (`normalize_keys` sends both through
+    // `to_sym`), so `:""` and `""` are the same value here.
     expect(() => translate("")).toThrow(ArgumentError);
-    expect(() => backend.translate("en", Symbol.for(""))).toThrow(ArgumentError);
   });
 
   it("raises InvalidLocale given no locale", () => {
@@ -57,14 +58,12 @@ describe("I18n::Backend::Base", () => {
 
   it("walks an array of defaults and resolves the first hit", () => {
     backend.storeTranslations("en", { fallback: "Fallback" });
-    expect(translate("missing", { default: [Symbol.for("also_missing"), "Literal"] })).toBe(
-      "Literal",
-    );
-    expect(translate("missing", { default: [Symbol.for("fallback")] })).toBe("Fallback");
+    expect(translate("missing", { default: [":also_missing", "Literal"] })).toBe("Literal");
+    expect(translate("missing", { default: [":fallback"] })).toBe("Fallback");
   });
 
   it("resolves a Symbol entry through the configured backend", () => {
-    backend.storeTranslations("en", { target: "Target", alias: Symbol.for("target") });
+    backend.storeTranslations("en", { target: "Target", alias: ":target" });
     expect(translate("alias")).toBe("Target");
   });
 

--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -35,8 +35,6 @@ describe("I18n::Backend::Base", () => {
   }
 
   it("raises ArgumentError given an empty String or Symbol key", () => {
-    // A Ruby Symbol key is a JS string (`normalize_keys` sends both through
-    // `to_sym`), so `:""` and `""` are the same value here.
     expect(() => translate("")).toThrow(ArgumentError);
   });
 

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -8,9 +8,10 @@
  * contract.
  *
  * A Ruby Symbol value is a JS string that keeps its leading colon — `":short"`
- * is `:short` — which is the discriminator Ruby gets from the type. `default`
- * and `resolve` still spell theirs as real JS symbols; converging those two is
- * story `i18n-symbol-values-are-colon-strings`.
+ * is `:short` — which is the discriminator Ruby gets from the type, and is how
+ * the value already renders through `inspect`. That is the spelling `localize`,
+ * `default` and `resolve` all use for the `Symbol === x` arms of the gem
+ * (base.rb:84, base.rb:154).
  *
  * Not ported here: `load_rb` (it `eval`s Ruby source, which trails has none of
  * — see the `SCOPED_SKIP_GROUPS` entry in `scripts/api-compare/conventions.ts`).
@@ -132,10 +133,6 @@ function isHash(value: unknown): value is TranslationData {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function symbolName(subject: symbol): string {
-  return Symbol.keyFor(subject) ?? subject.description ?? "";
-}
-
 /**
  * Ruby `Symbol === x`. A Ruby Symbol is a JS string that keeps its leading
  * colon (`":short"`), which is the discriminator Ruby gets from the type.
@@ -209,12 +206,10 @@ export abstract class Base {
 
   translate(
     locale: Locale | null | undefined,
-    key: TranslationKey | symbol | null | undefined,
+    key: TranslationKey | null | undefined,
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
-    if (key === "" || (typeof key === "symbol" && symbolName(key) === "")) {
-      throw new ArgumentError();
-    }
+    if (key === "") throw new ArgumentError();
     if (!truthy(locale)) throw new InvalidLocale(locale);
     if (key == null && !("default" in options)) return null;
 
@@ -255,11 +250,7 @@ export abstract class Base {
     return entry;
   }
 
-  exists(
-    locale: Locale,
-    key: TranslationKey | symbol,
-    options: TranslateOptions = EMPTY_HASH,
-  ): boolean {
+  exists(locale: Locale, key: TranslationKey, options: TranslateOptions = EMPTY_HASH): boolean {
     return this.lookup(locale, key, options.scope) != null;
   }
 
@@ -315,7 +306,7 @@ export abstract class Base {
   /** The method which actually looks up for the translation in the store. */
   protected abstract lookup(
     locale: Locale,
-    key: TranslationKey | symbol,
+    key: TranslationKey,
     scope?: unknown,
     options?: TranslateOptions,
   ): unknown;
@@ -331,7 +322,7 @@ export abstract class Base {
    */
   protected default(
     locale: Locale,
-    object: TranslationKey | symbol | null | undefined,
+    object: TranslationKey | null | undefined,
     subject: unknown,
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
@@ -355,17 +346,17 @@ export abstract class Base {
    */
   protected resolve(
     locale: Locale,
-    object: TranslationKey | symbol | null | undefined,
+    object: TranslationKey | null | undefined,
     subject: unknown,
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
     if (options.resolve === false) return subject;
     const result = catchException(() => {
-      if (typeof subject === "symbol") {
+      if (isSymbol(subject)) {
         // The gem goes through `I18n.translate`, which — with `throw: true` —
         // hands a MissingTranslation straight back to this `catch`, exactly as
         // calling the backend does. The `I18n.t` facade is not ported yet.
-        return config().backend.translate(locale, symbolName(subject), {
+        return config().backend.translate(locale, subject.slice(1), {
           ...options,
           locale,
           throw: true,
@@ -389,7 +380,7 @@ export abstract class Base {
 
   protected resolveEntry(
     locale: Locale,
-    object: TranslationKey | symbol | null | undefined,
+    object: TranslationKey | null | undefined,
     subject: unknown,
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -26,10 +26,6 @@ function isHash(value: unknown): value is TranslationData {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/**
- * Ruby `result.is_a?(Symbol)` (simple.rb:104). A Ruby Symbol is a JS string
- * that keeps its leading colon (`":other.key"`).
- */
 function isSymbol(value: unknown): value is string {
   return typeof value === "string" && value.startsWith(":");
 }

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -26,6 +26,14 @@ function isHash(value: unknown): value is TranslationData {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Ruby `result.is_a?(Symbol)` (simple.rb:104). A Ruby Symbol is a JS string
+ * that keeps its leading colon (`":other.key"`).
+ */
+function isSymbol(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(":");
+}
+
 export class Simple extends Base {
   private initializedFlag = false;
   private translationsStore: TranslationData | undefined;
@@ -115,13 +123,12 @@ export class Simple extends Base {
    */
   protected override lookup(
     locale: Locale,
-    key: TranslationKey | symbol,
+    key: TranslationKey,
     scope: unknown = [],
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
     if (!this.initialized()) this.initTranslations();
-    const name = typeof key === "symbol" ? (Symbol.keyFor(key) ?? key.description) : key;
-    const keys = normalizeKeys(locale, name, scope, options.separator as string | undefined);
+    const keys = normalizeKeys(locale, key, scope, options.separator as string | undefined);
 
     let result: unknown = this.translations();
     for (const rawKey of keys) {
@@ -131,7 +138,7 @@ export class Simple extends Base {
       const segment = String(rawKey);
       if (!(segment in result)) return null;
       result = result[segment];
-      if (typeof result === "symbol") {
+      if (isSymbol(result)) {
         result = this.resolveEntry(
           locale,
           segment,

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -155,7 +155,7 @@ describe("I18nTest", () => {
   });
 
   it("translate given an empty symbol as a key raises an I18n::ArgumentError", () => {
-    expect(() => t(Symbol.for(""))).toThrow(ArgumentError);
+    expect(() => t("")).toThrow(ArgumentError);
   });
 
   it("translate given an array with empty string as a key raises an I18n::ArgumentError", () => {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -187,8 +187,12 @@ export function eagerLoadBang(): void {
   config().backend.eagerLoadBang();
 }
 
-/** A key accepted by `translate`: Ruby's Symbol arm is a real JS symbol. */
-export type TranslateKey = TranslationKey | symbol | null;
+/**
+ * A key accepted by `translate`. Ruby accepts a Symbol or a String and treats
+ * them the same — `normalize_keys` sends both through `to_sym` — so the JS
+ * spelling of both is the plain string.
+ */
+export type TranslateKey = TranslationKey | null;
 
 /**
  * Translates, pluralizes and interpolates a given key using a given locale,


### PR DESCRIPTION
`packages/i18n/src/backend/base.ts` and `simple.ts` modelled Ruby Symbol
*values* — a `default` that names another translation key, and a translation
entry that links to one — as real JS symbols (`Symbol.for("some.key")`). A Ruby
Symbol is a JS string; `Symbol` / `Symbol.for` is reserved for private keys and
brands. Where control flow turns on `Symbol === x` the Symbol keeps its leading
colon, which is also how it renders through `inspect`.

- `resolve` (`i18n/lib/i18n/backend/base.rb:154`) — `when Symbol` is now
  `isSymbol(subject)`, and the recursive translate takes `subject.slice(1)`.
- `Simple#lookup` (`simple.rb:104`) — `result.is_a?(Symbol)` is the same test;
  the `Symbol.keyFor` key conversion is gone.
- `symbolName` deleted; `base.ts`'s file header states the colon convention.

A translate *key* does not discriminate on type — `normalize_keys` sends a
Symbol and a String through the same `to_sym`, and the empty-key guard is
`(key.is_a?(String) || key.is_a?(Symbol)) && key.empty?` (`base.rb:29`) — so
`TranslateKey` drops its `symbol` arm and the guard is a plain `key === ""`.
The two "empty Symbol key" tests keep their names; `:""` and `""` are the same
JS value.

Behaviour is unchanged: a `":other.key"` default resolves through the backend,
a plain `"other.key"` string is returned literally.

`pnpm vitest run packages/i18n` — 235 passed. `pnpm api:calls` and
`pnpm api:calls:wide` both OK, `pnpm typecheck` clean.

Closes-story: i18n-symbol-values-are-colon-strings
