### PR TITLE
fix(i18n): escape non-printable Unicode in String inspect as MRI does

### DIFF
--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -137,4 +137,16 @@ describe("exceptions", () => {
     expect(inspect("café 😀")).toBe('"café 😀"');
     expect(inspect("a\ud800b")).toBe('"a\\xED\\xA0\\x80b"');
   });
+
+  it("inspects a non-printable code point the way Ruby's String#inspect does", () => {
+    expect(inspect("͸")).toBe('"\\u0378"');
+    expect(inspect("퟿")).toBe('"\\uD7FF"');
+    expect(inspect("￾")).toBe('"\\uFFFE"');
+    expect(inspect("  ")).toBe('"\\u2028\\u2029"');
+    expect(inspect("\u{10ffff}")).toBe('"\\u{10FFFF}"');
+    expect(inspect("​")).toBe('"​"');
+    expect(inspect("­")).toBe('"­"');
+    expect(inspect("")).toBe('""');
+    expect(inspect(" ᠎")).toBe('" ᠎"');
+  });
 });

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -40,6 +40,16 @@ const RUBY_ESCAPES: Record<string, string> = {
 };
 
 /**
+ * MRI escapes every code point `rb_enc_isprint` rejects, which is wider than
+ * the C0/DEL/C1 controls: unassigned code points (`"͸".inspect` =>
+ * `"\\u0378"`), noncharacters (`"￾"`) and the line and paragraph
+ * separators all render escaped. `\p{Cf}` does not — soft hyphen, ZWSP and
+ * U+1D173 all print literally — and neither does private use (`\p{Co}`) or
+ * `\p{Zs}`. Surrogates are `\p{Cs}` but take the invalid-byte arm below.
+ */
+const NONPRINTABLE = /^[\p{Cc}\p{Cn}\p{Zl}\p{Zp}]$/u;
+
+/**
  * Ruby `String#inspect` (MRI `string.c`, `rb_str_inspect`). `JSON.stringify`
  * is not a stand-in: Ruby renders ESC as `\e`, escapes `#` before `{`, `$` and
  * `@` so the result re-parses as the same string, prints printable non-ASCII
@@ -58,8 +68,11 @@ function inspectString(value: string): string {
       result += "\\#";
     } else if (char in RUBY_ESCAPES) {
       result += RUBY_ESCAPES[char];
-    } else if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
-      result += `\\u${code.toString(16).toUpperCase().padStart(4, "0")}`;
+    } else if (NONPRINTABLE.test(char)) {
+      result +=
+        code <= 0xffff
+          ? `\\u${code.toString(16).toUpperCase().padStart(4, "0")}`
+          : `\\u{${code.toString(16).toUpperCase()}}`;
     } else if (code >= 0xd800 && code <= 0xdfff) {
       for (const byte of [0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f)]) {
         result += `\\x${byte.toString(16).toUpperCase()}`;


### PR DESCRIPTION
`inspectString` (`packages/i18n/src/exceptions.ts`) ports MRI's `rb_str_inspect`
(`string.c`), which escapes every code point `rb_enc_isprint` rejects. We only
escaped C0 controls, DEL and the C1 range, so unassigned code points,
noncharacters and the line/paragraph separators rendered literally — a
translation or interpolation value containing one produced a message the gem
would not (`vendor/i18n/lib/i18n/exceptions.rb:92`, `:99`, `:106`).

Replaces the hardcoded `code >= 0x80 && code <= 0x9f` test with an
`rb_enc_isprint` analogue, and adds MRI's `\u{XXXXX}` spelling for code points
above the BMP (`rb_str_inspect` switches form at `0xFFFF`).

Each category was checked against MRI rather than inferred from `\p{C}`:

- escaped: `"͸"` (Cn, unassigned) => `"͸"`, `"퟿"`, `"￾"`
  (noncharacter), U+2028/U+2029, `"\u{10FFFF}"`
- literal: ZWSP, soft hyphen and U+1D173 (all Cf), U+E000 (Co), U+2000 (Zs),
  U+180E

So the class is `Cc`, `Cn`, `Zl`, `Zp` — `Cf`, `Co` and `Zs` are printable in
MRI and stay out of it, and `Cs` is left to the existing invalid-byte arm that
renders a lone surrogate as `\xNN` bytes.

Existing inspect expectations are unchanged.

Closes-story: i18n-inspect-string-nonprintable-unicode
