### PR TITLE
chore(api-compare): declare i18n backend/flatten.rb deferred

### DIFF
--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1164,6 +1164,14 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
   },
   {
+    pattern: "backend/flatten.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — key-flattening helpers used only by the " +
+      "deferred `key_value.rb`, `cache_file.rb` and `memoize.rb` backends; " +
+      "`Simple` does not include it.",
+  },
+  {
     pattern: "backend/interpolation_compiler.rb",
     package: "i18n",
     reason:


### PR DESCRIPTION
`pnpm api:compare` reported i18n at `files: 13/14`, the one unmatched Ruby file
being `backend/flatten.rb` with all 8 members scored as a real gap.

`I18n::Backend::Flatten` (`vendor/i18n/lib/i18n/backend/flatten.rb:13`) is only
mixed into deferred backends — `key_value.rb:73` (`include Base, Flatten`),
`cache_file.rb:19`, `memoize.rb:38` — each of which already carries an
`unported-files.ts` entry. `Simple` includes `Base` only
(`vendor/i18n/lib/i18n/backend/simple.rb:20-23`), so nothing ported depends on
it. Flatten was simply missed when the sibling deferral entries were written.

Adds the `backend/flatten.rb` entry in the same shape as its siblings. No
`flatten.ts` stub.

After: `i18n — 130/135 methods (96.3%) | files: 13/13`. No other package moves.

Closes-story: i18n-defer-backend-flatten
