### PR TITLE
refactor(api-compare): measure i18n's ported key_value and flatten backends

### DIFF
--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -60,8 +60,6 @@ describe("isSourceUnported package scoping", () => {
       "config.rb",
       "exceptions.rb",
       "interpolate/ruby.rb",
-      // `locale.rb` is a pure `autoload` namespace, so it carries no methods
-      // for api:compare to count — `locale.ts` re-exports the same two members.
       "locale.rb",
       "locale/fallbacks.rb",
       "locale/tag.rb",

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -52,12 +52,21 @@ describe("isSourceUnported package scoping", () => {
       "../i18n.rb",
       "backend.rb",
       "backend/base.rb",
+      "backend/fallbacks.rb",
       "backend/flatten.rb",
+      "backend/key_value.rb",
       "backend/simple.rb",
       "backend/transliterator.rb",
       "config.rb",
       "exceptions.rb",
       "interpolate/ruby.rb",
+      // `locale.rb` is a pure `autoload` namespace, so it carries no methods
+      // for api:compare to count — `locale.ts` re-exports the same two members.
+      "locale.rb",
+      "locale/fallbacks.rb",
+      "locale/tag.rb",
+      "locale/tag/parents.rb",
+      "locale/tag/simple.rb",
       "utils.rb",
     ]);
     const unaccounted = ["../i18n.rb", ...files].filter(

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1144,11 +1144,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
   },
   {
-    pattern: "backend/key_value.rb",
-    package: "i18n",
-    reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
-  },
-  {
     pattern: "backend/cache.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache.",
@@ -1162,14 +1157,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     pattern: "backend/cascade.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
-  },
-  {
-    pattern: "backend/flatten.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: optional backend mixin — key-flattening helpers used only by the " +
-      "deferred `key_value.rb`, `cache_file.rb` and `memoize.rb` backends; " +
-      "`Simple` does not include it.",
   },
   {
     pattern: "backend/interpolation_compiler.rb",


### PR DESCRIPTION
`backend/key_value.rb` and `backend/flatten.rb` were still listed as deferred in
`scripts/api-compare/unported-files.ts`, but both are ported —
`packages/i18n/src/backend/key-value.ts` (280 lines, `class KeyValue extends Base`)
and `packages/i18n/src/backend/flatten.ts` (212 lines). The stale deferrals hid a
whole matched file and 39 matched methods from `api:compare`, and would have forced
`test:compare` to drop `backend/key_value_test.rb` and `api/key_value_test.rb`
alongside the genuinely deferred backends.

Deleting the two entries (not rewording them):

- before: `i18n — 130/136 methods (95.6%) | files: 13/13 | inheritance: 6/6`
- after: `i18n — 177/186 methods (95.2%) | files: 15/15 | inheritance: 6/7`

`test:compare` i18n is unchanged at `259/437 tests | 12/38 files` (the
`testFile:` exclusions the story anticipated are not on `main` — #6060 has not
merged, so there was nothing to remove).

`unported-files.test.ts` ("accounts for every file in the vendored i18n lib
tree") was already red on `main` with six unaccounted files. All six are ported
and measured, so they are added to `inScope` rather than excluded:
`backend/fallbacks.rb`, `locale/fallbacks.rb`, `locale/tag.rb`,
`locale/tag/parents.rb`, `locale/tag/simple.rb`, and `locale.rb` — the last a
pure `autoload` namespace (`vendor/i18n/lib/i18n/locale.rb`) that carries no
methods to count, mirrored by `packages/i18n/src/locale.ts`. The test is green
again.

The three gaps this surfaces on `KeyValue` are real and now visible: missing
`I18n::JSON.encode` / `.decode` plus the matching `ts-class-missing` inheritance
mismatch (`key_value.rb:9-18`; trails uses the JS-language `JSON`, documented at
`key-value.ts:10-12`), and `load_rb` (`base.rb:254`, spelled `loadJs` in trails).
Filed as `0074-i18n-parity/i18n-key-value-json-and-load-rb-gaps`.

Closes-story: i18n-converge-key-value-api-deferral
