### PR TITLE
fix(i18n): include Base into Backend::Simple instead of extending it

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -598,6 +598,9 @@ export abstract class Base {
    * Loads a plain JavaScript translations file. Evaluating the file must yield
    * translation data with locales as toplevel keys — the gem `eval`s Ruby
    * source for that hash, and a JS module's exports are the same hash.
+   *
+   * @noRailsEquivalent PERMANENT — the JS analogue of the gem's `load_rb`
+   * (base.rb:254-257) — there is no Ruby source to `eval` here.
    */
   protected loadJs(filename: string): [unknown, boolean] {
     const translations = readLocaleModule(filename);

--- a/packages/i18n/src/backend/simple.trails.test.ts
+++ b/packages/i18n/src/backend/simple.trails.test.ts
@@ -1,6 +1,7 @@
 /**
  * Trails-only cover for the shape of `Simple` — the gem has no test for it
- * because Ruby's `class Simple; include Implementation` needs none.
+ * because Ruby's `class Simple; include Implementation` needs none. The second
+ * case is the gem's own extension example (simple.rb:10-19).
  */
 
 import { describe, expect, it } from "vitest";
@@ -12,14 +13,11 @@ describe("Backend::Simple", () => {
   it("includes Base rather than inheriting from it", () => {
     expect(Object.getPrototypeOf(Simple)).not.toBe(Base);
     expect(new Simple()).not.toBeInstanceOf(Base);
-    // `include Base` (simple.rb:22) still puts every Base method on it.
     expect(typeof new Simple().translate).toBe("function");
     expect(typeof new Simple().transliterate).toBe("function");
   });
 
   it("keeps the seam a mixin sits in, with super reaching Simple's bodies", () => {
-    // The gem's own example: `I18n::Backend::Simple.include(Pluralization)`
-    // overrides a method and calls `super` (simple.rb:10-19).
     const seen: string[] = [];
     class Pluralization extends Simple {
       override storeTranslations(

--- a/packages/i18n/src/backend/simple.trails.test.ts
+++ b/packages/i18n/src/backend/simple.trails.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Trails-only cover for the shape of `Simple` — the gem has no test for it
+ * because Ruby's `class Simple; include Implementation` needs none.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { Base } from "./base.js";
+import { Simple } from "./simple.js";
+
+describe("Backend::Simple", () => {
+  it("includes Base rather than inheriting from it", () => {
+    expect(Object.getPrototypeOf(Simple)).not.toBe(Base);
+    expect(new Simple()).not.toBeInstanceOf(Base);
+    // `include Base` (simple.rb:22) still puts every Base method on it.
+    expect(typeof new Simple().translate).toBe("function");
+    expect(typeof new Simple().transliterate).toBe("function");
+  });
+
+  it("keeps the seam a mixin sits in, with super reaching Simple's bodies", () => {
+    // The gem's own example: `I18n::Backend::Simple.include(Pluralization)`
+    // overrides a method and calls `super` (simple.rb:10-19).
+    const seen: string[] = [];
+    class Pluralization extends Simple {
+      override storeTranslations(
+        locale: string,
+        data: Record<string, unknown>,
+        options = {},
+      ): unknown {
+        seen.push(locale);
+        return super.storeTranslations(locale, data, options);
+      }
+    }
+
+    const backend = new Pluralization();
+    backend.storeTranslations("en", { foo: "bar" });
+
+    expect(seen).toEqual(["en"]);
+    expect(backend.translate("en", "foo")).toBe("bar");
+  });
+});

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -10,12 +10,14 @@
  * `Simple.include(Pluralization)` lands *between* the two and its `super`
  * reaches `Implementation`. TypeScript has no module reopening, so this file
  * keeps the bodies in the `Simple` class itself and spells `include Base` as
- * the prototype copy below — the class body still wins over `Base`, and a
- * mixin over `Simple` (`Fallbacks(Simple)`) still sits above these bodies with
- * `super` reaching them, which is the seam `extends Base` collapsed. The two
- * `super` calls below are `Base.prototype.<m>.call(this)` for the same reason
- * Ruby resolves them to `Base`: a mixin included into `Simple` sits above
- * `Implementation`, never between it and `Base`.
+ * the prototype copy at the bottom — `include()` from
+ * `@blazetrails/activesupport` is that same copy, unreachable here only because
+ * that package depends on this one. The class body still wins over `Base`, as
+ * Ruby's `include` does, and a mixin over `Simple` (`Fallbacks(Simple)`) still
+ * sits above these bodies with `super` reaching them: the seam `extends Base`
+ * collapsed. The two `super` calls below are `Base.prototype.<m>.call(this)`
+ * for the reason Ruby resolves them to `Base` too — a mixin included into
+ * `Simple` sits above `Implementation`, never between it and `Base`.
  *
  * There is likewise no `MUTEX` — JS has no threads, so the concurrent-hash
  * machinery has nothing to guard.

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -4,10 +4,18 @@
  * A simple backend that reads translations from an in-memory hash. Relies on
  * the Base backend.
  *
- * The gem splits the code into a `Simple::Implementation` module so other
- * modules can be `include`d over it; TypeScript has no module reopening, so
- * `Simple` is a single class extending `Base`. There is likewise no `MUTEX` —
- * JS has no threads, so the concurrent-hash machinery has nothing to guard.
+ * The gem's `Simple` has no superclass: it splits the code into a
+ * `Simple::Implementation` module that `include Base` (simple.rb:20-22) and
+ * `include Implementation`s it back (simple.rb:107), so that a later
+ * `Simple.include(Pluralization)` lands *between* the two and its `super`
+ * reaches `Implementation`. TypeScript has no module reopening, so this file
+ * keeps the bodies in the `Simple` class itself and spells `include Base` as
+ * the prototype copy below — the class body still wins over `Base`, and a
+ * mixin over `Simple` (`Fallbacks(Simple)`) still sits above these bodies with
+ * `super` reaching them, which is the seam `extends Base` collapsed.
+ *
+ * There is likewise no `MUTEX` — JS has no threads, so the concurrent-hash
+ * machinery has nothing to guard.
  */
 
 import {
@@ -30,7 +38,19 @@ function isSymbol(value: unknown): value is string {
   return typeof value === "string" && value.startsWith(":");
 }
 
-export class Simple extends Base {
+/**
+ * Ruby `include Base` (simple.rb:22) as a type: the merged interface gives
+ * `Simple` every member `Base` declares, without an `extends` clause the gem
+ * does not have. The runtime half of the same `include` is the prototype copy
+ * at the bottom of this file; a TS interface has no `protected`, so `Base`'s
+ * protected members widen on the merged type, where the copy leaves them
+ * exactly where the gem has them.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unsafe-declaration-merging -- the merge is the point: it is `include Base` on the type side.
+export interface Simple extends Base {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- see the interface above.
+export class Simple {
   private initializedFlag = false;
   private translationsStore: TranslationData | undefined;
 
@@ -44,7 +64,7 @@ export class Simple extends Base {
    * for the translations hash, so existing translations will be overwritten by
    * new ones only at the deepest level of the hash.
    */
-  override storeTranslations(
+  storeTranslations(
     locale: Locale,
     data: TranslationData,
     options: TranslateOptions = EMPTY_HASH,
@@ -63,7 +83,7 @@ export class Simple extends Base {
   }
 
   /** Get available locales from the translations hash. */
-  override availableLocales(): Locale[] {
+  availableLocales(): Locale[] {
     if (!this.initialized()) this.initTranslations();
     const locales: Locale[] = [];
     for (const [locale, data] of Object.entries(this.translations())) {
@@ -75,15 +95,18 @@ export class Simple extends Base {
   }
 
   /** Clean up translations hash and set initialized to false on reload. */
-  override reloadBang(): void {
+  reloadBang(): void {
     this.initializedFlag = false;
     this.translationsStore = undefined;
-    super.reloadBang();
+    // Ruby's `super` from `Implementation` resolves to `Base`, the next
+    // ancestor — a mixin included into `Simple` sits above `Implementation`,
+    // never between it and `Base`.
+    Base.prototype.reloadBang.call(this);
   }
 
-  override eagerLoadBang(): void {
+  eagerLoadBang(): void {
     if (!this.initialized()) this.initTranslations();
-    super.eagerLoadBang();
+    Base.prototype.eagerLoadBang.call(this);
   }
 
   translations({ doInit = false }: { doInit?: boolean } = {}): TranslationData {
@@ -117,7 +140,7 @@ export class Simple extends Base {
    * keys, i.e. `currency.format` is regarded the same as `["currency",
    * "format"]`.
    */
-  protected override lookup(
+  protected lookup(
     locale: Locale,
     key: TranslationKey,
     scope: unknown = [],
@@ -144,5 +167,24 @@ export class Simple extends Base {
       }
     }
     return result;
+  }
+}
+
+/**
+ * Ruby `include Base` (simple.rb:22). `include` copies a module's instance
+ * methods into the ancestry *below* the class body, so a key the class body
+ * already defines is never replaced — the `hasOwnProperty` guard below. Some of
+ * `Base`'s members are TS class fields (`transliterate`, `loadYaml`), which
+ * only exist on an instance, so an instance is the second source read.
+ */
+for (const source of [Base.prototype, new (Base as unknown as new () => Base)()]) {
+  for (const key of Object.getOwnPropertyNames(source)) {
+    if (key === "constructor") continue;
+    if (Object.prototype.hasOwnProperty.call(Simple.prototype, key)) continue;
+    Object.defineProperty(
+      Simple.prototype,
+      key,
+      Object.getOwnPropertyDescriptor(source, key) as PropertyDescriptor,
+    );
   }
 }

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -12,7 +12,10 @@
  * keeps the bodies in the `Simple` class itself and spells `include Base` as
  * the prototype copy below — the class body still wins over `Base`, and a
  * mixin over `Simple` (`Fallbacks(Simple)`) still sits above these bodies with
- * `super` reaching them, which is the seam `extends Base` collapsed.
+ * `super` reaching them, which is the seam `extends Base` collapsed. The two
+ * `super` calls below are `Base.prototype.<m>.call(this)` for the same reason
+ * Ruby resolves them to `Base`: a mixin included into `Simple` sits above
+ * `Implementation`, never between it and `Base`.
  *
  * There is likewise no `MUTEX` — JS has no threads, so the concurrent-hash
  * machinery has nothing to guard.
@@ -98,9 +101,6 @@ export class Simple {
   reloadBang(): void {
     this.initializedFlag = false;
     this.translationsStore = undefined;
-    // Ruby's `super` from `Implementation` resolves to `Base`, the next
-    // ancestor — a mixin included into `Simple` sits above `Implementation`,
-    // never between it and `Base`.
     Base.prototype.reloadBang.call(this);
   }
 


### PR DESCRIPTION
## What

The gem's `I18n::Backend::Simple` has **no superclass**. It keeps its bodies in
a `Simple::Implementation` module that `include Base`
(`vendor/i18n/lib/i18n/backend/simple.rb:20-22`) and `include Implementation`s
it back (`simple.rb:107`) — so the documented
`I18n::Backend::Simple.include(I18n::Backend::Pluralization)` (`simple.rb:10-19`)
lands *between* `Simple` and `Base`, with its `super` reaching
`Implementation`. `packages/i18n/src/backend/simple.ts` ported that as
`class Simple extends Base`, which collapses the seam the deferred backend
mixins (`Pluralization`, `Memoize`, `Cascade`, `Fallbacks`) all rely on.

`Simple` now declares no superclass. `include Base` is spelled in both halves
the language needs:

- **type side** — a declaration-merged `interface Simple extends Base {}`, so
  `Simple` still has every `Base` member and `Fallbacks(Simple)` still
  typechecks;
- **runtime side** — a prototype copy at the bottom of the file that skips any
  key the class body defines, which is precisely Ruby's rule that `include`
  never displaces a class-body method. Two of `Base`'s members are TS class
  fields (`transliterate`, `loadYaml`), so an instance is the second source.

The two `super` calls become `Base.prototype.<m>.call(this)` — the same target
Ruby resolves, since a mixin included into `Simple` sits *above*
`Implementation`, never between it and `Base`.

`base.ts`'s `loadJs` picks up a `@noRailsEquivalent` — it is the JS analogue of
the gem's `load_rb` (`base.rb:254-257`), and the merged interface surfaces it
where the `extends` clause did not.

## Gates

- `pnpm api:compare`: i18n `inheritance: 5/6 (83.3%)` → **6/6 (100%)**; methods
  130/136, arity 74/76, files 13/13 unchanged.
- `pnpm api:calls` / `pnpm api:calls:wide`: OK, no new rows.
- `pnpm api:extra --package i18n`: `backend/simple.ts` drops off the report.
- `pnpm test:compare` i18n unchanged (259/437).
- `packages/i18n` suite green, including `backend/simple.test.ts` and
  `backend/fallbacks.test.ts`.

New `backend/simple.trails.test.ts` covers the shape itself (no gem test exists
for it): `Simple` is not a `Base` subclass yet answers `Base`'s methods, and a
mixin over it can override a method and reach the ported body through `super`.
Both fail on the `extends Base` baseline.

Closes-story: i18n-simple-include-base-not-extends
