### PR TITLE
fix(api-compare): accept the colon-prefixed spelling of a Ruby Symbol default

### DIFF
--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -171,6 +171,47 @@ def ident_name(node)
   nil
 end
 
+# Names a body tests against the Symbol class — `Symbol === format`,
+# `format.is_a?(Symbol)`, `format.kind_of?(Symbol)`. A Symbol default on such a
+# param is a discriminator: the Symbol branch is control flow the port has to
+# keep, so its TS spelling must carry the leading colon (CLAUDE.md, "Symbols vs
+# strings"). See I18n::Backend::Base#localize, i18n/lib/i18n/backend/base.rb:83.
+def symbol_discriminated_names(node, names = [])
+  return names unless node.is_a?(Array)
+  if node[0] == :binary && node[2] == :=== && const_name(node[1]) == "Symbol"
+    nm = node[3].is_a?(Array) && node[3][0] == :var_ref ? ident_name(node[3][1]) : nil
+    names << nm if nm
+  end
+  if node[0] == :method_add_arg
+    call = node[1]
+    meth = call.is_a?(Array) && call[0] == :call ? ident_name(call[3]) : nil
+    if %w[is_a? kind_of?].include?(meth) && arg_const_names(node[2]).include?("Symbol")
+      recv = call[1]
+      nm = recv.is_a?(Array) && recv[0] == :var_ref ? ident_name(recv[1]) : nil
+      names << nm if nm
+    end
+  end
+  node.each { |child| symbol_discriminated_names(child, names) }
+  names
+end
+
+def mark_symbol_discriminated(params, body)
+  names = symbol_discriminated_names(body)
+  return if names.empty?
+  params.each { |p| p[:symbolDiscriminated] = true if names.include?(p[:name]) }
+end
+
+def const_name(node)
+  return nil unless node.is_a?(Array)
+  return node[1] if node[0] == :@const
+  node[0] == :var_ref ? const_name(node[1]) : nil
+end
+
+def arg_const_names(args)
+  return [] unless args.is_a?(Array)
+  args.flat_map { |child| child.is_a?(Array) ? [const_name(child)] + arg_const_names(child) : [] }.compact
+end
+
 # Normalized body digest for source-hash pinning (RFC 0025). Hashes the def
 # BODY sexp only (not the surrounding class), with scanner-token positions
 # stripped, so the digest is insensitive to indentation, blank lines, and
@@ -590,6 +631,7 @@ class ApiExtractor
     return unless target
 
     body = node[3]
+    mark_symbol_discriminated(params, body)
     dep_info = detect_deps(body)
     calls, weak_calls = collect_method_calls(body)
 
@@ -643,6 +685,7 @@ class ApiExtractor
     return unless target
 
     body = node[5]
+    mark_symbol_discriminated(params, body)
     dep_info = detect_deps(body)
     calls, weak_calls = collect_method_calls(body)
 

--- a/scripts/api-compare/literals.test.ts
+++ b/scripts/api-compare/literals.test.ts
@@ -29,10 +29,22 @@ describe("compareLiteral", () => {
     );
   });
 
-  it("matches a Ruby symbol against a TS string of the same value", () => {
-    expect(compareLiteral({ kind: "symbol", value: "asc" }, { kind: "string", value: "asc" })).toBe(
-      "match",
-    );
+  it("matches a Ruby symbol against a TS string carrying its leading colon", () => {
+    expect(
+      compareLiteral({ kind: "symbol", value: "default" }, { kind: "string", value: ":default" }),
+    ).toBe("match");
+  });
+
+  it("matches a Ruby symbol against a bare TS string of the same value", () => {
+    expect(
+      compareLiteral({ kind: "symbol", value: "default" }, { kind: "string", value: "default" }),
+    ).toBe("match");
+  });
+
+  it("flags a Ruby symbol against a TS string naming a different value", () => {
+    expect(
+      compareLiteral({ kind: "symbol", value: "default" }, { kind: "string", value: ":short" }),
+    ).toBe("mismatch");
   });
 
   it("treats nil as equal to both null and undefined (TS undefined → nil)", () => {
@@ -93,7 +105,7 @@ describe("compareDefaults", () => {
       [ruby("order", { kind: "symbol", value: "asc" })],
       [[tsp("order", { kind: "string", value: "desc" })]],
     );
-    expect(res.mismatches).toEqual([{ name: "order", rubyValue: '"asc"', tsValue: '"desc"' }]);
+    expect(res.mismatches).toEqual([{ name: "order", rubyValue: ":asc", tsValue: '"desc"' }]);
   });
 
   it("excludes a non-literal default (skipped, not mismatched)", () => {

--- a/scripts/api-compare/literals.test.ts
+++ b/scripts/api-compare/literals.test.ts
@@ -47,6 +47,23 @@ describe("compareLiteral", () => {
     ).toBe("mismatch");
   });
 
+  it("matches a Symbol-discriminated default only against the colon-prefixed string", () => {
+    expect(
+      compareLiteral(
+        { kind: "symbol", value: "default" },
+        { kind: "string", value: ":default" },
+        true,
+      ),
+    ).toBe("match");
+    expect(
+      compareLiteral(
+        { kind: "symbol", value: "default" },
+        { kind: "string", value: "default" },
+        true,
+      ),
+    ).toBe("mismatch");
+  });
+
   it("treats nil as equal to both null and undefined (TS undefined → nil)", () => {
     expect(compareLiteral({ kind: "nil" }, { kind: "nil" })).toBe("match");
   });
@@ -106,6 +123,16 @@ describe("compareDefaults", () => {
       [[tsp("order", { kind: "string", value: "desc" })]],
     );
     expect(res.mismatches).toEqual([{ name: "order", rubyValue: ":asc", tsValue: '"desc"' }]);
+  });
+
+  it("flags a Symbol-discriminated default ported as a bare string", () => {
+    const res = compareDefaults(
+      [{ ...ruby("format", { kind: "symbol", value: "default" }), symbolDiscriminated: true }],
+      [[tsp("format", { kind: "string", value: "default" })]],
+    );
+    expect(res.mismatches).toEqual([
+      { name: "format", rubyValue: ":default", tsValue: '"default"' },
+    ]);
   });
 
   it("excludes a non-literal default (skipped, not mismatched)", () => {

--- a/scripts/api-compare/literals.ts
+++ b/scripts/api-compare/literals.ts
@@ -1,7 +1,8 @@
 // Literal parameter-default + constant comparison for api:compare (advisory —
 // never changes parity). Diffs a default/constant's literal *value* after
 // normalization absorbing cross-language noise (numeric underscores,
-// symbol→string, nil↔null/undefined, escapes); a non-literal is uncomparable.
+// symbol→string in either spelling, nil↔null/undefined, escapes); a non-literal
+// is uncomparable.
 
 import type { LiteralValue, ParamInfo } from "./types.js";
 import { snakeToCamel } from "./conventions.js";
@@ -54,6 +55,13 @@ export function compareLiteral(ruby: LiteralValue, ts: LiteralValue): LiteralVer
   const t = normalizeLiteral(ts);
   if (r === null || t === null) return "skip";
   if ((r === "nil") !== (t === "nil")) return "skip";
+  // A Ruby Symbol is a JS string, and CLAUDE.md ("Symbols vs strings") keeps the
+  // leading colon where a method's control flow turns on Symbol-vs-String
+  // (`I18n::Backend::Base#localize`'s `format = :default` → `":default"`).
+  // Nothing in the manifest says which arm a given default is, so both spellings
+  // of `:x` — `"x"` and `":x"` — are the same value to the comparator.
+  if (ruby.kind === "symbol" && t === `str::${canonString(String(ruby.value ?? ""))}`)
+    return "match";
   return r === t ? "match" : "mismatch";
 }
 
@@ -61,8 +69,9 @@ export function compareLiteral(ruby: LiteralValue, ts: LiteralValue): LiteralVer
 export function displayLiteral(lit: LiteralValue): string {
   switch (lit.kind) {
     case "string":
-    case "symbol":
       return JSON.stringify(lit.value ?? "");
+    case "symbol":
+      return `:${lit.value ?? ""}`;
     case "nil":
       return "nil";
     case "array":

--- a/scripts/api-compare/literals.ts
+++ b/scripts/api-compare/literals.ts
@@ -49,17 +49,18 @@ export type LiteralVerdict = "match" | "mismatch" | "skip";
 /** Compare two literals. "skip" when either side is non-literal (`expr`), or
  *  when exactly one side is `nil`: Rails uses `nil` as a sentinel and computes
  *  the committed value in the body (`validate_each(..., precision: nil)`), so it
- *  has no value to compare. `nil`↔`nil` (incl. TS undefined/null) still matches. */
+ *  has no value to compare. `nil`↔`nil` (incl. TS undefined/null) still matches.
+ *
+ *  A Ruby Symbol is a JS string, and CLAUDE.md ("Symbols vs strings") keeps the
+ *  leading colon where a method's control flow turns on Symbol-vs-String —
+ *  `I18n::Backend::Base#localize`'s `format = :default` ports as `":default"`.
+ *  Nothing in the manifest says which arm a given default is, so both spellings
+ *  of `:x` — `"x"` and `":x"` — are the same value here. */
 export function compareLiteral(ruby: LiteralValue, ts: LiteralValue): LiteralVerdict {
   const r = normalizeLiteral(ruby);
   const t = normalizeLiteral(ts);
   if (r === null || t === null) return "skip";
   if ((r === "nil") !== (t === "nil")) return "skip";
-  // A Ruby Symbol is a JS string, and CLAUDE.md ("Symbols vs strings") keeps the
-  // leading colon where a method's control flow turns on Symbol-vs-String
-  // (`I18n::Backend::Base#localize`'s `format = :default` → `":default"`).
-  // Nothing in the manifest says which arm a given default is, so both spellings
-  // of `:x` — `"x"` and `":x"` — are the same value to the comparator.
   if (ruby.kind === "symbol" && t === `str::${canonString(String(ruby.value ?? ""))}`)
     return "match";
   return r === t ? "match" : "mismatch";

--- a/scripts/api-compare/literals.ts
+++ b/scripts/api-compare/literals.ts
@@ -52,17 +52,26 @@ export type LiteralVerdict = "match" | "mismatch" | "skip";
  *  has no value to compare. `nil`↔`nil` (incl. TS undefined/null) still matches.
  *
  *  A Ruby Symbol is a JS string, and CLAUDE.md ("Symbols vs strings") keeps the
- *  leading colon where a method's control flow turns on Symbol-vs-String —
- *  `I18n::Backend::Base#localize`'s `format = :default` ports as `":default"`.
- *  Nothing in the manifest says which arm a given default is, so both spellings
- *  of `:x` — `"x"` and `":x"` — are the same value here. */
-export function compareLiteral(ruby: LiteralValue, ts: LiteralValue): LiteralVerdict {
+ *  leading colon only where a method's control flow turns on Symbol-vs-String.
+ *  `symbolDiscriminated` carries that distinction from the Ruby body: when the
+ *  body branches on `Symbol === x` (`I18n::Backend::Base#localize`,
+ *  i18n/lib/i18n/backend/base.rb:83) only `":x"` matches, and a bare `"x"` — a
+ *  port that bypassed the branch — is a mismatch. Elsewhere a Symbol is just a
+ *  name (`timestamp_column = :updated_at`) and the bare spelling is correct. */
+export function compareLiteral(
+  ruby: LiteralValue,
+  ts: LiteralValue,
+  symbolDiscriminated = false,
+): LiteralVerdict {
   const r = normalizeLiteral(ruby);
   const t = normalizeLiteral(ts);
   if (r === null || t === null) return "skip";
   if ((r === "nil") !== (t === "nil")) return "skip";
-  if (ruby.kind === "symbol" && t === `str::${canonString(String(ruby.value ?? ""))}`)
-    return "match";
+  if (ruby.kind === "symbol") {
+    const colon = `str::${canonString(String(ruby.value ?? ""))}`;
+    if (symbolDiscriminated) return t === colon ? "match" : "mismatch";
+    return t === colon || t === r ? "match" : "mismatch";
+  }
   return r === t ? "match" : "mismatch";
 }
 
@@ -109,7 +118,7 @@ export function compareDefaults(
     if (!rp.literal) continue;
     const tl = tsByName.get(snakeToCamel(rp.name)) ?? tsByName.get(rp.name);
     if (!tl) continue;
-    const verdict = compareLiteral(rp.literal, tl);
+    const verdict = compareLiteral(rp.literal, tl, rp.symbolDiscriminated);
     if (verdict === "skip") {
       result.skipped++;
       continue;

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -15,6 +15,10 @@ export interface ParamInfo {
   kind: "required" | "optional" | "rest" | "keyword" | "keyword_rest" | "block";
   default?: string;
   literal?: LiteralValue; // default value, when present; compared by literals.ts
+  /** Ruby side only: the body tests this param against `Symbol` (`Symbol === x`,
+   *  `x.is_a?(Symbol)`), so a Symbol default on it is a branch discriminator and
+   *  the TS spelling must keep the leading colon. See literals.ts. */
+  symbolDiscriminated?: boolean;
   /**
    * TS-side declared type text (e.g. `"Base"`), when available — lets a
    * consumer recognize a leading receiver/host param on standalone mixin


### PR DESCRIPTION
`pnpm api:compare`'s one remaining literal mismatch repo-wide was the colon
spelling this RFC adopted:

```json
{ "rubyFile": "backend/base.rb", "name": "format",
  "rubyValue": "\"default\"", "tsValue": "\":default\"", "kind": "default" }
```

`vendor/i18n/lib/i18n/backend/base.rb:77` declares
`def localize(locale, object, format = :default, options = EMPTY_HASH)` and
branches on `Symbol === format` at `base.rb:83` before translating
`date/time.formats.<key>`. `packages/i18n/src/backend/base.ts:265` correctly
spells that Symbol default `":default"` per CLAUDE.md ("Symbols vs strings" — a
Symbol keeps its leading colon where control flow turns on Symbol-vs-String).
The extractor rendered the Ruby Symbol bare, so the correct port scored as a
divergence.

## Change

CLAUDE.md scopes the colon spelling to the discriminator case, so the comparator
needs to know which case a default is in — and the Ruby body is where that lives:

- `extract-ruby-api.rb` marks a param `symbolDiscriminated` when the method body
  tests it against the Symbol class (`Symbol === x`, `x.is_a?(Symbol)`,
  `x.kind_of?(Symbol)`). Repo-wide that flags 25 params, exactly one of which
  carries a Symbol default: `localize`'s `format`.
- `compareLiteral` takes that flag. On a discriminated param only `":x"` matches
  and a bare `"x"` — a port that bypassed the Symbol branch — is a **mismatch**,
  which is the miss the reviewer flagged. Elsewhere a Symbol default is just a
  name (`timestamp_column = :updated_at`, `type = :invalid`, `kind = :silent`)
  and both spellings match, so the 16 correct ports that a blanket colon rule
  turns into false rows stay clean.
- `displayLiteral` renders a Symbol as `:x` so the report distinguishes it from
  a String.

No deviations; nothing baselined.

## Verification

- `pnpm vitest run scripts/api-compare/{literals,extract-ruby-api,extractor-schema}.test.ts`
  — 71 passed. Unit tests cover `:default`↔`":default"`, `:default`↔`"default"`,
  a differing value, and both arms of the discriminated case.
- `API_COMPARE_FORCE=1 pnpm api:compare` — **0** literal mismatches repo-wide
  (was 1); every other total unchanged.

Closes-story: i18n-literal-comparator-symbol-defaults
