### PR TITLE
refactor(i18n): drop the dead JS-symbol arm from normalizeKey

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -163,7 +163,7 @@ function isSymbol(value: unknown): value is string {
   return typeof value === "string" && value.startsWith(":");
 }
 
-/** Ruby `#to_s`, for the values a format argument can hold. */
+/** Ruby `#to_s` (i18n gem `lib/i18n.rb:447`), for the values a format argument can hold. */
 function toS(subject: unknown): string {
   if (subject == null) return "";
   return isSymbol(subject) ? subject.slice(1) : String(subject);

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -357,11 +357,6 @@ export function withLocale<T>(tmpLocale: Locale | false | null | undefined, bloc
 
 const normalizedKeyCache = newDoubleNestedCache();
 
-/**
- * Ruby's `key.to_s.split(separator)` (i18n gem `lib/i18n.rb:447`). Callers
- * apply `Symbol#to_s` themselves, so a Symbol-shaped `":name"` key never
- * reaches here.
- */
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
   let bySeparator = normalizedKeyCache.get(separator);
   if (bySeparator === undefined) {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -358,9 +358,9 @@ export function withLocale<T>(tmpLocale: Locale | false | null | undefined, bloc
 const normalizedKeyCache = newDoubleNestedCache();
 
 /**
- * Ruby's `key.to_s` on a Symbol is its name; `String(symbol)` is
- * `"Symbol(name)"`, which would otherwise reach the `Translation missing`
- * message through `MissingTranslation#keys`.
+ * Ruby's `key.to_s.split(separator)` (i18n gem `lib/i18n.rb:447`). Callers
+ * apply `Symbol#to_s` themselves, so a Symbol-shaped `":name"` key never
+ * reaches here.
  */
 function normalizeKey(key: unknown, separator: string): TranslationKey[] {
   let bySeparator = normalizedKeyCache.get(separator);
@@ -376,7 +376,6 @@ function normalizeKey(key: unknown, separator: string): TranslationKey[] {
     } else if (key === null || key === undefined) {
       normalized = [];
     } else {
-      if (typeof key === "symbol") key = Symbol.keyFor(key) ?? key.description;
       const keys = String(key)
         .split(separator)
         .filter((k) => k !== "");


### PR DESCRIPTION
Rails `normalize_key` (i18n gem `lib/i18n.rb:441-447`) is `key.to_s.split(separator)` — it has no Symbol branch. PR #6032 moved Ruby Symbol *values* onto the `":name"` spelling and #6031 converged the callers to apply `Symbol#to_s` at each call site, so nothing hands a JS `Symbol` to `I18n.translate` any more and the `typeof key === "symbol"` arm was unreachable.

Removes the arm (and the JSDoc that only existed to explain it), leaving the faithful `String(key)`, and cites `i18n.rb:447` on `normalizeKey`.

No behaviour change: `pnpm vitest run packages/i18n packages/activemodel` green (2337 tests). `pnpm api:calls` / `pnpm api:calls:wide` OK.

Closes-story: i18n-normalizekey-dead-symbol-arm
