### PR TITLE
fix(i18n): include Base into Chain and KeyValue instead of extending it

### DIFF
--- a/packages/i18n/src/backend/chain.ts
+++ b/packages/i18n/src/backend/chain.ts
@@ -1,9 +1,13 @@
 /**
  * Mirrors: i18n/lib/i18n/backend/chain.rb
  *
- * The gem splits the code into a `Chain::Implementation` module so other
- * modules can be `include`d over it; TypeScript has no module reopening, so
- * `Chain` is a single class extending `Base`, exactly as `Simple` is.
+ * The gem's `Chain` has no superclass: it splits the code into a
+ * `Chain::Implementation` module that `include Base` (chain.rb:21-23) and
+ * `include Implementation`s it back (chain.rb:127), so a module included over
+ * `Chain` lands *between* the two. TypeScript has no module reopening, so this
+ * file keeps the bodies in the `Chain` class itself and spells `include Base`
+ * as the prototype copy at the bottom, exactly as `simple.ts` does. The class
+ * body still wins over `Base`, as Ruby's `include` does.
  *
  * `translate` and `localize` each `return` from inside a `catch(:exception)`
  * block (chain.rb:65, chain.rb:85), which in Ruby leaves the enclosing method;
@@ -39,6 +43,15 @@ interface ChainedBackend extends Base {
 }
 
 /**
+ * Ruby `include Base` (chain.rb:22) as a type: the merged interface gives
+ * `Chain` every member `Base` declares, without an `extends` clause the gem
+ * does not have. The runtime half of the same `include` is the prototype copy
+ * at the bottom of this file.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unsafe-declaration-merging -- the merge is the point: it is `include Base` on the type side.
+export interface Chain extends Base {}
+
+/**
  * Backend that chains multiple other backends and checks each of them when
  * a translation needs to be looked up. This is useful when you want to use
  * standard translations with a Simple backend but store custom application
@@ -57,11 +70,11 @@ interface ChainedBackend extends Base {
  * Fallback translations using the `default` option are only used by the last
  * backend of a chain.
  */
-export class Chain extends Base {
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- see the interface above.
+export class Chain {
   backends: Base[];
 
   constructor(...backends: Base[]) {
-    super();
     this.backends = backends;
   }
 
@@ -73,15 +86,15 @@ export class Chain extends Base {
     return true;
   }
 
-  override reloadBang(): void {
+  reloadBang(): void {
     for (const backend of this.backends) backend.reloadBang();
   }
 
-  override eagerLoadBang(): void {
+  eagerLoadBang(): void {
     for (const backend of this.backends) backend.eagerLoadBang();
   }
 
-  override storeTranslations(
+  storeTranslations(
     locale: Locale,
     data: TranslationData,
     options: TranslateOptions = EMPTY_HASH,
@@ -89,11 +102,11 @@ export class Chain extends Base {
     return this.backends[0].storeTranslations(locale, data, options);
   }
 
-  override availableLocales(): Locale[] {
+  availableLocales(): Locale[] {
     return [...new Set(this.backends.flatMap((backend) => backend.availableLocales()))];
   }
 
-  override translate(
+  translate(
     locale: Locale | null | undefined,
     key: TranslationKey | null | undefined,
     defaultOptions: TranslateOptions = EMPTY_HASH,
@@ -119,15 +132,11 @@ export class Chain extends Base {
     throwException(new MissingTranslation(locale as Locale, key as TranslationKey, options));
   }
 
-  override exists(
-    locale: Locale,
-    key: TranslationKey,
-    options: TranslateOptions = EMPTY_HASH,
-  ): boolean {
+  exists(locale: Locale, key: TranslationKey, options: TranslateOptions = EMPTY_HASH): boolean {
     return this.backends.some((backend) => backend.exists(locale, key, options));
   }
 
-  override localize(
+  localize(
     locale: Locale,
     object: unknown,
     format: unknown = ":default",
@@ -179,5 +188,24 @@ export class Chain extends Base {
       copy[k] = isHash(valueFromOther) && isHash(v) ? this._deepMerge(valueFromOther, v) : v;
     }
     return copy;
+  }
+}
+
+/**
+ * Ruby `include Base` (chain.rb:22). `include` copies a module's instance
+ * methods into the ancestry *below* the class body, so a key the class body
+ * already defines is never replaced — the `hasOwnProperty` guard below. Some of
+ * `Base`'s members are TS class fields (`transliterate`, `loadYaml`), which
+ * only exist on an instance, so an instance is the second source read.
+ */
+for (const source of [Base.prototype, new (Base as unknown as new () => Base)()]) {
+  for (const key of Object.getOwnPropertyNames(source)) {
+    if (key === "constructor") continue;
+    if (Object.prototype.hasOwnProperty.call(Chain.prototype, key)) continue;
+    Object.defineProperty(
+      Chain.prototype,
+      key,
+      Object.getOwnPropertyDescriptor(source, key) as PropertyDescriptor,
+    );
   }
 }

--- a/packages/i18n/src/backend/key-value.ts
+++ b/packages/i18n/src/backend/key-value.ts
@@ -12,7 +12,9 @@
  * the trails mixin idiom — `this`-typed functions from `flatten.ts` assigned to
  * the class. The one `super` below is `Base.prototype.pluralize.call(this)` for
  * the reason Ruby resolves it to `Base` too — a module included into `KeyValue`
- * sits above `Implementation`, never between it and `Base`.
+ * sits above `Implementation`, never between it and `Base`. `pluralize` is
+ * protected, which TS only lets a `KeyValue` reach through another `KeyValue`,
+ * so `Base.prototype` is cast to what `include Base` already made it.
  *
  * `I18n::JSON` is `Oj` or `ActiveSupport::JSON` depending on what is
  * installed (key_value.rb:7-22); JS has `JSON` in the language, and its
@@ -240,8 +242,6 @@ export class KeyValue {
 
   protected pluralize(locale: Locale, entry: unknown, count: unknown): unknown {
     if (this.subtrees()) {
-      // `pluralize` is protected, which TS only lets a `KeyValue` reach through
-      // another `KeyValue`; the cast says what `include Base` already made true.
       return (Base.prototype as KeyValue).pluralize.call(this, locale, entry, count);
     } else {
       if (!isHash(entry)) return entry;

--- a/packages/i18n/src/backend/key-value.ts
+++ b/packages/i18n/src/backend/key-value.ts
@@ -1,11 +1,18 @@
 /**
  * Mirrors: i18n/lib/i18n/backend/key_value.rb
  *
- * The gem splits the code into a `KeyValue::Implementation` module so other
- * modules can be `include`d over it; TypeScript has no module reopening, so
- * `KeyValue` is a single class extending `Base`, exactly as `Simple` is. The
- * `include Flatten` is the trails mixin idiom — `this`-typed functions from
- * `flatten.ts` assigned to the class.
+ * The gem's `KeyValue` has no superclass: it splits the code into a
+ * `KeyValue::Implementation` module that `include Base, Flatten`
+ * (key_value.rb:69-73) and `include Implementation`s it back
+ * (key_value.rb:201), so a module included over `KeyValue` lands *between* the
+ * two. TypeScript has no module reopening, so this file keeps the bodies in the
+ * `KeyValue` class itself and spells `include Base` as the prototype copy at
+ * the bottom, exactly as `simple.ts` does; the class body still wins over
+ * `Base`, as Ruby's `include` does. The `Flatten` arm of the same `include` is
+ * the trails mixin idiom — `this`-typed functions from `flatten.ts` assigned to
+ * the class. The one `super` below is `Base.prototype.pluralize.call(this)` for
+ * the reason Ruby resolves it to `Base` too — a module included into `KeyValue`
+ * sits above `Implementation`, never between it and `Base`.
  *
  * `I18n::JSON` is `Oj` or `ActiveSupport::JSON` depending on what is
  * installed (key_value.rb:7-22); JS has `JSON` in the language, and its
@@ -66,6 +73,15 @@ function isSymbol(value: unknown): value is string {
 const SUBTREE_PROXY_METHODS = new Set(["get", "hasKey", "nil"]);
 
 /**
+ * Ruby `include Base` (key_value.rb:73) as a type: the merged interface gives
+ * `KeyValue` every member `Base` declares, without an `extends` clause the gem
+ * does not have. The runtime half of the same `include` is the prototype copy
+ * at the bottom of this file.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unsafe-declaration-merging -- the merge is the point: it is `include Base` on the type side.
+export interface KeyValue extends Base {}
+
+/**
  * This is a basic backend for key value stores. It receives on
  * initialization the store, which should respond to three methods:
  *
@@ -96,7 +112,8 @@ const SUBTREE_PROXY_METHODS = new Set(["get", "hasKey", "nil"]);
  * (`new KeyValue(store, false)`), which is useful when a KeyValue backend is
  * chained to a Simple backend.
  */
-export class KeyValue extends Base {
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- see the interface above.
+export class KeyValue {
   store: Store | null;
   private subtreesFlag: boolean;
 
@@ -117,7 +134,6 @@ export class KeyValue extends Base {
   translationsStore?: TranslationData;
 
   constructor(store: Store | null, subtrees = true) {
-    super();
     this.store = store;
     this.subtreesFlag = subtrees;
   }
@@ -127,7 +143,7 @@ export class KeyValue extends Base {
     return this.store != null;
   }
 
-  override storeTranslations(
+  storeTranslations(
     locale: Locale,
     data: TranslationData,
     options: TranslateOptions = EMPTY_HASH,
@@ -154,7 +170,7 @@ export class KeyValue extends Base {
     return flattened;
   }
 
-  override availableLocales(): Locale[] {
+  availableLocales(): Locale[] {
     let locales: (Locale | null)[] = [...this.store!.keys()].map((k) => {
       const index = k.indexOf(".");
       return index === -1 ? null : k.slice(0, index);
@@ -193,11 +209,11 @@ export class KeyValue extends Base {
   }
 
   /** Mirrors: `subtrees?` */
-  protected override subtrees(): boolean {
+  protected subtrees(): boolean {
     return this.subtreesFlag;
   }
 
-  protected override lookup(
+  protected lookup(
     locale: Locale,
     key: TranslationKey,
     scope: unknown = [],
@@ -222,14 +238,35 @@ export class KeyValue extends Base {
     return undefined;
   }
 
-  protected override pluralize(locale: Locale, entry: unknown, count: unknown): unknown {
+  protected pluralize(locale: Locale, entry: unknown, count: unknown): unknown {
     if (this.subtrees()) {
-      return super.pluralize(locale, entry, count);
+      // `pluralize` is protected, which TS only lets a `KeyValue` reach through
+      // another `KeyValue`; the cast says what `include Base` already made true.
+      return (Base.prototype as KeyValue).pluralize.call(this, locale, entry, count);
     } else {
       if (!isHash(entry)) return entry;
       const key = this.pluralizationKey(entry, count);
       return entry[key];
     }
+  }
+}
+
+/**
+ * Ruby `include Base` (key_value.rb:73). `include` copies a module's instance
+ * methods into the ancestry *below* the class body, so a key the class body
+ * already defines is never replaced — the `hasOwnProperty` guard below. Some of
+ * `Base`'s members are TS class fields (`transliterate`, `loadYaml`), which
+ * only exist on an instance, so an instance is the second source read.
+ */
+for (const source of [Base.prototype, new (Base as unknown as new () => Base)()]) {
+  for (const key of Object.getOwnPropertyNames(source)) {
+    if (key === "constructor") continue;
+    if (Object.prototype.hasOwnProperty.call(KeyValue.prototype, key)) continue;
+    Object.defineProperty(
+      KeyValue.prototype,
+      key,
+      Object.getOwnPropertyDescriptor(source, key) as PropertyDescriptor,
+    );
   }
 }
 


### PR DESCRIPTION
`I18n::Backend::Chain` (chain.rb:21-23,127) and `I18n::Backend::KeyValue`
(key_value.rb:69-73,201) have the same shape `Backend::Simple` did before
#6054: a class with no superclass whose bodies live in an `Implementation`
module that `include Base` (`include Base, Flatten` for `KeyValue`), included
back into the class. Both were ported as `class X extends Base`, which
collapses the mixin seam a module included over `Chain`/`KeyValue` needs.

Spelled as `simple.ts` does since #6054:

- a declaration-merged `interface X extends Base {}` for the type side, and
- a prototype copy at the bottom of the file for the runtime side, with the
  `hasOwnProperty` guard that makes the class body win as Ruby's `include`
  does.

`KeyValue`'s one `super.pluralize` becomes
`Base.prototype.pluralize.call(this)` — where Ruby resolves it too, since a
module included into `KeyValue` sits above `Implementation`, never between it
and `Base`. The `include Flatten` arm (key_value.rb:73) stays the this-typed
function assignments it already was.

`pnpm api:compare` i18n: 130/136 methods, inheritance 6/6 — unchanged.
`backend/chain.test.ts`, `backend/key-value.test.ts` and the rest of the
`packages/i18n` suite are green (395 tests).

Closes-story: i18n-chain-keyvalue-include-base-not-extends
