### PR TITLE
docs(i18n): attach preloadTranslationFiles' @noRailsEquivalent block to its declaration

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -67,20 +67,6 @@ export function registerFileReader(reader: FileReader): void {
 }
 
 /**
- * Reads every file in `I18n.load_path` into memory, so that the gem's loading
- * chain — `load_translations` / `load_file` / `load_yml` / `load_json`, and
- * `Simple#init_translations` above them — can stay synchronous exactly as the
- * gem writes it.
- *
- * @noRailsEquivalent PERMANENT — the gem has no preload because Ruby reads
- * files synchronously, so `init_translations` can read at its four lazy call
- * sites (simple.rb:83-86). Here the read is a Promise and those sites are
- * synchronous in Rails all the way up through `Error#message`,
- * `Naming#human` and `NumberConverter#format`; making them async would push a
- * deviation through five packages to remove one from this file. Awaiting the
- * I/O once at boot keeps the async fs and leaves every ported body verbatim.
- */
-/**
  * Registers an already-imported JavaScript locale module under the load-path
  * entry that names it, so that `load_rb`'s port can evaluate it synchronously.
  *
@@ -96,6 +82,20 @@ export function registerLocaleModule(filename: string, translations: unknown): v
   localeModules.set(filename, translations);
 }
 
+/**
+ * Reads every file in `I18n.load_path` into memory, so that the gem's loading
+ * chain — `load_translations` / `load_file` / `load_yml` / `load_json`, and
+ * `Simple#init_translations` above them — can stay synchronous exactly as the
+ * gem writes it.
+ *
+ * @noRailsEquivalent PERMANENT — the gem has no preload because Ruby reads
+ * files synchronously, so `init_translations` can read at its four lazy call
+ * sites (simple.rb:83-86). Here the read is a Promise and those sites are
+ * synchronous in Rails all the way up through `Error#message`,
+ * `Naming#human` and `NumberConverter#format`; making them async would push a
+ * deviation through five packages to remove one from this file. Awaiting the
+ * I/O once at boot keeps the async fs and leaves every ported body verbatim.
+ */
 export async function preloadTranslationFiles(...filenames: (string | string[])[]): Promise<void> {
   const paths = filenames.length === 0 ? config().loadPath : filenames;
   for (const filename of paths.flat()) {


### PR DESCRIPTION
`preloadTranslationFiles` in `packages/i18n/src/backend/base.ts` carried a
`@noRailsEquivalent PERMANENT` block, but a second JSDoc comment (for
`registerLocaleModule`) sat between the block and the declaration, so the tag
attached to the wrong function and the reason was lost. `api:extra` counted
`preloadTranslationFiles` as novel extra surface.

Moved `registerLocaleModule` and its own JSDoc above the preload block, so each
reason sits on the declaration it describes. Comment-only change.

`pnpm api:extra --package i18n`: novel 17 → 16, allowed 23 → 24;
`backend/base.ts` no longer appears in the novel list.

Not fixed here: `api:extra` also reports a pre-existing STALE
`@noRailsEquivalent` on `Base#loadJs` (present on `origin/main`) — the tag sits
on a `protected` method while the counted declaration is `loadJs` in
`backend/simple.ts`. Filed as `i18n-loadjs-norailsequivalent-tag-stale`.

Closes-story: i18n-preload-norailsequivalent-tag-detached
