### PR TITLE
fix(i18n): widen Date.parse to the spellings ::Date.parse accepts

### DIFF
--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -15,6 +15,30 @@ describe("Date", () => {
     }
   });
 
+  it("parses the spellings ::Date.parse takes, one per date_parse.c sub-parser", () => {
+    for (const str of [
+      "2008-07-02",
+      "2008/07/02",
+      "2008.07.02",
+      "20080702",
+      "Jul 2 2008",
+      "July 2nd, 2008",
+      "2 Jul 2008",
+      "2nd July 2008",
+      "2-Jul-2008",
+      "Wed, 2 Jul 2008",
+    ]) {
+      const date = RubyDate.parse(str);
+      expect([str, date.year, date.mon, date.day]).toEqual([str, 2008, 7, 2]);
+    }
+  });
+
+  it("reads a two-digit head with a four-digit tail as d/m/y, as s3e does", () => {
+    const date = RubyDate.parse("01/01/2012");
+    expect([date.year, date.mon, date.day]).toEqual([2012, 1, 1]);
+    expect(() => RubyDate.parse("12/13/2012")).toThrow("invalid date");
+  });
+
   it("raises on an unparseable string", () => {
     expect(() => RubyDate.parse("not a date")).toThrow(ArgumentError);
     expect(() => RubyDate.parse("not a date")).toThrow("invalid date");

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -27,6 +27,8 @@ describe("Date", () => {
       "2nd July 2008",
       "2-Jul-2008",
       "Wed, 2 Jul 2008",
+      "Wednesday, July 2, 2008",
+      "2008-07-02T10:30:00",
     ]) {
       const date = RubyDate.parse(str);
       expect([str, date.year, date.mon, date.day]).toEqual([str, 2008, 7, 2]);

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -30,6 +30,8 @@ describe("Date", () => {
       "Wed, 2 Jul 2008",
       "Wednesday, July 2, 2008",
       "2008-07-02T10:30:00",
+      "2008070210",
+      "20080702123456",
     ]) {
       const date = RubyDate.parse(str);
       expect([str, date.year, date.mon, date.day]).toEqual([str, 2008, 7, 2]);

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -41,6 +41,12 @@ describe("Date", () => {
     expect(() => RubyDate.parse("12/13/2012")).toThrow("invalid date");
   });
 
+  it("completes a two-digit year unless comp is false, as Ruby does", () => {
+    expect(RubyDate.parse("080702").year).toBe(2008);
+    expect(RubyDate.parse("690702").year).toBe(1969);
+    expect(RubyDate.parse("080702", false).year).toBe(8);
+  });
+
   it("raises on an unparseable string", () => {
     expect(() => RubyDate.parse("not a date")).toThrow(ArgumentError);
     expect(() => RubyDate.parse("not a date")).toThrow("invalid date");

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ArgumentError, Date as RubyDate, DateTime as RubyDateTime } from "./date.js";
 import { Time as RubyTime } from "./time.js";
 
@@ -45,9 +45,15 @@ describe("Date", () => {
   });
 
   it('completes a fragment from today, as "Feb 3rd".to_date does', () => {
-    const today = Temporal.Now.plainDateISO();
-    const date = RubyDate.parse("Feb 3rd");
-    expect([date.year, date.mon, date.day]).toEqual([today.year, 2, 3]);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2008-08-04T12:00:00Z"));
+    try {
+      expect(Temporal.Now.plainDateISO("UTC").year).toBe(2008);
+      const date = RubyDate.parse("Feb 3rd");
+      expect([date.year, date.mon, date.day]).toEqual([2008, 2, 3]);
+    } finally {
+      vi.useRealTimers();
+    }
     const partial = RubyDate.parse("2008/07");
     expect([partial.year, partial.mon, partial.day]).toEqual([2008, 7, 1]);
   });

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -3,6 +3,7 @@
  * These cover the members `I18n::Backend::Base#localize` duck-types.
  */
 
+import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect } from "vitest";
 import { ArgumentError, Date as RubyDate, DateTime as RubyDateTime } from "./date.js";
 import { Time as RubyTime } from "./time.js";
@@ -39,6 +40,19 @@ describe("Date", () => {
     const date = RubyDate.parse("01/01/2012");
     expect([date.year, date.mon, date.day]).toEqual([2012, 1, 1]);
     expect(() => RubyDate.parse("12/13/2012")).toThrow("invalid date");
+  });
+
+  it('completes a fragment from today, as "Feb 3rd".to_date does', () => {
+    const today = Temporal.Now.plainDateISO();
+    const date = RubyDate.parse("Feb 3rd");
+    expect([date.year, date.mon, date.day]).toEqual([today.year, 2, 3]);
+    const partial = RubyDate.parse("2008/07");
+    expect([partial.year, partial.mon, partial.day]).toEqual([2008, 7, 1]);
+  });
+
+  it("leaves a signed year uncompleted, as date_parse.c does", () => {
+    expect(RubyDate.parse("-08-07-02").year).toBe(-8);
+    expect(RubyDate.parse("+08-07-02").year).toBe(8);
   });
 
   it("completes a two-digit year unless comp is false, as Ruby does", () => {

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -139,6 +139,125 @@ export class ArgumentError extends Error {
 }
 
 /**
+ * @internal The alternations `date_parse.c` builds its patterns from
+ * (ruby/date, `date_parse.c` `ABBR_MONTHS` / `ABBR_DAYS`). Ruby matches the
+ * abbreviation and lets the rest of the name run off the end of the token, so
+ * `"Jul"`, `"July"` and `"JULY"` all land on the same month.
+ */
+const ABBR_MONTHS = "jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec";
+const ABBR_DAYS = "sun|mon|tue|wed|thu|fri|sat";
+
+/** @internal The `:year`/`:mon`/`:mday` of the Hash `Date._parse` answers. */
+interface DateParts {
+  year: number;
+  mon: number;
+  mday: number;
+}
+
+/** @internal `date_parse.c` `mon_num`: an abbreviation, or the head of a full name. */
+function monNum(str: string): number {
+  return ABBR_MONTH_NAMES.findIndex((m) => m.toLowerCase() === str.slice(0, 3).toLowerCase()) + 1;
+}
+
+/** @internal Ruby writes a `'`-prefixed number for a literal (uncompleted) year. */
+function num(str: string): number {
+  return Number(str.replace(/^'/, ""));
+}
+
+/**
+ * @internal `date_parse.c` `s3e`: the three fields of a `y-m-d`-shaped match
+ * are not always in that order — a two-digit head with a four-digit tail is
+ * `d/m/y`, which is why `"01/01/2012".to_date` is 1 Jan 2012 while
+ * `"12/13/2012".to_date` raises
+ * (activesupport/lib/active_support/core_ext/string/conversions.rb:38-41).
+ */
+function s3e(y: string | null, m: string, d: string | null): DateParts | null {
+  if (y !== null && d !== null && y.replace(/^[-+']/, "").length < 3 && d.length > 2) {
+    [y, d] = [d, y];
+  }
+  if (y === null || d === null) return null;
+  return { year: num(y), mon: num(m), mday: num(d) };
+}
+
+/** @internal `date_parse.c` `parse_day`: a leading day name is not a date field. */
+function parseDay(str: string): string {
+  return str.replace(new RegExp(`\\b(${ABBR_DAYS})[^-\\d\\s]*`, "i"), " ");
+}
+
+/** @internal `date_parse.c` `parse_eu`: `2nd July 2008`, `2 Jul 2008`, `2-Jul-2008`. */
+function parseEu(str: string): DateParts | null {
+  const m = new RegExp(
+    `'?(\\d+)[^-\\d\\s]*[-,.\\s]*(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]*('?-?\\d+)`,
+    "i",
+  ).exec(str);
+  return m ? { year: num(m[3]), mon: monNum(m[2]), mday: num(m[1]) } : null;
+}
+
+/** @internal `date_parse.c` `parse_us`: `Jul 2 2008`, `July 2nd, 2008`. */
+function parseUs(str: string): DateParts | null {
+  const m = new RegExp(
+    `\\b(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]+'?(\\d+)[^-\\d\\s]*[-,.\\s]*('?-?\\d+)`,
+    "i",
+  ).exec(str);
+  return m ? { year: num(m[3]), mon: monNum(m[1]), mday: num(m[2]) } : null;
+}
+
+/** @internal `date_parse.c` `parse_iso`: `2008-07-02`, and the unpadded `2008-7-2`. */
+function parseIso(str: string): DateParts | null {
+  const m = /([-+]?\d+)-(\d+)-(-?\d+)/.exec(str);
+  return m ? s3e(m[1], m[2], m[3]) : null;
+}
+
+/** @internal `date_parse.c` `parse_sla`: `2012/12/13`, `01/01/2012`. */
+function parseSla(str: string): DateParts | null {
+  const m = /([-+]?\d+)\/\s*(\d+)(?:\D\s*(-?\d+))?/.exec(str);
+  return m ? s3e(m[1], m[2], m[3] ?? null) : null;
+}
+
+/** @internal `date_parse.c` `parse_dot`: `2012.12.13`, `01.01.2012`. */
+function parseDot(str: string): DateParts | null {
+  const m = /([-+]?\d+)\.\s*(\d+)\.\s*(-?\d+)/.exec(str);
+  return m ? s3e(m[1], m[2], m[3]) : null;
+}
+
+/**
+ * @internal `date_parse.c` `parse_ddd`: an all-digit run. Only the widths that
+ * carry a whole date are taken — the shorter ones Ruby reads as `mmdd`, `ddd`
+ * or `dd` leave `:year` unset, and `Date.parse` raises on those anyway.
+ */
+function parseDdd(str: string): DateParts | null {
+  const m = /([-+]?)(\d{2,14})/.exec(str);
+  if (!m) return null;
+  const sign = m[1] === "-" ? "-" : "";
+  const digits = m[2];
+  if (digits.length === 8) {
+    return s3e(sign + digits.slice(0, 4), digits.slice(4, 6), digits.slice(6, 8));
+  }
+  if (digits.length === 6) {
+    return s3e(sign + digits.slice(0, 2), digits.slice(2, 4), digits.slice(4, 6));
+  }
+  return null;
+}
+
+/**
+ * @internal `date_parse.c` `date__parse`, which runs its sub-parsers in a fixed
+ * order and stops at the first that matches. The alphabetic pair goes first,
+ * then the numeric ones.
+ *
+ * @missingRailsCall `parse_time`, `parse_jis`, `parse_vms`, `parse_iso2`,
+ * `parse_year`, `parse_mon`, `parse_mday` and `parse_bc` are not ported: they
+ * read a time of day (which `::Date` discards), a calendar Rails never round-
+ * trips, or a fragment that leaves `Date.parse` raising for want of a `:year`.
+ */
+function _parse(str: string): DateParts | null {
+  str = parseDay(str);
+  if (/[a-z]/i.test(str)) {
+    return parseEu(str) ?? parseUs(str);
+  }
+  return parseIso(str) ?? parseSla(str) ?? parseDot(str) ?? parseDdd(str);
+}
+
+/**
  * @noRailsEquivalent PERMANENT — Ruby stdlib `::Date`. Rails never defines the
  * class, only reopens it, so there is no Rails counterpart for a port to
  * converge on; JS has no stdlib equivalent either (`Temporal.PlainDate` answers
@@ -155,18 +274,32 @@ export class Date {
   }
 
   /**
-   * Ruby `Date.parse`, narrowed to the `y-m-d` the callers use. The month and
-   * day are unpadded-tolerant because Ruby's is — `String#to_date` delegates
-   * straight to `::Date.parse`
+   * Ruby `Date.parse(str, comp = true)`, which runs `Date._parse` and then
+   * builds the date from the `:year`/`:mon`/`:mday` it found (ruby/date,
+   * `date_core.c` `date_s_parse` → `date__parse` in `date_parse.c`).
+   * `String#to_date` delegates straight to it
    * (activesupport/lib/active_support/core_ext/string/conversions.rb:47-48),
-   * and `i18n_test.rb:9` passes `"2008-7-2"`.
+   * so every spelling its doc example lists — `"1-1-2012"`, `"01/01/2012"`,
+   * `"2012-12-13"` — reaches here, and `activesupport/test/i18n_test.rb:9`
+   * passes the unpadded `"2008-7-2"`.
+   *
+   * `comp` is not taken: Rails only ever calls `::Date.parse(self, false)`, and
+   * `comp` governs nothing but two-digit-year completion, which `false` turns
+   * off — so the one behaviour trails needs is the default here.
+   *
+   * @missingRailsCall `Date._parse` is not a separate member here; its
+   * sub-parsers are the module-private functions below.
    */
   static parse(str: string): Date {
-    const match = /^(-?\d{4,})-(\d{1,2})-(\d{1,2})$/.exec(str);
+    const parts = _parse(str);
     // Ruby raises `Date::Error`, a subclass of `ArgumentError` that a nested
     // TS class cannot spell; the superclass is what callers rescue.
-    if (!match) throw new ArgumentError("invalid date");
-    return new Date(Number(match[1]), Number(match[2]), Number(match[3]));
+    if (!parts) throw new ArgumentError("invalid date");
+    try {
+      return new Date(parts.year, parts.mon, parts.mday);
+    } catch {
+      throw new ArgumentError("invalid date");
+    }
   }
 
   get year(): number {

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -147,11 +147,21 @@ export class ArgumentError extends Error {
 const ABBR_MONTHS = "jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec";
 const ABBR_DAYS = "sun|mon|tue|wed|thu|fri|sat";
 
-/** @internal The `:year`/`:mon`/`:mday` of the Hash `Date._parse` answers. */
+/**
+ * @internal The `:year`/`:mon`/`:mday` of the Hash `Date._parse` answers, plus
+ * the `:_comp` `date_parse.c` sets when the year token was short enough to
+ * complete and deletes again before answering.
+ */
 interface DateParts {
   year: number;
   mon: number;
   mday: number;
+  _comp?: boolean;
+}
+
+/** @internal `date_parse.c` `comp_year69`: `69` is 1969, `68` is 2068. */
+function compYear69(y: number): number {
+  return y >= 69 ? y + 1900 : y + 2000;
 }
 
 /** @internal `date_parse.c` `mon_num`: an abbreviation, or the head of a full name. */
@@ -171,7 +181,12 @@ function s3e(y: string | null, m: string, d: string | null): DateParts | null {
     [y, d] = [d, y];
   }
   if (y === null || d === null) return null;
-  return { year: Number(y), mon: Number(m), mday: Number(d) };
+  return {
+    year: Number(y),
+    mon: Number(m),
+    mday: Number(d),
+    _comp: y.replace(/^[-+]/, "").length < 3,
+  };
 }
 
 /** @internal `date_parse.c` `parse_day`: a leading day name is not a date field. */
@@ -185,7 +200,14 @@ function parseEu(str: string): DateParts | null {
     `'?(\\d+)[^-\\d\\s]*[-,.\\s]*(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]*'?(-?\\d+)`,
     "i",
   ).exec(str);
-  return m ? { year: Number(m[3]), mon: monNum(m[2]), mday: Number(m[1]) } : null;
+  return m
+    ? {
+        year: Number(m[3]),
+        mon: monNum(m[2]),
+        mday: Number(m[1]),
+        _comp: m[3].replace(/^-/, "").length < 3,
+      }
+    : null;
 }
 
 /** @internal `date_parse.c` `parse_us`: `Jul 2 2008`, `July 2nd, 2008`. */
@@ -194,7 +216,14 @@ function parseUs(str: string): DateParts | null {
     `\\b(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]+'?(\\d+)[^-\\d\\s]*[-,.\\s]*'?(-?\\d+)`,
     "i",
   ).exec(str);
-  return m ? { year: Number(m[3]), mon: monNum(m[1]), mday: Number(m[2]) } : null;
+  return m
+    ? {
+        year: Number(m[3]),
+        mon: monNum(m[1]),
+        mday: Number(m[2]),
+        _comp: m[3].replace(/^-/, "").length < 3,
+      }
+    : null;
 }
 
 /** @internal `date_parse.c` `parse_iso`: `2008-07-02`, and the unpadded `2008-7-2`. */
@@ -260,15 +289,11 @@ export class Date {
    * `"2012-12-13"` — reaches here, and `activesupport/test/i18n_test.rb:9`
    * passes the unpadded `"2008-7-2"`.
    *
-   * `comp` is not taken: Rails only ever calls `::Date.parse(self, false)`, and
-   * `comp` governs nothing but two-digit-year completion, which `false` turns
-   * off — so the one behaviour trails needs is the default here.
-   *
-   * @missingRailsCall `Date._parse` is not a separate member here; its
-   * sub-parsers are the module-private functions below.
+   * `comp` completes a two-digit year, which is why `"080702"` is 2008 here
+   * and 0008 through Rails' `::Date.parse(self, false)`.
    */
-  static parse(str: string): Date {
-    const parts = Date._parse(str);
+  static parse(str: string, comp = true): Date {
+    const parts = Date._parse(str, comp);
     // Ruby raises `Date::Error`, a subclass of `ArgumentError` that a nested
     // TS class cannot spell; the superclass is what callers rescue.
     if (!parts) throw new ArgumentError("invalid date");
@@ -293,13 +318,17 @@ export class Date {
    * round-trips, or a fragment that leaves `Date.parse` raising for want of a
    * `:year`.
    */
-  static _parse(str: string): DateParts | null {
+  static _parse(str: string, comp = true): DateParts | null {
     str = parseDay(str);
+    let parts: DateParts | null = null;
     if (/[a-z]/i.test(str)) {
-      const parts = parseEu(str) ?? parseUs(str);
-      if (parts) return parts;
+      parts = parseEu(str) ?? parseUs(str);
     }
-    return parseIso(str) ?? parseSla(str) ?? parseDot(str) ?? parseDdd(str);
+    parts ??= parseIso(str) ?? parseSla(str) ?? parseDot(str) ?? parseDdd(str);
+    if (parts === null) return null;
+    if (comp && parts._comp === true) parts.year = compYear69(parts.year);
+    delete parts._comp;
+    return parts;
   }
 
   get year(): number {

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -159,11 +159,6 @@ function monNum(str: string): number {
   return ABBR_MONTH_NAMES.findIndex((m) => m.toLowerCase() === str.slice(0, 3).toLowerCase()) + 1;
 }
 
-/** @internal Ruby writes a `'`-prefixed number for a literal (uncompleted) year. */
-function num(str: string): number {
-  return Number(str.replace(/^'/, ""));
-}
-
 /**
  * @internal `date_parse.c` `s3e`: the three fields of a `y-m-d`-shaped match
  * are not always in that order — a two-digit head with a four-digit tail is
@@ -172,11 +167,11 @@ function num(str: string): number {
  * (activesupport/lib/active_support/core_ext/string/conversions.rb:38-41).
  */
 function s3e(y: string | null, m: string, d: string | null): DateParts | null {
-  if (y !== null && d !== null && y.replace(/^[-+']/, "").length < 3 && d.length > 2) {
+  if (y !== null && d !== null && y.replace(/^[-+]/, "").length < 3 && d.length > 2) {
     [y, d] = [d, y];
   }
   if (y === null || d === null) return null;
-  return { year: num(y), mon: num(m), mday: num(d) };
+  return { year: Number(y), mon: Number(m), mday: Number(d) };
 }
 
 /** @internal `date_parse.c` `parse_day`: a leading day name is not a date field. */
@@ -187,19 +182,19 @@ function parseDay(str: string): string {
 /** @internal `date_parse.c` `parse_eu`: `2nd July 2008`, `2 Jul 2008`, `2-Jul-2008`. */
 function parseEu(str: string): DateParts | null {
   const m = new RegExp(
-    `'?(\\d+)[^-\\d\\s]*[-,.\\s]*(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]*('?-?\\d+)`,
+    `'?(\\d+)[^-\\d\\s]*[-,.\\s]*(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]*'?(-?\\d+)`,
     "i",
   ).exec(str);
-  return m ? { year: num(m[3]), mon: monNum(m[2]), mday: num(m[1]) } : null;
+  return m ? { year: Number(m[3]), mon: monNum(m[2]), mday: Number(m[1]) } : null;
 }
 
 /** @internal `date_parse.c` `parse_us`: `Jul 2 2008`, `July 2nd, 2008`. */
 function parseUs(str: string): DateParts | null {
   const m = new RegExp(
-    `\\b(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]+'?(\\d+)[^-\\d\\s]*[-,.\\s]*('?-?\\d+)`,
+    `\\b(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]+'?(\\d+)[^-\\d\\s]*[-,.\\s]*'?(-?\\d+)`,
     "i",
   ).exec(str);
-  return m ? { year: num(m[3]), mon: monNum(m[1]), mday: num(m[2]) } : null;
+  return m ? { year: Number(m[3]), mon: monNum(m[1]), mday: Number(m[2]) } : null;
 }
 
 /** @internal `date_parse.c` `parse_iso`: `2008-07-02`, and the unpadded `2008-7-2`. */
@@ -240,24 +235,6 @@ function parseDdd(str: string): DateParts | null {
 }
 
 /**
- * @internal `date_parse.c` `date__parse`, which runs its sub-parsers in a fixed
- * order and stops at the first that matches. The alphabetic pair goes first,
- * then the numeric ones.
- *
- * @missingRailsCall `parse_time`, `parse_jis`, `parse_vms`, `parse_iso2`,
- * `parse_year`, `parse_mon`, `parse_mday` and `parse_bc` are not ported: they
- * read a time of day (which `::Date` discards), a calendar Rails never round-
- * trips, or a fragment that leaves `Date.parse` raising for want of a `:year`.
- */
-function _parse(str: string): DateParts | null {
-  str = parseDay(str);
-  if (/[a-z]/i.test(str)) {
-    return parseEu(str) ?? parseUs(str);
-  }
-  return parseIso(str) ?? parseSla(str) ?? parseDot(str) ?? parseDdd(str);
-}
-
-/**
  * @noRailsEquivalent PERMANENT — Ruby stdlib `::Date`. Rails never defines the
  * class, only reopens it, so there is no Rails counterpart for a port to
  * converge on; JS has no stdlib equivalent either (`Temporal.PlainDate` answers
@@ -291,7 +268,7 @@ export class Date {
    * sub-parsers are the module-private functions below.
    */
   static parse(str: string): Date {
-    const parts = _parse(str);
+    const parts = Date._parse(str);
     // Ruby raises `Date::Error`, a subclass of `ArgumentError` that a nested
     // TS class cannot spell; the superclass is what callers rescue.
     if (!parts) throw new ArgumentError("invalid date");
@@ -300,6 +277,29 @@ export class Date {
     } catch {
       throw new ArgumentError("invalid date");
     }
+  }
+
+  /**
+   * Ruby `Date._parse(str, comp = true)` (ruby/date, `date_parse.c`
+   * `date__parse`), which runs its sub-parsers in a fixed order and stops at
+   * the first that matches: the alphabetic pair first, then the numeric ones.
+   * Ruby answers a Hash of whatever fields it found; the fields trails reads
+   * are `:year`, `:mon` and `:mday`, so a match that leaves any of them unset
+   * is `null` here.
+   *
+   * @missingRailsCall `parse_time`, `parse_jis`, `parse_vms`, `parse_iso2`,
+   * `parse_year`, `parse_mon`, `parse_mday` and `parse_bc` are not ported: they
+   * read a time of day (which `::Date` discards), a calendar Rails never
+   * round-trips, or a fragment that leaves `Date.parse` raising for want of a
+   * `:year`.
+   */
+  static _parse(str: string): DateParts | null {
+    str = parseDay(str);
+    if (/[a-z]/i.test(str)) {
+      const parts = parseEu(str) ?? parseUs(str);
+      if (parts) return parts;
+    }
+    return parseIso(str) ?? parseSla(str) ?? parseDot(str) ?? parseDdd(str);
   }
 
   get year(): number {

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -148,14 +148,15 @@ const ABBR_MONTHS = "jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec";
 const ABBR_DAYS = "sun|mon|tue|wed|thu|fri|sat";
 
 /**
- * @internal The `:year`/`:mon`/`:mday` of the Hash `Date._parse` answers, plus
- * the `:_comp` `date_parse.c` sets when the year token was short enough to
- * complete and deletes again before answering.
+ * @internal The `:year`/`:mon`/`:mday` of the Hash `Date._parse` answers — any
+ * of them absent when the string named only a fragment — plus the `:_comp`
+ * `date_parse.c` sets when the year token is completable and deletes again
+ * before answering.
  */
 interface DateParts {
-  year: number;
-  mon: number;
-  mday: number;
+  year?: number;
+  mon?: number;
+  mday?: number;
   _comp?: boolean;
 }
 
@@ -170,22 +171,35 @@ function monNum(str: string): number {
 }
 
 /**
- * @internal `date_parse.c` `s3e`: the three fields of a `y-m-d`-shaped match
- * are not always in that order — a two-digit head with a four-digit tail is
- * `d/m/y`, which is why `"01/01/2012".to_date` is 1 Jan 2012 while
+ * @internal `date_parse.c` `s3e`, which decides which of a match's numeric
+ * tokens is the year: a token of more than two digits is one, a shorter one is
+ * a month or a day. That is why `"01/01/2012".to_date` is 1 Jan 2012 while
  * `"12/13/2012".to_date` raises
- * (activesupport/lib/active_support/core_ext/string/conversions.rb:38-41).
+ * (activesupport/lib/active_support/core_ext/string/conversions.rb:38-41), and
+ * why `"07/08"` names no year at all.
+ *
+ * A signed year is never completable (`date_parse.c:172-181`, `:250-251`), so
+ * `"-08-07-02"` is year -8 rather than 1992.
  */
-function s3e(y: string | null, m: string, d: string | null): DateParts | null {
-  if (y !== null && d !== null && y.replace(/^[-+]/, "").length < 3 && d.length > 2) {
+function s3e(y: string | null, m: string, d: string | null): DateParts {
+  if (y === null && d !== null && d.length > 2) {
+    y = d;
+    d = null;
+  }
+  if (y !== null && d === null) {
+    if (y.replace(/^[-+]/, "").length > 2) return { year: Number(y), mon: Number(m), _comp: false };
+    if (m.length > 2) return { year: Number(m), mon: Number(y), _comp: false };
+    return { mon: Number(y), mday: Number(m) };
+  }
+  if (y === null) return { mon: Number(m), mday: Number(d) };
+  if (y.replace(/^[-+]/, "").length < 3 && d !== null && d.length > 2) {
     [y, d] = [d, y];
   }
-  if (y === null || d === null) return null;
   return {
     year: Number(y),
     mon: Number(m),
     mday: Number(d),
-    _comp: y.replace(/^[-+]/, "").length < 3,
+    _comp: /^\d{1,2}$/.test(y),
   };
 }
 
@@ -194,36 +208,22 @@ function parseDay(str: string): string {
   return str.replace(new RegExp(`\\b(${ABBR_DAYS})[^-\\d\\s]*`, "i"), " ");
 }
 
-/** @internal `date_parse.c` `parse_eu`: `2nd July 2008`, `2 Jul 2008`, `2-Jul-2008`. */
+/** @internal `date_parse.c` `parse_eu`: `2nd July 2008`, `2 Jul 2008`, `3 Feb`. */
 function parseEu(str: string): DateParts | null {
   const m = new RegExp(
-    `'?(\\d+)[^-\\d\\s]*[-,.\\s]*(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]*'?(-?\\d+)`,
+    `'?(\\d+)[^-\\d\\s]*[-,.\\s]*(${ABBR_MONTHS})[^-\\d\\s]*(?:[,.\\s]+'?([-+]?\\d+)|[-,.\\s]*'?(\\d+))?`,
     "i",
   ).exec(str);
-  return m
-    ? {
-        year: Number(m[3]),
-        mon: monNum(m[2]),
-        mday: Number(m[1]),
-        _comp: m[3].replace(/^-/, "").length < 3,
-      }
-    : null;
+  return m ? s3e(m[3] ?? m[4] ?? null, String(monNum(m[2])), m[1]) : null;
 }
 
-/** @internal `date_parse.c` `parse_us`: `Jul 2 2008`, `July 2nd, 2008`. */
+/** @internal `date_parse.c` `parse_us`: `Jul 2 2008`, `July 2nd, 2008`, `Feb 2008`. */
 function parseUs(str: string): DateParts | null {
   const m = new RegExp(
-    `\\b(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]+'?(\\d+)[^-\\d\\s]*[-,.\\s]*'?(-?\\d+)`,
+    `\\b(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]+'?(\\d+)[^-\\d\\s]*(?:[,.\\s]+'?([-+]?\\d+)|[-,.\\s]*'?(\\d+))?`,
     "i",
   ).exec(str);
-  return m
-    ? {
-        year: Number(m[3]),
-        mon: monNum(m[1]),
-        mday: Number(m[2]),
-        _comp: m[3].replace(/^-/, "").length < 3,
-      }
-    : null;
+  return m ? s3e(m[3] ?? m[4] ?? null, String(monNum(m[1])), m[2]) : null;
 }
 
 /** @internal `date_parse.c` `parse_iso`: `2008-07-02`, and the unpadded `2008-7-2`. */
@@ -232,7 +232,7 @@ function parseIso(str: string): DateParts | null {
   return m ? s3e(m[1], m[2], m[3]) : null;
 }
 
-/** @internal `date_parse.c` `parse_sla`: `2012/12/13`, `01/01/2012`. */
+/** @internal `date_parse.c` `parse_sla`: `2012/12/13`, `01/01/2012`, `2008/07`. */
 function parseSla(str: string): DateParts | null {
   const m = /([-+]?\d+)\/\s*(\d+)(?:\D\s*(-?\d+))?/.exec(str);
   return m ? s3e(m[1], m[2], m[3] ?? null) : null;
@@ -245,12 +245,16 @@ function parseDot(str: string): DateParts | null {
 }
 
 /**
- * @internal `date_parse.c` `parse_ddd`: an all-digit run. Only the widths that
- * carry a whole date are taken — the shorter ones Ruby reads as `mmdd`, `ddd`
- * or `dd` leave `:year` unset, and `Date.parse` raises on those anyway.
+ * @internal `date_parse.c` `parse_ddd`: an all-digit run, read by its width.
+ *
+ * @missingRailsCall The two- and three-digit widths (a bare `:mday`, and the
+ * `:yday` of `"102"`) are not read. They are only reachable once `parse_time`
+ * has taken the time-of-day text out of the string, and `parse_time` is not
+ * ported — without it trails would read the minutes of `"07.2008"`, which Ruby
+ * rejects, as a day of the month. Raising is the safe side of that gap.
  */
 function parseDdd(str: string): DateParts | null {
-  const m = /([-+]?)(\d{2,14})/.exec(str);
+  const m = /([-+]?)(\d{4,14})/.exec(str);
   if (!m) return null;
   const sign = m[1] === "-" ? "-" : "";
   const digits = m[2];
@@ -260,7 +264,27 @@ function parseDdd(str: string): DateParts | null {
   if (digits.length === 6) {
     return s3e(sign + digits.slice(0, 2), digits.slice(2, 4), digits.slice(4, 6));
   }
+  if (digits.length === 4) {
+    return { mon: Number(digits.slice(0, 2)), mday: Number(digits.slice(2, 4)) };
+  }
   return null;
+}
+
+/**
+ * @internal `date_core.c` `rt_complete_frags` (`date_core.c:4021-4036`), which
+ * fills the fields the string left out: the ones above the highest it named
+ * come from `Date.today`, the ones below it are `1`. `"Feb 3rd".to_date` is
+ * this year's 3 February — the case Rails tests at
+ * `activesupport/test/core_ext/string_ext_test.rb:775`.
+ */
+function completeFrags(parts: DateParts): void {
+  const today = Temporal.Now.plainDateISO();
+  if (parts.year === undefined) {
+    parts.year = today.year;
+    if (parts.mon === undefined) parts.mon = today.month;
+  }
+  parts.mon ??= 1;
+  parts.mday ??= 1;
 }
 
 /**
@@ -297,8 +321,9 @@ export class Date {
     // Ruby raises `Date::Error`, a subclass of `ArgumentError` that a nested
     // TS class cannot spell; the superclass is what callers rescue.
     if (!parts) throw new ArgumentError("invalid date");
+    completeFrags(parts);
     try {
-      return new Date(parts.year, parts.mon, parts.mday);
+      return new Date(parts.year as number, parts.mon as number, parts.mday as number);
     } catch {
       throw new ArgumentError("invalid date");
     }
@@ -308,15 +333,14 @@ export class Date {
    * Ruby `Date._parse(str, comp = true)` (ruby/date, `date_parse.c`
    * `date__parse`), which runs its sub-parsers in a fixed order and stops at
    * the first that matches: the alphabetic pair first, then the numeric ones.
-   * Ruby answers a Hash of whatever fields it found; the fields trails reads
-   * are `:year`, `:mon` and `:mday`, so a match that leaves any of them unset
-   * is `null` here.
+   * Ruby answers a Hash of whatever fields it found, which is why a fragment
+   * such as `"Feb 3rd"` comes back without a `:year`; `null` is the Hash no
+   * sub-parser filled at all.
    *
    * @missingRailsCall `parse_time`, `parse_jis`, `parse_vms`, `parse_iso2`,
    * `parse_year`, `parse_mon`, `parse_mday` and `parse_bc` are not ported: they
-   * read a time of day (which `::Date` discards), a calendar Rails never
-   * round-trips, or a fragment that leaves `Date.parse` raising for want of a
-   * `:year`.
+   * read a time of day, which `::Date` discards, or a calendar Rails never
+   * round-trips.
    */
   static _parse(str: string, comp = true): DateParts | null {
     str = parseDay(str);
@@ -326,7 +350,9 @@ export class Date {
     }
     parts ??= parseIso(str) ?? parseSla(str) ?? parseDot(str) ?? parseDdd(str);
     if (parts === null) return null;
-    if (comp && parts._comp === true) parts.year = compYear69(parts.year);
+    if (comp && parts._comp === true && parts.year !== undefined) {
+      parts.year = compYear69(parts.year);
+    }
     delete parts._comp;
     return parts;
   }

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -247,18 +247,23 @@ function parseDot(str: string): DateParts | null {
 /**
  * @internal `date_parse.c` `parse_ddd`: an all-digit run, read by its width.
  *
- * @missingRailsCall The two- and three-digit widths (a bare `:mday`, and the
- * `:yday` of `"102"`) are not read. They are only reachable once `parse_time`
- * has taken the time-of-day text out of the string, and `parse_time` is not
- * ported — without it trails would read the minutes of `"07.2008"`, which Ruby
- * rejects, as a day of the month. Raising is the safe side of that gap.
+ * The 10-, 12- and 14-digit widths are the 8-digit date with a time of day
+ * after it (`date_parse.c:1815-1853`), and `::Date` discards that time, so they
+ * take the same branch.
+ *
+ * @missingRailsCall The widths that name no month — `2` (a bare `:mday`), and
+ * `3`, `5` and `7` (a `:yday`) — are not read. They are only reachable once
+ * `parse_time` has taken the time-of-day text out of the string, and
+ * `parse_time` is not ported: without it trails would read the minutes of
+ * `"07.2008"`, which Ruby rejects, as a day of the month. Raising is the safe
+ * side of that gap.
  */
 function parseDdd(str: string): DateParts | null {
   const m = /([-+]?)(\d{4,14})/.exec(str);
   if (!m) return null;
   const sign = m[1] === "-" ? "-" : "";
   const digits = m[2];
-  if (digits.length === 8) {
+  if (digits.length === 8 || digits.length === 10 || digits.length === 12 || digits.length === 14) {
     return s3e(sign + digits.slice(0, 4), digits.slice(4, 6), digits.slice(6, 8));
   }
   if (digits.length === 6) {


### PR DESCRIPTION
`Date.parse` matched only `/^(-?\d{4,})-(\d{1,2})-(\d{1,2})$/` and raised
`ArgumentError("invalid date")` on everything else. That was safe while the
class was a test-only shim for `I18n::Backend::Base#localize`'s duck type, but
it is now a shared `@blazetrails/i18n/date` export, and `String#to_date`
delegates straight to `::Date.parse`
(`activesupport/lib/active_support/core_ext/string/conversions.rb:47-48`) —
so a string Ruby parses was raising here.

`Date.parse` now runs `Date._parse`, a port of `date__parse` (ruby/date, `date_parse.c`): the
sub-parsers in Ruby's order, module-private, each at its Ruby name —
`parse_day`, `parse_eu`, `parse_us`, `parse_iso`, `parse_sla`, `parse_dot`,
`parse_ddd`, plus `s3e` and `mon_num`. `s3e` is what makes `"01/01/2012"` come
out 1 Jan 2012 while `"12/13/2012"` raises, exactly as the `to_date` doc
examples say.

`Date.parse(str, comp = true)` now takes `comp` too, and completes a two-digit
year through `comp_year69` — Rails passes `false`, which is what keeps
`"080702".to_date` at year 8.

`Date._parse` now answers fragments (`"Feb 3rd"`, `"2008/07"`, `"07/08"`) the
way Ruby does, and `Date.parse` completes them through `rt_complete_frags`
(`date_core.c:4021-4036`) — fields above the highest one named come from
`Date.today`, the ones below it are `1`. That is the case Rails tests at
`activesupport/test/core_ext/string_ext_test.rb:775`. `s3e` also follows Ruby
in never completing a *signed* year (`date_parse.c:172-181`, `:250-251`), so
`"-08-07-02"` stays year -8.

`parse_ddd` reads the 10-, 12- and 14-digit widths through the same branch as
the 8-digit one (`date_parse.c:1815-1853`); the trailing time of day is what
`::Date` discards.

Still narrowed, stated at the call site with the citation: `parse_time`,
`parse_jis`, `parse_vms`, `parse_iso2`, `parse_year`, `parse_mon`,
`parse_mday` and `parse_bc` are unported (`@missingRailsCall`) — they read a
time of day `::Date` discards, a calendar Rails never round-trips, or a
fragment that leaves `Date.parse` raising for want of a `:year`. The
pre-existing `ArgumentError`-for-`Date::Error` note is unchanged.

Also narrowed, at `parse_ddd`: the widths that name no month — `2` (a bare
`:mday`) and `3`/`5`/`7` (a `:yday`) — need `parse_time` to have removed the
time text first, and `parse_time` is unported; reading them without it would
turn `"07.2008"`'s minutes into a day where Ruby raises.

Checked against real Ruby: 68 spellings × both `comp` values — 136 results,
identical to `Date.parse` on every one except the four `:yday` widths named
above, which raise here by design.

Tests: one trails test per accepted spelling, plus the d/m/y disambiguation
and the unchanged `"invalid date"` raise.

Closes-story: i18n-date-parse-accepts-only-y-m-d
