### PR TITLE
fix(i18n): default separator on false in normalizeKeys

### DIFF
--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -124,7 +124,7 @@ export class Simple extends Base {
     options: TranslateOptions = EMPTY_HASH,
   ): unknown {
     if (!this.initialized()) this.initTranslations();
-    const keys = normalizeKeys(locale, key, scope, options.separator as string | undefined);
+    const keys = normalizeKeys(locale, key, scope, options.separator as string | false | undefined);
 
     let result: unknown = this.translations();
     for (const rawKey of keys) {

--- a/packages/i18n/src/i18n.trails.test.ts
+++ b/packages/i18n/src/i18n.trails.test.ts
@@ -48,4 +48,8 @@ describe("I18n.normalizeKeys memoization", () => {
     expect(normalizeKeys(null, "foo.bar", null, ".")).toEqual(["foo", "bar"]);
     expect(normalizeKeys(null, "foo.bar", null, "|")).toEqual(["foo.bar"]);
   });
+
+  it("falls back to the default separator when passed false", () => {
+    expect(normalizeKeys(null, "foo.bar", null, false)).toEqual(["foo", "bar"]);
+  });
 });

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -390,9 +390,10 @@ export function normalizeKeys(
   locale: Locale | null | undefined,
   key: unknown,
   scope: unknown,
-  separator?: string,
+  separator?: string | false | null,
 ): TranslationKey[] {
-  separator ??= defaultSeparator();
+  // Ruby's `separator ||= I18n.default_separator` also defaults on `false`.
+  if (separator == null || separator === false) separator = defaultSeparator();
   return [
     ...normalizeKey(locale, separator),
     ...normalizeKey(scope, separator),

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -392,7 +392,6 @@ export function normalizeKeys(
   scope: unknown,
   separator?: string | false | null,
 ): TranslationKey[] {
-  // Ruby's `separator ||= I18n.default_separator` also defaults on `false`.
   if (separator == null || separator === false) separator = defaultSeparator();
   return [
     ...normalizeKey(locale, separator),


### PR DESCRIPTION
`I18n.normalize_keys` spells the default as `separator ||= I18n.default_separator`
(`i18n/lib/i18n.rb`), which assigns for `nil` **and** `false`. The TS port used
`separator ??= defaultSeparator()`, so a caller passing `separator: false` kept
`false` and every key was split on the literal string `"false"`.

- `normalizeKeys` now defaults on `false` as well as `null`/`undefined`, and the
  parameter type admits `false`.
- `Simple#lookup` forwards `options.separator` with the widened type.
- Added a `separator: false` case to `i18n.trails.test.ts` (fails on baseline:
  `"foo.bar".split(false)` yields `["foo.bar"]`).

Swept `packages/i18n/src` for other `??=`/`??` standing in for Ruby `||=`/`||`:
the remaining ones are memo/lazy-init assignments (`config.ts`, `simple.ts`,
`fallbacks.ts`, `transliterator.ts`) whose slots can't hold `false`, and
`chain.ts`'s `namespace ?? {}` / `base.ts`'s `?? null`, which are nil-only by
construction. No further divergence found.

Closes-story: i18n-normalize-keys-separator-false
