### PR TITLE
test(i18n): wire Backend::Fallbacks into the Active Record i18n path

### DIFF
--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -11,6 +11,7 @@
 // non-test consumers.
 import "../sqlite/better-sqlite3.js";
 import { Base } from "../base.js";
+import { I18n } from "@blazetrails/activemodel";
 import { getZone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
 import { DelegateCache } from "../relation/delegation.js";
 import { ActiveRecord } from "../ar-config.js";
@@ -34,6 +35,13 @@ registerFakeAdapter();
 // caught. Production keeps the Rails default of `true` (delegation.rb:25); only
 // the test harness flips it.
 DelegateCache.delegateBaseMethods = false;
+
+// Mirror Rails activerecord/test/cases/helper.rb:35 — disable available locale
+// checks to avoid warnings running the test suite. The gem memoizes
+// `available_locales_set` (i18n/lib/i18n/config.rb:50-54) and clears it on
+// neither `store_translations` nor `backend=`, so without this a locale a case
+// stores after the first check never becomes visible to `with_locale`.
+I18n.setEnforceAvailableLocales(false);
 
 // Mirror Rails activerecord/test/cases/helper.rb:40
 Base.automaticallyInvertPluralAssociations = true;

--- a/packages/activerecord/src/test-helpers/i18n.ts
+++ b/packages/activerecord/src/test-helpers/i18n.ts
@@ -7,14 +7,24 @@ import { I18n } from "@blazetrails/activemodel";
 import { en as activemodelEn } from "@blazetrails/activemodel/locale/en";
 import { en } from "../locale/en.js";
 
-/** A fresh backend carrying the framework locales, as Rails' load path supplies them. */
-export function resetI18n(): void {
-  resetI18nEmpty();
+// Disable available locale checks to avoid warnings running the test suite.
+// activerecord/test/cases/helper.rb:35
+I18n.setEnforceAvailableLocales(false);
+
+/**
+ * A fresh backend carrying the framework locales, as Rails' load path supplies
+ * them. `backend` is the `I18n.backend = ...` half of the stand-in: Rails test
+ * cases that need a mixin over `Simple` declare their own backend class and
+ * assign an instance of it (activerecord/test/cases/validations/
+ * i18n_generate_message_validation_test.rb:14).
+ */
+export function resetI18n(backend: I18n.Base = new I18n.Simple()): void {
+  resetI18nEmpty(backend);
   I18n.backend().storeTranslations("en", activemodelEn);
   I18n.backend().storeTranslations("en", en);
 }
 
 /** A fresh backend with no framework locales — Rails' `I18n.load_path.clear`. */
-export function resetI18nEmpty(): void {
-  I18n.setBackend(new I18n.Simple());
+export function resetI18nEmpty(backend: I18n.Base = new I18n.Simple()): void {
+  I18n.setBackend(backend);
 }

--- a/packages/activerecord/src/test-helpers/i18n.ts
+++ b/packages/activerecord/src/test-helpers/i18n.ts
@@ -2,13 +2,17 @@
  * Active Record's arm of the same load-path stand-in Active Model's
  * `test-helpers/i18n.ts` documents: a fresh backend plus the `en.yml` data
  * Rails' `I18n.load_path` would re-read.
+ *
+ * It also carries `activerecord/test/cases/helper.rb:35` — "Disable available
+ * locale checks to avoid warnings running the test suite." The gem memoizes
+ * `available_locales_set` (i18n/lib/i18n/config.rb:50-54) and clears it on
+ * neither `store_translations` nor `backend=`, so without this a locale a case
+ * stores after the first check never becomes visible to `with_locale`.
  */
 import { I18n } from "@blazetrails/activemodel";
 import { en as activemodelEn } from "@blazetrails/activemodel/locale/en";
 import { en } from "../locale/en.js";
 
-// Disable available locale checks to avoid warnings running the test suite.
-// activerecord/test/cases/helper.rb:35
 I18n.setEnforceAvailableLocales(false);
 
 /**

--- a/packages/activerecord/src/test-helpers/i18n.ts
+++ b/packages/activerecord/src/test-helpers/i18n.ts
@@ -2,18 +2,10 @@
  * Active Record's arm of the same load-path stand-in Active Model's
  * `test-helpers/i18n.ts` documents: a fresh backend plus the `en.yml` data
  * Rails' `I18n.load_path` would re-read.
- *
- * It also carries `activerecord/test/cases/helper.rb:35` — "Disable available
- * locale checks to avoid warnings running the test suite." The gem memoizes
- * `available_locales_set` (i18n/lib/i18n/config.rb:50-54) and clears it on
- * neither `store_translations` nor `backend=`, so without this a locale a case
- * stores after the first check never becomes visible to `with_locale`.
  */
 import { I18n } from "@blazetrails/activemodel";
 import { en as activemodelEn } from "@blazetrails/activemodel/locale/en";
 import { en } from "../locale/en.js";
-
-I18n.setEnforceAvailableLocales(false);
 
 /**
  * A fresh backend carrying the framework locales, as Rails' load path supplies

--- a/packages/activerecord/src/test-helpers/i18n.ts
+++ b/packages/activerecord/src/test-helpers/i18n.ts
@@ -15,12 +15,7 @@ import { en } from "../locale/en.js";
  * i18n_generate_message_validation_test.rb:14).
  */
 export function resetI18n(backend: I18n.Base = new I18n.Simple()): void {
-  resetI18nEmpty(backend);
+  I18n.setBackend(backend);
   I18n.backend().storeTranslations("en", activemodelEn);
   I18n.backend().storeTranslations("en", en);
-}
-
-/** A fresh backend with no framework locales — Rails' `I18n.load_path.clear`. */
-export function resetI18nEmpty(backend: I18n.Base = new I18n.Simple()): void {
-  I18n.setBackend(backend);
 }

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll, afterEach, vi } from "vitest";
+import { describe, it, expect, afterAll, beforeEach, vi } from "vitest";
 import { Base } from "../index.js";
 import { I18n } from "@blazetrails/activemodel";
 import { RecordInvalid } from "../validations.js";
@@ -9,8 +9,11 @@ vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 fixtures({});
 
 describe("I18nGenerateMessageValidationTest", () => {
-  afterEach(() => {
-    resetI18n();
+  // activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:7-9
+  class Backend extends I18n.Fallbacks(I18n.Simple) {}
+
+  beforeEach(() => {
+    resetI18n(new Backend());
   });
   afterAll(() => {
     vi.unstubAllEnvs();
@@ -69,7 +72,7 @@ describe("I18nGenerateMessageValidationTest", () => {
   });
 
   it("RecordInvalid exception translation falls back to the :errors namespace", () => {
-    resetI18nEmpty();
+    resetI18nEmpty(new Backend());
     I18n.backend().storeTranslations("en", {
       errors: { messages: { record_invalid: "fallback message" } },
     });
@@ -79,7 +82,7 @@ describe("I18nGenerateMessageValidationTest", () => {
   });
 
   it("translation for 'taken' can be overridden", () => {
-    resetI18nEmpty();
+    resetI18nEmpty(new Backend());
     I18n.backend().storeTranslations("en", {
       errors: { attributes: { title: { taken: "Custom taken message" } } },
     });
@@ -90,7 +93,7 @@ describe("I18nGenerateMessageValidationTest", () => {
   });
 
   it("translation for 'taken' can be overridden in activerecord scope", () => {
-    resetI18nEmpty();
+    resetI18nEmpty(new Backend());
     I18n.backend().storeTranslations("en", {
       activerecord: { errors: { messages: { taken: "Custom taken message" } } },
     });
@@ -101,7 +104,7 @@ describe("I18nGenerateMessageValidationTest", () => {
   });
 
   it("translation for 'taken' can be overridden in activerecord model scope", () => {
-    resetI18nEmpty();
+    resetI18nEmpty(new Backend());
     I18n.backend().storeTranslations("en", {
       activerecord: { errors: { models: { topic: { taken: "Custom taken message" } } } },
     });
@@ -112,7 +115,7 @@ describe("I18nGenerateMessageValidationTest", () => {
   });
 
   it("translation for 'taken' can be overridden in activerecord attributes scope", () => {
-    resetI18nEmpty();
+    resetI18nEmpty(new Backend());
     I18n.backend().storeTranslations("en", {
       activerecord: {
         errors: { models: { topic: { attributes: { title: { taken: "Custom taken message" } } } } },
@@ -124,14 +127,8 @@ describe("I18nGenerateMessageValidationTest", () => {
     );
   });
 
-  // Rails' case builds its backend as `class Backend < I18n::Backend::Simple;
-  // include I18n::Backend::Fallbacks; end`
-  // (activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:7-9).
-  // `i18n/backend/fallbacks.rb` has no port yet — story `i18n-backend-fallbacks`
-  // — so there is no locale chain for "en-US" to walk up. Unskip with that story;
-  // nothing else about this case changes.
-  it.skip("activerecord attributes scope falls back to parent locale before it falls back to the :errors namespace", () => {
-    resetI18nEmpty();
+  it("activerecord attributes scope falls back to parent locale before it falls back to the :errors namespace", () => {
+    resetI18nEmpty(new Backend());
     I18n.backend().storeTranslations("en", {
       activerecord: {
         errors: { models: { topic: { attributes: { title: { taken: "custom en message" } } } } },

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -3,7 +3,7 @@ import { Base } from "../index.js";
 import { I18n } from "@blazetrails/activemodel";
 import { RecordInvalid } from "../validations.js";
 import { fixtures } from "../test-fixtures.js";
-import { resetI18n, resetI18nEmpty } from "../test-helpers/i18n.js";
+import { resetI18n } from "../test-helpers/i18n.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 fixtures({});
@@ -14,6 +14,23 @@ describe("I18nGenerateMessageValidationTest", () => {
    * — `class Backend < I18n::Backend::Simple; include I18n::Backend::Fallbacks; end`.
    */
   class Backend extends I18n.Fallbacks(I18n.Simple) {}
+
+  /**
+   * Mirrors: activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:17-25
+   * — snapshots the load path and backend, clears/replaces both, yields, and
+   * restores both in `ensure`. Trails' framework locales are modules rather
+   * than load-path entries, so a fresh backend is the whole of
+   * `I18n.load_path.clear` plus `I18n.backend = Backend.new`.
+   */
+  function resetI18nLoadPath(fn: () => void): void {
+    const oldBackend = I18n.backend();
+    I18n.setBackend(new Backend());
+    try {
+      fn();
+    } finally {
+      I18n.setBackend(oldBackend);
+    }
+  }
 
   beforeEach(() => {
     resetI18n(new Backend());
@@ -75,80 +92,88 @@ describe("I18nGenerateMessageValidationTest", () => {
   });
 
   it("RecordInvalid exception translation falls back to the :errors namespace", () => {
-    resetI18nEmpty(new Backend());
-    I18n.backend().storeTranslations("en", {
-      errors: { messages: { record_invalid: "fallback message" } },
+    resetI18nLoadPath(() => {
+      I18n.backend().storeTranslations("en", {
+        errors: { messages: { record_invalid: "fallback message" } },
+      });
+      const topic = makeTopic();
+      topic.errors.add("title", "blank");
+      expect(new RecordInvalid(topic).message).toBe("fallback message");
     });
-    const topic = makeTopic();
-    topic.errors.add("title", "blank");
-    expect(new RecordInvalid(topic).message).toBe("fallback message");
   });
 
   it("translation for 'taken' can be overridden", () => {
-    resetI18nEmpty(new Backend());
-    I18n.backend().storeTranslations("en", {
-      errors: { attributes: { title: { taken: "Custom taken message" } } },
+    resetI18nLoadPath(() => {
+      I18n.backend().storeTranslations("en", {
+        errors: { attributes: { title: { taken: "Custom taken message" } } },
+      });
+      const topic = makeTopic();
+      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+        "Custom taken message",
+      );
     });
-    const topic = makeTopic();
-    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
-      "Custom taken message",
-    );
   });
 
   it("translation for 'taken' can be overridden in activerecord scope", () => {
-    resetI18nEmpty(new Backend());
-    I18n.backend().storeTranslations("en", {
-      activerecord: { errors: { messages: { taken: "Custom taken message" } } },
+    resetI18nLoadPath(() => {
+      I18n.backend().storeTranslations("en", {
+        activerecord: { errors: { messages: { taken: "Custom taken message" } } },
+      });
+      const topic = makeTopic();
+      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+        "Custom taken message",
+      );
     });
-    const topic = makeTopic();
-    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
-      "Custom taken message",
-    );
   });
 
   it("translation for 'taken' can be overridden in activerecord model scope", () => {
-    resetI18nEmpty(new Backend());
-    I18n.backend().storeTranslations("en", {
-      activerecord: { errors: { models: { topic: { taken: "Custom taken message" } } } },
+    resetI18nLoadPath(() => {
+      I18n.backend().storeTranslations("en", {
+        activerecord: { errors: { models: { topic: { taken: "Custom taken message" } } } },
+      });
+      const topic = makeTopic();
+      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+        "Custom taken message",
+      );
     });
-    const topic = makeTopic();
-    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
-      "Custom taken message",
-    );
   });
 
   it("translation for 'taken' can be overridden in activerecord attributes scope", () => {
-    resetI18nEmpty(new Backend());
-    I18n.backend().storeTranslations("en", {
-      activerecord: {
-        errors: { models: { topic: { attributes: { title: { taken: "Custom taken message" } } } } },
-      },
+    resetI18nLoadPath(() => {
+      I18n.backend().storeTranslations("en", {
+        activerecord: {
+          errors: {
+            models: { topic: { attributes: { title: { taken: "Custom taken message" } } } },
+          },
+        },
+      });
+      const topic = makeTopic();
+      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+        "Custom taken message",
+      );
     });
-    const topic = makeTopic();
-    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
-      "Custom taken message",
-    );
   });
 
   it("activerecord attributes scope falls back to parent locale before it falls back to the :errors namespace", () => {
-    resetI18nEmpty(new Backend());
-    I18n.backend().storeTranslations("en", {
-      activerecord: {
-        errors: { models: { topic: { attributes: { title: { taken: "custom en message" } } } } },
-      },
-    });
-    I18n.backend().storeTranslations("en-US", {
-      errors: { messages: { taken: "generic en-US fallback" } },
-    });
+    resetI18nLoadPath(() => {
+      I18n.backend().storeTranslations("en", {
+        activerecord: {
+          errors: { models: { topic: { attributes: { title: { taken: "custom en message" } } } } },
+        },
+      });
+      I18n.backend().storeTranslations("en-US", {
+        errors: { messages: { taken: "generic en-US fallback" } },
+      });
 
-    const topic = makeTopic();
-    I18n.withLocale("en-US", () => {
-      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
-        "custom en message",
-      );
-      expect(topic.errors.generateMessage("heading", "taken", { value: "heading" })).toBe(
-        "generic en-US fallback",
-      );
+      const topic = makeTopic();
+      I18n.withLocale("en-US", () => {
+        expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+          "custom en message",
+        );
+        expect(topic.errors.generateMessage("heading", "taken", { value: "heading" })).toBe(
+          "generic en-US fallback",
+        );
+      });
     });
   });
 });

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -9,7 +9,10 @@ vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 fixtures({});
 
 describe("I18nGenerateMessageValidationTest", () => {
-  // activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:7-9
+  /**
+   * Mirrors: activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:7-9
+   * — `class Backend < I18n::Backend::Simple; include I18n::Backend::Fallbacks; end`.
+   */
   class Backend extends I18n.Fallbacks(I18n.Simple) {}
 
   beforeEach(() => {


### PR DESCRIPTION
Rails builds this test case's backend as
`class Backend < I18n::Backend::Simple; include I18n::Backend::Fallbacks; end`
(`activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:7-9`)
and assigns an instance of it in `setup` (`:14`) and in `reset_i18n_load_path`
(`:20`). `i18n-backend-fallbacks` (#6029) landed the port, so this declares that
class in the trails counterpart and routes the AR helper's backend assignment
through it.

That unskips `activerecord attributes scope falls back to parent locale before
it falls back to the :errors namespace`, whose skip comment named this exact
blocker. The default `I18n::Locale::Fallbacks` already yields `["en-US", "en"]`,
so — as in Rails — no `setFallbacks` call is needed.

- `resetI18nLoadPath` ports `reset_i18n_load_path` (`:17-25`) as the block
  method Rails defines: it snapshots the backend, installs a fresh `Backend`,
  yields, and restores in `finally`. All six cases wrap their body in it, as
  they do in Ruby. The previous port had flattened this into a bare backend
  swap, dropping both the block scoping and the `ensure` restore.
- `resetI18n` takes the backend, so the `I18n.backend = Backend.new` half of the
  load-path stand-in can name a mixin over `Simple` the way Rails test cases do
  (`:14`). Default stays `new Simple()`, so every other caller is unchanged.
- `afterEach` becomes `beforeEach`, matching Rails' `setup` — every case in the
  file runs against `Backend`, as it does in Ruby.
- `cases/helper.ts` picks up `activerecord/test/cases/helper.rb:35`, in Rails
  source order between the `:29` and `:40` entries already there. Without it
  `withLocale("en-US")` raises `InvalidLocale`: the gem memoizes
  `available_locales_set` (`i18n/lib/i18n/config.rb:50-54`) and clears it on
  neither `store_translations` nor `backend=`, so a locale stored after the
  first check never becomes visible.
- `resetI18nEmpty` loses its last caller with the block method and is deleted.

No bespoke fallback-chain computation remains in `activemodel` or
`activerecord` — #6026 removed the last of it with the old `I18nService` shim.

Gates: `api:calls` OK (14 baselined), `api:calls:wide` OK (2218 baselined, no
movement), typecheck and eslint clean, 3 files.

CI note: every red check reports the same
`Argument of type 'symbol' is not assignable to 'TranslateKey'` errors in
`packages/i18n/src/backend/fallbacks.ts`, `activemodel/naming.ts`,
`activemodel/validations.ts` and `activerecord/validations.ts` — none of which
this PR touches. That is #6032's Symbol-spelling flip landing on top of #6029;
main is red at `408ac79ba` for the same reason and a central fixer is on it.

Closes-story: i18n-ar-fallbacks-wiring
