### PR TITLE
fix(actionview): drop the locale: false guard toSentence must not have

### DIFF
--- a/packages/actionview/src/helpers/output-safety-helper.ts
+++ b/packages/actionview/src/helpers/output-safety-helper.ts
@@ -116,19 +116,12 @@ export function toSentence(array: unknown[], options: ToSentenceOptions = {}): S
     twoWordsConnector: " and ",
     lastWordConnector: ", and ",
   };
-  // `output_safety_helper.rb:50` guards only on `defined?(I18n)`, but its
-  // ActiveSupport twin also skips the lookup for `locale: false`
-  // (core_ext/array/conversions.rb:68) and this is the html_safe-aware version
-  // of that method; `I18n.translate` would otherwise read `false` as "no locale
-  // given" and fall back to `I18n.locale` (i18n.ts:238).
-  if (options.locale !== false) {
-    const i18nConnectors = I18n.translate("support.array", {
-      locale: options.locale ?? null,
-      default: {},
-    }) as Record<string, string>;
-    for (const [k, v] of Object.entries(i18nConnectors)) {
-      defaultConnectors[I18N_KEY_MAP[k] ?? k] = v;
-    }
+  const i18nConnectors = I18n.translate("support.array", {
+    locale: options.locale ?? null,
+    default: {},
+  }) as Record<string, string>;
+  for (const [k, v] of Object.entries(i18nConnectors)) {
+    defaultConnectors[I18N_KEY_MAP[k] ?? k] = v;
   }
   // Ruby's `default_connectors.merge!(options)` overrides on key presence; a TS
   // caller forwarding an absent option passes `undefined`, which must not

--- a/packages/actionview/src/template/output-safety-helper.trails.test.ts
+++ b/packages/actionview/src/template/output-safety-helper.trails.test.ts
@@ -45,12 +45,16 @@ describe("OutputSafetyHelperI18nTest", () => {
     expect(toSentence(["one", "two"], { twoWordsConnector: " - " }).toString()).toBe("one - two");
   });
 
-  it("to_sentence skips the I18n lookup for locale: false", () => {
+  // Unlike Array#to_sentence (core_ext/array/conversions.rb:68), the
+  // html_safe-aware helper has no `locale: false` guard
+  // (output_safety_helper.rb:50), and `I18n.translate` reads `false` as
+  // "no locale given" and falls back to `I18n.locale` (i18n.ts:238).
+  it("to_sentence looks the connectors up under I18n.locale for locale: false", () => {
     I18n.backend().storeTranslations("en", {
       support: { array: { two_words_connector: " y " } },
     });
 
-    expect(toSentence(["one", "two"], { locale: false }).toString()).toBe("one and two");
+    expect(toSentence(["one", "two"], { locale: false }).toString()).toBe("one y two");
   });
 
   it("to_sentence rejects unknown options", () => {


### PR DESCRIPTION
`ActionView::Helpers::OutputSafetyHelper#to_sentence` guards its
`support.array` lookup only on `defined?(I18n)`
(`actionview/lib/action_view/helpers/output_safety_helper.rb:50-53`) — it passes
`options[:locale]` straight into `I18n.translate`. Our port carried over the
`locale: false` guard from the ActiveSupport twin
(`activesupport/lib/active_support/core_ext/array/conversions.rb:68`), where it
is real, and so diverged.

`I18n.translate` does `locale ||= config.locale`, which our port already matches
(`packages/i18n/src/i18n.ts:238`), so a Ruby caller passing `locale: false` to
the ActionView helper gets the default locale's connectors.

- Drop the `options.locale !== false` branch and its justifying comment from
  `packages/actionview/src/helpers/output-safety-helper.ts`; the body now
  matches `output_safety_helper.rb:50-53` line for line.
- `assert_valid_keys` guard and merge order untouched.
- The trails-only `locale: false` test now asserts the Rails behaviour
  (`I18n.locale`'s connectors), with the ActiveSupport contrast noted at the
  test.

`pnpm api:calls` and `pnpm api:calls:wide` both clean; the actionview
output-safety suite passes (5/5).

Closes-story: actionview-to-sentence-locale-false-guard-diverges
