### PR TITLE
refactor(activesupport): converge the i18n date test double onto a real Date

### DIFF
--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -383,7 +383,7 @@ export class DeleteRestrictionError extends ActiveRecordError {
  * assignments that displace nothing — a fresh association, an `id`-matched
  * update, a reused unsaved build — stay on the synchronous setter.
  *
- * @noRailsEquivalent Rails has no such error because `ship_attributes=` does
+ * @noRailsEquivalent PERMANENT — Rails has no such error because `ship_attributes=` does
  * the displacement inline; a JS property setter's value expression cannot be
  * awaited by any caller syntax, so the write is unimplementable there and the
  * refusal is the honest port. Sibling of `HasOnePersistedAssignmentError` /

--- a/packages/activesupport/src/date.trails.test.ts
+++ b/packages/activesupport/src/date.trails.test.ts
@@ -7,9 +7,11 @@ import { describe, it, expect } from "vitest";
 import { ArgumentError, Date as RubyDate } from "./date.js";
 
 describe("Date", () => {
-  it("parses a y-m-d string", () => {
-    const date = RubyDate.parse("2008-07-02");
-    expect([date.year, date.mon, date.day]).toEqual([2008, 7, 2]);
+  it("parses a y-m-d string, padded or not", () => {
+    for (const str of ["2008-07-02", "2008-7-2"]) {
+      const date = RubyDate.parse(str);
+      expect([date.year, date.mon, date.day]).toEqual([2008, 7, 2]);
+    }
   });
 
   it("raises on an unparseable string", () => {

--- a/packages/activesupport/src/date.trails.test.ts
+++ b/packages/activesupport/src/date.trails.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Trails-only: Ruby's `::Date` is stdlib, so it has no Rails test to mirror.
+ * These cover the members `I18n::Backend::Base#localize` duck-types.
+ */
+
+import { describe, it, expect } from "vitest";
+import { ArgumentError, Date as RubyDate } from "./date.js";
+
+describe("Date", () => {
+  it("parses a y-m-d string", () => {
+    const date = RubyDate.parse("2008-07-02");
+    expect([date.year, date.mon, date.day]).toEqual([2008, 7, 2]);
+  });
+
+  it("raises on an unparseable string", () => {
+    expect(() => RubyDate.parse("not a date")).toThrow(ArgumentError);
+    expect(() => RubyDate.parse("not a date")).toThrow("invalid date");
+  });
+
+  it("counts wday from Sunday, as Ruby does", () => {
+    expect(RubyDate.parse("2008-07-02").wday).toBe(3);
+    expect(RubyDate.parse("2008-07-06").wday).toBe(0);
+  });
+
+  it("does not answer sec or hour, so localize resolves it against date.formats", () => {
+    const date = RubyDate.parse("2008-07-02");
+    expect("sec" in date).toBe(false);
+    expect("hour" in date).toBe(false);
+  });
+
+  it("formats the strftime directives the date formats use", () => {
+    const date = RubyDate.parse("2008-07-02");
+    expect(date.strftime("%Y-%m-%d")).toBe("2008-07-02");
+    expect(date.strftime("%b %d")).toBe("Jul 02");
+    expect(date.strftime("%B %d, %Y")).toBe("July 02, 2008");
+    expect(date.strftime("%a %A")).toBe("Wed Wednesday");
+  });
+
+  it("strips the padding for the %-d flag and leaves unknown directives alone", () => {
+    const date = RubyDate.parse("2008-07-02");
+    expect(date.strftime("%-m/%-d")).toBe("7/2");
+    expect(date.strftime("%Q")).toBe("%Q");
+  });
+});

--- a/packages/activesupport/src/date.ts
+++ b/packages/activesupport/src/date.ts
@@ -73,7 +73,13 @@ export class Date {
     this.#plain = new Temporal.PlainDate(year, month, day);
   }
 
-  /** Ruby `Date.parse`, narrowed to the ISO-ish `y-m-d` the callers use. */
+  /**
+   * Ruby `Date.parse`, narrowed to the `y-m-d` the callers use. The month and
+   * day are unpadded-tolerant because Ruby's is — `String#to_date` delegates
+   * straight to `::Date.parse`
+   * (activesupport/lib/active_support/core_ext/string/conversions.rb:47-48),
+   * and `i18n_test.rb:9` passes `"2008-7-2"`.
+   */
   static parse(str: string): Date {
     const match = /^(-?\d{4,})-(\d{1,2})-(\d{1,2})$/.exec(str);
     // Ruby raises `Date::Error`, a subclass of `ArgumentError` that a nested

--- a/packages/activesupport/src/date.ts
+++ b/packages/activesupport/src/date.ts
@@ -66,10 +66,11 @@ export class ArgumentError extends Error {
  * only the members a caller duck-types.
  */
 export class Date {
-  readonly plain: Temporal.PlainDate;
+  readonly #plain: Temporal.PlainDate;
 
-  constructor(plain: Temporal.PlainDate) {
-    this.plain = plain;
+  /** Ruby `Date.new(year, month, day)`. */
+  constructor(year: number, month: number, day: number) {
+    this.#plain = new Temporal.PlainDate(year, month, day);
   }
 
   /** Ruby `Date.parse`, narrowed to the ISO-ish `y-m-d` the callers use. */
@@ -78,28 +79,28 @@ export class Date {
     // Ruby raises `Date::Error`, a subclass of `ArgumentError` that a nested
     // TS class cannot spell; the superclass is what callers rescue.
     if (!match) throw new ArgumentError("invalid date");
-    return new Date(new Temporal.PlainDate(Number(match[1]), Number(match[2]), Number(match[3])));
+    return new Date(Number(match[1]), Number(match[2]), Number(match[3]));
   }
 
   get year(): number {
-    return this.plain.year;
+    return this.#plain.year;
   }
 
   get mon(): number {
-    return this.plain.month;
+    return this.#plain.month;
   }
 
   get month(): number {
-    return this.plain.month;
+    return this.#plain.month;
   }
 
   get day(): number {
-    return this.plain.day;
+    return this.#plain.day;
   }
 
   /** Ruby counts Sunday as 0; `Temporal.PlainDate#dayOfWeek` counts Monday as 1. */
   get wday(): number {
-    return this.plain.dayOfWeek % 7;
+    return this.#plain.dayOfWeek % 7;
   }
 
   strftime(format: string): string {
@@ -109,7 +110,7 @@ export class Date {
       m: () => pad2(this.mon),
       d: () => pad2(this.day),
       e: () => String(this.day).padStart(2, " "),
-      j: () => String(this.plain.dayOfYear).padStart(3, "0"),
+      j: () => String(this.#plain.dayOfYear).padStart(3, "0"),
       F: () => `${this.year}-${pad2(this.mon)}-${pad2(this.day)}`,
       A: () => DAY_NAMES[this.wday],
       a: () => ABBR_DAY_NAMES[this.wday],

--- a/packages/activesupport/src/date.ts
+++ b/packages/activesupport/src/date.ts
@@ -1,0 +1,130 @@
+/**
+ * Ruby's stdlib `::Date`, as much of it as trails needs. Rails does not define
+ * the class — it only reopens it in `core_ext/date/*.rb`, whose calculations
+ * live in `time-ext.ts` here, over `Temporal.PlainDate`.
+ *
+ * `Temporal.PlainDate` is trails' `::Date` value (`TimeWithZone#toDate` returns
+ * one), but it answers `dayOfWeek`/`month` rather than Ruby's `wday`/`mon` and
+ * has no `strftime`, so it cannot be handed to a method that duck-types a Ruby
+ * date. `I18n::Backend::Base#localize` is exactly such a method: it asks for
+ * `strftime`, `wday` and `mon`, and picks `date.formats` over `time.formats` by
+ * the *absence* of `sec` (i18n/lib/i18n/backend/base.rb:105-115, ported at
+ * `packages/i18n/src/backend/base.ts:245-271`). This wrapper is that duck type,
+ * and its lack of `sec`/`hour` is the distinction Ruby gets from `Date` not
+ * being a `Time`.
+ */
+
+import { Temporal } from "./temporal.js";
+
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const ABBR_DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+const ABBR_MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+export class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
+/**
+ * @noRailsEquivalent PERMANENT — Ruby stdlib `::Date`. Rails never defines the
+ * class, only reopens it, so there is no Rails counterpart for a port to
+ * converge on; JS has no stdlib equivalent either (`Temporal.PlainDate` answers
+ * `dayOfWeek`/`month`, not `wday`/`mon`, and has no `strftime`). trails carries
+ * only the members a caller duck-types.
+ */
+export class Date {
+  readonly plain: Temporal.PlainDate;
+
+  constructor(plain: Temporal.PlainDate) {
+    this.plain = plain;
+  }
+
+  /** Ruby `Date.parse`, narrowed to the ISO-ish `y-m-d` the callers use. */
+  static parse(str: string): Date {
+    const match = /^(-?\d{4,})-(\d{1,2})-(\d{1,2})$/.exec(str);
+    // Ruby raises `Date::Error`, a subclass of `ArgumentError` that a nested
+    // TS class cannot spell; the superclass is what callers rescue.
+    if (!match) throw new ArgumentError("invalid date");
+    return new Date(new Temporal.PlainDate(Number(match[1]), Number(match[2]), Number(match[3])));
+  }
+
+  get year(): number {
+    return this.plain.year;
+  }
+
+  get mon(): number {
+    return this.plain.month;
+  }
+
+  get month(): number {
+    return this.plain.month;
+  }
+
+  get day(): number {
+    return this.plain.day;
+  }
+
+  /** Ruby counts Sunday as 0; `Temporal.PlainDate#dayOfWeek` counts Monday as 1. */
+  get wday(): number {
+    return this.plain.dayOfWeek % 7;
+  }
+
+  strftime(format: string): string {
+    const tokens: Record<string, () => string> = {
+      Y: () => String(this.year),
+      y: () => pad2(this.year % 100),
+      m: () => pad2(this.mon),
+      d: () => pad2(this.day),
+      e: () => String(this.day).padStart(2, " "),
+      j: () => String(this.plain.dayOfYear).padStart(3, "0"),
+      F: () => `${this.year}-${pad2(this.mon)}-${pad2(this.day)}`,
+      A: () => DAY_NAMES[this.wday],
+      a: () => ABBR_DAY_NAMES[this.wday],
+      B: () => MONTH_NAMES[this.mon - 1],
+      b: () => ABBR_MONTH_NAMES[this.mon - 1],
+      h: () => ABBR_MONTH_NAMES[this.mon - 1],
+      "%": () => "%",
+    };
+
+    return format.replace(/%(-?)([A-Za-z%])/g, (match, flag, spec) => {
+      const fn = tokens[spec];
+      if (!fn) return match;
+      let result = fn();
+      if (flag === "-") result = result.replace(/^[0 ]+/, "") || "0";
+      return result;
+    });
+  }
+}

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -22,7 +22,7 @@ describe("I18nTest", () => {
 
   beforeEach(async () => {
     await reloadTranslations();
-    date = RubyDate.parse("2008-07-02");
+    date = RubyDate.parse("2008-7-2");
     time = TimeZone.find("UTC").local(2008, 7, 2, 16, 47, 1);
   });
 

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -3,88 +3,13 @@ import { I18n } from "./i18n.js";
 import { en } from "./locale/en.js";
 import { toSentence } from "./array-utils.js";
 import { TimeZone } from "./values/time-zone.js";
+import { Date as RubyDate } from "./date.js";
 import type { TimeWithZone } from "./time-with-zone.js";
 
 /** `I18n.reload!` plus the `en` locale Rails re-reads from its load path. */
 async function reloadTranslations(): Promise<void> {
   await I18n.reloadBang();
   I18n.backend().storeTranslations("en", en);
-}
-
-const MONTHNAMES = [
-  null,
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];
-const ABBR_MONTHNAMES = [
-  null,
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
-
-/**
- * Stands in for Ruby's `::Date` (`Date.parse("2008-7-2")` in `setup`), which
- * trails has no analogue of. `localize` duck-types its object
- * (i18n/lib/i18n/backend/base.rb:78-92): `Date` answers `strftime`, `wday` and
- * `mon` but not `sec`, which is what selects `date.formats` over
- * `time.formats` (base.rb:82). Mirrors the stand-in in
- * i18n/src/backend/localization.test.ts.
- */
-class RubyDate {
-  readonly utc: Date;
-
-  constructor(year: number, month: number, day: number) {
-    this.utc = new Date(Date.UTC(year, month - 1, day));
-  }
-
-  get wday(): number {
-    return this.utc.getUTCDay();
-  }
-
-  get mon(): number {
-    return this.utc.getUTCMonth() + 1;
-  }
-
-  strftime(format: string): string {
-    return format.replace(/%([A-Za-z%])/g, (match, directive: string) => {
-      switch (directive) {
-        case "Y":
-          return String(this.utc.getUTCFullYear());
-        case "m":
-          return String(this.mon).padStart(2, "0");
-        case "d":
-          return String(this.utc.getUTCDate()).padStart(2, "0");
-        case "b":
-          return ABBR_MONTHNAMES[this.mon]!;
-        case "B":
-          return MONTHNAMES[this.mon]!;
-        case "%":
-          return "%";
-        default:
-          return match;
-      }
-    });
-  }
 }
 
 // Rails' activesupport/test/abstract_unit.rb:35 turns the check off for the
@@ -97,7 +22,7 @@ describe("I18nTest", () => {
 
   beforeEach(async () => {
     await reloadTranslations();
-    date = new RubyDate(2008, 7, 2);
+    date = RubyDate.parse("2008-07-02");
     time = TimeZone.find("UTC").local(2008, 7, 2, 16, 47, 1);
   });
 


### PR DESCRIPTION
Repitched. #6014 landed the four `test_date_localization_*` cases from
`activesupport/test/i18n_test.rb:18-31` while this branch was open, satisfying
story `as-i18n-localization-tests-over-shared-i18n` on `main`. What is left is
the shape those cases were written against, which this PR converges.

## The problem

#6014 restored the cases with a `RubyDate` class inlined in `i18n.test.ts`,
mirroring the stand-in in `packages/i18n/src/backend/localization.test.ts`.
That is the second hand-rolled `strftime` in the tree, and neither copy is
usable outside its own test file.

They exist because `I18n::Backend::Base#localize` duck-types a Ruby date — it
asks for `strftime`, `wday` and `mon`, and picks `date.formats` over
`time.formats` by the *absence* of `sec`
(`i18n/lib/i18n/backend/base.rb:105-115`, ported at
`packages/i18n/src/backend/base.ts:245-271`) — and trails has no object
satisfying the date arm:

- `TimeWithZone` answers `sec` (`time-with-zone.ts:241`), so it always resolves
  `time.formats`.
- `Temporal.PlainDate`, what `TimeWithZone#toDate` returns
  (`time-with-zone.ts:322`), answers `dayOfWeek`/`month` rather than Ruby's
  `wday`/`mon` and has no `strftime`, failing the duck-type check at
  `base.ts:257` outright.

## The change

Adds `packages/activesupport/src/date.ts` — Ruby stdlib `::Date` over a
`Temporal.PlainDate`, carrying only the members a caller duck-types: `parse`,
`year`, `mon`, `month`, `day`, `wday`, `strftime` — and deletes the
activesupport double in favour of it. The nine localization cases, their names,
their order and their assertions are unchanged from #6014.

The omission of `sec`/`hour` is deliberate: it is the distinction Ruby gets
from `Date` not being a `Time`.

`Date.parse` raises `ArgumentError` with Ruby's `"invalid date"`. Ruby raises
`Date::Error`, a subclass of `ArgumentError` that a nested TS class cannot
spell; that is noted at the raise site.

## Deviations

- `Date` is tagged `@noRailsEquivalent PERMANENT`. Rails never defines the
  class — it only reopens it in `core_ext/date/*.rb`, whose calculations
  already live in `time-ext.ts` here — so there is no Rails counterpart for a
  port to converge on, and JS has no stdlib equivalent.
- The `localization.test.ts` double stays. `packages/i18n` is a *dependency* of
  activesupport, so it cannot import from it; converging that one needs the
  `Date` to live lower down, which is not this PR's call to make.

## Drive-by

`extra-surface` requires every `@noRailsEquivalent` reason to open with a
permanence claim, and #5997 landed
`activerecord associations/errors.ts NestedAttributesDisplacementError`
without one, which hard-fails `pnpm api:extra` for every branch. Its reason
already states a language shortcoming, so it is classified `PERMANENT` here —
one word, no behaviour change. Called out because it is outside this PR's
package.

## Gates

- `pnpm api:calls` — OK (14 baselined, no new rows)
- `pnpm api:calls:wide` — OK (2217 baselined, no new rows)
- `pnpm api:extra --package activesupport` — clean; `date.ts` reports 2 novel
  names, `mon` and `wday`, both genuine Ruby `Date` members covered by the
  class's `PERMANENT` tag
- `pnpm test:compare` — 15136/22643, delta 0 (no test added, removed or
  renamed; only a helper class deleted from a test file)

`date.trails.test.ts` is trails-only because Ruby's `Date` is stdlib and has no
Rails test to mirror.

Closes-story: as-i18n-localization-tests-over-shared-i18n
