### PR TITLE
test(i18n): port the remaining i18n_test.rb facade cases

### DIFF
--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -3,7 +3,12 @@
  */
 
 import { enforceAvailableLocalesBang, type Locale, type TranslationKey } from "./i18n.js";
-import { ExceptionHandler, MissingInterpolationArgument } from "./exceptions.js";
+import {
+  ExceptionHandler,
+  MissingInterpolationArgument,
+  NoMethodError,
+  inspect,
+} from "./exceptions.js";
 import { DEFAULT_INTERPOLATION_PATTERNS } from "./interpolate/ruby.js";
 import type { Base } from "./backend/base.js";
 import { Simple } from "./backend/simple.js";
@@ -53,6 +58,13 @@ export class Config {
 
   set locale(locale: Locale | false) {
     enforceAvailableLocalesBang(locale);
+    // Ruby's `locale && locale.to_sym`: a Symbol is a plain string here, so
+    // `to_sym` is the identity for one (and `&&` short-circuits on
+    // `nil`/`false`); anything else has no `to_sym` and raises, which is why
+    // assigning junk is not silently ignored.
+    if (locale != null && locale !== false && typeof locale !== "string") {
+      throw new NoMethodError(`undefined method 'to_sym' for ${inspect(locale)}`);
+    }
     this.localeValue = locale;
   }
 
@@ -74,6 +86,13 @@ export class Config {
 
   set defaultLocale(locale: Locale) {
     enforceAvailableLocalesBang(locale);
+    // Ruby's `locale && locale.to_sym`: a Symbol is a plain string here, so
+    // `to_sym` is the identity for one (and `&&` short-circuits on
+    // `nil`/`false`); anything else has no `to_sym` and raises, which is why
+    // assigning junk is not silently ignored.
+    if (locale != null && (locale as Locale | false) !== false && typeof locale !== "string") {
+      throw new NoMethodError(`undefined method 'to_sym' for ${inspect(locale)}`);
+    }
     defaultLocale = locale;
   }
 

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -56,12 +56,13 @@ export class Config {
     return this.localeValue ?? this.defaultLocale;
   }
 
+  /**
+   * Sets the current locale. Ruby's `locale && locale.to_sym`: a Symbol is a
+   * plain string here, so `to_sym` is the identity for one; anything else has
+   * no `to_sym` and raises.
+   */
   set locale(locale: Locale | false) {
     enforceAvailableLocalesBang(locale);
-    // Ruby's `locale && locale.to_sym`: a Symbol is a plain string here, so
-    // `to_sym` is the identity for one (and `&&` short-circuits on
-    // `nil`/`false`); anything else has no `to_sym` and raises, which is why
-    // assigning junk is not silently ignored.
     if (locale != null && locale !== false && typeof locale !== "string") {
       throw new NoMethodError(`undefined method 'to_sym' for ${inspect(locale)}`);
     }
@@ -84,13 +85,10 @@ export class Config {
     return defaultLocale;
   }
 
+  /** Sets the default locale; `to_sym` as in `locale=` above. */
   set defaultLocale(locale: Locale) {
     enforceAvailableLocalesBang(locale);
-    // Ruby's `locale && locale.to_sym`: a Symbol is a plain string here, so
-    // `to_sym` is the identity for one (and `&&` short-circuits on
-    // `nil`/`false`); anything else has no `to_sym` and raises, which is why
-    // assigning junk is not silently ignored.
-    if (locale != null && (locale as Locale | false) !== false && typeof locale !== "string") {
+    if (locale != null && (locale as unknown) !== false && typeof locale !== "string") {
       throw new NoMethodError(`undefined method 'to_sym' for ${inspect(locale)}`);
     }
     defaultLocale = locale;

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -119,6 +119,22 @@ export class ArgumentError extends Error {
   }
 }
 
+/**
+ * Mirror of Ruby's `NoMethodError`, raised where the gem sends a method to a
+ * receiver that does not respond to it — `locale.to_sym` in `Config#locale=`
+ * and `Config#default_locale=` (i18n/lib/i18n/config.rb:17, :37), which is
+ * what makes junk assignment fail rather than be ignored.
+ *
+ * @noRailsEquivalent PERMANENT — a Ruby core class the gem raises but does not
+ * define; JS has no `NoMethodError`, so the port has to carry one.
+ */
+export class NoMethodError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
 export class Disabled extends ArgumentError {
   constructor(method: string) {
     super(`I18n.${method} is currently disabled, likely because your application is still in its loading phase.

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -278,10 +278,12 @@ describe("I18nTest", () => {
   });
 
   it("localize given an unavailable locale rases an I18n::InvalidLocale", () => {
-    config().enforceAvailableLocales = true;
-    // Ruby's `Time.now`: `enforce_available_locales!` (i18n.rb:335) raises
-    // before the object is asked for anything, so a `strftime` duck is enough.
-    expect(() => localize({ strftime: () => "" }, { locale: "klingon" })).toThrow(InvalidLocale);
+    try {
+      config().enforceAvailableLocales = true;
+      expect(() => localize({ strftime: () => "" }, { locale: "klingon" })).toThrow(InvalidLocale);
+    } finally {
+      config().enforceAvailableLocales = false;
+    }
   });
 
   it("localize raises Disabled if locale is false", () => {
@@ -382,7 +384,6 @@ describe("I18nTest", () => {
   });
 
   it("default_locale= doesn't ignore junk", () => {
-    // Ruby passes `Class`; any non-Symbol/String receiver has no `to_sym`.
     expect(() => setDefaultLocale(Config as unknown as string)).toThrow(NoMethodError);
   });
 

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -1,7 +1,7 @@
 /** Mirrors: i18n/test/i18n_test.rb */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ArgumentError, Disabled, InvalidLocale } from "./exceptions.js";
+import { ArgumentError, Disabled, InvalidLocale, NoMethodError } from "./exceptions.js";
 import * as I18n from "./i18n.js";
 import {
   RESERVED_KEYS,
@@ -265,6 +265,25 @@ describe("I18nTest", () => {
     });
   });
 
+  it("localize given nil raises an I18n::ArgumentError", () => {
+    expect(() => localize(null)).toThrow(ArgumentError);
+  });
+
+  it("localize given nil and default returns default", () => {
+    expect(localize(null, { default: null })).toBe(null);
+  });
+
+  it("localize given an Object raises an I18n::ArgumentError", () => {
+    expect(() => localize({})).toThrow(ArgumentError);
+  });
+
+  it("localize given an unavailable locale rases an I18n::InvalidLocale", () => {
+    config().enforceAvailableLocales = true;
+    // Ruby's `Time.now`: `enforce_available_locales!` (i18n.rb:335) raises
+    // before the object is asked for anything, so a `strftime` duck is enough.
+    expect(() => localize({ strftime: () => "" }, { locale: "klingon" })).toThrow(InvalidLocale);
+  });
+
   it("localize raises Disabled if locale is false", () => {
     withLocale(false, () => {
       expect(() => localize(null)).toThrow(Disabled);
@@ -362,6 +381,11 @@ describe("I18nTest", () => {
     expect(defaultLocale()).toBe("de");
   });
 
+  it("default_locale= doesn't ignore junk", () => {
+    // Ruby passes `Class`; any non-Symbol/String receiver has no `to_sym`.
+    expect(() => setDefaultLocale(Config as unknown as string)).toThrow(NoMethodError);
+  });
+
   it("raises an I18n::InvalidLocale exception when setting an unavailable default locale", () => {
     config().enforceAvailableLocales = true;
     expect(() => setDefaultLocale("klingon")).toThrow(InvalidLocale);
@@ -369,6 +393,10 @@ describe("I18nTest", () => {
 
   it("uses the default locale as a locale by default", () => {
     expect(locale()).toBe(defaultLocale());
+  });
+
+  it("locale= doesn't ignore junk", () => {
+    expect(() => setLocale(Config as unknown as string)).toThrow(NoMethodError);
   });
 
   it("raises an I18n::InvalidLocale exception when setting an unavailable locale", () => {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1228,6 +1228,24 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "TS counterpart by design.",
   },
   {
+    testFile: "i18n_test.rb",
+    tests: ["exposes its VERSION constant"],
+    reason:
+      "Asserts `I18n::VERSION`, which lives in the `version.rb` excluded above " +
+      "— trails carries the version in package.json, so there is no constant.",
+  },
+  {
+    testFile: "i18n_test.rb",
+    tests: [
+      "sets the current locale to Thread.current",
+      "I18n.locale is preserved in Fiber context",
+    ],
+    reason:
+      "Both read the config back off `Thread.current.thread_variable_get(:i18n_config)` / a " +
+      "`Fiber`. trails keeps one process-wide config and Node has neither thread-local " +
+      "storage of this shape nor Fibers, so there is nothing to assert.",
+  },
+  {
     pattern: "tests/",
     package: "i18n",
     reason:


### PR DESCRIPTION
Ports the six portable cases left in `i18n/test/i18n_test.rb` and excludes the three Ruby-runtime-only ones, closing the 73/82 gap `pnpm test:compare --missing` reported (now 79/79).

- The four `localize` guard cases (i18n_test.rb:360-379) exercise `backend/base.ts`'s existing nil/Object arms (i18n/lib/i18n/backend/base.rb:79-82) and the `enforce_available_locales!` check (i18n/lib/i18n.rb:335).
- `default_locale= / locale= doesn't ignore junk` (i18n_test.rb:42, :66) needed the implementation: `Config#locale=` and `#default_locale=` dropped Ruby's `locale && locale.to_sym` (i18n/lib/i18n/config.rb:17, :37), so junk was silently stored. Both setters now mirror it — a Symbol is a plain string here, `nil`/`false` short-circuit, anything else has no `to_sym` and raises `NoMethodError` (a Ruby core class, added to exceptions.ts with a PERMANENT `@noRailsEquivalent` tag).
- `exposes its VERSION constant`, `sets the current locale to Thread.current` and `I18n.locale is preserved in Fiber context` are excluded in `scripts/api-compare/unported-files.ts`, one reason each: no VERSION constant (version.rb is already excluded), and no thread-local config or Fibers in Node.

Gates: i18n suite 359/359 green, `api:calls` / `api:calls:wide` OK, `api:extra --package i18n` 0 new novel, `test:compare` i18n_test.rb 79/79 ✓.

Closes-story: i18n-facade-remaining-test-cases
