### PR TITLE
fix(i18n): converge the Symbol-value callers onto the colon-string spelling

### DIFF
--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -1,5 +1,5 @@
 import { humanize, deepDup } from "@blazetrails/activesupport";
-import { MissingTranslation, catchException } from "@blazetrails/i18n";
+import { MissingTranslation, catchException, type TranslateKey } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 
 /** The model instance that owns this error. Rails tests pass null for base-only errors. */
@@ -125,7 +125,7 @@ export class Error {
       ? baseClass.humanAttributeName(attribute, { default: attrName, base })
       : attrName;
 
-    return I18n.t((defaults.shift() as string).slice(1), {
+    return I18n.t(defaults.shift() as TranslateKey, {
       default: defaults,
       attribute: attrName,
       message,
@@ -193,7 +193,7 @@ export class Error {
 
       if (options.message == null || options.message === false) {
         const translation = catchException(() =>
-          I18n.translate((defaults[0] as string).slice(1), {
+          I18n.translate(defaults[0] as TranslateKey, {
             ...options,
             default: defaults.slice(1),
             throw: true,
@@ -210,14 +210,14 @@ export class Error {
     defaults.push(`:errors.attributes.${attribute}.${type}`);
     defaults.push(`:errors.messages.${type}`);
 
-    const key = (defaults.shift() as string).slice(1);
+    const key = defaults.shift();
     if (options.message != null && options.message !== false) {
       defaults = [options.message];
       delete options.message;
     }
     options.default = defaults;
 
-    return I18n.translate(key, options) as string;
+    return I18n.translate(key as TranslateKey, options) as string;
   }
 
   constructor(

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -1,5 +1,5 @@
 import { humanize, deepDup } from "@blazetrails/activesupport";
-import { MissingTranslation, catchException, type TranslateKey } from "@blazetrails/i18n";
+import { MissingTranslation, catchException } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 
 /** The model instance that owns this error. Rails tests pass null for base-only errors. */
@@ -102,28 +102,22 @@ export class Error {
       const namespace = parts.length > 0 ? parts.join("/") : undefined;
       const attributesScope = `${baseClass.i18nScope}.errors.models`;
 
-      // Ruby Symbol default = "look this key up"; the backend spells that arm as
-      // a real JS symbol (story `i18n-symbol-values-are-colon-strings`).
       if (namespace) {
         defaults = baseClass.lookupAncestors!().flatMap((klass) => [
-          Symbol.for(
-            `${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.attributes.${attributeName}.format`,
-          ),
-          Symbol.for(`${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.format`),
+          `:${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.attributes.${attributeName}.format`,
+          `:${attributesScope}.${klass.modelName!.i18nKey}/${namespace}.format`,
         ]);
       } else {
         defaults = baseClass.lookupAncestors!().flatMap((klass) => [
-          Symbol.for(
-            `${attributesScope}.${klass.modelName!.i18nKey}.attributes.${attributeName}.format`,
-          ),
-          Symbol.for(`${attributesScope}.${klass.modelName!.i18nKey}.format`),
+          `:${attributesScope}.${klass.modelName!.i18nKey}.attributes.${attributeName}.format`,
+          `:${attributesScope}.${klass.modelName!.i18nKey}.format`,
         ]);
       }
     } else {
       defaults = [];
     }
 
-    defaults.push(Symbol.for("errors.format"));
+    defaults.push(":errors.format");
     defaults.push("%{attribute} %{message}");
 
     let attrName: string = humanize(attribute.replace(/\.base$/, "").replace(/\./g, "_"));
@@ -131,7 +125,7 @@ export class Error {
       ? baseClass.humanAttributeName(attribute, { default: attrName, base })
       : attrName;
 
-    return I18n.t(defaults.shift() as TranslateKey, {
+    return I18n.t((defaults.shift() as string).slice(1), {
       default: defaults,
       attribute: attrName,
       message,
@@ -192,16 +186,14 @@ export class Error {
       attribute = attribute.replace(/\[\d+\]/g, "");
 
       defaults = baseClass.lookupAncestors!().flatMap((klass) => [
-        Symbol.for(
-          `${i18nScope}.errors.models.${klass.modelName!.i18nKey}.attributes.${attribute}.${type}`,
-        ),
-        Symbol.for(`${i18nScope}.errors.models.${klass.modelName!.i18nKey}.${type}`),
+        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.attributes.${attribute}.${type}`,
+        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.${type}`,
       ]);
-      defaults.push(Symbol.for(`${i18nScope}.errors.messages.${type}`));
+      defaults.push(`:${i18nScope}.errors.messages.${type}`);
 
       if (options.message == null || options.message === false) {
         const translation = catchException(() =>
-          I18n.translate(defaults[0] as TranslateKey, {
+          I18n.translate((defaults[0] as string).slice(1), {
             ...options,
             default: defaults.slice(1),
             throw: true,
@@ -215,17 +207,17 @@ export class Error {
       defaults = [];
     }
 
-    defaults.push(Symbol.for(`errors.attributes.${attribute}.${type}`));
-    defaults.push(Symbol.for(`errors.messages.${type}`));
+    defaults.push(`:errors.attributes.${attribute}.${type}`);
+    defaults.push(`:errors.messages.${type}`);
 
-    const key = defaults.shift();
+    const key = (defaults.shift() as string).slice(1);
     if (options.message != null && options.message !== false) {
       defaults = [options.message];
       delete options.message;
     }
     options.default = defaults;
 
-    return I18n.translate(key as TranslateKey, options) as string;
+    return I18n.translate(key, options) as string;
   }
 
   constructor(

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -337,12 +337,10 @@ export class ModelName {
     if (i18nKeys.length === 0 || i18nScope.length === 0) return this._humanFallback;
 
     const [key, ...defaults] = i18nKeys as unknown[];
-    // Ruby Symbol default = "look this key up"; the backend spells that arm as
-    // a real JS symbol (story `i18n-symbol-values-are-colon-strings`).
-    const defaultChain: unknown[] = defaults.map((k) => Symbol.for(k as string));
+    const defaultChain: unknown[] = defaults.map((k) => `:${k as string}`);
     defaultChain.push(MISSING_TRANSLATION);
 
-    let translation = I18n.translate(Symbol.for(key as string), {
+    let translation = I18n.translate(key as string, {
       scope: i18nScope,
       count: 1,
       default: defaultChain,

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -9,6 +9,7 @@
  * express the contract here as an interface for the static side.
  */
 import { humanize, isPresent } from "@blazetrails/activesupport";
+import type { TranslateKey } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 import type { ModelName } from "./naming.js";
 
@@ -101,7 +102,7 @@ export function humanAttributeName(
   if (options.default != null) defaults.push(options.default);
   if (!raiseOnMissing) defaults.push(MISSING_TRANSLATION);
 
-  let translation = I18n.translate((defaults.shift() as string).slice(1), {
+  let translation = I18n.translate(defaults.shift() as TranslateKey, {
     count: 1,
     raise: raiseOnMissing,
     ...options,

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -9,7 +9,6 @@
  * express the contract here as an interface for the static side.
  */
 import { humanize, isPresent } from "@blazetrails/activesupport";
-import type { TranslateKey } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 import type { ModelName } from "./naming.js";
 
@@ -85,26 +84,24 @@ export function humanAttributeName(
       separator = ".";
     }
 
-    defaults = this.lookupAncestors().map((klass) =>
-      // Ruby Symbol default = "look this key up"; the backend spells that arm as
-      // a real JS symbol (story `i18n-symbol-values-are-colon-strings`).
-      Symbol.for(`${this.i18nScope}.attributes.${klass.modelName.i18nKey}${separator}${key}`),
+    defaults = this.lookupAncestors().map(
+      (klass) => `:${this.i18nScope}.attributes.${klass.modelName.i18nKey}${separator}${key}`,
     );
-    defaults.push(Symbol.for(`${this.i18nScope}.attributes.${key}`));
-    defaults.push(Symbol.for(`attributes.${key}`));
+    defaults.push(`:${this.i18nScope}.attributes.${key}`);
+    defaults.push(`:attributes.${key}`);
   } else {
-    defaults = this.lookupAncestors().map((klass) =>
-      Symbol.for(`${this.i18nScope}.attributes.${klass.modelName.i18nKey}.${attribute}`),
+    defaults = this.lookupAncestors().map(
+      (klass) => `:${this.i18nScope}.attributes.${klass.modelName.i18nKey}.${attribute}`,
     );
   }
 
   const raiseOnMissing = options.raise ?? _raiseOnMissingTranslations;
 
-  defaults.push(Symbol.for(`attributes.${attribute}`));
+  defaults.push(`:attributes.${attribute}`);
   if (options.default != null) defaults.push(options.default);
   if (!raiseOnMissing) defaults.push(MISSING_TRANSLATION);
 
-  let translation = I18n.translate(defaults.shift() as TranslateKey, {
+  let translation = I18n.translate((defaults.shift() as string).slice(1), {
     count: 1,
     raise: raiseOnMissing,
     ...options,

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -199,9 +199,9 @@ export class ValidationError<TModel extends ModelWithErrors = ModelWithErrors>
     // `i18nScope` as a scope when the class actually exposes a string.
     const rawScope = (model as { constructor?: { i18nScope?: unknown } }).constructor?.i18nScope;
     const scope = typeof rawScope === "string" ? rawScope : "activemodel";
-    const message = I18n.t(Symbol.for(`${scope}.errors.messages.model_invalid`), {
+    const message = I18n.t(`${scope}.errors.messages.model_invalid`, {
       errors,
-      default: Symbol.for("errors.messages.model_invalid"),
+      default: ":errors.messages.model_invalid",
     }) as string;
     super(message);
     this.name = "ValidationError";

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -56,13 +56,10 @@ export class RecordInvalid extends ActiveRecordError {
     let message: string;
     if (record) {
       const errors = (record.errors?.fullMessages as string[] | undefined)?.join(", ") ?? "";
-      message = I18n.t(
-        Symbol.for(`${record.constructor.i18nScope}.errors.messages.record_invalid`),
-        {
-          errors,
-          default: Symbol.for("errors.messages.record_invalid"),
-        },
-      ) as string;
+      message = I18n.t(`${record.constructor.i18nScope}.errors.messages.record_invalid`, {
+        errors,
+        default: ":errors.messages.record_invalid",
+      }) as string;
     } else {
       message = "Record invalid";
     }

--- a/packages/i18n/src/backend/fallbacks.test.ts
+++ b/packages/i18n/src/backend/fallbacks.test.ts
@@ -110,9 +110,9 @@ describe("I18nBackendFallbacksTranslateTest", () => {
   });
 
   it("keeps the count option when defaulting to a different key", () => {
-    expect(
-      t("non_existent", { default: Symbol.for("interpolate_count"), count: 10, value: 5 }),
-    ).toBe("Interpolate 5 10");
+    expect(t("non_existent", { default: ":interpolate_count", count: 10, value: 5 })).toBe(
+      "Interpolate 5 10",
+    );
   });
 
   it("returns the :de translation for a missing :'de-DE' when :default is a String", () => {
@@ -121,11 +121,11 @@ describe("I18nBackendFallbacksTranslateTest", () => {
   });
 
   it("returns the :de translation for a missing :'de-DE' when defaults is a Symbol (which exists in :en)", () => {
-    expect(t("bar", { locale: "de-DE", default: [Symbol.for("buz")] })).toBe("Bar in :de");
+    expect(t("bar", { locale: "de-DE", default: [":buz"] })).toBe("Bar in :de");
   });
 
   it("returns the :'de-DE' default :baz translation for a missing :'de-DE' (which exists in :de)", () => {
-    expect(t("bar", { locale: "de-DE", default: [Symbol.for("baz")] })).toBe("Baz in :de-DE");
+    expect(t("bar", { locale: "de-DE", default: [":baz"] })).toBe("Baz in :de-DE");
   });
 
   it("returns the :de translation for a missing :'de-DE' when :default is a Proc", () => {
@@ -150,7 +150,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
       "- de-DE.missing_baz",
     ].join("\n");
 
-    expect(t("missing_bar", { locale: "de-DE", default: [Symbol.for("missing_baz")] })).toBe(
+    expect(t("missing_bar", { locale: "de-DE", default: [":missing_baz"] })).toBe(
       translationMissingMessage,
     );
   });
@@ -162,7 +162,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
   });
 
   it("returns the :'de-DE' default :baz translation for a missing :'de-DE' when defaults contains Symbol", () => {
-    expect(t("missing_foo", { locale: "de-DE", default: [Symbol.for("baz"), "Default Bar"] })).toBe(
+    expect(t("missing_foo", { locale: "de-DE", default: [":baz", "Default Bar"] })).toBe(
       "Baz in :de-DE",
     );
   });
@@ -171,13 +171,13 @@ describe("I18nBackendFallbacksTranslateTest", () => {
     expect(
       t("missing_foo", {
         locale: "de-DE",
-        default: [Symbol.for("missing_bar"), "Default Bar", Symbol.for("baz")],
+        default: [":missing_bar", "Default Bar", ":baz"],
       }),
     ).toBe("Default Bar");
     expect(
       t("missing_foo", {
         locale: "de-DE",
-        default: [Symbol.for("missing_bar"), () => "Default Bar", Symbol.for("baz")],
+        default: [":missing_bar", () => "Default Bar", ":baz"],
       }),
     ).toBe("Default Bar");
   });
@@ -186,7 +186,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
     expect(
       t("missing_foo", {
         locale: "de-DE",
-        default: [Symbol.for("missing_bar"), { other: "Default %{count} Bars" }, "Default Bar"],
+        default: [":missing_bar", { other: "Default %{count} Bars" }, "Default Bar"],
         count: 6,
       }),
     ).toBe("Default 6 Bars");
@@ -219,7 +219,7 @@ describe("I18nBackendFallbacksTranslateTest", () => {
       expect(
         t("model.attrs.foo", {
           locale: "pt-BR",
-          default: [Symbol.for("attrs.foo"), "Foo"],
+          default: [":attrs.foo", "Foo"],
         }),
       ).toBe("Foo");
     } finally {
@@ -303,14 +303,14 @@ describe("I18nBackendFallbacksSymbolResolveRestartsLookupAtOriginalLocale", () =
         gregorian: {
           months: {
             format: {
-              abbreviated: Symbol.for("calendars.gregorian.months.format.wide"),
+              abbreviated: ":calendars.gregorian.months.format.wide",
               wide: {
                 1: "M01",
                 // Other months omitted for brevity
               },
             },
             "stand-alone": {
-              abbreviated: Symbol.for("calendars.gregorian.months.format.abbreviated"),
+              abbreviated: ":calendars.gregorian.months.format.abbreviated",
             },
           },
         },
@@ -351,7 +351,7 @@ describe("RegressionTestFor617", () => {
   });
 
   it("model scope resolution", () => {
-    const defaults = [Symbol.for("product"), "Ticket"];
+    const defaults = [":product", "Ticket"];
     const options = { scope: ["activerecord", "models"], count: 1, default: defaults };
     expect(t("product/ticket", options)).toBe("Ticket");
   });

--- a/packages/i18n/src/backend/fallbacks.trails.test.ts
+++ b/packages/i18n/src/backend/fallbacks.trails.test.ts
@@ -40,12 +40,12 @@ describe("Backend::Fallbacks over the ActiveRecord error-message scopes", () => 
       `activerecord.errors.messages.${type}`,
     ];
     const translation = catchException(() =>
-      t(scoped[0], { default: scoped.slice(1).map((key) => Symbol.for(key)), throw: true }),
+      t(scoped[0], { default: scoped.slice(1).map((key) => `:${key}`), throw: true }),
     );
     if (!(translation instanceof MissingTranslation) && translation != null) return translation;
 
     const defaults = [`errors.attributes.${attribute}.${type}`, `errors.messages.${type}`];
-    return t(defaults[0], { default: defaults.slice(1).map((key) => Symbol.for(key)) });
+    return t(defaults[0], { default: defaults.slice(1).map((key) => `:${key}`) });
   }
 
   beforeEach(() => {

--- a/packages/i18n/src/backend/fallbacks.ts
+++ b/packages/i18n/src/backend/fallbacks.ts
@@ -59,6 +59,14 @@ function truthy(value: unknown): boolean {
   return value !== undefined && value !== null && value !== false;
 }
 
+/**
+ * Ruby `Symbol === x`. A Ruby Symbol is a JS string that keeps its leading
+ * colon (`":other.key"`), which is the discriminator Ruby gets from the type.
+ */
+function isSymbol(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(":");
+}
+
 // TS requires exactly `any[]` here: a mixin base must be `new (...args: any[])`.
 type BackendConstructor = abstract new (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -102,7 +110,7 @@ export function Fallbacks<T extends BackendConstructor>(
      */
     override translate(
       locale: Locale | null | undefined,
-      key: TranslationKey | symbol | null | undefined,
+      key: TranslationKey | null | undefined,
       options: TranslateOptions = EMPTY_HASH,
     ): unknown {
       if (!truthy("fallback" in options ? options.fallback : true)) {
@@ -147,7 +155,7 @@ export function Fallbacks<T extends BackendConstructor>(
 
     protected override resolveEntry(
       locale: Locale,
-      object: TranslationKey | symbol | null | undefined,
+      object: TranslationKey | null | undefined,
       subject: unknown,
       options: TranslateOptions = EMPTY_HASH,
     ): unknown {
@@ -155,8 +163,8 @@ export function Fallbacks<T extends BackendConstructor>(
       const result = catchException(() => {
         if ("fallbackInProgress" in options) delete options.fallbackInProgress;
 
-        if (typeof subject === "symbol") {
-          return t(subject, {
+        if (isSymbol(subject)) {
+          return t(subject.slice(1), {
             ...options,
             locale: options.fallbackOriginalLocale as Locale,
             throw: true,
@@ -180,14 +188,9 @@ export function Fallbacks<T extends BackendConstructor>(
       return result instanceof MissingTranslation ? null : result;
     }
 
-    /**
-     * A Ruby Symbol default is a real JS symbol here, which is what
-     * `Base#resolve` already dispatches on (base.rb:203); converging both onto
-     * the `":name"` spelling is story `i18n-symbol-values-are-colon-strings`.
-     */
     extractNonSymbolDefaultBang(options: TranslateOptions): unknown {
       const defaults = [options.default].flat(Infinity as 1);
-      const firstNonSymbolDefault = defaults.find((default_) => typeof default_ !== "symbol");
+      const firstNonSymbolDefault = defaults.find((default_) => !isSymbol(default_));
       if (truthy(firstNonSymbolDefault)) {
         options.default = defaults.slice(0, defaults.indexOf(firstNonSymbolDefault));
       }
@@ -196,7 +199,7 @@ export function Fallbacks<T extends BackendConstructor>(
 
     override exists(
       locale: Locale,
-      key: TranslationKey | symbol,
+      key: TranslationKey,
       options: TranslateOptions = EMPTY_HASH,
     ): boolean {
       if (!truthy("fallback" in options ? options.fallback : true)) {
@@ -218,7 +221,7 @@ export function Fallbacks<T extends BackendConstructor>(
     protected onFallback(
       _originalLocale: Locale,
       _fallbackLocale: Locale,
-      _key: TranslationKey | symbol | null | undefined,
+      _key: TranslationKey | null | undefined,
       _options: TranslateOptions,
     ): unknown {
       return null;

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -339,8 +339,6 @@ export function withLocale<T>(tmpLocale: Locale | false | null | undefined, bloc
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
   if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
   if (key === null || key === undefined) return [];
-  // Ruby `key.to_s`, where a Symbol key is a JS string carrying its leading
-  // colon (`":other.key"`) and `to_s` drops it.
   if (typeof key === "string" && key.startsWith(":")) key = key.slice(1);
   const keys = String(key)
     .split(separator)

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -339,7 +339,9 @@ export function withLocale<T>(tmpLocale: Locale | false | null | undefined, bloc
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
   if (Array.isArray(key)) return key.flatMap((k) => normalizeKey(k, separator));
   if (key === null || key === undefined) return [];
-  if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;
+  // Ruby `key.to_s`, where a Symbol key is a JS string carrying its leading
+  // colon (`":other.key"`) and `to_s` drops it.
+  if (typeof key === "string" && key.startsWith(":")) key = key.slice(1);
   const keys = String(key)
     .split(separator)
     .filter((k) => k !== "");


### PR DESCRIPTION
`pnpm build` fails on `main` at b548cd2e with eight `TS2345` errors, which reds
**Build & Type Check**, **Unit Tests**, **Leaf Tests** and **Virtualized DX Type
Tests** together.

#6032 converted `packages/i18n/src/backend/base.ts` and `simple.ts` from real JS
symbols to the `":name"` spelling for Ruby Symbol *values*. The callers that
build those values were merged in parallel (#6026, #6029) and still hand in
`Symbol.for(...)`, so the two halves no longer typecheck against each other.

## What changed

- **`i18n/backend/fallbacks.ts`** (`i18n/lib/i18n/backend/fallbacks.rb:68`) —
  `when Symbol` is `isSymbol(subject)` and the recursive `I18n.translate` takes
  `subject.slice(1)`, matching `Base#resolve` (`base.rb:154`).
  `extract_non_symbol_default!` (`fallbacks.rb:88`) tests the same predicate.
  The `| symbol` arms come off the `key` / `object` parameters: `normalize_keys`
  sends a Symbol and a String through the same `to_s`, so a translate *key* does
  not discriminate on type.
- **`i18n.ts` `normalizeKey`** (`i18n.rb:441`) kept a `Symbol.keyFor` arm #6032
  missed; it is now the colon-stripping `key.to_s` of `i18n.rb:447`. That is what
  makes `MissingTranslation`'s "Options considered were" list render
  `de-DE.missing_baz` rather than `de-DE.:missing_baz`.
- **`activemodel`** `naming.ts` (`naming.rb:206`), `translation.ts`
  (`translation.rb:35`), `error.ts` (`error.rb:100,130`), `validations.ts`
  (`validations.rb:496`) and **`activerecord/validations.ts`**
  (`validations.rb:60`) build their `default:` chains as `":key"` strings. Where
  Ruby shifts a Symbol off the chain to use as the key it hands that Symbol
  straight to `I18n.translate` — `to_s` happens inside `normalize_key` — so the
  call sites pass the Symbol spelling through rather than pre-stripping it.
- The two `fallbacks` test files move their `Symbol.for(...)` fixtures to the
  same spelling. No test name changes.

`isSymbol` is a third file-local copy of the predicate `base.ts` and `simple.ts`
already carry — the idiom #6032 settled for Ruby's `Symbol === x`. It is not
exported, so it adds no surface (`pnpm api:extra` is unchanged).

## Verification

- `pnpm build` clean (was eight `TS2345` errors).
- `pnpm vitest run packages/activemodel` — 1984 passed.
- `pnpm vitest run packages/i18n` + the four activemodel suites — 695 passed.
- `pnpm vitest run packages/activerecord/src/validations{.test.ts,}` — 136 passed.
- `pnpm api:calls` OK (14 baselined), `pnpm api:calls:wide` OK (2218 baselined).
  Neither baseline widened.

## Out of scope

One i18n failure predates this branch and is untouched by it: `exceptions.test.ts`
expects Ruby 3.4's `{this: "was given"}` Hash inspect where we still emit the
pre-3.4 `{:this=>"was given"}`. Confirmed by reproducing it on a stashed tree at
b548cd2e. Filed as `0061-ci-failures/i18n-hash-inspect-ruby-34-form` rather than
folded in here.

`ModelName#i18nKey` returns a plain string where Rails' `i18n_key` is a Symbol
(`naming.rb:189`), so `naming.ts` re-adds the colon when it builds a default
chain out of `i18nKeys`. That is the contract #6032 chose for keys and changing
it would ripple through every `${i18nKey}` key path; not touched here.

Closes-story: red-b548cd2e
