### PR TITLE
feat(activesupport): consult I18n support.array connectors in toSentence

### DIFF
--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -57,6 +57,10 @@ export function inGroupsOf<T>(
 /**
  * Convert an array to a sentence string.
  * `["a", "b", "c"]` → `"a, b, and c"`
+ *
+ * Ruby's `default_connectors.merge!(options)` overrides on key presence; a TS
+ * caller forwarding an absent option passes `undefined`, which must not
+ * override, so the merge skips `undefined` values.
  */
 export function toSentence(
   array: string[],
@@ -80,8 +84,6 @@ export function toSentence(
     Object.assign(defaultConnectors, camelizeI18nKeys(i18nConnectors));
   }
   for (const [k, v] of Object.entries(options)) {
-    // Ruby's `merge!(options)` overrides on key presence; a TS caller forwarding
-    // an absent option passes `undefined`, which must not override.
     if (v !== undefined) defaultConnectors[k] = v as string;
   }
   const { wordsConnector, twoWordsConnector, lastWordConnector } = defaultConnectors;

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -2,6 +2,27 @@
  * Array utilities mirroring Rails ActiveSupport array extensions.
  */
 
+import { I18n } from "./i18n.js";
+
+/**
+ * `support.array` is stored under Ruby's snake_case keys, but the options
+ * `toSentence` merges them into are camelCase. Same shape as
+ * `number-helper/number-converter.ts`'s own key map.
+ */
+const I18N_KEY_MAP: Record<string, string> = {
+  words_connector: "wordsConnector",
+  two_words_connector: "twoWordsConnector",
+  last_word_connector: "lastWordConnector",
+};
+
+function camelizeI18nKeys(obj: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    result[I18N_KEY_MAP[k] ?? k] = v;
+  }
+  return result;
+}
+
 /**
  * Wraps a value in an array. `null`/`undefined` → `[]`, arrays pass through,
  * scalars become `[value]`.
@@ -43,13 +64,27 @@ export function toSentence(
     wordsConnector?: string;
     twoWordsConnector?: string;
     lastWordConnector?: string;
+    locale?: string | false;
   } = {},
 ): string {
-  const {
-    wordsConnector = ", ",
-    twoWordsConnector = " and ",
-    lastWordConnector = ", and ",
-  } = options;
+  const defaultConnectors: Record<string, string> = {
+    wordsConnector: ", ",
+    twoWordsConnector: " and ",
+    lastWordConnector: ", and ",
+  };
+  if (options.locale !== false) {
+    const i18nConnectors = I18n.translate("support.array", {
+      locale: options.locale ?? null,
+      default: {},
+    }) as Record<string, string>;
+    Object.assign(defaultConnectors, camelizeI18nKeys(i18nConnectors));
+  }
+  for (const [k, v] of Object.entries(options)) {
+    // Ruby's `merge!(options)` overrides on key presence; a TS caller forwarding
+    // an absent option passes `undefined`, which must not override.
+    if (v !== undefined) defaultConnectors[k] = v as string;
+  }
+  const { wordsConnector, twoWordsConnector, lastWordConnector } = defaultConnectors;
 
   if (array.length === 0) return "";
   if (array.length === 1) return array[0];

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -2,6 +2,7 @@
  * Array utilities mirroring Rails ActiveSupport array extensions.
  */
 
+import { assertValidKeys } from "./hash-utils.js";
 import { I18n } from "./i18n.js";
 
 /**
@@ -71,6 +72,8 @@ export function toSentence(
     locale?: string | false;
   } = {},
 ): string {
+  assertValidKeys(options, ["wordsConnector", "twoWordsConnector", "lastWordConnector", "locale"]);
+
   const defaultConnectors: Record<string, string> = {
     wordsConnector: ", ",
     twoWordsConnector: " and ",

--- a/packages/activesupport/src/core-ext/array/conversions.test.ts
+++ b/packages/activesupport/src/core-ext/array/conversions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import { toSentence } from "../../array-utils.js";
+import { ArgumentError } from "../../hash-utils.js";
 
 describe("ToSentenceTest", () => {
   it("plain array to sentence", () => {
@@ -49,8 +50,11 @@ describe("ToSentenceTest", () => {
   });
 
   it("with invalid options", () => {
-    // Unknown options are ignored
-    expect(toSentence(["a", "b", "c"], {})).toBe("a, b, and c");
+    expect(() => toSentence(["one", "two"], { passing: "invalid option" } as never)).toThrowError(
+      new ArgumentError(
+        "Unknown key: :passing. Valid keys are: :wordsConnector, :twoWordsConnector, :lastWordConnector, :locale",
+      ),
+    );
   });
 
   it("always returns string", () => {

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -154,23 +154,30 @@ describe("I18nTest", () => {
   });
 
   it("to sentence", () => {
-    expect(toSentence(["a", "b", "c"])).toBe("a, b, and c");
-
-    I18n.backend().storeTranslations("en", {
-      support: { array: { two_words_connector: " & " } },
-    });
-    const twoWords = I18n.translate("support.array.two_words_connector") as string;
-    expect(toSentence(["a", "b"], { twoWordsConnector: twoWords })).toBe("a & b");
-
-    I18n.backend().storeTranslations("en", {
-      support: { array: { last_word_connector: " and " } },
-    });
-    const lastWord = I18n.translate("support.array.last_word_connector") as string;
-    expect(toSentence(["a", "b", "c"], { lastWordConnector: lastWord })).toBe("a, b and c");
+    const defaultTwoWordsConnector = I18n.translate("support.array.two_words_connector");
+    const defaultLastWordConnector = I18n.translate("support.array.last_word_connector");
+    try {
+      expect(toSentence(["a", "b", "c"])).toBe("a, b, and c");
+      I18n.backend().storeTranslations("en", {
+        support: { array: { two_words_connector: " & " } },
+      });
+      expect(toSentence(["a", "b"])).toBe("a & b");
+      I18n.backend().storeTranslations("en", {
+        support: { array: { last_word_connector: " and " } },
+      });
+      expect(toSentence(["a", "b", "c"])).toBe("a, b and c");
+    } finally {
+      I18n.backend().storeTranslations("en", {
+        support: { array: { two_words_connector: defaultTwoWordsConnector } },
+      });
+      I18n.backend().storeTranslations("en", {
+        support: { array: { last_word_connector: defaultLastWordConnector } },
+      });
+    }
   });
 
   it("to sentence with empty i18n store", () => {
-    expect(toSentence(["a", "b", "c"])).toBe("a, b, and c");
+    expect(toSentence(["a", "b", "c"], { locale: "empty" })).toBe("a, b, and c");
   });
 
   it("ordinals resolve through the number.nth lambdas", () => {


### PR DESCRIPTION
`toSentence` hardcoded the three connectors as TS default parameters, so a
locale defining `support.array.*` was never consulted and `locale:` was not
accepted at all.

Ports `activesupport/lib/active_support/core_ext/array/conversions.rb:60-84`:
the hardcoded `default_connectors`, then `I18n.translate(:'support.array',
locale: options[:locale], default: {})` merged over them when
`options[:locale] != false`, then the caller's options merged over both.
Translation keys are snake_cased in the store, so they go through a key map,
same shape as the one `number-helper/number-converter.ts:62-75` already has.

Restores the two ported tests to their
`activesupport/test/i18n_test.rb:89-105` bodies: `to sentence` now calls bare
`toSentence` and relies on the lookup inside it, with the `ensure` restore of
the two defaults; `to sentence with empty i18n store` passes `locale: "empty"`.

Closes-story: as-to-sentence-i18n-connectors
