### PR TITLE
fix(api-compare): apply the rb→js token rename so load_rb resolves to loadJs

### DIFF
--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -73,6 +73,15 @@ describe("snakeToCamel", () => {
     expect(snakeToCamel("visit_Erb_Node")).toBe("visitTseNode");
   });
 
+  it("renames `rb` token to `js` (a Ruby source file is a JS one)", () => {
+    // I18n::Backend::Base#load_rb evaluates a locale file written as executable
+    // source in the host language; its port loads a `.js` locale module, so
+    // `load_rb` has to resolve to `loadJs` for api:compare to match it.
+    expect(snakeToCamel("load_rb")).toBe("loadJs");
+    expect(snakeToCamel("rb")).toBe("js");
+    expect(snakeToCamel("rb_handler")).toBe("jsHandler");
+  });
+
   it("does NOT rename `erb` when it appears as a substring of another token", () => {
     // Guard: only standalone snake-case segments should be substituted,
     // not embedded substrings like `verb`, `verbatim`, `superb`, `reverb`.
@@ -80,6 +89,8 @@ describe("snakeToCamel", () => {
     expect(snakeToCamel("verbatim_copy")).toBe("verbatimCopy");
     expect(snakeToCamel("http_verb")).toBe("httpVerb");
     expect(snakeToCamel("superb_thing")).toBe("superbThing");
+    // `erb` must keep winning the alternation over the shorter `rb`.
+    expect(snakeToCamel("compile_erb")).toBe("compileTse");
   });
 });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -30,7 +30,7 @@ const TOKEN_RENAMES: Record<string, string> = {
 
 function applyTokenRenames(snake: string): string {
   return snake.replace(
-    /(^|_)(erb|ERB|Erb)(?=_|$)/g,
+    /(^|_)(erb|ERB|Erb|rb)(?=_|$)/g,
     (_m, pre, tok: string) => pre + TOKEN_RENAMES[tok],
   );
 }


### PR DESCRIPTION
## What changed

`applyTokenRenames` (`scripts/api-compare/conventions.ts:31`) matched only
`erb|ERB|Erb`. `TOKEN_RENAMES` has carried an `rb: "js"` entry since #6017 — with
a comment explaining that `I18n::Backend::Base#load_rb` loads a translation file
written as executable source in the host language, and that its port loads a
`.js` locale module — and `docs/ruby-ts-conventions.md` publishes the rename in
its Token renames table. But the regex never included `rb`, so **the entry was
dead code**: `load_rb` still resolved to `loadRb` and reported missing against
the ported `loadJs`.

This widens the alternation to `erb|ERB|Erb|rb`, making the already-merged,
already-documented rename real. One line, plus a regression test.

## On the scoped skip (review feedback)

The review asks to either keep the `load_rb` scoped skip, or back the rename
with a Rails-grounded reason. Taking the second option, on three grounds:

**1. The convention is already merged and already documented — this PR only
makes the implementation match it.** #6017 added the `rb: "js"` entry *and* its
justifying comment, and `docs/ruby-ts-conventions.md` is generated from that same
file and CI-verified, so the table row asserting `rb → js` is live on `main`
today. The doc currently describes behavior the code does not implement. That
gap is the bug being fixed here; this PR introduces no new convention.

**2. Keeping the scoped skip is the anti-pattern CLAUDE.md forbids.** The story's
original bullet was "keep the scoped skip but rewrite its reason" — which is
precisely *"do not close [a convergence story] by writing a better justification
for the deviation, by broadening a baseline reason, or by moving it to a
different register."* `SCOPED_SKIP_GROUPS` is named there as a burndown ledger.
`load_rb`'s arm **is** ported — as `loadJs`, by #6017 — so a skip entry would
now assert something false and hold a real match out of the denominator.

**3. "Global naming convention" is global in form but singular in effect.**
`load_rb` is the **only** name in the entire vendored corpus (Rails, i18n, rack,
globalid, did_you_mean) with a standalone `rb` token — measured against
`rails-api.json`, 1 name, versus 8 for the established `erb` → `tse` rename. The
mechanism, the token-boundary anchoring, and the blast radius are all the same
shape as `erb`, which is the existing precedent for exactly this case: a
host-language file-format token that differs between Ruby and trails.

Rails reference: `vendor/i18n/lib/i18n/backend/base.rb:254-256` (`load_rb`),
dispatched by `load_file`'s extension arms at `:240-247`. Rails' method stays
`load_rb`; only its trails spelling is `loadJs`, which is what the rename encodes.

The story's acceptance criteria predated #6017 and specified the scoped-skip
outcome. I amended the story to reconcile it with the merged design rather than
leave the PR contradicting it — see the "Amended 2026-08-04 — superseded in part
by #6017" section of `i18n-backend-load-rb-decision`.

## Scope note

This branch originally carried a full port of the `.rb` arm (a `loadTs` loader
with `.js`/`.mjs` aliases, a `registerLocaleModules` seam, the `en` fixture, and
the two Rails `simple_test.rb` cases). **#6017 landed all of it** while this PR
was open — as `loadJs` + `registerLocaleModule`, dispatched off `.js`, with the
`en.ts` fixture registered under its emitted `en.js` name. Reapplying any of it
on rebase would have reverted the merged design, so the superseded commits were
dropped and only the genuinely-missing piece is kept.

## Verification

`pnpm api:compare`, measured against `origin/main` with a fresh build both times:

| package | before | after |
| --- | --- | --- |
| i18n | 180/184 (97.8%), arity 114/114 | **183/184 (99.5%)**, arity 117/117 |

Per-file, `backend/simple.rb` goes 27/28 → **28/28 (100%)**; `backend/base.rb`
and `backend/key_value.rb` also reach 100%. The three recovered methods are the
`load_rb` misses on those three entities (the latter two resolve through
`include Base`).

**Every other package is byte-identical** before and after — I diffed the full
per-package totals table, since the rename is global. Token boundaries keep
`verb`/`verbatim`/`superb` untouched, and `erb` still wins the alternation over
the shorter `rb`; both are asserted in the tests.

- `pnpm test:compare` — `backend/simple_test.rb` **30/31** (unchanged; the two
  `.rb` cases were landed by #6017, and the remaining gap is
  `store_translations: converts the given locale to a Symbol`, which the story
  explicitly scopes out).
- `pnpm api:calls` — `OK (14 baselined)`, no new rows.
- `pnpm api:calls:wide` — `OK (2216 baselined)`, no new rows.
- `pnpm api:extra --package i18n` — unchanged; this PR adds no TS surface.
- `pnpm typecheck` clean; `scripts/api-compare/conventions.test.ts` 49 passed.

The new test fails on baseline (`expected 'loadRb' to be 'loadJs'`), verified by
reverting the regex.

Closes-story: i18n-backend-load-rb-decision
