### PR TITLE
refactor(i18n): strip a Symbol key's colon in normalizeKey, not three toS copies

### DIFF
--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -2,14 +2,6 @@ import { humanize, deepDup } from "@blazetrails/activesupport";
 import { MissingTranslation, catchException, type TranslateKey } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 
-/**
- * Ruby `Symbol#to_s`, which drops the leading colon the Symbol spelling of a
- * default carries when that default is taken as the translate key.
- */
-function toS(value: unknown): unknown {
-  return typeof value === "string" && value.startsWith(":") ? value.slice(1) : value;
-}
-
 /** The model instance that owns this error. Rails tests pass null for base-only errors. */
 type ModelBase = object | null;
 
@@ -133,7 +125,7 @@ export class Error {
       ? baseClass.humanAttributeName(attribute, { default: attrName, base })
       : attrName;
 
-    return I18n.t(toS(defaults.shift()) as TranslateKey, {
+    return I18n.t(defaults.shift() as TranslateKey, {
       default: defaults,
       attribute: attrName,
       message,
@@ -201,7 +193,7 @@ export class Error {
 
       if (options.message == null || options.message === false) {
         const translation = catchException(() =>
-          I18n.translate(toS(defaults[0]) as TranslateKey, {
+          I18n.translate(defaults[0] as TranslateKey, {
             ...options,
             default: defaults.slice(1),
             throw: true,
@@ -218,7 +210,7 @@ export class Error {
     defaults.push(`:errors.attributes.${attribute}.${type}`);
     defaults.push(`:errors.messages.${type}`);
 
-    const key = toS(defaults.shift());
+    const key = defaults.shift();
     if (options.message != null && options.message !== false) {
       defaults = [options.message];
       delete options.message;

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -102,7 +102,7 @@ export function humanAttributeName(
   if (options.default != null) defaults.push(options.default);
   if (!raiseOnMissing) defaults.push(MISSING_TRANSLATION);
 
-  let translation = I18n.translate(toS(defaults.shift()) as TranslateKey, {
+  let translation = I18n.translate(defaults.shift() as TranslateKey, {
     count: 1,
     raise: raiseOnMissing,
     ...options,
@@ -112,14 +112,6 @@ export function humanAttributeName(
     translation = isPresent(attribute) ? humanize(attribute) : humanize(namespace);
   }
   return translation as string;
-}
-
-/**
- * Ruby `Symbol#to_s`, which drops the leading colon the Symbol spelling of a
- * default carries when that default is taken as the translate key.
- */
-function toS(value: unknown): unknown {
-  return typeof value === "string" && value.startsWith(":") ? value.slice(1) : value;
 }
 
 function _walkAncestors(

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -98,14 +98,6 @@ function inspectSymbolOrString(value: string): string {
 }
 
 /**
- * Ruby `Symbol#to_s`, which drops the leading colon our Symbol spelling
- * carries. A String arm is returned as it stands, as Ruby's `to_s` does.
- */
-function toS(value: TranslationKey): TranslationKey {
-  return typeof value === "string" && value.startsWith(":") ? value.slice(1) : value;
-}
-
-/**
  * Mirrors: I18n::ArgumentError, the root of every error in this file.
  *
  * `message` is passed straight through rather than defaulting to `""`, so
@@ -230,7 +222,7 @@ export class Base extends ArgumentError {
   }
 
   normalizedOption(key: TranslationKey): string {
-    return normalizeKeys(this.locale, toS(key), this.options.scope).join(".");
+    return normalizeKeys(this.locale, key, this.options.scope).join(".");
   }
 
   override toString(): string {

--- a/packages/i18n/src/i18n.trails.test.ts
+++ b/packages/i18n/src/i18n.trails.test.ts
@@ -53,3 +53,25 @@ describe("I18n.normalizeKeys memoization", () => {
     expect(normalizeKeys(null, "foo.bar", null, false)).toEqual(["foo", "bar"]);
   });
 });
+
+/**
+ * Trails-only: the gem gets this from `Symbol#to_s` in `normalize_key`
+ * (i18n.rb:447), so it has no case of its own. Our Symbol spelling is a
+ * colon-prefixed string, and this is the one place that colon is dropped.
+ */
+describe("I18n.normalizeKeys on a Symbol key", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+  });
+
+  it("drops the leading colon of a Symbol key, scope and locale", () => {
+    expect(normalizeKeys(null, ":errors.format", null)).toEqual(["errors", "format"]);
+    expect(normalizeKeys(null, "format", ":errors")).toEqual(["errors", "format"]);
+    expect(normalizeKeys(":en" as never, "format", null)).toEqual(["en", "format"]);
+  });
+
+  it("drops the leading colon of each Symbol in an Array key", () => {
+    expect(normalizeKeys(null, [":errors", "format"], null)).toEqual(["errors", "format"]);
+  });
+});

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -371,7 +371,11 @@ function normalizeKey(key: unknown, separator: string): TranslationKey[] {
     } else if (key === null || key === undefined) {
       normalized = [];
     } else {
-      const keys = String(key)
+      // Ruby's `key.to_s`. A Symbol is spelled here as a colon-prefixed
+      // string, and `Symbol#to_s` drops that colon — this is the one place
+      // Rails converts a Symbol key to its name, so callers that pull a
+      // `":errors.format"` default out of a chain pass it through as it is.
+      const keys = (typeof key === "string" && key.startsWith(":") ? key.slice(1) : String(key))
         .split(separator)
         .filter((k) => k !== "");
       normalized = keys.map((k) => {

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -371,10 +371,6 @@ function normalizeKey(key: unknown, separator: string): TranslationKey[] {
     } else if (key === null || key === undefined) {
       normalized = [];
     } else {
-      // Ruby's `key.to_s`. A Symbol is spelled here as a colon-prefixed
-      // string, and `Symbol#to_s` drops that colon — this is the one place
-      // Rails converts a Symbol key to its name, so callers that pull a
-      // `":errors.format"` default out of a chain pass it through as it is.
       const keys = (typeof key === "string" && key.startsWith(":") ? key.slice(1) : String(key))
         .split(separator)
         .filter((k) => k !== "");


### PR DESCRIPTION
Ruby converts a Symbol translate key to its name in exactly one place —
`normalize_key`'s `key.to_s` (`vendor/i18n/lib/i18n.rb:447`). PR #6031 spelled
that conversion as a file-private `toS` copy in three files instead, so any new
caller pulling a `":errors.format"` default out of a chain and passing it as a
key would silently look up a key with a leading colon.

- `packages/i18n/src/i18n.ts` `normalizeKey` now drops the leading colon of our
  Symbol spelling where Rails calls `to_s`, ahead of the `split(separator)`.
- Deleted the three copies: `packages/i18n/src/exceptions.ts`
  (`MissingTranslation#normalized_option`, `i18n/lib/i18n/exceptions.rb:73`),
  `packages/activemodel/src/translation.ts`
  (`active_model/translation.rb:32`) and `packages/activemodel/src/error.ts`
  (`active_model/error.rb:98` and `:131`) — those call sites now pass the
  shifted default straight through, as the Ruby does.

`packages/i18n/src/backend/flatten.ts`'s `toS` is a different Rails `to_s`
(`resolve_link`'s link value, not a key) and stays.

Tests: `pnpm vitest run packages/i18n packages/activemodel` (2364), the AR
validations + i18n files (144), and `packages/actionview` (505) all green.
`pnpm api:calls` and `pnpm api:calls:wide` both OK.


Regression cover lands in `packages/i18n/src/i18n.trails.test.ts` — the gem has no case of its own here because it gets the drop from `Symbol#to_s`. Both new cases fail on baseline (`String(":errors.format").split(".")` keeps the colon).

Closes-story: i18n-symbol-to-s-single-boundary
