### PR TITLE
refactor(i18n): stop pre-stripping the Symbol colon in backend/base arms

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -339,7 +339,9 @@ export abstract class Base {
       const key = format;
       const type = respondTo(object, "sec") ? "time" : "date";
       options = { ...options, raise: true, object, locale };
-      format = t(`${type}.formats.${key.slice(1)}`, options);
+      // `:"#{type}.formats.#{key}"` — interpolating a Symbol yields its name,
+      // and the built key is itself a Symbol, so it keeps the leading colon.
+      format = t(`:${type}.formats.${key.slice(1)}`, options);
     }
 
     format = this.translateLocalizationFormat(locale, object as Localizable, format, options);
@@ -421,7 +423,7 @@ export abstract class Base {
         // The gem goes through `I18n.translate`, which — with `throw: true` —
         // hands a MissingTranslation straight back to this `catch`, exactly as
         // calling the backend does. The `I18n.t` facade is not ported yet.
-        return config().backend.translate(locale, subject.slice(1), {
+        return config().backend.translate(locale, subject, {
           ...options,
           locale,
           throw: true,

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -319,6 +319,13 @@ export abstract class Base {
    * Acts the same as `strftime`, but uses a localized version of the format
    * string. Takes a key from the date/time formats translations as a format
    * argument (*e.g.*, `short` in `date.formats`).
+   *
+   * The Symbol `format` arm builds its lookup key the way the gem does, with
+   * `:"#{type}.formats.#{key}"`. Interpolating a Ruby Symbol yields its name,
+   * which for a `":short"`-spelled Symbol is `.slice(1)` — the interpolation
+   * itself, not a pre-strip of a value passed on to `translate`. The key that
+   * results is a Symbol, so it keeps its own leading colon and `normalizeKey`
+   * is still the only place a colon is dropped from a value in flight.
    */
   localize(
     locale: Locale,

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -339,8 +339,6 @@ export abstract class Base {
       const key = format;
       const type = respondTo(object, "sec") ? "time" : "date";
       options = { ...options, raise: true, object, locale };
-      // `:"#{type}.formats.#{key}"` — interpolating a Symbol yields its name,
-      // and the built key is itself a Symbol, so it keeps the leading colon.
       format = t(`:${type}.formats.${key.slice(1)}`, options);
     }
 


### PR DESCRIPTION
Follow-up to #6052, which moved the Ruby `Symbol#to_s` colon drop to the single
boundary the gem puts it at — `normalizeKey` in `packages/i18n/src/i18n.ts`
(`vendor/i18n/lib/i18n.rb:447`). Two colon-stripping sites in
`backend/base.ts` were out of that PR's scope.

**`#resolve`'s Symbol arm** (`vendor/i18n/lib/i18n/backend/base.rb:153-162`) —
`I18n.translate(subject, ...)` passes the Symbol through untouched. We now
forward `subject` verbatim instead of `subject.slice(1)`; `normalizeKey` drops
the colon. This is the divergence the story was about.

**`#localize`'s Symbol `format` arm** (`vendor/i18n/lib/i18n/backend/base.rb:84-88`)
— the audited site turns out not to be the same class of divergence, and the
`.slice(1)` stays. Rails writes `I18n.t(:"#{type}.formats.#{key}", **options)`:
the Symbol is not forwarded, it is *interpolated into a new key*, and Ruby
interpolation calls `to_s` right there. In our `":short"` spelling, `"#{key}"`
**is** `key.slice(1)` — the `.slice(1)` is the interpolation operator, not a
pre-strip of a value in flight. What was actually wrong was the other half:
Rails' `:"..."` produces a **Symbol** and ours produced a String, so the built
key now keeps its own leading colon (`:date.formats.short`) and `normalizeKey`
remains the only place a colon is dropped from a value being passed on.
Justified at the call site in `localize`'s JSDoc rather than in this body.

No observable behavior change: every consumer of the key (`Simple#lookup`,
`MissingTranslation#message` / `#normalizedOption`) routes it through
`normalizeKeys`, so there is no baseline-failing regression test to add.
`packages/i18n` (395 tests) and `packages/activemodel` (1984, covering the
i18n validation/default chains) are green; `pnpm api:calls` ratchet OK.

Closes-story: backend-base-symbol-arms-pre-strip-colon
