### PR TITLE
chore(i18n): exclude deferred i18n backend suites from test:compare

### DIFF
--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -53,6 +53,7 @@ describe("isSourceUnported package scoping", () => {
       "backend.rb",
       "backend/base.rb",
       "backend/flatten.rb",
+      "backend/key_value.rb",
       "backend/simple.rb",
       "backend/transliterator.rb",
       "config.rb",

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1145,6 +1145,12 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/key_value.rb",
+    testFile: "backend/key_value_test.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
+  },
+  {
+    testFile: "api/key_value_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
   },

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1224,9 +1224,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Suite for the deferred `backend/pluralization.rb` looked up under a scope.",
   },
   // --- i18n: api/ suites that install a deferred backend ---
-  // Each is one "make sure we use <X>" case asserting `I18n.backend.class`;
-  // the rest of the file is the shared `I18n::Tests::*` modules re-run against
-  // that backend. With the backend deferred there is nothing to install.
   {
     testFile: "api/all_features_test.rb",
     package: "i18n",
@@ -1268,12 +1265,11 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "concern with no trails consumer; Rails' own I18n usage never touches it.",
   },
   {
-    // Lives at test/i18n/, outside the `gettext/` prefix above.
     testFile: "gettext_plural_keys_test.rb",
     package: "i18n",
     reason:
-      "Pre-1.0: gettext .po support — exercises `I18n::Gettext.plural_keys`, " +
-      "part of the deferred gettext surface.",
+      "Pre-1.0: gettext .po support — exercises `I18n::Gettext.plural_keys`. " +
+      "Sits at test/i18n/, outside the `gettext/` prefix above.",
   },
   {
     pattern: "locale/tag/rfc4646.rb",

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1150,16 +1150,19 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/cache.rb",
+    testFile: "backend/cache_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache.",
   },
   {
     pattern: "backend/cache_file.rb",
+    testFile: "backend/cache_file_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches parsed translation files on disk.",
   },
   {
     pattern: "backend/cascade.rb",
+    testFile: "backend/cascade_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
   },
@@ -1173,6 +1176,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/interpolation_compiler.rb",
+    testFile: "backend/interpolation_compiler_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — compiles interpolations into Ruby " +
@@ -1180,16 +1184,19 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/lazy_loadable.rb",
+    testFile: "backend/lazy_loadable_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup.",
   },
   {
     pattern: "backend/memoize.rb",
+    testFile: "backend/memoize_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — memoizes lookups per locale.",
   },
   {
     pattern: "backend/metadata.rb",
+    testFile: "backend/metadata_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — attaches lookup metadata onto the " +
@@ -1197,6 +1204,53 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "backend/pluralization.rb",
+    testFile: "backend/pluralization_test.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data.",
+  },
+  {
+    testFile: "backend/pluralization_fallback_test.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data. " +
+      "Suite for the deferred `backend/pluralization.rb` composed with Fallbacks.",
+  },
+  {
+    testFile: "backend/pluralization_scope_test.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data. " +
+      "Suite for the deferred `backend/pluralization.rb` looked up under a scope.",
+  },
+  // --- i18n: api/ suites that install a deferred backend ---
+  // Each is one "make sure we use <X>" case asserting `I18n.backend.class`;
+  // the rest of the file is the shared `I18n::Tests::*` modules re-run against
+  // that backend. With the backend deferred there is nothing to install.
+  {
+    testFile: "api/all_features_test.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: optional backend mixins — a Chain of every deferred mixin " +
+      "(Cascade, Memoize, Metadata, Pluralization, Fallbacks) at once.",
+  },
+  {
+    testFile: "api/cascade_test.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
+  },
+  {
+    testFile: "api/lazy_loadable_test.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup.",
+  },
+  {
+    testFile: "api/memoize_test.rb",
+    package: "i18n",
+    reason: "Pre-1.0: optional backend mixin — memoizes lookups per locale.",
+  },
+  {
+    testFile: "api/pluralization_test.rb",
     package: "i18n",
     reason:
       "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data.",
@@ -1206,11 +1260,20 @@ export const UNPORTED_FILES: UnportedFile[] = [
     // Deliberately broad: covers `gettext.rb`, `gettext/*` and the
     // `backend/gettext.rb` mixin in one entry.
     pattern: "gettext",
+    testFile: "gettext/",
     package: "i18n",
     reason:
       "Pre-1.0: gettext .po support — the catalogue parser, the `_`/`n_`/`s_` " +
       "helpers, and the backend mixin that loads .po files. A Ruby toolchain " +
       "concern with no trails consumer; Rails' own I18n usage never touches it.",
+  },
+  {
+    // Lives at test/i18n/, outside the `gettext/` prefix above.
+    testFile: "gettext_plural_keys_test.rb",
+    package: "i18n",
+    reason:
+      "Pre-1.0: gettext .po support — exercises `I18n::Gettext.plural_keys`, " +
+      "part of the deferred gettext surface.",
   },
   {
     pattern: "locale/tag/rfc4646.rb",
@@ -1222,6 +1285,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     pattern: "middleware.rb",
+    testFile: "i18n/middleware_test.rb",
     package: "i18n",
     reason:
       "Rack middleware that resets `I18n.locale` after each request. trails " +

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1144,17 +1144,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
   },
   {
-    pattern: "backend/key_value.rb",
-    testFile: "backend/key_value_test.rb",
-    package: "i18n",
-    reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
-  },
-  {
-    testFile: "api/key_value_test.rb",
-    package: "i18n",
-    reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
-  },
-  {
     pattern: "backend/cache.rb",
     testFile: "backend/cache_test.rb",
     package: "i18n",
@@ -1171,14 +1160,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     testFile: "backend/cascade_test.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
-  },
-  {
-    pattern: "backend/flatten.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: optional backend mixin — key-flattening helpers used only by the " +
-      "deferred `key_value.rb`, `cache_file.rb` and `memoize.rb` backends; " +
-      "`Simple` does not include it.",
   },
   {
     pattern: "backend/interpolation_compiler.rb",


### PR DESCRIPTION
`pnpm test:compare` counted every case in the i18n suites for backends RFC 0074
declares deferrable — the same files `scripts/api-compare/unported-files.ts`
already excludes from `api:compare`. Those entries carried only `pattern:`, so
the test side kept counting them and the i18n percentage could never reach 100%
nor distinguish "unported deferred suite" from "real test gap".

This adds `testFile:` to the deferred i18n entries (each reusing its existing
reason) plus test-only entries for the suites with no 1:1 source file:
`backend/pluralization_{fallback,scope}_test.rb`, `gettext_plural_keys_test.rb`
(it sits at `test/i18n/`, outside the `gettext/` prefix), and the `api/*`
"make sure we use <X>" cases whose backend is deferred.

Kept counted — their implementation is being ported, not deferred:

- `backend/chain_test.rb` and `api/chain_test.rb` (story `i18n-backend-chain`)
- `locale/tag/*` (story `i18n-locale-tag-rfc4646`)
- `api/fallbacks_test.rb`, `api/override_test.rb` — `backend/fallbacks.rb` and
  the `I18n` module-override path are ported, so these are genuine gaps

i18n test:compare before → after: **259/437 (59.3%), 12/38 files** →
**256/308 (83.1%), 12/19 files**. Every remaining ✗ row is a real gap.

### KeyValue and Flatten: converged, not excluded

Two review rounds converged on the same root cause from opposite directions:
the manifest called `backend/key_value.rb` deferred while
`packages/i18n/src/backend/key-value.ts` (280 lines, `class KeyValue extends
Base`) is a real port of `vendor/i18n/lib/i18n/backend/key_value.rb:69-145`,
with `backend/key_value_test.rb` already green at 14/14. `backend/flatten.rb`
was stale the same way (`packages/i18n/src/backend/flatten.ts`, 212 lines).

Per CLAUDE.md — a deviation register is debt, not permission — both deferrals
are **deleted** rather than extended with `testFile:` rows. Both suites keep
counting, `api/key_value_test.rb` is a legitimately-counted genuine gap
alongside `api/chain` and `api/fallbacks`, and `backend/key_value.rb` joins the
`inScope` set in `unported-files.test.ts`.

`API_COMPARE_FORCE=1 pnpm api:compare`, i18n:

| | before | after |
|---|---|---|
| methods | 130/136 (95.6%) | **177/186 (95.2%)** |
| files | 13/13 | **15/15** |
| inheritance | 6/6 | 6/7 |

47 more methods and 2 more files measured. The inheritance row is `I18n::JSON`
(`key_value.rb:7-22`), a load-time shim picking `Oj` or `ActiveSupport::JSON`;
JS has native `JSON`, so there is no class to mirror. A `SCOPED_SKIP_GROUPS`
entry does **not** suppress it (the inheritance check does not consult that
register), so rather than commit an inert register row I left it reported and
filed story `i18n-key-value-residual-api-gaps` under RFC 0074 with the
measurements and the 3 newly-visible missing methods. CI has no inheritance
ratchet, so this does not gate.

### Gates

`unported-overmatch.test.ts` passes (no whole-file entry resolves to more than
one vendored file). `unported-files.test.ts` still fails on the pre-existing
`locale.rb` / `locale/tag*.rb` / `locale/fallbacks.rb` lib-tree gap — the
unaccounted set is **byte-identical** to `origin/main`, verified by diffing the
failure output with this branch's two files checked out from `main`.

Closes-story: i18n-test-compare-deferred-suite-exclusions
