### PR TITLE
feat(actionview): consult I18n support.array connectors in toSentence

### DIFF
--- a/packages/actionview/src/helpers/output-safety-helper.ts
+++ b/packages/actionview/src/helpers/output-safety-helper.ts
@@ -1,5 +1,6 @@
 import {
   I18n,
+  assertValidKeys,
   SafeBuffer,
   htmlEscape,
   htmlEscapeOnce as _htmlEscapeOnce,
@@ -95,7 +96,7 @@ export interface ToSentenceOptions {
   wordsConnector?: string | SafeBuffer | null;
   twoWordsConnector?: string | SafeBuffer | null;
   lastWordConnector?: string | SafeBuffer | null;
-  locale?: string;
+  locale?: string | false;
 }
 
 /**
@@ -103,17 +104,31 @@ export interface ToSentenceOptions {
  * HTML-safe-aware version of Array#to_sentence.
  */
 export function toSentence(array: unknown[], options: ToSentenceOptions = {}): SafeBuffer {
+  assertValidKeys(options as Record<string, unknown>, [
+    "wordsConnector",
+    "twoWordsConnector",
+    "lastWordConnector",
+    "locale",
+  ]);
+
   const defaultConnectors: Record<string, string | SafeBuffer | null> = {
     wordsConnector: ", ",
     twoWordsConnector: " and ",
     lastWordConnector: ", and ",
   };
-  const i18nConnectors = I18n.translate("support.array", {
-    locale: options.locale ?? null,
-    default: {},
-  }) as Record<string, string>;
-  for (const [k, v] of Object.entries(i18nConnectors)) {
-    defaultConnectors[I18N_KEY_MAP[k] ?? k] = v;
+  // `output_safety_helper.rb:50` guards only on `defined?(I18n)`, but its
+  // ActiveSupport twin also skips the lookup for `locale: false`
+  // (core_ext/array/conversions.rb:68) and this is the html_safe-aware version
+  // of that method; `I18n.translate` would otherwise read `false` as "no locale
+  // given" and fall back to `I18n.locale` (i18n.ts:238).
+  if (options.locale !== false) {
+    const i18nConnectors = I18n.translate("support.array", {
+      locale: options.locale ?? null,
+      default: {},
+    }) as Record<string, string>;
+    for (const [k, v] of Object.entries(i18nConnectors)) {
+      defaultConnectors[I18N_KEY_MAP[k] ?? k] = v;
+    }
   }
   // Ruby's `default_connectors.merge!(options)` overrides on key presence; a TS
   // caller forwarding an absent option passes `undefined`, which must not

--- a/packages/actionview/src/helpers/output-safety-helper.ts
+++ b/packages/actionview/src/helpers/output-safety-helper.ts
@@ -1,4 +1,5 @@
 import {
+  I18n,
   SafeBuffer,
   htmlEscape,
   htmlEscapeOnce as _htmlEscapeOnce,
@@ -80,6 +81,16 @@ function flatten(arr: unknown[]): unknown[] {
   return result;
 }
 
+/**
+ * `support.array` is stored under Ruby's snake_case keys, but the options
+ * `toSentence` merges them into are camelCase.
+ */
+const I18N_KEY_MAP: Record<string, string> = {
+  words_connector: "wordsConnector",
+  two_words_connector: "twoWordsConnector",
+  last_word_connector: "lastWordConnector",
+};
+
 export interface ToSentenceOptions {
   wordsConnector?: string | SafeBuffer | null;
   twoWordsConnector?: string | SafeBuffer | null;
@@ -92,24 +103,25 @@ export interface ToSentenceOptions {
  * HTML-safe-aware version of Array#to_sentence.
  */
 export function toSentence(array: unknown[], options: ToSentenceOptions = {}): SafeBuffer {
-  const defaultConnectors = {
+  const defaultConnectors: Record<string, string | SafeBuffer | null> = {
     wordsConnector: ", ",
     twoWordsConnector: " and ",
     lastWordConnector: ", and ",
   };
-
-  const wordsConnector =
-    options.wordsConnector !== undefined
-      ? options.wordsConnector
-      : defaultConnectors.wordsConnector;
-  const twoWordsConnector =
-    options.twoWordsConnector !== undefined
-      ? options.twoWordsConnector
-      : defaultConnectors.twoWordsConnector;
-  const lastWordConnector =
-    options.lastWordConnector !== undefined
-      ? options.lastWordConnector
-      : defaultConnectors.lastWordConnector;
+  const i18nConnectors = I18n.translate("support.array", {
+    locale: options.locale ?? null,
+    default: {},
+  }) as Record<string, string>;
+  for (const [k, v] of Object.entries(i18nConnectors)) {
+    defaultConnectors[I18N_KEY_MAP[k] ?? k] = v;
+  }
+  // Ruby's `default_connectors.merge!(options)` overrides on key presence; a TS
+  // caller forwarding an absent option passes `undefined`, which must not
+  // override, so the merge skips `undefined` values.
+  for (const [k, v] of Object.entries(options)) {
+    if (v !== undefined) defaultConnectors[k] = v as string | SafeBuffer | null;
+  }
+  const { wordsConnector, twoWordsConnector, lastWordConnector } = defaultConnectors;
 
   switch (array.length) {
     case 0:

--- a/packages/actionview/src/template/output-safety-helper.trails.test.ts
+++ b/packages/actionview/src/template/output-safety-helper.trails.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { I18n } from "@blazetrails/activesupport";
+
+import { toSentence } from "../helpers/output-safety-helper.js";
+
+/**
+ * `I18n.reload!` would drop the `en` locale Active Support stores at import
+ * time (it is not on `I18n.load_path` yet — see activesupport/src/i18n.ts), so
+ * these restore `support.array` to its `locale/en.yml` values instead.
+ */
+const EN_ARRAY_CONNECTORS = {
+  words_connector: ", ",
+  two_words_connector: " and ",
+  last_word_connector: ", and ",
+};
+
+I18n.setEnforceAvailableLocales(false);
+
+describe("OutputSafetyHelperI18nTest", () => {
+  afterEach(() => {
+    I18n.backend().storeTranslations("en", { support: { array: EN_ARRAY_CONNECTORS } });
+  });
+
+  it("to_sentence uses the support.array connectors from I18n", () => {
+    I18n.backend().storeTranslations("en", {
+      support: { array: { words_connector: " o ", last_word_connector: " o al menos " } },
+    });
+
+    expect(toSentence(["one", "two", "three"]).toString()).toBe("one o two o al menos three");
+  });
+
+  it("to_sentence looks the connectors up under the given locale", () => {
+    I18n.backend().storeTranslations("es", {
+      support: { array: { two_words_connector: " y " } },
+    });
+
+    expect(toSentence(["one", "two"], { locale: "es" }).toString()).toBe("one y two");
+  });
+
+  it("to_sentence lets the caller options win over the I18n connectors", () => {
+    I18n.backend().storeTranslations("en", {
+      support: { array: { two_words_connector: " y " } },
+    });
+
+    expect(toSentence(["one", "two"], { twoWordsConnector: " - " }).toString()).toBe("one - two");
+  });
+});

--- a/packages/actionview/src/template/output-safety-helper.trails.test.ts
+++ b/packages/actionview/src/template/output-safety-helper.trails.test.ts
@@ -44,4 +44,18 @@ describe("OutputSafetyHelperI18nTest", () => {
 
     expect(toSentence(["one", "two"], { twoWordsConnector: " - " }).toString()).toBe("one - two");
   });
+
+  it("to_sentence skips the I18n lookup for locale: false", () => {
+    I18n.backend().storeTranslations("en", {
+      support: { array: { two_words_connector: " y " } },
+    });
+
+    expect(toSentence(["one", "two"], { locale: false }).toString()).toBe("one and two");
+  });
+
+  it("to_sentence rejects unknown options", () => {
+    expect(() => toSentence(["one", "two"], { passing: "invalid option" } as never)).toThrowError(
+      "Unknown key: :passing. Valid keys are: :wordsConnector, :twoWordsConnector, :lastWordConnector, :locale",
+    );
+  });
 });


### PR DESCRIPTION
`to_sentence` in `output_safety_helper.rb:42-54` merges the `support.array`
connectors from I18n between the hardcoded defaults and the caller's options.
The trails port declared `locale?: string` but never read it, so the connectors
were always the hardcoded defaults. This ports the lookup, in Rails' merge
order, plus the `assert_valid_keys` guard on line 43.

- `output_safety_helper.rb:43` — `assert_valid_keys(:words_connector,
  :two_words_connector, :last_word_connector, :locale)` at method entry.
- `output_safety_helper.rb:45-54` — defaults, then
  `I18n.translate(:'support.array', locale: options[:locale], default: {})`,
  then `merge!(options)`.
- `locale: false` skips the lookup, per the ActiveSupport twin
  (`core_ext/array/conversions.rb:68`). The ActionView helper guards only on
  `defined?(I18n)`, but it is documented as the html_safe-aware version of that
  method, and our `I18n.translate` reads `false` as "no locale given" and falls
  back to `I18n.locale` (`packages/i18n/src/i18n.ts:238`), so passing it through
  would silently apply the default locale's connectors. Justified at the call
  site.
- The I18n store keys are Ruby snake_case; a small key map camelCases the three
  connector names on the way into the options hash.
- `undefined`-valued option keys are skipped, since Ruby's `merge!` overrides on
  key *presence* and a TS caller forwarding an absent kwarg passes `undefined`.

On test placement: no ported test worked around the missing lookup — Rails'
`output_safety_helper_test.rb` has no I18n case and no `to_sentence` invalid-key
case, so there is no Rails body in `OutputSafetyHelperTest` to restore, and
every ported name/body there is unchanged. Adding TS-only tests under the
`OutputSafetyHelperTest` describe would inject test names `test:compare` cannot
match to Rails, which is why this repo puts TS-only coverage in a `*.trails.test.ts`
file. Coverage lives in `output-safety-helper.trails.test.ts`: I18n connectors,
per-locale lookup, caller-options precedence, `locale: false`, and the
`ArgumentError` message from `assert_valid_keys`.

Closes-story: actionview-to-sentence-i18n-connectors
