### PR TITLE
fix(actionview): init translations before storing in the to_sentence i18n test

### DIFF
--- a/packages/actionview/src/template/output-safety-helper.trails.test.ts
+++ b/packages/actionview/src/template/output-safety-helper.trails.test.ts
@@ -1,24 +1,22 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { I18n } from "@blazetrails/activesupport";
 
 import { toSentence } from "../helpers/output-safety-helper.js";
 
-/**
- * `I18n.reload!` would drop the `en` locale Active Support stores at import
- * time (it is not on `I18n.load_path` yet — see activesupport/src/i18n.ts), so
- * these restore `support.array` to its `locale/en.yml` values instead.
- */
-const EN_ARRAY_CONNECTORS = {
-  words_connector: ", ",
-  two_words_connector: " and ",
-  last_word_connector: ", and ",
-};
-
 I18n.setEnforceAvailableLocales(false);
 
 describe("OutputSafetyHelperI18nTest", () => {
+  // `store_translations` does not initialize (simple.rb:35-45), so a store that
+  // lands before the first lookup is deep-merged *under* `locale/en.yml` when
+  // `#lookup` finally runs `init_translations` (simple.rb:81-84, 92). Rails'
+  // own connector test reads a default first for the same reason
+  // (activesupport/test/i18n_test.rb:91).
+  beforeEach(() => {
+    I18n.translate("support.array.words_connector");
+  });
+
   afterEach(() => {
-    I18n.backend().storeTranslations("en", { support: { array: EN_ARRAY_CONNECTORS } });
+    I18n.reloadBang();
   });
 
   it("to_sentence uses the support.array connectors from I18n", () => {


### PR DESCRIPTION
## Problem

Leaf Tests is red on `main`: `OutputSafetyHelperI18nTest > to_sentence uses the support.array connectors from I18n` reads back the `en.yml` defaults (`"one, two, and three"`) instead of the connectors it just stored.

## Cause

`Simple#store_translations` does not initialize (`i18n/lib/i18n/backend/simple.rb:35-45`). A store that lands before the first lookup is deep-merged *under* `locale/en.yml` when `#lookup` finally runs `init_translations` (`simple.rb:81-84, 92`) — the file wins.

That was latent until #6017 (`7c1e478`) put Active Support's `en` on `I18n.load_path`, at which point the lazy load actually had a file to overwrite the stored connectors with. The port is faithful; the test relied on the old eager-store behavior, and its header comment ("it is not on `I18n.load_path` yet") is now stale.

## Fix

Read a default first so `init_translations` runs before the store — exactly what Rails' own connector test does (`activesupport/test/i18n_test.rb:91`) — and restore with `I18n.reloadBang()`, which is faithful now that `en` is on the load path, replacing the hand-rolled `EN_ARRAY_CONNECTORS` constants.

Test-only change; no source touched.

## Verification

`pnpm vitest run packages/actionview packages/activesupport` — 4674 passed, 0 failed.

Closes-story: red-7c1e478d
