### PR TITLE
refactor(i18n): camelize I18n payload keys at the lookup boundary

### DIFF
--- a/packages/actionview/src/helpers/output-safety-helper.ts
+++ b/packages/actionview/src/helpers/output-safety-helper.ts
@@ -111,10 +111,6 @@ export function toSentence(array: unknown[], options: ToSentenceOptions = {}): S
     locale: options.locale ?? null,
     default: {},
   }) as Record<string, string>;
-  // Rails merges the payload straight in (output_safety_helper.rb:51) because
-  // the store keys and the option keys are the same symbols; ours are
-  // snake_case in the store and camelCase in the options, so camelize at the
-  // boundary.
   for (const [k, v] of Object.entries(i18nConnectors)) {
     defaultConnectors[camelize(k, "lower")] = v;
   }

--- a/packages/actionview/src/helpers/output-safety-helper.ts
+++ b/packages/actionview/src/helpers/output-safety-helper.ts
@@ -1,6 +1,7 @@
 import {
   I18n,
   assertValidKeys,
+  camelize,
   SafeBuffer,
   htmlEscape,
   htmlEscapeOnce as _htmlEscapeOnce,
@@ -82,16 +83,6 @@ function flatten(arr: unknown[]): unknown[] {
   return result;
 }
 
-/**
- * `support.array` is stored under Ruby's snake_case keys, but the options
- * `toSentence` merges them into are camelCase.
- */
-const I18N_KEY_MAP: Record<string, string> = {
-  words_connector: "wordsConnector",
-  two_words_connector: "twoWordsConnector",
-  last_word_connector: "lastWordConnector",
-};
-
 export interface ToSentenceOptions {
   wordsConnector?: string | SafeBuffer | null;
   twoWordsConnector?: string | SafeBuffer | null;
@@ -120,8 +111,12 @@ export function toSentence(array: unknown[], options: ToSentenceOptions = {}): S
     locale: options.locale ?? null,
     default: {},
   }) as Record<string, string>;
+  // Rails merges the payload straight in (output_safety_helper.rb:51) because
+  // the store keys and the option keys are the same symbols; ours are
+  // snake_case in the store and camelCase in the options, so camelize at the
+  // boundary.
   for (const [k, v] of Object.entries(i18nConnectors)) {
-    defaultConnectors[I18N_KEY_MAP[k] ?? k] = v;
+    defaultConnectors[camelize(k, "lower")] = v;
   }
   // Ruby's `default_connectors.merge!(options)` overrides on key presence; a TS
   // caller forwarding an absent option passes `undefined`, which must not

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -66,9 +66,6 @@ export function toSentence(
       locale: options.locale ?? null,
       default: {},
     }) as Record<string, string>;
-    // Rails merges the payload straight in (conversions.rb:70) because the
-    // store keys and the option keys are the same symbols; ours are snake_case
-    // in the store and camelCase in the options, so camelize at the boundary.
     for (const [k, v] of Object.entries(i18nConnectors)) {
       defaultConnectors[camelize(k, "lower")] = v;
     }

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -4,25 +4,7 @@
 
 import { assertValidKeys } from "./hash-utils.js";
 import { I18n } from "./i18n.js";
-
-/**
- * `support.array` is stored under Ruby's snake_case keys, but the options
- * `toSentence` merges them into are camelCase. Same shape as
- * `number-helper/number-converter.ts`'s own key map.
- */
-const I18N_KEY_MAP: Record<string, string> = {
-  words_connector: "wordsConnector",
-  two_words_connector: "twoWordsConnector",
-  last_word_connector: "lastWordConnector",
-};
-
-function camelizeI18nKeys(obj: Record<string, string>): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    result[I18N_KEY_MAP[k] ?? k] = v;
-  }
-  return result;
-}
+import { camelize } from "./inflector.js";
 
 /**
  * Wraps a value in an array. `null`/`undefined` → `[]`, arrays pass through,
@@ -84,7 +66,12 @@ export function toSentence(
       locale: options.locale ?? null,
       default: {},
     }) as Record<string, string>;
-    Object.assign(defaultConnectors, camelizeI18nKeys(i18nConnectors));
+    // Rails merges the payload straight in (conversions.rb:70) because the
+    // store keys and the option keys are the same symbols; ours are snake_case
+    // in the store and camelCase in the options, so camelize at the boundary.
+    for (const [k, v] of Object.entries(i18nConnectors)) {
+      defaultConnectors[camelize(k, "lower")] = v;
+    }
   }
   for (const [k, v] of Object.entries(options)) {
     if (v !== undefined) defaultConnectors[k] = v as string;

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -20,6 +20,14 @@
  * `.json` arms of the same dispatch.
  *
  * `run_load_hooks(:i18n)` and `i18n/backend/fallbacks` have no port yet.
+ *
+ * Locale payloads keep Ruby's snake_case keys (that is what the `.yml` files
+ * and `storeTranslations` callers carry), while the option hashes Rails merges
+ * them into are camelCase here. Where a Rails body merges a translation
+ * straight into options — `Array#to_sentence`, `to_sentence` in
+ * `output_safety_helper.rb`, `NumberConverter#i18n_format_options` — camelize
+ * the keys at the lookup boundary with `camelize(key, "lower")` from
+ * `inflector.ts`. Do not introduce a per-file snake_case→camelCase key map.
  */
 
 import * as I18n from "@blazetrails/i18n";

--- a/packages/activesupport/src/number-helper/number-converter.ts
+++ b/packages/activesupport/src/number-helper/number-converter.ts
@@ -125,9 +125,6 @@ export abstract class NumberConverter<TOptions extends NumberFormatOptions = Num
   protected i18nFormatOptions(): Record<string, unknown> {
     const locale = (this.opts as Record<string, unknown>).locale as string | undefined;
     const raw = I18n.translate("number.format", { locale, default: {} });
-    // Rails merges the payload straight in (number_converter.rb:157) because the
-    // store keys and the option keys are the same symbols; ours are snake_case
-    // in the store and camelCase in the options, so camelize at the boundary.
     const options: Record<string, unknown> = {};
     if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
       for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {

--- a/packages/activesupport/src/number-helper/number-converter.ts
+++ b/packages/activesupport/src/number-helper/number-converter.ts
@@ -1,4 +1,5 @@
 import { I18n } from "../i18n.js";
+import { camelize } from "../inflector.js";
 
 export type NumberFormatOptions = object;
 
@@ -58,20 +59,6 @@ const DEFAULTS: Record<string, Record<string, unknown>> = {
     },
   },
 };
-
-const I18N_KEY_MAP: Record<string, string> = {
-  round_mode: "roundMode",
-  strip_insignificant_zeros: "stripInsignificantZeros",
-  negative_format: "negativeFormat",
-};
-
-function camelizeI18nKeys(obj: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    result[I18N_KEY_MAP[k] ?? k] = v;
-  }
-  return result;
-}
 
 export abstract class NumberConverter<TOptions extends NumberFormatOptions = NumberFormatOptions> {
   protected number: unknown;
@@ -138,16 +125,23 @@ export abstract class NumberConverter<TOptions extends NumberFormatOptions = Num
   protected i18nFormatOptions(): Record<string, unknown> {
     const locale = (this.opts as Record<string, unknown>).locale as string | undefined;
     const raw = I18n.translate("number.format", { locale, default: {} });
-    const options =
-      typeof raw === "object" && raw !== null && !Array.isArray(raw)
-        ? camelizeI18nKeys({ ...(raw as Record<string, unknown>) })
-        : {};
+    // Rails merges the payload straight in (number_converter.rb:157) because the
+    // store keys and the option keys are the same symbols; ours are snake_case
+    // in the store and camelCase in the options, so camelize at the boundary.
+    const options: Record<string, unknown> = {};
+    if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+      for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+        options[camelize(k, "lower")] = v;
+      }
+    }
 
     const ns = (this.constructor as typeof NumberConverter).namespace;
     if (ns) {
       const nsRaw = I18n.translate(`number.${ns}.format`, { locale, default: {} });
       if (typeof nsRaw === "object" && nsRaw !== null && !Array.isArray(nsRaw)) {
-        Object.assign(options, camelizeI18nKeys({ ...(nsRaw as Record<string, unknown>) }));
+        for (const [k, v] of Object.entries(nsRaw as Record<string, unknown>)) {
+          options[camelize(k, "lower")] = v;
+        }
       }
     }
     return options;


### PR DESCRIPTION
Rails merges I18n payloads straight into option hashes because the store keys and the option keys are the same Ruby symbols. trails needed a bridge only because our option hashes are camelCase, and three ports each grew their own private snake_case→camelCase key map for it.

This drops all three maps in favour of the settled idiom: `camelize(key, "lower")` (already public in `@blazetrails/activesupport`) applied at the lookup boundary.

- `packages/activesupport/src/array-utils.ts` (`core_ext/array/conversions.rb:70`)
- `packages/actionview/src/helpers/output-safety-helper.ts` (`output_safety_helper.rb:51`)
- `packages/activesupport/src/number-helper/number-converter.ts` (`number_converter.rb:157`)

The idiom is documented in the `packages/activesupport/src/i18n.ts` module comment, where the other I18n-consuming ports will find it.

No public surface added; `pnpm api:calls` and `pnpm api:calls:wide` both OK.

Closes-story: i18n-connector-key-camelization-duplicated
